### PR TITLE
ci: publish app assets append-only to r2

### DIFF
--- a/.github/scripts/publish-okou-app-assets.sh
+++ b/.github/scripts/publish-okou-app-assets.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 3 )); then
+  echo "usage: $0 <r2-endpoint> <bucket> <assets-directory>" >&2
+  exit 1
+fi
+
+OKOU_APP_R2_ENDPOINT="${1%/}"
+OKOU_APP_R2_BUCKET="$2"
+OKOU_APP_ASSETS_DIRECTORY="${3%/}"
+
+if [[ ! -d "$OKOU_APP_ASSETS_DIRECTORY" ]]; then
+  echo "app assets directory does not exist: $OKOU_APP_ASSETS_DIRECTORY" >&2
+  exit 1
+fi
+if [[ -z "$(find "$OKOU_APP_ASSETS_DIRECTORY" -type f -print -quit)" ]]; then
+  echo "app assets directory is empty: $OKOU_APP_ASSETS_DIRECTORY" >&2
+  exit 1
+fi
+
+content_type_for_app_asset() {
+  case "${1,,}" in
+    *.js) printf '%s\n' 'application/javascript' ;;
+    *.css) printf '%s\n' 'text/css; charset=utf-8' ;;
+    *.json | *.map) printf '%s\n' 'application/json' ;;
+    *.wasm) printf '%s\n' 'application/wasm' ;;
+    *.svg) printf '%s\n' 'image/svg+xml' ;;
+    *.png) printf '%s\n' 'image/png' ;;
+    *.jpg | *.jpeg) printf '%s\n' 'image/jpeg' ;;
+    *.webp) printf '%s\n' 'image/webp' ;;
+    *.avif) printf '%s\n' 'image/avif' ;;
+    *.gif) printf '%s\n' 'image/gif' ;;
+    *.ico) printf '%s\n' 'image/x-icon' ;;
+    *.woff) printf '%s\n' 'font/woff' ;;
+    *.woff2) printf '%s\n' 'font/woff2' ;;
+    *.ttf) printf '%s\n' 'font/ttf' ;;
+    *.otf) printf '%s\n' 'font/otf' ;;
+    *) printf '%s\n' 'application/octet-stream' ;;
+  esac
+}
+
+publish_app_asset() {
+  local source_path=$1
+  local relative_path="${source_path#"$OKOU_APP_ASSETS_DIRECTORY"/}"
+  local asset_name="${relative_path##*/}"
+
+  if [[ "$relative_path" == *.map ]] &&
+    [[ ! "$asset_name" =~ -[[:alnum:]_-]{8,}\.[^.]+\.map$ ]]; then
+    echo "Skipping unhashed source map: $relative_path"
+    return 0
+  fi
+
+  local object_key="okou-app/assets/${relative_path}"
+  local aws_output status
+  if aws_output="$(aws s3api head-object \
+    --endpoint-url "$OKOU_APP_R2_ENDPOINT" \
+    --bucket "$OKOU_APP_R2_BUCKET" \
+    --key "$object_key" 2>&1)"; then
+    echo "App asset already exists: $object_key"
+    return 0
+  else
+    status=$?
+  fi
+
+  if ! grep -Eqi '404|NotFound|Not Found|NoSuchKey' <<< "$aws_output"; then
+    printf '%s\n' "$aws_output" >&2
+    return "$status"
+  fi
+
+  local content_type
+  content_type="$(content_type_for_app_asset "$relative_path")"
+  if aws_output="$(aws s3api put-object \
+    --endpoint-url "$OKOU_APP_R2_ENDPOINT" \
+    --bucket "$OKOU_APP_R2_BUCKET" \
+    --key "$object_key" \
+    --body "$source_path" \
+    --content-type "$content_type" \
+    --cache-control 'public, max-age=31536000, immutable' \
+    --if-none-match '*' 2>&1)"; then
+    echo "Published app asset: $object_key"
+    return 0
+  else
+    status=$?
+  fi
+
+  if grep -Eqi 'PreconditionFailed|412' <<< "$aws_output"; then
+    echo "App asset already exists: $object_key"
+    return 0
+  fi
+
+  printf '%s\n' "$aws_output" >&2
+  return "$status"
+}
+
+export OKOU_APP_R2_ENDPOINT OKOU_APP_R2_BUCKET OKOU_APP_ASSETS_DIRECTORY
+export -f content_type_for_app_asset publish_app_asset
+
+find "$OKOU_APP_ASSETS_DIRECTORY" -type f -print0 |
+  sort -z |
+  xargs -0 -r -n 1 -P 16 bash -c \
+    "set -euo pipefail; publish_app_asset \"\$1\"" _
+
+echo "App asset publication complete"

--- a/.github/scripts/publish-okou-app-assets.sh
+++ b/.github/scripts/publish-okou-app-assets.sh
@@ -43,32 +43,8 @@ content_type_for_app_asset() {
 publish_app_asset() {
   local source_path=$1
   local relative_path="${source_path#"$OKOU_APP_ASSETS_DIRECTORY"/}"
-  local asset_name="${relative_path##*/}"
-
-  if [[ "$relative_path" == *.map ]] &&
-    [[ ! "$asset_name" =~ -[[:alnum:]_-]{8,}\.[^.]+\.map$ ]]; then
-    echo "Skipping unhashed source map: $relative_path"
-    return 0
-  fi
-
   local object_key="okou-app/assets/${relative_path}"
-  local aws_output status
-  if aws_output="$(aws s3api head-object \
-    --endpoint-url "$OKOU_APP_R2_ENDPOINT" \
-    --bucket "$OKOU_APP_R2_BUCKET" \
-    --key "$object_key" 2>&1)"; then
-    echo "App asset already exists: $object_key"
-    return 0
-  else
-    status=$?
-  fi
-
-  if ! grep -Eqi '404|NotFound|Not Found|NoSuchKey' <<< "$aws_output"; then
-    printf '%s\n' "$aws_output" >&2
-    return "$status"
-  fi
-
-  local content_type
+  local aws_output content_type status
   content_type="$(content_type_for_app_asset "$relative_path")"
   if aws_output="$(aws s3api put-object \
     --endpoint-url "$OKOU_APP_R2_ENDPOINT" \
@@ -96,9 +72,48 @@ publish_app_asset() {
 export OKOU_APP_R2_ENDPOINT OKOU_APP_R2_BUCKET OKOU_APP_ASSETS_DIRECTORY
 export -f content_type_for_app_asset publish_app_asset
 
-find "$OKOU_APP_ASSETS_DIRECTORY" -type f -print0 |
-  sort -z |
-  xargs -0 -r -n 1 -P 16 bash -c \
-    "set -euo pipefail; publish_app_asset \"\$1\"" _
+existing_assets_json="$(mktemp)"
+existing_assets="$(mktemp)"
+pending_assets="$(mktemp)"
+sorted_assets="$(mktemp)"
+trap 'rm -f "$existing_assets_json" "$existing_assets" "$pending_assets" "$sorted_assets"' EXIT
+
+aws s3api list-objects-v2 \
+  --endpoint-url "$OKOU_APP_R2_ENDPOINT" \
+  --bucket "$OKOU_APP_R2_BUCKET" \
+  --prefix 'okou-app/assets/' \
+  --output json \
+  --no-cli-pager > "$existing_assets_json"
+jq -r '(.Contents // [])[] | .Key' \
+  "$existing_assets_json" > "$existing_assets"
+
+declare -A existing_asset_keys=()
+while IFS= read -r object_key; do
+  existing_asset_keys["$object_key"]=1
+done < "$existing_assets"
+echo "Found ${#existing_asset_keys[@]} existing app assets in R2"
+
+find "$OKOU_APP_ASSETS_DIRECTORY" -type f -print0 | sort -z > "$sorted_assets"
+while IFS= read -r -d '' source_path; do
+  relative_path="${source_path#"$OKOU_APP_ASSETS_DIRECTORY"/}"
+  asset_name="${relative_path##*/}"
+
+  if [[ "$relative_path" == *.map ]] &&
+    [[ ! "$asset_name" =~ -[[:alnum:]_-]{8,}\.[^.]+\.map$ ]]; then
+    echo "Skipping unhashed source map: $relative_path"
+    continue
+  fi
+
+  object_key="okou-app/assets/${relative_path}"
+  if [[ -n "${existing_asset_keys["$object_key"]+present}" ]]; then
+    echo "App asset already exists: $object_key"
+    continue
+  fi
+
+  printf '%s\0' "$source_path" >> "$pending_assets"
+done < "$sorted_assets"
+
+xargs -0 -r -n 1 -P 16 bash -c \
+  "set -euo pipefail; publish_app_asset \"\$1\"" _ < "$pending_assets"
 
 echo "App asset publication complete"

--- a/.github/scripts/tests/deploy-okou-pages-workflow-test.sh
+++ b/.github/scripts/tests/deploy-okou-pages-workflow-test.sh
@@ -53,6 +53,8 @@ rollback_job = rollback["jobs"]["rollback-app"]
 rollback_verification_job = rollback["jobs"]["verify-production-domains"]
 
 preview_step = find_step(turbo_job, "Deploy Cloudflare Pages preview")
+prepare_preview_step = find_step(turbo_job, "Prepare Cloudflare Pages preview")
+publish_assets_step = find_step(turbo_job, "Publish immutable app assets to R2")
 release_step = find_step(release_job, "Deploy Cloudflare Pages production")
 release_api_verification_step = find_step(
     release_api_job, "Verify production App and API domains"
@@ -67,6 +69,28 @@ require_fragments(
     preview_step,
     [shared_script, '"$PAGES_DIST"', '"$CF_PAGES_PROJECT_NAME"', '"$PAGES_BRANCH"', '"$ARTIFACT_SHA"'],
 )
+require_fragments(prepare_preview_step, ['echo "canonical-dist=$canonical_dist"'])
+require_fragments(
+    publish_assets_step,
+    [
+        "bash .github/scripts/publish-okou-app-assets.sh",
+        '"$r2_endpoint"',
+        '"$R2_BUCKET_NAME"',
+        '"$CANONICAL_ASSETS"',
+    ],
+)
+if publish_assets_step.get("env", {}).get("CANONICAL_ASSETS") != (
+    "${{ steps.pages-preview.outputs.canonical-dist }}/assets"
+):
+    raise RuntimeError("R2 publication must use canonical app assets")
+
+turbo_steps = turbo_job["steps"]
+if not (
+    turbo_steps.index(prepare_preview_step)
+    < turbo_steps.index(publish_assets_step)
+    < turbo_steps.index(preview_step)
+):
+    raise RuntimeError("R2 asset publication must run before Pages deployment")
 require_fragments(
     release_step,
     [shared_script, '"$PAGES_DIST"', '"$CF_PAGES_PROJECT_NAME"', "production", '"$ARTIFACT_SHA"'],

--- a/.github/scripts/tests/publish-okou-app-assets-test.sh
+++ b/.github/scripts/tests/publish-okou-app-assets-test.sh
@@ -49,6 +49,7 @@ shift 2
 endpoint=""
 bucket=""
 key=""
+prefix=""
 body=""
 content_type=""
 cache_control=""
@@ -58,10 +59,13 @@ while (( $# > 0 )); do
     --endpoint-url) endpoint=$2; shift 2 ;;
     --bucket) bucket=$2; shift 2 ;;
     --key) key=$2; shift 2 ;;
+    --prefix) prefix=$2; shift 2 ;;
     --body) body=$2; shift 2 ;;
     --content-type) content_type=$2; shift 2 ;;
     --cache-control) cache_control=$2; shift 2 ;;
     --if-none-match) if_none_match=$2; shift 2 ;;
+    --output) shift 2 ;;
+    --no-cli-pager) shift ;;
     *) echo "unexpected aws argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -77,17 +81,9 @@ printf '%s|%s|%s|%s|%s|%s|%s\n' \
 
 object_path="${MOCK_OBJECT_STORE}/${key}"
 case "$operation" in
-  head-object)
-    if [[ "$key" == 'okou-app/assets/race-Yzab5678.js' ]]; then
-      echo 'An error occurred (404) when calling the HeadObject operation: Not Found' >&2
-      exit 254
-    fi
-    if [[ -f "$object_path" ]]; then
-      printf '{}\n'
-    else
-      echo 'An error occurred (404) when calling the HeadObject operation: Not Found' >&2
-      exit 254
-    fi
+  list-objects-v2)
+    [[ "$prefix" == 'okou-app/assets/' ]] || exit 2
+    printf '{"Contents":[{"Key":"okou-app/assets/existing-UvWx1234.js"}]}\n'
     ;;
   put-object)
     if [[ "$key" == 'okou-app/assets/race-Yzab5678.js' ]]; then
@@ -127,6 +123,13 @@ grep -Fq 'App asset already exists: okou-app/assets/race-Yzab5678.js' <<< "$outp
   fail "conditional write race was not treated as an existing object"
 grep -Fq 'App asset publication complete' <<< "$output" ||
   fail "publication did not complete"
+
+if [[ "$(grep -Fc 'list-objects-v2|' "$aws_log")" -ne 1 ]]; then
+  fail "existing assets were not listed exactly once"
+fi
+if grep -Fq 'head-object|' "$aws_log"; then
+  fail "an asset used a redundant HEAD request"
+fi
 
 assert_put 'okou-app/assets/app-AbCd1234.js' 'application/javascript'
 assert_put 'okou-app/assets/style-EfGh5678.css' 'text/css; charset=utf-8'

--- a/.github/scripts/tests/publish-okou-app-assets-test.sh
+++ b/.github/scripts/tests/publish-okou-app-assets-test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+script="${repo_root}/.github/scripts/publish-okou-app-assets.sh"
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+assets_directory="${test_root}/assets"
+fake_bin="${test_root}/bin"
+object_store="${test_root}/objects"
+aws_log="${test_root}/aws.log"
+mkdir -p \
+  "$assets_directory/nested" \
+  "$fake_bin" \
+  "$object_store/okou-app/assets"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_put() {
+  local key=$1 content_type=$2
+  grep -Fqx \
+    "put-object|https://test.r2.example|test-bucket|${key}|${content_type}|public, max-age=31536000, immutable|*" \
+    "$aws_log" || fail "missing conditional upload for ${key}"
+}
+
+printf 'javascript\n' > "${assets_directory}/app-AbCd1234.js"
+printf 'css\n' > "${assets_directory}/style-EfGh5678.css"
+printf '{}\n' > "${assets_directory}/data-IjKl9012.json"
+printf 'font\n' > "${assets_directory}/font-MnOp3456.woff2"
+printf '{}\n' > "${assets_directory}/app-AbCd1234.js.map"
+printf 'svg\n' > "${assets_directory}/nested/logo-Qrst7890.svg"
+printf 'existing source\n' > "${assets_directory}/existing-UvWx1234.js"
+printf 'race source\n' > "${assets_directory}/race-Yzab5678.js"
+printf '{}\n' > "${assets_directory}/runtime.js.map"
+
+printf 'retained existing bytes\n' \
+  > "${object_store}/okou-app/assets/existing-UvWx1234.js"
+
+cat > "${fake_bin}/aws" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ "$1" == "s3api" ]] || exit 2
+operation=$2
+shift 2
+endpoint=""
+bucket=""
+key=""
+body=""
+content_type=""
+cache_control=""
+if_none_match=""
+while (( $# > 0 )); do
+  case "$1" in
+    --endpoint-url) endpoint=$2; shift 2 ;;
+    --bucket) bucket=$2; shift 2 ;;
+    --key) key=$2; shift 2 ;;
+    --body) body=$2; shift 2 ;;
+    --content-type) content_type=$2; shift 2 ;;
+    --cache-control) cache_control=$2; shift 2 ;;
+    --if-none-match) if_none_match=$2; shift 2 ;;
+    *) echo "unexpected aws argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+printf '%s|%s|%s|%s|%s|%s|%s\n' \
+  "$operation" \
+  "$endpoint" \
+  "$bucket" \
+  "$key" \
+  "$content_type" \
+  "$cache_control" \
+  "$if_none_match" >> "$MOCK_AWS_LOG"
+
+object_path="${MOCK_OBJECT_STORE}/${key}"
+case "$operation" in
+  head-object)
+    if [[ "$key" == 'okou-app/assets/race-Yzab5678.js' ]]; then
+      echo 'An error occurred (404) when calling the HeadObject operation: Not Found' >&2
+      exit 254
+    fi
+    if [[ -f "$object_path" ]]; then
+      printf '{}\n'
+    else
+      echo 'An error occurred (404) when calling the HeadObject operation: Not Found' >&2
+      exit 254
+    fi
+    ;;
+  put-object)
+    if [[ "$key" == 'okou-app/assets/race-Yzab5678.js' ]]; then
+      printf 'concurrent writer bytes\n' > "$object_path"
+      echo 'An error occurred (PreconditionFailed) when calling the PutObject operation: 412' >&2
+      exit 254
+    fi
+    if [[ -f "$object_path" ]]; then
+      echo 'An error occurred (PreconditionFailed) when calling the PutObject operation: 412' >&2
+      exit 254
+    fi
+    mkdir -p "$(dirname "$object_path")"
+    cp "$body" "$object_path"
+    printf '{}\n'
+    ;;
+  *) exit 2 ;;
+esac
+BASH
+chmod +x "${fake_bin}/aws"
+
+: > "$aws_log"
+output="$({
+  PATH="${fake_bin}:$PATH" \
+    MOCK_AWS_LOG="$aws_log" \
+    MOCK_OBJECT_STORE="$object_store" \
+    bash "$script" \
+      https://test.r2.example \
+      test-bucket \
+      "$assets_directory"
+} 2>&1)"
+
+grep -Fq 'Skipping unhashed source map: runtime.js.map' <<< "$output" ||
+  fail "unhashed source map was not reported as skipped"
+grep -Fq 'App asset already exists: okou-app/assets/existing-UvWx1234.js' <<< "$output" ||
+  fail "existing object was not reported"
+grep -Fq 'App asset already exists: okou-app/assets/race-Yzab5678.js' <<< "$output" ||
+  fail "conditional write race was not treated as an existing object"
+grep -Fq 'App asset publication complete' <<< "$output" ||
+  fail "publication did not complete"
+
+assert_put 'okou-app/assets/app-AbCd1234.js' 'application/javascript'
+assert_put 'okou-app/assets/style-EfGh5678.css' 'text/css; charset=utf-8'
+assert_put 'okou-app/assets/data-IjKl9012.json' 'application/json'
+assert_put 'okou-app/assets/font-MnOp3456.woff2' 'font/woff2'
+assert_put 'okou-app/assets/app-AbCd1234.js.map' 'application/json'
+assert_put 'okou-app/assets/nested/logo-Qrst7890.svg' 'image/svg+xml'
+assert_put 'okou-app/assets/race-Yzab5678.js' 'application/javascript'
+
+if grep -Fq 'runtime.js.map' "$aws_log"; then
+  fail "unhashed source map reached R2"
+fi
+if grep -Fq 'put-object|https://test.r2.example|test-bucket|okou-app/assets/existing-UvWx1234.js' "$aws_log"; then
+  fail "existing object was uploaded again"
+fi
+grep -Fqx 'retained existing bytes' \
+  "${object_store}/okou-app/assets/existing-UvWx1234.js" ||
+  fail "existing object was modified"
+grep -Fqx 'concurrent writer bytes' \
+  "${object_store}/okou-app/assets/race-Yzab5678.js" ||
+  fail "conditional upload replaced the concurrent writer"
+cmp -s \
+  "${assets_directory}/app-AbCd1234.js.map" \
+  "${object_store}/okou-app/assets/app-AbCd1234.js.map" ||
+  fail "hashed source map was not published"
+
+echo "publish okou app assets tests passed"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -261,6 +261,7 @@ jobs:
             .github/scripts/fetch-okou-desktop-artifact.sh \
             .github/scripts/list-okou-pages-preview-pr-numbers.sh \
             .github/scripts/pass-release-pr-ci-gates.sh \
+            .github/scripts/publish-okou-app-assets.sh \
             .github/scripts/reconcile-and-start-runner-groups.sh \
             .github/scripts/reconcile-runner-binary-groups.sh \
             .github/actions/report-memory-peak/report.sh \
@@ -288,6 +289,7 @@ jobs:
             .github/scripts/tests/deploy-cli-local-test.sh \
             .github/scripts/tests/deploy-okou-pages-test.sh \
             .github/scripts/tests/deploy-okou-pages-workflow-test.sh \
+            .github/scripts/tests/publish-okou-app-assets-test.sh \
             .github/scripts/tests/download-verified-test.sh \
             .github/scripts/tests/fetch-okou-desktop-artifact-test.sh \
             .github/scripts/tests/list-okou-pages-preview-pr-numbers-test.sh \

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1465,9 +1465,20 @@ jobs:
             "$api_origin"
 
           {
+            echo "canonical-dist=$canonical_dist"
             echo "dist=$pages_dist"
             echo "url=https://${PAGES_BRANCH}.${CF_PAGES_PROJECT_NAME}.pages.dev"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Publish immutable app assets to R2
+        env:
+          CANONICAL_ASSETS: ${{ steps.pages-preview.outputs.canonical-dist }}/assets
+        run: |
+          r2_endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          bash .github/scripts/publish-okou-app-assets.sh \
+            "$r2_endpoint" \
+            "$R2_BUCKET_NAME" \
+            "$CANONICAL_ASSETS"
 
       - name: Deploy Cloudflare Pages preview
         id: pages-deploy


### PR DESCRIPTION
## Summary

- publish canonical Vite files from dist/assets to the shared R2 bucket under okou-app/assets
- skip existing objects and use If-None-Match on writes so the namespace remains append-only under concurrent builds
- publish hashed source maps while skipping any source map without a Vite hash
- leave the existing commit-addressed archive and Cloudflare Pages payload unchanged

## Testing

- bash .github/scripts/tests/publish-okou-app-assets-test.sh
- bash .github/scripts/tests/prepare-okou-pages-dist-test.sh
- bash .github/scripts/tests/fetch-okou-app-artifact-test.sh
- bash .github/scripts/tests/deploy-okou-pages-workflow-test.sh
- Bash syntax validation for GitHub scripts and tests
- ShellCheck v0.11.0 on touched shell files
- Prettier 3.8.1 on touched workflows
- actionlint v1.7.12