### PR TITLE
refactor(runner): finish vm-to-sandbox terminology cleanup

### DIFF
--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -767,7 +767,6 @@ after = snapshot(workload, control)
 for event in ("max", "oom", "oom_kill", "oom_group_kill"):
     if after["workload_events"].get(event, 0) != before["workload_events"].get(event, 0):
         raise RuntimeError(f"memory pressure triggered workload-local {event}")
-marker_dir.joinpath("memory-reclaim-sandbox").write_text("ready\n")
 print(
     json.dumps(
         {

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -113,7 +113,7 @@ set -eu
 marker=/tmp/vm0-process-containment
 rm -rf "$marker"
 mkdir -p "$marker"
-touch "$marker/vm-reuse-marker"
+touch "$marker/sandbox-reuse-marker"
 
 expected_path="/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games:$HOME/go/bin:$HOME/.cargo/bin"
 if [ "$PATH" != "$expected_path" ]; then
@@ -341,7 +341,7 @@ VERIFY_PROMPT=$(cat <<'PROMPT'
 set -eu
 marker=/tmp/vm0-process-containment
 base=/sys/fs/cgroup/vm0-exec
-test -f "$marker/vm-reuse-marker"
+test -f "$marker/sandbox-reuse-marker"
 if [ -e "$marker/profile-executed" ]; then
   echo "sandbox login profile executed before Guest Agent" >&2
   exit 1
@@ -413,7 +413,7 @@ sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   --chat-thread-id "$CHAT_THREAD_ID" \
   --session-id "$SESSION_ID" \
   --feature-flag sandboxReuse=true \
-  --prompt 'test -f /tmp/vm0-process-containment/vm-reuse-marker' \
+  --prompt 'test -f /tmp/vm0-process-containment/sandbox-reuse-marker' \
   || fail "Turn 3 failed; healthy cleanup did not re-enter reuse"
 
 echo "--- Pressure: sustain CPU saturation with live process control ---"
@@ -767,7 +767,7 @@ after = snapshot(workload, control)
 for event in ("max", "oom", "oom_kill", "oom_group_kill"):
     if after["workload_events"].get(event, 0) != before["workload_events"].get(event, 0):
         raise RuntimeError(f"memory pressure triggered workload-local {event}")
-marker_dir.joinpath("memory-reclaim-vm").write_text("ready\n")
+marker_dir.joinpath("memory-reclaim-sandbox").write_text("ready\n")
 print(
     json.dumps(
         {
@@ -921,7 +921,7 @@ import time
 
 marker = pathlib.Path("/tmp/vm0-process-containment")
 marker.mkdir()
-(marker / "pid-pressure-vm").touch()
+(marker / "pid-pressure-sandbox").touch()
 relative = next(
     line.removeprefix("0::").strip()
     for line in pathlib.Path("/proc/self/cgroup").read_text().splitlines()
@@ -989,7 +989,7 @@ sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   --chat-thread-id "$PID_CHAT_THREAD_ID" \
   --session-id "$PID_SESSION_ID" \
   --feature-flag sandboxReuse=true \
-  --prompt 'test -f /tmp/vm0-process-containment/pid-pressure-vm' \
+  --prompt 'test -f /tmp/vm0-process-containment/pid-pressure-sandbox' \
   || fail "PID-pressure cleanup did not preserve safe sandbox reuse"
 
 LOGS=$(sudo journalctl --no-pager "_SYSTEMD_INVOCATION_ID=$INVOCATION_ID" 2>&1) \

--- a/.github/scripts/tests/vm0-monitoring-runner-status-collect-test.sh
+++ b/.github/scripts/tests/vm0-monitoring-runner-status-collect-test.sh
@@ -102,11 +102,11 @@ test_missing_and_empty_runner_roots_emit_zero_metrics() {
   assert_zero_snapshot
 }
 
-test_aggregates_current_legacy_and_future_statuses() {
+test_aggregates_current_and_future_statuses() {
   reset_dirs
   mkdir -p \
     "$runners_dir/current" \
-    "$runners_dir/legacy" \
+    "$runners_dir/draining" \
     "$runners_dir/future" \
     "$runners_dir/stopped"
 
@@ -128,15 +128,15 @@ test_aggregates_current_legacy_and_future_statuses() {
 }
 EOF
 
-  cat >"$runners_dir/legacy/status.json" <<EOF
+  cat >"$runners_dir/draining/status.json" <<EOF
 {
   "mode": "draining",
   "active_runs": [
-    {"run_id": "legacy-run", "sandbox_id": "$uuid_f"},
+    {"run_id": "draining-run", "sandbox_id": "$uuid_f"},
     {"run_id": "duplicate-idle", "sandbox_id": "$uuid_d"}
   ],
-  "idle_vms": [
-    {"sandbox_id": "$uuid_g", "session_id": "legacy-session"}
+  "idle_sandboxes": [
+    {"sandbox_id": "$uuid_g", "session_id": "session"}
   ]
 }
 EOF
@@ -170,18 +170,16 @@ EOF
   assert_line 'vm0_runner_status_files{result="stopped"} 1'
   assert_line 'vm0_runner_status_files{result="invalid"} 0'
   assert_line 'vm0_runner_status_collection_success 1'
-  if grep -qE "sandbox_id|run_id|reuse_key|session_id|$uuid_a|legacy-run" \
+  if grep -qE "sandbox_id|run_id|reuse_key|session_id|$uuid_a|draining-run" \
     "$output_file"; then
     fail "identity-level data leaked into metrics"
   fi
 }
 
-test_idle_field_compatibility_precedence() {
+test_canonical_idle_field_behavior() {
   reset_dirs
   mkdir -p \
     "$runners_dir/canonical" \
-    "$runners_dir/legacy" \
-    "$runners_dir/mirrored" \
     "$runners_dir/canonical-empty" \
     "$runners_dir/omitted"
 
@@ -189,13 +187,7 @@ test_idle_field_compatibility_precedence() {
     "{\"mode\":\"running\",\"idle_sandboxes\":[{\"sandbox_id\":\"$uuid_a\"}]}" \
     >"$runners_dir/canonical/status.json"
   printf '%s\n' \
-    "{\"mode\":\"running\",\"idle_vms\":[{\"sandbox_id\":\"$uuid_b\"}]}" \
-    >"$runners_dir/legacy/status.json"
-  printf '%s\n' \
-    "{\"mode\":\"running\",\"idle_sandboxes\":[{\"sandbox_id\":\"$uuid_c\"}],\"idle_vms\":[{\"sandbox_id\":\"$uuid_d\"}]}" \
-    >"$runners_dir/mirrored/status.json"
-  printf '%s\n' \
-    "{\"mode\":\"running\",\"idle_sandboxes\":[],\"idle_vms\":[{\"sandbox_id\":\"$uuid_e\"}]}" \
+    "{\"mode\":\"running\",\"idle_sandboxes\":[]}" \
     >"$runners_dir/canonical-empty/status.json"
   printf '%s\n' '{"mode":"running"}' \
     >"$runners_dir/omitted/status.json"
@@ -203,11 +195,11 @@ test_idle_field_compatibility_precedence() {
   run_collector
 
   assert_line 'vm0_runner_sandboxes{state="active"} 0'
-  assert_line 'vm0_runner_sandboxes{state="idle"} 3'
+  assert_line 'vm0_runner_sandboxes{state="idle"} 1'
   assert_line 'vm0_runner_sandboxes{state="preparing"} 0'
   assert_line 'vm0_runner_sandboxes{state="unknown"} 0'
-  assert_line 'vm0_runner_instances{mode="running"} 5'
-  assert_line 'vm0_runner_status_files{result="included"} 5'
+  assert_line 'vm0_runner_instances{mode="running"} 3'
+  assert_line 'vm0_runner_status_files{result="included"} 3'
   assert_line 'vm0_runner_status_files{result="invalid"} 0'
   assert_line 'vm0_runner_status_collection_success 1'
 }
@@ -228,10 +220,10 @@ EOF
   printf '%s\n' '{"mode":"running","active_runs":{}}' \
     >"$runners_dir/malformed-shape/status.json"
   printf '%s\n' \
-    "{\"mode\":\"running\",\"idle_sandboxes\":null,\"idle_vms\":[{\"sandbox_id\":\"$uuid_b\"}]}" \
+    "{\"mode\":\"running\",\"idle_sandboxes\":null}" \
     >"$runners_dir/malformed-canonical/status.json"
   printf '%s\n' \
-    '{"mode":"running","idle_vms":[{"sandbox_id":"not-a-uuid"}]}' \
+    '{"mode":"running","idle_sandboxes":[{"sandbox_id":"not-a-uuid"}]}' \
     >"$runners_dir/invalid-id/status.json"
 
   run_collector
@@ -444,8 +436,8 @@ test_playbook_provisions_collector_identity_and_cadence() {
 }
 
 test_missing_and_empty_runner_roots_emit_zero_metrics
-test_aggregates_current_legacy_and_future_statuses
-test_idle_field_compatibility_precedence
+test_aggregates_current_and_future_statuses
+test_canonical_idle_field_behavior
 test_invalid_files_publish_partial_metrics
 test_rejects_runner_and_status_symlinks
 test_output_is_deterministic_and_replaced_atomically

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -861,7 +861,7 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
         run: .github/scripts/runner-behavior-systemd-reload.sh
 
-      - name: Test VM keep-alive across conversation turns
+      - name: Test sandbox keep-alive across conversation turns
         timeout-minutes: 5
         env:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}

--- a/ansible/files/vm0-monitoring-runner-status-collect.py
+++ b/ansible/files/vm0-monitoring-runner-status-collect.py
@@ -73,8 +73,7 @@ def parse_status(path: Path) -> tuple[str, list[tuple[str, str]]]:
             )
         sandbox_states.append((sandbox_id, state))
 
-    idle_field = "idle_sandboxes" if "idle_sandboxes" in status else "idle_vms"
-    for entry in parse_collection(status, idle_field):
+    for entry in parse_collection(status, "idle_sandboxes"):
         _, sandbox_id = parse_sandbox_entry(entry)
         sandbox_states.append((sandbox_id, "idle"))
 

--- a/crates/README.md
+++ b/crates/README.md
@@ -1,30 +1,30 @@
 # Rust Crates
 
-This workspace contains Rust crates for the vm0 sandbox runtime — VM orchestration, guest execution, vsock communication, and supporting services.
+This workspace contains Rust crates for the vm0 sandbox runtime — sandbox orchestration, guest execution, vsock communication, and supporting services.
 
 ## Crates
 
-| Crate                 | Description                                                                                                                         |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| **runner**            | Sandbox orchestrator — polls for jobs (API or local queue), manages VM lifecycle, proxy, service install, and bridges to sandbox-fc |
-| **sandbox**           | Sandbox trait and shared types — `SandboxFactory`, `Sandbox`, `SandboxConfig`, `ExecRequest`, `ExecResult`                          |
-| **sandbox-fc**        | Firecracker sandbox implementation — VM lifecycle, network namespace pool, NBD COW, snapshot restore                                |
-| **nbd-cow**           | Userspace NBD COW device — block-level copy-on-write via Linux NBD, bitmap tracking, no dm-snapshot/loop devices                    |
-| **vsock-proto**       | Wire protocol encoding/decoding shared by host and guest — length-prefixed binary messages                                          |
-| **vsock-host**        | Host-side async vsock client (tokio) — connects to guest via Unix domain sockets                                                    |
-| **vsock-guest**       | Guest-side vsock library — IPC over vsock/Unix sockets, embedded in guest-init as PID 2                                             |
-| **vsock-test**        | Integration tests for vsock — real host + real guest over Unix sockets                                                              |
-| **guest-init**        | Init process (PID 1) for Firecracker VMs — virtual filesystem setup, env config, signal handling, forks vsock-guest                 |
-| **guest-agent**       | Guest orchestrator — CLI execution, heartbeat, telemetry upload, and checkpoint creation inside the VM                              |
-| **guest-contracts**   | Runner/guest contracts — bootstrap environment variables, runtime path layout, and private runtime file helpers                     |
-| **guest-tool-exec**   | Explicit shell-tool launcher and runtime hook adapter for per-tool cgroup placement                                                |
-| **guest-common**      | Guest-only shared utilities — logging macros and telemetry recording                                                                |
-| **guest-download**    | Downloads and extracts storage archives — parallel downloads (4 concurrent), streaming extraction, retry logic                      |
-| **guest-mock-claude** | Mock Claude CLI for testing — executes bash commands and outputs Claude-compatible JSONL                                            |
-| **guest-mock-codex**  | Mock Codex app-server for testing — speaks JSON-RPC over stdio and persists session artifacts                                       |
-| **guest-reseed**      | Entropy reseed after snapshot restore — mixes stdin entropy into /dev/urandom and forces CRNG reseed via RNDRESEEDCRNG              |
-| **guest-write-file**  | Direct file writer for vsock `write_file` — writes stdin to guest files without shell startup overhead                              |
-| **ably-subscriber**   | Ably Pub/Sub subscribe-only realtime client — WebSocket/MessagePack protocol with token auth and automatic reconnection             |
+| Crate                 | Description                                                                                                                              |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **runner**            | Sandbox orchestrator — polls for jobs (API or local queue), manages sandbox lifecycle, proxy, service install, and bridges to sandbox-fc |
+| **sandbox**           | Sandbox trait and shared types — `SandboxFactory`, `Sandbox`, `SandboxConfig`, `ExecRequest`, `ExecResult`                               |
+| **sandbox-fc**        | Firecracker sandbox implementation — VM lifecycle, network namespace pool, NBD COW, snapshot restore                                     |
+| **nbd-cow**           | Userspace NBD COW device — block-level copy-on-write via Linux NBD, bitmap tracking, no dm-snapshot/loop devices                         |
+| **vsock-proto**       | Wire protocol encoding/decoding shared by host and guest — length-prefixed binary messages                                               |
+| **vsock-host**        | Host-side async vsock client (tokio) — connects to guest via Unix domain sockets                                                         |
+| **vsock-guest**       | Guest-side vsock library — IPC over vsock/Unix sockets, embedded in guest-init as PID 2                                                  |
+| **vsock-test**        | Integration tests for vsock — real host + real guest over Unix sockets                                                                   |
+| **guest-init**        | Init process (PID 1) for Firecracker VMs — virtual filesystem setup, env config, signal handling, forks vsock-guest                      |
+| **guest-agent**       | Guest orchestrator — CLI execution, heartbeat, telemetry upload, and checkpoint creation inside the VM                                   |
+| **guest-contracts**   | Runner/guest contracts — bootstrap environment variables, runtime path layout, and private runtime file helpers                          |
+| **guest-tool-exec**   | Explicit shell-tool launcher and runtime hook adapter for per-tool cgroup placement                                                      |
+| **guest-common**      | Guest-only shared utilities — logging macros and telemetry recording                                                                     |
+| **guest-download**    | Downloads and extracts storage archives — parallel downloads (4 concurrent), streaming extraction, retry logic                           |
+| **guest-mock-claude** | Mock Claude CLI for testing — executes bash commands and outputs Claude-compatible JSONL                                                 |
+| **guest-mock-codex**  | Mock Codex app-server for testing — speaks JSON-RPC over stdio and persists session artifacts                                            |
+| **guest-reseed**      | Entropy reseed after snapshot restore — mixes stdin entropy into /dev/urandom and forces CRNG reseed via RNDRESEEDCRNG                   |
+| **guest-write-file**  | Direct file writer for vsock `write_file` — writes stdin to guest files without shell startup overhead                                   |
+| **ably-subscriber**   | Ably Pub/Sub subscribe-only realtime client — WebSocket/MessagePack protocol with token auth and automatic reconnection                  |
 
 ## Architecture
 

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -61,7 +61,7 @@ pub const CANONICAL_SANDBOX_ID_ENV: &str = "OKOU_SANDBOX_ID";
 
 /// Wire value for the runner's sandbox-reuse decision.
 ///
-/// `reused` means an idle VM was unparked. Other values describe why reuse did
+/// `reused` means an idle sandbox was unparked. Other values describe why reuse did
 /// not happen, such as `poolMiss` or `noReuseKey`.
 ///
 /// Guest readers retain this legacy alias as a rollback fallback.

--- a/crates/runner/mitm-addon/tests/test_registry_loading.py
+++ b/crates/runner/mitm-addon/tests/test_registry_loading.py
@@ -21,29 +21,6 @@ class TestLoadRegistry:
         assert "10.200.0.1" in result
         assert result["10.200.0.1"]["runId"] == "run-abc-123"
 
-    def test_does_not_read_legacy_vms_collection(self, tmp_path):
-        path = tmp_path / "registry.json"
-        path.write_text(
-            json.dumps(
-                {
-                    "vms": {
-                        "10.200.0.1": {
-                            "runId": "run-legacy",
-                            "billableFirewalls": [],
-                            "cliAgentType": "claude-code",
-                        }
-                    },
-                    "updatedAt": 0,
-                }
-            )
-        )
-
-        state = registry.load_registry_state(str(path))
-
-        assert not isinstance(state, registry.RegistryUnavailable)
-        assert state.sandboxes == {}
-        assert state.invalid_sandboxes == {}
-
     def test_classifies_invalid_registered_sandbox_entries(self, tmp_path):
         path = tmp_path / "registry.json"
         path.write_text(

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -1477,8 +1477,9 @@ mod tests {
             .map(|idle_sandboxes| {
                 idle_sandboxes
                     .iter()
-                    .filter_map(|vm| {
-                        vm.get("reuse_key")
+                    .filter_map(|sandbox| {
+                        sandbox
+                            .get("reuse_key")
                             .and_then(|reuse_key| reuse_key.as_str())
                             .map(str::to_string)
                     })

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1263,7 +1263,7 @@ impl StartLoopTestObserver {
             })
     }
 
-    fn notify_vm_parked_for_reuse(&self, run_id: RunId, reuse_key: String) {
+    fn notify_sandbox_parked_for_reuse(&self, run_id: RunId, reuse_key: String) {
         self.record(StartLoopEvent::SandboxParkedForReuse { run_id, reuse_key });
     }
 
@@ -1349,7 +1349,7 @@ impl StartLoopTestObserver {
         .await
     }
 
-    async fn wait_vm_parked_for_reuse(&self, run_id: RunId, timeout: Duration) -> String {
+    async fn wait_sandbox_parked_for_reuse(&self, run_id: RunId, timeout: Duration) -> String {
         self.wait_for(timeout, "sandbox parked for reuse", |event| match event {
             StartLoopEvent::SandboxParkedForReuse {
                 run_id: observed_run_id,

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -516,12 +516,12 @@ mod tests {
                 .map(|idle_sandboxes| {
                     idle_sandboxes
                         .iter()
-                        .map(|vm| {
-                            let reuse_key = vm
+                        .map(|sandbox| {
+                            let reuse_key = sandbox
                                 .get("reuse_key")
                                 .and_then(|reuse_key| reuse_key.as_str())
                                 .expect("idle sandbox must include reuse_key");
-                            let sandbox_id = vm
+                            let sandbox_id = sandbox
                                 .get("sandbox_id")
                                 .and_then(|sandbox| sandbox.as_str())
                                 .expect("idle sandbox must include sandbox_id");

--- a/crates/runner/src/cmd/start/ownership.rs
+++ b/crates/runner/src/cmd/start/ownership.rs
@@ -177,8 +177,9 @@ mod tests {
             .map(|idle_sandboxes| {
                 idle_sandboxes
                     .iter()
-                    .filter_map(|vm| {
-                        vm.get("reuse_key")
+                    .filter_map(|sandbox| {
+                        sandbox
+                            .get("reuse_key")
                             .and_then(|reuse_key| reuse_key.as_str())
                             .map(str::to_string)
                     })

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -890,7 +890,7 @@ async fn finalize_sandbox_for_completion_inner(
                             "sandbox parked for reuse"
                         );
                         #[cfg(test)]
-                        test_observer.notify_vm_parked_for_reuse(run_id, reuse_key.clone());
+                        test_observer.notify_sandbox_parked_for_reuse(run_id, reuse_key.clone());
                         cleanup_state.mark_idle_pool_owned();
                         #[cfg(test)]
                         maybe_panic_outer_job(
@@ -1903,7 +1903,7 @@ mod tests {
         )
         .await;
         let observed_reuse_key = observer
-            .wait_vm_parked_for_reuse(run_id, Duration::from_secs(1))
+            .wait_sandbox_parked_for_reuse(run_id, Duration::from_secs(1))
             .await;
 
         assert_eq!(observed_reuse_key, reuse_key);

--- a/crates/runner/src/cmd/start/tests/budget.rs
+++ b/crates/runner/src/cmd/start/tests/budget.rs
@@ -188,7 +188,7 @@ async fn idle_sandbox_remains_reusable_until_capacity_is_needed() {
 // -----------------------------------------------------------------------
 
 #[tokio::test(flavor = "current_thread")]
-async fn budget_pressure_starts_fresh_vm_before_idle_destroy_finishes() {
+async fn budget_pressure_starts_fresh_sandbox_before_idle_destroy_finishes() {
     let destroy_gate = sandbox_mock::MockLifecycleGate::new();
     let wait_gate = sandbox_mock::MockLifecycleGate::new();
     let idle_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());

--- a/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
@@ -531,7 +531,7 @@ async fn park_panic_destroys_sandbox_reports_completion_and_releases_budget() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn pool_full_rejected_vm_keeps_budget_until_destroy_and_completion() {
+async fn pool_full_rejected_sandbox_keeps_budget_until_destroy_and_completion() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let destroy_gate = MockLifecycleGate::new();
     overrides.set_destroy_lifecycle_gate(destroy_gate.clone());

--- a/crates/runner/src/cmd/start/tests/idle_reuse/parking.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/parking.rs
@@ -28,7 +28,7 @@ fn context_with_session_opt(
 }
 
 #[tokio::test(start_paused = true)]
-async fn job_with_session_parks_vm() {
+async fn job_with_session_parks_sandbox() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let run_handle = tokio::spawn(run(config));
 
@@ -465,7 +465,7 @@ async fn sequential_same_reuse_key_cycle() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn same_thread_reuses_vm_across_provider_session_change() {
+async fn same_thread_reuses_sandbox_across_provider_session_change() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let run_handle = tokio::spawn(run(config));
@@ -624,7 +624,7 @@ async fn reuse_cycle_invokes_park_and_unpark_symmetrically() {
 /// A successful job with a session triggers `Sandbox::park()` exactly once
 /// when the sandbox is handed off to the idle pool.
 #[tokio::test(start_paused = true)]
-async fn park_called_when_vm_enters_idle_pool() {
+async fn park_called_when_sandbox_enters_idle_pool() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let counter = Arc::clone(&overrides);
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);

--- a/crates/runner/src/cmd/start/tests/idle_reuse/same_thread_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/same_thread_reuse.rs
@@ -195,7 +195,7 @@ async fn invalid_resume_session_fails_before_fresh_sandbox_creation() {
 // -----------------------------------------------------------------------
 
 #[tokio::test(start_paused = true)]
-async fn profile_mismatch_destroys_stale_vm() {
+async fn profile_mismatch_destroys_stale_sandbox() {
     let (config, env) = mock_run_config(two_profiles(), 16, 32768, 4);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let budget = Arc::clone(&config.capacity.budget);

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -1288,7 +1288,7 @@ async fn selected_finalizing_candidate_claims_while_predecessor_is_running() {
 }
 
 #[tokio::test]
-async fn finalizing_fallback_starts_fresh_vm_before_idle_destroy_finishes() {
+async fn finalizing_fallback_starts_fresh_sandbox_before_idle_destroy_finishes() {
     let destroy_gate = sandbox_mock::MockLifecycleGate::new();
     let wait_gate = sandbox_mock::MockLifecycleGate::new();
     let idle_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
@@ -1367,7 +1367,7 @@ async fn finalizing_fallback_starts_fresh_vm_before_idle_destroy_finishes() {
 }
 
 #[tokio::test]
-async fn finalizing_capacity_wait_rechecks_when_an_active_vm_parks_idle() {
+async fn finalizing_capacity_wait_rechecks_when_an_active_sandbox_parks_idle() {
     let destroy_gate = sandbox_mock::MockLifecycleGate::new();
     let wait_gate = sandbox_mock::MockLifecycleGate::new();
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
@@ -1439,7 +1439,7 @@ async fn finalizing_capacity_wait_rechecks_when_an_active_vm_parks_idle() {
     wait_gate.release_one();
     let parked_reuse_key = env
         .start_observer
-        .wait_vm_parked_for_reuse(capacity_source_run_id, Duration::from_secs(5))
+        .wait_sandbox_parked_for_reuse(capacity_source_run_id, Duration::from_secs(5))
         .await;
     assert_eq!(parked_reuse_key, capacity_source_reuse_key);
     destroy_gate
@@ -1466,7 +1466,7 @@ async fn finalizing_capacity_wait_rechecks_when_an_active_vm_parks_idle() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn finalizing_immediate_handoff_reuses_matching_vm_past_preference_deadline() {
+async fn finalizing_immediate_handoff_reuses_matching_sandbox_past_preference_deadline() {
     let destroy_gate = sandbox_mock::MockLifecycleGate::new();
     let wait_gate = sandbox_mock::MockLifecycleGate::new();
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());

--- a/crates/runner/src/cmd/start/tests/support/status.rs
+++ b/crates/runner/src/cmd/start/tests/support/status.rs
@@ -37,7 +37,7 @@ pub(in super::super) async fn status_idle_reuse_keys_and_active_runs(
     let mut reuse_keys: Vec<String> = status
         .idle_sandboxes
         .into_iter()
-        .map(|vm| vm.reuse_key)
+        .map(|sandbox| sandbox.reuse_key)
         .collect();
     reuse_keys.sort_unstable();
     let mut run_ids: Vec<String> = status

--- a/crates/runner/src/dns/log.rs
+++ b/crates/runner/src/dns/log.rs
@@ -53,7 +53,7 @@ impl DnsReadinessLogObservation {
     }
 }
 
-/// Tail dnsmasq stderr and write DNS log entries to per-VM network JSONL.
+/// Tail dnsmasq stderr and write DNS log entries to per-sandbox network JSONL.
 ///
 /// dnsmasq `--log-queries=extra --log-facility=-` outputs lines like:
 /// ```text

--- a/crates/runner/src/dns/mod.rs
+++ b/crates/runner/src/dns/mod.rs
@@ -1,6 +1,6 @@
-//! DNS proxy for sandbox VMs using dnsmasq.
+//! DNS proxy for runner sandboxes using dnsmasq.
 //!
-//! Spawns a dnsmasq process that serves as the DNS resolver for all VMs.
+//! Spawns a dnsmasq process that serves as the DNS resolver for all sandboxes.
 //! DNS queries are intercepted via iptables REDIRECT (PREROUTING chain)
 //! and forwarded to upstream resolvers (8.8.8.8, 8.8.4.4).
 //!
@@ -9,7 +9,7 @@
 //! - Layer 2: iptables DROP external UDP/TCP 53 and TCP 853 (bypass prevention)
 //! - Layer 3: IPv4/IPv6 INPUT filters reject direct access to dnsmasq's wildcard
 //!   port from interfaces outside the runner's netns pool
-//! - Layer 4: dnsmasq validates each request against the runner's VM-facing
+//! - Layer 4: dnsmasq validates each request against the runner's sandbox-facing
 //!   veth interface pattern (listener access control)
 //!
 //! VM resolv.conf points to an external nameserver (e.g. 8.8.8.8) as a dummy
@@ -17,7 +17,7 @@
 //! VM subnet and redirect to dnsmasq before packets reach FORWARD/POSTROUTING.
 //!
 //! Log format: dnsmasq `--log-queries=extra` outputs to stderr, parsed by a background
-//! async task that submits per-VM network JSON rows through `NetworkLogManager`.
+//! async task that submits per-sandbox network JSON rows through `NetworkLogManager`.
 
 mod log;
 mod port;

--- a/crates/runner/src/dns/proxy.rs
+++ b/crates/runner/src/dns/proxy.rs
@@ -214,7 +214,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn dnsmasq_args_use_wildcard_sockets_with_vm_interface_access_control() {
+    fn dnsmasq_args_use_wildcard_sockets_with_sandbox_interface_access_control() {
         let args = dnsmasq_args(5353, "vm0-ve-0a-*");
 
         assert!(args.contains(&"--interface=vm0-ve-0a-*".to_string()));

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -618,7 +618,7 @@ pub(crate) async fn execute_job_with_prepared_notifier(
         .record(&context, params, &mut telemetry);
 
     record_reuse_result(&mut telemetry, dispatch.reuse_result);
-    record_api_latency("api_to_vm_start", &context, &mut telemetry);
+    record_api_latency("api_to_sandbox_start", &context, &mut telemetry);
 
     let sandbox_id = dispatch.id.to_string();
     let outcome = match validate_execution_context_before_sandbox(
@@ -729,7 +729,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
         .record(&context, params, &mut telemetry);
 
     record_reuse_result(&mut telemetry, SandboxReuseResult::Reused);
-    record_api_latency("api_to_vm_start", &context, &mut telemetry);
+    record_api_latency("api_to_sandbox_start", &context, &mut telemetry);
 
     let sandbox_id = idle_sandbox.sandbox_id();
     let ReusableIdleSandboxParts {

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -1081,11 +1081,13 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let factory = ObservedMockSandboxFactory::new();
+    let mut context = minimal_context();
+    context.api_start_time = Some(chrono::Utc::now().timestamp_millis().max(0) as u64);
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (_outcome, telemetry) = execute_job_with_prepared_notifier(
         &factory,
-        minimal_context(),
+        context,
         NewSandboxDispatch {
             id: SandboxId::new_v4(),
             reuse_result: SandboxReuseResult::PoolMiss,
@@ -1125,6 +1127,7 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
         "runner_agent_placement_broker_setup",
         "runner_agent_shell_spawn",
         "runner_agent_bootstrap_ready_wait",
+        "api_to_sandbox_start",
         "sandbox_reuse_miss",
         "sandbox_create",
         "workspace_drive_mount",
@@ -1550,9 +1553,11 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
     let cancel = tokio_util::sync::CancellationToken::new();
     let (idle_sandbox, _lease) =
         make_reusable_idle_sandbox(sandbox, outcome.source_ip, "test-session").await;
+    let mut context = minimal_context();
+    context.api_start_time = Some(chrono::Utc::now().timestamp_millis().max(0) as u64);
     let (_outcome, telemetry) = execute_job_reuse_with_hooks(
         idle_sandbox,
-        minimal_context(),
+        context,
         &config,
         &default_params(),
         RunCancellationSignals::hard_only(cancel),
@@ -1584,6 +1589,7 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
         "runner_agent_placement_broker_setup",
         "runner_agent_shell_spawn",
         "runner_agent_bootstrap_ready_wait",
+        "api_to_sandbox_start",
         "sandbox_reuse_hit",
         "agent_execute",
     ] {

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -1679,7 +1679,6 @@ exit 42
         let raw = tokio::fs::read_to_string(&registry_path).await.unwrap();
         let registry: serde_json::Value = serde_json::from_str(&raw).unwrap();
         assert_eq!(registry["sandboxes"], serde_json::json!({}));
-        assert!(registry.get("vms").is_none());
     }
 
     #[tokio::test]

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -1319,7 +1319,6 @@ mod tests {
 
         let status = read_status(&path);
         assert!(status.get("idle_sandboxes").is_none());
-        assert!(status.get("idle_vms").is_none());
 
         let sb1 = SandboxId::new_v4();
         let sb2 = SandboxId::new_v4();
@@ -1343,7 +1342,6 @@ mod tests {
         );
 
         let status = read_status(&path);
-        assert!(status.get("idle_vms").is_none());
         let sandboxes = status["idle_sandboxes"].as_array().unwrap();
         assert_eq!(sandboxes.len(), 2);
         assert_eq!(sandboxes[0]["reuse_key"], "sess-1");

--- a/crates/runner/src/status_file.rs
+++ b/crates/runner/src/status_file.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use serde::Deserialize;
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Deserializer};
 
 use crate::error::RunnerError;
 use crate::ids::RunId;
@@ -87,8 +87,8 @@ pub(crate) struct StatusForDoctor {
     #[serde(default)]
     pub(crate) active_runs: Vec<StatusActiveRun>,
     pub(crate) started_at: String,
-    #[serde(default, deserialize_with = "deserialize_present_idle_sandboxes")]
-    idle_sandboxes: Option<Vec<StatusIdleSandbox>>,
+    #[serde(default)]
+    idle_sandboxes: Vec<StatusIdleSandbox>,
     #[serde(default)]
     pub(crate) proxy_port: Option<u16>,
     #[serde(default)]
@@ -97,17 +97,8 @@ pub(crate) struct StatusForDoctor {
 
 impl StatusForDoctor {
     pub(crate) fn idle_sandboxes(&self) -> &[StatusIdleSandbox] {
-        self.idle_sandboxes.as_deref().unwrap_or(&[])
+        &self.idle_sandboxes
     }
-}
-
-fn deserialize_present_idle_sandboxes<'de, D>(
-    deserializer: D,
-) -> Result<Option<Vec<StatusIdleSandbox>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    Vec::deserialize(deserializer).map(Some)
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/runner/src/status_file.rs
+++ b/crates/runner/src/status_file.rs
@@ -89,8 +89,6 @@ pub(crate) struct StatusForDoctor {
     pub(crate) started_at: String,
     #[serde(default, deserialize_with = "deserialize_present_idle_sandboxes")]
     idle_sandboxes: Option<Vec<StatusIdleSandbox>>,
-    #[serde(default, rename = "idle_vms")]
-    legacy_idle_sandboxes: Vec<StatusIdleSandbox>,
     #[serde(default)]
     pub(crate) proxy_port: Option<u16>,
     #[serde(default)]
@@ -99,9 +97,7 @@ pub(crate) struct StatusForDoctor {
 
 impl StatusForDoctor {
     pub(crate) fn idle_sandboxes(&self) -> &[StatusIdleSandbox] {
-        self.idle_sandboxes
-            .as_deref()
-            .unwrap_or(&self.legacy_idle_sandboxes)
+        self.idle_sandboxes.as_deref().unwrap_or(&[])
     }
 }
 
@@ -217,65 +213,50 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn doctor_idle_sandbox_fields_follow_compatibility_precedence() {
-        let cases = [
-            (
-                "legacy only",
-                r#""idle_vms":[{"reuse_key":"legacy","sandbox_id":"sandbox-legacy"}]"#,
-                &["legacy"][..],
-            ),
-            (
-                "mirrored",
-                r#""idle_sandboxes":[{"reuse_key":"canonical","sandbox_id":"sandbox-canonical"}],"idle_vms":[{"reuse_key":"legacy","sandbox_id":"sandbox-legacy"}]"#,
-                &["canonical"][..],
-            ),
-            (
-                "canonical only",
-                r#""idle_sandboxes":[{"reuse_key":"canonical","sandbox_id":"sandbox-canonical"}]"#,
-                &["canonical"][..],
-            ),
-            (
-                "canonical empty",
-                r#""idle_sandboxes":[],"idle_vms":[{"reuse_key":"legacy","sandbox_id":"sandbox-legacy"}]"#,
-                &[][..],
-            ),
-            ("neither", "", &[][..]),
-        ];
+    async fn doctor_defaults_omitted_idle_sandboxes_to_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        tokio::fs::write(
+            dir.path().join("status.json"),
+            r#"{"mode":"running","started_at":"2026-04-13T00:00:00.000Z"}"#,
+        )
+        .await
+        .unwrap();
 
-        for (name, idle_fields, expected_reuse_keys) in cases {
-            let dir = tempfile::tempdir().unwrap();
-            let separator = if idle_fields.is_empty() { "" } else { "," };
-            let content = format!(
-                r#"{{"mode":"running","started_at":"2026-04-13T00:00:00.000Z"{separator}{idle_fields}}}"#
-            );
-            tokio::fs::write(dir.path().join("status.json"), content)
-                .await
-                .unwrap();
+        let status = read_as::<StatusForDoctor>(dir.path())
+            .await
+            .unwrap()
+            .unwrap();
 
-            let status = read_as::<StatusForDoctor>(dir.path())
-                .await
-                .unwrap()
-                .unwrap();
-            let reuse_keys: Vec<&str> = status
-                .idle_sandboxes()
-                .iter()
-                .map(|sandbox| sandbox.reuse_key.as_str())
-                .collect();
-
-            assert_eq!(reuse_keys, expected_reuse_keys, "{name}");
-        }
+        assert!(status.idle_sandboxes().is_empty());
     }
 
     #[tokio::test]
-    async fn doctor_rejects_malformed_present_canonical_idle_sandboxes() {
+    async fn doctor_accepts_explicit_empty_idle_sandboxes() {
+        let dir = tempfile::tempdir().unwrap();
+        tokio::fs::write(
+            dir.path().join("status.json"),
+            r#"{"mode":"running","started_at":"2026-04-13T00:00:00.000Z","idle_sandboxes":[]}"#,
+        )
+        .await
+        .unwrap();
+
+        let status = read_as::<StatusForDoctor>(dir.path())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(status.idle_sandboxes().is_empty());
+    }
+
+    #[tokio::test]
+    async fn doctor_rejects_malformed_present_idle_sandboxes() {
         let dir = tempfile::tempdir().unwrap();
         tokio::fs::write(
             dir.path().join("status.json"),
             r#"{
                 "mode":"running",
                 "started_at":"2026-04-13T00:00:00.000Z",
-                "idle_sandboxes":null,
-                "idle_vms":[{"reuse_key":"legacy","sandbox_id":"sandbox-legacy"}]
+                "idle_sandboxes":null
             }"#,
         )
         .await

--- a/crates/sandbox-fc/src/network/pool/types.rs
+++ b/crates/sandbox-fc/src/network/pool/types.rs
@@ -13,7 +13,7 @@ pub struct NetnsInfo {
     /// Host-side veth device name (e.g. `vm0-ve-00-00`).
     pub(super) host_device: String,
     /// Veth namespace-side IP (e.g. `10.200.0.2`). This is the source IP
-    /// that the proxy sees after NAT, used as the VM registry key.
+    /// that the proxy sees after NAT, used as the sandbox registry key.
     pub(super) peer_ip: String,
 }
 
@@ -36,7 +36,7 @@ impl NetnsInfo {
         &self.host_device
     }
 
-    /// Returns the namespace-side veth IP used to identify the VM behind NAT.
+    /// Returns the namespace-side veth IP used to identify the sandbox behind NAT.
     pub fn peer_ip(&self) -> &str {
         &self.peer_ip
     }

--- a/crates/sandbox/src/runtime.rs
+++ b/crates/sandbox/src/runtime.rs
@@ -27,7 +27,7 @@ pub trait SandboxRuntime: Send + Sync {
 
     /// Return the host interface pattern that runner-managed DNS should bind.
     ///
-    /// Backends that create VM-facing host interfaces can return a scoped
+    /// Backends that create sandbox-facing host interfaces can return a scoped
     /// pattern here so dnsmasq avoids listening on unrelated host interfaces.
     /// When this returns a pattern, the caller must start DNS and call
     /// [`Self::activate_dns_readiness`] before creating factories.

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -498,7 +498,7 @@ pub trait SandboxFinalExecParkObserver: Send {
 /// Production backends must make dropping an active sandbox a best-effort
 /// emergency cleanup path. If runner-side code unwinds before calling
 /// [`SandboxFactory::destroy()`](crate::SandboxFactory::destroy), `Drop`
-/// must not silently leave a VM process and associated host resources alive.
+/// must not silently leave a backing process and associated host resources alive.
 /// This fallback is only a safety net: callers must not treat drop-triggered
 /// cleanup as proof that explicit destroy completed.
 #[async_trait]
@@ -509,7 +509,7 @@ pub trait Sandbox: Send + Sync + Any {
     /// process. Used in logs, metrics, and socket/path derivation.
     fn id(&self) -> &str;
     /// The network-visible source IP address for this sandbox.
-    /// Used as the key for proxy VM registration.
+    /// Used as the key for proxy sandbox registration.
     fn source_ip(&self) -> &str;
     /// Host-side PID of the sandbox backing process (e.g. firecracker).
     /// Used for host diagnostics like OOM detection.

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -231,7 +231,7 @@ fn handle_quiesce_operations(
 
     match operation_state.enter_quiescing() {
         // Quiescing atomically fences new guest operations. Once pending is
-        // zero, this is the final race-free boundary before the VM is parked.
+        // zero, this is the final race-free boundary before the sandbox is parked.
         QuiesceResult::Quiesced => {
             match verify_exec_process_containment_empty(process_containment_mode) {
                 Ok(()) => send_empty_response(MSG_OPERATIONS_QUIESCED, seq, writer),

--- a/crates/vsock-guest/src/shell_command.rs
+++ b/crates/vsock-guest/src/shell_command.rs
@@ -14,7 +14,7 @@
 //! loading the root-owned system profile, production `sudo` commands run as
 //! root, and debug/test-support builds run as the current user unless `sudo`
 //! requests the local `sudo sh -c` wrapper. The production wrapper must stay
-//! non-login: sandbox-owned profile files may persist across VM reuse and must
+//! non-login: sandbox-owned profile files may persist across sandbox reuse and must
 //! never run before the trusted command bootstrap.
 //!
 //! The env-script path is one security boundary. Env keys must be shell

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -167,10 +167,10 @@ status writer, and the independently deployed host monitoring collector scans
 every versioned runner directory. Status schema changes must cover those
 old/new combinations rather than treating the file as process-private state.
 
-Current status writers, maintenance readers, and the host monitoring collector
-use `idle_sandboxes` and omit the field when the collection is empty. A status
-file without the canonical collection is treated as containing no idle
-sandboxes by current consumers.
+Current status writers publish `idle_sandboxes` and omit the field when the
+collection is empty. Current maintenance readers and the host monitoring
+collector read only `idle_sandboxes`; a status file without the canonical
+collection is treated as containing no idle sandboxes.
 
 The proxy registry and embedded mitm-addon are also a runner-private contract.
 The runner binary embeds the addon sources, recreates the addon directory and

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -167,11 +167,10 @@ status writer, and the independently deployed host monitoring collector scans
 every versioned runner directory. Status schema changes must cover those
 old/new combinations rather than treating the file as process-private state.
 
-Current status writers publish `idle_sandboxes` only and omit the field when
-the collection is empty. Current maintenance readers and the host monitoring
-collector prefer `idle_sandboxes` by key presence and fall back to `idle_vms`
-only for retained legacy status files. They never concatenate both fields.
-`idle_vms` is read-only historical compatibility, not a current writer field.
+Current status writers, maintenance readers, and the host monitoring collector
+use `idle_sandboxes` and omit the field when the collection is empty. A status
+file without the canonical collection is treated as containing no idle
+sandboxes by current consumers.
 
 The proxy registry and embedded mitm-addon are also a runner-private contract.
 The runner binary embeds the addon sources, recreates the addon directory and

--- a/docs/testing/anti-patterns.md
+++ b/docs/testing/anti-patterns.md
@@ -97,13 +97,13 @@ afterEach(() => {
 
 it("should write file", () => {
   const testPath = join(tempDir, "registry.json");
-  const registry = new VMRegistry(testPath);
+  const registry = new SandboxRegistry(testPath);
 
   registry.register("172.16.0.2", "run-123", "token-abc");
 
   // Verify actual file was written
   const content = JSON.parse(readFileSync(testPath, "utf-8"));
-  expect(content.vms["172.16.0.2"]).toMatchObject({
+  expect(content.sandboxes["172.16.0.2"]).toMatchObject({
     runId: "run-123",
     sandboxToken: "token-abc",
   });

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -226,7 +226,7 @@ cmd_exec() {
   COMMAND="${3:?Usage: $0 exec <run-id> <command...>}"
   shift 3
   COMMAND="$COMMAND $*"
-  log "Executing in VM $RUN_ID: $COMMAND"
+  log "Executing in sandbox $RUN_ID: $COMMAND"
   ESCAPED_COMMAND=$(printf '%q' "$COMMAND")
   ssh_cmd "$RUNNER_BIN exec $RUN_ID -- $ESCAPED_COMMAND"
 }

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -442,7 +442,7 @@ const webhookCompleteBodySchema = z
     error: z.string().optional(),
     lastEventSequence: eventSequenceNumberSchema.optional(),
     // Sandbox id the run executed against. Optional because a run that fails
-    // before VM creation has no sandbox. Persisted to agent_runs.sandbox_id;
+    // before sandbox creation has no sandbox. Persisted to agent_runs.sandbox_id;
     // the 255-char cap matches the DB column (defense in depth).
     sandboxId: z.string().max(255).optional(),
     sandboxReuseResult: sandboxReuseResultSchema.optional(),


### PR DESCRIPTION
## Summary

- Remove the retired `idle_vms` fallback from the runner maintenance reader and host monitoring collector, and remove migration-only tests for retired status and proxy-registry keys.
- Finish the semantic VM-to-sandbox audit for provider-neutral runner lifecycle helpers, tests, behavior markers, operator output, generic contracts, current documentation, and the API latency action.
- Preserve concrete Firecracker/KVM, guest VM, pause/snapshot/vCPU, vsock ABI, VM0 namespace, fixed-path, and historical terminology.

## Compatibility

- Current readers consume only `idle_sandboxes`. An omitted collection remains empty; a present malformed canonical collection remains invalid. Legacy-only status files no longer contribute idle entries.
- New telemetry emits `api_to_sandbox_start`. Historical rows remain `api_to_vm_start`; continuity queries spanning the deployment boundary should include both action names.
- No frontend/backend API, runner protocol, queue payload, or user workflow changes.

## Validation

- `cargo fmt --all --check`
- `CARGO_BUILD_JOBS=1 cargo test -p runner` — 3374 passed, 0 failed; guest inventory passed
- `CARGO_BUILD_JOBS=1 cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `CARGO_BUILD_JOBS=1 RUSTDOCFLAGS='-D warnings' cargo doc -p runner --no-deps`
- Monitoring collector integration test and affected shell syntax checks
- mitm-addon lock, Ruff, BasedPyright, and full pytest — 7194 passed
- `@okouai/api-contracts` formatting, lint, type-check, scoped Knip, and tests — 638 passed
- Final tracked-source semantic audit and `git diff --check`

Closes #30164
