### PR TITLE
docs(runner): document storage baseline telemetry semantics

### DIFF
--- a/crates/runner/src/executor/storage_baseline_observation.rs
+++ b/crates/runner/src/executor/storage_baseline_observation.rs
@@ -1,3 +1,15 @@
+//! Process-local shadow observations for likely storage-baseline candidates.
+//!
+//! The observer measures whether the exact set of entries marked as baseline candidates is stable
+//! across consecutive jobs. It is an observational telemetry aid only: its result does not affect
+//! storage selection, materialization, cache reuse, or any other execution decision.
+//!
+//! In production, the observer is owned by [`super::ExecutorConfig`], so its state is local to the
+//! Runner process and resets when the Runner restarts. The previous candidate set is kept separately
+//! for each configured profile and [`EffectiveCliFramework`]. Candidate identities remain in this
+//! process-local state only; they are not emitted to telemetry, persisted, hashed, or transformed
+//! into stable pseudonyms.
+
 use std::collections::HashMap;
 use std::sync::Mutex;
 
@@ -14,6 +26,13 @@ const REMOVED_COUNT_ACTION: &str = "runner_storage_baseline_removed_count";
 const CHANGED_AT_PATH_COUNT_ACTION: &str = "runner_storage_baseline_changed_at_path_count";
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+/// The exact identity used when comparing one baseline-candidate mount.
+///
+/// The identity consists of the mount path, VAS storage name, VAS version ID, and optional
+/// instructions target filename. Other [`StorageEntry`] fields, including the archive URL and
+/// size, do not participate in this observation. The derived [`Ord`] implementation provides the
+/// deterministic ordering used for the candidate vector before it is compared with the previous
+/// observation.
 struct CandidateIdentity {
     mount_path: String,
     vas_storage_name: String,
@@ -33,6 +52,12 @@ impl From<&StorageEntry> for CandidateIdentity {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
+/// Scope of a process-local previous candidate set.
+///
+/// Observations are independent for each configured profile and effective CLI framework. The
+/// framework is the normalized [`EffectiveCliFramework`] value, rather than the raw CLI-agent
+/// string: `codex` maps to `Codex`, `pi` maps to `Pi`, and empty, `claude-code`, or unrecognized
+/// values map to `ClaudeCode`.
 struct ObservationKey {
     profile_name: String,
     framework: EffectiveCliFramework,
@@ -47,11 +72,48 @@ struct Observation {
 }
 
 #[derive(Default)]
+/// Process-local observer for exact baseline-candidate stability.
+///
+/// The previous candidate vector is protected by one mutex so concurrent executor entry points
+/// observe and replace a key's state atomically. The production instance lives in
+/// [`super::ExecutorConfig`], which gives the observation its Runner-process lifetime; a new
+/// process (or a newly constructed observer) starts without a previous observation. The stored
+/// [`CandidateIdentity`] values never leave this in-memory map and are not serialized, logged,
+/// persisted, hashed, or converted to stable pseudonyms.
 pub(crate) struct StorageBaselineObserver {
     previous: Mutex<HashMap<ObservationKey, Vec<CandidateIdentity>>>,
 }
 
 impl StorageBaselineObserver {
+    /// Record the current baseline-candidate observation and its bounded telemetry dimensions.
+    ///
+    /// Only read-only manifest entries with `baseline_candidate` set are considered. Their
+    /// [`CandidateIdentity`] values are sorted before comparison, so incoming manifest order does
+    /// not affect the result. For a given [`ObservationKey`], the stability outcome is:
+    ///
+    /// - `first` when this is the first non-empty candidate set; it becomes the previous set and
+    ///   all change counts are zero.
+    /// - `same` when the sorted candidate set exactly matches the previous set; all change counts
+    ///   are zero and the previous set is retained.
+    /// - `changed` when a non-empty candidate set differs from the previous set; the new set
+    ///   replaces the previous set.
+    /// - `none` when there are no candidates; all counts are zero and the previous non-empty set is
+    ///   not replaced.
+    ///
+    /// For `changed`, `candidate_count` is the number of current candidates. `added_count` counts
+    /// current candidates whose mount path was absent from the previous set, `removed_count` counts
+    /// previous candidates whose mount path is absent from the current set, and
+    /// `changed_at_path_count` counts current candidates whose mount path exists in both sets but
+    /// whose complete identity differs. Each count is recorded using the fixed labels `0`, `1`,
+    /// `2`, `3_4`, `5_8`, `9_16`, or `17_plus`.
+    ///
+    /// The stability outcome is emitted as
+    /// `runner_storage_baseline_candidate_stability`; the four count dimensions are emitted as
+    /// `runner_storage_baseline_candidate_count`, `runner_storage_baseline_added_count`,
+    /// `runner_storage_baseline_removed_count`, and
+    /// `runner_storage_baseline_changed_at_path_count`. These are bounded telemetry dimensions;
+    /// no candidate identity is included. This method does not affect storage selection,
+    /// materialization, or any other execution behavior.
     pub(crate) fn record(
         &self,
         context: &ExecutionContext,
@@ -166,6 +228,10 @@ impl StorageBaselineObserver {
     }
 }
 
+/// Convert a raw count to the fixed low-cardinality telemetry label set.
+///
+/// The labels represent the exact ranges `0`, `1`, `2`, `3..=4`, `5..=8`, `9..=16`, and `17+`,
+/// respectively.
 fn count_bucket(count: usize) -> &'static str {
     match count {
         0 => "0",


### PR DESCRIPTION
## Summary

- document the storage-baseline observer's process-local lifecycle and profile/framework keying
- define the exact candidate identity, ordering, outcomes, change counts, and telemetry buckets
- record the observational-only and raw-identity privacy boundaries

## Behavior and exclusions

This PR adds Rustdoc only to `crates/runner/src/executor/storage_baseline_observation.rs`. It does
not change executable statements, telemetry values, state transitions, storage selection,
materialization, cache behavior, serialized payloads, tests, or deployment behavior. It explicitly
documents that `none` does not replace the previous non-empty baseline and that raw identities stay
in process-local memory without telemetry emission, persistence, hashing, or stable pseudonyms.

Closes #30123

## Validation

Passed:

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo check --manifest-path crates/Cargo.toml -p runner --tests`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `git diff --check`

The focused Runner test was attempted with a private `TMPDIR`, single-job compilation, disabled
debug info, and workspace-local Cargo targets, but the binary link was killed with exit 137 by the
3.8 GiB/no-swap execution environment before tests ran. `cargo check --tests` passed for the same
Runner test target; no test source was changed.
