### PR TITLE
test(runner): stabilize heartbeat coalescing coverage

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -169,6 +169,38 @@ async fn sleep_until_optional_instant(deadline: Option<Instant>) {
     }
 }
 
+enum RoutineHeartbeatTrigger {
+    Interval(tokio::time::Interval),
+    #[cfg(test)]
+    Manual(mpsc::UnboundedReceiver<()>),
+}
+
+impl RoutineHeartbeatTrigger {
+    fn interval() -> Self {
+        let mut interval = tokio::time::interval_at(
+            tokio::time::Instant::now() + HEARTBEAT_PERIOD,
+            HEARTBEAT_PERIOD,
+        );
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        Self::Interval(interval)
+    }
+
+    async fn tick(&mut self) {
+        match self {
+            Self::Interval(interval) => {
+                interval.tick().await;
+            }
+            #[cfg(test)]
+            Self::Manual(receiver) => {
+                receiver
+                    .recv()
+                    .await
+                    .expect("manual routine heartbeat sender should remain open");
+            }
+        }
+    }
+}
+
 type WorkspaceCacheChangeFuture = BoxFuture<
     'static,
     (
@@ -935,6 +967,7 @@ async fn run_start_with_home(
             test_observer: StartLoopTestObserver::default(),
             before_initial_workspace_cache_scan: None,
             after_initial_workspace_cache_scan: None,
+            manual_routine_heartbeat_rx: None,
         },
     };
 
@@ -1034,6 +1067,7 @@ struct RunTestHooks {
     test_observer: StartLoopTestObserver,
     before_initial_workspace_cache_scan: Option<StartLoopTestGate>,
     after_initial_workspace_cache_scan: Option<StartLoopTestGate>,
+    manual_routine_heartbeat_rx: Option<mpsc::UnboundedReceiver<()>>,
 }
 
 enum SignalSource {
@@ -1580,7 +1614,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         signals,
         orphan_reap,
         #[cfg(test)]
-        test_hooks,
+        mut test_hooks,
     } = config;
     let SandboxRuntimeConfig {
         mut runtime,
@@ -1759,13 +1793,17 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     );
 
     // -----------------------------------------------------------------------
-    // Heartbeat interval — same first-tick delay as above.
+    // Heartbeat interval — same first-tick delay as above. One integration
+    // test injects manual ticks so its coalescing assertions do not advance
+    // unrelated Runner timers.
     // -----------------------------------------------------------------------
-    let mut heartbeat_tick = tokio::time::interval_at(
-        tokio::time::Instant::now() + HEARTBEAT_PERIOD,
-        HEARTBEAT_PERIOD,
-    );
-    heartbeat_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    #[cfg(test)]
+    let mut heartbeat_tick = match test_hooks.manual_routine_heartbeat_rx.take() {
+        Some(receiver) => RoutineHeartbeatTrigger::Manual(receiver),
+        None => RoutineHeartbeatTrigger::interval(),
+    };
+    #[cfg(not(test))]
+    let mut heartbeat_tick = RoutineHeartbeatTrigger::interval();
 
     // -----------------------------------------------------------------------
     // Main loop

--- a/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
@@ -24,6 +24,20 @@ async fn wait_for_blocked_routine_heartbeat(env: &MockRunEnv) {
     );
 }
 
+async fn trigger_routine_heartbeat(
+    trigger: &tokio::sync::mpsc::UnboundedSender<()>,
+    env: &MockRunEnv,
+    expected_mode: RunnerMode,
+) {
+    let cursor = env.start_observer.cursor();
+    trigger
+        .send(())
+        .expect("manual routine heartbeat receiver should remain open");
+    env.start_observer
+        .wait_routine_heartbeat_requested_after(cursor, expected_mode, Duration::from_secs(5))
+        .await;
+}
+
 // -----------------------------------------------------------------------
 // Test 2: Discover survives heartbeat ticks (regression #8783)
 //
@@ -120,12 +134,14 @@ async fn blocked_heartbeat_does_not_block_job_discovery_or_reaping() {
     shutdown(&env, run_handle).await;
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn heartbeat_triggers_coalesce_into_one_current_mode_follow_up() {
     let wait_gate = sandbox_mock::MockLifecycleGate::new();
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
-    let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
+    let (mut config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
+    let (heartbeat_trigger, heartbeat_trigger_rx) = tokio::sync::mpsc::unbounded_channel();
+    config.test_hooks.manual_routine_heartbeat_rx = Some(heartbeat_trigger_rx);
     let status_path = env._temp_dir.path().join("status.json");
     env.handle.block_heartbeats();
     let run_handle = tokio::spawn(run(config));
@@ -137,9 +153,9 @@ async fn heartbeat_triggers_coalesce_into_one_current_mode_follow_up() {
     wait_gate
         .wait_entered(1, Duration::from_secs(5))
         .await
-        .expect("job should finish pre-spawn before heartbeat time advances");
+        .expect("job should finish pre-spawn before the first routine heartbeat");
 
-    tokio::time::advance(HEARTBEAT_PERIOD).await;
+    trigger_routine_heartbeat(&heartbeat_trigger, &env, RunnerMode::Running).await;
     assert!(
         env.handle
             .wait_heartbeat_past(0, Duration::from_secs(5))
@@ -159,30 +175,12 @@ async fn heartbeat_triggers_coalesce_into_one_current_mode_follow_up() {
         *mode = RunnerMode::Draining;
         false
     });
-    let second_tick_cursor = env.start_observer.cursor();
-    tokio::time::advance(HEARTBEAT_PERIOD).await;
-    tokio::task::yield_now().await;
-    env.start_observer
-        .wait_routine_heartbeat_requested_after(
-            second_tick_cursor,
-            RunnerMode::Draining,
-            Duration::from_secs(5),
-        )
-        .await;
+    trigger_routine_heartbeat(&heartbeat_trigger, &env, RunnerMode::Draining).await;
     wait_status_mode(&status_path, "draining", Duration::from_secs(5)).await;
 
     // A further tick while the first request is blocked must collapse into
     // the same dirty follow-up rather than overlap or queue another payload.
-    let third_tick_cursor = env.start_observer.cursor();
-    tokio::time::advance(HEARTBEAT_PERIOD).await;
-    tokio::task::yield_now().await;
-    env.start_observer
-        .wait_routine_heartbeat_requested_after(
-            third_tick_cursor,
-            RunnerMode::Draining,
-            Duration::from_secs(5),
-        )
-        .await;
+    trigger_routine_heartbeat(&heartbeat_trigger, &env, RunnerMode::Draining).await;
     assert_eq!(env.handle.heartbeat_count(), 1);
     assert_eq!(env.handle.max_heartbeat_in_flight(), 1);
 

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -301,6 +301,7 @@ fn build_mock_run_config_with_runtime(
             test_observer: start_observer.clone(),
             before_initial_workspace_cache_scan: None,
             after_initial_workspace_cache_scan: None,
+            manual_routine_heartbeat_rx: None,
         },
     };
 


### PR DESCRIPTION
## Summary

- add a test-only manual routine-heartbeat source while preserving the production 10-second interval and missed-tick behavior
- drive the coalescing regression test with explicit ticks instead of Tokio's paused clock
- keep coverage at the real runner main-loop entry point, including lifecycle sampling, status persistence, provider calls, single-flight behavior, and heartbeat sequencing

## Why

The paused-clock test intermittently advanced unrelated runner deadlines while waiting for routine-heartbeat work to be observed. Depending on scheduling, those deadlines could move the runner into `stopping` or let the assertion run before the intended tick was processed, producing either an extra heartbeat or a timeout. The production coalescing behavior was not the source of the race.

## Validation

- `cargo fmt --all -- --check`
- target test: 100/100 repeated passes
- `cargo test -p runner cmd::start::tests::main_loop::heartbeat --all-features` (9 passed)
- `cargo test -p runner --all-targets --all-features --quiet -- --test-threads=1` (3374 passed, 26 ignored, plus 1 integration test passed)
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- repository pre-commit hooks: workspace Rust format, Clippy, docs, and file-size checks passed

## Scope

Production heartbeat cadence and `HeartbeatController` behavior are unchanged. Unrelated proxy runtime-marker discovery flakes observed only during parallel full-suite runs are intentionally excluded; those legacy/conflict scenarios are already being replaced by #30161 / #30166, and the serial full runner suite is green.

Closes #30179
