### PR TITLE
fix(platform): anchor bootstrap skeleton to visible viewport

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -1080,26 +1080,6 @@
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
     <script>
-      // iOS can report standalone display mode one paint after document
-      // startup. Resolve it synchronously from navigator.standalone so the
-      // skeleton never paints at 100dvh before moving to 100lvh.
-      (function () {
-        var standalone =
-          navigator.standalone === true ||
-          window.matchMedia("(display-mode: standalone)").matches;
-        if (
-          standalone &&
-          window.CSS &&
-          window.CSS.supports("height", "100lvh")
-        ) {
-          document.documentElement.style.setProperty(
-            "--zero-viewport-height",
-            "100lvh",
-          );
-        }
-      })();
-    </script>
-    <script>
       // Inline theme detection — mirrors signals/theme.ts resolveTheme() + applyTheme()
       (function () {
         var p = localStorage.getItem("theme");
@@ -1222,13 +1202,13 @@
         #app-bootstrap-skeleton {
           position: fixed;
           inset: 0;
+          /* Fixed insets follow WebKit's reachable layout viewport. Avoid the
+             standalone viewport unit, which can resolve after first paint. */
           z-index: 60;
           box-sizing: border-box;
           display: none;
           align-items: center;
           justify-content: center;
-          height: var(--zero-viewport-height);
-          min-height: var(--zero-viewport-height);
           background: #fdfdfe;
           color: rgba(20, 23, 29, 0.7);
           font-family:

--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -3,68 +3,6 @@ import { describe, expect, it } from "vitest";
 import indexHtml from "../../../../index.html?raw";
 import { readGlobalCss } from "./global-css.ts";
 
-type ViewportEntrypoint = (
-  windowObject: Pick<Window, "matchMedia"> & { CSS: typeof CSS },
-  documentObject: Document,
-  navigatorObject: Navigator & { standalone?: boolean },
-) => void;
-
-function getInlineScriptSource(marker: string): string {
-  const source = [...indexHtml.matchAll(/<script>([\s\S]*?)<\/script>/gi)]
-    .map((match) => {
-      return match[1];
-    })
-    .find((script) => {
-      return script?.includes(marker);
-    });
-
-  if (source === undefined) {
-    throw new Error(`Unable to find inline script containing ${marker}`);
-  }
-  return source;
-}
-
-function resolveStandaloneViewport({
-  displayModeStandalone,
-  navigatorStandalone,
-  supportsLargeViewport,
-}: {
-  displayModeStandalone: boolean;
-  navigatorStandalone: boolean;
-  supportsLargeViewport: boolean;
-}): string {
-  const testDocument = document.implementation.createHTMLDocument();
-  const executeEntrypoint = new Function(
-    "window",
-    "document",
-    "navigator",
-    getInlineScriptSource("navigator.standalone === true"),
-  ) as ViewportEntrypoint;
-
-  executeEntrypoint(
-    {
-      CSS: {
-        supports(property: string, value: string) {
-          return (
-            supportsLargeViewport && property === "height" && value === "100lvh"
-          );
-        },
-      } as typeof CSS,
-      matchMedia() {
-        return { matches: displayModeStandalone } as MediaQueryList;
-      },
-    },
-    testDocument,
-    { standalone: navigatorStandalone } as Navigator & {
-      standalone?: boolean;
-    },
-  );
-
-  return testDocument.documentElement.style.getPropertyValue(
-    "--zero-viewport-height",
-  );
-}
-
 function getViewportDirectives(): string[] {
   const match = /<meta\s+name="viewport"\s+content="([^"]+)"/.exec(indexHtml);
   return (
@@ -95,50 +33,17 @@ describe("platform entrypoint safe area behavior", () => {
     ).toBeFalsy();
     expect(viewportDirectives).not.toContain("maximum-scale=1.0");
     expect(viewportDirectives).not.toContain("user-scalable=no");
+  });
+
+  it("centers the bootstrap skeleton against the fixed viewport", () => {
+    const rule = /#app-bootstrap-skeleton\s*{([^}]*)}/.exec(indexHtml)?.[1];
 
     expect(indexHtml).toMatch(/--zero-viewport-height:\s*100dvh;/);
     expect(indexHtml).toMatch(/--zero-viewport-height:\s*100lvh;/);
-    expect(indexHtml).toMatch(
-      /#app-bootstrap-skeleton\s*{[\s\S]*height:\s*var\(--zero-viewport-height\);/,
-    );
-  });
-
-  it("locks the standalone viewport height before the skeleton can paint", () => {
-    const standaloneResolverIndex = indexHtml.indexOf(
-      "navigator.standalone === true",
-    );
-    const skeletonIndex = indexHtml.indexOf('id="app-bootstrap-skeleton"');
-
-    expect(standaloneResolverIndex).toBeGreaterThan(-1);
-    expect(standaloneResolverIndex).toBeLessThan(skeletonIndex);
-    expect(
-      resolveStandaloneViewport({
-        displayModeStandalone: false,
-        navigatorStandalone: true,
-        supportsLargeViewport: true,
-      }),
-    ).toBe("100lvh");
-    expect(
-      resolveStandaloneViewport({
-        displayModeStandalone: true,
-        navigatorStandalone: false,
-        supportsLargeViewport: true,
-      }),
-    ).toBe("100lvh");
-    expect(
-      resolveStandaloneViewport({
-        displayModeStandalone: false,
-        navigatorStandalone: false,
-        supportsLargeViewport: true,
-      }),
-    ).toBe("");
-    expect(
-      resolveStandaloneViewport({
-        displayModeStandalone: true,
-        navigatorStandalone: false,
-        supportsLargeViewport: false,
-      }),
-    ).toBe("");
+    expect(rule).toBeDefined();
+    expect(rule).toMatch(/position:\s*fixed;/);
+    expect(rule).toMatch(/inset:\s*0;/);
+    expect(rule).not.toMatch(/(?:^|[;\s])(?:min-)?height\s*:/);
   });
 
   it("suppresses the bottom safe-area inset only while the keyboard is open", () => {


### PR DESCRIPTION
## Summary

- size the bootstrap skeleton from its fixed `inset: 0` bounds instead of `--zero-viewport-height`
- remove the synchronous standalone `100lvh` override added in #30053
- preserve the existing `dvh`/`lvh` app-shell contract used by iOS keyboard and caret handling
- replace the obsolete resolver test with a regression assertion that the bootstrap overlay has no viewport-unit height

## Root cause

#30053 assumed `100lvh` was the stable target and only moved that switch before first paint. On affected iOS 26 Home Screen apps, WebKit can expose a large viewport that is taller than the reachable layout viewport. The bootstrap overlay combined `inset: 0` with an explicit height tied to that unit, so resolving standalone geometry re-centered the avatar and produced the visible downward jump.

The fixed overlay already has the correct geometry source: its containing layout viewport. Removing the explicit height keeps its center stable while leaving the post-bootstrap PWA shell behavior unchanged.

Upstream context: https://bugs.webkit.org/show_bug.cgi?id=301994

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter=!api --filter=!@okouai/app`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm -F @okouai/app exec vitest run src/views/css/__tests__/entrypoint-safe-area.test.ts` (5 passed)
- final Platform lint, type check, Prettier check, and targeted test rerun passed