### PR TITLE
test(platform): stabilize workflow suggestion reload lifecycle

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
@@ -702,12 +702,27 @@ describe("chat composer models", () => {
 
   it("reloads workflow suggestions and highlights without remounting the composer", async () => {
     const user = userEvent.setup({ delay: null });
-    let workflows: ReturnType<typeof workflowSummary>[] = [];
+    const initialWorkflowsRequested = context.mocks.deferred<void>();
+    const releaseInitialWorkflows = context.mocks.deferred<void>();
+    const reloadedWorkflow = workflowSummary({
+      name: "new-chat-workflow",
+      displayName: "New Chat Workflow",
+      description: "Created by the current chat run",
+      agentId: AGENT_ID,
+    });
+    let workflowPhase: "initial" | "reloaded" = "initial";
     mockOrgModelRoutes("claude-fable-5");
     mockAgent();
     mockThread();
-    context.mocks.api(workflowsCollectionContract.list, ({ respond }) => {
-      return respond(200, workflows);
+    context.mocks.api(workflowsCollectionContract.list, async ({ respond }) => {
+      if (workflowPhase === "initial") {
+        if (!initialWorkflowsRequested.settled()) {
+          initialWorkflowsRequested.resolve();
+        }
+        await releaseInitialWorkflows.promise;
+        return respond(200, []);
+      }
+      return respond(200, [reloadedWorkflow]);
     });
 
     detachedSetupPage({
@@ -726,21 +741,19 @@ describe("chat composer models", () => {
         "true",
       );
     });
-    const editor = await findComposerEditor();
-    await user.click(editor);
+    await initialWorkflowsRequested.promise;
+    await user.click(await findComposerEditor());
     await user.keyboard("/");
+    await expect(
+      screen.findByText("Loading workflows..."),
+    ).resolves.toBeInTheDocument();
+    releaseInitialWorkflows.resolve();
     await expect(
       screen.findByText("No matching workflows"),
     ).resolves.toBeInTheDocument();
+    const editor = await findComposerEditor();
 
-    workflows = [
-      workflowSummary({
-        name: "new-chat-workflow",
-        displayName: "New Chat Workflow",
-        description: "Created by the current chat run",
-        agentId: AGENT_ID,
-      }),
-    ];
+    workflowPhase = "reloaded";
     act(() => {
       context.mocks.ably.trigger(
         `chatThreadWorkflowsChanged:${THREAD_ID}`,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
@@ -736,13 +736,13 @@ describe("chat composer models", () => {
           `chatThreadWorkflowsChanged:${THREAD_ID}`,
         ),
       ).toBeTruthy();
-      expect(screen.getByTestId("app-skeleton")).toHaveAttribute(
-        "aria-hidden",
-        "true",
-      );
     });
     await initialWorkflowsRequested.promise;
-    await user.click(await findComposerEditor());
+    const thread = await screen.findByLabelText("Chat thread");
+    const initialEditor = await within(thread).findByRole("textbox", {
+      name: "Message",
+    });
+    await user.click(initialEditor);
     await user.keyboard("/");
     await expect(
       screen.findByText("Loading workflows..."),


### PR DESCRIPTION
## Summary

- control the initial workflow-list response in the composer reload integration test
- target the `Message` editor inside the rendered chat thread before sending `/`
- assert the real `loading -> empty -> realtime reload` lifecycle while preserving composer identity, insertion, and highlighting coverage

## Root cause

The test had two independent readiness assumptions. The original version treated the hidden app skeleton and the installed Ably subscription as proof that the initial workflow resource had settled. The first PR commit controlled that resource lifecycle, but it still located the composer globally after the skeleton became hidden.

CI showed that this second assumption was also unsafe: the skeleton handoff tracks initial event readiness, not ownership of the rendered target chat thread. Under load, `/` could be sent to a first-paint composer before the target thread's editor was available, so the slash menu never opened and `Loading workflows...` was absent.

The test now waits for the rendered `Chat thread` region and finds its accessible `Message` editor within that region before typing. This synchronizes on the user-visible surface that owns the workflow reload behavior without adding retries or timeout changes.

## Scope

This changes test synchronization only. It does not change production behavior, increase timeouts, skip tests, or add retries.

## Validation

- Target test passed in 6 independent focused runs on the current worktree.
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-editor-and-suggestions.test.tsx --maxWorkers=1 --silent=passed-only` — passed (22/22).
- `pnpm format` — passed.
- `pnpm -F @okouai/app lint` — passed.
- `pnpm -F @okouai/app check-types` — passed.
- `pnpm knip` — passed.
- Pre-commit hook — passed, including repository-wide Turbo type checks and commitlint.

Closes #30134
