### PR TITLE
fix(ci): ignore non-loaded runner units during image preparation

### DIFF
--- a/.github/scripts/prepare-runner-image.sh
+++ b/.github/scripts/prepare-runner-image.sh
@@ -103,7 +103,7 @@ UNIT_PREFIX="vm0-runner-${JOB_REF}-"
 
 declare -a PRIMARY_UNITS=()
 discover_primary_units() {
-  local output unit rest suffix
+  local output line unit load_state active_state sub_state description suffix
   if ! output=$(sudo systemctl list-units \
     --all --full --no-legend --plain "${UNIT_PREFIX}*.service" 2>&1); then
     printf '%s\n' "$output" >&2
@@ -111,13 +111,21 @@ discover_primary_units() {
   fi
 
   PRIMARY_UNITS=()
-  while read -r unit rest; do
+  while IFS= read -r line; do
+    read -r unit load_state active_state sub_state description <<< "$line"
     [ -n "$unit" ] || continue
     case "$unit" in
       "${UNIT_PREFIX}"*.service)
         suffix=${unit#"${UNIT_PREFIX}"}
         suffix=${suffix%.service}
         if [[ "$suffix" =~ ^[0-9]+$ ]]; then
+          if [ "$load_state" != "loaded" ]; then
+            continue
+          fi
+          if [ -z "$active_state" ] || [ -z "$sub_state" ]; then
+            echo "malformed loaded runner service row: ${line}" >&2
+            return 1
+          fi
           PRIMARY_UNITS+=("$unit")
         fi
         ;;

--- a/.github/scripts/tests/prepare-runner-image-test.sh
+++ b/.github/scripts/tests/prepare-runner-image-test.sh
@@ -370,12 +370,6 @@ set_unit_state() {
   printf '%s\n' "$load_state" > "${case_dir}/load-state/${unit}"
 }
 
-add_list_row() {
-  local case_dir=$1
-  local row=$2
-  printf '%s\n' "$row" >> "${case_dir}/extra-list-rows"
-}
-
 run_remote_case() {
   local case_dir=$1
   local list_failure=${2:-}
@@ -461,7 +455,7 @@ grep -q 'mock list-units failure' "${discovery_failure_case}/out" || fail "expec
 
 malformed_loaded_case="${TMPDIR}/remote-malformed-loaded"
 prepare_remote_case "$malformed_loaded_case"
-add_list_row "$malformed_loaded_case" "vm0-runner-pr-123-2.service loaded active"
+printf '%s\n' "vm0-runner-pr-123-2.service loaded active" >> "${malformed_loaded_case}/extra-list-rows"
 run_remote_case "$malformed_loaded_case"
 if grep -q '^mutate ' "${malformed_loaded_case}/systemctl.log"; then
   fail "malformed loaded row must prevent shared-path mutation"

--- a/.github/scripts/tests/prepare-runner-image-test.sh
+++ b/.github/scripts/tests/prepare-runner-image-test.sh
@@ -305,8 +305,10 @@ case "$command" in
       [ -f "$state_path" ] || continue
       unit=${state_path##*/}
       state=$(< "$state_path")
-      printf '%s loaded %s fixture fixture\n' "$unit" "$state"
+      load_state=$(< "${SYSTEMCTL_LOAD_STATE_DIR}/${unit}")
+      printf '%s %s %s fixture fixture\n' "$unit" "$load_state" "$state"
     done
+    cat "$SYSTEMCTL_EXTRA_LIST_ROWS_FILE"
     ;;
   stop)
     {
@@ -352,9 +354,10 @@ chmod +x "${TMPDIR}/bin/ssh" "${TMPDIR}/bin/sudo" "${TMPDIR}/bin/systemctl"
 
 prepare_remote_case() {
   local case_dir=$1
-  mkdir -p "${case_dir}/state"
+  mkdir -p "${case_dir}/state" "${case_dir}/load-state"
   : > "${case_dir}/ssh.log"
   : > "${case_dir}/systemctl.log"
+  : > "${case_dir}/extra-list-rows"
   printf '0\n' > "${case_dir}/gc-count"
 }
 
@@ -362,7 +365,15 @@ set_unit_state() {
   local case_dir=$1
   local unit=$2
   local state=$3
+  local load_state=${4:-loaded}
   printf '%s\n' "$state" > "${case_dir}/state/${unit}"
+  printf '%s\n' "$load_state" > "${case_dir}/load-state/${unit}"
+}
+
+add_list_row() {
+  local case_dir=$1
+  local row=$2
+  printf '%s\n' "$row" >> "${case_dir}/extra-list-rows"
 }
 
 run_remote_case() {
@@ -378,6 +389,8 @@ run_remote_case() {
     SSH_REACH_GC="${REMOTE_REACH_GC:-}" \
     SYSTEMCTL_LOG="${case_dir}/systemctl.log" \
     SYSTEMCTL_STATE_DIR="${case_dir}/state" \
+    SYSTEMCTL_LOAD_STATE_DIR="${case_dir}/load-state" \
+    SYSTEMCTL_EXTRA_LIST_ROWS_FILE="${case_dir}/extra-list-rows" \
     SYSTEMCTL_LIST_FAILURE="$list_failure" \
     SYSTEMCTL_STOP_FAILURE_UNIT="$stop_failure_unit" \
     SYSTEMCTL_STICKY_UNIT="$sticky_unit" \
@@ -402,6 +415,8 @@ set_unit_state "$success_case" "vm0-runner-pr-123-7.service" active
 set_unit_state "$success_case" "vm0-runner-pr-123-exec.service" active
 set_unit_state "$success_case" "vm0-runner-pr-123-keepalive.service" active
 set_unit_state "$success_case" "vm0-runner-pr-123-cancel.service" active
+set_unit_state "$success_case" "vm0-runner-pr-123-9.service" active not-found
+set_unit_state "$success_case" "vm0-runner-pr-123-10.service" active masked
 run_remote_case "$success_case"
 grep -q 'ci@dev-arm-1 uname -m' "${success_case}/ssh.log" || fail "valid supplied runner must reach the SSH boundary"
 grep -Eq '^stop .*vm0-runner-pr-123-2\.service([[:space:]]|$)' "${success_case}/systemctl.log" || fail "expected primary runner suffix 2 to stop"
@@ -412,9 +427,14 @@ fi
 if grep '^stop ' "${success_case}/systemctl.log" | grep -q 'vm0-runner-pr-123-1\.service'; then
   fail "architecture-subset index must not determine the stopped service"
 fi
+if grep -Eq '^(stop|show|reset-failed).*vm0-runner-pr-123-(9|10)\.service' "${success_case}/systemctl.log"; then
+  fail "non-loaded primary runner rows must not participate in cleanup"
+fi
 [ "$(< "${success_case}/state/vm0-runner-pr-123-2.service")" = "inactive" ] || fail "expected primary runner suffix 2 to be inactive"
 [ "$(< "${success_case}/state/vm0-runner-pr-123-7.service")" = "inactive" ] || fail "expected primary runner suffix 7 to be inactive"
 [ "$(< "${success_case}/state/vm0-runner-pr-123-exec.service")" = "active" ] || fail "expected auxiliary runner to remain active"
+[ "$(< "${success_case}/state/vm0-runner-pr-123-9.service")" = "active" ] || fail "expected not-found runner row to remain untouched"
+[ "$(< "${success_case}/state/vm0-runner-pr-123-10.service")" = "active" ] || fail "expected masked runner row to remain untouched"
 last_show_line=$(grep -n '^show ' "${success_case}/systemctl.log" | tail -n1 | cut -d: -f1)
 first_mutation_line=$(grep -n '^mutate ' "${success_case}/systemctl.log" | head -n1 | cut -d: -f1)
 [ -n "$last_show_line" ] || fail "expected post-stop state verification"
@@ -438,6 +458,15 @@ if grep -q '^mutate ' "${discovery_failure_case}/systemctl.log"; then
   fail "discovery failure must prevent shared-path mutation"
 fi
 grep -q 'mock list-units failure' "${discovery_failure_case}/out" || fail "expected discovery failure output"
+
+malformed_loaded_case="${TMPDIR}/remote-malformed-loaded"
+prepare_remote_case "$malformed_loaded_case"
+add_list_row "$malformed_loaded_case" "vm0-runner-pr-123-2.service loaded active"
+run_remote_case "$malformed_loaded_case"
+if grep -q '^mutate ' "${malformed_loaded_case}/systemctl.log"; then
+  fail "malformed loaded row must prevent shared-path mutation"
+fi
+grep -q 'malformed loaded runner service row: vm0-runner-pr-123-2.service loaded active' "${malformed_loaded_case}/out" || fail "expected malformed loaded row output"
 
 stop_failure_case="${TMPDIR}/remote-stop-failure"
 prepare_remote_case "$stop_failure_case"


### PR DESCRIPTION
## Summary

- parse the `LOAD`, `ACTIVE`, and `SUB` columns from Runner service discovery
- admit only matching numeric units whose load state is exactly `loaded`
- fail closed for malformed matching loaded rows before shared runner paths mutate
- cover mixed loaded, `not-found`, and `masked` rows through the production script entry point

## Scope

- no generic `runner gc` behavior changes
- no service or directory naming changes
- no workflow YAML, API, persisted data, or runner protocol changes

## Validation

- `bash -n .github/scripts/prepare-runner-image.sh`
- `bash -n .github/scripts/tests/prepare-runner-image-test.sh`
- `.github/scripts/tests/prepare-runner-image-test.sh`
- `git diff --check`
- `./scripts/check-file-size.sh .github/scripts/prepare-runner-image.sh .github/scripts/tests/prepare-runner-image-test.sh`

Closes #30235
