### PR TITLE
docs(rust): document pi rpc lifecycle and event projection

### DIFF
--- a/crates/guest-agent/src/cli/pi_rpc.rs
+++ b/crates/guest-agent/src/cli/pi_rpc.rs
@@ -1,4 +1,217 @@
 //! Official Pi RPC command lifecycle and public-event projection.
+//!
+//! ## Ownership and data flow
+//!
+//! The sandbox TypeScript host resolves the API-first handoff, restores the
+//! validated H1 session file, writes one private startup-boundary record to
+//! stdout, and then enters Pi's official `runRpcMode`. The guest-agent owns the
+//! other side of that boundary. Its stdout loop in `cli/mod.rs` admits the
+//! boundary before any official RPC record, starts the shared event pipeline
+//! from the installed sequence, and then applies this module's projection.
+//!
+//! There are two coupled JSONL paths after startup:
+//!
+//! - The guest writer owns child stdin. It sends `get_state`, the initial
+//!   `prompt`, and later `steer` commands for accepted active-input frames. The
+//!   stdout loop routes `response` records into the writer's response channel.
+//! - The stdout loop owns child stdout. It retains each ordinary raw record in
+//!   the best-effort local agent transcript, projects supported records into
+//!   the existing public event shape, and passes projected events through
+//!   normalization, secret masking, sequencing, bounded FIFO delivery, and the
+//!   HTTP event worker. The startup control is the exception: it is consumed
+//!   before the transcript and public pipeline and is never delivered.
+//!
+//! The public event pipeline is deliberately created only after boundary
+//! installation. `CliEventIngestor` and `EventDeliveryRuntime` receive the same
+//! installed first sequence, so the first public event and the delivery
+//! acknowledgement watermark cannot start from different boundaries.
+//!
+//! ## API-first startup boundary
+//!
+//! The host emits this private control record before official RPC output:
+//!
+//! ```json
+//! {
+//!   "type": "vm0_pi_api_first_turn_boundary",
+//!   "schemaVersion": 1,
+//!   "sandboxEventSequenceStart": 4
+//! }
+//! ```
+//!
+//! The control record's schema version is independent of the API manifest
+//! version. The host maps a manifest v1 handoff to sequence `1`; a manifest v2
+//! supplies its positive `sandboxEventSequenceStart`. Rust accepts the private
+//! control only when its type and schema version are exact, all fields are
+//! known, and the sequence is in `1..=i32::MAX` (`1..=2,147,483,647`).
+//!
+//! `PiRpcStartupBoundary` is a fail-closed one-time gate:
+//!
+//! - Before installation, a non-control JSON record fails with
+//!   `PI_HANDOFF_BOUNDARY_MISSING`. A malformed control, invalid schema, zero,
+//!   overflowing, or otherwise invalid sequence fails with
+//!   `PI_HANDOFF_BOUNDARY_INVALID`.
+//! - The first valid control installs the boundary. A second control before an
+//!   official record is a duplicate; a different value is a conflict; and a
+//!   control after an official record is late. Each is terminal and rejects
+//!   the stream.
+//! - After a rejection, `discard_remaining` makes all later records
+//!   non-projecting. Invalid non-JSON input is also fatal while the boundary is
+//!   still required, or when the raw line resembles the control type.
+//! - `cli/mod.rs` consumes the installed control before projection. It is not
+//!   written to the agent transcript, assigned a public sequence, sent to the
+//!   webhook, or rendered as an agent/Chat event.
+//!
+//! This ordering is the API-first reader contract: no official RPC record may
+//! reach projection, masking, sequencing, or delivery until the boundary that
+//! authorized the restored H1 session has been installed.
+//!
+//! ## Command and acknowledgement lifecycle
+//!
+//! `write_commands` has one serialized command flow. It first writes
+//! `get_state` with ID `<run-id>:pi:get-state` and waits for a response with
+//! the exact ID, command name, and `success: true`. The successful response is
+//! sent to the response channel and is also used by the projection to emit
+//! `system/init` after validating the configured session ID, returned
+//! `data.sessionId`, and required `data.sessionFile`.
+//!
+//! The writer then sends the initial `prompt` with ID
+//! `<run-id>:pi:initial-prompt` and waits for its exactly correlated successful
+//! response. Once that acknowledgement arrives, each accepted active-input
+//! frame is sent as a `steer` command whose ID is the frame's delivery UUID and
+//! whose message is the frame text. A matching successful `steer` response is
+//! recorded with `mark_backend_accepted_without_replay`; it does not create a
+//! replay user event in the Pi path. A failed or interrupted steer marks the
+//! delivery failed and enters the writer's abort/error path.
+//!
+//! Normal response waits reject an unexpected ID, unexpected command,
+//! unsuccessful response, or a closed response channel. Abort is different in
+//! one respect: it ignores unrelated response IDs while waiting for its own
+//! acknowledgement. It writes ID `<run-id>:pi:abort`, requires the matching
+//! successful `abort` response, and has a ten-second timeout covering the write
+//! and acknowledgement wait.
+//!
+//! The guest keeps child stdin owned by this writer after the initial prompt.
+//! The host's official RPC loop therefore remains alive while the guest waits
+//! for active input and while stdout drains through `agent_settled`. After a
+//! projected terminal result, Pi active input closes when no follow-up frame is
+//! pending; final guest cleanup closes it in all remaining cases, allowing the
+//! host to observe stdin EOF.
+//!
+//! User cancellation closes active-input state and cancels the Pi writer. When
+//! cancellation wins while the writer is waiting for a command response, the
+//! writer sends the bounded `abort` command. If cancellation wins inside the
+//! cancellable stdin write itself, that write returns an interruption error
+//! before an abort can be written; this is a distinct early-write failure path.
+//! The final guest control result records `Run cancelled by user` and the
+//! `UserCancellation` termination reason. Current Pi tool-result events do not
+//! carry a `vm0_user_cancelled` field: that marker was removed with Chat Tool
+//! Activity in #30215. Claude-only replay filtering is enabled outside this
+//! module; Pi does not set `replay_user_messages`.
+//!
+//! ## Record admission and projection
+//!
+//! `PiRpcProjection::project` receives only official records admitted after the
+//! startup boundary. The common loop records the raw JSONL line locally even
+//! when the record has no public projection. The routing contract is:
+//!
+//! - `response`: every response is routed to the command channel. Only the
+//!   first successful `get_state` response emits `system/init`; prompt, steer,
+//!   abort, and other responses are acknowledgement records only. The raw
+//!   response remains in the local transcript.
+//! - `message_end` with an assistant message: the latest assistant terminal
+//!   state is cached. Supported content is emitted as an `assistant` event;
+//!   empty content, unknown content blocks, and assistant messages with no
+//!   supported content emit no public event, but their raw records remain local.
+//! - `message_end` with a `toolResult` message: required tool-result fields are
+//!   validated and one public `user` event containing one `tool_result` block is
+//!   emitted. The raw record remains local. Other message roles are ignored
+//!   publicly and retained locally.
+//! - `agent_settled`: this is the sole Pi owner of the public terminal
+//!   `result` event. It consumes the cached assistant terminal state. Neither
+//!   `message_end` nor `agent_end` owns the public terminal result.
+//! - `extension_error`: no public event is emitted. Projection becomes
+//!   terminal and returns an execution error; later records are discarded from
+//!   public projection while the stdout loop continues its controlled failure
+//!   and local-transcript handling.
+//! - Unsupported official records, including `agent_end`, emit no public
+//!   event and are retained locally unless the projection is already terminal.
+//!
+//! After projection, assistant and user events with multiple content blocks
+//! are split by `provider_event_normalization` into one independently
+//! sequenced public event per block. The source order is retained, and common
+//! masking and bounded delivery happen after that normalization.
+//!
+//! ## Public event shapes
+//!
+//! A successful `get_state` projects to:
+//!
+//! ```json
+//! {
+//!   "type": "system",
+//!   "subtype": "init",
+//!   "session_id": "<configured-session-id>",
+//!   "session_file": "<returned-session-file>"
+//! }
+//! ```
+//!
+//! An assistant `message_end` projects to an `assistant` envelope whose
+//! message contains `id`, `role: "assistant"`, ordered `content`, `model`, and
+//! `usage`. The ID is `responseId` when supplied, otherwise
+//! `<run-id>:<timestamp>:<model>`. Usage maps `input`, `output`, `cacheRead`,
+//! and `cacheWrite` to `input_tokens`, `output_tokens`,
+//! `cache_read_input_tokens`, and `cache_creation_input_tokens`.
+//!
+//! Text blocks are trimmed and empty text is omitted. A `toolCall` requires a
+//! non-empty `id` and `name` plus an object `arguments`, and becomes a
+//! `{type: "tool_use", id, name, input}` block. Unknown assistant content
+//! types are omitted. A tool-only assistant message still produces an
+//! assistant event because its `toolCall` block is supported.
+//!
+//! A `toolResult` message requires a non-empty `toolCallId`, an array
+//! `content`, and a boolean `isError`. It becomes:
+//!
+//! ```json
+//! {
+//!   "type": "user",
+//!   "session_id": "<configured-session-id>",
+//!   "message": {
+//!     "role": "user",
+//!     "content": [{
+//!       "type": "tool_result",
+//!       "tool_use_id": "<toolCallId>",
+//!       "content": [],
+//!       "is_error": false
+//!     }]
+//!   }
+//! }
+//! ```
+//!
+//! Tool-result text blocks retain their text. Image blocks become base64 image
+//! sources with `mimeType` mapped to `media_type` and `data` mapped to
+//! `data`; unsupported result content blocks are omitted. The resulting `user`
+//! event is a tool result, not a replayable prompt, and has no
+//! `vm0_user_cancelled` field.
+//!
+//! ## Terminal result and failure ownership
+//!
+//! Each assistant `message_end` updates `PiAssistantTerminal`; it does not
+//! itself close the public run. `stopReason` values `error` and `aborted` set
+//! the cached failure flag. The result text uses `errorMessage` when present,
+//! otherwise the joined non-empty assistant text. If both are empty, it falls
+//! back to `Pi model turn <stopReason>` when a stop reason exists.
+//!
+//! When `agent_settled` arrives, the cached state is consumed and the public
+//! result contains `type: "result"`, `subtype: "error_during_execution"` and
+//! `is_error: true` for a cached failure, or `subtype: "success"` and
+//! `is_error: false` otherwise. It also contains the selected `result` text,
+//! configured `session_id`, and elapsed `duration_ms`. With no cached assistant
+//! message, the default terminal state is successful with an empty result.
+//!
+//! The common guest loop treats this projected result as the terminal JSONL
+//! event: it masks the printed result, closes idle Pi active input, and drains
+//! successful delivery or aborts unsent delivery on a control/error path. A
+//! user cancellation can subsequently override the final guest control
+//! diagnostic, but it does not mutate the public tool-result shape.
 
 use std::time::Instant;
 

--- a/turbo/apps/cli/src/lib/pi-agent-loop.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.ts
@@ -103,7 +103,23 @@ export async function piSandboxAgentConfigFromEnv(
   };
 }
 
-/** Run the official sandbox-owned Pi RPC host until guest-agent closes stdin. */
+/**
+ * Resolve the API-first handoff and run the official sandbox-owned Pi RPC host.
+ *
+ * The handoff resolver validates the immutable manifest and restored H1
+ * session, maps manifest v1 to sequence 1 or reads the manifest v2 sequence,
+ * and returns the session file plus the authoritative first Sandbox event
+ * sequence. This host then writes one private JSONL startup-control record with
+ * that sequence before entering `runPiOfficialRpcMode`.
+ *
+ * The guest-agent consumes that control record before admitting any official
+ * Pi RPC record, so the control is not an agent event, Chat event, transcript
+ * line, or public delivery. `runPiOfficialRpcMode` owns the official RPC
+ * command/record stream; guest-agent owns its stdin and keeps it open through
+ * `agent_settled`, closing it only after terminal handling and active-input
+ * quiescence. The host consequently remains in official RPC mode until the
+ * guest closes stdin.
+ */
 export async function runPiSandboxAgentLoop(args: {
   readonly config: PiSandboxAgentConfig;
   readonly cwd?: string;


### PR DESCRIPTION
## Summary

- Document the Pi RPC startup boundary, command/acknowledgement lifecycle, record routing, public-event projection, terminal ownership, and active-input cancellation behavior at the Rust implementation boundary.
- Synchronize the TypeScript host comment with the validated API-first handoff, private boundary emission, official RPC startup ordering, and stdin lifetime.
- Record the current absence of the removed `vm0_user_cancelled` Pi tool-result marker.

## Scope

This is a documentation-only change. Runtime behavior, public event schemas, API contracts, tests, and fixtures are unchanged.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --lib --tests -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent pi_rpc`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test pi_cli_handoff_boundary --quiet`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test pi_cli_run_id_env --test pi_cli_settlement_errors --quiet`
- `pnpm exec prettier --check apps/cli/src/lib/pi-agent-loop.ts`
- `pnpm --filter @okouai/cli run lint`
- `pnpm --filter @okouai/cli run check-types`

Closes #30200
