### PR TITLE
refactor(runner): separate addon process logging

### DIFF
--- a/crates/runner/mitm-addon/src/addon_process_logging.py
+++ b/crates/runner/mitm-addon/src/addon_process_logging.py
@@ -2,8 +2,6 @@
 
 import json
 import os
-import re
-from collections.abc import Mapping
 from typing import Literal
 
 AddonProcessEventLevel = Literal["warn", "error"]
@@ -11,16 +9,8 @@ AddonProcessEventLevel = Literal["warn", "error"]
 ADDON_PROCESS_EVENT_PREFIX = "VM0_ADDON_EVENT "
 ADDON_PROCESS_EVENT_VERSION = 1
 MAX_ADDON_PROCESS_EVENT_BYTES = 4096
-MAX_ADDON_PROCESS_EVENT_FIELDS = 16
 _MAX_MESSAGE_CHARACTERS = 2048
-_MAX_FIELD_VALUE_CHARACTERS = 256
-_EVENT_NAME_PATTERN = re.compile(r"[a-z][a-z0-9_]{0,79}\Z")
 _TRUNCATION_SUFFIX = "..."
-
-
-def _validate_event_name(name: str, field: str) -> None:
-    if _EVENT_NAME_PATTERN.fullmatch(name) is None:
-        raise ValueError(f"invalid addon process event {field}: {name!r}")
 
 
 def _serialize_event(payload: dict[str, object]) -> bytes:
@@ -39,9 +29,6 @@ def _bounded_event(payload: dict[str, object], message: str) -> bytes:
         return record
 
     payload["message"] = ""
-    if len(_serialize_event(payload)) > MAX_ADDON_PROCESS_EVENT_BYTES:
-        raise ValueError("addon process event fields exceed the record size limit")
-
     low = 0
     high = len(bounded_message)
     best = ""
@@ -60,31 +47,10 @@ def _bounded_event(payload: dict[str, object], message: str) -> bytes:
     return _serialize_event(payload)
 
 
-def _validated_fields(fields: Mapping[str, str] | None) -> dict[str, str]:
-    if fields is None:
-        return {}
-    if len(fields) > MAX_ADDON_PROCESS_EVENT_FIELDS:
-        raise ValueError("too many addon process event fields")
-
-    validated: dict[str, str] = {}
-    for name, value in sorted(fields.items()):
-        _validate_event_name(name, "field name")
-        if not isinstance(value, str):
-            raise TypeError(f"addon process event field {name!r} must be a string")
-        if len(value) > _MAX_FIELD_VALUE_CHARACTERS:
-            raise ValueError(f"addon process event field {name!r} is too long")
-        validated[name] = value
-    return validated
-
-
 def emit_addon_process_event(
     level: AddonProcessEventLevel,
-    event_type: str,
-    reason: str,
-    /,
-    *,
     message: str,
-    fields: Mapping[str, str] | None = None,
+    /,
 ) -> None:
     """Write one bounded addon event directly to mitmdump stderr.
 
@@ -93,16 +59,10 @@ def emit_addon_process_event(
     """
     if level not in ("warn", "error"):
         raise ValueError(f"invalid addon process event level: {level!r}")
-    _validate_event_name(event_type, "type")
-    _validate_event_name(reason, "reason")
 
     payload: dict[str, object] = {
         "version": ADDON_PROCESS_EVENT_VERSION,
         "level": level,
-        "type": event_type,
-        "reason": reason,
-        "component": "mitm_addon",
-        "fields": _validated_fields(fields),
     }
 
     record = _bounded_event(payload, message)

--- a/crates/runner/mitm-addon/src/addon_process_logging.py
+++ b/crates/runner/mitm-addon/src/addon_process_logging.py
@@ -1,0 +1,97 @@
+"""Structured addon process events consumed by the Runner."""
+
+import json
+import os
+import re
+from typing import Literal
+
+AddonProcessEventLevel = Literal["warn", "error"]
+UnderbillingClass = Literal["confirmed", "risk"]
+
+ADDON_PROCESS_EVENT_PREFIX = "VM0_ADDON_EVENT "
+ADDON_PROCESS_EVENT_VERSION = 1
+MAX_ADDON_PROCESS_EVENT_BYTES = 4096
+_MAX_DETAIL_CHARACTERS = 2048
+_EVENT_NAME_PATTERN = re.compile(r"[a-z][a-z0-9_]{0,79}\Z")
+_TRUNCATION_SUFFIX = "..."
+
+
+def _validate_event_name(name: str, field: str) -> None:
+    if _EVENT_NAME_PATTERN.fullmatch(name) is None:
+        raise ValueError(f"invalid addon process event {field}: {name!r}")
+
+
+def _serialize_event(payload: dict[str, str | int]) -> bytes:
+    return (
+        ADDON_PROCESS_EVENT_PREFIX.encode()
+        + json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode()
+        + b"\n"
+    )
+
+
+def _bounded_event(payload: dict[str, str | int], detail: str) -> bytes:
+    bounded_detail = detail[:_MAX_DETAIL_CHARACTERS]
+    payload["detail"] = bounded_detail
+    record = _serialize_event(payload)
+    if len(record) <= MAX_ADDON_PROCESS_EVENT_BYTES:
+        return record
+
+    low = 0
+    high = len(bounded_detail)
+    best = ""
+    while low <= high:
+        middle = (low + high) // 2
+        candidate = bounded_detail[:middle] + _TRUNCATION_SUFFIX
+        payload["detail"] = candidate
+        record = _serialize_event(payload)
+        if len(record) <= MAX_ADDON_PROCESS_EVENT_BYTES:
+            best = candidate
+            low = middle + 1
+        else:
+            high = middle - 1
+
+    payload["detail"] = best
+    return _serialize_event(payload)
+
+
+def emit_addon_process_event(
+    level: AddonProcessEventLevel,
+    event_type: str,
+    reason: str,
+    /,
+    *,
+    detail: str,
+    underbilling_class: UnderbillingClass | None = None,
+    counter: str | None = None,
+) -> None:
+    """Write one bounded addon event directly to mitmdump stderr.
+
+    The Runner recognizes only this versioned envelope. The write is best
+    effort because observability failure must not interrupt proxy traffic.
+    """
+    if level not in ("warn", "error"):
+        raise ValueError(f"invalid addon process event level: {level!r}")
+    _validate_event_name(event_type, "type")
+    _validate_event_name(reason, "reason")
+    if underbilling_class not in (None, "confirmed", "risk"):
+        raise ValueError(f"invalid addon process event underbilling_class: {underbilling_class!r}")
+    if counter is not None:
+        _validate_event_name(counter, "counter")
+
+    payload: dict[str, str | int] = {
+        "version": ADDON_PROCESS_EVENT_VERSION,
+        "level": level,
+        "type": event_type,
+        "reason": reason,
+        "component": "mitm_addon",
+    }
+    if underbilling_class is not None:
+        payload["underbilling_class"] = underbilling_class
+    if counter is not None:
+        payload["counter"] = counter
+
+    record = _bounded_event(payload, detail)
+    try:
+        os.write(2, record)
+    except OSError:
+        return

--- a/crates/runner/mitm-addon/src/addon_process_logging.py
+++ b/crates/runner/mitm-addon/src/addon_process_logging.py
@@ -3,15 +3,17 @@
 import json
 import os
 import re
+from collections.abc import Mapping
 from typing import Literal
 
 AddonProcessEventLevel = Literal["warn", "error"]
-UnderbillingClass = Literal["confirmed", "risk"]
 
 ADDON_PROCESS_EVENT_PREFIX = "VM0_ADDON_EVENT "
 ADDON_PROCESS_EVENT_VERSION = 1
 MAX_ADDON_PROCESS_EVENT_BYTES = 4096
+MAX_ADDON_PROCESS_EVENT_FIELDS = 16
 _MAX_DETAIL_CHARACTERS = 2048
+_MAX_FIELD_VALUE_CHARACTERS = 256
 _EVENT_NAME_PATTERN = re.compile(r"[a-z][a-z0-9_]{0,79}\Z")
 _TRUNCATION_SUFFIX = "..."
 
@@ -21,7 +23,7 @@ def _validate_event_name(name: str, field: str) -> None:
         raise ValueError(f"invalid addon process event {field}: {name!r}")
 
 
-def _serialize_event(payload: dict[str, str | int]) -> bytes:
+def _serialize_event(payload: dict[str, object]) -> bytes:
     return (
         ADDON_PROCESS_EVENT_PREFIX.encode()
         + json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode()
@@ -29,12 +31,16 @@ def _serialize_event(payload: dict[str, str | int]) -> bytes:
     )
 
 
-def _bounded_event(payload: dict[str, str | int], detail: str) -> bytes:
+def _bounded_event(payload: dict[str, object], detail: str) -> bytes:
     bounded_detail = detail[:_MAX_DETAIL_CHARACTERS]
     payload["detail"] = bounded_detail
     record = _serialize_event(payload)
     if len(record) <= MAX_ADDON_PROCESS_EVENT_BYTES:
         return record
+
+    payload["detail"] = ""
+    if len(_serialize_event(payload)) > MAX_ADDON_PROCESS_EVENT_BYTES:
+        raise ValueError("addon process event fields exceed the record size limit")
 
     low = 0
     high = len(bounded_detail)
@@ -54,6 +60,23 @@ def _bounded_event(payload: dict[str, str | int], detail: str) -> bytes:
     return _serialize_event(payload)
 
 
+def _validated_fields(fields: Mapping[str, str] | None) -> dict[str, str]:
+    if fields is None:
+        return {}
+    if len(fields) > MAX_ADDON_PROCESS_EVENT_FIELDS:
+        raise ValueError("too many addon process event fields")
+
+    validated: dict[str, str] = {}
+    for name, value in sorted(fields.items()):
+        _validate_event_name(name, "field name")
+        if not isinstance(value, str):
+            raise TypeError(f"addon process event field {name!r} must be a string")
+        if len(value) > _MAX_FIELD_VALUE_CHARACTERS:
+            raise ValueError(f"addon process event field {name!r} is too long")
+        validated[name] = value
+    return validated
+
+
 def emit_addon_process_event(
     level: AddonProcessEventLevel,
     event_type: str,
@@ -61,8 +84,7 @@ def emit_addon_process_event(
     /,
     *,
     detail: str,
-    underbilling_class: UnderbillingClass | None = None,
-    counter: str | None = None,
+    fields: Mapping[str, str] | None = None,
 ) -> None:
     """Write one bounded addon event directly to mitmdump stderr.
 
@@ -73,22 +95,15 @@ def emit_addon_process_event(
         raise ValueError(f"invalid addon process event level: {level!r}")
     _validate_event_name(event_type, "type")
     _validate_event_name(reason, "reason")
-    if underbilling_class not in (None, "confirmed", "risk"):
-        raise ValueError(f"invalid addon process event underbilling_class: {underbilling_class!r}")
-    if counter is not None:
-        _validate_event_name(counter, "counter")
 
-    payload: dict[str, str | int] = {
+    payload: dict[str, object] = {
         "version": ADDON_PROCESS_EVENT_VERSION,
         "level": level,
         "type": event_type,
         "reason": reason,
         "component": "mitm_addon",
+        "fields": _validated_fields(fields),
     }
-    if underbilling_class is not None:
-        payload["underbilling_class"] = underbilling_class
-    if counter is not None:
-        payload["counter"] = counter
 
     record = _bounded_event(payload, detail)
     try:

--- a/crates/runner/mitm-addon/src/addon_process_logging.py
+++ b/crates/runner/mitm-addon/src/addon_process_logging.py
@@ -1,4 +1,4 @@
-"""Structured addon process events consumed by the Runner."""
+"""Addon log records transported to Axiom through the Runner."""
 
 import json
 import os
@@ -11,12 +11,18 @@ ADDON_PROCESS_EVENT_VERSION = 1
 MAX_ADDON_PROCESS_EVENT_BYTES = 4096
 _MAX_MESSAGE_CHARACTERS = 2048
 _TRUNCATION_SUFFIX = "..."
+_RESERVED_LOG_FIELDS = frozenset(("version", "level", "message"))
 
 
 def _serialize_event(payload: dict[str, object]) -> bytes:
     return (
         ADDON_PROCESS_EVENT_PREFIX.encode()
-        + json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode()
+        + json.dumps(
+            payload,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        ).encode()
         + b"\n"
     )
 
@@ -29,6 +35,9 @@ def _bounded_event(payload: dict[str, object], message: str) -> bytes:
         return record
 
     payload["message"] = ""
+    if len(_serialize_event(payload)) > MAX_ADDON_PROCESS_EVENT_BYTES:
+        raise ValueError("addon process event fields exceed the record size limit")
+
     low = 0
     high = len(bounded_message)
     best = ""
@@ -51,19 +60,25 @@ def emit_addon_process_event(
     level: AddonProcessEventLevel,
     message: str,
     /,
+    **fields: object,
 ) -> None:
-    """Write one bounded addon event directly to mitmdump stderr.
+    """Write one bounded addon log record directly to mitmdump stderr.
 
-    The Runner recognizes only this versioned envelope. The write is best
+    The Runner recognizes only this versioned envelope. Other than the
+    transport ``version`` and logger-owned ``level`` and ``message``, fields
+    are passed through without an event-specific schema. Values must be JSON
+    serializable. Runner-owned Axiom metadata such as time, context, service,
+    hostname, and Runner version remains authoritative. The write is best
     effort because observability failure must not interrupt proxy traffic.
     """
     if level not in ("warn", "error"):
         raise ValueError(f"invalid addon process event level: {level!r}")
 
-    payload: dict[str, object] = {
-        "version": ADDON_PROCESS_EVENT_VERSION,
-        "level": level,
-    }
+    payload: dict[str, object] = {"version": ADDON_PROCESS_EVENT_VERSION}
+    payload.update(
+        (name, value) for name, value in fields.items() if name not in _RESERVED_LOG_FIELDS
+    )
+    payload["level"] = level
 
     record = _bounded_event(payload, message)
     try:

--- a/crates/runner/mitm-addon/src/addon_process_logging.py
+++ b/crates/runner/mitm-addon/src/addon_process_logging.py
@@ -12,7 +12,7 @@ ADDON_PROCESS_EVENT_PREFIX = "VM0_ADDON_EVENT "
 ADDON_PROCESS_EVENT_VERSION = 1
 MAX_ADDON_PROCESS_EVENT_BYTES = 4096
 MAX_ADDON_PROCESS_EVENT_FIELDS = 16
-_MAX_DETAIL_CHARACTERS = 2048
+_MAX_MESSAGE_CHARACTERS = 2048
 _MAX_FIELD_VALUE_CHARACTERS = 256
 _EVENT_NAME_PATTERN = re.compile(r"[a-z][a-z0-9_]{0,79}\Z")
 _TRUNCATION_SUFFIX = "..."
@@ -31,24 +31,24 @@ def _serialize_event(payload: dict[str, object]) -> bytes:
     )
 
 
-def _bounded_event(payload: dict[str, object], detail: str) -> bytes:
-    bounded_detail = detail[:_MAX_DETAIL_CHARACTERS]
-    payload["detail"] = bounded_detail
+def _bounded_event(payload: dict[str, object], message: str) -> bytes:
+    bounded_message = message[:_MAX_MESSAGE_CHARACTERS]
+    payload["message"] = bounded_message
     record = _serialize_event(payload)
     if len(record) <= MAX_ADDON_PROCESS_EVENT_BYTES:
         return record
 
-    payload["detail"] = ""
+    payload["message"] = ""
     if len(_serialize_event(payload)) > MAX_ADDON_PROCESS_EVENT_BYTES:
         raise ValueError("addon process event fields exceed the record size limit")
 
     low = 0
-    high = len(bounded_detail)
+    high = len(bounded_message)
     best = ""
     while low <= high:
         middle = (low + high) // 2
-        candidate = bounded_detail[:middle] + _TRUNCATION_SUFFIX
-        payload["detail"] = candidate
+        candidate = bounded_message[:middle] + _TRUNCATION_SUFFIX
+        payload["message"] = candidate
         record = _serialize_event(payload)
         if len(record) <= MAX_ADDON_PROCESS_EVENT_BYTES:
             best = candidate
@@ -56,7 +56,7 @@ def _bounded_event(payload: dict[str, object], detail: str) -> bytes:
         else:
             high = middle - 1
 
-    payload["detail"] = best
+    payload["message"] = best
     return _serialize_event(payload)
 
 
@@ -83,7 +83,7 @@ def emit_addon_process_event(
     reason: str,
     /,
     *,
-    detail: str,
+    message: str,
     fields: Mapping[str, str] | None = None,
 ) -> None:
     """Write one bounded addon event directly to mitmdump stderr.
@@ -105,7 +105,7 @@ def emit_addon_process_event(
         "fields": _validated_fields(fields),
     }
 
-    record = _bounded_event(payload, detail)
+    record = _bounded_event(payload, message)
     try:
         os.write(2, record)
     except OSError:

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -8,14 +8,13 @@ Exports:
 - JSON usage decompression with diagnostic error classification.
 """
 
-import contextlib
 import zlib
 from collections.abc import Callable
 from typing import Literal, NamedTuple
 
 import brotli  # type: ignore[import-untyped]
 import zstandard
-from mitmproxy import ctx, http
+from mitmproxy import http
 
 from body_limits import (
     DEFAULT_BODY_DECODE_LIMIT,
@@ -79,18 +78,6 @@ class StreamDecodeSession(NamedTuple):
     finish_error: _StreamDecodeFinishError
 
 
-def _log_streaming_decode_error(encoding_label: str, exc: Exception) -> None:
-    with contextlib.suppress(AttributeError):
-        # ctx.log unavailable outside mitmproxy runtime
-        ctx.log.debug(f"Streaming decompression failed ({encoding_label}): {exc}")
-
-
-def _log_streaming_decode_skipped(reason: str) -> None:
-    with contextlib.suppress(AttributeError):
-        # ctx.log unavailable outside mitmproxy runtime
-        ctx.log.debug(f"Streaming decompression skipped: {reason}")
-
-
 def _feed_chunks(feed: _StreamDecodeFeed, data: bytes, max_decoded_chunk: int) -> None:
     for offset in range(0, len(data), max_decoded_chunk):
         feed(data[offset : offset + max_decoded_chunk])
@@ -148,14 +135,13 @@ def _create_zlib_stream_decode_session(
             )
             try:
                 decoded = obj.decompress(data, max_length=max_length)
-            except zlib.error as exc:
+            except zlib.error:
                 if pending_decoded:
                     feed(bytes(pending_decoded))
                     if should_continue is not None and not should_continue():
                         inspection_stopped = True
                         return
                 decode_error = INVALID_COMPRESSED_BODY
-                _log_streaming_decode_error(encoding_label, exc)
                 return
             if probing_for_additional_output and decoded:
                 if pending_decoded:
@@ -230,11 +216,7 @@ def stream_decode_skip_reason(headers: http.Headers) -> str | None:
 
 def can_stream_decode_usage(headers: http.Headers) -> bool:
     """Return whether usage parsers can safely consume this response stream."""
-    reason = stream_decode_skip_reason(headers)
-    if reason is None:
-        return True
-    _log_streaming_decode_skipped(reason)
-    return False
+    return stream_decode_skip_reason(headers) is None
 
 
 def can_decode_json_usage_body(headers: http.Headers) -> bool:
@@ -329,9 +311,7 @@ def decompress_body(
     body returns ``b""`` — callers that short-circuit via ``if not body`` rely
     on that (see #10287).
     """
-    result = _decode_body_bounded(data, headers, max_output=max_output)
-    _log_body_decompression_failure(result, headers)
-    return result.body
+    return _decode_body_bounded(data, headers, max_output=max_output).body
 
 
 def _decode_single_zlib_stream_for_network_log_capture(
@@ -452,16 +432,6 @@ def decode_response_body_for_network_log_capture(
     if encoding == "zstd":
         return _decode_zstd_for_network_log_capture(data, max_output)
     return None
-
-
-def _log_body_decompression_failure(result: _BodyDecodeResult, headers: http.Headers) -> None:
-    if result.failed and result.error is not None:
-        with contextlib.suppress(AttributeError):
-            # ctx.log unavailable outside mitmproxy runtime
-            ctx.log.debug(
-                "Decompression failed "
-                f"({headers.get('content-encoding', '').strip().lower()}): {result.error}"
-            )
 
 
 def _decompress_zlib_best_effort_bounded(
@@ -597,8 +567,6 @@ def _decompress_zlib_json_usage_body(
     data: bytes,
     encoding: Literal["gzip", "deflate"],
     max_output: int,
-    *,
-    log_errors: bool,
 ) -> tuple[bytes, str | None]:
     if max_output <= 0:
         return b"", DECODED_BODY_LIMIT_EXCEEDED if data else None
@@ -616,11 +584,7 @@ def _decompress_zlib_json_usage_body(
             member_data = input_cursor.take()
             try:
                 decoded = obj.decompress(member_data, max_length=remaining_output + 1)
-            except zlib.error as exc:
-                if log_errors:
-                    with contextlib.suppress(AttributeError):
-                        # ctx.log unavailable outside mitmproxy runtime
-                        ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
+            except zlib.error:
                 return b"", INVALID_COMPRESSED_BODY
 
             if len(decoded) > remaining_output:
@@ -679,8 +643,6 @@ def _validate_complete_zstd_frames(data: bytes, max_output: int) -> str | None:
 def _decompress_zstd_json_usage_body(
     data: bytes,
     max_output: int,
-    *,
-    log_errors: bool,
 ) -> tuple[bytes, str | None]:
     if max_output <= 0:
         return b"", DECODED_BODY_LIMIT_EXCEEDED if data else None
@@ -690,11 +652,7 @@ def _decompress_zstd_json_usage_body(
             body = reader.read(max_output)
             # Force validation of any trailing frame without accumulating it.
             extra = reader.read(1)
-    except zstandard.ZstdError as exc:
-        if log_errors:
-            with contextlib.suppress(AttributeError):
-                # ctx.log unavailable outside mitmproxy runtime
-                ctx.log.debug(f"Decompression failed (zstd): {exc}")
+    except zstandard.ZstdError:
         return b"", INVALID_COMPRESSED_BODY
 
     if extra:
@@ -706,15 +664,12 @@ def _decode_supported_body_with_complete_status(
     data: bytes,
     encoding: str,
     max_output: int,
-    *,
-    log_errors: bool = True,
 ) -> tuple[bytes, str | None]:
     if encoding in ("gzip", "deflate"):
         return _decompress_zlib_json_usage_body(
             data,
             encoding,
             max_output,
-            log_errors=log_errors,
         )
     if encoding == "br":
         try:
@@ -723,11 +678,7 @@ def _decode_supported_body_with_complete_status(
                 max_output,
                 validate_complete_input=True,
             )
-        except brotli.error as exc:
-            if log_errors:
-                with contextlib.suppress(AttributeError):
-                    # ctx.log unavailable outside mitmproxy runtime
-                    ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
+        except brotli.error:
             return b"", INVALID_COMPRESSED_BODY
         if limited:
             return body, DECODED_BODY_LIMIT_EXCEEDED
@@ -735,7 +686,7 @@ def _decode_supported_body_with_complete_status(
             return body, INCOMPLETE_COMPRESSED_BODY
         return body, None
     if encoding == "zstd":
-        return _decompress_zstd_json_usage_body(data, max_output, log_errors=log_errors)
+        return _decompress_zstd_json_usage_body(data, max_output)
     raise ValueError(f"unsupported content encoding: {encoding}")
 
 
@@ -768,8 +719,6 @@ def decompress_json_usage_body(
     data: bytes,
     headers: http.Headers,
     max_output: int = LARGE_RESPONSE_DECOMPRESS_LIMIT,
-    *,
-    log_errors: bool = True,
 ) -> tuple[bytes, str | None]:
     """Decompress a JSON usage response body with an observable empty-prefix error.
 
@@ -779,8 +728,6 @@ def decompress_json_usage_body(
     needs to distinguish a valid compressed empty response from an incomplete
     compressed frame that produced no JSON bytes.
 
-    Set ``log_errors`` to ``False`` when decoding on a worker thread where the
-    mitmproxy logging context must not be accessed.
     """
     encoding = headers.get("content-encoding", "").strip().lower()
     if encoding in _SUPPORTED_ONE_SHOT_BODY_ENCODINGS:
@@ -788,7 +735,6 @@ def decompress_json_usage_body(
             data,
             encoding,
             max_output,
-            log_errors=log_errors,
         )
     if encoding and encoding != "identity" and data:
         return b"", "unsupported content encoding"

--- a/crates/runner/mitm-addon/src/builtin_firewall_cache.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_cache.py
@@ -3,13 +3,13 @@
 import json
 import os
 import stat
-from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, NamedTuple
 
 from mitmproxy import ctx
 
+import addon_process_logging
 import builtin_base_url_template
 import builtin_host_policy
 import matching
@@ -241,7 +241,12 @@ def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnaps
             state.failed_reason = "cache_invalid"
             state.loaded_key = None
             state.catalog = None
-            _warn(f"Failed to read builtin firewall catalog cache: {exc}")
+            addon_process_logging.emit_addon_process_event(
+                "warn",
+                "addon_process_integrity",
+                "builtin_firewall_catalog_cache_read_failed",
+                detail=f"Failed to read builtin firewall catalog cache: {exc}",
+            )
             return BuiltinFirewallCatalogSnapshot(
                 key,
                 None,
@@ -472,8 +477,3 @@ def _base_url_template_syntax_target(firewall_name: str, raw_base: str) -> str |
         last_index = reference.end
     result.append(raw_base[last_index:])
     return "".join(result)
-
-
-def _warn(message: str) -> None:
-    with suppress(Exception):
-        ctx.log.warn(message)

--- a/crates/runner/mitm-addon/src/builtin_firewall_cache.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_cache.py
@@ -245,7 +245,7 @@ def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnaps
                 "warn",
                 "addon_process_integrity",
                 "builtin_firewall_catalog_cache_read_failed",
-                detail=f"Failed to read builtin firewall catalog cache: {exc}",
+                message=f"Failed to read builtin firewall catalog cache: {exc}",
             )
             return BuiltinFirewallCatalogSnapshot(
                 key,

--- a/crates/runner/mitm-addon/src/builtin_firewall_cache.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_cache.py
@@ -243,9 +243,7 @@ def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnaps
             state.catalog = None
             addon_process_logging.emit_addon_process_event(
                 "warn",
-                "addon_process_integrity",
-                "builtin_firewall_catalog_cache_read_failed",
-                message=f"Failed to read builtin firewall catalog cache: {exc}",
+                f"Failed to read builtin firewall catalog cache: {exc}",
             )
             return BuiltinFirewallCatalogSnapshot(
                 key,

--- a/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
+++ b/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
@@ -926,7 +926,6 @@ def _validate_response_snapshot(
             body,
             headers,
             max_output=MAX_ENTRY_BYTES,
-            log_errors=False,
         )
         if decode_error == body_decoding.DECODED_BODY_LIMIT_EXCEEDED:
             return "response_size"

--- a/crates/runner/mitm-addon/src/jsonl_writer.py
+++ b/crates/runner/mitm-addon/src/jsonl_writer.py
@@ -402,10 +402,10 @@ def _warn_drop_once(log_name: str) -> None:
     )
 
 
-def _warn(reason: str, detail: str) -> None:
+def _warn(reason: str, message: str) -> None:
     addon_process_logging.emit_addon_process_event(
         "warn",
         "addon_process_integrity",
         reason,
-        detail=detail,
+        message=message,
     )

--- a/crates/runner/mitm-addon/src/jsonl_writer.py
+++ b/crates/runner/mitm-addon/src/jsonl_writer.py
@@ -74,7 +74,6 @@ def write_jsonl_line(log_path: str, line: bytes, log_name: str) -> None:
             dropped = True
         elif not _ensure_worker_locked():
             _warn(
-                "jsonl_writer_start_failed",
                 f"Failed to start JSONL writer for {log_name} log",
             )
             return
@@ -173,7 +172,7 @@ def shutdown_writer(*, timeout: float | None = SHUTDOWN_JOIN_TIMEOUT_SECONDS) ->
     if worker is not threading.current_thread():
         worker.join(timeout=timeout)
         if worker.is_alive():
-            _warn("jsonl_writer_shutdown_timeout", "JSONL writer shutdown timed out")
+            _warn("JSONL writer shutdown timed out")
             return False
 
     with _condition:
@@ -287,7 +286,6 @@ def _report_append_failure(log_name: str, exc: Exception) -> None:
 
     _last_append_failure_warning_at = now
     _warn(
-        "jsonl_writer_append_failed",
         f"Failed to write {log_name} log: {type(exc).__name__}: {exc}",
     )
 
@@ -302,7 +300,7 @@ def _report_append_recovery() -> None:
 
     _last_append_failure_at = None
     _last_append_failure_warning_at = None
-    _warn("jsonl_writer_recovered", "JSONL log writes recovered")
+    _warn("JSONL log writes recovered")
 
 
 def _append_lines(log_path: str, lines: list[bytes]) -> None:
@@ -397,15 +395,12 @@ def _warn_drop_once(log_name: str) -> None:
             return
         _drop_warning_logged = True
     _warn(
-        "jsonl_writer_backlog_full",
         f"Dropping {log_name} log because the JSONL writer backlog is full",
     )
 
 
-def _warn(reason: str, message: str) -> None:
+def _warn(message: str) -> None:
     addon_process_logging.emit_addon_process_event(
         "warn",
-        "addon_process_integrity",
-        reason,
-        message=message,
+        message,
     )

--- a/crates/runner/mitm-addon/src/jsonl_writer.py
+++ b/crates/runner/mitm-addon/src/jsonl_writer.py
@@ -5,10 +5,9 @@ import queue
 import threading
 import time
 from collections import defaultdict
-from contextlib import suppress
 from dataclasses import dataclass
 
-from mitmproxy import ctx
+import addon_process_logging
 
 MAX_PENDING_JSONL_WRITES = 4096
 MAX_PENDING_JSONL_BYTES = 32 * 1024 * 1024
@@ -74,7 +73,10 @@ def write_jsonl_line(log_path: str, line: bytes, log_name: str) -> None:
         ):
             dropped = True
         elif not _ensure_worker_locked():
-            _warn(f"Failed to start JSONL writer for {log_name} log")
+            _warn(
+                "jsonl_writer_start_failed",
+                f"Failed to start JSONL writer for {log_name} log",
+            )
             return
         else:
             sequence = _accepted_by_path.get(log_path, 0) + 1
@@ -97,7 +99,7 @@ def flush_log_path(log_path: str, *, timeout: float | None = None) -> bool:
     """Wait until writes accepted so far for ``log_path`` have been processed.
 
     Processing includes append attempts that fail. Those failures are reported
-    through mitmproxy warnings and do not affect the return value. Return
+    through addon process events and do not affect the return value. Return
     ``False`` only when a configured timeout expires with accepted writes still
     pending; ``True`` does not confirm that every line was persisted.
     """
@@ -128,7 +130,7 @@ def flush_all_logs() -> None:
     """Wait until writes accepted so far for every path have been processed.
 
     Processing includes append attempts that fail. Those failures are reported
-    through mitmproxy warnings, and returning does not confirm that every line
+    through addon process events, and returning does not confirm that every line
     was persisted.
     """
     with _condition:
@@ -171,7 +173,7 @@ def shutdown_writer(*, timeout: float | None = SHUTDOWN_JOIN_TIMEOUT_SECONDS) ->
     if worker is not threading.current_thread():
         worker.join(timeout=timeout)
         if worker.is_alive():
-            _warn("JSONL writer shutdown timed out")
+            _warn("jsonl_writer_shutdown_timeout", "JSONL writer shutdown timed out")
             return False
 
     with _condition:
@@ -284,7 +286,10 @@ def _report_append_failure(log_name: str, exc: Exception) -> None:
         return
 
     _last_append_failure_warning_at = now
-    _warn(f"Failed to write {log_name} log: {type(exc).__name__}: {exc}")
+    _warn(
+        "jsonl_writer_append_failed",
+        f"Failed to write {log_name} log: {type(exc).__name__}: {exc}",
+    )
 
 
 def _report_append_recovery() -> None:
@@ -297,7 +302,7 @@ def _report_append_recovery() -> None:
 
     _last_append_failure_at = None
     _last_append_failure_warning_at = None
-    _warn("JSONL log writes recovered")
+    _warn("jsonl_writer_recovered", "JSONL log writes recovered")
 
 
 def _append_lines(log_path: str, lines: list[bytes]) -> None:
@@ -391,9 +396,16 @@ def _warn_drop_once(log_name: str) -> None:
         if _drop_warning_logged:
             return
         _drop_warning_logged = True
-    _warn(f"Dropping {log_name} log because the JSONL writer backlog is full")
+    _warn(
+        "jsonl_writer_backlog_full",
+        f"Dropping {log_name} log because the JSONL writer backlog is full",
+    )
 
 
-def _warn(message: str) -> None:
-    with suppress(Exception):
-        ctx.log.warn(message)
+def _warn(reason: str, detail: str) -> None:
+    addon_process_logging.emit_addon_process_event(
+        "warn",
+        "addon_process_integrity",
+        reason,
+        detail=detail,
+    )

--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -10,8 +10,9 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from mitmproxy import ctx, http
+from mitmproxy import http
 
+import addon_process_logging
 import flow_metadata
 import flow_metadata_keys as metadata_keys
 import jsonl_writer
@@ -58,7 +59,12 @@ def _encode_jsonl_entry(entry: dict, log_name: str) -> bytes | None:
     try:
         return (json.dumps(entry) + "\n").encode()
     except Exception as e:
-        ctx.log.warn(f"Failed to encode {log_name} log: {type(e).__name__}: {e}")
+        addon_process_logging.emit_addon_process_event(
+            "warn",
+            "addon_process_integrity",
+            "log_encoding_failed",
+            detail=f"Failed to encode {log_name} log: {type(e).__name__}: {e}",
+        )
 
     return None
 

--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -63,7 +63,7 @@ def _encode_jsonl_entry(entry: dict, log_name: str) -> bytes | None:
             "warn",
             "addon_process_integrity",
             "log_encoding_failed",
-            detail=f"Failed to encode {log_name} log: {type(e).__name__}: {e}",
+            message=f"Failed to encode {log_name} log: {type(e).__name__}: {e}",
         )
 
     return None

--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -61,9 +61,7 @@ def _encode_jsonl_entry(entry: dict, log_name: str) -> bytes | None:
     except Exception as e:
         addon_process_logging.emit_addon_process_event(
             "warn",
-            "addon_process_integrity",
-            "log_encoding_failed",
-            message=f"Failed to encode {log_name} log: {type(e).__name__}: {e}",
+            f"Failed to encode {log_name} log: {type(e).__name__}: {e}",
         )
 
     return None

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1365,7 +1365,7 @@ async def request(flow: http.HTTPFlow) -> None:
                 "warn",
                 "addon_process_integrity",
                 "missing_client_ip",
-                detail="No client IP available, passing through",
+                message="No client IP available, passing through",
             )
             return
         if isinstance(classification, request_classification.BlockingRequestClassification):

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -25,6 +25,8 @@ from typing import Literal, NoReturn
 from mitmproxy import connection, ctx, http, tcp, tls
 from mitmproxy.addonmanager import Loader
 
+import addon_process_logging
+
 # --- Sub-module imports ---
 #
 # auth_base_forwarder/body_capture/connector_diagnostics/connector_intent/content_length/
@@ -1359,7 +1361,12 @@ async def request(flow: http.HTTPFlow) -> None:
             _start_request_timing(flow)
 
         if classification.kind == "no_client_ip":
-            ctx.log.warn("No client IP available, passing through")
+            addon_process_logging.emit_addon_process_event(
+                "warn",
+                "addon_process_integrity",
+                "missing_client_ip",
+                detail="No client IP available, passing through",
+            )
             return
         if isinstance(classification, request_classification.BlockingRequestClassification):
             if isinstance(classification, request_classification.PublicDestinationDenied):

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1363,9 +1363,7 @@ async def request(flow: http.HTTPFlow) -> None:
         if classification.kind == "no_client_ip":
             addon_process_logging.emit_addon_process_event(
                 "warn",
-                "addon_process_integrity",
-                "missing_client_ip",
-                message="No client IP available, passing through",
+                "No client IP available, passing through",
             )
             return
         if isinstance(classification, request_classification.BlockingRequestClassification):

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -526,9 +526,7 @@ def load_registry_state(registry_path: str) -> RegistryState:
             state.stat_error_logged = True
             addon_process_logging.emit_addon_process_event(
                 "warn",
-                "addon_process_integrity",
-                "proxy_registry_stat_failed",
-                message=f"Failed to stat proxy registry: {message}",
+                f"Failed to stat proxy registry: {message}",
             )
         return _mark_unavailable(state, reason="stat_failed", message=message)
 
@@ -560,9 +558,7 @@ def load_registry_state(registry_path: str) -> RegistryState:
                 state.read_error_key = key
                 addon_process_logging.emit_addon_process_event(
                     "warn",
-                    "addon_process_integrity",
-                    "proxy_registry_read_failed",
-                    message=f"Failed to read proxy registry: {message}",
+                    f"Failed to read proxy registry: {message}",
                 )
             return _mark_unavailable(state, reason="read_failed", message=message)
         except (ValueError, RecursionError) as e:
@@ -571,9 +567,7 @@ def load_registry_state(registry_path: str) -> RegistryState:
             state.read_error_key = None
             addon_process_logging.emit_addon_process_event(
                 "warn",
-                "addon_process_integrity",
-                "proxy_registry_parse_failed",
-                message=f"Failed to parse proxy registry: {message}",
+                f"Failed to parse proxy registry: {message}",
             )
             return _mark_unavailable(state, reason="parse_failed", message=message)
 
@@ -591,9 +585,7 @@ def load_registry_state(registry_path: str) -> RegistryState:
     if invalid_sandboxes:
         addon_process_logging.emit_addon_process_event(
             "warn",
-            "addon_process_integrity",
-            "proxy_registry_entries_rejected",
-            message=(f"Rejected {len(invalid_sandboxes)} invalid proxy registry sandbox entries"),
+            f"Rejected {len(invalid_sandboxes)} invalid proxy registry sandbox entries",
         )
     new_compiled_registry, new_compiled_policy_registry = _compile_registry(
         new_registry,

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -5,8 +5,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from mitmproxy import ctx
-
+import addon_process_logging
 import matching
 import registry_firewalls
 import state_file
@@ -525,7 +524,12 @@ def load_registry_state(registry_path: str) -> RegistryState:
         message = str(e)
         if not state.stat_error_logged:
             state.stat_error_logged = True
-            ctx.log.warn(f"Failed to stat proxy registry: {message}")
+            addon_process_logging.emit_addon_process_event(
+                "warn",
+                "addon_process_integrity",
+                "proxy_registry_stat_failed",
+                detail=f"Failed to stat proxy registry: {message}",
+            )
         return _mark_unavailable(state, reason="stat_failed", message=message)
 
     with opened_file:
@@ -554,13 +558,23 @@ def load_registry_state(registry_path: str) -> RegistryState:
             state.failed_key = None
             if key != state.read_error_key:
                 state.read_error_key = key
-                ctx.log.warn(f"Failed to read proxy registry: {message}")
+                addon_process_logging.emit_addon_process_event(
+                    "warn",
+                    "addon_process_integrity",
+                    "proxy_registry_read_failed",
+                    detail=f"Failed to read proxy registry: {message}",
+                )
             return _mark_unavailable(state, reason="read_failed", message=message)
         except (ValueError, RecursionError) as e:
             message = str(e)
             state.failed_key = key
             state.read_error_key = None
-            ctx.log.warn(f"Failed to parse proxy registry: {message}")
+            addon_process_logging.emit_addon_process_event(
+                "warn",
+                "addon_process_integrity",
+                "proxy_registry_parse_failed",
+                detail=f"Failed to parse proxy registry: {message}",
+            )
             return _mark_unavailable(state, reason="parse_failed", message=message)
 
     (
@@ -575,7 +589,12 @@ def load_registry_state(registry_path: str) -> RegistryState:
         builtin_firewall_catalog_cache_path=builtin_catalog_cache_path,
     )
     if invalid_sandboxes:
-        ctx.log.warn(f"Rejected {len(invalid_sandboxes)} invalid proxy registry sandbox entries")
+        addon_process_logging.emit_addon_process_event(
+            "warn",
+            "addon_process_integrity",
+            "proxy_registry_entries_rejected",
+            detail=(f"Rejected {len(invalid_sandboxes)} invalid proxy registry sandbox entries"),
+        )
     new_compiled_registry, new_compiled_policy_registry = _compile_registry(
         new_registry,
         builtin_cache_keys,

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -528,7 +528,7 @@ def load_registry_state(registry_path: str) -> RegistryState:
                 "warn",
                 "addon_process_integrity",
                 "proxy_registry_stat_failed",
-                detail=f"Failed to stat proxy registry: {message}",
+                message=f"Failed to stat proxy registry: {message}",
             )
         return _mark_unavailable(state, reason="stat_failed", message=message)
 
@@ -562,7 +562,7 @@ def load_registry_state(registry_path: str) -> RegistryState:
                     "warn",
                     "addon_process_integrity",
                     "proxy_registry_read_failed",
-                    detail=f"Failed to read proxy registry: {message}",
+                    message=f"Failed to read proxy registry: {message}",
                 )
             return _mark_unavailable(state, reason="read_failed", message=message)
         except (ValueError, RecursionError) as e:
@@ -573,7 +573,7 @@ def load_registry_state(registry_path: str) -> RegistryState:
                 "warn",
                 "addon_process_integrity",
                 "proxy_registry_parse_failed",
-                detail=f"Failed to parse proxy registry: {message}",
+                message=f"Failed to parse proxy registry: {message}",
             )
             return _mark_unavailable(state, reason="parse_failed", message=message)
 
@@ -593,7 +593,7 @@ def load_registry_state(registry_path: str) -> RegistryState:
             "warn",
             "addon_process_integrity",
             "proxy_registry_entries_rejected",
-            detail=(f"Rejected {len(invalid_sandboxes)} invalid proxy registry sandbox entries"),
+            message=(f"Rejected {len(invalid_sandboxes)} invalid proxy registry sandbox entries"),
         )
     new_compiled_registry, new_compiled_policy_registry = _compile_registry(
         new_registry,

--- a/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
+++ b/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
@@ -218,7 +218,7 @@ def _flush_usage_for_runner_request() -> None:
             "warn",
             "addon_process_integrity",
             "runner_usage_flush_failed",
-            detail=f"Failed to flush delivery work after runner request ({type(exc).__name__})",
+            message=f"Failed to flush delivery work after runner request ({type(exc).__name__})",
         )
     finally:
         usage.write_pending_snapshot(flush_request_id=flush_request_id)
@@ -269,7 +269,7 @@ def _flush_jsonl_for_runner_request(request_path: Path, state_path: Path) -> Non
                 "warn",
                 "addon_process_integrity",
                 "runner_jsonl_flush_timeout",
-                detail="JSONL flush did not complete before timeout",
+                message="JSONL flush did not complete before timeout",
             )
     except Exception as exc:
         pending = 1
@@ -277,7 +277,7 @@ def _flush_jsonl_for_runner_request(request_path: Path, state_path: Path) -> Non
             "warn",
             "addon_process_integrity",
             "runner_jsonl_flush_failed",
-            detail=f"Failed to flush JSONL logs after runner request ({type(exc).__name__})",
+            message=f"Failed to flush JSONL logs after runner request ({type(exc).__name__})",
         )
     finally:
         state_written = _write_jsonl_flush_state(
@@ -345,7 +345,7 @@ def _write_jsonl_flush_state(
                 "warn",
                 "addon_process_integrity",
                 "runner_jsonl_flush_state_write_failed",
-                detail=f"Failed to write JSONL flush state: {type(exc).__name__}: {exc}",
+                message=f"Failed to write JSONL flush state: {type(exc).__name__}: {exc}",
             )
             return False
 

--- a/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
+++ b/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
@@ -9,8 +9,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Literal
 
-from mitmproxy import ctx
-
+import addon_process_logging
 import anthropic_accounting
 import claude_output_timing
 import codex_output_timing
@@ -215,7 +214,12 @@ def _flush_usage_for_runner_request() -> None:
     try:
         _flush_delivery_work(trigger="runner")
     except Exception as exc:
-        ctx.log.warn(f"Failed to flush delivery work after runner request ({type(exc).__name__})")
+        addon_process_logging.emit_addon_process_event(
+            "warn",
+            "addon_process_integrity",
+            "runner_usage_flush_failed",
+            detail=f"Failed to flush delivery work after runner request ({type(exc).__name__})",
+        )
     finally:
         usage.write_pending_snapshot(flush_request_id=flush_request_id)
 
@@ -261,10 +265,20 @@ def _flush_jsonl_for_runner_request(request_path: Path, state_path: Path) -> Non
         ):
             pending = 1
             timed_out = True
-            ctx.log.warn("JSONL flush did not complete before timeout")
+            addon_process_logging.emit_addon_process_event(
+                "warn",
+                "addon_process_integrity",
+                "runner_jsonl_flush_timeout",
+                detail="JSONL flush did not complete before timeout",
+            )
     except Exception as exc:
         pending = 1
-        ctx.log.warn(f"Failed to flush JSONL logs after runner request ({type(exc).__name__})")
+        addon_process_logging.emit_addon_process_event(
+            "warn",
+            "addon_process_integrity",
+            "runner_jsonl_flush_failed",
+            detail=f"Failed to flush JSONL logs after runner request ({type(exc).__name__})",
+        )
     finally:
         state_written = _write_jsonl_flush_state(
             state_path,
@@ -327,7 +341,12 @@ def _write_jsonl_flush_state(
         except OSError as exc:
             with suppress(OSError):
                 tmp_path.unlink()
-            ctx.log.warn(f"Failed to write JSONL flush state: {type(exc).__name__}: {exc}")
+            addon_process_logging.emit_addon_process_event(
+                "warn",
+                "addon_process_integrity",
+                "runner_jsonl_flush_state_write_failed",
+                detail=f"Failed to write JSONL flush state: {type(exc).__name__}: {exc}",
+            )
             return False
 
 

--- a/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
+++ b/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
@@ -216,9 +216,7 @@ def _flush_usage_for_runner_request() -> None:
     except Exception as exc:
         addon_process_logging.emit_addon_process_event(
             "warn",
-            "addon_process_integrity",
-            "runner_usage_flush_failed",
-            message=f"Failed to flush delivery work after runner request ({type(exc).__name__})",
+            f"Failed to flush delivery work after runner request ({type(exc).__name__})",
         )
     finally:
         usage.write_pending_snapshot(flush_request_id=flush_request_id)
@@ -267,17 +265,13 @@ def _flush_jsonl_for_runner_request(request_path: Path, state_path: Path) -> Non
             timed_out = True
             addon_process_logging.emit_addon_process_event(
                 "warn",
-                "addon_process_integrity",
-                "runner_jsonl_flush_timeout",
-                message="JSONL flush did not complete before timeout",
+                "JSONL flush did not complete before timeout",
             )
     except Exception as exc:
         pending = 1
         addon_process_logging.emit_addon_process_event(
             "warn",
-            "addon_process_integrity",
-            "runner_jsonl_flush_failed",
-            message=f"Failed to flush JSONL logs after runner request ({type(exc).__name__})",
+            f"Failed to flush JSONL logs after runner request ({type(exc).__name__})",
         )
     finally:
         state_written = _write_jsonl_flush_state(
@@ -343,9 +337,7 @@ def _write_jsonl_flush_state(
                 tmp_path.unlink()
             addon_process_logging.emit_addon_process_event(
                 "warn",
-                "addon_process_integrity",
-                "runner_jsonl_flush_state_write_failed",
-                message=f"Failed to write JSONL flush state: {type(exc).__name__}: {exc}",
+                f"Failed to write JSONL flush state: {type(exc).__name__}: {exc}",
             )
             return False
 

--- a/crates/runner/mitm-addon/src/usage/buffer/logging.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/logging.py
@@ -22,7 +22,7 @@ Operators should use ``retained_source_event_count`` and
 ``dropped_source_event_count`` and ``dropped_webhook_batch_count`` for confirmed
 drops. Dropped retained batches also include ``retained_retry_count``. When no
 proxy log path exists, ordinary flush records are skipped; underbilling records
-use the stderr fallback in ``log_usage_underbilling``.
+use the process event in ``log_usage_underbilling``.
 """
 
 from __future__ import annotations

--- a/crates/runner/mitm-addon/src/usage/counters.py
+++ b/crates/runner/mitm-addon/src/usage/counters.py
@@ -32,10 +32,10 @@ _usage_state_id = str(uuid.uuid4())
 # filesystem trouble.  Emit one error signal per addon process on first failure —
 # enough to seed the operator investigation without spamming logs under
 # persistent FS pressure.  Deliberately uses the canonical underbilling
-# helper's stderr fallback because the per-job proxy log shares the same
+# helper's process event because the per-job proxy log shares the same
 # filesystem we just failed to write and is likely affected by the same root
-# cause.  The runner stderr bridge parses the leading key=value fields and
-# re-emits them as structured tracing fields.
+# cause. The runner parses the versioned event envelope and re-emits it as
+# structured tracing fields.
 _pending_write_error_logged = False
 _FLUSH_REQUEST_FILE = "usage-flush-request"
 

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -241,13 +241,15 @@ def log_usage_underbilling(
         parts.append(rendered_fields)
     parts.append(_render_process_event_message(str(message)))
     counter = extra.get("counter")
+    event_fields = {"underbilling_class": underbilling_class}
+    if isinstance(counter, str):
+        event_fields["counter"] = counter
     addon_process_logging.emit_addon_process_event(
         "error",
         USAGE_UNDERBILLING_LOG_TYPE,
         reason,
         detail=" ".join(parts),
-        underbilling_class=underbilling_class,
-        counter=counter if isinstance(counter, str) else None,
+        fields=event_fields,
     )
 
     if proxy_log_path:

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -248,7 +248,7 @@ def log_usage_underbilling(
         "error",
         USAGE_UNDERBILLING_LOG_TYPE,
         reason,
-        detail=" ".join(parts),
+        message=" ".join(parts),
         fields=event_fields,
     )
 

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import reprlib
 from typing import Literal
 
-from mitmproxy import ctx
-
+import addon_process_logging
 from logging_utils import log_proxy_entry, sanitize_proxy_log_extra_value
 
 UnderbillingClass = Literal["confirmed", "risk"]
@@ -59,7 +58,7 @@ _SECRET_COMPACT_FIELD_MARKERS = (
 )
 
 
-def _stderr_field_key_words(key: str) -> tuple[str, ...]:
+def _process_event_field_key_words(key: str) -> tuple[str, ...]:
     words: list[str] = []
     current = ""
     for index, ch in enumerate(key):
@@ -85,16 +84,16 @@ _SECRET_FIELD_MARKERS = (
     "password",
     "secret",
 )
-_STDERR_FIELD_KEY_MAX_CHARS = 80
-_STDERR_FIELD_VALUE_MAX_CHARS = 256
-_STDERR_MESSAGE_MAX_CHARS = 512
+_PROCESS_EVENT_FIELD_KEY_MAX_CHARS = 80
+_PROCESS_EVENT_FIELD_VALUE_MAX_CHARS = 256
+_PROCESS_EVENT_MESSAGE_MAX_CHARS = 512
 _TRUNCATION_SUFFIX = "..."
 
 
-def _stderr_field_is_secret_like(key: str, value: object) -> bool:
+def _process_event_field_is_secret_like(key: str, value: object) -> bool:
     if value is None or isinstance(value, bool):
         return False
-    words = _stderr_field_key_words(key)
+    words = _process_event_field_key_words(key)
     normalized_key = "".join(words)
     if any(pair[0] in words and pair[1] in words for pair in _SECRET_FIELD_WORD_PAIRS):
         return True
@@ -111,21 +110,21 @@ def _stderr_field_is_secret_like(key: str, value: object) -> bool:
     return any(marker in normalized_key for marker in _SECRET_FIELD_MARKERS)
 
 
-def _truncate_stderr_text(value: str, max_chars: int) -> str:
+def _truncate_process_event_text(value: str, max_chars: int) -> str:
     if len(value) <= max_chars:
         return value
     limit = max_chars - len(_TRUNCATION_SUFFIX)
     return value[:limit] + _TRUNCATION_SUFFIX
 
 
-def _render_stderr_field_key(key: str) -> str:
+def _render_process_event_field_key(key: str) -> str:
     rendered = "".join(
         ch if ch.isascii() and (ch.isalnum() or ch in ("_", "-", ".")) else "_" for ch in key
     )
-    return _truncate_stderr_text(rendered or "_", _STDERR_FIELD_KEY_MAX_CHARS)
+    return _truncate_process_event_text(rendered or "_", _PROCESS_EVENT_FIELD_KEY_MAX_CHARS)
 
 
-def _render_stderr_text(value: str, max_chars: int, *, preserve_spaces: bool) -> str:
+def _render_process_event_text(value: str, max_chars: int, *, preserve_spaces: bool) -> str:
     rendered: list[str] = []
     truncated_prefix: list[str] = []
     rendered_len = 0
@@ -158,16 +157,20 @@ def _render_stderr_text(value: str, max_chars: int, *, preserve_spaces: bool) ->
     return "".join(rendered)
 
 
-def _single_token_stderr_value(value: str) -> str:
-    return _render_stderr_text(value, _STDERR_FIELD_VALUE_MAX_CHARS, preserve_spaces=False)
+def _single_token_process_event_value(value: str) -> str:
+    return _render_process_event_text(
+        value,
+        _PROCESS_EVENT_FIELD_VALUE_MAX_CHARS,
+        preserve_spaces=False,
+    )
 
 
-def _render_stderr_message(value: str) -> str:
-    return _render_stderr_text(value, _STDERR_MESSAGE_MAX_CHARS, preserve_spaces=True)
+def _render_process_event_message(value: str) -> str:
+    return _render_process_event_text(value, _PROCESS_EVENT_MESSAGE_MAX_CHARS, preserve_spaces=True)
 
 
-def _render_stderr_field_value(key: str, value: object) -> str:
-    if _stderr_field_is_secret_like(key, value):
+def _render_process_event_field_value(key: str, value: object) -> str:
+    if _process_event_field_is_secret_like(key, value):
         return "[redacted]"
     sanitized = sanitize_proxy_log_extra_value(key, value)
     if isinstance(sanitized, bool):
@@ -178,12 +181,13 @@ def _render_stderr_field_value(key: str, value: object) -> str:
         rendered = str(sanitized)
     else:
         rendered = reprlib.repr(sanitized)
-    return _single_token_stderr_value(rendered)
+    return _single_token_process_event_value(rendered)
 
 
-def _render_stderr_extra_fields(fields: dict[str, object]) -> str:
+def _render_process_event_extra_fields(fields: dict[str, object]) -> str:
     return " ".join(
-        f"{_render_stderr_field_key(key)}={_render_stderr_field_value(key, fields[key])}"
+        f"{_render_process_event_field_key(key)}="
+        f"{_render_process_event_field_value(key, fields[key])}"
         for key in sorted(fields)
         if key not in _UNDERBILLING_PROTECTED_FIELDS
     )
@@ -215,34 +219,41 @@ def log_usage_underbilling(
     """Log a usage-underbilling signal with the underbilling field contract.
 
     ``type``, ``reason``, ``underbilling_class``, and ``component`` are owned
-    by this helper and cannot be overridden by caller context.  Without a
-    proxy log path, the stderr fallback additionally applies key-based secret
-    redaction, exact-``url`` sanitization, escaping, and truncation.
+    by this helper and cannot be overridden by caller context. The Runner event
+    applies key-based secret redaction, exact-``url`` sanitization, escaping,
+    and truncation.
 
-    When a proxy log path is available, this still writes structured JSONL
-    through ``log_proxy_entry``.  In that path, the proxy-log extra-field
-    contract still applies; callers must not assume broad proxy-log redaction
-    for arbitrary context.
+    When a proxy log path is available, the signal is also written as
+    structured JSONL through ``log_proxy_entry``. In that path, the proxy-log
+    extra-field contract still applies; callers must not assume broad proxy-log
+    redaction for arbitrary context.
     """
     fields = underbilling_fields(reason, underbilling_class, **extra)
-    if not proxy_log_path:
-        parts = [
-            (
-                f"type={USAGE_UNDERBILLING_LOG_TYPE} "
-                f"reason={_single_token_stderr_value(str(reason))} "
-                f"underbilling_class={_single_token_stderr_value(str(underbilling_class))} "
-                f"component={USAGE_UNDERBILLING_COMPONENT_MITM_ADDON}"
-            )
-        ]
-        if rendered_fields := _render_stderr_extra_fields(fields):
-            parts.append(rendered_fields)
-        parts.append(_render_stderr_message(str(message)))
-        ctx.log.error(" ".join(parts))
-        return
-
-    log_proxy_entry(
-        proxy_log_path,
+    parts = [
+        (
+            f"type={USAGE_UNDERBILLING_LOG_TYPE} "
+            f"reason={_single_token_process_event_value(str(reason))} "
+            f"underbilling_class={_single_token_process_event_value(str(underbilling_class))} "
+            f"component={USAGE_UNDERBILLING_COMPONENT_MITM_ADDON}"
+        )
+    ]
+    if rendered_fields := _render_process_event_extra_fields(fields):
+        parts.append(rendered_fields)
+    parts.append(_render_process_event_message(str(message)))
+    counter = extra.get("counter")
+    addon_process_logging.emit_addon_process_event(
         "error",
-        message,
-        **fields,
+        USAGE_UNDERBILLING_LOG_TYPE,
+        reason,
+        detail=" ".join(parts),
+        underbilling_class=underbilling_class,
+        counter=counter if isinstance(counter, str) else None,
     )
+
+    if proxy_log_path:
+        log_proxy_entry(
+            proxy_log_path,
+            "error",
+            message,
+            **fields,
+        )

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -84,7 +84,6 @@ _SECRET_FIELD_MARKERS = (
     "password",
     "secret",
 )
-_PROCESS_EVENT_FIELD_KEY_MAX_CHARS = 80
 _PROCESS_EVENT_FIELD_VALUE_MAX_CHARS = 256
 _PROCESS_EVENT_MESSAGE_MAX_CHARS = 512
 _TRUNCATION_SUFFIX = "..."
@@ -115,13 +114,6 @@ def _truncate_process_event_text(value: str, max_chars: int) -> str:
         return value
     limit = max_chars - len(_TRUNCATION_SUFFIX)
     return value[:limit] + _TRUNCATION_SUFFIX
-
-
-def _render_process_event_field_key(key: str) -> str:
-    rendered = "".join(
-        ch if ch.isascii() and (ch.isalnum() or ch in ("_", "-", ".")) else "_" for ch in key
-    )
-    return _truncate_process_event_text(rendered or "_", _PROCESS_EVENT_FIELD_KEY_MAX_CHARS)
 
 
 def _render_process_event_text(value: str, max_chars: int, *, preserve_spaces: bool) -> str:
@@ -169,28 +161,26 @@ def _render_process_event_message(value: str) -> str:
     return _render_process_event_text(value, _PROCESS_EVENT_MESSAGE_MAX_CHARS, preserve_spaces=True)
 
 
-def _render_process_event_field_value(key: str, value: object) -> str:
+def _render_process_event_field_value(key: str, value: object) -> object:
     if _process_event_field_is_secret_like(key, value):
         return "[redacted]"
     sanitized = sanitize_proxy_log_extra_value(key, value)
-    if isinstance(sanitized, bool):
-        rendered = "true" if sanitized else "false"
-    elif sanitized is None:
-        rendered = "null"
-    elif isinstance(sanitized, str | int | float):
-        rendered = str(sanitized)
-    else:
-        rendered = reprlib.repr(sanitized)
-    return _single_token_process_event_value(rendered)
+    if sanitized is None or isinstance(sanitized, bool | int | float):
+        return sanitized
+    if isinstance(sanitized, str):
+        return _truncate_process_event_text(sanitized, _PROCESS_EVENT_FIELD_VALUE_MAX_CHARS)
+    return _truncate_process_event_text(
+        reprlib.repr(sanitized),
+        _PROCESS_EVENT_FIELD_VALUE_MAX_CHARS,
+    )
 
 
-def _render_process_event_extra_fields(fields: dict[str, object]) -> str:
-    return " ".join(
-        f"{_render_process_event_field_key(key)}="
-        f"{_render_process_event_field_value(key, fields[key])}"
+def _render_process_event_extra_fields(fields: dict[str, object]) -> dict[str, object]:
+    return {
+        key: _render_process_event_field_value(key, fields[key])
         for key in sorted(fields)
         if key not in _UNDERBILLING_PROTECTED_FIELDS
-    )
+    }
 
 
 def underbilling_fields(
@@ -219,9 +209,9 @@ def log_usage_underbilling(
     """Log a usage-underbilling signal with the underbilling field contract.
 
     ``type``, ``reason``, ``underbilling_class``, and ``component`` are owned
-    by this helper and cannot be overridden by caller context. The Runner event
-    applies key-based secret redaction, exact-``url`` sanitization, escaping,
-    and truncation.
+    by this helper and cannot be overridden by caller context. The Axiom copy
+    applies key-based secret redaction, exact-``url`` sanitization, and value
+    bounds before using the generic addon log transport.
 
     When a proxy log path is available, the signal is also written as
     structured JSONL through ``log_proxy_entry``. In that path, the proxy-log
@@ -229,20 +219,15 @@ def log_usage_underbilling(
     redaction for arbitrary context.
     """
     fields = underbilling_fields(reason, underbilling_class, **extra)
-    parts = [
-        (
-            f"type={USAGE_UNDERBILLING_LOG_TYPE} "
-            f"reason={_single_token_process_event_value(str(reason))} "
-            f"underbilling_class={_single_token_process_event_value(str(underbilling_class))} "
-            f"component={USAGE_UNDERBILLING_COMPONENT_MITM_ADDON}"
-        )
-    ]
-    if rendered_fields := _render_process_event_extra_fields(fields):
-        parts.append(rendered_fields)
-    parts.append(_render_process_event_message(str(message)))
+    process_event_fields = _render_process_event_extra_fields(fields)
     addon_process_logging.emit_addon_process_event(
         "error",
-        " ".join(parts),
+        _render_process_event_message(str(message)),
+        **process_event_fields,
+        type=USAGE_UNDERBILLING_LOG_TYPE,
+        reason=_single_token_process_event_value(str(reason)),
+        underbilling_class=_single_token_process_event_value(str(underbilling_class)),
+        component=USAGE_UNDERBILLING_COMPONENT_MITM_ADDON,
     )
 
     if proxy_log_path:

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -240,16 +240,9 @@ def log_usage_underbilling(
     if rendered_fields := _render_process_event_extra_fields(fields):
         parts.append(rendered_fields)
     parts.append(_render_process_event_message(str(message)))
-    counter = extra.get("counter")
-    event_fields = {"underbilling_class": underbilling_class}
-    if isinstance(counter, str):
-        event_fields["counter"] = counter
     addon_process_logging.emit_addon_process_event(
         "error",
-        USAGE_UNDERBILLING_LOG_TYPE,
-        reason,
-        message=" ".join(parts),
-        fields=event_fields,
+        " ".join(parts),
     )
 
     if proxy_log_path:

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -8,9 +8,9 @@ Fixtures here exist for two reasons:
    :class:`mitmproxy.http.Headers` via ``mitmproxy.test`` helpers so tests
    exercise real attribute/property semantics (``pretty_host``,
    ``pretty_url``, ``content`` decompression, header casing, …).
-2. **Stubbing at the genuine external boundary (``mitmproxy.ctx``)**.
-   ``mitm_ctx`` replaces ``ctx.options`` and ``ctx.log`` for handler tests
-   that cannot rely on a running ``mitmdump`` process.
+2. **Stubbing at genuine external boundaries**. ``mitm_ctx`` replaces
+   ``ctx.options`` and captures addon process events for handler tests that
+   cannot rely on a running ``mitmdump`` process.
 """
 
 import contextlib
@@ -45,6 +45,7 @@ import upstream_admission
 import upstream_destination_binding
 import usage
 from tests.auth_state_helpers import clear_auth_state
+from tests.process_log_helpers import capture_addon_process_events
 from tests.usage_helpers import UsageWebhookServer, fresh_usage_executor_context
 from usage.providers import connectors as _usage_connectors
 
@@ -357,12 +358,12 @@ class _StubOptions:
 
 @pytest.fixture
 def mitm_ctx(tmp_path):
-    """Stub ``mitmproxy.ctx.options`` and ``ctx.log`` for a test block.
+    """Stub ``mitmproxy.ctx.options`` and addon process events for a test block.
 
     Returns a context-manager factory: calling ``mitm_ctx(registry_path=...)``
-    patches in a concrete options stub for settings consumed by the addon and
-    modeled by these tests, plus a ``MagicMock`` log. The log stays on
-    ``MagicMock`` so tests that need to assert on warn/debug calls can do so;
+    patches in a concrete options stub for settings consumed by the addon and a
+    ``MagicMock`` process-event capture. WARN and ERROR event details are
+    exposed as ``log.warn`` and ``log.error`` calls for focused assertions.
     ``options`` stays concrete so unexpected attribute access fails instead of
     silently creating another mock.
 
@@ -398,10 +399,9 @@ def mitm_ctx(tmp_path):
             client_version=client_version,
             ssl_insecure=ssl_insecure,
         )
-        log = MagicMock()
         with (
             patch.object(mitm_addon.ctx, "options", options, create=True),
-            patch.object(mitm_addon.ctx, "log", log, create=True),
+            capture_addon_process_events() as log,
         ):
             platform_api.configure_client_headers(
                 client_session_id=client_session_id,

--- a/crates/runner/mitm-addon/tests/process_log_helpers.py
+++ b/crates/runner/mitm-addon/tests/process_log_helpers.py
@@ -21,10 +21,10 @@ def capture_addon_process_events() -> Iterator[MagicMock]:
         payload = json.JSONDecoder().decode(record[len(prefix) :].decode())
         assert isinstance(payload, dict)
         level = payload.get("level")
-        detail = payload.get("detail")
+        message = payload.get("message")
         assert level in ("warn", "error")
-        assert isinstance(detail, str)
-        getattr(log, level)(detail)
+        assert isinstance(message, str)
+        getattr(log, level)(message)
         return len(record)
 
     stderr = MagicMock()

--- a/crates/runner/mitm-addon/tests/process_log_helpers.py
+++ b/crates/runner/mitm-addon/tests/process_log_helpers.py
@@ -1,5 +1,6 @@
 """Test capture for addon process events."""
 
+import json
 from collections.abc import Iterator
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
@@ -9,25 +10,24 @@ import addon_process_logging
 
 @contextmanager
 def capture_addon_process_events() -> Iterator[MagicMock]:
-    """Expose WARN and ERROR event details through a small mock log."""
+    """Capture the external stderr write after real event serialization."""
     log = MagicMock()
 
-    def capture(
-        level: addon_process_logging.AddonProcessEventLevel,
-        _event_type: str,
-        _reason: str,
-        /,
-        *,
-        detail: str,
-        underbilling_class: addon_process_logging.UnderbillingClass | None = None,
-        counter: str | None = None,
-    ) -> None:
-        del underbilling_class, counter
+    def capture(fd: int, record: bytes) -> int:
+        assert fd == 2
+        prefix = addon_process_logging.ADDON_PROCESS_EVENT_PREFIX.encode()
+        assert record.startswith(prefix)
+        assert record.endswith(b"\n")
+        payload = json.JSONDecoder().decode(record[len(prefix) :].decode())
+        assert isinstance(payload, dict)
+        level = payload.get("level")
+        detail = payload.get("detail")
+        assert level in ("warn", "error")
+        assert isinstance(detail, str)
         getattr(log, level)(detail)
+        return len(record)
 
-    with patch.object(
-        addon_process_logging,
-        "emit_addon_process_event",
-        side_effect=capture,
-    ):
+    stderr = MagicMock()
+    stderr.write.side_effect = capture
+    with patch.object(addon_process_logging, "os", stderr):
         yield log

--- a/crates/runner/mitm-addon/tests/process_log_helpers.py
+++ b/crates/runner/mitm-addon/tests/process_log_helpers.py
@@ -1,0 +1,33 @@
+"""Test capture for addon process events."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import addon_process_logging
+
+
+@contextmanager
+def capture_addon_process_events() -> Iterator[MagicMock]:
+    """Expose WARN and ERROR event details through a small mock log."""
+    log = MagicMock()
+
+    def capture(
+        level: addon_process_logging.AddonProcessEventLevel,
+        _event_type: str,
+        _reason: str,
+        /,
+        *,
+        detail: str,
+        underbilling_class: addon_process_logging.UnderbillingClass | None = None,
+        counter: str | None = None,
+    ) -> None:
+        del underbilling_class, counter
+        getattr(log, level)(detail)
+
+    with patch.object(
+        addon_process_logging,
+        "emit_addon_process_event",
+        side_effect=capture,
+    ):
+        yield log

--- a/crates/runner/mitm-addon/tests/process_log_helpers.py
+++ b/crates/runner/mitm-addon/tests/process_log_helpers.py
@@ -24,7 +24,15 @@ def capture_addon_process_events() -> Iterator[MagicMock]:
         message = payload.get("message")
         assert level in ("warn", "error")
         assert isinstance(message, str)
-        getattr(log, level)(message)
+        fields = {
+            key: value
+            for key, value in payload.items()
+            if key not in ("version", "level", "message")
+        }
+        if fields:
+            getattr(log, level)(message, fields)
+        else:
+            getattr(log, level)(message)
         return len(record)
 
     stderr = MagicMock()

--- a/crates/runner/mitm-addon/tests/test_addon_process_logging.py
+++ b/crates/runner/mitm-addon/tests/test_addon_process_logging.py
@@ -21,7 +21,7 @@ def test_emits_one_versioned_stderr_record() -> None:
             "error",
             "usage_underbilling",
             "pending_snapshot_write_failed",
-            detail="Failed to write pending count",
+            message="Failed to write pending count",
             fields={"underbilling_class": "risk", "counter": "reports"},
         )
 
@@ -35,27 +35,27 @@ def test_emits_one_versioned_stderr_record() -> None:
         "reason": "pending_snapshot_write_failed",
         "component": "mitm_addon",
         "fields": {"counter": "reports", "underbilling_class": "risk"},
-        "detail": "Failed to write pending count",
+        "message": "Failed to write pending count",
     }
 
 
-def test_bounds_and_single_lines_control_heavy_detail() -> None:
-    detail = "\x00\n" * 4096
+def test_bounds_and_single_lines_control_heavy_message() -> None:
+    message = "\x00\n" * 4096
 
     with patch.object(addon_process_logging.os, "write", return_value=1) as write:
         addon_process_logging.emit_addon_process_event(
             "warn",
             "addon_process_integrity",
             "jsonl_writer_append_failed",
-            detail=detail,
+            message=message,
         )
 
     [record] = [write.call_args.args[1]]
     assert len(record) <= addon_process_logging.MAX_ADDON_PROCESS_EVENT_BYTES
     assert record.count(b"\n") == 1
     event = _event_from_record(record)
-    assert isinstance(event["detail"], str)
-    assert event["detail"].endswith("...")
+    assert isinstance(event["message"], str)
+    assert event["message"].endswith("...")
 
 
 @pytest.mark.parametrize(
@@ -76,7 +76,7 @@ def test_rejects_unstable_root_field_names(
             "warn",
             event_type,
             reason,
-            detail="failed",
+            message="failed",
             fields=fields,
         )
 
@@ -91,7 +91,7 @@ def test_rejects_oversized_generic_fields() -> None:
             "error",
             "usage_underbilling",
             "test_failure",
-            detail="failed",
+            message="failed",
             fields=fields,
         )
 
@@ -102,5 +102,5 @@ def test_stderr_write_failure_does_not_escape() -> None:
             "warn",
             "addon_process_integrity",
             "jsonl_writer_append_failed",
-            detail="write failed",
+            message="write failed",
         )

--- a/crates/runner/mitm-addon/tests/test_addon_process_logging.py
+++ b/crates/runner/mitm-addon/tests/test_addon_process_logging.py
@@ -3,6 +3,8 @@
 import json
 from unittest.mock import patch
 
+import pytest
+
 import addon_process_logging
 
 
@@ -18,6 +20,13 @@ def test_emits_one_versioned_stderr_record() -> None:
         addon_process_logging.emit_addon_process_event(
             "error",
             "Failed to write pending count",
+            type="usage_underbilling",
+            reason="pending_snapshot_write_failed",
+            underbilling_class="risk",
+            retry_count=2,
+            retryable=True,
+            diagnostic={"phase": "flush"},
+            **{"future.field-name": ["value", 3]},
         )
 
     write.assert_called_once()
@@ -27,6 +36,31 @@ def test_emits_one_versioned_stderr_record() -> None:
         "version": 1,
         "level": "error",
         "message": "Failed to write pending count",
+        "type": "usage_underbilling",
+        "reason": "pending_snapshot_write_failed",
+        "underbilling_class": "risk",
+        "retry_count": 2,
+        "retryable": True,
+        "diagnostic": {"phase": "flush"},
+        "future.field-name": ["value", 3],
+    }
+
+
+def test_logger_owned_fields_cannot_be_overridden() -> None:
+    with patch.object(addon_process_logging.os, "write", return_value=1) as write:
+        addon_process_logging.emit_addon_process_event(
+            "error",
+            "owned message",
+            version=2,
+            level="warn",
+            message="wrong message",
+        )
+
+    event = _event_from_record(write.call_args.args[1])
+    assert event == {
+        "version": 1,
+        "level": "error",
+        "message": "owned message",
     }
 
 
@@ -53,3 +87,20 @@ def test_stderr_write_failure_does_not_escape() -> None:
             "warn",
             "write failed",
         )
+
+
+def test_rejects_fields_that_exceed_record_limit() -> None:
+    with (
+        patch.object(addon_process_logging.os, "write") as write,
+        pytest.raises(
+            ValueError,
+            match="addon process event fields exceed the record size limit",
+        ),
+    ):
+        addon_process_logging.emit_addon_process_event(
+            "warn",
+            "write failed",
+            oversized="x" * addon_process_logging.MAX_ADDON_PROCESS_EVENT_BYTES,
+        )
+
+    write.assert_not_called()

--- a/crates/runner/mitm-addon/tests/test_addon_process_logging.py
+++ b/crates/runner/mitm-addon/tests/test_addon_process_logging.py
@@ -1,7 +1,6 @@
 """Tests for the addon-to-Runner process event boundary."""
 
 import json
-from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -23,8 +22,7 @@ def test_emits_one_versioned_stderr_record() -> None:
             "usage_underbilling",
             "pending_snapshot_write_failed",
             detail="Failed to write pending count",
-            underbilling_class="risk",
-            counter="reports",
+            fields={"underbilling_class": "risk", "counter": "reports"},
         )
 
     write.assert_called_once()
@@ -36,8 +34,7 @@ def test_emits_one_versioned_stderr_record() -> None:
         "type": "usage_underbilling",
         "reason": "pending_snapshot_write_failed",
         "component": "mitm_addon",
-        "underbilling_class": "risk",
-        "counter": "reports",
+        "fields": {"counter": "reports", "underbilling_class": "risk"},
         "detail": "Failed to write pending count",
     }
 
@@ -62,17 +59,17 @@ def test_bounds_and_single_lines_control_heavy_detail() -> None:
 
 
 @pytest.mark.parametrize(
-    ("event_type", "reason", "counter"),
+    ("event_type", "reason", "fields"),
     [
         ("Bad Type", "valid_reason", None),
         ("valid_type", "bad reason", None),
-        ("valid_type", "valid_reason", "bad counter"),
+        ("valid_type", "valid_reason", {"bad field": "value"}),
     ],
 )
 def test_rejects_unstable_root_field_names(
     event_type: str,
     reason: str,
-    counter: str | None,
+    fields: dict[str, str] | None,
 ) -> None:
     with pytest.raises(ValueError, match="invalid addon process event"):
         addon_process_logging.emit_addon_process_event(
@@ -80,18 +77,22 @@ def test_rejects_unstable_root_field_names(
             event_type,
             reason,
             detail="failed",
-            counter=counter,
+            fields=fields,
         )
 
 
-def test_rejects_invalid_underbilling_class() -> None:
-    with pytest.raises(ValueError, match="invalid addon process event underbilling_class"):
+def test_rejects_oversized_generic_fields() -> None:
+    fields = {
+        f"field_{index}": "value"
+        for index in range(addon_process_logging.MAX_ADDON_PROCESS_EVENT_FIELDS + 1)
+    }
+    with pytest.raises(ValueError, match="too many addon process event fields"):
         addon_process_logging.emit_addon_process_event(
             "error",
             "usage_underbilling",
             "test_failure",
             detail="failed",
-            underbilling_class=cast(addon_process_logging.UnderbillingClass, "invalid"),
+            fields=fields,
         )
 
 

--- a/crates/runner/mitm-addon/tests/test_addon_process_logging.py
+++ b/crates/runner/mitm-addon/tests/test_addon_process_logging.py
@@ -1,0 +1,105 @@
+"""Tests for the addon-to-Runner process event boundary."""
+
+import json
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+
+import addon_process_logging
+
+
+def _event_from_record(record: bytes) -> dict[str, object]:
+    assert record.endswith(b"\n")
+    prefix = addon_process_logging.ADDON_PROCESS_EVENT_PREFIX.encode()
+    assert record.startswith(prefix)
+    return json.loads(record[len(prefix) :])
+
+
+def test_emits_one_versioned_stderr_record() -> None:
+    with patch.object(addon_process_logging.os, "write", return_value=1) as write:
+        addon_process_logging.emit_addon_process_event(
+            "error",
+            "usage_underbilling",
+            "pending_snapshot_write_failed",
+            detail="Failed to write pending count",
+            underbilling_class="risk",
+            counter="reports",
+        )
+
+    write.assert_called_once()
+    fd, record = write.call_args.args
+    assert fd == 2
+    assert _event_from_record(record) == {
+        "version": 1,
+        "level": "error",
+        "type": "usage_underbilling",
+        "reason": "pending_snapshot_write_failed",
+        "component": "mitm_addon",
+        "underbilling_class": "risk",
+        "counter": "reports",
+        "detail": "Failed to write pending count",
+    }
+
+
+def test_bounds_and_single_lines_control_heavy_detail() -> None:
+    detail = "\x00\n" * 4096
+
+    with patch.object(addon_process_logging.os, "write", return_value=1) as write:
+        addon_process_logging.emit_addon_process_event(
+            "warn",
+            "addon_process_integrity",
+            "jsonl_writer_append_failed",
+            detail=detail,
+        )
+
+    [record] = [write.call_args.args[1]]
+    assert len(record) <= addon_process_logging.MAX_ADDON_PROCESS_EVENT_BYTES
+    assert record.count(b"\n") == 1
+    event = _event_from_record(record)
+    assert isinstance(event["detail"], str)
+    assert event["detail"].endswith("...")
+
+
+@pytest.mark.parametrize(
+    ("event_type", "reason", "counter"),
+    [
+        ("Bad Type", "valid_reason", None),
+        ("valid_type", "bad reason", None),
+        ("valid_type", "valid_reason", "bad counter"),
+    ],
+)
+def test_rejects_unstable_root_field_names(
+    event_type: str,
+    reason: str,
+    counter: str | None,
+) -> None:
+    with pytest.raises(ValueError, match="invalid addon process event"):
+        addon_process_logging.emit_addon_process_event(
+            "warn",
+            event_type,
+            reason,
+            detail="failed",
+            counter=counter,
+        )
+
+
+def test_rejects_invalid_underbilling_class() -> None:
+    with pytest.raises(ValueError, match="invalid addon process event underbilling_class"):
+        addon_process_logging.emit_addon_process_event(
+            "error",
+            "usage_underbilling",
+            "test_failure",
+            detail="failed",
+            underbilling_class=cast(addon_process_logging.UnderbillingClass, "invalid"),
+        )
+
+
+def test_stderr_write_failure_does_not_escape() -> None:
+    with patch.object(addon_process_logging.os, "write", side_effect=OSError("closed")):
+        addon_process_logging.emit_addon_process_event(
+            "warn",
+            "addon_process_integrity",
+            "jsonl_writer_append_failed",
+            detail="write failed",
+        )

--- a/crates/runner/mitm-addon/tests/test_addon_process_logging.py
+++ b/crates/runner/mitm-addon/tests/test_addon_process_logging.py
@@ -3,8 +3,6 @@
 import json
 from unittest.mock import patch
 
-import pytest
-
 import addon_process_logging
 
 
@@ -19,10 +17,7 @@ def test_emits_one_versioned_stderr_record() -> None:
     with patch.object(addon_process_logging.os, "write", return_value=1) as write:
         addon_process_logging.emit_addon_process_event(
             "error",
-            "usage_underbilling",
-            "pending_snapshot_write_failed",
-            message="Failed to write pending count",
-            fields={"underbilling_class": "risk", "counter": "reports"},
+            "Failed to write pending count",
         )
 
     write.assert_called_once()
@@ -31,10 +26,6 @@ def test_emits_one_versioned_stderr_record() -> None:
     assert _event_from_record(record) == {
         "version": 1,
         "level": "error",
-        "type": "usage_underbilling",
-        "reason": "pending_snapshot_write_failed",
-        "component": "mitm_addon",
-        "fields": {"counter": "reports", "underbilling_class": "risk"},
         "message": "Failed to write pending count",
     }
 
@@ -45,9 +36,7 @@ def test_bounds_and_single_lines_control_heavy_message() -> None:
     with patch.object(addon_process_logging.os, "write", return_value=1) as write:
         addon_process_logging.emit_addon_process_event(
             "warn",
-            "addon_process_integrity",
-            "jsonl_writer_append_failed",
-            message=message,
+            message,
         )
 
     [record] = [write.call_args.args[1]]
@@ -58,49 +47,9 @@ def test_bounds_and_single_lines_control_heavy_message() -> None:
     assert event["message"].endswith("...")
 
 
-@pytest.mark.parametrize(
-    ("event_type", "reason", "fields"),
-    [
-        ("Bad Type", "valid_reason", None),
-        ("valid_type", "bad reason", None),
-        ("valid_type", "valid_reason", {"bad field": "value"}),
-    ],
-)
-def test_rejects_unstable_root_field_names(
-    event_type: str,
-    reason: str,
-    fields: dict[str, str] | None,
-) -> None:
-    with pytest.raises(ValueError, match="invalid addon process event"):
-        addon_process_logging.emit_addon_process_event(
-            "warn",
-            event_type,
-            reason,
-            message="failed",
-            fields=fields,
-        )
-
-
-def test_rejects_oversized_generic_fields() -> None:
-    fields = {
-        f"field_{index}": "value"
-        for index in range(addon_process_logging.MAX_ADDON_PROCESS_EVENT_FIELDS + 1)
-    }
-    with pytest.raises(ValueError, match="too many addon process event fields"):
-        addon_process_logging.emit_addon_process_event(
-            "error",
-            "usage_underbilling",
-            "test_failure",
-            message="failed",
-            fields=fields,
-        )
-
-
 def test_stderr_write_failure_does_not_escape() -> None:
     with patch.object(addon_process_logging.os, "write", side_effect=OSError("closed")):
         addon_process_logging.emit_addon_process_event(
             "warn",
-            "addon_process_integrity",
-            "jsonl_writer_append_failed",
-            message="write failed",
+            "write failed",
         )

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -427,60 +427,32 @@ class TestStreamDecodeSession:
         assert b"".join(chunks) == plaintext
         assert session.finish_error() is None
 
-    def test_gzip_error_logs_once_and_short_circuits(self, headers, mitm_ctx):
+    def test_gzip_error_short_circuits(self, headers):
         chunks: list[bytes] = []
-        with mitm_ctx() as log:
-            session = create_stream_decode_session(
-                headers(("Content-Encoding", "gzip")), chunks.append
-            )
-            assert session is not None
-            session.feed(b"not gzip at all")
-            session.feed(b"more garbage")
-            session.feed(b"even more")
-        assert log.debug.call_count == 1
-        msg = log.debug.call_args[0][0]
-        assert "Streaming decompression failed" in msg
-        assert "gzip" in msg
+        session = create_stream_decode_session(headers(("Content-Encoding", "gzip")), chunks.append)
+        assert session is not None
+        session.feed(b"not gzip at all")
+        session.feed(b"more garbage")
+        session.feed(b"even more")
         assert chunks == []
         assert session.finish_error() == "invalid compressed body"
 
-    def test_brotli_unsafe_encoding_logs_once_and_does_not_feed(self, headers, mitm_ctx):
+    def test_brotli_unsafe_encoding_does_not_feed(self, headers):
         chunks: list[bytes] = []
-        with mitm_ctx() as log:
-            session = create_stream_decode_session(
-                headers(("Content-Encoding", "br")), chunks.append
-            )
+        session = create_stream_decode_session(headers(("Content-Encoding", "br")), chunks.append)
         assert session is None
-        assert log.debug.call_count == 1
-        assert "Streaming decompression skipped" in log.debug.call_args[0][0]
-        assert "br" in log.debug.call_args[0][0]
         assert chunks == []
 
-    def test_zstd_unsafe_encoding_logs_once_and_does_not_feed(self, headers, mitm_ctx):
+    def test_zstd_unsafe_encoding_does_not_feed(self, headers):
         chunks: list[bytes] = []
-        with mitm_ctx() as log:
-            session = create_stream_decode_session(
-                headers(("Content-Encoding", "zstd")), chunks.append
-            )
+        session = create_stream_decode_session(headers(("Content-Encoding", "zstd")), chunks.append)
         assert session is None
-        assert log.debug.call_count == 1
-        msg = log.debug.call_args[0][0]
-        assert "Streaming decompression skipped" in msg
-        assert "zstd" in msg
-        assert "hard-bounded" in msg
         assert chunks == []
 
-    def test_zstd_can_stream_decode_usage_is_false(self, headers, mitm_ctx):
-        with mitm_ctx() as log:
-            assert can_stream_decode_usage(headers(("Content-Encoding", "zstd"))) is False
-        assert log.debug.call_count == 1
-        msg = log.debug.call_args[0][0]
-        assert "Streaming decompression skipped" in msg
-        assert "zstd" in msg
-        assert "hard-bounded" in msg
+    def test_zstd_can_stream_decode_usage_is_false(self, headers):
+        assert can_stream_decode_usage(headers(("Content-Encoding", "zstd"))) is False
 
-    def test_error_without_ctx_log_does_not_raise(self, headers):
-        # No mitm_ctx patch — ctx.log is unavailable.  Guard must swallow.
+    def test_repeated_error_input_does_not_raise(self, headers):
         chunks: list[bytes] = []
         session = create_stream_decode_session(headers(("Content-Encoding", "gzip")), chunks.append)
         assert session is not None
@@ -489,15 +461,12 @@ class TestStreamDecodeSession:
         assert chunks == []
         assert session.finish_error() == "invalid compressed body"
 
-    def test_unsupported_encoding_logs_once_and_does_not_feed(self, headers, mitm_ctx):
+    def test_unsupported_encoding_does_not_feed(self, headers):
         chunks: list[bytes] = []
-        with mitm_ctx() as log:
-            session = create_stream_decode_session(
-                headers(("Content-Encoding", "compress")), chunks.append
-            )
+        session = create_stream_decode_session(
+            headers(("Content-Encoding", "compress")), chunks.append
+        )
         assert session is None
-        assert log.debug.call_count == 1
-        assert "unsupported content encoding" in log.debug.call_args[0][0]
         assert chunks == []
 
     def test_short_circuit_skips_decomp_fn_after_failure(self, headers, mitm_ctx, monkeypatch):

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -120,17 +120,12 @@ class TestXStreamPathRouting:
             {"content-type": "application/json", "content-encoding": "br"}
         )
 
-        with mitm_ctx() as log:
+        with mitm_ctx():
             mitm_addon.responseheaders(flow)
 
         assert callable(response_stream(flow))
         assert metadata_keys.X_NDJSON_STATE not in flow.metadata
         assert "connector_response_finish" not in flow.metadata
-        assert log.debug.call_count == 1
-        assert (
-            "Streaming decompression skipped: brotli streaming output cannot be bounded"
-            in log.debug.call_args[0][0]
-        )
 
     def test_unregistered_parser_factory_does_not_require_original_url(self, real_flow):
         flow = self._make_x_response_flow(real_flow, "/2/tweets/search/stream")

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -11,13 +11,18 @@ from tests.pending_helpers import assert_current_pending, assert_pending
 from tests.usage_buffer_helpers import RecordingEnqueue, event
 
 
-def assert_counter_underflow_message(message: str, counter: str) -> None:
+def assert_counter_underflow_log(call, counter: str) -> None:
+    message, fields = call.args
     assert message == (
-        "type=usage_underbilling reason=usage_pending_counter_underflow "
-        "underbilling_class=risk component=mitm_addon "
-        f"counter={counter} Usage pending counter release had no matching admission; "
-        "keeping counter non-negative."
+        "Usage pending counter release had no matching admission; keeping counter non-negative."
     )
+    assert fields == {
+        "type": "usage_underbilling",
+        "reason": "usage_pending_counter_underflow",
+        "underbilling_class": "risk",
+        "component": "mitm_addon",
+        "counter": counter,
+    }
 
 
 class TestUsagePendingCounter:
@@ -66,11 +71,11 @@ class TestUsagePendingCounter:
 
         assert mock_log.error.call_count == 2
         assert mock_log.warn.call_count == 0
-        messages = [call.args[0] for call in mock_log.error.call_args_list]
-        assert all("type=usage_underbilling" in message for message in messages)
-        assert all("reason=pending_snapshot_write_failed" in message for message in messages)
-        assert all("underbilling_class=risk" in message for message in messages)
-        assert all("component=mitm_addon" in message for message in messages)
+        fields = [call.args[1] for call in mock_log.error.call_args_list]
+        assert all(field["type"] == "usage_underbilling" for field in fields)
+        assert all(field["reason"] == "pending_snapshot_write_failed" for field in fields)
+        assert all(field["underbilling_class"] == "risk" for field in fields)
+        assert all(field["component"] == "mitm_addon" for field in fields)
 
     def test_increment_decrement_in_flight_flows(self, tmp_path):
         pending_path = tmp_path / "usage-pending"
@@ -253,7 +258,7 @@ class TestUsagePendingCounter:
         )
 
         assert mock_log.error.call_count == 1
-        assert_counter_underflow_message(mock_log.error.call_args[0][0], "flows")
+        assert_counter_underflow_log(mock_log.error.call_args, "flows")
         assert mock_log.warn.call_count == 0
 
     @pytest.mark.parametrize(
@@ -305,7 +310,7 @@ class TestUsagePendingCounter:
             flush_request_id="first-released",
         )
         assert mock_log.error.call_count == 1
-        assert_counter_underflow_message(mock_log.error.call_args[0][0], counter)
+        assert_counter_underflow_log(mock_log.error.call_args, counter)
 
         second.release()
         assert_current_pending(
@@ -322,9 +327,8 @@ class TestUsagePendingCounter:
             usage.decrement_in_flight_flows()
 
         assert mock_log.error.call_count == 2
-        messages = [call.args[0] for call in mock_log.error.call_args_list]
-        assert_counter_underflow_message(messages[0], "flows")
-        assert_counter_underflow_message(messages[1], "flows")
+        assert_counter_underflow_log(mock_log.error.call_args_list[0], "flows")
+        assert_counter_underflow_log(mock_log.error.call_args_list[1], "flows")
 
     def test_no_op_when_path_not_set(self, tmp_path):
         usage.set_pending_path("")
@@ -361,10 +365,13 @@ class TestUsagePendingCounter:
         assert list(tmp_path.glob(f"{pending_path.name}.*.tmp")) == []
         assert mock_log.error.call_count == 1
         assert mock_log.warn.call_count == 0
-        message = mock_log.error.call_args.args[0]
-        assert "reason=pending_snapshot_write_failed" in message
-        assert "error=replace\\sfailed\\nretry" in message
-        assert "\n" not in message
+        message, fields = mock_log.error.call_args.args
+        assert message == (
+            "Failed to write pending count. Subsequent failures in this process will be silent; "
+            "runner shutdown may hit the bounded proxy stop timeout."
+        )
+        assert fields["reason"] == "pending_snapshot_write_failed"
+        assert fields["error"] == "replace failed\nretry"
 
         usage.write_pending_snapshot(flush_request_id="recovered")
         assert_pending(
@@ -392,36 +399,23 @@ class TestUsagePendingCounter:
 
         assert mock_log.error.call_count == 1
         assert mock_log.warn.call_count == 0
-        message = mock_log.error.call_args[0][0]
-        rendered_fields, rendered_message = message.split(" Failed to write pending count.", 1)
-        field_tokens = rendered_fields.split()
-        assert [token.split("=", 1)[0] for token in field_tokens] == [
-            "type",
-            "reason",
-            "underbilling_class",
-            "component",
-            "error",
-            "error_type",
-            "pending_path",
-        ]
-        fields = dict(token.split("=", 1) for token in field_tokens)
+        message, fields = mock_log.error.call_args.args
         assert fields["type"] == "usage_underbilling"
         assert fields["reason"] == "pending_snapshot_write_failed"
         assert fields["underbilling_class"] == "risk"
         assert fields["component"] == "mitm_addon"
         assert fields["error_type"] == "OSError"
-        assert fields["error"].startswith("disk\\sfull\\n")
+        assert fields["error"].startswith("disk full\n")
         assert fields["pending_path"].startswith(str(tmp_path))
-        assert "\\n" in fields["pending_path"]
+        assert "\n" in fields["pending_path"]
         assert len(fields["error"]) == 256
         assert len(fields["pending_path"]) == 256
         assert fields["error"].endswith("...")
         assert fields["pending_path"].endswith("...")
-        assert rendered_message == (
-            " Subsequent failures in this process will be silent; runner shutdown may hit the "
-            "bounded proxy stop timeout."
+        assert message == (
+            "Failed to write pending count. Subsequent failures in this process will be silent; "
+            "runner shutdown may hit the bounded proxy stop timeout."
         )
-        assert "\n" not in message
 
     def test_write_failure_does_not_raise(self, tmp_path, mitm_ctx):
         """Write failures stay best-effort after the one-shot error signal — callers

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -377,7 +377,7 @@ class TestUsagePendingCounter:
 
     def test_write_failure_logs_underbilling_once_per_process(self, tmp_path, mitm_ctx):
         """Repeated OSErrors from pending snapshot writes emit exactly one
-        ``ctx.log.error`` per addon process — enough to seed FS-trouble
+        ERROR process event per addon process — enough to seed FS-trouble
         investigation without spamming logs on sustained failure."""
         pending_path = str(tmp_path / f"usage-pending\n{'p' * 400}")
         write_error = OSError(f"disk full\n{'e' * 400}")

--- a/crates/runner/mitm-addon/tests/test_logging_utils.py
+++ b/crates/runner/mitm-addon/tests/test_logging_utils.py
@@ -2,13 +2,14 @@
 
 import json
 from datetime import UTC, datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 import flow_metadata_keys as metadata_keys
 import logging_utils
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
+from tests.process_log_helpers import capture_addon_process_events
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 
 
@@ -24,7 +25,7 @@ class TestLogNetworkEntry:
 
         with (
             patch.object(logging_utils, "datetime") as clock,
-            patch.object(logging_utils.ctx, "log", MagicMock(), create=True),
+            capture_addon_process_events(),
         ):
             clock.now.return_value = current_time
             logging_utils.log_network_entry(log_path, entry)
@@ -42,7 +43,7 @@ class TestLogNetworkEntry:
         log_path = str(tmp_path / "net.jsonl")
         entry = {"timestamp": "caller-timestamp", "action": "ALLOW"}
 
-        with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             logging_utils.log_network_entry(log_path, entry)
 
         [parsed] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
@@ -53,7 +54,7 @@ class TestLogNetworkEntry:
     def test_appends_multiple(self, tmp_path):
         log_path = str(tmp_path / "net.jsonl")
 
-        with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             logging_utils.log_network_entry(log_path, {"n": 1})
             logging_utils.log_network_entry(log_path, {"n": 2})
 
@@ -61,18 +62,14 @@ class TestLogNetworkEntry:
         assert len(entries) == 2
 
     def test_no_path_is_noop(self):
-        log = MagicMock()
-
-        with patch.object(logging_utils.ctx, "log", log, create=True):
+        with capture_addon_process_events() as log:
             logging_utils.log_network_entry("", {"payload": b"binary"})
 
         log.warn.assert_not_called()
 
     def test_missing_parent_path_warns_and_does_not_raise(self, tmp_path):
         log_path = tmp_path / "missing" / "net.jsonl"
-        log = MagicMock()
-
-        with patch.object(logging_utils.ctx, "log", log, create=True):
+        with capture_addon_process_events() as log:
             logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
             logging_utils.flush_log_path(str(log_path))
 
@@ -83,9 +80,7 @@ class TestLogNetworkEntry:
 
     def test_non_serializable_entry_warns_without_creating_file(self, tmp_path):
         log_path = tmp_path / "net.jsonl"
-        log = MagicMock()
-
-        with patch.object(logging_utils.ctx, "log", log, create=True):
+        with capture_addon_process_events() as log:
             logging_utils.log_network_entry(str(log_path), {"payload": b"binary"})
 
         log.warn.assert_called_once()
@@ -96,11 +91,9 @@ class TestLogNetworkEntry:
 
     def test_full_backlog_warns_without_creating_file(self, tmp_path):
         log_path = tmp_path / "net.jsonl"
-        log = MagicMock()
-
         with (
             patch.object(logging_utils.jsonl_writer, "MAX_PENDING_JSONL_BYTES", 1),
-            patch.object(logging_utils.ctx, "log", log, create=True),
+            capture_addon_process_events() as log,
         ):
             logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
 
@@ -285,9 +278,7 @@ class TestLogProxyEntry:
         assert entries[1]["message"] == "second"
 
     def test_empty_path_no_op(self, tmp_path):
-        log = MagicMock()
-
-        with patch.object(logging_utils.ctx, "log", log, create=True):
+        with capture_addon_process_events() as log:
             logging_utils.log_proxy_entry(
                 "", "warn", "should not write", payload={"body": b"binary"}
             )
@@ -296,9 +287,7 @@ class TestLogProxyEntry:
         assert not list(tmp_path.iterdir())
 
     def test_missing_parent_path_warns_and_does_not_raise(self, tmp_path):
-        log = MagicMock()
-
-        with patch.object(logging_utils.ctx, "log", log, create=True):
+        with capture_addon_process_events() as log:
             logging_utils.log_proxy_entry(
                 str(tmp_path / "missing" / "proxy.jsonl"), "warn", "message"
             )
@@ -310,9 +299,7 @@ class TestLogProxyEntry:
         assert "FileNotFoundError" in warning
 
     def test_directory_path_warns_and_does_not_raise(self, tmp_path):
-        log = MagicMock()
-
-        with patch.object(logging_utils.ctx, "log", log, create=True):
+        with capture_addon_process_events() as log:
             logging_utils.log_proxy_entry(str(tmp_path), "warn", "message")
             logging_utils.flush_log_path(str(tmp_path))
 
@@ -323,9 +310,7 @@ class TestLogProxyEntry:
 
     def test_non_serializable_extra_warns_without_creating_file(self, tmp_path):
         proxy_path = tmp_path / "proxy-test.jsonl"
-        log = MagicMock()
-
-        with patch.object(logging_utils.ctx, "log", log, create=True):
+        with capture_addon_process_events() as log:
             logging_utils.log_proxy_entry(
                 str(proxy_path), "warn", "message", payload={"body": b"binary"}
             )
@@ -389,15 +374,13 @@ class TestJsonlWriterBehavior:
     def test_write_after_shutdown_is_noop_without_warning(self, tmp_path):
         network_path = tmp_path / "network.jsonl"
         proxy_path = tmp_path / "proxy.jsonl"
-        log = MagicMock()
-
         logging_utils.log_network_entry(str(network_path), {"action": "ALLOW"})
         logging_utils.log_proxy_entry(str(proxy_path), "info", "before shutdown")
         logging_utils.shutdown_log_writer()
         before_network_entries = _read_jsonl_entries_without_flush(network_path)
         before_entries = _read_jsonl_entries_without_flush(proxy_path)
 
-        with patch.object(logging_utils.ctx, "log", log, create=True):
+        with capture_addon_process_events() as log:
             logging_utils.log_network_entry(str(network_path), {"action": "DENY"})
             logging_utils.log_proxy_entry(str(proxy_path), "warn", "after shutdown")
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_parser_setup.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_parser_setup.py
@@ -78,17 +78,12 @@ class TestResponseHeadersModelJsonParser:
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
         flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
 
-        with mitm_ctx() as log:
+        with mitm_ctx():
             mitm_addon.responseheaders(flow)
 
         assert callable(response_stream(flow))
         assert "model_json_usage_finish" not in flow.metadata
         assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
-        assert any(
-            "Streaming decompression skipped: brotli streaming output cannot be bounded"
-            in call.args[0]
-            for call in log.debug.call_args_list
-        )
 
 
 class TestBodylessModelResponseParserAdmission:

--- a/crates/runner/mitm-addon/tests/test_registry_auth_cache_eviction.py
+++ b/crates/runner/mitm-addon/tests/test_registry_auth_cache_eviction.py
@@ -1,7 +1,6 @@
 """Tests for registry-driven auth-cache eviction."""
 
 import json
-from unittest.mock import MagicMock, patch
 
 import registry
 from firewall_auth_cache import FIREWALL_AUTH_REGISTRY_GENERATION_ATTRIBUTE
@@ -15,6 +14,7 @@ from tests.auth_state_helpers import (
     set_cached_headers,
     set_last_force_refresh_monotonic_at,
 )
+from tests.process_log_helpers import capture_addon_process_events
 from tests.registry_helpers import write_firewall_registry, write_simple_registry
 
 
@@ -106,7 +106,7 @@ class TestRegistryAuthCacheEviction:
 
         registry_file.unlink()
 
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             first_state = registry.load_registry_state(str(registry_file))
 
         assert isinstance(first_state, registry.RegistryUnavailable)
@@ -121,7 +121,7 @@ class TestRegistryAuthCacheEviction:
         mark_force_refresh(new_cache_key)
         set_last_force_refresh_monotonic_at(new_cache_key, 200.0)
 
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             second_state = registry.load_registry_state(str(registry_file))
 
         assert isinstance(second_state, registry.RegistryUnavailable)
@@ -147,7 +147,7 @@ class TestRegistryAuthCacheEviction:
         with registry_file.open("wb") as oversized_registry:
             oversized_registry.truncate(registry.MAX_REGISTRY_BYTES + 1)
 
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             first_state = registry.load_registry_state(str(registry_file))
 
         assert isinstance(first_state, registry.RegistryUnavailable)
@@ -162,7 +162,7 @@ class TestRegistryAuthCacheEviction:
         mark_force_refresh(new_cache_key)
         set_last_force_refresh_monotonic_at(new_cache_key, 200.0)
 
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             second_state = registry.load_registry_state(str(registry_file))
 
         assert isinstance(second_state, registry.RegistryUnavailable)
@@ -188,7 +188,7 @@ class TestRegistryAuthCacheEviction:
 
         registry_file.write_text("{ broken while evicting cache")
 
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             assert registry.load_registry(str(registry_file)) == {}
 
         assert not has_auth_state(old_cache_key)
@@ -201,7 +201,7 @@ class TestRegistryAuthCacheEviction:
         mark_force_refresh(new_cache_key)
         set_last_force_refresh_monotonic_at(new_cache_key, 200.0)
 
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             assert registry.load_registry(str(registry_file)) == {}
 
         assert cached_headers(new_cache_key)
@@ -257,7 +257,7 @@ class TestRegistryAuthCacheEviction:
             )
         )
 
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             registry.load_registry(str(registry_file))
 
         assert not has_auth_state(blank_run_key)
@@ -290,7 +290,7 @@ class TestRegistryAuthCacheEviction:
             )
         )
 
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             state = registry.load_registry_state(str(registry_file))
 
         assert not isinstance(state, registry.RegistryUnavailable)
@@ -331,7 +331,7 @@ class TestRegistryAuthCacheEviction:
             )
         )
 
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             registry.load_registry(str(registry_file))
 
         assert not has_auth_state(old_run_key)

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
@@ -1,13 +1,16 @@
 """Tests for registry built-in base URL variable resolution."""
 
 import json
+from collections.abc import Iterator
 from unittest.mock import MagicMock
 
 import pytest
 
+import builtin_firewall_cache
 import builtin_host_policy
 import registry
 from tests.builtin_firewall_cache_helpers import serialize_builtin_firewall_catalog_cache
+from tests.process_log_helpers import capture_addon_process_events
 from tests.registry_helpers import (
     assert_invalid_builtin_sandbox,
     write_trusted_catalog_cache_text,
@@ -25,13 +28,12 @@ class _RegistryOptions:
 
 
 @pytest.fixture(autouse=True)
-def registry_ctx(monkeypatch) -> MagicMock:
+def registry_ctx(monkeypatch) -> Iterator[MagicMock]:
     options = _RegistryOptions()
-    log = MagicMock()
-    monkeypatch.setattr(registry.ctx, "options", options, raising=False)
-    monkeypatch.setattr(registry.ctx, "log", log, raising=False)
+    monkeypatch.setattr(builtin_firewall_cache.ctx, "options", options, raising=False)
     _TEST_BUILTIN_FIREWALLS.clear()
-    return log
+    with capture_addon_process_events() as log:
+        yield log
 
 
 def install_test_builtin_firewall(
@@ -109,7 +111,7 @@ def write_builtin_firewall_registry(
     firewall = cache_firewall or _TEST_BUILTIN_FIREWALLS.get(name) or _builtin_firewall(name)
     cache_path = _cache_path_for_registry(path)
     _write_catalog_cache(cache_path, {firewall["name"]: firewall})
-    registry.ctx.options.vm0_builtin_firewall_catalog_cache_path = str(cache_path)
+    builtin_firewall_cache.ctx.options.vm0_builtin_firewall_catalog_cache_path = str(cache_path)
 
 
 class TestRegistryBuiltinBaseUrlVars:
@@ -1033,7 +1035,7 @@ class TestRegistryBuiltinBaseUrlVars:
         )
         cache_path = _cache_path_for_registry(path)
         _write_catalog_cache(cache_path, {"zendesk": _builtin_firewall("zendesk")})
-        registry.ctx.options.vm0_builtin_firewall_catalog_cache_path = str(cache_path)
+        builtin_firewall_cache.ctx.options.vm0_builtin_firewall_catalog_cache_path = str(cache_path)
 
         invalid_sandbox = assert_invalid_builtin_sandbox(path)
         assert "ZENDESK_SUBDOMAIN" in invalid_sandbox.message

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_core_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_core_cache.py
@@ -1,7 +1,6 @@
 """Tests for compiled built-in registry core-cache behavior and lifecycle."""
 
 import os
-from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -350,7 +349,6 @@ class TestRegistryBuiltinCoreCache:
                 registry_path=str(path),
                 builtin_firewall_catalog_cache_path=str(cache_path),
             ),
-            patch.object(registry.ctx, "log", MagicMock(), create=True),
         ):
             valid_context = registry.get_sandbox_context("10.200.0.1", str(path))
             omitted_context = registry.get_sandbox_context("10.200.0.2", str(path))

--- a/crates/runner/mitm-addon/tests/test_registry_context.py
+++ b/crates/runner/mitm-addon/tests/test_registry_context.py
@@ -1,10 +1,10 @@
 """Tests for registry sandbox lookup and public compiled context behavior."""
 
 import json
-from unittest.mock import MagicMock, patch
 
 import matching
 import registry
+from tests.process_log_helpers import capture_addon_process_events
 from tests.registry_helpers import write_firewall_registry
 
 
@@ -38,7 +38,7 @@ class TestGetSandboxInfo:
             )
         )
 
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             sandbox_info = registry.get_sandbox_info("10.200.0.1", str(path))
             assert sandbox_info is not None
             assert sandbox_info["runId"] == "good-run"
@@ -52,7 +52,7 @@ class TestGetSandboxInfo:
         path = tmp_path / "registry.json"
         path.write_text(json.dumps({"sandboxes": {"10.200.0.1": {"runId": ""}}, "updatedAt": 0}))
 
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             invalid_state = registry.load_registry_state(str(path))
 
         assert not isinstance(invalid_state, registry.RegistryUnavailable)
@@ -151,7 +151,7 @@ class TestGetSandboxContext:
             )
         )
 
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             assert registry.get_sandbox_context("10.200.0.1", str(path)) is not None
             assert registry.get_sandbox_context("10.200.0.2", str(path)) is None
             state = registry.load_registry_state(str(path))

--- a/crates/runner/mitm-addon/tests/test_registry_context_state.py
+++ b/crates/runner/mitm-addon/tests/test_registry_context_state.py
@@ -1,12 +1,12 @@
 """Tests for registry compiled context state and reload behavior."""
 
 import json
-from unittest.mock import MagicMock, patch
 
 import pytest
 
 import matching
 import registry
+from tests.process_log_helpers import capture_addon_process_events
 from tests.registry_helpers import pin_mtime, write_firewall_registry
 
 
@@ -130,7 +130,7 @@ class TestRegistryContextState:
         assert compiled_firewalls is not None
 
         path.write_text("{ broken")
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             unavailable_context = registry.get_sandbox_context("10.200.0.1", str(path))
             state = registry.load_registry_state(str(path))
 
@@ -150,7 +150,7 @@ class TestRegistryContextState:
         assert compiled_firewalls is not None
 
         path.unlink()
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             unavailable_context = registry.get_sandbox_context("10.200.0.1", str(path))
             state = registry.load_registry_state(str(path))
 
@@ -215,7 +215,7 @@ class TestRegistryContextState:
         data["sandboxes"]["10.200.0.1"]["firewalls"] = firewalls
         path.write_text(json.dumps(data))
 
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             context = registry.get_sandbox_context("10.200.0.1", str(path))
             state = registry.load_registry_state(str(path))
 
@@ -242,7 +242,7 @@ class TestRegistryContextState:
         data["sandboxes"]["10.200.0.1"]["firewalls"] = firewalls
         path.write_text(json.dumps(data))
 
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             context = registry.get_sandbox_context("10.200.0.1", str(path))
             state = registry.load_registry_state(str(path))
 

--- a/crates/runner/mitm-addon/tests/test_registry_loading.py
+++ b/crates/runner/mitm-addon/tests/test_registry_loading.py
@@ -2,12 +2,13 @@
 
 import json
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 import registry
 import state_file
+from tests.process_log_helpers import capture_addon_process_events
 from tests.registry_helpers import (
     pin_mtime,
     write_simple_registry,
@@ -47,7 +48,7 @@ class TestLoadRegistry:
             )
         )
 
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             state = registry.load_registry_state(str(path))
 
         assert not isinstance(state, registry.RegistryUnavailable)
@@ -181,7 +182,7 @@ class TestLoadRegistry:
         }
         path.write_text(json.dumps({"sandboxes": {"10.200.0.1": sandbox}, "updatedAt": 0}))
 
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             state = registry.load_registry_state(str(path))
 
         assert not isinstance(state, registry.RegistryUnavailable)
@@ -223,7 +224,7 @@ class TestLoadRegistry:
         }
         path.write_text(json.dumps({"sandboxes": {"10.200.0.1": sandbox}, "updatedAt": 0}))
 
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             state = registry.load_registry_state(str(path))
 
         assert not isinstance(state, registry.RegistryUnavailable)
@@ -232,7 +233,7 @@ class TestLoadRegistry:
 
     def test_missing_file_returns_empty(self, tmp_path):
         missing = str(tmp_path / "nonexistent.json")
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             result = registry.load_registry(missing)
             state = registry.load_registry_state(missing)
 
@@ -288,8 +289,7 @@ class TestLoadRegistry:
         write_simple_registry(path_a)
         registry.load_registry(str(path_a))
 
-        log = MagicMock()
-        with patch.object(registry.ctx, "log", log, create=True):
+        with capture_addon_process_events() as log:
             result = registry.load_registry(str(missing_b))
 
         assert result == {}
@@ -335,8 +335,7 @@ class TestLoadRegistry:
             )
         )
 
-        log = MagicMock()
-        with patch.object(registry.ctx, "log", log, create=True):
+        with capture_addon_process_events() as log:
             result = registry.load_registry(str(path))
             cached = registry.load_registry(str(path))
 
@@ -357,8 +356,7 @@ class TestLoadRegistry:
     def test_missing_file_logs_once_across_calls(self, tmp_path):
         """Stat-path failures repeated across requests emit at most one warn."""
         missing = str(tmp_path / "nonexistent.json")
-        log = MagicMock()
-        with patch.object(registry.ctx, "log", log, create=True):
+        with capture_addon_process_events() as log:
             for _ in range(5):
                 assert registry.load_registry(missing) == {}
 
@@ -369,8 +367,7 @@ class TestLoadRegistry:
         registry.load_registry(str(registry_file))
         registry_file.unlink()
 
-        log = MagicMock()
-        with patch.object(registry.ctx, "log", log, create=True):
+        with capture_addon_process_events() as log:
             result1 = registry.load_registry(str(registry_file))
             result2 = registry.load_registry(str(registry_file))
             state = registry.load_registry_state(str(registry_file))
@@ -394,7 +391,7 @@ class TestLoadRegistry:
         registry_file.unlink()
         registry_file.symlink_to(target)
 
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             result = registry.load_registry(str(registry_file))
             state = registry.load_registry_state(str(registry_file))
 
@@ -406,9 +403,8 @@ class TestLoadRegistry:
         path = tmp_path / "registry.json"
         max_registry_bytes = 5
         path.write_bytes(b" " * (max_registry_bytes + 1))
-        log = MagicMock()
         with (
-            patch.object(registry.ctx, "log", log, create=True),
+            capture_addon_process_events() as log,
             patch.object(registry, "MAX_REGISTRY_BYTES", max_registry_bytes),
             patch.object(registry.json, "loads", wraps=registry.json.loads) as spy,
         ):
@@ -424,9 +420,8 @@ class TestLoadRegistry:
         """Parse failure on a fixed file: key match short-circuits re-parse."""
         bad = tmp_path / "bad.json"
         bad.write_text("{ not valid json")
-        log = MagicMock()
         with (
-            patch.object(registry.ctx, "log", log, create=True),
+            capture_addon_process_events() as log,
             patch.object(registry.json, "loads", wraps=registry.json.loads) as spy,
         ):
             for _ in range(5):
@@ -440,9 +435,8 @@ class TestLoadRegistry:
         registry.load_registry(str(registry_file))
         registry_file.write_text("{ not valid json after success")
 
-        log = MagicMock()
         with (
-            patch.object(registry.ctx, "log", log, create=True),
+            capture_addon_process_events() as log,
             patch.object(registry.json, "loads", wraps=registry.json.loads) as spy,
         ):
             result1 = registry.load_registry(str(registry_file))
@@ -480,9 +474,8 @@ class TestLoadRegistry:
 
         registry_file.write_bytes(registry_payload)
 
-        log = MagicMock()
         with (
-            patch.object(registry.ctx, "log", log, create=True),
+            capture_addon_process_events() as log,
             patch.object(registry.json, "loads", wraps=registry.json.loads) as spy,
         ):
             state1 = registry.load_registry_state(str(registry_file))
@@ -502,9 +495,8 @@ class TestLoadRegistry:
         registry.load_registry(str(registry_file))
         registry_file.write_text(json.dumps({"sandboxes": ["broken"], "updatedAt": 0}))
 
-        log = MagicMock()
         with (
-            patch.object(registry.ctx, "log", log, create=True),
+            capture_addon_process_events() as log,
             patch.object(registry.json, "loads", wraps=registry.json.loads) as spy,
         ):
             result1 = registry.load_registry(str(registry_file))
@@ -523,9 +515,8 @@ class TestLoadRegistry:
         registry.load_registry(str(registry_file))
         registry_file.write_text(json.dumps(["broken"]))
 
-        log = MagicMock()
         with (
-            patch.object(registry.ctx, "log", log, create=True),
+            capture_addon_process_events() as log,
             patch.object(registry.json, "loads", wraps=registry.json.loads) as spy,
         ):
             result1 = registry.load_registry(str(registry_file))
@@ -544,8 +535,7 @@ class TestLoadRegistry:
         path = tmp_path / "registry.json"
         path.write_text("{ broken")
 
-        log = MagicMock()
-        with patch.object(registry.ctx, "log", log, create=True):
+        with capture_addon_process_events() as log:
             registry.load_registry(str(path))
             assert log.warn.call_count == 1
 
@@ -582,9 +572,8 @@ class TestLoadRegistry:
                 raise result
             return result
 
-        log = MagicMock()
         with (
-            patch.object(registry.ctx, "log", log, create=True),
+            capture_addon_process_events() as log,
             patch.object(state_file.os, "read", side_effect=read_with_one_failure) as spy,
         ):
             failed = registry.load_registry(str(registry_file))
@@ -617,8 +606,7 @@ class TestLoadRegistry:
         path.write_bytes(b"{" + b" " * (len(valid_bytes) - 1))
         first_stat = path.stat()
 
-        log = MagicMock()
-        with patch.object(registry.ctx, "log", log, create=True):
+        with capture_addon_process_events() as log:
             assert registry.load_registry(str(path)) == {}
 
             path.write_bytes(b"x" * (len(valid_bytes) + 1))
@@ -656,8 +644,7 @@ class TestLoadRegistry:
         """Successful load clears the flag so a later failure re-warns once."""
         path = tmp_path / "registry.json"
         path.write_text("{ broken")
-        log = MagicMock()
-        with patch.object(registry.ctx, "log", log, create=True):
+        with capture_addon_process_events() as log:
             registry.load_registry(str(path))  # parse fails → warn #1
             assert log.warn.call_count == 1
 

--- a/crates/runner/mitm-addon/tests/test_response_encoding_inspection_risk.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_inspection_risk.py
@@ -127,12 +127,11 @@ class TestResponseEncodingInspectionRisk:
             content_encoding="private-encoding-value",
         )
 
-        with mitm_ctx() as log:
+        with mitm_ctx():
             mitm_addon.responseheaders(flow)
 
         [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
         assert "private-encoding-value" not in str(entry)
-        assert "private-encoding-value" not in log.debug.call_args.args[0]
         assert entry["decode_skip_reason"] == "unsupported content encoding"
         assert flow.response is not None
         assert flow.response.status_code == 502

--- a/crates/runner/mitm-addon/tests/test_runner_jsonl_flush.py
+++ b/crates/runner/mitm-addon/tests/test_runner_jsonl_flush.py
@@ -8,7 +8,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -16,6 +16,7 @@ import jsonl_writer
 import logging_utils
 import runner_flush_lifecycle
 import usage
+from tests.process_log_helpers import capture_addon_process_events
 
 _RUNNER_USAGE_STATE_ID = "runner-state"
 _DEFAULT_JSONL_FLUSH_REQUEST_ID = "jsonl-request-1"
@@ -115,7 +116,7 @@ class TestRunnerJsonlFlush:
         logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
 
         with (
-            patch.object(logging_utils.ctx, "log", MagicMock(), create=True),
+            capture_addon_process_events(),
             running_jsonl_flush_worker(runner_jsonl_flush_files),
         ):
             runner_jsonl_flush_files.write_jsonl_flush_request()
@@ -164,11 +165,9 @@ class TestRunnerJsonlFlush:
         self, runner_jsonl_flush_files: RunnerJsonlFlushFiles
     ):
         log_path = runner_jsonl_flush_files.write_jsonl_flush_request()
-        log = MagicMock()
-
         with (
             patch.object(logging_utils, "flush_log_path", side_effect=RuntimeError("secret")),
-            patch.object(runner_flush_lifecycle.ctx, "log", log, create=True),
+            capture_addon_process_events() as log,
         ):
             runner_flush_lifecycle._flush_jsonl_for_runner_request(
                 runner_jsonl_flush_files.jsonl_flush_request_path,
@@ -196,7 +195,6 @@ class TestRunnerJsonlFlush:
         append_started = threading.Event()
         release_append = threading.Event()
         original_append_lines = jsonl_writer._append_lines
-        log = MagicMock()
 
         def append_lines(path: str, lines: list[bytes]) -> None:
             append_started.set()
@@ -218,7 +216,7 @@ class TestRunnerJsonlFlush:
                 "flush_log_path",
                 wraps=logging_utils.flush_log_path,
             ) as flush_log_path,
-            patch.object(runner_flush_lifecycle.ctx, "log", log, create=True),
+            capture_addon_process_events() as log,
         ):
             try:
                 logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
@@ -250,7 +248,7 @@ class TestRunnerJsonlFlush:
 
         with (
             patch.object(logging_utils, "flush_log_path") as flush_log_path,
-            patch.object(runner_flush_lifecycle.ctx, "log", MagicMock(), create=True),
+            capture_addon_process_events(),
             running_jsonl_flush_worker(runner_jsonl_flush_files),
         ):
             wait_for_jsonl_flush_state(runner_jsonl_flush_files)
@@ -266,7 +264,7 @@ class TestRunnerJsonlFlush:
         log_path = runner_jsonl_flush_files.write_jsonl_flush_request()
 
         with (
-            patch.object(runner_flush_lifecycle.ctx, "log", MagicMock(), create=True),
+            capture_addon_process_events(),
             patch.object(
                 logging_utils,
                 "flush_log_path",
@@ -312,7 +310,7 @@ class TestRunnerJsonlFlush:
                 "flush_log_path",
                 wraps=logging_utils.flush_log_path,
             ) as flush_log_path,
-            patch.object(runner_flush_lifecycle.ctx, "log", MagicMock(), create=True),
+            capture_addon_process_events(),
             patch.object(Path, "replace", new=fail_first_state_replace),
             running_jsonl_flush_worker(runner_jsonl_flush_files),
         ):

--- a/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
+++ b/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
@@ -10,13 +10,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from types import TracebackType
 from typing import Self
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 import runner_flush_lifecycle
 import usage
 from tests.pending_helpers import assert_pending
+from tests.process_log_helpers import capture_addon_process_events
 from tests.thread_helpers import ThreadUnderTest, wait_for_event
 from tests.usage_buffer_helpers import RecordingEnqueue, event
 from tests.usage_helpers import install_recording_usage_timer
@@ -399,7 +400,7 @@ class TestRunnerUsageFlushSignal:
                 "write_pending_snapshot",
                 side_effect=write_pending_snapshot,
             ),
-            patch.object(runner_flush_lifecycle.ctx, "log", MagicMock(), create=True),
+            capture_addon_process_events(),
         ):
             runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
             assert snapshotted.wait(timeout=1)
@@ -415,10 +416,8 @@ class TestRunnerUsageFlushSignal:
         pending_report.release()
 
     def test_runner_flush_failure_warns_without_error_text(self):
-        log = MagicMock()
-
         with (
-            patch.object(runner_flush_lifecycle.ctx, "log", log, create=True),
+            capture_addon_process_events() as log,
             patch.object(
                 usage,
                 "flush_usage_events",
@@ -468,7 +467,7 @@ class TestRunnerUsageFlushSignal:
             str(runner_usage_flush_files.proxy_log_path),
         )
 
-        with patch.object(runner_flush_lifecycle.ctx, "log", MagicMock(), create=True):
+        with capture_addon_process_events():
             runner_flush_lifecycle._flush_usage_for_runner_request()
 
         assert enqueue_calls == 1

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
@@ -1,5 +1,6 @@
 """Tests for usage-buffer timer and shutdown flush behavior."""
 
+import json
 import threading
 from collections.abc import Callable
 
@@ -1282,22 +1283,22 @@ def test_shutdown_retry_exhaustion_logs_underbilling_without_proxy_log_path(mitm
         enqueue.clear()
         assert usage.flush_usage_events(trigger="shutdown") == 0
 
-    messages = [call.args[0] for call in log.error.call_args_list]
+    fields = [call.args[1] for call in log.error.call_args_list]
     assert any(
-        message.startswith(
-            "type=usage_underbilling reason=shutdown_retained_without_retry "
-            "underbilling_class=risk component=mitm_addon "
-        )
-        for message in messages
+        field["type"] == "usage_underbilling"
+        and field["reason"] == "shutdown_retained_without_retry"
+        and field["underbilling_class"] == "risk"
+        and field["component"] == "mitm_addon"
+        for field in fields
     )
     assert any(
-        message.startswith(
-            "type=usage_underbilling reason=retry_budget_exhausted "
-            "underbilling_class=confirmed component=mitm_addon "
-        )
-        for message in messages
+        field["type"] == "usage_underbilling"
+        and field["reason"] == "retry_budget_exhausted"
+        and field["underbilling_class"] == "confirmed"
+        and field["component"] == "mitm_addon"
+        for field in fields
     )
-    assert all("secret-token" not in message for message in messages)
+    assert all("secret-token" not in json.dumps(field) for field in fields)
 
 
 def test_threshold_flush_cancels_scheduled_timer_and_allows_reschedule(tmp_path):

--- a/crates/runner/mitm-addon/tests/test_usage_underbilling.py
+++ b/crates/runner/mitm-addon/tests/test_usage_underbilling.py
@@ -1,12 +1,14 @@
 """Tests for usage underbilling log contracts."""
 
+import json
 from typing import cast
 
+import addon_process_logging
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from usage.underbilling import UnderbillingClass, log_usage_underbilling
 
 
-def test_underbilling_log_fields_cannot_be_overridden_by_context(tmp_path):
+def test_underbilling_writes_proxy_row_and_process_event(tmp_path, capfd):
     proxy_log_path = tmp_path / "proxy.jsonl"
 
     log_usage_underbilling(
@@ -34,8 +36,17 @@ def test_underbilling_log_fields_cannot_be_overridden_by_context(tmp_path):
     assert entry["message"] == "Usage underbilling signal"
     assert entry["timestamp"] != "wrong_timestamp"
 
+    process_record = capfd.readouterr().err.strip()
+    payload = process_record.removeprefix(addon_process_logging.ADDON_PROCESS_EVENT_PREFIX)
+    event = json.loads(payload)
+    assert event["level"] == "error"
+    assert event["type"] == "usage_underbilling"
+    assert event["reason"] == "expected_reason"
+    assert event["underbilling_class"] == "risk"
+    assert event["component"] == "mitm_addon"
 
-def test_underbilling_log_without_proxy_path_uses_stderr(mitm_ctx):
+
+def test_underbilling_log_without_proxy_path_uses_process_event(mitm_ctx):
     with mitm_ctx() as log:
         log_usage_underbilling(
             "",
@@ -57,7 +68,7 @@ def test_underbilling_log_without_proxy_path_uses_stderr(mitm_ctx):
     assert message.endswith("Usage underbilling signal")
 
 
-def test_underbilling_stderr_fallback_preserves_context(mitm_ctx):
+def test_underbilling_process_event_preserves_context(mitm_ctx):
     with mitm_ctx() as log:
         log_usage_underbilling(
             "",
@@ -100,7 +111,7 @@ def test_underbilling_stderr_fallback_preserves_context(mitm_ctx):
     assert message.endswith("Cannot report usage event")
 
 
-def test_underbilling_stderr_fallback_sanitizes_url(mitm_ctx):
+def test_underbilling_process_event_sanitizes_url(mitm_ctx):
     with mitm_ctx() as log:
         log_usage_underbilling(
             "",
@@ -117,7 +128,7 @@ def test_underbilling_stderr_fallback_sanitizes_url(mitm_ctx):
     assert "#fragment" not in message
 
 
-def test_underbilling_stderr_fallback_redacts_secret_strings_not_boolean_flags(mitm_ctx):
+def test_underbilling_process_event_redacts_secret_strings_not_boolean_flags(mitm_ctx):
     sensitive_context = {
         "sandbox_token": "secret-token",
         "missing_sandbox_token": True,
@@ -142,7 +153,7 @@ def test_underbilling_stderr_fallback_redacts_secret_strings_not_boolean_flags(m
     assert "secret-token" not in message
 
 
-def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
+def test_underbilling_process_event_redacts_common_key_fields(mitm_ctx):
     with mitm_ctx() as log:
         log_usage_underbilling(
             "",
@@ -249,7 +260,7 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
     assert "compact-private-key-value" not in message
 
 
-def test_underbilling_stderr_fallback_bounds_multiline_values(mitm_ctx):
+def test_underbilling_process_event_bounds_multiline_values(mitm_ctx):
     long_value = f"first line\n{'x' * 400}\nlast line"
 
     with mitm_ctx() as log:
@@ -269,7 +280,7 @@ def test_underbilling_stderr_fallback_bounds_multiline_values(mitm_ctx):
     assert len(message) < 420
 
 
-def test_underbilling_stderr_fallback_truncates_on_escape_boundaries(mitm_ctx):
+def test_underbilling_process_event_truncates_on_escape_boundaries(mitm_ctx):
     with mitm_ctx() as log:
         log_usage_underbilling(
             "",
@@ -286,7 +297,7 @@ def test_underbilling_stderr_fallback_truncates_on_escape_boundaries(mitm_ctx):
     assert len(message) < 420
 
 
-def test_underbilling_stderr_fallback_bounds_non_scalar_values(mitm_ctx):
+def test_underbilling_process_event_bounds_non_scalar_values(mitm_ctx):
     with mitm_ctx() as log:
         log_usage_underbilling(
             "",
@@ -302,7 +313,7 @@ def test_underbilling_stderr_fallback_bounds_non_scalar_values(mitm_ctx):
     assert len(message) < 420
 
 
-def test_underbilling_stderr_fallback_sanitizes_field_keys(mitm_ctx):
+def test_underbilling_process_event_sanitizes_field_keys(mitm_ctx):
     with mitm_ctx() as log:
         log_usage_underbilling(
             "",
@@ -317,7 +328,7 @@ def test_underbilling_stderr_fallback_sanitizes_field_keys(mitm_ctx):
     assert "bad key" not in message
 
 
-def test_underbilling_stderr_fallback_escapes_nonstandard_whitespace_and_controls(
+def test_underbilling_process_event_escapes_nonstandard_whitespace_and_controls(
     mitm_ctx,
 ):
     with mitm_ctx() as log:
@@ -336,7 +347,7 @@ def test_underbilling_stderr_fallback_escapes_nonstandard_whitespace_and_control
     assert "\x1b" not in message
 
 
-def test_underbilling_stderr_fallback_escapes_reason_and_message_controls(
+def test_underbilling_process_event_escapes_reason_and_message_controls(
     mitm_ctx,
 ):
     with mitm_ctx() as log:
@@ -357,7 +368,7 @@ def test_underbilling_stderr_fallback_escapes_reason_and_message_controls(
     assert "\x1b" not in message
 
 
-def test_underbilling_stderr_fallback_stringifies_prefix_values(mitm_ctx):
+def test_underbilling_process_event_stringifies_prefix_values(mitm_ctx):
     with mitm_ctx() as log:
         log_usage_underbilling(
             "",

--- a/crates/runner/mitm-addon/tests/test_usage_underbilling.py
+++ b/crates/runner/mitm-addon/tests/test_usage_underbilling.py
@@ -41,8 +41,8 @@ def test_underbilling_writes_proxy_row_and_process_event(tmp_path, capfd):
     assert event["level"] == "error"
     assert event["type"] == "usage_underbilling"
     assert event["reason"] == "expected_reason"
-    assert event["underbilling_class"] == "risk"
     assert event["component"] == "mitm_addon"
+    assert event["fields"] == {"underbilling_class": "risk"}
 
 
 def test_underbilling_log_without_proxy_path_uses_process_event(mitm_ctx):

--- a/crates/runner/mitm-addon/tests/test_usage_underbilling.py
+++ b/crates/runner/mitm-addon/tests/test_usage_underbilling.py
@@ -7,6 +7,13 @@ from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from usage.underbilling import log_usage_underbilling
 
 
+def _captured_process_log(log) -> tuple[str, dict[str, object]]:
+    message, fields = log.error.call_args.args
+    assert isinstance(message, str)
+    assert isinstance(fields, dict)
+    return message, fields
+
+
 def test_underbilling_writes_proxy_row_and_process_event(tmp_path, capfd):
     proxy_log_path = tmp_path / "proxy.jsonl"
 
@@ -41,11 +48,12 @@ def test_underbilling_writes_proxy_row_and_process_event(tmp_path, capfd):
     assert event == {
         "version": 1,
         "level": "error",
-        "message": (
-            "type=usage_underbilling reason=expected_reason "
-            "underbilling_class=risk component=mitm_addon run_id=run-1 "
-            "Usage underbilling signal"
-        ),
+        "message": "Usage underbilling signal",
+        "type": "usage_underbilling",
+        "reason": "expected_reason",
+        "underbilling_class": "risk",
+        "component": "mitm_addon",
+        "run_id": "run-1",
     }
 
 
@@ -63,12 +71,14 @@ def test_underbilling_log_without_proxy_path_uses_process_event(mitm_ctx):
         )
 
     log.error.assert_called_once()
-    message = log.error.call_args.args[0]
-    assert message.startswith(
-        "type=usage_underbilling reason=expected_reason "
-        "underbilling_class=risk component=mitm_addon "
-    )
-    assert message.endswith("Usage underbilling signal")
+    message, fields = _captured_process_log(log)
+    assert message == "Usage underbilling signal"
+    assert fields == {
+        "type": "usage_underbilling",
+        "reason": "expected_reason",
+        "underbilling_class": "risk",
+        "component": "mitm_addon",
+    }
 
 
 def test_underbilling_process_event_preserves_context(mitm_ctx):
@@ -94,24 +104,20 @@ def test_underbilling_process_event_preserves_context(mitm_ctx):
         )
 
     log.error.assert_called_once()
-    message = log.error.call_args.args[0]
-    assert message.startswith(
-        "type=usage_underbilling reason=missing_reporting_context "
-        "underbilling_class=confirmed component=mitm_addon "
-    )
-    assert "run_id=run-1" in message
-    assert "firewall_name=model-provider:anthropic" in message
-    assert "permission=messages:create" in message
-    assert "missing_sandbox_token=true" in message
-    assert "missing_api_url=false" in message
-    assert "dropped_webhook_batch_count=2" in message
-    assert "type=usage_event" not in message
-    assert "wrong_reason" not in message
-    assert "wrong_component" not in message
-    assert "level=debug" not in message
-    assert "message=wrong_message" not in message
-    assert "timestamp=wrong_timestamp" not in message
-    assert message.endswith("Cannot report usage event")
+    message, fields = _captured_process_log(log)
+    assert message == "Cannot report usage event"
+    assert fields == {
+        "type": "usage_underbilling",
+        "reason": "missing_reporting_context",
+        "underbilling_class": "confirmed",
+        "component": "mitm_addon",
+        "run_id": "run-1",
+        "firewall_name": "model-provider:anthropic",
+        "permission": "messages:create",
+        "missing_sandbox_token": True,
+        "missing_api_url": False,
+        "dropped_webhook_batch_count": 2,
+    }
 
 
 def test_underbilling_process_event_sanitizes_url(mitm_ctx):
@@ -124,11 +130,8 @@ def test_underbilling_process_event_sanitizes_url(mitm_ctx):
             url="https://user:pass@example.com/v1/search?token=secret#fragment",
         )
 
-    message = log.error.call_args.args[0]
-    assert "url=https://example.com/v1/search" in message
-    assert "user:pass" not in message
-    assert "token=secret" not in message
-    assert "#fragment" not in message
+    _, fields = _captured_process_log(log)
+    assert fields["url"] == "https://example.com/v1/search"
 
 
 def test_underbilling_process_event_redacts_secret_strings_not_boolean_flags(mitm_ctx):
@@ -148,12 +151,12 @@ def test_underbilling_process_event_redacts_secret_strings_not_boolean_flags(mit
             **sensitive_context,
         )
 
-    message = log.error.call_args.args[0]
-    assert "sandbox_token=[redacted]" in message
-    assert "authorization_header=[redacted]" in message
-    assert "missing_sandbox_token=true" in message
-    assert "retained_retry_count=3" in message
-    assert "secret-token" not in message
+    _, fields = _captured_process_log(log)
+    assert fields["sandbox_token"] == "[redacted]"
+    assert fields["authorization_header"] == "[redacted]"
+    assert fields["missing_sandbox_token"] is True
+    assert fields["retained_retry_count"] == 3
+    assert "secret-token" not in json.dumps(fields)
 
 
 def test_underbilling_process_event_redacts_common_key_fields(mitm_ctx):
@@ -199,68 +202,50 @@ def test_underbilling_process_event_redacts_common_key_fields(mitm_ctx):
             },
         )
 
-    message = log.error.call_args.args[0]
-    assert "api_key=[redacted]" in message
-    assert "access_key_id=[redacted]" in message
-    assert "private_key=[redacted]" in message
-    assert "credential_value=[redacted]" in message
-    assert "bearer=[redacted]" in message
-    assert "jwt=[redacted]" in message
-    assert "passwd=[redacted]" in message
-    assert "pwd=[redacted]" in message
-    assert "auth_header=[redacted]" in message
-    assert "authentication_header=[redacted]" in message
-    assert "oauth_token=[redacted]" in message
-    assert "sandbox_token_bytes=[redacted]" in message
-    assert "api-key=[redacted]" in message
-    assert "api_key_number=[redacted]" in message
-    assert "spaced_api_key=[redacted]" in message
-    assert "access_key_number=[redacted]" in message
-    assert "accessKeyId=[redacted]" in message
-    assert "private.key=[redacted]" in message
-    assert "privateKey=[redacted]" in message
-    assert "APIToken=[redacted]" in message
-    assert "XApiKey=[redacted]" in message
-    assert "AWSACCESSKEYID=[redacted]" in message
-    assert "github_accesstoken=[redacted]" in message
-    assert "openai_apikey=[redacted]" in message
-    assert "sessioncookie=[redacted]" in message
-    assert "signedjwt=[redacted]" in message
-    assert "dbpasswd=[redacted]" in message
-    assert "bearerCredential=[redacted]" in message
-    assert "ssh_privatekey=[redacted]" in message
-    assert "idempotency_key=diagnostic-key" in message
-    assert "input_tokens=42" in message
-    assert "tokenizer_name=usage-tokenizer" in message
-    assert "api-key-value" not in message
-    assert "123456" not in message
-    assert "access-key-value" not in message
-    assert "456789" not in message
-    assert "private-key-value" not in message
-    assert "credential-value" not in message
-    assert "bearer-value" not in message
-    assert "jwt-value" not in message
-    assert "passwd-value" not in message
-    assert "pwd-value" not in message
-    assert "short-auth-header-value" not in message
-    assert "authentication-header-value" not in message
-    assert "oauth-token-value" not in message
-    assert "upper-api-token-value" not in message
-    assert "prefixed-api-key-value" not in message
-    assert "upper-compact-access-key-value" not in message
-    assert "compact-access-token-value" not in message
-    assert "compact-api-key-value" not in message
-    assert "compact-cookie-value" not in message
-    assert "compact-jwt-value" not in message
-    assert "compact-passwd-value" not in message
-    assert "compact-bearer-value" not in message
-    assert "bytes-token-value" not in message
-    assert "hyphen-api-key-value" not in message
-    assert "spaced-api-key-value" not in message
-    assert "camel-access-key-value" not in message
-    assert "dotted-private-key-value" not in message
-    assert "camel-private-key-value" not in message
-    assert "compact-private-key-value" not in message
+    _, fields = _captured_process_log(log)
+    redacted_fields = {
+        "api_key",
+        "access_key_id",
+        "private_key",
+        "credential_value",
+        "bearer",
+        "jwt",
+        "passwd",
+        "pwd",
+        "auth_header",
+        "authentication_header",
+        "oauth_token",
+        "sandbox_token_bytes",
+        "api-key",
+        "api key number",
+        "spaced api key",
+        "access key number",
+        "accessKeyId",
+        "private.key",
+        "privateKey",
+        "APIToken",
+        "XApiKey",
+        "AWSACCESSKEYID",
+        "github_accesstoken",
+        "openai_apikey",
+        "sessioncookie",
+        "signedjwt",
+        "dbpasswd",
+        "bearerCredential",
+        "ssh_privatekey",
+    }
+    assert all(fields[name] == "[redacted]" for name in redacted_fields)
+    assert fields["idempotency_key"] == "diagnostic-key"
+    assert fields["input_tokens"] == "42"
+    assert fields["tokenizer_name"] == "usage-tokenizer"
+    serialized = json.dumps(fields)
+    assert "api-key-value" not in serialized
+    assert "access-key-value" not in serialized
+    assert "private-key-value" not in serialized
+    assert "credential-value" not in serialized
+    assert "bearer-value" not in serialized
+    assert "jwt-value" not in serialized
+    assert "bytes-token-value" not in serialized
 
 
 def test_underbilling_process_event_bounds_multiline_values(mitm_ctx):
@@ -275,15 +260,17 @@ def test_underbilling_process_event_bounds_multiline_values(mitm_ctx):
             parse_error=long_value,
         )
 
-    message = log.error.call_args.args[0]
+    _, fields = _captured_process_log(log)
+    parse_error = fields["parse_error"]
+    assert isinstance(parse_error, str)
     assert log.error.call_count == 1
-    assert "\n" not in message
-    assert "parse_error=first\\sline\\n" in message
-    assert "last line" not in message
-    assert len(message) < 420
+    assert parse_error.startswith("first line\n")
+    assert parse_error.endswith("...")
+    assert "last line" not in parse_error
+    assert len(parse_error) == 256
 
 
-def test_underbilling_process_event_truncates_on_escape_boundaries(mitm_ctx):
+def test_underbilling_process_event_preserves_structured_field_whitespace(mitm_ctx):
     with mitm_ctx() as log:
         log_usage_underbilling(
             "",
@@ -293,11 +280,8 @@ def test_underbilling_process_event_truncates_on_escape_boundaries(mitm_ctx):
             parse_error="\t" * 129,
         )
 
-    message = log.error.call_args.args[0]
-    assert "parse_error=" in message
-    assert "\\..." not in message
-    assert "\\t... Usage underbilling signal" in message
-    assert len(message) < 420
+    _, fields = _captured_process_log(log)
+    assert fields["parse_error"] == "\t" * 129
 
 
 def test_underbilling_process_event_bounds_non_scalar_values(mitm_ctx):
@@ -310,13 +294,14 @@ def test_underbilling_process_event_bounds_non_scalar_values(mitm_ctx):
             debug_payload={"items": ["x" * 400] * 20},
         )
 
-    message = log.error.call_args.args[0]
-    assert "debug_payload=" in message
-    assert "x" * 300 not in message
-    assert len(message) < 420
+    _, fields = _captured_process_log(log)
+    debug_payload = fields["debug_payload"]
+    assert isinstance(debug_payload, str)
+    assert "x" * 300 not in debug_payload
+    assert len(debug_payload) <= 256
 
 
-def test_underbilling_process_event_sanitizes_field_keys(mitm_ctx):
+def test_underbilling_process_event_preserves_field_keys(mitm_ctx):
     with mitm_ctx() as log:
         log_usage_underbilling(
             "",
@@ -326,9 +311,8 @@ def test_underbilling_process_event_sanitizes_field_keys(mitm_ctx):
             **{"bad key\nname": "value with spaces"},
         )
 
-    message = log.error.call_args.args[0]
-    assert "bad_key_name=value\\swith\\sspaces" in message
-    assert "bad key" not in message
+    _, fields = _captured_process_log(log)
+    assert fields["bad key\nname"] == "value with spaces"
 
 
 def test_underbilling_process_event_escapes_nonstandard_whitespace_and_controls(
@@ -343,11 +327,8 @@ def test_underbilling_process_event_escapes_nonstandard_whitespace_and_controls(
             parse_error="left\u00a0middle\f\x1b[31mright",
         )
 
-    message = log.error.call_args.args[0]
-    assert "parse_error=left\\smiddle\\s\\u001b[31mright" in message
-    assert "\u00a0" not in message
-    assert "\f" not in message
-    assert "\x1b" not in message
+    _, fields = _captured_process_log(log)
+    assert fields["parse_error"] == "left\u00a0middle\f\x1b[31mright"
 
 
 def test_underbilling_process_event_escapes_message_controls(mitm_ctx):
@@ -360,10 +341,10 @@ def test_underbilling_process_event_escapes_message_controls(mitm_ctx):
             run_id="run-1",
         )
 
-    message = log.error.call_args.args[0]
-    assert "reason=expected_reason" in message
-    assert "run_id=run-1" in message
-    assert message.endswith("Usage underbilling\\nsignal\\twith\\u001bcontrols")
+    message, fields = _captured_process_log(log)
+    assert fields["reason"] == "expected_reason"
+    assert fields["run_id"] == "run-1"
+    assert message == "Usage underbilling\\nsignal\\twith\\u001bcontrols"
     assert "\n" not in message
     assert "\t" not in message
     assert "\x1b" not in message

--- a/crates/runner/mitm-addon/tests/test_usage_underbilling.py
+++ b/crates/runner/mitm-addon/tests/test_usage_underbilling.py
@@ -38,11 +38,15 @@ def test_underbilling_writes_proxy_row_and_process_event(tmp_path, capfd):
     process_record = capfd.readouterr().err.strip()
     payload = process_record.removeprefix(addon_process_logging.ADDON_PROCESS_EVENT_PREFIX)
     event = json.loads(payload)
-    assert event["level"] == "error"
-    assert event["type"] == "usage_underbilling"
-    assert event["reason"] == "expected_reason"
-    assert event["component"] == "mitm_addon"
-    assert event["fields"] == {"underbilling_class": "risk"}
+    assert event == {
+        "version": 1,
+        "level": "error",
+        "message": (
+            "type=usage_underbilling reason=expected_reason "
+            "underbilling_class=risk component=mitm_addon run_id=run-1 "
+            "Usage underbilling signal"
+        ),
+    }
 
 
 def test_underbilling_log_without_proxy_path_uses_process_event(mitm_ctx):

--- a/crates/runner/mitm-addon/tests/test_usage_underbilling.py
+++ b/crates/runner/mitm-addon/tests/test_usage_underbilling.py
@@ -1,11 +1,10 @@
 """Tests for usage underbilling log contracts."""
 
 import json
-from typing import cast
 
 import addon_process_logging
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
-from usage.underbilling import UnderbillingClass, log_usage_underbilling
+from usage.underbilling import log_usage_underbilling
 
 
 def test_underbilling_writes_proxy_row_and_process_event(tmp_path, capfd):
@@ -347,39 +346,20 @@ def test_underbilling_process_event_escapes_nonstandard_whitespace_and_controls(
     assert "\x1b" not in message
 
 
-def test_underbilling_process_event_escapes_reason_and_message_controls(
-    mitm_ctx,
-):
+def test_underbilling_process_event_escapes_message_controls(mitm_ctx):
     with mitm_ctx() as log:
         log_usage_underbilling(
             "",
             "Usage underbilling\nsignal\twith\x1bcontrols",
-            "expected reason\nwith\tcontrols",
+            "expected_reason",
             "risk",
             run_id="run-1",
         )
 
     message = log.error.call_args.args[0]
-    assert "reason=expected\\sreason\\nwith\\tcontrols" in message
+    assert "reason=expected_reason" in message
     assert "run_id=run-1" in message
     assert message.endswith("Usage underbilling\\nsignal\\twith\\u001bcontrols")
     assert "\n" not in message
     assert "\t" not in message
     assert "\x1b" not in message
-
-
-def test_underbilling_process_event_stringifies_prefix_values(mitm_ctx):
-    with mitm_ctx() as log:
-        log_usage_underbilling(
-            "",
-            cast(str, 123),
-            cast(str, None),
-            cast(UnderbillingClass, True),
-            run_id="run-1",
-        )
-
-    message = log.error.call_args.args[0]
-    assert "reason=None" in message
-    assert "underbilling_class=True" in message
-    assert "run_id=run-1" in message
-    assert message.endswith("123")

--- a/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
@@ -29,11 +29,6 @@ from tests.x_flow_helpers import (
     make_x_stream_pipeline_flow,
 )
 
-_STREAM_DECODE_SKIP_REASONS = {
-    "br": "brotli streaming output cannot be bounded",
-    "zstd": "zstd streaming output cannot be hard-bounded",
-}
-
 
 def _compress_body(encoding: str, payload: bytes) -> bytes:
     if encoding == "gzip":
@@ -106,7 +101,7 @@ class TestXConnectorResponsePipeline:
         flow = make_x_pipeline_flow(real_flow, tmp_path, content_encoding=encoding_case)
         payload = b'{"data":[{"id":"1"}],"includes":{"users":[{"id":"u1"}]}}'
 
-        with mitm_ctx() as log:
+        with mitm_ctx():
             mitm_addon.responseheaders(flow)
         response_stream(flow)(_compress_body(encoding_case, payload))
         assert metadata_keys.STREAM_BUFFER in flow.metadata
@@ -119,11 +114,6 @@ class TestXConnectorResponsePipeline:
         assert by_category == {"posts.read": 1, "user.read": 1}
         assert "connector_response_finish" not in flow.metadata
         assert metadata_keys.X_NDJSON_STATE not in flow.metadata
-        assert log.debug.call_count == 1
-        assert (
-            f"Streaming decompression skipped: {_STREAM_DECODE_SKIP_REASONS[encoding_case]}"
-            in log.debug.call_args[0][0]
-        )
 
     @pytest.mark.parametrize("encoding_case", ["br", "zstd"])
     def test_full_response_pipeline_bounds_buffered_x_json_fallback_work(
@@ -211,16 +201,11 @@ class TestXConnectorResponsePipeline:
         assert flow.response is not None
         flow.response.headers["content-encoding"] = encoding_case
 
-        with mitm_ctx() as log:
+        with mitm_ctx():
             mitm_addon.responseheaders(flow)
 
         assert "connector_response_finish" not in flow.metadata
         assert metadata_keys.X_NDJSON_STATE not in flow.metadata
-        assert log.debug.call_count == 1
-        assert (
-            f"Streaming decompression skipped: {_STREAM_DECODE_SKIP_REASONS[encoding_case]}"
-            in log.debug.call_args[0][0]
-        )
 
     @pytest.mark.parametrize("encoding_case", ["gzip", "deflate", "br", "zstd"])
     def test_full_response_pipeline_truncated_compressed_x_json_does_not_bill(

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
@@ -242,13 +242,13 @@ def test_unparseable_no_hints_without_proxy_log_path_emits_process_event(
     with mitm_ctx(api_url="https://api.vm0.ai") as log:
         usage.report_connector_usage(flow, "run-abc-123")
 
-    messages = [call.args[0] for call in log.error.call_args_list]
+    fields = [call.args[1] for call in log.error.call_args_list]
     assert any(
-        message.startswith(
-            "type=usage_underbilling reason=unparseable_usage_response "
-            "underbilling_class=confirmed component=mitm_addon "
-        )
-        for message in messages
+        field["type"] == "usage_underbilling"
+        and field["reason"] == "unparseable_usage_response"
+        and field["underbilling_class"] == "confirmed"
+        and field["component"] == "mitm_addon"
+        for field in fields
     )
 
 

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
@@ -227,7 +227,7 @@ def test_unparseable_no_hints_writes_error_to_proxy_log(x_usage, tmp_path, real_
     assert "parse_error" not in entry
 
 
-def test_unparseable_no_hints_without_proxy_log_path_logs_stderr(
+def test_unparseable_no_hints_without_proxy_log_path_emits_process_event(
     x_usage, tmp_path, real_flow, mitm_ctx
 ):
     flow = x_usage.make_flow(

--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -68,11 +68,6 @@ const DEFAULT_AXIOM_URL: &str = "https://api.axiom.co";
 const SERVICE_NAME: &str = "runner";
 const AXIOM_TOKEN_ENV: &str = "AXIOM_TOKEN_TELEMETRY";
 const AXIOM_SUFFIX_ENV: &str = "AXIOM_DATASET_SUFFIX";
-/// A tracing string field containing a JSON object whose entries are expanded
-/// into the Axiom event. Static tracing fields and Runner-owned metadata win
-/// on collisions.
-const AXIOM_FIELDS_FIELD: &str = "axiom_fields";
-const AXIOM_FIELDS_MAX_ENTRIES: usize = 32;
 /// Target used for this layer's own diagnostics. Dispatcher diagnostics
 /// (non-success ingest responses, HTTP errors) remain visible to local
 /// logging, while the Axiom per-layer filter keeps any observed diagnostics
@@ -367,43 +362,32 @@ async fn flush(client: &Client, ingest_url: &str, token: &str, batch: &mut Vec<V
 /// (lowercase), `message`, `context`, plus any user-supplied fields —
 /// augmented with a Rust-only `service` discriminator.
 fn serialize_event(event: &Event<'_>, runner_hostname: Option<&str>) -> Value {
-    struct V {
-        fields: Map<String, Value>,
-        axiom_fields: Map<String, Value>,
-    }
-
+    struct V(Map<String, Value>);
     impl Visit for V {
         fn record_str(&mut self, f: &Field, v: &str) {
-            if f.name() == AXIOM_FIELDS_FIELD
-                && let Some(fields) = parse_axiom_fields(v)
-            {
-                self.axiom_fields = fields;
-                return;
-            }
-            self.fields.insert(
+            self.0.insert(
                 f.name().into(),
                 Value::String(format_bounded(format_args!("{v}"))),
             );
         }
         fn record_i64(&mut self, f: &Field, v: i64) {
-            self.fields.insert(f.name().into(), v.into());
+            self.0.insert(f.name().into(), v.into());
         }
         fn record_u64(&mut self, f: &Field, v: u64) {
-            self.fields.insert(f.name().into(), v.into());
+            self.0.insert(f.name().into(), v.into());
         }
         fn record_u128(&mut self, f: &Field, v: u128) {
             if let Ok(v) = u64::try_from(v) {
-                self.fields.insert(f.name().into(), v.into());
+                self.0.insert(f.name().into(), v.into());
             } else {
-                self.fields
-                    .insert(f.name().into(), Value::String(v.to_string()));
+                self.0.insert(f.name().into(), Value::String(v.to_string()));
             }
         }
         fn record_f64(&mut self, f: &Field, v: f64) {
-            self.fields.insert(f.name().into(), v.into());
+            self.0.insert(f.name().into(), v.into());
         }
         fn record_bool(&mut self, f: &Field, v: bool) {
-            self.fields.insert(f.name().into(), v.into());
+            self.0.insert(f.name().into(), v.into());
         }
         fn record_error(&mut self, f: &Field, err: &(dyn std::error::Error + 'static)) {
             // Mirror TS `serializeError` shape: an object with `message` and a
@@ -429,12 +413,12 @@ fn serialize_event(event: &Event<'_>, runner_hostname: Option<&str>) -> Value {
             if !chain.is_empty() {
                 obj.insert("chain".into(), Value::Array(chain));
             }
-            self.fields.insert(f.name().into(), Value::Object(obj));
+            self.0.insert(f.name().into(), Value::Object(obj));
         }
         fn record_debug(&mut self, f: &Field, v: &dyn std::fmt::Debug) {
             // Cap per-field size so a user who logs a huge struct via `?v`
             // can't blow past Axiom's body limit or starve the dispatcher.
-            self.fields.insert(
+            self.0.insert(
                 f.name().into(),
                 Value::String(format_bounded(format_args!("{v:?}"))),
             );
@@ -442,28 +426,10 @@ fn serialize_event(event: &Event<'_>, runner_hostname: Option<&str>) -> Value {
     }
 
     let meta = event.metadata();
-    let mut v = V {
-        fields: Map::new(),
-        axiom_fields: Map::new(),
-    };
+    let mut v = V(Map::new());
     event.record(&mut v);
 
-    let mut out = v.fields;
-    for (name, value) in v.axiom_fields {
-        if !matches!(
-            name.as_str(),
-            AXIOM_FIELDS_FIELD
-                | "_time"
-                | "level"
-                | "message"
-                | "context"
-                | "service"
-                | "runner_hostname"
-                | "runner_version"
-        ) {
-            out.entry(name).or_insert(value);
-        }
-    }
+    let mut out = v.0;
     out.insert(
         "_time".into(),
         Value::String(chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)),
@@ -485,28 +451,6 @@ fn serialize_event(event: &Event<'_>, runner_hostname: Option<&str>) -> Value {
         Value::String(env!("CARGO_PKG_VERSION").into()),
     );
     Value::Object(out)
-}
-
-fn parse_axiom_fields(encoded: &str) -> Option<Map<String, Value>> {
-    let mut fields = serde_json::from_str::<Map<String, Value>>(encoded).ok()?;
-    if fields.len() > AXIOM_FIELDS_MAX_ENTRIES {
-        return None;
-    }
-    for (name, value) in &mut fields {
-        let mut bytes = name.bytes();
-        if !matches!(bytes.next(), Some(byte) if byte.is_ascii_alphabetic())
-            || name.len() > 80
-            || !bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
-        {
-            return None;
-        }
-        match value {
-            Value::String(value) => *value = format_bounded(format_args!("{value}")),
-            Value::Null | Value::Bool(_) | Value::Number(_) => {}
-            Value::Array(_) | Value::Object(_) => return None,
-        }
-    }
-    Some(fields)
 }
 
 #[cfg(test)]

--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -68,6 +68,7 @@ const DEFAULT_AXIOM_URL: &str = "https://api.axiom.co";
 const SERVICE_NAME: &str = "runner";
 const AXIOM_TOKEN_ENV: &str = "AXIOM_TOKEN_TELEMETRY";
 const AXIOM_SUFFIX_ENV: &str = "AXIOM_DATASET_SUFFIX";
+const ADDON_LOG_TARGET: &str = "mitmdump_addon";
 /// Target used for this layer's own diagnostics. Dispatcher diagnostics
 /// (non-success ingest responses, HTTP errors) remain visible to local
 /// logging, while the Axiom per-layer filter keeps any observed diagnostics
@@ -430,6 +431,13 @@ fn serialize_event(event: &Event<'_>, runner_hostname: Option<&str>) -> Value {
     event.record(&mut v);
 
     let mut out = v.0;
+    if meta.target() == ADDON_LOG_TARGET
+        && let Some(encoded) = out.get("message").and_then(Value::as_str)
+        && let Ok(addon_log) = serde_json::from_str::<Map<String, Value>>(encoded)
+    {
+        out = addon_log;
+        out.remove("runner_hostname");
+    }
     out.insert(
         "_time".into(),
         Value::String(chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)),

--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -68,6 +68,11 @@ const DEFAULT_AXIOM_URL: &str = "https://api.axiom.co";
 const SERVICE_NAME: &str = "runner";
 const AXIOM_TOKEN_ENV: &str = "AXIOM_TOKEN_TELEMETRY";
 const AXIOM_SUFFIX_ENV: &str = "AXIOM_DATASET_SUFFIX";
+/// A tracing string field containing a JSON object whose entries are expanded
+/// into the Axiom event. Static tracing fields and Runner-owned metadata win
+/// on collisions.
+const AXIOM_FIELDS_FIELD: &str = "axiom_fields";
+const AXIOM_FIELDS_MAX_ENTRIES: usize = 32;
 /// Target used for this layer's own diagnostics. Dispatcher diagnostics
 /// (non-success ingest responses, HTTP errors) remain visible to local
 /// logging, while the Axiom per-layer filter keeps any observed diagnostics
@@ -362,32 +367,43 @@ async fn flush(client: &Client, ingest_url: &str, token: &str, batch: &mut Vec<V
 /// (lowercase), `message`, `context`, plus any user-supplied fields —
 /// augmented with a Rust-only `service` discriminator.
 fn serialize_event(event: &Event<'_>, runner_hostname: Option<&str>) -> Value {
-    struct V(Map<String, Value>);
+    struct V {
+        fields: Map<String, Value>,
+        axiom_fields: Map<String, Value>,
+    }
+
     impl Visit for V {
         fn record_str(&mut self, f: &Field, v: &str) {
-            self.0.insert(
+            if f.name() == AXIOM_FIELDS_FIELD
+                && let Some(fields) = parse_axiom_fields(v)
+            {
+                self.axiom_fields = fields;
+                return;
+            }
+            self.fields.insert(
                 f.name().into(),
                 Value::String(format_bounded(format_args!("{v}"))),
             );
         }
         fn record_i64(&mut self, f: &Field, v: i64) {
-            self.0.insert(f.name().into(), v.into());
+            self.fields.insert(f.name().into(), v.into());
         }
         fn record_u64(&mut self, f: &Field, v: u64) {
-            self.0.insert(f.name().into(), v.into());
+            self.fields.insert(f.name().into(), v.into());
         }
         fn record_u128(&mut self, f: &Field, v: u128) {
             if let Ok(v) = u64::try_from(v) {
-                self.0.insert(f.name().into(), v.into());
+                self.fields.insert(f.name().into(), v.into());
             } else {
-                self.0.insert(f.name().into(), Value::String(v.to_string()));
+                self.fields
+                    .insert(f.name().into(), Value::String(v.to_string()));
             }
         }
         fn record_f64(&mut self, f: &Field, v: f64) {
-            self.0.insert(f.name().into(), v.into());
+            self.fields.insert(f.name().into(), v.into());
         }
         fn record_bool(&mut self, f: &Field, v: bool) {
-            self.0.insert(f.name().into(), v.into());
+            self.fields.insert(f.name().into(), v.into());
         }
         fn record_error(&mut self, f: &Field, err: &(dyn std::error::Error + 'static)) {
             // Mirror TS `serializeError` shape: an object with `message` and a
@@ -413,12 +429,12 @@ fn serialize_event(event: &Event<'_>, runner_hostname: Option<&str>) -> Value {
             if !chain.is_empty() {
                 obj.insert("chain".into(), Value::Array(chain));
             }
-            self.0.insert(f.name().into(), Value::Object(obj));
+            self.fields.insert(f.name().into(), Value::Object(obj));
         }
         fn record_debug(&mut self, f: &Field, v: &dyn std::fmt::Debug) {
             // Cap per-field size so a user who logs a huge struct via `?v`
             // can't blow past Axiom's body limit or starve the dispatcher.
-            self.0.insert(
+            self.fields.insert(
                 f.name().into(),
                 Value::String(format_bounded(format_args!("{v:?}"))),
             );
@@ -426,10 +442,28 @@ fn serialize_event(event: &Event<'_>, runner_hostname: Option<&str>) -> Value {
     }
 
     let meta = event.metadata();
-    let mut v = V(Map::new());
+    let mut v = V {
+        fields: Map::new(),
+        axiom_fields: Map::new(),
+    };
     event.record(&mut v);
 
-    let mut out = v.0;
+    let mut out = v.fields;
+    for (name, value) in v.axiom_fields {
+        if !matches!(
+            name.as_str(),
+            AXIOM_FIELDS_FIELD
+                | "_time"
+                | "level"
+                | "message"
+                | "context"
+                | "service"
+                | "runner_hostname"
+                | "runner_version"
+        ) {
+            out.entry(name).or_insert(value);
+        }
+    }
     out.insert(
         "_time".into(),
         Value::String(chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)),
@@ -451,6 +485,28 @@ fn serialize_event(event: &Event<'_>, runner_hostname: Option<&str>) -> Value {
         Value::String(env!("CARGO_PKG_VERSION").into()),
     );
     Value::Object(out)
+}
+
+fn parse_axiom_fields(encoded: &str) -> Option<Map<String, Value>> {
+    let mut fields = serde_json::from_str::<Map<String, Value>>(encoded).ok()?;
+    if fields.len() > AXIOM_FIELDS_MAX_ENTRIES {
+        return None;
+    }
+    for (name, value) in &mut fields {
+        let mut bytes = name.bytes();
+        if !matches!(bytes.next(), Some(byte) if byte.is_ascii_alphabetic())
+            || name.len() > 80
+            || !bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+        {
+            return None;
+        }
+        match value {
+            Value::String(value) => *value = format_bounded(format_args!("{value}")),
+            Value::Null | Value::Bool(_) | Value::Number(_) => {}
+            Value::Array(_) | Value::Object(_) => return None,
+        }
+    }
+    Some(fields)
 }
 
 #[cfg(test)]

--- a/crates/runner/src/axiom_layer/tests.rs
+++ b/crates/runner/src/axiom_layer/tests.rs
@@ -792,6 +792,38 @@ async fn none_option_fields_are_omitted_from_axiom_payload() {
     );
 }
 
+#[tokio::test]
+async fn generic_axiom_fields_expand_without_overwriting_owned_fields() {
+    let server = MockServer::start_async().await;
+
+    let (ingest, captured) = capture_axiom_ingest(&server).await;
+
+    let (layer, guard) =
+        init_with_base_url(&server.base_url(), "t", "test").expect("init must succeed");
+    let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
+    {
+        let _sub = tracing::subscriber::set_default(subscriber);
+        let fields = r#"{"underbilling_class":"risk","counter":"reports","type":"spoofed","message":"spoofed","service":"spoofed","runner_hostname":"spoofed"}"#.to_string();
+        tracing::error!(
+            target: "mitmdump_addon",
+            r#type = "usage_underbilling",
+            axiom_fields = fields.as_str(),
+            "generic addon fields"
+        );
+    }
+    guard.shutdown().await;
+
+    ingest.assert_calls_async(1).await;
+    let events = captured.events();
+    let event = event_with_message(&events, "generic addon fields");
+    assert_eq!(event["type"].as_str(), Some("usage_underbilling"));
+    assert_eq!(event["underbilling_class"].as_str(), Some("risk"));
+    assert_eq!(event["counter"].as_str(), Some("reports"));
+    assert_eq!(event["service"].as_str(), Some("runner"));
+    assert!(event.get("runner_hostname").is_none());
+    assert!(event.get("axiom_fields").is_none());
+}
+
 #[test]
 fn burst_past_channel_cap_drops_without_blocking() {
     let (tx, receiver) = tokio::sync::mpsc::channel(CHANNEL_CAP);

--- a/crates/runner/src/axiom_layer/tests.rs
+++ b/crates/runner/src/axiom_layer/tests.rs
@@ -12,9 +12,10 @@ use std::thread;
 use std::time::Duration;
 
 use super::{
-    AxiomGuard, AxiomLayer, BATCH_INTERVAL, BATCH_SIZE, CHANNEL_CAP, ERROR_SOURCE_MAX_DEPTH,
-    FLUSH_DEADLINE, INTERNAL_TARGET, Msg, TEXT_FIELD_MAX_BYTES, TRUNCATION_MARKER,
-    init_from_env_values, init_with_base_url, init_with_base_url_and_hostname, with_ingest_filter,
+    AXIOM_FIELDS_MAX_ENTRIES, AxiomGuard, AxiomLayer, BATCH_INTERVAL, BATCH_SIZE, CHANNEL_CAP,
+    ERROR_SOURCE_MAX_DEPTH, FLUSH_DEADLINE, INTERNAL_TARGET, Msg, TEXT_FIELD_MAX_BYTES,
+    TRUNCATION_MARKER, init_from_env_values, init_with_base_url, init_with_base_url_and_hostname,
+    with_ingest_filter,
 };
 use httpmock::Method::POST;
 use httpmock::MockServer;
@@ -822,6 +823,59 @@ async fn generic_axiom_fields_expand_without_overwriting_owned_fields() {
     assert_eq!(event["service"].as_str(), Some("runner"));
     assert!(event.get("runner_hostname").is_none());
     assert!(event.get("axiom_fields").is_none());
+}
+
+#[tokio::test]
+async fn generic_axiom_fields_validate_the_complete_map_before_expanding() {
+    let server = MockServer::start_async().await;
+
+    let (ingest, captured) = capture_axiom_ingest(&server).await;
+
+    let (layer, guard) =
+        init_with_base_url(&server.base_url(), "t", "test").expect("init must succeed");
+    let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
+    let too_many_fields = Value::Object(
+        (0..=AXIOM_FIELDS_MAX_ENTRIES)
+            .map(|index| (format!("field_{index}"), Value::String("value".to_string())))
+            .collect(),
+    )
+    .to_string();
+    let invalid_name = r#"{"bad-name":"value"}"#;
+    let nested_value = r#"{"nested":{"value":"unsafe"}}"#;
+    let scalar_values = r#"{"enabled":true,"attempts":2,"empty":null}"#;
+    {
+        let _sub = tracing::subscriber::set_default(subscriber);
+        tracing::warn!(
+            axiom_fields = too_many_fields.as_str(),
+            "too many generic fields"
+        );
+        tracing::warn!(axiom_fields = invalid_name, "invalid generic field name");
+        tracing::warn!(axiom_fields = nested_value, "nested generic field value");
+        tracing::warn!(axiom_fields = scalar_values, "scalar generic field values");
+    }
+    guard.shutdown().await;
+
+    ingest.assert_calls_async(1).await;
+    let events = captured.events();
+    for (message, encoded, rejected_field) in [
+        (
+            "too many generic fields",
+            too_many_fields.as_str(),
+            "field_0",
+        ),
+        ("invalid generic field name", invalid_name, "bad-name"),
+        ("nested generic field value", nested_value, "nested"),
+    ] {
+        let event = event_with_message(&events, message);
+        assert_eq!(event["axiom_fields"].as_str(), Some(encoded));
+        assert!(event.get(rejected_field).is_none());
+    }
+
+    let scalar_event = event_with_message(&events, "scalar generic field values");
+    assert_eq!(scalar_event["enabled"].as_bool(), Some(true));
+    assert_eq!(scalar_event["attempts"].as_u64(), Some(2));
+    assert_eq!(scalar_event.get("empty"), Some(&Value::Null));
+    assert!(scalar_event.get("axiom_fields").is_none());
 }
 
 #[test]

--- a/crates/runner/src/axiom_layer/tests.rs
+++ b/crates/runner/src/axiom_layer/tests.rs
@@ -12,10 +12,9 @@ use std::thread;
 use std::time::Duration;
 
 use super::{
-    AXIOM_FIELDS_MAX_ENTRIES, AxiomGuard, AxiomLayer, BATCH_INTERVAL, BATCH_SIZE, CHANNEL_CAP,
-    ERROR_SOURCE_MAX_DEPTH, FLUSH_DEADLINE, INTERNAL_TARGET, Msg, TEXT_FIELD_MAX_BYTES,
-    TRUNCATION_MARKER, init_from_env_values, init_with_base_url, init_with_base_url_and_hostname,
-    with_ingest_filter,
+    AxiomGuard, AxiomLayer, BATCH_INTERVAL, BATCH_SIZE, CHANNEL_CAP, ERROR_SOURCE_MAX_DEPTH,
+    FLUSH_DEADLINE, INTERNAL_TARGET, Msg, TEXT_FIELD_MAX_BYTES, TRUNCATION_MARKER,
+    init_from_env_values, init_with_base_url, init_with_base_url_and_hostname, with_ingest_filter,
 };
 use httpmock::Method::POST;
 use httpmock::MockServer;
@@ -791,91 +790,6 @@ async fn none_option_fields_are_omitted_from_axiom_payload() {
             .any(|event| json_contains_string(event, "None")),
         "None debug text should not be serialized into ingest payloads: {events:#?}",
     );
-}
-
-#[tokio::test]
-async fn generic_axiom_fields_expand_without_overwriting_owned_fields() {
-    let server = MockServer::start_async().await;
-
-    let (ingest, captured) = capture_axiom_ingest(&server).await;
-
-    let (layer, guard) =
-        init_with_base_url(&server.base_url(), "t", "test").expect("init must succeed");
-    let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
-    {
-        let _sub = tracing::subscriber::set_default(subscriber);
-        let fields = r#"{"underbilling_class":"risk","counter":"reports","type":"spoofed","message":"spoofed","service":"spoofed","runner_hostname":"spoofed"}"#.to_string();
-        tracing::error!(
-            target: "mitmdump_addon",
-            r#type = "usage_underbilling",
-            axiom_fields = fields.as_str(),
-            "generic addon fields"
-        );
-    }
-    guard.shutdown().await;
-
-    ingest.assert_calls_async(1).await;
-    let events = captured.events();
-    let event = event_with_message(&events, "generic addon fields");
-    assert_eq!(event["type"].as_str(), Some("usage_underbilling"));
-    assert_eq!(event["underbilling_class"].as_str(), Some("risk"));
-    assert_eq!(event["counter"].as_str(), Some("reports"));
-    assert_eq!(event["service"].as_str(), Some("runner"));
-    assert!(event.get("runner_hostname").is_none());
-    assert!(event.get("axiom_fields").is_none());
-}
-
-#[tokio::test]
-async fn generic_axiom_fields_validate_the_complete_map_before_expanding() {
-    let server = MockServer::start_async().await;
-
-    let (ingest, captured) = capture_axiom_ingest(&server).await;
-
-    let (layer, guard) =
-        init_with_base_url(&server.base_url(), "t", "test").expect("init must succeed");
-    let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
-    let too_many_fields = Value::Object(
-        (0..=AXIOM_FIELDS_MAX_ENTRIES)
-            .map(|index| (format!("field_{index}"), Value::String("value".to_string())))
-            .collect(),
-    )
-    .to_string();
-    let invalid_name = r#"{"bad-name":"value"}"#;
-    let nested_value = r#"{"nested":{"value":"unsafe"}}"#;
-    let scalar_values = r#"{"enabled":true,"attempts":2,"empty":null}"#;
-    {
-        let _sub = tracing::subscriber::set_default(subscriber);
-        tracing::warn!(
-            axiom_fields = too_many_fields.as_str(),
-            "too many generic fields"
-        );
-        tracing::warn!(axiom_fields = invalid_name, "invalid generic field name");
-        tracing::warn!(axiom_fields = nested_value, "nested generic field value");
-        tracing::warn!(axiom_fields = scalar_values, "scalar generic field values");
-    }
-    guard.shutdown().await;
-
-    ingest.assert_calls_async(1).await;
-    let events = captured.events();
-    for (message, encoded, rejected_field) in [
-        (
-            "too many generic fields",
-            too_many_fields.as_str(),
-            "field_0",
-        ),
-        ("invalid generic field name", invalid_name, "bad-name"),
-        ("nested generic field value", nested_value, "nested"),
-    ] {
-        let event = event_with_message(&events, message);
-        assert_eq!(event["axiom_fields"].as_str(), Some(encoded));
-        assert!(event.get(rejected_field).is_none());
-    }
-
-    let scalar_event = event_with_message(&events, "scalar generic field values");
-    assert_eq!(scalar_event["enabled"].as_bool(), Some(true));
-    assert_eq!(scalar_event["attempts"].as_u64(), Some(2));
-    assert_eq!(scalar_event.get("empty"), Some(&Value::Null));
-    assert!(scalar_event.get("axiom_fields").is_none());
 }
 
 #[test]

--- a/crates/runner/src/axiom_layer/tests.rs
+++ b/crates/runner/src/axiom_layer/tests.rs
@@ -12,9 +12,10 @@ use std::thread;
 use std::time::Duration;
 
 use super::{
-    AxiomGuard, AxiomLayer, BATCH_INTERVAL, BATCH_SIZE, CHANNEL_CAP, ERROR_SOURCE_MAX_DEPTH,
-    FLUSH_DEADLINE, INTERNAL_TARGET, Msg, TEXT_FIELD_MAX_BYTES, TRUNCATION_MARKER,
-    init_from_env_values, init_with_base_url, init_with_base_url_and_hostname, with_ingest_filter,
+    ADDON_LOG_TARGET, AxiomGuard, AxiomLayer, BATCH_INTERVAL, BATCH_SIZE, CHANNEL_CAP,
+    ERROR_SOURCE_MAX_DEPTH, FLUSH_DEADLINE, INTERNAL_TARGET, Msg, TEXT_FIELD_MAX_BYTES,
+    TRUNCATION_MARKER, init_from_env_values, init_with_base_url, init_with_base_url_and_hostname,
+    with_ingest_filter,
 };
 use httpmock::Method::POST;
 use httpmock::MockServer;
@@ -347,6 +348,63 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
         !has_event_with_message(&events, "info is below threshold, should not be ingested"),
         "INFO event should not be ingested: {events:#?}",
     );
+}
+
+#[tokio::test]
+async fn addon_log_fields_are_passed_through_without_an_intermediate_field() {
+    let server = MockServer::start_async().await;
+    let (ingest, captured) = capture_axiom_ingest(&server).await;
+    let (layer, guard) = init_with_base_url_and_hostname(
+        &server.base_url(),
+        "test-token",
+        "test",
+        Some("runner-host-1".to_string()),
+    )
+    .expect("init must succeed");
+    let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
+    let addon_log = serde_json::json!({
+        "level": "error",
+        "message": "Failed to write pending count",
+        "type": "usage_underbilling",
+        "reason": "pending_snapshot_write_failed",
+        "underbilling_class": "risk",
+        "retry_count": 2,
+        "retryable": true,
+        "diagnostic": {"phase": "flush"},
+        "future.field-name": ["value", 3],
+        "context": "addon-owned-context",
+        "service": "addon-owned-service",
+        "runner_hostname": "addon-owned-host",
+        "runner_version": "addon-owned-version",
+    })
+    .to_string();
+
+    {
+        let _sub = tracing::subscriber::set_default(subscriber);
+        tracing::error!(
+            target: ADDON_LOG_TARGET,
+            message = addon_log.as_str(),
+        );
+    }
+    guard.shutdown().await;
+
+    ingest.assert_calls_async(1).await;
+    let events = captured.events();
+    let event = event_with_message(&events, "Failed to write pending count");
+    assert_eq!(event["level"], json!("error"));
+    assert_eq!(event["type"], json!("usage_underbilling"));
+    assert_eq!(event["reason"], json!("pending_snapshot_write_failed"));
+    assert_eq!(event["underbilling_class"], json!("risk"));
+    assert_eq!(event["retry_count"], json!(2));
+    assert_eq!(event["retryable"], json!(true));
+    assert_eq!(event["diagnostic"], json!({"phase": "flush"}));
+    assert_eq!(event["future.field-name"], json!(["value", 3]));
+    assert_eq!(event["context"], json!(ADDON_LOG_TARGET));
+    assert_eq!(event["service"], json!("runner"));
+    assert_eq!(event["runner_hostname"], json!("runner-host-1"));
+    assert_eq!(event["runner_version"], json!(env!("CARGO_PKG_VERSION")));
+    assert!(event.get("version").is_none());
+    assert!(event.get("addon_log").is_none());
 }
 
 #[tokio::test]

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -1090,7 +1090,7 @@ mod tests {
 
     #[tokio::test]
     async fn stderr_monitor_discards_oversized_record_and_recovers() {
-        let next_record = br#"VM0_ADDON_EVENT {"version":1,"level":"error","type":"usage_underbilling","reason":"test_failure","component":"mitm_addon","underbilling_class":"risk","detail":"failed"}"#;
+        let next_record = br#"VM0_ADDON_EVENT {"version":1,"level":"error","type":"usage_underbilling","reason":"test_failure","component":"mitm_addon","fields":{"underbilling_class":"risk"},"detail":"failed"}"#;
         let (writer, reader) = tokio::io::duplex(1024);
         let future = async {
             let (_, port_in_use) = tokio::join!(

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -155,11 +155,14 @@ async fn monitor_mitmdump_stdout<R>(stdout: R)
 where
     R: AsyncRead + Unpin,
 {
+    // The launch contract disables flow output and sets TermLog to WARN. Addon
+    // events bypass TermLog on stderr, so remaining stdout is mitmproxy-owned
+    // warning-or-higher output.
     let mut reader = tokio::io::BufReader::new(stdout);
     while let Ok(Some(record)) = read_mitmdump_log_record(&mut reader).await {
         match record {
             MitmdumpLogRecord::Line(line) if !line.is_empty() => {
-                info!(target: "mitmdump", "{line}");
+                warn!(target: "mitmdump", "{line}");
             }
             MitmdumpLogRecord::Line(_) => {}
             MitmdumpLogRecord::Oversized { observed_bytes } => {
@@ -975,6 +978,7 @@ mod tests {
     use crate::paths::HomePaths;
     use std::os::unix::fs::PermissionsExt;
     use tokio::io::AsyncWriteExt;
+    use tracing::Level;
     use tracing::instrument::WithSubscriber;
     use tracing_subscriber::prelude::*;
     use tracing_test_support::{CapturedEvent, CapturedEvents};
@@ -1080,13 +1084,13 @@ mod tests {
             4,
             "overflow event leaked record content"
         );
-        captured_event(&events, "stdout recovered");
+        let recovered = captured_event(&events, "stdout recovered");
+        assert_eq!(recovered.level, Level::WARN);
     }
 
     #[tokio::test]
     async fn stderr_monitor_discards_oversized_record_and_recovers() {
-        let next_record = b"[error] type=usage_underbilling reason=test_failure \
-                            underbilling_class=risk component=mitm_addon";
+        let next_record = br#"VM0_ADDON_EVENT {"version":1,"level":"error","type":"usage_underbilling","reason":"test_failure","component":"mitm_addon","underbilling_class":"risk","detail":"failed"}"#;
         let (writer, reader) = tokio::io::duplex(1024);
         let future = async {
             let (_, port_in_use) = tokio::join!(
@@ -1119,14 +1123,14 @@ mod tests {
             "overflow event leaked record content"
         );
 
-        let recovered = captured_event(&events, "mitmdump usage underbilling signal");
+        let recovered = captured_event(&events, "mitmdump addon process event");
         assert_eq!(
             recovered.fields.get("reason").map(String::as_str),
             Some("test_failure")
         );
         assert_eq!(
-            recovered.fields.get("mitmdump_stderr").map(String::as_str),
-            Some(std::str::from_utf8(next_record).unwrap())
+            recovered.fields.get("addon_detail").map(String::as_str),
+            Some("failed")
         );
     }
 

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -155,14 +155,14 @@ async fn monitor_mitmdump_stdout<R>(stdout: R)
 where
     R: AsyncRead + Unpin,
 {
-    // The launch contract disables flow output and sets TermLog to WARN. Addon
-    // events bypass TermLog on stderr, so remaining stdout is mitmproxy-owned
-    // warning-or-higher output.
+    // TermLog is warning-only, but its level is not preserved in the text
+    // stream. Keep native stdout in Runner-local logs; addon events that need
+    // Axiom bypass TermLog through the stderr envelope.
     let mut reader = tokio::io::BufReader::new(stdout);
     while let Ok(Some(record)) = read_mitmdump_log_record(&mut reader).await {
         match record {
             MitmdumpLogRecord::Line(line) if !line.is_empty() => {
-                warn!(target: "mitmdump", "{line}");
+                info!(target: "mitmdump", "{line}");
             }
             MitmdumpLogRecord::Line(_) => {}
             MitmdumpLogRecord::Oversized { observed_bytes } => {
@@ -1085,7 +1085,7 @@ mod tests {
             "overflow event leaked record content"
         );
         let recovered = captured_event(&events, "stdout recovered");
-        assert_eq!(recovered.level, Level::WARN);
+        assert_eq!(recovered.level, Level::INFO);
     }
 
     #[tokio::test]

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -1090,7 +1090,7 @@ mod tests {
 
     #[tokio::test]
     async fn stderr_monitor_discards_oversized_record_and_recovers() {
-        let next_record = br#"VM0_ADDON_EVENT {"version":1,"level":"error","type":"usage_underbilling","reason":"test_failure","component":"mitm_addon","fields":{"underbilling_class":"risk"},"message":"failed"}"#;
+        let next_record = br#"VM0_ADDON_EVENT {"version":1,"level":"error","message":"failed"}"#;
         let (writer, reader) = tokio::io::duplex(1024);
         let future = async {
             let (_, port_in_use) = tokio::join!(
@@ -1125,10 +1125,10 @@ mod tests {
 
         let recovered = captured_event(&events, "failed");
         assert_eq!(
-            recovered.fields.get("reason").map(String::as_str),
-            Some("test_failure")
+            recovered.fields.len(),
+            1,
+            "unexpected fields: {recovered:#?}"
         );
-        assert!(!recovered.fields.contains_key("addon_detail"));
     }
 
     fn write_fake_listening_mitmdump(path: &Path) {

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -1123,11 +1123,24 @@ mod tests {
             "overflow event leaked record content"
         );
 
-        let recovered = captured_event(&events, "failed");
+        let recovered = events
+            .iter()
+            .find(|event| event.level == Level::ERROR)
+            .unwrap_or_else(|| panic!("missing recovered addon event; events={events:#?}"));
         assert_eq!(
             recovered.fields.len(),
             1,
             "unexpected fields: {recovered:#?}"
+        );
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(
+                recovered
+                    .fields
+                    .get("message")
+                    .expect("recovered addon event should have a message"),
+            )
+            .expect("recovered addon event should contain a JSON log"),
+            serde_json::json!({"level": "error", "message": "failed"})
         );
     }
 

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -1090,7 +1090,7 @@ mod tests {
 
     #[tokio::test]
     async fn stderr_monitor_discards_oversized_record_and_recovers() {
-        let next_record = br#"VM0_ADDON_EVENT {"version":1,"level":"error","type":"usage_underbilling","reason":"test_failure","component":"mitm_addon","fields":{"underbilling_class":"risk"},"detail":"failed"}"#;
+        let next_record = br#"VM0_ADDON_EVENT {"version":1,"level":"error","type":"usage_underbilling","reason":"test_failure","component":"mitm_addon","fields":{"underbilling_class":"risk"},"message":"failed"}"#;
         let (writer, reader) = tokio::io::duplex(1024);
         let future = async {
             let (_, port_in_use) = tokio::join!(
@@ -1123,15 +1123,12 @@ mod tests {
             "overflow event leaked record content"
         );
 
-        let recovered = captured_event(&events, "mitmdump addon process event");
+        let recovered = captured_event(&events, "failed");
         assert_eq!(
             recovered.fields.get("reason").map(String::as_str),
             Some("test_failure")
         );
-        assert_eq!(
-            recovered.fields.get("addon_detail").map(String::as_str),
-            Some("failed")
-        );
+        assert!(!recovered.fields.contains_key("addon_detail"));
     }
 
     fn write_fake_listening_mitmdump(path: &Path) {

--- a/crates/runner/src/proxy/stderr.rs
+++ b/crates/runner/src/proxy/stderr.rs
@@ -26,7 +26,7 @@ struct AddonProcessEvent {
     reason: String,
     component: String,
     fields: BTreeMap<String, String>,
-    detail: String,
+    message: String,
 }
 
 fn is_event_name(value: &str) -> bool {
@@ -56,32 +56,38 @@ fn parse_addon_process_event(line: &str) -> Option<AddonProcessEvent> {
 }
 
 fn log_addon_process_event(event: AddonProcessEvent) {
+    let AddonProcessEvent {
+        level,
+        event_type,
+        reason,
+        component,
+        fields,
+        message,
+        ..
+    } = event;
     let axiom_fields = serde_json::Value::Object(
-        event
-            .fields
+        fields
             .into_iter()
             .map(|(name, value)| (name, serde_json::Value::String(value)))
             .collect(),
     )
     .to_string();
-    match event.level {
+    match level {
         AddonProcessEventLevel::Warn => warn!(
             target: "mitmdump_addon",
-            r#type = event.event_type,
-            reason = event.reason,
-            component = event.component,
+            r#type = event_type,
+            reason,
+            component,
             axiom_fields = axiom_fields.as_str(),
-            addon_detail = event.detail,
-            "mitmdump addon process event"
+            message = message.as_str(),
         ),
         AddonProcessEventLevel::Error => error!(
             target: "mitmdump_addon",
-            r#type = event.event_type,
-            reason = event.reason,
-            component = event.component,
+            r#type = event_type,
+            reason,
+            component,
             axiom_fields = axiom_fields.as_str(),
-            addon_detail = event.detail,
-            "mitmdump addon process event"
+            message = message.as_str(),
         ),
     }
 }
@@ -135,7 +141,7 @@ mod tests {
     #[test]
     fn parses_versioned_underbilling_event() {
         let event = parse_addon_process_event(
-            r#"VM0_ADDON_EVENT {"version":1,"level":"error","type":"usage_underbilling","reason":"pending_snapshot_write_failed","component":"mitm_addon","fields":{"underbilling_class":"risk","counter":"reports"},"detail":"Failed to write pending count"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"error","type":"usage_underbilling","reason":"pending_snapshot_write_failed","component":"mitm_addon","fields":{"underbilling_class":"risk","counter":"reports"},"message":"Failed to write pending count"}"#,
         )
         .unwrap();
 
@@ -151,7 +157,7 @@ mod tests {
                     ("counter".to_string(), "reports".to_string()),
                     ("underbilling_class".to_string(), "risk".to_string()),
                 ]),
-                detail: "Failed to write pending count".to_string(),
+                message: "Failed to write pending count".to_string(),
             }
         );
     }
@@ -159,14 +165,14 @@ mod tests {
     #[test]
     fn parses_process_integrity_event() {
         let event = parse_addon_process_event(
-            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"jsonl_writer_append_failed","component":"mitm_addon","fields":{},"detail":"write failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"jsonl_writer_append_failed","component":"mitm_addon","fields":{},"message":"write failed"}"#,
         )
         .unwrap();
 
         assert_eq!(event.level, AddonProcessEventLevel::Warn);
         assert_eq!(event.event_type, "addon_process_integrity");
         assert_eq!(event.reason, "jsonl_writer_append_failed");
-        assert_eq!(event.detail, "write failed");
+        assert_eq!(event.message, "write failed");
     }
 
     #[test]
@@ -174,11 +180,11 @@ mod tests {
         for line in [
             "ordinary mitmdump warning",
             r#"prefix VM0_ADDON_EVENT {"version":1}"#,
-            r#"VM0_ADDON_EVENT {"version":2,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"mitm_addon","fields":{},"detail":"failed"}"#,
-            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"other","fields":{},"detail":"failed"}"#,
-            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"bad type","reason":"test_failure","component":"mitm_addon","fields":{},"detail":"failed"}"#,
-            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"mitm_addon","fields":{"bad field":"value"},"detail":"failed"}"#,
-            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"mitm_addon","fields":{},"extra":"unexpected","detail":"failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":2,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"mitm_addon","fields":{},"message":"failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"other","fields":{},"message":"failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"bad type","reason":"test_failure","component":"mitm_addon","fields":{},"message":"failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"mitm_addon","fields":{"bad field":"value"},"message":"failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"mitm_addon","fields":{},"extra":"unexpected","message":"failed"}"#,
         ] {
             assert!(
                 parse_addon_process_event(line).is_none(),
@@ -190,15 +196,15 @@ mod tests {
     #[test]
     fn reemits_underbilling_as_structured_error() {
         let event = capture_mitmdump_stderr_log(
-            r#"VM0_ADDON_EVENT {"version":1,"level":"error","type":"usage_underbilling","reason":"pending_snapshot_write_failed","component":"mitm_addon","fields":{"underbilling_class":"risk"},"detail":"Failed to write pending count"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"error","type":"usage_underbilling","reason":"pending_snapshot_write_failed","component":"mitm_addon","fields":{"underbilling_class":"risk"},"message":"Failed to write pending count"}"#,
         );
 
         assert_eq!(event.level, Level::ERROR);
-        assert_event_field(&event, "message", "mitmdump addon process event");
+        assert_event_field(&event, "message", "Failed to write pending count");
         assert_event_field(&event, "type", "usage_underbilling");
         assert_event_field(&event, "reason", "pending_snapshot_write_failed");
         assert_event_field(&event, "component", "mitm_addon");
-        assert_event_field(&event, "addon_detail", "Failed to write pending count");
+        assert!(!event.fields.contains_key("addon_detail"));
         assert_axiom_fields(
             &event,
             BTreeMap::from([("underbilling_class".to_string(), "risk".to_string())]),
@@ -208,14 +214,15 @@ mod tests {
     #[test]
     fn reemits_process_integrity_as_structured_warn() {
         let event = capture_mitmdump_stderr_log(
-            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"jsonl_writer_append_failed","component":"mitm_addon","fields":{},"detail":"write failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"jsonl_writer_append_failed","component":"mitm_addon","fields":{},"message":"write failed"}"#,
         );
 
         assert_eq!(event.level, Level::WARN);
         assert_event_field(&event, "type", "addon_process_integrity");
         assert_event_field(&event, "reason", "jsonl_writer_append_failed");
         assert_event_field(&event, "component", "mitm_addon");
-        assert_event_field(&event, "addon_detail", "write failed");
+        assert_event_field(&event, "message", "write failed");
+        assert!(!event.fields.contains_key("addon_detail"));
         assert_axiom_fields(&event, BTreeMap::new());
     }
 

--- a/crates/runner/src/proxy/stderr.rs
+++ b/crates/runner/src/proxy/stderr.rs
@@ -1,10 +1,13 @@
 //! Addon process-event parsing and mitmdump stderr re-emission.
 
 use serde::Deserialize;
+use std::collections::BTreeMap;
 use tracing::{error, warn};
 
 const ADDON_PROCESS_EVENT_PREFIX: &str = "VM0_ADDON_EVENT ";
 const ADDON_PROCESS_EVENT_VERSION: u8 = 1;
+const MAX_ADDON_PROCESS_EVENT_FIELDS: usize = 16;
+const MAX_ADDON_PROCESS_EVENT_FIELD_VALUE_CHARS: usize = 256;
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
@@ -22,11 +25,15 @@ struct AddonProcessEvent {
     event_type: String,
     reason: String,
     component: String,
-    #[serde(default)]
-    underbilling_class: Option<String>,
-    #[serde(default)]
-    counter: Option<String>,
+    fields: BTreeMap<String, String>,
     detail: String,
+}
+
+fn is_event_name(value: &str) -> bool {
+    let mut bytes = value.bytes();
+    matches!(bytes.next(), Some(b'a'..=b'z'))
+        && value.len() <= 80
+        && bytes.all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
 }
 
 fn parse_addon_process_event(line: &str) -> Option<AddonProcessEvent> {
@@ -34,20 +41,14 @@ fn parse_addon_process_event(line: &str) -> Option<AddonProcessEvent> {
     let event: AddonProcessEvent = serde_json::from_str(payload).ok()?;
     if event.version != ADDON_PROCESS_EVENT_VERSION
         || event.component != "mitm_addon"
-        || event.event_type.is_empty()
-        || event.reason.is_empty()
+        || !is_event_name(&event.event_type)
+        || !is_event_name(&event.reason)
+        || event.fields.len() > MAX_ADDON_PROCESS_EVENT_FIELDS
+        || event.fields.iter().any(|(name, value)| {
+            !is_event_name(name)
+                || value.chars().count() > MAX_ADDON_PROCESS_EVENT_FIELD_VALUE_CHARS
+        })
     {
-        return None;
-    }
-
-    if event.event_type == "usage_underbilling" {
-        if !matches!(
-            event.underbilling_class.as_deref(),
-            Some("confirmed" | "risk")
-        ) {
-            return None;
-        }
-    } else if event.underbilling_class.is_some() || event.counter.is_some() {
         return None;
     }
 
@@ -55,14 +56,21 @@ fn parse_addon_process_event(line: &str) -> Option<AddonProcessEvent> {
 }
 
 fn log_addon_process_event(event: AddonProcessEvent) {
+    let axiom_fields = serde_json::Value::Object(
+        event
+            .fields
+            .into_iter()
+            .map(|(name, value)| (name, serde_json::Value::String(value)))
+            .collect(),
+    )
+    .to_string();
     match event.level {
         AddonProcessEventLevel::Warn => warn!(
             target: "mitmdump_addon",
             r#type = event.event_type,
             reason = event.reason,
             component = event.component,
-            underbilling_class = event.underbilling_class,
-            counter = event.counter,
+            axiom_fields = axiom_fields.as_str(),
             addon_detail = event.detail,
             "mitmdump addon process event"
         ),
@@ -71,8 +79,7 @@ fn log_addon_process_event(event: AddonProcessEvent) {
             r#type = event.event_type,
             reason = event.reason,
             component = event.component,
-            underbilling_class = event.underbilling_class,
-            counter = event.counter,
+            axiom_fields = axiom_fields.as_str(),
             addon_detail = event.detail,
             "mitmdump addon process event"
         ),
@@ -115,10 +122,20 @@ mod tests {
         assert_eq!(actual, expected, "field {field} mismatch; event={event:#?}");
     }
 
+    fn assert_axiom_fields(event: &CapturedEvent, expected: BTreeMap<String, String>) {
+        let encoded = event
+            .fields
+            .get("axiom_fields")
+            .unwrap_or_else(|| panic!("missing axiom_fields; event={event:#?}"));
+        let actual: BTreeMap<String, String> =
+            serde_json::from_str(encoded).expect("axiom_fields should be valid JSON");
+        assert_eq!(actual, expected);
+    }
+
     #[test]
     fn parses_versioned_underbilling_event() {
         let event = parse_addon_process_event(
-            r#"VM0_ADDON_EVENT {"version":1,"level":"error","type":"usage_underbilling","reason":"pending_snapshot_write_failed","component":"mitm_addon","underbilling_class":"risk","counter":"reports","detail":"Failed to write pending count"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"error","type":"usage_underbilling","reason":"pending_snapshot_write_failed","component":"mitm_addon","fields":{"underbilling_class":"risk","counter":"reports"},"detail":"Failed to write pending count"}"#,
         )
         .unwrap();
 
@@ -130,8 +147,10 @@ mod tests {
                 event_type: "usage_underbilling".to_string(),
                 reason: "pending_snapshot_write_failed".to_string(),
                 component: "mitm_addon".to_string(),
-                underbilling_class: Some("risk".to_string()),
-                counter: Some("reports".to_string()),
+                fields: BTreeMap::from([
+                    ("counter".to_string(), "reports".to_string()),
+                    ("underbilling_class".to_string(), "risk".to_string()),
+                ]),
                 detail: "Failed to write pending count".to_string(),
             }
         );
@@ -140,7 +159,7 @@ mod tests {
     #[test]
     fn parses_process_integrity_event() {
         let event = parse_addon_process_event(
-            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"jsonl_writer_append_failed","component":"mitm_addon","detail":"write failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"jsonl_writer_append_failed","component":"mitm_addon","fields":{},"detail":"write failed"}"#,
         )
         .unwrap();
 
@@ -155,10 +174,11 @@ mod tests {
         for line in [
             "ordinary mitmdump warning",
             r#"prefix VM0_ADDON_EVENT {"version":1}"#,
-            r#"VM0_ADDON_EVENT {"version":2,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"mitm_addon","detail":"failed"}"#,
-            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"other","detail":"failed"}"#,
-            r#"VM0_ADDON_EVENT {"version":1,"level":"error","type":"usage_underbilling","reason":"test_failure","component":"mitm_addon","detail":"failed"}"#,
-            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"mitm_addon","extra":"unexpected","detail":"failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":2,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"mitm_addon","fields":{},"detail":"failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"other","fields":{},"detail":"failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"bad type","reason":"test_failure","component":"mitm_addon","fields":{},"detail":"failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"mitm_addon","fields":{"bad field":"value"},"detail":"failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"mitm_addon","fields":{},"extra":"unexpected","detail":"failed"}"#,
         ] {
             assert!(
                 parse_addon_process_event(line).is_none(),
@@ -170,23 +190,25 @@ mod tests {
     #[test]
     fn reemits_underbilling_as_structured_error() {
         let event = capture_mitmdump_stderr_log(
-            r#"VM0_ADDON_EVENT {"version":1,"level":"error","type":"usage_underbilling","reason":"pending_snapshot_write_failed","component":"mitm_addon","underbilling_class":"risk","detail":"Failed to write pending count"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"error","type":"usage_underbilling","reason":"pending_snapshot_write_failed","component":"mitm_addon","fields":{"underbilling_class":"risk"},"detail":"Failed to write pending count"}"#,
         );
 
         assert_eq!(event.level, Level::ERROR);
         assert_event_field(&event, "message", "mitmdump addon process event");
         assert_event_field(&event, "type", "usage_underbilling");
         assert_event_field(&event, "reason", "pending_snapshot_write_failed");
-        assert_event_field(&event, "underbilling_class", "risk");
         assert_event_field(&event, "component", "mitm_addon");
         assert_event_field(&event, "addon_detail", "Failed to write pending count");
-        assert!(!event.fields.contains_key("counter"));
+        assert_axiom_fields(
+            &event,
+            BTreeMap::from([("underbilling_class".to_string(), "risk".to_string())]),
+        );
     }
 
     #[test]
     fn reemits_process_integrity_as_structured_warn() {
         let event = capture_mitmdump_stderr_log(
-            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"jsonl_writer_append_failed","component":"mitm_addon","detail":"write failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"jsonl_writer_append_failed","component":"mitm_addon","fields":{},"detail":"write failed"}"#,
         );
 
         assert_eq!(event.level, Level::WARN);
@@ -194,8 +216,7 @@ mod tests {
         assert_event_field(&event, "reason", "jsonl_writer_append_failed");
         assert_event_field(&event, "component", "mitm_addon");
         assert_event_field(&event, "addon_detail", "write failed");
-        assert!(!event.fields.contains_key("underbilling_class"));
-        assert!(!event.fields.contains_key("counter"));
+        assert_axiom_fields(&event, BTreeMap::new());
     }
 
     #[test]

--- a/crates/runner/src/proxy/stderr.rs
+++ b/crates/runner/src/proxy/stderr.rs
@@ -1,13 +1,10 @@
 //! Addon process-event parsing and mitmdump stderr re-emission.
 
 use serde::Deserialize;
-use std::collections::BTreeMap;
 use tracing::{error, warn};
 
 const ADDON_PROCESS_EVENT_PREFIX: &str = "VM0_ADDON_EVENT ";
 const ADDON_PROCESS_EVENT_VERSION: u8 = 1;
-const MAX_ADDON_PROCESS_EVENT_FIELDS: usize = 16;
-const MAX_ADDON_PROCESS_EVENT_FIELD_VALUE_CHARS: usize = 256;
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
@@ -21,34 +18,13 @@ enum AddonProcessEventLevel {
 struct AddonProcessEvent {
     version: u8,
     level: AddonProcessEventLevel,
-    #[serde(rename = "type")]
-    event_type: String,
-    reason: String,
-    component: String,
-    fields: BTreeMap<String, String>,
     message: String,
-}
-
-fn is_event_name(value: &str) -> bool {
-    let mut bytes = value.bytes();
-    matches!(bytes.next(), Some(b'a'..=b'z'))
-        && value.len() <= 80
-        && bytes.all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
 }
 
 fn parse_addon_process_event(line: &str) -> Option<AddonProcessEvent> {
     let payload = line.strip_prefix(ADDON_PROCESS_EVENT_PREFIX)?;
     let event: AddonProcessEvent = serde_json::from_str(payload).ok()?;
-    if event.version != ADDON_PROCESS_EVENT_VERSION
-        || event.component != "mitm_addon"
-        || !is_event_name(&event.event_type)
-        || !is_event_name(&event.reason)
-        || event.fields.len() > MAX_ADDON_PROCESS_EVENT_FIELDS
-        || event.fields.iter().any(|(name, value)| {
-            !is_event_name(name)
-                || value.chars().count() > MAX_ADDON_PROCESS_EVENT_FIELD_VALUE_CHARS
-        })
-    {
+    if event.version != ADDON_PROCESS_EVENT_VERSION {
         return None;
     }
 
@@ -56,38 +32,14 @@ fn parse_addon_process_event(line: &str) -> Option<AddonProcessEvent> {
 }
 
 fn log_addon_process_event(event: AddonProcessEvent) {
-    let AddonProcessEvent {
-        level,
-        event_type,
-        reason,
-        component,
-        fields,
-        message,
-        ..
-    } = event;
-    let axiom_fields = serde_json::Value::Object(
-        fields
-            .into_iter()
-            .map(|(name, value)| (name, serde_json::Value::String(value)))
-            .collect(),
-    )
-    .to_string();
-    match level {
+    match event.level {
         AddonProcessEventLevel::Warn => warn!(
             target: "mitmdump_addon",
-            r#type = event_type,
-            reason,
-            component,
-            axiom_fields = axiom_fields.as_str(),
-            message = message.as_str(),
+            message = event.message.as_str(),
         ),
         AddonProcessEventLevel::Error => error!(
             target: "mitmdump_addon",
-            r#type = event_type,
-            reason,
-            component,
-            axiom_fields = axiom_fields.as_str(),
-            message = message.as_str(),
+            message = event.message.as_str(),
         ),
     }
 }
@@ -128,20 +80,10 @@ mod tests {
         assert_eq!(actual, expected, "field {field} mismatch; event={event:#?}");
     }
 
-    fn assert_axiom_fields(event: &CapturedEvent, expected: BTreeMap<String, String>) {
-        let encoded = event
-            .fields
-            .get("axiom_fields")
-            .unwrap_or_else(|| panic!("missing axiom_fields; event={event:#?}"));
-        let actual: BTreeMap<String, String> =
-            serde_json::from_str(encoded).expect("axiom_fields should be valid JSON");
-        assert_eq!(actual, expected);
-    }
-
     #[test]
-    fn parses_versioned_underbilling_event() {
+    fn parses_versioned_error_event() {
         let event = parse_addon_process_event(
-            r#"VM0_ADDON_EVENT {"version":1,"level":"error","type":"usage_underbilling","reason":"pending_snapshot_write_failed","component":"mitm_addon","fields":{"underbilling_class":"risk","counter":"reports"},"message":"Failed to write pending count"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"error","message":"Failed to write pending count"}"#,
         )
         .unwrap();
 
@@ -150,28 +92,19 @@ mod tests {
             AddonProcessEvent {
                 version: 1,
                 level: AddonProcessEventLevel::Error,
-                event_type: "usage_underbilling".to_string(),
-                reason: "pending_snapshot_write_failed".to_string(),
-                component: "mitm_addon".to_string(),
-                fields: BTreeMap::from([
-                    ("counter".to_string(), "reports".to_string()),
-                    ("underbilling_class".to_string(), "risk".to_string()),
-                ]),
                 message: "Failed to write pending count".to_string(),
             }
         );
     }
 
     #[test]
-    fn parses_process_integrity_event() {
+    fn parses_versioned_warn_event() {
         let event = parse_addon_process_event(
-            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"jsonl_writer_append_failed","component":"mitm_addon","fields":{},"message":"write failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","message":"write failed"}"#,
         )
         .unwrap();
 
         assert_eq!(event.level, AddonProcessEventLevel::Warn);
-        assert_eq!(event.event_type, "addon_process_integrity");
-        assert_eq!(event.reason, "jsonl_writer_append_failed");
         assert_eq!(event.message, "write failed");
     }
 
@@ -180,11 +113,10 @@ mod tests {
         for line in [
             "ordinary mitmdump warning",
             r#"prefix VM0_ADDON_EVENT {"version":1}"#,
-            r#"VM0_ADDON_EVENT {"version":2,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"mitm_addon","fields":{},"message":"failed"}"#,
-            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"other","fields":{},"message":"failed"}"#,
-            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"bad type","reason":"test_failure","component":"mitm_addon","fields":{},"message":"failed"}"#,
-            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"mitm_addon","fields":{"bad field":"value"},"message":"failed"}"#,
-            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"mitm_addon","fields":{},"extra":"unexpected","message":"failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":2,"level":"warn","message":"failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"info","message":"failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","message":"failed","extra":"unexpected"}"#,
         ] {
             assert!(
                 parse_addon_process_event(line).is_none(),
@@ -194,36 +126,27 @@ mod tests {
     }
 
     #[test]
-    fn reemits_underbilling_as_structured_error() {
-        let event = capture_mitmdump_stderr_log(
-            r#"VM0_ADDON_EVENT {"version":1,"level":"error","type":"usage_underbilling","reason":"pending_snapshot_write_failed","component":"mitm_addon","fields":{"underbilling_class":"risk"},"message":"Failed to write pending count"}"#,
-        );
+    fn reemits_addon_error_without_adding_fields() {
+        let message = "type=usage_underbilling reason=pending_snapshot_write_failed \
+                       underbilling_class=risk component=mitm_addon Failed to write pending count";
+        let event = capture_mitmdump_stderr_log(&format!(
+            r#"VM0_ADDON_EVENT {{"version":1,"level":"error","message":"{message}"}}"#
+        ));
 
         assert_eq!(event.level, Level::ERROR);
-        assert_event_field(&event, "message", "Failed to write pending count");
-        assert_event_field(&event, "type", "usage_underbilling");
-        assert_event_field(&event, "reason", "pending_snapshot_write_failed");
-        assert_event_field(&event, "component", "mitm_addon");
-        assert!(!event.fields.contains_key("addon_detail"));
-        assert_axiom_fields(
-            &event,
-            BTreeMap::from([("underbilling_class".to_string(), "risk".to_string())]),
-        );
+        assert_event_field(&event, "message", message);
+        assert_eq!(event.fields.len(), 1, "unexpected fields: {event:#?}");
     }
 
     #[test]
-    fn reemits_process_integrity_as_structured_warn() {
+    fn reemits_addon_warning_without_adding_fields() {
         let event = capture_mitmdump_stderr_log(
-            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"jsonl_writer_append_failed","component":"mitm_addon","fields":{},"message":"write failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","message":"write failed"}"#,
         );
 
         assert_eq!(event.level, Level::WARN);
-        assert_event_field(&event, "type", "addon_process_integrity");
-        assert_event_field(&event, "reason", "jsonl_writer_append_failed");
-        assert_event_field(&event, "component", "mitm_addon");
         assert_event_field(&event, "message", "write failed");
-        assert!(!event.fields.contains_key("addon_detail"));
-        assert_axiom_fields(&event, BTreeMap::new());
+        assert_eq!(event.fields.len(), 1, "unexpected fields: {event:#?}");
     }
 
     #[test]

--- a/crates/runner/src/proxy/stderr.rs
+++ b/crates/runner/src/proxy/stderr.rs
@@ -1,45 +1,54 @@
 //! Addon process-event parsing and mitmdump stderr re-emission.
 
-use serde::Deserialize;
+use serde_json::{Map, Value};
 use tracing::{error, warn};
 
 const ADDON_PROCESS_EVENT_PREFIX: &str = "VM0_ADDON_EVENT ";
 const ADDON_PROCESS_EVENT_VERSION: u8 = 1;
+const MAX_ADDON_PROCESS_EVENT_BYTES: usize = 4096;
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
+#[derive(Debug, PartialEq, Eq)]
 enum AddonProcessEventLevel {
     Warn,
     Error,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, PartialEq, Eq)]
 struct AddonProcessEvent {
-    version: u8,
     level: AddonProcessEventLevel,
-    message: String,
+    fields: Map<String, Value>,
 }
 
 fn parse_addon_process_event(line: &str) -> Option<AddonProcessEvent> {
+    if line.len() > MAX_ADDON_PROCESS_EVENT_BYTES {
+        return None;
+    }
     let payload = line.strip_prefix(ADDON_PROCESS_EVENT_PREFIX)?;
-    let event: AddonProcessEvent = serde_json::from_str(payload).ok()?;
-    if event.version != ADDON_PROCESS_EVENT_VERSION {
+    let mut fields = serde_json::from_str::<Map<String, Value>>(payload).ok()?;
+    let version = fields.remove("version")?.as_u64()?;
+    if version != u64::from(ADDON_PROCESS_EVENT_VERSION) {
         return None;
     }
 
-    Some(event)
+    let level = match fields.get("level")?.as_str()? {
+        "warn" => AddonProcessEventLevel::Warn,
+        "error" => AddonProcessEventLevel::Error,
+        _ => return None,
+    };
+    fields.get("message")?.as_str()?;
+    Some(AddonProcessEvent { level, fields })
 }
 
 fn log_addon_process_event(event: AddonProcessEvent) {
+    let encoded = Value::Object(event.fields).to_string();
     match event.level {
         AddonProcessEventLevel::Warn => warn!(
             target: "mitmdump_addon",
-            message = event.message.as_str(),
+            message = encoded.as_str(),
         ),
         AddonProcessEventLevel::Error => error!(
             target: "mitmdump_addon",
-            message = event.message.as_str(),
+            message = encoded.as_str(),
         ),
     }
 }
@@ -80,20 +89,35 @@ mod tests {
         assert_eq!(actual, expected, "field {field} mismatch; event={event:#?}");
     }
 
+    fn emitted_log(event: &CapturedEvent) -> Value {
+        let encoded = event
+            .fields
+            .get("message")
+            .unwrap_or_else(|| panic!("missing message; event={event:#?}"));
+        serde_json::from_str(encoded).expect("emitted log should be valid JSON")
+    }
+
     #[test]
     fn parses_versioned_error_event() {
         let event = parse_addon_process_event(
-            r#"VM0_ADDON_EVENT {"version":1,"level":"error","message":"Failed to write pending count"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"error","message":"Failed to write pending count","type":"usage_underbilling","reason":"pending_snapshot_write_failed","underbilling_class":"risk","retry_count":2,"retryable":true,"diagnostic":{"phase":"flush"},"future.field-name":["value",3]}"#,
         )
         .unwrap();
 
+        assert_eq!(event.level, AddonProcessEventLevel::Error);
         assert_eq!(
-            event,
-            AddonProcessEvent {
-                version: 1,
-                level: AddonProcessEventLevel::Error,
-                message: "Failed to write pending count".to_string(),
-            }
+            Value::Object(event.fields),
+            serde_json::json!({
+                "level": "error",
+                "message": "Failed to write pending count",
+                "type": "usage_underbilling",
+                "reason": "pending_snapshot_write_failed",
+                "underbilling_class": "risk",
+                "retry_count": 2,
+                "retryable": true,
+                "diagnostic": {"phase": "flush"},
+                "future.field-name": ["value", 3],
+            })
         );
     }
 
@@ -105,7 +129,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(event.level, AddonProcessEventLevel::Warn);
-        assert_eq!(event.message, "write failed");
+        assert_eq!(event.fields["message"], serde_json::json!("write failed"));
     }
 
     #[test]
@@ -116,7 +140,11 @@ mod tests {
             r#"VM0_ADDON_EVENT {"version":2,"level":"warn","message":"failed"}"#,
             r#"VM0_ADDON_EVENT {"version":1,"level":"info","message":"failed"}"#,
             r#"VM0_ADDON_EVENT {"version":1,"level":"warn"}"#,
-            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","message":"failed","extra":"unexpected"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","message":42}"#,
+            &format!(
+                "VM0_ADDON_EVENT {{\"version\":1,\"level\":\"warn\",\"message\":\"{}\"}}",
+                "x".repeat(MAX_ADDON_PROCESS_EVENT_BYTES)
+            ),
         ] {
             assert!(
                 parse_addon_process_event(line).is_none(),
@@ -126,26 +154,41 @@ mod tests {
     }
 
     #[test]
-    fn reemits_addon_error_without_adding_fields() {
-        let message = "type=usage_underbilling reason=pending_snapshot_write_failed \
-                       underbilling_class=risk component=mitm_addon Failed to write pending count";
-        let event = capture_mitmdump_stderr_log(&format!(
-            r#"VM0_ADDON_EVENT {{"version":1,"level":"error","message":"{message}"}}"#
-        ));
+    fn reemits_addon_error_with_opaque_log_record() {
+        let message = "Failed to write pending count";
+        let event = capture_mitmdump_stderr_log(
+            r#"VM0_ADDON_EVENT {"version":1,"level":"error","message":"Failed to write pending count","type":"usage_underbilling","reason":"pending_snapshot_write_failed","underbilling_class":"risk","retry_count":2,"retryable":true,"diagnostic":{"phase":"flush"},"future.field-name":["value",3]}"#,
+        );
 
         assert_eq!(event.level, Level::ERROR);
-        assert_event_field(&event, "message", message);
+        assert_eq!(
+            emitted_log(&event),
+            serde_json::json!({
+                "level": "error",
+                "message": message,
+                "type": "usage_underbilling",
+                "reason": "pending_snapshot_write_failed",
+                "underbilling_class": "risk",
+                "retry_count": 2,
+                "retryable": true,
+                "diagnostic": {"phase": "flush"},
+                "future.field-name": ["value", 3],
+            })
+        );
         assert_eq!(event.fields.len(), 1, "unexpected fields: {event:#?}");
     }
 
     #[test]
-    fn reemits_addon_warning_without_adding_fields() {
+    fn reemits_addon_warning_with_opaque_log_record() {
         let event = capture_mitmdump_stderr_log(
             r#"VM0_ADDON_EVENT {"version":1,"level":"warn","message":"write failed"}"#,
         );
 
         assert_eq!(event.level, Level::WARN);
-        assert_event_field(&event, "message", "write failed");
+        assert_eq!(
+            emitted_log(&event),
+            serde_json::json!({"level": "warn", "message": "write failed"})
+        );
         assert_eq!(event.fields.len(), 1, "unexpected fields: {event:#?}");
     }
 

--- a/crates/runner/src/proxy/stderr.rs
+++ b/crates/runner/src/proxy/stderr.rs
@@ -1,102 +1,87 @@
-//! Mitmdump stderr parsing and re-emission.
+//! Addon process-event parsing and mitmdump stderr re-emission.
 
+use serde::Deserialize;
 use tracing::{error, warn};
 
-#[derive(Debug, PartialEq, Eq)]
-struct MitmdumpUsageUnderbillingStderr<'a> {
-    reason: &'a str,
-    underbilling_class: &'a str,
-    component: &'a str,
-    counter: Option<&'a str>,
+const ADDON_PROCESS_EVENT_PREFIX: &str = "VM0_ADDON_EVENT ";
+const ADDON_PROCESS_EVENT_VERSION: u8 = 1;
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum AddonProcessEventLevel {
+    Warn,
+    Error,
 }
 
-fn mitmdump_underbilling_fields(line: &str) -> Option<&str> {
-    let mut rest = line.trim_start();
-
-    while let Some(after_open) = rest.strip_prefix('[') {
-        let Some(end) = after_open.find(']') else {
-            break;
-        };
-        rest = after_open[end + 1..].trim_start();
-    }
-
-    for prefix in ["Addon error:", "error:", "ERROR:"] {
-        if let Some(after_prefix) = rest.strip_prefix(prefix) {
-            rest = after_prefix.trim_start();
-            break;
-        }
-    }
-
-    if rest.starts_with("type=") {
-        Some(rest)
-    } else {
-        None
-    }
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct AddonProcessEvent {
+    version: u8,
+    level: AddonProcessEventLevel,
+    #[serde(rename = "type")]
+    event_type: String,
+    reason: String,
+    component: String,
+    #[serde(default)]
+    underbilling_class: Option<String>,
+    #[serde(default)]
+    counter: Option<String>,
+    detail: String,
 }
 
-fn parse_mitmdump_usage_underbilling_stderr(
-    line: &str,
-) -> Option<MitmdumpUsageUnderbillingStderr<'_>> {
-    let fields = mitmdump_underbilling_fields(line)?;
-    let mut tokens = fields.split_whitespace();
-    let (key, value) = tokens.next()?.split_once('=')?;
-    if key != "type" || value.trim_end_matches([',', ';']) != "usage_underbilling" {
+fn parse_addon_process_event(line: &str) -> Option<AddonProcessEvent> {
+    let payload = line.strip_prefix(ADDON_PROCESS_EVENT_PREFIX)?;
+    let event: AddonProcessEvent = serde_json::from_str(payload).ok()?;
+    if event.version != ADDON_PROCESS_EVENT_VERSION
+        || event.component != "mitm_addon"
+        || event.event_type.is_empty()
+        || event.reason.is_empty()
+    {
         return None;
     }
 
-    let mut reason = None;
-    let mut underbilling_class = None;
-    let mut component = None;
-    let mut counter = None;
-
-    for token in tokens {
-        let Some((key, value)) = token.split_once('=') else {
-            break;
-        };
-        let value = value.trim_end_matches([',', ';']);
-        match key {
-            "reason" => reason = Some(value),
-            "underbilling_class" if value == "confirmed" || value == "risk" => {
-                underbilling_class = Some(value);
-            }
-            "component" if !value.is_empty() => component = Some(value),
-            "counter" if !value.is_empty() => counter = Some(value),
-            _ => {}
+    if event.event_type == "usage_underbilling" {
+        if !matches!(
+            event.underbilling_class.as_deref(),
+            Some("confirmed" | "risk")
+        ) {
+            return None;
         }
+    } else if event.underbilling_class.is_some() || event.counter.is_some() {
+        return None;
     }
 
-    Some(MitmdumpUsageUnderbillingStderr {
-        reason: reason?,
-        underbilling_class: underbilling_class?,
-        component: component?,
-        counter,
-    })
+    Some(event)
+}
+
+fn log_addon_process_event(event: AddonProcessEvent) {
+    match event.level {
+        AddonProcessEventLevel::Warn => warn!(
+            target: "mitmdump_addon",
+            r#type = event.event_type,
+            reason = event.reason,
+            component = event.component,
+            underbilling_class = event.underbilling_class,
+            counter = event.counter,
+            addon_detail = event.detail,
+            "mitmdump addon process event"
+        ),
+        AddonProcessEventLevel::Error => error!(
+            target: "mitmdump_addon",
+            r#type = event.event_type,
+            reason = event.reason,
+            component = event.component,
+            underbilling_class = event.underbilling_class,
+            counter = event.counter,
+            addon_detail = event.detail,
+            "mitmdump addon process event"
+        ),
+    }
 }
 
 pub(super) fn log_mitmdump_stderr_line(line: &str) {
-    if let Some(signal) = parse_mitmdump_usage_underbilling_stderr(line) {
-        if let Some(counter) = signal.counter {
-            error!(
-                target: "mitmdump",
-                r#type = "usage_underbilling",
-                reason = signal.reason,
-                underbilling_class = signal.underbilling_class,
-                component = signal.component,
-                counter = counter,
-                mitmdump_stderr = %line,
-                "mitmdump usage underbilling signal"
-            );
-        } else {
-            error!(
-                target: "mitmdump",
-                r#type = "usage_underbilling",
-                reason = signal.reason,
-                underbilling_class = signal.underbilling_class,
-                component = signal.component,
-                mitmdump_stderr = %line,
-                "mitmdump usage underbilling signal"
-            );
-        }
+    if let Some(event) = parse_addon_process_event(line) {
+        log_addon_process_event(event);
         return;
     }
 
@@ -131,143 +116,95 @@ mod tests {
     }
 
     #[test]
-    fn parse_mitmdump_usage_underbilling_stderr_extracts_fields() {
-        let signal = parse_mitmdump_usage_underbilling_stderr(
-            "[error] type=usage_underbilling reason=pending_snapshot_write_failed \
-             underbilling_class=risk component=mitm_addon Failed to write pending count",
+    fn parses_versioned_underbilling_event() {
+        let event = parse_addon_process_event(
+            r#"VM0_ADDON_EVENT {"version":1,"level":"error","type":"usage_underbilling","reason":"pending_snapshot_write_failed","component":"mitm_addon","underbilling_class":"risk","counter":"reports","detail":"Failed to write pending count"}"#,
         )
         .unwrap();
 
         assert_eq!(
-            signal,
-            MitmdumpUsageUnderbillingStderr {
-                reason: "pending_snapshot_write_failed",
-                underbilling_class: "risk",
-                component: "mitm_addon",
-                counter: None,
+            event,
+            AddonProcessEvent {
+                version: 1,
+                level: AddonProcessEventLevel::Error,
+                event_type: "usage_underbilling".to_string(),
+                reason: "pending_snapshot_write_failed".to_string(),
+                component: "mitm_addon".to_string(),
+                underbilling_class: Some("risk".to_string()),
+                counter: Some("reports".to_string()),
+                detail: "Failed to write pending count".to_string(),
             }
         );
     }
 
     #[test]
-    fn parse_mitmdump_usage_underbilling_stderr_extracts_counter() {
-        let signal = parse_mitmdump_usage_underbilling_stderr(
-            "[error] type=usage_underbilling reason=usage_pending_counter_underflow \
-             underbilling_class=risk component=mitm_addon counter=reports unmatched release",
+    fn parses_process_integrity_event() {
+        let event = parse_addon_process_event(
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"jsonl_writer_append_failed","component":"mitm_addon","detail":"write failed"}"#,
         )
         .unwrap();
 
-        assert_eq!(
-            signal,
-            MitmdumpUsageUnderbillingStderr {
-                reason: "usage_pending_counter_underflow",
-                underbilling_class: "risk",
-                component: "mitm_addon",
-                counter: Some("reports"),
-            }
-        );
+        assert_eq!(event.level, AddonProcessEventLevel::Warn);
+        assert_eq!(event.event_type, "addon_process_integrity");
+        assert_eq!(event.reason, "jsonl_writer_append_failed");
+        assert_eq!(event.detail, "write failed");
     }
 
     #[test]
-    fn parse_mitmdump_usage_underbilling_stderr_allows_timestamped_error_prefix() {
-        let signal = parse_mitmdump_usage_underbilling_stderr(
-            "[12:34:56.789] [error] type=usage_underbilling \
-             reason=pending_snapshot_write_failed underbilling_class=risk \
-             component=mitm_addon Failed to write pending count",
-        )
-        .unwrap();
-
-        assert_eq!(
-            signal,
-            MitmdumpUsageUnderbillingStderr {
-                reason: "pending_snapshot_write_failed",
-                underbilling_class: "risk",
-                component: "mitm_addon",
-                counter: None,
-            }
-        );
+    fn rejects_unowned_or_invalid_envelopes() {
+        for line in [
+            "ordinary mitmdump warning",
+            r#"prefix VM0_ADDON_EVENT {"version":1}"#,
+            r#"VM0_ADDON_EVENT {"version":2,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"mitm_addon","detail":"failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"other","detail":"failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"error","type":"usage_underbilling","reason":"test_failure","component":"mitm_addon","detail":"failed"}"#,
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"test_failure","component":"mitm_addon","extra":"unexpected","detail":"failed"}"#,
+        ] {
+            assert!(
+                parse_addon_process_event(line).is_none(),
+                "unexpectedly parsed: {line}"
+            );
+        }
     }
 
     #[test]
-    fn parse_mitmdump_usage_underbilling_stderr_allows_mitmproxy_timestamp_prefix() {
-        let signal = parse_mitmdump_usage_underbilling_stderr(
-            "[12:34:56.789] type=usage_underbilling \
-             reason=pending_snapshot_write_failed underbilling_class=risk \
-             component=mitm_addon Failed to write pending count",
-        )
-        .unwrap();
-
-        assert_eq!(
-            signal,
-            MitmdumpUsageUnderbillingStderr {
-                reason: "pending_snapshot_write_failed",
-                underbilling_class: "risk",
-                component: "mitm_addon",
-                counter: None,
-            }
+    fn reemits_underbilling_as_structured_error() {
+        let event = capture_mitmdump_stderr_log(
+            r#"VM0_ADDON_EVENT {"version":1,"level":"error","type":"usage_underbilling","reason":"pending_snapshot_write_failed","component":"mitm_addon","underbilling_class":"risk","detail":"Failed to write pending count"}"#,
         );
-    }
-
-    #[test]
-    fn parse_mitmdump_usage_underbilling_stderr_ignores_regular_stderr() {
-        assert!(parse_mitmdump_usage_underbilling_stderr("ordinary mitmdump warning").is_none());
-        assert!(
-            parse_mitmdump_usage_underbilling_stderr(
-                "type=usage_underbilling reason=missing_fields"
-            )
-            .is_none()
-        );
-        assert!(
-            parse_mitmdump_usage_underbilling_stderr(
-                "ordinary stderr type=usage_underbilling reason=pending_snapshot_write_failed \
-                 underbilling_class=risk component=mitm_addon"
-            )
-            .is_none()
-        );
-        assert!(
-            parse_mitmdump_usage_underbilling_stderr(
-                "url=https://example.test/?type=usage_underbilling \
-                 reason=pending_snapshot_write_failed underbilling_class=risk component=mitm_addon"
-            )
-            .is_none()
-        );
-    }
-
-    #[test]
-    fn mitmdump_underbilling_stderr_reemits_structured_error() {
-        let line = "[error] type=usage_underbilling reason=pending_snapshot_write_failed \
-                    underbilling_class=risk component=mitm_addon Failed to write pending count";
-
-        let event = capture_mitmdump_stderr_log(line);
 
         assert_eq!(event.level, Level::ERROR);
-        assert_event_field(&event, "message", "mitmdump usage underbilling signal");
+        assert_event_field(&event, "message", "mitmdump addon process event");
         assert_event_field(&event, "type", "usage_underbilling");
         assert_event_field(&event, "reason", "pending_snapshot_write_failed");
         assert_event_field(&event, "underbilling_class", "risk");
         assert_event_field(&event, "component", "mitm_addon");
-        assert_event_field(&event, "mitmdump_stderr", line);
-        assert!(
-            !event.fields.contains_key("counter"),
-            "unexpected counter field; event={event:#?}"
-        );
+        assert_event_field(&event, "addon_detail", "Failed to write pending count");
+        assert!(!event.fields.contains_key("counter"));
     }
 
     #[test]
-    fn mitmdump_underbilling_stderr_reemits_counter_when_present() {
-        let line = "[error] type=usage_underbilling \
-                    reason=usage_pending_counter_underflow underbilling_class=risk \
-                    component=mitm_addon counter=reports unmatched release";
+    fn reemits_process_integrity_as_structured_warn() {
+        let event = capture_mitmdump_stderr_log(
+            r#"VM0_ADDON_EVENT {"version":1,"level":"warn","type":"addon_process_integrity","reason":"jsonl_writer_append_failed","component":"mitm_addon","detail":"write failed"}"#,
+        );
 
+        assert_eq!(event.level, Level::WARN);
+        assert_event_field(&event, "type", "addon_process_integrity");
+        assert_event_field(&event, "reason", "jsonl_writer_append_failed");
+        assert_event_field(&event, "component", "mitm_addon");
+        assert_event_field(&event, "addon_detail", "write failed");
+        assert!(!event.fields.contains_key("underbilling_class"));
+        assert!(!event.fields.contains_key("counter"));
+    }
+
+    #[test]
+    fn malformed_envelope_uses_ordinary_stderr_path() {
+        let line = "VM0_ADDON_EVENT not-json";
         let event = capture_mitmdump_stderr_log(line);
 
-        assert_eq!(event.level, Level::ERROR);
-        assert_event_field(&event, "message", "mitmdump usage underbilling signal");
-        assert_event_field(&event, "type", "usage_underbilling");
-        assert_event_field(&event, "reason", "usage_pending_counter_underflow");
-        assert_event_field(&event, "underbilling_class", "risk");
-        assert_event_field(&event, "component", "mitm_addon");
-        assert_event_field(&event, "counter", "reports");
-        assert_event_field(&event, "mitmdump_stderr", line);
+        assert_eq!(event.level, Level::WARN);
+        assert_event_field(&event, "message", &format!("stderr: {line}"));
+        assert!(!event.fields.contains_key("type"));
     }
 }

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -13,7 +13,7 @@ diagnostics on separate paths:
 | --- | --- | --- |
 | Proxied traffic | `network-{run_id}.jsonl` | Per-run network records. Runner flushes, reads, and uploads this file through the network-log pipeline. |
 | Addon run diagnostics | `proxy-{run_id}.jsonl` | Per-run structured diagnostics. This file is local and best effort; its row level does not automatically send a record to Axiom. |
-| Important addon process events | Exact `VM0_ADDON_EVENT` envelope on mitmdump stderr | Process-global failures and explicit dual-sink alerts. Runner strictly parses the bounded, versioned envelope and emits structured warning or error tracing that is eligible for Axiom. Underbilling also retains its proxy JSONL row when a run path is available. |
+| Important addon process events | Exact `VM0_ADDON_EVENT` envelope on mitmdump stderr | Process-global failures and explicit dual-sink alerts. Runner strictly parses the bounded, versioned envelope and emits structured warning or error tracing that is eligible for Axiom. Its generic `fields` map is expanded into queryable Axiom fields; underbilling also retains its proxy JSONL row when a run path is available. |
 | Mitmproxy-native output | Mitmdump stdout or unmatched stderr | Runner-owned process logging. With flow output disabled and terminal logging set to warning, Runner re-emits these records as ordinary warnings; they do not enter proxy JSONL. |
 
 Addon code must not use `ctx.log` for active logging: mitmproxy's terminal

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -13,7 +13,7 @@ diagnostics on separate paths:
 | --- | --- | --- |
 | Proxied traffic | `network-{run_id}.jsonl` | Per-run network records. Runner flushes, reads, and uploads this file through the network-log pipeline. |
 | Addon run diagnostics | `proxy-{run_id}.jsonl` | Per-run structured diagnostics. This file is local and best effort; its row level does not automatically send a record to Axiom. |
-| Important addon process events | Exact `VM0_ADDON_EVENT` envelope on mitmdump stderr | Process-global failures and explicit dual-sink alerts. Each producer supplies the bounded `message`; Runner preserves it as the tracing and Axiom message. Stable `type` and `reason` fields identify the event, and the generic `fields` map expands into queryable Axiom fields. Underbilling also retains its proxy JSONL row when a run path is available. |
+| Important addon process events | Exact `VM0_ADDON_EVENT` envelope on mitmdump stderr | Process-global failures and explicit dual-sink alerts. The envelope carries only the bounded addon-owned level and message; Runner re-emits them without parsing or adding log fields, and warning/error events are eligible for Axiom. Underbilling owns its canonical message format and also retains its structured proxy JSONL row when a run path is available. |
 | Mitmproxy-native output | Mitmdump stdout or unmatched stderr | Runner-owned process logging. Stdout remains local at info because its text stream does not preserve severity; unmatched stderr keeps the existing warning path. Neither enters proxy JSONL. |
 
 Addon code must not use `ctx.log` for active logging: mitmproxy's terminal

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -4,6 +4,24 @@
 
 The mitmproxy addon (`crates/runner/mitm-addon/`) is a Python module that intercepts HTTPS requests inside sandboxes. Tests live in `tests/` and use pytest.
 
+## Logging Boundaries
+
+The addon and Runner keep traffic records, run-local diagnostics, and process
+diagnostics on separate paths:
+
+| Source | Sink | Ownership and delivery |
+| --- | --- | --- |
+| Proxied traffic | `network-{run_id}.jsonl` | Per-run network records. Runner flushes, reads, and uploads this file through the network-log pipeline. |
+| Addon run diagnostics | `proxy-{run_id}.jsonl` | Per-run structured diagnostics. This file is local and best effort; its row level does not automatically send a record to Axiom. |
+| Important addon process events | Exact `VM0_ADDON_EVENT` envelope on mitmdump stderr | Process-global failures and explicit dual-sink alerts. Runner strictly parses the bounded, versioned envelope and emits structured warning or error tracing that is eligible for Axiom. Underbilling also retains its proxy JSONL row when a run path is available. |
+| Mitmproxy-native output | Mitmdump stdout or unmatched stderr | Runner-owned process logging. With flow output disabled and terminal logging set to warning, Runner re-emits these records as ordinary warnings; they do not enter proxy JSONL. |
+
+Addon code must not use `ctx.log` for active logging: mitmproxy's terminal
+handler does not preserve the addon/native ownership boundary at the Runner
+pipe. Use `log_proxy_entry` for ordinary attributable diagnostics and
+`emit_addon_process_event` only for the explicit process-integrity or alert
+events that need the independent Runner path.
+
 ## Environment Setup
 
 The addon uses uv for dependency management. The supported devcontainer installs
@@ -108,6 +126,7 @@ suites before committing the upgrade.
 | File                                                    | Tests                                                                                                                |
 | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | `test_addon_configuration.py`                           | Addon option registration and configuration updates                                                                  |
+| `test_addon_process_logging.py`                         | Bounded versioned addon process events written to Runner-owned stderr                                                |
 | `test_builtin_host_policy_contract.py`                  | Cross-stage malformed built-in host policy contracts                                                                 |
 | `test_connection_endpoints.py`                          | Connection endpoint shape validation and IPv6 tuple normalization                                                    |
 | `test_content_length.py`                                | Shared bounded Content-Length field parsing contract                                                                 |

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -14,7 +14,7 @@ diagnostics on separate paths:
 | Proxied traffic | `network-{run_id}.jsonl` | Per-run network records. Runner flushes, reads, and uploads this file through the network-log pipeline. |
 | Addon run diagnostics | `proxy-{run_id}.jsonl` | Per-run structured diagnostics. This file is local and best effort; its row level does not automatically send a record to Axiom. |
 | Important addon process events | Exact `VM0_ADDON_EVENT` envelope on mitmdump stderr | Process-global failures and explicit dual-sink alerts. Runner strictly parses the bounded, versioned envelope and emits structured warning or error tracing that is eligible for Axiom. Its generic `fields` map is expanded into queryable Axiom fields; underbilling also retains its proxy JSONL row when a run path is available. |
-| Mitmproxy-native output | Mitmdump stdout or unmatched stderr | Runner-owned process logging. With flow output disabled and terminal logging set to warning, Runner re-emits these records as ordinary warnings; they do not enter proxy JSONL. |
+| Mitmproxy-native output | Mitmdump stdout or unmatched stderr | Runner-owned process logging. Stdout remains local at info because its text stream does not preserve severity; unmatched stderr keeps the existing warning path. Neither enters proxy JSONL. |
 
 Addon code must not use `ctx.log` for active logging: mitmproxy's terminal
 handler does not preserve the addon/native ownership boundary at the Runner

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -13,7 +13,7 @@ diagnostics on separate paths:
 | --- | --- | --- |
 | Proxied traffic | `network-{run_id}.jsonl` | Per-run network records. Runner flushes, reads, and uploads this file through the network-log pipeline. |
 | Addon run diagnostics | `proxy-{run_id}.jsonl` | Per-run structured diagnostics. This file is local and best effort; its row level does not automatically send a record to Axiom. |
-| Important addon process events | Exact `VM0_ADDON_EVENT` envelope on mitmdump stderr | Process-global failures and explicit dual-sink alerts. Runner strictly parses the bounded, versioned envelope and emits structured warning or error tracing that is eligible for Axiom. Its generic `fields` map is expanded into queryable Axiom fields; underbilling also retains its proxy JSONL row when a run path is available. |
+| Important addon process events | Exact `VM0_ADDON_EVENT` envelope on mitmdump stderr | Process-global failures and explicit dual-sink alerts. Each producer supplies the bounded `message`; Runner preserves it as the tracing and Axiom message. Stable `type` and `reason` fields identify the event, and the generic `fields` map expands into queryable Axiom fields. Underbilling also retains its proxy JSONL row when a run path is available. |
 | Mitmproxy-native output | Mitmdump stdout or unmatched stderr | Runner-owned process logging. Stdout remains local at info because its text stream does not preserve severity; unmatched stderr keeps the existing warning path. Neither enters proxy JSONL. |
 
 Addon code must not use `ctx.log` for active logging: mitmproxy's terminal

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -13,14 +13,18 @@ diagnostics on separate paths:
 | --- | --- | --- |
 | Proxied traffic | `network-{run_id}.jsonl` | Per-run network records. Runner flushes, reads, and uploads this file through the network-log pipeline. |
 | Addon run diagnostics | `proxy-{run_id}.jsonl` | Per-run structured diagnostics. This file is local and best effort; its row level does not automatically send a record to Axiom. |
-| Important addon process events | Exact `VM0_ADDON_EVENT` envelope on mitmdump stderr | Process-global failures and explicit dual-sink alerts. The envelope carries only the bounded addon-owned level and message; Runner re-emits them without parsing or adding log fields, and warning/error events are eligible for Axiom. Underbilling owns its canonical message format and also retains its structured proxy JSONL row when a run path is available. |
+| Important addon process events | Exact `VM0_ADDON_EVENT` envelope on mitmdump stderr | Process-global failures and explicit dual-sink alerts. The versioned envelope carries one bounded addon-owned JSON log record: `level`, `message`, and any additional fields supplied by the addon logger. Runner does not maintain an event-family schema; it forwards the complete record so the additional fields remain top-level Axiom fields. Underbilling owns its canonical fields and also retains its structured proxy JSONL row when a run path is available. |
 | Mitmproxy-native output | Mitmdump stdout or unmatched stderr | Runner-owned process logging. Stdout remains local at info because its text stream does not preserve severity; unmatched stderr keeps the existing warning path. Neither enters proxy JSONL. |
 
 Addon code must not use `ctx.log` for active logging: mitmproxy's terminal
 handler does not preserve the addon/native ownership boundary at the Runner
 pipe. Use `log_proxy_entry` for ordinary attributable diagnostics and
 `emit_addon_process_event` only for the explicit process-integrity or alert
-events that need the independent Runner path.
+events that need the independent Runner path. The emitter owns `level` and
+`message`; callers may add other JSON-serializable fields directly without a
+nested fields map. Runner-owned Axiom metadata (`_time`, `context`, `service`,
+`runner_hostname`, and `runner_version`) remains authoritative. Callers remain
+responsible for redaction and bounded values.
 
 ## Environment Setup
 


### PR DESCRIPTION
## Summary

- add a bounded, versioned addon log envelope on mitmdump stderr containing the complete addon-owned JSON log record
- allow arbitrary additional JSON-serializable top-level fields; Runner validates only transport requirements and does not define business-event schemas
- preserve additional field names and JSON value types as top-level Axiom fields without an intermediate `fields` or transport field
- keep `version` transport-owned, `level` and `message` logger-owned, and standard Axiom metadata Runner-owned
- keep ordinary run diagnostics in `proxy-{run_id}.jsonl`; underbilling retains its structured proxy row and sends the same standardized fields through the generic Axiom path
- migrate process-global addon warnings away from `ctx.log`, remove inactive debug logging, and keep remaining mitmproxy-native stdout in Runner-local info logs
- document the network JSONL, proxy JSONL, addon log, and native process-log ownership boundaries

## Field contract

An addon record can contain fields such as:

```json
{
  "version": 1,
  "level": "error",
  "message": "Failed to write pending count",
  "type": "usage_underbilling",
  "reason": "pending_snapshot_write_failed",
  "underbilling_class": "risk",
  "retry_count": 2,
  "retryable": true,
  "diagnostic": { "phase": "flush" }
}
```

`version` is consumed by the transport. The remaining addon fields reach Axiom at the root. Runner supplies authoritative `_time`, `level`, `context`, `service`, `runner_hostname`, and `runner_version` values.

## Explicit exclusions

- no addon field whitelist or event-family schema in Runner
- no underbilling-specific parser in Runner
- no nested `fields` bag or private transport field in Axiom
- no changes to `network-{run_id}.jsonl` generation or upload
- no upload or retention changes for `proxy-{run_id}.jsonl`
- no API, database, queue, or external protocol changes
- no attempt to infer native mitmproxy error severity from its level-free text format
- no promotion of mitmproxy-native stdout to Axiom without structured severity

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (7198 passed)
- `cargo fmt -p runner --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --no-deps`
- `cargo test -p runner axiom_layer::tests::` (23 passed)
- `cargo test -p runner proxy::` (123 passed)
- `cargo test -p runner` (3370 passed, 26 ignored; guest inventory test passed)

Closes #30205
