### PR TITLE
refactor(guest): retire execution timeout legacy reader

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -26,7 +26,7 @@ const TEST_CLAUDE_CONFIG_DIR_ENV_KEY: &str = "OKOU_TEST_CLAUDE_CONFIG_DIR";
 #[cfg(debug_assertions)]
 const TEST_CODEX_HOME_DIR_ENV_KEY: &str = "OKOU_TEST_CODEX_HOME_DIR";
 
-const BOOTSTRAP_ALIAS_SOURCE_EVENT_COUNT: usize = 8;
+const BOOTSTRAP_ALIAS_SOURCE_EVENT_COUNT: usize = 7;
 
 #[derive(Clone, Copy)]
 struct BootstrapAliasSourceEventSpec {
@@ -64,10 +64,6 @@ const BOOTSTRAP_ALIAS_SOURCE_EVENT_INVENTORY: [BootstrapAliasSourceEventSpec;
         family: "private_payload_file_env_source",
         canonical_key: guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV,
     },
-    BootstrapAliasSourceEventSpec {
-        family: "agent_execution_timeout_env_source",
-        canonical_key: guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
-    },
 ];
 
 #[derive(Clone, Copy)]
@@ -79,7 +75,6 @@ enum BootstrapAlias {
     PostResultSigkillGrace,
     UserEnvFile,
     RunPayloadFile,
-    AgentExecutionTimeout,
 }
 
 #[derive(Clone, Copy)]
@@ -101,7 +96,7 @@ impl BootstrapAliasSource {
 
 /// Fixed-size, value-free source evidence captured while resolving bootstrap aliases.
 ///
-/// The internal slots correspond exactly to the eight canonical keys in
+/// The internal slots correspond exactly to the seven canonical keys in
 /// `BOOTSTRAP_ALIAS_SOURCE_EVENT_INVENTORY`. Only guest-agent's environment
 /// resolvers can populate them.
 #[derive(Clone, Default)]
@@ -113,7 +108,6 @@ pub struct BootstrapAliasSourceEvents {
     post_result_sigkill_grace: Option<BootstrapAliasSource>,
     user_env_file: Option<BootstrapAliasSource>,
     run_payload_file: Option<BootstrapAliasSource>,
-    agent_execution_timeout: Option<BootstrapAliasSource>,
 }
 
 impl BootstrapAliasSourceEvents {
@@ -126,7 +120,6 @@ impl BootstrapAliasSourceEvents {
             BootstrapAlias::PostResultSigkillGrace => &mut self.post_result_sigkill_grace,
             BootstrapAlias::UserEnvFile => &mut self.user_env_file,
             BootstrapAlias::RunPayloadFile => &mut self.run_payload_file,
-            BootstrapAlias::AgentExecutionTimeout => &mut self.agent_execution_timeout,
         };
         *slot = Some(source);
     }
@@ -140,7 +133,6 @@ impl BootstrapAliasSourceEvents {
             self.post_result_sigkill_grace,
             self.user_env_file,
             self.run_payload_file,
-            self.agent_execution_timeout,
         ]
     }
 
@@ -236,37 +228,6 @@ fn record_private_payload_file_env_source(
     if let Some(source) = source {
         events.record(alias, source);
     }
-}
-
-/// Resolve the runner-owned agent execution timeout at the single process-env
-/// capture boundary. Both aliases are reader-only during #28914 migration
-/// Stage 1; the runner writer remains
-/// [`guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV`].
-fn agent_execution_timeout_env_or_empty(
-    events: &mut BootstrapAliasSourceEvents,
-) -> Result<String, String> {
-    let canonical_key = guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV;
-    let legacy_key = guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV;
-    let canonical = std::env::var(canonical_key).ok();
-    let legacy = std::env::var(legacy_key).ok();
-
-    let (value, source) = match (canonical, legacy) {
-        (None, None) => return Ok(String::new()),
-        (Some(value), None) => (value, BootstrapAliasSource::CanonicalOnly),
-        (None, Some(value)) => (value, BootstrapAliasSource::LegacyOnly),
-        (Some(canonical), Some(legacy)) if canonical == legacy => {
-            (canonical, BootstrapAliasSource::Dual)
-        }
-        (Some(_), Some(_)) => {
-            return Err(format!(
-                "conflicting agent execution timeout environment aliases: \
-                 canonical_key={canonical_key} legacy_key={legacy_key} state=conflict"
-            ));
-        }
-    };
-
-    events.record(BootstrapAlias::AgentExecutionTimeout, source);
-    Ok(value)
 }
 
 /// Resolve one Guest Agent timing alias pair at the single process-env capture
@@ -562,9 +523,9 @@ impl GuestConfigRaw {
             vercel_bypass: env_or_empty(guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV),
             resume_session_id: env_or_empty(guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV),
             api_start_time: env_or_empty(guest_contracts::env::CANONICAL_API_START_TIME_ENV),
-            agent_execution_timeout_secs: agent_execution_timeout_env_or_empty(
-                &mut bootstrap_alias_sources,
-            )?,
+            agent_execution_timeout_secs: env_or_empty(
+                guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+            ),
             use_mock_claude: env_or_empty(guest_contracts::env::USE_MOCK_CLAUDE_ENV),
             mock_claude_path: std::env::var(guest_contracts::env::CANONICAL_MOCK_CLAUDE_PATH_ENV)
                 .ok(),
@@ -1180,10 +1141,6 @@ mod tests {
                     .unwrap_err();
             assert!(
                 error.contains(AGENT_EXECUTION_TIMEOUT_DIAGNOSTIC),
-                "{error}"
-            );
-            assert!(
-                !error.contains(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV),
                 "{error}"
             );
             assert!(

--- a/crates/guest-agent/tests/agent_execution_timeout_env_aliases.rs
+++ b/crates/guest-agent/tests/agent_execution_timeout_env_aliases.rs
@@ -1,4 +1,4 @@
-//! Agent execution timeout aliases are resolved once at the process-env boundary.
+//! Agent execution timeout is captured only from its canonical process env key.
 
 #![cfg(unix)]
 
@@ -8,23 +8,20 @@ use std::path::Path;
 use std::time::Duration;
 
 use guest_agent::env::{GuestConfig, GuestConfigRaw};
-use guest_agent::run_context::GuestRuntime;
 
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
+const RETIRED_AGENT_EXECUTION_TIMEOUT_SECS_ENV: &str = "VM0_AGENT_EXECUTION_TIMEOUT_SECS";
 const VALID_TIMEOUT: &str = "37";
-const CANONICAL_CONFLICT_TIMEOUT: &str = "41";
-const LEGACY_CONFLICT_TIMEOUT: &str = "43";
-const CANONICAL_INVALID_TIMEOUT: &str = "canonical-invalid-timeout-must-not-leak";
-const LEGACY_INVALID_TIMEOUT: &str = "legacy-invalid-timeout-must-not-leak";
+const STALE_TIMEOUT: &str = "43";
+const INVALID_TIMEOUT: &str = "canonical-invalid-timeout-must-not-leak";
 const TOO_LARGE_TIMEOUT: &str = "18446744073709551615";
-const SOURCE_EVENT: &str = "agent_execution_timeout_env_source";
 const PARSE_ERROR: &str = "agent execution timeout must be a positive integer number of seconds";
 const ZERO_ERROR: &str = "agent execution timeout must be greater than zero";
 const TOO_LARGE_ERROR: &str = "agent execution timeout is too large";
 
 #[derive(Clone, Copy)]
-enum AliasInput {
+enum EnvInput {
     Absent,
     Readable(&'static str),
     NonUnicode,
@@ -33,226 +30,109 @@ enum AliasInput {
 #[derive(Clone, Copy)]
 struct SuccessCase {
     name: &'static str,
-    canonical: AliasInput,
-    legacy: AliasInput,
+    canonical: EnvInput,
+    retired: EnvInput,
     expected_raw: &'static str,
     expected_timeout_secs: Option<u64>,
-    expected_source: Option<&'static str>,
-}
-
-#[derive(Clone, Copy)]
-struct ConflictCase {
-    name: &'static str,
-    canonical: &'static str,
-    legacy: &'static str,
 }
 
 #[derive(Clone, Copy)]
 struct ValidationCase {
     name: &'static str,
-    canonical: AliasInput,
-    legacy: AliasInput,
-    expected_raw: &'static str,
-    expected_source: &'static str,
+    canonical: &'static str,
+    retired: EnvInput,
     expected_error: &'static str,
 }
 
-const SUCCESS_CASES: [SuccessCase; 14] = [
+const SUCCESS_CASES: [SuccessCase; 9] = [
     SuccessCase {
         name: "both-absent",
-        canonical: AliasInput::Absent,
-        legacy: AliasInput::Absent,
+        canonical: EnvInput::Absent,
+        retired: EnvInput::Absent,
         expected_raw: "",
         expected_timeout_secs: None,
-        expected_source: None,
     },
     SuccessCase {
-        name: "canonical-only",
-        canonical: AliasInput::Readable(VALID_TIMEOUT),
-        legacy: AliasInput::Absent,
+        name: "retired-only",
+        canonical: EnvInput::Absent,
+        retired: EnvInput::Readable(STALE_TIMEOUT),
+        expected_raw: "",
+        expected_timeout_secs: None,
+    },
+    SuccessCase {
+        name: "canonical-empty-with-stale-retired",
+        canonical: EnvInput::Readable(""),
+        retired: EnvInput::Readable(STALE_TIMEOUT),
+        expected_raw: "",
+        expected_timeout_secs: None,
+    },
+    SuccessCase {
+        name: "canonical-non-unicode",
+        canonical: EnvInput::NonUnicode,
+        retired: EnvInput::Absent,
+        expected_raw: "",
+        expected_timeout_secs: None,
+    },
+    SuccessCase {
+        name: "canonical-non-unicode-with-stale-retired",
+        canonical: EnvInput::NonUnicode,
+        retired: EnvInput::Readable(STALE_TIMEOUT),
+        expected_raw: "",
+        expected_timeout_secs: None,
+    },
+    SuccessCase {
+        name: "canonical-valid",
+        canonical: EnvInput::Readable(VALID_TIMEOUT),
+        retired: EnvInput::Absent,
         expected_raw: VALID_TIMEOUT,
         expected_timeout_secs: Some(37),
-        expected_source: Some("canonical-only"),
     },
     SuccessCase {
-        name: "legacy-only",
-        canonical: AliasInput::Absent,
-        legacy: AliasInput::Readable(VALID_TIMEOUT),
+        name: "canonical-valid-with-equal-retired",
+        canonical: EnvInput::Readable(VALID_TIMEOUT),
+        retired: EnvInput::Readable(VALID_TIMEOUT),
         expected_raw: VALID_TIMEOUT,
         expected_timeout_secs: Some(37),
-        expected_source: Some("legacy-only"),
     },
     SuccessCase {
-        name: "equal-dual",
-        canonical: AliasInput::Readable(VALID_TIMEOUT),
-        legacy: AliasInput::Readable(VALID_TIMEOUT),
+        name: "canonical-valid-with-different-retired",
+        canonical: EnvInput::Readable(VALID_TIMEOUT),
+        retired: EnvInput::Readable(STALE_TIMEOUT),
         expected_raw: VALID_TIMEOUT,
         expected_timeout_secs: Some(37),
-        expected_source: Some("dual"),
     },
     SuccessCase {
-        name: "canonical-empty-only",
-        canonical: AliasInput::Readable(""),
-        legacy: AliasInput::Absent,
-        expected_raw: "",
-        expected_timeout_secs: None,
-        expected_source: Some("canonical-only"),
-    },
-    SuccessCase {
-        name: "legacy-empty-only",
-        canonical: AliasInput::Absent,
-        legacy: AliasInput::Readable(""),
-        expected_raw: "",
-        expected_timeout_secs: None,
-        expected_source: Some("legacy-only"),
-    },
-    SuccessCase {
-        name: "equal-dual-empty",
-        canonical: AliasInput::Readable(""),
-        legacy: AliasInput::Readable(""),
-        expected_raw: "",
-        expected_timeout_secs: None,
-        expected_source: Some("dual"),
-    },
-    SuccessCase {
-        name: "canonical-non-unicode-only",
-        canonical: AliasInput::NonUnicode,
-        legacy: AliasInput::Absent,
-        expected_raw: "",
-        expected_timeout_secs: None,
-        expected_source: None,
-    },
-    SuccessCase {
-        name: "legacy-non-unicode-only",
-        canonical: AliasInput::Absent,
-        legacy: AliasInput::NonUnicode,
-        expected_raw: "",
-        expected_timeout_secs: None,
-        expected_source: None,
-    },
-    SuccessCase {
-        name: "both-non-unicode",
-        canonical: AliasInput::NonUnicode,
-        legacy: AliasInput::NonUnicode,
-        expected_raw: "",
-        expected_timeout_secs: None,
-        expected_source: None,
-    },
-    SuccessCase {
-        name: "canonical-with-unreadable-legacy",
-        canonical: AliasInput::Readable(VALID_TIMEOUT),
-        legacy: AliasInput::NonUnicode,
+        name: "canonical-valid-with-non-unicode-retired",
+        canonical: EnvInput::Readable(VALID_TIMEOUT),
+        retired: EnvInput::NonUnicode,
         expected_raw: VALID_TIMEOUT,
         expected_timeout_secs: Some(37),
-        expected_source: Some("canonical-only"),
-    },
-    SuccessCase {
-        name: "legacy-with-unreadable-canonical",
-        canonical: AliasInput::NonUnicode,
-        legacy: AliasInput::Readable(VALID_TIMEOUT),
-        expected_raw: VALID_TIMEOUT,
-        expected_timeout_secs: Some(37),
-        expected_source: Some("legacy-only"),
-    },
-    SuccessCase {
-        name: "canonical-empty-with-unreadable-legacy",
-        canonical: AliasInput::Readable(""),
-        legacy: AliasInput::NonUnicode,
-        expected_raw: "",
-        expected_timeout_secs: None,
-        expected_source: Some("canonical-only"),
-    },
-    SuccessCase {
-        name: "legacy-empty-with-unreadable-canonical",
-        canonical: AliasInput::NonUnicode,
-        legacy: AliasInput::Readable(""),
-        expected_raw: "",
-        expected_timeout_secs: None,
-        expected_source: Some("legacy-only"),
     },
 ];
 
-const CONFLICT_CASES: [ConflictCase; 3] = [
-    ConflictCase {
-        name: "different-non-empty-values",
-        canonical: CANONICAL_CONFLICT_TIMEOUT,
-        legacy: LEGACY_CONFLICT_TIMEOUT,
-    },
-    ConflictCase {
-        name: "canonical-empty-legacy-non-empty",
-        canonical: "",
-        legacy: LEGACY_CONFLICT_TIMEOUT,
-    },
-    ConflictCase {
-        name: "canonical-non-empty-legacy-empty",
-        canonical: CANONICAL_CONFLICT_TIMEOUT,
-        legacy: "",
-    },
-];
-
-const VALIDATION_CASES: [ValidationCase; 8] = [
+const VALIDATION_CASES: [ValidationCase; 4] = [
     ValidationCase {
-        name: "canonical-invalid",
-        canonical: AliasInput::Readable(CANONICAL_INVALID_TIMEOUT),
-        legacy: AliasInput::Absent,
-        expected_raw: CANONICAL_INVALID_TIMEOUT,
-        expected_source: "canonical-only",
+        name: "canonical-invalid-with-stale-retired",
+        canonical: INVALID_TIMEOUT,
+        retired: EnvInput::Readable(VALID_TIMEOUT),
         expected_error: PARSE_ERROR,
     },
     ValidationCase {
-        name: "legacy-invalid",
-        canonical: AliasInput::Absent,
-        legacy: AliasInput::Readable(LEGACY_INVALID_TIMEOUT),
-        expected_raw: LEGACY_INVALID_TIMEOUT,
-        expected_source: "legacy-only",
+        name: "canonical-whitespace-with-stale-retired",
+        canonical: " 37 ",
+        retired: EnvInput::Readable(VALID_TIMEOUT),
         expected_error: PARSE_ERROR,
     },
     ValidationCase {
-        name: "canonical-whitespace",
-        canonical: AliasInput::Readable(" 37 "),
-        legacy: AliasInput::Absent,
-        expected_raw: " 37 ",
-        expected_source: "canonical-only",
-        expected_error: PARSE_ERROR,
-    },
-    ValidationCase {
-        name: "legacy-whitespace",
-        canonical: AliasInput::Absent,
-        legacy: AliasInput::Readable("37 "),
-        expected_raw: "37 ",
-        expected_source: "legacy-only",
-        expected_error: PARSE_ERROR,
-    },
-    ValidationCase {
-        name: "canonical-zero",
-        canonical: AliasInput::Readable("0"),
-        legacy: AliasInput::Absent,
-        expected_raw: "0",
-        expected_source: "canonical-only",
+        name: "canonical-zero-with-stale-retired",
+        canonical: "0",
+        retired: EnvInput::Readable(VALID_TIMEOUT),
         expected_error: ZERO_ERROR,
     },
     ValidationCase {
-        name: "legacy-zero",
-        canonical: AliasInput::Absent,
-        legacy: AliasInput::Readable("0"),
-        expected_raw: "0",
-        expected_source: "legacy-only",
-        expected_error: ZERO_ERROR,
-    },
-    ValidationCase {
-        name: "canonical-too-large",
-        canonical: AliasInput::Readable(TOO_LARGE_TIMEOUT),
-        legacy: AliasInput::Absent,
-        expected_raw: TOO_LARGE_TIMEOUT,
-        expected_source: "canonical-only",
-        expected_error: TOO_LARGE_ERROR,
-    },
-    ValidationCase {
-        name: "legacy-too-large",
-        canonical: AliasInput::Absent,
-        legacy: AliasInput::Readable(TOO_LARGE_TIMEOUT),
-        expected_raw: TOO_LARGE_TIMEOUT,
-        expected_source: "legacy-only",
+        name: "canonical-too-large-with-stale-retired",
+        canonical: TOO_LARGE_TIMEOUT,
+        retired: EnvInput::Readable(VALID_TIMEOUT),
         expected_error: TOO_LARGE_ERROR,
     },
 ];
@@ -273,64 +153,12 @@ fn remove_test_env(key: impl AsRef<OsStr>) {
     }
 }
 
-fn apply_alias(key: &str, input: AliasInput) {
+fn apply_env(key: &str, input: EnvInput) {
     remove_test_env(key);
     match input {
-        AliasInput::Absent => {}
-        AliasInput::Readable(value) => set_test_env(key, value),
-        AliasInput::NonUnicode => set_test_env(key, OsString::from_vec(vec![0xff])),
-    }
-}
-
-fn clear_timeout_env() {
-    remove_test_env(guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV);
-    remove_test_env(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV);
-}
-
-fn capture_raw(log_path: &Path) -> std::io::Result<(Result<GuestConfigRaw, String>, String)> {
-    guest_common::log::clear_system_log_file();
-    let raw = GuestConfigRaw::from_process_env();
-    assert!(
-        !log_path.exists(),
-        "raw capture installed or wrote a system-log sink"
-    );
-    let evidence = raw
-        .as_ref()
-        .map(|raw| {
-            raw.bootstrap_alias_source_events()
-                .map(|(family, key, source)| {
-                    format!("[captured] {family} key={key} source={source}")
-                })
-                .collect::<Vec<_>>()
-                .join("\n")
-        })
-        .unwrap_or_default();
-    Ok((raw, evidence))
-}
-
-fn assert_source_evidence(log: &str, case_name: &str, expected_source: Option<&str>) {
-    let source_messages = log
-        .lines()
-        .filter(|line| line.contains(SOURCE_EVENT))
-        .filter_map(|line| line.rsplit_once("] ").map(|(_, message)| message))
-        .collect::<Vec<_>>();
-
-    match expected_source {
-        Some(source) => {
-            let expected = format!(
-                "{SOURCE_EVENT} key={} source={source}",
-                guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV
-            );
-            assert_eq!(
-                source_messages,
-                [expected.as_str()],
-                "{case_name} emitted incorrect fixed source evidence"
-            );
-        }
-        None => assert!(
-            source_messages.is_empty(),
-            "{case_name} emitted source evidence for unreadable aliases"
-        ),
+        EnvInput::Absent => {}
+        EnvInput::Readable(value) => set_test_env(key, value),
+        EnvInput::NonUnicode => set_test_env(key, OsString::from_vec(vec![0xff])),
     }
 }
 
@@ -350,7 +178,7 @@ fn materialize_config(
         .map_err(|error| format!("write run payload: {error}"))?;
 
     GuestConfig::from_raw(GuestConfigRaw {
-        run_id: format!("agent-execution-timeout-alias-{case_name}"),
+        run_id: format!("agent-execution-timeout-{case_name}"),
         home: Some(tmp.to_string_lossy().into_owned()),
         guest_runtime_dir: Some(runtime_dir),
         run_payload_file: payload_path.to_string_lossy().into_owned(),
@@ -358,16 +186,7 @@ fn materialize_config(
     })
 }
 
-fn expected_conflict_error() -> String {
-    format!(
-        "conflicting agent execution timeout environment aliases: canonical_key={} \
-         legacy_key={} state=conflict",
-        guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
-        guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV
-    )
-}
-
-fn assert_source_neutral_validation_error(error: &str, case: ValidationCase) {
+fn assert_validation_error(error: &str, case: ValidationCase) {
     assert_eq!(
         error, case.expected_error,
         "{} returned the wrong validation category",
@@ -375,47 +194,41 @@ fn assert_source_neutral_validation_error(error: &str, case: ValidationCase) {
     );
     assert!(
         !error.contains(guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV),
-        "{} named the canonical alias",
+        "{} named the canonical key",
         case.name
     );
     assert!(
-        !error.contains(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV),
-        "{} named the legacy alias",
+        !error.contains(RETIRED_AGENT_EXECUTION_TIMEOUT_SECS_ENV),
+        "{} named the retired key",
         case.name
     );
-    if !case.expected_raw.is_empty() {
-        assert!(
-            !error.contains(case.expected_raw),
-            "{} exposed the raw timeout input",
-            case.name
-        );
-    }
+    assert!(
+        !error.contains(case.canonical),
+        "{} exposed the raw canonical input",
+        case.name
+    );
 }
 
 #[test]
-fn process_env_dual_reads_agent_execution_timeout_aliases_without_value_leaks() -> TestResult {
+fn process_env_uses_only_canonical_agent_execution_timeout() -> TestResult {
     let tmp = tempfile::tempdir()?;
 
     for case in SUCCESS_CASES {
-        apply_alias(
+        apply_env(
             guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
             case.canonical,
         );
-        apply_alias(
-            guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
-            case.legacy,
-        );
-        let (raw, log) = capture_raw(&tmp.path().join(format!("success-{}.log", case.name)))?;
-        let raw = raw.map_err(std::io::Error::other)?;
+        apply_env(RETIRED_AGENT_EXECUTION_TIMEOUT_SECS_ENV, case.retired);
+
+        let raw = GuestConfigRaw::from_process_env().map_err(std::io::Error::other)?;
         assert_eq!(
             raw.agent_execution_timeout_secs, case.expected_raw,
-            "{} resolved the wrong raw timeout",
+            "{} captured the wrong raw timeout",
             case.name
         );
-        assert_source_evidence(&log, case.name, case.expected_source);
 
-        let config = materialize_config(tmp.path(), &format!("success-{}", case.name), raw)
-            .map_err(std::io::Error::other)?;
+        let config =
+            materialize_config(tmp.path(), case.name, raw).map_err(std::io::Error::other)?;
         assert_eq!(
             config.agent_execution_timeout,
             case.expected_timeout_secs.map(Duration::from_secs),
@@ -424,101 +237,34 @@ fn process_env_dual_reads_agent_execution_timeout_aliases_without_value_leaks() 
         );
     }
 
-    let expected_conflict = expected_conflict_error();
-    for case in CONFLICT_CASES {
-        set_test_env(
-            guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
-            case.canonical,
-        );
-        set_test_env(
-            guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
-            case.legacy,
-        );
-        let (raw, log) = capture_raw(&tmp.path().join(format!("conflict-{}.log", case.name)))?;
-        let error = match raw {
-            Ok(_) => {
-                return Err(std::io::Error::other(format!(
-                    "{} accepted conflicting readable aliases",
-                    case.name
-                ))
-                .into());
-            }
-            Err(error) => error,
-        };
-        assert_eq!(
-            error, expected_conflict,
-            "{} returned the wrong fixed conflict diagnostic",
-            case.name
-        );
-        assert!(
-            !log.contains(SOURCE_EVENT),
-            "{} emitted success evidence for a conflict",
-            case.name
-        );
-    }
-
     for case in VALIDATION_CASES {
-        apply_alias(
+        apply_env(
             guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
-            case.canonical,
+            EnvInput::Readable(case.canonical),
         );
-        apply_alias(
-            guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
-            case.legacy,
-        );
-        let (raw, log) = capture_raw(&tmp.path().join(format!("validation-{}.log", case.name)))?;
-        let raw = raw.map_err(std::io::Error::other)?;
+        apply_env(RETIRED_AGENT_EXECUTION_TIMEOUT_SECS_ENV, case.retired);
+
+        let raw = GuestConfigRaw::from_process_env().map_err(std::io::Error::other)?;
         assert_eq!(
-            raw.agent_execution_timeout_secs, case.expected_raw,
-            "{} changed the selected raw timeout before validation",
+            raw.agent_execution_timeout_secs, case.canonical,
+            "{} changed the canonical raw timeout before validation",
             case.name
         );
-        assert_source_evidence(&log, case.name, Some(case.expected_source));
 
-        let error = match materialize_config(tmp.path(), &format!("validation-{}", case.name), raw)
-        {
+        let error = match materialize_config(tmp.path(), case.name, raw) {
             Ok(_) => {
                 return Err(std::io::Error::other(format!(
-                    "{} accepted an invalid timeout",
+                    "{} accepted an invalid canonical timeout",
                     case.name
                 ))
                 .into());
             }
             Err(error) => error,
         };
-        assert_source_neutral_validation_error(&error, case);
+        assert_validation_error(&error, case);
     }
 
-    set_test_env(
-        guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
-        CANONICAL_CONFLICT_TIMEOUT,
-    );
-    set_test_env(
-        guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
-        LEGACY_CONFLICT_TIMEOUT,
-    );
-    for key in [
-        process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
-        guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
-        guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
-        guest_contracts::process_containment::CANONICAL_TOOL_CGROUP_PROCS_ENV,
-        guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV,
-    ] {
-        remove_test_env(key);
-    }
-    let runtime_error = match GuestRuntime::from_process_env() {
-        Ok(_) => {
-            return Err(
-                "production runtime accepted conflicting agent execution timeout aliases".into(),
-            );
-        }
-        Err(error) => error,
-    };
-    assert_eq!(
-        runtime_error, expected_conflict,
-        "production runtime did not fail at timeout capture"
-    );
-
-    clear_timeout_env();
+    remove_test_env(guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV);
+    remove_test_env(RETIRED_AGENT_EXECUTION_TIMEOUT_SECS_ENV);
     Ok(())
 }

--- a/crates/guest-agent/tests/bootstrap_alias_source_events.rs
+++ b/crates/guest-agent/tests/bootstrap_alias_source_events.rs
@@ -25,15 +25,14 @@ const WORKSPACE_REUSE_VALUE: &str = "workspace-reuse-value-must-not-leak";
 const RESUME_SESSION_VALUE: &str = "resume-session-value-must-not-leak";
 const API_START_TIME_VALUE: &str = "api-start-time-value-must-not-leak";
 
-const SOURCE_EVENT_FAMILIES: [&str; 5] = [
+const SOURCE_EVENT_FAMILIES: [&str; 4] = [
     "api_url_env_source",
     "private_payload_file_env_source",
     "api_token_env_source",
-    "agent_execution_timeout_env_source",
     "guest_agent_tuning_env_source",
 ];
 
-const SOURCE_EVENTS: [(&str, &str); 8] = [
+const SOURCE_EVENTS: [(&str, &str); 7] = [
     (
         "api_url_env_source",
         guest_contracts::env::CANONICAL_API_URL_ENV,
@@ -61,10 +60,6 @@ const SOURCE_EVENTS: [(&str, &str); 8] = [
     (
         "private_payload_file_env_source",
         guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV,
-    ),
-    (
-        "agent_execution_timeout_env_source",
-        guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
     ),
 ];
 
@@ -257,6 +252,10 @@ fn bootstrap_alias_source_events_isolated_child() -> TestResult {
     assert_eq!(runtime.config.workspace_reuse_result, WORKSPACE_REUSE_VALUE);
     assert_eq!(runtime.config.resume_session_id, RESUME_SESSION_VALUE);
     assert_eq!(runtime.config.api_start_time, API_START_TIME_VALUE);
+    assert_eq!(
+        runtime.config.agent_execution_timeout,
+        Some(Duration::from_secs(37))
+    );
     println!("{CHILD_MARKER}");
     Ok(())
 }

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -9,6 +9,8 @@ use guest_agent::run_context::GuestRuntime;
 use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
+const RETIRED_AGENT_EXECUTION_TIMEOUT_SECS_ENV: &str = "VM0_AGENT_EXECUTION_TIMEOUT_SECS";
+
 #[tokio::test]
 async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
 -> Result<(), Box<dyn std::error::Error>> {
@@ -66,7 +68,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
         std::env::set_var("CLI_AGENT_TYPE", "claude-code");
         std::env::set_var("VM0_APPEND_SYSTEM_PROMPT", "runner append prompt");
         std::env::set_var("VM0_FEATURE_FLAGS", r#"{"flag":true}"#);
-        std::env::set_var(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV, "60");
+        std::env::set_var(RETIRED_AGENT_EXECUTION_TIMEOUT_SECS_ENV, "59");
         std::env::set_var(
             guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
             "60",
@@ -303,7 +305,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     assert!(!cli_env.contains_key("VM0_FEATURE_FLAGS"));
     for key in [
         guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
-        guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+        RETIRED_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
         guest_contracts::env::CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV,
         guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV,
         guest_contracts::env::CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV,

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1062,7 +1062,7 @@ pub unsafe fn clear_guest_agent_bootstrap_env_for_test() {
         guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV,
         "VM0_API_START_TIME",
         guest_contracts::env::CANONICAL_API_START_TIME_ENV,
-        guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+        "VM0_AGENT_EXECUTION_TIMEOUT_SECS",
         guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
         guest_contracts::env::SECRET_VALUES_ENV,
         guest_contracts::env::DISALLOWED_TOOLS_ENV,

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -86,19 +86,12 @@ pub const CANONICAL_RESUME_SESSION_ID_ENV: &str = "OKOU_RESUME_SESSION_ID";
 /// The runner emits an empty string when the timestamp is unavailable.
 pub const CANONICAL_API_START_TIME_ENV: &str = "OKOU_API_START_TIME";
 
-/// Maximum agent execution duration in seconds.
+/// Maximum agent execution duration in seconds, written by the runner.
 ///
 /// The runner owns this fixed lifecycle budget. Guest-agent uses it to stop
 /// the CLI before the later sandbox supervisor deadline, leaving time for
 /// recovery checkpointing and final telemetry. It is intentionally not a
 /// local user-tuning key.
-pub const AGENT_EXECUTION_TIMEOUT_SECS_ENV: &str = "VM0_AGENT_EXECUTION_TIMEOUT_SECS";
-
-/// Canonical agent execution timeout alias written by the runner.
-///
-/// Guest readers retain [`AGENT_EXECUTION_TIMEOUT_SECS_ENV`] as a rollback
-/// fallback until the canonical writer deployment, supported rollback window,
-/// and legacy-read-zero gates in #28914 are complete.
 pub const CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV: &str = "OKOU_AGENT_EXECUTION_TIMEOUT_SECS";
 
 /// Logical run-payload field name for sensitive values used by the guest-agent
@@ -610,10 +603,6 @@ mod tests {
         assert_eq!(PI_LAUNCH_PAYLOAD_FILENAME, "payload.json");
         assert_eq!(PI_MODEL_CONFIG_ENV, "OKOU_PI_MODEL_CONFIG");
         assert_eq!(CLI_AGENT_TYPE_ENV, "CLI_AGENT_TYPE");
-        assert_eq!(
-            AGENT_EXECUTION_TIMEOUT_SECS_ENV,
-            "VM0_AGENT_EXECUTION_TIMEOUT_SECS"
-        );
         assert_eq!(
             CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
             "OKOU_AGENT_EXECUTION_TIMEOUT_SECS"

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -463,7 +463,7 @@ fn build_env_json_required_keys() {
             .unwrap(),
         "7200"
     );
-    assert!(!env.contains_key(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV));
+    assert!(!env.contains_key("VM0_AGENT_EXECUTION_TIMEOUT_SECS"));
     assert_eq!(
         env.get(guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV)
             .unwrap(),


### PR DESCRIPTION
Parent EPIC: #28914

Closes #30289

## Summary

- capture the Runner-owned execution timeout only from `OKOU_AGENT_EXECUTION_TIMEOUT_SECS` at the Guest Agent process-environment boundary
- remove the retired shared constant, dual/conflict resolver, bootstrap alias/source slot, source event, and compatibility-only positive-reader coverage
- retain `VM0_AGENT_EXECUTION_TIMEOUT_SECS` only in deliberate retirement, cleanup, Runner-negative-writer, and CLI-child-isolation assertions

## Semantics and scope

Legacy-only input is ignored. When both spellings are present, equal or different, only the canonical value controls the raw capture and duration; the retired value cannot override selection or create a conflict. Canonical absent, empty, non-Unicode, valid, invalid, whitespace, zero, overflow/too-large, deadline, recovery checkpoint, and finalization behavior remains unchanged.

The production Runner writer remains unchanged and emits only `OKOU_AGENT_EXECUTION_TIMEOUT_SECS=7200`. This PR does not change `JOB_TIMEOUT`, Runner supervision, exit code 124, the four Guest Agent tuning contracts, another namespace wave, process containment, the temporary `VM0_*` ownership guard, deployment, or production state.

## Base, inventory, and overlap evidence

- final base: `7d0c3ad45d1361c0ee6463f8cc46feb00780e8f4`
- candidate head: `2348da4ccf853dd4c02ff0549b4f8ca81d7734af`
- production occurrences of `VM0_AGENT_EXECUTION_TIMEOUT_SECS`: zero
- final raw retired-key occurrences: four, all in focused negative/cleanup/isolation tests
- final occurrences of the retired shared symbol, timeout resolver, alias variant, source event, source slot, and conflict diagnostic: zero
- bootstrap source inventory composes with merged run-metadata and API-token waves: current `main` has eight slots and this PR removes only timeout, leaving seven
- pre-publication fully paginated open-PR audit: 25 PRs, 481 declared / 481 fetched changed files, zero mismatches
- current overlap is limited to #30293, which independently retires the API URL root reader, and stale #25722, which adds unrelated Cloudflare Access hunks; every shared-file hunk was inspected and neither is a functional dependency

## Validation

Passed on the final base/head unless noted:

- `cargo fmt --all -- --check`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo clippy -p guest-contracts --all-targets --all-features -- -D warnings`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo check -p guest-contracts --all-targets --all-features`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p guest-contracts` (123 unit tests plus integration and doc tests)
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo check -p guest-agent --all-targets --all-features`
- focused Guest Agent tests: `agent_execution_timeout_env_aliases`, `bootstrap_alias_source_events`, `cli_child_env`, the library timeout parser, SIGTERM/SIGKILL timeout, recovery checkpoint, both Codex timeout paths, and post-result execution deadline
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo check -p runner --all-targets --all-features`

The broader Guest Agent name-filter command exhausted the 16 GB workspace while linking unrelated test binaries; all exact timeout/recovery/finalization targets passed after removing generated Cargo output. `cargo test -p runner executor::tests::env_tests` reached its final test-binary link twice and the workload process group was OOM-killed without Rust diagnostics. The local cgroup evidence is `memory.max=3991613440`, `memory.peak=3991859200`, `oom=2`, `oom_kill=6`, and `oom_group_kill=2`; 12 GB of disk remained. Protected PR CI is authoritative for the Runner link.

No full Vitest suite or development server was run.

## Acceptance self-review

- [x] Guest Agent production capture reads only the canonical timeout key.
- [x] Legacy resolver, constant, source machinery, dual handling, and fixed conflict diagnostic are removed.
- [x] Legacy-only, equal-dual, different-dual, and non-Unicode retired inputs cannot affect canonical selection.
- [x] Canonical parse, zero, whitespace, overflow, deadline, recovery, and finalization semantics remain covered.
- [x] Runner still emits only the canonical `7200` value and retains a retired-key negative assertion.
- [x] Neither spelling reaches curated CLI children.
- [x] Tuning contracts, unrelated namespaces, Runner writer, and `VM0_*` ownership guard remain unchanged.
- [x] The diff is one focused commit and one focused PR linking #30289 and #28914.
- [x] No production, deployment, browser, rollback, drain, or contributor-PR action was performed.

## Fallbacks

This change removes the retired execution-timeout reader fallback and adds no new fallback. The production observation, drain, and rollback gates authorizing removal are recorded in #30289.
