### PR TITLE
perf(runner): aggregate model observations across jobs

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -246,6 +246,10 @@ def configure(updated: set[str]) -> None:
         api_url=get_api_url(),
         bearer_credential=os.environ.get(model_provider_failure.RUNNER_AUTH_ENV, ""),
     )
+    usage.configure_model_usage_observation_reporting(
+        api_url=get_api_url(),
+        runner_token=os.environ.get(model_provider_failure.RUNNER_AUTH_ENV, ""),
+    )
     if "vm0_usage_flush_interval_seconds" in updated:
         usage.configure_usage_buffer(
             flush_interval_seconds=ctx.options.vm0_usage_flush_interval_seconds
@@ -2005,7 +2009,7 @@ def done():
     finally:
         try:
             try:
-                usage.webhook.usage_executor.shutdown(wait=True)
+                usage.webhook.shutdown_delivery_executors(wait=True)
                 runner_flush_lifecycle.drain_delivery_work_after_executor_shutdown()
             finally:
                 auth_base_forwarder.shutdown_forward_request_workers(wait=False)

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1991,7 +1991,7 @@ def done():
     The runner flush lifecycle waits for any active SIGUSR1 delivery worker,
     retries buffered usage and retained diagnostic reports, drains accepted
     requests, and closes admission before this hook shuts down the usage
-    executor. It also performs a final JSONL marker observation and joins the
+    executors. It also performs a final JSONL marker observation and joins the
     marker watcher before the JSONL writer stops. Any retryable usage outcome
     retained by completed workers is then retried synchronously.
     Auth.base forwarding does not need to finish running work during shutdown.
@@ -2000,9 +2000,9 @@ def done():
     upstream work without joining daemon workers or waiting for slow upstream
     responses. JSONL writer shutdown is also bounded and best-effort; if it times
     out, process shutdown continues with accepted log entries possibly still
-    pending. After joining the usage executor, retained billing and diagnostic
-    work is drained through synchronous delivery. Model-provider failure delivery
-    stops admission and receives one bounded drain window.
+    pending. After joining the usage executors, retained billing, observation,
+    and diagnostic work is drained through synchronous delivery. Model-provider
+    failure delivery stops admission and receives one bounded drain window.
     """
     try:
         runner_flush_lifecycle.drain_and_close()

--- a/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
+++ b/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
@@ -212,7 +212,10 @@ def _flush_usage_for_runner_request() -> None:
     """
     flush_request_id = usage.read_usage_flush_request_id()
     try:
-        _flush_delivery_work(trigger="runner")
+        _flush_delivery_work(
+            trigger="runner",
+            include_observations=flush_request_id is not None,
+        )
     except Exception as exc:
         addon_process_logging.emit_addon_process_event(
             "warn",
@@ -222,9 +225,13 @@ def _flush_usage_for_runner_request() -> None:
         usage.write_pending_snapshot(flush_request_id=flush_request_id)
 
 
-def _flush_delivery_work(*, trigger: _DeliveryFlushTrigger) -> None:
+def _flush_delivery_work(
+    *, trigger: _DeliveryFlushTrigger, include_observations: bool = True
+) -> None:
     """Admit billing work before retained diagnostic reports."""
     usage.flush_usage_events(trigger=trigger)
+    if trigger == "runner" and include_observations:
+        usage.flush_model_usage_observations(trigger=trigger)
     _retry_retained_diagnostic_reports()
 
 

--- a/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
+++ b/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
@@ -229,9 +229,11 @@ def _flush_delivery_work(
     *, trigger: _DeliveryFlushTrigger, include_observations: bool = True
 ) -> None:
     """Admit billing work before retained diagnostic reports."""
-    usage.flush_usage_events(trigger=trigger)
-    if trigger == "runner" and include_observations:
-        usage.flush_model_usage_observations(trigger=trigger)
+    try:
+        usage.flush_usage_events(trigger=trigger)
+    finally:
+        if trigger == "runner" and include_observations:
+            usage.flush_model_usage_observations(trigger=trigger)
     _retry_retained_diagnostic_reports()
 
 
@@ -243,9 +245,9 @@ def _retry_retained_diagnostic_reports() -> None:
 
 
 def drain_delivery_work_after_executor_shutdown() -> None:
-    """Synchronously drain work after the usage executor has been joined.
+    """Synchronously drain work after both usage executors have been joined.
 
-    The caller must first shut down and join the executor so completed delivery
+    The caller must first shut down and join the executors so completed delivery
     callbacks cannot retain new billing work after the usage drain observes an
     empty state. New admissions then use webhook delivery's synchronous fallback.
     """

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -42,6 +42,8 @@ from .buffer import (
     buffer_usage_events,
     configure_usage_buffer,
     drain_usage_events_after_executor_shutdown,
+    flush_billing_usage_events,
+    flush_model_usage_observations,
     flush_usage_events,
     reset_usage_buffer_for_tests,
 )
@@ -99,6 +101,7 @@ from .providers.model_provider import (
     report_model_provider_usage_observation,
     report_model_provider_usage_source,
 )
+from .reporting_context import configure_model_usage_observation_reporting
 
 __all__ = [
     "DEFAULT_FLUSH_INTERVAL_SECONDS",
@@ -116,6 +119,7 @@ __all__ = [
     "buffer_source_model_usage_observations",
     "buffer_source_usage_events",
     "buffer_usage_events",
+    "configure_model_usage_observation_reporting",
     "configure_usage_buffer",
     "create_anthropic_messages_json_usage_extractor",
     "create_anthropic_messages_sse_usage_extractor",
@@ -134,6 +138,8 @@ __all__ = [
     "extract_openai_chat_completions_usage_with_error_from_json",
     "extract_openai_responses_usage_from_event",
     "extract_openai_responses_usage_with_error_from_json",
+    "flush_billing_usage_events",
+    "flush_model_usage_observations",
     "flush_usage_events",
     "has_connector_response_parser",
     "has_positive_model_provider_usage",

--- a/crates/runner/mitm-addon/src/usage/buffer/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/__init__.py
@@ -1,12 +1,12 @@
 """Process-local buffering for aggregate usage webhook uploads.
 
-This package owns the usage report buffer singleton used by the mitmproxy addon.
-The singleton is created on import with default settings, but its flush timer is
-scheduled lazily only after source events are accepted into the buffer.
+This package owns the billing and model observation report buffers used by the
+mitmproxy addon. The buffers are created on import with default settings, but
+their flush timers are scheduled lazily only after source events are accepted.
 
-Source event idempotency keys are deduped process-wide before destination
-bucketing. The seen-key set survives flushes and is bounded by
-``MAX_SOURCE_IDEMPOTENCY_KEYS``, evicting oldest keys first, so duplicate
+Source event idempotency keys are deduped within each process-local buffer
+before destination bucketing. Each seen-key set survives flushes and is bounded
+by ``MAX_SOURCE_IDEMPOTENCY_KEYS``, evicting oldest keys first, so duplicate
 response/error observations do not become separate aggregate rows.
 
 By default, accepted events are separated by webhook destination and output
@@ -91,7 +91,7 @@ _model_usage_observation_buffer = UsageEventBuffer(
 
 
 def configure_usage_buffer(*, flush_interval_seconds: float) -> None:
-    """Update singleton buffer settings for future timer scheduling.
+    """Update billing buffer settings for future timer scheduling.
 
     Existing scheduled timers are not rescheduled.
     """
@@ -223,7 +223,7 @@ def buffer_source_model_usage_observations(
 
 
 def flush_usage_events(*, trigger: UsageFlushTrigger) -> int:
-    """Attempt to admit buffered webhook batches from the singleton.
+    """Attempt to admit buffered webhook batches from both usage lanes.
 
     ``runner`` and ``shutdown`` wait for flush ownership. ``timer``,
     ``threshold``, and ``test`` defer when another invocation owns the flush;
@@ -240,10 +240,13 @@ def flush_usage_events(*, trigger: UsageFlushTrigger) -> int:
     retained work for a later timer when timers are enabled; shutdown does not
     schedule another timer.
     """
-    flushed = flush_billing_usage_events(trigger=trigger)
     if trigger == "runner":
-        return flushed
-    return flushed + flush_model_usage_observations(trigger=trigger)
+        return flush_billing_usage_events(trigger=trigger)
+    try:
+        billing_batches = flush_billing_usage_events(trigger=trigger)
+    finally:
+        observation_batches = flush_model_usage_observations(trigger=trigger)
+    return billing_batches + observation_batches
 
 
 def flush_billing_usage_events(*, trigger: UsageFlushTrigger) -> int:
@@ -257,17 +260,16 @@ def flush_model_usage_observations(*, trigger: UsageFlushTrigger) -> int:
 
 
 def seen_source_idempotency_keys(source_keys: Iterable[str]) -> set[str]:
-    """Return candidate source keys retained by process-local admission history."""
-    source_keys = tuple(source_keys)
-    return _usage_event_buffer.seen_source_idempotency_keys(
-        source_keys
-    ) | _model_usage_observation_buffer.seen_source_idempotency_keys(source_keys)
+    """Return candidate billing source keys retained by admission history."""
+    return _usage_event_buffer.seen_source_idempotency_keys(source_keys)
 
 
 def drain_usage_events_after_executor_shutdown() -> None:
-    """Synchronously drain usage retained after the executor has stopped."""
-    _usage_event_buffer.drain_usage_events_after_executor_shutdown()
-    _model_usage_observation_buffer.drain_usage_events_after_executor_shutdown()
+    """Synchronously drain usage retained after both executors have stopped."""
+    try:
+        _usage_event_buffer.drain_usage_events_after_executor_shutdown()
+    finally:
+        _model_usage_observation_buffer.drain_usage_events_after_executor_shutdown()
 
 
 def reset_usage_buffer_for_tests(

--- a/crates/runner/mitm-addon/src/usage/buffer/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/__init__.py
@@ -26,9 +26,11 @@ idempotency key.
 
 Flushes are triggered by buffer bounds, the lazy timer, or explicit lifecycle
 calls. Flush summaries include the conventional trigger labels captured by
-``UsageFlushTrigger``. Most summaries are ``usage_event_buffer_flush`` proxy-log
-records; retained or dropped batches can become ``usage_underbilling`` records
-under the contract documented by ``usage.buffer.logging``.
+``UsageFlushTrigger``. Billing summaries are ``usage_event_buffer_flush``
+proxy-log records, with billing-impacting retained or dropped batches promoted
+to ``usage_underbilling``. Successful model observation flushes are silent;
+their admission, delivery, retention, and drop anomalies use the generic addon
+process-event path documented by ``usage.buffer.logging``.
 """
 
 from __future__ import annotations

--- a/crates/runner/mitm-addon/src/usage/buffer/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/__init__.py
@@ -16,8 +16,8 @@ Source-preserving wrappers skip aggregation and keep the original event
 idempotency keys in the webhook payload for finalized source-level reports.
 
 ``ModelUsageObservation`` is a separate payload shape from ``UsageEvent``. The
-default observation path is separated by webhook destination and aggregated by
-``run_id`` and ``model``. It sums ``inputTokens``, ``outputTokens``,
+observation lane is process-wide and aggregated by canonical ``model`` across
+jobs. It sums ``inputTokens``, ``outputTokens``,
 ``cacheReadInputTokens``, and ``cacheCreationInputTokens`` independently, and
 starts a new segment before any one accumulated field would exceed the exact
 ``MAX_USAGE_QUANTITY`` bound. The source-preserving observation wrapper skips
@@ -35,6 +35,8 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
+from ..counters import set_buffered_model_usage_observations
+from ..webhook import enqueue_model_usage_observation_delivery
 from .models import (
     DEFAULT_FLUSH_INTERVAL_SECONDS,
     DEFAULT_FLUSH_JITTER_RATIO,
@@ -43,6 +45,7 @@ from .models import (
     MAX_BUFFERED_WEBHOOK_BATCHES,
     MAX_RETAINED_USAGE_BATCH_RETRIES,
     MAX_SOURCE_IDEMPOTENCY_KEYS,
+    MODEL_USAGE_OBSERVATION_FLUSH_INTERVAL_SECONDS,
     USAGE_EVENT_BATCH_SIZE,
     ModelUsageObservation,
     ResourceFieldName,
@@ -59,6 +62,7 @@ __all__ = [
     "MAX_BUFFERED_WEBHOOK_BATCHES",
     "MAX_RETAINED_USAGE_BATCH_RETRIES",
     "MAX_SOURCE_IDEMPOTENCY_KEYS",
+    "MODEL_USAGE_OBSERVATION_FLUSH_INTERVAL_SECONDS",
     "USAGE_EVENT_BATCH_SIZE",
     "ModelUsageObservation",
     "ResourceFieldName",
@@ -71,12 +75,19 @@ __all__ = [
     "buffer_usage_events",
     "configure_usage_buffer",
     "drain_usage_events_after_executor_shutdown",
+    "flush_billing_usage_events",
+    "flush_model_usage_observations",
     "flush_usage_events",
     "reset_usage_buffer_for_tests",
     "seen_source_idempotency_keys",
 ]
 
 _usage_event_buffer = UsageEventBuffer()
+_model_usage_observation_buffer = UsageEventBuffer(
+    flush_interval_seconds=MODEL_USAGE_OBSERVATION_FLUSH_INTERVAL_SECONDS,
+    enqueue_webhook=enqueue_model_usage_observation_delivery,
+    set_buffered_count=set_buffered_model_usage_observations,
+)
 
 
 def configure_usage_buffer(*, flush_interval_seconds: float) -> None:
@@ -115,7 +126,7 @@ def buffer_usage_events(
 
 def buffer_model_usage_observations(
     url: str,
-    sandbox_token: str,
+    runner_token: str,
     run_id: str,
     observations: Iterable[ModelUsageObservation],
     proxy_log_path: str,
@@ -132,15 +143,15 @@ def buffer_model_usage_observations(
     When provided, ``accepted_source_keys`` is populated only with keys admitted
     by this call.
 
-    The default output aggregates accepted observations by ``run_id`` and
-    ``model``, summing each token field independently into safe segments. A
+    The default output aggregates accepted observations by canonical ``model``
+    across jobs, summing each token field independently into safe segments. A
     threshold flush may be performed before this function returns when buffer
     bounds are reached; that flush does not mean final webhook delivery has
     completed.
     """
-    return _usage_event_buffer.buffer_model_usage_observations(
+    return _model_usage_observation_buffer.buffer_model_usage_observations(
         url,
-        sandbox_token,
+        runner_token,
         run_id,
         observations,
         proxy_log_path,
@@ -179,7 +190,7 @@ def buffer_source_usage_events(
 
 def buffer_source_model_usage_observations(
     url: str,
-    sandbox_token: str,
+    runner_token: str,
     run_id: str,
     observations: Iterable[ModelUsageObservation],
     proxy_log_path: str,
@@ -200,9 +211,9 @@ def buffer_source_model_usage_observations(
     bounds are reached; that flush does not mean final webhook delivery has
     completed.
     """
-    return _usage_event_buffer.buffer_model_usage_observations(
+    return _model_usage_observation_buffer.buffer_model_usage_observations(
         url,
-        sandbox_token,
+        runner_token,
         run_id,
         observations,
         proxy_log_path,
@@ -219,23 +230,44 @@ def flush_usage_events(*, trigger: UsageFlushTrigger) -> int:
     when timers are enabled, the buffered work remains eligible for a later
     timer.
 
+    A ``runner`` trigger flushes only billing; the runner lifecycle explicitly
+    flushes observations as well after validating a formal flush marker. Other
+    triggers flush billing first and then observations.
+
     Return the number of webhook batches admitted by this invocation. Zero
     does not prove that the buffer is empty. Admission does not wait for final
     delivery or retained-retry completion. Non-shutdown triggers schedule
     retained work for a later timer when timers are enabled; shutdown does not
     schedule another timer.
     """
+    flushed = flush_billing_usage_events(trigger=trigger)
+    if trigger == "runner":
+        return flushed
+    return flushed + flush_model_usage_observations(trigger=trigger)
+
+
+def flush_billing_usage_events(*, trigger: UsageFlushTrigger) -> int:
+    """Attempt to admit buffered billable usage batches."""
     return _usage_event_buffer.flush_usage_events(trigger=trigger)
+
+
+def flush_model_usage_observations(*, trigger: UsageFlushTrigger) -> int:
+    """Attempt to admit buffered process-level model observations."""
+    return _model_usage_observation_buffer.flush_usage_events(trigger=trigger)
 
 
 def seen_source_idempotency_keys(source_keys: Iterable[str]) -> set[str]:
     """Return candidate source keys retained by process-local admission history."""
-    return _usage_event_buffer.seen_source_idempotency_keys(source_keys)
+    source_keys = tuple(source_keys)
+    return _usage_event_buffer.seen_source_idempotency_keys(
+        source_keys
+    ) | _model_usage_observation_buffer.seen_source_idempotency_keys(source_keys)
 
 
 def drain_usage_events_after_executor_shutdown() -> None:
     """Synchronously drain usage retained after the executor has stopped."""
     _usage_event_buffer.drain_usage_events_after_executor_shutdown()
+    _model_usage_observation_buffer.drain_usage_events_after_executor_shutdown()
 
 
 def reset_usage_buffer_for_tests(
@@ -252,12 +284,26 @@ def reset_usage_buffer_for_tests(
     delivery bookkeeping, and source idempotency keys are discarded without
     flushing or waiting for delivery.
     """
-    global _usage_event_buffer
+    global _usage_event_buffer, _model_usage_observation_buffer
     _usage_event_buffer.close()
+    _model_usage_observation_buffer.close()
     _usage_event_buffer = UsageEventBuffer(
         timer_enabled=timer_enabled,
         timer_factory=timer_factory,
         enqueue_webhook=enqueue_webhook,
+        flush_owner_lock=flush_owner_lock,
+        max_retained_batch_retries=max_retained_batch_retries,
+    )
+    _model_usage_observation_buffer = UsageEventBuffer(
+        flush_interval_seconds=MODEL_USAGE_OBSERVATION_FLUSH_INTERVAL_SECONDS,
+        timer_enabled=timer_enabled,
+        timer_factory=timer_factory,
+        enqueue_webhook=(
+            enqueue_webhook
+            if enqueue_webhook is not None
+            else enqueue_model_usage_observation_delivery
+        ),
+        set_buffered_count=set_buffered_model_usage_observations,
         flush_owner_lock=flush_owner_lock,
         max_retained_batch_retries=max_retained_batch_retries,
     )

--- a/crates/runner/mitm-addon/src/usage/buffer/logging.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/logging.py
@@ -31,6 +31,7 @@ import time
 from collections.abc import Iterable
 from typing import Literal
 
+import addon_process_logging
 from logging_utils import log_proxy_entry
 
 from ..underbilling import log_usage_underbilling
@@ -46,6 +47,8 @@ type _UsageFlushPhase = Literal["started", "enqueued", "failed", "retained", "dr
 _RETRY_BUDGET_EXHAUSTED_REASON = "retry_budget_exhausted"
 _SHUTDOWN_RETAINED_WITHOUT_RETRY_REASON = "shutdown_retained_without_retry"
 _USAGE_QUANTITY_OUT_OF_RANGE_REASON = "usage_quantity_out_of_range"
+_MODEL_OBSERVATION_LOG_TYPE = "model_usage_observation"
+_MODEL_OBSERVATION_SUMMARY_TYPE = "model_usage_observation_buffer_flush"
 
 
 def _log_rejected_usage_quantity(
@@ -141,6 +144,13 @@ def _log_flush_summaries(
             message = "Usage event buffer flush dropped retained batches"
         elif phase == "enqueued" and summary.retained_webhook_batch_count:
             message = "Usage event buffer flush retained webhook batches for retry"
+        if summary.log_type == _MODEL_OBSERVATION_LOG_TYPE and (
+            phase in ("failed", "retained", "dropped") or retained_webhook_batch_count > 0
+        ):
+            process_level: addon_process_logging.AddonProcessEventLevel = (
+                "error" if phase in ("failed", "dropped") else "warn"
+            )
+            _log_model_observation_process_summary(level=process_level, fields=extra)
         if phase == "dropped":
             log_usage_underbilling(
                 summary.proxy_log_path,
@@ -172,6 +182,35 @@ def _log_flush_summaries(
             message,
             **extra,
         )
+
+
+def _log_model_observation_process_summary(
+    *,
+    level: addon_process_logging.AddonProcessEventLevel,
+    fields: dict[str, object],
+) -> None:
+    """Emit one scalar-only observation anomaly through the process logger."""
+    ordered_keys = (
+        "phase",
+        "trigger",
+        "flush_sequence",
+        "source_event_count",
+        "aggregate_event_count",
+        "webhook_batch_count",
+        "dropped_webhook_batch_count",
+        "retained_webhook_batch_count",
+        "retained_source_event_count",
+        "duration_ms",
+        "retained_retry_count",
+        "error_type",
+    )
+    process_fields = {key: fields[key] for key in ordered_keys if key in fields}
+    addon_process_logging.emit_addon_process_event(
+        level,
+        "Model usage observation buffer flush anomaly",
+        type=_MODEL_OBSERVATION_SUMMARY_TYPE,
+        **process_fields,
+    )
 
 
 def _elapsed_ms(started_at: float) -> int:

--- a/crates/runner/mitm-addon/src/usage/buffer/logging.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/logging.py
@@ -6,23 +6,27 @@ retained or dropped batches can be billing-impacting underbilling signals:
 - ``started`` marks enqueue/admission start.
 - ``enqueued`` marks enqueue/admission completion and may include retained
   counters for batches kept for retry.
-- ``failed`` marks an enqueue exception and logs at error level.
+- ``failed`` marks an enqueue exception or permanent asynchronous delivery
+  failure and logs at error level.
 - ``retained`` marks asynchronous delivery outcomes kept for retry.
 - ``dropped`` marks retained batches whose retry budget was exhausted.
 
-Dropped retained batches always emit ``usage_underbilling`` with
+Dropped retained billing batches always emit ``usage_underbilling`` with
 ``reason=retry_budget_exhausted`` and ``underbilling_class=confirmed``.
-Shutdown-retained batches emit ``usage_underbilling`` with
+Shutdown-retained billing batches emit ``usage_underbilling`` with
 ``reason=shutdown_retained_without_retry`` and ``underbilling_class=risk``.
 Failed shutdown admission remains an ordinary error record; its separate
 retained-only summary emits the shutdown underbilling signal.
+
+Model observation anomalies instead use their dedicated process event. They do
+not affect billing and must not also emit ``usage_underbilling``.
 
 Operators should use ``retained_source_event_count`` and
 ``retained_webhook_batch_count`` for retained work, and
 ``dropped_source_event_count`` and ``dropped_webhook_batch_count`` for confirmed
 drops. Dropped retained batches also include ``retained_retry_count``. When no
-proxy log path exists, ordinary flush records are skipped; underbilling records
-use the process event in ``log_usage_underbilling``.
+proxy log path exists, ordinary flush records are skipped. Billing underbilling
+and model observation anomalies use their respective generic process events.
 """
 
 from __future__ import annotations
@@ -94,6 +98,23 @@ def _log_dropped_batches(
     )
 
 
+def _log_permanent_delivery_failure(
+    trigger: UsageFlushTrigger,
+    flush_sequence: int,
+    pending_batch: _PendingBatch,
+) -> None:
+    """Emit the process-level anomaly for one lost observation batch."""
+    if pending_batch.batch.log_type != _MODEL_OBSERVATION_LOG_TYPE:
+        return
+    _log_flush_summaries(
+        "failed",
+        trigger,
+        flush_sequence,
+        _build_flush_summaries([pending_batch.batch]),
+        delivery_outcome="permanent_failure",
+    )
+
+
 def _log_flush_summaries(
     phase: _UsageFlushPhase,
     trigger: UsageFlushTrigger,
@@ -103,6 +124,7 @@ def _log_flush_summaries(
     duration_ms: int | None = None,
     error_type: str | None = None,
     retained_retry_count: int | None = None,
+    delivery_outcome: Literal["permanent_failure"] | None = None,
 ) -> None:
     for summary in summaries:
         retained_webhook_batch_count = summary.retained_webhook_batch_count
@@ -135,6 +157,8 @@ def _log_flush_summaries(
             extra["reason"] = _RETRY_BUDGET_EXHAUSTED_REASON
         if retained_retry_count is not None:
             extra["retained_retry_count"] = retained_retry_count
+        if delivery_outcome is not None:
+            extra["delivery_outcome"] = delivery_outcome
         level = "error" if phase == "failed" else "info"
         message = f"Usage event buffer flush {phase}"
         if phase == "retained":
@@ -151,7 +175,7 @@ def _log_flush_summaries(
                 "error" if phase in ("failed", "dropped") else "warn"
             )
             _log_model_observation_process_summary(level=process_level, fields=extra)
-        if phase == "dropped":
+        if phase == "dropped" and summary.log_type != _MODEL_OBSERVATION_LOG_TYPE:
             log_usage_underbilling(
                 summary.proxy_log_path,
                 message,
@@ -161,7 +185,8 @@ def _log_flush_summaries(
             )
             continue
         if (
-            phase in ("enqueued", "retained")
+            summary.log_type != _MODEL_OBSERVATION_LOG_TYPE
+            and phase in ("enqueued", "retained")
             and trigger == "shutdown"
             and retained_webhook_batch_count
         ):
@@ -203,6 +228,7 @@ def _log_model_observation_process_summary(
         "duration_ms",
         "retained_retry_count",
         "error_type",
+        "delivery_outcome",
     )
     process_fields = {key: fields[key] for key in ordered_keys if key in fields}
     addon_process_logging.emit_addon_process_event(

--- a/crates/runner/mitm-addon/src/usage/buffer/models.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/models.py
@@ -50,7 +50,7 @@ ResourceFieldName = Literal["provider", "model"]
 @dataclass(frozen=True)
 class _DestinationKey:
     url: str
-    sandbox_token: str
+    bearer_credential: str
     proxy_log_path: str
     resource_field_name: ResourceFieldName
     include_kind: bool
@@ -105,7 +105,7 @@ class _FlushEvent:
 @dataclass(frozen=True)
 class _FlushBatch:
     url: str
-    sandbox_token: str
+    bearer_credential: str
     payload: dict
     proxy_log_path: str
     log_type: str

--- a/crates/runner/mitm-addon/src/usage/buffer/models.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/models.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import Literal, TypedDict
 
 DEFAULT_FLUSH_INTERVAL_SECONDS = 30.0
+MODEL_USAGE_OBSERVATION_FLUSH_INTERVAL_SECONDS = 300.0
 DEFAULT_FLUSH_JITTER_RATIO = 0.2
 MAX_BUFFERED_SOURCE_EVENTS = 1_000
 MAX_AGGREGATE_BUCKETS = 100
@@ -72,7 +73,6 @@ class _AggregateBucket:
 
 @dataclass(frozen=True)
 class _ObservationAggregateKey:
-    run_id: str
     model: str
 
 
@@ -93,7 +93,6 @@ class _BufferedSourceEvent:
 
 @dataclass(frozen=True)
 class _BufferedSourceObservation:
-    run_id: str
     observation: ModelUsageObservation
 
 
@@ -123,6 +122,7 @@ class _PendingBatch:
 @dataclass
 class _FlushSummary:
     proxy_log_path: str
+    log_type: str
     source_event_count: int = 0
     aggregate_event_count: int = 0
     webhook_batch_count: int = 0

--- a/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
@@ -45,6 +45,7 @@ class _TimerHandle(Protocol):
 _TimerFactory = Callable[[float, Callable[[], None]], _TimerHandle]
 _DeliveryOutcomeCallback = Callable[[WebhookDeliveryOutcome], None]
 _EnqueueWebhook = Callable[[str, str, dict, str, str, _DeliveryOutcomeCallback], bool]
+_SetBufferedCount = Callable[[int], None]
 
 
 def _log_shutdown_retained_batches(
@@ -81,6 +82,7 @@ class UsageEventBuffer:
         timer_enabled: bool = True,
         timer_factory: _TimerFactory | None = None,
         enqueue_webhook: _EnqueueWebhook | None = None,
+        set_buffered_count: _SetBufferedCount = set_buffered_usage_events,
         flush_owner_lock: _FlushOwnerLock | None = None,
         max_retained_batch_retries: int = MAX_RETAINED_USAGE_BATCH_RETRIES,
     ) -> None:
@@ -92,6 +94,7 @@ class UsageEventBuffer:
             flush_owner_lock if flush_owner_lock is not None else threading.Lock()
         )
         self._enqueue_webhook = enqueue_webhook
+        self._set_buffered_count = set_buffered_count
         self._state = _UsageBufferState(max_retained_batch_retries=max_retained_batch_retries)
         self._flush_interval_seconds = max(1.0, flush_interval_seconds)
         self._jitter_ratio = max(0.0, jitter_ratio)
@@ -154,7 +157,7 @@ class UsageEventBuffer:
     def buffer_model_usage_observations(
         self,
         url: str,
-        sandbox_token: str,
+        runner_token: str,
         run_id: str,
         observations: Iterable[ModelUsageObservation],
         proxy_log_path: str,
@@ -168,7 +171,7 @@ class UsageEventBuffer:
         with self._lock:
             accepted_count = self._state.add_model_usage_observations(
                 url,
-                sandbox_token,
+                runner_token,
                 run_id,
                 observations,
                 proxy_log_path,
@@ -499,7 +502,7 @@ class UsageEventBuffer:
             raise
 
     def _sync_buffered_counter_locked(self) -> None:
-        set_buffered_usage_events(self._state.buffered_source_event_count())
+        self._set_buffered_count(self._state.buffered_source_event_count())
 
     def _schedule_timer_locked(self) -> _TimerHandle | None:
         if not self._timer_enabled or self._timer is not None:

--- a/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
@@ -10,7 +10,12 @@ from typing import Protocol
 
 from ..counters import set_buffered_usage_events
 from ..webhook import WebhookDeliveryOutcome, enqueue_webhook_delivery
-from .logging import _elapsed_ms, _log_dropped_batches, _log_flush_summaries
+from .logging import (
+    _elapsed_ms,
+    _log_dropped_batches,
+    _log_flush_summaries,
+    _log_permanent_delivery_failure,
+)
 from .models import (
     DEFAULT_FLUSH_INTERVAL_SECONDS,
     DEFAULT_FLUSH_JITTER_RATIO,
@@ -433,7 +438,9 @@ class UsageEventBuffer:
                 else enqueue_webhook_delivery
             ),
             lambda pending_batch: self._make_delivery_outcome_callback(
-                pending_flush, pending_batch
+                pending_flush,
+                pending_batch,
+                trigger,
             ),
         )
         _apply_retained_batch_counts(pending_flush.summaries, admission_result.retained_batches)
@@ -450,9 +457,15 @@ class UsageEventBuffer:
         self,
         pending_flush: _PendingFlush,
         pending_batch: _PendingBatch,
+        trigger: UsageFlushTrigger,
     ) -> _DeliveryOutcomeCallback:
         def callback(outcome: WebhookDeliveryOutcome) -> None:
-            self._record_delivery_outcome(pending_flush, pending_batch, outcome)
+            self._record_delivery_outcome(
+                pending_flush,
+                pending_batch,
+                outcome,
+                trigger,
+            )
 
         return callback
 
@@ -461,6 +474,7 @@ class UsageEventBuffer:
         pending_flush: _PendingFlush,
         pending_batch: _PendingBatch,
         outcome: WebhookDeliveryOutcome,
+        trigger: UsageFlushTrigger,
     ) -> None:
         timer_to_start: _TimerHandle | None = None
         completion: _DeliveryCompletion | None = None
@@ -474,6 +488,12 @@ class UsageEventBuffer:
                 timer_to_start = self._schedule_timer_if_buffered_locked()
             self._sync_buffered_counter_locked()
 
+        if outcome == "permanent_failure":
+            _log_permanent_delivery_failure(
+                trigger,
+                pending_flush.flush_sequence,
+                pending_batch,
+            )
         if completion is not None and completion.retained_batches:
             _log_flush_summaries(
                 "retained",
@@ -570,7 +590,7 @@ def _enqueue_batches(
         try:
             admitted = enqueue_webhook(
                 batch.url,
-                batch.sandbox_token,
+                batch.bearer_credential,
                 batch.payload,
                 batch.proxy_log_path,
                 batch.log_type,

--- a/crates/runner/mitm-addon/src/usage/buffer/state.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/state.py
@@ -235,18 +235,18 @@ class _UsageBufferState:
     def add_model_usage_observations(
         self,
         url: str,
-        sandbox_token: str,
+        runner_token: str,
         run_id: str,
         observations: Iterable[ModelUsageObservation],
-        proxy_log_path: str,
+        admission_log_path: str,
         *,
         preserve_source_idempotency: bool,
         accepted_source_keys: set[str] | None,
     ) -> int:
         destination = _DestinationKey(
             url,
-            sandbox_token,
-            proxy_log_path,
+            runner_token,
+            "",
             "model",
             False,
             "model_usage_observation",
@@ -257,7 +257,7 @@ class _UsageBufferState:
         for observation in observations:
             if not _observation_has_safe_quantities(observation):
                 _log_rejected_usage_quantity(
-                    proxy_log_path,
+                    admission_log_path,
                     run_id,
                     "model_usage_observation",
                 )
@@ -271,17 +271,13 @@ class _UsageBufferState:
                     source_observations = self._source_observations.setdefault(destination, [])
                 source_observations.append(
                     _BufferedSourceObservation(
-                        run_id=run_id,
                         observation=_copy_observation(observation),
                     )
                 )
             else:
                 if buckets is None:
                     buckets = self._observation_buckets.setdefault(destination, {})
-                aggregate_key = _ObservationAggregateKey(
-                    run_id=run_id,
-                    model=observation["model"],
-                )
+                aggregate_key = _ObservationAggregateKey(model=observation["model"])
                 segments = buckets.setdefault(aggregate_key, [])
                 if not segments or not _observation_fits_segment(segments[-1], observation):
                     segments.append(_ObservationAggregateBucket())
@@ -344,25 +340,12 @@ class _UsageBufferState:
                 for event_count in source_events_by_run.values()
             )
         for buckets in self._observation_buckets.values():
-            observations_by_run: dict[str, int] = {}
-            for aggregate_key, segments in buckets.items():
-                observations_by_run[aggregate_key.run_id] = observations_by_run.get(
-                    aggregate_key.run_id, 0
-                ) + len(segments)
-            count += sum(
-                (observation_count + USAGE_EVENT_BATCH_SIZE - 1) // USAGE_EVENT_BATCH_SIZE
-                for observation_count in observations_by_run.values()
-            )
+            observation_count = sum(len(segments) for segments in buckets.values())
+            count += (observation_count + USAGE_EVENT_BATCH_SIZE - 1) // USAGE_EVENT_BATCH_SIZE
         for source_observations in self._source_observations.values():
-            source_observations_by_run: dict[str, int] = {}
-            for source_observation in source_observations:
-                source_observations_by_run[source_observation.run_id] = (
-                    source_observations_by_run.get(source_observation.run_id, 0) + 1
-                )
-            count += sum(
-                (observation_count + USAGE_EVENT_BATCH_SIZE - 1) // USAGE_EVENT_BATCH_SIZE
-                for observation_count in source_observations_by_run.values()
-            )
+            count += (
+                len(source_observations) + USAGE_EVENT_BATCH_SIZE - 1
+            ) // USAGE_EVENT_BATCH_SIZE
         return count
 
     def has_schedulable_work(self) -> bool:
@@ -708,14 +691,14 @@ class _UsageBufferState:
                 item.log_type,
             ),
         ):
-            observations_by_run: dict[str, list[_FlushEvent]] = {}
+            observations: list[_FlushEvent] = []
             for aggregate_key in sorted(
                 buckets_by_destination[destination],
-                key=lambda item: (item.run_id, item.model),
+                key=lambda item: item.model,
             ):
                 segments = buckets_by_destination[destination][aggregate_key]
                 for segment_index, bucket in enumerate(segments):
-                    observations_by_run.setdefault(aggregate_key.run_id, []).append(
+                    observations.append(
                         _FlushEvent(
                             payload={
                                 "idempotencyKey": self._observation_aggregate_idempotency_key(
@@ -733,7 +716,7 @@ class _UsageBufferState:
                             source_event_count=bucket.source_event_count,
                         )
                     )
-            batches.extend(_observation_flush_batches(destination, observations_by_run))
+            batches.extend(_observation_flush_batches(destination, observations))
         return batches
 
     def _build_source_observation_flush_batches(
@@ -751,15 +734,15 @@ class _UsageBufferState:
                 item.log_type,
             ),
         ):
-            observations_by_run: dict[str, list[_FlushEvent]] = {}
+            observations: list[_FlushEvent] = []
             for source_observation in observations_by_destination[destination]:
-                observations_by_run.setdefault(source_observation.run_id, []).append(
+                observations.append(
                     _FlushEvent(
                         payload=dict(source_observation.observation),
                         source_event_count=1,
                     )
                 )
-            batches.extend(_observation_flush_batches(destination, observations_by_run))
+            batches.extend(_observation_flush_batches(destination, observations))
         return batches
 
     def _events_by_run(
@@ -835,9 +818,6 @@ class _UsageBufferState:
                 self._buffer_id,
                 str(flush_sequence),
                 destination.url,
-                destination.sandbox_token,
-                destination.proxy_log_path,
-                aggregate_key.run_id,
                 aggregate_key.model,
                 str(segment_index),
             ),
@@ -872,28 +852,25 @@ def _observation_fits_segment(
 
 def _observation_flush_batches(
     destination: _DestinationKey,
-    observations_by_run: dict[str, list[_FlushEvent]],
+    observations: list[_FlushEvent],
 ) -> list[_FlushBatch]:
     batches: list[_FlushBatch] = []
-    for run_id in sorted(observations_by_run):
-        observations = observations_by_run[run_id]
-        for start in range(0, len(observations), USAGE_EVENT_BATCH_SIZE):
-            batch_observations = observations[start : start + USAGE_EVENT_BATCH_SIZE]
-            batches.append(
-                _FlushBatch(
-                    url=destination.url,
-                    sandbox_token=destination.sandbox_token,
-                    payload={
-                        "runId": run_id,
-                        "events": [observation.payload for observation in batch_observations],
-                    },
-                    proxy_log_path=destination.proxy_log_path,
-                    log_type=destination.log_type,
-                    source_event_count=sum(
-                        observation.source_event_count for observation in batch_observations
-                    ),
-                )
+    for start in range(0, len(observations), USAGE_EVENT_BATCH_SIZE):
+        batch_observations = observations[start : start + USAGE_EVENT_BATCH_SIZE]
+        batches.append(
+            _FlushBatch(
+                url=destination.url,
+                sandbox_token=destination.sandbox_token,
+                payload={
+                    "events": [observation.payload for observation in batch_observations],
+                },
+                proxy_log_path=destination.proxy_log_path,
+                log_type=destination.log_type,
+                source_event_count=sum(
+                    observation.source_event_count for observation in batch_observations
+                ),
             )
+        )
     return batches
 
 

--- a/crates/runner/mitm-addon/src/usage/buffer/state.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/state.py
@@ -186,12 +186,12 @@ class _UsageBufferState:
         buckets: dict[_AggregateKey, list[_AggregateBucket]] | None = None
         source_events: list[_BufferedSourceEvent] | None = None
         destination = _DestinationKey(
-            url,
-            sandbox_token,
-            proxy_log_path,
-            resource_field_name,
-            include_kind,
-            log_type,
+            url=url,
+            bearer_credential=sandbox_token,
+            proxy_log_path=proxy_log_path,
+            resource_field_name=resource_field_name,
+            include_kind=include_kind,
+            log_type=log_type,
         )
         accepted_count = 0
         for event in events:
@@ -244,12 +244,12 @@ class _UsageBufferState:
         accepted_source_keys: set[str] | None,
     ) -> int:
         destination = _DestinationKey(
-            url,
-            runner_token,
-            "",
-            "model",
-            False,
-            "model_usage_observation",
+            url=url,
+            bearer_credential=runner_token,
+            proxy_log_path="",
+            resource_field_name="model",
+            include_kind=False,
+            log_type="model_usage_observation",
         )
         buckets: dict[_ObservationAggregateKey, list[_ObservationAggregateBucket]] | None = None
         source_observations: list[_BufferedSourceObservation] | None = None
@@ -597,7 +597,7 @@ class _UsageBufferState:
             key=lambda item: (
                 _destination_priority(item),
                 item.url,
-                item.sandbox_token,
+                item.bearer_credential,
                 item.proxy_log_path,
                 item.resource_field_name,
                 item.include_kind,
@@ -612,7 +612,7 @@ class _UsageBufferState:
                     batches.append(
                         _FlushBatch(
                             url=destination.url,
-                            sandbox_token=destination.sandbox_token,
+                            bearer_credential=destination.bearer_credential,
                             payload={
                                 "runId": run_id,
                                 "events": [event.payload for event in batch_events],
@@ -636,7 +636,7 @@ class _UsageBufferState:
             key=lambda item: (
                 _destination_priority(item),
                 item.url,
-                item.sandbox_token,
+                item.bearer_credential,
                 item.proxy_log_path,
                 item.resource_field_name,
                 item.include_kind,
@@ -658,7 +658,7 @@ class _UsageBufferState:
                     batches.append(
                         _FlushBatch(
                             url=destination.url,
-                            sandbox_token=destination.sandbox_token,
+                            bearer_credential=destination.bearer_credential,
                             payload={
                                 "runId": run_id,
                                 "events": [event.payload for event in batch_events],
@@ -686,7 +686,7 @@ class _UsageBufferState:
             key=lambda item: (
                 _destination_priority(item),
                 item.url,
-                item.sandbox_token,
+                item.bearer_credential,
                 item.proxy_log_path,
                 item.log_type,
             ),
@@ -729,7 +729,7 @@ class _UsageBufferState:
             key=lambda item: (
                 _destination_priority(item),
                 item.url,
-                item.sandbox_token,
+                item.bearer_credential,
                 item.proxy_log_path,
                 item.log_type,
             ),
@@ -795,7 +795,7 @@ class _UsageBufferState:
                 self._buffer_id,
                 str(flush_sequence),
                 destination.url,
-                destination.sandbox_token,
+                destination.bearer_credential,
                 destination.proxy_log_path,
                 aggregate_key.run_id,
                 aggregate_key.kind,
@@ -860,7 +860,7 @@ def _observation_flush_batches(
         batches.append(
             _FlushBatch(
                 url=destination.url,
-                sandbox_token=destination.sandbox_token,
+                bearer_credential=destination.bearer_credential,
                 payload={
                     "events": [observation.payload for observation in batch_observations],
                 },
@@ -914,7 +914,7 @@ def _flush_batch_sort_key(batch: _FlushBatch) -> tuple[object, ...]:
     return (
         _batch_priority(batch),
         batch.url,
-        batch.sandbox_token,
+        batch.bearer_credential,
         batch.proxy_log_path,
         batch.log_type,
         run_id if isinstance(run_id, str) else "",

--- a/crates/runner/mitm-addon/src/usage/buffer/summaries.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/summaries.py
@@ -16,27 +16,26 @@ def _apply_retained_batch_counts(
     summaries: Iterable[_FlushSummary],
     retained_batches: Iterable[_PendingBatch],
 ) -> None:
-    retained_batch_counts: dict[str, int] = {}
-    retained_source_counts: dict[str, int] = {}
+    retained_batch_counts: dict[tuple[str, str], int] = {}
+    retained_source_counts: dict[tuple[str, str], int] = {}
     for pending_batch in retained_batches:
         batch = pending_batch.batch
-        retained_batch_counts[batch.proxy_log_path] = (
-            retained_batch_counts.get(batch.proxy_log_path, 0) + 1
-        )
-        retained_source_counts[batch.proxy_log_path] = (
-            retained_source_counts.get(batch.proxy_log_path, 0) + batch.source_event_count
-        )
+        key = (batch.proxy_log_path, batch.log_type)
+        retained_batch_counts[key] = retained_batch_counts.get(key, 0) + 1
+        retained_source_counts[key] = retained_source_counts.get(key, 0) + batch.source_event_count
     for summary in summaries:
-        summary.retained_webhook_batch_count = retained_batch_counts.get(summary.proxy_log_path, 0)
-        summary.retained_source_event_count = retained_source_counts.get(summary.proxy_log_path, 0)
+        key = (summary.proxy_log_path, summary.log_type)
+        summary.retained_webhook_batch_count = retained_batch_counts.get(key, 0)
+        summary.retained_source_event_count = retained_source_counts.get(key, 0)
 
 
 def _build_flush_summaries(batches: Iterable[_FlushBatch]) -> list[_FlushSummary]:
-    summaries: dict[str, _FlushSummary] = {}
+    summaries: dict[tuple[str, str], _FlushSummary] = {}
     for batch in batches:
+        key = (batch.proxy_log_path, batch.log_type)
         summary = summaries.setdefault(
-            batch.proxy_log_path,
-            _FlushSummary(proxy_log_path=batch.proxy_log_path),
+            key,
+            _FlushSummary(proxy_log_path=batch.proxy_log_path, log_type=batch.log_type),
         )
         summary.source_event_count += batch.source_event_count
         events = batch.payload.get("events")
@@ -48,7 +47,7 @@ def _build_flush_summaries(batches: Iterable[_FlushBatch]) -> list[_FlushSummary
             summary.run_ids.add(run_id)
         summary.destinations.add((batch.url, batch.proxy_log_path))
 
-    return [summaries[path] for path in sorted(summaries)]
+    return [summaries[key] for key in sorted(summaries)]
 
 
 def _pending_flush_from_batches(flush_sequence: int, batches: list[_FlushBatch]) -> _PendingFlush:

--- a/crates/runner/mitm-addon/src/usage/counters.py
+++ b/crates/runner/mitm-addon/src/usage/counters.py
@@ -25,6 +25,7 @@ from .underbilling import log_usage_underbilling
 _counter_lock = threading.Lock()
 _pending_write_lock = threading.Lock()
 _buffered_usage_events = 0
+_buffered_model_usage_observations = 0
 _pending_path = ""
 _usage_state_id = str(uuid.uuid4())
 # One-shot guard: sustained pending snapshot write failure makes the runner
@@ -54,12 +55,14 @@ _pending_reports = _PendingCounter("reports")
 
 def reset_for_tests() -> None:
     """Reset mutable counter state between tests."""
-    global _buffered_usage_events, _pending_path, _usage_state_id, _pending_write_error_logged
+    global _buffered_usage_events, _buffered_model_usage_observations
+    global _pending_path, _usage_state_id, _pending_write_error_logged
     with _counter_lock:
         for counter in (_in_flight_flows, _buffered_reports, _pending_reports):
             counter.value = 0
             counter.underflow_logged = False
         _buffered_usage_events = 0
+        _buffered_model_usage_observations = 0
         _pending_path = ""
         _usage_state_id = str(uuid.uuid4())
         _pending_write_error_logged = False
@@ -88,7 +91,9 @@ def _pending_snapshot_locked(flush_request_id: str | None = None) -> tuple[str, 
         "usageStateId": _usage_state_id,
         "updatedAtMs": int(time.time() * 1000),
         "flows": _in_flight_flows.value,
-        "buffered": _buffered_usage_events + _buffered_reports.value,
+        "buffered": (
+            _buffered_usage_events + _buffered_model_usage_observations + _buffered_reports.value
+        ),
         "reports": _pending_reports.value,
     }
     if flush_request_id:
@@ -264,6 +269,12 @@ def set_buffered_usage_events(count: int) -> None:
     global _buffered_usage_events
     with _counter_lock:
         _buffered_usage_events = max(0, count)
+
+
+def set_buffered_model_usage_observations(count: int) -> None:
+    global _buffered_model_usage_observations
+    with _counter_lock:
+        _buffered_model_usage_observations = max(0, count)
 
 
 def _mark_counter_underflow(counter: _PendingCounter) -> bool:

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -16,7 +16,7 @@ Model-provider usage reporting is separate from platform billing. Run contexts
 set ``flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER]`` to the canonical model
 id the proxy should report for model token usage. Billable rows go to
 ``/api/webhooks/agent/usage-event``; model usage statistics go to
-``/api/webhooks/agent/model-usage-observation``.
+``/api/runners/model-usage-observations``.
 """
 
 import uuid
@@ -55,8 +55,10 @@ from ..model_tokens import (
 )
 from ..quantities import is_usage_quantity
 from ..reporting_context import (
+    ModelUsageObservationReportingContext,
     UsageReportingContext,
     log_usage_reporting_context_missing,
+    model_usage_observation_reporting_context,
     usage_reporting_context,
 )
 from ..underbilling import log_usage_underbilling
@@ -211,7 +213,7 @@ def report_model_provider_usage_observation(
     """Buffer model usage statistics for observable model-provider responses.
 
     Observations are sent to
-    ``/api/webhooks/agent/model-usage-observation`` and are separate from
+    ``/api/runners/model-usage-observations`` and are separate from
     billable ``/api/webhooks/agent/usage-event`` rows. The function returns
     ``False`` when any of these gates fails:
 
@@ -222,7 +224,7 @@ def report_model_provider_usage_observation(
     - At least one observation is built from the available model-provider
       usage sources, including a positive integer quantity in
       ``MODEL_USAGE_CATEGORIES``.
-    - ``sandbox_token`` and ``get_api_url()`` are both non-empty.
+    - The process has both an API URL and runner token configured.
 
     It returns ``True`` when all gates pass, at least one observation is built,
     and the complete reporting context allows the process-local buffer to be
@@ -240,7 +242,7 @@ def report_model_provider_usage_observation(
 
     Non-billable BYOK model-provider flows with ``MODEL_USAGE_PROVIDER`` are
     expected to report observations without reporting billable usage events.
-    All failed gates are silent by design except missing sandbox token or API
+    All failed gates are silent by design except missing runner token or API
     URL, which writes a proxy warning because that indicates an
     environment/reporting setup problem.
     """
@@ -248,7 +250,12 @@ def report_model_provider_usage_observation(
         return False
     if not is_model_provider_usage_observable(flow):
         return False
-    observations = _build_model_provider_usage_observations(flow, run_id)
+    canonical_model = flow_metadata.model_usage_provider(flow.metadata)
+    observations = _build_model_provider_usage_observations(
+        flow,
+        run_id,
+        canonical_model,
+    )
     if not observations:
         return False
     return _buffer_model_provider_usage_observations(
@@ -286,6 +293,7 @@ def report_model_provider_usage_source(
     observations: list[ModelUsageObservation] = []
     source_id = f"{flow.id}:{message_id}"
     provider = _reported_model(flow, source_usage)
+    canonical_model = flow_metadata.model_usage_provider(flow.metadata)
     can_report_usage = _is_billable_model_provider(flow, run_id)
     can_report_observation = bool(run_id and is_model_provider_usage_observable(flow))
     if can_report_usage:
@@ -312,39 +320,45 @@ def report_model_provider_usage_source(
         observations = _build_model_usage_observations(
             run_id,
             source_id,
-            provider,
+            canonical_model,
             source_usage,
         )
 
     if not usage_events and not observations:
         return
 
-    context = usage_reporting_context(flow)
-    if not context.is_complete:
-        if usage_events:
-            firewall_name = flow_metadata.firewall_name(flow.metadata)
-            log_usage_reporting_context_missing(context, run_id, firewall_name)
-        if observations:
-            _log_model_usage_observation_context_missing(context)
-        return
-
     accepted_usage_keys: set[str] = set()
     accepted_observation_keys: set[str] = set()
     if usage_events:
-        _buffer_source_model_provider_usage_events(
-            context,
-            run_id,
-            source_id,
-            usage_events,
-            accepted_source_keys=accepted_usage_keys,
-        )
+        billing_context = usage_reporting_context(flow)
+        if billing_context.is_complete:
+            _buffer_source_model_provider_usage_events(
+                billing_context,
+                run_id,
+                source_id,
+                usage_events,
+                accepted_source_keys=accepted_usage_keys,
+            )
+        else:
+            firewall_name = flow_metadata.firewall_name(flow.metadata)
+            log_usage_reporting_context_missing(
+                billing_context,
+                run_id,
+                firewall_name,
+            )
     if observations:
-        _buffer_source_model_provider_usage_observations(
-            context,
-            run_id,
-            observations,
-            accepted_source_keys=accepted_observation_keys,
+        observation_context = model_usage_observation_reporting_context(
+            flow_metadata.proxy_log_path(flow.metadata)
         )
+        if observation_context.is_complete:
+            _buffer_source_model_provider_usage_observations(
+                observation_context,
+                run_id,
+                observations,
+                accepted_source_keys=accepted_observation_keys,
+            )
+        else:
+            _log_model_usage_observation_context_missing(observation_context)
     _log_model_provider_usage_source(
         flow,
         run_id,
@@ -485,13 +499,13 @@ def _buffer_model_provider_usage_observations(
     *,
     accepted_source_keys: set[str] | None,
 ) -> bool:
-    context = usage_reporting_context(flow)
+    context = model_usage_observation_reporting_context(flow_metadata.proxy_log_path(flow.metadata))
     if not context.is_complete:
         _log_model_usage_observation_context_missing(context)
         return False
     buffer_model_usage_observations(
-        context.model_usage_observation_url(),
-        context.sandbox_token,
+        context.url(),
+        context.runner_token,
         run_id,
         observations,
         context.proxy_log_path,
@@ -535,15 +549,15 @@ def _buffer_source_model_provider_usage_events(
 
 
 def _buffer_source_model_provider_usage_observations(
-    context: UsageReportingContext,
+    context: ModelUsageObservationReportingContext,
     run_id: str,
     observations: list[ModelUsageObservation],
     *,
     accepted_source_keys: set[str],
 ) -> None:
     buffer_source_model_usage_observations(
-        context.model_usage_observation_url(),
-        context.sandbox_token,
+        context.url(),
+        context.runner_token,
         run_id,
         observations,
         context.proxy_log_path,
@@ -577,12 +591,16 @@ def _model_input_partition_source_key(
     )
 
 
-def _log_model_usage_observation_context_missing(context: UsageReportingContext) -> None:
+def _log_model_usage_observation_context_missing(
+    context: ModelUsageObservationReportingContext,
+) -> None:
     log_proxy_entry(
         context.proxy_log_path,
         "warn",
-        "Cannot report model usage observation: missing sandbox_token or api_url",
+        "Cannot report model usage observation: missing runner_token or api_url",
         type="model_usage_observation",
+        missing_runner_token=context.missing_runner_token,
+        missing_api_url=context.missing_api_url,
     )
 
 
@@ -616,6 +634,7 @@ def _build_model_provider_usage_events(
 def _build_model_provider_usage_observations(
     flow: http.HTTPFlow,
     run_id: str,
+    canonical_model: str,
 ) -> list[ModelUsageObservation]:
     observations: list[ModelUsageObservation] = []
     for source in _iter_model_provider_usage_sources(flow):
@@ -623,7 +642,7 @@ def _build_model_provider_usage_observations(
             _build_model_usage_observations(
                 run_id,
                 source.source_id,
-                _reported_model(flow, source.usage),
+                canonical_model,
                 source.usage,
             )
         )

--- a/crates/runner/mitm-addon/src/usage/reporting_context.py
+++ b/crates/runner/mitm-addon/src/usage/reporting_context.py
@@ -8,7 +8,7 @@ from platform_api import get_api_url
 from .underbilling import log_usage_underbilling
 
 USAGE_EVENT_WEBHOOK_PATH = "/api/webhooks/agent/usage-event"
-MODEL_USAGE_OBSERVATION_WEBHOOK_PATH = "/api/webhooks/agent/model-usage-observation"
+MODEL_USAGE_OBSERVATION_RUNNER_PATH = "/api/runners/model-usage-observations"
 AGENT_TELEMETRY_WEBHOOK_PATH = "/api/webhooks/agent/telemetry"
 
 
@@ -40,11 +40,55 @@ class UsageReportingContext:
     def usage_event_url(self) -> str:
         return self._url_for(USAGE_EVENT_WEBHOOK_PATH)
 
-    def model_usage_observation_url(self) -> str:
-        return self._url_for(MODEL_USAGE_OBSERVATION_WEBHOOK_PATH)
-
     def telemetry_url(self) -> str:
         return self._url_for(AGENT_TELEMETRY_WEBHOOK_PATH)
+
+
+class ModelUsageObservationReportingContext:
+    """Process-level runner context for non-billing model observations."""
+
+    __slots__ = ("api_url", "proxy_log_path", "runner_token")
+
+    def __init__(self, *, api_url: str, runner_token: str, proxy_log_path: str) -> None:
+        self.api_url = api_url
+        self.runner_token = runner_token
+        self.proxy_log_path = proxy_log_path
+
+    @property
+    def missing_runner_token(self) -> bool:
+        return not bool(self.runner_token)
+
+    @property
+    def missing_api_url(self) -> bool:
+        return not bool(self.api_url)
+
+    @property
+    def is_complete(self) -> bool:
+        return not self.missing_runner_token and not self.missing_api_url
+
+    def url(self) -> str:
+        return f"{self.api_url}{MODEL_USAGE_OBSERVATION_RUNNER_PATH}"
+
+
+_model_usage_observation_api_url = ""
+_model_usage_observation_runner_token = ""
+
+
+def configure_model_usage_observation_reporting(*, api_url: str, runner_token: str) -> None:
+    """Configure the process-level runner observation destination."""
+    global _model_usage_observation_api_url, _model_usage_observation_runner_token
+    _model_usage_observation_api_url = api_url
+    _model_usage_observation_runner_token = runner_token
+
+
+def model_usage_observation_reporting_context(
+    proxy_log_path: str,
+) -> ModelUsageObservationReportingContext:
+    return ModelUsageObservationReportingContext(
+        api_url=_model_usage_observation_api_url,
+        runner_token=_model_usage_observation_runner_token,
+        proxy_log_path=proxy_log_path,
+    )
 
 
 def log_usage_reporting_context_missing(

--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -1,9 +1,9 @@
 """Webhook delivery (HTTP + thread pool).
 
-Background thread pool processes usage reports in parallel; the runner
+Background thread pools process usage reports in parallel; the runner
 first waits for the pending counters to drain, then ``done()`` flushes
-submitted futures during mitmproxy shutdown.  Falls back to synchronous
-delivery if the executor has been shut down (drain/shutdown race) so
+submitted futures during mitmproxy shutdown. Falls back to synchronous
+delivery if an executor has been shut down (drain/shutdown race) so
 reports are not silently lost.
 """
 
@@ -366,6 +366,10 @@ def _pending_model_observation_delivery_payload_count() -> int:
         return _pending_model_observation_delivery_payloads
 
 
+def pending_model_observation_delivery_payload_count_for_tests() -> int:
+    return _pending_model_observation_delivery_payload_count()
+
+
 def _post_admitted_webhook_with_retry(
     url: str,
     bearer_credential: str,
@@ -563,10 +567,8 @@ def enqueue_model_usage_observation_delivery(
 
 def shutdown_delivery_executors(*, wait: bool) -> None:
     """Shut down each configured delivery executor exactly once."""
-    executors = (usage_executor, model_usage_observation_executor)
-    shut_down: set[int] = set()
-    for executor in executors:
-        if id(executor) in shut_down:
-            continue
-        shut_down.add(id(executor))
-        executor.shutdown(wait=wait)
+    try:
+        usage_executor.shutdown(wait=wait)
+    finally:
+        if model_usage_observation_executor is not usage_executor:
+            model_usage_observation_executor.shutdown(wait=wait)

--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -13,7 +13,7 @@ import time
 import urllib.error
 import urllib.parse
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Executor, ThreadPoolExecutor
 from typing import Literal
 
 import network_log_sanitization
@@ -299,9 +299,15 @@ usage_executor = ThreadPoolExecutor(
     max_workers=USAGE_WEBHOOK_WORKERS,
     thread_name_prefix="usage",
 )
+model_usage_observation_executor = ThreadPoolExecutor(
+    max_workers=USAGE_WEBHOOK_WORKERS,
+    thread_name_prefix="model-usage-observation",
+)
 
 _delivery_capacity_lock = threading.Lock()
 _pending_delivery_payloads = 0
+_model_observation_delivery_capacity_lock = threading.Lock()
+_pending_model_observation_delivery_payloads = 0
 
 
 def _try_acquire_delivery_capacity() -> int | None:
@@ -331,24 +337,49 @@ def pending_delivery_payload_count_for_tests() -> int:
 
 
 def reset_delivery_capacity_for_tests() -> None:
-    global _pending_delivery_payloads
+    global _pending_delivery_payloads, _pending_model_observation_delivery_payloads
     with _delivery_capacity_lock:
         _pending_delivery_payloads = 0
+    with _model_observation_delivery_capacity_lock:
+        _pending_model_observation_delivery_payloads = 0
+
+
+def _try_acquire_model_observation_delivery_capacity() -> int | None:
+    global _pending_model_observation_delivery_payloads
+    with _model_observation_delivery_capacity_lock:
+        if _pending_model_observation_delivery_payloads >= MAX_PENDING_WEBHOOK_PAYLOADS:
+            return None
+        _pending_model_observation_delivery_payloads += 1
+        return _pending_model_observation_delivery_payloads
+
+
+def _release_model_observation_delivery_capacity() -> None:
+    global _pending_model_observation_delivery_payloads
+    with _model_observation_delivery_capacity_lock:
+        if _pending_model_observation_delivery_payloads <= 0:
+            raise RuntimeError("model observation delivery capacity released without acquire")
+        _pending_model_observation_delivery_payloads -= 1
+
+
+def _pending_model_observation_delivery_payload_count() -> int:
+    with _model_observation_delivery_capacity_lock:
+        return _pending_model_observation_delivery_payloads
 
 
 def _post_admitted_webhook_with_retry(
     url: str,
-    sandbox_token: str,
+    bearer_credential: str,
     payload: dict,
     proxy_log_path: str,
     log_type: str,
     pending_report: PendingReportLease,
     delivery_outcome_callback: _DeliveryOutcomeCallback | None,
+    release_capacity: Callable[[], None],
 ) -> None:
     try:
         _post_webhook_with_retry(
             url,
-            sandbox_token,
+            bearer_credential,
             payload,
             proxy_log_path,
             log_type,
@@ -356,7 +387,7 @@ def _post_admitted_webhook_with_retry(
             delivery_outcome_callback=delivery_outcome_callback,
         )
     finally:
-        _release_delivery_capacity()
+        release_capacity()
 
 
 def enqueue_webhook_delivery(
@@ -391,19 +422,50 @@ def enqueue_webhook_delivery(
     Returns whether the payload was admitted to delivery.  ``False`` means
     delivery was saturated and the caller still owns retry handling.
     """
-    admitted_count = _try_acquire_delivery_capacity()
+    return _enqueue_webhook_delivery(
+        url=url,
+        bearer_credential=sandbox_token,
+        payload=payload,
+        proxy_log_path=proxy_log_path,
+        log_type=log_type,
+        delivery_outcome_callback=delivery_outcome_callback,
+        executor=usage_executor,
+        try_acquire_capacity=_try_acquire_delivery_capacity,
+        release_capacity=_release_delivery_capacity,
+        pending_delivery_count=_pending_delivery_payload_count,
+        saturation_label="usage delivery",
+        fallback_message="Webhook executor shut down, falling back to synchronous delivery",
+    )
+
+
+def _enqueue_webhook_delivery(
+    *,
+    url: str,
+    bearer_credential: str,
+    payload: dict,
+    proxy_log_path: str,
+    log_type: str,
+    delivery_outcome_callback: _DeliveryOutcomeCallback | None,
+    executor: Executor,
+    try_acquire_capacity: Callable[[], int | None],
+    release_capacity: Callable[[], None],
+    pending_delivery_count: Callable[[], int],
+    saturation_label: str,
+    fallback_message: str,
+) -> bool:
+    admitted_count = try_acquire_capacity()
     if admitted_count is None:
         _log_webhook_entry(
             proxy_log_path,
             "info",
-            "was not admitted because usage delivery is saturated",
+            f"was not admitted because {saturation_label} is saturated",
             url,
             log_type,
             payload,
             extra_fields={
                 "reason": "delivery_saturated",
                 "webhook_delivery_capacity": MAX_PENDING_WEBHOOK_PAYLOADS,
-                "webhook_delivery_pending": _pending_delivery_payload_count(),
+                "webhook_delivery_pending": pending_delivery_count(),
             },
         )
         return False
@@ -422,20 +484,21 @@ def enqueue_webhook_delivery(
             },
         )
     except Exception:
-        _release_delivery_capacity()
+        release_capacity()
         raise
 
     pending_report = admit_pending_report()
     try:
-        usage_executor.submit(
+        executor.submit(
             _post_admitted_webhook_with_retry,
             url,
-            sandbox_token,
+            bearer_credential,
             payload,
             proxy_log_path,
             log_type,
             pending_report,
             delivery_outcome_callback,
+            release_capacity,
         )
     except RuntimeError:
         # Executor shut down (done() already called during drain).
@@ -444,14 +507,14 @@ def enqueue_webhook_delivery(
             log_proxy_entry(
                 proxy_log_path,
                 "warn",
-                "Webhook executor shut down, falling back to synchronous delivery",
+                fallback_message,
                 type=log_type,
                 url=url,
             )
             fallback_started = True
             _post_webhook_with_retry(
                 url,
-                sandbox_token,
+                bearer_credential,
                 payload,
                 proxy_log_path,
                 log_type,
@@ -463,9 +526,47 @@ def enqueue_webhook_delivery(
                 pending_report.release()
             raise
         finally:
-            _release_delivery_capacity()
+            release_capacity()
     except Exception:
         pending_report.release()
-        _release_delivery_capacity()
+        release_capacity()
         raise
     return True
+
+
+def enqueue_model_usage_observation_delivery(
+    url: str,
+    runner_token: str,
+    payload: dict,
+    proxy_log_path: str,
+    log_type: str,
+    delivery_outcome_callback: _DeliveryOutcomeCallback | None = None,
+) -> bool:
+    """Submit a model observation without consuming billing delivery capacity."""
+    return _enqueue_webhook_delivery(
+        url=url,
+        bearer_credential=runner_token,
+        payload=payload,
+        proxy_log_path=proxy_log_path,
+        log_type=log_type,
+        delivery_outcome_callback=delivery_outcome_callback,
+        executor=model_usage_observation_executor,
+        try_acquire_capacity=_try_acquire_model_observation_delivery_capacity,
+        release_capacity=_release_model_observation_delivery_capacity,
+        pending_delivery_count=_pending_model_observation_delivery_payload_count,
+        saturation_label="model observation delivery",
+        fallback_message=(
+            "Model observation executor shut down, falling back to synchronous delivery"
+        ),
+    )
+
+
+def shutdown_delivery_executors(*, wait: bool) -> None:
+    """Shut down each configured delivery executor exactly once."""
+    executors = (usage_executor, model_usage_observation_executor)
+    shut_down: set[int] = set()
+    for executor in executors:
+        if id(executor) in shut_down:
+            continue
+        shut_down.add(id(executor))
+        executor.shutdown(wait=wait)

--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -100,9 +100,9 @@ def _raw_webhook_url_log_text_variants(raw_url: str) -> tuple[str, ...]:
     return tuple(sorted(variants, key=len, reverse=True))
 
 
-def _post_webhook(url: str, sandbox_token: str, data: bytes) -> None:
+def _post_webhook(url: str, bearer_credential: str, data: bytes) -> None:
     """POST JSON data to a platform webhook.  Raises on failure."""
-    req = make_api_request(url, data, sandbox_token)
+    req = make_api_request(url, data, bearer_credential)
     try:
         with _opener.open(req, timeout=10):
             pass
@@ -115,7 +115,7 @@ def _post_webhook(url: str, sandbox_token: str, data: bytes) -> None:
 
 def _post_webhook_with_retry(
     url: str,
-    sandbox_token: str,
+    bearer_credential: str,
     payload: dict,
     proxy_log_path: str,
     log_type: str,
@@ -132,7 +132,7 @@ def _post_webhook_with_retry(
     """
     try:
         outcome = _do_post_webhook_attempts(
-            url, sandbox_token, payload, proxy_log_path, log_type, max_retries
+            url, bearer_credential, payload, proxy_log_path, log_type, max_retries
         )
     except Exception:
         if delivery_outcome_callback is not None:
@@ -190,7 +190,7 @@ def _handle_retryable_webhook_failure(
 
 def _do_post_webhook_attempts(
     url: str,
-    sandbox_token: str,
+    bearer_credential: str,
     payload: dict,
     proxy_log_path: str,
     log_type: str,
@@ -214,7 +214,7 @@ def _do_post_webhook_attempts(
     payload_bytes = len(data)
     for attempt in range(max_retries + 1):
         try:
-            _post_webhook(url, sandbox_token, data)
+            _post_webhook(url, bearer_credential, data)
             _log_webhook_entry(
                 proxy_log_path,
                 "info",

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -484,7 +484,7 @@ def usage_webhook_api(mitm_ctx):
 
 @pytest.fixture
 def sync_usage_executor():
-    """Swap ``usage.webhook.usage_executor`` for a synchronous stub.
+    """Swap both usage webhook executors for a synchronous stub.
 
     Tests that want webhook side effects to complete before inline
     assertions can use this instead of a background thread plus explicit

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -81,6 +81,7 @@ def _reset_module_state() -> Iterator[None]:
     codex_output_timing.reset_for_tests()
     model_provider_failure.reset_for_tests()
     usage.reset_usage_buffer_for_tests()
+    usage.configure_model_usage_observation_reporting(api_url="", runner_token="")
     usage.webhook.reset_delivery_capacity_for_tests()
     usage.counters.reset_for_tests()
     logging_utils.reset_log_writer_for_tests()
@@ -407,9 +408,17 @@ def mitm_ctx(tmp_path):
                 client_session_id=client_session_id,
                 client_version=client_version,
             )
+            usage.configure_model_usage_observation_reporting(
+                api_url=api_url,
+                runner_token=str(uuid.uuid4()),
+            )
             try:
                 yield log
             finally:
+                usage.configure_model_usage_observation_reporting(
+                    api_url="",
+                    runner_token="",
+                )
                 platform_api.configure_client_headers(
                     client_session_id="",
                     client_version="",
@@ -518,8 +527,10 @@ def sync_usage_executor():
                 future.result()
 
     original = usage.webhook.usage_executor
+    original_observation = usage.webhook.model_usage_observation_executor
     executor = _InlineExecutor()
     usage.webhook.usage_executor = executor
+    usage.webhook.model_usage_observation_executor = executor
     try:
         yield executor
     finally:
@@ -527,6 +538,7 @@ def sync_usage_executor():
             executor.shutdown(wait=True)
         finally:
             usage.webhook.usage_executor = original
+            usage.webhook.model_usage_observation_executor = original_observation
 
 
 @pytest.fixture

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -143,6 +143,21 @@ class TestUsagePendingCounter:
         usage.write_pending_snapshot(flush_request_id="request-2")
         assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-2")
 
+    def test_buffered_snapshot_adds_billing_and_model_observation_lanes(self, tmp_path):
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
+
+        usage.counters.set_buffered_usage_events(2)
+        usage.counters.set_buffered_model_usage_observations(3)
+
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=5,
+            reports=0,
+            flush_request_id="both-lanes",
+        )
+
     def test_buffered_report_lease_composes_with_usage_events(self, tmp_path):
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))

--- a/crates/runner/mitm-addon/tests/test_done_hook.py
+++ b/crates/runner/mitm-addon/tests/test_done_hook.py
@@ -27,6 +27,7 @@ class TestDoneHook:
         with (
             patch.object(usage, "flush_usage_events") as flush_usage_events,
             patch.object(usage.webhook, "usage_executor", mock_executor),
+            patch.object(usage.webhook, "model_usage_observation_executor", mock_executor),
             patch.object(
                 mitm_addon.auth_base_forwarder,
                 "shutdown_forward_request_workers",
@@ -89,6 +90,7 @@ class TestDoneHook:
             patch.object(runner_flush_lifecycle, "_usage_flush_signal_lock", lock),
             patch.object(usage, "flush_usage_events", side_effect=flush_usage_events),
             patch.object(usage.webhook, "usage_executor", mock_executor),
+            patch.object(usage.webhook, "model_usage_observation_executor", mock_executor),
             patch.object(
                 mitm_addon.auth_base_forwarder,
                 "shutdown_forward_request_workers",
@@ -216,6 +218,7 @@ class TestDoneHook:
                 patch.object(runner_flush_lifecycle, "__file__", str(lifecycle_file)),
                 patch.object(usage, "flush_usage_events", side_effect=flush_usage_events),
                 patch.object(usage.webhook, "usage_executor", mock_executor),
+                patch.object(usage.webhook, "model_usage_observation_executor", mock_executor),
                 patch.object(
                     mitm_addon.auth_base_forwarder,
                     "shutdown_forward_request_workers",
@@ -291,6 +294,7 @@ class TestDoneHook:
                 side_effect=flush_usage_for_runner_request,
             ),
             patch.object(usage.webhook, "usage_executor", mock_executor),
+            patch.object(usage.webhook, "model_usage_observation_executor", mock_executor),
             patch.object(
                 mitm_addon.auth_base_forwarder,
                 "shutdown_forward_request_workers",
@@ -316,6 +320,7 @@ class TestDoneHook:
         with (
             patch.object(usage, "flush_usage_events"),
             patch.object(usage.webhook, "usage_executor", mock_executor),
+            patch.object(usage.webhook, "model_usage_observation_executor", mock_executor),
             patch.object(mitm_addon.auth_base_forwarder, "shutdown_forward_request_workers"),
             patch.object(mitm_addon, "shutdown_log_writer"),
         ):
@@ -346,6 +351,7 @@ class TestDoneHook:
                 "_flush_usage_for_runner_request",
             ) as flush_runner_usage,
             patch.object(usage.webhook, "usage_executor", mock_executor),
+            patch.object(usage.webhook, "model_usage_observation_executor", mock_executor),
             patch.object(
                 mitm_addon.auth_base_forwarder,
                 "shutdown_forward_request_workers",
@@ -451,6 +457,7 @@ class TestDoneHook:
         with (
             patch.object(runner_flush_lifecycle, "drain_and_close") as drain_and_close,
             patch.object(usage.webhook, "usage_executor", mock_executor),
+            patch.object(usage.webhook, "model_usage_observation_executor", mock_executor),
             patch.object(
                 usage,
                 "drain_usage_events_after_executor_shutdown",
@@ -631,6 +638,7 @@ class TestDoneHook:
 
         with (
             patch.object(usage.webhook, "usage_executor", mock_executor),
+            patch.object(usage.webhook, "model_usage_observation_executor", mock_executor),
             patch.object(mitm_addon.auth_base_forwarder, "shutdown_forward_request_workers"),
             patch.object(mitm_addon, "shutdown_log_writer"),
         ):

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -733,7 +733,7 @@ class TestErrorHandler:
         requests_by_path = {request.path: request for request in webhook.requests}
         assert set(requests_by_path) == {
             "/api/webhooks/agent/usage-event",
-            "/api/webhooks/agent/model-usage-observation",
+            "/api/runners/model-usage-observations",
         }
         body = requests_by_path["/api/webhooks/agent/usage-event"].json_body()
         assert body["runId"] == "run-int-002"
@@ -750,10 +750,8 @@ class TestErrorHandler:
         ]
         billing_key = body["events"][0]["idempotencyKey"]
         uuid.UUID(billing_key)
-        observation_body = requests_by_path[
-            "/api/webhooks/agent/model-usage-observation"
-        ].json_body()
-        assert observation_body["runId"] == "run-int-002"
+        observation_body = requests_by_path["/api/runners/model-usage-observations"].json_body()
+        assert set(observation_body) == {"events"}
         assert [
             {key: value for key, value in event.items() if key != "idempotencyKey"}
             for event in observation_body["events"]

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -306,13 +306,22 @@ class TestReportModelProviderUsage:
             "tokens.input": 100,
         }
 
+        runner_token = str(uuid.uuid4())
         with usage_webhook_api() as webhook:
+            usage.configure_model_usage_observation_reporting(
+                api_url=webhook.api_url,
+                runner_token=runner_token,
+            )
             usage.report_model_provider_usage_observation(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
 
         assert webhook.request_count == 1
-        assert webhook.requests[0].path == "/api/webhooks/agent/model-usage-observation"
-        body = webhook.requests[0].json_body()
+        request = webhook.requests[0]
+        assert request.path == "/api/runners/model-usage-observations"
+        assert request.header("authorization") == f"Bearer {runner_token}"
+        assert "tok-xyz" not in request.body.decode()
+        body = request.json_body()
+        assert set(body) == {"events"}
         assert set(body["events"][0]) == {
             "idempotencyKey",
             "model",
@@ -346,12 +355,10 @@ class TestReportModelProviderUsage:
         requests_by_path = {request.path: request for request in webhook.requests}
         assert set(requests_by_path) == {
             "/api/webhooks/agent/usage-event",
-            "/api/webhooks/agent/model-usage-observation",
+            "/api/runners/model-usage-observations",
         }
         usage_body = requests_by_path["/api/webhooks/agent/usage-event"].json_body()
-        observation_body = requests_by_path[
-            "/api/webhooks/agent/model-usage-observation"
-        ].json_body()
+        observation_body = requests_by_path["/api/runners/model-usage-observations"].json_body()
         assert usage_body["events"][0]["provider"] == "claude-sonnet-4-6"
         assert observation_body["events"][0]["model"] == "claude-sonnet-4-6"
         assert (
@@ -379,7 +386,7 @@ class TestReportModelProviderUsage:
         assert observed is False
         assert webhook.request_count == 0
 
-    def test_logs_warning_when_observation_missing_sandbox_token(
+    def test_logs_warning_when_observation_missing_runner_token(
         self, tmp_path, real_flow, mitm_ctx
     ):
         flow = real_flow(with_response=False, host="api.anthropic.com")
@@ -392,6 +399,10 @@ class TestReportModelProviderUsage:
         flow.metadata[metadata_keys.SANDBOX_PROXY_LOG_PATH] = str(proxy_log)
 
         with mitm_ctx(api_url="https://api.vm0.ai"):
+            usage.configure_model_usage_observation_reporting(
+                api_url="https://api.vm0.ai",
+                runner_token="",
+            )
             observed = usage.report_model_provider_usage_observation(flow, "run-abc-123")
 
         assert observed is False
@@ -400,9 +411,11 @@ class TestReportModelProviderUsage:
         assert entry["level"] == "warn"
         assert (
             entry["message"]
-            == "Cannot report model usage observation: missing sandbox_token or api_url"
+            == "Cannot report model usage observation: missing runner_token or api_url"
         )
         assert entry["type"] == "model_usage_observation"
+        assert entry["missing_runner_token"] is True
+        assert entry["missing_api_url"] is False
 
     def test_skips_non_model_provider(self, real_flow, usage_webhook_api):
         """Should NOT reach the webhook boundary for non-model-provider requests."""
@@ -580,12 +593,10 @@ class TestReportModelProviderUsage:
         requests_by_path = {request.path: request for request in webhook.requests}
         assert set(requests_by_path) == {
             "/api/webhooks/agent/usage-event",
-            "/api/webhooks/agent/model-usage-observation",
+            "/api/runners/model-usage-observations",
         }
         usage_body = requests_by_path["/api/webhooks/agent/usage-event"].json_body()
-        observation_body = requests_by_path[
-            "/api/webhooks/agent/model-usage-observation"
-        ].json_body()
+        observation_body = requests_by_path["/api/runners/model-usage-observations"].json_body()
         assert [
             {key: value for key, value in event.items() if key != "idempotencyKey"}
             for event in usage_body["events"]
@@ -829,7 +840,7 @@ class TestModelProviderResponseHookUsage:
         requests_by_path = {request.path: request for request in webhook.requests}
         assert set(requests_by_path) == {
             "/api/webhooks/agent/usage-event",
-            "/api/webhooks/agent/model-usage-observation",
+            "/api/runners/model-usage-observations",
         }
         body = requests_by_path["/api/webhooks/agent/usage-event"].json_body()
         assert body["runId"] == "run-int-001"
@@ -837,9 +848,7 @@ class TestModelProviderResponseHookUsage:
         assert by_category["tokens.input"]["quantity"] == 100
         assert by_category["tokens.output"]["quantity"] == 500
         assert by_category["tokens.input"]["provider"] == "claude-sonnet-4-6"
-        observation_body = requests_by_path[
-            "/api/webhooks/agent/model-usage-observation"
-        ].json_body()
+        observation_body = requests_by_path["/api/runners/model-usage-observations"].json_body()
         assert observation_body["events"] == [
             {
                 "idempotencyKey": observation_body["events"][0]["idempotencyKey"],

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_source_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_source_reporting.py
@@ -39,7 +39,7 @@ def deferred_websocket_trim_scheduler(
 class TestModelProviderWebSocketUsageSourceRelease:
     """Tests for sources that cannot be delivered to the usage webhook."""
 
-    def test_model_websocket_missing_context_releases_positive_source(
+    def test_model_websocket_missing_billing_context_reports_observation_and_releases_source(
         self, tmp_path, real_flow, mitm_ctx
     ):
         flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
@@ -60,10 +60,8 @@ class TestModelProviderWebSocketUsageSourceRelease:
         assert model_provider_usage_sources(flow) == {}
         entries = read_jsonl_entries_after_flush(proxy_log)
         [entry] = [entry for entry in entries if entry.get("type") == "usage_underbilling"]
-        [observation_entry] = [
-            entry for entry in entries if entry.get("type") == "model_usage_observation"
-        ]
-        assert not any(entry.get("type") == "model_usage_source" for entry in entries)
+        [source_entry] = [entry for entry in entries if entry.get("type") == "model_usage_source"]
+        assert not any(entry.get("type") == "model_usage_observation" for entry in entries)
         assert entry["type"] == "usage_underbilling"
         assert entry["reason"] == "missing_reporting_context"
         assert entry["underbilling_class"] == "confirmed"
@@ -71,10 +69,10 @@ class TestModelProviderWebSocketUsageSourceRelease:
         assert entry["firewall_name"] == "model-provider:openai-api-key"
         assert entry["missing_sandbox_token"] is True
         assert entry["missing_api_url"] is False
-        assert observation_entry["level"] == "warn"
-        assert (
-            observation_entry["message"]
-            == "Cannot report model usage observation: missing sandbox_token or api_url"
+        assert all(event["buffer_accepted"] is False for event in source_entry["usage_events"])
+        assert all(
+            observation["buffer_accepted"] is True
+            for observation in source_entry["model_usage_observations"]
         )
 
     def test_model_websocket_missing_api_url_releases_positive_source(

--- a/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
+++ b/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
@@ -335,6 +335,41 @@ class TestRunnerUsageFlushSignal:
             flush_request_id=_DEFAULT_USAGE_FLUSH_REQUEST_ID,
         )
 
+    def test_formal_runner_request_attempts_observations_when_billing_flush_fails(
+        self,
+        runner_usage_flush_files: RunnerUsageFlushFiles,
+        mitm_ctx,
+    ) -> None:
+        observations_flushed = threading.Event()
+        runner_usage_flush_files.write_usage_flush_request()
+
+        with (
+            mitm_ctx(),
+            patch.object(
+                usage,
+                "flush_usage_events",
+                side_effect=OSError("billing unavailable"),
+            ) as flush_usage_events,
+            patch.object(
+                usage,
+                "flush_model_usage_observations",
+                side_effect=lambda *, trigger: observations_flushed.set() or 0,
+            ) as flush_model_usage_observations,
+        ):
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
+            assert observations_flushed.wait(timeout=1)
+            wait_for_usage_flush_worker_to_stop()
+
+        flush_usage_events.assert_called_once_with(trigger="runner")
+        flush_model_usage_observations.assert_called_once_with(trigger="runner")
+        assert_pending(
+            runner_usage_flush_files.pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id=_DEFAULT_USAGE_FLUSH_REQUEST_ID,
+        )
+
     def test_signal_worker_start_handoff_to_closed_shutdown_does_not_spawn_worker(
         self, runner_usage_flush_files: RunnerUsageFlushFiles
     ) -> None:

--- a/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
+++ b/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
@@ -278,6 +278,63 @@ class TestRunnerUsageFlushSignal:
             flush_request_id="request-1",
         )
 
+    def test_unmarked_signal_does_not_flush_model_observations(
+        self, runner_usage_flush_files: RunnerUsageFlushFiles
+    ) -> None:
+        billing_flushed = threading.Event()
+
+        with (
+            patch.object(
+                usage,
+                "flush_usage_events",
+                side_effect=lambda *, trigger: billing_flushed.set() or 0,
+            ) as flush_usage_events,
+            patch.object(
+                usage,
+                "flush_model_usage_observations",
+            ) as flush_model_usage_observations,
+        ):
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
+            assert billing_flushed.wait(timeout=1)
+            wait_for_usage_flush_worker_to_stop()
+
+        flush_usage_events.assert_called_once_with(trigger="runner")
+        flush_model_usage_observations.assert_not_called()
+        assert_pending(
+            runner_usage_flush_files.pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+        )
+
+    def test_formal_runner_request_flushes_model_observations_before_acknowledgement(
+        self, runner_usage_flush_files: RunnerUsageFlushFiles
+    ) -> None:
+        observations_flushed = threading.Event()
+        runner_usage_flush_files.write_usage_flush_request()
+
+        with (
+            patch.object(usage, "flush_usage_events", return_value=0) as flush_usage_events,
+            patch.object(
+                usage,
+                "flush_model_usage_observations",
+                side_effect=lambda *, trigger: observations_flushed.set() or 0,
+            ) as flush_model_usage_observations,
+        ):
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
+            assert observations_flushed.wait(timeout=1)
+            wait_for_usage_flush_worker_to_stop()
+
+        flush_usage_events.assert_called_once_with(trigger="runner")
+        flush_model_usage_observations.assert_called_once_with(trigger="runner")
+        assert_pending(
+            runner_usage_flush_files.pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id=_DEFAULT_USAGE_FLUSH_REQUEST_ID,
+        )
+
     def test_signal_worker_start_handoff_to_closed_shutdown_does_not_spawn_worker(
         self, runner_usage_flush_files: RunnerUsageFlushFiles
     ) -> None:

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_aggregation.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_aggregation.py
@@ -76,7 +76,7 @@ def test_flush_keeps_model_observation_source_vector_in_one_safe_segment(tmp_pat
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
 
     usage.buffer_model_usage_observations(
-        "https://api.test/api/webhooks/agent/model-usage-observation",
+        "https://api.test/api/runners/model-usage-observations",
         "token-a",
         "run-1",
         [
@@ -197,7 +197,7 @@ def test_rejects_out_of_range_model_observation_before_recording_idempotency(tmp
 
     assert (
         usage.buffer_source_model_usage_observations(
-            "https://api.test/api/webhooks/agent/model-usage-observation",
+            "https://api.test/api/runners/model-usage-observations",
             "token-a",
             "run-1",
             [
@@ -229,7 +229,7 @@ def test_model_usage_observation_buffer_uses_model_event_shape(tmp_path):
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
 
     usage.buffer_model_usage_observations(
-        "https://api.test/api/webhooks/agent/model-usage-observation",
+        "https://api.test/api/runners/model-usage-observations",
         "token-a",
         "run-1",
         [
@@ -490,7 +490,7 @@ def test_source_preserving_observation_buffer_uses_model_event_shape(tmp_path):
     accepted_source_keys: set[str] = set()
 
     usage.buffer_source_model_usage_observations(
-        "https://api.test/api/webhooks/agent/model-usage-observation",
+        "https://api.test/api/runners/model-usage-observations",
         "token-a",
         "run-1",
         [
@@ -508,7 +508,6 @@ def test_source_preserving_observation_buffer_uses_model_event_shape(tmp_path):
 
     enqueue.assert_called_once()
     assert enqueue.last_call.payload == {
-        "runId": "run-1",
         "events": [
             {
                 "idempotencyKey": "source-1",
@@ -521,6 +520,81 @@ def test_source_preserving_observation_buffer_uses_model_event_shape(tmp_path):
         ],
     }
     assert enqueue.last_call.log_type == "model_usage_observation"
+
+
+def test_source_observations_batch_across_runs_without_changing_source_keys(tmp_path):
+    enqueue = RecordingEnqueue()
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+
+    for run_id, source_key in (("run-1", "source-1"), ("run-2", "source-2")):
+        usage.buffer_source_model_usage_observations(
+            "https://api.test/api/runners/model-usage-observations",
+            "runner-token",
+            run_id,
+            [observation(source_key=source_key, input_tokens=10)],
+            str(tmp_path / f"{run_id}.jsonl"),
+        )
+
+    assert usage.flush_model_usage_observations(trigger="test") == 1
+    assert set(enqueue.last_call.payload) == {"events"}
+    assert {
+        flushed_observation["idempotencyKey"]
+        for flushed_observation in enqueue.last_call.payload["events"]
+    } == {"source-1", "source-2"}
+
+
+def test_model_observations_aggregate_same_model_across_runs(tmp_path):
+    enqueue = RecordingEnqueue()
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+
+    for run_id, source_key, input_tokens in (
+        ("run-1", "source-1", 10),
+        ("run-2", "source-2", 7),
+    ):
+        usage.buffer_model_usage_observations(
+            "https://api.test/api/runners/model-usage-observations",
+            "runner-token",
+            run_id,
+            [observation(source_key=source_key, input_tokens=input_tokens)],
+            str(tmp_path / f"{run_id}.jsonl"),
+        )
+
+    assert usage.flush_model_usage_observations(trigger="test") == 1
+    enqueue.assert_called_once()
+    assert enqueue.last_call.proxy_log_path == ""
+    assert enqueue.last_call.payload.keys() == {"events"}
+    [flushed_observation] = enqueue.last_call.payload["events"]
+    uuid.UUID(flushed_observation.pop("idempotencyKey"))
+    assert flushed_observation == {
+        "model": "claude-sonnet-4-6",
+        "inputTokens": 17,
+        "outputTokens": 0,
+        "cacheReadInputTokens": 0,
+        "cacheCreationInputTokens": 0,
+    }
+
+
+def test_model_observations_keep_different_canonical_models_separate(tmp_path):
+    enqueue = RecordingEnqueue()
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+
+    for run_id, source_key, model in (
+        ("run-1", "source-1", "model-a"),
+        ("run-2", "source-2", "model-b"),
+    ):
+        usage.buffer_model_usage_observations(
+            "https://api.test/api/runners/model-usage-observations",
+            "runner-token",
+            run_id,
+            [observation(source_key=source_key, model=model, input_tokens=10)],
+            str(tmp_path / f"{run_id}.jsonl"),
+        )
+
+    assert usage.flush_model_usage_observations(trigger="test") == 1
+    assert {
+        (flushed_observation["model"], flushed_observation["inputTokens"])
+        for flushed_observation in enqueue.last_call.payload["events"]
+    } == {("model-a", 10), ("model-b", 10)}
 
 
 def test_flush_keeps_runs_categories_providers_and_destinations_separate(tmp_path):
@@ -708,7 +782,7 @@ def test_flushes_when_model_observation_bucket_count_reaches_exact_bound(tmp_pat
     proxy_log_path = str(tmp_path / "proxy.jsonl")
 
     usage.buffer_model_usage_observations(
-        "https://api.test/api/webhooks/agent/model-usage-observation",
+        "https://api.test/api/runners/model-usage-observations",
         "token-a",
         "run-1",
         [
@@ -721,7 +795,7 @@ def test_flushes_when_model_observation_bucket_count_reaches_exact_bound(tmp_pat
 
     final_index = usage_buffer.MAX_AGGREGATE_BUCKETS - 1
     usage.buffer_model_usage_observations(
-        "https://api.test/api/webhooks/agent/model-usage-observation",
+        "https://api.test/api/runners/model-usage-observations",
         "token-a",
         "run-1",
         [
@@ -735,7 +809,7 @@ def test_flushes_when_model_observation_bucket_count_reaches_exact_bound(tmp_pat
 
     enqueue.assert_called_once()
     payload = enqueue.last_call.payload
-    assert payload["runId"] == "run-1"
+    assert "runId" not in payload
     assert len(payload["events"]) == usage_buffer.MAX_AGGREGATE_BUCKETS
     assert {flushed_observation["model"] for flushed_observation in payload["events"]} == {
         f"model-{index}" for index in range(usage_buffer.MAX_AGGREGATE_BUCKETS)

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -456,7 +456,7 @@ def test_billable_usage_is_admitted_before_model_usage_observation(tmp_path):
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
     proxy_log_path = str(tmp_path / "proxy.jsonl")
     usage.buffer_model_usage_observations(
-        "https://api.test/api/webhooks/agent/model-usage-observation",
+        "https://api.test/api/runners/model-usage-observations",
         "token-a",
         "run-1",
         [observation(source_key="observation-source", input_tokens=1)],
@@ -488,7 +488,7 @@ def test_live_billable_usage_preempts_retained_model_usage_observation(tmp_path)
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
     proxy_log_path = str(tmp_path / "proxy.jsonl")
     usage.buffer_model_usage_observations(
-        "https://api.test/api/webhooks/agent/model-usage-observation",
+        "https://api.test/api/runners/model-usage-observations",
         "token-a",
         "run-1",
         [observation(source_key="observation-source", input_tokens=1)],

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -26,6 +26,71 @@ def assert_usage_buffer_drained(enqueue: RecordingEnqueue) -> None:
     enqueue.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "post_executor_drain",
+    [pytest.param(False, id="flush"), pytest.param(True, id="post-executor-drain")],
+)
+def test_billing_lane_failure_still_attempts_observation_lane(tmp_path, post_executor_drain: bool):
+    def fail_billing_enqueue(
+        url: str,
+        sandbox_token: str,
+        payload: dict,
+        path: str,
+        log_type: str,
+        delivery_outcome_callback: DeliveryOutcomeCallback,
+    ) -> bool:
+        del url, sandbox_token, payload, path
+        if log_type == "usage_event":
+            raise OSError("billing unavailable")
+        delivery_outcome_callback("success")
+        return True
+
+    enqueue = RecordingEnqueue(side_effect=fail_billing_enqueue)
+    pending_path = tmp_path / "usage-pending"
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+    usage.set_pending_path(str(pending_path))
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [event(source_key="billing-source")],
+        proxy_log_path,
+    )
+    usage.buffer_model_usage_observations(
+        "https://api.test/api/runners/model-usage-observations",
+        "runner-token",
+        "run-1",
+        [observation(source_key="observation-source", input_tokens=1)],
+        proxy_log_path,
+    )
+
+    if post_executor_drain:
+        with pytest.raises(OSError, match="billing unavailable"):
+            usage.drain_usage_events_after_executor_shutdown()
+    else:
+        with pytest.raises(OSError, match="billing unavailable"):
+            usage.flush_usage_events(trigger="shutdown")
+
+    assert [call.log_type for call in enqueue.calls] == [
+        "usage_event",
+        "model_usage_observation",
+    ]
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=1,
+        reports=0,
+        flush_request_id="billing-failed-observation-drained",
+    )
+
+    enqueue.side_effect = None
+    if post_executor_drain:
+        usage.drain_usage_events_after_executor_shutdown()
+    else:
+        assert usage.flush_billing_usage_events(trigger="shutdown") == 1
+
+
 def test_pre_admission_failure_retains_source_event_and_releases_delivery_ownership(
     tmp_path,
 ):

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_idempotency.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_idempotency.py
@@ -4,7 +4,7 @@ import uuid
 
 import usage
 import usage.buffer as usage_buffer
-from tests.usage_buffer_helpers import RecordingEnqueue, event
+from tests.usage_buffer_helpers import RecordingEnqueue, event, observation
 
 
 def test_rejected_events_do_not_leave_empty_destination_buckets(tmp_path):
@@ -121,6 +121,29 @@ def test_aggregate_idempotency_key_changes_between_flush_batches(tmp_path):
     assert keys[0] != keys[1]
     for key in keys:
         uuid.UUID(key)
+
+
+def test_model_observation_aggregate_idempotency_key_survives_retained_retry(tmp_path):
+    enqueue = RecordingEnqueue(return_value=False)
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+
+    usage.buffer_model_usage_observations(
+        "https://api.test/api/runners/model-usage-observations",
+        "runner-token",
+        "run-1",
+        [observation(source_key="source-1", input_tokens=10)],
+        str(tmp_path / "proxy.jsonl"),
+    )
+
+    assert usage.flush_model_usage_observations(trigger="test") == 0
+    first_key = enqueue.last_call.payload["events"][0]["idempotencyKey"]
+
+    enqueue.return_value = True
+    assert usage.flush_model_usage_observations(trigger="test") == 1
+    second_key = enqueue.last_call.payload["events"][0]["idempotencyKey"]
+
+    assert first_key == second_key
+    uuid.UUID(first_key)
 
 
 def test_source_dedupe_survives_flush_boundary(tmp_path):

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
@@ -55,7 +55,7 @@ def test_flush_logs_aggregate_summary_without_token(tmp_path):
     assert entries[1]["duration_ms"] >= 0
 
 
-def test_model_observation_flush_logs_scalar_only_process_summary(tmp_path, capsys):
+def test_successful_model_observation_flush_does_not_log_to_process_stderr(tmp_path, capsys):
     enqueue = RecordingEnqueue()
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
 
@@ -75,27 +75,48 @@ def test_model_observation_flush_logs_scalar_only_process_summary(tmp_path, caps
 
     assert usage.flush_model_usage_observations(trigger="test") == 1
 
-    lines = capsys.readouterr().err.splitlines()
-    assert len(lines) == 2
-    assert "phase=started" in lines[0]
-    assert "phase=enqueued" in lines[1]
-    for line in lines:
-        assert line.startswith("type=model_usage_observation_buffer_flush ")
-        assert "trigger=test" in line
-        assert "source_event_count=1" in line
-        assert "aggregate_event_count=1" in line
-        assert "webhook_batch_count=1" in line
-        assert not any(
-            sensitive in line
-            for sensitive in (
-                "secret-runner-token",
-                "secret-run-id",
-                "secret-source-key",
-                "secret-model",
-                "sensitive-api.test",
-                "secret-proxy.jsonl",
+    assert capsys.readouterr().err == ""
+
+
+def test_retained_model_observation_flush_logs_scalar_only_process_summary(tmp_path, capsys):
+    enqueue = RecordingEnqueue(return_value=False)
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+
+    usage.buffer_model_usage_observations(
+        "https://sensitive-api.test/api/runners/model-usage-observations",
+        "secret-runner-token",
+        "secret-run-id",
+        [
+            observation(
+                source_key="secret-source-key",
+                model="secret-model",
+                input_tokens=10,
             )
+        ],
+        str(tmp_path / "secret-proxy.jsonl"),
+    )
+
+    assert usage.flush_model_usage_observations(trigger="test") == 0
+
+    [line] = capsys.readouterr().err.splitlines()
+    assert line.startswith("type=model_usage_observation_buffer_flush ")
+    assert "phase=enqueued" in line
+    assert "trigger=test" in line
+    assert "source_event_count=1" in line
+    assert "aggregate_event_count=1" in line
+    assert "webhook_batch_count=1" in line
+    assert "retained_webhook_batch_count=1" in line
+    assert not any(
+        sensitive in line
+        for sensitive in (
+            "secret-runner-token",
+            "secret-run-id",
+            "secret-source-key",
+            "secret-model",
+            "sensitive-api.test",
+            "secret-proxy.jsonl",
         )
+    )
 
 
 def test_flush_logs_isolate_summaries_across_proxy_log_paths(tmp_path):

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
@@ -80,7 +80,11 @@ def test_successful_model_observation_flush_does_not_log_process_event(tmp_path)
     assert log.mock_calls == []
 
 
-def test_retained_model_observation_flush_logs_scalar_only_process_summary(tmp_path):
+@pytest.mark.parametrize("trigger", ["test", "shutdown"])
+def test_retained_model_observation_flush_logs_scalar_only_process_summary(
+    tmp_path,
+    trigger,
+):
     enqueue = RecordingEnqueue(return_value=False)
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
 
@@ -99,15 +103,16 @@ def test_retained_model_observation_flush_logs_scalar_only_process_summary(tmp_p
     )
 
     with capture_addon_process_events() as log:
-        assert usage.flush_model_usage_observations(trigger="test") == 0
+        assert usage.flush_model_usage_observations(trigger=trigger) == 0
 
     log.warn.assert_called_once()
+    log.error.assert_not_called()
     message, fields = log.warn.call_args.args
     assert message == "Model usage observation buffer flush anomaly"
     assert fields == {
         "type": "model_usage_observation_buffer_flush",
         "phase": "enqueued",
-        "trigger": "test",
+        "trigger": trigger,
         "flush_sequence": 1,
         "source_event_count": 1,
         "aggregate_event_count": 1,
@@ -167,13 +172,18 @@ def test_failed_model_observation_flush_logs_process_summary(tmp_path):
 
 
 @pytest.mark.parametrize(
-    ("max_retained_batch_retries", "expected_phase"),
-    [(20, "retained"), (0, "dropped")],
+    ("max_retained_batch_retries", "delivery_outcome", "expected_phase"),
+    [
+        (20, "retryable_failure", "retained"),
+        (0, "retryable_failure", "dropped"),
+        (20, "permanent_failure", "failed"),
+    ],
 )
 def test_model_observation_delivery_anomaly_logs_process_summary(
     tmp_path,
     mitm_ctx,
     max_retained_batch_retries,
+    delivery_outcome,
     expected_phase,
 ):
     callbacks: list[DeliveryOutcomeCallback] = []
@@ -205,15 +215,25 @@ def test_model_observation_delivery_anomaly_logs_process_summary(
     with mitm_ctx() as log:
         assert usage.flush_model_usage_observations(trigger="test") == 1
         assert log.mock_calls == []
-        callbacks[0]("retryable_failure")
+        callbacks[0](delivery_outcome)
 
-    process_call = (log.warn if expected_phase == "retained" else log.error).call_args_list[0]
+    process_call = (log.warn if expected_phase == "retained" else log.error).call_args
+    if expected_phase == "retained":
+        log.warn.assert_called_once()
+        log.error.assert_not_called()
+    else:
+        log.error.assert_called_once()
+        log.warn.assert_not_called()
     message, fields = process_call.args
     assert message == "Model usage observation buffer flush anomaly"
     assert fields["type"] == "model_usage_observation_buffer_flush"
     assert fields["phase"] == expected_phase
     assert fields["source_event_count"] == 1
     assert fields["webhook_batch_count"] == 1
+    if delivery_outcome == "permanent_failure":
+        assert fields["delivery_outcome"] == "permanent_failure"
+    else:
+        assert "delivery_outcome" not in fields
     assert "sensitive" not in json.dumps(fields)
 
 

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
@@ -119,6 +119,85 @@ def test_retained_model_observation_flush_logs_scalar_only_process_summary(tmp_p
     )
 
 
+def test_failed_model_observation_flush_logs_process_summary(tmp_path, capsys):
+    def fail_enqueue(
+        url: str,
+        runner_token: str,
+        payload: dict,
+        path: str,
+        log_type: str,
+    ) -> bool:
+        del url, runner_token, payload, path, log_type
+        raise RuntimeError("sensitive failure")
+
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=RecordingEnqueue(side_effect=fail_enqueue))
+    usage.buffer_model_usage_observations(
+        "https://sensitive-api.test/api/runners/model-usage-observations",
+        "secret-runner-token",
+        "secret-run-id",
+        [observation(source_key="secret-source-key", model="secret-model")],
+        str(tmp_path / "secret-proxy.jsonl"),
+    )
+
+    with pytest.raises(RuntimeError, match="sensitive failure"):
+        usage.flush_model_usage_observations(trigger="test")
+
+    [line] = capsys.readouterr().err.splitlines()
+    assert "phase=failed" in line
+    assert "error_type=RuntimeError" in line
+    assert "sensitive" not in line
+
+
+@pytest.mark.parametrize(
+    ("max_retained_batch_retries", "expected_phase"),
+    [(20, "retained"), (0, "dropped")],
+)
+def test_model_observation_delivery_anomaly_logs_process_summary(
+    tmp_path,
+    capsys,
+    mitm_ctx,
+    max_retained_batch_retries,
+    expected_phase,
+):
+    callbacks: list[DeliveryOutcomeCallback] = []
+
+    def enqueue_webhook(
+        url: str,
+        runner_token: str,
+        payload: dict,
+        path: str,
+        log_type: str,
+        delivery_outcome_callback: DeliveryOutcomeCallback,
+    ) -> bool:
+        del url, runner_token, payload, path, log_type
+        callbacks.append(delivery_outcome_callback)
+        return True
+
+    usage.reset_usage_buffer_for_tests(
+        enqueue_webhook=enqueue_webhook,
+        max_retained_batch_retries=max_retained_batch_retries,
+    )
+    usage.buffer_model_usage_observations(
+        "https://sensitive-api.test/api/runners/model-usage-observations",
+        "secret-runner-token",
+        "secret-run-id",
+        [observation(source_key="secret-source-key", model="secret-model")],
+        str(tmp_path / "secret-proxy.jsonl"),
+    )
+
+    assert usage.flush_model_usage_observations(trigger="test") == 1
+    assert capsys.readouterr().err == ""
+
+    with mitm_ctx():
+        callbacks[0]("retryable_failure")
+
+    [line] = capsys.readouterr().err.splitlines()
+    assert f"phase={expected_phase}" in line
+    assert "source_event_count=1" in line
+    assert "webhook_batch_count=1" in line
+    assert "sensitive" not in line
+
+
 def test_flush_logs_isolate_summaries_across_proxy_log_paths(tmp_path):
     enqueue = RecordingEnqueue(return_value=False)
     usage.reset_usage_buffer_for_tests(

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
@@ -5,6 +5,7 @@ import json
 import pytest
 
 import usage
+from tests.process_log_helpers import capture_addon_process_events
 from tests.usage_buffer_helpers import (
     DeliveryOutcomeCallback,
     RecordingEnqueue,
@@ -55,7 +56,7 @@ def test_flush_logs_aggregate_summary_without_token(tmp_path):
     assert entries[1]["duration_ms"] >= 0
 
 
-def test_successful_model_observation_flush_does_not_log_to_process_stderr(tmp_path, capsys):
+def test_successful_model_observation_flush_does_not_log_process_event(tmp_path):
     enqueue = RecordingEnqueue()
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
 
@@ -73,12 +74,13 @@ def test_successful_model_observation_flush_does_not_log_to_process_stderr(tmp_p
         str(tmp_path / "secret-proxy.jsonl"),
     )
 
-    assert usage.flush_model_usage_observations(trigger="test") == 1
+    with capture_addon_process_events() as log:
+        assert usage.flush_model_usage_observations(trigger="test") == 1
 
-    assert capsys.readouterr().err == ""
+    assert log.mock_calls == []
 
 
-def test_retained_model_observation_flush_logs_scalar_only_process_summary(tmp_path, capsys):
+def test_retained_model_observation_flush_logs_scalar_only_process_summary(tmp_path):
     enqueue = RecordingEnqueue(return_value=False)
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
 
@@ -96,18 +98,28 @@ def test_retained_model_observation_flush_logs_scalar_only_process_summary(tmp_p
         str(tmp_path / "secret-proxy.jsonl"),
     )
 
-    assert usage.flush_model_usage_observations(trigger="test") == 0
+    with capture_addon_process_events() as log:
+        assert usage.flush_model_usage_observations(trigger="test") == 0
 
-    [line] = capsys.readouterr().err.splitlines()
-    assert line.startswith("type=model_usage_observation_buffer_flush ")
-    assert "phase=enqueued" in line
-    assert "trigger=test" in line
-    assert "source_event_count=1" in line
-    assert "aggregate_event_count=1" in line
-    assert "webhook_batch_count=1" in line
-    assert "retained_webhook_batch_count=1" in line
+    log.warn.assert_called_once()
+    message, fields = log.warn.call_args.args
+    assert message == "Model usage observation buffer flush anomaly"
+    assert fields == {
+        "type": "model_usage_observation_buffer_flush",
+        "phase": "enqueued",
+        "trigger": "test",
+        "flush_sequence": 1,
+        "source_event_count": 1,
+        "aggregate_event_count": 1,
+        "webhook_batch_count": 1,
+        "dropped_webhook_batch_count": 0,
+        "retained_webhook_batch_count": 1,
+        "retained_source_event_count": 1,
+        "duration_ms": fields["duration_ms"],
+    }
+    assert isinstance(fields["duration_ms"], int)
     assert not any(
-        sensitive in line
+        sensitive in json.dumps(fields)
         for sensitive in (
             "secret-runner-token",
             "secret-run-id",
@@ -119,7 +131,7 @@ def test_retained_model_observation_flush_logs_scalar_only_process_summary(tmp_p
     )
 
 
-def test_failed_model_observation_flush_logs_process_summary(tmp_path, capsys):
+def test_failed_model_observation_flush_logs_process_summary(tmp_path):
     def fail_enqueue(
         url: str,
         runner_token: str,
@@ -139,13 +151,19 @@ def test_failed_model_observation_flush_logs_process_summary(tmp_path, capsys):
         str(tmp_path / "secret-proxy.jsonl"),
     )
 
-    with pytest.raises(RuntimeError, match="sensitive failure"):
+    with (
+        capture_addon_process_events() as log,
+        pytest.raises(RuntimeError, match="sensitive failure"),
+    ):
         usage.flush_model_usage_observations(trigger="test")
 
-    [line] = capsys.readouterr().err.splitlines()
-    assert "phase=failed" in line
-    assert "error_type=RuntimeError" in line
-    assert "sensitive" not in line
+    log.error.assert_called_once()
+    message, fields = log.error.call_args.args
+    assert message == "Model usage observation buffer flush anomaly"
+    assert fields["type"] == "model_usage_observation_buffer_flush"
+    assert fields["phase"] == "failed"
+    assert fields["error_type"] == "RuntimeError"
+    assert "sensitive" not in json.dumps(fields)
 
 
 @pytest.mark.parametrize(
@@ -154,7 +172,6 @@ def test_failed_model_observation_flush_logs_process_summary(tmp_path, capsys):
 )
 def test_model_observation_delivery_anomaly_logs_process_summary(
     tmp_path,
-    capsys,
     mitm_ctx,
     max_retained_batch_retries,
     expected_phase,
@@ -185,17 +202,19 @@ def test_model_observation_delivery_anomaly_logs_process_summary(
         str(tmp_path / "secret-proxy.jsonl"),
     )
 
-    assert usage.flush_model_usage_observations(trigger="test") == 1
-    assert capsys.readouterr().err == ""
-
-    with mitm_ctx():
+    with mitm_ctx() as log:
+        assert usage.flush_model_usage_observations(trigger="test") == 1
+        assert log.mock_calls == []
         callbacks[0]("retryable_failure")
 
-    [line] = capsys.readouterr().err.splitlines()
-    assert f"phase={expected_phase}" in line
-    assert "source_event_count=1" in line
-    assert "webhook_batch_count=1" in line
-    assert "sensitive" not in line
+    process_call = (log.warn if expected_phase == "retained" else log.error).call_args_list[0]
+    message, fields = process_call.args
+    assert message == "Model usage observation buffer flush anomaly"
+    assert fields["type"] == "model_usage_observation_buffer_flush"
+    assert fields["phase"] == expected_phase
+    assert fields["source_event_count"] == 1
+    assert fields["webhook_batch_count"] == 1
+    assert "sensitive" not in json.dumps(fields)
 
 
 def test_flush_logs_isolate_summaries_across_proxy_log_paths(tmp_path):

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
@@ -10,6 +10,7 @@ from tests.usage_buffer_helpers import (
     RecordingEnqueue,
     event,
     flush_log_entries,
+    observation,
 )
 
 
@@ -52,6 +53,49 @@ def test_flush_logs_aggregate_summary_without_token(tmp_path):
     assert "duration_ms" not in entries[0]
     assert isinstance(entries[1]["duration_ms"], int)
     assert entries[1]["duration_ms"] >= 0
+
+
+def test_model_observation_flush_logs_scalar_only_process_summary(tmp_path, capsys):
+    enqueue = RecordingEnqueue()
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+
+    usage.buffer_model_usage_observations(
+        "https://sensitive-api.test/api/runners/model-usage-observations",
+        "secret-runner-token",
+        "secret-run-id",
+        [
+            observation(
+                source_key="secret-source-key",
+                model="secret-model",
+                input_tokens=10,
+            )
+        ],
+        str(tmp_path / "secret-proxy.jsonl"),
+    )
+
+    assert usage.flush_model_usage_observations(trigger="test") == 1
+
+    lines = capsys.readouterr().err.splitlines()
+    assert len(lines) == 2
+    assert "phase=started" in lines[0]
+    assert "phase=enqueued" in lines[1]
+    for line in lines:
+        assert line.startswith("type=model_usage_observation_buffer_flush ")
+        assert "trigger=test" in line
+        assert "source_event_count=1" in line
+        assert "aggregate_event_count=1" in line
+        assert "webhook_batch_count=1" in line
+        assert not any(
+            sensitive in line
+            for sensitive in (
+                "secret-runner-token",
+                "secret-run-id",
+                "secret-source-key",
+                "secret-model",
+                "sensitive-api.test",
+                "secret-proxy.jsonl",
+            )
+        )
 
 
 def test_flush_logs_isolate_summaries_across_proxy_log_paths(tmp_path):

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
@@ -1106,14 +1106,18 @@ def test_timer_flush_failure_reschedules_retry_without_real_sleep(tmp_path):
     )
 
 
-def test_timer_delivery_failure_after_enqueue_reschedules_retry(tmp_path):
+@pytest.mark.parametrize(
+    "log_type",
+    ["usage_event", "model_usage_observation"],
+)
+def test_timer_delivery_failure_after_enqueue_reschedules_retry(tmp_path, log_type: str):
     callbacks: list[Callable[[usage.webhook.WebhookDeliveryOutcome], None]] = []
     enqueued_keys: list[str] = []
     pending_path = tmp_path / "usage-pending"
 
-    def enqueue_webhook(url, sandbox_token, payload, path, log_type, delivery_callback):
+    def enqueue_webhook(url, sandbox_token, payload, path, delivery_log_type, delivery_callback):
         del url, sandbox_token, path
-        assert log_type == "usage_event"
+        assert delivery_log_type == log_type
         enqueued_keys.append(payload["events"][0]["idempotencyKey"])
         if len(enqueued_keys) == 1:
             callbacks.append(delivery_callback)
@@ -1123,13 +1127,22 @@ def test_timer_delivery_failure_after_enqueue_reschedules_retry(tmp_path):
 
     timers = install_recording_usage_timer(enqueue_webhook=enqueue_webhook)
     usage.set_pending_path(str(pending_path))
-    usage.buffer_usage_events(
-        "https://api.test/api/webhooks/agent/usage-event",
-        "token-a",
-        "run-1",
-        [event(source_key="source-1", quantity=10)],
-        str(tmp_path / "proxy.jsonl"),
-    )
+    if log_type == "usage_event":
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [event(source_key="source-1", quantity=10)],
+            str(tmp_path / "proxy.jsonl"),
+        )
+    else:
+        usage.buffer_model_usage_observations(
+            "https://api.test/api/runners/model-usage-observations",
+            "runner-token",
+            "run-1",
+            [observation(source_key="source-1", input_tokens=10)],
+            str(tmp_path / "proxy.jsonl"),
+        )
 
     timers[0].callback()
 

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
@@ -753,7 +753,7 @@ def test_priority_preempted_flush_keeps_timer_for_usage_buffered_during_enqueue(
     proxy_log_path = str(tmp_path / "proxy.jsonl")
     usage.set_pending_path(str(pending_path))
     usage.buffer_model_usage_observations(
-        "https://api.test/api/webhooks/agent/model-usage-observation",
+        "https://api.test/api/runners/model-usage-observations",
         "token-a",
         "run-1",
         [observation(source_key="observation-source", input_tokens=1)],
@@ -788,7 +788,7 @@ def test_priority_preempted_flush_keeps_timer_for_usage_buffered_during_enqueue(
                 [event(source_key="usage-source-2")],
                 path,
             )
-            assert len(timers) == 3
+            assert len(timers) == 4
         return True
 
     enqueue.side_effect = enqueue_and_buffer_later_usage
@@ -819,6 +819,31 @@ def test_priority_preempted_flush_keeps_timer_for_usage_buffered_during_enqueue(
         reports=0,
         flush_request_id="priority-drained",
     )
+
+
+def test_model_observation_timer_is_fixed_and_independent_from_billing_configuration(tmp_path):
+    enqueue = RecordingEnqueue()
+    timers = install_recording_usage_timer(enqueue_webhook=enqueue)
+    usage.configure_usage_buffer(flush_interval_seconds=5)
+
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "sandbox-token",
+        "run-1",
+        [event(source_key="usage-source")],
+        str(tmp_path / "billing.jsonl"),
+    )
+    usage.buffer_model_usage_observations(
+        "https://api.test/api/runners/model-usage-observations",
+        "runner-token",
+        "run-1",
+        [observation(source_key="observation-source", input_tokens=1)],
+        str(tmp_path / "observation.jsonl"),
+    )
+
+    assert len(timers) == 2
+    assert 4 <= timers[0].delay <= 6
+    assert 240 <= timers[1].delay <= 360
 
 
 def test_failed_timer_start_allows_idempotent_replay_to_reschedule(tmp_path):

--- a/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
@@ -142,12 +142,10 @@ class TestUsageReportingIdempotency:
         requests_by_path = {request.path: request for request in webhook.requests}
         assert set(requests_by_path) == {
             "/api/webhooks/agent/usage-event",
-            "/api/webhooks/agent/model-usage-observation",
+            "/api/runners/model-usage-observations",
         }
         body = requests_by_path["/api/webhooks/agent/usage-event"].json_body()
-        observation_body = requests_by_path[
-            "/api/webhooks/agent/model-usage-observation"
-        ].json_body()
+        observation_body = requests_by_path["/api/runners/model-usage-observations"].json_body()
         assert body["events"][0]["quantity"] == 10
         assert observation_body["events"][0]["inputTokens"] == 10
         assert body["events"][0]["provider"] == "claude-sonnet-4-6"
@@ -191,12 +189,10 @@ class TestUsageReportingIdempotency:
         requests_by_path = {request.path: request for request in webhook.requests}
         assert set(requests_by_path) == {
             "/api/webhooks/agent/usage-event",
-            "/api/webhooks/agent/model-usage-observation",
+            "/api/runners/model-usage-observations",
         }
         body = requests_by_path["/api/webhooks/agent/usage-event"].json_body()
-        observation_body = requests_by_path[
-            "/api/webhooks/agent/model-usage-observation"
-        ].json_body()
+        observation_body = requests_by_path["/api/runners/model-usage-observations"].json_body()
         assert body["events"][0]["quantity"] == 10
         assert observation_body["events"][0]["inputTokens"] == 10
         assert body["events"][0]["provider"] == "claude-sonnet-4-6"

--- a/crates/runner/mitm-addon/tests/test_webhook_delivery_admission.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_delivery_admission.py
@@ -266,6 +266,39 @@ def test_does_not_admit_when_delivery_capacity_is_saturated(tmp_path):
     assert "secret-payload" not in json.dumps(saturated_entry)
 
 
+def test_model_observation_saturation_does_not_consume_billing_capacity(tmp_path):
+    observation_executor = QueuedUsageExecutor()
+    billing_executor = QueuedUsageExecutor()
+
+    with (
+        patch.object(
+            usage.webhook,
+            "model_usage_observation_executor",
+            observation_executor,
+        ),
+        patch.object(usage.webhook, "usage_executor", billing_executor),
+    ):
+        for _ in range(usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS):
+            assert usage.webhook.enqueue_model_usage_observation_delivery(
+                "https://api.vm0.ai/api/runners/model-usage-observations",
+                "runner-token",
+                {"events": []},
+                "",
+                "model_usage_observation",
+            )
+
+        assert usage.webhook.enqueue_webhook_delivery(
+            "https://api.vm0.ai/api/webhooks/agent/usage-event",
+            "sandbox-token",
+            {"runId": "run-1", "events": []},
+            str(tmp_path / "proxy.jsonl"),
+            "usage_event",
+        )
+
+    assert len(observation_executor.submissions) == usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS
+    assert len(billing_executor.submissions) == 1
+
+
 def test_delivery_capacity_released_after_success(
     mitm_ctx, tmp_path, sync_usage_executor, usage_webhook_server
 ):

--- a/crates/runner/mitm-addon/tests/test_webhook_delivery_admission.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_delivery_admission.py
@@ -3,7 +3,7 @@
 import json
 import time
 import urllib.request
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -360,6 +360,98 @@ def test_delivery_capacity_released_when_outcome_callback_fails(
         reports=0,
         flush_request_id="callback-failed",
     )
+
+
+def test_model_observation_capacity_released_when_outcome_callback_fails(
+    mitm_ctx, tmp_path, sync_usage_executor, usage_webhook_server
+):
+    pending_path = tmp_path / "usage-pending"
+    usage.set_pending_path(str(pending_path))
+    usage_webhook_server.queue_response(204)
+
+    def fail_callback(_outcome: usage.webhook.WebhookDeliveryOutcome) -> None:
+        raise RuntimeError("callback failed")
+
+    with mitm_ctx():
+        assert usage.webhook.enqueue_model_usage_observation_delivery(
+            usage_webhook_server.url("/api/runners/model-usage-observations"),
+            "runner-token",
+            {"events": []},
+            "",
+            "model_usage_observation",
+            delivery_outcome_callback=fail_callback,
+        )
+
+    with pytest.raises(RuntimeError, match="callback failed"):
+        sync_usage_executor.shutdown(wait=True)
+
+    assert usage_webhook_server.request_count == 1
+    assert usage.webhook.pending_model_observation_delivery_payload_count_for_tests() == 0
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="observation-callback-failed",
+    )
+
+
+def test_model_observation_uses_sync_fallback_after_its_executor_shutdown(
+    mitm_ctx, tmp_path, usage_webhook_server
+):
+    pending_path = tmp_path / "usage-pending"
+    billing_executor = QueuedUsageExecutor()
+    usage.set_pending_path(str(pending_path))
+    usage_webhook_server.queue_response(204)
+
+    with (
+        mitm_ctx(),
+        patch.object(usage.webhook, "usage_executor", billing_executor),
+        patch.object(
+            usage.webhook.model_usage_observation_executor,
+            "submit",
+            side_effect=RuntimeError("shutdown"),
+        ),
+    ):
+        assert usage.webhook.enqueue_model_usage_observation_delivery(
+            usage_webhook_server.url("/api/runners/model-usage-observations"),
+            "runner-token",
+            {"events": []},
+            "",
+            "model_usage_observation",
+        )
+
+    assert usage_webhook_server.request_count == 1
+    assert not billing_executor.submissions
+    assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+    assert usage.webhook.pending_model_observation_delivery_payload_count_for_tests() == 0
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="observation-sync-fallback",
+    )
+
+
+def test_shutdown_delivery_executors_attempts_observation_after_billing_failure():
+    billing_executor = MagicMock()
+    observation_executor = MagicMock()
+    billing_executor.shutdown.side_effect = RuntimeError("billing shutdown failed")
+
+    with (
+        patch.object(usage.webhook, "usage_executor", billing_executor),
+        patch.object(
+            usage.webhook,
+            "model_usage_observation_executor",
+            observation_executor,
+        ),
+        pytest.raises(RuntimeError, match="billing shutdown failed"),
+    ):
+        usage.webhook.shutdown_delivery_executors(wait=True)
+
+    billing_executor.shutdown.assert_called_once_with(wait=True)
+    observation_executor.shutdown.assert_called_once_with(wait=True)
 
 
 def test_delivery_capacity_released_after_retry_exhaustion(

--- a/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
@@ -623,7 +623,7 @@ def test_model_observation_v2_404_is_a_permanent_error(
     usage_webhook_server.queue_response(404)
 
     assert usage.webhook.enqueue_webhook_delivery(
-        usage_webhook_server.url("/api/webhooks/agent/model-usage-observation"),
+        usage_webhook_server.url("/api/runners/model-usage-observations"),
         "tok",
         {"runId": "run-1", "events": []},
         str(proxy_log),
@@ -633,7 +633,7 @@ def test_model_observation_v2_404_is_a_permanent_error(
     sync_usage_executor.shutdown(wait=True)
 
     assert [request.path for request in usage_webhook_server.requests] == [
-        "/api/webhooks/agent/model-usage-observation"
+        "/api/runners/model-usage-observations"
     ]
     entries = [entry for entry in read_jsonl_entries_after_flush(proxy_log) if "attempt" in entry]
     assert len(entries) == 1

--- a/crates/runner/mitm-addon/tests/usage_helpers.py
+++ b/crates/runner/mitm-addon/tests/usage_helpers.py
@@ -126,8 +126,10 @@ def install_recording_usage_timer(
 def fresh_usage_executor_context() -> Iterator[ThreadPoolExecutor]:
     """Install a temporary usage executor and restore the original on exit."""
     original = usage.webhook.usage_executor
+    original_observation = usage.webhook.model_usage_observation_executor
     executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage-test")
     usage.webhook.usage_executor = executor
+    usage.webhook.model_usage_observation_executor = executor
     try:
         yield executor
     finally:
@@ -140,6 +142,7 @@ def fresh_usage_executor_context() -> Iterator[ThreadPoolExecutor]:
                 usage.drain_usage_events_after_executor_shutdown()
         finally:
             usage.webhook.usage_executor = original
+            usage.webhook.model_usage_observation_executor = original_observation
 
 
 @dataclass(frozen=True)
@@ -220,7 +223,7 @@ class UsageWebhookServer:
         return [
             event
             for request in self.requests
-            if request.path == "/api/webhooks/agent/model-usage-observation"
+            if request.path == "/api/runners/model-usage-observations"
             for body in [request.json_body()]
             for event in body.get("events", [])
             if isinstance(event, dict)

--- a/crates/runner/mitm-addon/tests/usage_helpers.py
+++ b/crates/runner/mitm-addon/tests/usage_helpers.py
@@ -124,7 +124,7 @@ def install_recording_usage_timer(
 
 @contextlib.contextmanager
 def fresh_usage_executor_context() -> Iterator[ThreadPoolExecutor]:
-    """Install a temporary usage executor and restore the original on exit."""
+    """Install temporary usage executors and restore the originals on exit."""
     original = usage.webhook.usage_executor
     original_observation = usage.webhook.model_usage_observation_executor
     executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage-test")


### PR DESCRIPTION
## Summary

- aggregate model usage observations across runs in a dedicated five-minute process buffer
- deliver observation batches to the runner ingestion endpoint with runner authentication, independent retry capacity, and runner-shutdown draining
- keep observation flush, drain, delivery-capacity cleanup, and executor shutdown attempts independent from billing failures
- emit scalar-only observation admission, permanent-delivery, retention, and drop anomalies through the generic addon process-event logger for Axiom

## Scope

- billing usage remains run-owned, uses the existing delivery lane, and keeps its current flush behavior
- ordinary run-owned diagnostics continue using proxy JSONL
- only observation anomalies use the warning/error process-event channel; successful process flushes do not write stderr or produce Axiom warning/error rows
- observation loss does not emit or duplicate billing-only `usage_underbilling` events
- process-event summaries exclude model, URL, run, path, payload identity, and credentials
- the runner ingestion API itself is unchanged; it was delivered by #30172
- no fallback or dual-write to the retired per-run observation webhook is added

## Validation

- `cd crates/runner/mitm-addon && uv lock --check`
- `cd crates/runner/mitm-addon && uv sync --locked`
- `cd crates/runner/mitm-addon && uv run --no-sync ruff format --check .`
- `cd crates/runner/mitm-addon && uv run --no-sync ruff check .`
- `cd crates/runner/mitm-addon && uv run --no-sync basedpyright -p .`
- `cd crates/runner/mitm-addon && uv run --no-sync python -m pytest tests/` (7221 passed)
- `cd crates && cargo test -p runner proxy::stderr::tests` (6 passed)

Closes #30173

Parent delivery context: #30143
