### PR TITLE
fix(platform): navigate on push notification click

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/notification-click-navigation.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/notification-click-navigation.test.ts
@@ -1,0 +1,53 @@
+import { waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { setupBootstrap } from "../../__tests__/page-helper.ts";
+import { pathname$ } from "../route.ts";
+import { ROUTES } from "../route-paths.ts";
+import { testContext } from "./test-helpers.ts";
+
+const context = testContext();
+const THREAD_ID = "00000000-0000-4000-8000-000000000001";
+
+async function setupNotificationClickListener(origin = "https://app.okou.ai") {
+  context.mocks.browser.url(`${origin}${ROUTES.error}`);
+  const serviceWorker = context.mocks.browser.serviceWorker();
+  await setupBootstrap({ context, path: ROUTES.error });
+  return serviceWorker;
+}
+
+describe("notification click navigation", () => {
+  it.each([
+    [
+      "an absolute Okou",
+      "https://app.okou.ai",
+      `https://app.okou.ai/chats/${THREAD_ID}`,
+    ],
+    [
+      "an absolute VM0",
+      "https://app.vm0.ai",
+      `https://app.vm0.ai/chats/${THREAD_ID}`,
+    ],
+    ["a relative", "https://app.okou.ai", `/chats/${THREAD_ID}`],
+  ])("navigates to the chat from %s URL", async (_name, origin, url) => {
+    const serviceWorker = await setupNotificationClickListener(origin);
+
+    serviceWorker.dispatchMessage({ type: "NOTIFICATION_CLICK", url });
+
+    await waitFor(() => {
+      expect(context.store.get(pathname$)).toBe(`/chats/${THREAD_ID}`);
+    });
+  });
+
+  it.each([
+    ["an external", `https://example.com/chats/${THREAD_ID}`],
+    ["a cross-brand", `https://app.vm0.ai/chats/${THREAD_ID}`],
+    ["a non-chat", `https://app.okou.ai/activities/${THREAD_ID}`],
+  ])("does not navigate for %s URL", async (_name, url) => {
+    const serviceWorker = await setupNotificationClickListener();
+
+    serviceWorker.dispatchMessage({ type: "NOTIFICATION_CLICK", url });
+
+    expect(context.store.get(pathname$)).toBe(ROUTES.error);
+  });
+});

--- a/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
+++ b/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
@@ -119,6 +119,10 @@ interface BrowserDownloadMock {
   readonly revokedUrls: string[];
 }
 
+interface BrowserServiceWorkerMock {
+  readonly dispatchMessage: (data: unknown) => void;
+}
+
 interface ImageDimensionsMockValue {
   width: number;
   height: number;
@@ -295,6 +299,9 @@ export function createTestMocks(getSignal: () => AbortSignal) {
         mockMatchMedia((query) => {
           return query === "(display-mode: standalone)" ? enabled : false;
         });
+      },
+      serviceWorker: (): BrowserServiceWorkerMock => {
+        return mockServiceWorker(getSignal());
       },
       userAgent: (ua: string): void => {
         vi.spyOn(navigator, "userAgent", "get").mockReturnValue(ua);
@@ -566,6 +573,24 @@ function mockMatchMedia(matches: boolean | ((query: string) => boolean)): void {
     };
     return mediaQueryList;
   });
+}
+
+function mockServiceWorker(signal: AbortSignal): BrowserServiceWorkerMock {
+  const serviceWorker = new EventTarget();
+  const descriptor = defineWindowProperty(
+    navigator,
+    "serviceWorker",
+    serviceWorker,
+  );
+  restoreOnAbort(signal, () => {
+    restoreWindowProperty(navigator, "serviceWorker", descriptor);
+  });
+
+  return {
+    dispatchMessage(data: unknown): void {
+      serviceWorker.dispatchEvent(new MessageEvent("message", { data }));
+    },
+  };
 }
 
 function mockClipboardWriteText(): ClipboardWriteMock {

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -485,17 +485,36 @@ const setupFeatureSwitches$ = command(
   },
 );
 
+function notificationChatThreadId(data: unknown): string | null {
+  if (
+    typeof data !== "object" ||
+    data === null ||
+    !("type" in data) ||
+    data.type !== "NOTIFICATION_CLICK" ||
+    !("url" in data) ||
+    typeof data.url !== "string" ||
+    !URL.canParse(data.url, window.location.origin)
+  ) {
+    return null;
+  }
+
+  const url = new URL(data.url, window.location.origin);
+  if (url.origin !== window.location.origin) {
+    return null;
+  }
+
+  return /^\/chats\/([^/]+)$/u.exec(url.pathname)?.[1] ?? null;
+}
+
 const setupNotificationListener$ = command(({ set }, signal: AbortSignal) => {
   navigator.serviceWorker?.addEventListener(
     "message",
-    onDomEventFn((event: MessageEvent): void => {
-      if (event.data?.type === "NOTIFICATION_CLICK" && event.data.url) {
-        const match = /^\/chats\/(.+)$/.exec(event.data.url as string);
-        if (match) {
-          set(detachedNavigateTo$, "/chats/:threadId", {
-            pathParams: { threadId: match[1] },
-          });
-        }
+    onDomEventFn((event: MessageEvent<unknown>): void => {
+      const threadId = notificationChatThreadId(event.data);
+      if (threadId) {
+        set(detachedNavigateTo$, ROUTES.chat, {
+          pathParams: { threadId },
+        });
       }
     }),
     {


### PR DESCRIPTION
## Summary

- parse Web Push click payloads at the platform bootstrap boundary so same-origin absolute Okou/VM0 URLs and relative chat URLs reach the SPA router
- require the active platform origin and an exact `/chats/:threadId` path before internal navigation, rejecting external, cross-brand, and non-chat targets
- add bootstrap-level Service Worker message integration coverage for the production absolute payload shape and relative URL compatibility

## Root cause

The API emits brand-specific absolute notification URLs. When a same-origin window already exists, the Service Worker forwards that URL unchanged and focuses the client, but the platform listener only matched relative `/chats/...` strings. The absolute payload was therefore ignored after focus.

This keeps the backend absolute URL contract and the Service Worker `openWindow(url)` fallback unchanged.

## Verification

- `cd turbo && pnpm exec prettier --check apps/platform/src/signals/bootstrap.ts apps/platform/src/signals/__tests__/test-mocks.ts apps/platform/src/signals/__tests__/notification-click-navigation.test.ts`
- `cd turbo && pnpm -F @okouai/app lint`
- `cd turbo && pnpm -F @okouai/app check-types`
- `cd turbo && pnpm -F @okouai/app exec vitest run src/signals/__tests__/notification-click-navigation.test.ts` (6 tests)
- `cd turbo && pnpm knip --workspace @okouai/app`

No full local Vitest suite or development server was run.
