### PR TITLE
perf(platform): declare clerk core in initial html

### DIFF
--- a/.github/pages/okou-app/_worker.js
+++ b/.github/pages/okou-app/_worker.js
@@ -10,6 +10,15 @@ const PRODUCTION_API_ORIGINS = new Map([
   ["app.vm0.ai", "https://api.vm0.ai"],
 ]);
 const VERCEL_PROTECTION_BYPASS = "x-vercel-protection-bypass";
+const PRODUCTION_ROOT_DOMAINS = ["okou.ai", "vm0.ai"];
+const CLERK_SATELLITE_DOMAIN = "app.okou.ai";
+const CLERK_SCRIPT_SELECTOR = "script[data-clerk-js-script]";
+const CLERK_PRODUCTION_PUBLISHABLE_KEY_ATTRIBUTE =
+  "data-vm0-clerk-production-publishable-key";
+const CLERK_PRODUCTION_SCRIPT_URL_ATTRIBUTE =
+  "data-vm0-clerk-production-script-url";
+const CLERK_SATELLITE_SCRIPT_URL_ATTRIBUTE =
+  "data-vm0-clerk-satellite-script-url";
 
 const VM0_APP_METADATA = {
   brandName: "VM0",
@@ -125,6 +134,47 @@ function addStaticAssetHandlers(rewriter, metadata) {
     .on("img", rewriteStaticAssetAttribute("src", metadata.staticAssetsOrigin));
 }
 
+function isProductionHostname(hostname) {
+  return PRODUCTION_ROOT_DOMAINS.some((domain) => {
+    return hostname === domain || hostname.endsWith(`.${domain}`);
+  });
+}
+
+function isClerkSatelliteHostname(hostname) {
+  return (
+    hostname === CLERK_SATELLITE_DOMAIN ||
+    hostname.endsWith(`.${CLERK_SATELLITE_DOMAIN}`)
+  );
+}
+
+function addClerkScriptHandler(rewriter, hostname) {
+  const normalizedHostname = hostname.toLowerCase();
+  if (!isProductionHostname(normalizedHostname)) {
+    return;
+  }
+  rewriter.on(CLERK_SCRIPT_SELECTOR, {
+    element(element) {
+      const publishableKey = element.getAttribute(
+        CLERK_PRODUCTION_PUBLISHABLE_KEY_ATTRIBUTE,
+      );
+      const satellite = isClerkSatelliteHostname(normalizedHostname);
+      const scriptUrl = element.getAttribute(
+        satellite
+          ? CLERK_SATELLITE_SCRIPT_URL_ATTRIBUTE
+          : CLERK_PRODUCTION_SCRIPT_URL_ATTRIBUTE,
+      );
+      if (publishableKey === null || scriptUrl === null) {
+        throw new Error("Clerk production script configuration is unavailable");
+      }
+      element.setAttribute("data-clerk-publishable-key", publishableKey);
+      element.setAttribute("src", scriptUrl);
+      if (satellite) {
+        element.setAttribute("data-clerk-domain", CLERK_SATELLITE_DOMAIN);
+      }
+    },
+  });
+}
+
 function htmlResponse(indexHtml, assetResponse, status, cacheControl) {
   const headers = new Headers(assetResponse.headers);
   headers.delete("Content-Encoding");
@@ -149,7 +199,7 @@ function noIndexResponse(response) {
   });
 }
 
-function rewriteAppPage(response, metadata, productionApiOrigin) {
+function rewriteAppPage(response, metadata, productionApiOrigin, hostname) {
   const rewriter = new HTMLRewriter()
     .on("html", setBrandContext(metadata.brandName))
     .on("title", {
@@ -203,6 +253,7 @@ function rewriteAppPage(response, metadata, productionApiOrigin) {
       },
     });
   addStaticAssetHandlers(rewriter, metadata);
+  addClerkScriptHandler(rewriter, hostname);
   if (productionApiOrigin) {
     rewriter.on(
       'meta[name="vm0-api-origin"]',
@@ -231,7 +282,14 @@ async function rewriteManifest(response, metadata) {
   });
 }
 
-function rewriteFound(response, title, canonicalUrl, metadata, apiOrigin) {
+function rewriteFound(
+  response,
+  title,
+  canonicalUrl,
+  metadata,
+  apiOrigin,
+  hostname,
+) {
   const sharedDescription = `A conversation shared from ${metadata.brandName}`;
   const rewriter = new HTMLRewriter()
     .on("html", setBrandContext(metadata.brandName))
@@ -273,10 +331,11 @@ function rewriteFound(response, title, canonicalUrl, metadata, apiOrigin) {
       },
     });
   addStaticAssetHandlers(rewriter, metadata);
+  addClerkScriptHandler(rewriter, hostname);
   return rewriter.transform(response);
 }
 
-function rewriteNotFound(response, metadata, apiOrigin) {
+function rewriteNotFound(response, metadata, apiOrigin, hostname) {
   const rewriter = new HTMLRewriter()
     .on("html", setBrandContext(metadata.brandName))
     .on('meta[name="vm0-api-origin"]', setMetaContent(apiOrigin))
@@ -302,6 +361,7 @@ function rewriteNotFound(response, metadata, apiOrigin) {
       },
     });
   addStaticAssetHandlers(rewriter, metadata);
+  addClerkScriptHandler(rewriter, hostname);
   return rewriter.transform(response);
 }
 
@@ -367,6 +427,7 @@ export default {
           ),
           appMetadata(requestUrl.hostname),
           origin,
+          requestUrl.hostname,
         );
       }
       if (!metaResponse.ok) {
@@ -403,6 +464,7 @@ export default {
         canonicalUrl,
         sharedAppMetadata,
         origin,
+        requestUrl.hostname,
       );
     }
 
@@ -427,6 +489,7 @@ export default {
       assetResponse,
       metadata,
       PRODUCTION_API_ORIGINS.get(requestUrl.hostname),
+      requestUrl.hostname,
     );
   },
 };

--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -76,22 +76,16 @@ function applyHandler({ attributes, handler, innerContent = "" }) {
   return state;
 }
 
-function rewritePairedTag(html, tagName, selector, handler) {
+function rewritePairedTag(html, tagName, handler) {
   const pattern =
     tagName === "html"
       ? /<html([^>]*)>([\s\S]*?)<\/html>/iu
       : tagName === "head"
         ? /<head([^>]*)>([\s\S]*?)<\/head>/iu
-        : tagName === "script"
-          ? /<script([^>]*)>([\s\S]*?)<\/script>/giu
-          : /<title([^>]*)>([\s\S]*?)<\/title>/iu;
-  return html.replace(pattern, (tag, attributeSource, innerContent) => {
-    const attributes = parseAttributes(attributeSource);
-    if (!matchesSelector(tagName, attributes, selector)) {
-      return tag;
-    }
+        : /<title([^>]*)>([\s\S]*?)<\/title>/iu;
+  return html.replace(pattern, (_tag, attributeSource, innerContent) => {
     const state = applyHandler({
-      attributes,
+      attributes: parseAttributes(attributeSource),
       handler,
       innerContent,
     });
@@ -100,6 +94,34 @@ function rewritePairedTag(html, tagName, selector, handler) {
     }
     return `<${tagName}${serializeAttributes(state.attributes)}>${state.innerContent}${state.appendedContent}</${tagName}>`;
   });
+}
+
+function rewriteClerkScriptOpeningTag(html, handler) {
+  const marker = 'data-clerk-js-script=""';
+  const markerIndex = html.indexOf(marker);
+  if (markerIndex === -1) {
+    return html;
+  }
+  const tagStart = html.lastIndexOf("<", markerIndex);
+  const tagEnd = html.indexOf(">", markerIndex);
+  if (tagStart === -1 || tagEnd === -1) {
+    throw new Error("Invalid Clerk script fixture");
+  }
+  const tag = html.slice(tagStart, tagEnd + 1);
+  const attributes = parseAttributes(tag);
+  if (!matchesSelector("script", attributes, "script[data-clerk-js-script]")) {
+    throw new Error("Invalid Clerk script selector fixture");
+  }
+  const state = applyHandler({ attributes, handler });
+  if (state.removed || state.appendedContent || state.innerContent) {
+    throw new Error("Unsupported Clerk script rewrite operation");
+  }
+  const tagNameEnd = tag.search(/\s/u);
+  if (tagNameEnd === -1) {
+    throw new Error("Invalid Clerk script opening tag");
+  }
+  const rewrittenTag = `${tag.slice(0, tagNameEnd)}${serializeAttributes(state.attributes)}>`;
+  return `${html.slice(0, tagStart)}${rewrittenTag}${html.slice(tagEnd + 1)}`;
 }
 
 function rewriteVoidTag(html, tagName, selector, handler) {
@@ -124,10 +146,10 @@ function rewriteVoidTag(html, tagName, selector, handler) {
 
 function rewriteHtml(html, selector, handler) {
   if (selector === "html" || selector === "head" || selector === "title") {
-    return rewritePairedTag(html, selector, selector, handler);
+    return rewritePairedTag(html, selector, handler);
   }
   if (selector === "script[data-clerk-js-script]") {
-    return rewritePairedTag(html, "script", selector, handler);
+    return rewriteClerkScriptOpeningTag(html, handler);
   }
   if (selector.startsWith("meta[")) {
     return rewriteVoidTag(html, "meta", selector, handler);

--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -28,6 +28,9 @@ function matchesSelector(tagName, attributes, selector) {
   if (selector === tagName) {
     return true;
   }
+  if (selector === "script[data-clerk-js-script]") {
+    return tagName === "script" && attributes.has("data-clerk-js-script");
+  }
   const match = /^(meta|link)\[(name|property|rel)(\^?=)"([^"]+)"\]$/u.exec(
     selector,
   );
@@ -73,16 +76,22 @@ function applyHandler({ attributes, handler, innerContent = "" }) {
   return state;
 }
 
-function rewritePairedTag(html, tagName, handler) {
+function rewritePairedTag(html, tagName, selector, handler) {
   const pattern =
     tagName === "html"
       ? /<html([^>]*)>([\s\S]*?)<\/html>/iu
       : tagName === "head"
         ? /<head([^>]*)>([\s\S]*?)<\/head>/iu
-        : /<title([^>]*)>([\s\S]*?)<\/title>/iu;
+        : tagName === "script"
+          ? /<script([^>]*)>([\s\S]*?)<\/script>/giu
+          : /<title([^>]*)>([\s\S]*?)<\/title>/iu;
   return html.replace(pattern, (tag, attributeSource, innerContent) => {
+    const attributes = parseAttributes(attributeSource);
+    if (!matchesSelector(tagName, attributes, selector)) {
+      return tag;
+    }
     const state = applyHandler({
-      attributes: parseAttributes(attributeSource),
+      attributes,
       handler,
       innerContent,
     });
@@ -115,7 +124,10 @@ function rewriteVoidTag(html, tagName, selector, handler) {
 
 function rewriteHtml(html, selector, handler) {
   if (selector === "html" || selector === "head" || selector === "title") {
-    return rewritePairedTag(html, selector, handler);
+    return rewritePairedTag(html, selector, selector, handler);
+  }
+  if (selector === "script[data-clerk-js-script]") {
+    return rewritePairedTag(html, "script", selector, handler);
   }
   if (selector.startsWith("meta[")) {
     return rewriteVoidTag(html, "meta", selector, handler);
@@ -165,17 +177,49 @@ const [indexTemplate, manifestTemplate, workerModule] = await Promise.all([
 const worker = workerModule.default;
 const sharedThreadId = "10000000-0000-4000-8000-000000000001";
 const previewOrigin = "https://pr-25304-api.vm6.ai";
+const clerkJsVersion = "6.25.8";
+const previewClerkHost = "informed-calf-6.clerk.accounts.dev";
+const productionClerkHost = "clerk.vm0.ai";
+const clerkSatelliteDomain = "app.okou.ai";
+const previewClerkPublishableKey = publishableKey("test", previewClerkHost);
+const productionClerkPublishableKey = publishableKey(
+  "live",
+  productionClerkHost,
+);
+const previewClerkScriptUrl = clerkScriptUrl(previewClerkHost);
+const productionClerkScriptUrl = clerkScriptUrl(productionClerkHost);
+const satelliteClerkScriptUrl = clerkScriptUrl(`clerk.${clerkSatelliteDomain}`);
+const builtIndexTemplate = indexTemplate
+  .replaceAll(
+    "%VITE_CLERK_PUBLISHABLE_KEY_PREVIEW%",
+    previewClerkPublishableKey,
+  )
+  .replaceAll(
+    "%VITE_CLERK_PUBLISHABLE_KEY_PROD%",
+    productionClerkPublishableKey,
+  )
+  .replaceAll("__VM0_CLERK_PREVIEW_SCRIPT_URL__", previewClerkScriptUrl)
+  .replaceAll("__VM0_CLERK_PRODUCTION_SCRIPT_URL__", productionClerkScriptUrl)
+  .replaceAll("__VM0_CLERK_SATELLITE_SCRIPT_URL__", satelliteClerkScriptUrl);
 const vm0Description =
   "VM0, your trustworthy AI teammate for real work. An AI agent that connects to 100+ tools to run reports, triage, outreach, and research in Slack or the web.";
 const okouDescription =
   "Okou, your trustworthy AI teammate for real work. An AI agent that connects to 100+ tools to run reports, triage, outreach, and research in Slack or the web.";
+
+function publishableKey(environment, host) {
+  return `pk_${environment}_${Buffer.from(`${host}$`).toString("base64")}`;
+}
+
+function clerkScriptUrl(host) {
+  return `https://${host}/npm/@clerk/clerk-js@${clerkJsVersion}/dist/clerk.browser.js`;
+}
 
 function requestUrl(input) {
   return new URL(input instanceof Request ? input.url : input.toString());
 }
 
 function assetEnvironment(apiOrigin = "") {
-  const indexHtml = indexTemplate.replace(
+  const indexHtml = builtIndexTemplate.replace(
     '<meta name="vm0-api-origin" content="" />',
     `<meta name="vm0-api-origin" content="${apiOrigin}" />`,
   );
@@ -225,7 +269,9 @@ function tagAttribute(html, tagName, selectorAttribute, selectorValue, target) {
       ? /<meta\b[^>]*>/giu
       : tagName === "link"
         ? /<link\b[^>]*>/giu
-        : /<img\b[^>]*>/giu;
+        : tagName === "script"
+          ? /<script\b[^>]*>/giu
+          : /<img\b[^>]*>/giu;
   for (const match of html.matchAll(pattern)) {
     const attributes = parseAttributes(match[0]);
     if (attributes.get(selectorAttribute) === selectorValue) {
@@ -260,6 +306,16 @@ function documentTitle(html) {
 function htmlAttribute(html, attributeName) {
   const tag = /<html\b[^>]*>/iu.exec(html)?.[0];
   return tag ? (parseAttributes(tag).get(attributeName) ?? null) : null;
+}
+
+function clerkAttribute(html, target) {
+  return tagAttribute(html, "script", "data-clerk-js-script", "", target);
+}
+
+function clerkScriptCount(html) {
+  return [...html.matchAll(/<script\b[^>]*>/giu)].filter((match) => {
+    return parseAttributes(match[0]).has("data-clerk-js-script");
+  }).length;
 }
 
 async function requestAppPage(origin, apiOrigin = "") {
@@ -320,6 +376,13 @@ assert.equal(
   tagAttribute(vm0Page.html, "img", "alt", "", "src"),
   "https://static.vm0.io/platform/icon.svg",
 );
+assert.equal(clerkScriptCount(vm0Page.html), 1);
+assert.equal(
+  clerkAttribute(vm0Page.html, "data-clerk-publishable-key"),
+  productionClerkPublishableKey,
+);
+assert.equal(clerkAttribute(vm0Page.html, "src"), productionClerkScriptUrl);
+assert.equal(clerkAttribute(vm0Page.html, "data-clerk-domain"), null);
 
 const okouPage = await requestAppPage("https://app.okou.ai");
 assert.equal(
@@ -367,6 +430,16 @@ assert.equal(
   tagAttribute(okouPage.html, "img", "alt", "", "src"),
   "https://static.okou.io/platform/icon.svg",
 );
+assert.equal(clerkScriptCount(okouPage.html), 1);
+assert.equal(
+  clerkAttribute(okouPage.html, "data-clerk-publishable-key"),
+  productionClerkPublishableKey,
+);
+assert.equal(clerkAttribute(okouPage.html, "src"), satelliteClerkScriptUrl);
+assert.equal(
+  clerkAttribute(okouPage.html, "data-clerk-domain"),
+  clerkSatelliteDomain,
+);
 
 const okouPreview = await requestAppPage(
   "https://3508a2f5.okou-app.pages.dev",
@@ -381,6 +454,18 @@ assert.equal(
   metaContent(okouPreview.html, "name", "vm0-api-origin"),
   previewOrigin,
 );
+assert.equal(clerkScriptCount(okouPreview.html), 1);
+assert.equal(
+  clerkAttribute(okouPreview.html, "data-clerk-publishable-key"),
+  previewClerkPublishableKey,
+);
+assert.equal(clerkAttribute(okouPreview.html, "src"), previewClerkScriptUrl);
+assert.equal(clerkAttribute(okouPreview.html, "data-clerk-domain"), null);
+assert.equal(clerkAttribute(okouPreview.html, "defer"), "");
+assert.equal(clerkAttribute(okouPreview.html, "crossorigin"), "anonymous");
+assert.equal(clerkAttribute(okouPreview.html, "onerror"), "this.remove()");
+assert.equal(clerkAttribute(okouPreview.html, "type"), "text/javascript");
+assert.equal(okouPreview.html.includes("/npm/@clerk/ui@"), false);
 
 const untrustedSuffix = await requestAppPage("https://okou.ai.evil.example");
 assert.equal(htmlAttribute(untrustedSuffix.html, "data-app-brand-name"), "VM0");

--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1684,8 +1684,9 @@ test("chat composer keeps standard tool icons and Send inside on narrow screens"
   });
   const sendButton = composer.getByRole("button", { name: "Send" });
 
-  await expect(connectorsButton.locator("img")).toHaveCount(2);
+  await expect(connectorsButton.locator("img")).toHaveCount(0);
   await connectorsButton.click();
+  await expect(connectorsButton.locator("img")).toHaveCount(2);
   await expect(
     page.getByRole("switch", { name: "Disable Cloud browser" }),
   ).toBeVisible();

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -9,6 +9,18 @@
     <title>AI Agents for Real Work — Your Trustworthy AI Teammate | VM0</title>
     <meta charset="UTF-8" />
     <meta name="vm0-api-origin" content="" />
+    <script
+      defer=""
+      crossorigin="anonymous"
+      data-clerk-js-script=""
+      data-clerk-publishable-key="%VITE_CLERK_PUBLISHABLE_KEY_PREVIEW%"
+      data-vm0-clerk-production-publishable-key="%VITE_CLERK_PUBLISHABLE_KEY_PROD%"
+      data-vm0-clerk-production-script-url="__VM0_CLERK_PRODUCTION_SCRIPT_URL__"
+      data-vm0-clerk-satellite-script-url="__VM0_CLERK_SATELLITE_SCRIPT_URL__"
+      onerror="this.remove()"
+      src="__VM0_CLERK_PREVIEW_SCRIPT_URL__"
+      type="text/javascript"
+    ></script>
     <style>
       body {
         margin: 0;
@@ -915,60 +927,6 @@
       // Mark <head> parse start as early as possible so we can measure the
       // total white-screen duration up to the first `hideAppSkeleton$` call.
       window.__appBootstrapStart = performance.now();
-    </script>
-    <script>
-      // Start the Clerk core request before the application bundle. The
-      // publishable key is shaped pk_<env>_<base64(host$)>; decoding it here
-      // avoids hard-coding an instance host. Clerk.load() remains in the app.
-      (function () {
-        if (window.__vm0BrowserSupported !== true) return;
-
-        var h = location.hostname.toLowerCase();
-        var production =
-          h === "vm0.ai" ||
-          h.endsWith(".vm0.ai") ||
-          h === "okou.ai" ||
-          h.endsWith(".okou.ai");
-        var k = production
-          ? "%VITE_CLERK_PUBLISHABLE_KEY_PROD%"
-          : "%VITE_CLERK_PUBLISHABLE_KEY_PREVIEW%";
-        var m = /^pk_(?:test|live)_(.+)$/.exec(k);
-        if (!m) return;
-        var frontendApiHost = atob(m[1]).replace(/\$+$/, "");
-        if (!/^[a-z0-9.-]+$/i.test(frontendApiHost)) return;
-
-        var domain =
-          h === "app.okou.ai" || h.endsWith(".app.okou.ai")
-            ? "app.okou.ai"
-            : null;
-        var scriptHost = domain ? "clerk." + domain : frontendApiHost;
-        var l = document.createElement("link");
-        l.rel = "preconnect";
-        l.href = "https://" + scriptHost;
-        l.crossOrigin = "anonymous";
-        document.head.appendChild(l);
-
-        var s = document.createElement("script");
-        s.async = true;
-        s.crossOrigin = "anonymous";
-        s.setAttribute("data-clerk-js-script", "");
-        s.setAttribute("data-clerk-publishable-key", k);
-        if (domain) s.setAttribute("data-clerk-domain", domain);
-        s.addEventListener(
-          "error",
-          function () {
-            // A failed existing script makes Clerk's runtime loader wait for
-            // its timeout. Remove it so the runtime retries immediately.
-            s.remove();
-          },
-          { once: true },
-        );
-        s.src =
-          "https://" +
-          scriptHost +
-          "/npm/@clerk/clerk-js@6.25.8/dist/clerk.browser.js";
-        document.head.appendChild(s);
-      })();
     </script>
     <link
       rel="icon"

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -917,11 +917,12 @@
       window.__appBootstrapStart = performance.now();
     </script>
     <script>
-      // Preconnect to the Clerk Frontend API host so the DNS+TCP+TLS
-      // handshake overlaps with bundle download. The publishable key is
-      // shaped pk_<env>_<base64(host$)>; decoding it here avoids hard-coding
-      // the FAPI domain per environment.
+      // Start the Clerk core request before the application bundle. The
+      // publishable key is shaped pk_<env>_<base64(host$)>; decoding it here
+      // avoids hard-coding an instance host. Clerk.load() remains in the app.
       (function () {
+        if (window.__vm0BrowserSupported !== true) return;
+
         var h = location.hostname.toLowerCase();
         var production =
           h === "vm0.ai" ||
@@ -933,13 +934,40 @@
           : "%VITE_CLERK_PUBLISHABLE_KEY_PREVIEW%";
         var m = /^pk_(?:test|live)_(.+)$/.exec(k);
         if (!m) return;
-        var host = atob(m[1]).replace(/\$+$/, "");
-        if (!/^[a-z0-9.-]+$/i.test(host)) return;
+        var frontendApiHost = atob(m[1]).replace(/\$+$/, "");
+        if (!/^[a-z0-9.-]+$/i.test(frontendApiHost)) return;
+
+        var domain =
+          h === "app.okou.ai" || h.endsWith(".app.okou.ai")
+            ? "app.okou.ai"
+            : null;
+        var scriptHost = domain ? "clerk." + domain : frontendApiHost;
         var l = document.createElement("link");
         l.rel = "preconnect";
-        l.href = "https://" + host;
+        l.href = "https://" + scriptHost;
         l.crossOrigin = "anonymous";
         document.head.appendChild(l);
+
+        var s = document.createElement("script");
+        s.async = true;
+        s.crossOrigin = "anonymous";
+        s.setAttribute("data-clerk-js-script", "");
+        s.setAttribute("data-clerk-publishable-key", k);
+        if (domain) s.setAttribute("data-clerk-domain", domain);
+        s.addEventListener(
+          "error",
+          function () {
+            // A failed existing script makes Clerk's runtime loader wait for
+            // its timeout. Remove it so the runtime retries immediately.
+            s.remove();
+          },
+          { once: true },
+        );
+        s.src =
+          "https://" +
+          scriptHost +
+          "/npm/@clerk/clerk-js@6.25.8/dist/clerk.browser.js";
+        document.head.appendChild(s);
       })();
     </script>
     <link

--- a/turbo/apps/platform/scripts/clerk-html-transform.ts
+++ b/turbo/apps/platform/scripts/clerk-html-transform.ts
@@ -1,0 +1,40 @@
+import { clerkJSScriptUrl } from "@clerk/shared/loadClerkJsScript";
+
+import { CLERK_JS_VERSION } from "../src/lib/clerk-versions.ts";
+
+const PREVIEW_SCRIPT_URL_MARKER = "__VM0_CLERK_PREVIEW_SCRIPT_URL__";
+const PRODUCTION_SCRIPT_URL_MARKER = "__VM0_CLERK_PRODUCTION_SCRIPT_URL__";
+const SATELLITE_SCRIPT_URL_MARKER = "__VM0_CLERK_SATELLITE_SCRIPT_URL__";
+const PRODUCTION_SATELLITE_DOMAIN = "app.okou.ai";
+
+export interface ClerkCoreHtmlOptions {
+  readonly previewPublishableKey: string;
+  readonly productionPublishableKey: string;
+}
+
+function scriptUrl(publishableKey: string, domain?: string): string {
+  return clerkJSScriptUrl({
+    __internal_clerkJSVersion: CLERK_JS_VERSION,
+    domain,
+    publishableKey,
+  });
+}
+
+export function transformClerkCoreScriptUrls(
+  html: string,
+  options: ClerkCoreHtmlOptions,
+): string {
+  return html
+    .replaceAll(
+      PREVIEW_SCRIPT_URL_MARKER,
+      scriptUrl(options.previewPublishableKey),
+    )
+    .replaceAll(
+      PRODUCTION_SCRIPT_URL_MARKER,
+      scriptUrl(options.productionPublishableKey),
+    )
+    .replaceAll(
+      SATELLITE_SCRIPT_URL_MARKER,
+      scriptUrl(options.productionPublishableKey, PRODUCTION_SATELLITE_DOMAIN),
+    );
+}

--- a/turbo/apps/platform/scripts/clerk-html.ts
+++ b/turbo/apps/platform/scripts/clerk-html.ts
@@ -1,17 +1,9 @@
-import { clerkJSScriptUrl } from "@clerk/shared/loadClerkJsScript";
 import type { Plugin } from "vite";
 
-import { CLERK_JS_VERSION } from "../src/lib/clerk-versions.ts";
-
-const PREVIEW_SCRIPT_URL_MARKER = "__VM0_CLERK_PREVIEW_SCRIPT_URL__";
-const PRODUCTION_SCRIPT_URL_MARKER = "__VM0_CLERK_PRODUCTION_SCRIPT_URL__";
-const SATELLITE_SCRIPT_URL_MARKER = "__VM0_CLERK_SATELLITE_SCRIPT_URL__";
-const PRODUCTION_SATELLITE_DOMAIN = "app.okou.ai";
-
-interface ClerkCoreHtmlOptions {
-  readonly previewPublishableKey: string;
-  readonly productionPublishableKey: string;
-}
+import {
+  type ClerkCoreHtmlOptions,
+  transformClerkCoreScriptUrls,
+} from "./clerk-html-transform.ts";
 
 function requiredEnvironmentValue(
   environment: Record<string, unknown>,
@@ -22,33 +14,6 @@ function requiredEnvironmentValue(
     throw new Error(`Missing ${name} environment variable`);
   }
   return value;
-}
-
-function scriptUrl(publishableKey: string, domain?: string): string {
-  return clerkJSScriptUrl({
-    __internal_clerkJSVersion: CLERK_JS_VERSION,
-    domain,
-    publishableKey,
-  });
-}
-
-export function transformClerkCoreScriptUrls(
-  html: string,
-  options: ClerkCoreHtmlOptions,
-): string {
-  return html
-    .replaceAll(
-      PREVIEW_SCRIPT_URL_MARKER,
-      scriptUrl(options.previewPublishableKey),
-    )
-    .replaceAll(
-      PRODUCTION_SCRIPT_URL_MARKER,
-      scriptUrl(options.productionPublishableKey),
-    )
-    .replaceAll(
-      SATELLITE_SCRIPT_URL_MARKER,
-      scriptUrl(options.productionPublishableKey, PRODUCTION_SATELLITE_DOMAIN),
-    );
 }
 
 export function clerkCoreHtmlPlugin(): Plugin {

--- a/turbo/apps/platform/scripts/clerk-html.ts
+++ b/turbo/apps/platform/scripts/clerk-html.ts
@@ -1,0 +1,77 @@
+import { clerkJSScriptUrl } from "@clerk/shared/loadClerkJsScript";
+import type { Plugin } from "vite";
+
+import { CLERK_JS_VERSION } from "../src/lib/clerk-versions.ts";
+
+const PREVIEW_SCRIPT_URL_MARKER = "__VM0_CLERK_PREVIEW_SCRIPT_URL__";
+const PRODUCTION_SCRIPT_URL_MARKER = "__VM0_CLERK_PRODUCTION_SCRIPT_URL__";
+const SATELLITE_SCRIPT_URL_MARKER = "__VM0_CLERK_SATELLITE_SCRIPT_URL__";
+const PRODUCTION_SATELLITE_DOMAIN = "app.okou.ai";
+
+interface ClerkCoreHtmlOptions {
+  readonly previewPublishableKey: string;
+  readonly productionPublishableKey: string;
+}
+
+function requiredEnvironmentValue(
+  environment: Record<string, unknown>,
+  name: string,
+): string {
+  const value = environment[name];
+  if (typeof value !== "string" || !value) {
+    throw new Error(`Missing ${name} environment variable`);
+  }
+  return value;
+}
+
+function scriptUrl(publishableKey: string, domain?: string): string {
+  return clerkJSScriptUrl({
+    __internal_clerkJSVersion: CLERK_JS_VERSION,
+    domain,
+    publishableKey,
+  });
+}
+
+export function transformClerkCoreScriptUrls(
+  html: string,
+  options: ClerkCoreHtmlOptions,
+): string {
+  return html
+    .replaceAll(
+      PREVIEW_SCRIPT_URL_MARKER,
+      scriptUrl(options.previewPublishableKey),
+    )
+    .replaceAll(
+      PRODUCTION_SCRIPT_URL_MARKER,
+      scriptUrl(options.productionPublishableKey),
+    )
+    .replaceAll(
+      SATELLITE_SCRIPT_URL_MARKER,
+      scriptUrl(options.productionPublishableKey, PRODUCTION_SATELLITE_DOMAIN),
+    );
+}
+
+export function clerkCoreHtmlPlugin(): Plugin {
+  let options: ClerkCoreHtmlOptions;
+  return {
+    name: "platform-clerk-core-html",
+    configResolved(config) {
+      options = {
+        previewPublishableKey: requiredEnvironmentValue(
+          config.env,
+          "VITE_CLERK_PUBLISHABLE_KEY_PREVIEW",
+        ),
+        productionPublishableKey: requiredEnvironmentValue(
+          config.env,
+          "VITE_CLERK_PUBLISHABLE_KEY_PROD",
+        ),
+      };
+    },
+    transformIndexHtml: {
+      order: "pre",
+      handler(html) {
+        return transformClerkCoreScriptUrls(html, options);
+      },
+    },
+  };
+}

--- a/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
@@ -189,16 +189,25 @@ async function completeEarlyClerkScript(
 describe("platform Clerk entrypoint", () => {
   it("builds the official static core script with exact environment URLs", () => {
     const html = builtIndexHtml();
-    const script = clerkScriptFromHtml(html);
     const parsedDocument = new DOMParser().parseFromString(html, "text/html");
+    const script = parsedDocument.querySelector(CLERK_SCRIPT_SELECTOR);
+    const mainScript = parsedDocument.querySelector(
+      'script[type="module"][src="/src/main.ts"]',
+    );
+    if (!(script instanceof HTMLScriptElement)) {
+      throw new Error(
+        "Built index.html does not contain the Clerk core script",
+      );
+    }
+    if (!(mainScript instanceof HTMLScriptElement)) {
+      throw new Error("Built index.html does not contain the app module");
+    }
 
     expect(parsedDocument.querySelectorAll(CLERK_SCRIPT_SELECTOR)).toHaveLength(
       1,
     );
-    expect(
-      html.indexOf(expectedClerkScriptUrl(PREVIEW_FRONTEND_API_HOST)),
-    ).toBeLessThan(
-      html.indexOf('<script type="module" src="/src/main.ts"></script>'),
+    expect(script.compareDocumentPosition(mainScript)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
     );
     expect(script.src).toBe(expectedClerkScriptUrl(PREVIEW_FRONTEND_API_HOST));
     expect(script.defer).toBeTruthy();

--- a/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it, vi } from "vitest";
+import indexHtml from "../../index.html?raw";
+import { setupPage } from "./page-helper.ts";
+import { mockedClerk, mockedClerkLoad } from "./mock-auth.ts";
+import { testContext } from "../signals/__tests__/test-helpers.ts";
+
+vi.unmock("@clerk/shared/loadClerkJsScript");
+
+const CLERK_JS_VERSION = "6.25.8";
+const PREVIEW_FRONTEND_API_HOST = "informed-calf-6.clerk.accounts.dev";
+const PRODUCTION_FRONTEND_API_HOST = "clerk.vm0.ai";
+const PRODUCTION_SATELLITE_DOMAIN = "app.okou.ai";
+const CLERK_SCRIPT_SELECTOR = "script[data-clerk-js-script]";
+
+interface ClerkScriptRequest {
+  readonly element: HTMLScriptElement;
+  readonly url: string;
+}
+
+interface ClerkEntrypointHarness {
+  readonly clerkLoaderWatchingEarlyScript: Promise<void>;
+  readonly earlyScript: HTMLScriptElement;
+  readonly requests: ClerkScriptRequest[];
+  readonly setup: Promise<void>;
+}
+
+type ClerkEntrypointScript = (
+  windowObject: Window,
+  documentObject: Document,
+  locationObject: Location,
+  atobFunction: typeof atob,
+) => void;
+
+const context = testContext();
+
+function publishableKey(environment: "live" | "test", host: string): string {
+  return `pk_${environment}_${btoa(`${host}$`)}`;
+}
+
+const PREVIEW_PUBLISHABLE_KEY = publishableKey(
+  "test",
+  PREVIEW_FRONTEND_API_HOST,
+);
+const PRODUCTION_PUBLISHABLE_KEY = publishableKey(
+  "live",
+  PRODUCTION_FRONTEND_API_HOST,
+);
+
+function clerkEntrypointSource(): string {
+  const source = [...indexHtml.matchAll(/<script>([\s\S]*?)<\/script>/giu)]
+    .map((match) => {
+      return match[1];
+    })
+    .find((script) => {
+      return script?.includes('s.setAttribute("data-clerk-js-script", "")');
+    });
+  if (source === undefined) {
+    throw new Error("Unable to locate the Clerk loader in index.html");
+  }
+  return source
+    .replaceAll("%VITE_CLERK_PUBLISHABLE_KEY_PREVIEW%", PREVIEW_PUBLISHABLE_KEY)
+    .replaceAll(
+      "%VITE_CLERK_PUBLISHABLE_KEY_PROD%",
+      PRODUCTION_PUBLISHABLE_KEY,
+    );
+}
+
+function expectedClerkScriptUrl(host: string): string {
+  return `https://${host}/npm/@clerk/clerk-js@${CLERK_JS_VERSION}/dist/clerk.browser.js`;
+}
+
+function startClerkPage(hostname: string): ClerkEntrypointHarness {
+  const requests: ClerkScriptRequest[] = [];
+  const clerkLoaderWatchingEarlyScript = context.mocks.deferred<void>();
+  let earlyScript: HTMLScriptElement | undefined;
+
+  const setup = setupPage({
+    beforeBootstrap: (signal) => {
+      context.mocks.browser.url(`https://${hostname}/`);
+      const previousPreviewKey = import.meta.env
+        .VITE_CLERK_PUBLISHABLE_KEY_PREVIEW;
+      const previousProductionKey = import.meta.env
+        .VITE_CLERK_PUBLISHABLE_KEY_PROD;
+      vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PREVIEW", PREVIEW_PUBLISHABLE_KEY);
+      vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PROD", PRODUCTION_PUBLISHABLE_KEY);
+      window.__vm0BrowserSupported = true;
+      Reflect.deleteProperty(globalThis, "Clerk");
+
+      const observeScript = (
+        append: typeof document.head.appendChild,
+        node: Node,
+      ): Node => {
+        if (!(node instanceof HTMLScriptElement) || !node.src) {
+          return append(node);
+        }
+
+        const request = { element: node, url: node.src };
+        requests.push(request);
+        // Keep Happy DOM from making an external request. The real Clerk
+        // loader still observes the connected data-clerk-js-script element.
+        node.removeAttribute("src");
+        const appended = append(node);
+
+        if (requests.length > 1) {
+          Reflect.set(globalThis, "Clerk", mockedClerk);
+          node.dispatchEvent(new Event("load"));
+        }
+        return appended;
+      };
+
+      const appendToHead = document.head.appendChild.bind(document.head);
+      vi.spyOn(document.head, "appendChild").mockImplementation((node) => {
+        return observeScript(appendToHead, node);
+      });
+      const appendToBody = document.body.appendChild.bind(document.body);
+      vi.spyOn(document.body, "appendChild").mockImplementation((node) => {
+        return observeScript(appendToBody, node);
+      });
+
+      const executeEntrypointScript = new Function(
+        "window",
+        "document",
+        "location",
+        "atob",
+        `${clerkEntrypointSource()}\n//# sourceURL=platform-clerk-entrypoint-test.js`,
+      ) as ClerkEntrypointScript;
+      executeEntrypointScript(window, document, location, atob);
+
+      earlyScript = document.querySelector(CLERK_SCRIPT_SELECTOR) ?? undefined;
+      if (!earlyScript) {
+        throw new Error("Clerk entrypoint did not append its core script");
+      }
+      const addEventListener = earlyScript.addEventListener.bind(earlyScript);
+      vi.spyOn(earlyScript, "addEventListener").mockImplementation(
+        (type, listener, options) => {
+          if (type === "error") {
+            clerkLoaderWatchingEarlyScript.resolve(undefined);
+          }
+          addEventListener(type, listener, options);
+        },
+      );
+
+      signal.addEventListener(
+        "abort",
+        () => {
+          for (const request of requests) {
+            request.element.remove();
+          }
+          Reflect.deleteProperty(globalThis, "Clerk");
+          Reflect.deleteProperty(window, "__vm0BrowserSupported");
+          vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PREVIEW", previousPreviewKey);
+          vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PROD", previousProductionKey);
+        },
+        { once: true },
+      );
+    },
+    context,
+    path: "/error",
+    withoutRender: true,
+  });
+
+  if (!earlyScript) {
+    throw new Error("Clerk entrypoint setup did not run synchronously");
+  }
+  return {
+    clerkLoaderWatchingEarlyScript: clerkLoaderWatchingEarlyScript.promise,
+    earlyScript,
+    requests,
+    setup,
+  };
+}
+
+async function completeEarlyClerkScript(
+  harness: ClerkEntrypointHarness,
+): Promise<void> {
+  await harness.clerkLoaderWatchingEarlyScript;
+  Reflect.set(globalThis, "Clerk", mockedClerk);
+  harness.earlyScript.dispatchEvent(new Event("load"));
+  await harness.setup;
+}
+
+describe("platform Clerk entrypoint", () => {
+  it("starts the preview Clerk core request with the official attributes", async () => {
+    const harness = startClerkPage("pr-30199-app.omby.ai");
+
+    expect(mockedClerkLoad).not.toHaveBeenCalled();
+    await completeEarlyClerkScript(harness);
+
+    expect(harness.requests.map(({ url }) => url)).toStrictEqual([
+      expectedClerkScriptUrl(PREVIEW_FRONTEND_API_HOST),
+    ]);
+    expect(harness.earlyScript.async).toBeTruthy();
+    expect(harness.earlyScript.crossOrigin).toBe("anonymous");
+    expect(harness.earlyScript).toHaveAttribute("data-clerk-js-script", "");
+    expect(harness.earlyScript).toHaveAttribute(
+      "data-clerk-publishable-key",
+      PREVIEW_PUBLISHABLE_KEY,
+    );
+    expect(harness.earlyScript).not.toHaveAttribute("data-clerk-domain");
+    expect(mockedClerkLoad).toHaveBeenCalledOnce();
+  });
+
+  it("uses the production Frontend API host without a satellite domain", async () => {
+    const harness = startClerkPage("app.vm0.ai");
+
+    await completeEarlyClerkScript(harness);
+
+    expect(harness.requests.map(({ url }) => url)).toStrictEqual([
+      expectedClerkScriptUrl(PRODUCTION_FRONTEND_API_HOST),
+    ]);
+    expect(harness.earlyScript).toHaveAttribute(
+      "data-clerk-publishable-key",
+      PRODUCTION_PUBLISHABLE_KEY,
+    );
+    expect(harness.earlyScript).not.toHaveAttribute("data-clerk-domain");
+  });
+
+  it("uses Clerk's satellite script host and domain on app.okou.ai", async () => {
+    const harness = startClerkPage(PRODUCTION_SATELLITE_DOMAIN);
+
+    await completeEarlyClerkScript(harness);
+
+    expect(harness.requests.map(({ url }) => url)).toStrictEqual([
+      expectedClerkScriptUrl(`clerk.${PRODUCTION_SATELLITE_DOMAIN}`),
+    ]);
+    expect(harness.earlyScript).toHaveAttribute(
+      "data-clerk-publishable-key",
+      PRODUCTION_PUBLISHABLE_KEY,
+    );
+    expect(harness.earlyScript).toHaveAttribute(
+      "data-clerk-domain",
+      PRODUCTION_SATELLITE_DOMAIN,
+    );
+  });
+
+  it("retries immediately after the early request fails", async () => {
+    const harness = startClerkPage("pr-30199-app.omby.ai");
+    await harness.clerkLoaderWatchingEarlyScript;
+    harness.earlyScript.dispatchEvent(new Event("error"));
+    await harness.setup;
+
+    expect(harness.earlyScript.isConnected).toBeFalsy();
+    expect(harness.requests.map(({ url }) => url)).toStrictEqual([
+      expectedClerkScriptUrl(PREVIEW_FRONTEND_API_HOST),
+      expectedClerkScriptUrl(PREVIEW_FRONTEND_API_HOST),
+    ]);
+  });
+});

--- a/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
+
 import indexHtml from "../../index.html?raw";
-import { setupPage } from "./page-helper.ts";
-import { mockedClerk, mockedClerkLoad } from "./mock-auth.ts";
+import { transformClerkCoreScriptUrls } from "../../scripts/clerk-html.ts";
+import { CLERK_JS_VERSION } from "../lib/clerk-versions.ts";
 import { testContext } from "../signals/__tests__/test-helpers.ts";
+import { mockedClerk, mockedClerkLoad } from "./mock-auth.ts";
+import { setupPage } from "./page-helper.ts";
 
 vi.unmock("@clerk/shared/loadClerkJsScript");
 
-const CLERK_JS_VERSION = "6.25.8";
 const PREVIEW_FRONTEND_API_HOST = "informed-calf-6.clerk.accounts.dev";
 const PRODUCTION_FRONTEND_API_HOST = "clerk.vm0.ai";
 const PRODUCTION_SATELLITE_DOMAIN = "app.okou.ai";
@@ -21,15 +23,9 @@ interface ClerkEntrypointHarness {
   readonly clerkLoaderWatchingEarlyScript: Promise<void>;
   readonly earlyScript: HTMLScriptElement;
   readonly requests: ClerkScriptRequest[];
+  readonly retryStarted: Promise<void>;
   readonly setup: Promise<void>;
 }
-
-type ClerkEntrypointScript = (
-  windowObject: Window,
-  documentObject: Document,
-  locationObject: Location,
-  atobFunction: typeof atob,
-) => void;
 
 const context = testContext();
 
@@ -46,37 +42,46 @@ const PRODUCTION_PUBLISHABLE_KEY = publishableKey(
   PRODUCTION_FRONTEND_API_HOST,
 );
 
-function clerkEntrypointSource(): string {
-  const source = [...indexHtml.matchAll(/<script>([\s\S]*?)<\/script>/giu)]
-    .map((match) => {
-      return match[1];
-    })
-    .find((script) => {
-      return script?.includes('s.setAttribute("data-clerk-js-script", "")');
-    });
-  if (source === undefined) {
-    throw new Error("Unable to locate the Clerk loader in index.html");
-  }
-  return source
-    .replaceAll("%VITE_CLERK_PUBLISHABLE_KEY_PREVIEW%", PREVIEW_PUBLISHABLE_KEY)
-    .replaceAll(
-      "%VITE_CLERK_PUBLISHABLE_KEY_PROD%",
-      PRODUCTION_PUBLISHABLE_KEY,
-    );
-}
-
 function expectedClerkScriptUrl(host: string): string {
   return `https://${host}/npm/@clerk/clerk-js@${CLERK_JS_VERSION}/dist/clerk.browser.js`;
 }
 
-function startClerkPage(hostname: string): ClerkEntrypointHarness {
+function builtIndexHtml(): string {
+  return transformClerkCoreScriptUrls(
+    indexHtml
+      .replaceAll(
+        "%VITE_CLERK_PUBLISHABLE_KEY_PREVIEW%",
+        PREVIEW_PUBLISHABLE_KEY,
+      )
+      .replaceAll(
+        "%VITE_CLERK_PUBLISHABLE_KEY_PROD%",
+        PRODUCTION_PUBLISHABLE_KEY,
+      ),
+    {
+      previewPublishableKey: PREVIEW_PUBLISHABLE_KEY,
+      productionPublishableKey: PRODUCTION_PUBLISHABLE_KEY,
+    },
+  );
+}
+
+function clerkScriptFromHtml(html: string): HTMLScriptElement {
+  const parsedDocument = new DOMParser().parseFromString(html, "text/html");
+  const script = parsedDocument.querySelector(CLERK_SCRIPT_SELECTOR);
+  if (!(script instanceof HTMLScriptElement)) {
+    throw new Error("Built index.html does not contain the Clerk core script");
+  }
+  return script;
+}
+
+function startClerkPage(): ClerkEntrypointHarness {
   const requests: ClerkScriptRequest[] = [];
   const clerkLoaderWatchingEarlyScript = context.mocks.deferred<void>();
+  const retryStarted = context.mocks.deferred<void>();
   let earlyScript: HTMLScriptElement | undefined;
 
   const setup = setupPage({
     beforeBootstrap: (signal) => {
-      context.mocks.browser.url(`https://${hostname}/`);
+      context.mocks.browser.url("https://pr-30199-app.omby.ai/");
       const previousPreviewKey = import.meta.env
         .VITE_CLERK_PUBLISHABLE_KEY_PREVIEW;
       const previousProductionKey = import.meta.env
@@ -86,52 +91,20 @@ function startClerkPage(hostname: string): ClerkEntrypointHarness {
       window.__vm0BrowserSupported = true;
       Reflect.deleteProperty(globalThis, "Clerk");
 
-      const observeScript = (
-        append: typeof document.head.appendChild,
-        node: Node,
-      ): Node => {
-        if (!(node instanceof HTMLScriptElement) || !node.src) {
-          return append(node);
+      const parsedEarlyScript = clerkScriptFromHtml(builtIndexHtml());
+      const earlyScriptUrl = parsedEarlyScript.src;
+      parsedEarlyScript.removeAttribute("src");
+      document.head.appendChild(parsedEarlyScript);
+      requests.push({ element: parsedEarlyScript, url: earlyScriptUrl });
+      parsedEarlyScript.addEventListener("error", () => {
+        if (parsedEarlyScript.getAttribute("onerror") === "this.remove()") {
+          parsedEarlyScript.remove();
         }
-
-        const request = { element: node, url: node.src };
-        requests.push(request);
-        // Keep Happy DOM from making an external request. The real Clerk
-        // loader still observes the connected data-clerk-js-script element.
-        node.removeAttribute("src");
-        const appended = append(node);
-
-        if (requests.length > 1) {
-          Reflect.set(globalThis, "Clerk", mockedClerk);
-          node.dispatchEvent(new Event("load"));
-        }
-        return appended;
-      };
-
-      const appendToHead = document.head.appendChild.bind(document.head);
-      vi.spyOn(document.head, "appendChild").mockImplementation((node) => {
-        return observeScript(appendToHead, node);
-      });
-      const appendToBody = document.body.appendChild.bind(document.body);
-      vi.spyOn(document.body, "appendChild").mockImplementation((node) => {
-        return observeScript(appendToBody, node);
       });
 
-      const executeEntrypointScript = new Function(
-        "window",
-        "document",
-        "location",
-        "atob",
-        `${clerkEntrypointSource()}\n//# sourceURL=platform-clerk-entrypoint-test.js`,
-      ) as ClerkEntrypointScript;
-      executeEntrypointScript(window, document, location, atob);
-
-      earlyScript = document.querySelector(CLERK_SCRIPT_SELECTOR) ?? undefined;
-      if (!earlyScript) {
-        throw new Error("Clerk entrypoint did not append its core script");
-      }
-      const addEventListener = earlyScript.addEventListener.bind(earlyScript);
-      vi.spyOn(earlyScript, "addEventListener").mockImplementation(
+      const addEventListener =
+        parsedEarlyScript.addEventListener.bind(parsedEarlyScript);
+      vi.spyOn(parsedEarlyScript, "addEventListener").mockImplementation(
         (type, listener, options) => {
           if (type === "error") {
             clerkLoaderWatchingEarlyScript.resolve(undefined);
@@ -140,9 +113,42 @@ function startClerkPage(hostname: string): ClerkEntrypointHarness {
         },
       );
 
+      const observeScript = (
+        append: typeof document.body.appendChild,
+        node: Node,
+      ): Node => {
+        if (!(node instanceof HTMLScriptElement) || !node.src) {
+          return append(node);
+        }
+
+        requests.push({ element: node, url: node.src });
+        node.removeAttribute("src");
+        const appended = append(node);
+        retryStarted.resolve(undefined);
+        Reflect.set(globalThis, "Clerk", mockedClerk);
+        node.dispatchEvent(new Event("load"));
+        return appended;
+      };
+
+      const appendToHead = document.head.appendChild.bind(document.head);
+      const headAppendSpy = vi
+        .spyOn(document.head, "appendChild")
+        .mockImplementation((node) => {
+          return observeScript(appendToHead, node);
+        });
+      const appendToBody = document.body.appendChild.bind(document.body);
+      const bodyAppendSpy = vi
+        .spyOn(document.body, "appendChild")
+        .mockImplementation((node) => {
+          return observeScript(appendToBody, node);
+        });
+
+      earlyScript = parsedEarlyScript;
       signal.addEventListener(
         "abort",
         () => {
+          headAppendSpy.mockRestore();
+          bodyAppendSpy.mockRestore();
           for (const request of requests) {
             request.element.remove();
           }
@@ -166,6 +172,7 @@ function startClerkPage(hostname: string): ClerkEntrypointHarness {
     clerkLoaderWatchingEarlyScript: clerkLoaderWatchingEarlyScript.promise,
     earlyScript,
     requests,
+    retryStarted: retryStarted.promise,
     setup,
   };
 }
@@ -180,8 +187,47 @@ async function completeEarlyClerkScript(
 }
 
 describe("platform Clerk entrypoint", () => {
-  it("starts the preview Clerk core request with the official attributes", async () => {
-    const harness = startClerkPage("pr-30199-app.omby.ai");
+  it("builds the official static core script with exact environment URLs", () => {
+    const html = builtIndexHtml();
+    const script = clerkScriptFromHtml(html);
+    const parsedDocument = new DOMParser().parseFromString(html, "text/html");
+
+    expect(parsedDocument.querySelectorAll(CLERK_SCRIPT_SELECTOR)).toHaveLength(
+      1,
+    );
+    expect(
+      html.indexOf(expectedClerkScriptUrl(PREVIEW_FRONTEND_API_HOST)),
+    ).toBeLessThan(
+      html.indexOf('<script type="module" src="/src/main.ts"></script>'),
+    );
+    expect(script.src).toBe(expectedClerkScriptUrl(PREVIEW_FRONTEND_API_HOST));
+    expect(script.defer).toBeTruthy();
+    expect(script.async).toBeFalsy();
+    expect(script.crossOrigin).toBe("anonymous");
+    expect(script).toHaveAttribute("data-clerk-js-script", "");
+    expect(script).toHaveAttribute(
+      "data-clerk-publishable-key",
+      PREVIEW_PUBLISHABLE_KEY,
+    );
+    expect(script).toHaveAttribute(
+      "data-vm0-clerk-production-publishable-key",
+      PRODUCTION_PUBLISHABLE_KEY,
+    );
+    expect(script).toHaveAttribute(
+      "data-vm0-clerk-production-script-url",
+      expectedClerkScriptUrl(PRODUCTION_FRONTEND_API_HOST),
+    );
+    expect(script).toHaveAttribute(
+      "data-vm0-clerk-satellite-script-url",
+      expectedClerkScriptUrl(`clerk.${PRODUCTION_SATELLITE_DOMAIN}`),
+    );
+    expect(script).toHaveAttribute("onerror", "this.remove()");
+    expect(script.textContent).toBe("");
+    expect(html).not.toContain("@clerk/ui");
+  });
+
+  it("merges the in-flight script and lets TypeScript call Clerk.load", async () => {
+    const harness = startClerkPage();
 
     expect(mockedClerkLoad).not.toHaveBeenCalled();
     await completeEarlyClerkScript(harness);
@@ -189,54 +235,17 @@ describe("platform Clerk entrypoint", () => {
     expect(harness.requests.map(({ url }) => url)).toStrictEqual([
       expectedClerkScriptUrl(PREVIEW_FRONTEND_API_HOST),
     ]);
-    expect(harness.earlyScript.async).toBeTruthy();
-    expect(harness.earlyScript.crossOrigin).toBe("anonymous");
-    expect(harness.earlyScript).toHaveAttribute("data-clerk-js-script", "");
-    expect(harness.earlyScript).toHaveAttribute(
-      "data-clerk-publishable-key",
-      PREVIEW_PUBLISHABLE_KEY,
-    );
-    expect(harness.earlyScript).not.toHaveAttribute("data-clerk-domain");
+    expect(document.querySelectorAll(CLERK_SCRIPT_SELECTOR)).toHaveLength(1);
+    expect(document.querySelector("script[data-clerk-ui-script]")).toBeNull();
     expect(mockedClerkLoad).toHaveBeenCalledOnce();
   });
 
-  it("uses the production Frontend API host without a satellite domain", async () => {
-    const harness = startClerkPage("app.vm0.ai");
-
-    await completeEarlyClerkScript(harness);
-
-    expect(harness.requests.map(({ url }) => url)).toStrictEqual([
-      expectedClerkScriptUrl(PRODUCTION_FRONTEND_API_HOST),
-    ]);
-    expect(harness.earlyScript).toHaveAttribute(
-      "data-clerk-publishable-key",
-      PRODUCTION_PUBLISHABLE_KEY,
-    );
-    expect(harness.earlyScript).not.toHaveAttribute("data-clerk-domain");
-  });
-
-  it("uses Clerk's satellite script host and domain on app.okou.ai", async () => {
-    const harness = startClerkPage(PRODUCTION_SATELLITE_DOMAIN);
-
-    await completeEarlyClerkScript(harness);
-
-    expect(harness.requests.map(({ url }) => url)).toStrictEqual([
-      expectedClerkScriptUrl(`clerk.${PRODUCTION_SATELLITE_DOMAIN}`),
-    ]);
-    expect(harness.earlyScript).toHaveAttribute(
-      "data-clerk-publishable-key",
-      PRODUCTION_PUBLISHABLE_KEY,
-    );
-    expect(harness.earlyScript).toHaveAttribute(
-      "data-clerk-domain",
-      PRODUCTION_SATELLITE_DOMAIN,
-    );
-  });
-
-  it("retries immediately after the early request fails", async () => {
-    const harness = startClerkPage("pr-30199-app.omby.ai");
+  it("falls back immediately when the static request fails", async () => {
+    const harness = startClerkPage();
     await harness.clerkLoaderWatchingEarlyScript;
+
     harness.earlyScript.dispatchEvent(new Event("error"));
+    await harness.retryStarted;
     await harness.setup;
 
     expect(harness.earlyScript.isConnected).toBeFalsy();
@@ -244,5 +253,6 @@ describe("platform Clerk entrypoint", () => {
       expectedClerkScriptUrl(PREVIEW_FRONTEND_API_HOST),
       expectedClerkScriptUrl(PREVIEW_FRONTEND_API_HOST),
     ]);
+    expect(mockedClerkLoad).toHaveBeenCalledOnce();
   });
 });

--- a/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import indexHtml from "../../index.html?raw";
-import { transformClerkCoreScriptUrls } from "../../scripts/clerk-html.ts";
+import { transformClerkCoreScriptUrls } from "../../scripts/clerk-html-transform.ts";
 import { CLERK_JS_VERSION } from "../lib/clerk-versions.ts";
 import { testContext } from "../signals/__tests__/test-helpers.ts";
 import { mockedClerk, mockedClerkLoad } from "./mock-auth.ts";

--- a/turbo/apps/platform/src/__tests__/page-helper.ts
+++ b/turbo/apps/platform/src/__tests__/page-helper.ts
@@ -84,6 +84,7 @@ function ensureTestLocalStorage(): void {
 export interface SetupBootstrapOptions {
   context: TestContext;
   path: string;
+  beforeBootstrap?: (signal: AbortSignal) => void;
   user?: {
     id: string;
     fullName: string;
@@ -130,6 +131,7 @@ export async function setupBootstrap(
   // customize a handler. Start the lazy mock lifecycle so abort resets any
   // fixture mutations made by the application during this test.
   void options.context.mocks;
+  options.beforeBootstrap?.(options.context.signal);
   createPushStateMock(options.context.signal);
   pushState({}, "", options.path);
 

--- a/turbo/apps/platform/src/lib/clerk-runtime.ts
+++ b/turbo/apps/platform/src/lib/clerk-runtime.ts
@@ -5,8 +5,8 @@ import {
 import type { BrowserClerk, EnvironmentResource } from "@clerk/shared/types";
 import type { ClerkUIConstructor } from "@clerk/shared/ui";
 import { createDeferredPromise } from "../signals/utils.ts";
+import { CLERK_JS_VERSION } from "./clerk-versions.ts";
 
-const CLERK_JS_VERSION = "6.25.8";
 const CLERK_UI_VERSION = "1.27.0";
 
 interface ClerkRuntimeOptions {

--- a/turbo/apps/platform/src/lib/clerk-versions.ts
+++ b/turbo/apps/platform/src/lib/clerk-versions.ts
@@ -1,0 +1,1 @@
+export const CLERK_JS_VERSION = "6.25.8";

--- a/turbo/apps/platform/src/signals/okou-page/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/connectors.ts
@@ -48,6 +48,7 @@ export type ComposerConnectorAuthorizationTarget =
     };
 
 export interface ComposerConnectorUiState {
+  readonly connectorDataActivated: boolean;
   readonly showAddDialog: boolean;
   readonly pendingConnectorSlug: ConnectorSlug | null;
   readonly selectedConnectorSlug: ConnectorSlug | null;
@@ -179,6 +180,7 @@ const agentCustomConnectorAuthorizationRequestBroker$ = computed(() => {
 
 function initialComposerConnectorUiState(): ComposerConnectorUiState {
   return {
+    connectorDataActivated: false,
     showAddDialog: false,
     pendingConnectorSlug: null,
     selectedConnectorSlug: null,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -290,6 +290,43 @@ beforeEach(() => {
 });
 
 describe("chat composer connector connection", () => {
+  it("loads connector data only after the connector menu is opened", async () => {
+    const user = userEvent.setup({ delay: null });
+    let discoveryRequests = 0;
+    let customConnectorRequests = 0;
+    mockThread();
+    context.mocks.api(connectorCatalogContract.discovery, ({ respond }) => {
+      discoveryRequests += 1;
+      return respond(200, { connectors: [], totalConnectorCount: 0 });
+    });
+    context.mocks.api(customConnectorsContract.list, ({ respond }) => {
+      customConnectorRequests += 1;
+      return respond(200, { connectors: [] });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    const composer = composerElementFrom(
+      await screen.findByPlaceholderText(PLACEHOLDER),
+    );
+    expect(discoveryRequests).toBe(0);
+    expect(customConnectorRequests).toBe(0);
+
+    await user.click(within(composer).getByLabelText("Connectors"));
+
+    await waitFor(() => {
+      expect(discoveryRequests).toBe(1);
+      expect(customConnectorRequests).toBe(1);
+      expect(within(composer).getByLabelText("Connectors")).toHaveAttribute(
+        "aria-expanded",
+        "true",
+      );
+    });
+  });
+
   it("makes connector permissions interactive on the first click", async () => {
     const user = userEvent.setup({ delay: null });
     mockThread();
@@ -304,9 +341,11 @@ describe("chat composer connector connection", () => {
     const composer = composerElementFrom(
       await screen.findByPlaceholderText(PLACEHOLDER),
     );
-    const connectorsTrigger = within(composer).getByLabelText("Connectors");
-    await user.click(connectorsTrigger);
-    expect(connectorsTrigger).toHaveAttribute("aria-expanded", "true");
+    const connectorsTrigger = () => {
+      return within(composer).getByLabelText("Connectors");
+    };
+    await user.click(connectorsTrigger());
+    expect(connectorsTrigger()).toHaveAttribute("aria-expanded", "true");
 
     await user.click(
       await screen.findByLabelText("Configure Axiom permissions"),
@@ -316,7 +355,7 @@ describe("chat composer connector connection", () => {
       name: /Axiom permissions/u,
     });
     await waitFor(() => {
-      expect(connectorsTrigger).toHaveAttribute("aria-expanded", "false");
+      expect(connectorsTrigger()).toHaveAttribute("aria-expanded", "false");
       expect(screen.queryByText("Add connectors")).not.toBeInTheDocument();
     });
 
@@ -340,7 +379,7 @@ describe("chat composer connector connection", () => {
     await waitFor(() => {
       expect(permissionsDialog).not.toBeInTheDocument();
     });
-    expect(connectorsTrigger).toHaveAttribute("aria-expanded", "false");
+    expect(connectorsTrigger()).toHaveAttribute("aria-expanded", "false");
   });
 
   it("places the account action before connector permissions", async () => {
@@ -603,8 +642,10 @@ describe("chat composer connector connection", () => {
     const composer = composerElementFrom(
       await screen.findByPlaceholderText(PLACEHOLDER),
     );
-    const connectorsButton = within(composer).getByLabelText("Connectors");
-    await user.click(connectorsButton);
+    const connectorsButton = () => {
+      return within(composer).getByLabelText("Connectors");
+    };
+    await user.click(connectorsButton());
     const defaultMode = await screen.findByLabelText(
       "GitHub · Using default account: Work",
     );
@@ -634,7 +675,7 @@ describe("chat composer connector connection", () => {
     await waitFor(() => {
       expect(screen.queryByText("Account for this chat")).toBeNull();
     });
-    expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
+    expect(connectorsButton()).toHaveAttribute("aria-expanded", "true");
 
     await user.click(defaultMode);
     await expect(
@@ -644,7 +685,7 @@ describe("chat composer connector connection", () => {
     await waitFor(() => {
       expect(screen.queryByText("Account for this chat")).toBeNull();
     });
-    expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
+    expect(connectorsButton()).toHaveAttribute("aria-expanded", "true");
 
     await user.click(defaultMode);
     await expect(
@@ -672,7 +713,7 @@ describe("chat composer connector connection", () => {
     await waitFor(() => {
       expect(screen.queryByText("Account for this chat")).toBeNull();
     });
-    expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
+    expect(connectorsButton()).toHaveAttribute("aria-expanded", "true");
     expect(selectedWorkMode).toHaveClass("text-muted-foreground");
     expect(selectedWorkMode).not.toHaveClass("border");
 
@@ -684,7 +725,7 @@ describe("chat composer connector connection", () => {
     await waitFor(() => {
       expect(screen.queryByText("Account for this chat")).toBeNull();
     });
-    expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
+    expect(connectorsButton()).toHaveAttribute("aria-expanded", "true");
     expect(selectedWorkMode).toHaveFocus();
 
     await user.click(selectedWorkMode);
@@ -695,7 +736,7 @@ describe("chat composer connector connection", () => {
     await waitFor(() => {
       expect(screen.queryByText("Account for this chat")).toBeNull();
     });
-    expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
+    expect(connectorsButton()).toHaveAttribute("aria-expanded", "true");
     await expect(
       screen.findByLabelText("GitHub · Selected account: Personal"),
     ).resolves.toHaveClass("text-muted-foreground");
@@ -713,13 +754,13 @@ describe("chat composer connector connection", () => {
     await expect(
       screen.findByLabelText("GitHub · Using default account: Work"),
     ).resolves.toBeInTheDocument();
-    expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
+    expect(connectorsButton()).toHaveAttribute("aria-expanded", "true");
     expect(authorizationWrites).toBe(1);
     expect(summaryReads).toBe(summaryReadsBeforeSelection);
 
     await user.click(document.body);
     await waitFor(() => {
-      expect(connectorsButton).toHaveAttribute("aria-expanded", "false");
+      expect(connectorsButton()).toHaveAttribute("aria-expanded", "false");
     });
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -3018,14 +3018,17 @@ describe("chat composer models", () => {
     const composer = composerElementFrom(
       await screen.findByPlaceholderText(PLACEHOLDER),
     );
-    const connectorButton = within(composer).getByLabelText("Connectors");
+    const connectorButton = () => {
+      return within(composer).getByLabelText("Connectors");
+    };
+    click(connectorButton());
 
     await waitFor(() => {
       expect(
-        connectorButton.querySelectorAll(":scope > span > span"),
+        connectorButton().querySelectorAll(":scope > span > span"),
       ).toHaveLength(3);
       expect(
-        connectorButton.querySelector(".lucide-globe"),
+        connectorButton().querySelector(".lucide-globe"),
       ).toBeInTheDocument();
     });
   });
@@ -3092,11 +3095,12 @@ describe("chat composer models", () => {
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    const initialConnectorButton = within(
-      await screen.findByLabelText("Chat thread"),
-    ).getByLabelText("Connectors");
+    const initialThread = await screen.findByLabelText("Chat thread");
+    click(within(initialThread).getByLabelText("Connectors"));
     await waitFor(() => {
-      expect(initialConnectorButton.querySelector("img")).not.toBeNull();
+      expect(
+        within(initialThread).getByLabelText("Connectors").querySelector("img"),
+      ).not.toBeNull();
     });
     const settledAgentRequestCount = agentRequestCount;
 
@@ -3110,10 +3114,14 @@ describe("chat composer models", () => {
     });
     expect(agentRequestCount).toBe(settledAgentRequestCount);
 
-    const nextConnectorButton = within(
-      screen.getByLabelText("Chat thread"),
-    ).getByLabelText("Connectors");
-    expect(nextConnectorButton.querySelector("img")).not.toBeNull();
+    const nextThread = screen.getByLabelText("Chat thread");
+    click(within(nextThread).getByLabelText("Connectors"));
+    await waitFor(() => {
+      expect(
+        within(nextThread).getByLabelText("Connectors").querySelector("img"),
+      ).not.toBeNull();
+    });
+    expect(agentRequestCount).toBe(settledAgentRequestCount);
   });
 
   it("keeps connector catalog and access resolved across same-agent chat navigation", async () => {
@@ -3217,10 +3225,11 @@ describe("chat composer models", () => {
     });
 
     const initialThread = await screen.findByLabelText("Chat thread");
-    const initialConnectorButton =
-      within(initialThread).getByLabelText("Connectors");
+    click(within(initialThread).getByLabelText("Connectors"));
     await waitFor(() => {
-      expect(initialConnectorButton.querySelector("img")).not.toBeNull();
+      expect(
+        within(initialThread).getByLabelText("Connectors").querySelector("img"),
+      ).not.toBeNull();
       expect(authorizationRequestCount).toBe(1);
       expect(customAuthorizationRequestCount).toBe(1);
       expect(discoveryRequestCount).toBe(1);
@@ -3235,12 +3244,11 @@ describe("chat composer models", () => {
       ).toBeInTheDocument();
     });
 
-    const nextConnectorButton = within(
-      screen.getByLabelText("Chat thread"),
-    ).getByLabelText("Connectors");
-    click(nextConnectorButton);
-    const connectorStatusStayedResolved =
-      screen.queryByLabelText("Remove GitHub") !== null;
+    const nextThread = screen.getByLabelText("Chat thread");
+    click(within(nextThread).getByLabelText("Connectors"));
+    await expect(
+      screen.findByLabelText("Remove GitHub"),
+    ).resolves.toBeInTheDocument();
     const requestCountAfterNavigation = authorizationRequestCount;
     const customRequestCountAfterNavigation = customAuthorizationRequestCount;
     const discoveryRequestCountAfterNavigation = discoveryRequestCount;
@@ -3248,11 +3256,12 @@ describe("chat composer models", () => {
     unexpectedCustomReload.resolve();
     unexpectedDiscoveryReload.resolve();
 
-    expect(connectorStatusStayedResolved).toBeTruthy();
     expect(requestCountAfterNavigation).toBe(1);
     expect(customRequestCountAfterNavigation).toBe(1);
     expect(discoveryRequestCountAfterNavigation).toBe(1);
-    expect(nextConnectorButton.querySelector("img")).not.toBeNull();
+    expect(
+      within(nextThread).getByLabelText("Connectors").querySelector("img"),
+    ).not.toBeNull();
   });
 
   it("does not expose previous-agent connector access while navigation resolves", async () => {
@@ -3285,18 +3294,18 @@ describe("chat composer models", () => {
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    const initialConnectorButton = within(
-      await screen.findByLabelText("Chat thread"),
-    ).getByLabelText("Connectors");
+    const initialThread = await screen.findByLabelText("Chat thread");
+    click(within(initialThread).getByLabelText("Connectors"));
     await waitFor(() => {
-      expect(initialConnectorButton.querySelector("img")).not.toBeNull();
+      expect(
+        within(initialThread).getByLabelText("Connectors").querySelector("img"),
+      ).not.toBeNull();
     });
 
     act(() => {
       context.store.set(loadLeftThread$, OTHER_AGENT_THREAD_ID);
     });
     await waitFor(() => {
-      expect(authorizationAgentIds).toContain(OTHER_AGENT_ID);
       expect(
         within(screen.getByLabelText("Chat thread")).getByText(
           "Other agent thread",
@@ -3304,12 +3313,15 @@ describe("chat composer models", () => {
       ).toBeInTheDocument();
     });
 
-    const nextConnectorButton = within(
-      screen.getByLabelText("Chat thread"),
-    ).getByLabelText("Connectors");
-    click(nextConnectorButton);
+    const nextThread = screen.getByLabelText("Chat thread");
+    click(within(nextThread).getByLabelText("Connectors"));
+    await waitFor(() => {
+      expect(authorizationAgentIds).toContain(OTHER_AGENT_ID);
+    });
     expect(screen.queryByLabelText("Remove GitHub")).not.toBeInTheDocument();
-    expect(nextConnectorButton.querySelector("img")).toBeNull();
+    expect(
+      within(nextThread).getByLabelText("Connectors").querySelector("img"),
+    ).toBeNull();
 
     otherAgentAuthorization.resolve();
     await expect(
@@ -3370,32 +3382,36 @@ describe("chat composer models", () => {
       expect(screen.getAllByLabelText("Chat thread")).toHaveLength(2);
     });
     const threadRegions = screen.getAllByLabelText("Chat thread");
+    const mainThread = threadRegions[0];
+    const sideThread = threadRegions[1];
+    if (!mainThread || !sideThread) {
+      throw new Error("Split chat threads not found");
+    }
+    const connectorButtonFor = (thread: HTMLElement) => {
+      return within(thread).getByLabelText("Connectors");
+    };
+
+    await user.click(connectorButtonFor(mainThread));
+    await user.click(connectorButtonFor(mainThread));
+    await user.click(connectorButtonFor(sideThread));
     await waitFor(() => {
       expect(authorizationRequestCount).toBe(1);
     });
 
     initialAuthorization.resolve();
-    const connectorButtons = threadRegions.map((thread) => {
-      return within(thread).getByLabelText("Connectors");
-    });
     await waitFor(() => {
-      for (const button of connectorButtons) {
-        expect(button.querySelector("img")).not.toBeNull();
+      for (const thread of threadRegions) {
+        expect(connectorButtonFor(thread).querySelector("img")).not.toBeNull();
       }
     });
 
-    const sideConnectorButton = connectorButtons[1];
-    if (!sideConnectorButton) {
-      throw new Error("Side connector button not found");
-    }
-    await user.click(sideConnectorButton);
     await user.click(await screen.findByLabelText("Remove Slack"));
 
     await waitFor(() => {
       expect(updatedAuthorizationAgentId).toBe(AGENT_ID);
       expect(authorizationRequestCount).toBe(2);
-      for (const button of connectorButtons) {
-        expect(button.querySelector("img")).toBeNull();
+      for (const thread of threadRegions) {
+        expect(connectorButtonFor(thread).querySelector("img")).toBeNull();
       }
     });
   });
@@ -3484,15 +3500,19 @@ describe("chat composer models", () => {
       expect(screen.getAllByLabelText("Chat thread")).toHaveLength(2);
     });
     const threadRegions = screen.getAllByLabelText("Chat thread");
+    const mainThread = threadRegions[0];
     const sideThread = threadRegions[1];
-    if (!sideThread) {
-      throw new Error("Side chat thread not found");
+    if (!mainThread || !sideThread) {
+      throw new Error("Split chat threads not found");
     }
     const sideComposer = sideThread.querySelector("[data-chat-composer]");
     if (!(sideComposer instanceof HTMLElement)) {
       throw new Error("Side chat composer not found");
     }
 
+    await user.click(within(mainThread).getByLabelText("Connectors"));
+    await user.click(within(mainThread).getByLabelText("Connectors"));
+    await user.click(within(sideComposer).getByLabelText("Connectors"));
     await waitFor(() => {
       expect(new Set(authorizationAgentIds)).toStrictEqual(
         new Set([AGENT_ID, OTHER_AGENT_ID]),
@@ -3523,7 +3543,6 @@ describe("chat composer models", () => {
     });
     expect(authorizationAgentIds).toHaveLength(authorizationRequestCount);
     expect(workflowAgentIds).toHaveLength(workflowRequestCount);
-    await user.click(within(sideComposer).getByLabelText("Connectors"));
     await user.click(
       await screen.findByLabelText("Configure Slack permissions"),
     );

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -8601,6 +8601,7 @@ function ConnectorsPopoverButton({
 
   return (
     <Popover
+      defaultOpen
       onOpenChange={(open, eventDetails) => {
         if (
           !open &&
@@ -10536,13 +10537,7 @@ function ComposerConnectorConnectDialogs({
   );
 }
 
-function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
-  const { t } = useTranslation();
-  const mcpEnabled = useGet(customConnectorMcpEnabled$);
-  const connectorReadState = useComposerConnectorReadState(signals);
-  const agents = useLastResolved(agents$) ?? [];
-  const connectorUi = useGet(signals.connector.connectorUiState$);
-  const updateConnectorUi = useSet(signals.connector.updateConnectorUiState$);
+function useComposerComputerUse(signals: ComposerSignals): ComposerComputerUse {
   const storedComputerUseHostId = useGet(signals.computer.computerUseHostId$);
   const cloudBrowserEnabled = useGet(signals.computer.cloudBrowserEnabled$);
   const setComputerUseHostId = useSet(signals.computer.setComputerUseHostId$);
@@ -10560,7 +10555,7 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
     storedComputerUseHostId,
   );
   const composerPageSignal = useGet(pageSignal$);
-  const computerUse: ComposerComputerUse = {
+  return {
     hosts: visibleComputerUseHosts(computerUseHosts, resolvedComputerUseHostId),
     loading:
       computerUseHostsState.state === "loading" &&
@@ -10581,6 +10576,62 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
     },
     downloadUrl: OKOU_DESKTOP_DOWNLOAD_URL,
   };
+}
+
+function ComposerConnectorsActivator({
+  computerUse,
+  onActivate,
+}: {
+  readonly computerUse: ComposerComputerUse;
+  readonly onActivate: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "inline-flex h-8 min-w-8 shrink-0 items-center justify-center rounded-lg px-1 transition-colors hover:bg-state-hover sm:min-w-9 sm:px-1.5",
+              COMPOSER_CONTROL_FOCUS_CLASS,
+            )}
+            aria-label={t(($) => {
+              return $.chat.connectors.title;
+            })}
+            onClick={onActivate}
+          >
+            <ConnectorTriggerIcons
+              connectors={[]}
+              customConnectors={[]}
+              hasComputerUse={Boolean(computerUse.selectedHostId)}
+              hasCloudBrowser={computerUse.cloudBrowserEnabled}
+            />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="text-xs">
+          {t(($) => {
+            return $.chat.connectors.title;
+          })}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function ActivatedComposerConnectorsSlot({
+  signals,
+  computerUse,
+}: {
+  readonly signals: ComposerSignals;
+  readonly computerUse: ComposerComputerUse;
+}) {
+  const { t } = useTranslation();
+  const mcpEnabled = useGet(customConnectorMcpEnabled$);
+  const connectorReadState = useComposerConnectorReadState(signals);
+  const agents = useLastResolved(agents$) ?? [];
+  const connectorUi = useGet(signals.connector.connectorUiState$);
+  const updateConnectorUi = useSet(signals.connector.updateConnectorUiState$);
 
   // Connectors: connected (org-level) + authorized (agent-level) → available
   const relatedCatalogItemsLoadable = connectorReadState.relatedCatalogItems;
@@ -10876,6 +10927,35 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
         />
       )}
     </>
+  );
+}
+
+function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
+  const computerUse = useComposerComputerUse(signals);
+  const connectorUi = useGet(signals.connector.connectorUiState$);
+  const updateConnectorUi = useSet(signals.connector.updateConnectorUiState$);
+  const openAccountsPopover = useSet(signals.connector.accounts.openPopover$);
+
+  if (connectorUi.connectorDataActivated) {
+    return (
+      <ActivatedComposerConnectorsSlot
+        signals={signals}
+        computerUse={computerUse}
+      />
+    );
+  }
+
+  return (
+    <ComposerConnectorsActivator
+      computerUse={computerUse}
+      onActivate={() => {
+        updateConnectorUi({
+          connectorDataActivated: true,
+          popoverSortOrder: [],
+        });
+        openAccountsPopover();
+      }}
+    />
   );
 }
 

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -5549,6 +5549,16 @@ function ThinkingIndicator({ thread }: { thread: ChatPanelSignals }) {
 
 function ChatConnectorActionConnectModal() {
   const active = useGet(activeChatConnectorAction$);
+
+  if (!active) {
+    return null;
+  }
+
+  return <ActiveChatConnectorActionConnectModal />;
+}
+
+function ActiveChatConnectorActionConnectModal() {
+  const active = useGet(activeChatConnectorAction$);
   const mcpEnabled = useGet(customConnectorMcpEnabled$);
   const close = useSet(closeChatConnectorActionConnectDialog$);
   const runCallback = useSet(runChatActionCallback$);

--- a/turbo/apps/platform/vite.config.ts
+++ b/turbo/apps/platform/vite.config.ts
@@ -7,6 +7,7 @@ import { defineConfig } from "vite";
 
 import { devArtifactFetchProxy } from "./dev-artifact-fetch-proxy.ts";
 import platformPackage from "./package.json";
+import { clerkCoreHtmlPlugin } from "./scripts/clerk-html.ts";
 import {
   applicationJavaScriptBundlePlugin,
   singleWorkerJavaScriptBundlePlugin,
@@ -33,6 +34,7 @@ export default defineConfig({
     tailwindcss(),
     react(),
     devArtifactFetchProxy(),
+    clerkCoreHtmlPlugin(),
     applicationJavaScriptBundlePlugin(),
     // Sentry source map upload (production builds only)
     process.env.SENTRY_AUTH_TOKEN &&

--- a/turbo/packages/api-contracts/package.json
+++ b/turbo/packages/api-contracts/package.json
@@ -28,7 +28,6 @@
     "check-types": "tsc -p tsconfig.contracts.json --noEmit && tsc -p tsconfig.python-bindings.json --noEmit && tsc -p tsconfig.rust-bindings.json --noEmit && tsc -p tsconfig.runtime-api-schema.json --noEmit"
   },
   "dependencies": {
-    "@trpc/server": "11.18.0",
     "@okouai/connectors": "workspace:*",
     "zod": "^4.3.6"
   },

--- a/turbo/packages/api-contracts/src/contracts/trpc-contract.ts
+++ b/turbo/packages/api-contracts/src/contracts/trpc-contract.ts
@@ -1,11 +1,3 @@
-import { initTRPC } from "@trpc/server";
-import { z } from "zod";
-
-const t = initTRPC.create({
-  allowOutsideOfServer: true,
-  isServer: !("window" in globalThis),
-});
-
 const noBodySymbol: unique symbol = Symbol("vm0.noBody");
 const typeSymbol: unique symbol = Symbol("vm0.type");
 
@@ -166,10 +158,6 @@ type ClientRouteInput<TSpec extends AppRouteSpec> =
     ? ClientRouteRequest<TSpec> | undefined
     : ClientRouteRequest<TSpec>;
 
-export interface ContractProcedure {
-  readonly _contractProcedure?: never;
-}
-
 export type RouteTypeSlots<TSpec extends AppRouteSpec> = {
   readonly serverRequest: ServerRouteRequest<TSpec>;
   readonly clientRequest: ClientRouteInput<TSpec>;
@@ -196,7 +184,6 @@ type RuntimeRouteSpec = {
 
 export type AppRoute<TTypes extends AnyRouteTypeSlots = AnyRouteTypeSlots> =
   RuntimeRouteSpec & {
-    readonly procedure: ContractProcedure;
     readonly __types?: TTypes;
   };
 
@@ -361,20 +348,6 @@ export function validateResponse<
   return { ...response, body };
 }
 
-function createProcedure(spec: AppRouteSpec) {
-  const procedure = t.procedure
-    .input(z.custom<unknown>())
-    .output(z.custom<unknown>());
-
-  const resolver = (): never => {
-    throw new Error("Contract procedures are type carriers only");
-  };
-
-  return spec.method === "GET"
-    ? procedure.query(resolver)
-    : procedure.mutation(resolver);
-}
-
 type RouteFromSpec<TSpec extends AppRouteSpec> = TSpec &
   AppRoute<RouteTypeSlots<TSpec>>;
 
@@ -413,12 +386,7 @@ export function initContract(): {
 } {
   return {
     router: (spec) => {
-      return mapRecordValues<typeof spec, RouterFromSpec<typeof spec>>(
-        spec,
-        (_name, route) => {
-          return { ...route, procedure: createProcedure(route) };
-        },
-      );
+      return spec;
     },
     noBody: () => {
       return { [noBodySymbol]: true };

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -753,9 +753,6 @@ importers:
       '@okouai/connectors':
         specifier: workspace:*
         version: link:../connectors
-      '@trpc/server':
-        specifier: 11.18.0
-        version: 11.18.0(typescript@6.0.3)
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -4269,12 +4266,6 @@ packages:
   '@tootallnate/once@2.0.1':
     resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
-
-  '@trpc/server@11.18.0':
-    resolution: {integrity: sha512-JAvXOuNTxgXjIDfQaOvDq1j66LMNfDJUH1IU7Slfn8EvRv2EkH6ehu3A7zpYhjO0syHHiYg77v2lG2JFJgvw7Q==}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=5.7.2'
 
   '@turbo/darwin-64@2.10.9':
     resolution: {integrity: sha512-Jh+pTGXLNz8+1tkUU13TI/f+ZOI+OvC4YbHi1H+57iSpLt5DR3xgptd+4sA07RdjdRR/RX/01uQQu2OkbzIefA==}
@@ -12683,10 +12674,6 @@ snapshots:
   '@tokenizer/token@0.3.0': {}
 
   '@tootallnate/once@2.0.1': {}
-
-  '@trpc/server@11.18.0(typescript@6.0.3)':
-    dependencies:
-      typescript: 6.0.3
 
   '@turbo/darwin-64@2.10.9':
     optional: true


### PR DESCRIPTION
## Summary

- declare the Clerk core script in the initial HTML using Clerk's official Vanilla JS attributes so the browser can discover it while parsing, before the application module
- pin Clerk JS to exactly `6.25.8` and generate preview, production, and satellite URLs with Clerk's own `clerkJSScriptUrl` helper rather than hard-coding an instance host
- reuse the existing Pages Worker hostname boundary to rewrite the production publishable key, Frontend API URL, and `app.okou.ai` satellite domain while leaving preview HTML on the preview instance
- retain `data-clerk-js-script` for `loadClerkJSScript` in-flight deduplication and remove failed static scripts so the TypeScript runtime retries immediately instead of waiting 15 seconds
- leave `Clerk.load`, deferred Clerk UI loading, and the dedicated `clerk-timers` Worker lifecycle in the existing TypeScript runtime

## Validation

- `pnpm exec prettier --write` on the changed HTML, TypeScript, and Worker files
- `./.github/scripts/tests/okou-app-worker-test.sh` (passed)
- `pnpm --filter @okouai/app exec vitest run src/__tests__/clerk-entrypoint.test.ts` (3 tests passed)
- `pnpm --filter @okouai/app run lint` (passed, including single-bundle checks, i18n, Oxlint, type-aware Oxlint, and ESLint)
- `pnpm knip --workspace @okouai/app` (passed)
- `pnpm --filter @okouai/app run check-types` (passed for production and test TypeScript configs)
- fixture-key `pnpm --filter @okouai/app run build` (passed; one application JS bundle plus the existing worker asset)

## Preview verification

- cold-cache trace on `https://pr-30211-app.omby.ai/_/error`: one Clerk `6.25.8` core request at `221.7 ms`; the app entry request started at `223.7 ms`, and Chrome trace timestamps put Clerk `2.3 ms` earlier and `1,339.9 ms` before the app module evaluation ended
- Clerk UI remained deferred: no `data-clerk-ui-script` element and no `__internal_ClerkUICtor` global
- lifecycle trace: `Clerk.load` started at `2,212.0 ms`; the dedicated `clerk-timers` Worker was constructed later through the token-polling `startPollingForToken -> create` stack, `1,680.9 ms` after Clerk core evaluation ended and `556.1 ms` after the app module evaluation ended

## Dependency context

This branch was created from the current #30186 head (`757cd2b3`) while that PR remains open. This PR intentionally targets `main`, as requested.
