### PR TITLE
test(platform): stabilize workflow reload synchronization

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
@@ -702,8 +702,8 @@ describe("chat composer models", () => {
 
   it("reloads workflow suggestions and highlights without remounting the composer", async () => {
     const user = userEvent.setup({ delay: null });
-    const initialWorkflowsRequested = context.mocks.deferred<void>();
-    const releaseInitialWorkflows = context.mocks.deferred<void>();
+    const reloadWorkflowsRequested = context.mocks.deferred<void>();
+    const releaseReloadWorkflows = context.mocks.deferred<void>();
     const reloadedWorkflow = workflowSummary({
       name: "new-chat-workflow",
       displayName: "New Chat Workflow",
@@ -716,12 +716,12 @@ describe("chat composer models", () => {
     mockThread();
     context.mocks.api(workflowsCollectionContract.list, async ({ respond }) => {
       if (workflowPhase === "initial") {
-        if (!initialWorkflowsRequested.settled()) {
-          initialWorkflowsRequested.resolve();
-        }
-        await releaseInitialWorkflows.promise;
         return respond(200, []);
       }
+      if (!reloadWorkflowsRequested.settled()) {
+        reloadWorkflowsRequested.resolve();
+      }
+      await releaseReloadWorkflows.promise;
       return respond(200, [reloadedWorkflow]);
     });
 
@@ -741,17 +741,12 @@ describe("chat composer models", () => {
         "true",
       );
     });
-    await initialWorkflowsRequested.promise;
     const thread = await screen.findByLabelText("Chat thread");
     const initialEditor = await within(thread).findByRole("textbox", {
       name: "Message",
     });
     await user.click(initialEditor);
     await user.keyboard("/");
-    await expect(
-      screen.findByText("Loading workflows..."),
-    ).resolves.toBeInTheDocument();
-    releaseInitialWorkflows.resolve();
     await expect(
       screen.findByText("No matching workflows"),
     ).resolves.toBeInTheDocument();
@@ -764,6 +759,8 @@ describe("chat composer models", () => {
         null,
       );
     });
+    await reloadWorkflowsRequested.promise;
+    releaseReloadWorkflows.resolve();
 
     await expect(
       screen.findByText("new-chat-workflow"),


### PR DESCRIPTION
## Summary

- let the composer's initial workflow list resolve before native slash interaction
- move the explicit request barrier to the Ably-triggered reload that the test owns
- preserve the empty-menu, reload causality, unchanged-editor, insertion, and highlighting coverage

## Root cause

The test deliberately held the initial workflow response while trying to open the slash menu. That same response is awaited by the editor's mounted workflow-name synchronization, so the test interacted while the composer ref command was still in flight. Shell readiness, Ably subscription, and a thread-scoped textbox do not establish completion of that synchronization, and the slash state could be lost under shard scheduling.

The initial request now returns its empty list normally. The visible empty menu proves that the initial workflow value resolved before the editor identity baseline is captured. The test then switches the handler to reload mode, triggers the thread's Ably topic, waits until the reload request starts, and releases that response before asserting the new workflow.

## Loading behavior

The initial `Loading workflows...` assertion is removed rather than moved to reload. The composer uses `useLastLoadable`, so a reload intentionally retains the last resolved empty list while the replacement request is pending. Changing production reload semantics solely to preserve a transient test assertion would add user-visible behavior outside this fix.

## Scope

- one existing Platform page integration test
- no production, UI, API, database, dependency, protocol, timeout, retry, skip, or internal-mock changes

## Validation

- focused named test: 11 sequential runs passed with one worker
- full `chat-composer-editor-and-suggestions.test.tsx`: 22/22 passed
- CI-equivalent Platform shard 7/8 with coverage: 21 files, 364/364 tests passed
- `pnpm format`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip`
- pre-commit hooks: Prettier, Knip, repository-wide Turbo type checks, file-size check, and commitlint passed

Closes #30217
