### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -113,7 +113,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.27.0"
-CLAUDE_CODE_VERSION="2.1.250"
+CLAUDE_CODE_VERSION="2.1.251"
 CODEX_CLI_VERSION="0.150.1"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.3.1"


### PR DESCRIPTION
## Summary

- Update Claude Code from `2.1.250` to `2.1.251`.

The pinned Go, Codex CLI, Google Workspace CLI, xurl, agent-browser, pnpm, and Chromium versions remain current. Node.js 24 remains the current LTS major, and PostgreSQL 18 remains the current supported major.

## Verification

- `bash -n crates/runner/scripts/build-template.sh`
- `git diff --check`
- Confirmed Claude Code 2.1.251 standalone binaries and manifest are available for linux-x64 and linux-arm64.
- Confirmed the pinned Chromium snapshot still provides version 151.0.7922.173-1~deb12u1 for amd64 and arm64.