### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -393,7 +393,7 @@ dependencies = [
  "http-body 0.4.6",
  "http-body 1.1.0",
  "hyper 0.14.32",
- "hyper 1.11.0",
+ "hyper 1.11.1",
  "hyper-rustls",
  "hyper-util",
  "indexmap",
@@ -1601,7 +1601,7 @@ dependencies = [
  "headers",
  "http 1.5.0",
  "http-body-util",
- "hyper 1.11.0",
+ "hyper 1.11.1",
  "hyper-util",
  "path-tree",
  "regex",
@@ -1652,9 +1652,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1679,7 +1679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.5.0",
- "hyper 1.11.0",
+ "hyper 1.11.1",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
@@ -1700,7 +1700,7 @@ dependencies = [
  "futures-util",
  "http 1.5.0",
  "http-body 1.1.0",
- "hyper 1.11.0",
+ "hyper 1.11.1",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -1841,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -2530,7 +2530,7 @@ dependencies = [
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
- "hyper 1.11.0",
+ "hyper 1.11.1",
  "hyper-rustls",
  "hyper-util",
  "js-sys",


### PR DESCRIPTION
## Summary

- Update `hyper` from 1.11.0 to 1.11.1.
- Update `indexmap` from 2.14.0 to 2.14.1.

## Dependencies not updated

- `generic-array` remains at 0.14.7 because `crypto-common` 0.1.7 pins it exactly; 0.14.9 cannot be selected without an upstream dependency migration.

## Manual version bumps

- None. This PR changes only `crates/Cargo.lock`.

## Test status

- `cargo test --workspace --exclude runner --no-fail-fast`: every completed test target and doctest passed except one `sandbox-fc` library test. That target passed 811 of 812 tests; `prepare_workspace_drive_image_without_seed_truncates_and_formats_fresh_image` requires the unavailable host command `mkfs.ext4`. The identical failure reproduces against the unchanged `main` lockfile.
- `cargo check -p runner --tests`: passed.
- Full runner test execution was not attempted locally because this 3.8 GiB, no-swap host previously OOM-killed runner test-binary linking at approximately 3.70 GiB RSS; the complete runner test surface was compiled with `cargo check` instead.
