### PR TITLE
refactor(ops): cut production runner host tuning aliases to canonical

### DIFF
--- a/.github/scripts/tests/runner-host-env-alias-cutover-ansible-test.sh
+++ b/.github/scripts/tests/runner-host-env-alias-cutover-ansible-test.sh
@@ -1,0 +1,358 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+ansible_config="$repo_root/ansible/ansible.cfg"
+inventory="$script_dir/fixtures/runner-promotion-local.ini"
+promote_playbook="$repo_root/ansible/playbooks/promote-runner.yml"
+cutover_helper="$repo_root/ansible/files/runner-host-env-alias-cutover.py"
+
+if ! command -v ansible-playbook >/dev/null; then
+  echo "ansible-playbook is required" >&2
+  exit 1
+fi
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+assert_file_equals() {
+  local expected=$1
+  local actual=$2
+  if ! cmp -s "$expected" "$actual"; then
+    echo "expected exact file equality: $expected $actual" >&2
+    diff -u "$expected" "$actual" >&2 || true
+    exit 1
+  fi
+}
+
+assert_no_backup() {
+  if [ -e "$backup_file" ]; then
+    fail "host env cutover backup was not finalized"
+  fi
+}
+
+case "$(uname -m)" in
+  x86_64)
+    runner_target=x86_64-unknown-linux-musl
+    ;;
+  aarch64)
+    runner_target=aarch64-unknown-linux-musl
+    ;;
+  *)
+    fail "unsupported test architecture: $(uname -m)"
+    ;;
+esac
+
+tmp="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+test_home="$tmp/home"
+test_bin="$tmp/bin"
+data_dir="$tmp/vm0-runner"
+runner_release=v999.0.0
+runner_bin_dir="$data_dir/bin/$runner_release"
+host_env_file="$data_dir/host.env"
+backup_file="$data_dir/.host.env.okou-alias-cutover-backup"
+invocation_log="$data_dir/runner-invocations"
+mkdir -p \
+  "$test_home" \
+  "$test_bin" \
+  "$data_dir/locks" \
+  "$data_dir/runners/$runner_release" \
+  "$runner_bin_dir"
+
+fake_systemctl="$test_bin/systemctl"
+cat >"$fake_systemctl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  list-units)
+    printf '%s\n' 'vm0-runner-v998.0.0.service loaded active running old runner'
+    ;;
+  list-unit-files)
+    ;;
+  *)
+    echo "unexpected systemctl invocation: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$fake_systemctl"
+
+fake_runner="$runner_bin_dir/runner"
+cat >"$fake_runner" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+data_dir="$(cd "$(dirname "$0")/../.." && pwd)"
+host_env_file="$data_dir/host.env"
+invocation_log="$data_dir/runner-invocations"
+
+alias_state=absent
+if [ -f "$host_env_file" ]; then
+  if grep -Eq '^[[:space:]]*VM0_RUNNER_(CONCURRENCY_FACTOR|DISK_BANDWIDTH_MIB_PER_SEC|DISK_IOPS|NET_RX_MIB_PER_SEC|NET_TX_MIB_PER_SEC)[[:space:]]*=' "$host_env_file"; then
+    alias_state=legacy
+  elif grep -Eq '^[[:space:]]*OKOU_RUNNER_(CONCURRENCY_FACTOR|DISK_BANDWIDTH_MIB_PER_SEC|DISK_IOPS|NET_RX_MIB_PER_SEC|NET_TX_MIB_PER_SEC)[[:space:]]*=' "$host_env_file"; then
+    alias_state=canonical
+  fi
+fi
+printf '%s|%s\n' "$*" "$alias_state" >>"$invocation_log"
+
+case "${1:-}" in
+  service)
+    case "${2:-}" in
+      install)
+        [ "$alias_state" != legacy ] || exit 1
+        [ ! -e "$data_dir/fail-install" ] || exit 1
+        touch "$data_dir/target-installed"
+        exit 0
+        ;;
+      wait-running)
+        [ -e "$data_dir/target-installed" ] || exit 1
+        [ ! -e "$data_dir/fail-wait" ] || exit 1
+        exit 0
+        ;;
+      stop)
+        touch "$data_dir/target-stopped"
+        [ ! -e "$data_dir/fail-stop" ] || exit 1
+        exit 0
+        ;;
+      drain)
+        [ -e "$data_dir/target-healthy" ] || exit 1
+        exit 0
+        ;;
+    esac
+    ;;
+  doctor)
+    if [ ! -e "$data_dir/target-healthy" ] && [ -e "$data_dir/fail-health" ]; then
+      exit 1
+    fi
+    touch "$data_dir/target-healthy"
+    exit 0
+    ;;
+  gc)
+    [ "$*" = "gc --keep-latest 6 --protect-version v999.0.0" ] || exit 1
+    exit 0
+    ;;
+esac
+
+echo "unexpected runner invocation: $*" >&2
+exit 1
+EOF
+chmod +x "$fake_runner"
+
+HOME="$test_home" \
+  ANSIBLE_CONFIG="$ansible_config" \
+  ANSIBLE_NOCOLOR=1 \
+  ansible-playbook -i "$inventory" --syntax-check "$promote_playbook" >/dev/null
+
+reset_scenario() {
+  rm -f \
+    "$data_dir"/fail-install \
+    "$data_dir"/fail-wait \
+    "$data_dir"/fail-health \
+    "$data_dir"/fail-stop \
+    "$data_dir"/target-installed \
+    "$data_dir"/target-healthy \
+    "$data_dir"/target-stopped \
+    "$host_env_file" \
+    "$backup_file"
+  : >"$invocation_log"
+}
+
+run_promotion() {
+  local output_file=$1
+  PATH="$test_bin:$PATH" \
+    HOME="$test_home" \
+    ANSIBLE_CONFIG="$ansible_config" \
+    ANSIBLE_NOCOLOR=1 \
+    ansible-playbook \
+      -i "$inventory" \
+      --limit runner-promotion-a \
+      -e "data_dir=$data_dir" \
+      -e "runner_host_env_file=$host_env_file" \
+      -e "runner_version=999.0.0" \
+      -e "runner_target=$runner_target" \
+      "$promote_playbook" >"$output_file" 2>&1
+}
+
+expect_success() {
+  local output_file=$1
+  if ! run_promotion "$output_file"; then
+    sed -n '1,240p' "$output_file" >&2
+    fail "expected runner promotion to succeed"
+  fi
+}
+
+expect_failure() {
+  local output_file=$1
+  if run_promotion "$output_file"; then
+    sed -n '1,240p' "$output_file" >&2
+    fail "expected runner promotion to fail"
+  fi
+}
+
+reset_scenario
+legacy_file="$tmp/legacy.env"
+canonical_file="$tmp/canonical.env"
+cat >"$legacy_file" <<'EOF'
+# Preserve this comment and every blank line.
+
+  VM0_RUNNER_CONCURRENCY_FACTOR = 1.5000
+# Preserve the suffix too.
+EOF
+cat >"$canonical_file" <<'EOF'
+# Preserve this comment and every blank line.
+
+  OKOU_RUNNER_CONCURRENCY_FACTOR = 1.5000
+# Preserve the suffix too.
+EOF
+cp "$legacy_file" "$host_env_file"
+chmod 0640 "$host_env_file"
+metadata_before=$(stat -c '%u:%g:%a' "$host_env_file")
+expect_success "$tmp/legacy-success.out"
+assert_file_equals "$canonical_file" "$host_env_file"
+[ "$(stat -c '%u:%g:%a' "$host_env_file")" = "$metadata_before" ] || \
+  fail "host env ownership or mode changed"
+assert_no_backup
+
+health_line=$(grep -nF "doctor --name $runner_release|canonical" "$invocation_log" | head -n 1 | cut -d: -f1)
+drain_line=$(grep -nF 'service drain --name v998.0.0|canonical' "$invocation_log" | cut -d: -f1)
+if [ -z "$health_line" ] || [ -z "$drain_line" ] || [ "$health_line" -ge "$drain_line" ]; then
+  fail "target health must succeed before an old service drains"
+fi
+
+replay_metadata=$(stat -c '%u:%g:%a:%Y:%i' "$host_env_file")
+expect_success "$tmp/canonical-replay.out"
+assert_file_equals "$canonical_file" "$host_env_file"
+[ "$(stat -c '%u:%g:%a:%Y:%i' "$host_env_file")" = "$replay_metadata" ] || \
+  fail "canonical replay edited host.env"
+assert_no_backup
+
+reset_scenario
+all_legacy_file="$tmp/all-legacy.env"
+all_canonical_file="$tmp/all-canonical.env"
+cat >"$all_legacy_file" <<'EOF'
+VM0_RUNNER_CONCURRENCY_FACTOR=1.5
+VM0_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC=2000
+VM0_RUNNER_DISK_IOPS=200000
+VM0_RUNNER_NET_RX_MIB_PER_SEC=1250
+VM0_RUNNER_NET_TX_MIB_PER_SEC=1000
+EOF
+cat >"$all_canonical_file" <<'EOF'
+OKOU_RUNNER_CONCURRENCY_FACTOR=1.5
+OKOU_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC=2000
+OKOU_RUNNER_DISK_IOPS=200000
+OKOU_RUNNER_NET_RX_MIB_PER_SEC=1250
+OKOU_RUNNER_NET_TX_MIB_PER_SEC=1000
+EOF
+cp "$all_legacy_file" "$host_env_file"
+"$cutover_helper" migrate "$host_env_file" >"$tmp/pending-migration.out"
+grep -Fqx 'host_env_alias_cutover=migrated' "$tmp/pending-migration.out" || \
+  fail "initial helper migration did not report its fixed state"
+assert_file_equals "$all_canonical_file" "$host_env_file"
+[ -f "$backup_file" ] || fail "pending migration did not retain its restoration file"
+pending_file_identity=$(stat -c '%u:%g:%a:%Y:%i' "$host_env_file")
+pending_backup_identity=$(stat -c '%u:%g:%a:%Y:%i' "$backup_file")
+"$cutover_helper" migrate "$host_env_file" >"$tmp/pending-replay.out"
+grep -Fqx 'host_env_alias_cutover=migrated' "$tmp/pending-replay.out" || \
+  fail "pending migration replay did not converge"
+[ "$(stat -c '%u:%g:%a:%Y:%i' "$host_env_file")" = "$pending_file_identity" ] || \
+  fail "pending migration replay rewrote host.env"
+[ "$(stat -c '%u:%g:%a:%Y:%i' "$backup_file")" = "$pending_backup_identity" ] || \
+  fail "pending migration replay replaced its restoration file"
+expect_success "$tmp/pending-replay-promotion.out"
+assert_file_equals "$all_canonical_file" "$host_env_file"
+assert_no_backup
+
+reset_scenario
+mixed_file="$tmp/mixed.env"
+mixed_expected="$tmp/mixed-expected.env"
+cat >"$mixed_file" <<'EOF'
+OKOU_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC = 2000
+VM0_RUNNER_DISK_IOPS=200000
+# NET_RX is intentionally absent.
+ VM0_RUNNER_NET_TX_MIB_PER_SEC = 1000
+EOF
+cat >"$mixed_expected" <<'EOF'
+OKOU_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC = 2000
+OKOU_RUNNER_DISK_IOPS=200000
+# NET_RX is intentionally absent.
+ OKOU_RUNNER_NET_TX_MIB_PER_SEC = 1000
+EOF
+cp "$mixed_file" "$host_env_file"
+expect_success "$tmp/mixed-success.out"
+assert_file_equals "$mixed_expected" "$host_env_file"
+assert_no_backup
+if grep -Fq 'VM0_RUNNER_' "$host_env_file"; then
+  fail "present I/O aliases did not move in one file transaction"
+fi
+
+reset_scenario
+expect_success "$tmp/missing-success.out"
+[ ! -e "$host_env_file" ] || fail "missing host.env was created"
+assert_no_backup
+
+for conflict_kind in aliases duplicate; do
+  reset_scenario
+  case "$conflict_kind" in
+    aliases)
+      cat >"$host_env_file" <<'EOF'
+OKOU_RUNNER_CONCURRENCY_FACTOR=canonical-value-must-not-leak
+VM0_RUNNER_CONCURRENCY_FACTOR=legacy-value-must-not-leak
+EOF
+      ;;
+    duplicate)
+      cat >"$host_env_file" <<'EOF'
+VM0_RUNNER_DISK_IOPS=first-value-must-not-leak
+VM0_RUNNER_DISK_IOPS=second-value-must-not-leak
+EOF
+      ;;
+  esac
+  cp -p "$host_env_file" "$tmp/$conflict_kind-original.env"
+  expect_failure "$tmp/$conflict_kind-conflict.out"
+  assert_file_equals "$tmp/$conflict_kind-original.env" "$host_env_file"
+  assert_no_backup
+  [ ! -s "$invocation_log" ] || fail "alias conflict reached target installation"
+  grep -Fq 'host_env_alias_cutover=conflict' "$tmp/$conflict_kind-conflict.out" || \
+    fail "alias conflict did not report its fixed state"
+  if grep -Fq 'value-must-not-leak' "$tmp/$conflict_kind-conflict.out"; then
+    fail "configured value leaked into Ansible output"
+  fi
+done
+
+for failure_point in install wait health; do
+  reset_scenario
+  cat >"$host_env_file" <<'EOF'
+# exact failure restoration
+VM0_RUNNER_CONCURRENCY_FACTOR = restoration-value-must-not-leak
+EOF
+  chmod 0640 "$host_env_file"
+  cp -p "$host_env_file" "$tmp/$failure_point-original.env"
+  touch "$data_dir/fail-$failure_point"
+  if [ "$failure_point" = health ]; then
+    touch "$data_dir/fail-stop"
+  fi
+  expect_failure "$tmp/$failure_point-failure.out"
+  assert_file_equals "$tmp/$failure_point-original.env" "$host_env_file"
+  [ "$(stat -c '%u:%g:%a' "$host_env_file")" = "$(stat -c '%u:%g:%a' "$tmp/$failure_point-original.env")" ] || \
+    fail "failure restoration changed ownership or mode"
+  assert_no_backup
+  grep -Fq "service stop --name $runner_release --force --cleanup failed-start|canonical" "$invocation_log" || \
+    fail "failed target was not stopped before restoration"
+  if grep -Fq 'service drain --name' "$invocation_log"; then
+    fail "old service drained after target failure"
+  fi
+  if grep -Fq 'restoration-value-must-not-leak' "$tmp/$failure_point-failure.out"; then
+    fail "restored value leaked into Ansible output"
+  fi
+done
+
+echo "runner-host-env-alias-cutover-ansible-test: ok"

--- a/.github/scripts/tests/runner-promotion-ansible-test.sh
+++ b/.github/scripts/tests/runner-promotion-ansible-test.sh
@@ -164,6 +164,7 @@ if ! PATH="$test_bin:$PATH" \
     -i "$inventory" \
     --forks 2 \
     -e "data_dir=$data_dir" \
+    -e "runner_host_env_file=$tmp/host.env" \
     -e "runner_version=999.0.0" \
     -e "runner_target=$runner_target" \
     "$promote_playbook" >"$tmp/promote-output" 2>&1; then

--- a/ansible/files/runner-host-env-alias-cutover.py
+++ b/ansible/files/runner-host-env-alias-cutover.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Atomically cut Runner host tuning aliases to their canonical names."""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+ALIAS_PAIRS = (
+    ("OKOU_RUNNER_CONCURRENCY_FACTOR", "VM0_RUNNER_CONCURRENCY_FACTOR"),
+    (
+        "OKOU_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC",
+        "VM0_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC",
+    ),
+    ("OKOU_RUNNER_DISK_IOPS", "VM0_RUNNER_DISK_IOPS"),
+    ("OKOU_RUNNER_NET_RX_MIB_PER_SEC", "VM0_RUNNER_NET_RX_MIB_PER_SEC"),
+    ("OKOU_RUNNER_NET_TX_MIB_PER_SEC", "VM0_RUNNER_NET_TX_MIB_PER_SEC"),
+)
+ALIASES = {
+    alias: (canonical, alias != canonical)
+    for canonical, legacy in ALIAS_PAIRS
+    for alias in (canonical, legacy)
+}
+BACKUP_SUFFIX = ".okou-alias-cutover-backup"
+RESULT_PREFIX = "host_env_alias_cutover="
+
+
+class CutoverConflict(Exception):
+    """The cutover cannot proceed without weakening file safety."""
+
+
+def exists(path: Path) -> bool:
+    return os.path.lexists(path)
+
+
+def backup_path(path: Path) -> Path:
+    return path.with_name(f".{path.name}{BACKUP_SUFFIX}")
+
+
+def fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def read_regular_file(path: Path) -> tuple[bytes, os.stat_result]:
+    before = os.lstat(path)
+    if not stat.S_ISREG(before.st_mode):
+        raise CutoverConflict
+
+    with path.open("rb") as source:
+        content = source.read()
+        opened = os.fstat(source.fileno())
+
+    if (before.st_dev, before.st_ino) != (opened.st_dev, opened.st_ino):
+        raise CutoverConflict
+    return content, opened
+
+
+def metadata_identity(metadata: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_uid,
+        metadata.st_gid,
+        stat.S_IMODE(metadata.st_mode),
+    )
+
+
+def ownership_and_mode(metadata: os.stat_result) -> tuple[int, int, int]:
+    return (
+        metadata.st_uid,
+        metadata.st_gid,
+        stat.S_IMODE(metadata.st_mode),
+    )
+
+
+def transform(content: bytes) -> tuple[bytes, bool]:
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise CutoverConflict from error
+
+    provided: set[str] = set()
+    rewritten: list[str] = []
+    changed = False
+
+    for line in text.splitlines(keepends=True):
+        equals = line.find("=")
+        if equals < 0:
+            rewritten.append(line)
+            continue
+
+        prefix = line[:equals]
+        start = 0
+        while start < len(prefix) and prefix[start].isspace():
+            start += 1
+        end = len(prefix)
+        while end > start and prefix[end - 1].isspace():
+            end -= 1
+
+        key = prefix[start:end]
+        alias = ALIASES.get(key)
+        if alias is None:
+            rewritten.append(line)
+            continue
+
+        canonical, is_legacy = alias
+        if canonical in provided:
+            raise CutoverConflict
+        provided.add(canonical)
+
+        if is_legacy:
+            prefix = f"{prefix[:start]}{canonical}{prefix[end:]}"
+            line = f"{prefix}{line[equals:]}"
+            changed = True
+        rewritten.append(line)
+
+    return "".join(rewritten).encode("utf-8"), changed
+
+
+def write_sibling(
+    destination: Path,
+    content: bytes,
+    metadata: os.stat_result,
+    *,
+    replace: bool,
+) -> None:
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.tmp-",
+        dir=destination.parent,
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as output:
+            output.write(content)
+            output.flush()
+            os.fchown(output.fileno(), metadata.st_uid, metadata.st_gid)
+            os.fchmod(output.fileno(), stat.S_IMODE(metadata.st_mode))
+            os.fsync(output.fileno())
+
+        os.utime(
+            temporary,
+            ns=(metadata.st_atime_ns, metadata.st_mtime_ns),
+            follow_symlinks=False,
+        )
+        if replace:
+            os.replace(temporary, destination)
+        else:
+            os.link(temporary, destination)
+            temporary.unlink()
+        fsync_directory(destination.parent)
+    finally:
+        if exists(temporary):
+            temporary.unlink()
+
+
+def restore(path: Path) -> str:
+    backup = backup_path(path)
+    if not exists(backup):
+        return "already-restored"
+
+    original, original_metadata = read_regular_file(backup)
+    canonical, changed = transform(original)
+    if not changed:
+        raise CutoverConflict
+
+    if exists(path):
+        current, current_metadata = read_regular_file(path)
+        if current == original and ownership_and_mode(
+            current_metadata
+        ) == ownership_and_mode(original_metadata):
+            backup.unlink()
+            fsync_directory(path.parent)
+            return "restored"
+        if current not in {original, canonical}:
+            raise CutoverConflict
+
+    os.replace(backup, path)
+    fsync_directory(path.parent)
+
+    restored, restored_metadata = read_regular_file(path)
+    if restored != original or ownership_and_mode(
+        restored_metadata
+    ) != ownership_and_mode(original_metadata):
+        raise CutoverConflict
+    return "restored"
+
+
+def migrate_with_backup(path: Path, backup: Path) -> str:
+    original, original_metadata = read_regular_file(backup)
+    canonical, changed = transform(original)
+    if not changed or not exists(path):
+        raise CutoverConflict
+
+    current, current_metadata = read_regular_file(path)
+    if current == canonical:
+        if ownership_and_mode(current_metadata) != ownership_and_mode(
+            original_metadata
+        ):
+            raise CutoverConflict
+        return "migrated"
+    if current != original:
+        raise CutoverConflict
+
+    write_sibling(path, canonical, original_metadata, replace=True)
+    return "migrated"
+
+
+def migrate(path: Path) -> str:
+    backup = backup_path(path)
+    if exists(backup):
+        return migrate_with_backup(path, backup)
+    if not exists(path):
+        return "absent"
+
+    original, original_metadata = read_regular_file(path)
+    canonical, changed = transform(original)
+    if not changed:
+        return "already-canonical"
+
+    try:
+        write_sibling(backup, original, original_metadata, replace=False)
+        current, current_metadata = read_regular_file(path)
+        if current != original or metadata_identity(
+            current_metadata
+        ) != metadata_identity(original_metadata):
+            raise CutoverConflict
+        write_sibling(path, canonical, original_metadata, replace=True)
+    except (CutoverConflict, OSError) as error:
+        try:
+            restore(path)
+        except (CutoverConflict, OSError) as restore_error:
+            raise CutoverConflict from restore_error
+        raise CutoverConflict from error
+    return "migrated"
+
+
+def finalize(path: Path) -> str:
+    backup = backup_path(path)
+    if not exists(backup):
+        return "already-canonical"
+    if not exists(path):
+        raise CutoverConflict
+
+    original, original_metadata = read_regular_file(backup)
+    canonical, changed = transform(original)
+    current, current_metadata = read_regular_file(path)
+    if not changed or current != canonical:
+        raise CutoverConflict
+    if ownership_and_mode(current_metadata) != ownership_and_mode(original_metadata):
+        raise CutoverConflict
+
+    backup.unlink()
+    fsync_directory(path.parent)
+    return "migrated"
+
+
+def main() -> int:
+    if len(sys.argv) != 3 or sys.argv[1] not in {"migrate", "restore", "finalize"}:
+        print(f"{RESULT_PREFIX}conflict")
+        return 2
+
+    action = sys.argv[1]
+    path = Path(sys.argv[2])
+    try:
+        if action == "migrate":
+            result = migrate(path)
+        elif action == "restore":
+            result = restore(path)
+        else:
+            result = finalize(path)
+    except (CutoverConflict, OSError):
+        print(f"{RESULT_PREFIX}conflict")
+        return 1
+
+    print(f"{RESULT_PREFIX}{result}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ansible/playbooks/promote-runner.yml
+++ b/ansible/playbooks/promote-runner.yml
@@ -36,10 +36,22 @@
     data_dir: /var/lib/vm0-runner
     bin_dir: "{{ data_dir }}/bin/{{ runner_release }}"
     runner_dir: "{{ data_dir }}/runners/{{ runner_release }}"
+    runner_host_env_file: /etc/vm0-runner/host.env
 
   tasks:
     - name: Validate runner architecture
       include_tasks: ../tasks/validate-runner-architecture.yml
+
+    - name: Migrate runner host tuning aliases atomically
+      script:
+        cmd: >-
+          ../files/runner-host-env-alias-cutover.py migrate
+          {{ runner_host_env_file | quote }}
+        executable: python3
+      register: runner_host_env_alias_migration
+      changed_when: >-
+        'host_env_alias_cutover=migrated'
+        in runner_host_env_alias_migration.stdout
 
     # ========================================
     # Phase 3b: Install systemd service (traffic cutover point)
@@ -73,12 +85,35 @@
       rescue:
         - name: Stop failed target runner service with runner cleanup
           command: "{{ bin_dir }}/runner service stop --name {{ runner_release }} --force --cleanup failed-start"
+          failed_when: false
+
+        - name: Restore runner host tuning aliases after target failure
+          script:
+            cmd: >-
+              ../files/runner-host-env-alias-cutover.py restore
+              {{ runner_host_env_file | quote }}
+            executable: python3
+          register: runner_host_env_alias_restoration
+          changed_when: >-
+            'host_env_alias_cutover=restored'
+            in runner_host_env_alias_restoration.stdout
 
         - name: Fail promote after target runner readiness failure
           fail:
             msg: >-
               Runner {{ runner_release }} failed readiness or health checks and
-              was stopped to avoid leaving a non-admitting service running.
+              the exact pre-promotion host configuration was restored.
+
+    - name: Finalize runner host tuning alias migration
+      script:
+        cmd: >-
+          ../files/runner-host-env-alias-cutover.py finalize
+          {{ runner_host_env_file | quote }}
+        executable: python3
+      register: runner_host_env_alias_finalization
+      changed_when: >-
+        'host_env_alias_cutover=migrated'
+        in runner_host_env_alias_finalization.stdout
 
     # ========================================
     # Phase 5: Drain old runners + Cleanup

--- a/docs/runner-host-configuration.md
+++ b/docs/runner-host-configuration.md
@@ -126,6 +126,45 @@ classification during that window. A parse or alias-conflict failure emits no
 successful-load event, so missing expected host coverage is a failed gate, not
 evidence that the legacy spelling is absent.
 
+## Promotion-Integrated Canonical Cutover
+
+The pre-cutover production evidence gate used only the value-free alias-source
+event above. A fixed query over
+`2026-08-28T10:40:00Z..2026-08-29T00:55:56Z` found nine successful loads: all
+three production hosts on Runner `0.178.0`, `0.178.1`, and `0.178.2`. Every
+concurrency override used the legacy spelling, while all four I/O settings were
+absent. The query did not retrieve configured values, raw lines, or file
+contents.
+
+Every rollback target covered by that gate, Runner `0.177.5` through `0.178.2`,
+is a descendant of the dual-reader merge
+`88cf42132c3150a1f116d888049f083010fd598f`. Those targets can therefore start
+from either spelling. A target outside that ancestry is not a supported
+rollback until its host-file compatibility is established separately.
+
+The normal Runner promotion migrates the five logical alias pairs immediately
+before installing the target service. It fails before mutation when one
+logical setting has duplicate active definitions or both spellings. Otherwise
+it rewrites every legacy key, including all present I/O keys, through one
+same-directory flushed temporary file and atomic rename. Values, comments,
+blank lines, file ownership, and mode are preserved. Missing files and files
+that are already canonical are no-ops, and a replay after the atomic rename
+reuses the same transaction state instead of creating another backup.
+
+The already-running Runner does not reload `host.env`, so it remains available
+with its previously loaded value while the file changes. Promotion starts and
+health-checks the target against the canonical file before draining any old
+service. If target installation, readiness, or health fails, promotion stops
+the failed target and atomically restores the exact pre-migration file before
+reporting failure. Task output reports only fixed states and never includes a
+configured value, raw line, temporary-file content, or whole-file diff.
+
+The cutover does not remove the legacy readers or alias-source telemetry. After
+a Runner release containing this promotion change, every intended host must
+report each field as `canonical` or `absent`, with no `legacy` result, for the
+full Runner drain and rollback observation window before #28914 can remove
+compatibility.
+
 Bandwidth values may be fractional. After conversion from MiB/s, the byte/s
 value must be at least `1`, must fit in a `u64`, and is rounded down to an
 integer. Disk IOPS must parse directly as a nonzero `u64`.


### PR DESCRIPTION
## Summary

- migrate all five strict Runner host-tuning aliases from `VM0_*` to `OKOU_*` as one promotion-integrated file transaction
- preserve exact values, surrounding content, ownership, and mode through same-directory flushed temporary files and atomic replacement
- restore the exact pre-migration file after target install, readiness, or doctor failure, while keeping the already-running Runner untouched
- keep legacy readers and value-free alias-source telemetry in place for the later production observation gate

## Safety and replay behavior

- missing files and canonical-only files are no-ops
- duplicate active definitions or both spellings for one logical field fail before mutation and emit only a fixed `conflict` state
- all present I/O aliases move in the same atomic file replacement
- a deterministic sibling backup makes replay after a completed rename converge without a second edit or ambiguous backup
- the backup is finalized only after target readiness and health pass; old services drain afterward
- a failed target is stopped best-effort before atomic restoration, and a stop failure cannot prevent restoration

## Refreshed implementation evidence

- Refreshed base: `408da4db311d4c3d9f14addf77599f1e50589d1a`
- Pushed head: `9572a2b85d245c5ce9d9d1625cc9b0042fea45fc`
- Open-PR audit completed at `2026-08-29T01:14:05Z`: 1 open-PR page, 28 open PRs, 29 non-empty changed-file pages, and 526/526 GitHub-declared/fetched files
- The only overlap was seven332's #30093 at head `4089cb52a7c0daadd231878cedf80bfb09f926f7`: `ansible/playbooks/promote-runner.yml`, `ansible/playbooks/rollback-runner.yml`, `.github/scripts/tests/runner-promotion-ansible-test.sh`, and `docs/runner-host-configuration.md`. Its hunks independently separate GC service/binary/config selectors. This PR does not modify rollback, absorb that work, or treat it as an ordering blocker.

## Exact file scope

- `.github/scripts/tests/runner-host-env-alias-cutover-ansible-test.sh`
- `.github/scripts/tests/runner-promotion-ansible-test.sh`
- `ansible/files/runner-host-env-alias-cutover.py`
- `ansible/playbooks/promote-runner.yml`
- `docs/runner-host-configuration.md`

## Verification

- `npx --yes prettier@3.8.1 --check ansible/playbooks/promote-runner.yml docs/runner-host-configuration.md`
- `ruff format --check ansible/files/runner-host-env-alias-cutover.py`
- `ruff check ansible/files/runner-host-env-alias-cutover.py`
- `shellcheck .github/scripts/tests/runner-host-env-alias-cutover-ansible-test.sh`
- `shellcheck .github/scripts/tests/runner-promotion-ansible-test.sh`
- Python compile check for `ansible/files/runner-host-env-alias-cutover.py`
- `bash -n` for both focused shell tests
- `.github/scripts/tests/runner-host-env-alias-cutover-ansible-test.sh`
- `.github/scripts/tests/runner-promotion-ansible-test.sh`
- `./scripts/check-file-size.sh <exact staged files>`
- `git diff --check`

The focused Ansible checks used a temporary `ansible-core 2.21.3` prefix because the local runtime did not have `ansible-playbook` preinstalled. Per repository policy, no full local Vitest suite or development server was run; protected CI remains required.

No production host was accessed or mutated. No release, deployment, environment approval, or production acceptance was performed.

Closes #30188
Part of #28914
