### PR TITLE
perf(platform): bound stable chunk graph traversal

### DIFF
--- a/turbo/apps/platform/scripts/check-stable-chunks.node.ts
+++ b/turbo/apps/platform/scripts/check-stable-chunks.node.ts
@@ -8,6 +8,98 @@ import { build } from "vite";
 
 import { createStableChunkName } from "../src/lib/stable-chunks.ts";
 
+function normalizeModuleId(moduleId: string): string {
+  return moduleId.replaceAll("\\", "/");
+}
+
+function createLazyDiamond(root: string) {
+  const graph = new Map<string, readonly string[]>();
+  const modules = new Set<string>();
+  const lazyRoot = `${root}/diamond-root.js`;
+  let current = lazyRoot;
+  modules.add(current);
+
+  // Ten split/join layers form a 41-node fan-in diamond. A reverse path walk
+  // revisits the shared suffix exponentially; the forward closure must never
+  // enter this disconnected graph.
+  for (let index = 0; index < 10; index += 1) {
+    const left = `${root}/diamond-${index}-left.js`;
+    const right = `${root}/diamond-${index}-right.js`;
+    const join = `${root}/diamond-${index}-join.js`;
+    const next = `${root}/diamond-${index}-next.js`;
+    graph.set(current, [left, right]);
+    graph.set(left, [join]);
+    graph.set(right, [join]);
+    graph.set(join, [next]);
+    modules.add(left);
+    modules.add(right);
+    modules.add(join);
+    modules.add(next);
+    current = next;
+  }
+
+  const cycle = `${root}/cycle.js`;
+  graph.set(current, [cycle]);
+  graph.set(cycle, [current]);
+  modules.add(cycle);
+  return { cycle, graph, lazyRoot, modules };
+}
+
+for (const callbackOrder of ["startup-first", "lazy-first"] as const) {
+  await test(`computes the static startup closure once (${callbackOrder})`, () => {
+    const root = "/fixture";
+    const entryModuleId = `${root}/src/main.ts`;
+    const startupA = `${root}/node_modules/react/startup-a.js`;
+    const startupB = `${root}/node_modules/react-dom/startup-b.js`;
+    const sharedVendor = `${root}/node_modules/scheduler/shared.js`;
+    const lazy = createLazyDiamond(`${root}/node_modules/lucide-react/lazy`);
+    const graph = new Map<string, readonly string[]>([
+      [entryModuleId, [startupA, startupB]],
+      [startupA, [startupB, sharedVendor]],
+      [startupB, [startupA, sharedVendor]],
+      [sharedVendor, []],
+      ...lazy.graph,
+    ]);
+    const visits = new Map<string, number>();
+    const context = {
+      getModuleInfo(moduleId: string) {
+        const normalizedId = normalizeModuleId(moduleId);
+        visits.set(normalizedId, (visits.get(normalizedId) ?? 0) + 1);
+        const importedIds = graph.get(normalizedId);
+        return importedIds ? { importedIds } : null;
+      },
+    };
+    const stableChunkName = createStableChunkName(entryModuleId);
+    const startupCallbacks = [startupA, startupB, sharedVendor];
+    const lazyCallbacks = [lazy.lazyRoot, lazy.cycle];
+    const callbacks =
+      callbackOrder === "startup-first"
+        ? [...startupCallbacks, ...lazyCallbacks]
+        : [...lazyCallbacks, ...startupCallbacks];
+
+    for (let repeat = 0; repeat < 3; repeat += 1) {
+      for (const moduleId of callbacks) {
+        assert.equal(
+          stableChunkName(moduleId, context),
+          startupCallbacks.includes(moduleId) ? "vendor-foundation" : null,
+        );
+      }
+    }
+
+    for (const moduleId of [entryModuleId, startupA, startupB, sharedVendor]) {
+      assert.equal(visits.get(moduleId), 1, `${moduleId} visited once`);
+    }
+    for (const moduleId of lazy.modules) {
+      assert.equal(
+        visits.get(moduleId) ?? 0,
+        0,
+        `${moduleId} was not traversed`,
+      );
+    }
+    assert.equal(visits.size, 4);
+  });
+}
+
 await test("groups cyclic startup vendors without absorbing lazy-only modules", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "vm0-stable-chunks-"));
   const entryModuleId = path.join(root, "src/main.js");

--- a/turbo/apps/platform/src/lib/stable-chunks.ts
+++ b/turbo/apps/platform/src/lib/stable-chunks.ts
@@ -1,5 +1,5 @@
 interface ChunkModuleInfo {
-  readonly importers: readonly string[];
+  readonly importedIds: readonly string[];
 }
 
 interface ChunkingContext {
@@ -102,48 +102,47 @@ function packageChunkName(moduleId: string): string | null {
 
 export function createStableChunkName(entryModuleId: string) {
   const normalizedEntryModuleId = normalizeModuleId(entryModuleId);
-  const startupModules = new Set<string>();
+  let startupModules: ReadonlySet<string> | undefined;
 
-  // Walking static importers back to main keeps feature-only dependencies in
-  // Rolldown's normal lazy chunks instead of pulling them into startup.
-  function isStartupModule(
-    moduleId: string,
-    context: ChunkingContext,
-    visiting = new Set<string>(),
-  ): boolean {
-    if (startupModules.has(moduleId)) {
-      return true;
-    }
-    if (normalizeModuleId(moduleId) === normalizedEntryModuleId) {
-      startupModules.add(moduleId);
-      return true;
-    }
-    if (visiting.has(moduleId)) {
-      return false;
+  function getStartupModules(context: ChunkingContext): ReadonlySet<string> {
+    if (startupModules) {
+      return startupModules;
     }
 
-    const moduleInfo = context.getModuleInfo(moduleId);
-    if (moduleInfo === null) {
-      return false;
+    const visited = new Set<string>();
+    const pending = [normalizedEntryModuleId];
+    while (pending.length > 0) {
+      const moduleId = pending.pop();
+      if (moduleId === undefined) {
+        continue;
+      }
+      const normalizedModuleId = normalizeModuleId(moduleId);
+      if (visited.has(normalizedModuleId)) {
+        continue;
+      }
+      visited.add(normalizedModuleId);
+
+      const moduleInfo = context.getModuleInfo(moduleId);
+      if (moduleInfo === null) {
+        continue;
+      }
+      for (const importedId of moduleInfo.importedIds) {
+        if (!visited.has(normalizeModuleId(importedId))) {
+          pending.push(importedId);
+        }
+      }
     }
 
-    visiting.add(moduleId);
-    const startupModule = moduleInfo.importers.some((importerId) => {
-      return isStartupModule(importerId, context, visiting);
-    });
-    visiting.delete(moduleId);
-    // A false result can be specific to the current cycle traversal. Cache only
-    // proven reachability so later Rolldown callbacks cannot inherit that
-    // contextual miss and become order-dependent.
-    if (startupModule) {
-      startupModules.add(moduleId);
-    }
-    return startupModule;
+    startupModules = visited;
+    return startupModules;
   }
 
   return (moduleId: string, context: ChunkingContext): string | null => {
     const chunkName = packageChunkName(moduleId);
-    if (chunkName === null || !isStartupModule(moduleId, context)) {
+    if (
+      chunkName === null ||
+      !getStartupModules(context).has(normalizeModuleId(moduleId))
+    ) {
       return null;
     }
     return chunkName;


### PR DESCRIPTION
## Summary

- compute the statically imported startup-module closure once from the entry module instead of walking reverse importer paths for every chunk callback
- preserve stable vendor chunk names while leaving lazy-only dependencies in Rolldown's normal dynamic chunks
- cover callback-order independence, cyclic startup imports, and a disconnected fan-in graph that previously amplified repeated traversal

## Memory and build evidence

Local controlled production-build comparison on the same checkout and dependency state:

- `main`: transformed 7,497 modules but did not finish after 189.5 seconds; manually stopped at a 2,394.9 MiB cgroup peak
- this branch: completed in 12.1 seconds with a 1,750.2 MiB cgroup peak

The final production manifest build emits all four stable vendor chunks, keeps 111 dynamic entries, and leaves Mermaid parser/diagram modules lazy.

## Verification

- `corepack pnpm -F @okouai/app lint:build-config`
- `corepack pnpm -F @okouai/app lint:static-assets`
- `corepack pnpm -F @okouai/app lint:localized-ui`
- `corepack pnpm -F @okouai/app i18n:check`
- `corepack pnpm -F @okouai/app exec oxlint`
- `corepack pnpm -F @okouai/app exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json`
- `corepack pnpm -F @okouai/app exec eslint . --max-warnings 0`
- `corepack pnpm -F @okouai/app check-types`
- `corepack pnpm knip --workspace @okouai/app`
- `corepack pnpm -F @okouai/app exec vite build --manifest --logLevel warn`

## Staging verification

Validated the PR preview for head `1d19ade0aea6fc8cda9f5a1f52e417542ab22c3d` (the preview checkout merge contains that exact head):

- App: `https://pr-30168-app.omby.ai`
- API: `https://pr-30168-api.vm6.ai`
- Browser: Headless Chrome 151, 1280x900 viewport, fresh Clerk test account, no feature switches, `realAgentInPreview` off; onboarding skipped with the in-product "I will explore on my own" path
- PASS: cold sign-in load fetched `vendor-auth`, `vendor-content`, `vendor-foundation`, and `vendor-services` with HTTP 200
- PASS: Chat, Agents, Workflows, Connectors, and Artifacts rendered after client-side navigation with no page errors or chunk-load failures
- PASS: the deployed `vendor-content` chunk still references a separate `flowDiagram` chunk; dynamically importing that exact deployed chunk completed successfully, exported `diagram`, and fetched the chunk plus all six transitive module chunks with HTTP 200
- PASS: a full-page reload fetched all four stable vendor chunks with HTTP 200 and produced no page errors

The current guest mock runner echoed the `@ECHO@` fixture instead of replaying Claude JSONL, so the lazy Mermaid boundary was validated through the exact deployed dynamic module import rather than treating that runner behavior as a chunk failure.

## Fallbacks

None.
