### PR TITLE
refactor(cli): use canonical api url in ordinary tests

### DIFF
--- a/turbo/apps/cli/src/commands/__tests__/credit.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/credit.test.ts
@@ -63,7 +63,7 @@ describe("okou credit command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     server.use(stubBillingStatus());
   });

--- a/turbo/apps/cli/src/commands/__tests__/upgrade.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/upgrade.test.ts
@@ -8,7 +8,7 @@ describe("okou upgrade command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/whoami.test.ts
@@ -169,7 +169,7 @@ describe("okou whoami command", () => {
           exp: 2000,
         }),
       );
-      vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+      vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
 
       await runWhoami();
 
@@ -200,7 +200,7 @@ describe("okou whoami command", () => {
           exp: 2000,
         }),
       );
-      vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+      vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
       server.use(
         http.get("http://localhost:3000/api/org", () => {
           return HttpResponse.json(
@@ -294,7 +294,7 @@ describe("okou whoami command", () => {
       });
       vi.stubEnv("OKOU_AGENT_ID", "agent-123");
       vi.stubEnv("OKOU_TOKEN", token);
-      vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+      vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
         http.get("http://localhost:3000/api/connectors", () => {
@@ -367,7 +367,7 @@ describe("okou whoami command", () => {
       });
       vi.stubEnv("OKOU_AGENT_ID", "agent-123");
       vi.stubEnv("OKOU_TOKEN", token);
-      vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+      vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
         http.get("http://localhost:3000/api/connectors", () => {
@@ -415,7 +415,7 @@ describe("okou whoami command", () => {
       });
       vi.stubEnv("OKOU_AGENT_ID", "agent-123");
       vi.stubEnv("OKOU_TOKEN", token);
-      vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+      vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
         http.get("http://localhost:3000/api/connectors", () => {
@@ -458,7 +458,7 @@ describe("okou whoami command", () => {
       });
       vi.stubEnv("OKOU_AGENT_ID", "agent-123");
       vi.stubEnv("OKOU_TOKEN", token);
-      vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+      vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
         http.get("http://localhost:3000/api/connectors", () => {
@@ -496,7 +496,7 @@ describe("okou whoami command", () => {
       });
       vi.stubEnv("OKOU_AGENT_ID", "agent-123");
       vi.stubEnv("OKOU_TOKEN", token);
-      vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+      vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
         http.get("http://localhost:3000/api/connectors", () => {
@@ -560,7 +560,7 @@ describe("okou whoami command", () => {
       });
       vi.stubEnv("OKOU_AGENT_ID", "agent-123");
       vi.stubEnv("OKOU_TOKEN", token);
-      vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+      vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
         http.get("http://localhost:3000/api/connectors", () => {
@@ -639,7 +639,7 @@ describe("okou whoami command", () => {
       });
       vi.stubEnv("OKOU_AGENT_ID", "agent-123");
       vi.stubEnv("OKOU_TOKEN", token);
-      vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+      vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
 
       const serverOnlyDetail = catalogPermissionDetail({
         connectorSlug: "server-only",
@@ -720,7 +720,7 @@ describe("okou whoami command", () => {
       });
       vi.stubEnv("OKOU_AGENT_ID", "agent-123");
       vi.stubEnv("OKOU_TOKEN", token);
-      vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+      vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
         http.get("http://localhost:3000/api/connectors", () => {
@@ -778,7 +778,7 @@ describe("okou whoami command", () => {
       });
       vi.stubEnv("OKOU_AGENT_ID", "agent-123");
       vi.stubEnv("OKOU_TOKEN", token);
-      vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+      vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
         http.get("http://localhost:3000/api/connectors", () => {
@@ -852,7 +852,7 @@ describe("okou whoami command", () => {
       });
       vi.stubEnv("OKOU_AGENT_ID", "agent-123");
       vi.stubEnv("OKOU_TOKEN", token);
-      vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+      vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
         http.get("http://localhost:3000/api/connectors", () => {
@@ -924,7 +924,7 @@ describe("okou whoami command", () => {
       });
       vi.stubEnv("OKOU_AGENT_ID", "agent-123");
       vi.stubEnv("OKOU_TOKEN", token);
-      vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+      vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
         http.get("http://localhost:3000/api/connectors", () => {
@@ -998,7 +998,7 @@ describe("okou whoami command", () => {
       });
       vi.stubEnv("OKOU_AGENT_ID", "agent-123");
       vi.stubEnv("OKOU_TOKEN", token);
-      vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+      vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
         http.get("http://localhost:3000/api/connectors", () => {

--- a/turbo/apps/cli/src/commands/agent/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/create.test.ts
@@ -38,7 +38,7 @@ describe("okou agent create command", () => {
     mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
     mockConsoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 

--- a/turbo/apps/cli/src/commands/agent/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/delete.test.ts
@@ -32,7 +32,7 @@ describe("okou agent delete command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 

--- a/turbo/apps/cli/src/commands/agent/__tests__/edit.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/edit.test.ts
@@ -38,7 +38,7 @@ describe("okou agent edit command", () => {
     mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
     mockConsoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 

--- a/turbo/apps/cli/src/commands/agent/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/list.test.ts
@@ -32,7 +32,7 @@ describe("okou agent list command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 

--- a/turbo/apps/cli/src/commands/agent/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/view.test.ts
@@ -102,7 +102,7 @@ describe("okou agent view command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     server.use(mockUserPermissionGrantsHandler());
     server.use(stubConnectorCatalogPermissions(defaultPermissionDetails));

--- a/turbo/apps/cli/src/commands/banking/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/banking/__tests__/index.test.ts
@@ -34,7 +34,7 @@ describe("okou banking command", () => {
   beforeEach(async () => {
     await fs.rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_APP_URL", "https://app.example.test");
     vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);

--- a/turbo/apps/cli/src/commands/browser/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/browser/__tests__/index.test.ts
@@ -70,7 +70,7 @@ describe("okou browser command", () => {
       recursive: true,
       force: true,
     });
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
     spawnSyncMock.mockReturnValue({ status: 0 });

--- a/turbo/apps/cli/src/commands/chat/__tests__/cancel.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/cancel.test.ts
@@ -23,7 +23,7 @@ describe("okou chat cancel command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
     server.use(

--- a/turbo/apps/cli/src/commands/chat/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/create.test.ts
@@ -26,7 +26,7 @@ describe("okou chat create command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", CURRENT_THREAD_ID);
   });

--- a/turbo/apps/cli/src/commands/chat/__tests__/get.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/get.test.ts
@@ -31,7 +31,7 @@ describe("okou chat get command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
   });

--- a/turbo/apps/cli/src/commands/chat/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/list.test.ts
@@ -103,7 +103,7 @@ describe("okou chat list command", () => {
   beforeEach(async () => {
     chalk.level = 0;
     cacheDirectory = await mkdtemp(join(tmpdir(), "chat-list-"));
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", okouToken());
     vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
     vi.stubEnv("XDG_CACHE_HOME", cacheDirectory);

--- a/turbo/apps/cli/src/commands/chat/__tests__/messages.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/messages.test.ts
@@ -90,7 +90,7 @@ describe("okou chat messages command", () => {
   }) as never);
 
   beforeEach(() => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
   });

--- a/turbo/apps/cli/src/commands/chat/__tests__/model.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/model.test.ts
@@ -79,7 +79,7 @@ describe("okou chat model command", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
   });

--- a/turbo/apps/cli/src/commands/chat/__tests__/rename.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/rename.test.ts
@@ -30,7 +30,7 @@ describe("okou chat rename command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
   });

--- a/turbo/apps/cli/src/commands/chat/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/send.test.ts
@@ -39,7 +39,7 @@ describe("okou chat send command", () => {
   beforeEach(() => {
     chalk.level = 0;
     tempDir = mkdtempSync(path.join(tmpdir(), "chat-send-"));
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
   });

--- a/turbo/apps/cli/src/commands/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/computer-use/__tests__/computer-use.test.ts
@@ -279,7 +279,7 @@ describe("computer-use command visibility", () => {
   );
 
   it("should guide missing computer-use capability errors to delegated authorization", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "run-token-without-computer-use");
 
     server.use(
@@ -319,7 +319,7 @@ describe("computer-use command visibility", () => {
   });
 
   it("should poll pending command results every 500ms", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     let pollCount = 0;
@@ -419,7 +419,6 @@ describe("computer-use command visibility", () => {
   it("should prefer the canonical backend URL without adding a trailing slash", async () => {
     vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_API_BACKEND_URL", "canonical.example.test/");
-    vi.stubEnv("VM0_API_BACKEND_URL", "https://legacy.example.test");
 
     server.use(
       http.post(
@@ -523,7 +522,7 @@ describe("computer-use command visibility", () => {
   });
 
   it("should print screenshot and app state file paths for get-app-state", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     const screenshotBytes = Buffer.from("test-png-data");
@@ -594,7 +593,7 @@ describe("computer-use command visibility", () => {
   });
 
   it("should send click snapshot coordinates and mouse options", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     server.use(
@@ -671,7 +670,7 @@ describe("computer-use command visibility", () => {
   });
 
   it("should send click element indexes", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     const screenshotBytes = Buffer.from("test-png-data");
@@ -755,7 +754,7 @@ describe("computer-use command visibility", () => {
   });
 
   it("should send press-key snapshot id and key", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     server.use(
@@ -817,7 +816,7 @@ describe("computer-use command visibility", () => {
   });
 
   it("should send type-text snapshot id and text", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     server.use(
@@ -876,7 +875,7 @@ describe("computer-use command visibility", () => {
   });
 
   it("should call an mcp plugin tool with json arguments", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     let createBody: unknown;
@@ -941,7 +940,7 @@ describe("computer-use command visibility", () => {
   });
 
   it("should list a server's mcp tools via the reserved tools/list call", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     let createBody: unknown;
@@ -1002,7 +1001,7 @@ describe("computer-use command visibility", () => {
   });
 
   it("should list mcp servers reported by linked hosts", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     server.use(
@@ -1043,7 +1042,7 @@ describe("computer-use command visibility", () => {
   });
 
   it("should guide empty mcp setup to Okou Desktop", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     server.use(
@@ -1068,7 +1067,7 @@ describe("computer-use command visibility", () => {
   });
 
   it("should download pointer-backed screenshots through the API proxy", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     const screenshotBytes = Buffer.from("proxy-png-bytes");
@@ -1134,7 +1133,7 @@ describe("computer-use command visibility", () => {
   });
 
   it("should mark expired pointer screenshots in command output", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     server.use(

--- a/turbo/apps/cli/src/commands/connector/__tests__/check.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/check.test.ts
@@ -239,7 +239,7 @@ describe("okou connector check command", () => {
     vi.unstubAllEnvs();
     vi.clearAllMocks();
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", API_BASE_URL);
+    vi.stubEnv("OKOU_API_BACKEND_URL", API_BASE_URL);
     vi.stubEnv("OKOU_TOKEN", buildOkouToken());
     vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
     vi.stubEnv("OKOU_CHAT_THREAD_ID", "");
@@ -659,7 +659,7 @@ describe("okou connector check command", () => {
     ])(
       "maps $name links to the platform origin",
       async ({ baseUrl, platformOrigin }) => {
-        vi.stubEnv("VM0_API_BACKEND_URL", baseUrl);
+        vi.stubEnv("OKOU_API_BACKEND_URL", baseUrl);
         stubDiagnostic(resolvedEnvironment(), undefined, baseUrl);
         stubResolvedDependencies("github", {
           connector: null,

--- a/turbo/apps/cli/src/commands/connector/__tests__/connect.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/connect.test.ts
@@ -52,7 +52,7 @@ describe("okou connector connect command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     connectCommand.setOptionValue("accountName", undefined);
     connectCommand.setOptionValue("add", undefined);

--- a/turbo/apps/cli/src/commands/connector/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/list.test.ts
@@ -126,7 +126,7 @@ describe("okou connector list command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     listCommand.setOptionValue("agent", undefined);
     listCommand.setOptionValue("json", false);

--- a/turbo/apps/cli/src/commands/connector/__tests__/permission-request.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/permission-request.test.ts
@@ -103,7 +103,7 @@ describe("okou connector permission-request command", () => {
   beforeEach(() => {
     vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", "");
-    vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.vm0.ai");
     const result = resolvedUrlDiagnostic();
     stubDiagnostic(result, "https://app.vm0.ai");
     stubDiagnostic(result, "https://www.vm0.ai");
@@ -118,7 +118,7 @@ describe("okou connector permission-request command", () => {
   });
 
   it("outputs an allow grant link without choosing the user's duration", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.vm0.ai");
     vi.stubEnv("OKOU_AGENT_ID", "agent-abc-123");
     let diagnosticRequest:
       | ReturnType<typeof connectorCheckRequestSchema.parse>
@@ -161,7 +161,7 @@ describe("okou connector permission-request command", () => {
   });
 
   it("uses the agent permission page inside an automated run", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.vm0.ai");
     vi.stubEnv("OKOU_AGENT_ID", "agent-abc-123");
     vi.stubEnv("ZERO_WORKFLOW_ID", "wf-789");
 
@@ -188,7 +188,7 @@ describe("okou connector permission-request command", () => {
   });
 
   it("includes the current thread and callback prompt in the grant URL", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.vm0.ai");
     vi.stubEnv("OKOU_AGENT_ID", "agent-abc-123");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", "thread-abc-123");
 
@@ -216,7 +216,7 @@ describe("okou connector permission-request command", () => {
   });
 
   it("rejects callback prompts outside the current web chat", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.vm0.ai");
     vi.stubEnv("OKOU_AGENT_ID", "agent-abc-123");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", "");
 
@@ -269,7 +269,7 @@ describe("okou connector permission-request command", () => {
   });
 
   it("outputs an allow grant link for unknown endpoints", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.vm0.ai");
     vi.stubEnv("OKOU_AGENT_ID", "agent-abc-123");
     const unknownUrl = "https://api.cloudflare.com/client/v4/example";
     stubDiagnostic(
@@ -307,7 +307,7 @@ describe("okou connector permission-request command", () => {
   });
 
   it("uses the agents landing page when OKOU_AGENT_ID is not set", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.vm0.ai");
     vi.stubEnv("OKOU_AGENT_ID", "");
 
     await permissionRequestCommand.parseAsync([
@@ -326,7 +326,7 @@ describe("okou connector permission-request command", () => {
   });
 
   it("uses --agent when OKOU_AGENT_ID is not set", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.vm0.ai");
     vi.stubEnv("OKOU_AGENT_ID", "");
 
     await permissionRequestCommand.parseAsync([
@@ -348,7 +348,7 @@ describe("okou connector permission-request command", () => {
   });
 
   it("--agent overrides OKOU_AGENT_ID", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.vm0.ai");
     vi.stubEnv("OKOU_AGENT_ID", "env-agent-123");
 
     await permissionRequestCommand.parseAsync([
@@ -369,7 +369,7 @@ describe("okou connector permission-request command", () => {
   });
 
   it("transforms www.vm0.ai to app.vm0.ai", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "https://www.vm0.ai");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "https://www.vm0.ai");
     vi.stubEnv("OKOU_AGENT_ID", "agent-1");
 
     await permissionRequestCommand.parseAsync([
@@ -389,7 +389,7 @@ describe("okou connector permission-request command", () => {
   });
 
   it("prints sensitive Slack user-token guidance for chat:write enable", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.vm0.ai");
     vi.stubEnv("OKOU_AGENT_ID", "agent-abc-123");
     const url = "https://slack.com/api/chat.postMessage";
     stubDiagnostic(
@@ -427,7 +427,7 @@ describe("okou connector permission-request command", () => {
   });
 
   it("prints sensitive Gmail sending guidance for messages.send enable", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.vm0.ai");
     vi.stubEnv("OKOU_AGENT_ID", "agent-abc-123");
     const url = "https://gmail.googleapis.com/gmail/v1/users/me/messages/send";
     stubDiagnostic(
@@ -468,7 +468,7 @@ describe("okou connector permission-request command", () => {
   });
 
   it("validates a server-authored connector absent from the CLI bundle", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.vm0.ai");
     const url = "https://api.server-only.example/v1/records";
     stubDiagnostic(
       resolvedUrlDiagnostic({
@@ -525,7 +525,7 @@ describe("okou connector permission-request command", () => {
 
   it("exits with authentication guidance when no token is available", async () => {
     vi.stubEnv("OKOU_TOKEN", "");
-    vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.vm0.ai");
 
     await expect(async () => {
       await permissionRequestCommand.parseAsync([
@@ -679,7 +679,7 @@ describe("okou connector permission-request command", () => {
   });
 
   it("outputs a delegated authorization link for computer-use enable when authenticated", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "run-token");
 
     server.use(
@@ -760,7 +760,7 @@ describe("okou connector permission-request command", () => {
   });
 
   it("outputs a delegated authorization link for cloud browser enable", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "run-token");
 
     server.use(

--- a/turbo/apps/cli/src/commands/connector/__tests__/run-account-context.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/run-account-context.test.ts
@@ -84,7 +84,7 @@ describe("run connector account inspection", () => {
     directory = mkdtempSync(join(tmpdir(), "okou-run-account-"));
     contextPath = join(directory, "context.json");
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
     vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", contextPath);

--- a/turbo/apps/cli/src/commands/connector/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/search.test.ts
@@ -149,7 +149,7 @@ describe("okou connector search command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     server.use(stubCustomConnectors([]), stubAgentCustomConnectors([]));
   });

--- a/turbo/apps/cli/src/commands/connector/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/status.test.ts
@@ -122,7 +122,7 @@ describe("okou connector status command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("OKOU_APP_URL", "");
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_AGENT_ID", "");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", "");
@@ -331,7 +331,7 @@ describe("okou connector status command", () => {
     it("uses the production app origin in authorization links", async () => {
       const apiOrigin = "https://api.vm0.ai";
       vi.stubEnv("APP_URL", "https://unrelated.example.test");
-      vi.stubEnv("VM0_API_BACKEND_URL", apiOrigin);
+      vi.stubEnv("OKOU_API_BACKEND_URL", apiOrigin);
       server.use(
         stubConnectorCatalogStatus(
           [statusItemFromConnector(connectedGithub)],
@@ -358,7 +358,7 @@ describe("okou connector status command", () => {
     it("prefers OKOU_APP_URL in authorization links", async () => {
       const apiOrigin = "https://api.example.test";
       const appOrigin = "https://app.example.test";
-      vi.stubEnv("VM0_API_BACKEND_URL", apiOrigin);
+      vi.stubEnv("OKOU_API_BACKEND_URL", apiOrigin);
       vi.stubEnv("OKOU_APP_URL", `${appOrigin}/ignored-path`);
       server.use(
         stubConnectorCatalogStatus(

--- a/turbo/apps/cli/src/commands/connector/account/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/connector/account/__tests__/list.test.ts
@@ -74,7 +74,7 @@ describe("okou connector account list command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     listConnectorAccountsCommand.setOptionValue("json", false);
     listConnectorAccountsCommand.setOptionValue("search", undefined);

--- a/turbo/apps/cli/src/commands/connector/custom/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/__tests__/create.test.ts
@@ -115,7 +115,7 @@ describe("okou connector custom create", () => {
   beforeEach(() => {
     chalk.level = 0;
     tempDir = mkdtempSync(join(tmpdir(), "custom-connector-create-"));
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", buildOkouToken(["connector:write"]));
     vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
   });

--- a/turbo/apps/cli/src/commands/connector/custom/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/__tests__/index.test.ts
@@ -19,7 +19,7 @@ describe("okou connector custom readers", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 

--- a/turbo/apps/cli/src/commands/connector/custom/__tests__/update.test.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/__tests__/update.test.ts
@@ -113,7 +113,7 @@ describe("okou connector custom update", () => {
   beforeEach(() => {
     chalk.level = 0;
     tempDir = mkdtempSync(join(tmpdir(), "custom-connector-update-"));
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", buildOkouToken());
   });
 

--- a/turbo/apps/cli/src/commands/doctor/__tests__/credit.test.ts
+++ b/turbo/apps/cli/src/commands/doctor/__tests__/credit.test.ts
@@ -49,7 +49,7 @@ describe("okou doctor credit command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_APP_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     server.use(stubOrg(), stubBillingStatus());

--- a/turbo/apps/cli/src/commands/feishu/__tests__/download-file.test.ts
+++ b/turbo/apps/cli/src/commands/feishu/__tests__/download-file.test.ts
@@ -22,7 +22,7 @@ describe("okou feishu download-file command", () => {
   let tempDir: string;
 
   beforeEach(() => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     tempDir = mkdtempSync(join(tmpdir(), "feishu-download-file-"));
   });

--- a/turbo/apps/cli/src/commands/feishu/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/feishu/__tests__/send.test.ts
@@ -19,7 +19,7 @@ describe("okou feishu message send command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 

--- a/turbo/apps/cli/src/commands/feishu/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/feishu/__tests__/upload-file.test.ts
@@ -28,7 +28,7 @@ describe("okou feishu upload-file command", () => {
   let filePath: string;
 
   beforeEach(() => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     tempDir = mkdtempSync(join(tmpdir(), "feishu-upload-file-"));
     filePath = join(tempDir, "report.pdf");

--- a/turbo/apps/cli/src/commands/finance/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/finance/__tests__/index.test.ts
@@ -57,7 +57,7 @@ describe("okou finance command", () => {
   beforeEach(async () => {
     await fs.rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-zero-token");
     for (const command of financeCommand.commands) {
       command.setOptionValue("json", undefined);

--- a/turbo/apps/cli/src/commands/generate/__tests__/avatar-video.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/avatar-video.test.ts
@@ -64,7 +64,7 @@ describe("okou generate avatar-video command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     server.use(stubBillingStatus());
   });

--- a/turbo/apps/cli/src/commands/generate/__tests__/image-batch.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/image-batch.test.ts
@@ -35,7 +35,7 @@ describe("okou generate image-batch command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 

--- a/turbo/apps/cli/src/commands/generate/__tests__/image.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/image.test.ts
@@ -63,7 +63,7 @@ describe("okou generate image command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 

--- a/turbo/apps/cli/src/commands/generate/__tests__/lister.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/lister.test.ts
@@ -182,7 +182,7 @@ describe("okou generate lister", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
     server.use(stubBillingStatus(true));

--- a/turbo/apps/cli/src/commands/generate/__tests__/presentation.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/presentation.test.ts
@@ -20,7 +20,7 @@ describe("okou generate presentation command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 

--- a/turbo/apps/cli/src/commands/generate/__tests__/sprite.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/sprite.test.ts
@@ -24,7 +24,7 @@ describe("okou generate sprite command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 

--- a/turbo/apps/cli/src/commands/generate/__tests__/video.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/video.test.ts
@@ -113,7 +113,7 @@ describe("okou generate video command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     server.use(stubBillingStatus(true));
   });

--- a/turbo/apps/cli/src/commands/generate/__tests__/voice.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/voice.test.ts
@@ -38,7 +38,7 @@ describe("okou generate voice command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 

--- a/turbo/apps/cli/src/commands/generate/__tests__/website.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/website.test.ts
@@ -54,7 +54,7 @@ describe("okou generate website command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("OKOU_TOKEN", undefined);
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/github/__tests__/download-file.test.ts
+++ b/turbo/apps/cli/src/commands/github/__tests__/download-file.test.ts
@@ -24,7 +24,7 @@ describe("okou github download-file command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     tmpDir = join(tmpdir(), `github-download-file-test-${Date.now()}`);

--- a/turbo/apps/cli/src/commands/github/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/github/__tests__/upload-file.test.ts
@@ -27,7 +27,7 @@ describe("okou github upload-file command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     tmpDir = join(tmpdir(), `github-upload-file-test-${Date.now()}`);

--- a/turbo/apps/cli/src/commands/goal/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/goal/__tests__/index.test.ts
@@ -20,7 +20,7 @@ describe("okou goal command", () => {
   }) as never);
 
   beforeEach(() => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-okou-token");
     vi.stubEnv("ZERO_TOKEN", undefined);
     vi.stubEnv("OKOU_APP_URL", undefined);

--- a/turbo/apps/cli/src/commands/host/__tests__/clone.test.ts
+++ b/turbo/apps/cli/src/commands/host/__tests__/clone.test.ts
@@ -40,7 +40,7 @@ describe("okou host clone command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     tempDir = join(tmpdir(), `host-clone-${Date.now()}`);
     mkdirSync(tempDir, { recursive: true });

--- a/turbo/apps/cli/src/commands/host/__tests__/publish.test.ts
+++ b/turbo/apps/cli/src/commands/host/__tests__/publish.test.ts
@@ -44,7 +44,7 @@ describe("okou host publish command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     tempDir = join(tmpdir(), `host-publish-${Date.now()}`);
     mkdirSync(tempDir, { recursive: true });

--- a/turbo/apps/cli/src/commands/host/__tests__/versions.test.ts
+++ b/turbo/apps/cli/src/commands/host/__tests__/versions.test.ts
@@ -14,7 +14,7 @@ describe("okou host versions command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 

--- a/turbo/apps/cli/src/commands/mail/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/mail/__tests__/index.test.ts
@@ -65,7 +65,7 @@ describe("okou mail", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
     vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);

--- a/turbo/apps/cli/src/commands/maps/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/maps/__tests__/index.test.ts
@@ -31,7 +31,7 @@ describe("okou maps command", () => {
   beforeEach(async () => {
     await fs.rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-zero-token");
   });
 

--- a/turbo/apps/cli/src/commands/mcp/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/mcp/__tests__/index.test.ts
@@ -220,7 +220,7 @@ describe("okou mcp command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 

--- a/turbo/apps/cli/src/commands/model-provider/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/model-provider/__tests__/index.test.ts
@@ -59,7 +59,7 @@ describe("okou model-provider command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     mockConsoleLog.mockClear();
   });

--- a/turbo/apps/cli/src/commands/model/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/model/__tests__/index.test.ts
@@ -42,7 +42,7 @@ describe("okou model command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     mockConsoleLog.mockClear();
   });

--- a/turbo/apps/cli/src/commands/people-search/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/people-search/__tests__/index.test.ts
@@ -70,7 +70,7 @@ describe("okou people-search command", () => {
   beforeEach(async () => {
     await fs.rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-zero-token");
     peopleSearchCommand.setOptionValue("limit", 5);
     peopleSearchCommand.setOptionValue("json", undefined);

--- a/turbo/apps/cli/src/commands/phone/__tests__/commands.test.ts
+++ b/turbo/apps/cli/src/commands/phone/__tests__/commands.test.ts
@@ -31,7 +31,7 @@ describe("okou phone commands", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();

--- a/turbo/apps/cli/src/commands/presentation-template/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/presentation-template/__tests__/index.test.ts
@@ -116,7 +116,7 @@ describe("okou presentation-template publish", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     tempDir = join(tmpdir(), `presentation-template-${Date.now().toString()}`);

--- a/turbo/apps/cli/src/commands/recognize/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/recognize/__tests__/index.test.ts
@@ -69,7 +69,7 @@ describe("okou recognize command", () => {
   let tempDir: string;
 
   beforeEach(() => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     tempDir = join(tmpdir(), `image-recognition-${randomUUID()}`);
     mkdirSync(tempDir, { recursive: true });

--- a/turbo/apps/cli/src/commands/resource/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/resource/__tests__/index.test.ts
@@ -152,7 +152,7 @@ describe("okou resource pull command", () => {
 
   beforeEach(async () => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     outputDir = await mkdtemp(path.join(tmpdir(), "resource-pull-test-"));
     mockExit.mockClear();

--- a/turbo/apps/cli/src/commands/scrape/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/scrape/__tests__/index.test.ts
@@ -46,7 +46,7 @@ describe("okou scrape command", () => {
   beforeEach(async () => {
     await fs.rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-zero-token");
   });
 

--- a/turbo/apps/cli/src/commands/search/__tests__/chat-source.test.ts
+++ b/turbo/apps/cli/src/commands/search/__tests__/chat-source.test.ts
@@ -40,7 +40,7 @@ describe("okou search --source chat", () => {
     // Clear any prior spy call history before each test so assertions only
     // see calls made by the current case.
     vi.clearAllMocks();
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     // Commander retains collector state across parseAsync calls on the
     // same command instance. Reset before each case.

--- a/turbo/apps/cli/src/commands/seo/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/seo/__tests__/index.test.ts
@@ -58,7 +58,7 @@ describe("okou seo command", () => {
   beforeEach(async () => {
     await fs.rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-zero-token");
     for (const command of seoCommand.commands) {
       command.setOptionValue("json", undefined);

--- a/turbo/apps/cli/src/commands/slack/__tests__/download-file.test.ts
+++ b/turbo/apps/cli/src/commands/slack/__tests__/download-file.test.ts
@@ -32,7 +32,7 @@ describe("okou slack download-file command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     tmpDir = join(tmpdir(), `download-file-test-${Date.now()}`);

--- a/turbo/apps/cli/src/commands/slack/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/slack/__tests__/send.test.ts
@@ -27,7 +27,7 @@ describe("okou slack message send command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 

--- a/turbo/apps/cli/src/commands/slack/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/slack/__tests__/upload-file.test.ts
@@ -42,7 +42,7 @@ describe("okou slack upload-file command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     // Create temp file for tests

--- a/turbo/apps/cli/src/commands/social/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/social/__tests__/index.test.ts
@@ -136,7 +136,7 @@ describe("okou social command", () => {
 
   beforeEach(async () => {
     await fs.rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-zero-token");
     for (const command of socialCommand.commands) {
       command.setOptionValue("input", undefined);

--- a/turbo/apps/cli/src/commands/teams/__tests__/download-file.test.ts
+++ b/turbo/apps/cli/src/commands/teams/__tests__/download-file.test.ts
@@ -29,7 +29,7 @@ describe("okou teams download-file command", () => {
     chalk.level = 0;
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     tmpDir = join(tmpdir(), `teams-download-file-test-${Date.now()}`);

--- a/turbo/apps/cli/src/commands/teams/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/teams/__tests__/send.test.ts
@@ -24,7 +24,7 @@ describe("okou teams message send command", () => {
     chalk.level = 0;
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 

--- a/turbo/apps/cli/src/commands/teams/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/teams/__tests__/upload-file.test.ts
@@ -31,7 +31,7 @@ describe("okou teams upload-file command", () => {
   beforeEach(() => {
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     tmpDir = join(tmpdir(), `teams-upload-file-test-${Date.now()}`);

--- a/turbo/apps/cli/src/commands/telegram/__tests__/bot-list.test.ts
+++ b/turbo/apps/cli/src/commands/telegram/__tests__/bot-list.test.ts
@@ -22,7 +22,7 @@ describe("okou telegram bot list command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();

--- a/turbo/apps/cli/src/commands/telegram/__tests__/download-file.test.ts
+++ b/turbo/apps/cli/src/commands/telegram/__tests__/download-file.test.ts
@@ -27,7 +27,7 @@ describe("okou telegram download-file command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     tmpDir = join(tmpdir(), `telegram-download-file-test-${Date.now()}`);

--- a/turbo/apps/cli/src/commands/telegram/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/telegram/__tests__/send.test.ts
@@ -22,7 +22,7 @@ describe("okou telegram message send command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();

--- a/turbo/apps/cli/src/commands/telegram/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/telegram/__tests__/upload-file.test.ts
@@ -31,7 +31,7 @@ describe("okou telegram upload-file command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     tmpDir = join(tmpdir(), `telegram-upload-file-test-${Date.now()}`);

--- a/turbo/apps/cli/src/commands/video/__tests__/frames.test.ts
+++ b/turbo/apps/cli/src/commands/video/__tests__/frames.test.ts
@@ -53,7 +53,7 @@ function readStdout(): string {
 
 describe("okou video frames command", () => {
   beforeEach(() => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     mockStdoutWrite.mockClear();
   });

--- a/turbo/apps/cli/src/commands/video/__tests__/transcribe.test.ts
+++ b/turbo/apps/cli/src/commands/video/__tests__/transcribe.test.ts
@@ -54,7 +54,7 @@ function readStdout(): string {
 
 describe("okou video transcribe command", () => {
   beforeEach(() => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     mockStdoutWrite.mockClear();
   });

--- a/turbo/apps/cli/src/commands/weather/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/weather/__tests__/index.test.ts
@@ -35,7 +35,7 @@ describe("okou weather command", () => {
   beforeEach(async () => {
     await fs.rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-zero-token");
   });
 

--- a/turbo/apps/cli/src/commands/web-search/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/web-search/__tests__/index.test.ts
@@ -65,7 +65,7 @@ describe("okou web-search command", () => {
   beforeEach(async () => {
     await fs.rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-zero-token");
     webSearchCommand.setOptionValue("limit", 5);
     webSearchCommand.setOptionValue("recency", undefined);

--- a/turbo/apps/cli/src/commands/web/__tests__/download-file.test.ts
+++ b/turbo/apps/cli/src/commands/web/__tests__/download-file.test.ts
@@ -31,7 +31,7 @@ describe("okou web download-file command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     tmpDir = join(tmpdir(), `web-download-test-${Date.now()}`);

--- a/turbo/apps/cli/src/commands/web/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/web/__tests__/upload-file.test.ts
@@ -49,7 +49,7 @@ describe("okou web upload-file command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     tmpDir = join(tmpdir(), `web-upload-test-${Date.now()}`);

--- a/turbo/apps/cli/src/commands/workflow/__tests__/copy.test.ts
+++ b/turbo/apps/cli/src/commands/workflow/__tests__/copy.test.ts
@@ -66,7 +66,7 @@ describe("okou workflow copy command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 

--- a/turbo/apps/cli/src/commands/workflow/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/workflow/__tests__/create.test.ts
@@ -46,7 +46,7 @@ describe("okou workflow create command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_AGENT_ID", "");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", "");

--- a/turbo/apps/cli/src/commands/workflow/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/workflow/__tests__/delete.test.ts
@@ -67,7 +67,7 @@ describe("okou workflow delete command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 

--- a/turbo/apps/cli/src/commands/workflow/__tests__/edit.test.ts
+++ b/turbo/apps/cli/src/commands/workflow/__tests__/edit.test.ts
@@ -72,7 +72,7 @@ describe("okou workflow edit command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     workflowDir = join(tmpdir(), `test-workflow-edit-${Date.now()}`);

--- a/turbo/apps/cli/src/commands/workflow/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/workflow/__tests__/list.test.ts
@@ -26,7 +26,7 @@ describe("okou workflow list command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 

--- a/turbo/apps/cli/src/commands/workflow/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/workflow/__tests__/view.test.ts
@@ -46,7 +46,7 @@ describe("okou workflow view command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_AGENT_ID", undefined);
   });

--- a/turbo/apps/cli/src/commands/workflow/automation/__tests__/automation.test.ts
+++ b/turbo/apps/cli/src/commands/workflow/automation/__tests__/automation.test.ts
@@ -359,7 +359,7 @@ describe("okou workflow automation commands", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     chalk.level = 0;
-    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     server.use(
       http.get(THREAD_METADATA_URL, () => {


### PR DESCRIPTION
Parent EPIC: #28914

Closes #30302

## Summary

- Move the 131 ordinary `VM0_API_BACKEND_URL` test setups across the 87 scoped CLI test files to the canonical `OKOU_API_BACKEND_URL` contract: replace 130 writers and remove the one incidental legacy setup where the canonical key was already present.
- Preserve every URL byte, request expectation, routing assertion, command behavior, and the dedicated compatibility coverage.
- Keep `turbo/apps/cli/src/lib/api/config.ts`, `turbo/apps/cli/src/lib/api/__tests__/config.test.ts`, and `turbo/apps/cli/src/test/setup.ts` unchanged.

## Scope evidence

- Edit base: `7d0c3ad45d1361c0ee6463f8cc46feb00780e8f4`.
- Refreshed publication base: `e82196c8457a5362a93ef8abe5862ffb6a92283b`.
- Reviewed head: `8bd6a866585beb508e568d3a737b901552710993`.
- Final diff: exactly 87 scoped test files, 130 insertions, and 131 deletions.
- Exact-head changed-line review: all 130 added lines are canonical `vi.stubEnv` writers; all 131 removed lines are ordinary legacy writers. Alias-normalized whole-file comparison passed for 87/87 files with zero mismatches.
- Final CLI retired-name inventory is exactly eight occurrences across the three intentional files: two production reads, five dedicated compatibility cases, and one test-harness cleanup.
- `config.ts` is byte-for-byte unchanged at SHA-256 `fbe7dc2de46c3d6e4d20ec1b884e7e5688623f4ada9c9a7385f1061e15daeb83`.
- Pre-edit paginated audit: 28 open PRs and 497/497 declared/fetched changed files, zero mismatch.
- Pre-publication paginated audit: 28 open PRs and 509/509 declared/fetched changed files, zero mismatch; one PR required multiple changed-file pages.
- The only scoped path overlaps remain #30280 (`messages.test.ts`), #29068 (`website.test.ts`), and #28110 (`image.test.ts`). Their unrelated hunks are inventory only; no contributor PR was modified or awaited.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- 88 individually enumerated, foreground CLI Vitest files passed: all 87 changed test files plus `src/lib/api/__tests__/config.test.ts` (13 compatibility-matrix tests).
- `git diff --check origin/main...HEAD`
- Repeated full-repository caller inventory, exact CLI writer inventory, retained-surface diff, normalized-file comparison, and fully paginated open-PR changed-file audit.

The current Okou run injects host-only connector-context and default-image-model values. Unchanged `main` reproduced the two affected single-file failures under those inherited values; the current branch passed after unsetting them only for local test commands. No source workaround was added.

The full local Vitest suite was not run, and no development server was started, per repository instructions.

## Rollback

Revert this test-only PR to restore the ordinary legacy test setup keys. The production dual reader and every retained compatibility surface remain unchanged, so no release, deployment, or production cutover is involved.
