### PR TITLE
perf(api): isolate pi runtime declarations

### DIFF
--- a/turbo/apps/api/scripts/check-typecheck-boundaries.mjs
+++ b/turbo/apps/api/scripts/check-typecheck-boundaries.mjs
@@ -111,6 +111,38 @@ function importBindings(sourceFile) {
   return bindings;
 }
 
+function moduleReferences(sourceFile) {
+  const references = [];
+  function visit(node) {
+    let specifier;
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      specifier = node.moduleSpecifier.text;
+    } else if (
+      ts.isImportTypeNode(node) &&
+      ts.isLiteralTypeNode(node.argument) &&
+      ts.isStringLiteral(node.argument.literal)
+    ) {
+      specifier = node.argument.literal.text;
+    } else if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      specifier = node.arguments[0].text;
+    }
+    if (specifier) {
+      references.push({ node, specifier });
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+  return references;
+}
+
 const baselineRoots = typeScriptRoots(baselineConfig);
 const ownersByRoot = new Map();
 const counts = new Map();
@@ -159,6 +191,7 @@ let setupAppCalls = 0;
 let createAppCalls = 0;
 const implicitRouteCalls = [];
 const lowerLayerRouteImports = [];
+const nativePiRuntimeImports = [];
 
 for (const root of baselineRoots) {
   const source = fs.readFileSync(root, "utf8");
@@ -183,6 +216,20 @@ for (const root of baselineRoots) {
           resolve(sourceRoot, `signals/${directory}`) + "/",
         );
       }));
+
+  for (const reference of moduleReferences(sourceFile)) {
+    if (
+      !isTestRoot &&
+      (reference.specifier === "@okouai/pi-agent-runtime/node" ||
+        reference.specifier.startsWith("@earendil-works/"))
+    ) {
+      const line =
+        sourceFile.getLineAndCharacterOfPosition(
+          reference.node.getStart(sourceFile),
+        ).line + 1;
+      nativePiRuntimeImports.push(`${display(root)}:${line}`);
+    }
+  }
 
   for (const imported of importBindings(sourceFile)) {
     const target = resolveRelativeImport(root, imported.specifier);
@@ -264,6 +311,12 @@ if (lowerLayerRouteImports.length > 0) {
   fail(
     "Lower layers must not import route or bootstrap aggregation modules:",
     lowerLayerRouteImports,
+  );
+}
+if (nativePiRuntimeImports.length > 0) {
+  fail(
+    "API production modules must use the declaration-isolated Pi API entrypoint:",
+    nativePiRuntimeImports,
   );
 }
 

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -12,9 +12,9 @@ import {
   webhookCheckpointsPrepareHistoryContract,
 } from "@okouai/api-contracts/contracts/webhooks";
 import {
-  MemoryPiSession,
+  inspectPiSessionJsonl,
   UnsupportedPiSessionVersionError,
-} from "@okouai/pi-agent-runtime/node";
+} from "@okouai/pi-agent-runtime/api";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { agentSessions } from "@okouai/db/schema/agent-session";
 import { blobs } from "@okouai/db/schema/blob";
@@ -354,7 +354,7 @@ function validatePiCheckpointSession(
   }
   const parsed = safeSync(() => {
     const jsonl = new TextDecoder("utf-8", { fatal: true }).decode(raw);
-    return MemoryPiSession.fromJsonl(jsonl);
+    return inspectPiSessionJsonl(jsonl);
   });
   if ("error" in parsed) {
     return piCheckpointError(
@@ -367,13 +367,13 @@ function validatePiCheckpointSession(
     );
   }
   const session = parsed.ok;
-  if (session.getSessionId() !== sessionId) {
+  if (session.sessionId !== sessionId) {
     return piCheckpointError(
       "PI_H2_SESSION_MISMATCH",
       "Pi H2 native session id does not match the launch session",
     );
   }
-  if (!session.isSettledCheckpoint()) {
+  if (!session.isSettledCheckpoint) {
     return piCheckpointError(
       "PI_H2_NOT_SETTLED",
       "Pi H2 is not a settled native session checkpoint",

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
@@ -12,12 +12,12 @@ import { activeInputDeliveries } from "@okouai/db/schema/active-input-delivery";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { blobs } from "@okouai/db/schema/blob";
 import {
-  MemoryPiSession,
+  inspectPiSessionJsonl,
   runPiApiFirstTurn,
   type PiApiFirstTurnResult,
   UnsupportedPiResourceSnapshotError,
   UnsupportedPiSessionVersionError,
-} from "@okouai/pi-agent-runtime/node";
+} from "@okouai/pi-agent-runtime/api";
 import { command } from "ccstate";
 import { and, eq } from "drizzle-orm";
 
@@ -317,7 +317,7 @@ function validateResumeSession(args: {
     return;
   }
   const parsed = safeSync(() => {
-    return MemoryPiSession.fromJsonl(args.loaded.jsonl ?? "");
+    return inspectPiSessionJsonl(args.loaded.jsonl ?? "");
   });
   if ("error" in parsed) {
     if (parsed.error instanceof UnsupportedPiSessionVersionError) {
@@ -334,7 +334,7 @@ function validateResumeSession(args: {
     );
   }
   const session = parsed.ok;
-  if (session.getSessionId() !== args.sessionId) {
+  if (session.sessionId !== args.sessionId) {
     throw piApiFirstTurnError(
       "PI_H0_SESSION_MISMATCH",
       "Pi H0 session id does not match the launch session",
@@ -803,7 +803,7 @@ function validateApiFirstTurnH1(
     );
   }
   const parsed = safeSync(() => {
-    return MemoryPiSession.fromJsonl(turn.sessionJsonl);
+    return inspectPiSessionJsonl(turn.sessionJsonl);
   });
   if ("error" in parsed) {
     throw piApiFirstTurnError(
@@ -813,15 +813,15 @@ function validateApiFirstTurnH1(
     );
   }
   const committedSession = parsed.ok;
-  if (committedSession.getSessionId() !== sessionId) {
+  if (committedSession.sessionId !== sessionId) {
     throw piApiFirstTurnError(
       "PI_H1_INVALID",
       "Pi H1 session id does not match the launch session",
     );
   }
   if (
-    (turn.handoffRequired && !committedSession.hasPendingToolCalls()) ||
-    (!turn.handoffRequired && !committedSession.isSettledCheckpoint())
+    (turn.handoffRequired && !committedSession.hasPendingToolCalls) ||
+    (!turn.handoffRequired && !committedSession.isSettledCheckpoint)
   ) {
     throw piApiFirstTurnError(
       "PI_H1_INVALID",

--- a/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.ts
+++ b/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.ts
@@ -8,7 +8,10 @@ import {
   type PiApiFirstTurnConfig,
   type PiApiFirstTurnManifest,
 } from "@okouai/api-contracts/contracts/runners";
-import { MemoryPiSession } from "@okouai/pi-agent-runtime/node";
+import {
+  inspectPiSessionJsonl,
+  type PiSessionInspection,
+} from "@okouai/pi-agent-runtime/api";
 
 const MANIFEST_MAX_BYTES = 16 * 1024;
 const INITIAL_POLL_DELAY_MS = 100;
@@ -309,10 +312,10 @@ async function restoreSession(args: {
     );
   }
 
-  let session: MemoryPiSession;
+  let session: PiSessionInspection;
   try {
     const jsonl = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-    session = MemoryPiSession.fromJsonl(jsonl);
+    session = inspectPiSessionJsonl(jsonl);
   } catch (error) {
     throw new PiApiFirstTurnHandoffError(
       "PI_HANDOFF_H1_INVALID",
@@ -320,13 +323,13 @@ async function restoreSession(args: {
       { cause: error },
     );
   }
-  if (session.getSessionId() !== args.sessionId) {
+  if (session.sessionId !== args.sessionId) {
     throw new PiApiFirstTurnHandoffError(
       "PI_HANDOFF_SESSION_MISMATCH",
       "Pi API first-turn H1 session id does not match the launch",
     );
   }
-  if (!session.hasPendingToolCalls()) {
+  if (!session.hasPendingToolCalls) {
     throw new PiApiFirstTurnHandoffError(
       "PI_HANDOFF_H1_INVALID",
       "Pi API first-turn H1 contains no pending Sandbox tool calls",

--- a/turbo/packages/pi-agent-runtime/package.json
+++ b/turbo/packages/pi-agent-runtime/package.json
@@ -8,6 +8,10 @@
       "types": "./dist/index.d.ts",
       "import": "./src/index.ts"
     },
+    "./api": {
+      "types": "./dist/api.d.ts",
+      "import": "./src/api.ts"
+    },
     "./node": {
       "types": "./dist/node.d.ts",
       "import": "./src/node.ts"
@@ -17,7 +21,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "oxlint && oxlint --type-aware -c ../../.oxlintrc.typeaware.json && eslint . --max-warnings 0",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && pnpm run check-public-declarations",
+    "check-public-declarations": "node scripts/check-public-declarations.mjs",
     "check-types": "tsc --noEmit"
   },
   "dependencies": {

--- a/turbo/packages/pi-agent-runtime/scripts/check-public-declarations.mjs
+++ b/turbo/packages/pi-agent-runtime/scripts/check-public-declarations.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import { dirname, extname, join, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const distRoot = resolve(packageRoot, "dist");
+const nativeExports = new Set(["./node"]);
+const forbiddenPackages = [
+  "@anthropic-ai",
+  "@earendil-works",
+  "@google/genai",
+  "@google/generative-ai",
+  "@modelcontextprotocol",
+  "@sinclair/typebox",
+  "openai",
+  "typebox",
+  "undici-types",
+];
+
+function fail(message, details = []) {
+  process.stderr.write(`${message}\n`);
+  for (const detail of details) {
+    process.stderr.write(`  ${detail}\n`);
+  }
+  process.exitCode = 1;
+}
+
+function matchesForbiddenPackage(specifier) {
+  return forbiddenPackages.some((packageName) => {
+    return specifier === packageName || specifier.startsWith(`${packageName}/`);
+  });
+}
+
+function packageSpecifierFromFile(fileName) {
+  const normalized = fileName.replaceAll("\\", "/");
+  const marker = "/node_modules/";
+  const markerIndex = normalized.lastIndexOf(marker);
+  if (markerIndex === -1) {
+    return undefined;
+  }
+  const segments = normalized.slice(markerIndex + marker.length).split("/");
+  if (segments[0]?.startsWith("@")) {
+    return segments.length >= 2 ? `${segments[0]}/${segments[1]}` : segments[0];
+  }
+  return segments[0];
+}
+
+function moduleSpecifiers(sourceFile) {
+  const specifiers = [];
+  function visit(node) {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      specifiers.push(node.moduleSpecifier.text);
+    } else if (
+      ts.isImportTypeNode(node) &&
+      ts.isLiteralTypeNode(node.argument) &&
+      ts.isStringLiteral(node.argument.literal)
+    ) {
+      specifiers.push(node.argument.literal.text);
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+  return specifiers;
+}
+
+function resolveRelativeDeclaration(importer, specifier) {
+  const target = resolve(dirname(importer), specifier);
+  const extension = extname(target);
+  const candidates = [target, `${target}.d.ts`, join(target, "index.d.ts")];
+  if (extension === ".js" || extension === ".mjs" || extension === ".cjs") {
+    candidates.push(`${target.slice(0, -extension.length)}.d.ts`);
+  }
+  return candidates.find((candidate) => {
+    return fs.existsSync(candidate) && fs.statSync(candidate).isFile();
+  });
+}
+
+const packageJson = JSON.parse(
+  fs.readFileSync(resolve(packageRoot, "package.json"), "utf8"),
+);
+const entryFiles = [];
+for (const [exportName, exportTarget] of Object.entries(
+  packageJson.exports ?? {},
+)) {
+  if (nativeExports.has(exportName)) {
+    continue;
+  }
+  const typesTarget = exportTarget?.types;
+  if (typeof typesTarget !== "string") {
+    fail(`Clean export ${exportName} must declare one types target`);
+    continue;
+  }
+  const entryFile = resolve(packageRoot, typesTarget);
+  if (!entryFile.startsWith(`${distRoot}/`) || !fs.existsSync(entryFile)) {
+    fail(`Clean export ${exportName} has an invalid generated types target`, [
+      typesTarget,
+    ]);
+    continue;
+  }
+  entryFiles.push(entryFile);
+}
+
+const visitedDeclarations = new Set();
+const directViolations = [];
+const unresolvedDeclarations = [];
+const pendingDeclarations = [...entryFiles];
+while (pendingDeclarations.length > 0) {
+  const fileName = pendingDeclarations.pop();
+  if (!fileName || visitedDeclarations.has(fileName)) {
+    continue;
+  }
+  visitedDeclarations.add(fileName);
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    fs.readFileSync(fileName, "utf8"),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  for (const specifier of moduleSpecifiers(sourceFile)) {
+    if (matchesForbiddenPackage(specifier)) {
+      directViolations.push(`${fileName}: ${specifier}`);
+      continue;
+    }
+    if (!specifier.startsWith(".")) {
+      continue;
+    }
+    const declaration = resolveRelativeDeclaration(fileName, specifier);
+    if (!declaration) {
+      unresolvedDeclarations.push(`${fileName}: ${specifier}`);
+      continue;
+    }
+    pendingDeclarations.push(declaration);
+  }
+}
+
+if (directViolations.length > 0) {
+  fail("Clean public declarations reference forbidden SDK packages:", [
+    ...directViolations,
+  ]);
+}
+if (unresolvedDeclarations.length > 0) {
+  fail("Clean public declarations contain unresolved relative references:", [
+    ...unresolvedDeclarations,
+  ]);
+}
+
+const configPath = resolve(packageRoot, "tsconfig.build.json");
+const config = ts.readConfigFile(configPath, ts.sys.readFile);
+if (config.error) {
+  throw new Error(
+    ts.flattenDiagnosticMessageText(config.error.messageText, "\n"),
+  );
+}
+const parsedConfig = ts.parseJsonConfigFileContent(
+  config.config,
+  ts.sys,
+  packageRoot,
+  undefined,
+  configPath,
+);
+const program = ts.createProgram({
+  rootNames: entryFiles,
+  options: {
+    ...parsedConfig.options,
+    composite: false,
+    declaration: false,
+    declarationMap: false,
+    incremental: false,
+    noEmit: true,
+    tsBuildInfoFile: undefined,
+    types: [],
+  },
+});
+const resolvedViolations = program.getSourceFiles().flatMap((sourceFile) => {
+  const packageSpecifier = packageSpecifierFromFile(sourceFile.fileName);
+  return packageSpecifier && matchesForbiddenPackage(packageSpecifier)
+    ? [`${packageSpecifier}: ${sourceFile.fileName}`]
+    : [];
+});
+if (resolvedViolations.length > 0) {
+  fail("Clean public declaration programs resolve forbidden SDK packages:", [
+    ...resolvedViolations,
+  ]);
+}
+
+if (process.exitCode !== 1) {
+  process.stdout.write(
+    `Public declaration boundary: entries=${entryFiles.length}; declarations=${visitedDeclarations.size}; forbidden=0\n`,
+  );
+}

--- a/turbo/packages/pi-agent-runtime/src/api-turn.ts
+++ b/turbo/packages/pi-agent-runtime/src/api-turn.ts
@@ -1,33 +1,67 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 
 import { piAgentStream } from "./model";
-import type { PiPreheatedResourceSnapshot } from "./resources";
 import { MemoryPiSession, runPiFirstModelTurn } from "./session-memory";
 import { createPiAgentSessionForRuntime } from "./session-runtime";
-import type { PiAgentModelConfig } from "./types";
+import type {
+  PiApiAssistantContent,
+  PiApiAssistantMessage,
+  PiApiFirstTurnArgs,
+  PiApiFirstTurnResult,
+} from "./api-types";
+import { UnsupportedPiResourceSnapshotError } from "./errors";
 
-export interface PiApiFirstTurnResult {
-  readonly assistantMessage: Awaited<
-    ReturnType<typeof runPiFirstModelTurn>
-  >["assistantMessage"];
-  readonly handoffRequired: boolean;
-  readonly sessionJsonl: string;
+function projectAssistantContent(
+  message: AssistantMessage,
+): PiApiAssistantContent[] {
+  return message.content.flatMap((content): PiApiAssistantContent[] => {
+    switch (content.type) {
+      case "text": {
+        return [{ type: "text", text: content.text }];
+      }
+      case "toolCall": {
+        return [
+          {
+            type: "toolCall",
+            id: content.id,
+            name: content.name,
+            arguments: content.arguments,
+          },
+        ];
+      }
+      case "thinking": {
+        return [];
+      }
+      default: {
+        const unsupportedContent: never = content;
+        return unsupportedContent;
+      }
+    }
+  });
 }
 
-export class UnsupportedPiResourceSnapshotError extends Error {}
+export function projectPiApiAssistantMessage(
+  message: AssistantMessage,
+): PiApiAssistantMessage {
+  return {
+    content: projectAssistantContent(message),
+    model: message.model,
+    responseId: message.responseId,
+    stopReason: message.stopReason,
+    timestamp: message.timestamp,
+    usage: {
+      input: message.usage.input,
+      output: message.usage.output,
+      cacheRead: message.usage.cacheRead,
+      cacheWrite: message.usage.cacheWrite,
+    },
+  };
+}
 
 /** Run exactly one provider request using Pi's official prompt and tool schemas. */
 export async function runPiApiFirstTurn(
-  args: {
-    readonly cwd: string;
-    readonly agentDir: string;
-    readonly sessionId: string;
-    readonly sessionJsonl?: string;
-    readonly prompt: string;
-    readonly appendSystemPrompt: string | null;
-    readonly model: PiAgentModelConfig;
-    readonly resourceSnapshot: PiPreheatedResourceSnapshot;
-  },
+  args: PiApiFirstTurnArgs,
   signal?: AbortSignal,
 ): Promise<PiApiFirstTurnResult> {
   const memorySession = args.sessionJsonl
@@ -70,7 +104,11 @@ export async function runPiApiFirstTurn(
         signal,
       },
     });
-    return { ...turn, sessionJsonl: memorySession.toJsonl() };
+    return {
+      assistantMessage: projectPiApiAssistantMessage(turn.assistantMessage),
+      handoffRequired: turn.handoffRequired,
+      sessionJsonl: memorySession.toJsonl(),
+    };
   } finally {
     shell.session.dispose();
   }

--- a/turbo/packages/pi-agent-runtime/src/api-types.ts
+++ b/turbo/packages/pi-agent-runtime/src/api-types.ts
@@ -1,0 +1,88 @@
+import type { PiAgentModelConfig } from "./types";
+
+export interface PiPreheatedAgentsFile {
+  readonly path: string;
+  readonly content: string;
+}
+
+export interface PiPreheatedSkill {
+  readonly name: string;
+  readonly description: string;
+  readonly filePath: string;
+  readonly baseDir: string;
+  readonly scope: "user" | "project" | "temporary";
+  readonly disableModelInvocation: boolean;
+}
+
+export interface PiPreheatedResourceSnapshot {
+  readonly schemaVersion: 1;
+  readonly agentsFiles: readonly PiPreheatedAgentsFile[];
+  readonly skills: readonly PiPreheatedSkill[];
+}
+
+export interface PiApiAssistantTextContent {
+  readonly type: "text";
+  readonly text: string;
+}
+
+export interface PiApiAssistantToolCallContent {
+  readonly type: "toolCall";
+  readonly id: string;
+  readonly name: string;
+  readonly arguments: Readonly<Record<string, unknown>>;
+}
+
+export type PiApiAssistantContent =
+  | PiApiAssistantTextContent
+  | PiApiAssistantToolCallContent;
+
+export type PiApiAssistantStopReason =
+  | "pending"
+  | "stop"
+  | "length"
+  | "toolUse"
+  | "error"
+  | "aborted"
+  | "deferred";
+
+export interface PiApiAssistantMessage {
+  readonly content: readonly PiApiAssistantContent[];
+  readonly model: string;
+  readonly responseId?: string;
+  readonly stopReason: PiApiAssistantStopReason;
+  readonly timestamp: number;
+  readonly usage: {
+    readonly input: number;
+    readonly output: number;
+    readonly cacheRead: number;
+    readonly cacheWrite: number;
+  };
+}
+
+export interface PiApiFirstTurnArgs {
+  readonly cwd: string;
+  readonly agentDir: string;
+  readonly sessionId: string;
+  readonly sessionJsonl?: string;
+  readonly prompt: string;
+  readonly appendSystemPrompt: string | null;
+  readonly model: PiAgentModelConfig;
+  readonly resourceSnapshot: PiPreheatedResourceSnapshot;
+}
+
+export interface PiApiFirstTurnResult {
+  readonly assistantMessage: PiApiAssistantMessage;
+  readonly handoffRequired: boolean;
+  readonly sessionJsonl: string;
+}
+
+export interface PiSessionInspection {
+  readonly sessionId: string;
+  readonly hasPendingToolCalls: boolean;
+  readonly isSettledCheckpoint: boolean;
+}
+
+export type RunPiApiFirstTurn = (
+  args: PiApiFirstTurnArgs,
+  signal?: AbortSignal,
+) => Promise<PiApiFirstTurnResult>;

--- a/turbo/packages/pi-agent-runtime/src/api.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/api.test.ts
@@ -1,0 +1,121 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { CURRENT_SESSION_VERSION } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+
+import { inspectPiSessionJsonl, UnsupportedPiSessionVersionError } from "./api";
+import { projectPiApiAssistantMessage } from "./api-turn";
+import { MemoryPiSession } from "./session-memory";
+
+const SESSION_ID = "00000000-0000-4000-8000-000000000123";
+
+describe("Pi API facade", () => {
+  it("projects only API-consumed assistant fields", () => {
+    const nativeMessage: AssistantMessage = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "before tools" },
+        { type: "thinking", thinking: "private reasoning" },
+        {
+          type: "toolCall",
+          id: "call-1",
+          name: "read",
+          arguments: { path: "/workspace/AGENTS.md" },
+        },
+      ],
+      api: "openai-responses",
+      provider: "deepseek",
+      model: "deepseek-v4-flash",
+      responseId: "response-1",
+      errorMessage: "native-only diagnostic",
+      usage: {
+        input: 11,
+        output: 7,
+        cacheRead: 3,
+        cacheWrite: 2,
+        reasoning: 5,
+        totalTokens: 18,
+        cost: {
+          input: 0.1,
+          output: 0.2,
+          cacheRead: 0.03,
+          cacheWrite: 0.02,
+          total: 0.35,
+        },
+      },
+      stopReason: "toolUse",
+      timestamp: 123,
+    };
+
+    expect(projectPiApiAssistantMessage(nativeMessage)).toStrictEqual({
+      content: [
+        { type: "text", text: "before tools" },
+        {
+          type: "toolCall",
+          id: "call-1",
+          name: "read",
+          arguments: { path: "/workspace/AGENTS.md" },
+        },
+      ],
+      model: "deepseek-v4-flash",
+      responseId: "response-1",
+      stopReason: "toolUse",
+      timestamp: 123,
+      usage: {
+        input: 11,
+        output: 7,
+        cacheRead: 3,
+        cacheWrite: 2,
+      },
+    });
+  });
+
+  it("projects native session state into a narrow inspection result", () => {
+    const session = MemoryPiSession.create({
+      cwd: "/home/user/workspace",
+      id: SESSION_ID,
+    });
+    session.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "complete" }],
+      api: "openai-responses",
+      provider: "deepseek",
+      model: "deepseek-v4-flash",
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+      stopReason: "stop",
+      timestamp: 1,
+    });
+
+    expect(inspectPiSessionJsonl(session.toJsonl())).toStrictEqual({
+      sessionId: SESSION_ID,
+      hasPendingToolCalls: false,
+      isSettledCheckpoint: true,
+    });
+  });
+
+  it("preserves the clean entrypoint's unsupported-version error identity", () => {
+    const jsonl = `${JSON.stringify({
+      type: "session",
+      version: CURRENT_SESSION_VERSION + 1,
+      id: SESSION_ID,
+      timestamp: new Date(0).toISOString(),
+      cwd: "/home/user/workspace",
+    })}\n`;
+
+    expect(() => {
+      inspectPiSessionJsonl(jsonl);
+    }).toThrow(UnsupportedPiSessionVersionError);
+  });
+});

--- a/turbo/packages/pi-agent-runtime/src/api.ts
+++ b/turbo/packages/pi-agent-runtime/src/api.ts
@@ -1,0 +1,47 @@
+import { runPiApiFirstTurn as runPiApiFirstTurnImpl } from "./api-turn";
+import { MemoryPiSession } from "./session-memory";
+import type {
+  PiApiAssistantContent,
+  PiApiAssistantMessage,
+  PiApiAssistantStopReason,
+  PiApiAssistantTextContent,
+  PiApiAssistantToolCallContent,
+  PiApiFirstTurnArgs,
+  PiApiFirstTurnResult,
+  PiPreheatedAgentsFile,
+  PiPreheatedResourceSnapshot,
+  PiPreheatedSkill,
+  PiSessionInspection,
+  RunPiApiFirstTurn,
+} from "./api-types";
+import {
+  UnsupportedPiResourceSnapshotError,
+  UnsupportedPiSessionVersionError,
+} from "./errors";
+export { UnsupportedPiResourceSnapshotError, UnsupportedPiSessionVersionError };
+export type {
+  PiApiAssistantContent,
+  PiApiAssistantMessage,
+  PiApiAssistantStopReason,
+  PiApiAssistantTextContent,
+  PiApiAssistantToolCallContent,
+  PiApiFirstTurnArgs,
+  PiApiFirstTurnResult,
+  PiPreheatedAgentsFile,
+  PiPreheatedResourceSnapshot,
+  PiPreheatedSkill,
+  PiSessionInspection,
+};
+
+/** Run one provider turn without exposing Pi's native declaration surface. */
+export const runPiApiFirstTurn: RunPiApiFirstTurn = runPiApiFirstTurnImpl;
+
+/** Inspect one native Pi JSONL session through a stable structural result. */
+export function inspectPiSessionJsonl(jsonl: string): PiSessionInspection {
+  const session = MemoryPiSession.fromJsonl(jsonl);
+  return {
+    sessionId: session.getSessionId(),
+    hasPendingToolCalls: session.hasPendingToolCalls(),
+    isSettledCheckpoint: session.isSettledCheckpoint(),
+  };
+}

--- a/turbo/packages/pi-agent-runtime/src/errors.ts
+++ b/turbo/packages/pi-agent-runtime/src/errors.ts
@@ -1,0 +1,3 @@
+export class UnsupportedPiResourceSnapshotError extends Error {}
+
+export class UnsupportedPiSessionVersionError extends Error {}

--- a/turbo/packages/pi-agent-runtime/src/index.ts
+++ b/turbo/packages/pi-agent-runtime/src/index.ts
@@ -1,3 +1,9 @@
-export { isPiAgentModelSupported } from "./model";
+import { isPiAgentModelSupported as isPiAgentModelSupportedImpl } from "./model";
+import type { PiAgentModelConfig } from "./types";
+
+/** Whether Pi's native provider catalog knows this model. */
+export const isPiAgentModelSupported: (config: PiAgentModelConfig) => boolean =
+  isPiAgentModelSupportedImpl;
+
 export { PI_OPENAI_COMPATIBLE_PROVIDERS } from "./types";
 export type { PiAgentModelConfig, PiOpenAICompatibleProvider } from "./types";

--- a/turbo/packages/pi-agent-runtime/src/node.ts
+++ b/turbo/packages/pi-agent-runtime/src/node.ts
@@ -1,16 +1,14 @@
 export { resumePiApiFirstTurn, runPiOfficialRpcMode } from "./rpc";
+export { runPiApiFirstTurn } from "./api";
+export { MemoryPiSession } from "./session-memory";
 export {
-  runPiApiFirstTurn,
   UnsupportedPiResourceSnapshotError,
-} from "./api-turn";
-export type { PiApiFirstTurnResult } from "./api-turn";
-export {
-  MemoryPiSession,
   UnsupportedPiSessionVersionError,
-} from "./session-memory";
+} from "./errors";
 export type {
+  PiApiFirstTurnResult,
   PiPreheatedAgentsFile,
   PiPreheatedResourceSnapshot,
   PiPreheatedSkill,
-} from "./resources";
+} from "./api-types";
 export * from "./index";

--- a/turbo/packages/pi-agent-runtime/src/resources.ts
+++ b/turbo/packages/pi-agent-runtime/src/resources.ts
@@ -3,25 +3,10 @@ import {
   type Skill,
 } from "@earendil-works/pi-coding-agent";
 
-export interface PiPreheatedAgentsFile {
-  readonly path: string;
-  readonly content: string;
-}
-
-export interface PiPreheatedSkill {
-  readonly name: string;
-  readonly description: string;
-  readonly filePath: string;
-  readonly baseDir: string;
-  readonly scope: "user" | "project" | "temporary";
-  readonly disableModelInvocation: boolean;
-}
-
-export interface PiPreheatedResourceSnapshot {
-  readonly schemaVersion: 1;
-  readonly agentsFiles: readonly PiPreheatedAgentsFile[];
-  readonly skills: readonly PiPreheatedSkill[];
-}
+import type {
+  PiPreheatedResourceSnapshot,
+  PiPreheatedSkill,
+} from "./api-types";
 
 function officialSkill(skill: PiPreheatedSkill): Skill {
   return {

--- a/turbo/packages/pi-agent-runtime/src/session-memory.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-memory.test.ts
@@ -16,11 +16,8 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { afterEach, describe, expect, it } from "vitest";
 
-import {
-  MemoryPiSession,
-  runPiFirstModelTurn,
-  UnsupportedPiSessionVersionError,
-} from "./session-memory";
+import { MemoryPiSession, runPiFirstModelTurn } from "./session-memory";
+import { UnsupportedPiSessionVersionError } from "./errors";
 
 const SESSION_ID = "00000000-0000-4000-8000-000000000123";
 const temporaryDirectories: string[] = [];

--- a/turbo/packages/pi-agent-runtime/src/session-memory.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-memory.ts
@@ -25,6 +25,8 @@ import {
   type SessionHeader,
 } from "@earendil-works/pi-coding-agent";
 
+import { UnsupportedPiSessionVersionError } from "./errors";
+
 interface CreateMemoryPiSessionOptions {
   readonly cwd: string;
   readonly id: string;
@@ -63,8 +65,6 @@ type NewMemorySessionEntry =
 // this default when opening a new session, and when opening an older session
 // that has messages but no explicit thinking_level_change entry.
 const PI_DEFAULT_THINKING_LEVEL: ModelThinkingLevel = "medium";
-
-export class UnsupportedPiSessionVersionError extends Error {}
 
 function assertSessionHeader(entry: FileEntry | undefined): SessionHeader {
   if (entry?.type !== "session" || typeof entry.id !== "string") {

--- a/turbo/packages/pi-agent-runtime/src/session-runtime.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-runtime.ts
@@ -9,9 +9,9 @@ import {
   type SessionManager,
 } from "@earendil-works/pi-coding-agent";
 
+import type { PiPreheatedResourceSnapshot } from "./api-types";
 import { piAgentStream, resolvePiAgentModel } from "./model";
 import { piPreheatedResourceLoaderOptions } from "./resources";
-import type { PiPreheatedResourceSnapshot } from "./resources";
 import type { PiAgentModelConfig } from "./types";
 
 function registeredModelConfig(


### PR DESCRIPTION
## Summary

- add a declaration-isolated `@okouai/pi-agent-runtime/api` entrypoint for API first-turn execution and Pi session inspection
- move API and CLI first-turn consumers from the native `/node` surface to narrow structural types while retaining `/node` for sandbox/native consumers
- project native Pi assistant messages to only the fields consumed by the API without changing the canonical session JSONL
- add generated-declaration and API import-boundary guards to prevent Pi/model SDK types from leaking back into clean API typecheck programs

## Why

The API only needs a narrow first-turn result and three session-state checks, but importing the native Pi entrypoint makes TypeScript resolve the full Pi/model SDK declaration graph. `skipLibCheck` does not avoid parsing, binding, and resolving those declarations.

This PR restores that declaration boundary without changing the native runtime entrypoint. It is intentionally a first-stage memory fix: the remaining API source/test graph still accounts for substantial RSS.

## Memory evidence

Matched cold process-tree measurements on current `origin/main` (`8199ac1f30`) with the same API core command:

| Check | `origin/main` | This PR | Delta |
| --- | ---: | ---: | ---: |
| API core peak RSS | 3155.3 MiB | 3086.2 MiB | -69.1 MiB |

These are single cold runs on one host. RSS is nonlinear and noisy, so this delta is evidence for partial recovery, not a stable guarantee and not something to add linearly to other typecheck savings.

The generated declaration guard resolves both clean package exports (`.` and `./api`) and reports 5 reachable declaration files with 0 forbidden SDK references.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/pi-agent-runtime exec vitest run src/api.test.ts` (3 tests)
- `pnpm --filter @okouai/pi-agent-runtime exec vitest run src/session-memory.test.ts` (6 tests)
- `pnpm --filter @okouai/cli exec vitest run src/lib/pi-api-first-turn-handoff.test.ts` (20 tests)

A filtered API first-turn BDD case was also attempted, but its suite setup could not connect to local PostgreSQL on port 5432, so no BDD assertion ran locally. Full Vitest was not run.
