### PR TITLE
refactor(guest): retire legacy tool cgroup reader

### DIFF
--- a/crates/guest-contracts/src/process_containment.rs
+++ b/crates/guest-contracts/src/process_containment.rs
@@ -59,12 +59,11 @@ pub const WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV: &str = "VM0_WORKLOAD_CGROUP_PROCS_
 /// uses cloned descriptors only from CLI-child `pre_exec` hooks.
 pub const CANONICAL_WORKLOAD_CGROUP_PROCS_ENV: &str = "OKOU_WORKLOAD_CGROUP_PROCS_ENDPOINT";
 
-/// Legacy tool-placement endpoint spelling retained for downstream rollback.
+/// Retired tool-placement endpoint spelling retained for boundary scrubbing.
 ///
 /// Guest Agent no longer reads this spelling from the root bootstrap, but
-/// still scrubs it after capturing the canonical pair. `guest-tool-exec` and
-/// the managed mock launcher continue reading it from rollback-retained managed
-/// CLI children until the downstream cleanup gates in #28914 are complete.
+/// still scrubs it after capturing the canonical pair. Root-bootstrap and child
+/// environment tests also name it to prove stale input is removed or ignored.
 pub const TOOL_CGROUP_PROCS_ENDPOINT_ENV: &str = "VM0_TOOL_CGROUP_PROCS_ENDPOINT";
 
 /// Canonical alias for [`TOOL_CGROUP_PROCS_ENDPOINT_ENV`].
@@ -75,10 +74,9 @@ pub const TOOL_CGROUP_PROCS_ENDPOINT_ENV: &str = "VM0_TOOL_CGROUP_PROCS_ENDPOINT
 /// used by [`TOOL_EXEC_PATH`] to request a unique tool cgroup before executing
 /// user code.
 ///
-/// `guest-tool-exec` retains [`TOOL_CGROUP_PROCS_ENDPOINT_ENV`] as a rollback
-/// fallback until the downstream-writer cutover is released, pre-cutover Guest
-/// runtimes and reusable sandboxes are drained, the observation and rollback
-/// windows are complete, and legacy reads are zero under #28914.
+/// `guest-tool-exec` and the managed mock launcher consult only this spelling;
+/// [`TOOL_CGROUP_PROCS_ENDPOINT_ENV`] remains a retired-key identifier rather
+/// than a downstream compatibility input.
 pub const CANONICAL_TOOL_CGROUP_PROCS_ENV: &str = "OKOU_TOOL_CGROUP_PROCS_ENDPOINT";
 
 /// Smallest Runner profile vCPU count validated for workload containment.
@@ -316,7 +314,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cgroup_placement_environment_contracts_preserve_legacy_aliases() {
+    fn cgroup_placement_environment_contracts_preserve_retired_keys() {
         assert_eq!(
             WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
             "VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT"

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -4,22 +4,19 @@ mod stream_json_input;
 
 use crate::args::ParsedArgs;
 use crate::scenario::MockScenario;
-use guest_contracts::process_containment::{
-    CANONICAL_TOOL_CGROUP_PROCS_ENV, TOOL_CGROUP_PROCS_ENDPOINT_ENV, TOOL_EXEC_PATH,
-};
+use guest_contracts::process_containment::{CANONICAL_TOOL_CGROUP_PROCS_ENV, TOOL_EXEC_PATH};
 use std::ffi::OsStr;
 use std::io::BufReader;
 use std::process::{Command, ExitCode};
 
 fn bash_tool_command() -> Command {
     let canonical = std::env::var_os(CANONICAL_TOOL_CGROUP_PROCS_ENV);
-    let legacy = std::env::var_os(TOOL_CGROUP_PROCS_ENDPOINT_ENV);
-    let binary = bash_tool_binary(canonical.as_deref(), legacy.as_deref());
+    let binary = bash_tool_binary(canonical.as_deref());
     Command::new(binary)
 }
 
-fn bash_tool_binary(canonical: Option<&OsStr>, legacy: Option<&OsStr>) -> &'static str {
-    if canonical.is_some() || legacy.is_some() {
+fn bash_tool_binary(canonical: Option<&OsStr>) -> &'static str {
+    if canonical.is_some() {
         TOOL_EXEC_PATH
     } else {
         "bash"
@@ -160,18 +157,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn either_tool_endpoint_alias_selects_the_managed_launcher() {
+    fn canonical_tool_endpoint_presence_selects_the_managed_launcher() {
         let endpoint = OsStr::new("endpoint");
         let empty = OsStr::new("");
 
-        assert_eq!(bash_tool_binary(None, None), "bash");
-        assert_eq!(bash_tool_binary(Some(endpoint), None), TOOL_EXEC_PATH);
-        assert_eq!(bash_tool_binary(None, Some(endpoint)), TOOL_EXEC_PATH);
-        assert_eq!(
-            bash_tool_binary(Some(endpoint), Some(endpoint)),
-            TOOL_EXEC_PATH
-        );
-        assert_eq!(bash_tool_binary(Some(empty), None), TOOL_EXEC_PATH);
-        assert_eq!(bash_tool_binary(None, Some(empty)), TOOL_EXEC_PATH);
+        assert_eq!(bash_tool_binary(None), "bash");
+        assert_eq!(bash_tool_binary(Some(endpoint)), TOOL_EXEC_PATH);
+        assert_eq!(bash_tool_binary(Some(empty)), TOOL_EXEC_PATH);
     }
 }

--- a/crates/guest-tool-exec/src/lib.rs
+++ b/crates/guest-tool-exec/src/lib.rs
@@ -14,7 +14,7 @@ use guest_contracts::managed_command::{
 };
 use guest_contracts::process_containment::{
     CANONICAL_TOOL_CGROUP_PROCS_ENV, EXEC_CGROUP_NAME_PREFIX, RUNTIME_CGROUP_NAME,
-    TOOL_CGROUP_PROCS_ENDPOINT_ENV, WORKLOAD_CGROUP_NAME,
+    WORKLOAD_CGROUP_NAME,
 };
 use serde::Deserialize;
 use serde_json::{Map, Value, json};
@@ -130,43 +130,27 @@ fn place_managed_tool() -> io::Result<()> {
     place_current_process(&endpoint)
 }
 
-/// Resolve Stage 1 compatibility between managed CLI children and this tool
-/// reader. Existing runners and reusable sandboxes can run for the two-hour
-/// guest runtime budget plus bounded finalization. #28914 owns the later
-/// writer-cutover and reader-removal follow-ups; remove the legacy branch only
-/// after the reader floor, drain, rollback window, and legacy-read-zero gates.
+/// Resolve the canonical endpoint written to managed CLI children by Guest
+/// Agent. The endpoint value stays out of diagnostics on every invalid path.
 fn tool_placement_endpoint_from_process_env() -> io::Result<String> {
-    let canonical = env::var_os(CANONICAL_TOOL_CGROUP_PROCS_ENV);
-    let legacy = env::var_os(TOOL_CGROUP_PROCS_ENDPOINT_ENV);
-    resolve_tool_placement_endpoint(canonical, legacy)
+    resolve_tool_placement_endpoint(env::var_os(CANONICAL_TOOL_CGROUP_PROCS_ENV))
 }
 
-fn resolve_tool_placement_endpoint(
-    canonical: Option<OsString>,
-    legacy: Option<OsString>,
-) -> io::Result<String> {
-    let canonical = tool_placement_endpoint_value(canonical)?;
-    let legacy = tool_placement_endpoint_value(legacy)?;
-    let endpoint = match (canonical, legacy) {
-        (None, None) => {
-            return Err(io::Error::new(
+fn resolve_tool_placement_endpoint(canonical: Option<OsString>) -> io::Result<String> {
+    let endpoint = canonical
+        .ok_or_else(|| {
+            io::Error::new(
                 io::ErrorKind::PermissionDenied,
                 "managed runtime is missing the tool placement endpoint",
-            ));
-        }
-        (Some(endpoint), None) | (None, Some(endpoint)) => endpoint,
-        (Some(canonical), Some(legacy)) if canonical == legacy => canonical,
-        (Some(_), Some(_)) => {
-            return Err(io::Error::new(
+            )
+        })?
+        .into_string()
+        .map_err(|_| {
+            io::Error::new(
                 io::ErrorKind::InvalidInput,
-                format!(
-                    "conflicting tool placement environment aliases: canonical_key={} \
-                     legacy_key={} state=conflict",
-                    CANONICAL_TOOL_CGROUP_PROCS_ENV, TOOL_CGROUP_PROCS_ENDPOINT_ENV
-                ),
-            ));
-        }
-    };
+                "tool placement endpoint is not valid UTF-8",
+            )
+        })?;
     if endpoint.is_empty() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -174,19 +158,6 @@ fn resolve_tool_placement_endpoint(
         ));
     }
     Ok(endpoint)
-}
-
-fn tool_placement_endpoint_value(value: Option<OsString>) -> io::Result<Option<String>> {
-    value
-        .map(|value| {
-            value.into_string().map_err(|_| {
-                io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "tool placement endpoint is not valid UTF-8",
-                )
-            })
-        })
-        .transpose()
 }
 
 fn current_process_is_runtime() -> io::Result<bool> {
@@ -341,111 +312,36 @@ mod tests {
     }
 
     #[test]
-    fn resolves_tool_placement_aliases_and_preserves_empty_validation() {
-        for (name, canonical, legacy, expected) in [
-            (
-                "canonical-only",
-                Some("canonical-endpoint"),
-                None,
-                "canonical-endpoint",
-            ),
-            (
-                "legacy-only",
-                None,
-                Some("legacy-endpoint"),
-                "legacy-endpoint",
-            ),
-            (
-                "equal-dual",
-                Some("shared-endpoint"),
-                Some("shared-endpoint"),
-                "shared-endpoint",
-            ),
-        ] {
-            let endpoint = resolve_tool_placement_endpoint(
-                canonical.map(OsString::from),
-                legacy.map(OsString::from),
-            )
-            .unwrap();
-            assert_eq!(endpoint, expected, "{name} resolved incorrectly");
-        }
+    fn resolves_canonical_tool_placement_endpoint() {
+        let endpoint =
+            resolve_tool_placement_endpoint(Some(OsString::from("canonical-endpoint"))).unwrap();
 
-        for (name, canonical, legacy) in [
-            ("canonical-empty", Some(""), None),
-            ("legacy-empty", None, Some("")),
-            ("dual-empty", Some(""), Some("")),
-        ] {
-            let error = resolve_tool_placement_endpoint(
-                canonical.map(OsString::from),
-                legacy.map(OsString::from),
-            )
-            .unwrap_err();
-            assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
-            assert_eq!(
-                error.to_string(),
-                "tool placement endpoint is empty",
-                "{name}"
-            );
-        }
+        assert_eq!(endpoint, "canonical-endpoint");
     }
 
     #[test]
-    fn rejects_tool_placement_conflicts_and_invalid_encoding_without_values() {
-        let conflict = resolve_tool_placement_endpoint(
-            Some(OsString::from("canonical-must-not-leak")),
-            Some(OsString::from("legacy-must-not-leak")),
-        )
-        .unwrap_err();
-        assert_eq!(conflict.kind(), io::ErrorKind::InvalidInput);
+    fn rejects_missing_empty_and_non_unicode_canonical_endpoint_without_values() {
+        let missing = resolve_tool_placement_endpoint(None).unwrap_err();
+        assert_eq!(missing.kind(), io::ErrorKind::PermissionDenied);
         assert_eq!(
-            conflict.to_string(),
-            format!(
-                "conflicting tool placement environment aliases: canonical_key={} \
-                 legacy_key={} state=conflict",
-                CANONICAL_TOOL_CGROUP_PROCS_ENV, TOOL_CGROUP_PROCS_ENDPOINT_ENV
-            )
+            missing.to_string(),
+            "managed runtime is missing the tool placement endpoint"
         );
-        assert!(!conflict.to_string().contains("must-not-leak"));
 
-        for (name, canonical, legacy) in [
-            (
-                "canonical-non-unicode",
-                Some(OsString::from_vec(vec![0xff])),
-                None,
-            ),
-            (
-                "legacy-non-unicode",
-                None,
-                Some(OsString::from_vec(vec![0xff])),
-            ),
-            (
-                "readable-with-non-unicode",
-                Some(OsString::from("canonical-must-not-leak")),
-                Some(OsString::from_vec(vec![0xff])),
-            ),
-        ] {
-            let error = resolve_tool_placement_endpoint(canonical, legacy).unwrap_err();
-            assert_eq!(error.kind(), io::ErrorKind::InvalidInput, "{name}");
-            assert_eq!(
-                error.to_string(),
-                "tool placement endpoint is not valid UTF-8",
-                "{name}"
-            );
-            assert!(!error.to_string().contains("must-not-leak"), "{name}");
-        }
+        let empty = resolve_tool_placement_endpoint(Some(OsString::new())).unwrap_err();
+        assert_eq!(empty.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(empty.to_string(), "tool placement endpoint is empty");
 
-        for (name, canonical, legacy) in [
-            ("canonical-empty", "", "legacy-must-not-leak"),
-            ("legacy-empty", "canonical-must-not-leak", ""),
-        ] {
-            let error = resolve_tool_placement_endpoint(
-                Some(OsString::from(canonical)),
-                Some(OsString::from(legacy)),
-            )
-            .unwrap_err();
-            assert_eq!(error.to_string(), conflict.to_string(), "{name}");
-            assert!(!error.to_string().contains("must-not-leak"), "{name}");
-        }
+        let non_unicode = resolve_tool_placement_endpoint(Some(OsString::from_vec(
+            b"canonical-must-not-leak\xff".to_vec(),
+        )))
+        .unwrap_err();
+        assert_eq!(non_unicode.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(
+            non_unicode.to_string(),
+            "tool placement endpoint is not valid UTF-8"
+        );
+        assert!(!non_unicode.to_string().contains("must-not-leak"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- resolve managed tool placement only from `OKOU_TOOL_CGROUP_PROCS_ENDPOINT`
- select the mock managed launcher only when the canonical endpoint key is present
- retain retired shared constants for root-boundary scrubbing and negative coverage

## Verification

- `cargo fmt --check`
- `cargo clippy -p guest-tool-exec --all-targets --all-features -- -D warnings`
- `cargo check -p guest-tool-exec --all-targets --all-features`
- `cargo test -p guest-tool-exec` (9 passed)
- `cargo clippy -p guest-mock-claude --all-targets --all-features -- -D warnings`
- `cargo check -p guest-mock-claude --all-targets --all-features`
- `env -u OKOU_TOOL_CGROUP_PROCS_ENDPOINT cargo test -p guest-mock-claude` (70 passed; the managed implementation environment injects this canonical key)
- `cargo clippy -p guest-contracts --all-targets --all-features -- -D warnings`
- `cargo check -p guest-contracts --all-targets --all-features`
- `cargo test -p guest-contracts cgroup_placement_environment_contracts`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-tool-exec -p guest-mock-claude -p guest-contracts --all-features --no-deps`
- `bash -n .github/scripts/runner-behavior-process-containment.sh`
- `shellcheck .github/scripts/runner-behavior-process-containment.sh`

Closes #30276

Refs #28914
