### PR TITLE
test: remove retired morning brief route tombstone

### DIFF
--- a/turbo/apps/api/src/__tests__/vercel-crons.test.ts
+++ b/turbo/apps/api/src/__tests__/vercel-crons.test.ts
@@ -194,21 +194,4 @@ describe("vercel cron config", () => {
       routePaths.has("/api/internal/cron/aggregate-model-stats"),
     ).toBeFalsy();
   });
-
-  it("does not register retired Morning Brief launch paths", () => {
-    const routePaths = new Set(
-      ROUTES.map(({ route }) => {
-        return route.path;
-      }),
-    );
-    const cronPaths = new Set(
-      (readVercelConfig().crons ?? []).map(({ path }) => {
-        return path;
-      }),
-    );
-
-    expect(routePaths.has("/api/cron/execute-morning-briefs")).toBeFalsy();
-    expect(cronPaths.has("/api/cron/execute-morning-briefs")).toBeFalsy();
-    expect(routePaths.has("/api/morning-brief/trigger")).toBeFalsy();
-  });
 });


### PR DESCRIPTION
## Summary

- Remove the explicit `does not register retired Morning Brief launch paths` tombstone assertion identified during post-merge review of #30267.
- Preserve the exact `expectedVercelCrons` inventory assertion, duplicate-path protection, and verification that configured cron paths are registered API routes.
- Leave all runtime routes, cron configuration, contracts, feature switches, UI, writers, callbacks, compatibility fallbacks, migrations, Official Workflow behavior, release files, and production state unchanged.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `DATABASE_URL='postgresql://postgres:postgres@localhost:5432/vm0_test' pnpm --filter api exec vitest run src/__tests__/vercel-crons.test.ts` — 1 file passed, 3 tests passed

## Self-review

- Reviewed the authoritative one-file diff against current `REVIEW.md`, `docs/bad-smell.md`, `docs/testing.md`, the API testing references, and `docs/fallback.md`.
- No P0 or P1 findings; no new fallback or compatibility behavior; no release-triggering files.

Repair for #30267 under #30264 and EPIC #28905.

Closes #30271
