### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/turbo/apps/platform/src/signals/org.ts
+++ b/turbo/apps/platform/src/signals/org.ts
@@ -28,12 +28,8 @@ export const createdOrganizationsCount$ = computed(async (get) => {
   get(reloadCreatedOrganizationsCount$);
   const createClient = get(apiClient$);
   const client = createClient(orgContract);
-  const result = await accept(client.createdCount(), [200, 404]);
-  // Rollout fallback for new App -> old API: the old API predates this
-  // additive route, so preserve its Clerk-gated creation-entry behavior.
-  // Remove after that API no longer serves or remains a rollback target.
-  // Follow-up: https://github.com/vm0-ai/vm0/issues/29866
-  return result.status === 200 ? result.body.createdOrganizationsCount : 0;
+  const result = await accept(client.createdCount(), [200]);
+  return result.body.createdOrganizationsCount;
 });
 
 /**

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-switcher.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-switcher.test.tsx
@@ -212,63 +212,6 @@ describe("zero org switcher", () => {
     });
   });
 
-  it("preserves workspace creation while the count endpoint rolls out", async () => {
-    context.mocks.api(orgContract.createdCount, ({ respond }) => {
-      return respond(404, {
-        error: { message: "Not found", code: "NOT_FOUND" },
-      });
-    });
-    context.mocks.data.org({
-      id: "org_current",
-      name: "Solo",
-      role: "admin",
-      createdBy: "other-user-456",
-    });
-
-    detachedSetupPage({
-      context,
-      path: "/",
-      user: {
-        id: "test-user-123",
-        fullName: "Alex Rivera",
-        email: "alex.rivera@example.test",
-        createOrganizationEnabled: true,
-        createOrganizationsLimit: 1,
-      },
-      org: {
-        activeOrg: {
-          id: "org_current",
-          name: "Solo",
-          slug: "solo",
-        },
-        memberships: [
-          {
-            id: "membership_current",
-            organization: {
-              id: "org_current",
-              name: "Solo",
-            },
-          },
-        ],
-      },
-    });
-
-    const orgSwitcher = await waitFor(() => {
-      const label = screen.getByText("Solo");
-      const trigger = label.closest("button");
-      if (!trigger) {
-        throw new Error("Org switcher trigger not found");
-      }
-      return trigger;
-    });
-
-    click(orgSwitcher);
-
-    await waitFor(() => {
-      expect(screen.getByText("Create workspace")).toBeInTheDocument();
-    });
-  });
-
   it("hides workspace creation after reaching the limit while another workspace is active", async () => {
     context.mocks.api(orgContract.createdCount, ({ respond }) => {
       return respond(200, { createdOrganizationsCount: 1 });

--- a/turbo/packages/api-contracts/src/contracts/org-routes.ts
+++ b/turbo/packages/api-contracts/src/contracts/org-routes.ts
@@ -32,7 +32,6 @@ export const orgContract = c.router({
       }),
       401: apiErrorSchema,
       403: apiErrorSchema,
-      404: apiErrorSchema,
       503: apiErrorSchema,
     },
     summary: "Get current user's created organization count",


### PR DESCRIPTION
Removes the new-app-to-old-API 404 fallback on `GET /api/org/created-count`. Closes the removal gate in #29866.

## Cohort — `createdOrganizationsCount$` 404 fallback

**Old boundary:** #29841 added `GET /api/org/created-count` so the Platform can apply Clerk's user-level organization creation limit. During rollout a newly promoted App could still reach an API version from before that additive route, so the App accepted `404` and fell back to `0`, which preserves the previous Clerk-gated creation-entry behavior.

**New boundary:** the App accepts only `200` and reads `createdOrganizationsCount` directly. The contract no longer declares `404` for this route.

Removed:
- `404: apiErrorSchema` from `orgContract.createdCount`
- the `[200, 404]` accept list, the status branch, and the rollout comment in `createdOrganizationsCount$`
- the `preserves workspace creation while the count endpoint rolls out` Platform regression, which only asserted the old-API `404` response

**Window:** the consumer is a new App calling an older API, so the governing gate is the old API leaving service — canonical window 1 — plus the issue's explicit requirement that it no longer be a retained rollback target.

**Rollout evidence (observed):**
- #29841 merged `2026-08-27T10:18:54Z` (`72b37b48f06`).
- First `api/production` deployment containing it: `da3369e093`, `2026-08-27T11:03:33Z`, confirmed with `git merge-base --is-ancestor` walking the deployment list forward from oldest.
- **15 further `api/production` deployments** have been promoted since, so the last build predating the route (`fad505ecaf`, `2026-08-27T10:03:33Z`) is 16 deployments back and is no longer the rollback target.
- Elapsed: **34.0 hours**.

**Axiom evidence (read-only), dataset `vm0-request-log-prod`:**
- Range `2026-08-27T11:03:33Z` → `2026-08-28T21:00:00Z`, explicit `startTime`/`endTime`, exact named-field filter `path_template == "/api/org/created-count"`, grouped by `method` and `status`: `GET 200` × 15 and `OPTIONS 204` × 14 (CORS preflight). **Zero `404` responses.**
- Last observed request: `2026-08-28T18:22:39Z`, so the route is live and being exercised, not dormant.
- Coverage over the same range and filter, bucketed 12h: 12 / 9 / 8 requests. The route is continuously instrumented across the whole window, so the absent `404` is a covered observation rather than a gap.

**No legitimate 404 remains:** `getCreatedOrganizationsCountInner$` in `turbo/apps/api/src/signals/routes/org-read.ts` returns only `200` or, on a Clerk rate limit, `503` via `providerUnavailable`. Its `authRoute({ accept: ["session"] })` wrapper produces `401`/`403`, both still declared. `404` was reachable only from an API build that did not have the route at all.

**503 behavior is unchanged:** `503` was never in the App's accept list, so the Clerk-rate-limit path already rejects `createdOrganizationsCount$` and `org-switcher.tsx` already hides creation when the loadable is not `hasData`. This change does not touch that path.

**MaskDB:** not applicable. No schema, column, or persisted payload is involved.

## Explicitly deferred

- **Appearance preference fallback (#30076).** #30051 reached `api/production` at `2026-08-28T06:25:54Z` — only **14.6 hours** before this run, with 7 later production deployments. Its cleanup makes `userPreferencesResponseSchema` strict, and `hasServerAppearancePreferences` already throws on a partial response, so a premature rollback would fail the whole preferences load rather than degrade. Held to the same bar this cohort met.
- **Official workflow queue markers (`web-chat-public-brand-context.service.ts`, #29908).** The gate requires proving no pending unrevoked or runless marker rows remain, and removal changes queue rejection semantics rather than deleting a dead branch.
- **`PREVIOUS_PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS_BY_SHA256`.** The republication commit did not bump the CLI package version, so `x_client_version` cannot separate pre- from post-republication execution contexts and the requested digest is not part of `path_template`.
- **Queued-launch-context brand reads** for Telegram, AgentPhone, and Feishu. MaskDB's projection still does not expose `public_brand` on `chat_telegram_context`, `chat_agentphone_context`, `chat_feishu_context`, or `feishu_org_connections`, and `feishu_chat_ingress` is still absent.
- **`agentphone-connect-params.ts` `parseBrandState` and `agentphone.service.ts`.** `minimumSupportedVersion` is still `0.781.1` while the pre-rollout app was `0.788.0`.
- **Chat Event snapshot fallbacks (#29362).** A dedicated one-time cleanup workflow already owns this surface around #30140.

## Checks (run once against the combined diff)

- `pnpm format`
- `pnpm -F @okouai/app lint`, `pnpm -F @okouai/api-contracts lint` (no new warnings)
- `pnpm -F @okouai/api-contracts check-types`, `pnpm -F api check-types`, `pnpm -F @okouai/app check-types`
- `pnpm knip` (no new unused files, exports, or dependencies)
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/org-switcher.test.tsx` — 5 passing
- `pnpm -F api exec vitest run src/signals/routes/__tests__/org-team.bdd.test.ts src/__tests__/api-namespace-compatibility.test.ts` — 21 passing against a local Postgres with `timezone=UTC`

Full coverage is left to the PR pipeline; no full local Vitest run and no local dev server.

Closes #29866.
