### PR TITLE
refactor(desktop): retire notarization api legacy aliases

### DIFF
--- a/turbo/apps/desktop/forge.config.js
+++ b/turbo/apps/desktop/forge.config.js
@@ -40,17 +40,15 @@ function desktopNotarizeOptions() {
     };
   }
 
-  if (
-    !process.env.OKOU_DESKTOP_NOTARIZE_API_KEY_PATH &&
-    !process.env.VM0_DESKTOP_NOTARIZE_API_KEY_PATH
-  ) {
-    return {
-      keychainProfile: DEFAULT_NOTARIZE_KEYCHAIN_PROFILE,
-      keychain: DEFAULT_NOTARIZE_KEYCHAIN,
-    };
+  const apiEnvironment = resolveDesktopNotarizeApiEnvironment();
+  if (apiEnvironment) {
+    return apiEnvironment;
   }
 
-  return resolveDesktopNotarizeApiEnvironment();
+  return {
+    keychainProfile: DEFAULT_NOTARIZE_KEYCHAIN_PROFILE,
+    keychain: DEFAULT_NOTARIZE_KEYCHAIN,
+  };
 }
 
 const { identity: desktopIdentity } = resolveDesktopBuildConfig();

--- a/turbo/apps/desktop/scripts/desktop-notarize-api-environment.js
+++ b/turbo/apps/desktop/scripts/desktop-notarize-api-environment.js
@@ -1,87 +1,21 @@
-const CREDENTIAL_ALIASES = [
-  {
-    canonical: "OKOU_DESKTOP_NOTARIZE_API_KEY_PATH",
-    legacy: "VM0_DESKTOP_NOTARIZE_API_KEY_PATH",
-    option: "appleApiKey",
-  },
-  {
-    canonical: "OKOU_DESKTOP_NOTARIZE_API_KEY_ID",
-    legacy: "VM0_DESKTOP_NOTARIZE_API_KEY_ID",
-    option: "appleApiKeyId",
-  },
-  {
-    canonical: "OKOU_DESKTOP_NOTARIZE_API_ISSUER",
-    legacy: "VM0_DESKTOP_NOTARIZE_API_ISSUER",
-    option: "appleApiIssuer",
-  },
-];
-
-function presentEnvironmentValue(name) {
-  return process.env[name] || undefined;
-}
-
-function aliasState(values) {
-  return CREDENTIAL_ALIASES.flatMap((alias, index) => [
-    `${alias.canonical}=${values.canonical[index] ? "present" : "absent"}`,
-    `${alias.legacy}=${values.legacy[index] ? "present" : "absent"}`,
-  ]).join(" ");
-}
-
-function resolvedOptions(source, values) {
-  console.info(`desktop_notarize_api_env_source source=${source}`);
-  return Object.fromEntries(
-    CREDENTIAL_ALIASES.map((alias, index) => [alias.option, values[index]]),
-  );
-}
-
-// The release workflow and documented local-build surface now use the canonical
-// triple. Keep legacy reads for a unit-revert rollback of that writer/docs
-// change. Remove them only after a signed Desktop release checks out a target
-// containing the canonical writer, records canonical-only source evidence,
-// completes the supported rollback window, and records zero legacy-use evidence
-// under #28914.
 function resolveDesktopNotarizeApiEnvironment() {
-  const values = {
-    canonical: CREDENTIAL_ALIASES.map((alias) =>
-      presentEnvironmentValue(alias.canonical),
-    ),
-    legacy: CREDENTIAL_ALIASES.map((alias) =>
-      presentEnvironmentValue(alias.legacy),
-    ),
-  };
-  const canonicalCount = values.canonical.filter(Boolean).length;
-  const legacyCount = values.legacy.filter(Boolean).length;
+  const appleApiKey =
+    process.env.OKOU_DESKTOP_NOTARIZE_API_KEY_PATH || undefined;
+  const appleApiKeyId =
+    process.env.OKOU_DESKTOP_NOTARIZE_API_KEY_ID || undefined;
+  const appleApiIssuer =
+    process.env.OKOU_DESKTOP_NOTARIZE_API_ISSUER || undefined;
 
-  if (canonicalCount === 0 && legacyCount === 0) {
+  if (!appleApiKey && !appleApiKeyId && !appleApiIssuer) {
     return undefined;
   }
-  if (canonicalCount === CREDENTIAL_ALIASES.length && legacyCount === 0) {
-    return resolvedOptions("canonical-only", values.canonical);
-  }
-  if (canonicalCount === 0 && legacyCount === CREDENTIAL_ALIASES.length) {
-    return resolvedOptions("legacy-only", values.legacy);
-  }
-  if (
-    canonicalCount === CREDENTIAL_ALIASES.length &&
-    legacyCount === CREDENTIAL_ALIASES.length
-  ) {
-    if (
-      values.canonical.every((value, index) => value === values.legacy[index])
-    ) {
-      return resolvedOptions("dual", values.canonical);
-    }
+  if (!appleApiKey || !appleApiKeyId || !appleApiIssuer) {
     throw new Error(
-      `Desktop notarization API credential aliases conflict: state=conflict ${aliasState(values)}`,
+      "Desktop notarization API credentials are incomplete: state=incomplete",
     );
   }
-  if (canonicalCount > 0 && legacyCount > 0) {
-    throw new Error(
-      `Desktop notarization API credentials mix canonical and legacy aliases: state=mixed ${aliasState(values)}`,
-    );
-  }
-  throw new Error(
-    `Desktop notarization API credentials are incomplete: state=incomplete ${aliasState(values)}`,
-  );
+
+  return { appleApiKey, appleApiKeyId, appleApiIssuer };
 }
 
 module.exports = { resolveDesktopNotarizeApiEnvironment };

--- a/turbo/apps/desktop/src/desktop-notarize-entry-points.test.ts
+++ b/turbo/apps/desktop/src/desktop-notarize-entry-points.test.ts
@@ -28,14 +28,14 @@ const canonicalAliases = {
   keyId: "OKOU_DESKTOP_NOTARIZE_API_KEY_ID",
   issuer: "OKOU_DESKTOP_NOTARIZE_API_ISSUER",
 } as const;
-const legacyAliases = {
+const retiredAliases = {
   keyPath: "VM0_DESKTOP_NOTARIZE_API_KEY_PATH",
   keyId: "VM0_DESKTOP_NOTARIZE_API_KEY_ID",
   issuer: "VM0_DESKTOP_NOTARIZE_API_ISSUER",
 } as const;
-const allAliases = [
+const credentialAliases = [
   ...Object.values(canonicalAliases),
-  ...Object.values(legacyAliases),
+  ...Object.values(retiredAliases),
 ];
 const canonicalKeychainAliases = {
   profile: "OKOU_DESKTOP_NOTARIZE_KEYCHAIN_PROFILE",
@@ -103,15 +103,13 @@ export async function notarize(options) {
   const mode = process.env.TEST_NOTARIZE_MODE;
   let credentialsAreUnchanged = false;
   if (mode === "api") {
-    const prefix =
-      process.env.TEST_EXPECTED_API_SOURCE === "legacy-only" ? "VM0" : "OKOU";
     credentialsAreUnchanged =
       options.appleApiKey ===
-        process.env[prefix + "_DESKTOP_NOTARIZE_API_KEY_PATH"] &&
+        process.env.OKOU_DESKTOP_NOTARIZE_API_KEY_PATH &&
       options.appleApiKeyId ===
-        process.env[prefix + "_DESKTOP_NOTARIZE_API_KEY_ID"] &&
+        process.env.OKOU_DESKTOP_NOTARIZE_API_KEY_ID &&
       options.appleApiIssuer ===
-        process.env[prefix + "_DESKTOP_NOTARIZE_API_ISSUER"] &&
+        process.env.OKOU_DESKTOP_NOTARIZE_API_ISSUER &&
       options.keychainProfile === undefined &&
       options.keychain === undefined;
   } else if (mode === "default-keychain") {
@@ -151,12 +149,20 @@ type CredentialCase =
   | "absent"
   | "empty"
   | "canonical-only"
-  | "legacy-only"
-  | "dual"
-  | "conflict"
-  | "mixed"
-  | "incomplete";
+  | "canonical-and-retired"
+  | "retired-only"
+  | IncompleteCredentialCase;
 type SuccessfulSource = "canonical-only" | "legacy-only" | "dual";
+
+const incompleteCredentialCases = [
+  "key-path-only",
+  "key-id-only",
+  "issuer-only",
+  "without-key-path",
+  "without-key-id",
+  "without-issuer",
+] as const;
+type IncompleteCredentialCase = (typeof incompleteCredentialCases)[number];
 
 interface SigningIdentityInput {
   readonly canonical?: string;
@@ -175,6 +181,17 @@ interface CredentialValues {
   readonly keyId: string;
   readonly issuer: string;
 }
+
+const incompleteCredentialFields: Readonly<
+  Record<IncompleteCredentialCase, readonly (keyof CredentialValues)[]>
+> = {
+  "key-path-only": ["keyPath"],
+  "key-id-only": ["keyId"],
+  "issuer-only": ["issuer"],
+  "without-key-path": ["keyId", "issuer"],
+  "without-key-id": ["keyPath", "issuer"],
+  "without-issuer": ["keyPath", "keyId"],
+};
 
 interface TestHarness {
   readonly directory: string;
@@ -218,7 +235,7 @@ function credentialValues(directory: string): CredentialValues {
 
 function assignCredentialValues(
   environment: NodeJS.ProcessEnv,
-  aliases: typeof canonicalAliases | typeof legacyAliases,
+  aliases: typeof canonicalAliases | typeof retiredAliases,
   values: CredentialValues,
 ): void {
   environment[aliases.keyPath] = values.keyPath;
@@ -235,39 +252,28 @@ function applyCredentialCase(
     return [];
   }
   if (credentialCase === "empty") {
-    for (const alias of allAliases) {
+    for (const alias of credentialAliases) {
       environment[alias] = "";
     }
     return [];
   }
 
   const canonical = credentialValues(directory);
-  const legacy =
-    credentialCase === "dual" ? canonical : credentialValues(directory);
+  const retired = credentialValues(directory);
   if (credentialCase === "canonical-only") {
     assignCredentialValues(environment, canonicalAliases, canonical);
-    for (const alias of Object.values(legacyAliases)) {
-      environment[alias] = "";
-    }
-  } else if (credentialCase === "legacy-only") {
-    assignCredentialValues(environment, legacyAliases, legacy);
-    for (const alias of Object.values(canonicalAliases)) {
-      environment[alias] = "";
-    }
-  } else if (credentialCase === "dual" || credentialCase === "conflict") {
+  } else if (credentialCase === "canonical-and-retired") {
     assignCredentialValues(environment, canonicalAliases, canonical);
-    assignCredentialValues(environment, legacyAliases, legacy);
-  } else if (credentialCase === "mixed") {
-    environment[canonicalAliases.keyPath] = canonical.keyPath;
-    environment[legacyAliases.keyId] = legacy.keyId;
-    environment[legacyAliases.issuer] = legacy.issuer;
+    assignCredentialValues(environment, retiredAliases, retired);
+  } else if (credentialCase === "retired-only") {
+    assignCredentialValues(environment, retiredAliases, retired);
   } else {
-    environment[canonicalAliases.keyPath] = canonical.keyPath;
-    environment[canonicalAliases.keyId] = canonical.keyId;
-    environment[canonicalAliases.issuer] = "";
+    for (const field of incompleteCredentialFields[credentialCase]) {
+      environment[canonicalAliases[field]] = canonical[field];
+    }
   }
 
-  return allAliases.flatMap((alias) => {
+  return credentialAliases.flatMap((alias) => {
     const value = environment[alias];
     return value ? [value] : [];
   });
@@ -336,7 +342,6 @@ function runForge(
   credentialCase: CredentialCase,
   options: {
     readonly notarize?: boolean;
-    readonly source?: SuccessfulSource;
     readonly keychainMode?: "default-keychain" | "custom-keychain";
     readonly keychainInput?: KeychainEnvironmentInput;
     readonly expectedKeychainProfile?: string;
@@ -388,9 +393,11 @@ function runForge(
     expectedSigningIdentity === "-" ? "false" : "true";
   environment.TEST_EXPECTED_SIGNING_TIMESTAMP =
     expectedSigningIdentity === "-" ? "none" : "absent";
-  if (options.source) {
+  if (
+    credentialCase === "canonical-only" ||
+    credentialCase === "canonical-and-retired"
+  ) {
     environment.TEST_NOTARIZE_MODE = "api";
-    environment.TEST_EXPECTED_API_SOURCE = options.source;
   }
   if (options.keychainMode) {
     environment.TEST_NOTARIZE_MODE = options.keychainMode;
@@ -467,13 +474,6 @@ function runPackagedAppHelper(
   }
   environment.TEST_EXPECTED_IDENTITY_VALIDATION = "true";
   environment.TEST_EXPECTED_SIGNING_TIMESTAMP = "absent";
-  if (
-    credentialCase === "canonical-only" ||
-    credentialCase === "legacy-only" ||
-    credentialCase === "dual"
-  ) {
-    environment.TEST_EXPECTED_API_SOURCE = credentialCase;
-  }
 
   const processResult = spawnSync(
     process.execPath,
@@ -497,12 +497,6 @@ function runPackagedAppHelper(
     trace: trace(harness),
     sensitiveValues: [...credentialValues, ...signingIdentityValues],
   };
-}
-
-function sourceEvents(result: EntryPointResult): readonly string[] {
-  return result.process.stdout
-    .split("\n")
-    .filter((line) => line.startsWith("desktop_notarize_api_env_source "));
 }
 
 function keychainSourceEvents(result: EntryPointResult): readonly string[] {
@@ -540,26 +534,23 @@ function expectNoSensitiveValueDisclosure(result: EntryPointResult): void {
   expect(output.includes("length=")).toBe(false);
 }
 
-function expectSuccessfulApiEntryPoint(
-  result: EntryPointResult,
-  source: SuccessfulSource,
-): void {
+function expectSuccessfulApiEntryPoint(result: EntryPointResult): void {
   expect(result.process.status === 0).toBe(true);
   expect(result.trace).toBe("sign\nnotarize\n");
-  expect(sourceEvents(result)).toStrictEqual([
-    `desktop_notarize_api_env_source source=${source}`,
-  ]);
   expectNoSensitiveValueDisclosure(result);
 }
 
 function expectFailedBeforeExternalSideEffects(
   result: EntryPointResult,
-  state: "absent" | "conflict" | "mixed" | "incomplete",
+  state: "absent" | "incomplete",
 ): void {
   expect(result.process.status === 1).toBe(true);
   expect(result.trace).toBe("");
-  expect(sourceEvents(result)).toStrictEqual([]);
-  expect(result.process.stderr.includes(`state=${state}`)).toBe(true);
+  expect(result.process.stderr).toContain(
+    state === "absent"
+      ? "Desktop notarization API environment is required: state=absent"
+      : "Desktop notarization API credentials are incomplete: state=incomplete",
+  );
   expectNoSensitiveValueDisclosure(result);
 }
 
@@ -572,48 +563,52 @@ afterEach(() => {
 describe("Desktop Forge notarization entry point", () => {
   const precedenceProfile = ` precedence-profile-${randomUUID()} `;
 
-  it.each([
-    ["canonical-only", "canonical-only"],
-    ["legacy-only", "legacy-only"],
-    ["dual", "dual"],
-  ] as const)(
-    "uses one complete %s API credential set",
-    (credentialCase, source) => {
-      expectSuccessfulApiEntryPoint(
-        runForge(credentialCase, { source }),
-        source,
+  it("uses one complete canonical API credential set byte-for-byte", () => {
+    expectSuccessfulApiEntryPoint(runForge("canonical-only"));
+  });
+
+  it("keeps canonical credentials authoritative over hostile retired values", () => {
+    expectSuccessfulApiEntryPoint(runForge("canonical-and-retired"));
+  });
+
+  it.each(incompleteCredentialCases)(
+    "rejects the incomplete canonical %s shape before signing",
+    (credentialCase) => {
+      expectFailedBeforeExternalSideEffects(
+        runForge(credentialCase),
+        "incomplete",
       );
     },
   );
 
-  it.each([
-    ["conflict", "conflict"],
-    ["mixed", "mixed"],
-    ["incomplete", "incomplete"],
-  ] as const)(
-    "rejects %s API credentials before signing",
-    (credentialCase, state) => {
-      expectFailedBeforeExternalSideEffects(runForge(credentialCase), state);
-    },
-  );
-
-  it.each(["absent", "empty"] as const)(
-    "keeps the default Keychain profile when API aliases are %s",
+  it.each(["absent", "empty", "retired-only"] as const)(
+    "keeps the default Keychain profile when API credentials are %s",
     (credentialCase) => {
       const result = runForge(credentialCase, {
         keychainMode: "default-keychain",
       });
       expect(result.process.status === 0).toBe(true);
       expect(result.trace).toBe("sign\nnotarize\n");
-      expect(sourceEvents(result)).toStrictEqual([]);
+      expectNoSensitiveValueDisclosure(result);
     },
   );
 
   it.each([
-    ["conflict", { canonicalProfile: precedenceProfile }, "canonical-only"],
-    ["mixed", { legacyProfile: precedenceProfile }, "legacy-only"],
     [
-      "incomplete",
+      "canonical and retired API credentials",
+      "canonical-and-retired",
+      { canonicalProfile: precedenceProfile },
+      "canonical-only",
+    ],
+    [
+      "retired-only API credentials",
+      "retired-only",
+      { legacyProfile: precedenceProfile },
+      "legacy-only",
+    ],
+    [
+      "incomplete canonical API credentials",
+      "key-path-only",
       {
         canonicalProfile: precedenceProfile,
         legacyProfile: precedenceProfile,
@@ -621,8 +616,8 @@ describe("Desktop Forge notarization entry point", () => {
       "dual",
     ],
   ] as const)(
-    "keeps a custom Keychain profile ahead of %s API aliases",
-    (credentialCase, keychainInput, source) => {
+    "keeps a custom Keychain profile ahead of %s",
+    (_, credentialCase, keychainInput, source) => {
       const result = runForge(credentialCase, {
         keychainMode: "custom-keychain",
         keychainInput,
@@ -630,7 +625,6 @@ describe("Desktop Forge notarization entry point", () => {
       });
       expect(result.process.status === 0).toBe(true);
       expect(result.trace).toBe("sign\nnotarize\n");
-      expect(sourceEvents(result)).toStrictEqual([]);
       expect(keychainSourceEvents(result)).toStrictEqual([
         `desktop_notarize_keychain_env_source key=${canonicalKeychainAliases.profile} source=${source}`,
       ]);
@@ -648,7 +642,6 @@ describe("Desktop Forge notarization entry point", () => {
     });
     expect(result.process.status === 0).toBe(true);
     expect(result.trace).toBe("sign\n");
-    expect(sourceEvents(result)).toStrictEqual([]);
     expect(keychainSourceEvents(result)).toStrictEqual([]);
     expectNoSensitiveValueDisclosure(result);
   });
@@ -687,7 +680,6 @@ describe("Desktop Forge Keychain notarization environment entry point", () => {
 
       expect(result.process.status, result.process.stderr).toBe(0);
       expect(result.trace).toBe("sign\nnotarize\n");
-      expect(sourceEvents(result)).toStrictEqual([]);
       expect(keychainSourceEvents(result)).toStrictEqual([
         `desktop_notarize_keychain_env_source key=${canonicalKeychainAliases.profile} source=${source}`,
       ]);
@@ -725,7 +717,6 @@ describe("Desktop Forge Keychain notarization environment entry point", () => {
 
       expect(result.process.status, result.process.stderr).toBe(0);
       expect(result.trace).toBe("sign\nnotarize\n");
-      expect(sourceEvents(result)).toStrictEqual([]);
       expect(keychainSourceEvents(result)).toStrictEqual([]);
       expectNoSensitiveValueDisclosure(result);
     },
@@ -797,7 +788,7 @@ describe("Desktop Forge Keychain notarization environment entry point", () => {
 
   it("rejects conflicting profile aliases before external effects", () => {
     const profile = `profile-${randomUUID()}`;
-    const result = runForge("conflict", {
+    const result = runForge("canonical-and-retired", {
       keychainMode: "custom-keychain",
       keychainInput: {
         canonicalProfile: profile,
@@ -807,7 +798,6 @@ describe("Desktop Forge Keychain notarization environment entry point", () => {
 
     expect(result.process.status).toBe(1);
     expect(result.trace).toBe("");
-    expect(sourceEvents(result)).toStrictEqual([]);
     expect(keychainSourceEvents(result)).toStrictEqual([]);
     expect(result.process.stderr).toContain(
       `Desktop notarization Keychain environment aliases conflict: canonical_key=${canonicalKeychainAliases.profile} legacy_key=${legacyKeychainAliases.profile} state=conflict`,
@@ -816,7 +806,7 @@ describe("Desktop Forge Keychain notarization environment entry point", () => {
   });
 
   it("rejects conflicting path aliases only under a selected profile", () => {
-    const result = runForge("conflict", {
+    const result = runForge("canonical-and-retired", {
       keychainMode: "custom-keychain",
       keychainInput: {
         canonicalProfile: sharedProfile,
@@ -828,7 +818,6 @@ describe("Desktop Forge Keychain notarization environment entry point", () => {
 
     expect(result.process.status).toBe(1);
     expect(result.trace).toBe("");
-    expect(sourceEvents(result)).toStrictEqual([]);
     expect(keychainSourceEvents(result)).toStrictEqual([
       `desktop_notarize_keychain_env_source key=${canonicalKeychainAliases.profile} source=canonical-only`,
     ]);
@@ -840,11 +829,10 @@ describe("Desktop Forge Keychain notarization environment entry point", () => {
 
   it("ignores unequal path-only aliases when API mode is selected", () => {
     const result = runForge("canonical-only", {
-      source: "canonical-only",
       keychainInput: { canonicalPath, legacyPath },
     });
 
-    expectSuccessfulApiEntryPoint(result, "canonical-only");
+    expectSuccessfulApiEntryPoint(result);
     expect(keychainSourceEvents(result)).toStrictEqual([]);
   });
 });
@@ -930,32 +918,32 @@ describe("Desktop Forge signing identity entry point", () => {
 });
 
 describe("packaged Desktop signing and notarization entry point", () => {
-  it.each([
-    ["canonical-only", "canonical-only"],
-    ["legacy-only", "legacy-only"],
-    ["dual", "dual"],
-  ] as const)(
-    "uses one complete %s API credential set",
-    (credentialCase, source) => {
-      expectSuccessfulApiEntryPoint(
+  it("uses one complete canonical API credential set byte-for-byte", () => {
+    expectSuccessfulApiEntryPoint(runPackagedAppHelper("canonical-only"));
+  });
+
+  it("keeps canonical credentials authoritative over hostile retired values", () => {
+    expectSuccessfulApiEntryPoint(
+      runPackagedAppHelper("canonical-and-retired"),
+    );
+  });
+
+  it.each(incompleteCredentialCases)(
+    "rejects the incomplete canonical %s shape before signing",
+    (credentialCase) => {
+      expectFailedBeforeExternalSideEffects(
         runPackagedAppHelper(credentialCase),
-        source,
+        "incomplete",
       );
     },
   );
 
-  it.each([
-    ["conflict", "conflict"],
-    ["mixed", "mixed"],
-    ["incomplete", "incomplete"],
-    ["absent", "absent"],
-    ["empty", "absent"],
-  ] as const)(
+  it.each(["absent", "empty", "retired-only"] as const)(
     "rejects %s API credentials before signing",
-    (credentialCase, state) => {
+    (credentialCase) => {
       expectFailedBeforeExternalSideEffects(
         runPackagedAppHelper(credentialCase),
-        state,
+        "absent",
       );
     },
   );
@@ -966,7 +954,6 @@ describe("packaged Desktop signing and notarization entry point", () => {
     });
     expect(result.process.status === 1).toBe(true);
     expect(result.trace).toBe("");
-    expect(sourceEvents(result)).toStrictEqual([]);
     expect(
       result.process.stderr.includes(
         "Expected a Zero Computer Use.app directory",
@@ -981,7 +968,6 @@ describe("packaged Desktop signing and notarization entry point", () => {
     });
     expect(result.process.status === 1).toBe(true);
     expect(result.trace).toBe("");
-    expect(sourceEvents(result)).toStrictEqual([]);
     expect(
       result.process.stderr.includes(
         "Usage: sign-and-notarize-packaged-app.mjs",
@@ -1009,7 +995,7 @@ describe("packaged Desktop signing identity entry point", () => {
         signingIdentity: input,
       });
 
-      expectSuccessfulApiEntryPoint(result, "canonical-only");
+      expectSuccessfulApiEntryPoint(result);
       expectSigningIdentitySource(result, source);
     },
   );
@@ -1021,9 +1007,6 @@ describe("packaged Desktop signing identity entry point", () => {
 
     expect(result.process.status).toBe(1);
     expect(result.trace).toBe("");
-    expect(sourceEvents(result)).toStrictEqual([
-      "desktop_notarize_api_env_source source=canonical-only",
-    ]);
     expectSigningIdentitySource(result, undefined);
     expect(result.process.stderr).toContain(
       "OKOU_DESKTOP_SIGNING_IDENTITY is required",


### PR DESCRIPTION
## Summary

- remove the terminal VM0_DESKTOP_NOTARIZE_API_* reader branches, alias-state machinery, rollout comment, and migration source telemetry
- preserve the canonical credential triple as one atomic set, exact Apple option bytes, fail-before-side-effect validation, and Forge custom/default Keychain behavior
- replace compatibility cases with focused canonical lifecycle and retired-input isolation coverage across both real Desktop entry points

## Verification

- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'
- pnpm --filter @okouai/app run check-types
- pnpm --filter api run check-types
- pnpm --filter @okouai/desktop exec vitest run src/desktop-notarize-entry-points.test.ts (60 tests)
- bash -n .github/scripts/tests/deploy-desktop-workflow-test.sh
- shellcheck .github/scripts/tests/deploy-desktop-workflow-test.sh
- bash .github/scripts/tests/deploy-desktop-workflow-test.sh

## Scope evidence

- exactly six raw retired credential-name occurrences remain across the two required negative test files
- zero desktop_notarize_api_env_source occurrences remain
- the release workflow, README, standalone packaged-app helper, and Desktop workflow contract test are unchanged
- final pre-publish audit covered 27 open PRs and 490/490 changed files with zero target-file overlaps and zero pagination mismatches

Closes #30305
Refs #28914
