### PR TITLE
refactor(desktop): retire signing identity legacy alias

### DIFF
--- a/.github/scripts/tests/deploy-desktop-workflow-test.sh
+++ b/.github/scripts/tests/deploy-desktop-workflow-test.sh
@@ -19,22 +19,24 @@ ruby -e '
   desktop_text = File.read(ARGV[0])
   release_text = File.read(ARGV[1])
 
+  canonical_signing_identity = "OKOU_DESKTOP_SIGNING_IDENTITY"
   canonical_writer_counts = {
     "OKOU_DESKTOP_PRODUCT" => [8, 2],
     "OKOU_DESKTOP_PLATFORM_URL" => [11, 2],
+    canonical_signing_identity => [0, 5],
   }
   canonical_writer_counts.each do |name, expected_counts|
     actual_counts = [desktop_text.scan(name).length, release_text.scan(name).length]
-    raise "Desktop workflows must use the complete canonical product/platform writer surface" unless actual_counts == expected_counts
+    raise "Desktop workflows must use the complete canonical environment writer surface" unless actual_counts == expected_counts
   end
   legacy_prefix = "VM0_"
-  legacy_names = ["DESKTOP_PRODUCT", "DESKTOP_PLATFORM_URL"].map do |suffix|
+  legacy_names = ["DESKTOP_PRODUCT", "DESKTOP_PLATFORM_URL", "DESKTOP_SIGNING_IDENTITY"].map do |suffix|
     legacy_prefix + suffix
   end
   legacy_writer_present = legacy_names.any? do |name|
     desktop_text.include?(name) || release_text.include?(name)
   end
-  raise "Desktop workflows must not use legacy product/platform writers" if legacy_writer_present
+  raise "Desktop workflows must not use legacy environment writers" if legacy_writer_present
 
   detector = desktop.fetch("detect-desktop-version")
   build = desktop.fetch("build-macos")
@@ -73,6 +75,8 @@ ruby -e '
   raise "canonical artifact must upload the Okou archive" unless artifact_upload.include?("okou-app.tar.gz")
 
   promote = release.fetch("promote-desktop-release")
+  expected_signing_identity = "Developer ID Application: Max & Zoe, Inc. (C5UWSXYB67)"
+  raise "Desktop promotion must define the canonical signing identity" unless promote.fetch("env").fetch(canonical_signing_identity) == expected_signing_identity
   raise "Desktop promotion must use production environment" unless promote.fetch("environment") == "production"
   checkout = promote.fetch("steps").find { |step| step["uses"].to_s.start_with?("actions/checkout@") }
   raise "Desktop promotion must check out release_target" unless checkout.fetch("with").fetch("ref") == ARGV[4]

--- a/turbo/apps/desktop/scripts/desktop-signing-identity-environment.js
+++ b/turbo/apps/desktop/scripts/desktop-signing-identity-environment.js
@@ -1,36 +1,5 @@
-const CANONICAL_SIGNING_IDENTITY = "OKOU_DESKTOP_SIGNING_IDENTITY";
-const LEGACY_SIGNING_IDENTITY = "VM0_DESKTOP_SIGNING_IDENTITY";
-
-// The production release workflow is canonical-only during this writer stage.
-// Keep the legacy alias for rollback until an exact signed Desktop release
-// proves two canonical-only reader events with zero legacy-only, dual, or
-// conflict events, signing and notarization outputs remain unchanged, and the
-// supported rollback window completes under #28914.
 function resolveDesktopSigningIdentityEnvironment() {
-  const canonicalValue = process.env[CANONICAL_SIGNING_IDENTITY];
-  const legacyValue = process.env[LEGACY_SIGNING_IDENTITY];
-  const canonicalPresent = canonicalValue !== undefined;
-  const legacyPresent = legacyValue !== undefined;
-
-  if (!canonicalPresent && !legacyPresent) {
-    return undefined;
-  }
-  if (canonicalPresent && legacyPresent && canonicalValue !== legacyValue) {
-    throw new Error(
-      `Desktop signing identity environment aliases conflict: canonical_key=${CANONICAL_SIGNING_IDENTITY} legacy_key=${LEGACY_SIGNING_IDENTITY} state=conflict`,
-    );
-  }
-
-  const source =
-    canonicalPresent && legacyPresent
-      ? "dual"
-      : canonicalPresent
-        ? "canonical-only"
-        : "legacy-only";
-  console.info(
-    `desktop_signing_identity_env_source key=${CANONICAL_SIGNING_IDENTITY} source=${source}`,
-  );
-  return canonicalPresent ? canonicalValue : legacyValue;
+  return process.env.OKOU_DESKTOP_SIGNING_IDENTITY;
 }
 
 module.exports = { resolveDesktopSigningIdentityEnvironment };

--- a/turbo/apps/desktop/src/desktop-notarize-entry-points.test.ts
+++ b/turbo/apps/desktop/src/desktop-notarize-entry-points.test.ts
@@ -152,7 +152,6 @@ type CredentialCase =
   | "canonical-and-retired"
   | "retired-only"
   | IncompleteCredentialCase;
-type SuccessfulSource = "canonical-only" | "legacy-only" | "dual";
 
 const incompleteCredentialCases = [
   "key-path-only",
@@ -383,10 +382,8 @@ function runForge(
     environment,
     signingIdentity,
   );
-  const configuredSigningIdentity =
-    signingIdentity.canonical ?? signingIdentity.legacy;
   const expectedSigningIdentity =
-    configuredSigningIdentity ??
+    signingIdentity.canonical ??
     (environment.CI === "true" ? "-" : developerIdApplicationIdentity);
   environment.TEST_EXPECTED_SIGNING_IDENTITY = expectedSigningIdentity;
   environment.TEST_EXPECTED_IDENTITY_VALIDATION =
@@ -461,14 +458,13 @@ function runPackagedAppHelper(
     credentialCase,
   );
   const signingIdentity = options.signingIdentity ?? {
-    legacy: ` ${randomUUID()} `,
+    canonical: ` ${randomUUID()} `,
   };
   const signingIdentityValues = applySigningIdentityInput(
     environment,
     signingIdentity,
   );
-  const expectedSigningIdentity =
-    signingIdentity.canonical ?? signingIdentity.legacy;
+  const expectedSigningIdentity = signingIdentity.canonical;
   if (expectedSigningIdentity !== undefined) {
     environment.TEST_EXPECTED_SIGNING_IDENTITY = expectedSigningIdentity;
   }
@@ -503,27 +499,6 @@ function keychainSourceEvents(result: EntryPointResult): readonly string[] {
   return result.process.stdout
     .split("\n")
     .filter((line) => line.startsWith("desktop_notarize_keychain_env_source "));
-}
-
-function signingIdentitySourceEvents(
-  result: EntryPointResult,
-): readonly string[] {
-  return result.process.stdout
-    .split("\n")
-    .filter((line) => line.startsWith("desktop_signing_identity_env_source "));
-}
-
-function expectSigningIdentitySource(
-  result: EntryPointResult,
-  source: SuccessfulSource | undefined,
-): void {
-  expect(signingIdentitySourceEvents(result)).toStrictEqual(
-    source
-      ? [
-          `desktop_signing_identity_env_source key=${canonicalSigningIdentityAlias} source=${source}`,
-        ]
-      : [],
-  );
 }
 
 function expectNoSensitiveValueDisclosure(result: EntryPointResult): void {
@@ -838,30 +813,30 @@ describe("Desktop Forge Keychain notarization environment entry point", () => {
 });
 
 describe("Desktop Forge signing identity entry point", () => {
-  const sharedIdentity = ` ${randomUUID()} `;
+  const canonicalIdentity = ` ${randomUUID()} `;
+  const hostileRetiredIdentity = `retired-${randomUUID()}`;
 
-  it.each([
-    ["canonical-only", { canonical: sharedIdentity }, "canonical-only"],
-    ["legacy-only", { legacy: sharedIdentity }, "legacy-only"],
-    [
-      "byte-equal dual",
-      { canonical: sharedIdentity, legacy: sharedIdentity },
-      "dual",
-    ],
-  ] as const)(
-    "passes the %s identity through unchanged",
-    (_, input, source) => {
-      const result = runForge("absent", {
-        notarize: false,
-        signingIdentity: input,
-      });
+  it("passes the canonical identity through unchanged", () => {
+    const result = runForge("absent", {
+      notarize: false,
+      signingIdentity: { canonical: canonicalIdentity },
+    });
 
-      expect(result.process.status, result.process.stderr).toBe(0);
-      expect(result.trace).toBe("sign\n");
-      expectSigningIdentitySource(result, source);
-      expectNoSensitiveValueDisclosure(result);
-    },
-  );
+    expect(result.process.status, result.process.stderr).toBe(0);
+    expect(result.trace).toBe("sign\n");
+    expectNoSensitiveValueDisclosure(result);
+  });
+
+  it("does not replace an explicit-empty canonical identity", () => {
+    const result = runForge("absent", {
+      notarize: false,
+      signingIdentity: { canonical: "" },
+    });
+
+    expect(result.process.status, result.process.stderr).toBe(0);
+    expect(result.trace).toBe("sign\n");
+    expectNoSensitiveValueDisclosure(result);
+  });
 
   it.each([
     ["CI", true],
@@ -877,42 +852,32 @@ describe("Desktop Forge signing identity entry point", () => {
 
       expect(result.process.status, result.process.stderr).toBe(0);
       expect(result.trace).toBe("sign\n");
-      expectSigningIdentitySource(result, undefined);
       expectNoSensitiveValueDisclosure(result);
     },
   );
 
-  it.each([
-    ["canonical-only", { canonical: "" }, "canonical-only"],
-    ["legacy-only", { legacy: "" }, "legacy-only"],
-    ["byte-equal dual", { canonical: "", legacy: "" }, "dual"],
-  ] as const)(
-    "does not replace an explicit-empty %s identity",
-    (_, input, source) => {
-      const result = runForge("absent", {
-        notarize: false,
-        signingIdentity: input,
-      });
-
-      expect(result.process.status, result.process.stderr).toBe(0);
-      expect(result.trace).toBe("sign\n");
-      expectSigningIdentitySource(result, source);
-      expectNoSensitiveValueDisclosure(result);
-    },
-  );
-
-  it("rejects conflicting aliases before signing", () => {
+  it("treats retired-only input as absent", () => {
     const result = runForge("absent", {
       notarize: false,
-      signingIdentity: { canonical: "", legacy: ` ${randomUUID()} ` },
+      signingIdentity: { legacy: hostileRetiredIdentity },
     });
 
-    expect(result.process.status).toBe(1);
-    expect(result.trace).toBe("");
-    expectSigningIdentitySource(result, undefined);
-    expect(result.process.stderr).toContain(
-      `Desktop signing identity environment aliases conflict: canonical_key=${canonicalSigningIdentityAlias} legacy_key=${legacySigningIdentityAlias} state=conflict`,
-    );
+    expect(result.process.status, result.process.stderr).toBe(0);
+    expect(result.trace).toBe("sign\n");
+    expectNoSensitiveValueDisclosure(result);
+  });
+
+  it("uses the canonical identity unchanged with hostile retired input", () => {
+    const result = runForge("absent", {
+      notarize: false,
+      signingIdentity: {
+        canonical: canonicalIdentity,
+        legacy: hostileRetiredIdentity,
+      },
+    });
+
+    expect(result.process.status, result.process.stderr).toBe(0);
+    expect(result.trace).toBe("sign\n");
     expectNoSensitiveValueDisclosure(result);
   });
 });
@@ -978,56 +943,38 @@ describe("packaged Desktop signing and notarization entry point", () => {
 });
 
 describe("packaged Desktop signing identity entry point", () => {
-  const sharedIdentity = ` ${randomUUID()} `;
+  const canonicalIdentity = ` ${randomUUID()} `;
+  const hostileRetiredIdentity = `retired-${randomUUID()}`;
 
   it.each([
-    ["canonical-only", { canonical: sharedIdentity }, "canonical-only"],
-    ["legacy-only", { legacy: sharedIdentity }, "legacy-only"],
+    ["canonical-only", { canonical: canonicalIdentity }],
     [
-      "byte-equal dual",
-      { canonical: sharedIdentity, legacy: sharedIdentity },
-      "dual",
+      "canonical with hostile retired input",
+      {
+        canonical: canonicalIdentity,
+        legacy: hostileRetiredIdentity,
+      },
     ],
-  ] as const)(
-    "passes the %s identity through unchanged",
-    (_, input, source) => {
-      const result = runPackagedAppHelper("canonical-only", {
-        signingIdentity: input,
-      });
-
-      expectSuccessfulApiEntryPoint(result);
-      expectSigningIdentitySource(result, source);
-    },
-  );
-
-  it("keeps the existing required-variable failure when both aliases are absent", () => {
+  ] as const)("passes the %s identity through unchanged", (_, input) => {
     const result = runPackagedAppHelper("canonical-only", {
-      signingIdentity: {},
+      signingIdentity: input,
     });
 
-    expect(result.process.status).toBe(1);
-    expect(result.trace).toBe("");
-    expectSigningIdentitySource(result, undefined);
-    expect(result.process.stderr).toContain(
-      "OKOU_DESKTOP_SIGNING_IDENTITY is required",
-    );
-    expectNoSensitiveValueDisclosure(result);
+    expectSuccessfulApiEntryPoint(result);
   });
 
   it.each([
-    ["canonical-only", { canonical: "" }, "canonical-only"],
-    ["legacy-only", { legacy: "" }, "legacy-only"],
-    ["byte-equal dual", { canonical: "", legacy: "" }, "dual"],
+    ["absent", {}],
+    ["retired-only", { legacy: hostileRetiredIdentity }],
   ] as const)(
-    "keeps the existing required-variable failure for an explicit-empty %s identity",
-    (_, input, source) => {
+    "keeps the required-variable failure for %s canonical input",
+    (_, input) => {
       const result = runPackagedAppHelper("canonical-only", {
         signingIdentity: input,
       });
 
       expect(result.process.status).toBe(1);
       expect(result.trace).toBe("");
-      expectSigningIdentitySource(result, source);
       expect(result.process.stderr).toContain(
         "OKOU_DESKTOP_SIGNING_IDENTITY is required",
       );
@@ -1035,16 +982,18 @@ describe("packaged Desktop signing identity entry point", () => {
     },
   );
 
-  it("rejects conflicting aliases before signing or notarization", () => {
+  it("keeps the required-variable failure for an explicit-empty canonical identity", () => {
     const result = runPackagedAppHelper("canonical-only", {
-      signingIdentity: { canonical: "", legacy: ` ${randomUUID()} ` },
+      signingIdentity: {
+        canonical: "",
+        legacy: hostileRetiredIdentity,
+      },
     });
 
     expect(result.process.status).toBe(1);
     expect(result.trace).toBe("");
-    expectSigningIdentitySource(result, undefined);
     expect(result.process.stderr).toContain(
-      `Desktop signing identity environment aliases conflict: canonical_key=${canonicalSigningIdentityAlias} legacy_key=${legacySigningIdentityAlias} state=conflict`,
+      "OKOU_DESKTOP_SIGNING_IDENTITY is required",
     );
     expectNoSensitiveValueDisclosure(result);
   });


### PR DESCRIPTION
## Summary

- make the shared Desktop signing-identity resolver read only `OKOU_DESKTOP_SIGNING_IDENTITY`, preserving exact bytes, `undefined`, and an explicit empty string
- replace the legacy-only/equal-dual/conflict/source-telemetry matrix with canonical lifecycle and retired-input isolation coverage at both real signing entry points
- extend the existing Desktop workflow contract to lock the canonical signing-identity writer and exact production identity without changing either release workflow

## Scope and evidence

- issue: closes #30311; parent EPIC #28914
- initial dispatch base: `e82196c8457a5362a93ef8abe5862ffb6a92283b`
- reviewed final base after normal refresh/rebase: `8ba2d24dc54d0d359c9efdd1e23a7e4a10ab8532`
- reviewed head: `30b737354d1773b9cec4c7e7986a8116456af3c0`
- preserved the canonical-only notarization API result merged by #30315 while resolving the shared-test-container overlap
- retained the production-removal evidence recorded in #30311: signed release `desktop-v0.38.121`, release run `33290018946`, promotion job `99201556042`, and the seven exact rollback RevertIds
- final fully paginated open-PR audit: 24 stable PRs, 441 declared files, 441 fetched files, zero count mismatches, and zero signing-identity semantic hits; only #25722 overlaps `.github/workflows/release-please.yml`, in unrelated API Worker hunks

No fallback or compatibility reader is introduced. The one retained retired-input fixture is the issue-required fail-closed isolation boundary: it proves the retired variable is inert and cannot override or conflict with canonical input.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (14/14 tasks; Desktop 0 warnings/errors)
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app' --log-order grouped` (13/13 tasks)
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- final-head `pnpm exec prettier --check apps/desktop/scripts/desktop-signing-identity-environment.js apps/desktop/src/desktop-notarize-entry-points.test.ts`
- final-head `bash -n ../.github/scripts/tests/deploy-desktop-workflow-test.sh`
- final-head `pnpm --filter @okouai/desktop run lint`
- final-head `pnpm --filter @okouai/desktop run check-types`
- final-head `pnpm knip` (passed; 50 existing configuration hints)
- final-head `pnpm --filter @okouai/desktop exec vitest run src/desktop-notarize-entry-points.test.ts` (54/54)
- final-head `bash ../.github/scripts/tests/deploy-desktop-workflow-test.sh`
- `git diff --check origin/main`

## Exact inventory

- raw `VM0_DESKTOP_SIGNING_IDENTITY`: exactly 1 occurrence, only in `desktop-notarize-entry-points.test.ts`
- `desktop_signing_identity_env_source`: 0 occurrences
- resolver production callers: exactly Forge config and the packaged-app signing helper
- changed files: exactly the shared resolver, focused real-entry-point test, and workflow contract test
- unchanged protected surfaces: release workflow, Forge implementation, packaged signing helper, and EPIC-wide guest-contract ownership guard

No full local Vitest suite, dev server, release, workflow dispatch, deployment, environment approval, or browser action was run.
