### PR TITLE
fix(db): extend chat event contraction migration timeout

### DIFF
--- a/turbo/packages/db/src/migrations/1027_remove_chat_event_legacy_snapshot_fallbacks.sql
+++ b/turbo/packages/db/src/migrations/1027_remove_chat_event_legacy_snapshot_fallbacks.sql
@@ -1,6 +1,7 @@
 -- Contract the converged Chat Event Snapshot pointer set to canonical V7.
 -- Immutable R2 objects are intentionally untouched here. The permanent,
 -- reference-aware R2 garbage collector owns deletion after its grace period.
+SET LOCAL statement_timeout = '2min';--> statement-breakpoint
 DO $$
 DECLARE
   uncovered_legacy_count bigint;
@@ -44,4 +45,5 @@ END;
 $$;--> statement-breakpoint
 
 DELETE FROM "chat_event_snapshots"
-WHERE "archive_schema_version" < 7;
+WHERE "archive_schema_version" < 7;--> statement-breakpoint
+SET LOCAL statement_timeout = '10s';

--- a/turbo/packages/db/src/migrations/1028_contract_chat_event_snapshot_v7.sql
+++ b/turbo/packages/db/src/migrations/1028_contract_chat_event_snapshot_v7.sql
@@ -1,3 +1,4 @@
+SET LOCAL statement_timeout = '2min';--> statement-breakpoint
 ALTER TABLE "chat_event_snapshots" DROP CONSTRAINT "chat_event_snapshots_canonical_projection_check";--> statement-breakpoint
 ALTER TABLE "chat_event_snapshots" DROP CONSTRAINT "chat_event_snapshots_projection_check";--> statement-breakpoint
 ALTER TABLE "chat_event_snapshots" DROP CONSTRAINT "chat_event_snapshots_terminal_cursor_check";--> statement-breakpoint
@@ -12,4 +13,5 @@ ALTER TABLE "chat_event_snapshots" ADD CONSTRAINT "chat_event_snapshots_terminal
           "chat_event_snapshots"."terminal_event_id" IS NOT NULL
           AND "chat_event_snapshots"."terminal_seq_id" > 0
           AND "chat_event_snapshots"."terminal_seq_id" <= "chat_event_snapshots"."last_seq_id"
-        ));
+        ));--> statement-breakpoint
+SET LOCAL statement_timeout = '10s';


### PR DESCRIPTION
## Summary

- Give migration 1027's fail-closed coverage scan and legacy snapshot-pointer deletion a transaction-local two-minute statement budget.
- Give migration 1028's schema contraction the same transaction-local budget.
- Explicitly restore `statement_timeout` to `10s` after each migration while leaving the runner's `1s` `lock_timeout` unchanged.

## Incident context

The canonical production migration smoke after #30226 failed twice in temporary Neon production clones because migration 1027's first safety query exceeded the migration runner's 10-second statement timeout. A production read-only execution of that exact coverage query returned zero uncovered rows quickly, so this repair addresses the cold-clone execution budget.

Production has not applied migrations 1027 or 1028. Schema and data semantics are unchanged: migration 1027 retains its existing fail-closed safety query and legacy-pointer deletion, and migration 1028 retains every existing schema operation and constraint. Both timeout overrides use `SET LOCAL` and are explicitly restored to the runner default of `10s` before the migration transaction completes.

`CI_CHECK_IMMUTABLE_MIGRATE` remains untouched in this implementation run; the parent coordinator owns its temporary switch and restoration.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged workspace, App, and API type-check commands from the repository pre-commit workflow
- `pnpm --filter @okouai/db lint`
- `pnpm --filter @okouai/db run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter @okouai/db test:migration-consistency` on PostgreSQL 17.11
  - migration-runner timeout defaults passed
  - Chat Event Snapshot V7 fail-closed and contraction validation passed
  - all 221 migrations and snapshots replayed with an intact chain
  - consecutive resets passed
  - existing migrations and the regenerated schema were functionally equivalent
