### PR TITLE
fix(ci): wait for app runtime convergence

### DIFF
--- a/.github/scripts/tests/deploy-okou-pages-workflow-test.sh
+++ b/.github/scripts/tests/deploy-okou-pages-workflow-test.sh
@@ -73,6 +73,7 @@ release_sentry_step = find_step(
     release_job, "Upload Cloudflare Pages source maps to Sentry"
 )
 release_step = find_step(release_job, "Deploy Cloudflare Pages production")
+release_finish_step = find_step(release_job, "Finish GitHub Deployment")
 release_api_verification_step = find_step(
     release_api_job, "Verify production App and API domains"
 )
@@ -186,7 +187,7 @@ if preview_gateway_step.get("env", {}).get("CANONICAL_ASSETS") != (
     "${{ steps.pages-preview.outputs.canonical-dist }}/assets"
 ):
     raise RuntimeError("SharedWorker smoke test must use canonical app assets")
-require_fragments(
+release_step_source = require_fragments(
     release_step,
     [
         shared_script,
@@ -195,16 +196,44 @@ require_fragments(
         "production",
         '"$ARTIFACT_SHA"',
         "bash .github/scripts/verify-okou-app-runtime.sh",
+        '"$pages_url"',
         '"https://static.okou.io/okou-app/assets"',
         '"$CANONICAL_ASSETS"',
         '"https://app.vm0.ai"',
         '"https://app.okou.ai"',
     ],
 )
+if release_step_source.count(shared_script) != 1:
+    raise RuntimeError(
+        "production readiness polling must follow exactly one Pages deployment"
+    )
+runtime_verifier = "bash .github/scripts/verify-okou-app-runtime.sh"
+domain_verifier = "bash .github/scripts/verify-okou-production-domains.sh"
+if not (
+    release_step_source.index(shared_script)
+    < release_step_source.index(runtime_verifier)
+    < release_step_source.index(domain_verifier)
+    < release_step_source.index('echo "url=$production_url"')
+):
+    raise RuntimeError(
+        "production readiness and domain verification must finish before success output"
+    )
 if release_step.get("env", {}).get("CANONICAL_ASSETS") != (
     "${{ steps.pages-production.outputs.canonical-dist }}/assets"
 ):
     raise RuntimeError("production deploy must verify the canonical App bundles")
+if release_step.get("env", {}).get("OKOU_APP_RUNTIME_MAX_ATTEMPTS") != "60":
+    raise RuntimeError("production runtime convergence must use 60 bounded probes")
+if not (
+    release_steps.index(release_step) < release_steps.index(release_finish_step)
+):
+    raise RuntimeError(
+        "production readiness must finish before the GitHub Deployment is reported"
+    )
+if release_finish_step.get("with", {}).get("status") != "${{ job.status }}":
+    raise RuntimeError(
+        "GitHub Deployment completion must fail closed on readiness verification"
+    )
 require_fragments(
     rollback_step,
     [shared_script, '"$PAGES_DIST"', '"$CF_PAGES_PROJECT_NAME"', "production", '"$TARGET_COMMIT"'],

--- a/.github/scripts/tests/verify-okou-app-runtime-test.sh
+++ b/.github/scripts/tests/verify-okou-app-runtime-test.sh
@@ -8,7 +8,9 @@ trap 'rm -rf "$test_root"' EXIT
 assets_directory="${test_root}/assets"
 fake_bin="${test_root}/bin"
 curl_log="${test_root}/curl.log"
+sleep_log="${test_root}/sleep.log"
 html_source="${test_root}/index.html"
+old_html_source="${test_root}/old-index.html"
 mkdir -p "$assets_directory" "$fake_bin"
 
 fail() {
@@ -31,6 +33,13 @@ cat > "$html_source" <<'HTML'
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/vendor-EfGh5678.js">
 HTML
 
+cat > "$old_html_source" <<'HTML'
+<!doctype html>
+<script type="module" crossorigin src="https://static.test/okou-app/assets/app-Old12345.js"></script>
+<link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/rolldown-runtime-Old12345.js">
+<link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/vendor-Old12345.js">
+HTML
+
 cat > "${fake_bin}/curl" <<'BASH'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -47,19 +56,41 @@ for (( index = 0; index < ${#arguments[@]}; index += 1 )); do
   esac
 done
 if [[ "$asset_url" == */sign-up ]]; then
-  cp "$MOCK_HTML_SOURCE" "$output_file"
+  if [[ "${MOCK_DOCUMENT_MODE:-success}" == "transport-failure" ]]; then
+    echo 'curl: (56) simulated document transport failure' >&2
+    exit 56
+  fi
+  document_source="$MOCK_HTML_SOURCE"
+  if [[ -n "${MOCK_HTML_SEQUENCE_STATE:-}" ]]; then
+    document_attempt="$(<"$MOCK_HTML_SEQUENCE_STATE")"
+    document_attempt=$((document_attempt + 1))
+    printf '%s\n' "$document_attempt" >"$MOCK_HTML_SEQUENCE_STATE"
+    sequence_source="${MOCK_HTML_SEQUENCE_DIR}/${document_attempt}.html"
+    if [[ -f "$sequence_source" ]]; then
+      document_source="$sequence_source"
+    fi
+  fi
+  cp "$document_source" "$output_file"
 fi
 if [[ -n "$write_out" ]]; then
   printf '%s' "${MOCK_WORKER_STATUS:-206}"
 fi
 BASH
-chmod +x "${fake_bin}/curl"
+
+cat > "${fake_bin}/sleep" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "${1:?sleep delay is required}" >>"$MOCK_SLEEP_LOG"
+BASH
+chmod +x "${fake_bin}/curl" "${fake_bin}/sleep"
 
 : > "$curl_log"
+: > "$sleep_log"
 output="$({
   PATH="${fake_bin}:$PATH" \
     MOCK_CURL_LOG="$curl_log" \
     MOCK_HTML_SOURCE="$html_source" \
+    MOCK_SLEEP_LOG="$sleep_log" \
     bash "$script" \
       https://app.test \
       https://static.test/okou-app/assets \
@@ -79,9 +110,99 @@ for expected_url in \
     fail "runtime verifier did not probe ${expected_url}"
 done
 
+if OKOU_APP_RUNTIME_MAX_ATTEMPTS=0 \
+  bash "$script" \
+    https://app.test \
+    https://static.test/okou-app/assets \
+    "$assets_directory" > "${test_root}/invalid-bound.log" 2>&1; then
+  fail "invalid runtime convergence bound did not fail closed"
+fi
+grep -Fq 'OKOU_APP_RUNTIME_MAX_ATTEMPTS must be a positive integer' \
+  "${test_root}/invalid-bound.log" ||
+  fail "invalid runtime convergence bound was not identified"
+
+sequence_directory="${test_root}/html-sequence"
+sequence_state="${test_root}/html-sequence.state"
+mkdir -p "$sequence_directory"
+cp "$old_html_source" "${sequence_directory}/1.html"
+cp "$html_source" "${sequence_directory}/2.html"
+printf '0\n' > "$sequence_state"
+: > "$curl_log"
+: > "$sleep_log"
+PATH="${fake_bin}:$PATH" \
+  MOCK_CURL_LOG="$curl_log" \
+  MOCK_HTML_SEQUENCE_DIR="$sequence_directory" \
+  MOCK_HTML_SEQUENCE_STATE="$sequence_state" \
+  MOCK_HTML_SOURCE="$html_source" \
+  MOCK_SLEEP_LOG="$sleep_log" \
+  OKOU_APP_RUNTIME_MAX_ATTEMPTS=3 \
+  bash "$script" \
+    https://app.test \
+    https://static.test/okou-app/assets \
+    "$assets_directory" >/dev/null
+[[ "$(<"$sequence_state")" == "2" ]] ||
+  fail "old runtime document did not converge on the second probe"
+[[ "$(grep -Fc 'https://app.test/sign-up' "$curl_log")" == "2" ]] ||
+  fail "runtime convergence did not fetch exactly two documents"
+grep -Fxq '10' "$sleep_log" ||
+  fail "runtime convergence did not wait between semantic probes"
+
+: > "$curl_log"
+: > "$sleep_log"
+if PATH="${fake_bin}:$PATH" \
+  MOCK_CURL_LOG="$curl_log" \
+  MOCK_HTML_SOURCE="$old_html_source" \
+  MOCK_SLEEP_LOG="$sleep_log" \
+  OKOU_APP_RUNTIME_MAX_ATTEMPTS=3 \
+  bash "$script" \
+    https://app.test \
+    https://static.test/okou-app/assets \
+    "$assets_directory" > "${test_root}/semantic-failure.log" 2>&1; then
+  fail "permanent semantic mismatch did not exhaust the convergence bound"
+fi
+[[ "$(grep -Fc 'https://app.test/sign-up' "$curl_log")" == "3" ]] ||
+  fail "permanent semantic mismatch did not use the bounded probe count"
+[[ "$(wc -l < "$sleep_log")" == "2" ]] ||
+  fail "permanent semantic mismatch used an unexpected retry count"
+grep -Fq 'App runtime document did not converge for https://app.test after probe 3/3' \
+  "${test_root}/semantic-failure.log" ||
+  fail "semantic exhaustion did not identify the origin and bound"
+grep -Fq 'app-AbCd1234.js' "${test_root}/semantic-failure.log" ||
+  fail "semantic exhaustion did not report the expected module"
+grep -Fq 'app-Old12345.js' "${test_root}/semantic-failure.log" ||
+  fail "semantic exhaustion did not report the observed module"
+
+: > "$curl_log"
+: > "$sleep_log"
+if PATH="${fake_bin}:$PATH" \
+  MOCK_CURL_LOG="$curl_log" \
+  MOCK_DOCUMENT_MODE=transport-failure \
+  MOCK_HTML_SOURCE="$html_source" \
+  MOCK_SLEEP_LOG="$sleep_log" \
+  OKOU_APP_RUNTIME_MAX_ATTEMPTS=3 \
+  bash "$script" \
+    https://transport.test \
+    https://static.test/okou-app/assets \
+    "$assets_directory" > "${test_root}/transport-failure.log" 2>&1; then
+  fail "permanent document transport failure did not exhaust the convergence bound"
+fi
+[[ "$(grep -Fc 'https://transport.test/sign-up' "$curl_log")" == "3" ]] ||
+  fail "document transport failure did not use the bounded probe count"
+grep -Fq 'App runtime document did not converge for https://transport.test after probe 3/3' \
+  "${test_root}/transport-failure.log" ||
+  fail "transport exhaustion did not identify the origin and bound"
+grep -Fq 'curl exit 56' "${test_root}/transport-failure.log" ||
+  fail "transport exhaustion did not preserve the final curl status"
+grep -Fq 'simulated document transport failure' \
+  "${test_root}/transport-failure.log" ||
+  fail "transport exhaustion did not preserve the final curl evidence"
+
+: > "$curl_log"
+: > "$sleep_log"
 if PATH="${fake_bin}:$PATH" \
   MOCK_CURL_LOG="$curl_log" \
   MOCK_HTML_SOURCE="$html_source" \
+  MOCK_SLEEP_LOG="$sleep_log" \
   MOCK_WORKER_STATUS=200 \
   bash "$script" \
     https://app.test \
@@ -93,9 +214,12 @@ grep -Fq 'SharedWorker same-origin proxy returned HTTP 200' \
   "${test_root}/worker-failure.log" || fail "worker failure was not identified"
 
 sed -i '/vendor-EfGh5678/d' "$html_source"
+: > "$curl_log"
+: > "$sleep_log"
 if PATH="${fake_bin}:$PATH" \
   MOCK_CURL_LOG="$curl_log" \
   MOCK_HTML_SOURCE="$html_source" \
+  MOCK_SLEEP_LOG="$sleep_log" \
   bash "$script" \
     https://app.test \
     https://static.test/okou-app/assets \
@@ -104,5 +228,8 @@ if PATH="${fake_bin}:$PATH" \
 fi
 grep -Fq 'Expected CDN runtime/vendor modulepreloads' \
   "${test_root}/html-failure.log" || fail "HTML failure was not identified"
+grep -Fq 'App runtime document did not converge for https://app.test after probe 1/1' \
+  "${test_root}/html-failure.log" ||
+  fail "malformed document failure did not exhaust the convergence bound"
 
 echo "verify okou app runtime tests passed"

--- a/.github/scripts/verify-okou-app-runtime.sh
+++ b/.github/scripts/verify-okou-app-runtime.sh
@@ -9,15 +9,22 @@ fi
 app_url="${1%/}"
 public_assets_url="${2%/}"
 assets_directory="${3%/}"
+document_max_attempts="${OKOU_APP_RUNTIME_MAX_ATTEMPTS:-1}"
 
 if [[ ! -d "$assets_directory" ]]; then
   echo "app assets directory does not exist: $assets_directory" >&2
   exit 1
 fi
+if [[ ! "$document_max_attempts" =~ ^[1-9][0-9]*$ ]]; then
+  echo "OKOU_APP_RUNTIME_MAX_ATTEMPTS must be a positive integer" >&2
+  exit 1
+fi
 
 layout_files="$(mktemp)"
 document_body="$(mktemp)"
-trap 'rm -f "$layout_files" "$document_body"' EXIT
+curl_error="$(mktemp)"
+probe_evidence="$(mktemp)"
+trap 'rm -f "$layout_files" "$document_body" "$curl_error" "$probe_evidence"' EXIT
 
 declare -a app_files=()
 declare -a vendor_files=()
@@ -48,26 +55,32 @@ app_asset_url="${public_assets_url}/${app_files[0]}"
 vendor_asset_url="${public_assets_url}/${vendor_files[0]}"
 runtime_asset_url="${public_assets_url}/${runtime_files[0]}"
 worker_asset_url="${app_url}/okou-app/assets/${worker_files[0]}"
+document_url="${app_url}/sign-up"
+document_retry_delay_seconds=10
+document_wait_started=$SECONDS
+document_wait_deadline=$((document_wait_started + 600))
 
-curl \
-  --fail \
-  --silent \
-  --show-error \
-  --location \
-  --connect-timeout 10 \
-  --max-time 30 \
-  --retry 6 \
-  --retry-delay 2 \
-  --retry-max-time 90 \
-  --retry-all-errors \
-  --output "$document_body" \
-  "${app_url}/sign-up"
-
-python3 - \
-  "$document_body" \
-  "$app_asset_url" \
-  "$runtime_asset_url" \
-  "$vendor_asset_url" <<'PY'
+for ((attempt = 1; attempt <= document_max_attempts; attempt++)); do
+  : >"$curl_error"
+  : >"$probe_evidence"
+  if curl \
+    --fail \
+    --silent \
+    --show-error \
+    --location \
+    --connect-timeout 10 \
+    --max-time 30 \
+    --retry 6 \
+    --retry-delay 2 \
+    --retry-max-time 90 \
+    --retry-all-errors \
+    --output "$document_body" \
+    "$document_url" 2>"$curl_error"; then
+    if python3 - \
+      "$document_body" \
+      "$app_asset_url" \
+      "$runtime_asset_url" \
+      "$vendor_asset_url" 2>"$probe_evidence" <<'PY'
 from html.parser import HTMLParser
 from pathlib import Path
 import sys
@@ -107,6 +120,45 @@ if len(parser.module_preloads) != 2 or set(parser.module_preloads) != expected_p
         f"got {parser.module_preloads}"
     )
 PY
+    then
+      break
+    fi
+  else
+    curl_status=$?
+    {
+      printf 'Transport probe failed for %s (curl exit %s)\n' \
+        "$document_url" \
+        "$curl_status"
+      cat "$curl_error"
+    } >"$probe_evidence"
+  fi
+
+  if ((attempt == document_max_attempts || SECONDS >= document_wait_deadline)); then
+    elapsed_seconds=$((SECONDS - document_wait_started))
+    printf \
+      'App runtime document did not converge for %s after probe %s/%s (%ss); final probe evidence:\n' \
+      "$app_url" \
+      "$attempt" \
+      "$document_max_attempts" \
+      "$elapsed_seconds" \
+      >&2
+    cat "$probe_evidence" >&2
+    exit 1
+  fi
+
+  printf \
+    '::warning title=Waiting for app runtime convergence::%s has not converged (attempt %s/%s)\n' \
+    "$document_url" \
+    "$attempt" \
+    "$document_max_attempts" \
+    >&2
+  remaining_seconds=$((document_wait_deadline - SECONDS))
+  sleep_seconds=$document_retry_delay_seconds
+  if ((remaining_seconds < sleep_seconds)); then
+    sleep_seconds=$remaining_seconds
+  fi
+  sleep "$sleep_seconds"
+done
 
 for asset_url in \
   "$app_asset_url" \

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1728,6 +1728,7 @@ jobs:
           CF_PAGES_PROJECT_NAME: ${{ vars.CF_PAGES_PROJECT_NAME }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CF_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_DEPLOY_API_TOKEN }}
+          OKOU_APP_RUNTIME_MAX_ATTEMPTS: "60"
           PAGES_DIST: ${{ steps.pages-production.outputs.pages-dist }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- add production-only bounded semantic convergence polling after the successful Cloudflare Pages deployment
- require the exact app module and exact runtime/vendor preloads before continuing, while preserving final expected/observed or transport evidence on exhaustion
- keep non-production verifier callers single-attempt and lock the release workflow to one Pages deploy before all three origins, SharedWorker validation, domain verification, and deployment completion

## Safety invariants

- exact artifact SHA selection is unchanged
- append-only R2/CDN asset publication and verification are unchanged
- Pages is invoked once; readiness polling never redeploys
- `okou-app.pages.dev`, `app.vm0.ai`, and `app.okou.ai` remain required
- the same-origin SharedWorker range check and production-domain verification remain fail-closed
- no preceding-bundle fallback or wrong-document acceptance is introduced

## Validation

- `npx --yes prettier@3.8.1 --check .github/workflows/release-please.yml`
- `bash -n .github/scripts/verify-okou-app-runtime.sh .github/scripts/tests/verify-okou-app-runtime-test.sh .github/scripts/tests/deploy-okou-pages-workflow-test.sh`
- `shellcheck .github/scripts/verify-okou-app-runtime.sh .github/scripts/tests/verify-okou-app-runtime-test.sh .github/scripts/tests/deploy-okou-pages-workflow-test.sh`
- `bash .github/scripts/check-workflow-shell-compatibility.sh .github/workflows/release-please.yml`
- `bash .github/scripts/tests/verify-okou-app-runtime-test.sh`
- `bash .github/scripts/tests/deploy-okou-pages-test.sh`
- `bash .github/scripts/tests/deploy-okou-pages-workflow-test.sh`
- `git diff --check origin/main...HEAD`

## Inventory

- based on `main@7d0c3ad45d1361c0ee6463f8cc46feb00780e8f4`
- refreshed 25 open PRs across 26 changed-file pages: 481 declared / 481 fetched, zero reconciliation mismatch, stable PR set
- stale #25722 remains an independent adjacent API Worker/preview change; no commits or implementation were imported

Fixes #30298
