### PR TITLE
fix(platform): recover shared database authentication

### DIFF
--- a/turbo/apps/platform/src/shared-database/__tests__/auth-recovering-client.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/auth-recovering-client.test.ts
@@ -166,6 +166,38 @@ describe("auth recovering shared database bridge", () => {
     expect(inner.heartbeats).toHaveLength(1);
   });
 
+  it("allows a later recovery after a token refresh rejects", async () => {
+    const inner = new FakeBridge();
+    inner.queryErrors.push(
+      authenticationBlockedError(),
+      authenticationBlockedError(),
+    );
+    const refreshError = new Error("Clerk token refresh failed");
+    let refreshes = 0;
+    const bridge = new AuthRecoveringSharedDatabaseBridge(
+      inner,
+      () => {
+        refreshes += 1;
+        return refreshes === 1
+          ? Promise.reject(refreshError)
+          : Promise.resolve("replacement-token");
+      },
+      context.signal,
+    );
+    await bridge.heartbeat(heartbeat(), context.signal);
+
+    await expect(query(bridge, context.signal)).rejects.toBe(refreshError);
+    await expect(query(bridge, context.signal)).resolves.toStrictEqual([]);
+
+    expect(refreshes).toBe(2);
+    expect(inner.queryCalls).toBe(3);
+    expect(
+      inner.heartbeats.map((value) => {
+        return value.identity.token;
+      }),
+    ).toStrictEqual(["initial-token", "replacement-token"]);
+  });
+
   it("surfaces a second auth rejection without another query retry", async () => {
     const inner = new FakeBridge();
     inner.queryErrors.push(

--- a/turbo/apps/platform/src/shared-database/__tests__/auth-recovering-client.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/auth-recovering-client.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { testContext } from "../../signals/__tests__/test-helpers.ts";
+import { createChildAbortController } from "../../signals/utils.ts";
+import { AuthRecoveringSharedDatabaseBridge } from "../auth-recovering-client.ts";
+import type {
+  SharedDatabaseBridge,
+  SharedDatabaseHeartbeat,
+} from "../bridge.ts";
+import type {
+  SharedDatabaseDataKey,
+  SharedDatabaseQuery,
+  SharedDatabaseQueryResult,
+} from "../data-key.ts";
+import {
+  SHARED_DATABASE_AUTH_BLOCKED_ERROR_NAME,
+  type SharedDatabaseHeartbeatResult,
+} from "../protocol.ts";
+
+class FakeBridge implements SharedDatabaseBridge {
+  readonly heartbeats: SharedDatabaseHeartbeat[] = [];
+  readonly queryErrors: Error[] = [];
+  queryCalls = 0;
+
+  heartbeat(
+    heartbeat: SharedDatabaseHeartbeat,
+    _signal: AbortSignal,
+  ): Promise<SharedDatabaseHeartbeatResult> {
+    this.heartbeats.push(heartbeat);
+    return Promise.resolve({ clientReconnected: false });
+  }
+
+  query<TKey extends SharedDatabaseDataKey>(
+    _query: SharedDatabaseQuery<TKey>,
+    _signal: AbortSignal,
+  ): Promise<SharedDatabaseQueryResult<TKey>> {
+    this.queryCalls += 1;
+    const error = this.queryErrors.shift();
+    if (error) {
+      return Promise.reject(error);
+    }
+    return Promise.resolve([] as SharedDatabaseQueryResult<TKey>);
+  }
+
+  on(
+    _dataKey: SharedDatabaseDataKey,
+    _callback: () => void,
+    _signal: AbortSignal,
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+const context = testContext();
+
+function heartbeat(token = "initial-token"): SharedDatabaseHeartbeat {
+  return {
+    identity: {
+      userId: "auth-recovery-user",
+      orgId: "auth-recovery-org",
+      token,
+    },
+  };
+}
+
+function dataKey(): SharedDatabaseDataKey {
+  return {
+    kind: "chat-event",
+    userId: "auth-recovery-user",
+    orgId: "auth-recovery-org",
+    threadId: "auth-recovery-thread",
+  };
+}
+
+function query(
+  bridge: AuthRecoveringSharedDatabaseBridge,
+  signal: AbortSignal,
+) {
+  return bridge.query(
+    {
+      dataKey: dataKey(),
+      afterSeqId: null,
+      consistency: "catch-up",
+    },
+    signal,
+  );
+}
+
+function authenticationBlockedError(): Error {
+  const error = new Error(
+    "Shared database remote synchronization is blocked by authentication",
+  );
+  error.name = SHARED_DATABASE_AUTH_BLOCKED_ERROR_NAME;
+  return error;
+}
+
+describe("auth recovering shared database bridge", () => {
+  it("refreshes the credential and retries an auth-blocked query once", async () => {
+    const inner = new FakeBridge();
+    inner.queryErrors.push(authenticationBlockedError());
+    let refreshes = 0;
+    const bridge = new AuthRecoveringSharedDatabaseBridge(
+      inner,
+      () => {
+        refreshes += 1;
+        return Promise.resolve("replacement-token");
+      },
+      context.signal,
+    );
+    await bridge.heartbeat(heartbeat(), context.signal);
+
+    await expect(query(bridge, context.signal)).resolves.toStrictEqual([]);
+
+    expect(refreshes).toBe(1);
+    expect(inner.queryCalls).toBe(2);
+    expect(
+      inner.heartbeats.map((value) => {
+        return value.identity.token;
+      }),
+    ).toStrictEqual(["initial-token", "replacement-token"]);
+  });
+
+  it("coalesces worker-initiated authentication recovery", async () => {
+    const inner = new FakeBridge();
+    const refresh = context.mocks.deferred<string | null>();
+    let refreshes = 0;
+    const bridge = new AuthRecoveringSharedDatabaseBridge(
+      inner,
+      () => {
+        refreshes += 1;
+        return refresh.promise;
+      },
+      context.signal,
+    );
+    await bridge.heartbeat(heartbeat(), context.signal);
+
+    const first = bridge.authenticationRequired();
+    const second = bridge.authenticationRequired();
+    expect(refreshes).toBe(1);
+    refresh.resolve("replacement-token");
+    await Promise.all([first, second]);
+
+    expect(
+      inner.heartbeats.map((value) => {
+        return value.identity.token;
+      }),
+    ).toStrictEqual(["initial-token", "replacement-token"]);
+  });
+
+  it("does not retry when Clerk returns the rejected token", async () => {
+    const inner = new FakeBridge();
+    const blocked = authenticationBlockedError();
+    inner.queryErrors.push(blocked);
+    const bridge = new AuthRecoveringSharedDatabaseBridge(
+      inner,
+      () => {
+        return Promise.resolve("initial-token");
+      },
+      context.signal,
+    );
+    await bridge.heartbeat(heartbeat(), context.signal);
+
+    await expect(query(bridge, context.signal)).rejects.toBe(blocked);
+
+    expect(inner.queryCalls).toBe(1);
+    expect(inner.heartbeats).toHaveLength(1);
+  });
+
+  it("surfaces a second auth rejection without another query retry", async () => {
+    const inner = new FakeBridge();
+    inner.queryErrors.push(
+      authenticationBlockedError(),
+      authenticationBlockedError(),
+    );
+    let refreshes = 0;
+    const bridge = new AuthRecoveringSharedDatabaseBridge(
+      inner,
+      () => {
+        refreshes += 1;
+        return Promise.resolve("replacement-token");
+      },
+      context.signal,
+    );
+    await bridge.heartbeat(heartbeat(), context.signal);
+
+    await expect(query(bridge, context.signal)).rejects.toMatchObject({
+      name: SHARED_DATABASE_AUTH_BLOCKED_ERROR_NAME,
+    });
+
+    expect(refreshes).toBe(1);
+    expect(inner.queryCalls).toBe(2);
+
+    inner.queryErrors.push(authenticationBlockedError());
+    await expect(query(bridge, context.signal)).rejects.toMatchObject({
+      name: SHARED_DATABASE_AUTH_BLOCKED_ERROR_NAME,
+    });
+    expect(refreshes).toBe(1);
+    expect(inner.queryCalls).toBe(3);
+  });
+
+  it("continues root auth recovery after the query caller aborts", async () => {
+    const inner = new FakeBridge();
+    inner.queryErrors.push(authenticationBlockedError());
+    const refresh = context.mocks.deferred<string | null>();
+    let refreshes = 0;
+    const bridge = new AuthRecoveringSharedDatabaseBridge(
+      inner,
+      () => {
+        refreshes += 1;
+        return refresh.promise;
+      },
+      context.signal,
+    );
+    await bridge.heartbeat(heartbeat(), context.signal);
+    const caller = createChildAbortController(context.signal);
+
+    const pending = query(bridge, caller.signal);
+    await vi.waitFor(() => {
+      expect(refreshes).toBe(1);
+    });
+    caller.abort(new DOMException("Query cancelled", "AbortError"));
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+
+    refresh.resolve("replacement-token");
+    await bridge.authenticationRequired();
+    expect(inner.queryCalls).toBe(1);
+    expect(
+      inner.heartbeats.map((value) => {
+        return value.identity.token;
+      }),
+    ).toStrictEqual(["initial-token", "replacement-token"]);
+  });
+});

--- a/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
@@ -149,6 +149,7 @@ function installProtocolBridge(): {
     platformPort,
     location.origin,
     {
+      authenticationRequired: vi.fn<() => void>(),
       reloadRequired: vi.fn<() => void>(),
       statusChanged: vi.fn<(status: SharedDatabaseConnectionStatus) => void>(),
     },
@@ -316,6 +317,7 @@ describe("shared database MessagePort protocol", () => {
         return connectProtocolTransport(events);
       },
       events: {
+        authenticationRequired: vi.fn<() => void>(),
         reloadRequired: vi.fn<() => void>(),
         statusChanged:
           vi.fn<(status: SharedDatabaseConnectionStatus) => void>(),
@@ -327,6 +329,7 @@ describe("shared database MessagePort protocol", () => {
         return connectProtocolTransport(events);
       },
       events: {
+        authenticationRequired: vi.fn<() => void>(),
         reloadRequired: vi.fn<() => void>(),
         statusChanged: (status) => {
           staleTabStatuses.push(status);
@@ -413,6 +416,7 @@ describe("shared database MessagePort protocol", () => {
         return connectProtocolTransport(events);
       },
       events: {
+        authenticationRequired: vi.fn<() => void>(),
         reloadRequired: vi.fn<() => void>(),
         statusChanged:
           vi.fn<(status: SharedDatabaseConnectionStatus) => void>(),
@@ -463,6 +467,7 @@ describe("shared database MessagePort protocol", () => {
   it("validates results and handles callback cleanup plus control messages", async () => {
     const [platformPort, serverPort] = messagePortPair();
     const statuses: SharedDatabaseConnectionStatus[] = [];
+    let authenticationRequests = 0;
     let reloads = 0;
     let subscriptionId: string | null = null;
     let observedHeartbeat: SharedDatabaseClientMessage | null = null;
@@ -472,6 +477,9 @@ describe("shared database MessagePort protocol", () => {
       platformPort,
       location.origin,
       {
+        authenticationRequired: () => {
+          authenticationRequests += 1;
+        },
         reloadRequired: () => {
           reloads += 1;
         },
@@ -562,10 +570,12 @@ describe("shared database MessagePort protocol", () => {
       ),
     ).rejects.toMatchObject({ name: "ZodError" });
 
+    serverPort.postMessage({ type: "authentication-required" });
     serverPort.postMessage({ type: "status", status: "disconnected" });
     serverPort.postMessage({ type: "reload-required" });
     await vi.waitFor(() => {
       expect(statuses).toStrictEqual(["disconnected"]);
+      expect(authenticationRequests).toBe(1);
       expect(reloads).toBe(1);
     });
   });

--- a/turbo/apps/platform/src/shared-database/__tests__/reconnecting-client.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/reconnecting-client.test.ts
@@ -136,6 +136,7 @@ describe("reconnecting shared database bridge", () => {
         return created;
       },
       events: {
+        authenticationRequired: vi.fn<() => void>(),
         reloadRequired: vi.fn<() => void>(),
         statusChanged: (status) => {
           statuses.push(status);
@@ -192,6 +193,7 @@ describe("reconnecting shared database bridge", () => {
         return created;
       },
       events: {
+        authenticationRequired: vi.fn<() => void>(),
         reloadRequired: vi.fn<() => void>(),
         statusChanged:
           vi.fn<(status: SharedDatabaseConnectionStatus) => void>(),
@@ -245,6 +247,7 @@ describe("reconnecting shared database bridge", () => {
         return created;
       },
       events: {
+        authenticationRequired: vi.fn<() => void>(),
         reloadRequired: vi.fn<() => void>(),
         statusChanged:
           vi.fn<(status: SharedDatabaseConnectionStatus) => void>(),
@@ -279,6 +282,7 @@ describe("reconnecting shared database bridge", () => {
         return created;
       },
       events: {
+        authenticationRequired: vi.fn<() => void>(),
         reloadRequired: vi.fn<() => void>(),
         statusChanged:
           vi.fn<(status: SharedDatabaseConnectionStatus) => void>(),

--- a/turbo/apps/platform/src/shared-database/__tests__/worker-runtime.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/worker-runtime.test.ts
@@ -53,7 +53,13 @@ function chatEventSchemaVersionResponseHeaders(): Record<string, string> {
 
 type WorkerEvent = Extract<
   SharedDatabaseWorkerMessage,
-  { readonly type: "append" | "reload-required" | "status" }
+  {
+    readonly type:
+      | "append"
+      | "authentication-required"
+      | "reload-required"
+      | "status";
+  }
 >;
 
 function identity(): SharedDatabaseIdentity {
@@ -1654,7 +1660,9 @@ describe("shared database worker runtime", () => {
 
   it("blocks on 401 until heartbeat supplies a different token", async () => {
     const workerEvents: WorkerEvent[] = [];
+    const secondClientEvents: WorkerEvent[] = [];
     const clientId = await connectRuntime(workerEvents);
+    await connectRuntime(secondClientEvents);
     const dataKey = chatEventKey(crypto.randomUUID());
     const recoveredRow = chatEventRow(dataKey.threadId, 1);
     let authorized = false;
@@ -1705,6 +1713,16 @@ describe("shared database worker runtime", () => {
       }),
     ).rejects.toMatchObject({ name: "SharedDatabaseAuthBlockedError" });
     expect(authorizationHeaders).toStrictEqual(["Bearer initial-token"]);
+    expect(
+      workerEvents.filter((event) => {
+        return event.type === "authentication-required";
+      }),
+    ).toHaveLength(1);
+    expect(
+      secondClientEvents.filter((event) => {
+        return event.type === "authentication-required";
+      }),
+    ).toHaveLength(1);
 
     context.mocks.ably.triggerOnChannel(
       realtimeChannel(),
@@ -1728,6 +1746,11 @@ describe("shared database worker runtime", () => {
       }),
     ).rejects.toMatchObject({ name: "SharedDatabaseAuthBlockedError" });
     expect(authorizationHeaders).toStrictEqual(["Bearer initial-token"]);
+    expect(
+      workerEvents.filter((event) => {
+        return event.type === "authentication-required";
+      }),
+    ).toHaveLength(1);
 
     authorized = true;
     await context.workerStore.set(

--- a/turbo/apps/platform/src/shared-database/auth-recovering-client.ts
+++ b/turbo/apps/platform/src/shared-database/auth-recovering-client.ts
@@ -1,0 +1,177 @@
+import {
+  createChildAbortController,
+  createDeferredPromise,
+  settle,
+  withCleanup,
+} from "../signals/utils.ts";
+import type {
+  SharedDatabaseBridge,
+  SharedDatabaseHeartbeat,
+} from "./bridge.ts";
+import type {
+  SharedDatabaseDataKey,
+  SharedDatabaseQuery,
+  SharedDatabaseQueryResult,
+} from "./data-key.ts";
+import {
+  SHARED_DATABASE_AUTH_BLOCKED_ERROR_NAME,
+  type SharedDatabaseHeartbeatResult,
+} from "./protocol.ts";
+
+interface AuthenticationRecoveryAttempt {
+  readonly rejectedToken: string;
+  readonly work: Promise<boolean>;
+}
+
+function isAuthenticationBlockedError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.name === SHARED_DATABASE_AUTH_BLOCKED_ERROR_NAME
+  );
+}
+
+function waitForSharedWork<T>(
+  work: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  signal.throwIfAborted();
+  const waitController = createChildAbortController(signal);
+  const aborted = createDeferredPromise<never>(waitController.signal);
+  return withCleanup(Promise.race([work, aborted.promise]), () => {
+    waitController.abort(
+      new DOMException("Shared database auth recovery completed", "AbortError"),
+    );
+  });
+}
+
+export class AuthRecoveringSharedDatabaseBridge implements SharedDatabaseBridge {
+  private heartbeatRegistration: SharedDatabaseHeartbeat | null = null;
+  private activeRecovery: Promise<boolean> | null = null;
+  private lastRecovery: AuthenticationRecoveryAttempt | null = null;
+  private retryingQueries = 0;
+
+  constructor(
+    private readonly bridge: SharedDatabaseBridge,
+    private readonly forceRefreshToken: (
+      signal: AbortSignal,
+    ) => Promise<string | null>,
+    private readonly rootSignal: AbortSignal,
+  ) {}
+
+  async heartbeat(
+    heartbeat: SharedDatabaseHeartbeat,
+    signal: AbortSignal,
+  ): Promise<SharedDatabaseHeartbeatResult> {
+    this.heartbeatRegistration = heartbeat;
+    return await this.bridge.heartbeat(heartbeat, signal);
+  }
+
+  async query<TKey extends SharedDatabaseDataKey>(
+    query: SharedDatabaseQuery<TKey>,
+    signal: AbortSignal,
+  ): Promise<SharedDatabaseQueryResult<TKey>> {
+    const first = await settle(this.bridge.query(query, signal), signal);
+    if (first.ok) {
+      return first.value;
+    }
+    if (!isAuthenticationBlockedError(first.error)) {
+      throw first.error;
+    }
+
+    const recovered = await this.recoverAuthentication(signal);
+    if (!recovered) {
+      throw first.error;
+    }
+
+    const retryToken = this.requireHeartbeatRegistration().identity.token;
+    this.retryingQueries += 1;
+    const retry = await withCleanup(
+      settle(this.bridge.query(query, signal), signal),
+      () => {
+        this.retryingQueries -= 1;
+      },
+    );
+    if (retry.ok) {
+      return retry.value;
+    }
+    if (isAuthenticationBlockedError(retry.error)) {
+      this.lastRecovery = {
+        rejectedToken: retryToken,
+        work: Promise.resolve(false),
+      };
+    }
+    throw retry.error;
+  }
+
+  async on(
+    dataKey: SharedDatabaseDataKey,
+    callback: () => void,
+    signal: AbortSignal,
+  ): Promise<void> {
+    await this.bridge.on(dataKey, callback, signal);
+  }
+
+  async authenticationRequired(): Promise<void> {
+    if (this.retryingQueries > 0) {
+      return;
+    }
+    await this.recoverAuthentication(this.rootSignal);
+  }
+
+  private recoverAuthentication(signal: AbortSignal): Promise<boolean> {
+    const heartbeat = this.requireHeartbeatRegistration();
+    const work = this.authenticationRecoveryWork(heartbeat);
+    return waitForSharedWork(work, signal);
+  }
+
+  private requireHeartbeatRegistration(): SharedDatabaseHeartbeat {
+    if (!this.heartbeatRegistration) {
+      throw new Error("Shared database heartbeat is required first");
+    }
+    return this.heartbeatRegistration;
+  }
+
+  private authenticationRecoveryWork(
+    rejectedHeartbeat: SharedDatabaseHeartbeat,
+  ): Promise<boolean> {
+    if (this.activeRecovery) {
+      return this.activeRecovery;
+    }
+    if (this.lastRecovery?.rejectedToken === rejectedHeartbeat.identity.token) {
+      return this.lastRecovery.work;
+    }
+
+    const recovery = withCleanup(
+      this.runAuthenticationRecovery(rejectedHeartbeat),
+      () => {
+        if (this.activeRecovery === recovery) {
+          this.activeRecovery = null;
+        }
+      },
+    );
+    this.activeRecovery = recovery;
+    this.lastRecovery = {
+      rejectedToken: rejectedHeartbeat.identity.token,
+      work: recovery,
+    };
+    return recovery;
+  }
+
+  private async runAuthenticationRecovery(
+    rejectedHeartbeat: SharedDatabaseHeartbeat,
+  ): Promise<boolean> {
+    const token = await this.forceRefreshToken(this.rootSignal);
+    this.rootSignal.throwIfAborted();
+    if (!token || token === rejectedHeartbeat.identity.token) {
+      return false;
+    }
+    await this.heartbeat(
+      {
+        ...rejectedHeartbeat,
+        identity: { ...rejectedHeartbeat.identity, token },
+      },
+      this.rootSignal,
+    );
+    return true;
+  }
+}

--- a/turbo/apps/platform/src/shared-database/auth-recovering-client.ts
+++ b/turbo/apps/platform/src/shared-database/auth-recovering-client.ts
@@ -1,6 +1,7 @@
 import {
   createChildAbortController,
   createDeferredPromise,
+  onRejection,
   settle,
   withCleanup,
 } from "../signals/utils.ts";
@@ -142,7 +143,11 @@ export class AuthRecoveringSharedDatabaseBridge implements SharedDatabaseBridge 
     }
 
     const recovery = withCleanup(
-      this.runAuthenticationRecovery(rejectedHeartbeat),
+      onRejection(this.runAuthenticationRecovery(rejectedHeartbeat), () => {
+        if (this.lastRecovery?.work === recovery) {
+          this.lastRecovery = null;
+        }
+      }),
       () => {
         if (this.activeRecovery === recovery) {
           this.activeRecovery = null;

--- a/turbo/apps/platform/src/shared-database/bridge.ts
+++ b/turbo/apps/platform/src/shared-database/bridge.ts
@@ -31,6 +31,7 @@ export interface SharedDatabaseBridge {
 }
 
 export interface SharedDatabaseBridgeEvents {
+  readonly authenticationRequired: () => void;
   readonly reloadRequired: () => void;
   readonly statusChanged: (status: SharedDatabaseConnectionStatus) => void;
 }

--- a/turbo/apps/platform/src/shared-database/message-port-client.ts
+++ b/turbo/apps/platform/src/shared-database/message-port-client.ts
@@ -54,6 +54,10 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
         this.events.reloadRequired();
         return;
       }
+      if (message.type === "authentication-required") {
+        this.events.authenticationRequired();
+        return;
+      }
       if (message.type === "status") {
         this.events.statusChanged(message.status);
         return;

--- a/turbo/apps/platform/src/shared-database/protocol.ts
+++ b/turbo/apps/platform/src/shared-database/protocol.ts
@@ -7,6 +7,8 @@ import {
 
 export const SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME =
   "SharedDatabaseClientNotConnectedError";
+export const SHARED_DATABASE_AUTH_BLOCKED_ERROR_NAME =
+  "SharedDatabaseAuthBlockedError";
 
 export const sharedDatabaseHeartbeatResultSchema = z
   .object({ clientReconnected: z.boolean() })
@@ -110,6 +112,10 @@ const reloadRequiredMessageSchema = z
   .object({ type: z.literal("reload-required") })
   .strict();
 
+const authenticationRequiredMessageSchema = z
+  .object({ type: z.literal("authentication-required") })
+  .strict();
+
 export const sharedDatabaseConnectionStatusSchema = z.enum([
   "connecting",
   "connected",
@@ -132,6 +138,7 @@ export const sharedDatabaseWorkerMessageSchema = z.discriminatedUnion("type", [
   errorMessageSchema,
   appendMessageSchema,
   reloadRequiredMessageSchema,
+  authenticationRequiredMessageSchema,
   statusMessageSchema,
 ]);
 

--- a/turbo/apps/platform/src/shared-database/reconnecting-client.ts
+++ b/turbo/apps/platform/src/shared-database/reconnecting-client.ts
@@ -272,6 +272,11 @@ export class ReconnectingSharedDatabaseBridge implements SharedDatabaseBridge {
     const generation = ++this.generation;
     this.options.events.statusChanged("connecting");
     const bridge = this.options.createBridge({
+      authenticationRequired: () => {
+        if (this.connection?.generation === generation) {
+          this.options.events.authenticationRequired();
+        }
+      },
       reloadRequired: () => {
         if (this.connection?.generation === generation) {
           this.options.events.reloadRequired();

--- a/turbo/apps/platform/src/shared-database/test-bridge.ts
+++ b/turbo/apps/platform/src/shared-database/test-bridge.ts
@@ -31,7 +31,13 @@ import { createDeferredPromise } from "../signals/utils.ts";
 
 type DirectWorkerEvent = Extract<
   SharedDatabaseWorkerMessage,
-  { readonly type: "append" | "reload-required" | "status" }
+  {
+    readonly type:
+      | "append"
+      | "authentication-required"
+      | "reload-required"
+      | "status";
+  }
 >;
 
 async function waitForWorkerOperation<T>(
@@ -72,6 +78,9 @@ class DirectSharedDatabaseBridge implements SharedDatabaseBridge {
     }
     if (event.type === "reload-required") {
       location.reload();
+      return;
+    }
+    if (event.type === "authentication-required") {
       return;
     }
     this.platformStore.set(setSharedDatabaseConnectionStatus$, event.status);

--- a/turbo/apps/platform/src/shared-database/worker-runtime.ts
+++ b/turbo/apps/platform/src/shared-database/worker-runtime.ts
@@ -43,6 +43,7 @@ import {
   type SharedDatabaseQueryResult,
 } from "./data-key.ts";
 import {
+  SHARED_DATABASE_AUTH_BLOCKED_ERROR_NAME,
   SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME,
   type SharedDatabaseConnectionStatus,
   type SharedDatabaseHeartbeatResult,
@@ -82,7 +83,11 @@ function chatEventRowsQuery(cursor: ChatEventCursor) {
 type WorkerClientEvent = Extract<
   SharedDatabaseWorkerMessage,
   {
-    readonly type: "append" | "reload-required" | "status";
+    readonly type:
+      | "append"
+      | "authentication-required"
+      | "reload-required"
+      | "status";
   }
 >;
 
@@ -186,7 +191,7 @@ class SharedDatabaseAuthBlockedError extends Error {
     super(
       "Shared database remote synchronization is blocked by authentication",
     );
-    this.name = "SharedDatabaseAuthBlockedError";
+    this.name = SHARED_DATABASE_AUTH_BLOCKED_ERROR_NAME;
   }
 }
 
@@ -1455,7 +1460,7 @@ export class SharedDatabaseWorkerRuntime {
     credential: CredentialState,
     rejectedToken: string,
   ): void {
-    if (credential.token !== rejectedToken) {
+    if (credential.token !== rejectedToken || credential.authBlocked) {
       return;
     }
     L.debug("auth.block", {
@@ -1477,6 +1482,7 @@ export class SharedDatabaseWorkerRuntime {
         client.identity?.userId === credential.userId &&
         client.identity.orgId === credential.orgId
       ) {
+        client.emit({ type: "authentication-required" });
         client.emit({ type: "status", status: "disconnected" });
       }
     }

--- a/turbo/apps/platform/src/signals/__tests__/shared-database-browser.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/shared-database-browser.test.ts
@@ -5,6 +5,7 @@ import type {
   SharedDatabaseHeartbeat,
   SharedDatabasePortLike,
 } from "../../shared-database/bridge.ts";
+import type { AuthRecovery } from "../auth-retry.ts";
 import { heartbeatSharedDatabase$ } from "../shared-database.ts";
 import { setupSharedDatabaseBridge$ } from "../shared-database-browser.ts";
 import { testContext } from "./test-helpers.ts";
@@ -12,6 +13,7 @@ import { testContext } from "./test-helpers.ts";
 const context = testContext();
 
 class TestSharedWorkerPort implements SharedDatabasePortLike {
+  readonly heartbeatTokens: string[] = [];
   private listener: ((event: MessageEvent<unknown>) => void) | null = null;
 
   postMessage(value: unknown): void {
@@ -24,6 +26,15 @@ class TestSharedWorkerPort implements SharedDatabasePortLike {
       typeof value.requestId !== "string"
     ) {
       return;
+    }
+    if (
+      "identity" in value &&
+      typeof value.identity === "object" &&
+      value.identity !== null &&
+      "token" in value.identity &&
+      typeof value.identity.token === "string"
+    ) {
+      this.heartbeatTokens.push(value.identity.token);
     }
     const requestId = value.requestId;
     queueMicrotask(() => {
@@ -40,6 +51,16 @@ class TestSharedWorkerPort implements SharedDatabasePortLike {
   }
 
   start(): void {}
+
+  requireAuthentication(): void {
+    queueMicrotask(() => {
+      this.listener?.(
+        new MessageEvent("message", {
+          data: { type: "authentication-required" },
+        }),
+      );
+    });
+  }
 
   close(): void {
     this.listener = null;
@@ -106,6 +127,10 @@ class TestSharedWorker {
       }),
     );
   }
+
+  requireAuthentication(): void {
+    this.port.requireAuthentication();
+  }
 }
 
 function installSharedWorkerMock(): {
@@ -134,8 +159,19 @@ function sharedDatabaseHeartbeat(): SharedDatabaseHeartbeat {
   };
 }
 
-async function setupBridge(): Promise<void> {
-  context.store.set(setupSharedDatabaseBridge$, context.signal);
+function authRecovery(replacementToken = "replacement-token"): AuthRecovery {
+  return {
+    getToken: () => {
+      return Promise.resolve("shared-worker-token");
+    },
+    forceRefreshToken: () => {
+      return Promise.resolve(replacementToken);
+    },
+  };
+}
+
+async function setupBridge(recovery = authRecovery()): Promise<void> {
+  context.store.set(setupSharedDatabaseBridge$, recovery, context.signal);
   await context.store.set(
     heartbeatSharedDatabase$,
     sharedDatabaseHeartbeat(),
@@ -144,6 +180,20 @@ async function setupBridge(): Promise<void> {
 }
 
 describe("shared database browser bridge", () => {
+  it("forces an auth refresh when the worker rejects its credential", async () => {
+    const { workers } = installSharedWorkerMock();
+    await setupBridge();
+
+    workers[0]!.requireAuthentication();
+
+    await vi.waitFor(() => {
+      expect(workers[0]!.port.heartbeatTokens).toStrictEqual([
+        "shared-worker-token",
+        "replacement-token",
+      ]);
+    });
+  });
+
   it("creates the shared worker with the Okou core service identity", async () => {
     const { constructorCalls } = installSharedWorkerMock();
 

--- a/turbo/apps/platform/src/signals/authenticated-daemons.ts
+++ b/turbo/apps/platform/src/signals/authenticated-daemons.ts
@@ -1,6 +1,6 @@
 import { command } from "ccstate";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import { clerk$ } from "./auth.ts";
+import { authRecovery$, clerk$ } from "./auth.ts";
 import {
   subscribeChatThreadReadCursorUpdated$,
   subscribeThreadListChanged$,
@@ -39,7 +39,9 @@ export const setupAuthenticatedDaemons$ = command(
       get(featureSwitch$)[FeatureSwitchKey.SharedChatDatabase] ?? false;
     set(selectSharedDatabaseMode$, sharedDatabaseEnabled);
     if (sharedDatabaseEnabled) {
-      set(setupSharedDatabaseBridge$, signal);
+      const authRecovery = await get(authRecovery$);
+      signal.throwIfAborted();
+      set(setupSharedDatabaseBridge$, authRecovery, signal);
       await set(heartbeatSharedDatabaseNow$, signal);
       signal.throwIfAborted();
     }

--- a/turbo/apps/platform/src/signals/shared-database-browser.ts
+++ b/turbo/apps/platform/src/signals/shared-database-browser.ts
@@ -4,6 +4,7 @@ import { getCapturedPreviewBypassForTarget } from "../lib/preview-bypass-cookie.
 import { sentryLogContext } from "../lib/sentry-config.ts";
 import { resolveApiBaseForTarget } from "./api-base.ts";
 import { authRecovery$, authenticatedIdentity$ } from "./auth.ts";
+import type { AuthRecovery } from "./auth-retry.ts";
 import { logger } from "./log.ts";
 import {
   createChildAbortController,
@@ -15,6 +16,7 @@ import {
   withCleanup,
 } from "./utils.ts";
 import { MessagePortSharedDatabaseBridge } from "../shared-database/message-port-client.ts";
+import { AuthRecoveringSharedDatabaseBridge } from "../shared-database/auth-recovering-client.ts";
 import {
   ReconnectingSharedDatabaseBridge,
   SharedDatabaseTransportError,
@@ -28,6 +30,7 @@ import {
 } from "./shared-database.ts";
 
 const MAX_HEARTBEAT_INTERVAL_MS = 60_000;
+const AUTHENTICATION_REQUIRED_EVENT = "authentication-required";
 const L = logger("SharedDatabaseBrowser");
 
 interface JwtLifetime {
@@ -139,13 +142,14 @@ async function resolveWorkerRecovery(
 }
 
 export const setupSharedDatabaseBridge$ = command(
-  ({ get, set }, signal: AbortSignal): void => {
+  ({ get, set }, authRecovery: AuthRecovery, signal: AbortSignal): void => {
     signal.throwIfAborted();
     if (get(sharedDatabaseBridgeInstalled$)) {
       return;
     }
     const apiBaseUrl = resolveApiBaseForTarget("api");
-    const bridge = new ReconnectingSharedDatabaseBridge({
+    const authenticationRequiredTarget = new EventTarget();
+    const reconnectingBridge = new ReconnectingSharedDatabaseBridge({
       createBridge: (events) => {
         const worker = new SharedDatabaseWorker({ name: "okou core service" });
         const portBridge = new MessagePortSharedDatabaseBridge(
@@ -187,6 +191,11 @@ export const setupSharedDatabaseBridge$ = command(
         return portBridge;
       },
       events: {
+        authenticationRequired: () => {
+          authenticationRequiredTarget.dispatchEvent(
+            new Event(AUTHENTICATION_REQUIRED_EVENT),
+          );
+        },
         reloadRequired: () => {
           location.reload();
         },
@@ -195,6 +204,20 @@ export const setupSharedDatabaseBridge$ = command(
         },
       },
     });
+    const bridge = new AuthRecoveringSharedDatabaseBridge(
+      reconnectingBridge,
+      async (recoverySignal) => {
+        return await authRecovery.forceRefreshToken(recoverySignal);
+      },
+      signal,
+    );
+    authenticationRequiredTarget.addEventListener(
+      AUTHENTICATION_REQUIRED_EVENT,
+      onDomEventFn(async () => {
+        await bridge.authenticationRequired();
+      }),
+      { signal },
+    );
     set(installSharedDatabaseBridge$, bridge);
   },
 );


### PR DESCRIPTION
## Summary

- broadcast SharedWorker authentication failures to every matching app client
- force-refresh the Clerk token, heartbeat the replacement credential, and coalesce concurrent recovery waiters
- retry an auth-blocked query once while keeping root recovery alive after caller cancellation and preventing retry loops after a second 401

## Context

PR #30263 merged while this PR was being verified and made the SharedWorker startup graph DOM-free. This branch is rebased onto that merge (`2f2113e`) and deliberately drops its duplicate DOM fix; the resulting preview includes both the startup fix from `main` and this PRs 401 recovery.

## Verification

- `pnpm format`
- app lint, Knip, app/API-contract/workspace type checks
- 5 focused SharedWorker files / 43 tests passed after the rebase
- full final-head PR pipeline passed, including all 8 App test shards, types, lint, Knip, security scans, deploys, and serial E2E

## Preview QA

Target: `503b467ab01d6894c39222dd4b3439f64184474d` on `https://pr-30265-app.omby.ai` with API `https://pr-30265-api.vm6.ai`, Chromium 151, 1440x1000. Preview org-admin account; onboarding completed through the UI, not bypassed. Enabled switch: `sharedChatDatabase`.

- **PASS — Worker startup:** preview requested `shared-database-worker-K0-lrqwl.js`; no `document is not defined`, Worker load error, or page exception.
- **PASS — thread synchronization:** API-created fixture `9e3c3f4d-864b-485d-b9a7-12b090fb6197` appeared in the Worker-backed thread list.
- **PASS — 401 recovery:** an injected invalid credential produced one `authentication-required` broadcast and `SharedDatabaseAuthBlockedError`; Clerk force refresh rotated the token and the second 500ms catch-up attempt succeeded without a page reload.

![sharedChatDatabase enabled](https://cdn.okou.io/artifacts/ehykq9g6u8.png)

![Worker-backed thread visible after recovery](https://cdn.okou.io/artifacts/14whbepczj.png)