### PR TITLE
fix(ci): use exact releases for rollback dashboard

### DIFF
--- a/.github/scripts/tests/resolve-production-rollback-target-test.sh
+++ b/.github/scripts/tests/resolve-production-rollback-target-test.sh
@@ -459,11 +459,13 @@ ruby -e '
 
   expected_target = "$" + "{{ needs.release-please.outputs.release_target }}"
   expected_tags = "$" + "{{ needs.release-please.outputs.release_tags }}"
+  workflow_source = "$" + "{{ github.sha }}"
   desktop_target = "desktop-v" + "$" + "{{ needs.release-please.outputs.desktop_version }}"
   checkout_ref_exceptions = {
     "queue-production-deploy" => "main",
     "refresh-release-pull-request" => "main",
     "publish-desktop-update-manifest" => desktop_target,
+    "update-rollback-dashboard" => workflow_source,
   }
   release.each do |job_name, job|
     checkout_steps = job.fetch("steps", []).select do |step|

--- a/.github/scripts/tests/resolve-production-rollback-target-test.sh
+++ b/.github/scripts/tests/resolve-production-rollback-target-test.sh
@@ -287,6 +287,110 @@ assert_failure \
   bash "$release_target_script"
 [ ! -s "$multiple_release_target_output" ] || fail "ambiguous release SHAs must not publish an output"
 
+release_tags_script="${tmp_dir}/resolve-release-tags.sh"
+ruby -e '
+  require "json"
+  require "yaml"
+  workflow = YAML.safe_load(File.read(ARGV[0]), aliases: true)
+  release_job = workflow.fetch("jobs").fetch("release-please")
+  release_tags_step = release_job.fetch("steps").find { |step| step["id"] == "release-tags" }
+  raise "missing current release tag resolver step" unless release_tags_step
+
+  resolver_env = release_tags_step.fetch("env")
+  unless resolver_env.keys == ["RELEASE_TAGS", "DESKTOP_RELEASE_CREATED", "DESKTOP_VERSION"]
+    raise "release tag resolver environment has unexpected inputs"
+  end
+
+  projection = resolver_env.fetch("RELEASE_TAGS")
+  projected_paths = projection.scan(/steps\.release\.outputs\[\x27([^\x27]+)--tag_name\x27\]/).flatten
+  output_reference_count = projection.scan(/steps\.release\.outputs/).length
+  unless output_reference_count == projected_paths.length
+    raise "release bodies, changelogs, and complete outputs must not enter the release tag resolver environment"
+  end
+
+  configured_paths = JSON.parse(File.read(ARGV[1])).fetch("packages").keys
+  missing_paths = configured_paths - projected_paths
+  unknown_paths = projected_paths - configured_paths
+  duplicate_paths = projected_paths.group_by(&:itself).select { |_, paths| paths.length > 1 }.keys
+  unless missing_paths.empty? && unknown_paths.empty? && duplicate_paths.empty?
+    raise "release tag projection mismatch: missing=#{missing_paths.sort}, unknown=#{unknown_paths.sort}, duplicates=#{duplicate_paths.sort}"
+  end
+
+  desktop_release_created = "$" + "{{ steps.release.outputs[\x27turbo/apps/desktop--release_created\x27] }}"
+  desktop_version = "$" + "{{ steps.release.outputs[\x27turbo/apps/desktop--version\x27] }}"
+  unless resolver_env.fetch("DESKTOP_RELEASE_CREATED") == desktop_release_created &&
+      resolver_env.fetch("DESKTOP_VERSION") == desktop_version
+    raise "release tag resolver must derive the Okou Desktop tag from the Desktop release outputs"
+  end
+
+  puts release_tags_step.fetch("run")
+' \
+  "${repo_root}/.github/workflows/release-please.yml" \
+  "${repo_root}/release-please-config.json" \
+  >"$release_tags_script"
+
+release_tags_output="${tmp_dir}/release-tags.output"
+RELEASE_TAGS='[null,"","api-v1.2.3","app-v4.5.6"]' \
+  DESKTOP_RELEASE_CREATED='' \
+  DESKTOP_VERSION='' \
+  GITHUB_OUTPUT="$release_tags_output" \
+  bash "$release_tags_script"
+grep -Fqx 'tags=["api-v1.2.3","app-v4.5.6"]' "$release_tags_output" || \
+  fail "release tag resolver did not publish the current release tags"
+
+desktop_release_tags_output="${tmp_dir}/desktop-release-tags.output"
+RELEASE_TAGS='["desktop-v4.5.6"]' \
+  DESKTOP_RELEASE_CREATED=true \
+  DESKTOP_VERSION=4.5.6 \
+  GITHUB_OUTPUT="$desktop_release_tags_output" \
+  bash "$release_tags_script"
+grep -Fqx 'tags=["desktop-v4.5.6","okou-desktop-v4.5.6"]' "$desktop_release_tags_output" || \
+  fail "release tag resolver did not publish the derived Okou Desktop tag"
+
+missing_release_tags_output="${tmp_dir}/missing-release-tags.output"
+assert_failure \
+  "release-please returned no release tag" \
+  env \
+  RELEASE_TAGS='[null,""]' \
+  DESKTOP_RELEASE_CREATED='' \
+  DESKTOP_VERSION='' \
+  GITHUB_OUTPUT="$missing_release_tags_output" \
+  bash "$release_tags_script"
+[ ! -s "$missing_release_tags_output" ] || fail "missing release tags must not publish an output"
+
+non_string_release_tags_output="${tmp_dir}/non-string-release-tags.output"
+assert_failure \
+  "release-please returned non-string release tag" \
+  env \
+  RELEASE_TAGS='["api-v1.2.3",123]' \
+  DESKTOP_RELEASE_CREATED='' \
+  DESKTOP_VERSION='' \
+  GITHUB_OUTPUT="$non_string_release_tags_output" \
+  bash "$release_tags_script"
+[ ! -s "$non_string_release_tags_output" ] || fail "non-string release tags must not publish an output"
+
+invalid_release_tags_output="${tmp_dir}/invalid-release-tags.output"
+assert_failure \
+  "release-please returned invalid release tag" \
+  env \
+  RELEASE_TAGS='["not-a-version-tag"]' \
+  DESKTOP_RELEASE_CREATED='' \
+  DESKTOP_VERSION='' \
+  GITHUB_OUTPUT="$invalid_release_tags_output" \
+  bash "$release_tags_script"
+[ ! -s "$invalid_release_tags_output" ] || fail "invalid release tags must not publish an output"
+
+duplicate_release_tags_output="${tmp_dir}/duplicate-release-tags.output"
+assert_failure \
+  "release-please returned duplicate release tags: api-v1.2.3" \
+  env \
+  RELEASE_TAGS='["api-v1.2.3","api-v1.2.3"]' \
+  DESKTOP_RELEASE_CREATED='' \
+  DESKTOP_VERSION='' \
+  GITHUB_OUTPUT="$duplicate_release_tags_output" \
+  bash "$release_tags_script"
+[ ! -s "$duplicate_release_tags_output" ] || fail "duplicate release tags must not publish an output"
+
 ruby -e '
   require "yaml"
   rollback_config = YAML.safe_load(File.read(ARGV[0]), aliases: true)
@@ -349,9 +453,12 @@ ruby -e '
   raise "production queue must wait for release detection" unless queue_needs.include?("detect-release-commit")
   release_target_output = "$" + "{{ steps.release-target.outputs.sha }}"
   raise "release job must expose the resolved release target" unless release_job.fetch("outputs").fetch("release_target") == release_target_output
+  release_tags_output = "$" + "{{ steps.release-tags.outputs.tags }}"
+  raise "release job must expose the current release tags" unless release_job.fetch("outputs").fetch("release_tags") == release_tags_output
   raise "release workflow must not use the triggering workflow SHA as a release target" if File.read(ARGV[1]).include?("github.event.workflow_run.head_sha")
 
   expected_target = "$" + "{{ needs.release-please.outputs.release_target }}"
+  expected_tags = "$" + "{{ needs.release-please.outputs.release_tags }}"
   desktop_target = "desktop-v" + "$" + "{{ needs.release-please.outputs.desktop_version }}"
   checkout_ref_exceptions = {
     "queue-production-deploy" => "main",
@@ -377,7 +484,17 @@ ruby -e '
   schema_step = release.fetch("deploy-api-schema").fetch("steps").find { |step| step["name"] == "Publish Runtime API Schema" }
   raise "Runtime API Schema must use the resolved release target" unless schema_step.fetch("env").fetch("RELEASE_SHA") == expected_target
   dashboard_step = release.fetch("update-rollback-dashboard").fetch("steps").find { |step| step["name"] == "Update rollback dashboard issue" }
+  dashboard_job = release.fetch("update-rollback-dashboard")
+  dashboard_needs = Array(dashboard_job.fetch("needs"))
+  raise "rollback dashboard must wait for Desktop promotion" unless dashboard_needs.include?("promote-desktop-release")
+  dashboard_condition = dashboard_job.fetch("if")
+  unless dashboard_condition.include?("needs.release-please.outputs.desktop_release_created != \x27true\x27") &&
+      dashboard_condition.include?("needs.promote-desktop-release.result == \x27success\x27")
+    raise "rollback dashboard must require successful applicable Desktop promotion"
+  end
   raise "rollback dashboard must use the resolved release target" unless dashboard_step.fetch("env").fetch("RELEASE_TARGET") == expected_target
+  raise "rollback dashboard must use the current release tags" unless dashboard_step.fetch("env").fetch("RELEASE_TAGS") == expected_tags
+  raise "rollback dashboard must pass the current release tags to the helper" unless dashboard_step.fetch("run").include?("\"$RELEASE_TAGS\"")
 
   artifact_fetch_helper = "fetch-okou-app-artifact.sh"
   release_app_step = release.fetch("promote-app-production").fetch("steps").find { |step| step["id"] == "pages-production" }

--- a/.github/scripts/tests/resolve-production-rollback-target-test.sh
+++ b/.github/scripts/tests/resolve-production-rollback-target-test.sh
@@ -464,7 +464,6 @@ ruby -e '
     "queue-production-deploy" => "main",
     "refresh-release-pull-request" => "main",
     "publish-desktop-update-manifest" => desktop_target,
-    "update-rollback-dashboard" => "main",
   }
   release.each do |job_name, job|
     checkout_steps = job.fetch("steps", []).select do |step|

--- a/.github/scripts/tests/update-rollback-dashboard-body-test.sh
+++ b/.github/scripts/tests/update-rollback-dashboard-body-test.sh
@@ -354,12 +354,12 @@ if PATH="${fake_bin}:$PATH" \
   GITHUB_REPOSITORY=vm0-ai/vm0 \
   MOCK_RELEASES_FILE="$releases_file" \
   "$TARGET" "$body_file" "$target_commit" "$rollback_url" \
-  '["missing-v1.0.0"]' \
+  '["app-v1.2.3","missing-v1.0.0"]' \
   >"${tmp_dir}/unavailable.out" 2>"${tmp_dir}/unavailable.err"; then
-  fail "unavailable release tag should fail"
+  fail "partially unavailable release tags should fail"
 fi
 if [ -s "${tmp_dir}/unavailable.out" ]; then
-  fail "unavailable release tag produced a partial dashboard"
+  fail "partially unavailable release tags produced a partial dashboard"
 fi
 
 echo "update-rollback-dashboard-body tests passed"

--- a/.github/scripts/tests/update-rollback-dashboard-body-test.sh
+++ b/.github/scripts/tests/update-rollback-dashboard-body-test.sh
@@ -18,15 +18,27 @@ cat >"${fake_bin}/gh" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 [ "${1:-}" = "api" ]
-release_prefix=repos/vm0-ai/vm0/releases/tags/
-[[ "${2:-}" == "${release_prefix}"* ]]
-release_tag=${2#"$release_prefix"}
-jq -e --arg release_tag "$release_tag" \
-  --arg returned_tag "${MOCK_RETURNED_RELEASE_TAG:-}" \
-  '.[]
-   | select(.tag_name == $release_tag)
-   | if $returned_tag == "" then . else .tag_name = $returned_tag end' \
-  "$MOCK_RELEASES_FILE"
+if [ -n "${MOCK_GH_LOG:-}" ]; then
+  printf '%s\n' "${2:-}" >>"$MOCK_GH_LOG"
+fi
+case "${2:-}" in
+  repos/vm0-ai/vm0/releases\?per_page=100)
+    jq . "$MOCK_RELEASES_FILE"
+    ;;
+  repos/vm0-ai/vm0/releases/tags/*)
+    release_prefix=repos/vm0-ai/vm0/releases/tags/
+    release_tag=${2#"$release_prefix"}
+    jq -e --arg release_tag "$release_tag" \
+      --arg returned_tag "${MOCK_RETURNED_RELEASE_TAG:-}" \
+      '.[]
+       | select(.tag_name == $release_tag)
+       | if $returned_tag == "" then . else .tag_name = $returned_tag end' \
+      "$MOCK_RELEASES_FILE"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
 SH
 chmod +x "${fake_bin}/gh"
 
@@ -133,11 +145,33 @@ jq -n --arg target "$target_commit" '[
   }
 ]' >"$releases_file"
 
+exact_lookup_log="${tmp_dir}/exact-lookups.log"
 PATH="${fake_bin}:$PATH" \
   GITHUB_REPOSITORY=vm0-ai/vm0 \
+  MOCK_GH_LOG="$exact_lookup_log" \
   MOCK_RELEASES_FILE="$releases_file" \
   "$TARGET" "$body_file" "$target_commit" "$rollback_url" \
   "$(release_tags_for_target "$target_commit")" >"$output_file"
+if grep -Fqx \
+  'repos/vm0-ai/vm0/releases?per_page=100' \
+  "$exact_lookup_log"; then
+  fail "exact-tag invocation listed repository releases"
+fi
+
+legacy_output_file="${tmp_dir}/legacy-output.md"
+legacy_lookup_log="${tmp_dir}/legacy-lookups.log"
+PATH="${fake_bin}:$PATH" \
+  GITHUB_REPOSITORY=vm0-ai/vm0 \
+  MOCK_GH_LOG="$legacy_lookup_log" \
+  MOCK_RELEASES_FILE="$releases_file" \
+  "$TARGET" "$body_file" "$target_commit" "$rollback_url" \
+  >"$legacy_output_file"
+cmp "$output_file" "$legacy_output_file" || \
+  fail "legacy workflow invocation did not preserve dashboard output"
+grep -Fqx \
+  'repos/vm0-ai/vm0/releases?per_page=100' \
+  "$legacy_lookup_log" || \
+  fail "legacy workflow invocation did not use compatibility discovery"
 
 grep -Fqx -- "[Rollback](${rollback_url})" "$output_file"
 grep -Fqx -- "<summary>07-23-2026 07:39:40 SGT</summary>" "$output_file"

--- a/.github/scripts/tests/update-rollback-dashboard-body-test.sh
+++ b/.github/scripts/tests/update-rollback-dashboard-body-test.sh
@@ -18,27 +18,15 @@ cat >"${fake_bin}/gh" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 [ "${1:-}" = "api" ]
-if [ -n "${MOCK_GH_LOG:-}" ]; then
-  printf '%s\n' "${2:-}" >>"$MOCK_GH_LOG"
-fi
-case "${2:-}" in
-  repos/vm0-ai/vm0/releases\?per_page=100)
-    jq . "$MOCK_RELEASES_FILE"
-    ;;
-  repos/vm0-ai/vm0/releases/tags/*)
-    release_prefix=repos/vm0-ai/vm0/releases/tags/
-    release_tag=${2#"$release_prefix"}
-    jq -e --arg release_tag "$release_tag" \
-      --arg returned_tag "${MOCK_RETURNED_RELEASE_TAG:-}" \
-      '.[]
-       | select(.tag_name == $release_tag)
-       | if $returned_tag == "" then . else .tag_name = $returned_tag end' \
-      "$MOCK_RELEASES_FILE"
-    ;;
-  *)
-    exit 2
-    ;;
-esac
+release_prefix=repos/vm0-ai/vm0/releases/tags/
+[[ "${2:-}" == "${release_prefix}"* ]]
+release_tag=${2#"$release_prefix"}
+jq -e --arg release_tag "$release_tag" \
+  --arg returned_tag "${MOCK_RETURNED_RELEASE_TAG:-}" \
+  '.[]
+   | select(.tag_name == $release_tag)
+   | if $returned_tag == "" then . else .tag_name = $returned_tag end' \
+  "$MOCK_RELEASES_FILE"
 SH
 chmod +x "${fake_bin}/gh"
 
@@ -145,33 +133,11 @@ jq -n --arg target "$target_commit" '[
   }
 ]' >"$releases_file"
 
-exact_lookup_log="${tmp_dir}/exact-lookups.log"
 PATH="${fake_bin}:$PATH" \
   GITHUB_REPOSITORY=vm0-ai/vm0 \
-  MOCK_GH_LOG="$exact_lookup_log" \
   MOCK_RELEASES_FILE="$releases_file" \
   "$TARGET" "$body_file" "$target_commit" "$rollback_url" \
   "$(release_tags_for_target "$target_commit")" >"$output_file"
-if grep -Fqx \
-  'repos/vm0-ai/vm0/releases?per_page=100' \
-  "$exact_lookup_log"; then
-  fail "exact-tag invocation listed repository releases"
-fi
-
-legacy_output_file="${tmp_dir}/legacy-output.md"
-legacy_lookup_log="${tmp_dir}/legacy-lookups.log"
-PATH="${fake_bin}:$PATH" \
-  GITHUB_REPOSITORY=vm0-ai/vm0 \
-  MOCK_GH_LOG="$legacy_lookup_log" \
-  MOCK_RELEASES_FILE="$releases_file" \
-  "$TARGET" "$body_file" "$target_commit" "$rollback_url" \
-  >"$legacy_output_file"
-cmp "$output_file" "$legacy_output_file" || \
-  fail "legacy workflow invocation did not preserve dashboard output"
-grep -Fqx \
-  'repos/vm0-ai/vm0/releases?per_page=100' \
-  "$legacy_lookup_log" || \
-  fail "legacy workflow invocation did not use compatibility discovery"
 
 grep -Fqx -- "[Rollback](${rollback_url})" "$output_file"
 grep -Fqx -- "<summary>07-23-2026 07:39:40 SGT</summary>" "$output_file"

--- a/.github/scripts/tests/update-rollback-dashboard-body-test.sh
+++ b/.github/scripts/tests/update-rollback-dashboard-body-test.sh
@@ -18,8 +18,15 @@ cat >"${fake_bin}/gh" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 [ "${1:-}" = "api" ]
-[ "${2:-}" = "repos/vm0-ai/vm0/releases?per_page=100" ]
-jq . "$MOCK_RELEASES_FILE"
+release_prefix=repos/vm0-ai/vm0/releases/tags/
+[[ "${2:-}" == "${release_prefix}"* ]]
+release_tag=${2#"$release_prefix"}
+jq -e --arg release_tag "$release_tag" \
+  --arg returned_tag "${MOCK_RETURNED_RELEASE_TAG:-}" \
+  '.[]
+   | select(.tag_name == $release_tag)
+   | if $returned_tag == "" then . else .tag_name = $returned_tag end' \
+  "$MOCK_RELEASES_FILE"
 SH
 chmod +x "${fake_bin}/gh"
 
@@ -27,6 +34,17 @@ body_file="${tmp_dir}/body.md"
 output_file="${tmp_dir}/output.md"
 releases_file="${tmp_dir}/releases.json"
 rollback_url=https://github.com/vm0-ai/vm0/actions/workflows/rollback-production.yml
+
+release_tags_from_file() {
+  jq -c '[.[].tag_name]' "$releases_file"
+}
+
+release_tags_for_target() {
+  local target=$1
+  jq -c --arg target "$target" \
+    '[.[] | select(.target_commitish == $target) | .tag_name]' \
+    "$releases_file"
+}
 
 cat >"$body_file" <<'EOF'
 This issue is automatically maintained by CI. Do not edit manually.
@@ -100,6 +118,13 @@ jq -n --arg target "$target_commit" '[
     body: "## [0.618.0](https://example.test/app) (2026-07-22)\n\n### Features\n\n* app feature\n\n### Dependencies\n\n* app dependency"
   },
   {
+    tag_name: "okou-desktop-v0.618.0",
+    target_commitish: $target,
+    html_url: "https://github.com/vm0-ai/vm0/releases/tag/okou-desktop-v0.618.0",
+    published_at: "2026-07-22T23:39:35Z",
+    body: "Signed and notarized Okou release"
+  },
+  {
     tag_name: "unrelated-v9.9.9",
     target_commitish: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     html_url: "https://example.test/unrelated",
@@ -111,7 +136,8 @@ jq -n --arg target "$target_commit" '[
 PATH="${fake_bin}:$PATH" \
   GITHUB_REPOSITORY=vm0-ai/vm0 \
   MOCK_RELEASES_FILE="$releases_file" \
-  "$TARGET" "$body_file" "$target_commit" "$rollback_url" >"$output_file"
+  "$TARGET" "$body_file" "$target_commit" "$rollback_url" \
+  "$(release_tags_for_target "$target_commit")" >"$output_file"
 
 grep -Fqx -- "[Rollback](${rollback_url})" "$output_file"
 grep -Fqx -- "<summary>07-23-2026 07:39:40 SGT</summary>" "$output_file"
@@ -120,6 +146,7 @@ grep -Fqx -- "* PDT 07-22-2026 16:39:40" "$output_file"
 grep -Fqx -- "### [app](https://github.com/vm0-ai/vm0/releases/tag/app-v0.618.0): \`0.618.0\`" "$output_file"
 grep -Fqx -- "### [api](https://github.com/vm0-ai/vm0/releases/tag/api-v1.303.0): \`1.303.0\`" "$output_file"
 grep -Fqx -- "### [runner-rs](https://github.com/vm0-ai/vm0/releases/tag/runner-rs-v0.147.2): \`0.147.2\`" "$output_file"
+grep -Fqx -- "### [okou-desktop](https://github.com/vm0-ai/vm0/releases/tag/okou-desktop-v0.618.0): \`0.618.0\`" "$output_file"
 grep -Fqx -- "### [core](https://github.com/vm0-ai/vm0/releases/tag/core-v8.452.0): \`8.452.0\`" "$output_file"
 grep -Fqx -- "### [zeta](https://github.com/vm0-ai/vm0/releases/tag/zeta-v2.0.0): \`2.0.0\`" "$output_file"
 grep -Fqx -- "#### Features" "$output_file"
@@ -142,11 +169,13 @@ app_line=$(grep -n '^### \[app\]' "$output_file" | cut -d: -f1)
 api_line=$(grep -n '^### \[api\]' "$output_file" | cut -d: -f1)
 runner_line=$(grep -n '^### \[runner-rs\]' "$output_file" | cut -d: -f1)
 core_line=$(grep -n '^### \[core\]' "$output_file" | cut -d: -f1)
+okou_desktop_line=$(grep -n '^### \[okou-desktop\]' "$output_file" | cut -d: -f1)
 zeta_line=$(grep -n '^### \[zeta\]' "$output_file" | cut -d: -f1)
 if ! [ "$app_line" -lt "$api_line" ] || \
   ! [ "$api_line" -lt "$runner_line" ] || \
   ! [ "$runner_line" -lt "$core_line" ] || \
-  ! [ "$core_line" -lt "$zeta_line" ]; then
+  ! [ "$core_line" -lt "$okou_desktop_line" ] || \
+  ! [ "$okou_desktop_line" -lt "$zeta_line" ]; then
   fail "release artifacts are not ordered by production priority"
 fi
 
@@ -169,7 +198,7 @@ if grep -Fq '#### Dependencies' "$output_file" || \
   grep -Fq 'trailing dependency' "$output_file"; then
   fail "dependency-only changelog sections were not removed"
 fi
-if sed -n '/^### \[core\]/,/^### \[zeta\]/p' "$output_file" |
+if sed -n '/^### \[core\]/,/^### \[okou-desktop\]/p' "$output_file" |
   grep -Fq '**Change Log**'; then
   fail "dependency-only release retained an empty changelog heading"
 fi
@@ -209,7 +238,8 @@ for digit in 2 3 4 5 6 7 8; do
   PATH="${fake_bin}:$PATH" \
     GITHUB_REPOSITORY=vm0-ai/vm0 \
     MOCK_RELEASES_FILE="$releases_file" \
-    "$TARGET" "$output_file" "$commit" "$rollback_url" >"${output_file}.next"
+    "$TARGET" "$output_file" "$commit" "$rollback_url" \
+    "$(release_tags_for_target "$commit")" >"${output_file}.next"
   mv "${output_file}.next" "$output_file"
 done
 
@@ -232,7 +262,8 @@ write_single_release "$latest_commit" "2026-07-22T23:39:48Z"
 PATH="${fake_bin}:$PATH" \
   GITHUB_REPOSITORY=vm0-ai/vm0 \
   MOCK_RELEASES_FILE="$releases_file" \
-  "$TARGET" "$output_file" "$latest_commit" "$rollback_url" >"${output_file}.next"
+  "$TARGET" "$output_file" "$latest_commit" "$rollback_url" \
+  "$(release_tags_for_target "$latest_commit")" >"${output_file}.next"
 duplicate_count=$(grep -c "ROLLBACK_ENTRY_START ${latest_commit}" "${output_file}.next")
 if [ "$duplicate_count" -ne 1 ]; then
   fail "duplicate target commit was not collapsed"
@@ -248,7 +279,8 @@ for digit in 1 2 3 4 5 6 7; do
   PATH="${fake_bin}:$PATH" \
     GITHUB_REPOSITORY=vm0-ai/vm0 \
     MOCK_RELEASES_FILE="$releases_file" \
-    "$TARGET" "$body_file" "$commit" "$rollback_url" >"${body_file}.next"
+    "$TARGET" "$body_file" "$commit" "$rollback_url" \
+    "$(release_tags_for_target "$commit")" >"${body_file}.next"
   mv "${body_file}.next" "$body_file"
 done
 
@@ -278,9 +310,56 @@ if PATH="${fake_bin}:$PATH" \
   GITHUB_REPOSITORY=vm0-ai/vm0 \
   MOCK_RELEASES_FILE="$releases_file" \
   "$TARGET" "$body_file" "$target_commit" "$rollback_url" \
+  "$(release_tags_from_file)" \
   >"${tmp_dir}/missing.out" 2>"${tmp_dir}/missing.err"; then
   fail "missing release artifacts should fail"
 fi
-grep -Fq "No release artifacts found for target ${target_commit}" "${tmp_dir}/missing.err"
+grep -Fq "Release artifacts do not all target ${target_commit}" "${tmp_dir}/missing.err"
+
+if PATH="${fake_bin}:$PATH" \
+  GITHUB_REPOSITORY=vm0-ai/vm0 \
+  MOCK_RELEASES_FILE="$releases_file" \
+  MOCK_RETURNED_RELEASE_TAG=other-v1.2.3 \
+  "$TARGET" "$body_file" \
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  "$rollback_url" \
+  '["app-v1.2.3"]' \
+  >"${tmp_dir}/wrong-tag.out" 2>"${tmp_dir}/wrong-tag.err"; then
+  fail "mismatched release tag should fail"
+fi
+grep -Fq \
+  "Release artifacts do not match the requested release tags" \
+  "${tmp_dir}/wrong-tag.err"
+
+for invalid_release_tags in \
+  '[]' \
+  '[123]' \
+  '["not-a-version-tag"]' \
+  '["app-v1.2.3","app-v1.2.3"]' \
+  'not-json'; do
+  if PATH="${fake_bin}:$PATH" \
+    GITHUB_REPOSITORY=vm0-ai/vm0 \
+    MOCK_RELEASES_FILE="$releases_file" \
+    "$TARGET" "$body_file" "$target_commit" "$rollback_url" \
+    "$invalid_release_tags" \
+    >"${tmp_dir}/invalid-tags.out" 2>"${tmp_dir}/invalid-tags.err"; then
+    fail "invalid release tag input should fail"
+  fi
+  grep -Fq \
+    "release tags must be a non-empty JSON array of unique version tags" \
+    "${tmp_dir}/invalid-tags.err"
+done
+
+if PATH="${fake_bin}:$PATH" \
+  GITHUB_REPOSITORY=vm0-ai/vm0 \
+  MOCK_RELEASES_FILE="$releases_file" \
+  "$TARGET" "$body_file" "$target_commit" "$rollback_url" \
+  '["missing-v1.0.0"]' \
+  >"${tmp_dir}/unavailable.out" 2>"${tmp_dir}/unavailable.err"; then
+  fail "unavailable release tag should fail"
+fi
+if [ -s "${tmp_dir}/unavailable.out" ]; then
+  fail "unavailable release tag produced a partial dashboard"
+fi
 
 echo "update-rollback-dashboard-body tests passed"

--- a/.github/scripts/update-rollback-dashboard-body.sh
+++ b/.github/scripts/update-rollback-dashboard-body.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -ne 3 ] && [ "$#" -ne 4 ]; then
-  echo "usage: update-rollback-dashboard-body.sh BODY_FILE TARGET_COMMIT ROLLBACK_URL [RELEASE_TAGS_JSON]" >&2
+if [ "$#" -ne 4 ]; then
+  echo "usage: update-rollback-dashboard-body.sh BODY_FILE TARGET_COMMIT ROLLBACK_URL RELEASE_TAGS_JSON" >&2
   exit 2
 fi
 
 body_file=$1
 target_commit=$2
 rollback_url=$3
+release_tags=$4
 
 if [[ ! "$target_commit" =~ ^[0-9a-f]{40}$ ]]; then
   echo "target commit must be a full lowercase SHA-1: $target_commit" >&2
@@ -16,29 +17,6 @@ if [[ ! "$target_commit" =~ ^[0-9a-f]{40}$ ]]; then
 fi
 
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
-
-if [ "$#" -eq 3 ]; then
-  # TODO(#30182): Remove this pre-#30180 workflow compatibility path after
-  # every release workflow started before the merge has exceeded its lifetime.
-  release_tags=$(
-    gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
-      jq -ce --arg target "$target_commit" '
-        [
-          .[]
-          | select(.target_commitish == $target)
-          | .tag_name
-          | select(test("^.+-v[0-9]"))
-        ]
-        | if length == 0 then
-            error("No release artifacts found for target " + $target)
-          else
-            .
-          end
-      '
-  )
-else
-  release_tags=$4
-fi
 
 jq -e '
   type == "array" and

--- a/.github/scripts/update-rollback-dashboard-body.sh
+++ b/.github/scripts/update-rollback-dashboard-body.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -ne 4 ]; then
-  echo "usage: update-rollback-dashboard-body.sh BODY_FILE TARGET_COMMIT ROLLBACK_URL RELEASE_TAGS_JSON" >&2
+if [ "$#" -ne 3 ] && [ "$#" -ne 4 ]; then
+  echo "usage: update-rollback-dashboard-body.sh BODY_FILE TARGET_COMMIT ROLLBACK_URL [RELEASE_TAGS_JSON]" >&2
   exit 2
 fi
 
 body_file=$1
 target_commit=$2
 rollback_url=$3
-release_tags=$4
 
 if [[ ! "$target_commit" =~ ^[0-9a-f]{40}$ ]]; then
   echo "target commit must be a full lowercase SHA-1: $target_commit" >&2
@@ -17,6 +16,29 @@ if [[ ! "$target_commit" =~ ^[0-9a-f]{40}$ ]]; then
 fi
 
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+if [ "$#" -eq 3 ]; then
+  # TODO(#30182): Remove this pre-#30180 workflow compatibility path after
+  # every release workflow started before the merge has exceeded its lifetime.
+  release_tags=$(
+    gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
+      jq -ce --arg target "$target_commit" '
+        [
+          .[]
+          | select(.target_commitish == $target)
+          | .tag_name
+          | select(test("^.+-v[0-9]"))
+        ]
+        | if length == 0 then
+            error("No release artifacts found for target " + $target)
+          else
+            .
+          end
+      '
+  )
+else
+  release_tags=$4
+fi
 
 jq -e '
   type == "array" and

--- a/.github/scripts/update-rollback-dashboard-body.sh
+++ b/.github/scripts/update-rollback-dashboard-body.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -ne 3 ]; then
-  echo "usage: update-rollback-dashboard-body.sh BODY_FILE TARGET_COMMIT ROLLBACK_URL" >&2
+if [ "$#" -ne 4 ]; then
+  echo "usage: update-rollback-dashboard-body.sh BODY_FILE TARGET_COMMIT ROLLBACK_URL RELEASE_TAGS_JSON" >&2
   exit 2
 fi
 
 body_file=$1
 target_commit=$2
 rollback_url=$3
+release_tags=$4
 
 if [[ ! "$target_commit" =~ ^[0-9a-f]{40}$ ]]; then
   echo "target commit must be a full lowercase SHA-1: $target_commit" >&2
@@ -16,6 +17,16 @@ if [[ ! "$target_commit" =~ ^[0-9a-f]{40}$ ]]; then
 fi
 
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+jq -e '
+  type == "array" and
+  length > 0 and
+  all(.[]; type == "string" and test("^.+-v[0-9]")) and
+  length == (unique | length)
+' <<<"$release_tags" >/dev/null || {
+  echo "release tags must be a non-empty JSON array of unique version tags" >&2
+  exit 2
+}
 
 work_dir=$(mktemp -d)
 entries_dir="${work_dir}/entries"
@@ -26,29 +37,37 @@ rendered_body_file="${work_dir}/body.md"
 mkdir -p "$entries_dir"
 trap 'rm -rf "$work_dir"' EXIT
 
-gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" >"$releases_file"
+while IFS= read -r release_tag; do
+  gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${release_tag}"
+done < <(jq -r '.[]' <<<"$release_tags") | jq -s . >"$releases_file"
 
-jq -ce --arg target "$target_commit" '
-  [
-    .[]
-    | select(.target_commitish == $target)
-    | select(.tag_name | test("^.+-v[0-9]"))
-    | (.tag_name | capture("^(?<artifact>.+)-v(?<version>[0-9].*)$")) as $tag
-    | {
-        artifact: $tag.artifact,
-        version: $tag.version,
-        url: .html_url,
-        published_at: .published_at,
-        body: (.body // ""),
-        priority: (
-          if $tag.artifact == "app" then 0
-          elif $tag.artifact == "api" then 1
-          elif $tag.artifact == "runner-rs" then 2
-          else 3
-          end
-        )
-      }
-  ]
+jq -ce \
+  --arg target "$target_commit" \
+  --argjson expected_tags "$release_tags" '
+  if ([.[].tag_name] | sort) != ($expected_tags | sort) then
+    error("Release artifacts do not match the requested release tags")
+  elif any(.[]; .target_commitish != $target) then
+    error("Release artifacts do not all target " + $target)
+  else
+    [
+      .[]
+      | (.tag_name | capture("^(?<artifact>.+)-v(?<version>[0-9].*)$")) as $tag
+      | {
+          artifact: $tag.artifact,
+          version: $tag.version,
+          url: .html_url,
+          published_at: .published_at,
+          body: (.body // ""),
+          priority: (
+            if $tag.artifact == "app" then 0
+            elif $tag.artifact == "api" then 1
+            elif $tag.artifact == "runner-rs" then 2
+            else 3
+            end
+          )
+        }
+    ]
+  end
   | if length == 0 then
       error("No release artifacts found for target " + $target)
     else

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1825,7 +1825,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
         with:
-          ref: ${{ needs.release-please.outputs.release_target }}
+          ref: ${{ github.sha }}
 
       - name: Update rollback dashboard issue
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -76,6 +76,7 @@ jobs:
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       release_target: ${{ steps.release-target.outputs.sha }}
+      release_tags: ${{ steps.release-tags.outputs.tags }}
       api_release_created: ${{ steps.release.outputs['turbo/apps/api--release_created'] }}
       core_release_created: ${{ steps.release.outputs['turbo/packages/core--release_created'] }}
       api_contracts_release_created: ${{ steps.release.outputs['turbo/packages/api-contracts--release_created'] }}
@@ -174,6 +175,90 @@ jobs:
           )
 
           echo "sha=$release_target" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve current release tags
+        id: release-tags
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        env:
+          RELEASE_TAGS: >-
+            [
+              ${{ toJSON(steps.release.outputs['crates/ably-subscriber--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/api-contracts--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-agent--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-common--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-contracts--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-download--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-init--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-mock-claude--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-mock-codex--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-reseed--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-session-prune--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-tool-exec--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-write-file--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/nbd-cow--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/process-control-ipc--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/runner--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/sandbox--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/sandbox-fc--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/sandbox-mock--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/shell-quote--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/tracing-test-support--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/vsock-guest--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/vsock-host--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/vsock-proto--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['crates/vsock-test--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['turbo/apps/api--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['turbo/apps/cli--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['turbo/apps/desktop--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['turbo/apps/host-worker--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['turbo/apps/platform--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['turbo/packages/api-contracts--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['turbo/packages/connectors--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['turbo/packages/connector-catalog-validation--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['turbo/packages/core--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['turbo/packages/db--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['turbo/packages/pi-agent-runtime--tag_name']) }},
+              ${{ toJSON(steps.release.outputs['turbo/packages/ui--tag_name']) }}
+            ]
+          DESKTOP_RELEASE_CREATED: ${{ steps.release.outputs['turbo/apps/desktop--release_created'] }}
+          DESKTOP_VERSION: ${{ steps.release.outputs['turbo/apps/desktop--version'] }}
+        run: |
+          set -euo pipefail
+
+          derived_release_tags='[]'
+          if [ "$DESKTOP_RELEASE_CREATED" = "true" ]; then
+            derived_release_tags=$(jq -nc \
+              --arg tag "okou-desktop-v${DESKTOP_VERSION}" \
+              '[$tag]')
+          fi
+
+          release_tags=$(
+            jq -ce --argjson derived_release_tags "$derived_release_tags" '
+              (. + $derived_release_tags)
+              | map(select(. != null and . != ""))
+              | map(
+                  if type != "string" then
+                    error("release-please returned non-string release tag: " + tostring)
+                  elif test("^.+-v[0-9]") then
+                    .
+                  else
+                    error("release-please returned invalid release tag: " + .)
+                  end
+                )
+              | if length == 0 then
+                  error("release-please returned no release tag")
+                elif length != (unique | length) then
+                  error(
+                    "release-please returned duplicate release tags: " +
+                    (group_by(.) | map(select(length > 1) | .[0]) | join(", "))
+                  )
+                else
+                  .
+                end
+            ' <<<"$RELEASE_TAGS"
+          )
+
+          echo "tags=$release_tags" >> "$GITHUB_OUTPUT"
 
   # Refreshing the release pull request is a separate job so that a failure here
   # cannot skip the release and deployment jobs above. release-please recomputes
@@ -1720,6 +1805,7 @@ jobs:
         release-please,
         promote-api-production,
         promote-app-production,
+        promote-desktop-release,
         promote-runner-production,
       ]
     if: >-
@@ -1728,6 +1814,8 @@ jobs:
       needs.promote-api-production.result == 'success' &&
       (needs.release-please.outputs.app_release_created != 'true' ||
        needs.promote-app-production.result == 'success') &&
+      (needs.release-please.outputs.desktop_release_created != 'true' ||
+       needs.promote-desktop-release.result == 'success') &&
       (needs.release-please.outputs.runner_rs_release_created != 'true' ||
        needs.promote-runner-production.result == 'success')
     runs-on: ubuntu-latest
@@ -1744,6 +1832,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ vars.ROLLBACK_ISSUE_NUMBER }}
           RELEASE_TARGET: ${{ needs.release-please.outputs.release_target }}
+          RELEASE_TAGS: ${{ needs.release-please.outputs.release_tags }}
           ROLLBACK_URL: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/rollback-production.yml
         run: |
           set -euo pipefail
@@ -1758,7 +1847,8 @@ jobs:
           updated_body=$(bash .github/scripts/update-rollback-dashboard-body.sh \
             /tmp/rollback-dashboard.md \
             "$RELEASE_TARGET" \
-            "$ROLLBACK_URL")
+            "$ROLLBACK_URL" \
+            "$RELEASE_TAGS")
 
           gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}" \
             -X PATCH \

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1825,7 +1825,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
         with:
-          ref: main
+          ref: ${{ needs.release-please.outputs.release_target }}
 
       - name: Update rollback dashboard issue
         env:


### PR DESCRIPTION
## Summary

- pass the exact set of releases created by release-please to the rollback dashboard job
- include the derived Okou Desktop release after its promotion completes
- fetch releases directly by tag and fail before updating the dashboard if a tag is missing, mismatched, or targets another commit
- check out the helper from the workflow source commit so old in-flight and batched-push workflows keep an atomic caller/helper interface

## Scope

This changes release discovery for the rollback dashboard only. It does not change production promotion behavior, rollback inputs, dashboard formatting, or product UI and user flows.

## Validation

- `bash .github/scripts/tests/update-rollback-dashboard-body-test.sh`
- Bash syntax validation for the changed workflow scripts
- `pnpm exec prettier --check ../.github/workflows/release-please.yml`
- actionlint 1.7.12
- static validation of all 37 release tag projections and the workflow-source checkout
- live read-only exact-tag checks for the original failing App release and a Desktop release pair

## Production acceptance context

This repair follows the #30151 acceptance path for #28905.

Closes #27801

