### PR TITLE
fix(runner): recover stalled exact-reuse activation

### DIFF
--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -10,11 +10,12 @@ use tracing::info;
 use super::active_runs::{ActiveRunHandoffRequest, ActiveRunReuseState};
 use super::factory_lifecycle::SharedFactory;
 use super::idle_lifecycle::{
-    IdlePressureRequest, IdlePressureSelection, select_idle_entry_for_pressure,
+    IdlePressureRequest, IdlePressureSelection, ReservedIdleActivation,
+    select_idle_entry_for_pressure,
 };
 use super::job_discovery::{
-    ClaimedJobSetup, FinalizingAdmission, ReadyClaimedResource, ReservedActivation,
-    ReservedActivationRequest, activate_reserved_idle, build_spawn_job_request,
+    ClaimedActivationGuard, ClaimedJobSetup, FinalizingAdmission, ReadyClaimedResource,
+    ReservedActivation, ReservedActivationRequest, activate_reserved_idle, build_spawn_job_request,
     reserve_reusable_idle_for_spawn, rollback_reserved_idle_for_spawn,
 };
 use super::job_spawn::{SpawnContext, run_job};
@@ -24,7 +25,7 @@ use crate::executor::{
     ExecutionFailure, FinalizingHandoffOutcome, RunnerPreSpawnPhase, RunnerPreSpawnTiming,
     validate_resume_session_id,
 };
-use crate::idle_pool::{FinalizingHandoffCandidate, ReservedIdleSandbox};
+use crate::idle_pool::FinalizingHandoffCandidate;
 use crate::ids::RunId;
 use crate::provider::ClaimedJob;
 use crate::resource_budget::{BudgetLease, ResourceBudget};
@@ -50,7 +51,7 @@ pub(super) struct FinalizingClaimRequest {
 
 enum FinalizingWaitOutcome {
     Handoff(Box<FinalizingHandoffCandidate>),
-    Exact(Box<ReservedIdleSandbox>),
+    Exact(ReservedIdleActivation),
     Fallback {
         reason: &'static str,
         handoff_outcome: FinalizingHandoffOutcome,
@@ -73,7 +74,7 @@ impl FinalizingWaitOutcome {
 
 enum FinalizingResource {
     Handoff(Box<FinalizingHandoffCandidate>),
-    Exact(Box<ReservedIdleSandbox>),
+    Exact(ReservedIdleActivation),
     Fresh(BudgetLease),
 }
 
@@ -169,7 +170,7 @@ async fn run_finalizing_claim(
         Ok(Ok(resource)) => resource,
         Ok(Err(failure)) => {
             if let Some(reservation) = reserved_exact.take() {
-                rollback_reserved_idle_for_spawn(*reservation, &ctx).await;
+                rollback_reserved_idle_for_spawn(reservation, &ctx).await;
             }
             return complete_claimed_without_sandbox(
                 claimed,
@@ -183,7 +184,7 @@ async fn run_finalizing_claim(
         }
         Err(payload) => {
             if let Some(reservation) = reserved_exact.take() {
-                rollback_reserved_idle_for_spawn(*reservation, &ctx).await;
+                rollback_reserved_idle_for_spawn(reservation, &ctx).await;
             }
             let cancellation = complete_claimed_without_sandbox(
                 claimed,
@@ -206,6 +207,8 @@ async fn run_finalizing_claim(
         claimed.context().reuse_key().map(str::to_owned),
         profile_name.clone(),
     );
+    let cancellation_handle = cancellation.handle();
+    let mut activation_transfer_guard = None;
     let ready = match resource {
         FinalizingResource::Fresh(active_lease) => ReadyClaimedResource {
             reuse_entry: None,
@@ -214,8 +217,26 @@ async fn run_finalizing_claim(
             idle_snapshot: None,
         },
         FinalizingResource::Exact(reservation) => {
+            let transfer_guard = cancellation_handle.transfer_guard().await;
+            if cancellation_handle.is_cancelled() {
+                drop(transfer_guard);
+                drop(active_run_guard);
+                rollback_reserved_idle_for_spawn(reservation, &ctx).await;
+                pre_spawn_timing
+                    .record_finalizing_handoff_outcome(FinalizingHandoffOutcome::ActivationFailed);
+                return complete_claimed_without_sandbox(
+                    claimed,
+                    cancellation,
+                    ExecutionFailure::cancelled(),
+                    None,
+                    pre_spawn_timing.finalizing_handoff_outcome(),
+                    &ctx,
+                )
+                .await;
+            }
+            activation_transfer_guard = Some(transfer_guard);
             match activate_reserved_idle(
-                *reservation,
+                reservation,
                 ReservedActivationRequest {
                     run_id,
                     profile_name: &profile_name,
@@ -251,6 +272,7 @@ async fn run_finalizing_claim(
                     reuse_result,
                     error,
                 } => {
+                    drop(activation_transfer_guard.take());
                     drop(active_run_guard);
                     pre_spawn_timing.record_finalizing_handoff_outcome(
                         FinalizingHandoffOutcome::ActivationFailed,
@@ -296,6 +318,26 @@ async fn run_finalizing_claim(
                         .await;
                     }
                 };
+            let idle_snapshot = ctx.idle_pool.lock().await.status_snapshot();
+            let reservation = ReservedIdleActivation::new(reservation, idle_snapshot);
+            let transfer_guard = cancellation_handle.transfer_guard().await;
+            if cancellation_handle.is_cancelled() {
+                drop(transfer_guard);
+                drop(active_run_guard);
+                rollback_reserved_idle_for_spawn(reservation, &ctx).await;
+                pre_spawn_timing
+                    .record_finalizing_handoff_outcome(FinalizingHandoffOutcome::ActivationFailed);
+                return complete_claimed_without_sandbox(
+                    claimed,
+                    cancellation,
+                    ExecutionFailure::cancelled(),
+                    None,
+                    pre_spawn_timing.finalizing_handoff_outcome(),
+                    &ctx,
+                )
+                .await;
+            }
+            activation_transfer_guard = Some(transfer_guard);
             match activate_reserved_idle(
                 reservation,
                 ReservedActivationRequest {
@@ -333,6 +375,7 @@ async fn run_finalizing_claim(
                     reuse_result,
                     error,
                 } => {
+                    drop(activation_transfer_guard.take());
                     drop(active_run_guard);
                     pre_spawn_timing.record_finalizing_handoff_outcome(
                         FinalizingHandoffOutcome::ActivationFailed,
@@ -352,7 +395,7 @@ async fn run_finalizing_claim(
             }
         }
     };
-    let request = build_spawn_job_request(
+    let mut activation = ClaimedActivationGuard::new(
         ClaimedJobSetup {
             claimed,
             cancellation,
@@ -368,14 +411,38 @@ async fn run_finalizing_claim(
             active_run_guard,
         },
         &ctx,
-    )
-    .await;
+    );
+    let request = match AssertUnwindSafe(build_spawn_job_request(&mut activation, &ctx))
+        .catch_unwind()
+        .await
+    {
+        Ok(Ok(request)) => request,
+        Ok(Err(error)) => {
+            return activation
+                .recover(
+                    "active_status_persistence_failed",
+                    format!("persist active runner ownership: {error}"),
+                )
+                .await;
+        }
+        Err(panic) => {
+            let cancellation = activation
+                .recover(
+                    "activation_setup_panicked",
+                    "claimed activation setup panicked".to_owned(),
+                )
+                .await;
+            cancellation.unregister().await;
+            std::panic::resume_unwind(panic);
+        }
+    };
+    drop(activation_transfer_guard);
     run_job(request, ctx).await
 }
 
 async fn prepare_finalizing_resource(
     request: FinalizingPreparation<'_>,
-    reserved_exact: &mut Option<Box<ReservedIdleSandbox>>,
+    reserved_exact: &mut Option<ReservedIdleActivation>,
 ) -> Result<FinalizingResource, Box<ExecutionFailure>> {
     let FinalizingPreparation {
         claimed,
@@ -464,7 +531,7 @@ async fn prepare_finalizing_resource(
 
 async fn wait_for_finalizing_resource(
     request: FinalizingWait<'_>,
-    reserved_exact: &mut Option<Box<ReservedIdleSandbox>>,
+    reserved_exact: &mut Option<ReservedIdleActivation>,
 ) -> FinalizingWaitOutcome {
     let FinalizingWait {
         run_id,
@@ -522,11 +589,10 @@ async fn wait_for_finalizing_resource(
                 Some(admission.history_generation_run_id),
                 ctx,
             )
-            .await
-            .map(Box::new);
+            .await;
             if cancel.is_cancelled() {
                 if let Some(reservation) = reserved_exact.take() {
-                    rollback_reserved_idle_for_spawn(*reservation, ctx).await;
+                    rollback_reserved_idle_for_spawn(reservation, ctx).await;
                     ctx.reuse_state_notify.notify_one();
                 }
                 return FinalizingWaitOutcome::cancelled(None);
@@ -754,7 +820,7 @@ async fn reserve_fallback_exact(
     device_rate_limits: &Option<sandbox::DeviceRateLimits>,
     history_generation_run_id: RunId,
     ctx: &SpawnContext,
-) -> Result<Option<Box<ReservedIdleSandbox>>, Box<ExecutionFailure>> {
+) -> Result<Option<ReservedIdleActivation>, Box<ExecutionFailure>> {
     let Some(reservation) = reserve_reusable_idle_for_spawn(
         reuse_key,
         profile_name,
@@ -766,18 +832,18 @@ async fn reserve_fallback_exact(
     else {
         return Ok(None);
     };
-    accept_fallback_exact(cancellation, Box::new(reservation), ctx)
+    accept_fallback_exact(cancellation, reservation, ctx)
         .await
         .map(Some)
 }
 
 async fn accept_fallback_exact(
     cancellation: &RunCancellationRegistration,
-    reservation: Box<ReservedIdleSandbox>,
+    reservation: ReservedIdleActivation,
     ctx: &SpawnContext,
-) -> Result<Box<ReservedIdleSandbox>, Box<ExecutionFailure>> {
+) -> Result<ReservedIdleActivation, Box<ExecutionFailure>> {
     if cancellation.token().is_cancelled() {
-        rollback_reserved_idle_for_spawn(*reservation, ctx).await;
+        rollback_reserved_idle_for_spawn(reservation, ctx).await;
         ctx.reuse_state_notify.notify_one();
         return Err(ExecutionFailure::cancelled().into());
     }

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -1,7 +1,10 @@
 //! Idle-pool lifecycle and status helpers for `runner start`.
 
+use std::ops::Deref;
 use std::sync::Arc;
+use std::{future::Future, panic::AssertUnwindSafe};
 
+use futures_util::FutureExt;
 use sandbox::{DeviceRateLimits, SandboxId};
 use tokio::sync::Notify;
 use tokio::task::JoinSet;
@@ -14,7 +17,7 @@ use crate::idle_pool::{
 };
 use crate::ids::RunId;
 use crate::resource_budget::BudgetLease;
-use crate::status::StatusTracker;
+use crate::status::{StatusResult, StatusTracker};
 
 pub(super) type SharedIdlePool = Arc<tokio::sync::Mutex<IdlePool>>;
 
@@ -49,6 +52,18 @@ impl IdleDestroyTracker {
             let result = destroy_idle_payload_and_wait(payload, context).await;
             if result.workspace_cache_promoted {
                 reuse_state_notify.notify_one();
+            }
+        }));
+    }
+
+    pub(super) fn spawn_cleanup(
+        &self,
+        cleanup: impl Future<Output = ()> + Send + 'static,
+        context: &'static str,
+    ) {
+        drop(self.tasks.spawn(async move {
+            if AssertUnwindSafe(cleanup).catch_unwind().await.is_err() {
+                warn!(context, "tracked activation cleanup panicked");
             }
         }));
     }
@@ -98,9 +113,38 @@ pub(super) struct IdlePressureRequest<'a> {
 }
 
 pub(super) enum IdlePressureSelection {
-    Reusable(Box<ReservedIdleSandbox>),
+    Reusable(ReservedIdleActivation),
     Retiring(RetiringIdleEntry),
     Empty,
+}
+
+/// A parked sandbox reservation paired with the idle snapshot captured by the
+/// same pool mutation. Keeping both together lets claimed activation publish
+/// active ownership before unpark without reacquiring the pool.
+pub(super) struct ReservedIdleActivation {
+    reservation: Box<ReservedIdleSandbox>,
+    idle_snapshot: IdlePoolSnapshot,
+}
+
+impl ReservedIdleActivation {
+    pub(super) fn new(reservation: ReservedIdleSandbox, idle_snapshot: IdlePoolSnapshot) -> Self {
+        Self {
+            reservation: Box::new(reservation),
+            idle_snapshot,
+        }
+    }
+
+    pub(super) fn into_parts(self) -> (ReservedIdleSandbox, IdlePoolSnapshot) {
+        (*self.reservation, self.idle_snapshot)
+    }
+}
+
+impl Deref for ReservedIdleActivation {
+    type Target = ReservedIdleSandbox;
+
+    fn deref(&self) -> &Self::Target {
+        &self.reservation
+    }
 }
 
 impl RetiringIdleEntry {
@@ -145,36 +189,49 @@ pub(super) async fn select_idle_entry_for_pressure(
         let snapshot = pool.status_snapshot();
         (selection, snapshot)
     };
-    let selection = match selection {
+    match selection {
         IdlePoolPressureSelection::Reusable(reservation) => {
-            IdlePressureSelection::Reusable(reservation)
+            IdlePressureSelection::Reusable(ReservedIdleActivation {
+                reservation,
+                idle_snapshot: snapshot,
+            })
         }
         IdlePoolPressureSelection::Evicted(job) => {
             let reuse_key = job.reuse_key().to_owned();
             let profile_name = job.profile_name().to_owned();
             let budget_lease =
                 spawn_idle_destroy_job_retaining_lease(tracker, *job, request.context);
-            IdlePressureSelection::Retiring(RetiringIdleEntry {
+            let selection = IdlePressureSelection::Retiring(RetiringIdleEntry {
                 budget_lease,
                 reuse_key,
                 profile_name,
-            })
+            });
+            set_idle_status_snapshot(status, snapshot).await;
+            selection
         }
-        IdlePoolPressureSelection::Empty => return IdlePressureSelection::Empty,
-    };
-    set_idle_status_snapshot(status, snapshot).await;
-    selection
+        IdlePoolPressureSelection::Empty => IdlePressureSelection::Empty,
+    }
 }
 
 pub(super) async fn set_idle_status_snapshot(status: &StatusTracker, snapshot: IdlePoolSnapshot) {
-    let applied = status
+    let result = status
         .set_idle_info_at_revision(snapshot.revision, snapshot.idle_sandboxes)
         .await;
-    if !applied {
-        info!(
-            revision = snapshot.revision,
-            "ignored stale idle pool status snapshot"
-        );
+    match result {
+        Ok(false) => {
+            info!(
+                revision = snapshot.revision,
+                "ignored stale idle pool status snapshot"
+            );
+        }
+        Ok(true) => {}
+        Err(error) => {
+            warn!(
+                revision = snapshot.revision,
+                %error,
+                "failed to persist idle pool status snapshot"
+            );
+        }
     }
 }
 
@@ -183,7 +240,7 @@ pub(super) async fn add_running_run_with_idle_status_snapshot(
     run_id: RunId,
     sandbox_id: SandboxId,
     snapshot: IdlePoolSnapshot,
-) {
+) -> StatusResult<()> {
     let applied = status
         .add_running_run_with_idle_info_at_revision(
             run_id,
@@ -191,13 +248,14 @@ pub(super) async fn add_running_run_with_idle_status_snapshot(
             snapshot.revision,
             snapshot.idle_sandboxes,
         )
-        .await;
+        .await?;
     if !applied {
         info!(
             revision = snapshot.revision,
             "ignored stale idle pool status snapshot while adding active run"
         );
     }
+    Ok(())
 }
 
 pub(super) async fn add_preparing_run_with_idle_status_snapshot(
@@ -205,7 +263,7 @@ pub(super) async fn add_preparing_run_with_idle_status_snapshot(
     run_id: RunId,
     sandbox_id: SandboxId,
     snapshot: IdlePoolSnapshot,
-) {
+) -> StatusResult<()> {
     let applied = status
         .add_preparing_run_with_idle_info_at_revision(
             run_id,
@@ -213,13 +271,14 @@ pub(super) async fn add_preparing_run_with_idle_status_snapshot(
             snapshot.revision,
             snapshot.idle_sandboxes,
         )
-        .await;
+        .await?;
     if !applied {
         info!(
             revision = snapshot.revision,
             "ignored stale idle pool status snapshot while adding preparing run"
         );
     }
+    Ok(())
 }
 
 pub(super) fn spawn_idle_destroy_job(

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -26,6 +26,7 @@ use super::idle_lifecycle::{
     select_idle_entry_for_pressure, set_idle_status_snapshot, spawn_idle_destroy_job,
 };
 use super::job_spawn::{JobProfile, SpawnContext, SpawnJobRequest, spawn_job};
+use super::ownership::{OwnershipTransitions, RunSandbox};
 #[cfg(test)]
 use super::{OuterJobPanicPoint, maybe_panic_outer_job};
 use crate::config::ProfileConfig;
@@ -129,6 +130,7 @@ pub(super) struct FinalizingAdmission {
 
 struct ExactSpeculation {
     outcome: ExactSpeculationOutcome,
+    sandbox_id: SandboxId,
     idle_snapshot: IdlePoolSnapshot,
     preparation_started_at: Instant,
     preparation_completed_at: Instant,
@@ -140,6 +142,7 @@ struct ExactSpeculation {
 
 struct ExactSpeculationReservation {
     reservation: Box<ReservedIdleSandbox>,
+    sandbox_id: SandboxId,
     idle_snapshot: IdlePoolSnapshot,
 }
 
@@ -183,6 +186,11 @@ struct ReuseAdmissionRequest<'a> {
     workspace_disk_mb: u32,
     context: &'a ExecutionContext,
     job_lease: BudgetLease,
+}
+
+struct ReuseFromPoolFailure {
+    reuse_result: SandboxReuseResult,
+    error: String,
 }
 
 struct ClaimAdmissionRequest<'a> {
@@ -376,7 +384,7 @@ pub(super) async fn handle_discovered_job(
     ) = match resource {
         SandboxAdmittedResource::Fresh(job_lease) => {
             let (reuse_entry, active_lease, reuse_result, idle_snapshot, refresh, transfer_guard) =
-                try_reuse_from_pool(
+                match try_reuse_from_pool(
                     run_id,
                     ReuseAdmissionRequest {
                         profile_name: &profile_name,
@@ -389,7 +397,22 @@ pub(super) async fn handle_discovered_job(
                     &mut pre_spawn_timing,
                     &cancellation_handle,
                 )
-                .await;
+                .await
+                {
+                    Ok(ready) => ready,
+                    Err(failure) => {
+                        complete_claimed_failure(
+                            claimed,
+                            cancellation,
+                            Some(failure.reuse_result),
+                            crate::executor::ExecutionFailure::from_error(failure.error),
+                            &ctx,
+                        )
+                        .await;
+                        drop(active_run_guard);
+                        return DiscoveredJobResult::completed(true);
+                    }
+                };
             (
                 reuse_entry,
                 active_lease,
@@ -896,14 +919,13 @@ async fn recover_claimed_activation_failure(
     if cleanup_completed {
         remove_failed_activation_status(&ctx.status, run_id, sandbox_id).await;
     } else {
-        warn!(
-            run_id = %run_id,
-            sandbox_id = %sandbox_id,
-            recovery_reason = reason,
-            recovery_outcome = "orphaned_after_uncertain_destroy",
-            "activation recovery could not prove sandbox destruction; keeping active status for orphan reconciliation"
+        retain_uncertain_activation_ownership(
+            ctx.status.as_ref(),
+            &ctx.orphaned_active_runs,
+            run_id,
+            sandbox_id,
+            reason,
         );
-        ctx.orphaned_active_runs.insert(run_id, sandbox_id);
     }
     drop(active_run_guard);
     cancellation
@@ -1013,6 +1035,7 @@ async fn claim_with_local_admission(
         LocalAdmissionResource::ExactSpeculative(speculative) => {
             let ExactSpeculationReservation {
                 reservation,
+                sandbox_id,
                 idle_snapshot,
             } = speculative;
             let claim = async {
@@ -1023,6 +1046,7 @@ async fn claim_with_local_admission(
             let ((claimed, claim_returned_at), preparation) = tokio::join!(claim, preparation);
             let speculation = ExactSpeculation {
                 outcome: preparation.outcome,
+                sandbox_id,
                 idle_snapshot,
                 preparation_started_at: preparation.started_at,
                 preparation_completed_at: preparation.completed_at,
@@ -1309,6 +1333,7 @@ async fn exact_speculative_preparation(
     reservation: ReservedIdleActivation,
     ctx: &DiscoveredJobContext<'_>,
 ) -> PreferencePreparation {
+    let sandbox_id = reservation.sandbox_id();
     let (reservation, idle_snapshot) = reservation.into_parts();
     if let Err(error) = ctx
         .status
@@ -1328,6 +1353,7 @@ async fn exact_speculative_preparation(
         resource: Some(LocalAdmissionResource::ExactSpeculative(
             ExactSpeculationReservation {
                 reservation: Box::new(reservation),
+                sandbox_id,
                 idle_snapshot,
             },
         )),
@@ -1763,6 +1789,7 @@ async fn activate_speculated_exact(
     } = request;
     let ExactSpeculation {
         outcome,
+        sandbox_id,
         idle_snapshot,
         preparation_started_at,
         preparation_completed_at,
@@ -1793,14 +1820,16 @@ async fn activate_speculated_exact(
                 error,
                 "speculative exact-reuse preparation failed, destroying before fresh fallback"
             );
-            return cleanup_reserved_for_fresh_fallback(
+            return cleanup_claimed_speculation_for_fresh_fallback(
                 *destroy_job,
                 SandboxReuseResult::UnparkFailed,
                 "speculative_exact_reuse_prepare_failed",
+                run_id,
+                sandbox_id,
+                &idle_snapshot,
                 ctx.spawn_ctx,
             )
-            .await
-            .into();
+            .await;
         }
     };
 
@@ -1813,7 +1842,7 @@ async fn activate_speculated_exact(
             reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
             "claimed reuse key does not match speculatively prepared idle sandbox"
         );
-        return cleanup_reserved_for_fresh_fallback(
+        return cleanup_claimed_speculation_for_fresh_fallback(
             sandbox.into_destroy_job("speculative_reuse_session_mismatch"),
             if requested_reuse_key.is_none() {
                 SandboxReuseResult::NoReuseKey
@@ -1821,10 +1850,12 @@ async fn activate_speculated_exact(
                 SandboxReuseResult::PoolMiss
             },
             "speculative_reuse_session_mismatch",
+            run_id,
+            sandbox_id,
+            &idle_snapshot,
             ctx.spawn_ctx,
         )
-        .await
-        .into();
+        .await;
     }
 
     if let Some(cache) = ctx.spawn_ctx.exec_config.workspace_cache.as_ref() {
@@ -1847,14 +1878,16 @@ async fn activate_speculated_exact(
                 mismatch = mismatch.as_str(),
                 "workspace promotion identity mismatch after speculative preparation"
             );
-            return cleanup_reserved_for_fresh_fallback(
+            return cleanup_claimed_speculation_for_fresh_fallback(
                 sandbox.into_destroy_job("speculative_workspace_promotion_mismatch"),
                 SandboxReuseResult::PoolMiss,
                 "speculative_workspace_promotion_mismatch",
+                run_id,
+                sandbox_id,
+                &idle_snapshot,
                 ctx.spawn_ctx,
             )
-            .await
-            .into();
+            .await;
         }
     }
 
@@ -1888,14 +1921,16 @@ async fn activate_speculated_exact(
                         error = %error,
                         "speculative exact-reuse timezone correction transport failed"
                     );
-                    return cleanup_reserved_for_fresh_fallback(
+                    return cleanup_claimed_speculation_for_fresh_fallback(
                         sandbox.into_destroy_job("speculative_timezone_correction_failed"),
                         SandboxReuseResult::UnparkFailed,
                         "speculative_timezone_correction_failed",
+                        run_id,
+                        sandbox_id,
+                        &idle_snapshot,
                         ctx.spawn_ctx,
                     )
-                    .await
-                    .into();
+                    .await;
                 }
                 Err(_) => {
                     speculation_timing.timezone_correction =
@@ -1909,14 +1944,16 @@ async fn activate_speculated_exact(
                         run_id = %run_id,
                         "speculative exact-reuse timezone correction panicked"
                     );
-                    return cleanup_reserved_for_fresh_fallback(
+                    return cleanup_claimed_speculation_for_fresh_fallback(
                         sandbox.into_destroy_job("speculative_timezone_correction_panicked"),
                         SandboxReuseResult::UnparkFailed,
                         "speculative_timezone_correction_panicked",
+                        run_id,
+                        sandbox_id,
+                        &idle_snapshot,
                         ctx.spawn_ctx,
                     )
-                    .await
-                    .into();
+                    .await;
                 }
             }
             true
@@ -2193,7 +2230,13 @@ pub(super) async fn activate_reserved_idle(
             )
             .await;
             if matches!(activation, FreshFallbackActivation::CannotStart { .. }) {
-                remove_failed_activation_status(&ctx.status, run_id, sandbox_id).await;
+                retain_uncertain_activation_ownership(
+                    &ctx.status,
+                    &ctx.orphaned_active_runs,
+                    run_id,
+                    sandbox_id,
+                    "reserved_reuse_unpark_failed",
+                );
             }
             activation.into()
         }
@@ -2233,6 +2276,63 @@ async fn remove_failed_activation_status(
             );
         }
     }
+}
+
+fn retain_uncertain_activation_ownership(
+    status: &StatusTracker,
+    orphaned_active_runs: &super::orphan_reap::OrphanedActiveRuns,
+    run_id: RunId,
+    sandbox_id: SandboxId,
+    reason: &'static str,
+) {
+    warn!(
+        run_id = %run_id,
+        sandbox_id = %sandbox_id,
+        recovery_reason = reason,
+        recovery_outcome = "orphaned_after_uncertain_destroy",
+        "activation cleanup could not prove sandbox destruction; keeping active status for orphan reconciliation"
+    );
+    OwnershipTransitions::new(status)
+        .active_ownership_unknown(orphaned_active_runs, RunSandbox::new(run_id, sandbox_id));
+}
+
+async fn cleanup_claimed_speculation_for_fresh_fallback(
+    destroy_job: crate::idle_pool::IdleDestroyJob,
+    reuse_result: SandboxReuseResult,
+    cleanup_context: &'static str,
+    run_id: RunId,
+    sandbox_id: SandboxId,
+    idle_snapshot: &IdlePoolSnapshot,
+    ctx: &SpawnContext,
+) -> PendingExactActivation {
+    let activation =
+        cleanup_reserved_for_fresh_fallback(destroy_job, reuse_result, cleanup_context, ctx).await;
+    if matches!(activation, FreshFallbackActivation::CannotStart { .. }) {
+        if let Err(error) = add_preparing_run_with_idle_status_snapshot(
+            &ctx.status,
+            run_id,
+            sandbox_id,
+            idle_snapshot.clone(),
+        )
+        .await
+        {
+            warn!(
+                run_id = %run_id,
+                sandbox_id = %sandbox_id,
+                %error,
+                recovery_reason = cleanup_context,
+                "failed to persist uncertain speculative activation ownership"
+            );
+        }
+        retain_uncertain_activation_ownership(
+            &ctx.status,
+            &ctx.orphaned_active_runs,
+            run_id,
+            sandbox_id,
+            cleanup_context,
+        );
+    }
+    activation.into()
 }
 
 async fn cleanup_reserved_for_fresh_fallback(
@@ -2305,14 +2405,17 @@ async fn try_reuse_from_pool(
     ctx: &mut DiscoveredJobContext<'_>,
     pre_spawn_timing: &mut RunnerPreSpawnTiming,
     cancellation: &RunCancellationHandle,
-) -> (
-    Option<ReusableIdleSandbox>,
-    BudgetLease,
-    SandboxReuseResult,
-    Option<IdlePoolSnapshot>,
-    bool,
-    Option<OwnedMutexGuard<()>>,
-) {
+) -> Result<
+    (
+        Option<ReusableIdleSandbox>,
+        BudgetLease,
+        SandboxReuseResult,
+        Option<IdlePoolSnapshot>,
+        bool,
+        Option<OwnedMutexGuard<()>>,
+    ),
+    ReuseFromPoolFailure,
+> {
     let ReuseAdmissionRequest {
         profile_name,
         device_rate_limits,
@@ -2324,14 +2427,14 @@ async fn try_reuse_from_pool(
     let started_at = Instant::now();
     let Some(reuse_key) = context.reuse_key() else {
         pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
-        return (
+        return Ok((
             None,
             job_lease,
             SandboxReuseResult::NoReuseKey,
             None,
             false,
             None,
-        );
+        ));
     };
     // Take the entry under the pool lock, then drop the lock before any awaits
     // so unpark does not block other take/park operations.
@@ -2381,14 +2484,14 @@ async fn try_reuse_from_pool(
                         entry.into_destroy_job_without_workspace_promotion_for_mismatch(),
                         "reuse_workspace_promotion_mismatch",
                     );
-                    return (
+                    return Ok((
                         None,
                         job_lease,
                         SandboxReuseResult::PoolMiss,
                         Some(snapshot),
                         needs_reuse_state_refresh,
                         None,
-                    );
+                    ));
                 }
             }
             let idle_snapshot = snapshot.clone();
@@ -2401,14 +2504,14 @@ async fn try_reuse_from_pool(
                     ctx.spawn_ctx,
                 )
                 .await;
-                return (
+                return Ok((
                     None,
                     job_lease,
                     SandboxReuseResult::PoolMiss,
                     None,
                     needs_reuse_state_refresh,
                     None,
-                );
+                ));
             }
             let status_started_at = Instant::now();
             if let Err(error) = add_preparing_run_with_idle_status_snapshot(
@@ -2435,14 +2538,14 @@ async fn try_reuse_from_pool(
                     ctx.spawn_ctx,
                 )
                 .await;
-                return (
+                return Ok((
                     None,
                     job_lease,
                     SandboxReuseResult::PoolMiss,
                     None,
                     needs_reuse_state_refresh,
                     None,
-                );
+                ));
             }
             pre_spawn_timing
                 .record_phase_elapsed(RunnerPreSpawnPhase::ActiveStatusPublish, status_started_at);
@@ -2469,14 +2572,14 @@ async fn try_reuse_from_pool(
                     // fresh-job lease and move the idle lease to the outer job
                     // task before handing the sandbox to the executor.
                     drop(job_lease);
-                    (
+                    Ok((
                         Some(*sandbox),
                         budget_lease,
                         SandboxReuseResult::Reused,
                         Some(snapshot),
                         needs_reuse_state_refresh,
                         Some(transfer_guard),
-                    )
+                    ))
                 }
                 IdleUnparkResult::Failed { destroy_job, error } => {
                     warn!(
@@ -2486,16 +2589,40 @@ async fn try_reuse_from_pool(
                         error = %error,
                         "unpark failed, destroying idle sandbox and falling through to fresh create"
                     );
-                    destroy_idle_jobs_and_wait(vec![*destroy_job], "reuse_unpark_failed").await;
+                    let cleanup = destroy_job.run_retaining_lease("reuse_unpark_failed").await;
+                    if cleanup.workspace_cache_promoted {
+                        ctx.spawn_ctx.reuse_state_notify.notify_one();
+                    }
                     drop(transfer_guard);
-                    (
-                        None,
-                        job_lease,
-                        SandboxReuseResult::UnparkFailed,
-                        Some(snapshot),
-                        needs_reuse_state_refresh,
-                        None,
-                    )
+                    match cleanup.outcome {
+                        DestroyOutcome::Completed => {
+                            drop(cleanup.budget_lease);
+                            Ok((
+                                None,
+                                job_lease,
+                                SandboxReuseResult::UnparkFailed,
+                                Some(snapshot),
+                                needs_reuse_state_refresh,
+                                None,
+                            ))
+                        }
+                        DestroyOutcome::Uncertain => {
+                            drop(cleanup.budget_lease);
+                            drop(job_lease);
+                            retain_uncertain_activation_ownership(
+                                &ctx.spawn_ctx.status,
+                                &ctx.spawn_ctx.orphaned_active_runs,
+                                run_id,
+                                sandbox_id,
+                                "reuse_unpark_failed",
+                            );
+                            Err(ReuseFromPoolFailure {
+                                reuse_result: SandboxReuseResult::UnparkFailed,
+                                error: "idle sandbox cleanup was uncertain; fresh replacement was not started"
+                                    .to_owned(),
+                            })
+                        }
+                    }
                 }
             }
         }
@@ -2512,14 +2639,14 @@ async fn try_reuse_from_pool(
                 stale.into_destroy_job(),
                 "reuse_device_limit_mismatch",
             );
-            (
+            Ok((
                 None,
                 job_lease,
                 SandboxReuseResult::DeviceLimitMismatch,
                 Some(snapshot),
                 needs_reuse_state_refresh,
                 None,
-            )
+            ))
         }
         Some((stale, snapshot)) => {
             info!(
@@ -2535,14 +2662,14 @@ async fn try_reuse_from_pool(
                 stale.into_destroy_job(),
                 "reuse_profile_mismatch",
             );
-            (
+            Ok((
                 None,
                 job_lease,
                 SandboxReuseResult::ProfileMismatch,
                 Some(snapshot),
                 needs_reuse_state_refresh,
                 None,
-            )
+            ))
         }
         None => {
             info!(
@@ -2551,14 +2678,14 @@ async fn try_reuse_from_pool(
                 reuse_key_kind = reuse_key_kind(reuse_key),
                 "no idle sandbox found for reuse key"
             );
-            (
+            Ok((
                 None,
                 job_lease,
                 SandboxReuseResult::PoolMiss,
                 None,
                 needs_reuse_state_refresh,
                 None,
-            )
+            ))
         }
     }
 }

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -4,6 +4,7 @@
 //! module owns the body that turns a discovered job into a claimed spawned job.
 
 use std::collections::BTreeMap;
+use std::mem::ManuallyDrop;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::time::Instant;
@@ -19,12 +20,14 @@ use super::active_runs::{ActiveRunGuard, ActiveRunReuseProof};
 use super::factory_lifecycle::SharedFactory;
 use super::finalizing_claim::{FinalizingClaimRequest, spawn_finalizing_claim};
 use super::idle_lifecycle::{
-    IdlePressureRequest, IdlePressureSelection, SharedIdlePool,
-    add_preparing_run_with_idle_status_snapshot, add_running_run_with_idle_status_snapshot,
-    destroy_idle_jobs_and_wait, select_idle_entry_for_pressure, set_idle_status_snapshot,
-    spawn_idle_destroy_job,
+    IdleDestroyTracker, IdlePressureRequest, IdlePressureSelection, ReservedIdleActivation,
+    SharedIdlePool, add_preparing_run_with_idle_status_snapshot,
+    add_running_run_with_idle_status_snapshot, destroy_idle_jobs_and_wait,
+    select_idle_entry_for_pressure, set_idle_status_snapshot, spawn_idle_destroy_job,
 };
 use super::job_spawn::{JobProfile, SpawnContext, SpawnJobRequest, spawn_job};
+#[cfg(test)]
+use super::{OuterJobPanicPoint, maybe_panic_outer_job};
 use crate::config::ProfileConfig;
 use crate::executor::{
     ExactReuseSpeculationTiming, RunnerPreSpawnOperationTiming, RunnerPreSpawnPhase,
@@ -41,14 +44,14 @@ use crate::ids::RunId;
 use crate::lifecycle::RunnerMode;
 use crate::paths::short_digest;
 use crate::provider::{
-    ClaimedJob, JobCandidate, RunnerPreferenceRemovalReason, RunnerPreferenceTier,
+    ClaimedJob, JobCandidate, JobProvider, RunnerPreferenceRemovalReason, RunnerPreferenceTier,
 };
 use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::run_cancellation::{
     RunCancellationHandle, RunCancellationRegistration, RunCancellationRegistry,
 };
 use crate::runner_process_identity::RunnerProcessIdentity;
-use crate::status::StatusTracker;
+use crate::status::{StatusPersistenceError, StatusTracker};
 use crate::types::{
     CompleteRequest, ExecutionContext, HeldWorkspaceState, SandboxReuseResult,
     WORKSPACE_AFFINITY_VERSION, reuse_key_kind,
@@ -99,21 +102,21 @@ struct LocalAdmission {
 
 enum LocalAdmissionResource {
     Fresh(BudgetLease),
-    Reusable(Box<ReservedIdleSandbox>),
-    ExactSpeculative(Box<ReservedIdleSandbox>),
+    Reusable(ReservedIdleActivation),
+    ExactSpeculative(ExactSpeculationReservation),
     Finalizing(FinalizingAdmission),
 }
 
 enum AdmittedResource {
     Fresh(BudgetLease),
-    Reusable(Box<ReservedIdleSandbox>),
+    Reusable(ReservedIdleActivation),
     ExactSpeculation(ExactSpeculation),
     Finalizing(FinalizingAdmission),
 }
 
 enum SandboxAdmittedResource {
     Fresh(BudgetLease),
-    Reusable(Box<ReservedIdleSandbox>),
+    Reusable(ReservedIdleActivation),
     ExactSpeculation(ExactSpeculation),
 }
 
@@ -126,12 +129,18 @@ pub(super) struct FinalizingAdmission {
 
 struct ExactSpeculation {
     outcome: ExactSpeculationOutcome,
+    idle_snapshot: IdlePoolSnapshot,
     preparation_started_at: Instant,
     preparation_completed_at: Instant,
     claim_started_at: Instant,
     claim_returned_at: Instant,
     unpark: RunnerPreSpawnOperationTiming,
     guest_restore: Option<RunnerPreSpawnOperationTiming>,
+}
+
+struct ExactSpeculationReservation {
+    reservation: Box<ReservedIdleSandbox>,
+    idle_snapshot: IdlePoolSnapshot,
 }
 
 struct ExactSpeculationPreparation {
@@ -355,6 +364,7 @@ pub(super) async fn handle_discovered_job(
         claimed.context().reuse_key().map(str::to_owned),
         profile_name.clone(),
     );
+    let cancellation_handle = cancellation.handle();
 
     let (
         reuse_entry,
@@ -365,7 +375,7 @@ pub(super) async fn handle_discovered_job(
         activation_transfer_guard,
     ) = match resource {
         SandboxAdmittedResource::Fresh(job_lease) => {
-            let (reuse_entry, active_lease, reuse_result, idle_snapshot, refresh) =
+            let (reuse_entry, active_lease, reuse_result, idle_snapshot, refresh, transfer_guard) =
                 try_reuse_from_pool(
                     run_id,
                     ReuseAdmissionRequest {
@@ -377,6 +387,7 @@ pub(super) async fn handle_discovered_job(
                     },
                     &mut ctx,
                     &mut pre_spawn_timing,
+                    &cancellation_handle,
                 )
                 .await;
             (
@@ -385,12 +396,28 @@ pub(super) async fn handle_discovered_job(
                 reuse_result,
                 idle_snapshot,
                 refresh,
-                None,
+                transfer_guard,
             )
         }
         SandboxAdmittedResource::Reusable(reservation) => {
+            let transfer_guard = cancellation_handle.transfer_guard().await;
+            if cancellation_handle.is_cancelled() {
+                drop(transfer_guard);
+                drop(active_run_guard);
+                complete_claimed_without_sandbox(
+                    claimed,
+                    cancellation,
+                    SandboxAdmittedResource::Reusable(reservation),
+                    job_workspace_disk_mb,
+                    None,
+                    crate::executor::ExecutionFailure::cancelled(),
+                    &mut ctx,
+                )
+                .await;
+                return DiscoveredJobResult::completed(true);
+            }
             match activate_reserved_idle(
-                *reservation,
+                reservation,
                 ReservedActivationRequest {
                     run_id,
                     profile_name: &profile_name,
@@ -414,23 +441,36 @@ pub(super) async fn handle_discovered_job(
                     reuse_result,
                     Some(idle_snapshot),
                     true,
-                    None,
+                    Some(transfer_guard),
                 ),
                 ReservedActivation::CannotStart {
                     budget_lease,
                     reuse_result,
                     error,
                 } => {
-                    complete_claimed_without_sandbox(
-                        claimed,
-                        cancellation,
-                        SandboxAdmittedResource::Fresh(budget_lease),
-                        job_workspace_disk_mb,
-                        Some(reuse_result),
-                        crate::executor::ExecutionFailure::from_error(error),
-                        &mut ctx,
-                    )
-                    .await;
+                    drop(transfer_guard);
+                    let failure = crate::executor::ExecutionFailure::from_error(error);
+                    if let Some(budget_lease) = budget_lease {
+                        complete_claimed_without_sandbox(
+                            claimed,
+                            cancellation,
+                            SandboxAdmittedResource::Fresh(budget_lease),
+                            job_workspace_disk_mb,
+                            Some(reuse_result),
+                            failure,
+                            &mut ctx,
+                        )
+                        .await;
+                    } else {
+                        complete_claimed_failure(
+                            claimed,
+                            cancellation,
+                            Some(reuse_result),
+                            failure,
+                            &ctx,
+                        )
+                        .await;
+                    }
                     return DiscoveredJobResult::completed(true);
                 }
             }
@@ -449,7 +489,7 @@ pub(super) async fn handle_discovered_job(
                 &mut pre_spawn_timing,
             )
             .await;
-            match finish_exact_activation(pending, &cancellation.handle(), run_id, &ctx).await {
+            match finish_exact_activation(pending, &cancellation.handle(), run_id).await {
                 ExactActivation::Ready {
                     reuse_entry,
                     active_lease,
@@ -511,7 +551,7 @@ pub(super) async fn handle_discovered_job(
         }
     };
 
-    let request = build_spawn_job_request(
+    let mut activation = ClaimedActivationGuard::new(
         ClaimedJobSetup {
             claimed,
             cancellation,
@@ -532,8 +572,35 @@ pub(super) async fn handle_discovered_job(
             active_run_guard,
         },
         ctx.spawn_ctx,
-    )
-    .await;
+    );
+    let request = match AssertUnwindSafe(build_spawn_job_request(&mut activation, ctx.spawn_ctx))
+        .catch_unwind()
+        .await
+    {
+        Ok(Ok(request)) => request,
+        Ok(Err(error)) => {
+            let cancellation = activation
+                .recover(
+                    "active_status_persistence_failed",
+                    format!("persist active runner ownership: {error}"),
+                )
+                .await;
+            cancellation.unregister().await;
+            drop(activation_transfer_guard);
+            return DiscoveredJobResult::completed(true);
+        }
+        Err(panic) => {
+            let cancellation = activation
+                .recover(
+                    "activation_setup_panicked",
+                    "claimed activation setup panicked".to_owned(),
+                )
+                .await;
+            cancellation.unregister().await;
+            drop(activation_transfer_guard);
+            std::panic::resume_unwind(panic);
+        }
+    };
     spawn_job(request, ctx.spawn_ctx, ctx.jobs);
     drop(activation_transfer_guard);
     DiscoveredJobResult::completed(needs_reuse_state_refresh)
@@ -561,10 +628,139 @@ pub(super) struct ClaimedJobSetup {
     pub(super) active_run_guard: ActiveRunGuard,
 }
 
+#[derive(Clone)]
+struct ActivationRecoveryContext {
+    provider: Arc<dyn JobProvider>,
+    status: Arc<StatusTracker>,
+    reuse_state_notify: Arc<tokio::sync::Notify>,
+}
+
+impl ActivationRecoveryContext {
+    fn new(ctx: &SpawnContext) -> Self {
+        Self {
+            provider: Arc::clone(&ctx.provider),
+            status: Arc::clone(&ctx.status),
+            reuse_state_notify: Arc::clone(&ctx.reuse_state_notify),
+        }
+    }
+}
+
+pub(super) struct ClaimedActivationGuard {
+    setup: ManuallyDrop<ClaimedJobSetup>,
+    armed: bool,
+    sandbox_id: SandboxId,
+    recovery: ActivationRecoveryContext,
+    cleanup: IdleDestroyTracker,
+}
+
+impl ClaimedActivationGuard {
+    pub(super) fn new(setup: ClaimedJobSetup, ctx: &SpawnContext) -> Self {
+        let sandbox_id = match &setup.resource.reuse_entry {
+            Some(entry) => entry.sandbox_id(),
+            None => SandboxId::new_v4(),
+        };
+        Self {
+            setup: ManuallyDrop::new(setup),
+            armed: true,
+            sandbox_id,
+            recovery: ActivationRecoveryContext::new(ctx),
+            cleanup: ctx.idle_destroy_tracker.clone(),
+        }
+    }
+
+    pub(super) async fn recover(
+        mut self,
+        reason: &'static str,
+        error: String,
+    ) -> RunCancellationRegistration {
+        recover_claimed_activation_failure(
+            self.take_setup(),
+            self.sandbox_id,
+            reason,
+            error,
+            &self.recovery,
+        )
+        .await
+    }
+
+    fn take_setup(&mut self) -> ClaimedJobSetup {
+        self.armed = false;
+        // SAFETY: `armed` is true exactly while `setup` has not been taken.
+        // Every take clears it first, and `Drop` only takes while it is true.
+        unsafe { ManuallyDrop::take(&mut self.setup) }
+    }
+}
+
+impl Drop for ClaimedActivationGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let setup = self.take_setup();
+        let sandbox_id = self.sandbox_id;
+        let recovery = self.recovery.clone();
+        self.cleanup.spawn_cleanup(
+            async move {
+                let cancellation = recover_claimed_activation_failure(
+                    setup,
+                    sandbox_id,
+                    "activation_task_dropped",
+                    "claimed activation task dropped before executor ownership transfer".to_owned(),
+                    &recovery,
+                )
+                .await;
+                cancellation.unregister().await;
+            },
+            "claimed_activation_drop",
+        );
+    }
+}
+
 pub(super) async fn build_spawn_job_request(
-    setup: ClaimedJobSetup,
+    activation: &mut ClaimedActivationGuard,
     ctx: &SpawnContext,
-) -> SpawnJobRequest {
+) -> Result<SpawnJobRequest, StatusPersistenceError> {
+    let setup = &mut *activation.setup;
+    let run_id = setup.claimed.context().run_id;
+    let sandbox_id = activation.sandbox_id;
+    #[cfg(test)]
+    maybe_panic_outer_job(
+        ctx.outer_job_panic,
+        OuterJobPanicPoint::ClaimedActivation,
+        run_id,
+    );
+    let started_at = Instant::now();
+    let status_result = publish_active_run_status(
+        &ctx.status,
+        run_id,
+        sandbox_id,
+        setup.resource.reuse_entry.is_some(),
+        setup.resource.idle_snapshot.clone(),
+    )
+    .await;
+    setup
+        .pre_spawn_timing
+        .record_phase_elapsed(RunnerPreSpawnPhase::ActiveStatusPublish, started_at);
+    status_result?;
+    #[cfg(test)]
+    ctx.test_observer.notify_active_run_status_published(run_id);
+
+    let session_history_restore_plan =
+        build_session_history_restore_plan(SessionHistoryRestorePlanInput {
+            http: &ctx.exec_config.http,
+            cpu: &ctx.exec_config.session_history_cpu,
+            context: setup.claimed.context(),
+            cancel: setup.cancellation.token(),
+            reuse_result: setup.resource.reuse_result,
+            restored_identity: setup
+                .resource
+                .reuse_entry
+                .as_ref()
+                .and_then(ReusableIdleSandbox::restored_session_identity),
+            pre_spawn_timing: &mut setup.pre_spawn_timing,
+            probe: Some(&ctx.exec_config.session_history_probe),
+        });
+
     let ClaimedJobSetup {
         claimed,
         cancellation,
@@ -576,47 +772,18 @@ pub(super) async fn build_spawn_job_request(
         device_rate_limits,
         factory,
         resource,
-        mut pre_spawn_timing,
+        pre_spawn_timing,
         active_run_guard,
-    } = setup;
+    } = activation.take_setup();
     let ReadyClaimedResource {
         reuse_entry,
         active_lease,
         reuse_result,
         idle_snapshot,
     } = resource;
-    let run_id = claimed.context().run_id;
-    let session_history_restore_plan =
-        build_session_history_restore_plan(SessionHistoryRestorePlanInput {
-            http: &ctx.exec_config.http,
-            cpu: &ctx.exec_config.session_history_cpu,
-            context: claimed.context(),
-            cancel: cancellation.token(),
-            reuse_result,
-            restored_identity: reuse_entry
-                .as_ref()
-                .and_then(ReusableIdleSandbox::restored_session_identity),
-            pre_spawn_timing: &mut pre_spawn_timing,
-            probe: Some(&ctx.exec_config.session_history_probe),
-        });
-    let sandbox_id = match &reuse_entry {
-        Some(entry) => entry.sandbox_id(),
-        None => SandboxId::new_v4(),
-    };
-    let started_at = Instant::now();
-    publish_active_run_status(
-        &ctx.status,
-        run_id,
-        sandbox_id,
-        reuse_entry.is_some(),
-        idle_snapshot,
-    )
-    .await;
-    #[cfg(test)]
-    ctx.test_observer.notify_active_run_status_published(run_id);
-    pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::ActiveStatusPublish, started_at);
+    drop(idle_snapshot);
 
-    SpawnJobRequest {
+    Ok(SpawnJobRequest {
         claimed,
         sandbox_id,
         job_profile: JobProfile {
@@ -635,7 +802,7 @@ pub(super) async fn build_spawn_job_request(
         pre_spawn_timing,
         session_history_restore_plan,
         active_run_guard,
-    }
+    })
 }
 
 async fn publish_active_run_status(
@@ -644,16 +811,86 @@ async fn publish_active_run_status(
     sandbox_id: SandboxId,
     reused_idle: bool,
     idle_snapshot: Option<IdlePoolSnapshot>,
-) {
+) -> Result<(), StatusPersistenceError> {
     if let Some(snapshot) = idle_snapshot {
         if reused_idle {
-            add_running_run_with_idle_status_snapshot(status, run_id, sandbox_id, snapshot).await;
+            add_running_run_with_idle_status_snapshot(status, run_id, sandbox_id, snapshot).await
         } else {
-            add_preparing_run_with_idle_status_snapshot(status, run_id, sandbox_id, snapshot).await;
+            add_preparing_run_with_idle_status_snapshot(status, run_id, sandbox_id, snapshot).await
         }
     } else {
-        status.add_preparing_run(run_id, sandbox_id).await;
+        status.add_preparing_run(run_id, sandbox_id).await
     }
+}
+
+async fn recover_claimed_activation_failure(
+    setup: ClaimedJobSetup,
+    sandbox_id: SandboxId,
+    reason: &'static str,
+    error: String,
+    ctx: &ActivationRecoveryContext,
+) -> RunCancellationRegistration {
+    let ClaimedJobSetup {
+        claimed,
+        cancellation,
+        profile_name: _,
+        vcpu: _,
+        memory_mb: _,
+        workspace_disk_mb: _,
+        restore_guest_state: _,
+        device_rate_limits: _,
+        factory,
+        resource,
+        pre_spawn_timing: _,
+        active_run_guard,
+    } = setup;
+    let ReadyClaimedResource {
+        reuse_entry,
+        active_lease,
+        reuse_result,
+        idle_snapshot: _,
+    } = resource;
+    let (context, completion_auth, active_input_source) = claimed.into_parts();
+    let run_id = context.run_id;
+    drop(active_input_source);
+    warn!(
+        run_id = %run_id,
+        sandbox_id = %sandbox_id,
+        error,
+        recovery_reason = reason,
+        activation_phase = "before_executor_handoff",
+        recovery_outcome = "destroy_or_release",
+        "recovering claimed activation before executor handoff"
+    );
+    let execution_failure = crate::executor::ExecutionFailure::from_error(error);
+    ctx.provider
+        .complete(
+            CompleteRequest {
+                run_id,
+                exit_code: execution_failure.exit_code,
+                error: Some(execution_failure.error),
+                sandbox_id: None,
+                sandbox_reuse_result: Some(reuse_result),
+                workspace_reuse_result: None,
+                active_input_delivery_ids: Vec::new(),
+            },
+            completion_auth,
+        )
+        .await;
+    if let Some(reuse_entry) = reuse_entry {
+        let promoted = reuse_entry
+            .into_destroy_job(factory, active_lease, reason)
+            .run_with_context(reason)
+            .await;
+        if promoted {
+            ctx.reuse_state_notify.notify_one();
+        }
+    } else {
+        drop(active_lease);
+    }
+    remove_failed_activation_status(&ctx.status, run_id, sandbox_id).await;
+    drop(active_run_guard);
+    cancellation
 }
 
 async fn claim_with_local_admission(
@@ -757,7 +994,11 @@ async fn claim_with_local_admission(
                 Instant::now(),
             )
         }
-        LocalAdmissionResource::ExactSpeculative(reservation) => {
+        LocalAdmissionResource::ExactSpeculative(speculative) => {
+            let ExactSpeculationReservation {
+                reservation,
+                idle_snapshot,
+            } = speculative;
             let claim = async {
                 let claimed = ctx.spawn_ctx.provider.claim(candidate).await;
                 (claimed, Instant::now())
@@ -766,6 +1007,7 @@ async fn claim_with_local_admission(
             let ((claimed, claim_returned_at), preparation) = tokio::join!(claim, preparation);
             let speculation = ExactSpeculation {
                 outcome: preparation.outcome,
+                idle_snapshot,
                 preparation_started_at: preparation.started_at,
                 preparation_completed_at: preparation.completed_at,
                 claim_started_at,
@@ -951,7 +1193,7 @@ async fn prepare_ranked_preference_candidate(
         .await
     {
         return if reservation.guest_timezone_intent().is_usable_prediction() {
-            exact_speculative_preparation(candidate, reservation)
+            exact_speculative_preparation(candidate, reservation, ctx).await
         } else {
             reusable_preparation(candidate, reservation)
         };
@@ -1038,23 +1280,41 @@ fn ordinary_preparation(candidate: JobCandidate) -> PreferencePreparation {
 
 fn reusable_preparation(
     candidate: JobCandidate,
-    reservation: ReservedIdleSandbox,
+    reservation: ReservedIdleActivation,
 ) -> PreferencePreparation {
     PreferencePreparation::Ready(PreparedCandidate {
         candidate,
-        resource: Some(LocalAdmissionResource::Reusable(Box::new(reservation))),
+        resource: Some(LocalAdmissionResource::Reusable(reservation)),
     })
 }
 
-fn exact_speculative_preparation(
+async fn exact_speculative_preparation(
     candidate: JobCandidate,
-    reservation: ReservedIdleSandbox,
+    reservation: ReservedIdleActivation,
+    ctx: &DiscoveredJobContext<'_>,
 ) -> PreferencePreparation {
+    let (reservation, idle_snapshot) = reservation.into_parts();
+    if let Err(error) = ctx
+        .status
+        .set_idle_info_at_revision(idle_snapshot.revision, idle_snapshot.idle_sandboxes.clone())
+        .await
+    {
+        warn!(%error, "failed to persist exact speculation idle reservation");
+        rollback_reserved_idle_for_spawn(
+            ReservedIdleActivation::new(reservation, idle_snapshot),
+            ctx.spawn_ctx,
+        )
+        .await;
+        return ordinary_preparation(candidate);
+    }
     PreferencePreparation::Ready(PreparedCandidate {
         candidate,
-        resource: Some(LocalAdmissionResource::ExactSpeculative(Box::new(
-            reservation,
-        ))),
+        resource: Some(LocalAdmissionResource::ExactSpeculative(
+            ExactSpeculationReservation {
+                reservation: Box::new(reservation),
+                idle_snapshot,
+            },
+        )),
     })
 }
 
@@ -1133,7 +1393,7 @@ async fn acquire_local_admission_resource(
             && let Some(reservation) =
                 reserve_reusable_idle(reuse_key, profile_name, device_rate_limits, None, ctx).await
         {
-            return Some(LocalAdmissionResource::Reusable(Box::new(reservation)));
+            return Some(LocalAdmissionResource::Reusable(reservation));
         }
 
         if retiring_leases.is_empty() {
@@ -1193,7 +1453,7 @@ async fn reserve_reusable_idle(
     device_rate_limits: &Option<sandbox::DeviceRateLimits>,
     history_generation_run_id: Option<RunId>,
     ctx: &DiscoveredJobContext<'_>,
-) -> Option<ReservedIdleSandbox> {
+) -> Option<ReservedIdleActivation> {
     reserve_reusable_idle_for_spawn(
         reuse_key,
         profile_name,
@@ -1210,7 +1470,7 @@ pub(super) async fn reserve_reusable_idle_for_spawn(
     device_rate_limits: &Option<sandbox::DeviceRateLimits>,
     history_generation_run_id: Option<RunId>,
     ctx: &SpawnContext,
-) -> Option<ReservedIdleSandbox> {
+) -> Option<ReservedIdleActivation> {
     let (reservation, snapshot) = {
         let mut pool = ctx.idle_pool.lock().await;
         let reservation = match history_generation_run_id {
@@ -1225,14 +1485,14 @@ pub(super) async fn reserve_reusable_idle_for_spawn(
         let snapshot = pool.status_snapshot();
         (reservation, snapshot)
     };
-    set_idle_status_snapshot(&ctx.status, snapshot).await;
-    Some(reservation)
+    Some(ReservedIdleActivation::new(reservation, snapshot))
 }
 
 pub(super) async fn rollback_reserved_idle_for_spawn(
-    reservation: ReservedIdleSandbox,
+    reservation: ReservedIdleActivation,
     ctx: &SpawnContext,
 ) {
+    let (reservation, _) = reservation.into_parts();
     let (restore_result, snapshot) = {
         let mut pool = ctx.idle_pool.lock().await;
         let restore_result = pool.restore_reserved(reservation);
@@ -1257,23 +1517,15 @@ async fn rollback_untracked_resource(
     match resource {
         LocalAdmissionResource::Fresh(budget_lease) => drop(budget_lease),
         LocalAdmissionResource::Finalizing(_) => {}
-        LocalAdmissionResource::Reusable(reservation)
-        | LocalAdmissionResource::ExactSpeculative(reservation) => {
-            let (restore_result, snapshot) = {
-                let mut pool = ctx.idle_pool.lock().await;
-                let restore_result = pool.restore_reserved(*reservation);
-                let snapshot = pool.status_snapshot();
-                (restore_result, snapshot)
-            };
-            set_idle_status_snapshot(ctx.status, snapshot).await;
-            if let RestoreReservedIdleResult::Rejected(destroy_job) = restore_result {
-                spawn_idle_destroy_job(
-                    &ctx.spawn_ctx.idle_destroy_tracker,
-                    *destroy_job,
-                    "reserved_idle_rollback_rejected",
-                );
-                ctx.spawn_ctx.reuse_state_notify.notify_one();
-            }
+        LocalAdmissionResource::Reusable(reservation) => {
+            rollback_reserved_idle_for_spawn(reservation, ctx.spawn_ctx).await;
+        }
+        LocalAdmissionResource::ExactSpeculative(speculative) => {
+            rollback_reserved_idle_for_spawn(
+                ReservedIdleActivation::new(*speculative.reservation, speculative.idle_snapshot),
+                ctx.spawn_ctx,
+            )
+            .await;
         }
     }
 }
@@ -1396,7 +1648,7 @@ pub(super) enum ReservedActivation {
         idle_snapshot: IdlePoolSnapshot,
     },
     CannotStart {
-        budget_lease: BudgetLease,
+        budget_lease: Option<BudgetLease>,
         reuse_result: SandboxReuseResult,
         error: String,
     },
@@ -1433,7 +1685,7 @@ impl From<FreshFallbackActivation> for ReservedActivation {
                 reuse_result,
                 error,
             } => Self::CannotStart {
-                budget_lease,
+                budget_lease: Some(budget_lease),
                 reuse_result,
                 error,
             },
@@ -1445,6 +1697,7 @@ enum PendingExactActivation {
     Prepared {
         sandbox: Box<SpeculativeIdleSandbox>,
         guest_state_prepared: bool,
+        idle_snapshot: IdlePoolSnapshot,
     },
     FreshFallback(FreshFallbackActivation),
 }
@@ -1494,6 +1747,7 @@ async fn activate_speculated_exact(
     } = request;
     let ExactSpeculation {
         outcome,
+        idle_snapshot,
         preparation_started_at,
         preparation_completed_at,
         claim_started_at,
@@ -1664,6 +1918,7 @@ async fn activate_speculated_exact(
     PendingExactActivation::Prepared {
         sandbox,
         guest_state_prepared,
+        idle_snapshot,
     }
 }
 
@@ -1671,12 +1926,12 @@ async fn finish_exact_activation(
     activation: PendingExactActivation,
     cancellation: &RunCancellationHandle,
     run_id: RunId,
-    ctx: &DiscoveredJobContext<'_>,
 ) -> ExactActivation {
     match activation {
         PendingExactActivation::Prepared {
             sandbox,
             guest_state_prepared,
+            idle_snapshot,
         } => {
             let transfer_guard = cancellation.transfer_guard().await;
             if cancellation.is_cancelled() {
@@ -1699,7 +1954,7 @@ async fn finish_exact_activation(
                 reuse_entry: Some(Box::new(reuse_entry)),
                 active_lease,
                 reuse_result: SandboxReuseResult::Reused,
-                idle_snapshot: ctx.idle_pool.lock().await.status_snapshot(),
+                idle_snapshot,
                 transfer_guard,
             }
         }
@@ -1748,11 +2003,12 @@ async fn finish_exact_activation(
 }
 
 pub(super) async fn activate_reserved_idle(
-    reservation: ReservedIdleSandbox,
+    reservation: ReservedIdleActivation,
     request: ReservedActivationRequest<'_>,
     ctx: &SpawnContext,
     pre_spawn_timing: &mut RunnerPreSpawnTiming,
 ) -> ReservedActivation {
+    let (reservation, idle_snapshot) = reservation.into_parts();
     let ReservedActivationRequest {
         run_id,
         profile_name,
@@ -1840,6 +2096,50 @@ pub(super) async fn activate_reserved_idle(
         }
     }
 
+    let sandbox_id = reservation.sandbox_id();
+    let status_started_at = Instant::now();
+    if let Err(error) = add_preparing_run_with_idle_status_snapshot(
+        &ctx.status,
+        run_id,
+        sandbox_id,
+        idle_snapshot.clone(),
+    )
+    .await
+    {
+        warn!(
+            run_id = %run_id,
+            sandbox_id = %sandbox_id,
+            %error,
+            activation_phase = "preparing_commit",
+            recovery_outcome = "restore_parked",
+            "failed to persist reserved sandbox activation ownership"
+        );
+        recover_failed_parked_activation_status(
+            ReservedIdleActivation::new(reservation, idle_snapshot),
+            run_id,
+            sandbox_id,
+            ctx,
+        )
+        .await;
+        return ReservedActivation::CannotStart {
+            budget_lease: None,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            error: format!("persist preparing reuse ownership: {error}"),
+        };
+    }
+    pre_spawn_timing
+        .record_phase_elapsed(RunnerPreSpawnPhase::ActiveStatusPublish, status_started_at);
+    info!(
+        run_id = %run_id,
+        sandbox_id = %sandbox_id,
+        activation_phase = "preparing_committed",
+        "reserved sandbox activation ownership persisted"
+    );
+    #[cfg(test)]
+    ctx.test_observer
+        .notify_reserved_preparing_committed(run_id)
+        .await;
+
     let started_at = Instant::now();
     let unpark_result = reservation.try_unpark_for_run(run_id).await;
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleUnpark, started_at);
@@ -1854,7 +2154,6 @@ pub(super) async fn activate_reserved_idle(
                 reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
                 "reusing pre-claim reserved idle sandbox for reuse key"
             );
-            let idle_snapshot = ctx.idle_pool.lock().await.status_snapshot();
             ReservedActivation::Ready {
                 reuse_entry: Some(sandbox),
                 active_lease: budget_lease,
@@ -1870,14 +2169,52 @@ pub(super) async fn activate_reserved_idle(
                 error = %error,
                 "reserved idle sandbox unpark failed, destroying before fresh fallback"
             );
-            cleanup_reserved_for_fresh_fallback(
+            let activation = cleanup_reserved_for_fresh_fallback(
                 *destroy_job,
                 SandboxReuseResult::UnparkFailed,
                 "reserved_reuse_unpark_failed",
                 ctx,
             )
-            .await
-            .into()
+            .await;
+            if matches!(activation, FreshFallbackActivation::CannotStart { .. }) {
+                remove_failed_activation_status(&ctx.status, run_id, sandbox_id).await;
+            }
+            activation.into()
+        }
+    }
+}
+
+async fn recover_failed_parked_activation_status(
+    reservation: ReservedIdleActivation,
+    run_id: RunId,
+    sandbox_id: SandboxId,
+    ctx: &SpawnContext,
+) {
+    remove_failed_activation_status(&ctx.status, run_id, sandbox_id).await;
+    rollback_reserved_idle_for_spawn(reservation, ctx).await;
+}
+
+async fn remove_failed_activation_status(
+    status: &StatusTracker,
+    run_id: RunId,
+    sandbox_id: SandboxId,
+) {
+    match status.remove_run_if_matching(run_id, sandbox_id).await {
+        Ok(true) => {}
+        Ok(false) => {
+            warn!(
+                run_id = %run_id,
+                sandbox_id = %sandbox_id,
+                "failed activation status had already changed before recovery"
+            );
+        }
+        Err(error) => {
+            warn!(
+                run_id = %run_id,
+                sandbox_id = %sandbox_id,
+                %error,
+                "failed to persist active status removal during activation recovery"
+            );
         }
     }
 }
@@ -1951,12 +2288,14 @@ async fn try_reuse_from_pool(
     request: ReuseAdmissionRequest<'_>,
     ctx: &mut DiscoveredJobContext<'_>,
     pre_spawn_timing: &mut RunnerPreSpawnTiming,
+    cancellation: &RunCancellationHandle,
 ) -> (
     Option<ReusableIdleSandbox>,
     BudgetLease,
     SandboxReuseResult,
     Option<IdlePoolSnapshot>,
     bool,
+    Option<OwnedMutexGuard<()>>,
 ) {
     let ReuseAdmissionRequest {
         profile_name,
@@ -1969,15 +2308,21 @@ async fn try_reuse_from_pool(
     let started_at = Instant::now();
     let Some(reuse_key) = context.reuse_key() else {
         pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
-        return (None, job_lease, SandboxReuseResult::NoReuseKey, None, false);
+        return (
+            None,
+            job_lease,
+            SandboxReuseResult::NoReuseKey,
+            None,
+            false,
+            None,
+        );
     };
     // Take the entry under the pool lock, then drop the lock before any awaits
     // so unpark does not block other take/park operations.
-    let (taken, snapshot) = {
+    let taken = {
         let mut pool = ctx.idle_pool.lock().await;
-        let taken = pool.take(reuse_key);
-        let snapshot = taken.as_ref().map(|_| pool.status_snapshot());
-        (taken, snapshot)
+        pool.take_reserved(reuse_key)
+            .map(|entry| (entry, pool.status_snapshot()))
     };
     let took_idle_session = taken.is_some();
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
@@ -1991,7 +2336,7 @@ async fn try_reuse_from_pool(
         .record_phase_elapsed(RunnerPreSpawnPhase::WorkspaceCacheStateLookup, started_at);
     let needs_reuse_state_refresh = took_idle_session || claimed_workspace_cache_reuse_key;
     match taken {
-        Some(entry)
+        Some((entry, snapshot))
             if entry.profile_name() == profile_name
                 && entry.device_rate_limits() == device_rate_limits =>
         {
@@ -2024,11 +2369,72 @@ async fn try_reuse_from_pool(
                         None,
                         job_lease,
                         SandboxReuseResult::PoolMiss,
-                        snapshot,
+                        Some(snapshot),
                         needs_reuse_state_refresh,
+                        None,
                     );
                 }
             }
+            let idle_snapshot = snapshot.clone();
+            let sandbox_id = entry.sandbox_id();
+            let transfer_guard = cancellation.transfer_guard().await;
+            if cancellation.is_cancelled() {
+                drop(transfer_guard);
+                rollback_reserved_idle_for_spawn(
+                    ReservedIdleActivation::new(entry, idle_snapshot),
+                    ctx.spawn_ctx,
+                )
+                .await;
+                return (
+                    None,
+                    job_lease,
+                    SandboxReuseResult::PoolMiss,
+                    None,
+                    needs_reuse_state_refresh,
+                    None,
+                );
+            }
+            let status_started_at = Instant::now();
+            if let Err(error) = add_preparing_run_with_idle_status_snapshot(
+                ctx.status,
+                run_id,
+                sandbox_id,
+                idle_snapshot.clone(),
+            )
+            .await
+            {
+                drop(transfer_guard);
+                warn!(
+                    run_id = %run_id,
+                    sandbox_id = %sandbox_id,
+                    %error,
+                    activation_phase = "preparing_commit",
+                    recovery_outcome = "restore_parked",
+                    "failed to persist claimed idle sandbox activation ownership"
+                );
+                recover_failed_parked_activation_status(
+                    ReservedIdleActivation::new(entry, idle_snapshot),
+                    run_id,
+                    sandbox_id,
+                    ctx.spawn_ctx,
+                )
+                .await;
+                return (
+                    None,
+                    job_lease,
+                    SandboxReuseResult::PoolMiss,
+                    None,
+                    needs_reuse_state_refresh,
+                    None,
+                );
+            }
+            pre_spawn_timing
+                .record_phase_elapsed(RunnerPreSpawnPhase::ActiveStatusPublish, status_started_at);
+            #[cfg(test)]
+            ctx.spawn_ctx
+                .test_observer
+                .notify_reserved_preparing_committed(run_id)
+                .await;
             let started_at = Instant::now();
             let unpark_result = entry.try_unpark_for_run(run_id).await;
             pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleUnpark, started_at);
@@ -2051,8 +2457,9 @@ async fn try_reuse_from_pool(
                         Some(*sandbox),
                         budget_lease,
                         SandboxReuseResult::Reused,
-                        snapshot,
+                        Some(snapshot),
                         needs_reuse_state_refresh,
+                        Some(transfer_guard),
                     )
                 }
                 IdleUnparkResult::Failed { destroy_job, error } => {
@@ -2063,22 +2470,20 @@ async fn try_reuse_from_pool(
                         error = %error,
                         "unpark failed, destroying idle sandbox and falling through to fresh create"
                     );
-                    spawn_idle_destroy_job(
-                        &ctx.spawn_ctx.idle_destroy_tracker,
-                        *destroy_job,
-                        "reuse_unpark_failed",
-                    );
+                    destroy_idle_jobs_and_wait(vec![*destroy_job], "reuse_unpark_failed").await;
+                    drop(transfer_guard);
                     (
                         None,
                         job_lease,
                         SandboxReuseResult::UnparkFailed,
-                        snapshot,
+                        Some(snapshot),
                         needs_reuse_state_refresh,
+                        None,
                     )
                 }
             }
         }
-        Some(stale) if stale.profile_name() == profile_name => {
+        Some((stale, snapshot)) if stale.profile_name() == profile_name => {
             info!(
                 run_id = %run_id,
                 reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
@@ -2095,11 +2500,12 @@ async fn try_reuse_from_pool(
                 None,
                 job_lease,
                 SandboxReuseResult::DeviceLimitMismatch,
-                snapshot,
+                Some(snapshot),
                 needs_reuse_state_refresh,
+                None,
             )
         }
-        Some(stale) => {
+        Some((stale, snapshot)) => {
             info!(
                 run_id = %run_id,
                 reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
@@ -2117,8 +2523,9 @@ async fn try_reuse_from_pool(
                 None,
                 job_lease,
                 SandboxReuseResult::ProfileMismatch,
-                snapshot,
+                Some(snapshot),
                 needs_reuse_state_refresh,
+                None,
             )
         }
         None => {
@@ -2134,6 +2541,7 @@ async fn try_reuse_from_pool(
                 SandboxReuseResult::PoolMiss,
                 None,
                 needs_reuse_state_refresh,
+                None,
             )
         }
     }
@@ -2222,7 +2630,8 @@ mod tests {
             false,
             Some(idle_snapshot()),
         )
-        .await;
+        .await
+        .unwrap();
 
         assert_eq!(read_active_run_phase(&status_path), "preparing");
     }
@@ -2240,7 +2649,8 @@ mod tests {
             true,
             Some(idle_snapshot()),
         )
-        .await;
+        .await
+        .unwrap();
 
         assert_eq!(read_active_run_phase(&status_path), "running");
     }

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -632,6 +632,7 @@ pub(super) struct ClaimedJobSetup {
 struct ActivationRecoveryContext {
     provider: Arc<dyn JobProvider>,
     status: Arc<StatusTracker>,
+    orphaned_active_runs: super::orphan_reap::OrphanedActiveRuns,
     reuse_state_notify: Arc<tokio::sync::Notify>,
 }
 
@@ -640,6 +641,7 @@ impl ActivationRecoveryContext {
         Self {
             provider: Arc::clone(&ctx.provider),
             status: Arc::clone(&ctx.status),
+            orphaned_active_runs: ctx.orphaned_active_runs.clone(),
             reuse_state_notify: Arc::clone(&ctx.reuse_state_notify),
         }
     }
@@ -877,18 +879,32 @@ async fn recover_claimed_activation_failure(
             completion_auth,
         )
         .await;
-    if let Some(reuse_entry) = reuse_entry {
-        let promoted = reuse_entry
+    let cleanup_completed = if let Some(reuse_entry) = reuse_entry {
+        let cleanup = reuse_entry
             .into_destroy_job(factory, active_lease, reason)
-            .run_with_context(reason)
+            .run_retaining_lease(reason)
             .await;
-        if promoted {
+        if cleanup.workspace_cache_promoted {
             ctx.reuse_state_notify.notify_one();
         }
+        drop(cleanup.budget_lease);
+        cleanup.outcome == DestroyOutcome::Completed
     } else {
         drop(active_lease);
+        true
+    };
+    if cleanup_completed {
+        remove_failed_activation_status(&ctx.status, run_id, sandbox_id).await;
+    } else {
+        warn!(
+            run_id = %run_id,
+            sandbox_id = %sandbox_id,
+            recovery_reason = reason,
+            recovery_outcome = "orphaned_after_uncertain_destroy",
+            "activation recovery could not prove sandbox destruction; keeping active status for orphan reconciliation"
+        );
+        ctx.orphaned_active_runs.insert(run_id, sandbox_id);
     }
-    remove_failed_activation_status(&ctx.status, run_id, sandbox_id).await;
     drop(active_run_guard);
     cancellation
 }

--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -353,7 +353,7 @@ mod tests {
         let cleanup_state = RunCleanupState::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
-        status.add_run(run_id, sandbox_id).await;
+        status.add_run(run_id, sandbox_id).await.unwrap();
 
         FinalizationReady::new(BudgetOwnership::active(ActiveBudgetLease::new(lease)))
             .settle(
@@ -419,7 +419,7 @@ mod tests {
         let cleanup_state = RunCleanupState::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
-        status.add_run(run_id, sandbox_id).await;
+        status.add_run(run_id, sandbox_id).await.unwrap();
 
         FinalizationReady::new(BudgetOwnership::idle_owned())
             .settle(
@@ -453,8 +453,8 @@ mod tests {
         let run_id = RunId::new_v4();
         let completed_sandbox_id = SandboxId::new_v4();
         let current_sandbox_id = SandboxId::new_v4();
-        status.add_run(run_id, completed_sandbox_id).await;
-        status.add_run(run_id, current_sandbox_id).await;
+        status.add_run(run_id, completed_sandbox_id).await.unwrap();
+        status.add_run(run_id, current_sandbox_id).await.unwrap();
 
         FinalizationReady::new(BudgetOwnership::active(ActiveBudgetLease::new(lease)))
             .settle(
@@ -485,7 +485,7 @@ mod tests {
         let cleanup_state = RunCleanupState::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
-        status.add_run(run_id, sandbox_id).await;
+        status.add_run(run_id, sandbox_id).await.unwrap();
 
         FinalizationReady::new(BudgetOwnership::active(
             ActiveBudgetLease::from_idle_park_lease(lease),

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -29,6 +29,7 @@ use super::sandbox_finalization::{
 };
 #[cfg(test)]
 use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
+use crate::error::RunnerError;
 use crate::executor::{
     self, ExecutorConfig, RunnerPreSpawnConcurrency, RunnerPreSpawnPhase, RunnerPreSpawnTiming,
     SessionHistoryRestorePlan,
@@ -644,15 +645,17 @@ pub(super) async fn run_job(
             move |run_id, sandbox_id| {
                 let status = Arc::clone(&status_for_prepared);
                 async move {
-                    if !status
+                    match status
                         .mark_run_running_if_matching(run_id, sandbox_id)
                         .await
                     {
-                        warn!(
-                            run_id = %run_id,
-                            sandbox_id = %sandbox_id,
-                            "sandbox prepared after active run status changed"
-                        );
+                        Ok(true) => Ok(()),
+                        Ok(false) => Err(RunnerError::Internal(format!(
+                            "sandbox {sandbox_id} prepared after active status changed for run {run_id}"
+                        ))),
+                        Err(error) => Err(RunnerError::Internal(format!(
+                            "persist prepared sandbox {sandbox_id} as running for run {run_id}: {error}"
+                        ))),
                     }
                 }
                 .boxed()
@@ -946,7 +949,7 @@ mod tests {
                 None,
                 None,
             ));
-            status.write_initial().await;
+            status.write_initial().await.unwrap();
             let parking_gate = ParkingGate::new_open();
             let idle_pool = Arc::new(tokio::sync::Mutex::new(IdlePool::new_with_parking_gate(
                 IdlePoolConfig { max_idle: 10 },
@@ -1582,11 +1585,12 @@ mod tests {
         let cleanup_state = RunCleanupState::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
-        fixture.status.add_run(run_id, sandbox_id).await;
+        fixture.status.add_run(run_id, sandbox_id).await.unwrap();
         fixture
             .status
             .remove_run_if_matching(run_id, sandbox_id)
-            .await;
+            .await
+            .unwrap();
         cleanup_state.mark_status_removed();
 
         fixture.cleanup(run_id, sandbox_id, cleanup_state).await;
@@ -1603,7 +1607,7 @@ mod tests {
         let fixture = CleanupPanickedJobFixture::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
-        fixture.status.add_run(run_id, sandbox_id).await;
+        fixture.status.add_run(run_id, sandbox_id).await.unwrap();
         fixture
             .cleanup(run_id, sandbox_id, RunCleanupState::new())
             .await;
@@ -1621,7 +1625,7 @@ mod tests {
         let cleanup_state = RunCleanupState::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
-        fixture.status.add_run(run_id, sandbox_id).await;
+        fixture.status.add_run(run_id, sandbox_id).await.unwrap();
         cleanup_state.mark_destroy_completed();
 
         fixture.cleanup(run_id, sandbox_id, cleanup_state).await;
@@ -1640,8 +1644,16 @@ mod tests {
         let run_id = RunId::new_v4();
         let completed_sandbox_id = SandboxId::new_v4();
         let current_sandbox_id = SandboxId::new_v4();
-        fixture.status.add_run(run_id, completed_sandbox_id).await;
-        fixture.status.add_run(run_id, current_sandbox_id).await;
+        fixture
+            .status
+            .add_run(run_id, completed_sandbox_id)
+            .await
+            .unwrap();
+        fixture
+            .status
+            .add_run(run_id, current_sandbox_id)
+            .await
+            .unwrap();
         let stale_cancellation = fixture.tokens.register(run_id).await.unwrap();
         assert!(stale_cancellation.unregister().await);
         let replacement_cancellation = fixture.tokens.register(run_id).await.unwrap();
@@ -1684,7 +1696,7 @@ mod tests {
             fixture.idle_pool.lock().await.park(candidate),
             ParkResult::Parked
         ));
-        fixture.status.add_run(run_id, sandbox_id).await;
+        fixture.status.add_run(run_id, sandbox_id).await.unwrap();
         cleanup_state.mark_idle_pool_owned();
 
         fixture.cleanup(run_id, sandbox_id, cleanup_state).await;

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -336,7 +336,12 @@ async fn publish_live_runner_instance_or_shutdown_startup_resources(
             }
             resources.kmsg_handle.stop().await;
             resources.memory_prefetch.drain().await;
-            resources.status.set_mode(RunnerMode::Stopped).await;
+            if let Err(status_error) = resources.status.set_mode(RunnerMode::Stopped).await {
+                warn!(
+                    error = %status_error,
+                    "failed to persist stopped status after live runner publication failure"
+                );
+            }
             Err(e)
         }
     }
@@ -357,7 +362,9 @@ async fn shutdown_startup_resources_after_startup_failure(
     }
     resources.kmsg_handle.stop().await;
     resources.memory_prefetch.drain().await;
-    resources.status.set_mode(RunnerMode::Stopped).await;
+    if let Err(error) = resources.status.set_mode(RunnerMode::Stopped).await {
+        warn!(%error, context, "failed to persist stopped status after startup failure");
+    }
 }
 
 async fn abort_signal_handler_task(handler_task: SignalHandlerTask, context: &'static str) {
@@ -1035,6 +1042,7 @@ enum StartLoopEvent {
     DestroyTasksDrainEntered,
     DestroyTasksDrainCompleted,
     FinalizingCapacityWaitEntered { run_id: RunId },
+    ReservedPreparingCommitted { run_id: RunId },
     ActiveRunStatusPublished { run_id: RunId },
     BeforeIdlePoolOwnershipTransfer { run_id: RunId },
     SandboxParkedForReuse { run_id: RunId, reuse_key: String },
@@ -1081,6 +1089,7 @@ struct StartLoopTestObserver {
 struct StartLoopTestObserverInner {
     events: std::sync::Mutex<Vec<StartLoopEvent>>,
     notify: tokio::sync::Notify,
+    reserved_preparing_gate: std::sync::Mutex<Option<StartLoopTestGate>>,
 }
 
 #[cfg(test)]
@@ -1199,6 +1208,29 @@ impl StartLoopTestObserver {
 
     fn notify_active_run_status_published(&self, run_id: RunId) {
         self.record(StartLoopEvent::ActiveRunStatusPublished { run_id });
+    }
+
+    fn gate_reserved_preparing_commit(&self) -> StartLoopTestGate {
+        let gate = StartLoopTestGate::default();
+        *self
+            .inner
+            .reserved_preparing_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(gate.clone());
+        gate
+    }
+
+    async fn notify_reserved_preparing_committed(&self, run_id: RunId) {
+        self.record(StartLoopEvent::ReservedPreparingCommitted { run_id });
+        let gate = self
+            .inner
+            .reserved_preparing_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        if let Some(gate) = gate {
+            gate.enter_and_wait().await;
+        }
     }
 
     fn active_run_status_was_published(&self, run_id: RunId) -> bool {
@@ -1417,6 +1449,7 @@ mod start_loop_observer_tests {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum OuterJobPanicPoint {
     ClaimedWithoutSandbox,
+    ClaimedActivation,
     ActiveOrUnknown,
     IdlePoolOwned,
     HandoffOwned,
@@ -1565,7 +1598,27 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     let lifecycle = signal.lifecycle;
     let mut signal_handler_task = signal.handler_task;
 
-    shared.status.write_initial().await;
+    if let Err(error) = shared.status.write_initial().await {
+        shutdown_startup_resources_after_startup_failure(
+            StartupFailureResources {
+                provider: provider_state.provider.as_ref(),
+                runtime: Some(runtime.as_mut()),
+                mitm: &mut mitm,
+                kmsg_handle,
+                dns_handle,
+                memory_prefetch: &mut memory_prefetch,
+                status: shared.status.as_ref(),
+            },
+            "initial_status_persistence_failure",
+        )
+        .await;
+        if let Some(handler_task) = signal_handler_task.take() {
+            abort_signal_handler_task(handler_task, "initial_status_persistence_failure").await;
+        }
+        return Err(RunnerError::Internal(format!(
+            "persist initial runner status: {error}"
+        )));
+    }
 
     if let Err(e) = provider_state.provider.prepare_startup_readiness().await {
         let startup_readiness_cancelled = provider_state.cancel.is_cancelled();
@@ -1627,7 +1680,40 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         }
     };
     let startup_mode = lifecycle.mark_startup_ready();
-    shared.status.set_mode(startup_mode).await;
+    if let Err(error) = shared.status.set_mode(startup_mode).await {
+        handle_stopping_signal(
+            "startup status persistence failure",
+            &provider_state.cancel,
+            &provider_state.cancel_tokens,
+            &lifecycle,
+        )
+        .await;
+        if let Err(factory_error) = shutdown_factory_instances(&mut factories, None).await {
+            warn!(
+                error = %factory_error,
+                "failed to shut down factories after startup status persistence failure"
+            );
+        }
+        shutdown_startup_resources_after_startup_failure(
+            StartupFailureResources {
+                provider: provider_state.provider.as_ref(),
+                runtime: Some(runtime.as_mut()),
+                mitm: &mut mitm,
+                kmsg_handle,
+                dns_handle,
+                memory_prefetch: &mut memory_prefetch,
+                status: shared.status.as_ref(),
+            },
+            "startup_status_persistence_failure",
+        )
+        .await;
+        if let Some(handler_task) = signal_handler_task.take() {
+            abort_signal_handler_task(handler_task, "startup_status_persistence_failure").await;
+        }
+        return Err(RunnerError::Internal(format!(
+            "persist ready runner status: {error}"
+        )));
+    }
 
     let mut jobs: JoinSet<RunCancellationRegistration> = JoinSet::new();
 
@@ -1812,7 +1898,19 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         let mode = *mode_rx.borrow_and_update();
         if mode != current_mode {
             current_mode = mode;
-            shared.status.set_mode(mode).await;
+            if let Err(error) = shared.status.set_mode(mode).await {
+                handle_stopping_signal(
+                    "status persistence failure",
+                    &provider_state.cancel,
+                    &provider_state.cancel_tokens,
+                    &lifecycle,
+                )
+                .await;
+                terminal_error = Some(RunnerError::Internal(format!(
+                    "persist runner mode {mode:?}: {error}"
+                )));
+                break;
+            }
         }
         if mode != RunnerMode::Running {
             pending_finalizing_candidate = None;
@@ -2414,7 +2512,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     teardown.phase_complete("memory_prefetch_drain", phase);
 
     let phase = teardown.phase_start("status_stopped");
-    shared.status.set_mode(RunnerMode::Stopped).await;
+    if let Err(error) = shared.status.set_mode(RunnerMode::Stopped).await {
+        warn!(%error, "failed to persist final stopped runner status");
+    }
     teardown.phase_complete("status_stopped", phase);
     info!(total_teardown_ms = teardown.elapsed_ms(), "runner stopped");
 

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -352,7 +352,7 @@ mod tests {
         }
 
         async fn add_active_orphan(&self, run_id: RunId, sandbox_id: SandboxId) {
-            self.status.add_run(run_id, sandbox_id).await;
+            self.status.add_run(run_id, sandbox_id).await.unwrap();
             self.orphans.insert(run_id, sandbox_id);
         }
 

--- a/crates/runner/src/cmd/start/ownership.rs
+++ b/crates/runner/src/cmd/start/ownership.rs
@@ -6,6 +6,7 @@
 //! the right pool context. Slow sandbox operations stay outside this module.
 
 use sandbox::SandboxId;
+use tracing::warn;
 
 use super::idle_lifecycle::set_idle_status_snapshot;
 use super::orphan_reap::OrphanedActiveRuns;
@@ -131,9 +132,22 @@ impl<'a> OwnershipTransitions<'a> {
     }
 
     async fn remove_matching_active(&self, run: RunSandbox) -> bool {
-        self.status
+        match self
+            .status
             .remove_run_if_matching(run.run_id, run.sandbox_id)
             .await
+        {
+            Ok(removed) => removed,
+            Err(error) => {
+                warn!(
+                    run_id = %run.run_id,
+                    sandbox_id = %run.sandbox_id,
+                    %error,
+                    "failed to persist active run removal after ownership recovery"
+                );
+                false
+            }
+        }
     }
 }
 
@@ -205,7 +219,7 @@ mod tests {
         let transitions = OwnershipTransitions::new(&status);
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
-        status.add_run(run_id, sandbox_id).await;
+        status.add_run(run_id, sandbox_id).await.unwrap();
 
         assert!(
             transitions
@@ -231,8 +245,8 @@ mod tests {
         let run_id = RunId::new_v4();
         let stale_sandbox_id = SandboxId::new_v4();
         let current_sandbox_id = SandboxId::new_v4();
-        status.add_run(run_id, stale_sandbox_id).await;
-        status.add_run(run_id, current_sandbox_id).await;
+        status.add_run(run_id, stale_sandbox_id).await.unwrap();
+        status.add_run(run_id, current_sandbox_id).await.unwrap();
 
         assert!(
             !transitions
@@ -261,7 +275,7 @@ mod tests {
         let orphans = OrphanedActiveRuns::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
-        status.add_run(run_id, sandbox_id).await;
+        status.add_run(run_id, sandbox_id).await.unwrap();
 
         transitions.active_ownership_unknown(&orphans, RunSandbox::new(run_id, sandbox_id));
 
@@ -284,9 +298,9 @@ mod tests {
         let run_id = RunId::new_v4();
         let stale_sandbox_id = SandboxId::new_v4();
         let current_sandbox_id = SandboxId::new_v4();
-        status.add_run(run_id, stale_sandbox_id).await;
+        status.add_run(run_id, stale_sandbox_id).await.unwrap();
         orphans.insert(run_id, stale_sandbox_id);
-        status.add_run(run_id, current_sandbox_id).await;
+        status.add_run(run_id, current_sandbox_id).await.unwrap();
         orphans.insert(run_id, current_sandbox_id);
 
         let reconciled = transitions
@@ -318,9 +332,9 @@ mod tests {
         let run_id = RunId::new_v4();
         let stale_sandbox_id = SandboxId::new_v4();
         let current_sandbox_id = SandboxId::new_v4();
-        status.add_run(run_id, stale_sandbox_id).await;
+        status.add_run(run_id, stale_sandbox_id).await.unwrap();
         orphans.insert(run_id, stale_sandbox_id);
-        status.add_run(run_id, current_sandbox_id).await;
+        status.add_run(run_id, current_sandbox_id).await.unwrap();
 
         assert!(
             !transitions
@@ -347,7 +361,7 @@ mod tests {
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let idle_sandbox_id = SandboxId::new_v4();
-        status.add_run(run_id, sandbox_id).await;
+        status.add_run(run_id, sandbox_id).await.unwrap();
         orphans.insert(run_id, sandbox_id);
 
         let reconciled = transitions

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -1369,7 +1369,7 @@ mod tests {
                 None,
                 None,
             ));
-            status.write_initial().await;
+            status.write_initial().await.unwrap();
             let parking_gate = ParkingGate::new_open();
             let idle_pool: SharedIdlePool = Arc::new(tokio::sync::Mutex::new(
                 IdlePool::new_with_parking_gate(IdlePoolConfig { max_idle }, parking_gate.clone()),

--- a/crates/runner/src/cmd/start/signals.rs
+++ b/crates/runner/src/cmd/start/signals.rs
@@ -229,12 +229,22 @@ pub(super) async fn handle_stopping_signal(
     lifecycle.hard_stop();
     let handles = cancel_tokens.begin_hard_stop().await;
     let count = handles.len();
-    for (run_id, handle) in handles {
-        info!(run_id = %run_id, "cancelling active job for hard shutdown");
-        handle.request_hard_cancellation().await;
-    }
+    dispatch_hard_cancellations(handles).await;
     info!(active_jobs = count, "dispatched per-job cancellations");
     cancel.cancel();
+}
+
+async fn dispatch_hard_cancellations(
+    handles: Vec<(
+        crate::ids::RunId,
+        crate::run_cancellation::RunCancellationHandle,
+    )>,
+) {
+    futures_util::future::join_all(handles.into_iter().map(|(run_id, handle)| async move {
+        info!(run_id = %run_id, "cancelling active job for hard shutdown");
+        handle.request_hard_cancellation().await;
+    }))
+    .await;
 }
 
 #[cfg(test)]
@@ -257,6 +267,30 @@ mod tests {
         "cmd::start::signals::tests::early_sigusr1_buffered_before_spawn_child";
     const EARLY_SIGUSR2_CHILD: &str =
         "cmd::start::signals::tests::early_sigusr2_buffered_before_spawn_child";
+
+    #[tokio::test]
+    async fn hard_cancellation_dispatch_does_not_serialize_transfer_gate_waits() {
+        let blocked_run_id = RunId::new_v4();
+        let ready_run_id = RunId::new_v4();
+        let blocked = crate::run_cancellation::RunCancellationHandle::new();
+        let ready = crate::run_cancellation::RunCancellationHandle::new();
+        let transfer_guard = blocked.transfer_guard().await;
+        let ready_token = ready.token();
+        let blocked_token = blocked.token();
+        let dispatch = tokio::spawn(dispatch_hard_cancellations(vec![
+            (blocked_run_id, blocked),
+            (ready_run_id, ready),
+        ]));
+
+        tokio::time::timeout(Duration::from_secs(1), ready_token.cancelled())
+            .await
+            .expect("an unrelated transfer gate must not delay hard cancellation");
+        assert!(!blocked_token.is_cancelled());
+
+        drop(transfer_guard);
+        dispatch.await.unwrap();
+        assert!(blocked_token.is_cancelled());
+    }
 
     #[derive(Clone, Copy)]
     enum EarlySignalScenario {

--- a/crates/runner/src/cmd/start/tests/failure_recovery/reuse_failure.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/reuse_failure.rs
@@ -1,8 +1,9 @@
 use super::super::super::*;
 use super::super::support::{
     context_with_session, mock_run_config_with_overrides, publish_idle_status, push_job,
-    seed_idle_pool_with_overrides, shutdown, status_idle_reuse_keys, test_profiles,
-    wait_budget_count, wait_idle_pool_len, wait_status_idle_empty_with_active_run,
+    seed_idle_pool_with_overrides, shutdown, status_idle_reuse_keys,
+    status_idle_reuse_keys_and_active_runs, test_profiles, wait_budget_count,
+    wait_discover_entered, wait_idle_pool_len, wait_status_idle_empty_with_active_run,
 };
 
 use crate::types::SandboxReuseResult;
@@ -220,7 +221,7 @@ async fn uncertain_reserved_cleanup_fails_claim_without_starting_replacement() {
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let session_id = "sess-uncertain-cleanup";
 
-    seed_idle_pool_with_overrides(
+    let sandbox_id = seed_idle_pool_with_overrides(
         &idle_pool,
         &budget,
         &counter,
@@ -264,6 +265,95 @@ async fn uncertain_reserved_cleanup_fails_claim_without_starting_replacement() {
     assert_eq!(counter.destroy_call_count(), 1);
     assert_eq!(idle_pool.lock().await.len(), 0);
     wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
+    let status_path = env._temp_dir.path().join("status.json");
+    let (_, active_runs) = status_idle_reuse_keys_and_active_runs(&status_path).await;
+    assert_eq!(active_runs, vec![run_id.to_string()]);
+    let status: serde_json::Value =
+        serde_json::from_str(&tokio::fs::read_to_string(status_path).await.unwrap()).unwrap();
+    assert_eq!(
+        status["active_runs"][0]["sandbox_id"],
+        sandbox_id.to_string()
+    );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn uncertain_post_claim_pool_reuse_keeps_active_status_without_starting_replacement() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let counter = Arc::clone(&overrides);
+    overrides.push_unpark_result(Err(sandbox::SandboxError::IdleTransition {
+        transition: sandbox::SandboxIdleTransition::Unpark,
+        message: "simulated late pool unpark failure".into(),
+    }));
+    overrides.push_destroy_panic("simulated late pool destroy panic");
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 4, 8192, 2, overrides);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let status = Arc::clone(&config.shared.status);
+    let session_id = "sess-late-uncertain-cleanup";
+
+    env.handle.block_claims();
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(context_with_session(run_id, session_id)),
+    );
+    assert!(
+        env.handle
+            .wait_claim_in_flight(1, Duration::from_secs(5))
+            .await,
+        "provider claim did not reach its boundary"
+    );
+    let sandbox_id = seed_idle_pool_with_overrides(
+        &idle_pool,
+        &budget,
+        &counter,
+        session_id,
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
+    publish_idle_status(&idle_pool, &status).await;
+    env.handle.unblock_claims();
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("uncertain late pool cleanup should fail the claimed run");
+    assert_eq!(completion.exit_code, 1);
+    assert_eq!(completion.sandbox_id, None);
+    assert_eq!(
+        completion.reuse_result,
+        Some(SandboxReuseResult::UnparkFailed)
+    );
+    assert_eq!(
+        completion.error.as_deref(),
+        Some("idle sandbox cleanup was uncertain; fresh replacement was not started")
+    );
+    assert!(counter.start_agent_process_calls().is_empty());
+    assert_eq!(counter.park_call_count(), 0);
+    assert_eq!(counter.unpark_call_count(), 1);
+    assert_eq!(counter.destroy_call_count(), 1);
+    assert_eq!(idle_pool.lock().await.len(), 0);
+    wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
+
+    let status_path = env._temp_dir.path().join("status.json");
+    let (_, active_runs) = status_idle_reuse_keys_and_active_runs(&status_path).await;
+    assert_eq!(active_runs, vec![run_id.to_string()]);
+    let status: serde_json::Value =
+        serde_json::from_str(&tokio::fs::read_to_string(status_path).await.unwrap()).unwrap();
+    assert_eq!(
+        status["active_runs"][0]["sandbox_id"],
+        sandbox_id.to_string()
+    );
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/cmd/start/tests/idle_reuse/status.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/status.rs
@@ -73,6 +73,7 @@ async fn reuse_take_clears_idle_status_while_job_is_active() {
         status
             .set_idle_info_at_revision(snapshot.revision, snapshot.idle_sandboxes)
             .await
+            .unwrap()
     );
     assert_eq!(
         status_idle_reuse_keys(&status_path).await,

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -4,8 +4,9 @@ use super::super::support::{
     context_with_session, minimal_context, mock_run_config, mock_run_config_with_overrides,
     push_job, seed_idle_pool, seed_idle_pool_with_history_generation,
     seed_idle_pool_with_overrides, seed_idle_pool_with_speculative_timezone,
-    seed_workspace_cache_state, shutdown, test_profiles, two_profiles, wait_budget_count,
-    wait_cancel_handle, wait_cancel_token, wait_cancel_token_removed, wait_discover_entered,
+    seed_workspace_cache_state, shutdown, status_idle_reuse_keys_and_active_runs, test_profiles,
+    two_profiles, wait_budget_count, wait_cancel_handle, wait_cancel_token,
+    wait_cancel_token_removed, wait_discover_entered, wait_idle_pool_len,
     wait_status_idle_reuse_keys_and_active_runs,
 };
 use std::sync::Arc;
@@ -561,6 +562,447 @@ async fn reusable_claim_without_generation_target_reuses_sandbox() {
     );
 
     shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn reserved_reuse_persists_preparing_before_unpark_without_post_unpark_pool_wait() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher(&overrides);
+    let (config, env) =
+        mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, Arc::clone(&overrides));
+    let budget = Arc::clone(&config.capacity.budget);
+    let reuse_key = RunId::new_v4().to_string();
+    let sandbox_id = seed_idle_pool_with_overrides(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        &reuse_key,
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
+    let preparing_gate = env.start_observer.gate_reserved_preparing_commit();
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_session(run_id, &reuse_key)));
+    env.handle
+        .discover_tx
+        .send(matching_preference_candidate(run_id, &reuse_key))
+        .unwrap();
+
+    tokio::select! {
+        () = preparing_gate.entered.notified() => {}
+        completion = env.handle.wait_completion(run_id, Duration::from_secs(5)) => {
+            panic!("run completed before reserved preparing gate: {completion:?}");
+        }
+    }
+    let status_path = env._temp_dir.path().join("status.json");
+    let raw = tokio::fs::read_to_string(&status_path).await.unwrap();
+    let status: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    assert!(
+        status
+            .get("idle_sandboxes")
+            .and_then(serde_json::Value::as_array)
+            .is_none_or(Vec::is_empty)
+    );
+    let active = status["active_runs"].as_array().unwrap();
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0]["run_id"], run_id.to_string());
+    assert_eq!(active[0]["sandbox_id"], sandbox_id.to_string());
+    assert_eq!(active[0]["phase"], "preparing");
+    assert_eq!(overrides.unpark_call_count(), 0);
+    assert!(overrides.start_agent_process_calls().is_empty());
+
+    let pool_guard = env.idle_pool.lock().await;
+    preparing_gate.release();
+    env.start_observer
+        .wait_for(
+            Duration::from_secs(5),
+            "running status while idle pool is held",
+            |event| match event {
+                StartLoopEvent::ActiveRunStatusPublished {
+                    run_id: observed_run_id,
+                } if *observed_run_id == run_id => Some(()),
+                _ => None,
+            },
+        )
+        .await;
+    assert_eq!(overrides.unpark_call_count(), 1);
+    let raw = tokio::fs::read_to_string(&status_path).await.unwrap();
+    let status: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    assert_eq!(status["active_runs"][0]["phase"], "running");
+    drop(pool_guard);
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(30))
+        .await
+        .expect("reserved reuse should complete after running publication");
+    assert_eq!(completion.sandbox_id, Some(sandbox_id));
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn reserved_reuse_running_status_timeout_recovers_claim_and_sandbox() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher(&overrides);
+    let (mut config, env) =
+        mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, Arc::clone(&overrides));
+    let budget = Arc::clone(&config.capacity.budget);
+    let reuse_key = RunId::new_v4().to_string();
+    seed_idle_pool_with_overrides(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        &reuse_key,
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
+    let status_path = env._temp_dir.path().join("status.json");
+    let write_started = Arc::new(tokio::sync::Notify::new());
+    config.shared.status = Arc::new(StatusTracker::new_with_write_gate(
+        status_path.clone(),
+        4,
+        Arc::clone(&write_started),
+        Arc::new(tokio::sync::Semaphore::new(0)),
+    ));
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_session(run_id, &reuse_key)));
+    let running_write_started = write_started.notified();
+    env.handle
+        .discover_tx
+        .send(matching_preference_candidate(run_id, &reuse_key))
+        .unwrap();
+    tokio::select! {
+        () = running_write_started => {}
+        completion = env.handle.wait_completion(run_id, Duration::from_secs(5)) => {
+            panic!("run completed before running status write gate: {completion:?}");
+        }
+    }
+
+    let raw = tokio::fs::read_to_string(&status_path).await.unwrap();
+    let status: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    assert_eq!(status["active_runs"][0]["run_id"], run_id.to_string());
+    assert_eq!(status["active_runs"][0]["phase"], "preparing");
+    assert_eq!(overrides.unpark_call_count(), 1);
+    assert!(overrides.start_agent_process_calls().is_empty());
+
+    tokio::time::advance(Duration::from_secs(5)).await;
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("status timeout should complete the provider claim");
+    assert!(
+        completion
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("timed out"))
+    );
+    assert_eq!(completion.sandbox_id, None);
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    wait_idle_pool_len(&env.idle_pool, 0, Duration::from_secs(5)).await;
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert!(overrides.start_agent_process_calls().is_empty());
+    let (_, active_runs) = status_idle_reuse_keys_and_active_runs(&status_path).await;
+    assert!(active_runs.is_empty());
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn hard_shutdown_during_reserved_reuse_running_status_stall_converges() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher(&overrides);
+    let (mut config, env) =
+        mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, Arc::clone(&overrides));
+    let budget = Arc::clone(&config.capacity.budget);
+    let reuse_key = RunId::new_v4().to_string();
+    seed_idle_pool_with_overrides(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        &reuse_key,
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
+    let status_path = env._temp_dir.path().join("status.json");
+    let write_started = Arc::new(tokio::sync::Notify::new());
+    config.shared.status = Arc::new(StatusTracker::new_with_write_gate(
+        status_path.clone(),
+        4,
+        Arc::clone(&write_started),
+        Arc::new(tokio::sync::Semaphore::new(0)),
+    ));
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_session(run_id, &reuse_key)));
+    let running_write_started = write_started.notified();
+    env.handle
+        .discover_tx
+        .send(matching_preference_candidate(run_id, &reuse_key))
+        .unwrap();
+    tokio::select! {
+        () = running_write_started => {}
+        completion = env.handle.wait_completion(run_id, Duration::from_secs(5)) => {
+            panic!("run completed before running status write gate: {completion:?}");
+        }
+    }
+    assert_eq!(overrides.unpark_call_count(), 1);
+
+    let cancel = env.cancel.clone();
+    let cancel_tokens = env.cancel_tokens.clone();
+    let lifecycle = env.lifecycle.clone();
+    let stopping = tokio::spawn(async move {
+        handle_stopping_signal("TEST", &cancel, &cancel_tokens, &lifecycle).await;
+    });
+    tokio::task::yield_now().await;
+    assert!(
+        !stopping.is_finished(),
+        "hard shutdown should wait for the claimed activation transfer"
+    );
+    tokio::time::advance(Duration::from_secs(5)).await;
+    stopping.await.unwrap();
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("hard shutdown should recover the stalled provider claim");
+    assert!(
+        completion
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("timed out"))
+    );
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    wait_idle_pool_len(&env.idle_pool, 0, Duration::from_secs(5)).await;
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert!(overrides.start_agent_process_calls().is_empty());
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(5),
+        "hard shutdown should finish after the bounded status failure",
+    )
+    .await;
+    let raw = tokio::fs::read_to_string(&status_path).await.unwrap();
+    let status: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    assert_eq!(status["mode"], "stopped");
+    assert!(status["active_runs"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn reserved_reuse_running_status_write_error_recovers_claim_and_sandbox() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher(&overrides);
+    let (mut config, env) =
+        mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, Arc::clone(&overrides));
+    let budget = Arc::clone(&config.capacity.budget);
+    let reuse_key = RunId::new_v4().to_string();
+    seed_idle_pool_with_overrides(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        &reuse_key,
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
+    let status_dir = env._temp_dir.path().join("status-write-error");
+    tokio::fs::create_dir(&status_dir).await.unwrap();
+    let status_path = status_dir.join("status.json");
+    let status = Arc::new(StatusTracker::new(status_path.clone(), 1, None, None));
+    config.shared.status = Arc::clone(&status);
+    let preparing_gate = env.start_observer.gate_reserved_preparing_commit();
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_session(run_id, &reuse_key)));
+    env.handle
+        .discover_tx
+        .send(matching_preference_candidate(run_id, &reuse_key))
+        .unwrap();
+    tokio::select! {
+        () = preparing_gate.entered.notified() => {}
+        completion = env.handle.wait_completion(run_id, Duration::from_secs(5)) => {
+            panic!("run completed before reserved preparing gate: {completion:?}");
+        }
+    }
+    tokio::fs::remove_file(&status_path).await.unwrap();
+    tokio::fs::remove_dir(&status_dir).await.unwrap();
+    preparing_gate.release();
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("status write error should complete the provider claim");
+    assert!(
+        completion
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("write runner status"))
+    );
+    assert_eq!(completion.sandbox_id, None);
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    wait_idle_pool_len(&env.idle_pool, 0, Duration::from_secs(5)).await;
+    assert_eq!(overrides.unpark_call_count(), 1);
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert!(overrides.start_agent_process_calls().is_empty());
+
+    tokio::fs::create_dir(&status_dir).await.unwrap();
+    status.set_mode(RunnerMode::Running).await.unwrap();
+    let (_, active_runs) = status_idle_reuse_keys_and_active_runs(&status_path).await;
+    assert!(active_runs.is_empty());
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn reserved_reuse_activation_task_abort_recovers_claim_and_sandbox() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher(&overrides);
+    let (mut config, env) =
+        mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, Arc::clone(&overrides));
+    let budget = Arc::clone(&config.capacity.budget);
+    let reuse_key = RunId::new_v4().to_string();
+    seed_idle_pool_with_overrides(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        &reuse_key,
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
+    let status_path = env._temp_dir.path().join("status.json");
+    let write_started = Arc::new(tokio::sync::Notify::new());
+    config.shared.status = Arc::new(StatusTracker::new_with_write_gate(
+        status_path.clone(),
+        4,
+        Arc::clone(&write_started),
+        Arc::new(tokio::sync::Semaphore::new(0)),
+    ));
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_session(run_id, &reuse_key)));
+    let running_write_started = write_started.notified();
+    env.handle
+        .discover_tx
+        .send(matching_preference_candidate(run_id, &reuse_key))
+        .unwrap();
+    tokio::select! {
+        () = running_write_started => {}
+        completion = env.handle.wait_completion(run_id, Duration::from_secs(5)) => {
+            panic!("run completed before running status write gate: {completion:?}");
+        }
+    }
+    assert_eq!(overrides.unpark_call_count(), 1);
+    assert!(overrides.start_agent_process_calls().is_empty());
+
+    run_handle.abort();
+    assert!(run_handle.await.unwrap_err().is_cancelled());
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("dropping the activation task should complete the provider claim");
+    assert!(
+        completion
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("task dropped"))
+    );
+    assert_eq!(completion.sandbox_id, None);
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    wait_idle_pool_len(&env.idle_pool, 0, Duration::from_secs(5)).await;
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert!(overrides.start_agent_process_calls().is_empty());
+    let (_, active_runs) = status_idle_reuse_keys_and_active_runs(&status_path).await;
+    assert!(active_runs.is_empty());
+}
+
+#[tokio::test(start_paused = true)]
+async fn reserved_reuse_activation_panic_recovers_claim_and_sandbox() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher(&overrides);
+    let (mut config, env) =
+        mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, Arc::clone(&overrides));
+    config.test_hooks.outer_job_panic = Some(OuterJobPanicPoint::ClaimedActivation);
+    let budget = Arc::clone(&config.capacity.budget);
+    let reuse_key = RunId::new_v4().to_string();
+    seed_idle_pool_with_overrides(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        &reuse_key,
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
+    let status_path = env._temp_dir.path().join("status.json");
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_session(run_id, &reuse_key)));
+    env.handle
+        .discover_tx
+        .send(matching_preference_candidate(run_id, &reuse_key))
+        .unwrap();
+
+    assert!(run_handle.await.unwrap_err().is_panic());
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("activation panic should complete the provider claim");
+    assert_eq!(
+        completion.error.as_deref(),
+        Some("claimed activation setup panicked")
+    );
+    assert_eq!(completion.sandbox_id, None);
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    wait_idle_pool_len(&env.idle_pool, 0, Duration::from_secs(5)).await;
+    assert_eq!(overrides.unpark_call_count(), 1);
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert!(overrides.start_agent_process_calls().is_empty());
+    let (_, active_runs) = status_idle_reuse_keys_and_active_runs(&status_path).await;
+    assert!(active_runs.is_empty());
 }
 
 #[tokio::test(start_paused = true)]

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -882,6 +882,82 @@ async fn reserved_reuse_running_status_write_error_recovers_claim_and_sandbox() 
     shutdown(&env, run_handle).await;
 }
 
+#[tokio::test]
+async fn uncertain_activation_destroy_keeps_active_status_for_orphan_reconciliation() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher(&overrides);
+    overrides.push_destroy_panic("simulated activation recovery destroy panic");
+    let (mut config, env) =
+        mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, Arc::clone(&overrides));
+    let budget = Arc::clone(&config.capacity.budget);
+    let reuse_key = RunId::new_v4().to_string();
+    let sandbox_id = seed_idle_pool_with_overrides(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        &reuse_key,
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
+    let status_dir = env._temp_dir.path().join("uncertain-destroy-status");
+    tokio::fs::create_dir(&status_dir).await.unwrap();
+    let status_path = status_dir.join("status.json");
+    let status = Arc::new(StatusTracker::new(status_path.clone(), 1, None, None));
+    config.shared.status = Arc::clone(&status);
+    let preparing_gate = env.start_observer.gate_reserved_preparing_commit();
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_session(run_id, &reuse_key)));
+    env.handle
+        .discover_tx
+        .send(matching_preference_candidate(run_id, &reuse_key))
+        .unwrap();
+    tokio::select! {
+        () = preparing_gate.entered.notified() => {}
+        completion = env.handle.wait_completion(run_id, Duration::from_secs(5)) => {
+            panic!("run completed before reserved preparing gate: {completion:?}");
+        }
+    }
+    tokio::fs::remove_file(&status_path).await.unwrap();
+    tokio::fs::remove_dir(&status_dir).await.unwrap();
+    preparing_gate.release();
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("uncertain recovery should still complete the provider claim");
+    assert!(
+        completion
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("write runner status"))
+    );
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    wait_idle_pool_len(&env.idle_pool, 0, Duration::from_secs(5)).await;
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert!(overrides.start_agent_process_calls().is_empty());
+
+    tokio::fs::create_dir(&status_dir).await.unwrap();
+    status.set_mode(RunnerMode::Running).await.unwrap();
+    let (_, active_runs) = status_idle_reuse_keys_and_active_runs(&status_path).await;
+    assert_eq!(active_runs, vec![run_id.to_string()]);
+    let raw = tokio::fs::read_to_string(&status_path).await.unwrap();
+    let status_json: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    assert_eq!(
+        status_json["active_runs"][0]["sandbox_id"],
+        sandbox_id.to_string()
+    );
+
+    shutdown(&env, run_handle).await;
+}
+
 #[tokio::test(start_paused = true)]
 async fn reserved_reuse_activation_task_abort_recovers_claim_and_sandbox() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());

--- a/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
@@ -855,7 +855,7 @@ async fn cancellation_wins_when_speculative_cleanup_is_uncertain() {
     overrides.push_destroy_panic("simulated speculative destroy panic");
     let reuse_key = RunId::new_v4().to_string();
     let generation_run_id = RunId::new_v4();
-    seed_idle_pool_with_speculative_timezone(
+    let sandbox_id = seed_idle_pool_with_speculative_timezone(
         &env.idle_pool,
         &budget,
         &overrides,
@@ -906,9 +906,15 @@ async fn cancellation_wins_when_speculative_cleanup_is_uncertain() {
     );
     wait_idle_pool_len(&env.idle_pool, 0, Duration::from_secs(5)).await;
     wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
-    let (_, active_runs) =
-        status_idle_reuse_keys_and_active_runs(&env._temp_dir.path().join("status.json")).await;
-    assert!(active_runs.is_empty());
+    let status_path = env._temp_dir.path().join("status.json");
+    let (_, active_runs) = status_idle_reuse_keys_and_active_runs(&status_path).await;
+    assert_eq!(active_runs, vec![run_id.to_string()]);
+    let status: serde_json::Value =
+        serde_json::from_str(&tokio::fs::read_to_string(status_path).await.unwrap()).unwrap();
+    assert_eq!(
+        status["active_runs"][0]["sandbox_id"],
+        sandbox_id.to_string()
+    );
     assert!(!env.start_observer.active_run_status_was_published(run_id));
     assert!(overrides.start_agent_process_calls().is_empty());
     assert_eq!(overrides.destroy_call_count(), 1);

--- a/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
@@ -122,11 +122,11 @@ async fn blocked_heartbeat_does_not_block_job_discovery_or_reaping() {
 
 #[tokio::test(start_paused = true)]
 async fn heartbeat_triggers_coalesce_into_one_current_mode_follow_up() {
-    let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
-        Arc::clone(&gate),
-    ));
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
+    let status_path = env._temp_dir.path().join("status.json");
     env.handle.block_heartbeats();
     let run_handle = tokio::spawn(run(config));
 
@@ -134,6 +134,10 @@ async fn heartbeat_triggers_coalesce_into_one_current_mode_follow_up() {
     let run_id = RunId::new_v4();
     push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
     let _token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("job should finish pre-spawn before heartbeat time advances");
 
     tokio::time::advance(HEARTBEAT_PERIOD).await;
     assert!(
@@ -157,6 +161,7 @@ async fn heartbeat_triggers_coalesce_into_one_current_mode_follow_up() {
     });
     let second_tick_cursor = env.start_observer.cursor();
     tokio::time::advance(HEARTBEAT_PERIOD).await;
+    tokio::task::yield_now().await;
     env.start_observer
         .wait_routine_heartbeat_requested_after(
             second_tick_cursor,
@@ -164,11 +169,13 @@ async fn heartbeat_triggers_coalesce_into_one_current_mode_follow_up() {
             Duration::from_secs(5),
         )
         .await;
+    wait_status_mode(&status_path, "draining", Duration::from_secs(5)).await;
 
     // A further tick while the first request is blocked must collapse into
     // the same dirty follow-up rather than overlap or queue another payload.
     let third_tick_cursor = env.start_observer.cursor();
     tokio::time::advance(HEARTBEAT_PERIOD).await;
+    tokio::task::yield_now().await;
     env.start_observer
         .wait_routine_heartbeat_requested_after(
             third_tick_cursor,
@@ -218,7 +225,7 @@ async fn heartbeat_triggers_coalesce_into_one_current_mode_follow_up() {
     }
     assert_eq!(env.handle.max_heartbeat_in_flight(), 1);
 
-    gate.notify_one();
+    wait_gate.release_one();
     assert!(
         env.handle
             .wait_completion(run_id, Duration::from_secs(5))

--- a/crates/runner/src/cmd/start/tests/support/status.rs
+++ b/crates/runner/src/cmd/start/tests/support/status.rs
@@ -177,6 +177,7 @@ pub(in super::super) async fn publish_idle_status(pool: &SharedIdlePool, status:
         status
             .set_idle_info_at_revision(snapshot.revision, snapshot.idle_sandboxes)
             .await
+            .unwrap()
     );
 }
 

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -218,20 +218,23 @@ pub struct JobParams {
 
 #[derive(Clone)]
 pub(crate) struct SandboxPreparedNotifier {
-    callback: Arc<dyn Fn(RunId, SandboxId) -> BoxFuture<'static, ()> + Send + Sync>,
+    callback: Arc<dyn Fn(RunId, SandboxId) -> BoxFuture<'static, RunnerResult<()>> + Send + Sync>,
 }
 
 impl SandboxPreparedNotifier {
     pub(crate) fn new(
-        callback: impl Fn(RunId, SandboxId) -> BoxFuture<'static, ()> + Send + Sync + 'static,
+        callback: impl Fn(RunId, SandboxId) -> BoxFuture<'static, RunnerResult<()>>
+        + Send
+        + Sync
+        + 'static,
     ) -> Self {
         Self {
             callback: Arc::new(callback),
         }
     }
 
-    async fn notify(&self, run_id: RunId, sandbox_id: SandboxId) {
-        (self.callback)(run_id, sandbox_id).await;
+    async fn notify(&self, run_id: RunId, sandbox_id: SandboxId) -> RunnerResult<()> {
+        (self.callback)(run_id, sandbox_id).await
     }
 }
 

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -805,6 +805,15 @@ impl SandboxPrepareError {
             invalidate_consumed_workspace_cache: false,
         }
     }
+
+    fn fatal_after_cleanup(error: RunnerError, cleanup_completed: bool) -> Self {
+        Self {
+            error,
+            retry: SandboxPrepareRetry::None,
+            cleanup_completed,
+            invalidate_consumed_workspace_cache: false,
+        }
+    }
 }
 
 pub(super) async fn prepare_workspace_image(
@@ -1286,8 +1295,41 @@ async fn create_started_sandbox(
     };
     telemetry.record(WORKSPACE_DRIVE_MOUNT, mount_duration, true, None);
     record_workspace_drive_mount_guest_exec(telemetry, guest_duration, true);
-    if let Some(notifier) = sandbox_prepared {
-        notifier.notify(context.run_id, sandbox_id).await;
+    if let Some(notifier) = sandbox_prepared
+        && let Err(error) = notifier.notify(context.run_id, sandbox_id).await
+    {
+        if let Some(prepared_guest_runtime) = prepared_guest_runtime.take() {
+            prepared_guest_runtime
+                .finish(sandbox.as_ref(), telemetry)
+                .await;
+        }
+        let unregister_completed = match unregister_proxy_registry(
+            config,
+            &source_ip,
+            context.run_id,
+        )
+        .await
+        {
+            Ok(()) => true,
+            Err(unregister_error) => {
+                warn!(
+                    run_id = %context.run_id,
+                    error = %unregister_error,
+                    "failed to unregister sandbox from proxy after ownership publication failure"
+                );
+                false
+            }
+        };
+        network_log_session
+            .close_for_upload(context.run_id, &config.network_log_drain)
+            .await;
+        let destroy_completed = destroy_sandbox_panic_safe(factory, sandbox)
+            .await
+            .is_completed();
+        return Err(SandboxPrepareError::fatal_after_cleanup(
+            error,
+            unregister_completed && destroy_completed,
+        ));
     }
 
     Ok(PreparedSandboxRun {

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -436,6 +436,7 @@ async fn execute_new_sandbox_notifies_after_successful_prepare() {
             assert_eq!(run_id, expected_run_id);
             assert_eq!(prepared_sandbox_id, sandbox_id);
             notifications.fetch_add(1, Ordering::SeqCst);
+            Ok(())
         }
         .boxed()
     });
@@ -465,6 +466,51 @@ async fn execute_new_sandbox_notifies_after_successful_prepare() {
 }
 
 #[tokio::test]
+async fn execute_new_sandbox_destroys_before_workload_when_prepared_notification_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let ctx = minimal_context();
+    let notifier = SandboxPreparedNotifier::new(move |_run_id, _sandbox_id| {
+        async move {
+            Err(RunnerError::Internal(
+                "status publication failed".to_owned(),
+            ))
+        }
+        .boxed()
+    });
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = execute_new_sandbox_with_prepared_notifier(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        NewSandboxHooks {
+            controls: RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+            prepared_run_payload: prepare_run_payload_for_run(&ctx).unwrap(),
+            sandbox_prepared: Some(&notifier),
+        },
+    )
+    .await;
+    let error = match result {
+        Ok(_) => panic!("prepared notification failure should stop sandbox execution"),
+        Err(error) => error,
+    };
+
+    assert!(error.to_string().contains("status publication failed"));
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert!(overrides.start_agent_process_calls().is_empty());
+    assert_proxy_registry_empty(dir.path()).await;
+}
+
+#[tokio::test]
 async fn execute_new_sandbox_replaces_one_dns_unready_attachment_before_workload() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
@@ -483,6 +529,7 @@ async fn execute_new_sandbox_replaces_one_dns_unready_attachment_before_workload
         async move {
             assert_eq!(prepared_sandbox_id, sandbox_id);
             notifications.fetch_add(1, Ordering::SeqCst);
+            Ok(())
         }
         .boxed()
     });
@@ -859,6 +906,7 @@ async fn execute_new_sandbox_does_not_notify_before_start_failure() {
         let notifications = Arc::clone(&notifications_for_callback);
         async move {
             notifications.fetch_add(1, Ordering::SeqCst);
+            Ok(())
         }
         .boxed()
     });
@@ -902,6 +950,7 @@ async fn execute_new_sandbox_does_not_notify_after_post_start_prepare_failure() 
         let notifications = Arc::clone(&notifications_for_callback);
         async move {
             notifications.fetch_add(1, Ordering::SeqCst);
+            Ok(())
         }
         .boxed()
     });

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -127,6 +127,11 @@ impl IdlePool {
         entry
     }
 
+    pub(crate) fn take_reserved(&mut self, reuse_key: &str) -> Option<ReservedIdleSandbox> {
+        self.take(reuse_key)
+            .map(|entry| ReservedIdleSandbox { entry })
+    }
+
     pub fn has_reusable(
         &self,
         reuse_key: &str,

--- a/crates/runner/src/idle_pool/entry.rs
+++ b/crates/runner/src/idle_pool/entry.rs
@@ -373,6 +373,36 @@ impl ReusableIdleSandbox {
             guest_state_prepared,
         }
     }
+
+    pub(crate) fn into_destroy_job(
+        self,
+        factory: Arc<Box<dyn SandboxFactory>>,
+        budget_lease: BudgetLease,
+        reason: &'static str,
+    ) -> IdleDestroyJob {
+        let Self {
+            sandbox,
+            metadata,
+            workspace_promotion,
+            guest_state_prepared: _,
+        } = self;
+        let IdleSandboxMetadata {
+            reuse_key,
+            profile_name,
+            ..
+        } = metadata;
+        IdleDestroyJob {
+            payload: IdleSandboxResources {
+                sandbox,
+                factory,
+                workspace_promotion,
+            }
+            .into_destroy_payload(WorkspacePromotionPolicy::AbandonUnpublished(reason)),
+            budget_lease,
+            reuse_key,
+            profile_name,
+        }
+    }
 }
 
 /// Physical resources needed to destroy an idle sandbox, without its budget lease.
@@ -720,6 +750,10 @@ impl IdleEntry {
 }
 
 impl ReservedIdleSandbox {
+    pub(crate) fn sandbox_id(&self) -> SandboxId {
+        self.entry.metadata.sandbox_id
+    }
+
     pub fn reuse_key(&self) -> &str {
         self.entry.reuse_key()
     }

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -1,11 +1,13 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use sandbox::SandboxId;
 use serde::Serialize;
 use tokio::sync::Mutex;
+use tracing::warn;
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::ids::RunId;
@@ -112,12 +114,98 @@ struct PersistenceState {
     published_generation: u64,
 }
 
+struct SerializedStatusSnapshot {
+    generation: u64,
+    json: String,
+}
+
+struct DelayedPersistenceState {
+    active: bool,
+    pending: Option<SerializedStatusSnapshot>,
+}
+
+struct PersistenceCoordinator {
+    ordering: Arc<Mutex<PersistenceState>>,
+    delayed: std::sync::Mutex<DelayedPersistenceState>,
+    #[cfg(test)]
+    settled: tokio::sync::Notify,
+}
+
+impl PersistenceCoordinator {
+    fn new() -> Self {
+        Self {
+            ordering: Arc::new(Mutex::new(PersistenceState {
+                published_generation: 0,
+            })),
+            delayed: std::sync::Mutex::new(DelayedPersistenceState {
+                active: false,
+                pending: None,
+            }),
+            #[cfg(test)]
+            settled: tokio::sync::Notify::new(),
+        }
+    }
+
+    fn defer_if_delayed(
+        &self,
+        snapshot: SerializedStatusSnapshot,
+    ) -> Option<SerializedStatusSnapshot> {
+        let mut delayed = self
+            .delayed
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !delayed.active {
+            return Some(snapshot);
+        }
+        let replace = delayed
+            .pending
+            .as_ref()
+            .is_none_or(|pending| pending.generation < snapshot.generation);
+        if replace {
+            delayed.pending = Some(snapshot);
+        }
+        None
+    }
+
+    fn begin_delayed_write(&self) {
+        let mut delayed = self
+            .delayed
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        delayed.active = true;
+    }
+
+    fn take_pending_or_finish(&self) -> Option<SerializedStatusSnapshot> {
+        let mut delayed = self
+            .delayed
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match delayed.pending.take() {
+            Some(snapshot) => Some(snapshot),
+            None => {
+                delayed.active = false;
+                #[cfg(test)]
+                self.settled.notify_waiters();
+                None
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 #[derive(Clone)]
 struct StatusWriteGate {
     generation: u64,
+    phase: StatusWriteGatePhase,
     started: std::sync::Arc<tokio::sync::Notify>,
     release: std::sync::Arc<tokio::sync::Semaphore>,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum StatusWriteGatePhase {
+    BeforeWrite,
+    AtomicWrite,
 }
 
 /// Serialize as ISO 8601 with millisecond precision, matching JS `Date.toISOString()`.
@@ -135,7 +223,7 @@ pub struct StatusTracker {
     dns_port: Option<u16>,
     path: PathBuf,
     state: Mutex<MutableState>,
-    persistence: Mutex<PersistenceState>,
+    persistence: Arc<PersistenceCoordinator>,
     #[cfg(test)]
     write_gate: Option<StatusWriteGate>,
 }
@@ -188,9 +276,7 @@ impl StatusTracker {
                 idle_revision: 0,
                 idle_sandboxes: Vec::new(),
             }),
-            persistence: Mutex::new(PersistenceState {
-                published_generation: 0,
-            }),
+            persistence: Arc::new(PersistenceCoordinator::new()),
             #[cfg(test)]
             write_gate: None,
         }
@@ -206,6 +292,24 @@ impl StatusTracker {
         let mut tracker = Self::new(path, 4, None, None);
         tracker.write_gate = Some(StatusWriteGate {
             generation,
+            phase: StatusWriteGatePhase::BeforeWrite,
+            started,
+            release,
+        });
+        tracker
+    }
+
+    #[cfg(test)]
+    fn new_with_atomic_write_gate(
+        path: PathBuf,
+        generation: u64,
+        started: std::sync::Arc<tokio::sync::Notify>,
+        release: std::sync::Arc<tokio::sync::Semaphore>,
+    ) -> Self {
+        let mut tracker = Self::new(path, 4, None, None);
+        tracker.write_gate = Some(StatusWriteGate {
+            generation,
+            phase: StatusWriteGatePhase::AtomicWrite,
             started,
             release,
         });
@@ -443,48 +547,153 @@ impl StatusTracker {
     /// Publish an owned snapshot through same-directory atomic replacement.
     async fn persist_snapshot(&self, snapshot: StatusSnapshot) -> StatusResult<()> {
         let path = self.path.clone();
-        let persist = async {
-            let json = serde_json::to_string_pretty(&snapshot.status).map_err(|source| {
-                StatusPersistenceError::Serialize {
-                    path: path.clone(),
-                    source,
-                }
-            })?;
-
-            let mut persistence = self.persistence.lock().await;
-            if persistence.published_generation >= snapshot.generation {
-                return Ok(());
+        let deadline = tokio::time::Instant::now() + STATUS_PERSISTENCE_TIMEOUT;
+        let json = serde_json::to_string_pretty(&snapshot.status).map_err(|source| {
+            StatusPersistenceError::Serialize {
+                path: path.clone(),
+                source,
             }
+        })?;
+        if tokio::time::Instant::now() >= deadline {
+            return Err(StatusPersistenceError::Timeout {
+                path,
+                timeout: STATUS_PERSISTENCE_TIMEOUT,
+            });
+        }
 
-            #[cfg(test)]
-            if let Some(gate) = &self.write_gate
-                && gate.generation == snapshot.generation
-            {
-                gate.started.notify_one();
+        let persistence = Arc::clone(&self.persistence);
+        let mut serialized = SerializedStatusSnapshot {
+            generation: snapshot.generation,
+            json,
+        };
+        let Some(ready) = persistence.defer_if_delayed(serialized) else {
+            return Err(StatusPersistenceError::Timeout {
+                path,
+                timeout: STATUS_PERSISTENCE_TIMEOUT,
+            });
+        };
+        serialized = ready;
+
+        #[cfg(test)]
+        if let Some(gate) = &self.write_gate
+            && gate.generation == serialized.generation
+            && gate.phase == StatusWriteGatePhase::BeforeWrite
+        {
+            gate.started.notify_one();
+            let wait_for_gate = async {
                 let permit = gate
                     .release
                     .acquire()
                     .await
                     .expect("status write gate closed");
                 permit.forget();
+            };
+            if tokio::time::timeout_at(deadline, wait_for_gate)
+                .await
+                .is_err()
+            {
+                return Err(StatusPersistenceError::Timeout {
+                    path,
+                    timeout: STATUS_PERSISTENCE_TIMEOUT,
+                });
             }
+        }
 
-            crate::private_fs::write_private_file(&path, json.as_bytes())
+        let Some(ready) = persistence.defer_if_delayed(serialized) else {
+            return Err(StatusPersistenceError::Timeout {
+                path,
+                timeout: STATUS_PERSISTENCE_TIMEOUT,
+            });
+        };
+        serialized = ready;
+        let ordering = Arc::clone(&persistence.ordering);
+        let mut ordering = match tokio::time::timeout_at(deadline, ordering.lock_owned()).await {
+            Ok(ordering) => ordering,
+            Err(_) => {
+                drop(persistence.defer_if_delayed(serialized));
+                return Err(StatusPersistenceError::Timeout {
+                    path,
+                    timeout: STATUS_PERSISTENCE_TIMEOUT,
+                });
+            }
+        };
+        if ordering.published_generation >= serialized.generation {
+            return Ok(());
+        }
+
+        let generation = serialized.generation;
+        let write_path = path.clone();
+        #[cfg(test)]
+        let atomic_write_gate = self.write_gate.clone();
+        let mut write = Box::pin(async move {
+            #[cfg(test)]
+            if let Some(gate) = &atomic_write_gate
+                && gate.generation == generation
+                && gate.phase == StatusWriteGatePhase::AtomicWrite
+            {
+                gate.started.notify_one();
+                let permit = gate
+                    .release
+                    .acquire()
+                    .await
+                    .expect("atomic status write gate closed");
+                permit.forget();
+            }
+            crate::private_fs::write_private_file(&write_path, serialized.json.as_bytes())
                 .await
                 .map_err(|source| StatusPersistenceError::Write {
-                    path: path.clone(),
+                    path: write_path,
                     source,
-                })?;
-            persistence.published_generation = snapshot.generation;
-            Ok(())
-        };
+                })
+        });
 
-        tokio::time::timeout(STATUS_PERSISTENCE_TIMEOUT, persist)
-            .await
-            .map_err(|_| StatusPersistenceError::Timeout {
-                path: self.path.clone(),
-                timeout: STATUS_PERSISTENCE_TIMEOUT,
-            })?
+        match tokio::time::timeout_at(deadline, write.as_mut()).await {
+            Ok(result) => {
+                result?;
+                ordering.published_generation = generation;
+                Ok(())
+            }
+            Err(_) => {
+                // Tokio filesystem operations run on the blocking pool. Once
+                // started, dropping their async wrapper cannot cancel the
+                // underlying write or rename. Keep the ordered future alive so
+                // a late older generation cannot replace a newer publication.
+                persistence.begin_delayed_write();
+                drop(tokio::spawn(async move {
+                    if let Err(error) = write.await {
+                        warn!(generation, %error, "timed-out status persistence later failed");
+                    } else {
+                        ordering.published_generation = generation;
+                    }
+                    while let Some(pending) = persistence.take_pending_or_finish() {
+                        let pending_generation = pending.generation;
+                        if ordering.published_generation >= pending_generation {
+                            continue;
+                        }
+                        if let Err(source) =
+                            crate::private_fs::write_private_file(&path, pending.json.as_bytes())
+                                .await
+                        {
+                            let error = StatusPersistenceError::Write {
+                                path: path.clone(),
+                                source,
+                            };
+                            warn!(
+                                generation = pending_generation,
+                                %error,
+                                "deferred status persistence failed"
+                            );
+                        } else {
+                            ordering.published_generation = pending_generation;
+                        }
+                    }
+                }));
+                Err(StatusPersistenceError::Timeout {
+                    path: self.path.clone(),
+                    timeout: STATUS_PERSISTENCE_TIMEOUT,
+                })
+            }
+        }
     }
 }
 
@@ -591,9 +800,9 @@ mod tests {
             assert_eq!(active.phase, ActiveRunPhase::Preparing);
         }
 
-        release.add_permits(2);
-        first.await.unwrap();
+        release.add_permits(1);
         second.await.unwrap();
+        first.await.unwrap();
 
         let status = read_status(&path);
         assert_eq!(status["mode"], "draining");
@@ -605,16 +814,15 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn blocked_status_write_times_out_and_releases_persistence_ordering() {
+    async fn pre_write_timeout_releases_persistence_ordering() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("status.json");
         let started = Arc::new(Notify::new());
-        let release = Arc::new(Semaphore::new(0));
         let tracker = Arc::new(StatusTracker::new_with_write_gate(
             path.clone(),
             1,
             Arc::clone(&started),
-            release,
+            Arc::new(Semaphore::new(0)),
         ));
 
         let write_started = started.notified();
@@ -625,8 +833,56 @@ mod tests {
 
         let error = write.await.unwrap().unwrap_err();
         assert!(matches!(error, StatusPersistenceError::Timeout { .. }));
+        assert!(
+            tracker.persistence.ordering.try_lock().is_ok(),
+            "a timeout before atomic I/O starts must release persistence ordering"
+        );
 
         tracker.set_mode(RunnerMode::Running).await.unwrap();
+        let status = read_status(&path);
+        assert_eq!(status["mode"], "running");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn atomic_write_timeout_keeps_ordering_and_coalesces_newer_generation() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Semaphore::new(0));
+        let tracker = Arc::new(StatusTracker::new_with_atomic_write_gate(
+            path.clone(),
+            1,
+            Arc::clone(&started),
+            Arc::clone(&release),
+        ));
+
+        let write_started = started.notified();
+        let write_tracker = Arc::clone(&tracker);
+        let write = tokio::spawn(async move { write_tracker.write_initial().await });
+        write_started.await;
+        tokio::time::advance(STATUS_PERSISTENCE_TIMEOUT).await;
+
+        let error = write.await.unwrap().unwrap_err();
+        assert!(matches!(error, StatusPersistenceError::Timeout { .. }));
+        assert!(
+            tracker.persistence.ordering.try_lock().is_err(),
+            "the timed-out write must keep ordering ownership until it finishes"
+        );
+
+        let error = tracker.set_mode(RunnerMode::Running).await.unwrap_err();
+        assert!(matches!(error, StatusPersistenceError::Timeout { .. }));
+        let settled = tracker.persistence.settled.notified();
+        release.add_permits(1);
+        settled.await;
+        assert!(
+            !tracker
+                .persistence
+                .delayed
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .active,
+            "the timed-out writer should publish the coalesced snapshot"
+        );
         let status = read_status(&path);
         assert_eq!(status["mode"], "running");
     }

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -1,12 +1,14 @@
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use sandbox::SandboxId;
 use serde::Serialize;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, OwnedMutexGuard};
 use tracing::warn;
 
 use crate::error::{RunnerError, RunnerResult};
@@ -131,6 +133,24 @@ struct PersistenceCoordinator {
     settled: tokio::sync::Notify,
 }
 
+type StatusWriteFuture = Pin<Box<dyn Future<Output = StatusResult<()>> + Send + 'static>>;
+
+enum InFlightStatusWriteState {
+    Active {
+        write: StatusWriteFuture,
+        ordering: OwnedMutexGuard<PersistenceState>,
+    },
+    Complete,
+}
+
+struct InFlightStatusWrite {
+    state: InFlightStatusWriteState,
+    persistence: Arc<PersistenceCoordinator>,
+    path: PathBuf,
+    generation: u64,
+    started: bool,
+}
+
 impl PersistenceCoordinator {
     fn new() -> Self {
         Self {
@@ -188,6 +208,101 @@ impl PersistenceCoordinator {
                 self.settled.notify_waiters();
                 None
             }
+        }
+    }
+}
+
+impl InFlightStatusWrite {
+    fn new(
+        write: StatusWriteFuture,
+        ordering: OwnedMutexGuard<PersistenceState>,
+        persistence: Arc<PersistenceCoordinator>,
+        path: PathBuf,
+        generation: u64,
+    ) -> Self {
+        Self {
+            state: InFlightStatusWriteState::Active { write, ordering },
+            persistence,
+            path,
+            generation,
+            started: false,
+        }
+    }
+
+    async fn finish(&mut self) -> StatusResult<()> {
+        self.started = true;
+        let result = match &mut self.state {
+            InFlightStatusWriteState::Active { write, .. } => write.as_mut().await,
+            InFlightStatusWriteState::Complete => return Ok(()),
+        };
+        if result.is_ok()
+            && let InFlightStatusWriteState::Active { ordering, .. } = &mut self.state
+        {
+            ordering.published_generation = self.generation;
+        }
+        self.state = InFlightStatusWriteState::Complete;
+        result
+    }
+}
+
+impl Drop for InFlightStatusWrite {
+    fn drop(&mut self) {
+        if !self.started || std::thread::panicking() {
+            return;
+        }
+        let InFlightStatusWriteState::Active { write, ordering } =
+            std::mem::replace(&mut self.state, InFlightStatusWriteState::Complete)
+        else {
+            return;
+        };
+        let persistence = Arc::clone(&self.persistence);
+        let path = self.path.clone();
+        let generation = self.generation;
+        // The caller can disappear independently of the five-second timeout.
+        // Keep any polled atomic replacement and its ordering guard alive so
+        // an older generation cannot finish after a recovery write.
+        persistence.begin_delayed_write();
+        drop(tokio::spawn(continue_in_flight_status_write(
+            write,
+            ordering,
+            persistence,
+            path,
+            generation,
+        )));
+    }
+}
+
+async fn continue_in_flight_status_write(
+    write: StatusWriteFuture,
+    mut ordering: OwnedMutexGuard<PersistenceState>,
+    persistence: Arc<PersistenceCoordinator>,
+    path: PathBuf,
+    generation: u64,
+) {
+    if let Err(error) = write.await {
+        warn!(generation, %error, "in-flight status persistence later failed");
+    } else {
+        ordering.published_generation = generation;
+    }
+    while let Some(pending) = persistence.take_pending_or_finish() {
+        let pending_generation = pending.generation;
+        if ordering.published_generation >= pending_generation {
+            continue;
+        }
+        if let Err(source) =
+            crate::private_fs::write_private_file(&path, pending.json.as_bytes()).await
+        {
+            let error = StatusPersistenceError::Write {
+                path: path.clone(),
+                source,
+            };
+            warn!(
+                generation = pending_generation,
+                %error,
+                "deferred status persistence failed"
+            );
+        } else {
+            ordering.published_generation = pending_generation;
         }
     }
 }
@@ -607,7 +722,7 @@ impl StatusTracker {
         };
         serialized = ready;
         let ordering = Arc::clone(&persistence.ordering);
-        let mut ordering = match tokio::time::timeout_at(deadline, ordering.lock_owned()).await {
+        let ordering = match tokio::time::timeout_at(deadline, ordering.lock_owned()).await {
             Ok(ordering) => ordering,
             Err(_) => {
                 drop(persistence.defer_if_delayed(serialized));
@@ -625,7 +740,7 @@ impl StatusTracker {
         let write_path = path.clone();
         #[cfg(test)]
         let atomic_write_gate = self.write_gate.clone();
-        let mut write = Box::pin(async move {
+        let write: StatusWriteFuture = Box::pin(async move {
             #[cfg(test)]
             if let Some(gate) = &atomic_write_gate
                 && gate.generation == generation
@@ -647,52 +762,14 @@ impl StatusTracker {
                 })
         });
 
-        match tokio::time::timeout_at(deadline, write.as_mut()).await {
-            Ok(result) => {
-                result?;
-                ordering.published_generation = generation;
-                Ok(())
-            }
-            Err(_) => {
-                // Tokio filesystem operations run on the blocking pool. Once
-                // started, dropping their async wrapper cannot cancel the
-                // underlying write or rename. Keep the ordered future alive so
-                // a late older generation cannot replace a newer publication.
-                persistence.begin_delayed_write();
-                drop(tokio::spawn(async move {
-                    if let Err(error) = write.await {
-                        warn!(generation, %error, "timed-out status persistence later failed");
-                    } else {
-                        ordering.published_generation = generation;
-                    }
-                    while let Some(pending) = persistence.take_pending_or_finish() {
-                        let pending_generation = pending.generation;
-                        if ordering.published_generation >= pending_generation {
-                            continue;
-                        }
-                        if let Err(source) =
-                            crate::private_fs::write_private_file(&path, pending.json.as_bytes())
-                                .await
-                        {
-                            let error = StatusPersistenceError::Write {
-                                path: path.clone(),
-                                source,
-                            };
-                            warn!(
-                                generation = pending_generation,
-                                %error,
-                                "deferred status persistence failed"
-                            );
-                        } else {
-                            ordering.published_generation = pending_generation;
-                        }
-                    }
-                }));
-                Err(StatusPersistenceError::Timeout {
-                    path: self.path.clone(),
-                    timeout: STATUS_PERSISTENCE_TIMEOUT,
-                })
-            }
+        let mut in_flight =
+            InFlightStatusWrite::new(write, ordering, persistence, path, generation);
+        match tokio::time::timeout_at(deadline, in_flight.finish()).await {
+            Ok(result) => result,
+            Err(_) => Err(StatusPersistenceError::Timeout {
+                path: self.path.clone(),
+                timeout: STATUS_PERSISTENCE_TIMEOUT,
+            }),
         }
     }
 }
@@ -882,6 +959,48 @@ mod tests {
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .active,
             "the timed-out writer should publish the coalesced snapshot"
+        );
+        let status = read_status(&path);
+        assert_eq!(status["mode"], "running");
+    }
+
+    #[tokio::test]
+    async fn atomic_write_task_abort_keeps_ordering_and_coalesces_newer_generation() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Semaphore::new(0));
+        let tracker = Arc::new(StatusTracker::new_with_atomic_write_gate(
+            path.clone(),
+            1,
+            Arc::clone(&started),
+            Arc::clone(&release),
+        ));
+
+        let write_started = started.notified();
+        let write_tracker = Arc::clone(&tracker);
+        let write = tokio::spawn(async move { write_tracker.write_initial().await });
+        write_started.await;
+        write.abort();
+        assert!(write.await.unwrap_err().is_cancelled());
+        assert!(
+            tracker.persistence.ordering.try_lock().is_err(),
+            "an aborted caller must not release ordering for a started write"
+        );
+
+        let error = tracker.set_mode(RunnerMode::Running).await.unwrap_err();
+        assert!(matches!(error, StatusPersistenceError::Timeout { .. }));
+        let settled = tracker.persistence.settled.notified();
+        release.add_permits(1);
+        settled.await;
+        assert!(
+            !tracker
+                .persistence
+                .delayed
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .active,
+            "the continued writer should publish the coalesced snapshot"
         );
         let status = read_status(&path);
         assert_eq!(status["mode"], "running");

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -38,8 +38,9 @@ pub type StatusResult<T> = Result<T, StatusPersistenceError>;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ActiveRunPhase {
-    /// The run is claimed and visible in `active_runs`, but a fresh sandbox is
-    /// still being prepared. Its Firecracker process may not exist yet.
+    /// The run is claimed and visible in `active_runs`, but sandbox activation
+    /// has not committed. A fresh Firecracker process may not exist yet, while
+    /// a reused process may still be parked.
     Preparing,
     /// The sandbox is prepared, and the run is expected to be associated with
     /// a Firecracker process.
@@ -230,9 +231,8 @@ impl StatusTracker {
         self.add_running_run(run_id, sandbox_id).await
     }
 
-    /// Register an active run that has been claimed while its fresh sandbox is
-    /// still being prepared. Its Firecracker process may not exist or be ready
-    /// yet.
+    /// Register an active run whose sandbox has not committed running ownership.
+    /// Its Firecracker process may not exist yet or may still be parked.
     pub async fn add_preparing_run(
         &self,
         run_id: RunId,
@@ -270,13 +270,6 @@ impl StatusTracker {
         self.persist_snapshot(snapshot).await
     }
 
-    /// Register an active run and replace the idle sandbox list in the same status
-    /// write if the idle snapshot is current. On duplicate `run_id`, the
-    /// previous `sandbox_id` is overwritten.
-    ///
-    /// This avoids a transient status.json gap during idle reuse where a sandbox
-    /// has been removed from `idle_sandboxes` but has not yet appeared in
-    /// `active_runs`.
     /// Register a running active run and replace the idle sandbox list in the same
     /// status write if the idle snapshot is current.
     pub async fn add_running_run_with_idle_info_at_revision(

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -1,15 +1,38 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use sandbox::SandboxId;
 use serde::Serialize;
 use tokio::sync::Mutex;
-use tracing::warn;
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::ids::RunId;
 use crate::lifecycle::RunnerMode;
+
+const STATUS_PERSISTENCE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Failure to publish one whole runner status snapshot.
+#[derive(Debug, thiserror::Error)]
+pub enum StatusPersistenceError {
+    #[error("serialize runner status for {path}: {source}")]
+    Serialize {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("write runner status {path}: {source}")]
+    Write {
+        path: PathBuf,
+        #[source]
+        source: RunnerError,
+    },
+    #[error("runner status persistence for {path} timed out after {timeout:?}")]
+    Timeout { path: PathBuf, timeout: Duration },
+}
+
+pub type StatusResult<T> = Result<T, StatusPersistenceError>;
 
 /// Active run lifecycle phase serialized as `active_runs[*].phase`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -91,6 +114,7 @@ struct PersistenceState {
 #[cfg(test)]
 #[derive(Clone)]
 struct StatusWriteGate {
+    generation: u64,
     started: std::sync::Arc<tokio::sync::Notify>,
     release: std::sync::Arc<tokio::sync::Semaphore>,
 }
@@ -172,24 +196,29 @@ impl StatusTracker {
     }
 
     #[cfg(test)]
-    fn new_with_write_gate(
+    pub(crate) fn new_with_write_gate(
         path: PathBuf,
+        generation: u64,
         started: std::sync::Arc<tokio::sync::Notify>,
         release: std::sync::Arc<tokio::sync::Semaphore>,
     ) -> Self {
         let mut tracker = Self::new(path, 4, None, None);
-        tracker.write_gate = Some(StatusWriteGate { started, release });
+        tracker.write_gate = Some(StatusWriteGate {
+            generation,
+            started,
+            release,
+        });
         tracker
     }
 
     /// Transition the reported lifecycle mode and flush the status file.
-    pub async fn set_mode(&self, mode: RunnerMode) {
+    pub async fn set_mode(&self, mode: RunnerMode) -> StatusResult<()> {
         let snapshot = {
             let mut state = self.state.lock().await;
             state.mode = mode;
             self.capture_changed_snapshot(&mut state)
         };
-        self.persist_snapshot(snapshot).await;
+        self.persist_snapshot(snapshot).await
     }
 
     /// Register an active run as running and flush the status file.
@@ -197,23 +226,27 @@ impl StatusTracker {
     /// This preserves the old helper semantics for tests and cleanup fixtures.
     /// Freshly claimed new-sandbox jobs should use [`add_preparing_run`].
     #[cfg(test)]
-    pub async fn add_run(&self, run_id: RunId, sandbox_id: SandboxId) {
-        self.add_running_run(run_id, sandbox_id).await;
+    pub async fn add_run(&self, run_id: RunId, sandbox_id: SandboxId) -> StatusResult<()> {
+        self.add_running_run(run_id, sandbox_id).await
     }
 
     /// Register an active run that has been claimed while its fresh sandbox is
     /// still being prepared. Its Firecracker process may not exist or be ready
     /// yet.
-    pub async fn add_preparing_run(&self, run_id: RunId, sandbox_id: SandboxId) {
+    pub async fn add_preparing_run(
+        &self,
+        run_id: RunId,
+        sandbox_id: SandboxId,
+    ) -> StatusResult<()> {
         self.add_run_with_phase(run_id, sandbox_id, ActiveRunPhase::Preparing)
-            .await;
+            .await
     }
 
     /// Register an active run whose Firecracker VM should already exist.
     #[cfg(test)]
-    pub async fn add_running_run(&self, run_id: RunId, sandbox_id: SandboxId) {
+    pub async fn add_running_run(&self, run_id: RunId, sandbox_id: SandboxId) -> StatusResult<()> {
         self.add_run_with_phase(run_id, sandbox_id, ActiveRunPhase::Running)
-            .await;
+            .await
     }
 
     async fn add_run_with_phase(
@@ -221,7 +254,7 @@ impl StatusTracker {
         run_id: RunId,
         sandbox_id: SandboxId,
         phase: ActiveRunPhase,
-    ) {
+    ) -> StatusResult<()> {
         let snapshot = {
             let mut state = self.state.lock().await;
             state.active_runs.insert(
@@ -234,7 +267,7 @@ impl StatusTracker {
             );
             self.capture_changed_snapshot(&mut state)
         };
-        self.persist_snapshot(snapshot).await;
+        self.persist_snapshot(snapshot).await
     }
 
     /// Register an active run and replace the idle sandbox list in the same status
@@ -252,7 +285,7 @@ impl StatusTracker {
         sandbox_id: SandboxId,
         revision: u64,
         idle_sandboxes: Vec<IdleSandbox>,
-    ) -> bool {
+    ) -> StatusResult<bool> {
         self.add_run_with_idle_info_at_revision(
             run_id,
             sandbox_id,
@@ -271,7 +304,7 @@ impl StatusTracker {
         sandbox_id: SandboxId,
         revision: u64,
         idle_sandboxes: Vec<IdleSandbox>,
-    ) -> bool {
+    ) -> StatusResult<bool> {
         self.add_run_with_idle_info_at_revision(
             run_id,
             sandbox_id,
@@ -289,7 +322,7 @@ impl StatusTracker {
         phase: ActiveRunPhase,
         revision: u64,
         idle_sandboxes: Vec<IdleSandbox>,
-    ) -> bool {
+    ) -> StatusResult<bool> {
         let (applied, snapshot) = {
             let mut state = self.state.lock().await;
             state.active_runs.insert(
@@ -304,45 +337,53 @@ impl StatusTracker {
             let snapshot = self.capture_changed_snapshot(&mut state);
             (applied, snapshot)
         };
-        self.persist_snapshot(snapshot).await;
-        applied
+        self.persist_snapshot(snapshot).await?;
+        Ok(applied)
     }
 
     /// Transition a preparing active run to running only if it still points at
     /// the expected sandbox.
-    pub async fn mark_run_running_if_matching(&self, run_id: RunId, sandbox_id: SandboxId) -> bool {
+    pub async fn mark_run_running_if_matching(
+        &self,
+        run_id: RunId,
+        sandbox_id: SandboxId,
+    ) -> StatusResult<bool> {
         let snapshot = {
             let mut state = self.state.lock().await;
             let Some(current) = state.active_runs.get_mut(&run_id) else {
-                return false;
+                return Ok(false);
             };
             if current.sandbox_id != sandbox_id {
-                return false;
+                return Ok(false);
             }
             current.phase = ActiveRunPhase::Running;
             current.phase_started_at = Utc::now();
             self.capture_changed_snapshot(&mut state)
         };
-        self.persist_snapshot(snapshot).await;
-        true
+        self.persist_snapshot(snapshot).await?;
+        Ok(true)
     }
 
     /// Drop an active run only if it still points at the expected sandbox.
     ///
     /// Returns `false` if another task already removed the run or reused the
     /// `run_id` with a different sandbox.
-    pub async fn remove_run_if_matching(&self, run_id: RunId, sandbox_id: SandboxId) -> bool {
+    pub async fn remove_run_if_matching(
+        &self,
+        run_id: RunId,
+        sandbox_id: SandboxId,
+    ) -> StatusResult<bool> {
         let snapshot = {
             let mut state = self.state.lock().await;
             let removed = matches!(state.active_runs.get(&run_id), Some(current) if current.sandbox_id == sandbox_id);
             if !removed {
-                return false;
+                return Ok(false);
             }
             state.active_runs.remove(&run_id);
             self.capture_changed_snapshot(&mut state)
         };
-        self.persist_snapshot(snapshot).await;
-        true
+        self.persist_snapshot(snapshot).await?;
+        Ok(true)
     }
 
     /// Replace the idle sandbox list only if the snapshot is at least as new as the
@@ -354,26 +395,26 @@ impl StatusTracker {
         &self,
         revision: u64,
         idle_sandboxes: Vec<IdleSandbox>,
-    ) -> bool {
+    ) -> StatusResult<bool> {
         let snapshot = {
             let mut state = self.state.lock().await;
             let applied = apply_idle_info_at_revision(&mut state, revision, idle_sandboxes);
             if !applied {
-                return false;
+                return Ok(false);
             }
             self.capture_changed_snapshot(&mut state)
         };
-        self.persist_snapshot(snapshot).await;
-        true
+        self.persist_snapshot(snapshot).await?;
+        Ok(true)
     }
 
     /// Write the initial status file.
-    pub async fn write_initial(&self) {
+    pub async fn write_initial(&self) -> StatusResult<()> {
         let snapshot = {
             let mut state = self.state.lock().await;
             self.capture_changed_snapshot(&mut state)
         };
-        self.persist_snapshot(snapshot).await;
+        self.persist_snapshot(snapshot).await
     }
 
     fn capture_changed_snapshot(&self, state: &mut MutableState) -> StatusSnapshot {
@@ -407,39 +448,50 @@ impl StatusTracker {
     }
 
     /// Publish an owned snapshot through same-directory atomic replacement.
-    async fn persist_snapshot(&self, snapshot: StatusSnapshot) {
-        let json = match serde_json::to_string_pretty(&snapshot.status) {
-            Ok(j) => j,
-            Err(e) => {
-                warn!(error = %e, "failed to serialize status");
-                return;
+    async fn persist_snapshot(&self, snapshot: StatusSnapshot) -> StatusResult<()> {
+        let path = self.path.clone();
+        let persist = async {
+            let json = serde_json::to_string_pretty(&snapshot.status).map_err(|source| {
+                StatusPersistenceError::Serialize {
+                    path: path.clone(),
+                    source,
+                }
+            })?;
+
+            let mut persistence = self.persistence.lock().await;
+            if persistence.published_generation >= snapshot.generation {
+                return Ok(());
             }
+
+            #[cfg(test)]
+            if let Some(gate) = &self.write_gate
+                && gate.generation == snapshot.generation
+            {
+                gate.started.notify_one();
+                let permit = gate
+                    .release
+                    .acquire()
+                    .await
+                    .expect("status write gate closed");
+                permit.forget();
+            }
+
+            crate::private_fs::write_private_file(&path, json.as_bytes())
+                .await
+                .map_err(|source| StatusPersistenceError::Write {
+                    path: path.clone(),
+                    source,
+                })?;
+            persistence.published_generation = snapshot.generation;
+            Ok(())
         };
 
-        let mut persistence = self.persistence.lock().await;
-        if persistence.published_generation >= snapshot.generation {
-            return;
-        }
-
-        #[cfg(test)]
-        if let Some(gate) = &self.write_gate {
-            gate.started.notify_one();
-            let permit = gate
-                .release
-                .acquire()
-                .await
-                .expect("status write gate closed");
-            permit.forget();
-        }
-
-        match crate::private_fs::write_private_file(&self.path, json.as_bytes()).await {
-            Ok(()) => {
-                persistence.published_generation = snapshot.generation;
-            }
-            Err(e) => {
-                warn!(error = %e, path = %self.path.display(), "failed to write status file");
-            }
-        }
+        tokio::time::timeout(STATUS_PERSISTENCE_TIMEOUT, persist)
+            .await
+            .map_err(|_| StatusPersistenceError::Timeout {
+                path: self.path.clone(),
+                timeout: STATUS_PERSISTENCE_TIMEOUT,
+            })?
     }
 }
 
@@ -491,7 +543,7 @@ mod tests {
         let path = dir.path().join("status.json");
         let tracker = StatusTracker::new(path.clone(), 4, None, None);
 
-        tracker.write_initial().await;
+        tracker.write_initial().await.unwrap();
 
         let status = read_status(&path);
         assert_eq!(status["mode"], "starting");
@@ -509,6 +561,7 @@ mod tests {
         let release = Arc::new(Semaphore::new(0));
         let tracker = Arc::new(StatusTracker::new_with_write_gate(
             path.clone(),
+            1,
             Arc::clone(&started),
             Arc::clone(&release),
         ));
@@ -518,7 +571,10 @@ mod tests {
         let first_write_started = started.notified();
         let first_tracker = Arc::clone(&tracker);
         let first = tokio::spawn(async move {
-            first_tracker.add_preparing_run(run_id, sandbox_id).await;
+            first_tracker
+                .add_preparing_run(run_id, sandbox_id)
+                .await
+                .unwrap();
         });
         first_write_started.await;
 
@@ -544,7 +600,7 @@ mod tests {
 
         release.add_permits(2);
         first.await.unwrap();
-        second.await;
+        second.await.unwrap();
 
         let status = read_status(&path);
         assert_eq!(status["mode"], "draining");
@@ -553,6 +609,49 @@ mod tests {
         assert_eq!(runs[0]["run_id"], run_id.to_string());
         assert_eq!(runs[0]["sandbox_id"], sandbox_id.to_string());
         assert_eq!(runs[0]["phase"], "preparing");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn blocked_status_write_times_out_and_releases_persistence_ordering() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Semaphore::new(0));
+        let tracker = Arc::new(StatusTracker::new_with_write_gate(
+            path.clone(),
+            1,
+            Arc::clone(&started),
+            release,
+        ));
+
+        let write_started = started.notified();
+        let write_tracker = Arc::clone(&tracker);
+        let write = tokio::spawn(async move { write_tracker.write_initial().await });
+        write_started.await;
+        tokio::time::advance(STATUS_PERSISTENCE_TIMEOUT).await;
+
+        let error = write.await.unwrap().unwrap_err();
+        assert!(matches!(error, StatusPersistenceError::Timeout { .. }));
+
+        tracker.set_mode(RunnerMode::Running).await.unwrap();
+        let status = read_status(&path);
+        assert_eq!(status["mode"], "running");
+    }
+
+    #[tokio::test]
+    async fn failed_status_write_is_reported_and_newer_generation_can_publish() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("missing");
+        let path = parent.join("status.json");
+        let tracker = StatusTracker::new(path.clone(), 4, None, None);
+
+        let error = tracker.write_initial().await.unwrap_err();
+        assert!(matches!(error, StatusPersistenceError::Write { .. }));
+
+        tokio::fs::create_dir(&parent).await.unwrap();
+        tracker.set_mode(RunnerMode::Running).await.unwrap();
+        let status = read_status(&path);
+        assert_eq!(status["mode"], "running");
     }
 
     #[tokio::test]
@@ -570,8 +669,8 @@ mod tests {
             (older, newer)
         };
 
-        tracker.persist_snapshot(newer).await;
-        tracker.persist_snapshot(older).await;
+        tracker.persist_snapshot(newer).await.unwrap();
+        tracker.persist_snapshot(older).await.unwrap();
 
         let status = read_status(&path);
         assert_eq!(status["mode"], "draining");
@@ -588,7 +687,7 @@ mod tests {
         std::os::unix::fs::symlink(&stale_target, &stale_tmp).unwrap();
         let tracker = StatusTracker::new(path.clone(), 4, None, None);
 
-        tracker.write_initial().await;
+        tracker.write_initial().await.unwrap();
 
         assert_eq!(std::fs::read(&stale_target).unwrap(), b"do not overwrite");
         assert!(
@@ -643,8 +742,8 @@ mod tests {
         let path = dir.path().join("status.json");
         let tracker = StatusTracker::new(path.clone(), 4, None, None);
 
-        tracker.write_initial().await;
-        tracker.set_mode(RunnerMode::Draining).await;
+        tracker.write_initial().await.unwrap();
+        tracker.set_mode(RunnerMode::Draining).await.unwrap();
 
         let status = read_status(&path);
         assert_eq!(status["mode"], "draining");
@@ -659,8 +758,8 @@ mod tests {
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
 
-        tracker.write_initial().await;
-        tracker.add_run(run_id, sandbox_id).await;
+        tracker.write_initial().await.unwrap();
+        tracker.add_run(run_id, sandbox_id).await.unwrap();
 
         let status = read_status(&path);
         let runs = status["active_runs"].as_array().unwrap();
@@ -680,8 +779,8 @@ mod tests {
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
 
-        tracker.write_initial().await;
-        tracker.add_preparing_run(run_id, sandbox_id).await;
+        tracker.write_initial().await.unwrap();
+        tracker.add_preparing_run(run_id, sandbox_id).await.unwrap();
 
         let status = read_status(&path);
         let runs = status["active_runs"].as_array().unwrap();
@@ -703,14 +802,21 @@ mod tests {
         let stale_sandbox_id = SandboxId::new_v4();
         let current_sandbox_id = SandboxId::new_v4();
 
-        tracker.write_initial().await;
-        tracker.add_preparing_run(run_id, stale_sandbox_id).await;
-        tracker.add_preparing_run(run_id, current_sandbox_id).await;
+        tracker.write_initial().await.unwrap();
+        tracker
+            .add_preparing_run(run_id, stale_sandbox_id)
+            .await
+            .unwrap();
+        tracker
+            .add_preparing_run(run_id, current_sandbox_id)
+            .await
+            .unwrap();
 
         assert!(
             !tracker
                 .mark_run_running_if_matching(run_id, stale_sandbox_id)
                 .await
+                .unwrap()
         );
         let status = read_status(&path);
         let runs = status["active_runs"].as_array().unwrap();
@@ -722,6 +828,7 @@ mod tests {
             tracker
                 .mark_run_running_if_matching(run_id, current_sandbox_id)
                 .await
+                .unwrap()
         );
         let status = read_status(&path);
         let runs = status["active_runs"].as_array().unwrap();
@@ -741,14 +848,14 @@ mod tests {
         let run2 = RunId::new_v4();
         let sb2 = SandboxId::new_v4();
 
-        tracker.write_initial().await;
-        tracker.add_run(run1, sb1).await;
-        tracker.add_run(run2, sb2).await;
+        tracker.write_initial().await.unwrap();
+        tracker.add_run(run1, sb1).await.unwrap();
+        tracker.add_run(run2, sb2).await.unwrap();
 
         let status = read_status(&path);
         assert_eq!(status["active_runs"].as_array().unwrap().len(), 2);
 
-        assert!(tracker.remove_run_if_matching(run1, sb1).await);
+        assert!(tracker.remove_run_if_matching(run1, sb1).await.unwrap());
 
         let status = read_status(&path);
         let runs = status["active_runs"].as_array().unwrap();
@@ -767,11 +874,16 @@ mod tests {
         let old_sandbox_id = SandboxId::new_v4();
         let current_sandbox_id = SandboxId::new_v4();
 
-        tracker.write_initial().await;
-        tracker.add_run(run_id, old_sandbox_id).await;
-        tracker.add_run(run_id, current_sandbox_id).await;
+        tracker.write_initial().await.unwrap();
+        tracker.add_run(run_id, old_sandbox_id).await.unwrap();
+        tracker.add_run(run_id, current_sandbox_id).await.unwrap();
 
-        assert!(!tracker.remove_run_if_matching(run_id, old_sandbox_id).await);
+        assert!(
+            !tracker
+                .remove_run_if_matching(run_id, old_sandbox_id)
+                .await
+                .unwrap()
+        );
 
         let status = read_status(&path);
         let runs = status["active_runs"].as_array().unwrap();
@@ -783,6 +895,7 @@ mod tests {
             tracker
                 .remove_run_if_matching(run_id, current_sandbox_id)
                 .await
+                .unwrap()
         );
 
         let status = read_status(&path);
@@ -794,7 +907,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("status.json");
         let tracker = StatusTracker::new(path.clone(), 4, Some(8080), None);
-        tracker.write_initial().await;
+        tracker.write_initial().await.unwrap();
 
         let status = read_status(&path);
         assert_eq!(status["proxy_port"], 8080);
@@ -806,7 +919,7 @@ mod tests {
         let path = dir.path().join("status.json");
         let tracker = StatusTracker::new(path.clone(), 4, None, None);
 
-        tracker.write_initial().await;
+        tracker.write_initial().await.unwrap();
 
         let status = read_status(&path);
         assert!(status.get("proxy_port").is_none());
@@ -818,7 +931,7 @@ mod tests {
         let path = dir.path().join("status.json");
         let tracker = StatusTracker::new(path.clone(), 4, None, None);
 
-        tracker.write_initial().await;
+        tracker.write_initial().await.unwrap();
 
         let status = read_status(&path);
         let started = status["started_at"].as_str().unwrap();
@@ -834,7 +947,7 @@ mod tests {
         let path = dir.path().join("status.json");
         let tracker = StatusTracker::new(path.clone(), 4, None, None);
 
-        tracker.write_initial().await;
+        tracker.write_initial().await.unwrap();
 
         let status = read_status(&path);
         assert!(status.get("idle_sandboxes").is_none());
@@ -858,6 +971,7 @@ mod tests {
                     ],
                 )
                 .await
+                .unwrap()
         );
 
         let status = read_status(&path);
@@ -878,7 +992,7 @@ mod tests {
         let stale_id = SandboxId::new_v4();
         let fresh_id = SandboxId::new_v4();
 
-        tracker.write_initial().await;
+        tracker.write_initial().await.unwrap();
         assert!(
             tracker
                 .set_idle_info_at_revision(
@@ -889,6 +1003,7 @@ mod tests {
                     }],
                 )
                 .await
+                .unwrap()
         );
         assert!(
             !tracker
@@ -900,6 +1015,7 @@ mod tests {
                     }],
                 )
                 .await
+                .unwrap()
         );
 
         let status = read_status(&path);
@@ -917,7 +1033,7 @@ mod tests {
         let original_id = SandboxId::new_v4();
         let replacement_id = SandboxId::new_v4();
 
-        tracker.write_initial().await;
+        tracker.write_initial().await.unwrap();
         assert!(
             tracker
                 .set_idle_info_at_revision(
@@ -928,6 +1044,7 @@ mod tests {
                     }],
                 )
                 .await
+                .unwrap()
         );
 
         // A cleanup/pressure eviction path captured this empty snapshot after
@@ -946,12 +1063,14 @@ mod tests {
                     }],
                 )
                 .await
+                .unwrap()
         );
 
         assert!(
             !tracker
                 .set_idle_info_at_revision(delayed_cleanup_revision, delayed_cleanup_snapshot)
                 .await
+                .unwrap()
         );
 
         let status = read_status(&path);
@@ -971,7 +1090,7 @@ mod tests {
         let run_id = RunId::new_v4();
         let active_id = SandboxId::new_v4();
 
-        tracker.write_initial().await;
+        tracker.write_initial().await.unwrap();
         assert!(
             tracker
                 .set_idle_info_at_revision(
@@ -982,6 +1101,7 @@ mod tests {
                     }],
                 )
                 .await
+                .unwrap()
         );
         assert!(
             !tracker
@@ -995,6 +1115,7 @@ mod tests {
                     }],
                 )
                 .await
+                .unwrap()
         );
 
         let status = read_status(&path);
@@ -1018,7 +1139,7 @@ mod tests {
         let run_id = RunId::new_v4();
         let active_id = SandboxId::new_v4();
 
-        tracker.write_initial().await;
+        tracker.write_initial().await.unwrap();
         assert!(
             tracker
                 .add_preparing_run_with_idle_info_at_revision(
@@ -1031,6 +1152,7 @@ mod tests {
                     }],
                 )
                 .await
+                .unwrap()
         );
 
         let status = read_status(&path);
@@ -1051,7 +1173,7 @@ mod tests {
         let path = dir.path().join("status.json");
         let tracker = StatusTracker::new(path.clone(), 4, None, None);
 
-        assert!(tracker.set_idle_info_at_revision(1, vec![]).await);
+        assert!(tracker.set_idle_info_at_revision(1, vec![]).await.unwrap());
 
         let status = read_status(&path);
         assert!(


### PR DESCRIPTION
## Summary

- persist a single `preparing` activation owner before unparking an exact-reuse sandbox, then transfer ownership to `running` before starting the executor
- bound status persistence and recover claimed activations after timeouts, write failures, panics, or task aborts
- preserve status generation ordering when a timed-out or caller-aborted atomic filesystem operation completes late, while coalescing later updates so resource cleanup does not queue behind the stalled write
- keep active/orphan evidence across reserved, opportunistic, and speculative reuse when cleanup cannot prove sandbox destruction, and do not start a replacement sandbox
- fail closed when startup, live, or fresh-sandbox status persistence fails, and fan out hard-stop cancellations concurrently
- add integration coverage for status stalls and write failures, activation abort and panic recovery, uncertain destruction, shutdown behavior, atomic-write timeout and task-abort ordering, and the persisted status shape

## Risks

- status writes that exceed five seconds now fail and enter recovery instead of waiting indefinitely
- a physical atomic write that has already started may finish after its caller times out or is aborted; it retains generation ordering in the background, and later status updates are reduced to the newest pending generation
- recovery destroys a reused sandbox whose activation ownership is uncertain, which may reduce reuse efficiency during persistence failures but prevents untracked execution
- if destruction panics, the conservative `preparing` entry remains visible until orphan reconciliation proves the Firecracker absent or another owner is established
- the transfer gate delays cancellation only while activation ownership is handed off; unrelated hard-stop cancellations now run concurrently

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-features` (3,362 passed, 26 ignored; guest inventory test passed)
- focused status persistence suite (26 passed)
- focused status atomic-write task-abort regression test
- focused reserved-reuse activation task-abort test
- `cargo test -p runner --all-features uncertain_ -- --quiet` (7 passed on the preceding head; unaffected by the status-only follow-up)
- repository pre-commit checks, including workspace Rust documentation, Clippy, file size, and commitlint

## Earlier local runner validation

An earlier branch head was deployed to `local-1` and exercised repeated exact reuse on the same thread. The runner reused the same sandbox and logged the intended ordering: committed `preparing` status, unpark, guest readiness, committed `running` status, then executor startup. No post-unpark idle-pool reacquisition occurred. A guest file-operation liveness failure also exercised the new fail-closed cleanup: the sandbox was destroyed, active status was removed, and runner heartbeat/discovery continued.

A planned 100-turn guest-level soak was not completed because separate guest-operation and post-agent-ready liveness behavior interrupted the test. Those observations do not establish an activation ownership regression and are outside this PR. After cleanup, normal-mode readiness could not be re-established because the development API tunnel was unavailable; no local test VMs remained. The latest status-only follow-up has full local Rust coverage above but was not separately deployed to `local-1`.

## Exclusions

- does not claim the original low-level mutex or guest-agent root cause is proven
- does not suppress diagnostics or extend existing operation timeouts

Closes #30056
