### PR TITLE
perf(runner): bound snapshot memory prefetch

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -541,12 +541,69 @@ async fn run_start_with_home(
         None
     };
 
-    // Start background prefetch of snapshot memory for all profiles.
-    let mut memory_prefetch = prefetch::MemoryPrefetchTasks::spawn(
-        resource_locks
-            .profile_paths()
-            .map(|(_, profile_paths)| profile_paths.snapshot_paths().memory()),
+    // Resource budget from host resources + config.
+    let host_cpus = host::cpu_count()?;
+    let host_memory_mb = u32::try_from(host::memory_mb()?).map_err(|_| {
+        RunnerError::Internal("host memory exceeds supported runner capacity".into())
+    })?;
+    let pre_spawn_capacity = host::pre_spawn_cpu_capacity(host_cpus)?;
+    let pre_spawn_vcpu_tokens = pre_spawn_capacity.tokens();
+    let pre_spawn_admission = PreSpawnAdmission::new(pre_spawn_vcpu_tokens)?;
+    let budget = Arc::new(ResourceBudget::new(
+        host_cpus as u32,
+        host_memory_mb,
+        concurrency_factor,
+        max_concurrent,
+    ));
+    info!(
+        host_cpus,
+        host_memory_mb,
+        concurrency_factor,
+        concurrency_factor_source = concurrency_factor_source.label(),
+        yaml_concurrency_factor,
+        max_concurrent,
+        effective_vcpu = budget.effective_vcpu(),
+        effective_memory_mb = budget.effective_memory_mb(),
+        profiles = runner_config.profiles.len(),
+        "resource budget initialized"
     );
+    match pre_spawn_capacity {
+        host::PreSpawnCpuCapacity::ExactPhysical(_) => {
+            info!(
+                capacity_source = "physical_topology",
+                pre_spawn_vcpu_tokens = pre_spawn_admission.total_tokens(),
+                host_logical_cpus = host_cpus,
+                "pre-spawn admission initialized"
+            );
+        }
+        host::PreSpawnCpuCapacity::ConservativeLogical(_) => {
+            warn!(
+                capacity_source = "logical_cpu_fallback",
+                reason = "topology directories are absent for all online CPUs",
+                pre_spawn_vcpu_tokens = pre_spawn_admission.total_tokens(),
+                host_logical_cpus = host_cpus,
+                "pre-spawn admission initialized"
+            );
+        }
+    }
+
+    let memory_prefetch_candidates = resource_locks
+        .profile_paths()
+        .map(|(name, profile_paths)| {
+            let profile = runner_config.profiles.get(name).ok_or_else(|| {
+                RunnerError::Internal(format!(
+                    "missing runner profile for locked image artifacts {name}"
+                ))
+            })?;
+            Ok(prefetch::MemoryPrefetchCandidate {
+                path: profile_paths.snapshot_paths().memory(),
+                memory_mb: profile.memory_mb,
+            })
+        })
+        .collect::<RunnerResult<Vec<_>>>()?;
+    let memory_prefetch_budget_mb = u64::from(budget.effective_memory_mb().min(host_memory_mb));
+    let mut memory_prefetch =
+        prefetch::MemoryPrefetchTasks::spawn(memory_prefetch_candidates, memory_prefetch_budget_mb);
 
     // Compute the smallest profile resources for budget pre-check.
     // When budget is exhausted for all profiles, we wait instead of polling.
@@ -589,49 +646,6 @@ async fn run_start_with_home(
     let kmsg_handle = kmsg_log::spawn(network_log_manager.clone())
         .map_err(|e| RunnerError::Internal(format!("kmsg monitor: {e}")))?;
 
-    // Resource budget from host resources + config.
-    let host_cpus = host::cpu_count()?;
-    let host_memory_mb = host::memory_mb()?;
-    let pre_spawn_capacity = host::pre_spawn_cpu_capacity(host_cpus)?;
-    let pre_spawn_vcpu_tokens = pre_spawn_capacity.tokens();
-    let pre_spawn_admission = PreSpawnAdmission::new(pre_spawn_vcpu_tokens)?;
-    let budget = Arc::new(ResourceBudget::new(
-        host_cpus as u32,
-        host_memory_mb as u32,
-        concurrency_factor,
-        max_concurrent,
-    ));
-    info!(
-        host_cpus,
-        host_memory_mb,
-        concurrency_factor,
-        concurrency_factor_source = concurrency_factor_source.label(),
-        yaml_concurrency_factor,
-        max_concurrent,
-        effective_vcpu = budget.effective_vcpu(),
-        effective_memory_mb = budget.effective_memory_mb(),
-        profiles = runner_config.profiles.len(),
-        "resource budget initialized"
-    );
-    match pre_spawn_capacity {
-        host::PreSpawnCpuCapacity::ExactPhysical(_) => {
-            info!(
-                capacity_source = "physical_topology",
-                pre_spawn_vcpu_tokens = pre_spawn_admission.total_tokens(),
-                host_logical_cpus = host_cpus,
-                "pre-spawn admission initialized"
-            );
-        }
-        host::PreSpawnCpuCapacity::ConservativeLogical(_) => {
-            warn!(
-                capacity_source = "logical_cpu_fallback",
-                reason = "topology directories are absent for all online CPUs",
-                pre_spawn_vcpu_tokens = pre_spawn_admission.total_tokens(),
-                host_logical_cpus = host_cpus,
-                "pre-spawn admission initialized"
-            );
-        }
-    }
     let io_limit_resolution =
         crate::io_limits::resolve_io_limits(&runner_config.profiles, &budget, &runner_host_env);
     let device_rate_limits = io_limit_resolution.device_rate_limits();

--- a/crates/runner/src/prefetch.rs
+++ b/crates/runner/src/prefetch.rs
@@ -1,11 +1,15 @@
+use std::collections::BTreeMap;
 use std::io::Read;
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
-use tokio::task::JoinHandle;
+use tokio::task::{JoinHandle, JoinSet};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 const MEMORY_PREFETCH_CHUNK_BYTES: usize = 1024 * 1024;
+const MEMORY_PREFETCH_CONCURRENCY: NonZeroUsize = NonZeroUsize::MIN;
 
 #[derive(Debug)]
 enum PrefetchOutcome {
@@ -15,30 +19,102 @@ enum PrefetchOutcome {
     ReadFailed { bytes: u64, error: std::io::Error },
 }
 
+pub(crate) struct MemoryPrefetchCandidate {
+    pub(crate) path: PathBuf,
+    pub(crate) memory_mb: u32,
+}
+
 pub(crate) struct MemoryPrefetchTasks {
     cancel: CancellationToken,
     handles: Vec<JoinHandle<()>>,
 }
 
 impl MemoryPrefetchTasks {
-    pub(crate) fn spawn(paths: impl IntoIterator<Item = PathBuf>) -> Self {
+    pub(crate) fn spawn(
+        candidates: impl IntoIterator<Item = MemoryPrefetchCandidate>,
+        budget_mb: u64,
+    ) -> Self {
+        Self::spawn_with(
+            candidates,
+            budget_mb,
+            MEMORY_PREFETCH_CONCURRENCY,
+            |path, cancel| {
+                let _ = prefetch_memory_with_cancel(path, cancel);
+            },
+        )
+    }
+
+    fn spawn_with<F>(
+        candidates: impl IntoIterator<Item = MemoryPrefetchCandidate>,
+        budget_mb: u64,
+        concurrency: NonZeroUsize,
+        prefetch: F,
+    ) -> Self
+    where
+        F: Fn(&Path, &CancellationToken) + Send + Sync + 'static,
+    {
         let cancel = CancellationToken::new();
-        let mut unique_paths = Vec::new();
-        for path in paths {
-            if !unique_paths.contains(&path) {
-                unique_paths.push(path);
+        let mut unique_candidates = BTreeMap::new();
+        for candidate in candidates {
+            unique_candidates
+                .entry(candidate.path)
+                .and_modify(|memory_mb: &mut u32| {
+                    *memory_mb = (*memory_mb).max(candidate.memory_mb);
+                })
+                .or_insert(candidate.memory_mb);
+        }
+
+        let unique_count = unique_candidates.len();
+        let mut candidates: Vec<_> = unique_candidates
+            .into_iter()
+            .map(|(path, memory_mb)| MemoryPrefetchCandidate { path, memory_mb })
+            .collect();
+        candidates.sort_by(|left, right| {
+            left.memory_mb
+                .cmp(&right.memory_mb)
+                .then_with(|| left.path.cmp(&right.path))
+        });
+
+        let mut selected = Vec::new();
+        let mut selected_memory_mb = 0_u64;
+        for candidate in candidates {
+            let candidate_memory_mb = u64::from(candidate.memory_mb);
+            if candidate_memory_mb <= budget_mb.saturating_sub(selected_memory_mb) {
+                selected_memory_mb += candidate_memory_mb;
+                selected.push(candidate);
+            } else {
+                info!(
+                    path = %candidate.path.display(),
+                    memory_mb = candidate.memory_mb,
+                    budget_mb,
+                    "memory prefetch deferred by startup budget"
+                );
             }
         }
 
-        let handles = unique_paths
-            .into_iter()
-            .map(|path| {
-                let cancel = cancel.clone();
-                tokio::task::spawn_blocking(move || {
-                    let _ = prefetch_memory_with_cancel(&path, &cancel);
-                })
-            })
-            .collect();
+        let selected_count = selected.len();
+        let deferred_count = unique_count - selected_count;
+        info!(
+            unique = unique_count,
+            selected = selected_count,
+            deferred = deferred_count,
+            selected_memory_mb,
+            budget_mb,
+            concurrency = concurrency.get(),
+            "memory prefetch schedule initialized"
+        );
+
+        let handles = if selected.is_empty() {
+            Vec::new()
+        } else {
+            let task_cancel = cancel.clone();
+            vec![tokio::spawn(run_prefetches(
+                selected,
+                task_cancel,
+                concurrency,
+                Arc::new(prefetch),
+            ))]
+        };
 
         Self { cancel, handles }
     }
@@ -73,6 +149,39 @@ impl MemoryPrefetchTasks {
         Self {
             cancel,
             handles: vec![handle],
+        }
+    }
+}
+
+async fn run_prefetches<F>(
+    candidates: Vec<MemoryPrefetchCandidate>,
+    cancel: CancellationToken,
+    concurrency: NonZeroUsize,
+    prefetch: Arc<F>,
+) where
+    F: Fn(&Path, &CancellationToken) + Send + Sync + 'static,
+{
+    let mut candidates = candidates.into_iter();
+    let mut active = JoinSet::new();
+
+    loop {
+        while active.len() < concurrency.get() && !cancel.is_cancelled() {
+            let Some(candidate) = candidates.next() else {
+                break;
+            };
+            let task_cancel = cancel.clone();
+            let task_prefetch = Arc::clone(&prefetch);
+            active.spawn_blocking(move || {
+                task_prefetch(&candidate.path, &task_cancel);
+            });
+        }
+
+        if active.is_empty() {
+            break;
+        }
+
+        if let Some(Err(error)) = active.join_next().await {
+            warn!(error = %error, "memory prefetch task failed");
         }
     }
 }
@@ -151,8 +260,9 @@ fn prefetch_reader<R: Read>(reader: &mut R, cancel: &CancellationToken) -> Prefe
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Condvar, Mutex};
     use std::time::Duration;
-    use tokio::sync::oneshot;
+    use tokio::sync::{mpsc, oneshot};
 
     #[test]
     fn prefetch_memory_reports_completed_bytes_for_multi_chunk_file() {
@@ -229,14 +339,102 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn memory_prefetch_tasks_deduplicate_paths() {
-        let path = PathBuf::from("/nonexistent/memory.bin");
-        let mut tasks = MemoryPrefetchTasks::spawn([path.clone(), path]);
+    async fn memory_prefetch_tasks_select_smallest_unique_paths_within_budget() {
+        let path_a = PathBuf::from("/snapshots/a/memory.bin");
+        let path_b = PathBuf::from("/snapshots/b/memory.bin");
+        let path_c = PathBuf::from("/snapshots/c/memory.bin");
+        let path_d = PathBuf::from("/snapshots/d/memory.bin");
+        let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+        let mut tasks = MemoryPrefetchTasks::spawn_with(
+            [
+                candidate(&path_a, 2),
+                candidate(&path_b, 2),
+                candidate(&path_c, 4),
+                candidate(&path_d, 1),
+                candidate(&path_a, 5),
+                candidate(&path_b, 2),
+            ],
+            7,
+            NonZeroUsize::MIN,
+            move |path, _| {
+                started_tx.send(path.to_path_buf()).unwrap();
+            },
+        );
 
         assert_eq!(tasks.task_count(), 1);
-
         tasks.drain().await;
         assert_eq!(tasks.task_count(), 0);
+
+        let mut started = Vec::new();
+        while let Ok(path) = started_rx.try_recv() {
+            started.push(path);
+        }
+        assert_eq!(started, [path_d, path_b, path_c]);
+    }
+
+    #[tokio::test]
+    async fn memory_prefetch_tasks_bound_active_blocking_work() {
+        let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+        let gate = Arc::new(BlockingGate::new(started_tx));
+        let task_gate = Arc::clone(&gate);
+        let mut tasks = MemoryPrefetchTasks::spawn_with(
+            [
+                candidate("/snapshots/a/memory.bin", 1),
+                candidate("/snapshots/b/memory.bin", 2),
+                candidate("/snapshots/c/memory.bin", 3),
+                candidate("/snapshots/d/memory.bin", 4),
+            ],
+            10,
+            NonZeroUsize::new(2).unwrap(),
+            move |path, _| task_gate.run(path),
+        );
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            started_rx.recv().await.unwrap();
+            started_rx.recv().await.unwrap();
+        })
+        .await
+        .expect("two prefetch tasks should enter the gate");
+        gate.release_all();
+        tasks.drain().await;
+
+        let state = gate.state();
+        assert_eq!(state.started.len(), 4);
+        assert_eq!(state.max_active, 2);
+        assert_eq!(state.active, 0);
+    }
+
+    #[tokio::test]
+    async fn memory_prefetch_tasks_cancel_queued_work_before_blocking_submission() {
+        let first_path = PathBuf::from("/snapshots/first/memory.bin");
+        let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+        let gate = Arc::new(BlockingGate::new(started_tx));
+        let task_gate = Arc::clone(&gate);
+        let mut tasks = MemoryPrefetchTasks::spawn_with(
+            [
+                candidate(&first_path, 1),
+                candidate("/snapshots/second/memory.bin", 2),
+                candidate("/snapshots/third/memory.bin", 3),
+            ],
+            6,
+            NonZeroUsize::MIN,
+            move |path, _| task_gate.run(path),
+        );
+
+        let started = tokio::time::timeout(Duration::from_secs(5), started_rx.recv())
+            .await
+            .expect("first prefetch should enter the gate")
+            .expect("prefetch gate should report the first path");
+        assert_eq!(started, first_path);
+
+        tasks.cancel();
+        gate.release_all();
+        tasks.drain().await;
+
+        let state = gate.state();
+        assert_eq!(state.started, [first_path]);
+        assert_eq!(state.max_active, 1);
+        assert_eq!(state.active, 0);
     }
 
     #[tokio::test]
@@ -282,6 +480,64 @@ mod tests {
             .await
             .expect("dropped prefetch owner should cancel task")
             .expect("prefetch task should report cancellation");
+    }
+
+    fn candidate(path: impl Into<PathBuf>, memory_mb: u32) -> MemoryPrefetchCandidate {
+        MemoryPrefetchCandidate {
+            path: path.into(),
+            memory_mb,
+        }
+    }
+
+    struct BlockingGate {
+        state: Mutex<BlockingGateState>,
+        release: Condvar,
+        started_tx: mpsc::UnboundedSender<PathBuf>,
+    }
+
+    #[derive(Clone)]
+    struct BlockingGateState {
+        released: bool,
+        active: usize,
+        max_active: usize,
+        started: Vec<PathBuf>,
+    }
+
+    impl BlockingGate {
+        fn new(started_tx: mpsc::UnboundedSender<PathBuf>) -> Self {
+            Self {
+                state: Mutex::new(BlockingGateState {
+                    released: false,
+                    active: 0,
+                    max_active: 0,
+                    started: Vec::new(),
+                }),
+                release: Condvar::new(),
+                started_tx,
+            }
+        }
+
+        fn run(&self, path: &Path) {
+            let mut state = self.state.lock().unwrap();
+            state.active += 1;
+            state.max_active = state.max_active.max(state.active);
+            state.started.push(path.to_path_buf());
+            self.started_tx.send(path.to_path_buf()).unwrap();
+
+            while !state.released {
+                state = self.release.wait(state).unwrap();
+            }
+            state.active -= 1;
+        }
+
+        fn release_all(&self) {
+            self.state.lock().unwrap().released = true;
+            self.release.notify_all();
+        }
+
+        fn state(&self) -> BlockingGateState {
+            self.state.lock().unwrap().clone()
+        }
     }
 
     struct TestReader {


### PR DESCRIPTION
## Summary

- select a deterministic, deduplicated snapshot-memory warm set within the smaller of physical and effective Runner memory capacity
- serialize startup snapshot reads through one owned coordinator so only one blocking prefetch is submitted at a time
- stop queued work before blocking submission on cancellation while preserving active-read cancellation and drain ownership
- report deferred paths and aggregate scheduling decisions without changing existing per-file outcomes

## Scope

- moves existing host resource discovery before startup prefetch scheduling
- keeps benchmark prefetch behavior unchanged
- adds no Runner YAML option, API, persistence, queue, heartbeat, guest protocol, or dependency change
- deferred snapshots remain available through Firecracker demand paging

## Validation

- `cargo check --manifest-path crates/Cargo.toml -p runner`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner prefetch` (28 passed)
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start` (348 passed, 4 ignored)
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner` (3353 passed, 26 ignored; guest inventory 1 passed)
- `git diff --check`
- pre-commit hooks: Rust formatting, workspace rustdoc, workspace Clippy, file-size check; commitlint

Closes #30117
