### PR TITLE
fix(sandbox-fc): release balloon fully under guest pressure

### DIFF
--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -812,7 +812,7 @@ if peak["workload_current"] <= legacy_memory_max:
         f"current={peak['workload_current']} legacy_max={legacy_memory_max}"
     )
 
-time.sleep(20)
+time.sleep(25)
 chunks.clear()
 gc.collect()
 time.sleep(1)
@@ -872,8 +872,9 @@ MEMORY_PRESSURE_AVAILABLE=$(sed -n \
 
 BALLOON_PRESSURE_SAMPLE=""
 BALLOON_DURING=""
+BALLOON_RELIEF_TIMEOUT_SECONDS=20
 SECONDS=0
-while [ "$SECONDS" -le 15 ]; do
+while [ "$SECONDS" -le "$BALLOON_RELIEF_TIMEOUT_SECONDS" ]; do
   BALLOON_DURING=$(sudo curl -sf --unix-socket "$PRESSURE_API_SOCK" \
     http://localhost/balloon/statistics \
     | jq -ce '{target_mib, actual_mib, free_memory, available_memory}') \
@@ -892,7 +893,7 @@ while [ "$SECONDS" -le 15 ]; do
 done
 if [ -z "$BALLOON_PRESSURE_SAMPLE" ]; then
   cat "$MEMORY_RECLAIM_OUTPUT"
-  fail "active balloon did not release its full target within 15s of Guest pressure: before=${BALLOON_BEFORE} during=${BALLOON_DURING}"
+  fail "active balloon did not release its full target within ${BALLOON_RELIEF_TIMEOUT_SECONDS}s of Guest pressure: before=${BALLOON_BEFORE} during=${BALLOON_DURING}"
 fi
 
 if wait "$MEMORY_RECLAIM_PID"; then

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -437,11 +437,11 @@ PRESSURE_SUBMIT_OUTPUT=$(mktemp)
 # Keep the final input after the pressure command so the mock turn cannot
 # finish first.
 sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
-  --timeout 140 \
+  --timeout 200 \
   --chat-thread-id "$PRESSURE_CHAT_THREAD_ID" \
   --session-id "$PRESSURE_SESSION_ID" \
   --feature-flag sandboxReuse=true \
-  --prompt '@active-input-smoke-ready:8' \
+  --prompt '@active-input-smoke-ready:10' \
   --active-input 'after=1ms,text=cpu-pressure-ready' \
   --active-input 'after=2s,text=cpu-pressure-one' \
   --active-input 'after=4s,text=cpu-pressure-two' \
@@ -449,7 +449,9 @@ sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   --active-input 'after=30s,text=memory-reclaim-one' \
   --active-input 'after=60s,text=memory-reclaim-two' \
   --active-input 'after=90s,text=memory-reclaim-three' \
-  --active-input 'after=120s,text=pressure-finish' \
+  --active-input 'after=120s,text=memory-reclaim-four' \
+  --active-input 'after=150s,text=memory-reclaim-five' \
+  --active-input 'after=180s,text=pressure-finish' \
   >"$PRESSURE_SUBMIT_OUTPUT" 2>&1 &
 PRESSURE_SUBMIT_PID=$!
 
@@ -652,11 +654,12 @@ LEAK_CLEANUP_MS=$PID_CLEANUP_MS
 
 echo "--- Pressure: cross the retired workload memory boundary through Guest reclaim ---"
 PRESSURE_API_SOCK="/run/vm0/sock/$PRESSURE_SANDBOX_ID/api.sock"
-BALLOON_MIN_STABLE_MIB=1536
+# Match the directly observed production checkpoint before applying pressure.
+BALLOON_MIN_STABLE_MIB=3072
 BALLOON_STABLE_TARGET=""
 BALLOON_STABLE_SAMPLES=0
 BALLOON_BEFORE=""
-for _ in $(seq 1 30); do
+for _ in $(seq 1 45); do
   BALLOON_SAMPLE=$(sudo curl -sf --unix-socket "$PRESSURE_API_SOCK" \
     http://localhost/balloon/statistics \
     | jq -ce '{target_mib, actual_mib, free_memory, available_memory}') \
@@ -948,7 +951,7 @@ SUBMITTED_PRESSURE_RUN_ID=$(jq -r '.run_id // empty' <<<"$PRESSURE_SUBMIT_JSON")
 PRESSURE_STREAM_LOG="/var/lib/vm0-runner/logs/system-stream-${PRESSURE_RUN_ID}.log"
 PRESSURE_METRICS_LOG="/var/lib/vm0-runner/logs/metrics-${PRESSURE_RUN_ID}.jsonl"
 sudo grep -F -q \
-  'RESULT=cpu-pressure-ready+cpu-pressure-one+cpu-pressure-two+cpu-pressure-three+memory-reclaim-one+memory-reclaim-two+memory-reclaim-three+pressure-finish' \
+  'RESULT=cpu-pressure-ready+cpu-pressure-one+cpu-pressure-two+cpu-pressure-three+memory-reclaim-one+memory-reclaim-two+memory-reclaim-three+memory-reclaim-four+memory-reclaim-five+pressure-finish' \
   "$PRESSURE_STREAM_LOG" \
   || fail "CPU-pressure active inputs were not all consumed in order"
 

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -65,6 +65,8 @@ SESSION_ID="e2e-process-containment-session"
 CHAT_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
 PRESSURE_SUBMIT_PID=""
 PRESSURE_SUBMIT_OUTPUT=""
+MEMORY_RECLAIM_PID=""
+MEMORY_RECLAIM_OUTPUT=""
 
 fail() { echo "FAIL: $1"; exit 1; }
 
@@ -80,6 +82,13 @@ wait_for_unit_inactive() {
 
 cleanup() {
   echo "--- Cleanup ---"
+  if [ -n "$MEMORY_RECLAIM_PID" ]; then
+    kill "$MEMORY_RECLAIM_PID" 2>/dev/null || true
+    wait "$MEMORY_RECLAIM_PID" 2>/dev/null || true
+  fi
+  if [ -n "$MEMORY_RECLAIM_OUTPUT" ]; then
+    rm -f "$MEMORY_RECLAIM_OUTPUT"
+  fi
   if [ -n "$PRESSURE_SUBMIT_PID" ]; then
     kill "$PRESSURE_SUBMIT_PID" 2>/dev/null || true
     wait "$PRESSURE_SUBMIT_PID" 2>/dev/null || true
@@ -428,7 +437,7 @@ PRESSURE_SUBMIT_OUTPUT=$(mktemp)
 # Keep the final input after the pressure command so the mock turn cannot
 # finish first.
 sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
-  --timeout 80 \
+  --timeout 140 \
   --chat-thread-id "$PRESSURE_CHAT_THREAD_ID" \
   --session-id "$PRESSURE_SESSION_ID" \
   --feature-flag sandboxReuse=true \
@@ -437,10 +446,10 @@ sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   --active-input 'after=2s,text=cpu-pressure-one' \
   --active-input 'after=4s,text=cpu-pressure-two' \
   --active-input 'after=6s,text=cpu-pressure-three' \
-  --active-input 'after=15s,text=memory-reclaim-one' \
-  --active-input 'after=30s,text=memory-reclaim-two' \
-  --active-input 'after=45s,text=memory-reclaim-three' \
-  --active-input 'after=65s,text=pressure-finish' \
+  --active-input 'after=30s,text=memory-reclaim-one' \
+  --active-input 'after=60s,text=memory-reclaim-two' \
+  --active-input 'after=90s,text=memory-reclaim-three' \
+  --active-input 'after=120s,text=pressure-finish' \
   >"$PRESSURE_SUBMIT_OUTPUT" 2>&1 &
 PRESSURE_SUBMIT_PID=$!
 
@@ -643,10 +652,38 @@ LEAK_CLEANUP_MS=$PID_CLEANUP_MS
 
 echo "--- Pressure: cross the retired workload memory boundary through Guest reclaim ---"
 PRESSURE_API_SOCK="/run/vm0/sock/$PRESSURE_SANDBOX_ID/api.sock"
-BALLOON_BEFORE=$(sudo curl -sf --unix-socket "$PRESSURE_API_SOCK" \
-  http://localhost/balloon/statistics \
-  | jq -ce '{target_mib, actual_mib, free_memory, available_memory}') \
-  || fail "failed to sample balloon before memory reclaim pressure"
+BALLOON_MIN_STABLE_MIB=1536
+BALLOON_STABLE_TARGET=""
+BALLOON_STABLE_SAMPLES=0
+BALLOON_BEFORE=""
+for _ in $(seq 1 30); do
+  BALLOON_SAMPLE=$(sudo curl -sf --unix-socket "$PRESSURE_API_SOCK" \
+    http://localhost/balloon/statistics \
+    | jq -ce '{target_mib, actual_mib, free_memory, available_memory}') \
+    || fail "failed to sample balloon before memory reclaim pressure"
+  BALLOON_TARGET=$(jq -r '.target_mib' <<<"$BALLOON_SAMPLE")
+  BALLOON_ACTUAL=$(jq -r '.actual_mib' <<<"$BALLOON_SAMPLE")
+  if [ "$BALLOON_TARGET" -ge "$BALLOON_MIN_STABLE_MIB" ] \
+    && [ "$BALLOON_ACTUAL" -eq "$BALLOON_TARGET" ]; then
+    if [ "$BALLOON_TARGET" = "$BALLOON_STABLE_TARGET" ]; then
+      BALLOON_STABLE_SAMPLES=$((BALLOON_STABLE_SAMPLES + 1))
+    else
+      BALLOON_STABLE_TARGET=$BALLOON_TARGET
+      BALLOON_STABLE_SAMPLES=1
+    fi
+    if [ "$BALLOON_STABLE_SAMPLES" -ge 2 ]; then
+      BALLOON_BEFORE=$BALLOON_SAMPLE
+      break
+    fi
+  else
+    BALLOON_STABLE_TARGET=""
+    BALLOON_STABLE_SAMPLES=0
+  fi
+  sleep 2
+done
+[ -n "$BALLOON_BEFORE" ] \
+  || fail "active balloon did not stabilize at or above ${BALLOON_MIN_STABLE_MIB} MiB"
+BALLOON_BEFORE_ACTUAL=$(jq -r '.actual_mib' <<<"$BALLOON_BEFORE")
 MEMORY_RECLAIM_COMMAND=$(cat <<'PYTHON'
 import gc
 import json
@@ -660,6 +697,7 @@ CHUNK_SIZE = 32 * MIB
 CONTROL_MEMORY_MIN = 384 * MIB
 WORKLOAD_MEMORY_RESERVE = 128 * MIB
 RETIRED_BOUNDARY_MARGIN = 64 * MIB
+PRESSURE_AVAILABLE = 192 * MIB
 
 
 def read_int(path):
@@ -740,6 +778,7 @@ if target >= configured_memory_max:
 before = snapshot(workload, control)
 deadline = time.monotonic() + 45
 chunks = []
+pressure_announced = False
 while read_int(workload / "memory.current") < target:
     if time.monotonic() >= deadline:
         current = read_int(workload / "memory.current")
@@ -750,16 +789,30 @@ while read_int(workload / "memory.current") < target:
     chunk = bytearray(CHUNK_SIZE)
     chunk[::PAGE_SIZE] = b"\x01" * (CHUNK_SIZE // PAGE_SIZE)
     chunks.append(chunk)
+    mem_available_bytes = (
+        read_key_values(pathlib.Path("/proc/meminfo"))["MemAvailable:"] * 1024
+    )
+    if not pressure_announced and mem_available_bytes < PRESSURE_AVAILABLE:
+        print(
+            f"memory-reclaim-pressure-ready available_bytes={mem_available_bytes}",
+            flush=True,
+        )
+        pressure_announced = True
     time.sleep(0.01)
 
 peak = snapshot(workload, control)
+if not pressure_announced:
+    raise RuntimeError(
+        "memory pressure did not cross the balloon pressure boundary: "
+        f"available={peak['mem_available_bytes']} boundary={PRESSURE_AVAILABLE}"
+    )
 if peak["workload_current"] <= legacy_memory_max:
     raise RuntimeError(
         "memory pressure did not cross the retired workload boundary: "
         f"current={peak['workload_current']} legacy_max={legacy_memory_max}"
     )
 
-time.sleep(6)
+time.sleep(20)
 chunks.clear()
 gc.collect()
 time.sleep(1)
@@ -783,12 +836,75 @@ print(
 )
 PYTHON
 )
-MEMORY_RECLAIM_RESULT=$(sudo "$BIN_DIR/runner" exec \
-  --timeout 60 \
+MEMORY_RECLAIM_OUTPUT=$(mktemp)
+sudo "$BIN_DIR/runner" exec \
+  --timeout 80 \
   --sandbox "$PRESSURE_SANDBOX_ID" \
-  -- python3 -c "$MEMORY_RECLAIM_COMMAND") \
-  || fail "workload could not cross the retired memory boundary"
+  -- python3 -c "$MEMORY_RECLAIM_COMMAND" \
+  >"$MEMORY_RECLAIM_OUTPUT" 2>&1 &
+MEMORY_RECLAIM_PID=$!
+
+MEMORY_PRESSURE_READY_LINE=""
+for _ in $(seq 1 60); do
+  MEMORY_PRESSURE_READY_LINE=$(grep -E \
+    '^memory-reclaim-pressure-ready available_bytes=[0-9]+$' \
+    "$MEMORY_RECLAIM_OUTPUT" | tail -1 || true)
+  [ -n "$MEMORY_PRESSURE_READY_LINE" ] && break
+  if ! kill -0 "$MEMORY_RECLAIM_PID" 2>/dev/null; then
+    if wait "$MEMORY_RECLAIM_PID"; then
+      MEMORY_RECLAIM_STATUS=0
+    else
+      MEMORY_RECLAIM_STATUS=$?
+    fi
+    MEMORY_RECLAIM_PID=""
+    cat "$MEMORY_RECLAIM_OUTPUT"
+    fail "workload exited with status ${MEMORY_RECLAIM_STATUS} before balloon pressure"
+  fi
+  sleep 1
+done
+[ -n "$MEMORY_PRESSURE_READY_LINE" ] \
+  || fail "workload did not reach the balloon pressure boundary"
+MEMORY_PRESSURE_AVAILABLE=$(sed -n \
+  's/^memory-reclaim-pressure-ready available_bytes=\([0-9][0-9]*\)$/\1/p' \
+  <<<"$MEMORY_PRESSURE_READY_LINE")
+[ "$MEMORY_PRESSURE_AVAILABLE" -lt $((192 * 1024 * 1024)) ] \
+  || fail "workload reported an invalid balloon pressure boundary"
+
+BALLOON_PRESSURE_SAMPLE=""
+BALLOON_DURING=""
+SECONDS=0
+while [ "$SECONDS" -le 15 ]; do
+  BALLOON_DURING=$(sudo curl -sf --unix-socket "$PRESSURE_API_SOCK" \
+    http://localhost/balloon/statistics \
+    | jq -ce '{target_mib, actual_mib, free_memory, available_memory}') \
+    || fail "failed to sample balloon during memory reclaim pressure"
+  BALLOON_DURING_TARGET=$(jq -r '.target_mib' <<<"$BALLOON_DURING")
+  BALLOON_DURING_ACTUAL=$(jq -r '.actual_mib' <<<"$BALLOON_DURING")
+  if [ "$BALLOON_DURING_TARGET" -eq 0 ] \
+    && [ "$BALLOON_DURING_ACTUAL" -lt "$BALLOON_BEFORE_ACTUAL" ]; then
+    BALLOON_PRESSURE_SAMPLE=$BALLOON_DURING
+    break
+  fi
+  if ! kill -0 "$MEMORY_RECLAIM_PID" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+if [ -z "$BALLOON_PRESSURE_SAMPLE" ]; then
+  cat "$MEMORY_RECLAIM_OUTPUT"
+  fail "active balloon did not release its full target within 15s of Guest pressure: before=${BALLOON_BEFORE} during=${BALLOON_DURING}"
+fi
+
+if wait "$MEMORY_RECLAIM_PID"; then
+  MEMORY_RECLAIM_STATUS=0
+else
+  MEMORY_RECLAIM_STATUS=$?
+fi
+MEMORY_RECLAIM_PID=""
+MEMORY_RECLAIM_RESULT=$(<"$MEMORY_RECLAIM_OUTPUT")
 printf '%s\n' "$MEMORY_RECLAIM_RESULT"
+[ "$MEMORY_RECLAIM_STATUS" -eq 0 ] \
+  || fail "workload could not cross the retired memory boundary"
 MEMORY_RECLAIM_JSON=$(awk '/^\{/{line=$0} END{print line}' <<<"$MEMORY_RECLAIM_RESULT")
 [ -n "$MEMORY_RECLAIM_JSON" ] \
   || fail "memory reclaim pressure did not emit a usage snapshot"
@@ -809,7 +925,9 @@ BALLOON_AFTER=$(sudo curl -sf --unix-socket "$PRESSURE_API_SOCK" \
   http://localhost/balloon/statistics \
   | jq -ce '{target_mib, actual_mib, free_memory, available_memory}') \
   || fail "failed to sample balloon after memory reclaim pressure"
-echo "memory-reclaim-balloon before=$BALLOON_BEFORE after=$BALLOON_AFTER"
+echo "memory-reclaim-balloon before=$BALLOON_BEFORE pressure=$BALLOON_PRESSURE_SAMPLE after=$BALLOON_AFTER"
+rm -f "$MEMORY_RECLAIM_OUTPUT"
+MEMORY_RECLAIM_OUTPUT=""
 
 if wait "$PRESSURE_SUBMIT_PID"; then
   PRESSURE_SUBMIT_STATUS=0
@@ -865,8 +983,8 @@ echo "--- Pressure: group-kill only the high-memory Bash tool ---"
 # The mock CLI launches two Bash children directly from the managed runtime.
 # The launcher places them in distinct tool cgroups before either shell runs.
 # One tool drives the existing workload limit to OOM while the other remains alive.
-# Use a fresh sandbox so the preceding extreme balloon-reclaim scenario cannot
-# delay Guest Agent startup and obscure the tool-isolation assertion.
+# Use a fresh sandbox so the tool-isolation assertion has an independent
+# lifecycle after the preceding extreme balloon-reclaim scenario.
 MEMORY_CHAT_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
 MEMORY_SESSION_ID="e2e-process-containment-memory"
 SECONDS=0

--- a/crates/sandbox-fc/src/balloon.rs
+++ b/crates/sandbox-fc/src/balloon.rs
@@ -306,11 +306,12 @@ async fn tick(client: &ApiClient, max_inflate: u32, tick_count: u64) {
     // Deflate decision: use available_memory (includes reclaimable cache).
     //
     // Inflation is deliberately gradual to avoid creating pressure, but
-    // pressure relief must not be proportional to the retained balloon size.
-    // A deficit-sized step every five seconds can otherwise take minutes from
-    // a highly inflated Guest and stall control work together with workload
-    // reclaim. Request the full active allocation back in one policy action;
-    // Firecracker still owns the physical deflation progress.
+    // pressure relief must not depend on physical convergence before the
+    // controller can request more. An actual-relative partial target can stay
+    // pinned when Firecracker's actual size stalls, retaining most of the
+    // balloon while control work competes with workload reclaim. Request the
+    // full active allocation back in one policy action; Firecracker still owns
+    // the physical deflation progress.
     if let Some(available_mib) = available_mib
         && available_mib < PRESSURE_AVAILABLE_MIB
     {
@@ -665,8 +666,9 @@ mod tests {
     #[tokio::test]
     async fn tick_releases_high_retention_near_pressure_boundary() {
         // A 4-GiB Guest can retain 3584 MiB. Just below the 192-MiB pressure
-        // boundary, the retired deficit-sized policy released only 65 MiB per
-        // five-second tick and could take minutes to reach target zero.
+        // boundary, the retired policy requested only partial relief. When
+        // physical actual stalled behind that pending target, its
+        // actual-relative candidate could not continue toward zero.
         let stats = r#"{"target_mib":3584,"actual_mib":3584,"target_pages":917504,"actual_pages":917504,"free_memory":52428800,"available_memory":200278016}"#;
         let patch = run_tick_with_mock(stats, 3584)
             .await

--- a/crates/sandbox-fc/src/balloon.rs
+++ b/crates/sandbox-fc/src/balloon.rs
@@ -18,6 +18,8 @@ const INFLATE_HYSTERESIS_MIB: i64 = 128;
 /// Deflate when `available_memory` (`MemAvailable`) drops below target by this
 /// much (MiB).
 /// Smaller than inflate hysteresis — respond faster to guest memory pressure.
+/// Crossing this boundary releases the entire active balloon target so Guest
+/// control liveness does not depend on the amount previously reclaimed.
 const DEFLATE_HYSTERESIS_MIB: i64 = 64;
 /// Guest available-memory pressure boundary used by both the continuous
 /// controller and one-shot idle park inflation.
@@ -301,14 +303,19 @@ async fn tick(client: &ApiClient, max_inflate: u32, tick_count: u64) {
         return;
     }
 
-    // Deflate decision: use available_memory (includes reclaimable cache)
+    // Deflate decision: use available_memory (includes reclaimable cache).
+    //
+    // Inflation is deliberately gradual to avoid creating pressure, but
+    // pressure relief must not be proportional to the retained balloon size.
+    // A deficit-sized step every five seconds can otherwise take minutes from
+    // a highly inflated Guest and stall control work together with workload
+    // reclaim. Request the full active allocation back in one policy action;
+    // Firecracker still owns the physical deflation progress.
     if let Some(available_mib) = available_mib
         && available_mib < PRESSURE_AVAILABLE_MIB
     {
-        let deficit = (TARGET_FREE_MIB - available_mib) as u32;
-        let candidate_target = current.saturating_sub(deficit);
-        let new_target = stats.target_mib.min(candidate_target);
-        if new_target < stats.target_mib {
+        let new_target = 0;
+        if stats.target_mib != new_target {
             info!(current, new_target, available_mib, "balloon deflate");
             if let Err(e) = client.patch_balloon(new_target).await {
                 warn!(error = %e, "balloon deflate failed");
@@ -641,7 +648,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tick_deflates_on_low_available_memory() {
+    async fn tick_releases_full_balloon_on_low_available_memory() {
         // available_memory = 128 MiB, below deflate threshold (192 MiB).
         // free_memory = 50 MiB (also low, no inflate).
         let stats = r#"{"target_mib":512,"actual_mib":512,"target_pages":131072,"actual_pages":131072,"free_memory":52428800,"available_memory":134217728}"#;
@@ -650,9 +657,21 @@ mod tests {
         let body = patch.unwrap();
         let amount = patch_amount_mib(&body);
         assert_eq!(
-            amount, 384,
-            "expected deflate target for 128 MiB available memory, got {amount}"
+            amount, 0,
+            "expected full pressure relief for 128 MiB available memory, got {amount}"
         );
+    }
+
+    #[tokio::test]
+    async fn tick_releases_high_retention_near_pressure_boundary() {
+        // A 4-GiB Guest can retain 3584 MiB. Just below the 192-MiB pressure
+        // boundary, the retired deficit-sized policy released only 65 MiB per
+        // five-second tick and could take minutes to reach target zero.
+        let stats = r#"{"target_mib":3584,"actual_mib":3584,"target_pages":917504,"actual_pages":917504,"free_memory":52428800,"available_memory":200278016}"#;
+        let patch = run_tick_with_mock(stats, 3584)
+            .await
+            .expect("expected PATCH releasing high balloon retention");
+        assert_eq!(patch_amount_mib(&patch), 0);
     }
 
     #[tokio::test]
@@ -669,31 +688,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tick_advances_pending_deflate_to_more_aggressive_candidate() {
-        // The 400 MiB target is below actual but above the 372 MiB
-        // actual-relative candidate, so the controller should advance it.
+    async fn tick_completes_pending_partial_deflate_on_pressure() {
+        // A partial deflate target from an older controller must not retain a
+        // multi-tick pressure path after the new policy takes ownership.
         let stats = r#"{"target_mib":400,"actual_mib":500,"target_pages":102400,"actual_pages":128000,"free_memory":52428800,"available_memory":134217728}"#;
         let patch = run_tick_with_mock(stats, 1536)
             .await
-            .expect("expected PATCH advancing pending deflation");
-        assert_eq!(patch_amount_mib(&patch), 372);
+            .expect("expected PATCH completing pending deflation");
+        assert_eq!(patch_amount_mib(&patch), 0);
     }
 
     #[tokio::test]
     async fn tick_reverses_pending_inflate_on_low_available_memory() {
-        // A target above actual means inflation is in flight. A new deflate
-        // signal should cross the actual size immediately: 500 - 128 = 372.
+        // A target above actual means inflation is in flight. Guest pressure
+        // must reverse it directly to full relief.
         let stats = r#"{"target_mib":1000,"actual_mib":500,"target_pages":256000,"actual_pages":128000,"free_memory":52428800,"available_memory":134217728}"#;
         let patch = run_tick_with_mock(stats, 1536)
             .await
             .expect("expected PATCH reversing pending inflation");
-        assert_eq!(patch_amount_mib(&patch), 372);
+        assert_eq!(patch_amount_mib(&patch), 0);
     }
 
     #[tokio::test]
-    async fn tick_deflate_saturates_when_deficit_exceeds_current() {
-        // available_memory = 0 MiB, so deficit is 256 MiB.
-        // current balloon is only 100 MiB, so target should saturate at 0.
+    async fn tick_releases_low_retention_on_pressure() {
+        // Full relief also applies when the retained balloon is smaller than
+        // the old deficit-sized step.
         let stats = r#"{"target_mib":100,"actual_mib":100,"target_pages":25600,"actual_pages":25600,"free_memory":0,"available_memory":0}"#;
         let patch = run_tick_with_mock(stats, 1536).await;
         assert!(patch.is_some(), "expected PATCH call for deflate");
@@ -701,7 +720,7 @@ mod tests {
         let amount = patch_amount_mib(&body);
         assert_eq!(
             amount, 0,
-            "expected saturated deflate target of 0, got {amount}"
+            "expected full pressure-relief target of 0, got {amount}"
         );
     }
 


### PR DESCRIPTION
## Summary

- release the full active Firecracker balloon target when the existing Guest MemAvailable < 192 MiB pressure boundary is crossed
- cover high retained targets, pending inflation, pending partial deflation, already-requested full relief, missing statistics, and post-pressure re-inflation through Firecracker API-backed tests
- require the real-metal process-containment scenario to stabilize target and actual at or above 3072 MiB before rapid anonymous-memory pressure
- keep active input and Guest metrics live through the enlarged stabilization and pressure window, then verify bounded target-zero and physical relief without workload-local OOM or reuse loss

## Root cause

The active balloon controller could retain up to 3584 MiB in a 4-GiB Guest while workload limits still assumed almost the full configured capacity.

Direct production samples showed target_mib=actual_mib=3306 as Guest MemAvailable fell to 118 MiB. The retired controller requested a partial target near 3167 MiB, then physical actual remained around 3293-3301 MiB for approximately ten minutes.

The retired pressure candidate was derived from actual_mib and merged with the already-pending target. Because physical convergence stalled, the next candidate could not become more aggressive than that pending target. The requested target became pinned above 3.1 GiB while Guest heartbeat, telemetry, events, process control, and recovery work lost scheduling together.

This change makes pressure relief independent of physical convergence: one valid pressure sample requests target zero. Firecracker still owns physical deflation, so the real-metal regression now starts from the directly observed production-equivalent checkpoint of at least 3072 MiB and verifies bounded actual progress.

## Preserved behavior

- existing 192/384-MiB pressure/inflation hysteresis
- five-second controller cadence and 256-MiB capped gradual inflation
- post-unpark target-zero guard and idle park lifecycle
- control/workload cgroup topology and workload memory limit
- active-input, Guest metric cadence, no-OOM, cleanup, and same-sandbox reuse assertions

## Explicit exclusions

- no Guest heartbeat, API timeout, lease, retry, or recovery protocol changes
- no server, database, queue, terminal-state, or user-visible configuration changes
- no cgroup topology or workload memory-limit changes
- no new production warning, cooldown, or cross-boundary resource protocol

## Validation

- bash -n .github/scripts/runner-behavior-process-containment.sh
- compiled the embedded memory-pressure Python command with python3
- verified the ten-input schedule, readiness count, 3072-MiB threshold, 90-second stabilization bound, and ordered result assertion
- git diff --check
- cargo fmt --all -- --check, from crates
- cargo test -p sandbox-fc balloon --lib: 61 passed
- cargo clippy -p sandbox-fc --lib --tests -- -D warnings

The strengthened real-metal process-containment scenario requires the repository's CI runner. Current-head CI must show a stable pre-pressure target and actual at or above 3072 MiB, target zero plus bounded physical relief, active inputs through 180 seconds, Guest metric gaps no greater than 15 seconds, no workload-local OOM, and successful cleanup and reuse.

Closes #30221
