### PR TITLE
fix(api): gate runtime webhooks after timeout

### DIFF
--- a/docs/active-input-delivery.md
+++ b/docs/active-input-delivery.md
@@ -54,6 +54,20 @@ Cancellation is visible immediately, and heartbeat timeout records an unknown
 consumer state, but neither path releases a reservation. Cooperative Guest
 completion and Runner post-exit completion are the existing quiescence signals.
 
+### Post-timeout Webhook Admission
+
+While timeout still represents an uncertain consumer state, runtime mutation
+webhooks stop creating new canonical work for that run. Heartbeat returns `404`,
+event batches retain their existing sequence acknowledgement but are ignored,
+and new checkpoint or checkpoint-history preparation requests return `400`.
+The existing completed Pi checkpoint exact-retry behavior is unchanged.
+
+Usage events, model-usage observations, and telemetry remain accepted after
+timeout because they report work that may already have happened. Storage and
+firewall admission, together with the atomic timeout-versus-completion boundary,
+are separate rollout stages; timeout alone still does not release an active
+input delivery.
+
 Codex execution timeout and cancellation first allow an in-flight `turn/steer`
 to settle within the bounded sink window. A successful response still persists
 its receipt. If the response remains pending, Guest drops the non-reusable

--- a/docs/active-input-delivery.md
+++ b/docs/active-input-delivery.md
@@ -62,11 +62,10 @@ event batches retain their existing sequence acknowledgement but are ignored,
 and new checkpoint or checkpoint-history preparation requests return `400`.
 The existing completed Pi checkpoint exact-retry behavior is unchanged.
 
-Usage events, model-usage observations, and telemetry remain accepted after
-timeout because they report work that may already have happened. Storage and
-firewall admission, together with the atomic timeout-versus-completion boundary,
-are separate rollout stages; timeout alone still does not release an active
-input delivery.
+Usage events and telemetry remain accepted after timeout because they report
+work that may already have happened. Storage and firewall admission, together
+with the atomic timeout-versus-completion boundary, are separate rollout stages;
+timeout alone still does not release an active input delivery.
 
 Codex execution timeout and cancellation first allow an in-flight `turn/steer`
 to settle within the bounded sink window. A successful response still persists

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
@@ -1007,6 +1007,36 @@ describe("sandbox cleanup", () => {
     });
   });
 
+  it("keeps a stale running run active when its heartbeat commits first", async () => {
+    const fixture = await trackRun(
+      insertRunFixture({
+        status: "running",
+        createdAt: minutesAgo(10),
+        lastHeartbeatAt: minutesAgo(3),
+      }),
+    );
+    const headers = {
+      authorization: `Bearer ${generateSandboxToken(
+        fixture.userId,
+        fixture.runId,
+        fixture.orgId,
+      )}`,
+    };
+
+    await webhooks.requestAgentHeartbeat(
+      { runId: fixture.runId },
+      headers,
+      [200],
+    );
+    const response = await cleanupRegisteredFixtures();
+
+    expect(response.body.results).toHaveLength(0);
+    await expect(findRun(fixture.runId)).resolves.toMatchObject({
+      status: "running",
+      error: null,
+    });
+  });
+
   it("exposes a pending-run timeout as terminal to connector runtime sync", async () => {
     const fixture = await trackRun(
       insertRunFixture({ status: "pending", createdAt: minutesAgo(6) }),

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -16048,6 +16048,54 @@ describe("HOOK-01: callback authentication failures", () => {
 });
 
 describe("RUN-03: timed-out run webhook admission", () => {
+  it("rejects heartbeats after ordinary terminal transitions", async () => {
+    const api = createRunsApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    const completed = await api.createRun(actor, {
+      agentId,
+      prompt: "complete before heartbeat",
+      modelProvider: "anthropic-api-key",
+    });
+    const failed = await api.createRun(actor, {
+      agentId,
+      prompt: "fail before heartbeat",
+      modelProvider: "anthropic-api-key",
+    });
+    const cancelled = await api.createRun(actor, {
+      agentId,
+      prompt: "cancel before heartbeat",
+      modelProvider: "anthropic-api-key",
+    });
+
+    await webhooks.requestAgentComplete(
+      { runId: completed.runId, exitCode: 0 },
+      {
+        authorization: `Bearer ${api.sandboxTokenForRun(actor, completed.runId)}`,
+      },
+      [200],
+    );
+    await webhooks.requestAgentComplete(
+      { runId: failed.runId, exitCode: 1 },
+      {
+        authorization: `Bearer ${api.sandboxTokenForRun(actor, failed.runId)}`,
+      },
+      [200],
+    );
+    await api.requestCancelRun(actor, cancelled.runId, [200]);
+
+    for (const runId of [completed.runId, failed.runId, cancelled.runId]) {
+      const heartbeat = await webhooks.requestAgentHeartbeat(
+        { runId },
+        {
+          authorization: `Bearer ${api.sandboxTokenForRun(actor, runId)}`,
+        },
+        [404],
+      );
+      expect(heartbeat.status).toBe(404);
+    }
+  });
+
   it("rejects runtime mutations while accepting reporting webhooks", async () => {
     const api = createRunsApi(context);
     const webhooks = createWebhookCallbackApi(context);
@@ -16255,6 +16303,38 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
     });
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(runId);
+    const sandboxHeaders = {
+      authorization: `Bearer ${claim.sandboxToken}`,
+    };
+    await webhooks.requestAgentEvents(
+      {
+        runId,
+        events: [
+          {
+            type: "assistant",
+            sequenceNumber: 0,
+            message: {
+              id: `msg_${randomUUID()}`,
+              content: [{ type: "text", text: "retained pre-timeout output" }],
+            },
+          },
+        ],
+      },
+      sandboxHeaders,
+      [200],
+    );
+    await flushWaitUntilForTest();
+    await expect(chat.listThreadEvents(actor, threadId)).resolves.toMatchObject(
+      {
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            runId,
+            content: "retained pre-timeout output",
+          }),
+        ]),
+      },
+    );
+
     await timeoutRunWithoutCallbacksFixture({ runId });
     await flushWaitUntilForTest();
     context.mocks.ably.publish.mockClear();
@@ -16281,7 +16361,7 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
         events: [
           {
             type: "assistant",
-            sequenceNumber: 0,
+            sequenceNumber: 1,
             message: {
               id: `msg_${randomUUID()}`,
               content: [{ type: "text", text: "ignored timed-out output" }],
@@ -16289,17 +16369,23 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
           },
         ],
       },
-      { authorization: `Bearer ${claim.sandboxToken}` },
+      sandboxHeaders,
       [200],
     );
     expect(response.body).toStrictEqual({
       received: 1,
-      firstSequence: 0,
-      lastSequence: 0,
+      firstSequence: 1,
+      lastSequence: 1,
     });
     await flushWaitUntilForTest();
 
     const messages = await chat.listThreadEvents(actor, threadId);
+    expect(messages.events).toContainEqual(
+      expect.objectContaining({
+        runId,
+        content: "retained pre-timeout output",
+      }),
+    );
     expect(messages.events).not.toContainEqual(
       expect.objectContaining({
         runId,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -84,6 +84,7 @@ import {
   setRunModelProviderFixture,
   setRunModelRuntimeRouteFixture,
 } from "../../../test-fixtures/agent-runs";
+import { timeoutRunWithoutCallbacksFixture } from "../../../test-fixtures/chat-events";
 import {
   createBddApi,
   expectApiError,
@@ -16046,6 +16047,155 @@ describe("HOOK-01: callback authentication failures", () => {
   });
 });
 
+describe("RUN-03: timed-out run webhook admission", () => {
+  it("rejects runtime mutations while accepting reporting webhooks", async () => {
+    const api = createRunsApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    const created = await api.createRun(actor, {
+      agentId,
+      prompt: "ignore runtime webhooks after timeout",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(created.runId);
+    const sandboxHeaders = {
+      authorization: `Bearer ${claim.sandboxToken}`,
+    };
+    await timeoutRunWithoutCallbacksFixture({ runId: created.runId });
+
+    const heartbeat = await webhooks.requestAgentHeartbeat(
+      { runId: created.runId },
+      sandboxHeaders,
+      [404],
+    );
+    expect(heartbeat.status).toBe(404);
+
+    let eventTraceRequests = 0;
+    server.use(
+      http.post(
+        "https://api.axiom.co/v1/datasets/agent-run-events/ingest",
+        () => {
+          eventTraceRequests += 1;
+          return HttpResponse.json({
+            ingested: 1,
+            failed: 0,
+            processedBytes: 1,
+            blocksCreated: 1,
+            walLength: 1,
+          });
+        },
+      ),
+    );
+    const events = await webhooks.requestAgentEvents(
+      {
+        runId: created.runId,
+        events: [
+          {
+            type: "result",
+            sequenceNumber: 0,
+            result: "late result after timeout",
+          },
+        ],
+      },
+      sandboxHeaders,
+      [200],
+    );
+    expect(events.body).toStrictEqual({
+      received: 1,
+      firstSequence: 0,
+      lastSequence: 0,
+    });
+    await flushWaitUntilForTest();
+    expect(eventTraceRequests).toBe(0);
+
+    const historyHash = createHash("sha256")
+      .update(`timed-out history ${created.runId}`)
+      .digest("hex");
+    const s3CallCount = context.mocks.s3.send.mock.calls.length;
+    const history = await webhooks.requestAgentCheckpointPrepareHistory(
+      {
+        runId: created.runId,
+        hash: historyHash,
+        rawSize: 32,
+        encodedSize: 32,
+        encoding: "identity",
+      },
+      sandboxHeaders,
+      [400],
+    );
+    expect(JSON.stringify(history.body)).toContain("[CHECKPOINT_RUN_TERMINAL]");
+    expect(context.mocks.s3.send.mock.calls).toHaveLength(s3CallCount);
+
+    const checkpoint = await webhooks.requestAgentCheckpoint(
+      {
+        runId: created.runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `timed-out-${created.runId}`,
+        cliAgentSessionHistoryDisposition: "unavailable",
+      },
+      sandboxHeaders,
+      [400],
+    );
+    expect(JSON.stringify(checkpoint.body)).toContain(
+      "[CHECKPOINT_RUN_TERMINAL]",
+    );
+
+    const usage = await webhooks.requestAgentUsageEvent(
+      {
+        runId: created.runId,
+        events: [
+          {
+            idempotencyKey: randomUUID(),
+            kind: "connector",
+            provider: "github",
+            category: "api_request",
+            quantity: 1,
+          },
+        ],
+      },
+      sandboxHeaders,
+      [200],
+    );
+    expect(usage.body).toStrictEqual({ success: true });
+
+    const observation = await webhooks.requestAgentModelUsageObservationV2(
+      {
+        runId: created.runId,
+        events: [
+          {
+            idempotencyKey: randomUUID(),
+            model: "claude-sonnet-4-6",
+            inputTokens: 12,
+            outputTokens: 3,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+          },
+        ],
+      },
+      sandboxHeaders,
+      [200],
+    );
+    expect(observation.body).toStrictEqual({ success: true });
+
+    const telemetry = await webhooks.requestAgentTelemetry(
+      {
+        runId: created.runId,
+        systemLog: "late teardown log",
+      },
+      sandboxHeaders,
+      [200],
+    );
+    expect(telemetry.body).toStrictEqual({
+      success: true,
+      id: created.runId,
+    });
+    await expect(api.readRun(actor, created.runId)).resolves.toMatchObject({
+      status: "timeout",
+    });
+  });
+});
+
 describe("HOOK-02: event-consumer dispatch failures", () => {
   it("keeps Axiom trace failures outside the required event ACK", async () => {
     const api = createRunsApi(context);
@@ -16113,6 +16263,72 @@ describe("HOOK-02: event-consumer dispatch failures", () => {
 });
 
 describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () => {
+  it("acknowledges and ignores assistant output after timeout", async () => {
+    const api = createRunsApi(context);
+    const chat = createChatFilesBddApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    const { runId, threadId } = await sendChatRunMessage(actor, {
+      agentId,
+      prompt: "ignore chat output after timeout",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(runId);
+    await timeoutRunWithoutCallbacksFixture({ runId });
+    await flushWaitUntilForTest();
+    context.mocks.ably.publish.mockClear();
+
+    let eventTraceRequests = 0;
+    server.use(
+      http.post(
+        "https://api.axiom.co/v1/datasets/agent-run-events/ingest",
+        () => {
+          eventTraceRequests += 1;
+          return HttpResponse.json({
+            ingested: 1,
+            failed: 0,
+            processedBytes: 1,
+            blocksCreated: 1,
+            walLength: 1,
+          });
+        },
+      ),
+    );
+    const response = await webhooks.requestAgentEvents(
+      {
+        runId,
+        events: [
+          {
+            type: "assistant",
+            sequenceNumber: 0,
+            message: {
+              id: `msg_${randomUUID()}`,
+              content: [{ type: "text", text: "ignored timed-out output" }],
+            },
+          },
+        ],
+      },
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      [200],
+    );
+    expect(response.body).toStrictEqual({
+      received: 1,
+      firstSequence: 0,
+      lastSequence: 0,
+    });
+    await flushWaitUntilForTest();
+
+    const messages = await chat.listThreadEvents(actor, threadId);
+    expect(messages.events).not.toContainEqual(
+      expect.objectContaining({
+        runId,
+        content: "ignored timed-out output",
+      }),
+    );
+    expect(eventTraceRequests).toBe(0);
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
   it("uses DB output acknowledged before completion and ignores a late duplicate", async () => {
     const api = createRunsApi(context);
     const chat = createChatFilesBddApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -16159,25 +16159,6 @@ describe("RUN-03: timed-out run webhook admission", () => {
     );
     expect(usage.body).toStrictEqual({ success: true });
 
-    const observation = await webhooks.requestAgentModelUsageObservationV2(
-      {
-        runId: created.runId,
-        events: [
-          {
-            idempotencyKey: randomUUID(),
-            model: "claude-sonnet-4-6",
-            inputTokens: 12,
-            outputTokens: 3,
-            cacheReadInputTokens: 0,
-            cacheCreationInputTokens: 0,
-          },
-        ],
-      },
-      sandboxHeaders,
-      [200],
-    );
-    expect(observation.body).toStrictEqual({ success: true });
-
     const telemetry = await webhooks.requestAgentTelemetry(
       {
         runId: created.runId,

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -9,7 +9,7 @@ import {
 } from "@okouai/api-contracts/contracts/webhooks";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { usageEvent } from "@okouai/db/schema/usage-event";
-import { and, eq, isNotNull } from "drizzle-orm";
+import { and, eq, inArray, isNotNull } from "drizzle-orm";
 import { isBuiltInModelProviderType } from "@okouai/api-contracts/contracts/model-providers";
 
 import { notFound } from "../../lib/error";
@@ -161,7 +161,13 @@ const heartbeat$ = command(async ({ get, set }, signal: AbortSignal) => {
   const result = await db
     .update(agentRuns)
     .set({ lastHeartbeatAt: nowDate() })
-    .where(and(eq(agentRuns.id, body.runId), eq(agentRuns.userId, auth.userId)))
+    .where(
+      and(
+        eq(agentRuns.id, body.runId),
+        eq(agentRuns.userId, auth.userId),
+        inArray(agentRuns.status, ["pending", "running"]),
+      ),
+    )
     .returning({ id: agentRuns.id });
   signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
@@ -1,4 +1,8 @@
 import { command } from "ccstate";
+import {
+  runStatusSchema,
+  type RunStatus,
+} from "@okouai/api-contracts/contracts/runs";
 import { and, eq, isNotNull, isNull, lte, sql } from "drizzle-orm";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { runOutputMaterializations } from "@okouai/db/schema/run-output-materialization";
@@ -21,6 +25,7 @@ import {
 } from "./chat-first-assistant-event-metric.service";
 import { chatThreadForRunFromDb } from "./chat-thread.service";
 import { writeRunMetadataInTransaction } from "./agent-run-metadata-write.service";
+import { lockChatQueueThread } from "./chat-event-queue.service";
 
 const RUN_OUTPUT_PROJECTION_LOCK_TIMEOUT = "1s";
 const RUN_OUTPUT_PROJECTION_STATEMENT_TIMEOUT = "5s";
@@ -41,6 +46,13 @@ export interface MaterializedChatProjection {
     readonly acknowledgedAt: number;
   } | null;
 }
+
+type RunOutputMaterializationResult =
+  | {
+      readonly outcome: "accepted";
+      readonly chatProjection: MaterializedChatProjection | null;
+    }
+  | { readonly outcome: "ignored-timeout" };
 
 export class AgentEventRunNotFoundError extends Error {
   constructor(runId: string) {
@@ -251,108 +263,111 @@ async function lockAgentRunForOutputMaterialization(
   tx: Tx,
   runId: string,
   signal: AbortSignal,
-): Promise<void> {
+): Promise<RunStatus> {
   const [run] = await tx
-    .select({ id: agentRuns.id })
+    .select({ status: agentRuns.status })
     .from(agentRuns)
     .where(eq(agentRuns.id, runId))
-    .for("key share")
+    .for("update")
     .limit(1);
   signal.throwIfAborted();
   if (!run) {
     throw new AgentEventRunNotFoundError(runId);
   }
+  return runStatusSchema.parse(run.status);
 }
 
-async function materializeRunOutputEvents(
-  writeDb: Db,
-  payload: EventConsumerPayload,
+type OutputMaterializationTransactionResult =
+  | RunOutputMaterializationResult
+  | { readonly outcome: "retry" };
+
+async function materializeAdmittedRunOutputEvents(
+  args: {
+    readonly tx: Tx;
+    readonly payload: EventConsumerPayload;
+    readonly thread: MaterializedChatProjection["thread"] | null;
+    readonly latestResult: OutputCandidate | null;
+    readonly latestOutput: OutputCandidate | null;
+  },
   signal: AbortSignal,
-): Promise<MaterializedChatProjection | null> {
-  const latestResult = latestCandidate(payload.events, resultText);
-  const latestOutput = latestCandidate(payload.events, callbackOutputText);
-
-  return await writeDb.transaction(async (tx) => {
-    await lockRunOutputProjection(tx, payload.runId, signal);
-    await lockAgentRunForOutputMaterialization(tx, payload.runId, signal);
-
-    const thread = await chatThreadForRunFromDb(tx, payload.runId);
-    signal.throwIfAborted();
-
-    let insertedRowCount = 0;
-    let shouldAttemptFirstAssistantEventClaim = false;
-    if (thread) {
-      const insertion = await insertRunOutputChatEvents(
-        tx,
-        payload,
-        thread,
-        signal,
-      );
-      insertedRowCount = insertion.insertedRowCount;
-      shouldAttemptFirstAssistantEventClaim =
-        insertion.shouldAttemptFirstAssistantEventClaim;
-    }
-
-    if (latestResult !== null || latestOutput !== null) {
-      const updatedAt = nowDate();
-      await tx
-        .insert(runOutputMaterializations)
-        .values({
-          runId: payload.runId,
-          latestResultSequence: latestResult?.sequenceNumber,
-          latestResultText: latestResult?.content,
-          latestOutputSequence: latestOutput?.sequenceNumber,
-          latestOutputText: latestOutput?.content,
-          updatedAt,
-        })
-        .onConflictDoUpdate({
-          target: runOutputMaterializations.runId,
-          set: {
-            latestResultSequence:
-              latestResult === null
-                ? runOutputMaterializations.latestResultSequence
-                : sql`case when ${lte(sql`coalesce(${runOutputMaterializations.latestResultSequence}, -1)`, latestResult.sequenceNumber)} then ${latestResult.sequenceNumber} else ${runOutputMaterializations.latestResultSequence} end`,
-            latestResultText:
-              latestResult === null
-                ? runOutputMaterializations.latestResultText
-                : sql`case when ${lte(sql`coalesce(${runOutputMaterializations.latestResultSequence}, -1)`, latestResult.sequenceNumber)} then ${latestResult.content} else ${runOutputMaterializations.latestResultText} end`,
-            latestOutputSequence:
-              latestOutput === null
-                ? runOutputMaterializations.latestOutputSequence
-                : sql`case when ${lte(sql`coalesce(${runOutputMaterializations.latestOutputSequence}, -1)`, latestOutput.sequenceNumber)} then ${latestOutput.sequenceNumber} else ${runOutputMaterializations.latestOutputSequence} end`,
-            latestOutputText:
-              latestOutput === null
-                ? runOutputMaterializations.latestOutputText
-                : sql`case when ${lte(sql`coalesce(${runOutputMaterializations.latestOutputSequence}, -1)`, latestOutput.sequenceNumber)} then ${latestOutput.content} else ${runOutputMaterializations.latestOutputText} end`,
-            updatedAt,
-          },
-        });
-    }
-    signal.throwIfAborted();
-
-    if (!thread) {
-      return null;
-    }
-
-    const acknowledgedAt = nowDate();
-    const firstAssistantClaimWhere = and(
-      eq(agentRuns.id, payload.runId),
-      isNotNull(agentRuns.apiStartedAt),
-      isNull(agentRuns.firstAssistantEventAcknowledgedAt),
+): Promise<RunOutputMaterializationResult> {
+  const { tx, payload, thread, latestResult, latestOutput } = args;
+  let insertedRowCount = 0;
+  let shouldAttemptFirstAssistantEventClaim = false;
+  if (thread) {
+    const insertion = await insertRunOutputChatEvents(
+      tx,
+      payload,
+      thread,
+      signal,
     );
-    if (!firstAssistantClaimWhere) {
-      throw new Error("First assistant acknowledgement predicate is empty");
-    }
-    const [firstAssistantClaim] =
-      insertedRowCount > 0 && shouldAttemptFirstAssistantEventClaim
-        ? await writeRunMetadataInTransaction(tx, {
-            patch: { firstAssistantEventAcknowledgedAt: acknowledgedAt },
-            where: firstAssistantClaimWhere,
-          })
-        : [];
-    signal.throwIfAborted();
+    insertedRowCount = insertion.insertedRowCount;
+    shouldAttemptFirstAssistantEventClaim =
+      insertion.shouldAttemptFirstAssistantEventClaim;
+  }
 
-    return {
+  if (latestResult !== null || latestOutput !== null) {
+    const updatedAt = nowDate();
+    await tx
+      .insert(runOutputMaterializations)
+      .values({
+        runId: payload.runId,
+        latestResultSequence: latestResult?.sequenceNumber,
+        latestResultText: latestResult?.content,
+        latestOutputSequence: latestOutput?.sequenceNumber,
+        latestOutputText: latestOutput?.content,
+        updatedAt,
+      })
+      .onConflictDoUpdate({
+        target: runOutputMaterializations.runId,
+        set: {
+          latestResultSequence:
+            latestResult === null
+              ? runOutputMaterializations.latestResultSequence
+              : sql`case when ${lte(sql`coalesce(${runOutputMaterializations.latestResultSequence}, -1)`, latestResult.sequenceNumber)} then ${latestResult.sequenceNumber} else ${runOutputMaterializations.latestResultSequence} end`,
+          latestResultText:
+            latestResult === null
+              ? runOutputMaterializations.latestResultText
+              : sql`case when ${lte(sql`coalesce(${runOutputMaterializations.latestResultSequence}, -1)`, latestResult.sequenceNumber)} then ${latestResult.content} else ${runOutputMaterializations.latestResultText} end`,
+          latestOutputSequence:
+            latestOutput === null
+              ? runOutputMaterializations.latestOutputSequence
+              : sql`case when ${lte(sql`coalesce(${runOutputMaterializations.latestOutputSequence}, -1)`, latestOutput.sequenceNumber)} then ${latestOutput.sequenceNumber} else ${runOutputMaterializations.latestOutputSequence} end`,
+          latestOutputText:
+            latestOutput === null
+              ? runOutputMaterializations.latestOutputText
+              : sql`case when ${lte(sql`coalesce(${runOutputMaterializations.latestOutputSequence}, -1)`, latestOutput.sequenceNumber)} then ${latestOutput.content} else ${runOutputMaterializations.latestOutputText} end`,
+          updatedAt,
+        },
+      });
+  }
+  signal.throwIfAborted();
+
+  if (!thread) {
+    return { outcome: "accepted", chatProjection: null };
+  }
+
+  const acknowledgedAt = nowDate();
+  const firstAssistantClaimWhere = and(
+    eq(agentRuns.id, payload.runId),
+    isNotNull(agentRuns.apiStartedAt),
+    isNull(agentRuns.firstAssistantEventAcknowledgedAt),
+  );
+  if (!firstAssistantClaimWhere) {
+    throw new Error("First assistant acknowledgement predicate is empty");
+  }
+  const [firstAssistantClaim] =
+    insertedRowCount > 0 && shouldAttemptFirstAssistantEventClaim
+      ? await writeRunMetadataInTransaction(tx, {
+          patch: { firstAssistantEventAcknowledgedAt: acknowledgedAt },
+          where: firstAssistantClaimWhere,
+        })
+      : [];
+  signal.throwIfAborted();
+
+  return {
+    outcome: "accepted",
+    chatProjection: {
       thread,
       insertedRowCount,
       firstAssistantAcknowledgement:
@@ -363,8 +378,58 @@ async function materializeRunOutputEvents(
               apiStartedAt: firstAssistantClaim.apiStartedAt.getTime(),
               acknowledgedAt: acknowledgedAt.getTime(),
             },
-    };
-  });
+    },
+  };
+}
+
+async function materializeRunOutputEvents(
+  writeDb: Db,
+  payload: EventConsumerPayload,
+  signal: AbortSignal,
+): Promise<RunOutputMaterializationResult> {
+  const latestResult = latestCandidate(payload.events, resultText);
+  const latestOutput = latestCandidate(payload.events, callbackOutputText);
+
+  let expectedThread = await chatThreadForRunFromDb(writeDb, payload.runId);
+  signal.throwIfAborted();
+  while (true) {
+    const result: OutputMaterializationTransactionResult =
+      await writeDb.transaction(async (tx) => {
+        await lockRunOutputProjection(tx, payload.runId, signal);
+        const threadLocked = expectedThread
+          ? await lockChatQueueThread(tx, expectedThread.chatThreadId)
+          : false;
+        signal.throwIfAborted();
+        const status = await lockAgentRunForOutputMaterialization(
+          tx,
+          payload.runId,
+          signal,
+        );
+        if (status === "timeout") {
+          return { outcome: "ignored-timeout" };
+        }
+
+        const thread = await chatThreadForRunFromDb(tx, payload.runId);
+        signal.throwIfAborted();
+        if (thread?.chatThreadId !== expectedThread?.chatThreadId) {
+          return { outcome: "retry" };
+        }
+        if (expectedThread && !threadLocked) {
+          throw new Error("Agent run retained a missing chat thread");
+        }
+
+        return await materializeAdmittedRunOutputEvents(
+          { tx, payload, thread, latestResult, latestOutput },
+          signal,
+        );
+      });
+    signal.throwIfAborted();
+    if (result.outcome !== "retry") {
+      return result;
+    }
+    expectedThread = await chatThreadForRunFromDb(writeDb, payload.runId);
+    signal.throwIfAborted();
+  }
 }
 
 export const materializeRunOutputEvents$ = command(
@@ -372,7 +437,7 @@ export const materializeRunOutputEvents$ = command(
     { set },
     payload: EventConsumerPayload,
     signal: AbortSignal,
-  ): Promise<MaterializedChatProjection | null> => {
+  ): Promise<RunOutputMaterializationResult> => {
     return await materializeRunOutputEvents(set(writeDb$), payload, signal);
   },
 );

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
@@ -405,10 +405,6 @@ async function materializeRunOutputEvents(
           payload.runId,
           signal,
         );
-        if (status === "timeout") {
-          return { outcome: "ignored-timeout" };
-        }
-
         const thread = await chatThreadForRunFromDb(tx, payload.runId);
         signal.throwIfAborted();
         if (thread?.chatThreadId !== expectedThread?.chatThreadId) {
@@ -416,6 +412,9 @@ async function materializeRunOutputEvents(
         }
         if (expectedThread && !threadLocked) {
           throw new Error("Agent run retained a missing chat thread");
+        }
+        if (status === "timeout") {
+          return { outcome: "ignored-timeout" };
         }
 
         return await materializeAdmittedRunOutputEvents(

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -82,6 +82,9 @@ interface PreparedSessionHistoryBlob {
   readonly insertedNewBlob: boolean;
 }
 
+type SessionHistoryBlobReadDb = Pick<Db, "select">;
+type SessionHistoryBlobWriteDb = Pick<Db, "insert" | "select" | "update">;
+
 const L = logger("webhooks:agent:checkpoints");
 
 class PiCheckpointValidationError extends Error {}
@@ -415,7 +418,7 @@ const validatePiCheckpoint$ = command(async function validatePiCheckpoint(
 });
 
 async function loadSessionHistoryBlobMetadata(
-  db: Db,
+  db: SessionHistoryBlobReadDb,
   hash: string,
 ): Promise<SessionHistoryBlobMetadata | undefined> {
   const [blob] = await db
@@ -432,7 +435,7 @@ async function loadSessionHistoryBlobMetadata(
 
 async function ensureSessionHistoryBlobMetadata(
   args: {
-    readonly db: Db;
+    readonly db: SessionHistoryBlobWriteDb;
     readonly body: PrepareHistoryBody;
     readonly requestedEncoding: string;
   },
@@ -501,22 +504,6 @@ export const prepareCheckpointHistoryUpload$ = command(
     signal: AbortSignal,
   ) => {
     const db = set(writeDb$);
-    const [run] = await db
-      .select({ id: agentRuns.id })
-      .from(agentRuns)
-      .where(
-        and(
-          eq(agentRuns.id, input.body.runId),
-          eq(agentRuns.userId, input.auth.userId),
-        ),
-      )
-      .limit(1);
-    signal.throwIfAborted();
-
-    if (!run) {
-      return notFound("Agent run not found");
-    }
-
     const requestedEncoding =
       input.body.encoding ?? SESSION_HISTORY_ENCODING_IDENTITY;
     if (
@@ -527,14 +514,50 @@ export const prepareCheckpointHistoryUpload$ = command(
         "Identity session history encodedSize must match rawSize",
       );
     }
-    const { blob, insertedNewBlob } = await ensureSessionHistoryBlobMetadata(
-      {
-        db,
-        body: input.body,
-        requestedEncoding,
-      },
-      signal,
-    );
+
+    const admission = await db.transaction(async (tx) => {
+      await lockAgentRunCheckpointLifecycle(tx, input.body.runId);
+      signal.throwIfAborted();
+      const [run] = await tx
+        .select({ status: agentRuns.status })
+        .from(agentRuns)
+        .where(
+          and(
+            eq(agentRuns.id, input.body.runId),
+            eq(agentRuns.userId, input.auth.userId),
+          ),
+        )
+        .for("update")
+        .limit(1);
+      signal.throwIfAborted();
+      if (!run) {
+        return { kind: "not-found" } as const;
+      }
+      const status = runStatusSchema.parse(run.status);
+      if (status === "timeout") {
+        return { kind: "timeout", status } as const;
+      }
+      return {
+        kind: "admitted",
+        prepared: await ensureSessionHistoryBlobMetadata(
+          {
+            db: tx,
+            body: input.body,
+            requestedEncoding,
+          },
+          signal,
+        ),
+      } as const;
+    });
+    signal.throwIfAborted();
+
+    if (admission.kind === "not-found") {
+      return notFound("Agent run not found");
+    }
+    if (admission.kind === "timeout") {
+      return badRequestMessage(checkpointRunStateError(admission.status));
+    }
+    const { blob, insertedNewBlob } = admission.prepared;
 
     if (blob.rawSize !== input.body.rawSize) {
       return badRequestMessage(
@@ -679,6 +702,10 @@ function piCheckpointRunStateError(status: RunStatus): string {
   const code =
     status === "queued" ? "PI_H2_RUN_NOT_ACTIVE" : "PI_H2_RUN_TERMINAL";
   return `[${code}] Pi H2 cannot become canonical while the run status is ${status}`;
+}
+
+function checkpointRunStateError(status: RunStatus): string {
+  return `[CHECKPOINT_RUN_TERMINAL] Checkpoint cannot become canonical while the run status is ${status}`;
 }
 
 interface ExistingPiCheckpoint {
@@ -923,6 +950,9 @@ async function commitAgentCheckpoint(
       return badRequestMessage(typeError);
     }
     const piRun = isPiCheckpointRun(run);
+    if (!piRun && run.status === "timeout") {
+      return badRequestMessage(checkpointRunStateError(run.status));
+    }
     if (piRun) {
       const admission = await admitPiCheckpoint(
         tx,

--- a/turbo/apps/api/src/signals/services/agent-webhook-events.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-events.service.ts
@@ -209,6 +209,24 @@ export const receiveAgentEvents$ = command(
       };
     }
 
+    if (projectionResult.value.outcome === "ignored-timeout") {
+      L.debug("Ignored events for timed-out run", {
+        runId: payload.runId,
+        status: "timeout",
+        eventCount: payload.events.length,
+        ...range,
+      });
+      return {
+        response: {
+          status: 200 as const,
+          body: {
+            received: payload.events.length,
+            ...range,
+          },
+        },
+      };
+    }
+
     L.debug(
       `Events ${range.firstSequence}-${range.lastSequence} accepted for run ${payload.runId} (${now() - startedAt}ms)`,
     );
@@ -222,7 +240,7 @@ export const receiveAgentEvents$ = command(
       },
       acceptedEvents: {
         payload,
-        chatProjection: projectionResult.value,
+        chatProjection: projectionResult.value.chatProjection,
       },
     };
   },


### PR DESCRIPTION
## Summary

- require an active run for heartbeat updates and stop progress callbacks when admission fails
- serialize timeout admission with event projection and acknowledge ignored timed-out batches without required or optional effects
- reject checkpoint creation and checkpoint-history preparation after timeout while preserving reporting webhooks
- document the staged post-timeout webhook policy

## Scope

- No request, response, status-enum, token, database-schema, or Runner protocol change.
- Legacy sandbox model-observation ingestion was removed independently by #30251; runner-level aggregate observations have no run-timeout admission semantics.
- Storage writeback and firewall admission remain in #30249.
- Atomic timeout/completion handling and active-input settlement remain in #30250.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit full-workspace Knip and type checks
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 --silent=passed-only` (221 passed)
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` (3635 passed; one unrelated shared-database Calendar watch count failed under the full parallel run and passed in isolation on a reset database)

Closes #30248

Parent context: #30246
