### PR TITLE
refactor(guest): retire api url root legacy reader

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -26,7 +26,7 @@ const TEST_CLAUDE_CONFIG_DIR_ENV_KEY: &str = "OKOU_TEST_CLAUDE_CONFIG_DIR";
 #[cfg(debug_assertions)]
 const TEST_CODEX_HOME_DIR_ENV_KEY: &str = "OKOU_TEST_CODEX_HOME_DIR";
 
-const BOOTSTRAP_ALIAS_SOURCE_EVENT_COUNT: usize = 5;
+const BOOTSTRAP_ALIAS_SOURCE_EVENT_COUNT: usize = 4;
 
 #[derive(Clone, Copy)]
 struct BootstrapAliasSourceEventSpec {
@@ -36,10 +36,6 @@ struct BootstrapAliasSourceEventSpec {
 
 const BOOTSTRAP_ALIAS_SOURCE_EVENT_INVENTORY: [BootstrapAliasSourceEventSpec;
     BOOTSTRAP_ALIAS_SOURCE_EVENT_COUNT] = [
-    BootstrapAliasSourceEventSpec {
-        family: "api_url_env_source",
-        canonical_key: guest_contracts::env::CANONICAL_API_URL_ENV,
-    },
     BootstrapAliasSourceEventSpec {
         family: "guest_agent_tuning_env_source",
         canonical_key: guest_contracts::env::CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV,
@@ -60,7 +56,6 @@ const BOOTSTRAP_ALIAS_SOURCE_EVENT_INVENTORY: [BootstrapAliasSourceEventSpec;
 
 #[derive(Clone, Copy)]
 enum BootstrapAlias {
-    ApiUrl,
     StuckToolTimeout,
     PostResultSigtermGrace,
     PostResultTotalCap,
@@ -86,12 +81,11 @@ impl BootstrapAliasSource {
 
 /// Fixed-size, value-free source evidence captured while resolving bootstrap aliases.
 ///
-/// The internal slots correspond exactly to the five canonical keys in
+/// The internal slots correspond exactly to the four canonical keys in
 /// `BOOTSTRAP_ALIAS_SOURCE_EVENT_INVENTORY`. Only guest-agent's environment
 /// resolvers can populate them.
 #[derive(Clone, Default)]
 pub struct BootstrapAliasSourceEvents {
-    api_url: Option<BootstrapAliasSource>,
     stuck_tool_timeout: Option<BootstrapAliasSource>,
     post_result_sigterm_grace: Option<BootstrapAliasSource>,
     post_result_total_cap: Option<BootstrapAliasSource>,
@@ -101,7 +95,6 @@ pub struct BootstrapAliasSourceEvents {
 impl BootstrapAliasSourceEvents {
     fn record(&mut self, alias: BootstrapAlias, source: BootstrapAliasSource) {
         let slot = match alias {
-            BootstrapAlias::ApiUrl => &mut self.api_url,
             BootstrapAlias::StuckToolTimeout => &mut self.stuck_tool_timeout,
             BootstrapAlias::PostResultSigtermGrace => &mut self.post_result_sigterm_grace,
             BootstrapAlias::PostResultTotalCap => &mut self.post_result_total_cap,
@@ -112,7 +105,6 @@ impl BootstrapAliasSourceEvents {
 
     fn sources(&self) -> [Option<BootstrapAliasSource>; BOOTSTRAP_ALIAS_SOURCE_EVENT_COUNT] {
         [
-            self.api_url,
             self.stuck_tool_timeout,
             self.post_result_sigterm_grace,
             self.post_result_total_cap,
@@ -138,37 +130,6 @@ impl BootstrapAliasSourceEvents {
 
 fn env_or_empty(name: &str) -> String {
     std::env::var(name).unwrap_or_default()
-}
-
-/// Resolve the Runner-to-Guest Agent API URL at the single process-env capture
-/// boundary. The production Runner writer is canonical-only, while managed
-/// CLI-child exposure remains [`guest_contracts::env::API_URL_ENV`]. Retain this
-/// fail-closed legacy reader until the exact canonical writer production release,
-/// complete legacy-writer service and reusable-sandbox drain, supported rollback
-/// window, and value-free legacy-source-zero gates.
-fn api_url_env_or_empty(events: &mut BootstrapAliasSourceEvents) -> Result<String, String> {
-    let canonical_key = guest_contracts::env::CANONICAL_API_URL_ENV;
-    let legacy_key = guest_contracts::env::API_URL_ENV;
-    let canonical = std::env::var(canonical_key).ok();
-    let legacy = std::env::var(legacy_key).ok();
-
-    let (value, source) = match (canonical, legacy) {
-        (None, None) => return Ok(String::new()),
-        (Some(value), None) => (value, BootstrapAliasSource::CanonicalOnly),
-        (None, Some(value)) => (value, BootstrapAliasSource::LegacyOnly),
-        (Some(canonical), Some(legacy)) if canonical == legacy => {
-            (canonical, BootstrapAliasSource::Dual)
-        }
-        (Some(_), Some(_)) => {
-            return Err(format!(
-                "conflicting API backend URL environment aliases: canonical_key={canonical_key} \
-                 legacy_key={legacy_key} state=conflict"
-            ));
-        }
-    };
-
-    events.record(BootstrapAlias::ApiUrl, source);
-    Ok(value)
 }
 
 /// Resolve one Guest Agent timing alias pair at the single process-env capture
@@ -403,7 +364,7 @@ impl GuestConfigRaw {
         guest_runtime_dir: Option<PathBuf>,
     ) -> Result<Self, String> {
         let mut bootstrap_alias_sources = BootstrapAliasSourceEvents::default();
-        let api_url = api_url_env_or_empty(&mut bootstrap_alias_sources)?;
+        let api_url = env_or_empty(guest_contracts::env::CANONICAL_API_URL_ENV);
 
         let stuck_tool_timeout_secs = guest_agent_tuning_env_or_empty(
             BootstrapAlias::StuckToolTimeout,

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -355,7 +355,7 @@ impl ApiHttpConfig {
     ) -> Result<Self, AgentError> {
         if base_url.is_empty() {
             return Err(AgentError::Http(
-                "VM0_API_BACKEND_URL is required when OKOU_API_TOKEN is set".into(),
+                "OKOU_API_BACKEND_URL is required when OKOU_API_TOKEN is set".into(),
             ));
         }
         if token.is_empty() {

--- a/crates/guest-agent/tests/api_url_env_aliases.rs
+++ b/crates/guest-agent/tests/api_url_env_aliases.rs
@@ -1,4 +1,4 @@
-//! API backend URL aliases are resolved once in this process-isolated test binary.
+//! Guest root captures only the canonical API URL in this process-isolated test binary.
 
 #![cfg(unix)]
 
@@ -11,157 +11,87 @@ use guest_agent::http::HttpClient;
 
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
-const CANONICAL_URL: &str = "https://canonical-api-url-must-not-leak.example.test/private-path";
-const LEGACY_URL: &str = "https://legacy-api-url-must-not-leak.example.test/private-path";
-const SHARED_URL: &str = "https://shared-api-url-must-not-leak.example.test/private-path";
+const CANONICAL_URL: &str =
+    "https://canonical-api-url-must-not-leak.example.test/%2F?raw=%20#fragment";
+const RETIRED_URL: &str = "https://retired-api-url-must-not-leak.example.test/private-path";
 const API_TOKEN: &str = "api-url-test-token-must-not-leak";
-const VALUE_MARKERS: [&str; 4] = [
+const VALUE_MARKERS: [&str; 3] = [
     "canonical-api-url-must-not-leak",
-    "legacy-api-url-must-not-leak",
-    "shared-api-url-must-not-leak",
+    "retired-api-url-must-not-leak",
     API_TOKEN,
 ];
 const SOURCE_EVENT: &str = "api_url_env_source";
+const CONFLICT_DIAGNOSTIC: &str = "conflicting API backend URL environment aliases";
 
 #[derive(Clone, Copy)]
-enum AliasInput {
+enum EnvInput {
     Absent,
     Readable(&'static str),
     NonUnicode,
 }
 
 #[derive(Clone, Copy)]
-struct SuccessCase {
+struct CaptureCase {
     name: &'static str,
-    canonical: AliasInput,
-    legacy: AliasInput,
+    canonical: EnvInput,
+    retired: EnvInput,
     expected_value: &'static str,
-    expected_source: Option<&'static str>,
 }
 
-#[derive(Clone, Copy)]
-struct ConflictCase {
-    name: &'static str,
-    canonical: &'static str,
-    legacy: &'static str,
-}
-
-const SUCCESS_CASES: [SuccessCase; 14] = [
-    SuccessCase {
+const CAPTURE_CASES: [CaptureCase; 9] = [
+    CaptureCase {
         name: "both-absent",
-        canonical: AliasInput::Absent,
-        legacy: AliasInput::Absent,
+        canonical: EnvInput::Absent,
+        retired: EnvInput::Absent,
         expected_value: "",
-        expected_source: None,
     },
-    SuccessCase {
-        name: "canonical-only",
-        canonical: AliasInput::Readable(CANONICAL_URL),
-        legacy: AliasInput::Absent,
+    CaptureCase {
+        name: "canonical-readable",
+        canonical: EnvInput::Readable(CANONICAL_URL),
+        retired: EnvInput::Absent,
         expected_value: CANONICAL_URL,
-        expected_source: Some("canonical-only"),
     },
-    SuccessCase {
-        name: "legacy-only",
-        canonical: AliasInput::Absent,
-        legacy: AliasInput::Readable(LEGACY_URL),
-        expected_value: LEGACY_URL,
-        expected_source: Some("legacy-only"),
-    },
-    SuccessCase {
-        name: "equal-dual",
-        canonical: AliasInput::Readable(SHARED_URL),
-        legacy: AliasInput::Readable(SHARED_URL),
-        expected_value: SHARED_URL,
-        expected_source: Some("dual"),
-    },
-    SuccessCase {
-        name: "canonical-empty-only",
-        canonical: AliasInput::Readable(""),
-        legacy: AliasInput::Absent,
+    CaptureCase {
+        name: "canonical-present-empty",
+        canonical: EnvInput::Readable(""),
+        retired: EnvInput::Absent,
         expected_value: "",
-        expected_source: Some("canonical-only"),
     },
-    SuccessCase {
-        name: "legacy-empty-only",
-        canonical: AliasInput::Absent,
-        legacy: AliasInput::Readable(""),
+    CaptureCase {
+        name: "canonical-non-unicode",
+        canonical: EnvInput::NonUnicode,
+        retired: EnvInput::Absent,
         expected_value: "",
-        expected_source: Some("legacy-only"),
     },
-    SuccessCase {
-        name: "equal-dual-empty",
-        canonical: AliasInput::Readable(""),
-        legacy: AliasInput::Readable(""),
+    CaptureCase {
+        name: "retired-readable-only",
+        canonical: EnvInput::Absent,
+        retired: EnvInput::Readable(RETIRED_URL),
         expected_value: "",
-        expected_source: Some("dual"),
     },
-    SuccessCase {
-        name: "canonical-non-unicode-only",
-        canonical: AliasInput::NonUnicode,
-        legacy: AliasInput::Absent,
-        expected_value: "",
-        expected_source: None,
-    },
-    SuccessCase {
-        name: "legacy-non-unicode-only",
-        canonical: AliasInput::Absent,
-        legacy: AliasInput::NonUnicode,
-        expected_value: "",
-        expected_source: None,
-    },
-    SuccessCase {
-        name: "both-non-unicode",
-        canonical: AliasInput::NonUnicode,
-        legacy: AliasInput::NonUnicode,
-        expected_value: "",
-        expected_source: None,
-    },
-    SuccessCase {
-        name: "canonical-with-unreadable-legacy",
-        canonical: AliasInput::Readable(CANONICAL_URL),
-        legacy: AliasInput::NonUnicode,
+    CaptureCase {
+        name: "canonical-readable-with-different-retired",
+        canonical: EnvInput::Readable(CANONICAL_URL),
+        retired: EnvInput::Readable(RETIRED_URL),
         expected_value: CANONICAL_URL,
-        expected_source: Some("canonical-only"),
     },
-    SuccessCase {
-        name: "legacy-with-unreadable-canonical",
-        canonical: AliasInput::NonUnicode,
-        legacy: AliasInput::Readable(LEGACY_URL),
-        expected_value: LEGACY_URL,
-        expected_source: Some("legacy-only"),
+    CaptureCase {
+        name: "canonical-readable-with-non-unicode-retired",
+        canonical: EnvInput::Readable(CANONICAL_URL),
+        retired: EnvInput::NonUnicode,
+        expected_value: CANONICAL_URL,
     },
-    SuccessCase {
-        name: "canonical-empty-with-unreadable-legacy",
-        canonical: AliasInput::Readable(""),
-        legacy: AliasInput::NonUnicode,
+    CaptureCase {
+        name: "canonical-empty-with-readable-retired",
+        canonical: EnvInput::Readable(""),
+        retired: EnvInput::Readable(RETIRED_URL),
         expected_value: "",
-        expected_source: Some("canonical-only"),
     },
-    SuccessCase {
-        name: "legacy-empty-with-unreadable-canonical",
-        canonical: AliasInput::NonUnicode,
-        legacy: AliasInput::Readable(""),
+    CaptureCase {
+        name: "canonical-non-unicode-with-readable-retired",
+        canonical: EnvInput::NonUnicode,
+        retired: EnvInput::Readable(RETIRED_URL),
         expected_value: "",
-        expected_source: Some("legacy-only"),
-    },
-];
-
-const CONFLICT_CASES: [ConflictCase; 3] = [
-    ConflictCase {
-        name: "different-readable-values",
-        canonical: CANONICAL_URL,
-        legacy: LEGACY_URL,
-    },
-    ConflictCase {
-        name: "canonical-empty-legacy-non-empty",
-        canonical: "",
-        legacy: LEGACY_URL,
-    },
-    ConflictCase {
-        name: "canonical-non-empty-legacy-empty",
-        canonical: CANONICAL_URL,
-        legacy: "",
     },
 ];
 
@@ -181,12 +111,12 @@ fn remove_test_env(key: impl AsRef<OsStr>) {
     }
 }
 
-fn apply_alias(key: &str, input: AliasInput) {
+fn apply_input(key: &str, input: EnvInput) {
     remove_test_env(key);
     match input {
-        AliasInput::Absent => {}
-        AliasInput::Readable(value) => set_test_env(key, value),
-        AliasInput::NonUnicode => set_test_env(key, OsString::from_vec(vec![0xff])),
+        EnvInput::Absent => {}
+        EnvInput::Readable(value) => set_test_env(key, value),
+        EnvInput::NonUnicode => set_test_env(key, OsString::from_vec(vec![0xff])),
     }
 }
 
@@ -200,7 +130,7 @@ fn clear_api_token_env() {
     remove_test_env("VM0_API_TOKEN");
 }
 
-fn capture_raw(log_path: &Path) -> std::io::Result<(Result<GuestConfigRaw, String>, String)> {
+fn capture_raw(log_path: &Path) -> (Result<GuestConfigRaw, String>, String) {
     guest_common::log::clear_system_log_file();
     let raw = GuestConfigRaw::from_process_env();
     assert!(
@@ -218,7 +148,7 @@ fn capture_raw(log_path: &Path) -> std::io::Result<(Result<GuestConfigRaw, Strin
                 .join("\n")
         })
         .unwrap_or_default();
-    Ok((raw, evidence))
+    (raw, evidence)
 }
 
 fn assert_value_free(text: &str, context: &str) {
@@ -230,33 +160,18 @@ fn assert_value_free(text: &str, context: &str) {
     }
 }
 
-fn assert_source_evidence(log: &str, case: SuccessCase) {
-    assert_value_free(log, case.name);
-    let source_messages = log
-        .lines()
-        .filter(|line| line.contains(SOURCE_EVENT))
-        .filter_map(|line| line.rsplit_once("] ").map(|(_, message)| message))
-        .collect::<Vec<_>>();
-
-    match case.expected_source {
-        Some(source) => {
-            let expected = format!(
-                "{SOURCE_EVENT} key={} source={source}",
-                guest_contracts::env::CANONICAL_API_URL_ENV
-            );
-            assert_eq!(
-                source_messages,
-                [expected.as_str()],
-                "{} emitted incorrect fixed source evidence",
-                case.name
-            );
-        }
-        None => assert!(
-            source_messages.is_empty(),
-            "{} emitted source evidence for unreadable aliases",
-            case.name
-        ),
-    }
+fn assert_no_retired_reader_evidence(evidence: &str, case: CaptureCase) {
+    assert_value_free(evidence, case.name);
+    assert!(
+        !evidence.contains(SOURCE_EVENT),
+        "{} emitted retired API URL source evidence: {evidence}",
+        case.name
+    );
+    assert!(
+        !evidence.contains(CONFLICT_DIAGNOSTIC),
+        "{} emitted the retired API URL conflict diagnostic: {evidence}",
+        case.name
+    );
 }
 
 fn materialize_config(
@@ -275,7 +190,7 @@ fn materialize_config(
         .map_err(|error| format!("write run payload: {error}"))?;
 
     GuestConfig::from_raw(GuestConfigRaw {
-        run_id: format!("api-url-alias-{scenario}"),
+        run_id: format!("api-url-capture-{scenario}"),
         home: Some(tmp.to_string_lossy().into_owned()),
         guest_runtime_dir: Some(runtime_dir),
         run_payload_file: payload_path.to_string_lossy().into_owned(),
@@ -283,12 +198,17 @@ fn materialize_config(
     })
 }
 
-fn assert_http_semantics(tmp: &Path, case: SuccessCase, raw: GuestConfigRaw) -> TestResult {
+fn assert_http_semantics(tmp: &Path, case: CaptureCase, raw: GuestConfigRaw) -> TestResult {
     let mut without_token = raw.clone();
     without_token.api_token.clear();
     let disabled_config =
         materialize_config(tmp, &format!("{}-http-disabled", case.name), without_token)
             .map_err(std::io::Error::other)?;
+    assert_eq!(
+        disabled_config.api_url, case.expected_value,
+        "{}",
+        case.name
+    );
     let disabled = HttpClient::for_config(&disabled_config)?;
     assert!(
         !disabled.has_api(),
@@ -301,6 +221,7 @@ fn assert_http_semantics(tmp: &Path, case: SuccessCase, raw: GuestConfigRaw) -> 
     let enabled_config =
         materialize_config(tmp, &format!("{}-http-enabled", case.name), with_token)
             .map_err(std::io::Error::other)?;
+    assert_eq!(enabled_config.api_url, case.expected_value, "{}", case.name);
     if case.expected_value.is_empty() {
         let error = match HttpClient::for_config(&enabled_config) {
             Ok(_) => {
@@ -314,8 +235,13 @@ fn assert_http_semantics(tmp: &Path, case: SuccessCase, raw: GuestConfigRaw) -> 
         };
         assert_value_free(&error, case.name);
         assert!(
-            error.contains(guest_contracts::env::API_URL_ENV),
-            "{} changed the missing API URL diagnostic: {error}",
+            error.contains(guest_contracts::env::CANONICAL_API_URL_ENV),
+            "{} changed the canonical missing API URL diagnostic: {error}",
+            case.name
+        );
+        assert!(
+            !error.contains(CONFLICT_DIAGNOSTIC),
+            "{} emitted the retired conflict diagnostic: {error}",
             case.name
         );
     } else {
@@ -325,97 +251,26 @@ fn assert_http_semantics(tmp: &Path, case: SuccessCase, raw: GuestConfigRaw) -> 
     Ok(())
 }
 
-fn expected_conflict_error() -> String {
-    format!(
-        "conflicting API backend URL environment aliases: canonical_key={} \
-         legacy_key={} state=conflict",
-        guest_contracts::env::CANONICAL_API_URL_ENV,
-        guest_contracts::env::API_URL_ENV
-    )
-}
-
-fn assert_conflict_precedes_private_payload_consumption(tmp: &Path) -> TestResult {
-    let runtime_dir = tmp.join("conflict-private-payload-runtime");
-    let user_env_dir = runtime_dir.join(guest_contracts::env::USER_ENV_PRIVATE_DIR_NAME);
-    let user_env_path = user_env_dir.join(guest_contracts::env::USER_ENV_FILENAME);
-    let run_payload_dir = runtime_dir.join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
-    let run_payload_path = run_payload_dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
-    std::fs::create_dir_all(&user_env_dir)?;
-    std::fs::create_dir_all(&run_payload_dir)?;
-    std::fs::write(
-        &user_env_path,
-        serde_json::to_vec(&std::collections::HashMap::from([(
-            "CUSTOM_USER_ENV",
-            "private-user-value",
-        )]))?,
-    )?;
-    std::fs::write(
-        &run_payload_path,
-        serde_json::to_vec(&guest_contracts::env::RunPayload::default())?,
-    )?;
-
-    for key in [
-        guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
-        guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV,
-        "VM0_USER_ENV_FILE",
-        guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV,
-        "VM0_RUN_PAYLOAD_FILE",
-    ] {
-        remove_test_env(key);
-    }
-    set_test_env(
-        guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
-        &runtime_dir,
-    );
-    set_test_env(
-        guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV,
-        &user_env_path,
-    );
-    set_test_env(
-        guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV,
-        &run_payload_path,
-    );
-    set_test_env(guest_contracts::env::RUN_ID_ENV, "api-url-conflict");
-    set_test_env("HOME", tmp);
-    set_test_env(guest_contracts::env::CANONICAL_API_URL_ENV, CANONICAL_URL);
-    set_test_env(guest_contracts::env::API_URL_ENV, LEGACY_URL);
-
-    let log_path = tmp.join("conflict-before-private-payload.log");
-    guest_common::log::set_system_log_file(&log_path);
-    let error = match GuestConfig::from_process_env() {
-        Ok(_) => return Err("API URL conflict consumed private payloads".into()),
-        Err(error) => error,
-    };
-    guest_common::log::clear_system_log_file();
-    let log = std::fs::read_to_string(log_path).unwrap_or_default();
-
-    assert_eq!(error, expected_conflict_error());
-    assert_value_free(&error, "private-payload-conflict-error");
-    assert_value_free(&log, "private-payload-conflict-log");
-    assert!(!log.contains(SOURCE_EVENT));
-    assert!(user_env_path.exists(), "conflict consumed private user env");
-    assert!(
-        run_payload_path.exists(),
-        "conflict consumed private run payload"
-    );
-    Ok(())
-}
-
 #[test]
-fn process_env_dual_reads_api_url_aliases_without_value_leaks() -> TestResult {
+fn process_env_captures_only_canonical_api_url_without_value_leaks() -> TestResult {
     let tmp = tempfile::tempdir()?;
     clear_api_token_env();
 
-    for case in SUCCESS_CASES {
-        apply_alias(guest_contracts::env::CANONICAL_API_URL_ENV, case.canonical);
-        apply_alias(guest_contracts::env::API_URL_ENV, case.legacy);
-        let (raw, log) = capture_raw(&tmp.path().join(format!("{}.log", case.name)))?;
+    for case in CAPTURE_CASES {
+        apply_input(guest_contracts::env::CANONICAL_API_URL_ENV, case.canonical);
+        apply_input(guest_contracts::env::API_URL_ENV, case.retired);
+        let (raw, evidence) = capture_raw(&tmp.path().join(format!("{}.log", case.name)));
         let raw = match raw {
             Ok(raw) => raw,
             Err(error) => {
                 assert_value_free(&error, case.name);
+                assert!(
+                    !error.contains(CONFLICT_DIAGNOSTIC),
+                    "{} retained the API URL conflict reader: {error}",
+                    case.name
+                );
                 return Err(std::io::Error::other(format!(
-                    "{} unexpectedly rejected a readable state",
+                    "{} unexpectedly rejected root API URL input: {error}",
                     case.name
                 ))
                 .into());
@@ -423,39 +278,13 @@ fn process_env_dual_reads_api_url_aliases_without_value_leaks() -> TestResult {
         };
         assert_eq!(
             raw.api_url, case.expected_value,
-            "{} resolved the wrong API URL state",
+            "{} captured the wrong root API URL",
             case.name
         );
-        assert_source_evidence(&log, case);
+        assert_no_retired_reader_evidence(&evidence, case);
         assert_http_semantics(tmp.path(), case, raw)?;
     }
 
-    let expected_error = expected_conflict_error();
-    for case in CONFLICT_CASES {
-        set_test_env(guest_contracts::env::CANONICAL_API_URL_ENV, case.canonical);
-        set_test_env(guest_contracts::env::API_URL_ENV, case.legacy);
-        let (raw, log) = capture_raw(&tmp.path().join(format!("{}.log", case.name)))?;
-        let error = match raw {
-            Ok(_) => {
-                return Err(std::io::Error::other(format!(
-                    "{} accepted conflicting readable aliases",
-                    case.name
-                ))
-                .into());
-            }
-            Err(error) => error,
-        };
-        assert_eq!(error, expected_error);
-        assert_value_free(&error, case.name);
-        assert_value_free(&log, case.name);
-        assert!(
-            !log.contains(SOURCE_EVENT),
-            "{} emitted success evidence for a conflict",
-            case.name
-        );
-    }
-
-    assert_conflict_precedes_private_payload_consumption(tmp.path())?;
     clear_api_url_env();
     clear_api_token_env();
     Ok(())

--- a/crates/guest-agent/tests/bootstrap_alias_source_events.rs
+++ b/crates/guest-agent/tests/bootstrap_alias_source_events.rs
@@ -31,11 +31,7 @@ const SOURCE_EVENT_FAMILIES: [&str; 3] = [
     "guest_agent_tuning_env_source",
 ];
 
-const SOURCE_EVENTS: [(&str, &str); 5] = [
-    (
-        "api_url_env_source",
-        guest_contracts::env::CANONICAL_API_URL_ENV,
-    ),
+const SOURCE_EVENTS: [(&str, &str); 4] = [
     (
         "guest_agent_tuning_env_source",
         guest_contracts::env::CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV,

--- a/crates/guest-agent/tests/guest_runtime_missing_api_url.rs
+++ b/crates/guest-agent/tests/guest_runtime_missing_api_url.rs
@@ -33,7 +33,7 @@ fn runtime_bootstrap_logs_missing_api_url_to_system_log() {
             run_payload_file,
         )
         .env(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token")
-        .env(guest_contracts::env::API_URL_ENV, "")
+        .env(guest_contracts::env::CANONICAL_API_URL_ENV, "")
         .output()
         .unwrap();
 
@@ -50,9 +50,9 @@ fn runtime_bootstrap_logs_missing_api_url_to_system_log() {
         "stderr should be fatal: {stderr}"
     );
     assert!(
-        stderr.contains(guest_contracts::env::API_URL_ENV),
+        stderr.contains(guest_contracts::env::CANONICAL_API_URL_ENV),
         "stderr should identify {}, got: {stderr}",
-        guest_contracts::env::API_URL_ENV
+        guest_contracts::env::CANONICAL_API_URL_ENV
     );
 
     let system_log_path = guest_contracts::runtime_paths::system_log_file(&runtime_dir);
@@ -62,8 +62,8 @@ fn runtime_bootstrap_logs_missing_api_url_to_system_log() {
         "system log should contain the fatal bootstrap diagnostic: {system_log}"
     );
     assert!(
-        system_log.contains(guest_contracts::env::API_URL_ENV),
+        system_log.contains(guest_contracts::env::CANONICAL_API_URL_ENV),
         "system log should identify {}, got: {system_log}",
-        guest_contracts::env::API_URL_ENV
+        guest_contracts::env::CANONICAL_API_URL_ENV
     );
 }

--- a/crates/guest-agent/tests/http_env_missing_api_url.rs
+++ b/crates/guest-agent/tests/http_env_missing_api_url.rs
@@ -28,7 +28,9 @@ fn for_config_requires_api_url_when_api_token_is_set() {
         panic!("missing API URL should fail fast");
     };
     assert!(
-        err.to_string().contains("VM0_API_BACKEND_URL"),
-        "error should identify VM0_API_BACKEND_URL, got: {err}"
+        err.to_string()
+            .contains(guest_contracts::env::CANONICAL_API_URL_ENV),
+        "error should identify {}, got: {err}",
+        guest_contracts::env::CANONICAL_API_URL_ENV
     );
 }

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -16,24 +16,21 @@
 //! selected runner-owned keys may cross the local user-env boundary as
 //! guest-agent timing overrides.
 
-/// Legacy backend API base URL spelling retained by compatibility readers.
+/// Legacy backend API URL spelling retained outside Guest root capture.
 ///
-/// The production Runner and the guest-agent's curated managed CLI-child
-/// environment do not emit this alias.
+/// Guest root capture reads only [`CANONICAL_API_URL_ENV`]. This spelling
+/// remains an independent compatibility input for the Runner operator and the
+/// managed CLI reader, and remains named by user-environment filtering and
+/// negative coverage. The production Runner and the guest-agent's curated
+/// managed CLI-child environment do not emit this alias.
 pub const API_URL_ENV: &str = "VM0_API_BACKEND_URL";
 
-/// Canonical backend API URL spelling written by the production Runner and
-/// exposed to managed CLI children.
+/// Canonical backend API URL spelling written by the production Runner, read at
+/// Guest root bootstrap, and exposed to managed CLI children.
 ///
-/// The Guest Agent bootstrap reader and Runner operator parser reuse this exact
-/// spelling but have independent rollout floors. On the Runner-to-Guest surface,
-/// the Runner emits only this canonical alias, while the Guest Agent retains
-/// [`API_URL_ENV`] as a rollback reader fallback. On the Guest-to-managed-CLI
-/// surface, the curated child environment emits only this canonical alias.
-/// Remove the legacy bootstrap reader only after the exact canonical writer
-/// production release, complete legacy-writer service and reusable-sandbox
-/// drain, supported rollback window, and value-free legacy-source-zero gates in
-/// #28914. Runner operator input retains its own independent support floor.
+/// The production Runner emits only this spelling and Guest root capture reads
+/// it without consulting [`API_URL_ENV`]. The Runner operator and downstream
+/// managed CLI reader retain independent compatibility contracts.
 pub const CANONICAL_API_URL_ENV: &str = "OKOU_API_BACKEND_URL";
 
 /// Stable run identifier used by guest-agent logs, telemetry, and runtime


### PR DESCRIPTION
## Summary

- capture the Guest root API URL only from `OKOU_API_BACKEND_URL`
- remove the root API URL alias resolver, source slot/event, conflict path, and legacy-root semantics
- update fixed root HTTP diagnostics, contract rustdoc, and focused canonical/retired-input coverage without changing independent readers or writers

Closes #30284

Parent EPIC: #28914

## Scope preservation

`API_URL_ENV` remains defined for the independent Runner operator, downstream managed CLI reader, filtering, and negative coverage. The PR does not change the Runner operator, Turbo CLI, Runner Guest writer, managed CLI child, E2E/preview configuration, API process, GitHub actions/variables, connector test-oauth, developer inputs, host-env rejection, hostile-input/isolation fixtures, token handling, Authorization, endpoints, retries, event delivery, or the temporary `VM0_*` ownership guard.

Sibling #30285 merged before initial publication and its managed-child canonical writer is preserved; none of its implementation files appear in this PR. Siblings #30290, #30292, #30301, #30307, and #30303 then merged first. This branch preserves their run-metadata, API-token, execution-timeout, private-payload, and timing-tuning retirements and removes only the final API URL source slot.

## Production, drain, and rollback gates

- Fixed Axiom window: `2026-08-29T00:00:00Z` through `2026-08-30T03:58:00Z` in `vm0-sandbox-telemetry-system-prod`.
- The terminal aggregate examined 120,626-120,627 rows and matched 3,534 API URL source rows across 3,533 runs. All 3,534 were exactly `api_url_env_source key=OKOU_API_BACKEND_URL source=canonical-only`; legacy-only, dual, and conflict were each 0 rows / 0 runs.
- Masked-production drain at `2026-08-30T03:47:12Z`: three live `vm0/production` Runner rows, 18 running production Agent runs, oldest start `2026-08-30T02:48:17.798Z`; no pre-cutover live run remained.
- Rollback dashboard #6792 retained seven release targets: `ea45a5b9f7943a0b9ea3e2fc2c3062d0f8841fe3`, `f51a5d5aef952bcf25179ecf30ec6d5b1b8cdf96`, `36fced59b3a9063a476e4b182d25506e5a38cef9`, `2dda17dc4c731fee363b53b532351cd78f8ba312`, `891b7383362fdd14ca044a958241f84f2498c241`, `b1440bfb43d75590ea1d0a43d9b8f0c8340832ef`, and `bee2e67a9490bcc80caafb992337f82c6f8e4766`.
- Local ancestry verification showed every rollback target contains reader merge `84295ac0c3d66185b90d59fc6afa3f79903aac9a` and canonical writer merge `f3bb3c589879d6782f7942afff00b8e9af242706`; targets are 457-499 commits ahead of the reader and 63-105 commits ahead of the writer.

## Refreshed inventory

- Initial clean base: `416b41325cd6a19c62e4f006b7ef7a4af2aca4cb`.
- Refreshed post-first-merge base: `27477c4cea651fc86fbea0194bd438946e6581ad`.
- Refreshed head: `a167e82cffa0d5c06ea3b9735ec766c69ec7d266`.
- Final publication audit at `2026-08-30T08:16:37Z`: 25 open PRs including this PR, one open-PR list page and 26 paginated changed-file pages, 463 declared / 463 fetched file records, zero mismatches.
- The only external scope overlap is #25722, which touches only unrelated Cloudflare Access hunks in the shared contract/HTTP files. Every overlapping hunk was inspected; it is not a functional dependency.
- After preserving merged #30290, #30292, #30301, #30307, and #30303, refreshed `main` has one bootstrap source slot; this PR removes exactly the API URL slot and leaves zero.
- Refreshed caller inventory from publication base to candidate: raw `VM0_API_BACKEND_URL` 75 occurrences / 39 files to 72 / 37; `API_URL_ENV` 104 / 47 to 96 / 48; `OKOU_API_BACKEND_URL` 206 / 131 to 207 / 132. The production root resolver/source/conflict symbols are absent, while the sole Runner Guest writer remains canonical-only.

## Validation

Passed on refreshed base `27477c4cea651fc86fbea0194bd438946e6581ad` and exact head `a167e82cffa0d5c06ea3b9735ec766c69ec7d266`:

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent --all-targets --all-features --locked -- -D warnings`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-D warnings' cargo check --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent --all-targets --all-features --locked`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent --all-features --no-deps --locked`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-contracts --locked` (134 tests plus doc tests)
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent --locked --test api_url_env_aliases --test bootstrap_alias_source_events --test http_env_missing_api_url --test guest_runtime_missing_api_url --test no_api_mode --test cli_child_env --test codex_app_server_backend_child_env`

No local Vitest suite or development server was run.
