### PR TITLE
perf(platform): defer connector data and trim contract runtime

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1684,8 +1684,9 @@ test("chat composer keeps standard tool icons and Send inside on narrow screens"
   });
   const sendButton = composer.getByRole("button", { name: "Send" });
 
-  await expect(connectorsButton.locator("img")).toHaveCount(2);
+  await expect(connectorsButton.locator("img")).toHaveCount(0);
   await connectorsButton.click();
+  await expect(connectorsButton.locator("img")).toHaveCount(2);
   await expect(
     page.getByRole("switch", { name: "Disable Cloud browser" }),
   ).toBeVisible();

--- a/turbo/apps/platform/src/signals/okou-page/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/connectors.ts
@@ -48,6 +48,7 @@ export type ComposerConnectorAuthorizationTarget =
     };
 
 export interface ComposerConnectorUiState {
+  readonly connectorDataActivated: boolean;
   readonly showAddDialog: boolean;
   readonly pendingConnectorSlug: ConnectorSlug | null;
   readonly selectedConnectorSlug: ConnectorSlug | null;
@@ -179,6 +180,7 @@ const agentCustomConnectorAuthorizationRequestBroker$ = computed(() => {
 
 function initialComposerConnectorUiState(): ComposerConnectorUiState {
   return {
+    connectorDataActivated: false,
     showAddDialog: false,
     pendingConnectorSlug: null,
     selectedConnectorSlug: null,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -290,6 +290,43 @@ beforeEach(() => {
 });
 
 describe("chat composer connector connection", () => {
+  it("loads connector data only after the connector menu is opened", async () => {
+    const user = userEvent.setup({ delay: null });
+    let discoveryRequests = 0;
+    let customConnectorRequests = 0;
+    mockThread();
+    context.mocks.api(connectorCatalogContract.discovery, ({ respond }) => {
+      discoveryRequests += 1;
+      return respond(200, { connectors: [], totalConnectorCount: 0 });
+    });
+    context.mocks.api(customConnectorsContract.list, ({ respond }) => {
+      customConnectorRequests += 1;
+      return respond(200, { connectors: [] });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    const composer = composerElementFrom(
+      await screen.findByPlaceholderText(PLACEHOLDER),
+    );
+    expect(discoveryRequests).toBe(0);
+    expect(customConnectorRequests).toBe(0);
+
+    await user.click(within(composer).getByLabelText("Connectors"));
+
+    await waitFor(() => {
+      expect(discoveryRequests).toBe(1);
+      expect(customConnectorRequests).toBe(1);
+      expect(within(composer).getByLabelText("Connectors")).toHaveAttribute(
+        "aria-expanded",
+        "true",
+      );
+    });
+  });
+
   it("makes connector permissions interactive on the first click", async () => {
     const user = userEvent.setup({ delay: null });
     mockThread();
@@ -304,9 +341,11 @@ describe("chat composer connector connection", () => {
     const composer = composerElementFrom(
       await screen.findByPlaceholderText(PLACEHOLDER),
     );
-    const connectorsTrigger = within(composer).getByLabelText("Connectors");
-    await user.click(connectorsTrigger);
-    expect(connectorsTrigger).toHaveAttribute("aria-expanded", "true");
+    const connectorsTrigger = () => {
+      return within(composer).getByLabelText("Connectors");
+    };
+    await user.click(connectorsTrigger());
+    expect(connectorsTrigger()).toHaveAttribute("aria-expanded", "true");
 
     await user.click(
       await screen.findByLabelText("Configure Axiom permissions"),
@@ -316,7 +355,7 @@ describe("chat composer connector connection", () => {
       name: /Axiom permissions/u,
     });
     await waitFor(() => {
-      expect(connectorsTrigger).toHaveAttribute("aria-expanded", "false");
+      expect(connectorsTrigger()).toHaveAttribute("aria-expanded", "false");
       expect(screen.queryByText("Add connectors")).not.toBeInTheDocument();
     });
 
@@ -340,7 +379,7 @@ describe("chat composer connector connection", () => {
     await waitFor(() => {
       expect(permissionsDialog).not.toBeInTheDocument();
     });
-    expect(connectorsTrigger).toHaveAttribute("aria-expanded", "false");
+    expect(connectorsTrigger()).toHaveAttribute("aria-expanded", "false");
   });
 
   it("places the account action before connector permissions", async () => {
@@ -603,8 +642,10 @@ describe("chat composer connector connection", () => {
     const composer = composerElementFrom(
       await screen.findByPlaceholderText(PLACEHOLDER),
     );
-    const connectorsButton = within(composer).getByLabelText("Connectors");
-    await user.click(connectorsButton);
+    const connectorsButton = () => {
+      return within(composer).getByLabelText("Connectors");
+    };
+    await user.click(connectorsButton());
     const defaultMode = await screen.findByLabelText(
       "GitHub · Using default account: Work",
     );
@@ -634,7 +675,7 @@ describe("chat composer connector connection", () => {
     await waitFor(() => {
       expect(screen.queryByText("Account for this chat")).toBeNull();
     });
-    expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
+    expect(connectorsButton()).toHaveAttribute("aria-expanded", "true");
 
     await user.click(defaultMode);
     await expect(
@@ -644,7 +685,7 @@ describe("chat composer connector connection", () => {
     await waitFor(() => {
       expect(screen.queryByText("Account for this chat")).toBeNull();
     });
-    expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
+    expect(connectorsButton()).toHaveAttribute("aria-expanded", "true");
 
     await user.click(defaultMode);
     await expect(
@@ -672,7 +713,7 @@ describe("chat composer connector connection", () => {
     await waitFor(() => {
       expect(screen.queryByText("Account for this chat")).toBeNull();
     });
-    expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
+    expect(connectorsButton()).toHaveAttribute("aria-expanded", "true");
     expect(selectedWorkMode).toHaveClass("text-muted-foreground");
     expect(selectedWorkMode).not.toHaveClass("border");
 
@@ -684,7 +725,7 @@ describe("chat composer connector connection", () => {
     await waitFor(() => {
       expect(screen.queryByText("Account for this chat")).toBeNull();
     });
-    expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
+    expect(connectorsButton()).toHaveAttribute("aria-expanded", "true");
     expect(selectedWorkMode).toHaveFocus();
 
     await user.click(selectedWorkMode);
@@ -695,7 +736,7 @@ describe("chat composer connector connection", () => {
     await waitFor(() => {
       expect(screen.queryByText("Account for this chat")).toBeNull();
     });
-    expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
+    expect(connectorsButton()).toHaveAttribute("aria-expanded", "true");
     await expect(
       screen.findByLabelText("GitHub · Selected account: Personal"),
     ).resolves.toHaveClass("text-muted-foreground");
@@ -713,13 +754,13 @@ describe("chat composer connector connection", () => {
     await expect(
       screen.findByLabelText("GitHub · Using default account: Work"),
     ).resolves.toBeInTheDocument();
-    expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
+    expect(connectorsButton()).toHaveAttribute("aria-expanded", "true");
     expect(authorizationWrites).toBe(1);
     expect(summaryReads).toBe(summaryReadsBeforeSelection);
 
     await user.click(document.body);
     await waitFor(() => {
-      expect(connectorsButton).toHaveAttribute("aria-expanded", "false");
+      expect(connectorsButton()).toHaveAttribute("aria-expanded", "false");
     });
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -3018,14 +3018,17 @@ describe("chat composer models", () => {
     const composer = composerElementFrom(
       await screen.findByPlaceholderText(PLACEHOLDER),
     );
-    const connectorButton = within(composer).getByLabelText("Connectors");
+    const connectorButton = () => {
+      return within(composer).getByLabelText("Connectors");
+    };
+    click(connectorButton());
 
     await waitFor(() => {
       expect(
-        connectorButton.querySelectorAll(":scope > span > span"),
+        connectorButton().querySelectorAll(":scope > span > span"),
       ).toHaveLength(3);
       expect(
-        connectorButton.querySelector(".lucide-globe"),
+        connectorButton().querySelector(".lucide-globe"),
       ).toBeInTheDocument();
     });
   });
@@ -3092,11 +3095,12 @@ describe("chat composer models", () => {
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    const initialConnectorButton = within(
-      await screen.findByLabelText("Chat thread"),
-    ).getByLabelText("Connectors");
+    const initialThread = await screen.findByLabelText("Chat thread");
+    click(within(initialThread).getByLabelText("Connectors"));
     await waitFor(() => {
-      expect(initialConnectorButton.querySelector("img")).not.toBeNull();
+      expect(
+        within(initialThread).getByLabelText("Connectors").querySelector("img"),
+      ).not.toBeNull();
     });
     const settledAgentRequestCount = agentRequestCount;
 
@@ -3110,10 +3114,14 @@ describe("chat composer models", () => {
     });
     expect(agentRequestCount).toBe(settledAgentRequestCount);
 
-    const nextConnectorButton = within(
-      screen.getByLabelText("Chat thread"),
-    ).getByLabelText("Connectors");
-    expect(nextConnectorButton.querySelector("img")).not.toBeNull();
+    const nextThread = screen.getByLabelText("Chat thread");
+    click(within(nextThread).getByLabelText("Connectors"));
+    await waitFor(() => {
+      expect(
+        within(nextThread).getByLabelText("Connectors").querySelector("img"),
+      ).not.toBeNull();
+    });
+    expect(agentRequestCount).toBe(settledAgentRequestCount);
   });
 
   it("keeps connector catalog and access resolved across same-agent chat navigation", async () => {
@@ -3217,10 +3225,11 @@ describe("chat composer models", () => {
     });
 
     const initialThread = await screen.findByLabelText("Chat thread");
-    const initialConnectorButton =
-      within(initialThread).getByLabelText("Connectors");
+    click(within(initialThread).getByLabelText("Connectors"));
     await waitFor(() => {
-      expect(initialConnectorButton.querySelector("img")).not.toBeNull();
+      expect(
+        within(initialThread).getByLabelText("Connectors").querySelector("img"),
+      ).not.toBeNull();
       expect(authorizationRequestCount).toBe(1);
       expect(customAuthorizationRequestCount).toBe(1);
       expect(discoveryRequestCount).toBe(1);
@@ -3235,12 +3244,11 @@ describe("chat composer models", () => {
       ).toBeInTheDocument();
     });
 
-    const nextConnectorButton = within(
-      screen.getByLabelText("Chat thread"),
-    ).getByLabelText("Connectors");
-    click(nextConnectorButton);
-    const connectorStatusStayedResolved =
-      screen.queryByLabelText("Remove GitHub") !== null;
+    const nextThread = screen.getByLabelText("Chat thread");
+    click(within(nextThread).getByLabelText("Connectors"));
+    await expect(
+      screen.findByLabelText("Remove GitHub"),
+    ).resolves.toBeInTheDocument();
     const requestCountAfterNavigation = authorizationRequestCount;
     const customRequestCountAfterNavigation = customAuthorizationRequestCount;
     const discoveryRequestCountAfterNavigation = discoveryRequestCount;
@@ -3248,11 +3256,12 @@ describe("chat composer models", () => {
     unexpectedCustomReload.resolve();
     unexpectedDiscoveryReload.resolve();
 
-    expect(connectorStatusStayedResolved).toBeTruthy();
     expect(requestCountAfterNavigation).toBe(1);
     expect(customRequestCountAfterNavigation).toBe(1);
     expect(discoveryRequestCountAfterNavigation).toBe(1);
-    expect(nextConnectorButton.querySelector("img")).not.toBeNull();
+    expect(
+      within(nextThread).getByLabelText("Connectors").querySelector("img"),
+    ).not.toBeNull();
   });
 
   it("does not expose previous-agent connector access while navigation resolves", async () => {
@@ -3285,18 +3294,18 @@ describe("chat composer models", () => {
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    const initialConnectorButton = within(
-      await screen.findByLabelText("Chat thread"),
-    ).getByLabelText("Connectors");
+    const initialThread = await screen.findByLabelText("Chat thread");
+    click(within(initialThread).getByLabelText("Connectors"));
     await waitFor(() => {
-      expect(initialConnectorButton.querySelector("img")).not.toBeNull();
+      expect(
+        within(initialThread).getByLabelText("Connectors").querySelector("img"),
+      ).not.toBeNull();
     });
 
     act(() => {
       context.store.set(loadLeftThread$, OTHER_AGENT_THREAD_ID);
     });
     await waitFor(() => {
-      expect(authorizationAgentIds).toContain(OTHER_AGENT_ID);
       expect(
         within(screen.getByLabelText("Chat thread")).getByText(
           "Other agent thread",
@@ -3304,12 +3313,15 @@ describe("chat composer models", () => {
       ).toBeInTheDocument();
     });
 
-    const nextConnectorButton = within(
-      screen.getByLabelText("Chat thread"),
-    ).getByLabelText("Connectors");
-    click(nextConnectorButton);
+    const nextThread = screen.getByLabelText("Chat thread");
+    click(within(nextThread).getByLabelText("Connectors"));
+    await waitFor(() => {
+      expect(authorizationAgentIds).toContain(OTHER_AGENT_ID);
+    });
     expect(screen.queryByLabelText("Remove GitHub")).not.toBeInTheDocument();
-    expect(nextConnectorButton.querySelector("img")).toBeNull();
+    expect(
+      within(nextThread).getByLabelText("Connectors").querySelector("img"),
+    ).toBeNull();
 
     otherAgentAuthorization.resolve();
     await expect(
@@ -3370,32 +3382,36 @@ describe("chat composer models", () => {
       expect(screen.getAllByLabelText("Chat thread")).toHaveLength(2);
     });
     const threadRegions = screen.getAllByLabelText("Chat thread");
+    const mainThread = threadRegions[0];
+    const sideThread = threadRegions[1];
+    if (!mainThread || !sideThread) {
+      throw new Error("Split chat threads not found");
+    }
+    const connectorButtonFor = (thread: HTMLElement) => {
+      return within(thread).getByLabelText("Connectors");
+    };
+
+    await user.click(connectorButtonFor(mainThread));
+    await user.click(connectorButtonFor(mainThread));
+    await user.click(connectorButtonFor(sideThread));
     await waitFor(() => {
       expect(authorizationRequestCount).toBe(1);
     });
 
     initialAuthorization.resolve();
-    const connectorButtons = threadRegions.map((thread) => {
-      return within(thread).getByLabelText("Connectors");
-    });
     await waitFor(() => {
-      for (const button of connectorButtons) {
-        expect(button.querySelector("img")).not.toBeNull();
+      for (const thread of threadRegions) {
+        expect(connectorButtonFor(thread).querySelector("img")).not.toBeNull();
       }
     });
 
-    const sideConnectorButton = connectorButtons[1];
-    if (!sideConnectorButton) {
-      throw new Error("Side connector button not found");
-    }
-    await user.click(sideConnectorButton);
     await user.click(await screen.findByLabelText("Remove Slack"));
 
     await waitFor(() => {
       expect(updatedAuthorizationAgentId).toBe(AGENT_ID);
       expect(authorizationRequestCount).toBe(2);
-      for (const button of connectorButtons) {
-        expect(button.querySelector("img")).toBeNull();
+      for (const thread of threadRegions) {
+        expect(connectorButtonFor(thread).querySelector("img")).toBeNull();
       }
     });
   });
@@ -3484,15 +3500,19 @@ describe("chat composer models", () => {
       expect(screen.getAllByLabelText("Chat thread")).toHaveLength(2);
     });
     const threadRegions = screen.getAllByLabelText("Chat thread");
+    const mainThread = threadRegions[0];
     const sideThread = threadRegions[1];
-    if (!sideThread) {
-      throw new Error("Side chat thread not found");
+    if (!mainThread || !sideThread) {
+      throw new Error("Split chat threads not found");
     }
     const sideComposer = sideThread.querySelector("[data-chat-composer]");
     if (!(sideComposer instanceof HTMLElement)) {
       throw new Error("Side chat composer not found");
     }
 
+    await user.click(within(mainThread).getByLabelText("Connectors"));
+    await user.click(within(mainThread).getByLabelText("Connectors"));
+    await user.click(within(sideComposer).getByLabelText("Connectors"));
     await waitFor(() => {
       expect(new Set(authorizationAgentIds)).toStrictEqual(
         new Set([AGENT_ID, OTHER_AGENT_ID]),
@@ -3523,7 +3543,6 @@ describe("chat composer models", () => {
     });
     expect(authorizationAgentIds).toHaveLength(authorizationRequestCount);
     expect(workflowAgentIds).toHaveLength(workflowRequestCount);
-    await user.click(within(sideComposer).getByLabelText("Connectors"));
     await user.click(
       await screen.findByLabelText("Configure Slack permissions"),
     );

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -8601,6 +8601,7 @@ function ConnectorsPopoverButton({
 
   return (
     <Popover
+      defaultOpen
       onOpenChange={(open, eventDetails) => {
         if (
           !open &&
@@ -10536,13 +10537,7 @@ function ComposerConnectorConnectDialogs({
   );
 }
 
-function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
-  const { t } = useTranslation();
-  const mcpEnabled = useGet(customConnectorMcpEnabled$);
-  const connectorReadState = useComposerConnectorReadState(signals);
-  const agents = useLastResolved(agents$) ?? [];
-  const connectorUi = useGet(signals.connector.connectorUiState$);
-  const updateConnectorUi = useSet(signals.connector.updateConnectorUiState$);
+function useComposerComputerUse(signals: ComposerSignals): ComposerComputerUse {
   const storedComputerUseHostId = useGet(signals.computer.computerUseHostId$);
   const cloudBrowserEnabled = useGet(signals.computer.cloudBrowserEnabled$);
   const setComputerUseHostId = useSet(signals.computer.setComputerUseHostId$);
@@ -10560,7 +10555,7 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
     storedComputerUseHostId,
   );
   const composerPageSignal = useGet(pageSignal$);
-  const computerUse: ComposerComputerUse = {
+  return {
     hosts: visibleComputerUseHosts(computerUseHosts, resolvedComputerUseHostId),
     loading:
       computerUseHostsState.state === "loading" &&
@@ -10581,6 +10576,62 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
     },
     downloadUrl: OKOU_DESKTOP_DOWNLOAD_URL,
   };
+}
+
+function ComposerConnectorsActivator({
+  computerUse,
+  onActivate,
+}: {
+  readonly computerUse: ComposerComputerUse;
+  readonly onActivate: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "inline-flex h-8 min-w-8 shrink-0 items-center justify-center rounded-lg px-1 transition-colors hover:bg-state-hover sm:min-w-9 sm:px-1.5",
+              COMPOSER_CONTROL_FOCUS_CLASS,
+            )}
+            aria-label={t(($) => {
+              return $.chat.connectors.title;
+            })}
+            onClick={onActivate}
+          >
+            <ConnectorTriggerIcons
+              connectors={[]}
+              customConnectors={[]}
+              hasComputerUse={Boolean(computerUse.selectedHostId)}
+              hasCloudBrowser={computerUse.cloudBrowserEnabled}
+            />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="text-xs">
+          {t(($) => {
+            return $.chat.connectors.title;
+          })}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function ActivatedComposerConnectorsSlot({
+  signals,
+  computerUse,
+}: {
+  readonly signals: ComposerSignals;
+  readonly computerUse: ComposerComputerUse;
+}) {
+  const { t } = useTranslation();
+  const mcpEnabled = useGet(customConnectorMcpEnabled$);
+  const connectorReadState = useComposerConnectorReadState(signals);
+  const agents = useLastResolved(agents$) ?? [];
+  const connectorUi = useGet(signals.connector.connectorUiState$);
+  const updateConnectorUi = useSet(signals.connector.updateConnectorUiState$);
 
   // Connectors: connected (org-level) + authorized (agent-level) → available
   const relatedCatalogItemsLoadable = connectorReadState.relatedCatalogItems;
@@ -10876,6 +10927,35 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
         />
       )}
     </>
+  );
+}
+
+function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
+  const computerUse = useComposerComputerUse(signals);
+  const connectorUi = useGet(signals.connector.connectorUiState$);
+  const updateConnectorUi = useSet(signals.connector.updateConnectorUiState$);
+  const openAccountsPopover = useSet(signals.connector.accounts.openPopover$);
+
+  if (connectorUi.connectorDataActivated) {
+    return (
+      <ActivatedComposerConnectorsSlot
+        signals={signals}
+        computerUse={computerUse}
+      />
+    );
+  }
+
+  return (
+    <ComposerConnectorsActivator
+      computerUse={computerUse}
+      onActivate={() => {
+        updateConnectorUi({
+          connectorDataActivated: true,
+          popoverSortOrder: [],
+        });
+        openAccountsPopover();
+      }}
+    />
   );
 }
 

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -5549,6 +5549,16 @@ function ThinkingIndicator({ thread }: { thread: ChatPanelSignals }) {
 
 function ChatConnectorActionConnectModal() {
   const active = useGet(activeChatConnectorAction$);
+
+  if (!active) {
+    return null;
+  }
+
+  return <ActiveChatConnectorActionConnectModal />;
+}
+
+function ActiveChatConnectorActionConnectModal() {
+  const active = useGet(activeChatConnectorAction$);
   const mcpEnabled = useGet(customConnectorMcpEnabled$);
   const close = useSet(closeChatConnectorActionConnectDialog$);
   const runCallback = useSet(runChatActionCallback$);

--- a/turbo/packages/api-contracts/package.json
+++ b/turbo/packages/api-contracts/package.json
@@ -28,7 +28,6 @@
     "check-types": "tsc -p tsconfig.contracts.json --noEmit && tsc -p tsconfig.python-bindings.json --noEmit && tsc -p tsconfig.rust-bindings.json --noEmit && tsc -p tsconfig.runtime-api-schema.json --noEmit"
   },
   "dependencies": {
-    "@trpc/server": "11.18.0",
     "@okouai/connectors": "workspace:*",
     "zod": "^4.3.6"
   },

--- a/turbo/packages/api-contracts/src/contracts/trpc-contract.ts
+++ b/turbo/packages/api-contracts/src/contracts/trpc-contract.ts
@@ -1,11 +1,3 @@
-import { initTRPC } from "@trpc/server";
-import { z } from "zod";
-
-const t = initTRPC.create({
-  allowOutsideOfServer: true,
-  isServer: !("window" in globalThis),
-});
-
 const noBodySymbol: unique symbol = Symbol("vm0.noBody");
 const typeSymbol: unique symbol = Symbol("vm0.type");
 
@@ -166,10 +158,6 @@ type ClientRouteInput<TSpec extends AppRouteSpec> =
     ? ClientRouteRequest<TSpec> | undefined
     : ClientRouteRequest<TSpec>;
 
-export interface ContractProcedure {
-  readonly _contractProcedure?: never;
-}
-
 export type RouteTypeSlots<TSpec extends AppRouteSpec> = {
   readonly serverRequest: ServerRouteRequest<TSpec>;
   readonly clientRequest: ClientRouteInput<TSpec>;
@@ -196,7 +184,6 @@ type RuntimeRouteSpec = {
 
 export type AppRoute<TTypes extends AnyRouteTypeSlots = AnyRouteTypeSlots> =
   RuntimeRouteSpec & {
-    readonly procedure: ContractProcedure;
     readonly __types?: TTypes;
   };
 
@@ -361,20 +348,6 @@ export function validateResponse<
   return { ...response, body };
 }
 
-function createProcedure(spec: AppRouteSpec) {
-  const procedure = t.procedure
-    .input(z.custom<unknown>())
-    .output(z.custom<unknown>());
-
-  const resolver = (): never => {
-    throw new Error("Contract procedures are type carriers only");
-  };
-
-  return spec.method === "GET"
-    ? procedure.query(resolver)
-    : procedure.mutation(resolver);
-}
-
 type RouteFromSpec<TSpec extends AppRouteSpec> = TSpec &
   AppRoute<RouteTypeSlots<TSpec>>;
 
@@ -413,12 +386,7 @@ export function initContract(): {
 } {
   return {
     router: (spec) => {
-      return mapRecordValues<typeof spec, RouterFromSpec<typeof spec>>(
-        spec,
-        (_name, route) => {
-          return { ...route, procedure: createProcedure(route) };
-        },
-      );
+      return spec;
     },
     noBody: () => {
       return { [noBodySymbol]: true };

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -753,9 +753,6 @@ importers:
       '@okouai/connectors':
         specifier: workspace:*
         version: link:../connectors
-      '@trpc/server':
-        specifier: 11.18.0
-        version: 11.18.0(typescript@6.0.3)
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -4269,12 +4266,6 @@ packages:
   '@tootallnate/once@2.0.1':
     resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
-
-  '@trpc/server@11.18.0':
-    resolution: {integrity: sha512-JAvXOuNTxgXjIDfQaOvDq1j66LMNfDJUH1IU7Slfn8EvRv2EkH6ehu3A7zpYhjO0syHHiYg77v2lG2JFJgvw7Q==}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=5.7.2'
 
   '@turbo/darwin-64@2.10.9':
     resolution: {integrity: sha512-Jh+pTGXLNz8+1tkUU13TI/f+ZOI+OvC4YbHi1H+57iSpLt5DR3xgptd+4sA07RdjdRR/RX/01uQQu2OkbzIefA==}
@@ -12683,10 +12674,6 @@ snapshots:
   '@tokenizer/token@0.3.0': {}
 
   '@tootallnate/once@2.0.1': {}
-
-  '@trpc/server@11.18.0(typescript@6.0.3)':
-    dependencies:
-      typescript: 6.0.3
 
   '@turbo/darwin-64@2.10.9':
     optional: true


### PR DESCRIPTION
## Summary

- build on the merged #30175 single-bundle platform output
- remove unused runtime tRPC procedure construction from API contracts and drop `@trpc/server`
- defer connector discovery and custom connector reads until the connector menu is opened for the first time
- avoid subscribing to custom connector data while the chat connector action modal is inactive

## Why

Cold chat entry was constructing a tRPC procedure for every contract route even though no runtime consumer reads it. The composer and an inactive chat action modal also subscribed to connector data during initial render, which put connector discovery and duplicate custom connector requests on the cold-load waterfall.

## Verification

- `pnpm check-types` in `packages/api-contracts`
- `pnpm check-types` in `apps/platform`
- `pnpm exec vitest run src/contracts/__tests__/connector-client-contract.test.ts` (9 passed)
- `pnpm exec vitest run src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx` (20 passed)
- `pnpm exec vitest run src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx` (78 passed)
- targeted Prettier, oxlint, type-aware oxlint, ESLint, and dependency-only Knip for the affected workspaces
- all required GitHub checks passed, including the deployed Playwright feature coverage

The page-level integration test verifies that connector discovery and custom connector requests stay at zero before the first menu open and each start exactly once after the click. Existing connector navigation and split-pane tests activate the menu before checking cache, deduplication, and agent isolation.

## Staging evidence

- preview merge `bc857008181a` has parents `48d88b92e7ff` (`main`) and `757cd2b3a3d1` (this PR head)
- single App asset: 7,031,201 raw bytes / 1,805,982 gzip bytes, down 15,155 raw / 5,131 gzip from #30175
- cold load: V8 module evaluation took 329.6 ms; the Clerk script request began 1.7 ms after evaluation ended
- before first connector-menu open: discovery/global custom/agent custom connector GET counts were all zero
- after first open and a warm reopen: those GET counts were still exactly one each
- stable 2.5-second render profile: zero commits; first connector open: 15 commits, 69 mounts, 481 updates, isolated to the connector/popover subtree
- `TiptapWorkflowComposer` and `ComposerSendButton` recorded zero updates during first connector open

Artifacts: [cold-cache waterfall](https://cdn.okou.io/artifacts/dpt6rqiidk.png), [sanitized HAR](https://cdn.okou.io/artifacts/hdun9fab87.har), [before opening connectors](https://cdn.okou.io/artifacts/mi8ktl1ip5.png), [connector menu open](https://cdn.okou.io/artifacts/29rfnzr3w4.png).

## Stack

- base branch: `main`
- rebased onto the #30175 squash merge `48d88b92e`
- implementation: `81aeec1ef`; focused platform coverage: `2d2ab9415`; deployed E2E coverage: `757cd2b3a`
