### PR TITLE
refactor(runner): retire legacy service lock namespace compatibility

### DIFF
--- a/crates/runner/src/cmd/gc/orphaned_locks.rs
+++ b/crates/runner/src/cmd/gc/orphaned_locks.rs
@@ -37,7 +37,7 @@ pub(super) async fn gc_orphaned_locks(home: &HomePaths, dry_run: bool) -> Runner
         // deleting a version that another process is installing or uninstalling.
         // Workspace GC owns base-dir lock lifecycle because those locks carry
         // the base_dir metadata needed to rediscover dead-runner workspaces.
-        if RunnerServiceUnit::is_reserved_lock_file_name(name)
+        if RunnerServiceUnit::from_lock_file_name(name).is_some()
             || entry.path() == home.systemd_daemon_reload_lock()
             || is_base_dir_lock_name(name)
         {
@@ -60,39 +60,68 @@ pub(super) async fn gc_orphaned_locks(home: &HomePaths, dry_run: bool) -> Runner
 
 #[cfg(test)]
 mod tests {
+    use nix::fcntl::{Flock, FlockArg};
+
     use super::*;
     use crate::cmd::gc::test_support::test_home;
+    use crate::lock;
 
     #[tokio::test]
-    async fn gc_orphaned_locks_preserves_service_lock_namespace() {
+    async fn gc_orphaned_locks_preserves_only_current_service_locks() {
         let dir = tempfile::tempdir().unwrap();
         let home = test_home(dir.path());
         let locks_dir = home.locks_dir();
         std::fs::create_dir_all(&locks_dir).unwrap();
-        let service_lock = RunnerServiceUnit::from_suffix("v1.0.0")
+        let version_service_lock = RunnerServiceUnit::from_suffix("v1.0.0")
+            .unwrap()
+            .lock_path(&home);
+        let staging_service_lock = RunnerServiceUnit::from_suffix("staging")
             .unwrap()
             .lock_path(&home);
         let historical_service_lock = locks_dir.join("service-vm0-runner-OLD_NAME.lock");
         let stale_lock = locks_dir.join("workspace-image-cache-test.lock");
-        std::fs::write(&service_lock, "").unwrap();
+        std::fs::write(&version_service_lock, "").unwrap();
+        std::fs::write(&staging_service_lock, "").unwrap();
         std::fs::write(&historical_service_lock, "").unwrap();
         std::fs::write(&stale_lock, "").unwrap();
 
         let report = gc_orphaned_locks(&home, false).await.unwrap();
 
-        assert_eq!(report.activity_count, 1);
+        assert_eq!(report.activity_count, 2);
         assert_eq!(report.freed_bytes, 0);
         assert!(
-            service_lock.exists(),
-            "canonical service locks must survive orphaned lock cleanup"
+            version_service_lock.exists(),
+            "canonical version service locks must survive orphaned lock cleanup"
         );
         assert!(
-            historical_service_lock.exists(),
-            "historical service lock names must remain protected during rolling upgrades"
+            staging_service_lock.exists(),
+            "canonical non-semver service locks must survive orphaned lock cleanup"
+        );
+        assert!(
+            !historical_service_lock.exists(),
+            "free historical service lock names should be cleaned as ordinary locks"
         );
         assert!(
             !stale_lock.exists(),
             "ordinary free locks should still be cleaned"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_orphaned_locks_preserves_held_historical_service_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let historical_service_lock = home.locks_dir().join("service-vm0-runner-OLD_NAME.lock");
+        let lock_file = lock::open_lock_file(&historical_service_lock).unwrap();
+        let _held_lock = Flock::lock(lock_file, FlockArg::LockExclusive).unwrap();
+
+        let report = gc_orphaned_locks(&home, false).await.unwrap();
+
+        assert_eq!(report.activity_count, 0);
+        assert_eq!(report.freed_bytes, 0);
+        assert!(
+            historical_service_lock.exists(),
+            "held historical service locks must survive orphaned lock cleanup"
         );
     }
 

--- a/crates/runner/src/cmd/service/target.rs
+++ b/crates/runner/src/cmd/service/target.rs
@@ -74,24 +74,13 @@ impl RunnerServiceUnit {
     ///
     /// Accepts `service-vm0-runner-<suffix>.lock` only when `<suffix>` passes
     /// the same validation as [`Self::from_suffix`]. Historical lock names
-    /// that use the reserved wrapper but fail current validation remain
-    /// classified by [`Self::is_reserved_lock_file_name`] for rolling compatibility.
+    /// that fail current validation are rejected.
     pub(crate) fn from_lock_file_name(file_name: &str) -> Option<Self> {
         let unit_name = file_name
             .strip_prefix(LOCK_PREFIX)?
             .strip_suffix(LOCK_SUFFIX)?;
         let suffix = unit_name.strip_prefix(UNIT_PREFIX)?;
         Self::from_suffix(suffix).ok()
-    }
-
-    /// Return whether a filename belongs to the reserved service-lock namespace.
-    ///
-    /// This intentionally recognizes the broad `service-*.lock` wrapper used
-    /// by historical runners, even when the enclosed unit name fails current
-    /// validation. General lock GC must preserve those paths while older
-    /// runner binaries can overlap with the current version.
-    pub(crate) fn is_reserved_lock_file_name(file_name: &str) -> bool {
-        file_name.starts_with(LOCK_PREFIX) && file_name.ends_with(LOCK_SUFFIX)
     }
 
     /// Return the validated suffix before adding the `vm0-runner-` prefix or
@@ -238,24 +227,5 @@ mod tests {
             RunnerServiceUnit::from_lock_file_name("workspace-image-cache-v1.0.0.lock").is_none()
         );
         assert!(RunnerServiceUnit::from_lock_file_name("service-vm0-runner-UPPER.lock").is_none());
-    }
-
-    #[test]
-    fn reserved_lock_file_name_classifier_preserves_historical_namespace() {
-        assert!(RunnerServiceUnit::is_reserved_lock_file_name(
-            "service-vm0-runner-v1.0.0.lock"
-        ));
-        assert!(RunnerServiceUnit::is_reserved_lock_file_name(
-            "service-vm0-runner-OLD_NAME.lock"
-        ));
-        assert!(RunnerServiceUnit::is_reserved_lock_file_name(
-            "service-.lock"
-        ));
-        assert!(!RunnerServiceUnit::is_reserved_lock_file_name(
-            "workspace-image-cache-v1.0.0.lock"
-        ));
-        assert!(!RunnerServiceUnit::is_reserved_lock_file_name(
-            "service-vm0-runner-v1.0.0"
-        ));
     }
 }


### PR DESCRIPTION
## Summary

- reserve only service lock filenames accepted by the current `RunnerServiceUnit` parser
- let unlocked noncanonical historical service locks use the ordinary orphan-lock cleanup path
- verify canonical version and non-version locks remain reserved while held historical locks remain protected

## Compatibility

The production fleet and every currently supported rollback target have used the strict service-unit parser since Runner `0.177.0`. Arbitrary older releases are intentionally outside the supported rollback boundary. A lock actively held by an unsupported older process is still protected by the existing flock probe and inode-safe cleanup path.

The canonical service lock path and the separate semver-only version lock GC policy are unchanged.

## Exclusions

- no changes to version service lock GC
- no changes to service names or canonical lock paths
- no support for arbitrary historical rollback targets

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::service::target::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::gc::orphaned_locks::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::gc::version_service_locks::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `lefthook run pre-commit`

Closes #29899
