### PR TITLE
docs(rust): document workspace image cache path scoping

### DIFF
--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -7,6 +7,34 @@
 //! follows the canonical-workspace semantics in `paths.rs`. A cache entry
 //! contains a `metadata.json` file and a `current.ext4` image file.
 //!
+//! ## Guest path and fingerprint scope
+//!
+//! A cache-safe guest working directory is an absolute, non-root path string: it
+//! starts with `/`, contains no NUL byte, and contains no component equal to
+//! `.` or `..`. Repeated and trailing `/` separators are normalized away. The
+//! normalizer only performs these string checks; it does not resolve host
+//! filesystem paths or symlinks. Root, relative, NUL-containing, and
+//! dot-component paths are unsafe.
+//!
+//! A mount path is in the workspace scope when its normalized form is exactly
+//! the normalized working directory or is a component-boundary descendant of
+//! it. This is deliberately stricter than a raw string-prefix check, so a path
+//! such as `/workspace2` is not inside `/workspace`. An invalid working or
+//! mount path fails closed and cannot make an entry eligible for cache reuse.
+//!
+//! Promotion filters both the storage and artifact fingerprint maps against
+//! this scope. Normalized paths are used only to decide membership; retained
+//! entries keep their original map keys and fingerprint values. Only
+//! fingerprints for state represented by the workspace image are persisted in
+//! cache metadata. On a cache hit, those persisted fingerprints become the
+//! previous storage state for the next storage plan.
+//!
+//! Unsafe paths have lifecycle effects at several boundaries. Active checkout
+//! and preparation use the fresh-workspace fallback, promotion identity
+//! rejects the path, and an unsafe lease cannot produce a promotion target.
+//! Metadata with an unsafe working directory is not reusable for metadata or
+//! held-state publication, and GC classifies the entry as unusable.
+//!
 //! ## Invariants
 //!
 //! - Within this module, entry paths are always derived from the same cache key

--- a/crates/runner/src/workspace_image_cache/path_safety.rs
+++ b/crates/runner/src/workspace_image_cache/path_safety.rs
@@ -1,5 +1,11 @@
 use crate::storage_fingerprints::StorageFingerprints;
 
+/// Retains fingerprints whose mount paths are within the normalized workspace scope.
+///
+/// Filtering is applied independently to both the storage and artifact maps. The
+/// paths are normalized only for the membership check; retained entries keep
+/// their original map keys and fingerprint values. If the working directory or
+/// a mount path is unsafe, that entry is excluded.
 pub(super) fn filter_storage_fingerprints_for_working_dir(
     fingerprints: &StorageFingerprints,
     working_dir: &str,
@@ -21,10 +27,22 @@ pub(super) fn filter_storage_fingerprints_for_working_dir(
     }
 }
 
+/// Returns whether `path` satisfies the cache-safe guest working-directory grammar.
+///
+/// A safe path starts with `/`, is not root, contains no NUL byte, and has no
+/// `.` or `..` component. Empty components from repeated or trailing separators
+/// are allowed because normalization removes them. This predicate checks the
+/// path string and does not access the filesystem.
 pub(super) fn is_safe_guest_working_dir(path: &str) -> bool {
     normalize_safe_guest_working_dir(path).is_some()
 }
 
+/// Validates and normalizes a guest path for cache identity and scope checks.
+///
+/// The returned path has one `/` between non-empty components and no trailing
+/// separator. The function returns `None` for relative paths, root, NUL bytes,
+/// or components equal to `.` or `..`; it does not resolve filesystem symlinks
+/// or otherwise canonicalize a host path.
 pub(super) fn normalize_safe_guest_working_dir(path: &str) -> Option<String> {
     if !path.starts_with('/') || path.as_bytes().contains(&0) {
         return None;
@@ -46,6 +64,12 @@ pub(super) fn normalize_safe_guest_working_dir(path: &str) -> Option<String> {
     Some(format!("/{}", components.join("/")))
 }
 
+/// Returns whether a mount path belongs to a working directory's workspace scope.
+///
+/// Both paths are normalized before comparison. An exact normalized match and
+/// a descendant with `/` at the component boundary are accepted; invalid paths
+/// are rejected. This intentionally avoids raw string-prefix matching, so
+/// `/workspace2` is not a descendant of `/workspace`.
 pub(super) fn is_workspace_scoped_path(mount_path: &str, working_dir: &str) -> bool {
     let Some(mount_path) = normalize_safe_guest_working_dir(mount_path) else {
         return false;


### PR DESCRIPTION
## Summary

- Document the cache-safe guest working-directory grammar and normalization rules.
- Document component-boundary workspace scope matching and fail-closed behavior.
- Document storage/artifact fingerprint filtering, representation preservation, previous-storage
  consumption, and lifecycle effects at the cache boundaries.

## Scope

This is a documentation-only change in the workspace image cache Rust module and path-safety
helpers. Runtime behavior, cache keys, metadata serialization, and cache metadata format are
unchanged.

Closes #30203

## Validation

- PASS: `cargo fmt --all --manifest-path crates/Cargo.toml -- --check`
- PASS: `cargo check --manifest-path crates/Cargo.toml -p runner --bin runner` with single-job,
  zero-debuginfo, and offline dependency settings.
- PASS: `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
  with the same low-memory settings.
- PASS: `cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps` with
  `RUSTDOCFLAGS=-D warnings`.
- NOT COMPLETED: `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner workspace_image_cache` was attempted twice with single-job, zero-debuginfo settings and was terminated with exit 137 while compiling workspace dependencies; no test assertion failure was reached.
