### PR TITLE
test(platform): wait for bootstrap before workflow slash input

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
@@ -736,6 +736,10 @@ describe("chat composer models", () => {
           `chatThreadWorkflowsChanged:${THREAD_ID}`,
         ),
       ).toBeTruthy();
+      expect(screen.getByTestId("app-skeleton")).toHaveAttribute(
+        "aria-hidden",
+        "true",
+      );
     });
     await initialWorkflowsRequested.promise;
     const thread = await screen.findByLabelText("Chat thread");


### PR DESCRIPTION
## Summary

- wait for the main chat bootstrap handoff before sending native slash input
- retain the target-thread editor lookup and controlled workflow response added by #30150
- preserve the loading, empty, realtime reload, editor identity, insertion, and highlighting coverage

## Root cause

The recurrence after #30150 still failed the initial `Loading workflows...` assertion, before the held initial response was released and before the realtime reload began. #30150 made the workflow resource deterministic and targeted the editor within `Chat thread`, but its final commit removed the hidden app-skeleton gate. Under shard scheduling, the thread composer could still be replaced by the bootstrap handoff after the editor lookup, causing native `/` input to be lost.

The test now requires all three independent boundaries before interaction: the Ably subscription needed by the later reload, the hidden app skeleton produced after `initialEventsReady$`, and the thread-scoped `Message` editor. The existing deferred response continues to own the workflow loading-to-empty transition.

## Scope

This is a one-file test synchronization change. It does not change production behavior, add retries or sleeps, increase timeouts, skip tests, add internal mocks, or alter the realtime reload assertions.

## Validation

- named test: 11 independent focused runs passed with one worker
- full `chat-composer-editor-and-suggestions.test.tsx`: 22/22 passed
- CI-equivalent Platform shard 7/8 with coverage: 21 files, 364/364 tests passed
- `pnpm format`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip`
- pre-commit hooks: Prettier, Knip, repository-wide Turbo type checks, file-size check, and commitlint passed

Closes #30134
