### PR TITLE
fix(platform): prevent mobile input focus zoom

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -1077,7 +1077,7 @@
     />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
     />
     <script>
       // Inline theme detection — mirrors signals/theme.ts resolveTheme() + applyTheme()

--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -31,8 +31,6 @@ describe("platform entrypoint safe area behavior", () => {
         return directive.startsWith("interactive-widget=");
       }),
     ).toBeFalsy();
-    expect(viewportDirectives).not.toContain("maximum-scale=1.0");
-    expect(viewportDirectives).not.toContain("user-scalable=no");
   });
 
   it("centers the bootstrap skeleton against the fixed viewport", () => {


### PR DESCRIPTION
## Summary

- restore the platform viewport scale lock removed in #30084
- prevent iOS from zooming the full page when focusing sub-16px inputs and editable composers
- remove the assertions that required the scale lock directives to stay absent
- preserve the remaining Auth cooldown, color, and safe-area changes from #30084

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/css/__tests__/entrypoint-safe-area.test.ts` (5 tests passed)
