### PR TITLE
refactor(guest): retire api token legacy reader

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -26,7 +26,7 @@ const TEST_CLAUDE_CONFIG_DIR_ENV_KEY: &str = "OKOU_TEST_CLAUDE_CONFIG_DIR";
 #[cfg(debug_assertions)]
 const TEST_CODEX_HOME_DIR_ENV_KEY: &str = "OKOU_TEST_CODEX_HOME_DIR";
 
-const BOOTSTRAP_ALIAS_SOURCE_EVENT_COUNT: usize = 9;
+const BOOTSTRAP_ALIAS_SOURCE_EVENT_COUNT: usize = 8;
 
 #[derive(Clone, Copy)]
 struct BootstrapAliasSourceEventSpec {
@@ -65,10 +65,6 @@ const BOOTSTRAP_ALIAS_SOURCE_EVENT_INVENTORY: [BootstrapAliasSourceEventSpec;
         canonical_key: guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV,
     },
     BootstrapAliasSourceEventSpec {
-        family: "api_token_env_source",
-        canonical_key: guest_contracts::env::CANONICAL_API_TOKEN_ENV,
-    },
-    BootstrapAliasSourceEventSpec {
         family: "agent_execution_timeout_env_source",
         canonical_key: guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
     },
@@ -83,7 +79,6 @@ enum BootstrapAlias {
     PostResultSigkillGrace,
     UserEnvFile,
     RunPayloadFile,
-    ApiToken,
     AgentExecutionTimeout,
 }
 
@@ -106,7 +101,7 @@ impl BootstrapAliasSource {
 
 /// Fixed-size, value-free source evidence captured while resolving bootstrap aliases.
 ///
-/// The internal slots correspond exactly to the nine canonical keys in
+/// The internal slots correspond exactly to the eight canonical keys in
 /// `BOOTSTRAP_ALIAS_SOURCE_EVENT_INVENTORY`. Only guest-agent's environment
 /// resolvers can populate them.
 #[derive(Clone, Default)]
@@ -118,7 +113,6 @@ pub struct BootstrapAliasSourceEvents {
     post_result_sigkill_grace: Option<BootstrapAliasSource>,
     user_env_file: Option<BootstrapAliasSource>,
     run_payload_file: Option<BootstrapAliasSource>,
-    api_token: Option<BootstrapAliasSource>,
     agent_execution_timeout: Option<BootstrapAliasSource>,
 }
 
@@ -132,7 +126,6 @@ impl BootstrapAliasSourceEvents {
             BootstrapAlias::PostResultSigkillGrace => &mut self.post_result_sigkill_grace,
             BootstrapAlias::UserEnvFile => &mut self.user_env_file,
             BootstrapAlias::RunPayloadFile => &mut self.run_payload_file,
-            BootstrapAlias::ApiToken => &mut self.api_token,
             BootstrapAlias::AgentExecutionTimeout => &mut self.agent_execution_timeout,
         };
         *slot = Some(source);
@@ -147,7 +140,6 @@ impl BootstrapAliasSourceEvents {
             self.post_result_sigkill_grace,
             self.user_env_file,
             self.run_payload_file,
-            self.api_token,
             self.agent_execution_timeout,
         ]
     }
@@ -244,34 +236,6 @@ fn record_private_payload_file_env_source(
     if let Some(source) = source {
         events.record(alias, source);
     }
-}
-
-/// Resolve the sensitive runner-to-guest API token at the single process-env
-/// capture boundary. Both aliases are reader-only during #28914 migration
-/// Stage 1; the runner writer remains [`guest_contracts::env::API_TOKEN_ENV`].
-fn api_token_env_or_empty(events: &mut BootstrapAliasSourceEvents) -> Result<String, String> {
-    let canonical_key = guest_contracts::env::CANONICAL_API_TOKEN_ENV;
-    let legacy_key = guest_contracts::env::API_TOKEN_ENV;
-    let canonical = std::env::var(canonical_key).ok();
-    let legacy = std::env::var(legacy_key).ok();
-
-    let (value, source) = match (canonical, legacy) {
-        (None, None) => return Ok(String::new()),
-        (Some(value), None) => (value, BootstrapAliasSource::CanonicalOnly),
-        (None, Some(value)) => (value, BootstrapAliasSource::LegacyOnly),
-        (Some(canonical), Some(legacy)) if canonical == legacy => {
-            (canonical, BootstrapAliasSource::Dual)
-        }
-        (Some(_), Some(_)) => {
-            return Err(format!(
-                "conflicting API token environment aliases: canonical_key={canonical_key} \
-                 legacy_key={legacy_key} state=conflict"
-            ));
-        }
-    };
-
-    events.record(BootstrapAlias::ApiToken, source);
-    Ok(value)
 }
 
 /// Resolve the runner-owned agent execution timeout at the single process-env
@@ -587,7 +551,7 @@ impl GuestConfigRaw {
         Ok(Self {
             run_id: env_or_empty(guest_contracts::env::RUN_ID_ENV),
             api_url,
-            api_token: api_token_env_or_empty(&mut bootstrap_alias_sources)?,
+            api_token: env_or_empty(guest_contracts::env::CANONICAL_API_TOKEN_ENV),
             sandbox_id: env_or_empty(guest_contracts::env::CANONICAL_SANDBOX_ID_ENV),
             sandbox_reuse_result: env_or_empty(
                 guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -96,7 +96,7 @@ fn format_reqwest_error(error: reqwest::Error) -> String {
 /// API-enabled runs build this during initialization and pass cheap clones to
 /// background tasks. That keeps webhook/S3 timeout configuration consistent
 /// across all HTTP calls and makes client-construction failures explicit at
-/// startup. Local/test runs without `VM0_API_TOKEN` use a disabled client so
+/// startup. Local/test runs without `OKOU_API_TOKEN` use a disabled client so
 /// they do not fail on HTTP stack setup they will never use.
 #[derive(Clone)]
 pub struct HttpClient {
@@ -129,7 +129,7 @@ impl HttpClient {
     /// Build an HTTP transport client without API webhook configuration.
     ///
     /// This constructor always initializes the underlying `reqwest` client and
-    /// does not check `VM0_API_TOKEN`. It can send presigned uploads, but
+    /// does not check `OKOU_API_TOKEN`. It can send presigned uploads, but
     /// webhook JSON posts require API config from [`Self::with_api_config`],
     /// or [`Self::for_config`].
     /// Production guest-agent initialization should use [`Self::for_config`]
@@ -267,7 +267,7 @@ impl HttpClient {
     fn inner(&self) -> Result<&Client, AgentError> {
         self.inner.as_ref().ok_or_else(|| {
             AgentError::Http(
-                "guest-agent HTTP client is disabled because VM0_API_TOKEN is unset".into(),
+                "guest-agent HTTP client is disabled because OKOU_API_TOKEN is unset".into(),
             )
         })
     }
@@ -355,12 +355,12 @@ impl ApiHttpConfig {
     ) -> Result<Self, AgentError> {
         if base_url.is_empty() {
             return Err(AgentError::Http(
-                "VM0_API_BACKEND_URL is required when VM0_API_TOKEN is set".into(),
+                "VM0_API_BACKEND_URL is required when OKOU_API_TOKEN is set".into(),
             ));
         }
         if token.is_empty() {
             return Err(AgentError::Http(
-                "VM0_API_TOKEN is required for enabled API HTTP config".into(),
+                "OKOU_API_TOKEN is required for enabled API HTTP config".into(),
             ));
         }
         reqwest::header::HeaderValue::from_str(&client_session_id)

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1164,7 +1164,7 @@ mod tests {
         for key in [
             guest_contracts::env::API_URL_ENV,
             guest_contracts::env::RUN_ID_ENV,
-            guest_contracts::env::API_TOKEN_ENV,
+            "VM0_API_TOKEN",
             guest_contracts::env::CANONICAL_API_TOKEN_ENV,
             "VM0_SANDBOX_ID",
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,

--- a/crates/guest-agent/tests/api_token_env_aliases.rs
+++ b/crates/guest-agent/tests/api_token_env_aliases.rs
@@ -1,4 +1,4 @@
-//! Sensitive API-token aliases are resolved once at the process-env boundary.
+//! Sensitive API token capture accepts only the canonical process-env key.
 
 #![cfg(unix)]
 
@@ -8,155 +8,100 @@ use std::path::Path;
 
 use guest_agent::env::{GuestConfig, GuestConfigRaw};
 use guest_agent::http::HttpClient;
-use guest_agent::run_context::GuestRuntime;
 
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
 const CANONICAL_TOKEN: &str = "canonical-token-must-not-leak";
-const LEGACY_TOKEN: &str = "legacy-token-must-not-leak";
-const SHARED_TOKEN: &str = "shared-token-must-not-leak";
-const TOKEN_VALUES: [&str; 3] = [CANONICAL_TOKEN, LEGACY_TOKEN, SHARED_TOKEN];
-const SOURCE_EVENT: &str = "api_token_env_source";
+const RETIRED_TOKEN: &str = "retired-token-must-not-leak";
+const TOKEN_VALUES: [&str; 2] = [CANONICAL_TOKEN, RETIRED_TOKEN];
 
 #[derive(Clone, Copy)]
-enum AliasInput {
+enum EnvInput {
     Absent,
     Readable(&'static str),
     NonUnicode,
 }
 
 #[derive(Clone, Copy)]
-struct SuccessCase {
+struct CaptureCase {
     name: &'static str,
-    canonical: AliasInput,
-    legacy: AliasInput,
+    canonical: EnvInput,
+    retired: EnvInput,
     expected_value: &'static str,
-    expected_source: Option<&'static str>,
 }
 
-#[derive(Clone, Copy)]
-struct ConflictCase {
-    name: &'static str,
-    canonical: &'static str,
-    legacy: &'static str,
-}
-
-const SUCCESS_CASES: [SuccessCase; 14] = [
-    SuccessCase {
+const CAPTURE_CASES: [CaptureCase; 12] = [
+    CaptureCase {
         name: "both-absent",
-        canonical: AliasInput::Absent,
-        legacy: AliasInput::Absent,
+        canonical: EnvInput::Absent,
+        retired: EnvInput::Absent,
         expected_value: "",
-        expected_source: None,
     },
-    SuccessCase {
-        name: "canonical-only",
-        canonical: AliasInput::Readable(CANONICAL_TOKEN),
-        legacy: AliasInput::Absent,
+    CaptureCase {
+        name: "retired-only-readable",
+        canonical: EnvInput::Absent,
+        retired: EnvInput::Readable(RETIRED_TOKEN),
+        expected_value: "",
+    },
+    CaptureCase {
+        name: "retired-only-empty",
+        canonical: EnvInput::Absent,
+        retired: EnvInput::Readable(""),
+        expected_value: "",
+    },
+    CaptureCase {
+        name: "retired-only-non-unicode",
+        canonical: EnvInput::Absent,
+        retired: EnvInput::NonUnicode,
+        expected_value: "",
+    },
+    CaptureCase {
+        name: "canonical-readable",
+        canonical: EnvInput::Readable(CANONICAL_TOKEN),
+        retired: EnvInput::Absent,
         expected_value: CANONICAL_TOKEN,
-        expected_source: Some("canonical-only"),
     },
-    SuccessCase {
-        name: "legacy-only",
-        canonical: AliasInput::Absent,
-        legacy: AliasInput::Readable(LEGACY_TOKEN),
-        expected_value: LEGACY_TOKEN,
-        expected_source: Some("legacy-only"),
-    },
-    SuccessCase {
-        name: "equal-dual",
-        canonical: AliasInput::Readable(SHARED_TOKEN),
-        legacy: AliasInput::Readable(SHARED_TOKEN),
-        expected_value: SHARED_TOKEN,
-        expected_source: Some("dual"),
-    },
-    SuccessCase {
-        name: "canonical-empty-only",
-        canonical: AliasInput::Readable(""),
-        legacy: AliasInput::Absent,
-        expected_value: "",
-        expected_source: Some("canonical-only"),
-    },
-    SuccessCase {
-        name: "legacy-empty-only",
-        canonical: AliasInput::Absent,
-        legacy: AliasInput::Readable(""),
-        expected_value: "",
-        expected_source: Some("legacy-only"),
-    },
-    SuccessCase {
-        name: "equal-dual-empty",
-        canonical: AliasInput::Readable(""),
-        legacy: AliasInput::Readable(""),
-        expected_value: "",
-        expected_source: Some("dual"),
-    },
-    SuccessCase {
-        name: "canonical-non-unicode-only",
-        canonical: AliasInput::NonUnicode,
-        legacy: AliasInput::Absent,
-        expected_value: "",
-        expected_source: None,
-    },
-    SuccessCase {
-        name: "legacy-non-unicode-only",
-        canonical: AliasInput::Absent,
-        legacy: AliasInput::NonUnicode,
-        expected_value: "",
-        expected_source: None,
-    },
-    SuccessCase {
-        name: "both-non-unicode",
-        canonical: AliasInput::NonUnicode,
-        legacy: AliasInput::NonUnicode,
-        expected_value: "",
-        expected_source: None,
-    },
-    SuccessCase {
-        name: "canonical-with-unreadable-legacy",
-        canonical: AliasInput::Readable(CANONICAL_TOKEN),
-        legacy: AliasInput::NonUnicode,
+    CaptureCase {
+        name: "canonical-readable-with-retired-readable",
+        canonical: EnvInput::Readable(CANONICAL_TOKEN),
+        retired: EnvInput::Readable(RETIRED_TOKEN),
         expected_value: CANONICAL_TOKEN,
-        expected_source: Some("canonical-only"),
     },
-    SuccessCase {
-        name: "legacy-with-unreadable-canonical",
-        canonical: AliasInput::NonUnicode,
-        legacy: AliasInput::Readable(LEGACY_TOKEN),
-        expected_value: LEGACY_TOKEN,
-        expected_source: Some("legacy-only"),
+    CaptureCase {
+        name: "canonical-readable-with-retired-empty",
+        canonical: EnvInput::Readable(CANONICAL_TOKEN),
+        retired: EnvInput::Readable(""),
+        expected_value: CANONICAL_TOKEN,
     },
-    SuccessCase {
-        name: "canonical-empty-with-unreadable-legacy",
-        canonical: AliasInput::Readable(""),
-        legacy: AliasInput::NonUnicode,
+    CaptureCase {
+        name: "canonical-readable-with-retired-non-unicode",
+        canonical: EnvInput::Readable(CANONICAL_TOKEN),
+        retired: EnvInput::NonUnicode,
+        expected_value: CANONICAL_TOKEN,
+    },
+    CaptureCase {
+        name: "canonical-empty",
+        canonical: EnvInput::Readable(""),
+        retired: EnvInput::Absent,
         expected_value: "",
-        expected_source: Some("canonical-only"),
     },
-    SuccessCase {
-        name: "legacy-empty-with-unreadable-canonical",
-        canonical: AliasInput::NonUnicode,
-        legacy: AliasInput::Readable(""),
+    CaptureCase {
+        name: "canonical-empty-with-retired-readable",
+        canonical: EnvInput::Readable(""),
+        retired: EnvInput::Readable(RETIRED_TOKEN),
         expected_value: "",
-        expected_source: Some("legacy-only"),
     },
-];
-
-const CONFLICT_CASES: [ConflictCase; 3] = [
-    ConflictCase {
-        name: "different-non-empty-values",
-        canonical: CANONICAL_TOKEN,
-        legacy: LEGACY_TOKEN,
+    CaptureCase {
+        name: "canonical-non-unicode",
+        canonical: EnvInput::NonUnicode,
+        retired: EnvInput::Absent,
+        expected_value: "",
     },
-    ConflictCase {
-        name: "canonical-empty-legacy-non-empty",
-        canonical: "",
-        legacy: LEGACY_TOKEN,
-    },
-    ConflictCase {
-        name: "canonical-non-empty-legacy-empty",
-        canonical: CANONICAL_TOKEN,
-        legacy: "",
+    CaptureCase {
+        name: "canonical-non-unicode-with-retired-readable",
+        canonical: EnvInput::NonUnicode,
+        retired: EnvInput::Readable(RETIRED_TOKEN),
+        expected_value: "",
     },
 ];
 
@@ -176,18 +121,18 @@ fn remove_test_env(key: impl AsRef<OsStr>) {
     }
 }
 
-fn apply_alias(key: &str, input: AliasInput) {
+fn apply_input(key: &str, input: EnvInput) {
     remove_test_env(key);
     match input {
-        AliasInput::Absent => {}
-        AliasInput::Readable(value) => set_test_env(key, value),
-        AliasInput::NonUnicode => set_test_env(key, OsString::from_vec(vec![0xff])),
+        EnvInput::Absent => {}
+        EnvInput::Readable(value) => set_test_env(key, value),
+        EnvInput::NonUnicode => set_test_env(key, OsString::from_vec(vec![0xff])),
     }
 }
 
 fn clear_api_token_env() {
     remove_test_env(guest_contracts::env::CANONICAL_API_TOKEN_ENV);
-    remove_test_env(guest_contracts::env::API_TOKEN_ENV);
+    remove_test_env("VM0_API_TOKEN");
 }
 
 fn capture_raw(log_path: &Path) -> std::io::Result<(Result<GuestConfigRaw, String>, String)> {
@@ -220,37 +165,21 @@ fn assert_value_free(text: &str, context: &str) {
     }
 }
 
-fn assert_source_evidence(log: &str, case: SuccessCase) {
-    assert_value_free(log, case.name);
-    let source_lines = log
-        .lines()
-        .filter(|line| line.contains(SOURCE_EVENT))
-        .collect::<Vec<_>>();
-    match case.expected_source {
-        Some(source) => {
-            let expected = format!(
-                "{SOURCE_EVENT} key={} source={source}",
-                guest_contracts::env::CANONICAL_API_TOKEN_ENV
-            );
-            assert!(
-                source_lines.len() == 1
-                    && source_lines
-                        .first()
-                        .and_then(|line| line.rsplit_once("] "))
-                        .is_some_and(|(_, message)| message == expected),
-                "{} emitted incorrect fixed source evidence",
-                case.name
-            );
-        }
-        None => assert!(
-            source_lines.is_empty(),
-            "{} emitted source evidence for unreadable aliases",
-            case.name
-        ),
-    }
+fn assert_no_token_migration_evidence(evidence: &str, case: CaptureCase) {
+    assert_value_free(evidence, case.name);
+    assert!(
+        !evidence.contains("api_token_env_source"),
+        "{} captured retired API-token source evidence",
+        case.name
+    );
+    assert!(
+        !evidence.contains("conflicting API token environment aliases"),
+        "{} captured a retired API-token conflict diagnostic",
+        case.name
+    );
 }
 
-fn assert_http_mode(tmp: &Path, case: SuccessCase, raw: GuestConfigRaw) -> TestResult {
+fn assert_http_mode(tmp: &Path, case: CaptureCase, raw: GuestConfigRaw) -> TestResult {
     let runtime_dir = tmp.join(format!("{}-runtime", case.name));
     let payload_dir = runtime_dir.join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
     let payload_path = payload_dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
@@ -261,7 +190,7 @@ fn assert_http_mode(tmp: &Path, case: SuccessCase, raw: GuestConfigRaw) -> TestR
     )?;
 
     let raw = GuestConfigRaw {
-        run_id: format!("api-token-alias-{}", case.name),
+        run_id: format!("api-token-canonical-{}", case.name),
         api_url: "http://127.0.0.1:1".to_string(),
         home: Some(tmp.to_string_lossy().into_owned()),
         guest_runtime_dir: Some(runtime_dir),
@@ -298,31 +227,23 @@ fn assert_http_mode(tmp: &Path, case: SuccessCase, raw: GuestConfigRaw) -> TestR
     Ok(())
 }
 
-fn expected_conflict_error() -> String {
-    format!(
-        "conflicting API token environment aliases: canonical_key={} legacy_key={} state=conflict",
-        guest_contracts::env::CANONICAL_API_TOKEN_ENV,
-        guest_contracts::env::API_TOKEN_ENV
-    )
-}
-
 #[test]
-fn process_env_dual_reads_api_token_aliases_without_value_leaks() -> TestResult {
+fn process_env_reads_only_canonical_api_token_without_value_leaks() -> TestResult {
     let tmp = tempfile::tempdir()?;
 
-    for case in SUCCESS_CASES {
-        apply_alias(
+    for case in CAPTURE_CASES {
+        apply_input(
             guest_contracts::env::CANONICAL_API_TOKEN_ENV,
             case.canonical,
         );
-        apply_alias(guest_contracts::env::API_TOKEN_ENV, case.legacy);
-        let (raw, log) = capture_raw(&tmp.path().join(format!("{}.log", case.name)))?;
+        apply_input("VM0_API_TOKEN", case.retired);
+        let (raw, evidence) = capture_raw(&tmp.path().join(format!("{}.log", case.name)))?;
         let raw = match raw {
             Ok(raw) => raw,
             Err(error) => {
                 assert_value_free(&error, case.name);
                 return Err(std::io::Error::other(format!(
-                    "{} unexpectedly rejected a readable state",
+                    "{} rejected canonical-only API-token capture",
                     case.name
                 ))
                 .into());
@@ -330,68 +251,12 @@ fn process_env_dual_reads_api_token_aliases_without_value_leaks() -> TestResult 
         };
         assert!(
             raw.api_token == case.expected_value,
-            "{} resolved the wrong token state",
+            "{} captured the wrong token state",
             case.name
         );
-        assert_source_evidence(&log, case);
+        assert_no_token_migration_evidence(&evidence, case);
         assert_http_mode(tmp.path(), case, raw)?;
     }
-
-    let expected_error = expected_conflict_error();
-    for case in CONFLICT_CASES {
-        set_test_env(
-            guest_contracts::env::CANONICAL_API_TOKEN_ENV,
-            case.canonical,
-        );
-        set_test_env(guest_contracts::env::API_TOKEN_ENV, case.legacy);
-        let (raw, log) = capture_raw(&tmp.path().join(format!("{}.log", case.name)))?;
-        let error = match raw {
-            Ok(_) => {
-                return Err(std::io::Error::other(format!(
-                    "{} accepted conflicting readable aliases",
-                    case.name
-                ))
-                .into());
-            }
-            Err(error) => error,
-        };
-        assert_value_free(&error, case.name);
-        assert_value_free(&log, case.name);
-        assert!(
-            error == expected_error,
-            "{} returned the wrong value-free conflict error",
-            case.name
-        );
-        assert!(
-            !log.contains(SOURCE_EVENT),
-            "{} emitted success evidence for a conflict",
-            case.name
-        );
-    }
-
-    set_test_env(
-        guest_contracts::env::CANONICAL_API_TOKEN_ENV,
-        CANONICAL_TOKEN,
-    );
-    set_test_env(guest_contracts::env::API_TOKEN_ENV, LEGACY_TOKEN);
-    for key in [
-        process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
-        guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
-        guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
-        guest_contracts::process_containment::CANONICAL_TOOL_CGROUP_PROCS_ENV,
-        guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV,
-    ] {
-        remove_test_env(key);
-    }
-    let runtime_error = match GuestRuntime::from_process_env() {
-        Ok(_) => return Err("production runtime accepted conflicting API token aliases".into()),
-        Err(error) => error,
-    };
-    assert_value_free(&runtime_error, "production-runtime-conflict");
-    assert!(
-        runtime_error == expected_error,
-        "production runtime did not fail at API token capture"
-    );
 
     clear_api_token_env();
     Ok(())

--- a/crates/guest-agent/tests/api_token_process_isolation.rs
+++ b/crates/guest-agent/tests/api_token_process_isolation.rs
@@ -19,7 +19,7 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
 #[tokio::test]
-async fn guest_agent_hides_api_token_aliases_from_its_cli_child() -> TestResult {
+async fn guest_agent_hides_canonical_and_retired_api_tokens_from_its_cli_child() -> TestResult {
     assert!(
         Path::new("/proc/self/environ").is_file(),
         "the process-isolation test requires procfs"
@@ -27,7 +27,7 @@ async fn guest_agent_hides_api_token_aliases_from_its_cli_child() -> TestResult 
     common::ensure_canonical_workspace_for_test()?;
 
     for (case, token_env) in [
-        ("legacy", guest_contracts::env::API_TOKEN_ENV),
+        ("retired", "VM0_API_TOKEN"),
         ("canonical", guest_contracts::env::CANONICAL_API_TOKEN_ENV),
     ] {
         assert_api_token_process_isolation(case, token_env).await?;
@@ -141,7 +141,7 @@ async fn assert_api_token_process_isolation(case: &str, token_env: &str) -> Test
 }
 
 fn write_process_inspection_probe(path: &Path, marker_path: &Path) -> TestResult {
-    let expected_legacy = format!("{}={API_TOKEN}", guest_contracts::env::API_TOKEN_ENV);
+    let expected_retired = format!("VM0_API_TOKEN={API_TOKEN}");
     let expected_canonical = format!(
         "{}={API_TOKEN}",
         guest_contracts::env::CANONICAL_API_TOKEN_ENV
@@ -166,7 +166,7 @@ fn write_process_inspection_probe(path: &Path, marker_path: &Path) -> TestResult
          printf '%s' \"$result\" > \"$marker\"\n\
          exit 1\n",
         quote_shell_arg(&marker_path.to_string_lossy()),
-        quote_shell_arg(&expected_legacy),
+        quote_shell_arg(&expected_retired),
         quote_shell_arg(&expected_canonical),
     );
     std::fs::write(path, script)?;

--- a/crates/guest-agent/tests/api_url_env_aliases.rs
+++ b/crates/guest-agent/tests/api_url_env_aliases.rs
@@ -197,7 +197,7 @@ fn clear_api_url_env() {
 
 fn clear_api_token_env() {
     remove_test_env(guest_contracts::env::CANONICAL_API_TOKEN_ENV);
-    remove_test_env(guest_contracts::env::API_TOKEN_ENV);
+    remove_test_env("VM0_API_TOKEN");
 }
 
 fn capture_raw(log_path: &Path) -> std::io::Result<(Result<GuestConfigRaw, String>, String)> {

--- a/crates/guest-agent/tests/bootstrap_alias_source_events.rs
+++ b/crates/guest-agent/tests/bootstrap_alias_source_events.rs
@@ -33,7 +33,7 @@ const SOURCE_EVENT_FAMILIES: [&str; 5] = [
     "guest_agent_tuning_env_source",
 ];
 
-const SOURCE_EVENTS: [(&str, &str); 9] = [
+const SOURCE_EVENTS: [(&str, &str); 8] = [
     (
         "api_url_env_source",
         guest_contracts::env::CANONICAL_API_URL_ENV,
@@ -61,10 +61,6 @@ const SOURCE_EVENTS: [(&str, &str); 9] = [
     (
         "private_payload_file_env_source",
         guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV,
-    ),
-    (
-        "api_token_env_source",
-        guest_contracts::env::CANONICAL_API_TOKEN_ENV,
     ),
     (
         "agent_execution_timeout_env_source",

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -246,7 +246,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
 
     assert!(!cli_env.contains_key("VM0_SECRET_VALUES"));
     for key in [
-        guest_contracts::env::API_TOKEN_ENV,
+        "VM0_API_TOKEN",
         guest_contracts::env::CANONICAL_API_TOKEN_ENV,
         guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV,
     ] {

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1047,7 +1047,7 @@ pub unsafe fn clear_guest_agent_bootstrap_env_for_test() {
         guest_contracts::env::API_URL_ENV,
         guest_contracts::env::CANONICAL_API_URL_ENV,
         guest_contracts::env::RUN_ID_ENV,
-        guest_contracts::env::API_TOKEN_ENV,
+        "VM0_API_TOKEN",
         guest_contracts::env::CANONICAL_API_TOKEN_ENV,
         "VM0_SANDBOX_ID",
         guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -40,16 +40,10 @@ pub const CANONICAL_API_URL_ENV: &str = "OKOU_API_BACKEND_URL";
 /// file path resolution.
 pub const RUN_ID_ENV: &str = "OKOU_RUN_ID";
 
-/// Legacy backend API bearer token alias retained by guest readers for rollback.
+/// Sensitive backend API bearer token for guest-agent calls.
 ///
 /// This value is runner-owned and must not be exposed through user-provided
 /// environment or CLI child env.
-pub const API_TOKEN_ENV: &str = "VM0_API_TOKEN";
-
-/// Canonical backend API bearer token alias written by the runner.
-///
-/// Guest readers retain [`API_TOKEN_ENV`] as the rollback fallback. This value
-/// has the same runner-owned isolation contract as the legacy alias.
 pub const CANONICAL_API_TOKEN_ENV: &str = "OKOU_API_TOKEN";
 
 /// Sandbox identifier assigned and written by the runner.
@@ -597,7 +591,6 @@ mod tests {
         assert_eq!(API_URL_ENV, "VM0_API_BACKEND_URL");
         assert_eq!(CANONICAL_API_URL_ENV, "OKOU_API_BACKEND_URL");
         assert_eq!(RUN_ID_ENV, "OKOU_RUN_ID");
-        assert_eq!(API_TOKEN_ENV, "VM0_API_TOKEN");
         assert_eq!(CANONICAL_API_TOKEN_ENV, "OKOU_API_TOKEN");
         assert_eq!(CANONICAL_SANDBOX_ID_ENV, "OKOU_SANDBOX_ID");
         assert_eq!(
@@ -838,7 +831,7 @@ mod tests {
             API_URL_ENV,
             CANONICAL_API_URL_ENV,
             RUN_ID_ENV,
-            API_TOKEN_ENV,
+            "VM0_API_TOKEN",
             CANONICAL_API_TOKEN_ENV,
             CANONICAL_SANDBOX_ID_ENV,
             CANONICAL_SANDBOX_REUSE_RESULT_ENV,

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -457,7 +457,7 @@ fn build_env_json_required_keys() {
             .unwrap(),
         "tok"
     );
-    assert!(!env.contains_key(guest_contracts::env::API_TOKEN_ENV));
+    assert!(!env.contains_key("VM0_API_TOKEN"));
     assert_eq!(
         env.get(guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV)
             .unwrap(),
@@ -760,7 +760,7 @@ fn fieldless_context_preserves_pre_platform_environment_filtering() {
             guest_contracts::env::PROMPT_ENV.into(),
             "user prompt".into(),
         ),
-        (guest_contracts::env::API_TOKEN_ENV.into(), "stolen".into()),
+        ("VM0_API_TOKEN".into(), "stolen".into()),
         (
             guest_contracts::env::WORKING_DIR_ENV.into(),
             "/legacy".into(),
@@ -820,7 +820,7 @@ fn fieldless_context_preserves_pre_platform_environment_filtering() {
             .unwrap(),
         "tok"
     );
-    assert!(!bootstrap_env.contains_key(guest_contracts::env::API_TOKEN_ENV));
+    assert!(!bootstrap_env.contains_key("VM0_API_TOKEN"));
     assert_eq!(
         bootstrap_env.get(guest_contracts::env::RUN_ID_ENV).unwrap(),
         &ctx.run_id.to_string()
@@ -842,7 +842,7 @@ fn fieldless_context_preserves_pre_platform_environment_filtering() {
         guest_contracts::env::PI_LAUNCH_CONFIG_ENV,
         guest_contracts::env::PI_MODEL_CONFIG_ENV,
         guest_contracts::env::PROMPT_ENV,
-        guest_contracts::env::API_TOKEN_ENV,
+        "VM0_API_TOKEN",
         guest_contracts::env::WORKING_DIR_ENV,
         "VM0_GUEST_RUNTIME_DIR",
         guest_contracts::env::FEATURE_FLAGS_ENV,
@@ -1703,7 +1703,7 @@ fn build_env_json_environment_cannot_override_system() {
             .unwrap(),
         "tok"
     );
-    assert!(!env.contains_key(guest_contracts::env::API_TOKEN_ENV));
+    assert!(!env.contains_key("VM0_API_TOKEN"));
     assert!(!env.contains_key("CUSTOM_ENV"));
     assert_eq!(user_env.get("CUSTOM_ENV").unwrap(), "kept");
     assert!(!user_env.contains_key("VM0_PROMPT"));

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -1151,7 +1151,7 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
             .unwrap(),
         "tok"
     );
-    assert!(!start_env.contains_key(guest_contracts::env::API_TOKEN_ENV));
+    assert!(!start_env.contains_key("VM0_API_TOKEN"));
     assert_eq!(
         start_env
             .get(guest_contracts::env::CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV)


### PR DESCRIPTION
Parent EPIC: #28914

Closes #30282

## Summary

- make Guest Agent API-token capture canonical-only at `GuestConfigRaw::from_process_env`
- remove the retired public alias constant, dual/conflict resolver, bootstrap alias/source slot, conflict diagnostic, and migration source event
- keep raw `VM0_API_TOKEN` literals only in retirement, hostile-input, cleanup, ownership, and process/CLI-isolation fixtures
- update active HTTP documentation and fixed diagnostics to name `OKOU_API_TOKEN`

## Scope and invariants

The reader still uses the existing `env_or_empty` behavior: absent or non-Unicode canonical input yields the empty disabled-client token, while readable input, including an empty string, is preserved exactly. Retired input is ignored and cannot override, conflict with, or disable canonical input.

This does not change the canonical Runner writer or credential source, Authorization behavior, HTTP endpoints or retries, authenticated-client construction, empty-token disabled-client behavior, API URL aliases, private payload, run metadata, timeout/tuning, process control, cgroups, ownership guards, or any other environment family. No production token material was selected, logged, formatted, hashed, measured, or otherwise derived during implementation or validation.

## Production gate

The issue's fixed aggregate-only Axiom gate covered `2026-08-29T00:00:00Z` through `2026-08-30T03:46:28Z`, was terminal and non-partial, examined 120,247 rows, and matched 3,511 fixed API-token source events across 3,510 runs. All were canonical-only; legacy-only, dual, and conflict counts were zero. The query selected only fixed labels, counts, distinct-run counts, and timestamps.

The fresh masked-production drain check at `2026-08-30T03:47:12Z` found three live production Runner rows and 18 running production Agent runs; the oldest started at `2026-08-30T02:48:17.798Z`. All seven retained rollback targets contain both the Stage 1 reader merge and canonical production writer merge.

## Base, inventory, and overlap evidence

- fresh implementation base: `416b41325cd6a19c62e4f006b7ef7a4af2aca4cb`
- initial publication base: `bb1a3d0e74e42dd40585ad4fe9826b5af42206cf`
- post-first-merge rebase base: `a29903337e4191d0a711b66064caede766a5c4b1`
- current head: `6bc3ea41b5568cf8d333d6b45191ff31e719ab7b`
- initial complete caller/literal inventory: 11 raw retired-key occurrences across four files
- final inventory: 19 raw retired-key occurrences across nine files, all deliberate negative/cleanup/ownership/isolation fixtures; production code contains none of the retired constant, resolver, alias variant, source family, or conflict diagnostic
- bootstrap source inventory and persistence expectation decrease exactly once: initially 14 to 13; after #30290 established the new canonical `main`, the composed current-main diff is 9 to 8
- initial fully paginated open-PR audit: 29 PRs, 500 declared and 500 fetched changed files, 30 pages, zero mismatch
- publication audit: 26 PRs, 493 declared and 493 fetched changed files, 27 pages, zero mismatch
- post-rebase audit: 25 PRs, 449 declared and 449 fetched changed files, 26 pages, zero mismatch

#30290 independently retired the run-metadata family and merged first. This branch was rebased onto that canonical result, preserving its canonical-only behavior and then removing only the API-token source slot. Current external overlap is limited to #30293, which independently retires the API URL root reader, and #25722, which adds Cloudflare Access support in shared files. Every overlapping hunk was inspected. None changes this token reader/writer contract or creates a functional dependency, so this PR proceeds under normal first-merge precedence.

## Validation

Passed:

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent --all-targets --all-features -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo check --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' CARGO_BUILD_JOBS=1 cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent --all-features --no-deps`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-contracts --all-features`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent --all-features --test api_token_env_aliases --test api_token_process_isolation --test bootstrap_alias_source_events --test cli_child_env --test integration`
- the broader focused Guest Agent token/capture/HTTP/isolation set, including API URL, missing-URL, no-API, and 109 HTTP integration tests

Runner evidence:

- `CARGO_BUILD_JOBS=1 cargo check --manifest-path crates/Cargo.toml -p runner --tests --all-features` passed on the functional implementation; a repeat after rebasing unrelated current-main commits was terminated with exit 137 at `Checking runner` and emitted no Rust diagnostic
- `CARGO_BUILD_JOBS=1 CARGO_PROFILE_TEST_DEBUG=0 cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::env_tests::build_env_json_required_keys -- --exact` compiled the source and dependencies, then the final test-binary link exited 137 without diagnostics
- cgroup evidence at the failed link: `memory.max=3991613440`, `memory.peak=3991617536`, with OOM/kill counters recorded; protected PR CI is authoritative for Runner linking

No full local Vitest suite or development server was run. This PR does not deploy or approve any environment.
