### PR TITLE
fix(platform): align clerk ui release set

### DIFF
--- a/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
@@ -46,6 +46,10 @@ function expectedClerkScriptUrl(host: string): string {
   return `https://${host}/npm/@clerk/clerk-js@${CLERK_JS_VERSION}/dist/clerk.browser.js`;
 }
 
+function expectedClerkUiScriptUrl(host: string): string {
+  return `https://${host}/npm/@clerk/ui@1.26.0/dist/ui.browser.js`;
+}
+
 function builtIndexHtml(): string {
   return transformClerkCoreScriptUrls(
     indexHtml
@@ -73,7 +77,7 @@ function clerkScriptFromHtml(html: string): HTMLScriptElement {
   return script;
 }
 
-function startClerkPage(): ClerkEntrypointHarness {
+function startClerkPage(path = "/error"): ClerkEntrypointHarness {
   const requests: ClerkScriptRequest[] = [];
   const clerkLoaderWatchingEarlyScript = context.mocks.deferred<void>();
   const retryStarted = context.mocks.deferred<void>();
@@ -90,6 +94,7 @@ function startClerkPage(): ClerkEntrypointHarness {
       vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PROD", PRODUCTION_PUBLISHABLE_KEY);
       window.__vm0BrowserSupported = true;
       Reflect.deleteProperty(globalThis, "Clerk");
+      Reflect.deleteProperty(globalThis, "__internal_ClerkUICtor");
 
       const parsedEarlyScript = clerkScriptFromHtml(builtIndexHtml());
       const earlyScriptUrl = parsedEarlyScript.src;
@@ -122,10 +127,19 @@ function startClerkPage(): ClerkEntrypointHarness {
         }
 
         requests.push({ element: node, url: node.src });
+        const isClerkUiRequest = node.src.includes("/npm/@clerk/ui@");
         node.removeAttribute("src");
         const appended = append(node);
-        retryStarted.resolve(undefined);
-        Reflect.set(globalThis, "Clerk", mockedClerk);
+        if (isClerkUiRequest) {
+          Reflect.set(
+            globalThis,
+            "__internal_ClerkUICtor",
+            function ClerkUI() {},
+          );
+        } else {
+          retryStarted.resolve(undefined);
+          Reflect.set(globalThis, "Clerk", mockedClerk);
+        }
         node.dispatchEvent(new Event("load"));
         return appended;
       };
@@ -153,6 +167,7 @@ function startClerkPage(): ClerkEntrypointHarness {
             request.element.remove();
           }
           Reflect.deleteProperty(globalThis, "Clerk");
+          Reflect.deleteProperty(globalThis, "__internal_ClerkUICtor");
           Reflect.deleteProperty(window, "__vm0BrowserSupported");
           vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PREVIEW", previousPreviewKey);
           vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PROD", previousProductionKey);
@@ -161,7 +176,7 @@ function startClerkPage(): ClerkEntrypointHarness {
       );
     },
     context,
-    path: "/error",
+    path,
     withoutRender: true,
   });
 
@@ -246,6 +261,18 @@ describe("platform Clerk entrypoint", () => {
     ]);
     expect(document.querySelectorAll(CLERK_SCRIPT_SELECTOR)).toHaveLength(1);
     expect(document.querySelector("script[data-clerk-ui-script]")).toBeNull();
+    expect(mockedClerkLoad).toHaveBeenCalledOnce();
+  });
+
+  it("loads the matching Clerk UI release only when the auth route requests it", async () => {
+    const harness = startClerkPage("/sign-in");
+
+    await completeEarlyClerkScript(harness);
+
+    expect(harness.requests.map(({ url }) => url)).toStrictEqual([
+      expectedClerkScriptUrl(PREVIEW_FRONTEND_API_HOST),
+      expectedClerkUiScriptUrl(PREVIEW_FRONTEND_API_HOST),
+    ]);
     expect(mockedClerkLoad).toHaveBeenCalledOnce();
   });
 

--- a/turbo/apps/platform/src/lib/clerk-runtime.ts
+++ b/turbo/apps/platform/src/lib/clerk-runtime.ts
@@ -5,9 +5,7 @@ import {
 import type { BrowserClerk, EnvironmentResource } from "@clerk/shared/types";
 import type { ClerkUIConstructor } from "@clerk/shared/ui";
 import { createDeferredPromise } from "../signals/utils.ts";
-import { CLERK_JS_VERSION } from "./clerk-versions.ts";
-
-const CLERK_UI_VERSION = "1.27.0";
+import { CLERK_JS_VERSION, CLERK_UI_VERSION } from "./clerk-versions.ts";
 
 interface ClerkRuntimeOptions {
   readonly publishableKey: string;

--- a/turbo/apps/platform/src/lib/clerk-versions.ts
+++ b/turbo/apps/platform/src/lib/clerk-versions.ts
@@ -1,1 +1,3 @@
+// Exact browser artifacts embedded by the @clerk/shared@4.25.8 release set.
 export const CLERK_JS_VERSION = "6.25.8";
+export const CLERK_UI_VERSION = "1.26.0";


### PR DESCRIPTION
## Summary

- align the deferred Clerk UI CDN pin to 1.26.0, matching the @clerk/shared 4.25.8 and Clerk core 6.25.8 release set
- keep the early core request, Clerk.load ownership, UI deferral, retry behavior, and clerk-timers lifecycle unchanged
- cover the real /sign-in setupPage path and its exact single UI request while preserving the existing no-unconditional-UI assertion

## Validation

- pnpm exec prettier --write apps/platform/src/lib/clerk-versions.ts apps/platform/src/lib/clerk-runtime.ts apps/platform/src/__tests__/clerk-entrypoint.test.ts
- pnpm --filter @okouai/app run lint
- pnpm --filter @okouai/app run check-types
- pnpm --filter @okouai/app exec vitest run src/__tests__/clerk-entrypoint.test.ts (4 tests passed)
- pre-commit: Prettier, Knip, all workspace TypeScript checks, file-size check, and commitlint