### PR TITLE
fix(runner): resolve service state from selected config

### DIFF
--- a/crates/runner/src/cmd/service/drain_resume.rs
+++ b/crates/runner/src/cmd/service/drain_resume.rs
@@ -90,7 +90,10 @@ use super::systemctl::{
     get_service_restart_policy, is_unit_active_bounded, read_unit_enablement,
     restore_unit_enablement, run_systemctl,
 };
-use super::{RunnerServiceUnit, ServiceFuture, acquire_service_lock};
+use super::{
+    RunnerServiceUnit, ServiceFuture, acquire_service_lock, read_unit_config_path,
+    selected_config_base_dir,
+};
 
 const DRAIN_SIGNAL_CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(10);
 const DRAIN_SIGNAL_CONVERGENCE_POLL_INTERVAL: Duration = Duration::from_millis(250);
@@ -168,6 +171,10 @@ trait ServiceResumeOps {
         unit: &'a RunnerServiceUnit,
         timeout: Duration,
     ) -> ServiceFuture<'a, bool>;
+    fn read_unit_config_path<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+    ) -> ServiceFuture<'a, Option<std::path::PathBuf>>;
     fn enablement<'a>(
         &'a mut self,
         unit: &'a RunnerServiceUnit,
@@ -276,6 +283,13 @@ impl ServiceResumeOps for RealServiceResumeOps {
         timeout: Duration,
     ) -> ServiceFuture<'a, bool> {
         Box::pin(async move { is_unit_active_bounded(unit, timeout).await })
+    }
+
+    fn read_unit_config_path<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+    ) -> ServiceFuture<'a, Option<std::path::PathBuf>> {
+        Box::pin(async move { read_unit_config_path(unit).await })
     }
 
     fn enablement<'a>(
@@ -942,7 +956,21 @@ async fn resume_with_ops(
     // is still Running can race with the pending SIGUSR1: SIGUSR2 is a no-op
     // in Running, but removing the restart override would let a later Draining
     // runner regain restart behavior.
-    let base_dir = home.runners_dir().join(unit.suffix());
+    let config_path = ops.read_unit_config_path(unit).await?.ok_or_else(|| {
+        RunnerError::Internal(format!(
+            "{} does not select a runner --config path — cannot resume",
+            unit.unit_name()
+        ))
+    })?;
+    let base_dir = selected_config_base_dir(unit, &config_path, home)
+        .await?
+        .ok_or_else(|| {
+            RunnerError::Internal(format!(
+                "cannot resolve a live runner instance for {} from selected config {} — cannot resume",
+                unit.unit_name(),
+                config_path.display()
+            ))
+        })?;
     let status = read_runner_status(&base_dir).await.map_err(|error| {
         RunnerError::Internal(format!(
             "cannot read status.json for {} during resume preflight: {error}",
@@ -1036,6 +1064,24 @@ mod tests {
         .unwrap();
     }
 
+    async fn publish_test_live_runner(
+        home: &HomePaths,
+        config_path: &Path,
+        base_dir: &Path,
+    ) -> crate::live_runner_instances::LiveRunnerInstanceHandle {
+        crate::live_runner_instances::publish(
+            home,
+            crate::live_runner_instances::LiveRunnerInstanceMetadata {
+                config_path: config_path.to_path_buf(),
+                base_dir: base_dir.to_path_buf(),
+                runner_group: "test".to_string(),
+                subcommand: "start".to_string(),
+            },
+        )
+        .await
+        .unwrap()
+    }
+
     async fn resume_after_preflight_for_test(ops: &mut FakeResumeOps) -> RunnerResult<()> {
         let dir = tempfile::tempdir().unwrap();
         write_test_status(dir.path(), "running", TEST_RUNNER_STARTED_AT).await;
@@ -1066,6 +1112,7 @@ mod tests {
     struct FakeResumeOps {
         events: Vec<&'static str>,
         active_results: VecDeque<RunnerResult<bool>>,
+        config_path: Option<PathBuf>,
         enablement_results: VecDeque<RunnerResult<SystemdUnitEnablement>>,
         write_error: bool,
         remove_error: bool,
@@ -1105,6 +1152,7 @@ mod tests {
             Self {
                 events: Vec::new(),
                 active_results: active_results(1),
+                config_path: Some(PathBuf::from("/tmp/runner-config.yaml")),
                 enablement_results: VecDeque::from([Ok(SystemdUnitEnablement::NotEnabled)]),
                 write_error: false,
                 remove_error: false,
@@ -1262,6 +1310,14 @@ mod tests {
             Box::pin(std::future::ready(
                 self.active_results.pop_front().unwrap_or(Ok(false)),
             ))
+        }
+
+        fn read_unit_config_path<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+        ) -> ServiceFuture<'a, Option<PathBuf>> {
+            self.events.push("read_config_path");
+            Box::pin(std::future::ready(Ok(self.config_path.clone())))
         }
 
         fn enablement<'a>(
@@ -2069,16 +2125,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resume_refuses_unresolved_selected_config_before_mutation() {
+        let unit = service_unit();
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        let mut no_config_ops = FakeResumeOps {
+            config_path: None,
+            ..FakeResumeOps::default()
+        };
+
+        let no_config_error = resume_with_ops(&unit, &home, &mut no_config_ops)
+            .await
+            .unwrap_err();
+
+        assert!(
+            no_config_error
+                .to_string()
+                .contains("does not select a runner --config path")
+        );
+        assert_eq!(no_config_ops.events, ["is_active", "read_config_path"]);
+
+        let config_path = dir.path().join("selected-config.yaml");
+        let mut no_record_ops = FakeResumeOps {
+            config_path: Some(config_path),
+            ..FakeResumeOps::default()
+        };
+
+        let no_record_error = resume_with_ops(&unit, &home, &mut no_record_ops)
+            .await
+            .unwrap_err();
+
+        assert!(
+            no_record_error
+                .to_string()
+                .contains("cannot resolve a live runner instance")
+        );
+        assert_eq!(no_record_ops.events, ["is_active", "read_config_path"]);
+    }
+
+    #[tokio::test]
     async fn resume_refuses_missing_status_before_mutation() {
         let unit = service_unit();
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("home"));
-        let mut ops = FakeResumeOps::default();
+        let config_path = dir.path().join("selected-config.yaml");
+        let base_dir = home.runners_dir().join("runner-release");
+        let _live_instance = publish_test_live_runner(&home, &config_path, &base_dir).await;
+        let mut ops = FakeResumeOps {
+            config_path: Some(config_path),
+            ..FakeResumeOps::default()
+        };
 
         let error = resume_with_ops(&unit, &home, &mut ops).await.unwrap_err();
 
         assert!(error.to_string().contains("cannot read status.json"));
-        assert_eq!(ops.events, ["is_active"]);
+        assert_eq!(ops.events, ["is_active", "read_config_path"]);
     }
 
     #[tokio::test]
@@ -2086,17 +2187,22 @@ mod tests {
         let unit = service_unit();
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("home"));
-        let base_dir = home.runners_dir().join(unit.suffix());
+        let config_path = dir.path().join("selected-config.yaml");
+        let base_dir = home.runners_dir().join("runner-release");
+        let _live_instance = publish_test_live_runner(&home, &config_path, &base_dir).await;
         tokio::fs::create_dir_all(&base_dir).await.unwrap();
         tokio::fs::write(base_dir.join("status.json"), "{")
             .await
             .unwrap();
-        let mut ops = FakeResumeOps::default();
+        let mut ops = FakeResumeOps {
+            config_path: Some(config_path),
+            ..FakeResumeOps::default()
+        };
 
         let error = resume_with_ops(&unit, &home, &mut ops).await.unwrap_err();
 
         assert!(error.to_string().contains("cannot read status.json"));
-        assert_eq!(ops.events, ["is_active"]);
+        assert_eq!(ops.events, ["is_active", "read_config_path"]);
     }
 
     #[tokio::test]
@@ -2104,7 +2210,9 @@ mod tests {
         let unit = service_unit();
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("home"));
-        let base_dir = home.runners_dir().join(unit.suffix());
+        let config_path = dir.path().join("selected-config.yaml");
+        let base_dir = home.runners_dir().join("runner-release");
+        let _live_instance = publish_test_live_runner(&home, &config_path, &base_dir).await;
         tokio::fs::create_dir_all(&base_dir).await.unwrap();
         tokio::fs::write(
             base_dir.join("status.json"),
@@ -2112,20 +2220,25 @@ mod tests {
         )
         .await
         .unwrap();
-        let mut ops = FakeResumeOps::default();
+        let mut ops = FakeResumeOps {
+            config_path: Some(config_path),
+            ..FakeResumeOps::default()
+        };
 
         let error = resume_with_ops(&unit, &home, &mut ops).await.unwrap_err();
 
         assert!(error.to_string().contains("running, not draining"));
-        assert_eq!(ops.events, ["is_active"]);
+        assert_eq!(ops.events, ["is_active", "read_config_path"]);
     }
 
     #[tokio::test]
-    async fn resume_verified_draining_status_reaches_transition() {
+    async fn resume_uses_selected_config_base_dir_for_transition() {
         let unit = service_unit();
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("home"));
-        let base_dir = home.runners_dir().join(unit.suffix());
+        let config_path = dir.path().join("selected-config.yaml");
+        let base_dir = home.runners_dir().join("runner-release");
+        let _live_instance = publish_test_live_runner(&home, &config_path, &base_dir).await;
         tokio::fs::create_dir_all(&base_dir).await.unwrap();
         tokio::fs::write(
             base_dir.join("status.json"),
@@ -2135,6 +2248,7 @@ mod tests {
         .unwrap();
         let mut ops = FakeResumeOps {
             active_results: active_results(2),
+            config_path: Some(config_path),
             status_update_on_signal: Some((
                 base_dir.join("status.json"),
                 test_status_content("running", TEST_RUNNER_STARTED_AT),
@@ -2148,6 +2262,7 @@ mod tests {
             ops.events,
             [
                 "is_active",
+                "read_config_path",
                 "is_enabled",
                 "remove_restart_override",
                 "enable",
@@ -2236,10 +2351,13 @@ mod tests {
         let unit = service_unit();
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("home"));
-        let base_dir = home.runners_dir().join(unit.suffix());
+        let config_path = dir.path().join("selected-config.yaml");
+        let base_dir = home.runners_dir().join("runner-release");
+        let _live_instance = publish_test_live_runner(&home, &config_path, &base_dir).await;
         write_test_status(&base_dir, "draining", TEST_RUNNER_STARTED_AT).await;
         let mut ops = FakeResumeOps {
             active_results: active_results(2),
+            config_path: Some(config_path),
             status_update_on_signal: Some((
                 base_dir.join("status.json"),
                 test_status_content("stopping", TEST_RUNNER_STARTED_AT),
@@ -2254,6 +2372,7 @@ mod tests {
             ops.events,
             [
                 "is_active",
+                "read_config_path",
                 "is_enabled",
                 "remove_restart_override",
                 "enable",

--- a/crates/runner/src/cmd/service/gate.rs
+++ b/crates/runner/src/cmd/service/gate.rs
@@ -310,6 +310,24 @@ mod tests {
         HomePaths::with_root(dir.path().join("vm0-runner"))
     }
 
+    async fn publish_test_live_runner(
+        home: &HomePaths,
+        config_path: &Path,
+        base_dir: &Path,
+    ) -> crate::live_runner_instances::LiveRunnerInstanceHandle {
+        crate::live_runner_instances::publish(
+            home,
+            crate::live_runner_instances::LiveRunnerInstanceMetadata {
+                config_path: config_path.to_path_buf(),
+                base_dir: base_dir.to_path_buf(),
+                runner_group: "test".to_string(),
+                subcommand: "start".to_string(),
+            },
+        )
+        .await
+        .unwrap()
+    }
+
     // -----------------------------------------------------------------
     // status.json reader
     // -----------------------------------------------------------------
@@ -650,17 +668,7 @@ mod tests {
         let unit = service_unit();
         let config_path = dir.path().join("selected-config.yaml");
         let base_dir = home.runners_dir().join("runner-release");
-        let _live_instance = crate::live_runner_instances::publish(
-            &home,
-            crate::live_runner_instances::LiveRunnerInstanceMetadata {
-                config_path: config_path.clone(),
-                base_dir: base_dir.clone(),
-                runner_group: "test".to_string(),
-                subcommand: "start".to_string(),
-            },
-        )
-        .await
-        .unwrap();
+        let _live_instance = publish_test_live_runner(&home, &config_path, &base_dir).await;
 
         let mut missing_ops =
             FakeGateOps::from_results([Ok(true)]).with_config_path(Some(config_path.clone()));
@@ -694,6 +702,31 @@ mod tests {
         assert_eq!(missing_ops.config_queries, 1);
         assert_eq!(malformed_ops.active_queries, 1);
         assert_eq!(malformed_ops.config_queries, 1);
+    }
+
+    #[tokio::test]
+    async fn check_active_jobs_gate_uses_selected_config_base_dir_for_safe_status() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = fake_home(&dir);
+        let unit = service_unit();
+        let config_path = dir.path().join("selected-config.yaml");
+        let base_dir = home.runners_dir().join("runner-release");
+        let _live_instance = publish_test_live_runner(&home, &config_path, &base_dir).await;
+        tokio::fs::create_dir_all(&base_dir).await.unwrap();
+        tokio::fs::write(
+            base_dir.join("status.json"),
+            r#"{"mode":"running","active_runs":[],"started_at":"2026-04-13T00:00:00Z"}"#,
+        )
+        .await
+        .unwrap();
+        let mut ops = FakeGateOps::from_results([Ok(true)]).with_config_path(Some(config_path));
+
+        check_active_jobs_gate(&unit, &home, false, "stop", &mut ops)
+            .await
+            .unwrap();
+
+        assert_eq!(ops.active_queries, 1);
+        assert_eq!(ops.config_queries, 1);
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/service/gate.rs
+++ b/crates/runner/src/cmd/service/gate.rs
@@ -6,22 +6,16 @@ use crate::paths::HomePaths;
 use crate::status_file::{self, StatusFileReadError, StatusForGate};
 use tracing::{info, warn};
 
-use super::ServiceFuture;
 use super::diagnostic::status_field_preview;
 use super::target::RunnerServiceUnit;
+use super::{ServiceFuture, selected_config_base_dir};
 
 pub(super) trait ActiveJobsGateOps {
     fn is_unit_active<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool>;
-}
-
-/// Resolve the runner's base_dir from its service name suffix and the caller's
-/// runner home using the project-wide `runners/<suffix>/` convention.
-///
-/// This matches `ansible/playbooks/build-runner.yml` and the `--runner-dirname`
-/// default in `runner config`. In production the home is
-/// `/var/lib/vm0-runner`; tests can supply an isolated home root.
-fn runner_base_dir(home: &HomePaths, unit: &RunnerServiceUnit) -> PathBuf {
-    home.runners_dir().join(unit.suffix())
+    fn read_unit_config_path<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+    ) -> ServiceFuture<'a, Option<PathBuf>>;
 }
 
 /// Parsed snapshot of the runner's status.json.
@@ -158,8 +152,7 @@ pub(super) async fn read_runner_status(
 ///
 /// ## Transient / race handling
 ///
-/// Each of these conditions returns `Ok(())` to let the operator through,
-/// erring on the side of "stop is usable" over "gate is strict":
+/// Each of these conditions returns `Ok(())` to let the operator through:
 ///
 /// 1. **Dead / crashed runner** — if the systemd unit is inactive, the
 ///    on-disk `active_runs` may be stale (runner was SIGKILLed before it
@@ -170,9 +163,11 @@ pub(super) async fn read_runner_status(
 ///    `run_with_config`) and systemd noticing the process has exited
 ///    (marking the unit inactive). Without this, the gate could spuriously
 ///    refuse a stop issued during that window.
-/// 3. **Status file unreadable / malformed** — missing file, permission
-///    denied, JSON parse error, bad `started_at`: warn-log and fall
-///    through. Matches the acceptance criteria.
+///
+/// Once systemd confirms that the unit is active, the gate fails closed unless
+/// the unit's selected config resolves to one verified live Runner record and
+/// that record's status is readable. Without that correlation, the gate cannot
+/// prove that teardown is safe. `--force` remains the explicit override.
 ///
 /// When the runner's `mode == "draining"`, we still refuse but flip the
 /// `draining` flag so the error renders a wait-or-force message (the
@@ -214,19 +209,28 @@ pub(super) async fn check_active_jobs_gate(
         return Ok(());
     }
 
-    let base_dir = runner_base_dir(home, unit);
-    let status = match read_runner_status(&base_dir).await {
-        Ok(status) => status,
-        Err(e) => {
-            warn!(
-                unit = %unit.unit_name(),
-                base_dir = %base_dir.display(),
-                error = %e,
-                "cannot read status.json — skipping active-jobs gate"
-            );
-            return Ok(());
-        }
-    };
+    let config_path = ops.read_unit_config_path(unit).await?.ok_or_else(|| {
+        RunnerError::Internal(format!(
+            "{} does not select a runner --config path; refusing service {command_name} while the unit is active; retry or pass --force to override the active-jobs gate",
+            unit.unit_name()
+        ))
+    })?;
+    let base_dir = selected_config_base_dir(unit, &config_path, home)
+        .await?
+        .ok_or_else(|| {
+            RunnerError::Internal(format!(
+                "cannot resolve a live runner instance for {} from selected config {}; refusing service {command_name} while the unit is active; retry or pass --force to override the active-jobs gate",
+                unit.unit_name(),
+                config_path.display()
+            ))
+        })?;
+    let status = read_runner_status(&base_dir).await.map_err(|error| {
+        RunnerError::Internal(format!(
+            "cannot read status.json for {} at {} while checking active jobs before service {command_name}: {error}; retry or pass --force to override the active-jobs gate",
+            unit.unit_name(),
+            base_dir.display()
+        ))
+    })?;
 
     match decide_gate(&status) {
         GateDecision::Bypass => Ok(()),
@@ -251,15 +255,24 @@ mod tests {
 
     struct FakeGateOps {
         active_results: VecDeque<RunnerResult<bool>>,
+        config_results: VecDeque<RunnerResult<Option<PathBuf>>>,
         active_queries: usize,
+        config_queries: usize,
     }
 
     impl FakeGateOps {
         fn from_results(results: impl IntoIterator<Item = RunnerResult<bool>>) -> Self {
             Self {
                 active_results: results.into_iter().collect(),
+                config_results: VecDeque::new(),
                 active_queries: 0,
+                config_queries: 0,
             }
+        }
+
+        fn with_config_path(mut self, config_path: Option<PathBuf>) -> Self {
+            self.config_results.push_back(Ok(config_path));
+            self
         }
     }
 
@@ -273,6 +286,18 @@ mod tests {
                 .active_results
                 .pop_front()
                 .expect("unexpected unit-active query");
+            Box::pin(std::future::ready(result))
+        }
+
+        fn read_unit_config_path<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+        ) -> ServiceFuture<'a, Option<PathBuf>> {
+            self.config_queries += 1;
+            let result = self
+                .config_results
+                .pop_front()
+                .expect("unexpected unit-config query");
             Box::pin(std::future::ready(result))
         }
     }
@@ -594,6 +619,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(ops.active_queries, 0);
+        assert_eq!(ops.config_queries, 0);
     }
 
     #[tokio::test]
@@ -613,32 +639,91 @@ mod tests {
                 .unwrap();
 
             assert_eq!(ops.active_queries, 1);
+            assert_eq!(ops.config_queries, 0);
         }
     }
 
     #[tokio::test]
-    async fn check_active_jobs_gate_bypasses_missing_and_malformed_status() {
+    async fn check_active_jobs_gate_fails_closed_for_missing_and_malformed_status() {
         let dir = tempfile::tempdir().unwrap();
         let home = fake_home(&dir);
         let unit = service_unit();
+        let config_path = dir.path().join("selected-config.yaml");
+        let base_dir = home.runners_dir().join("runner-release");
+        let _live_instance = crate::live_runner_instances::publish(
+            &home,
+            crate::live_runner_instances::LiveRunnerInstanceMetadata {
+                config_path: config_path.clone(),
+                base_dir: base_dir.clone(),
+                runner_group: "test".to_string(),
+                subcommand: "start".to_string(),
+            },
+        )
+        .await
+        .unwrap();
 
-        let mut missing_ops = FakeGateOps::from_results([Ok(true)]);
-        check_active_jobs_gate(&unit, &home, false, "stop", &mut missing_ops)
+        let mut missing_ops =
+            FakeGateOps::from_results([Ok(true)]).with_config_path(Some(config_path.clone()));
+        let missing_error = check_active_jobs_gate(&unit, &home, false, "stop", &mut missing_ops)
             .await
-            .unwrap();
+            .unwrap_err();
+        assert!(
+            missing_error
+                .to_string()
+                .contains("cannot read status.json")
+        );
 
-        let base_dir = runner_base_dir(&home, &unit);
         tokio::fs::create_dir_all(&base_dir).await.unwrap();
         tokio::fs::write(base_dir.join("status.json"), "not json")
             .await
             .unwrap();
 
-        let mut malformed_ops = FakeGateOps::from_results([Ok(true)]);
-        check_active_jobs_gate(&unit, &home, false, "stop", &mut malformed_ops)
-            .await
-            .unwrap();
+        let mut malformed_ops =
+            FakeGateOps::from_results([Ok(true)]).with_config_path(Some(config_path));
+        let malformed_error =
+            check_active_jobs_gate(&unit, &home, false, "stop", &mut malformed_ops)
+                .await
+                .unwrap_err();
+        assert!(
+            malformed_error
+                .to_string()
+                .contains("cannot read status.json")
+        );
 
         assert_eq!(missing_ops.active_queries, 1);
+        assert_eq!(missing_ops.config_queries, 1);
         assert_eq!(malformed_ops.active_queries, 1);
+        assert_eq!(malformed_ops.config_queries, 1);
+    }
+
+    #[tokio::test]
+    async fn check_active_jobs_gate_fails_closed_without_selected_config_or_live_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = fake_home(&dir);
+        let unit = service_unit();
+
+        let mut no_config_ops = FakeGateOps::from_results([Ok(true)]).with_config_path(None);
+        let no_config_error =
+            check_active_jobs_gate(&unit, &home, false, "uninstall", &mut no_config_ops)
+                .await
+                .unwrap_err();
+        assert!(
+            no_config_error
+                .to_string()
+                .contains("does not select a runner --config path")
+        );
+
+        let config_path = dir.path().join("selected-config.yaml");
+        let mut no_record_ops =
+            FakeGateOps::from_results([Ok(true)]).with_config_path(Some(config_path));
+        let no_record_error =
+            check_active_jobs_gate(&unit, &home, false, "uninstall", &mut no_record_ops)
+                .await
+                .unwrap_err();
+        assert!(
+            no_record_error
+                .to_string()
+                .contains("cannot resolve a live runner instance")
+        );
     }
 }

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -533,6 +533,13 @@ impl ActiveJobsGateOps for RealServiceUninstallOps {
     fn is_unit_active<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool> {
         Box::pin(async move { is_unit_active(unit).await })
     }
+
+    fn read_unit_config_path<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+    ) -> ServiceFuture<'a, Option<PathBuf>> {
+        Box::pin(async move { read_unit_config_path(unit).await })
+    }
 }
 
 impl ServiceUninstallOps for RealServiceUninstallOps {
@@ -571,7 +578,7 @@ async fn uninstall_with_ops(
     ops.uninstall_unit(unit).await
 }
 
-fn readiness_base_dir_from_live_instances(
+fn selected_config_base_dir_from_live_instances(
     unit: &RunnerServiceUnit,
     config_path: &Path,
     instances: &[LiveRunnerInstance],
@@ -585,19 +592,20 @@ fn readiness_base_dir_from_live_instances(
         [instance] => Ok(Some(instance.base_dir.clone())),
         [] => Ok(None),
         _ => Err(RunnerError::Internal(format!(
-            "{} has multiple live runner instance records for readiness",
-            unit.unit_name()
+            "{} has multiple live runner instance records for selected config {}",
+            unit.unit_name(),
+            config_path.display()
         ))),
     }
 }
 
-async fn readiness_base_dir(
+async fn selected_config_base_dir(
     unit: &RunnerServiceUnit,
     config_path: &Path,
     home: &HomePaths,
 ) -> RunnerResult<Option<PathBuf>> {
     let instances = live_runner_instances::try_list(home).await?;
-    readiness_base_dir_from_live_instances(unit, config_path, &instances)
+    selected_config_base_dir_from_live_instances(unit, config_path, &instances)
 }
 
 fn wait_running_timeout_error(
@@ -685,19 +693,21 @@ async fn wait_running(args: ServiceWaitRunningArgs) -> RunnerResult<()> {
             )));
         }
 
-        let base_dir =
-            match tokio::time::timeout_at(deadline, readiness_base_dir(&unit, &config_path, &home))
-                .await
-            {
-                Ok(result) => result?,
-                Err(_) => {
-                    return Err(wait_running_timeout_error(
-                        args.timeout_secs,
-                        &unit,
-                        &last_observation,
-                    ));
-                }
-            };
+        let base_dir = match tokio::time::timeout_at(
+            deadline,
+            selected_config_base_dir(&unit, &config_path, &home),
+        )
+        .await
+        {
+            Ok(result) => result?,
+            Err(_) => {
+                return Err(wait_running_timeout_error(
+                    args.timeout_secs,
+                    &unit,
+                    &last_observation,
+                ));
+            }
+        };
         match base_dir {
             Some(base_dir) => {
                 let status = match tokio::time::timeout_at(
@@ -1227,6 +1237,7 @@ profiles:
     struct FakeUninstallOps {
         events: Vec<&'static str>,
         gate_active_results: VecDeque<RunnerResult<bool>>,
+        gate_config_path: Option<PathBuf>,
     }
 
     impl ActiveJobsGateOps for FakeUninstallOps {
@@ -1240,6 +1251,14 @@ profiles:
                     .pop_front()
                     .expect("unexpected gate unit-active query"),
             ))
+        }
+
+        fn read_unit_config_path<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+        ) -> ServiceFuture<'a, Option<PathBuf>> {
+            self.events.push("gate_config_path");
+            Box::pin(std::future::ready(Ok(self.gate_config_path.clone())))
         }
     }
 
@@ -1277,11 +1296,23 @@ profiles:
     }
 
     #[tokio::test]
-    async fn uninstall_active_draining_jobs_refuses_before_service_mutation() {
+    async fn uninstall_uses_selected_config_base_dir_before_service_mutation() {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("vm0-runner"));
         let unit = service_unit();
-        let base_dir = home.runners_dir().join(unit.suffix());
+        let config_path = dir.path().join("selected-config.yaml");
+        let base_dir = home.runners_dir().join("runner-release");
+        let _live_instance = crate::live_runner_instances::publish(
+            &home,
+            crate::live_runner_instances::LiveRunnerInstanceMetadata {
+                config_path: config_path.clone(),
+                base_dir: base_dir.clone(),
+                runner_group: "test".to_string(),
+                subcommand: "start".to_string(),
+            },
+        )
+        .await
+        .unwrap();
         tokio::fs::create_dir_all(&base_dir).await.unwrap();
         let started_at = (chrono::Utc::now() - chrono::Duration::minutes(18))
             .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
@@ -1305,6 +1336,7 @@ profiles:
         let mut ops = FakeUninstallOps {
             events: Vec::new(),
             gate_active_results: VecDeque::from([Ok(true)]),
+            gate_config_path: Some(config_path),
         };
 
         let before_gate = chrono::Utc::now();
@@ -1313,7 +1345,10 @@ profiles:
             .unwrap_err();
         let after_gate = chrono::Utc::now();
 
-        assert_eq!(ops.events, ["acquire_lock", "gate_is_active"]);
+        assert_eq!(
+            ops.events,
+            ["acquire_lock", "gate_is_active", "gate_config_path"]
+        );
         let RunnerError::ActiveJobs(error) = error else {
             panic!("expected active-jobs refusal");
         };
@@ -1338,7 +1373,8 @@ profiles:
         let unit = RunnerServiceUnit::from_suffix("pr-123-1").unwrap();
 
         let config_path = PathBuf::from("/vm0-runner/runners/pr-123/runner.yaml");
-        let base_dir = readiness_base_dir_from_live_instances(&unit, &config_path, &[]).unwrap();
+        let base_dir =
+            selected_config_base_dir_from_live_instances(&unit, &config_path, &[]).unwrap();
 
         assert_eq!(base_dir, None);
     }
@@ -1357,7 +1393,7 @@ profiles:
         ];
 
         let base_dir =
-            readiness_base_dir_from_live_instances(&unit, &config_path, &instances).unwrap();
+            selected_config_base_dir_from_live_instances(&unit, &config_path, &instances).unwrap();
 
         assert_eq!(base_dir, Some(actual_base_dir));
     }
@@ -1377,8 +1413,8 @@ profiles:
             ),
         ];
 
-        let error =
-            readiness_base_dir_from_live_instances(&unit, &config_path, &instances).unwrap_err();
+        let error = selected_config_base_dir_from_live_instances(&unit, &config_path, &instances)
+            .unwrap_err();
 
         assert!(
             error.to_string().contains("multiple live runner instance"),

--- a/crates/runner/src/cmd/service/stop.rs
+++ b/crates/runner/src/cmd/service/stop.rs
@@ -13,7 +13,7 @@ use super::systemctl::{
     BoundedSystemctlOutcome, CleanupUnitActiveState, cleanup_unit_active_state_bounded,
     is_unit_active, is_unit_enabled_bounded, run_systemctl, run_systemctl_bounded,
 };
-use super::{RunnerServiceUnit, ServiceFuture, acquire_service_lock};
+use super::{RunnerServiceUnit, ServiceFuture, acquire_service_lock, read_unit_config_path};
 
 const CLEANUP_LOCK_TIMEOUT: TokioDuration = TokioDuration::from_secs(20);
 const CLEANUP_LOCK_POLL_INTERVAL: TokioDuration = TokioDuration::from_millis(250);
@@ -278,6 +278,13 @@ impl ServiceStopOps for RealServiceStopOps {
 impl ActiveJobsGateOps for RealServiceStopOps {
     fn is_unit_active<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool> {
         Box::pin(async move { is_unit_active(unit).await })
+    }
+
+    fn read_unit_config_path<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+    ) -> ServiceFuture<'a, Option<std::path::PathBuf>> {
+        Box::pin(async move { read_unit_config_path(unit).await })
     }
 }
 
@@ -596,6 +603,7 @@ mod tests {
         events: Vec<&'static str>,
         acquire_lock_error: bool,
         gate_active_results: VecDeque<RunnerResult<bool>>,
+        gate_config_path: Option<PathBuf>,
         active_results: VecDeque<RunnerResult<bool>>,
         stop_results: VecDeque<RunnerResult<()>>,
         bounded_stop_results: VecDeque<RunnerResult<BoundedSystemctlOutcome>>,
@@ -615,6 +623,7 @@ mod tests {
                 events: Vec::new(),
                 acquire_lock_error: false,
                 gate_active_results: VecDeque::from([Ok(false)]),
+                gate_config_path: Some(PathBuf::from("/tmp/runner-config.yaml")),
                 active_results: VecDeque::from([Ok(true)]),
                 stop_results: VecDeque::from([Ok(())]),
                 bounded_stop_results: VecDeque::from([Ok(BoundedSystemctlOutcome::Success)]),
@@ -643,6 +652,14 @@ mod tests {
                     .pop_front()
                     .expect("unexpected gate unit-active query"),
             ))
+        }
+
+        fn read_unit_config_path<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+        ) -> ServiceFuture<'a, Option<PathBuf>> {
+            self.events.push("gate_config_path");
+            Box::pin(std::future::ready(Ok(self.gate_config_path.clone())))
         }
     }
 
@@ -834,11 +851,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stop_default_active_jobs_refuses_before_service_mutation() {
+    async fn stop_uses_selected_config_base_dir_before_service_mutation() {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("vm0-runner"));
         let unit = service_unit();
-        let base_dir = home.runners_dir().join(unit.suffix());
+        let config_path = dir.path().join("selected-config.yaml");
+        let base_dir = home.runners_dir().join("runner-release");
+        let _live_instance = crate::live_runner_instances::publish(
+            &home,
+            crate::live_runner_instances::LiveRunnerInstanceMetadata {
+                config_path: config_path.clone(),
+                base_dir: base_dir.clone(),
+                runner_group: "test".to_string(),
+                subcommand: "start".to_string(),
+            },
+        )
+        .await
+        .unwrap();
         tokio::fs::create_dir_all(&base_dir).await.unwrap();
         let started_at = (chrono::Utc::now() - chrono::Duration::minutes(10))
             .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
@@ -862,6 +891,7 @@ mod tests {
         .unwrap();
         let mut ops = FakeStopOps {
             gate_active_results: VecDeque::from([Ok(true)]),
+            gate_config_path: Some(config_path),
             ..FakeStopOps::default()
         };
 
@@ -871,7 +901,10 @@ mod tests {
             .unwrap_err();
         let after_gate = chrono::Utc::now();
 
-        assert_eq!(ops.events, ["acquire_lock", "gate_is_active"]);
+        assert_eq!(
+            ops.events,
+            ["acquire_lock", "gate_is_active", "gate_config_path"]
+        );
         let RunnerError::ActiveJobs(error) = error else {
             panic!("expected active-jobs refusal");
         };


### PR DESCRIPTION
## Summary

- resolve the active Runner base directory from systemd's selected config and the verified live-instance registry
- make active stop/uninstall gates fail closed when config, live-record, or status correlation is unavailable
- make resume preflight and acknowledgement use the same resolved base directory
- cover stop, uninstall, and resume with deliberately different service suffix and Runner directory values

## Compatibility

- preserves the explicit `--force` gate bypass and confirmed-inactive behavior
- preserves readiness polling, drain transactions, resume rollback, and status-mode decisions
- introduces no CLI, API, config, status, live-record, database, or wire schema changes
- leaves systemd active-query error policy to #30241

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runner cmd::service --all-features`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --no-deps`
- `cargo test -p runner --all-targets --all-features`
- pre-commit Rust formatting, documentation, Clippy, and file-size checks

Closes #30044

Parent context: #30043
