### PR TITLE
refactor(platform): select clerk bootstrap config in browser

### DIFF
--- a/.github/pages/okou-app/_worker.js
+++ b/.github/pages/okou-app/_worker.js
@@ -17,15 +17,6 @@ const PRODUCTION_API_ORIGINS = new Map([
   ["app.vm0.ai", "https://api.vm0.ai"],
 ]);
 const VERCEL_PROTECTION_BYPASS = "x-vercel-protection-bypass";
-const PRODUCTION_ROOT_DOMAINS = ["okou.ai", "vm0.ai"];
-const CLERK_SATELLITE_DOMAIN = "app.okou.ai";
-const CLERK_SCRIPT_SELECTOR = "script[data-clerk-js-script]";
-const CLERK_PRODUCTION_PUBLISHABLE_KEY_ATTRIBUTE =
-  "data-vm0-clerk-production-publishable-key";
-const CLERK_PRODUCTION_SCRIPT_URL_ATTRIBUTE =
-  "data-vm0-clerk-production-script-url";
-const CLERK_SATELLITE_SCRIPT_URL_ATTRIBUTE =
-  "data-vm0-clerk-satellite-script-url";
 
 const VM0_APP_METADATA = {
   brandName: "VM0",
@@ -141,47 +132,6 @@ function addStaticAssetHandlers(rewriter, metadata) {
     .on("img", rewriteStaticAssetAttribute("src", metadata.staticAssetsOrigin));
 }
 
-function isProductionHostname(hostname) {
-  return PRODUCTION_ROOT_DOMAINS.some((domain) => {
-    return hostname === domain || hostname.endsWith(`.${domain}`);
-  });
-}
-
-function isClerkSatelliteHostname(hostname) {
-  return (
-    hostname === CLERK_SATELLITE_DOMAIN ||
-    hostname.endsWith(`.${CLERK_SATELLITE_DOMAIN}`)
-  );
-}
-
-function addClerkScriptHandler(rewriter, hostname) {
-  const normalizedHostname = hostname.toLowerCase();
-  if (!isProductionHostname(normalizedHostname)) {
-    return;
-  }
-  rewriter.on(CLERK_SCRIPT_SELECTOR, {
-    element(element) {
-      const publishableKey = element.getAttribute(
-        CLERK_PRODUCTION_PUBLISHABLE_KEY_ATTRIBUTE,
-      );
-      const satellite = isClerkSatelliteHostname(normalizedHostname);
-      const scriptUrl = element.getAttribute(
-        satellite
-          ? CLERK_SATELLITE_SCRIPT_URL_ATTRIBUTE
-          : CLERK_PRODUCTION_SCRIPT_URL_ATTRIBUTE,
-      );
-      if (publishableKey === null || scriptUrl === null) {
-        throw new Error("Clerk production script configuration is unavailable");
-      }
-      element.setAttribute("data-clerk-publishable-key", publishableKey);
-      element.setAttribute("src", scriptUrl);
-      if (satellite) {
-        element.setAttribute("data-clerk-domain", CLERK_SATELLITE_DOMAIN);
-      }
-    },
-  });
-}
-
 function htmlResponse(indexHtml, assetResponse, status, cacheControl) {
   const headers = new Headers(assetResponse.headers);
   headers.delete("Content-Encoding");
@@ -206,7 +156,7 @@ function noIndexResponse(response) {
   });
 }
 
-function rewriteAppPage(response, metadata, productionApiOrigin, hostname) {
+function rewriteAppPage(response, metadata, productionApiOrigin) {
   const rewriter = new HTMLRewriter()
     .on("html", setBrandContext(metadata.brandName))
     .on("title", {
@@ -260,7 +210,6 @@ function rewriteAppPage(response, metadata, productionApiOrigin, hostname) {
       },
     });
   addStaticAssetHandlers(rewriter, metadata);
-  addClerkScriptHandler(rewriter, hostname);
   if (productionApiOrigin) {
     rewriter.on(
       'meta[name="vm0-api-origin"]',
@@ -295,7 +244,6 @@ function rewriteFound(
   canonicalUrl,
   metadata,
   apiOrigin,
-  hostname,
 ) {
   const sharedDescription = `A conversation shared from ${metadata.brandName}`;
   const rewriter = new HTMLRewriter()
@@ -338,11 +286,10 @@ function rewriteFound(
       },
     });
   addStaticAssetHandlers(rewriter, metadata);
-  addClerkScriptHandler(rewriter, hostname);
   return rewriter.transform(response);
 }
 
-function rewriteNotFound(response, metadata, apiOrigin, hostname) {
+function rewriteNotFound(response, metadata, apiOrigin) {
   const rewriter = new HTMLRewriter()
     .on("html", setBrandContext(metadata.brandName))
     .on('meta[name="vm0-api-origin"]', setMetaContent(apiOrigin))
@@ -368,7 +315,6 @@ function rewriteNotFound(response, metadata, apiOrigin, hostname) {
       },
     });
   addStaticAssetHandlers(rewriter, metadata);
-  addClerkScriptHandler(rewriter, hostname);
   return rewriter.transform(response);
 }
 
@@ -460,7 +406,6 @@ export default {
           ),
           appMetadata(requestUrl.hostname),
           origin,
-          requestUrl.hostname,
         );
       }
       if (!metaResponse.ok) {
@@ -497,7 +442,6 @@ export default {
         canonicalUrl,
         sharedAppMetadata,
         origin,
-        requestUrl.hostname,
       );
     }
 
@@ -522,7 +466,6 @@ export default {
       assetResponse,
       metadata,
       PRODUCTION_API_ORIGINS.get(requestUrl.hostname),
-      requestUrl.hostname,
     );
   },
 };

--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -28,9 +28,6 @@ function matchesSelector(tagName, attributes, selector) {
   if (selector === tagName) {
     return true;
   }
-  if (selector === "script[data-clerk-js-script]") {
-    return tagName === "script" && attributes.has("data-clerk-js-script");
-  }
   const match = /^(meta|link)\[(name|property|rel)(\^?=)"([^"]+)"\]$/u.exec(
     selector,
   );
@@ -96,34 +93,6 @@ function rewritePairedTag(html, tagName, handler) {
   });
 }
 
-function rewriteClerkScriptOpeningTag(html, handler) {
-  const marker = 'data-clerk-js-script=""';
-  const markerIndex = html.indexOf(marker);
-  if (markerIndex === -1) {
-    return html;
-  }
-  const tagStart = html.lastIndexOf("<", markerIndex);
-  const tagEnd = html.indexOf(">", markerIndex);
-  if (tagStart === -1 || tagEnd === -1) {
-    throw new Error("Invalid Clerk script fixture");
-  }
-  const tag = html.slice(tagStart, tagEnd + 1);
-  const attributes = parseAttributes(tag);
-  if (!matchesSelector("script", attributes, "script[data-clerk-js-script]")) {
-    throw new Error("Invalid Clerk script selector fixture");
-  }
-  const state = applyHandler({ attributes, handler });
-  if (state.removed || state.appendedContent || state.innerContent) {
-    throw new Error("Unsupported Clerk script rewrite operation");
-  }
-  const tagNameEnd = tag.search(/\s/u);
-  if (tagNameEnd === -1) {
-    throw new Error("Invalid Clerk script opening tag");
-  }
-  const rewrittenTag = `${tag.slice(0, tagNameEnd)}${serializeAttributes(state.attributes)}>`;
-  return `${html.slice(0, tagStart)}${rewrittenTag}${html.slice(tagEnd + 1)}`;
-}
-
 function rewriteVoidTag(html, tagName, selector, handler) {
   const pattern =
     tagName === "meta"
@@ -147,9 +116,6 @@ function rewriteVoidTag(html, tagName, selector, handler) {
 function rewriteHtml(html, selector, handler) {
   if (selector === "html" || selector === "head" || selector === "title") {
     return rewritePairedTag(html, selector, handler);
-  }
-  if (selector === "script[data-clerk-js-script]") {
-    return rewriteClerkScriptOpeningTag(html, handler);
   }
   if (selector.startsWith("meta[")) {
     return rewriteVoidTag(html, "meta", selector, handler);
@@ -223,6 +189,7 @@ const builtIndexTemplate = indexTemplate
   .replaceAll("__VM0_CLERK_PREVIEW_SCRIPT_URL__", previewClerkScriptUrl)
   .replaceAll("__VM0_CLERK_PRODUCTION_SCRIPT_URL__", productionClerkScriptUrl)
   .replaceAll("__VM0_CLERK_SATELLITE_SCRIPT_URL__", satelliteClerkScriptUrl);
+const expectedClerkBootstrap = clerkBootstrap(builtIndexTemplate);
 const vm0Description =
   "VM0, your trustworthy AI teammate for real work. An AI agent that connects to 100+ tools to run reports, triage, outreach, and research in Slack or the web.";
 const okouDescription =
@@ -291,9 +258,7 @@ function tagAttribute(html, tagName, selectorAttribute, selectorValue, target) {
       ? /<meta\b[^>]*>/giu
       : tagName === "link"
         ? /<link\b[^>]*>/giu
-        : tagName === "script"
-          ? /<script\b[^>]*>/giu
-          : /<img\b[^>]*>/giu;
+        : /<img\b[^>]*>/giu;
   for (const match of html.matchAll(pattern)) {
     const attributes = parseAttributes(match[0]);
     if (attributes.get(selectorAttribute) === selectorValue) {
@@ -330,14 +295,15 @@ function htmlAttribute(html, attributeName) {
   return tag ? (parseAttributes(tag).get(attributeName) ?? null) : null;
 }
 
-function clerkAttribute(html, target) {
-  return tagAttribute(html, "script", "data-clerk-js-script", "", target);
-}
-
-function clerkScriptCount(html) {
-  return [...html.matchAll(/<script\b[^>]*>/giu)].filter((match) => {
-    return parseAttributes(match[0]).has("data-clerk-js-script");
-  }).length;
+function clerkBootstrap(html) {
+  const bootstrap =
+    /<script\b[^>]*data-vm0-clerk-bootstrap=""[^>]*>[\s\S]*?<\/script>/iu.exec(
+      html,
+    )?.[0];
+  if (!bootstrap) {
+    throw new Error("Clerk bootstrap script is unavailable");
+  }
+  return bootstrap;
 }
 
 async function requestAppPage(origin, apiOrigin = "") {
@@ -398,13 +364,7 @@ assert.equal(
   tagAttribute(vm0Page.html, "img", "alt", "", "src"),
   "https://static.vm0.io/platform/icon.svg",
 );
-assert.equal(clerkScriptCount(vm0Page.html), 1);
-assert.equal(
-  clerkAttribute(vm0Page.html, "data-clerk-publishable-key"),
-  productionClerkPublishableKey,
-);
-assert.equal(clerkAttribute(vm0Page.html, "src"), productionClerkScriptUrl);
-assert.equal(clerkAttribute(vm0Page.html, "data-clerk-domain"), null);
+assert.equal(clerkBootstrap(vm0Page.html), expectedClerkBootstrap);
 
 const okouPage = await requestAppPage("https://app.okou.ai");
 assert.equal(
@@ -452,16 +412,7 @@ assert.equal(
   tagAttribute(okouPage.html, "img", "alt", "", "src"),
   "https://static.okou.io/platform/icon.svg",
 );
-assert.equal(clerkScriptCount(okouPage.html), 1);
-assert.equal(
-  clerkAttribute(okouPage.html, "data-clerk-publishable-key"),
-  productionClerkPublishableKey,
-);
-assert.equal(clerkAttribute(okouPage.html, "src"), satelliteClerkScriptUrl);
-assert.equal(
-  clerkAttribute(okouPage.html, "data-clerk-domain"),
-  clerkSatelliteDomain,
-);
+assert.equal(clerkBootstrap(okouPage.html), expectedClerkBootstrap);
 
 const okouPreview = await requestAppPage(
   "https://3508a2f5.okou-app.pages.dev",
@@ -476,17 +427,7 @@ assert.equal(
   metaContent(okouPreview.html, "name", "vm0-api-origin"),
   previewOrigin,
 );
-assert.equal(clerkScriptCount(okouPreview.html), 1);
-assert.equal(
-  clerkAttribute(okouPreview.html, "data-clerk-publishable-key"),
-  previewClerkPublishableKey,
-);
-assert.equal(clerkAttribute(okouPreview.html, "src"), previewClerkScriptUrl);
-assert.equal(clerkAttribute(okouPreview.html, "data-clerk-domain"), null);
-assert.equal(clerkAttribute(okouPreview.html, "defer"), "");
-assert.equal(clerkAttribute(okouPreview.html, "crossorigin"), "anonymous");
-assert.equal(clerkAttribute(okouPreview.html, "onerror"), "this.remove()");
-assert.equal(clerkAttribute(okouPreview.html, "type"), "text/javascript");
+assert.equal(clerkBootstrap(okouPreview.html), expectedClerkBootstrap);
 assert.equal(okouPreview.html.includes("/npm/@clerk/ui@"), false);
 
 const untrustedSuffix = await requestAppPage("https://okou.ai.evil.example");

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -9,18 +9,47 @@
     <title>AI Agents for Real Work — Your Trustworthy AI Teammate | VM0</title>
     <meta charset="UTF-8" />
     <meta name="vm0-api-origin" content="" />
-    <script
-      defer=""
-      crossorigin="anonymous"
-      data-clerk-js-script=""
-      data-clerk-publishable-key="%VITE_CLERK_PUBLISHABLE_KEY_PREVIEW%"
-      data-vm0-clerk-production-publishable-key="%VITE_CLERK_PUBLISHABLE_KEY_PROD%"
-      data-vm0-clerk-production-script-url="__VM0_CLERK_PRODUCTION_SCRIPT_URL__"
-      data-vm0-clerk-satellite-script-url="__VM0_CLERK_SATELLITE_SCRIPT_URL__"
-      onerror="this.remove()"
-      src="__VM0_CLERK_PREVIEW_SCRIPT_URL__"
-      type="text/javascript"
-    ></script>
+    <script data-vm0-clerk-bootstrap="">
+      (function () {
+        var hostname = location.hostname.toLowerCase();
+        var production =
+          hostname === "vm0.ai" ||
+          hostname.endsWith(".vm0.ai") ||
+          hostname === "okou.ai" ||
+          hostname.endsWith(".okou.ai");
+        var satellite =
+          hostname === "app.okou.ai" || hostname.endsWith(".app.okou.ai");
+        var publishableKey = production
+          ? "%VITE_CLERK_PUBLISHABLE_KEY_PROD%"
+          : "%VITE_CLERK_PUBLISHABLE_KEY_PREVIEW%";
+        var scriptUrl = satellite
+          ? "__VM0_CLERK_SATELLITE_SCRIPT_URL__"
+          : production
+            ? "__VM0_CLERK_PRODUCTION_SCRIPT_URL__"
+            : "__VM0_CLERK_PREVIEW_SCRIPT_URL__";
+
+        document.documentElement.setAttribute(
+          "data-vm0-clerk-publishable-key",
+          publishableKey,
+        );
+
+        var script = document.createElement("script");
+        script.async = false;
+        script.defer = true;
+        script.crossOrigin = "anonymous";
+        script.dataset.clerkJsScript = "";
+        script.dataset.clerkPublishableKey = publishableKey;
+        if (satellite) {
+          script.dataset.clerkDomain = "app.okou.ai";
+        }
+        script.onerror = function () {
+          script.remove();
+        };
+        script.src = scriptUrl;
+        script.type = "text/javascript";
+        document.head.appendChild(script);
+      })();
+    </script>
     <style>
       body {
         margin: 0;

--- a/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
@@ -12,7 +12,14 @@ vi.unmock("@clerk/shared/loadClerkJsScript");
 const PREVIEW_FRONTEND_API_HOST = "informed-calf-6.clerk.accounts.dev";
 const PRODUCTION_FRONTEND_API_HOST = "clerk.vm0.ai";
 const PRODUCTION_SATELLITE_DOMAIN = "app.okou.ai";
+const CLERK_BOOTSTRAP_SELECTOR = "script[data-vm0-clerk-bootstrap]";
 const CLERK_SCRIPT_SELECTOR = "script[data-clerk-js-script]";
+
+type ClerkBootstrapScript = (
+  window: Window,
+  document: Document,
+  location: Location,
+) => void;
 
 interface ClerkScriptRequest {
   readonly element: HTMLScriptElement;
@@ -68,13 +75,46 @@ function builtIndexHtml(): string {
   );
 }
 
-function clerkScriptFromHtml(html: string): HTMLScriptElement {
+function clerkBootstrapSource(html: string): string {
   const parsedDocument = new DOMParser().parseFromString(html, "text/html");
-  const script = parsedDocument.querySelector(CLERK_SCRIPT_SELECTOR);
-  if (!(script instanceof HTMLScriptElement)) {
-    throw new Error("Built index.html does not contain the Clerk core script");
+  const bootstrap = parsedDocument.querySelector(CLERK_BOOTSTRAP_SELECTOR);
+  if (!(bootstrap instanceof HTMLScriptElement)) {
+    throw new Error("Built index.html does not contain the Clerk bootstrap");
   }
-  return script;
+  return bootstrap.textContent;
+}
+
+function executeClerkBootstrap(html: string): void {
+  const executeEntrypointScript = new Function(
+    "window",
+    "document",
+    "location",
+    `${clerkBootstrapSource(html)}\n//# sourceURL=platform-clerk-bootstrap-test.js`,
+  ) as ClerkBootstrapScript;
+  executeEntrypointScript(window, document, location);
+}
+
+function captureClerkBootstrapScript(url: string): HTMLScriptElement {
+  context.mocks.browser.url(url);
+  let clerkScript: HTMLScriptElement | undefined;
+  const appendSpy = vi
+    .spyOn(document.head, "appendChild")
+    .mockImplementation(<T extends Node>(node: T): T => {
+      if (
+        node instanceof HTMLScriptElement &&
+        node.dataset.clerkJsScript !== undefined
+      ) {
+        clerkScript = node;
+      }
+      return node;
+    });
+
+  executeClerkBootstrap(builtIndexHtml());
+  appendSpy.mockRestore();
+  if (!clerkScript) {
+    throw new Error("Clerk bootstrap did not create the core script");
+  }
+  return clerkScript;
 }
 
 function startClerkPage(path = "/error"): ClerkEntrypointHarness {
@@ -86,37 +126,9 @@ function startClerkPage(path = "/error"): ClerkEntrypointHarness {
   const setup = setupPage({
     beforeBootstrap: (signal) => {
       context.mocks.browser.url("https://pr-30199-app.omby.ai/");
-      const previousPreviewKey = import.meta.env
-        .VITE_CLERK_PUBLISHABLE_KEY_PREVIEW;
-      const previousProductionKey = import.meta.env
-        .VITE_CLERK_PUBLISHABLE_KEY_PROD;
-      vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PREVIEW", PREVIEW_PUBLISHABLE_KEY);
-      vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PROD", PRODUCTION_PUBLISHABLE_KEY);
       window.__vm0BrowserSupported = true;
       Reflect.deleteProperty(globalThis, "Clerk");
       Reflect.deleteProperty(globalThis, "__internal_ClerkUICtor");
-
-      const parsedEarlyScript = clerkScriptFromHtml(builtIndexHtml());
-      const earlyScriptUrl = parsedEarlyScript.src;
-      parsedEarlyScript.removeAttribute("src");
-      document.head.appendChild(parsedEarlyScript);
-      requests.push({ element: parsedEarlyScript, url: earlyScriptUrl });
-      parsedEarlyScript.addEventListener("error", () => {
-        if (parsedEarlyScript.getAttribute("onerror") === "this.remove()") {
-          parsedEarlyScript.remove();
-        }
-      });
-
-      const addEventListener =
-        parsedEarlyScript.addEventListener.bind(parsedEarlyScript);
-      vi.spyOn(parsedEarlyScript, "addEventListener").mockImplementation(
-        (type, listener, options) => {
-          if (type === "error") {
-            clerkLoaderWatchingEarlyScript.resolve(undefined);
-          }
-          addEventListener(type, listener, options);
-        },
-      );
 
       const observeScript = (
         append: typeof document.body.appendChild,
@@ -130,6 +142,13 @@ function startClerkPage(path = "/error"): ClerkEntrypointHarness {
         const isClerkUiRequest = node.src.includes("/npm/@clerk/ui@");
         node.removeAttribute("src");
         const appended = append(node);
+        if (
+          earlyScript === undefined &&
+          node.dataset.clerkJsScript !== undefined
+        ) {
+          earlyScript = node;
+          return appended;
+        }
         if (isClerkUiRequest) {
           Reflect.set(
             globalThis,
@@ -157,7 +176,20 @@ function startClerkPage(path = "/error"): ClerkEntrypointHarness {
           return observeScript(appendToBody, node);
         });
 
-      earlyScript = parsedEarlyScript;
+      executeClerkBootstrap(builtIndexHtml());
+      if (!earlyScript) {
+        throw new Error("Clerk bootstrap did not run synchronously");
+      }
+      const addEventListener = earlyScript.addEventListener.bind(earlyScript);
+      vi.spyOn(earlyScript, "addEventListener").mockImplementation(
+        (type, listener, options) => {
+          if (type === "error") {
+            clerkLoaderWatchingEarlyScript.resolve(undefined);
+          }
+          addEventListener(type, listener, options);
+        },
+      );
+
       signal.addEventListener(
         "abort",
         () => {
@@ -169,8 +201,6 @@ function startClerkPage(path = "/error"): ClerkEntrypointHarness {
           Reflect.deleteProperty(globalThis, "Clerk");
           Reflect.deleteProperty(globalThis, "__internal_ClerkUICtor");
           Reflect.deleteProperty(window, "__vm0BrowserSupported");
-          vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PREVIEW", previousPreviewKey);
-          vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PROD", previousProductionKey);
         },
         { once: true },
       );
@@ -202,53 +232,70 @@ async function completeEarlyClerkScript(
 }
 
 describe("platform Clerk entrypoint", () => {
-  it("builds the official static core script with exact environment URLs", () => {
+  it("declares the Clerk bootstrap before the app module", () => {
     const html = builtIndexHtml();
     const parsedDocument = new DOMParser().parseFromString(html, "text/html");
-    const script = parsedDocument.querySelector(CLERK_SCRIPT_SELECTOR);
+    const bootstrap = parsedDocument.querySelector(CLERK_BOOTSTRAP_SELECTOR);
     const mainScript = parsedDocument.querySelector(
       'script[type="module"][src="/src/main.ts"]',
     );
-    if (!(script instanceof HTMLScriptElement)) {
-      throw new Error(
-        "Built index.html does not contain the Clerk core script",
-      );
+    if (!(bootstrap instanceof HTMLScriptElement)) {
+      throw new Error("Built index.html does not contain the Clerk bootstrap");
     }
     if (!(mainScript instanceof HTMLScriptElement)) {
       throw new Error("Built index.html does not contain the app module");
     }
 
-    expect(parsedDocument.querySelectorAll(CLERK_SCRIPT_SELECTOR)).toHaveLength(
-      1,
-    );
-    expect(script.compareDocumentPosition(mainScript)).toBe(
+    expect(bootstrap.compareDocumentPosition(mainScript)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
-    expect(script.src).toBe(expectedClerkScriptUrl(PREVIEW_FRONTEND_API_HOST));
-    expect(script.defer).toBeTruthy();
-    expect(script.async).toBeFalsy();
-    expect(script.crossOrigin).toBe("anonymous");
-    expect(script).toHaveAttribute("data-clerk-js-script", "");
-    expect(script).toHaveAttribute(
-      "data-clerk-publishable-key",
-      PREVIEW_PUBLISHABLE_KEY,
-    );
-    expect(script).toHaveAttribute(
-      "data-vm0-clerk-production-publishable-key",
-      PRODUCTION_PUBLISHABLE_KEY,
-    );
-    expect(script).toHaveAttribute(
-      "data-vm0-clerk-production-script-url",
-      expectedClerkScriptUrl(PRODUCTION_FRONTEND_API_HOST),
-    );
-    expect(script).toHaveAttribute(
-      "data-vm0-clerk-satellite-script-url",
-      expectedClerkScriptUrl(`clerk.${PRODUCTION_SATELLITE_DOMAIN}`),
-    );
-    expect(script).toHaveAttribute("onerror", "this.remove()");
-    expect(script.textContent).toBe("");
     expect(html).not.toContain("@clerk/ui");
   });
+
+  it.each([
+    {
+      domain: null,
+      publishableKey: PREVIEW_PUBLISHABLE_KEY,
+      scriptUrl: expectedClerkScriptUrl(PREVIEW_FRONTEND_API_HOST),
+      url: "https://pr-30199-app.omby.ai/",
+    },
+    {
+      domain: null,
+      publishableKey: PRODUCTION_PUBLISHABLE_KEY,
+      scriptUrl: expectedClerkScriptUrl(PRODUCTION_FRONTEND_API_HOST),
+      url: "https://app.vm0.ai/",
+    },
+    {
+      domain: PRODUCTION_SATELLITE_DOMAIN,
+      publishableKey: PRODUCTION_PUBLISHABLE_KEY,
+      scriptUrl: expectedClerkScriptUrl(`clerk.${PRODUCTION_SATELLITE_DOMAIN}`),
+      url: "https://app.okou.ai/",
+    },
+    {
+      domain: null,
+      publishableKey: PREVIEW_PUBLISHABLE_KEY,
+      scriptUrl: expectedClerkScriptUrl(PREVIEW_FRONTEND_API_HOST),
+      url: "https://okou.ai.evil.example/",
+    },
+  ])(
+    "selects the Clerk core configuration on $url",
+    ({ domain, publishableKey, scriptUrl, url }) => {
+      const script = captureClerkBootstrapScript(url);
+
+      expect(document.documentElement.dataset.vm0ClerkPublishableKey).toBe(
+        publishableKey,
+      );
+      expect(script.src).toBe(scriptUrl);
+      expect(script.defer).toBeTruthy();
+      expect(script.async).toBeFalsy();
+      expect(script.crossOrigin).toBe("anonymous");
+      expect(script.dataset.clerkJsScript).toBe("");
+      expect(script.dataset.clerkPublishableKey).toBe(publishableKey);
+      expect(script.dataset.clerkDomain ?? null).toBe(domain);
+      expect(script.onerror).toStrictEqual(expect.any(Function));
+      expect(script.type).toBe("text/javascript");
+    },
+  );
 
   it("merges the in-flight script and lets TypeScript call Clerk.load", async () => {
     const harness = startClerkPage();
@@ -276,7 +323,7 @@ describe("platform Clerk entrypoint", () => {
     expect(mockedClerkLoad).toHaveBeenCalledOnce();
   });
 
-  it("falls back immediately when the static request fails", async () => {
+  it("falls back immediately when the bootstrap request fails", async () => {
     const harness = startClerkPage();
     await harness.clerkLoaderWatchingEarlyScript;
 

--- a/turbo/apps/platform/src/__tests__/platform-runtime-environment.test.ts
+++ b/turbo/apps/platform/src/__tests__/platform-runtime-environment.test.ts
@@ -66,6 +66,14 @@ const context = testContext();
 
 function setBrowserUrl(url: string, apiOriginMarker?: string | null): void {
   context.mocks.browser.url(url, { apiOriginMarker });
+  const hostname = new URL(url).hostname;
+  const production =
+    hostname === "vm0.ai" ||
+    hostname.endsWith(".vm0.ai") ||
+    isOkouProductionHostname(hostname);
+  document.documentElement.dataset.vm0ClerkPublishableKey = production
+    ? PRODUCTION_CLERK_KEY
+    : PREVIEW_CLERK_KEY;
 }
 
 function installImmediateIdleCallback(): void {

--- a/turbo/apps/platform/src/lib/platform-host.ts
+++ b/turbo/apps/platform/src/lib/platform-host.ts
@@ -28,6 +28,7 @@ const OKOU_ROOT_DOMAINS = [
   OKOU_PAGES_DOMAIN,
 ] as const;
 const PREVIEW_API_DOMAIN = "vm6.ai";
+const CLERK_PUBLISHABLE_KEY_ATTRIBUTE = "data-vm0-clerk-publishable-key";
 const PRODUCTION_HOSTED_SITE_DOMAINS = ["sites.vm0.io", "okou.app"] as const;
 const PREVIEW_HOSTED_SITE_DOMAINS = ["sites.vm7.io"] as const;
 export const PRODUCTION_SATELLITE_HOSTNAME = "app.okou.ai";
@@ -166,17 +167,20 @@ function optionalBuildValue(value: unknown): string | null {
   return normalized.length > 0 ? normalized : null;
 }
 
-function requiredBuildValue(value: unknown, name: string): string {
-  const normalized = optionalBuildValue(value);
-  if (!normalized) {
-    throw new Error(`Missing ${name} environment variable`);
+function resolveClerkPublishableKey(): string {
+  const publishableKey = document.documentElement.getAttribute(
+    CLERK_PUBLISHABLE_KEY_ATTRIBUTE,
+  );
+  if (!publishableKey) {
+    throw new Error("Missing Clerk publishable key from platform bootstrap");
   }
-  return normalized;
+  return publishableKey;
 }
 
 export function resolvePlatformRuntimeConfig(): PlatformRuntimeConfig {
   const environment = resolvePlatformEnvironment();
   const publicBrand = resolvePlatformPublicBrand(browserHostname());
+  const clerkPublishableKey = resolveClerkPublishableKey();
   const publicStaticAssetsBaseUrl = staticUrlForPublicBrand(
     "https://static.vm0.io",
     publicBrand,
@@ -186,10 +190,7 @@ export function resolvePlatformRuntimeConfig(): PlatformRuntimeConfig {
     return {
       environment,
       publicBrand,
-      clerkPublishableKey: requiredBuildValue(
-        import.meta.env.VITE_CLERK_PUBLISHABLE_KEY_PROD,
-        "VITE_CLERK_PUBLISHABLE_KEY_PROD",
-      ),
+      clerkPublishableKey,
       publicArtifactsBaseUrl: "https://cdn.vm0.io",
       publicStaticAssetsBaseUrl,
       zeroHostDomain: "sites.vm0.io",
@@ -207,10 +208,7 @@ export function resolvePlatformRuntimeConfig(): PlatformRuntimeConfig {
   return {
     environment,
     publicBrand,
-    clerkPublishableKey: requiredBuildValue(
-      import.meta.env.VITE_CLERK_PUBLISHABLE_KEY_PREVIEW,
-      "VITE_CLERK_PUBLISHABLE_KEY_PREVIEW",
-    ),
+    clerkPublishableKey,
     publicArtifactsBaseUrl: "https://cdn.vm7.io",
     publicStaticAssetsBaseUrl,
     zeroHostDomain: "sites.vm7.io",

--- a/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
@@ -25,6 +25,15 @@ const context = testContext();
 
 function setBrowserUrl(url: string): void {
   context.mocks.browser.url(url);
+  const hostname = new URL(url).hostname;
+  const production =
+    hostname === "vm0.ai" ||
+    hostname.endsWith(".vm0.ai") ||
+    hostname === "okou.ai" ||
+    hostname.endsWith(".okou.ai");
+  document.documentElement.dataset.vm0ClerkPublishableKey = production
+    ? "test_production_key"
+    : "test_preview_key";
 }
 
 describe("platform auth URLs", () => {

--- a/turbo/apps/platform/src/test/setup.ts
+++ b/turbo/apps/platform/src/test/setup.ts
@@ -45,6 +45,7 @@ vi.mock("@clerk/shared/loadClerkJsScript", () => {
 vi.hoisted(() => {
   vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PREVIEW", "test_preview_key");
   vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PROD", "test_production_key");
+  document.documentElement.dataset.vm0ClerkPublishableKey = "test_preview_key";
 });
 
 globalThis.indexedDB = indexedDB;
@@ -293,6 +294,7 @@ beforeAll(() => {
 beforeEach(() => {
   ensureTestLocalStorage();
   document.documentElement.dataset.appBrandName = "VM0";
+  document.documentElement.dataset.vm0ClerkPublishableKey = "test_preview_key";
 
   // Override console.error to throw on unexpected errors.
   // - NotSupportedError / AbortError: expected happy-dom noise, silently ignored.


### PR DESCRIPTION
## Summary

- select the Clerk publishable key and core script URL in an early inline browser bootstrap based on `location.hostname`
- persist the selected public key for the app runtime while preserving the existing in-flight script merge and retry behavior
- remove Clerk-specific HTML rewriting from the Cloudflare Pages Worker so preview and production can share one build artifact

## Testing

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app run lint:build-config`
- `pnpm --filter @okouai/app exec vitest run src/__tests__/clerk-entrypoint.test.ts`
- `pnpm --filter @okouai/app exec vitest run src/__tests__/platform-runtime-environment.test.ts`
- `bash .github/scripts/tests/okou-app-worker-test.sh`
