### PR TITLE
feat: publish morning brief as an official workflow

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
@@ -19,7 +19,10 @@ import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockEnv } from "../../../lib/env";
 import { createDeferredPromise } from "../../utils";
-import { createCronOfficialWorkflowCatalogRoutes } from "../cron-official-workflow-catalog";
+import {
+  createCronOfficialWorkflowCatalogRoutes,
+  cronOfficialWorkflowCatalogRoutes,
+} from "../cron-official-workflow-catalog";
 import { testOfficialWorkflowCatalogStateRoutes } from "../test-official-workflow-catalog-state";
 
 const context = testContext();
@@ -195,6 +198,15 @@ async function syncCatalog(candidate: unknown) {
   );
 }
 
+async function syncDeployedCatalog() {
+  return await accept(
+    setupApp({ context, routes: cronOfficialWorkflowCatalogRoutes })(
+      cronOfficialWorkflowCatalogContract,
+    ).sync({ headers: cronHeaders() }),
+    [200],
+  );
+}
+
 async function syncCatalogUnauthorized(candidate: unknown) {
   return await accept(
     syncClient(candidate).sync({ headers: cronHeaders("wrong-secret") }),
@@ -364,6 +376,103 @@ describe.sequential("Official Workflow catalog release boundary", () => {
       storages: 0,
       storageVersions: 0,
     });
+  });
+
+  it("releases the deployed Morning Brief catalog with stable executable identity", async () => {
+    const s3 = installVolumeS3Fixture();
+    const first = await syncDeployedCatalog();
+    expect(first.body).toMatchObject({
+      outcome: "accepted",
+      diagnostics: [],
+    });
+
+    const firstState = await readState("morning-brief");
+    const definition = firstState.body.definition;
+    expect(firstState.body.catalog?.payload.definitions).toHaveLength(1);
+    expect(definition).toMatchObject({
+      name: "morning-brief",
+      lifecycle: "active",
+      blueprints: [
+        {
+          key: "daily-delivery",
+          parameters: [
+            {
+              key: "timezone",
+              type: "string",
+              format: "timezone",
+              required: true,
+              derivation: { kind: "user-timezone" },
+            },
+          ],
+          desiredState: {
+            kind: "schedule",
+            schedule: {
+              type: "cron",
+              cronExpression: "0 7 * * *",
+              timezone: { parameter: "timezone" },
+            },
+          },
+          runtime: { resultEmail: true },
+        },
+      ],
+    });
+    expect(firstState.body.storage).toMatchObject({
+      storageName: "official-workflow@morning-brief",
+      orgId: SYSTEM_ORG_ID,
+      userId: VOLUME_ORG_USER_ID,
+      headVersionId: definition?.artifact.storageVersion,
+      versionCount: 1,
+    });
+    expect(firstState.body.counts).toStrictEqual({
+      releases: 1,
+      revisions: 1,
+      storages: 1,
+      storageVersions: 1,
+    });
+    expect(s3.objects.size).toBe(2);
+
+    const revision = definition?.revision;
+    expect(revision).toBeDefined();
+    if (!revision) {
+      throw new Error("Expected the Morning Brief Definition revision");
+    }
+    const exact = await readState("morning-brief", revision);
+    const instruction = exact.body.revision?.definition.workflow.instruction;
+    expect(exact.body.revision?.definition.workflow).toMatchObject({
+      displayName: "Morning Brief",
+      description:
+        "Summarize today's email, GitHub, calendar, and unread Chat priorities.",
+      files: [],
+    });
+    expect(instruction).toContain("Gmail connector skill");
+    expect(instruction).toContain("GitHub connector skill");
+    expect(instruction).toContain("Google Calendar connector skill");
+    expect(instruction).toContain("okou chat list --unread --all-agents");
+    expect(instruction).toContain("Never invent, infer, or claim source data");
+    expect(instruction).toContain("Do not send email");
+    expect(instruction).not.toMatch(
+      /morning-brief-(?:collect|run)|morning_brief|chat_morning_brief_context/,
+    );
+
+    const firstIdentity = {
+      revision: definition?.revision,
+      blueprintFingerprint: definition?.blueprints[0]?.fingerprint,
+      artifact: definition?.artifact,
+    };
+    s3.clearWrites();
+    const second = await syncDeployedCatalog();
+    expect(second.body).toMatchObject({
+      outcome: "unchanged",
+      releaseId: first.body.releaseId,
+      diagnostics: [],
+    });
+    const secondDefinition = (await readState("morning-brief")).body.definition;
+    expect({
+      revision: secondDefinition?.revision,
+      blueprintFingerprint: secondDefinition?.blueprints[0]?.fingerprint,
+      artifact: secondDefinition?.artifact,
+    }).toStrictEqual(firstIdentity);
+    expect(s3.writes).toStrictEqual([]);
   });
 
   it("accepts multiple Definitions as one release with exact system artifacts", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -71,7 +71,10 @@ import {
   setOfficialWorkflowAutomationAdmissionStateFixture,
 } from "./helpers/runtime-state";
 import { createRouteMocks } from "./helpers/route-test";
-import { createCronOfficialWorkflowCatalogRoutes } from "../cron-official-workflow-catalog";
+import {
+  createCronOfficialWorkflowCatalogRoutes,
+  cronOfficialWorkflowCatalogRoutes,
+} from "../cron-official-workflow-catalog";
 import { officialWorkflowRoutes } from "../official-workflows";
 import { testOfficialWorkflowCatalogStateRoutes } from "../test-official-workflow-catalog-state";
 import { testSystemStoragePresignedUrlCacheStateRoutes } from "../test-system-storage-presigned-url-cache-state";
@@ -608,6 +611,15 @@ async function syncCatalog(candidate: unknown) {
     syncClient(candidate).sync({
       headers: { authorization: `Bearer ${CRON_SECRET}` },
     }),
+    [200],
+  );
+}
+
+async function syncDeployedCatalog() {
+  return await accept(
+    setupApp({ context, routes: cronOfficialWorkflowCatalogRoutes })(
+      cronOfficialWorkflowCatalogContract,
+    ).sync({ headers: { authorization: `Bearer ${CRON_SECRET}` } }),
     [200],
   );
 }
@@ -1169,6 +1181,91 @@ beforeEach(async () => {
 });
 
 describe.sequential("Official Workflow installations", () => {
+  it("materializes the deployed Morning Brief through generic installation state", async () => {
+    installCatalogStorageFixture();
+    const synced = await syncDeployedCatalog();
+    expect(synced.body).toMatchObject({ outcome: "accepted", diagnostics: [] });
+
+    const { actor } = await workflowBdd.setupWorkflowOrg({
+      timezone: "Asia/Shanghai",
+    });
+    if (!actor.orgId) {
+      throw new Error("Expected organization-scoped actor");
+    }
+    const { agentId } = await workflowBdd.createAgent(actor);
+    onTestFinished(async () => {
+      installCatalogStorageFixture();
+      await bdd.deleteAgent(actor, agentId);
+      await cleanupCatalog();
+    });
+    const headers = authHeaders(actor);
+    await setOfficialWorkflowsEnabled(actor, true);
+
+    const discovered = await accept(officialClient().list({ headers }), [200]);
+    expect(discovered.body).toMatchObject([
+      {
+        name: "morning-brief",
+        displayName: "Morning Brief",
+      },
+    ]);
+
+    const installed = await accept(
+      officialClient().install({
+        headers,
+        params: { definitionName: "morning-brief" },
+        body: {
+          agentId,
+          blueprints: [{ blueprintKey: "daily-delivery", bindings: [] }],
+        },
+      }),
+      [201],
+    );
+    expect(installed.body.definition).toMatchObject({
+      name: "morning-brief",
+      lifecycle: "active",
+      blueprints: [{ key: "daily-delivery" }],
+    });
+    expect(installed.body.workflow).toMatchObject({
+      name: "morning-brief",
+      displayName: "Morning Brief",
+      agentId,
+      official: {
+        definitionName: "morning-brief",
+        installationState: "installed",
+        definitionLifecycle: "active",
+        readOnly: true,
+      },
+    });
+    expect(installed.body.workflow.automations).toHaveLength(1);
+    const automation = installed.body.workflow.automations[0];
+    expect(automation).toMatchObject({
+      kind: "schedule",
+      enabled: true,
+      schedule: {
+        type: "cron",
+        cronExpression: "0 7 * * *",
+        timezone: "Asia/Shanghai",
+      },
+      official: {
+        blueprintKey: "daily-delivery",
+        reconciliationStatus: "current",
+        intendedEnabled: true,
+        parameterBindings: [{ key: "timezone", value: "Asia/Shanghai" }],
+      },
+    });
+    if (!automation) {
+      throw new Error("Expected the Morning Brief Automation");
+    }
+    await expect(
+      readWorkflowAutomationAutonomyFixture(context, automation.id),
+    ).resolves.toMatchObject({
+      autonomyBudget: 10,
+      enabled: true,
+      officialBlueprintKey: "daily-delivery",
+      officialResultEmailEnabled: true,
+    });
+  });
+
   it("installs, guards, reconfigures, retires, and uninstalls through public boundaries", async () => {
     installCatalogStorageFixture();
     const suffix = randomUUID().replaceAll("-", "").slice(0, 10);

--- a/turbo/apps/api/src/signals/routes/test-official-workflow-catalog-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-official-workflow-catalog-state.ts
@@ -4,7 +4,11 @@ import {
   testOfficialWorkflowCatalogStateContract,
   type TestOfficialWorkflowCatalogStateActionBody,
 } from "@okouai/api-contracts/contracts/test-official-workflow-catalog-state";
-import { SYSTEM_ORG_ID, VOLUME_ORG_USER_ID } from "@okouai/core/storage-names";
+import {
+  getOfficialWorkflowDefinitionStorageName,
+  SYSTEM_ORG_ID,
+  VOLUME_ORG_USER_ID,
+} from "@okouai/core/storage-names";
 import {
   officialWorkflowCatalogReleases,
   officialWorkflowCatalogState,
@@ -19,7 +23,7 @@ import {
 } from "@okouai/db/schema/workflow";
 import { storages, storageVersions } from "@okouai/db/schema/storage";
 import { command } from "ccstate";
-import { and, asc, count, eq, like } from "drizzle-orm";
+import { and, asc, count, eq, like, or } from "drizzle-orm";
 
 import { nowDate } from "../../lib/time";
 import { testOverride } from "../../lib/singleton";
@@ -49,6 +53,8 @@ const actionBody$ = bodyResultOf(
   testOfficialWorkflowCatalogStateContract.action,
 );
 const TEST_STORAGE_NAME_PATTERN = "official-workflow@api-test-%";
+const DEPLOYED_TEST_STORAGE_NAME =
+  getOfficialWorkflowDefinitionStorageName("morning-brief");
 
 interface DormantMaterializationPause {
   readonly reached: ReturnType<typeof createDeferredPromise<void>>;
@@ -156,7 +162,10 @@ async function cleanupTestState(db: Db, signal: AbortSignal): Promise<void> {
       and(
         eq(storages.orgId, SYSTEM_ORG_ID),
         eq(storages.userId, VOLUME_ORG_USER_ID),
-        like(storages.name, TEST_STORAGE_NAME_PATTERN),
+        or(
+          like(storages.name, TEST_STORAGE_NAME_PATTERN),
+          eq(storages.name, DEPLOYED_TEST_STORAGE_NAME),
+        ),
       ),
     );
   signal.throwIfAborted();
@@ -174,7 +183,10 @@ async function catalogCounts(db: Db, signal: AbortSignal) {
           and(
             eq(storages.orgId, SYSTEM_ORG_ID),
             eq(storages.userId, VOLUME_ORG_USER_ID),
-            like(storages.name, TEST_STORAGE_NAME_PATTERN),
+            or(
+              like(storages.name, TEST_STORAGE_NAME_PATTERN),
+              eq(storages.name, DEPLOYED_TEST_STORAGE_NAME),
+            ),
           ),
         ),
       db
@@ -185,7 +197,10 @@ async function catalogCounts(db: Db, signal: AbortSignal) {
           and(
             eq(storages.orgId, SYSTEM_ORG_ID),
             eq(storages.userId, VOLUME_ORG_USER_ID),
-            like(storages.name, TEST_STORAGE_NAME_PATTERN),
+            or(
+              like(storages.name, TEST_STORAGE_NAME_PATTERN),
+              eq(storages.name, DEPLOYED_TEST_STORAGE_NAME),
+            ),
           ),
         ),
     ]);

--- a/turbo/apps/api/src/signals/services/official-workflow-catalog-source.ts
+++ b/turbo/apps/api/src/signals/services/official-workflow-catalog-source.ts
@@ -3,12 +3,69 @@ import {
   type OfficialWorkflowSourceCatalog,
 } from "@okouai/api-contracts/contracts/official-workflow-catalog";
 
+const MORNING_BRIEF_INSTRUCTION = `# Morning Brief
+
+Prepare a concise Markdown briefing that helps the user start the day with the most important current work.
+
+## Collect current context
+
+Attempt every source during each scheduled or manual run. Use only the ordinary connector skills, CLI commands, credentials, firewall rules, and capabilities available inside this sandbox.
+
+- Gmail: follow the Gmail connector skill to review recent or unread messages that may need attention. Prefer decisions, requests, deadlines, and blocked work over routine mail.
+- GitHub: follow the GitHub connector skill to review relevant notifications, review requests, assigned issues and pull requests, failing checks, and other recent work that may need action.
+- Google Calendar: follow the Google Calendar connector skill to review today's schedule and near-term meetings, deadlines, or conflicts.
+- Unread Chats: run \`okou chat list --unread --all-agents\`. For relevant unread threads, use \`okou chat messages --thread-id <thread-id> --output-dir threads\` to read the authorized history before summarizing it.
+
+If a source, connector, thread, or capability is unavailable, say that it was unavailable and continue with the other sources. Never invent, infer, or claim source data that was not read.
+
+## Produce the briefing
+
+Return only the briefing as concise Markdown. Choose short headings and bullets based on the information actually found instead of following a fixed schema. Prioritize time-sensitive commitments, decisions, blockers, conflicts, and clear next actions; include source names and dates or times when useful.
+
+Do not read application database tables or use internal application APIs, signed input or output URLs, or callback endpoints. Do not send email, drafts, chat messages, or provider-side updates. The platform owns any result-email delivery after the run succeeds.`;
+
 /**
- * The sole deployed source candidate. P0 intentionally ships no Definitions;
- * later catalog entries must use the same validated release boundary.
+ * The sole deployed source candidate. Every Definition uses the same validated
+ * release boundary and immutable shared-artifact publication path.
  */
 export const OFFICIAL_WORKFLOW_SOURCE_CATALOG: OfficialWorkflowSourceCatalog =
-  Object.freeze({
+  Object.freeze<OfficialWorkflowSourceCatalog>({
     schemaVersion: OFFICIAL_WORKFLOW_CATALOG_SCHEMA_VERSION,
-    definitions: [],
+    definitions: [
+      {
+        name: "morning-brief",
+        lifecycle: "active",
+        workflow: {
+          displayName: "Morning Brief",
+          description:
+            "Summarize today's email, GitHub, calendar, and unread Chat priorities.",
+          instruction: MORNING_BRIEF_INSTRUCTION,
+          files: [],
+        },
+        blueprints: [
+          {
+            key: "daily-delivery",
+            parameters: [
+              {
+                key: "timezone",
+                type: "string",
+                format: "timezone",
+                required: true,
+                derivation: { kind: "user-timezone" },
+              },
+            ],
+            desiredState: {
+              kind: "schedule",
+              schedule: {
+                type: "cron",
+                cronExpression: "0 7 * * *",
+                timezone: { parameter: "timezone" },
+              },
+            },
+            runtime: { resultEmail: true },
+          },
+        ],
+        presentation: { category: "productivity" },
+      },
+    ],
   });


### PR DESCRIPTION
## Summary

- publish `morning-brief` as the sole active Official Workflow Definition with the stable `daily-delivery` Blueprint, a `0 7 * * *` schedule, required user-timezone derivation, and generic Official result email
- keep executable collection inside the sandbox through ordinary Gmail, GitHub, Google Calendar, and unread-Chat capabilities, including `okou chat list --unread --all-agents`
- exercise the real deployed catalog through the generic release and installation boundaries, including deterministic revision, Blueprint fingerprint, artifact identity, enabled schedule materialization, and result-email state

## Scope guards

- preserves the complete legacy Morning Brief pipeline without calls, imports, backfill, dual-run, dual-write, disablement, or cleanup
- adds no Morning-Brief-specific server runtime, route, UI, feature switch, callback, renderer, delivery state, or output contract
- adds no database migration and performs no rollout, notification, or Production Release action

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/official-workflow-catalog-source.ts apps/api/src/signals/routes/test-official-workflow-catalog-state.ts apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts apps/api/src/signals/routes/__tests__/official-workflows.test.ts`
- `pnpm turbo run lint --concurrency=1 --log-order grouped --output-logs=errors-only`
- `pnpm knip`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts` (13 passed)
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/official-workflows.test.ts` (31 passed)
- `pnpm --filter @okouai/api-contracts exec vitest run src/contracts/__tests__/official-workflows.test.ts` (2 passed)
- `git diff --check origin/main...HEAD`
- final PR-head pipeline: 77 passed, 19 expected skips, 0 failed, 0 pending

## Preview QA

- exact deployed head: `2900f97e59c20670813f659ec4f2855dba843129`
- App: https://pr-30154-app.omby.ai
- API: https://pr-30154-api.vm6.ai
- PASS: a fresh preview org completed onboarding; the `officialWorkflows` Lab override rendered checked and the API reported both stored and effective values as `true`; Workflows exposed `Browse Official`; `/workflows/official` rendered successfully; `GET /api/official-workflows` returned 200
- BLOCKED: the real Definition detail/install flow could not be exercised because this preview database had no accepted catalog release and rendered `No Official Workflows are available.` The preview catalog cron had not populated the environment. No fake catalog, production data, or manual release input was created.
- Evidence: [enabled switch](https://cdn.vm0.io/artifacts/u12ctl6x73.png), [empty preview catalog](https://cdn.vm0.io/artifacts/39c7qwlm96.png)

References #30151
