### PR TITLE
refactor(api): remove legacy sandbox observation ingestion

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
@@ -10,7 +10,6 @@ import {
   webhookCompleteContract,
   webhookEventsContract,
   webhookHeartbeatContract,
-  webhookModelUsageObservationContract,
   webhookStoragesCommitContract,
   webhookStoragesPrepareContract,
   webhookStripeContract,
@@ -74,9 +73,6 @@ type AgentTelemetryBody = z.infer<
 >;
 type AgentUsageEventBody = z.infer<
   (typeof webhookUsageEventContract.send)["body"]
->;
-type AgentModelUsageObservationV2Body = z.infer<
-  (typeof webhookModelUsageObservationContract.send)["body"]
 >;
 type AgentStoragePrepareBody = z.infer<
   (typeof webhookStoragesPrepareContract.prepare)["body"]
@@ -787,38 +783,6 @@ export function createWebhookCallbackApi(context: TestContext) {
         ).send({
           headers,
           body: body as AgentUsageEventBody,
-        }),
-        statuses,
-      );
-    },
-
-    async requestAgentModelUsageObservationV2(
-      body: AgentModelUsageObservationV2Body,
-      headers: SandboxWebhookHeaders,
-      statuses: readonly (200 | 400 | 401 | 404 | 500)[],
-    ) {
-      return await accept(
-        setupApp({ context, routes: webhooksAgentHealthUsageTelemetryRoutes })(
-          webhookModelUsageObservationContract,
-        ).send({
-          headers,
-          body,
-        }),
-        statuses,
-      );
-    },
-
-    async requestAgentModelUsageObservationV2Unchecked(
-      body: unknown,
-      headers: SandboxWebhookHeaders,
-      statuses: readonly (400 | 401 | 404 | 500)[],
-    ) {
-      return await accept(
-        setupApp({ context, routes: webhooksAgentHealthUsageTelemetryRoutes })(
-          webhookModelUsageObservationContract,
-        ).send({
-          headers,
-          body: body as AgentModelUsageObservationV2Body,
         }),
         statuses,
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -17637,25 +17637,6 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
       "sandbox_reuse_result",
     );
 
-    const observed = await webhooks.requestAgentModelUsageObservationV2(
-      {
-        runId: created.runId,
-        events: [
-          {
-            idempotencyKey: randomUUID(),
-            model: "claude-sonnet-4-6",
-            inputTokens: 120,
-            outputTokens: 0,
-            cacheReadInputTokens: 0,
-            cacheCreationInputTokens: 0,
-          },
-        ],
-      },
-      sandboxHeaders,
-      [200],
-    );
-    expect(observed.body).toStrictEqual({ success: true });
-
     const artifactSnapshots = [
       {
         name: memoryArtifact.name,
@@ -18014,7 +17995,7 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
     expect(cancelled.status).toBe("cancelled");
   });
 
-  it("checkpoints direct compose runs without vars and accepts compact usage by event model", async () => {
+  it("checkpoints direct compose runs without vars", async () => {
     const bdd = createBddApi(context);
     const api = createRunsApi(context);
     const webhooks = createWebhookCallbackApi(context);
@@ -18044,35 +18025,6 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
     const sandboxHeaders = {
       authorization: `Bearer ${api.sandboxTokenForRun(actor, run.runId)}`,
     };
-
-    // With no pinned model the event model drives canonicalization: the
-    // unsupported event is skipped while the supported one is recorded.
-    const observed = await webhooks.requestAgentModelUsageObservationV2(
-      {
-        runId: run.runId,
-        events: [
-          {
-            idempotencyKey: randomUUID(),
-            model: "claude-sonnet-4-6",
-            inputTokens: 50,
-            outputTokens: 0,
-            cacheReadInputTokens: 0,
-            cacheCreationInputTokens: 0,
-          },
-          {
-            idempotencyKey: randomUUID(),
-            model: "custom-bdd-model",
-            inputTokens: 0,
-            outputTokens: 7,
-            cacheReadInputTokens: 0,
-            cacheCreationInputTokens: 0,
-          },
-        ],
-      },
-      sandboxHeaders,
-      [200],
-    );
-    expect(observed.body).toStrictEqual({ success: true });
 
     const historyHash = createHash("sha256")
       .update(`bdd null vars checkpoint ${run.runId}`)

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -2246,27 +2246,6 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
     expectApiError(mismatchedUsageEvent.body);
     expect(mismatchedUsageEvent.body.error.code).toBe("UNAUTHORIZED");
 
-    const mismatchedCompactModelUsage =
-      await api.requestAgentModelUsageObservationV2(
-        {
-          runId,
-          events: [
-            {
-              idempotencyKey: randomUUID(),
-              model: "claude-sonnet-4-6",
-              inputTokens: 1,
-              outputTokens: 0,
-              cacheReadInputTokens: 0,
-              cacheCreationInputTokens: 0,
-            },
-          ],
-        },
-        mismatchedHeaders,
-        [401],
-      );
-    expectApiError(mismatchedCompactModelUsage.body);
-    expect(mismatchedCompactModelUsage.body.error.code).toBe("UNAUTHORIZED");
-
     const malformedTelemetryBody = await api.requestAgentTelemetryUnchecked(
       {},
       headers,
@@ -2304,48 +2283,6 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
     );
     expectApiError(missingUsageRun.body);
     expect(missingUsageRun.body.error.code).toBe("NOT_FOUND");
-
-    const malformedCompactModelUsage =
-      await api.requestAgentModelUsageObservationV2Unchecked(
-        {
-          runId,
-          events: [
-            {
-              idempotencyKey: randomUUID(),
-              model: "claude-sonnet-4-6",
-              inputTokens: 0,
-              outputTokens: 0,
-              cacheReadInputTokens: 0,
-              cacheCreationInputTokens: 0,
-            },
-          ],
-        },
-        headers,
-        [400],
-      );
-    expectApiError(malformedCompactModelUsage.body);
-    expect(malformedCompactModelUsage.body.error.code).toBe("BAD_REQUEST");
-
-    const missingCompactModelUsageRun =
-      await api.requestAgentModelUsageObservationV2(
-        {
-          runId,
-          events: [
-            {
-              idempotencyKey: randomUUID(),
-              model: "claude-sonnet-4-6",
-              inputTokens: 1,
-              outputTokens: 0,
-              cacheReadInputTokens: 0,
-              cacheCreationInputTokens: 0,
-            },
-          ],
-        },
-        headers,
-        [404],
-      );
-    expectApiError(missingCompactModelUsageRun.body);
-    expect(missingCompactModelUsageRun.body.error.code).toBe("NOT_FOUND");
 
     const malformedTelemetryBucket = await api.requestAgentTelemetryUnchecked(
       {

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -1,7 +1,6 @@
 import { command } from "ccstate";
 import {
   webhookHeartbeatContract,
-  webhookModelUsageObservationContract,
   webhookTelemetryContract,
   webhookUsageEventContract,
   type RunnerPreSpawnConcurrencyBucket,
@@ -9,14 +8,9 @@ import {
   type SandboxReuseResult,
 } from "@okouai/api-contracts/contracts/webhooks";
 import { agentRuns } from "@okouai/db/schema/agent-run";
-import { modelUsageObservation } from "@okouai/db/schema/model-usage-observation";
 import { usageEvent } from "@okouai/db/schema/usage-event";
 import { and, eq, isNotNull } from "drizzle-orm";
-import {
-  isBuiltInModelProviderType,
-  isSupportedRunModel,
-  normalizeRunModelId,
-} from "@okouai/api-contracts/contracts/model-providers";
+import { isBuiltInModelProviderType } from "@okouai/api-contracts/contracts/model-providers";
 
 import { notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
@@ -265,76 +259,6 @@ const usageEvent$ = command(async ({ get, set }, signal: AbortSignal) => {
   };
 });
 
-const modelUsageObservationBody$ = bodyResultOf(
-  webhookModelUsageObservationContract.send,
-);
-const modelUsageObservation$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    const bodyResult = await get(modelUsageObservationBody$);
-    signal.throwIfAborted();
-    if (!bodyResult.ok) {
-      return bodyResult.response;
-    }
-
-    const body = bodyResult.data;
-    if (!getSandboxAuthForRun(body.runId, get(authorization$))) {
-      return unauthorizedRunMismatch;
-    }
-
-    const db = set(writeDb$);
-    const [runModelContext] = await db
-      .select({
-        selectedModel: agentRuns.selectedModel,
-      })
-      .from(agentRuns)
-      .where(
-        and(eq(agentRuns.id, body.runId), isNotNull(agentRuns.triggerSource)),
-      )
-      .limit(1);
-    signal.throwIfAborted();
-
-    if (!runModelContext) {
-      return notFound("Run not found");
-    }
-
-    const observedAt = nowDate();
-    const observationValues = body.events.flatMap((event) => {
-      const canonicalModel = normalizeRunModelId(
-        runModelContext.selectedModel ?? event.model,
-      );
-      if (!isSupportedRunModel(canonicalModel)) {
-        return [];
-      }
-      return [
-        {
-          model: canonicalModel,
-          inputTokens: event.inputTokens,
-          outputTokens: event.outputTokens,
-          cacheReadInputTokens: event.cacheReadInputTokens,
-          cacheCreationInputTokens: event.cacheCreationInputTokens,
-          observedAt,
-          idempotencyKey: event.idempotencyKey,
-        },
-      ];
-    });
-
-    if (observationValues.length > 0) {
-      await db
-        .insert(modelUsageObservation)
-        .values(observationValues)
-        .onConflictDoNothing({
-          target: [modelUsageObservation.idempotencyKey],
-        });
-    }
-    signal.throwIfAborted();
-
-    return {
-      status: 200 as const,
-      body: { success: true },
-    };
-  },
-);
-
 const telemetryBody$ = bodyResultOf(webhookTelemetryContract.send);
 const telemetry$ = command(async ({ get }, signal: AbortSignal) => {
   const bodyResult = await get(telemetryBody$);
@@ -464,10 +388,6 @@ export const webhooksAgentHealthUsageTelemetryRoutes: readonly RouteEntry[] = [
   {
     route: webhookUsageEventContract.send,
     handler: usageEvent$,
-  },
-  {
-    route: webhookModelUsageObservationContract.send,
-    handler: modelUsageObservation$,
   },
   {
     route: webhookTelemetryContract.send,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
@@ -10,7 +10,6 @@ import {
   ACTIVE_INPUT_DELIVERY_RECEIPT_MAX_IDS,
   webhookCheckpointsContract,
   webhookCompleteContract,
-  webhookModelUsageObservationContract,
   webhookStoragesCommitContract,
   webhookStoragesPrepareContract,
   webhookTelemetryContract,
@@ -18,28 +17,6 @@ import {
 
 const storageId = "00000000-0000-4000-8000-000000000000";
 const manifestHash = "a".repeat(64);
-
-describe("sandbox model usage observation contract", () => {
-  it("keeps the legacy run-partitioned payload", () => {
-    const body = {
-      runId: "00000000-0000-4000-8000-000000000001",
-      events: [
-        {
-          idempotencyKey: "00000000-0000-4000-8000-000000000002",
-          model: "gpt-5.6-sol",
-          inputTokens: 1,
-          outputTokens: 0,
-          cacheReadInputTokens: 0,
-          cacheCreationInputTokens: 0,
-        },
-      ],
-    };
-
-    expect(
-      webhookModelUsageObservationContract.send.body.parse(body),
-    ).toStrictEqual(body);
-  });
-});
 
 describe("agent checkpoint session history", () => {
   const baseBody = {

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -229,7 +229,6 @@ export {
   type WebhookTelemetryContract,
   type WebhookStoragesPrepareContract,
   type WebhookStoragesCommitContract,
-  webhookModelUsageObservationContract,
   webhookUsageEventContract,
   type WebhookClerkContract,
   type WebhookUsageEventContract,

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import { connectorSlugSchema } from "./connector-identity";
 import { apiErrorSchema } from "./errors";
-import { modelUsageObservationEventsSchema } from "./model-usage-observations";
 import {
   artifactMissingRootPolicySchema,
   RESUME_SESSION_HISTORY_MAX_BYTES,
@@ -1096,38 +1095,4 @@ export const webhookUsageEventContract = c.router({
   },
 });
 
-const webhookModelUsageObservationBodySchema = z
-  .object({
-    runId: z.string().min(1, "runId is required"),
-    events: modelUsageObservationEventsSchema,
-  })
-  .strict();
-
-/**
- * Compact model usage observation contract for
- * /api/webhooks/agent/model-usage-observation
- *
- * Each immutable event carries the four counters consumed by model rankings.
- */
-export const webhookModelUsageObservationContract = c.router({
-  send: {
-    method: "POST",
-    path: "/api/webhooks/agent/model-usage-observation",
-    headers: authHeadersSchema,
-    body: webhookModelUsageObservationBodySchema,
-    responses: {
-      200: z.object({
-        success: z.boolean(),
-      }),
-      400: apiErrorSchema,
-      401: apiErrorSchema,
-      404: apiErrorSchema,
-      500: apiErrorSchema,
-    },
-    summary: "Receive compact model usage observation data from sandbox",
-  },
-});
-
 export type WebhookUsageEventContract = typeof webhookUsageEventContract;
-export type WebhookModelUsageObservationContract =
-  typeof webhookModelUsageObservationContract;

--- a/turbo/packages/api-contracts/src/runtime-api-schema/routes.ts
+++ b/turbo/packages/api-contracts/src/runtime-api-schema/routes.ts
@@ -15,7 +15,6 @@ import {
   webhookEventsContract,
   webhookFirewallAuthContract,
   webhookHeartbeatContract,
-  webhookModelUsageObservationContract,
   webhookStoragesCommitContract,
   webhookStoragesPrepareContract,
   webhookTelemetryContract,
@@ -130,10 +129,5 @@ export const runtimeApiRouteBindings = [
     id: "webhooks.agent.usageEvent",
     owner: "mitm-addon",
     route: webhookUsageEventContract.send,
-  },
-  {
-    id: "webhooks.agent.modelUsageObservation",
-    owner: "mitm-addon",
-    route: webhookModelUsageObservationContract.send,
   },
 ] as const satisfies readonly RuntimeApiRouteBinding[];


### PR DESCRIPTION
## Summary

- remove the legacy sandbox model-usage observation contract, API handler, and runtime-schema binding
- remove integration-test helpers and scenarios that exercised the retired per-run webhook
- keep the process-wide runner ingestion route and its aggregation behavior unchanged

## Operational gate

- legacy runners were confirmed drained before removing the old route
- runtime API compatibility reports only the expected removal of `POST /api/webhooks/agent/model-usage-observation`

## Validation

- `pnpm format`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F @okouai/api-contracts test` (639 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/runner-model-usage-observations.test.ts src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=4 --silent=passed-only` (234 tests)
- `pnpm knip`
- runtime API schema build and compatibility lint against the production schema
- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (7,221 tests)

Closes #30174

Parent context: #30143
