### PR TITLE
fix(api): stop sandbox authority after run timeout

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-run-timeout.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-run-timeout.ts
@@ -1,0 +1,33 @@
+import { testCronCleanupSandboxesStateContract } from "@okouai/api-contracts/contracts/test-cron-cleanup-sandboxes-state";
+
+import { accept, type TestContext } from "../../../../__tests__/test-context";
+import { setupApp } from "../../../../__tests__/test-helpers";
+import { testCronCleanupSandboxesStateRoutes } from "../../test-cron-cleanup-sandboxes-state";
+
+export type TestTerminalRunStatus =
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "timeout";
+
+export async function transitionRunToTerminal(
+  context: TestContext,
+  runId: string,
+  status: TestTerminalRunStatus,
+) {
+  return await accept(
+    setupApp({ context, routes: testCronCleanupSandboxesStateRoutes })(
+      testCronCleanupSandboxesStateContract,
+    ).action({
+      body: { action: "transition-run-terminal", run_id: runId, status },
+    }),
+    [200],
+  );
+}
+
+export async function transitionRunToTimeout(
+  context: TestContext,
+  runId: string,
+) {
+  return await transitionRunToTerminal(context, runId, "timeout");
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-storages.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-storages.ts
@@ -38,6 +38,13 @@ interface BddStorageDownloadQuery {
   readonly version?: string;
 }
 
+interface BddStorageWritebackQuery {
+  readonly storageId: string;
+  readonly versionId: string;
+  readonly runId: string;
+  readonly parentVersionId: string;
+}
+
 function requireOrgId(actor: ApiTestUser): string {
   if (!actor.orgId) {
     throw new Error("Storage fixture requires an org-scoped actor");
@@ -168,6 +175,20 @@ export function createStoragesBddApi(context: TestContext) {
         throw new Error("Storage download action returned no result");
       }
       return response.download;
+    },
+
+    async inspectWriteback(query: BddStorageWritebackQuery) {
+      const response = await postAction(context, {
+        action: "inspect-writeback",
+        storageId: query.storageId,
+        versionId: query.versionId,
+        runId: query.runId,
+        parentVersionId: query.parentVersionId,
+      });
+      if (!response.writeback) {
+        throw new Error("Storage writeback inspection returned no result");
+      }
+      return response.writeback;
     },
   };
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -38,6 +38,11 @@ import {
   mockTestOAuthAuthCodeProvider,
 } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
+import {
+  transitionRunToTerminal,
+  transitionRunToTimeout,
+  type TestTerminalRunStatus,
+} from "./helpers/api-bdd-run-timeout";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import {
   setConnectorCredentialStorageState,
@@ -65,8 +70,14 @@ const TEST_DATA_KEY = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
  */
 
 const context = testContext();
+const TERMINAL_RUN_STATUSES = [
+  "completed",
+  "failed",
+  "cancelled",
+  "timeout",
+] as const satisfies readonly TestTerminalRunStatus[];
 
-async function firewallRun(): Promise<{
+async function firewallRun(existingActor?: ApiTestUser): Promise<{
   readonly actor: ApiTestUser;
   readonly runId: string;
   readonly headers: { readonly authorization: string };
@@ -74,7 +85,7 @@ async function firewallRun(): Promise<{
   const bdd = createBddApi(context);
   const runsApi = createRunsApi(context);
   const fw = createFirewallApi(context);
-  const actor = bdd.user();
+  const actor = existingActor ?? bdd.user();
   bdd.acceptAgentStorageWrites();
   runsApi.acceptStorageDownloads();
   runsApi.acceptTelemetryIngest();
@@ -1693,6 +1704,153 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     }
     expect(served.body.headers.Authorization).toBe("Bearer fresh-api-access");
     expect(served.body.refreshedConnectors).toStrictEqual([]);
+  });
+});
+
+describe("FW-5: timeout closes firewall credential authority", () => {
+  it.each(TERMINAL_RUN_STATUSES)(
+    "rejects a %s run before connector refresh",
+    async (status) => {
+      const fw = createFirewallApi(context);
+      const { actor, runId, headers } = await firewallRun();
+      await fw.seedTestConnector(actor, {
+        connectorSlug: "test-oauth",
+        authMethod: "oauth",
+        accessToken: "stale-access",
+        refreshToken: "refresh-1",
+        expiresIn: -60,
+      });
+      let refreshRequests = 0;
+      fw.mockTestOauthTokenRefresh(() => {
+        refreshRequests += 1;
+        return fw.oauthTokenResponse({
+          accessToken: "must-not-refresh",
+          expiresIn: 3600,
+        });
+      });
+
+      const terminal = await transitionRunToTerminal(context, runId, status);
+      expect(terminal.body.ok).toBeTruthy();
+      const denied = await fw.requestFirewallAuth(
+        headers,
+        {
+          encryptedSecrets: fw.encryptedSecretsBody({
+            TEST_OAUTH_TOKEN: "stale-access",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
+          },
+          ...(await exactSecretConnectorSources(actor, {
+            TEST_OAUTH_TOKEN: "test-oauth",
+          })),
+        },
+        [403],
+      );
+      if (denied.status !== 403) {
+        throw new Error("Expected timed-out firewall auth to be forbidden");
+      }
+      expect(denied.body.error.code).toBe("FORBIDDEN");
+      expect(refreshRequests).toBe(0);
+    },
+  );
+
+  it("withholds static connector credentials when timeout wins during resolution", async () => {
+    const fw = createFirewallApi(context);
+    const { actor, runId, headers } = await firewallRun();
+    await fw.seedTestConnector(actor, {
+      connectorSlug: "test-oauth",
+      authMethod: "oauth",
+      accessToken: "current-access",
+      refreshToken: "refresh-1",
+      expiresIn: 3600,
+    });
+    const decryptGate = gateFirstStoredSecretDecrypt();
+    const pending = fw.requestFirewallAuth(
+      headers,
+      {
+        encryptedSecrets: fw.encryptedSecretsBody({}),
+        authHeaders: {
+          Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
+        },
+        ...(await exactSecretConnectorSources(actor, {
+          TEST_OAUTH_TOKEN: "test-oauth",
+        })),
+      },
+      [403],
+    );
+    await decryptGate.started;
+    const timeout = await transitionRunToTimeout(context, runId);
+    expect(timeout.body.ok).toBeTruthy();
+    decryptGate.release();
+
+    const denied = await pending;
+    if (denied.status !== 403) {
+      throw new Error("Expected final firewall admission to be forbidden");
+    }
+    expect(denied.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("preserves shared refresh state while withholding it from the timed-out run", async () => {
+    const fw = createFirewallApi(context);
+    const { actor, runId, headers } = await firewallRun();
+    await fw.seedTestConnector(actor, {
+      connectorSlug: "test-oauth",
+      authMethod: "oauth",
+      accessToken: "stale-access",
+      refreshToken: "refresh-1",
+      expiresIn: -60,
+    });
+    const refreshStarted = createDeferredPromise<void>(context.signal);
+    const releaseRefresh = createDeferredPromise<void>(context.signal);
+    onTestFinished(() => {
+      if (!releaseRefresh.settled()) {
+        releaseRefresh.resolve(undefined);
+      }
+    });
+    let refreshRequests = 0;
+    fw.mockTestOauthTokenRefresh(async () => {
+      refreshRequests += 1;
+      refreshStarted.resolve(undefined);
+      await releaseRefresh.promise;
+      return fw.oauthTokenResponse({
+        accessToken: "shared-fresh-access",
+        refreshToken: "shared-refresh-2",
+        expiresIn: 3600,
+      });
+    });
+    const sources = await exactSecretConnectorSources(actor, {
+      TEST_OAUTH_TOKEN: "test-oauth",
+    });
+    const body = {
+      encryptedSecrets: fw.encryptedSecretsBody({
+        TEST_OAUTH_TOKEN: "stale-access",
+      }),
+      authHeaders: {
+        Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
+      },
+      ...sources,
+    };
+
+    const pending = fw.requestFirewallAuth(headers, body, [403]);
+    await refreshStarted.promise;
+    const timeout = await transitionRunToTimeout(context, runId);
+    expect(timeout.body.ok).toBeTruthy();
+    releaseRefresh.resolve(undefined);
+    const denied = await pending;
+    if (denied.status !== 403) {
+      throw new Error("Expected refreshed credential response to be forbidden");
+    }
+    expect(denied.body.error.code).toBe("FORBIDDEN");
+
+    const activeRun = await firewallRun(actor);
+    const served = await fw.requestFirewallAuth(activeRun.headers, body, [200]);
+    if (served.status !== 200) {
+      throw new Error("Expected refreshed shared state to remain usable");
+    }
+    expect(served.body.headers.Authorization).toBe(
+      "Bearer shared-fresh-access",
+    );
+    expect(refreshRequests).toBe(1);
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -3093,6 +3093,147 @@ describe("WHCB-10: timeout closes sandbox storage write authority", () => {
       }),
     ).resolves.toStrictEqual(before);
   });
+
+  it("keeps a deduplicated head move provable after timeout", async () => {
+    const fixture = await sandboxStorageWriteFixture(
+      "timeout deduplicated retry",
+    );
+    const storages = createStoragesBddApi(context);
+    const initialVersionId = fixture.mount.versionId;
+    const restoredFiles = [
+      {
+        path: "restored.txt",
+        hash: createHash("sha256")
+          .update(`restored ${fixture.runId}`)
+          .digest("hex"),
+        size: 1024,
+      },
+    ];
+    const restoredMessage = "restored before timeout";
+    const restoredPrepare = await api.requestAgentStoragePrepare(
+      {
+        runId: fixture.runId,
+        storageId: fixture.mount.storageId,
+        parentVersionId: initialVersionId,
+        files: restoredFiles,
+      },
+      fixture.headers,
+      [200],
+    );
+    if (restoredPrepare.status !== 200) {
+      throw new Error("Expected restored version prepare to succeed");
+    }
+    await api.requestAgentStorageCommit(
+      {
+        runId: fixture.runId,
+        storageId: fixture.mount.storageId,
+        versionId: restoredPrepare.body.versionId,
+        parentVersionId: initialVersionId,
+        files: restoredFiles,
+        message: restoredMessage,
+      },
+      fixture.headers,
+      [200],
+    );
+
+    const replacementFiles = [
+      {
+        path: "replacement.txt",
+        hash: createHash("sha256")
+          .update(`replacement ${fixture.runId}`)
+          .digest("hex"),
+        size: 4096,
+      },
+    ];
+    const replacementPrepare = await api.requestAgentStoragePrepare(
+      {
+        runId: fixture.runId,
+        storageId: fixture.mount.storageId,
+        parentVersionId: restoredPrepare.body.versionId,
+        files: replacementFiles,
+      },
+      fixture.headers,
+      [200],
+    );
+    if (replacementPrepare.status !== 200) {
+      throw new Error("Expected replacement version prepare to succeed");
+    }
+    await api.requestAgentStorageCommit(
+      {
+        runId: fixture.runId,
+        storageId: fixture.mount.storageId,
+        versionId: replacementPrepare.body.versionId,
+        parentVersionId: restoredPrepare.body.versionId,
+        files: replacementFiles,
+        message: "replacement before restore",
+      },
+      fixture.headers,
+      [200],
+    );
+
+    const restored = await api.requestAgentStorageCommit(
+      {
+        runId: fixture.runId,
+        storageId: fixture.mount.storageId,
+        versionId: restoredPrepare.body.versionId,
+        parentVersionId: replacementPrepare.body.versionId,
+        files: restoredFiles,
+        message: restoredMessage,
+      },
+      fixture.headers,
+      [200],
+    );
+    if (restored.status !== 200) {
+      throw new Error("Expected deduplicated head move to succeed");
+    }
+    expect(restored.body).toMatchObject({
+      success: true,
+      versionId: restoredPrepare.body.versionId,
+      size: 1024,
+      fileCount: 1,
+      deduplicated: true,
+    });
+
+    const before = await storages.inspectWriteback({
+      storageId: fixture.mount.storageId,
+      versionId: restoredPrepare.body.versionId,
+      runId: fixture.runId,
+      parentVersionId: replacementPrepare.body.versionId,
+    });
+    expect(before.storage).toMatchObject({
+      headVersionId: restoredPrepare.body.versionId,
+      size: 1024,
+      fileCount: 1,
+    });
+    expect(before.lineageCount).toBe(1);
+
+    const timeout = await transitionRunToTimeout(context, fixture.runId);
+    expect(timeout.body.ok).toBeTruthy();
+    const retried = await api.requestAgentStorageCommit(
+      {
+        runId: fixture.runId,
+        storageId: fixture.mount.storageId,
+        versionId: restoredPrepare.body.versionId,
+        parentVersionId: replacementPrepare.body.versionId,
+        files: restoredFiles,
+        message: restoredMessage,
+      },
+      fixture.headers,
+      [200],
+    );
+    if (retried.status !== 200) {
+      throw new Error("Expected deduplicated exact retry to succeed");
+    }
+    expect(retried.body.deduplicated).toBeTruthy();
+    await expect(
+      storages.inspectWriteback({
+        storageId: fixture.mount.storageId,
+        versionId: restoredPrepare.body.versionId,
+        runId: fixture.runId,
+        parentVersionId: replacementPrepare.body.versionId,
+      }),
+    ).resolves.toStrictEqual(before);
+  });
 });
 
 describe("WHCB-07: Stripe billing lifecycle webhooks", () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -42,6 +42,11 @@ import {
   expectCanonicalStorageManifest,
 } from "./helpers/api-bdd-runs";
 import { createStoragesBddApi } from "./helpers/api-bdd-storages";
+import {
+  transitionRunToTerminal,
+  transitionRunToTimeout,
+  type TestTerminalRunStatus,
+} from "./helpers/api-bdd-run-timeout";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createUserConfigBddApi } from "./helpers/api-bdd-user-config";
 import {
@@ -61,6 +66,12 @@ import {
 } from "./helpers/connector-credential-storage-state";
 
 const context = testContext();
+const TERMINAL_RUN_STATUSES = [
+  "completed",
+  "failed",
+  "cancelled",
+  "timeout",
+] as const satisfies readonly TestTerminalRunStatus[];
 const api = createWebhookCallbackApi(context);
 const store = createStore();
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
@@ -111,6 +122,42 @@ function orgOf(actor: ApiTestUser): string {
     throw new Error("Expected an org-scoped actor");
   }
   return actor.orgId;
+}
+
+async function sandboxStorageWriteFixture(label: string) {
+  const bdd = createBddApi(context);
+  const runs = createRunsApi(context);
+  const actor = bdd.user();
+  bdd.acceptAgentStorageWrites();
+  runs.acceptStorageDownloads();
+  runs.acceptTelemetryIngest();
+  const runnerGroup = runs.configureRunnerGroup();
+  await runs.heartbeatRunner(runnerGroup);
+  await runs.grantProEntitlement(actor);
+  await runs.ensureOrgModelProvider(actor);
+  const agent = await bdd.createAgent(actor, {
+    displayName: `BDD sandbox storage ${label}`,
+    visibility: "private",
+  });
+  const run = await runs.createRun(actor, {
+    agentId: agent.agentId,
+    prompt: `write ${label} from the sandbox`,
+    modelProvider: "anthropic-api-key",
+  });
+  const claim = await runs.claimRunnerJob(run.runId);
+  const manifest = expectCanonicalStorageManifest(claim.storageManifest);
+  const mount = manifest?.storageMounts.find((candidate) => {
+    return candidate.writeback === true;
+  });
+  if (!mount) {
+    throw new Error("Expected a canonical writeback mount");
+  }
+  return {
+    actor,
+    runId: run.runId,
+    mount,
+    headers: { authorization: `Bearer ${claim.sandboxToken}` },
+  };
 }
 
 function oauthStateFromAuthorizationUrl(authorizationUrl: string): string {
@@ -2860,6 +2907,189 @@ describe("WHCB-09: sandbox storage writes and checkpoint history blobs land in t
     await runs.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await runs.readRun(actor, run.runId);
     expect(cancelled.status).toBe("cancelled");
+  });
+});
+
+describe("WHCB-10: timeout closes sandbox storage write authority", () => {
+  it.each(TERMINAL_RUN_STATUSES)(
+    "rejects prepare before issuing upload URLs after %s",
+    async (status) => {
+      const fixture = await sandboxStorageWriteFixture("timeout prepare");
+      const signedUrlCalls = context.mocks.s3.getSignedUrl.mock.calls.length;
+
+      const terminal = await transitionRunToTerminal(
+        context,
+        fixture.runId,
+        status,
+      );
+      expect(terminal.body.ok).toBeTruthy();
+
+      const prepared = await api.requestAgentStoragePrepare(
+        {
+          runId: fixture.runId,
+          storageId: fixture.mount.storageId,
+          files: [
+            {
+              path: `${status}.txt`,
+              hash: createHash("sha256").update(status).digest("hex"),
+              size: 1,
+            },
+          ],
+        },
+        fixture.headers,
+        [404],
+      );
+      expectApiError(prepared.body);
+      expect(prepared.body.error.code).toBe("NOT_FOUND");
+      expect(context.mocks.s3.getSignedUrl).toHaveBeenCalledTimes(
+        signedUrlCalls,
+      );
+    },
+  );
+
+  it("keeps prepare-then-timeout commit completely write-free", async () => {
+    const fixture = await sandboxStorageWriteFixture("timeout commit");
+    const storages = createStoragesBddApi(context);
+    const parentVersionId = fixture.mount.versionId;
+    const files = [
+      {
+        path: "timeout.txt",
+        hash: createHash("sha256")
+          .update(`timeout ${fixture.runId}`)
+          .digest("hex"),
+        size: 2048,
+      },
+    ];
+    const prepared = await api.requestAgentStoragePrepare(
+      {
+        runId: fixture.runId,
+        storageId: fixture.mount.storageId,
+        parentVersionId,
+        files,
+      },
+      fixture.headers,
+      [200],
+    );
+    if (prepared.status !== 200) {
+      throw new Error("Expected storage prepare to succeed before timeout");
+    }
+    const before = await storages.inspectWriteback({
+      storageId: fixture.mount.storageId,
+      versionId: prepared.body.versionId,
+      runId: fixture.runId,
+      parentVersionId,
+    });
+    expect(before.version).toBeNull();
+    expect(before.lineageCount).toBe(0);
+
+    const timeout = await transitionRunToTimeout(context, fixture.runId);
+    expect(timeout.body.ok).toBeTruthy();
+
+    const committed = await api.requestAgentStorageCommit(
+      {
+        runId: fixture.runId,
+        storageId: fixture.mount.storageId,
+        versionId: prepared.body.versionId,
+        parentVersionId,
+        files,
+        message: "must not commit after timeout",
+      },
+      fixture.headers,
+      [404],
+    );
+    expectApiError(committed.body);
+    expect(committed.body.error.code).toBe("NOT_FOUND");
+    await expect(
+      storages.inspectWriteback({
+        storageId: fixture.mount.storageId,
+        versionId: prepared.body.versionId,
+        runId: fixture.runId,
+        parentVersionId,
+      }),
+    ).resolves.toStrictEqual(before);
+  });
+
+  it("acknowledges a proven committed retry after timeout without writes", async () => {
+    const fixture = await sandboxStorageWriteFixture("timeout exact retry");
+    const storages = createStoragesBddApi(context);
+    const parentVersionId = fixture.mount.versionId;
+    const files = [
+      {
+        path: "committed.txt",
+        hash: createHash("sha256")
+          .update(`committed ${fixture.runId}`)
+          .digest("hex"),
+        size: 4096,
+      },
+    ];
+    const message = "committed before timeout";
+    const prepared = await api.requestAgentStoragePrepare(
+      {
+        runId: fixture.runId,
+        storageId: fixture.mount.storageId,
+        parentVersionId,
+        files,
+      },
+      fixture.headers,
+      [200],
+    );
+    if (prepared.status !== 200) {
+      throw new Error("Expected storage prepare to succeed before timeout");
+    }
+    await api.requestAgentStorageCommit(
+      {
+        runId: fixture.runId,
+        storageId: fixture.mount.storageId,
+        versionId: prepared.body.versionId,
+        parentVersionId,
+        files,
+        message,
+      },
+      fixture.headers,
+      [200],
+    );
+    const before = await storages.inspectWriteback({
+      storageId: fixture.mount.storageId,
+      versionId: prepared.body.versionId,
+      runId: fixture.runId,
+      parentVersionId,
+    });
+    expect(before.version).not.toBeNull();
+    expect(before.lineageCount).toBe(1);
+
+    const timeout = await transitionRunToTimeout(context, fixture.runId);
+    expect(timeout.body.ok).toBeTruthy();
+
+    const retried = await api.requestAgentStorageCommit(
+      {
+        runId: fixture.runId,
+        storageId: fixture.mount.storageId,
+        versionId: prepared.body.versionId,
+        parentVersionId,
+        files,
+        message,
+      },
+      fixture.headers,
+      [200],
+    );
+    if (retried.status !== 200) {
+      throw new Error("Expected exact committed retry to succeed");
+    }
+    expect(retried.body).toMatchObject({
+      success: true,
+      versionId: prepared.body.versionId,
+      size: 4096,
+      fileCount: 1,
+      deduplicated: true,
+    });
+    await expect(
+      storages.inspectWriteback({
+        storageId: fixture.mount.storageId,
+        versionId: prepared.body.versionId,
+        runId: fixture.runId,
+        parentVersionId,
+      }),
+    ).resolves.toStrictEqual(before);
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -2984,6 +2984,7 @@ describe("WHCB-10: timeout closes sandbox storage write authority", () => {
 
     const timeout = await transitionRunToTimeout(context, fixture.runId);
     expect(timeout.body.ok).toBeTruthy();
+    const s3Calls = context.mocks.s3.send.mock.calls.length;
 
     const committed = await api.requestAgentStorageCommit(
       {
@@ -2999,6 +3000,7 @@ describe("WHCB-10: timeout closes sandbox storage write authority", () => {
     );
     expectApiError(committed.body);
     expect(committed.body.error.code).toBe("NOT_FOUND");
+    expect(context.mocks.s3.send).toHaveBeenCalledTimes(s3Calls);
     await expect(
       storages.inspectWriteback({
         storageId: fixture.mount.storageId,

--- a/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
@@ -919,6 +919,50 @@ async function getExportJobForAction(
   return actionOk({ export_job: job ?? null });
 }
 
+const TEST_TERMINAL_RUN_STATUSES = [
+  "completed",
+  "failed",
+  "cancelled",
+  "timeout",
+] as const;
+
+async function transitionRunTerminalForAction(
+  db: Db,
+  body: Record<string, unknown>,
+  signal: AbortSignal,
+) {
+  const runId = readString(body, "run_id");
+  const status = readString(body, "status");
+  if (!runId) {
+    return actionBadRequest("run_id is required");
+  }
+  const terminalStatus = TEST_TERMINAL_RUN_STATUSES.find((candidate) => {
+    return candidate === status;
+  });
+  if (!terminalStatus) {
+    return actionBadRequest("terminal status is required");
+  }
+  const [updated] = await db
+    .update(agentRuns)
+    .set({
+      status: terminalStatus,
+      completedAt: nowDate(),
+      error:
+        terminalStatus === "completed"
+          ? null
+          : `Run entered ${terminalStatus} in endpoint integration fixture`,
+    })
+    .where(
+      and(
+        eq(agentRuns.id, runId),
+        inArray(agentRuns.status, ["pending", "running"]),
+      ),
+    )
+    .returning({ id: agentRuns.id });
+  signal.throwIfAborted();
+  return updated ? actionOk() : actionBadRequest("active run not found");
+}
+
 const cronCleanupSandboxesActionHandlers = {
   "seed-run": seedRunForAction,
   "seed-run-ownership": seedRunOwnershipForAction,
@@ -937,6 +981,7 @@ const cronCleanupSandboxesActionHandlers = {
   "get-queue-entry": getQueueEntryForAction,
   "get-queue-marker-revoker": getQueueMarkerRevokerForAction,
   "get-export-job": getExportJobForAction,
+  "transition-run-terminal": transitionRunTerminalForAction,
 } satisfies Record<
   CronCleanupSandboxesAction,
   CronCleanupSandboxesActionHandler

--- a/turbo/apps/api/src/signals/routes/test-storage-fixture.ts
+++ b/turbo/apps/api/src/signals/routes/test-storage-fixture.ts
@@ -3,9 +3,10 @@ import {
   type TestStorageStateActionBody,
 } from "@okouai/api-contracts/contracts/test-storage-fixture";
 import { VOLUME_ORG_USER_ID } from "@okouai/core/storage-names";
+import { storageVersionLineage } from "@okouai/db/schema/storage-version-lineage";
 import { storages, storageVersions } from "@okouai/db/schema/storage";
 import { command } from "ccstate";
-import { and, desc, eq } from "drizzle-orm";
+import { and, count, desc, eq } from "drizzle-orm";
 
 import { conflict, notFound } from "../../lib/error";
 import { nowDate } from "../../lib/time";
@@ -298,6 +299,65 @@ async function downloadStorageState(
   });
 }
 
+async function inspectWritebackState(
+  db: Db,
+  body: StorageStateAction<"inspect-writeback">,
+  signal: AbortSignal,
+) {
+  const [storage] = await db
+    .select({
+      headVersionId: storages.headVersionId,
+      size: storages.size,
+      fileCount: storages.fileCount,
+      updatedAt: storages.updatedAt,
+    })
+    .from(storages)
+    .where(eq(storages.id, body.storageId))
+    .limit(1);
+  signal.throwIfAborted();
+  const [version] = await db
+    .select({
+      archiveSize: storageVersions.archiveSize,
+      size: storageVersions.size,
+      fileCount: storageVersions.fileCount,
+      message: storageVersions.message,
+      createdBy: storageVersions.createdBy,
+      createdAt: storageVersions.createdAt,
+    })
+    .from(storageVersions)
+    .where(
+      and(
+        eq(storageVersions.storageId, body.storageId),
+        eq(storageVersions.id, body.versionId),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+  const [lineage] = await db
+    .select({ count: count() })
+    .from(storageVersionLineage)
+    .where(
+      and(
+        eq(storageVersionLineage.storageId, body.storageId),
+        eq(storageVersionLineage.versionId, body.versionId),
+        eq(storageVersionLineage.runId, body.runId),
+        eq(storageVersionLineage.parentVersionId, body.parentVersionId),
+      ),
+    );
+  signal.throwIfAborted();
+  return actionOk({
+    writeback: {
+      storage: storage
+        ? { ...storage, updatedAt: storage.updatedAt.toISOString() }
+        : null,
+      version: version
+        ? { ...version, createdAt: version.createdAt.toISOString() }
+        : null,
+      lineageCount: lineage?.count ?? 0,
+    },
+  });
+}
+
 const action$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (!isTestEndpointAllowed(get(request$))) {
     return testEndpointNotFoundResponse();
@@ -320,6 +380,9 @@ const action$ = command(async ({ get, set }, signal: AbortSignal) => {
     }
     case "download": {
       return await downloadStorageState(db, bodyResult.data, signal);
+    }
+    case "inspect-writeback": {
+      return await inspectWritebackState(db, bodyResult.data, signal);
     }
   }
 });

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -130,6 +130,7 @@ const LOW_BILLABLE_FIREWALL_CREDIT_THRESHOLD = 1000;
 const FIREWALL_AUTH_REFRESH_TIMEOUT_MS = 30_000;
 const REFRESH_TIMEOUT_ERROR_CODE = "oauth_refresh_timeout";
 const MAX_OAUTH_REFRESH_LOG_FIELD_LENGTH = 128;
+const ACTIVE_FIREWALL_AUTH_RUN_STATUSES = ["pending", "running"] as const;
 const databaseTimestampMicrosRowSchema = z.object({
   now: pgInt8ToBigIntSchema,
 });
@@ -291,6 +292,18 @@ function forbiddenModelProviderOwner(): ResolveFirewallAuthResult {
     body: {
       error: {
         message: "Invalid model-provider secret owner",
+        code: "FORBIDDEN",
+      },
+    },
+  };
+}
+
+function forbiddenTerminalRun(): ResolveFirewallAuthResult {
+  return {
+    status: 403,
+    body: {
+      error: {
+        message: "Agent run is no longer active",
         code: "FORBIDDEN",
       },
     },
@@ -4254,12 +4267,25 @@ function missingResolvedSecretsResponse(args: {
   );
 }
 
-async function findRefreshRunOrgId(
+interface FirewallAuthRun {
+  readonly orgId: string;
+  readonly status: typeof agentRuns.$inferSelect.status;
+}
+
+function firewallAuthRunIsActive(
+  status: typeof agentRuns.$inferSelect.status,
+): boolean {
+  return ACTIVE_FIREWALL_AUTH_RUN_STATUSES.some((activeStatus) => {
+    return status === activeStatus;
+  });
+}
+
+async function findFirewallAuthRun(
   db: Db,
   auth: SandboxAuth,
-): Promise<string | null> {
+): Promise<FirewallAuthRun | undefined> {
   const [run] = await db
-    .select({ orgId: agentRuns.orgId })
+    .select({ orgId: agentRuns.orgId, status: agentRuns.status })
     .from(agentRuns)
     .where(
       and(
@@ -4269,7 +4295,28 @@ async function findRefreshRunOrgId(
       ),
     )
     .limit(1);
-  return run?.orgId ?? null;
+  return run;
+}
+
+async function admitFirewallAuthResponse(
+  db: Db,
+  auth: SandboxAuth,
+): Promise<boolean> {
+  return await db.transaction(async (tx) => {
+    const [run] = await tx
+      .select({ status: agentRuns.status })
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.id, auth.runId),
+          eq(agentRuns.userId, auth.userId),
+          eq(agentRuns.orgId, auth.orgId),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    return run !== undefined && firewallAuthRunIsActive(run.status);
+  });
 }
 
 async function decryptFirewallAuthSecrets(
@@ -5563,15 +5610,19 @@ export async function resolveFirewallAuth(
 ): Promise<ResolveFirewallAuthResult> {
   const matchedFirewall = body.matchedFirewall;
   const customConnectorId = matchedFirewall?.customConnectorId;
+  const run = await findFirewallAuthRun(db, auth);
+  if (!run) {
+    L.warn(`[${auth.runId}] Run not found for firewall auth`);
+    return badRequestMessage("Run not found");
+  }
+  if (!firewallAuthRunIsActive(run.status)) {
+    return forbiddenTerminalRun();
+  }
+  const orgId = run.orgId;
   const forceRefreshStartedAtMicros =
     customConnectorId === undefined && body.forceRefresh === true
       ? await currentDatabaseTimestampMicros(db)
       : null;
-  const orgId = await findRefreshRunOrgId(db, auth);
-  if (!orgId) {
-    L.warn(`[${auth.runId}] Run not found for firewall auth`);
-    return badRequestMessage("Run not found");
-  }
   const referenced = collectReferencedKeys(
     body.authHeaders,
     body.authBase,
@@ -5635,10 +5686,16 @@ export async function resolveFirewallAuth(
   if (!resolution.ok) {
     return resolution.response;
   }
-  return finalizeFirewallAuth({
+  const finalized = finalizeFirewallAuth({
     body,
     referenced,
     material: resolution.material,
     billableExpiresAt: billableCacheExpiry.expiresAt,
   });
+  if (finalized.status !== 200) {
+    return finalized;
+  }
+  return (await admitFirewallAuthResponse(db, auth))
+    ? finalized
+    : forbiddenTerminalRun();
 }

--- a/turbo/apps/api/src/signals/services/storage-write.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-write.service.ts
@@ -7,9 +7,9 @@ import { and, eq } from "drizzle-orm";
 
 import { badRequestMessage, notFound } from "../../lib/error";
 import { env } from "../../lib/env";
-import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
-import type { AuthContext } from "../../types/auth";
+import type { Tx } from "../../lib/db-types";
+import type { SandboxAuth } from "../../types/auth";
 import { writeDb$, type Db } from "../external/db";
 import {
   downloadManifest,
@@ -19,13 +19,12 @@ import {
   type S3ObjectHead,
   verifyS3FilesExist,
 } from "../external/s3";
-import { tapError } from "../utils";
 import {
   computeContentHashFromHashes,
   type FileEntryWithHash,
 } from "./storage-content-hash.service";
 
-const L = logger("storage-write");
+const ACTIVE_SANDBOX_STORAGE_RUN_STATUSES = ["pending", "running"] as const;
 
 interface StorageChanges {
   readonly deleted?: readonly string[];
@@ -40,7 +39,7 @@ interface PrepareStorageUploadInput {
 }
 
 interface PrepareStorageInput extends PrepareStorageUploadInput {
-  readonly auth: AuthContext;
+  readonly auth: SandboxAuth;
   readonly storageId: string;
 }
 
@@ -57,16 +56,22 @@ interface CommitStorageUploadInput {
 }
 
 interface CommitStorageInput extends CommitStorageUploadInput {
-  readonly auth: AuthContext;
+  readonly auth: SandboxAuth;
   readonly storageId: string;
 }
 
 interface CommitStorageForStorageInput extends CommitStorageUploadInput {
   readonly storageId: string;
+  readonly sandboxAuth?: SandboxAuth;
 }
 
 type StorageRow = typeof storages.$inferSelect;
 type StorageVersionRow = typeof storageVersions.$inferSelect;
+
+interface MountedWritebackStorage {
+  readonly runStatus: typeof agentRuns.$inferSelect.status;
+  readonly storage: StorageRow;
+}
 
 function storageRowSelection() {
   return {
@@ -169,22 +174,22 @@ function storageServiceNotConfigured(): StorageErrorResponse {
 async function findMountedWritebackStorage(
   args: {
     readonly db: Db;
-    readonly auth: AuthContext;
+    readonly auth: SandboxAuth;
     readonly storageId: string;
   },
   signal: AbortSignal,
-): Promise<StorageRow | StorageErrorResponse> {
-  if (!hasRunId(args.auth)) {
-    return notFound("Writeback storage not found");
-  }
-
+): Promise<MountedWritebackStorage | StorageErrorResponse> {
   const [run] = await args.db
-    .select({ storageMounts: agentRuns.storageMounts })
+    .select({
+      status: agentRuns.status,
+      storageMounts: agentRuns.storageMounts,
+    })
     .from(agentRuns)
     .where(
       and(
         eq(agentRuns.id, args.auth.runId),
         eq(agentRuns.userId, args.auth.userId),
+        eq(agentRuns.orgId, args.auth.orgId),
       ),
     )
     .limit(1);
@@ -215,13 +220,72 @@ async function findMountedWritebackStorage(
     .limit(1);
   signal.throwIfAborted();
 
-  return storage ?? notFound("Writeback storage not found");
+  return storage
+    ? { runStatus: run.status, storage }
+    : notFound("Writeback storage not found");
 }
 
-function hasRunId(auth: AuthContext): auth is AuthContext & {
-  readonly runId: string;
-} {
-  return "runId" in auth && typeof auth.runId === "string";
+async function lockMountedWritebackStorage(
+  args: {
+    readonly tx: Tx;
+    readonly auth: SandboxAuth;
+    readonly storageId: string;
+  },
+  signal: AbortSignal,
+): Promise<MountedWritebackStorage | StorageErrorResponse> {
+  const [run] = await args.tx
+    .select({
+      status: agentRuns.status,
+      storageMounts: agentRuns.storageMounts,
+    })
+    .from(agentRuns)
+    .where(
+      and(
+        eq(agentRuns.id, args.auth.runId),
+        eq(agentRuns.userId, args.auth.userId),
+        eq(agentRuns.orgId, args.auth.orgId),
+      ),
+    )
+    .for("update")
+    .limit(1);
+  signal.throwIfAborted();
+
+  if (!run) {
+    return notFound("Agent run not found");
+  }
+
+  const mount = run.storageMounts?.find((entry) => {
+    return entry.storageId === args.storageId && entry.writeback === true;
+  });
+  if (!mount) {
+    return notFound("Writeback storage not found");
+  }
+
+  const [storage] = await args.tx
+    .select(storageRowSelection())
+    .from(storages)
+    .where(
+      and(
+        eq(storages.id, mount.storageId),
+        eq(storages.orgId, mount.orgId),
+        eq(storages.userId, mount.userId),
+        eq(storages.name, mount.name),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+
+  return storage
+    ? { runStatus: run.status, storage }
+    : notFound("Writeback storage not found");
+}
+
+function sandboxStorageRunIsActive(
+  status: typeof agentRuns.$inferSelect.status,
+): boolean {
+  return ACTIVE_SANDBOX_STORAGE_RUN_STATUSES.some((activeStatus) => {
+    return status === activeStatus;
+  });
 }
 
 function mergeWithBaseVersion(
@@ -319,7 +383,7 @@ async function resolveStorageForPrepare(
     readonly input: PrepareStorageInput;
   },
   signal: AbortSignal,
-): Promise<StorageRow | StorageErrorResponse> {
+): Promise<MountedWritebackStorage | StorageErrorResponse> {
   return await findMountedWritebackStorage(
     {
       db: args.db,
@@ -336,7 +400,7 @@ async function resolveStorageForCommit(
     readonly input: CommitStorageInput;
   },
   signal: AbortSignal,
-): Promise<StorageRow | StorageErrorResponse> {
+): Promise<MountedWritebackStorage | StorageErrorResponse> {
   return await findMountedWritebackStorage(
     {
       db: args.db,
@@ -543,162 +607,64 @@ function verifyUploadedStorageFiles(
   });
 }
 
-function commitExistingStorageVersion(
-  args: {
-    readonly db: Db;
-    readonly bucket: string;
-    readonly storage: StorageRow;
-    readonly version: StorageVersionRow;
-    readonly input: CommitStorageUploadInput;
-  },
-  signal: AbortSignal,
-): Computed<Promise<CommitStorageResponse>> {
-  return computed(async (get): Promise<CommitStorageResponse> => {
-    const explicitEmptyVersion = args.version.fileCount === 0;
-    const verification = explicitEmptyVersion
-      ? null
-      : await get(
-          verifyUploadedStorageFiles(
-            {
-              bucket: args.bucket,
-              s3Key: args.version.s3Key,
-              fileCount: args.version.fileCount,
-            },
-            signal,
-          ),
-        );
-    signal.throwIfAborted();
-
-    if (verification && verification.kind !== "verified") {
-      return s3FilesMissingConflict();
-    }
-
-    const verifiedArchiveSize =
-      verification?.kind === "verified" ? verification.archiveSize : undefined;
-    const archiveSizeChanged =
-      verifiedArchiveSize !== undefined &&
-      args.version.archiveSize !== verifiedArchiveSize;
-    const headChanged = args.storage.headVersionId !== args.input.versionId;
-    if (archiveSizeChanged || headChanged) {
-      await args.db.transaction(async (tx) => {
-        if (archiveSizeChanged) {
-          await tx
-            .update(storageVersions)
-            .set({ archiveSize: verifiedArchiveSize })
-            .where(
-              and(
-                eq(storageVersions.id, args.version.id),
-                eq(storageVersions.storageId, args.storage.id),
-              ),
-            );
-        }
-        if (headChanged) {
-          await tx
-            .update(storages)
-            .set({
-              headVersionId: args.input.versionId,
-              updatedAt: nowDate(),
-            })
-            .where(eq(storages.id, args.storage.id));
-        }
-      });
-      signal.throwIfAborted();
-    }
-
-    return {
-      status: 200,
-      body: {
-        success: true,
-        versionId: args.input.versionId,
-        storageName: args.storage.name,
-        size: Number(args.version.size),
-        fileCount: args.version.fileCount,
-        deduplicated: true,
-      },
-    };
-  });
-}
-
-async function insertStorageVersionAndUpdateHead(args: {
-  readonly db: Db;
-  readonly storageId: string;
-  readonly s3Key: string;
-  readonly input: CommitStorageUploadInput;
-  readonly size: number;
+interface VerifiedStorageCommit {
   readonly archiveSize: number;
-  readonly fileCount: number;
-}): Promise<void> {
-  await args.db.transaction(async (tx) => {
-    const [insertedVersion] = await tx
-      .insert(storageVersions)
-      .values({
-        id: args.input.versionId,
-        storageId: args.storageId,
-        s3Key: args.s3Key,
-        size: args.size,
-        archiveSize: args.archiveSize,
-        fileCount: args.fileCount,
-        message: args.input.message ?? null,
-        createdBy: args.input.runId ? "agent" : "user",
-      })
-      .onConflictDoNothing()
-      .returning({ id: storageVersions.id });
-
-    let version = insertedVersion;
-    if (!version) {
-      const [updatedVersion] = await tx
-        .update(storageVersions)
-        .set({ archiveSize: args.archiveSize })
-        .where(
-          and(
-            eq(storageVersions.storageId, args.storageId),
-            eq(storageVersions.id, args.input.versionId),
-          ),
-        )
-        .returning({ id: storageVersions.id });
-      version = updatedVersion;
-    }
-
-    if (!version) {
-      throw new Error(`Version ${args.input.versionId} not found after insert`);
-    }
-
-    await tx
-      .update(storages)
-      .set({
-        headVersionId: args.input.versionId,
-        size: args.size,
-        fileCount: args.fileCount,
-        updatedAt: nowDate(),
-      })
-      .where(eq(storages.id, args.storageId));
-  });
+  readonly existingBeforeTransaction: boolean;
+  readonly s3Key: string;
 }
 
-function commitNewStorageVersion(
+function verifyStorageCommit(
   args: {
-    readonly db: Db;
     readonly bucket: string;
     readonly storage: StorageRow;
+    readonly version: StorageVersionRow | undefined;
     readonly input: CommitStorageUploadInput;
   },
   signal: AbortSignal,
-): Computed<Promise<CommitStorageResponse>> {
-  return computed(async (get): Promise<CommitStorageResponse> => {
-    const s3Key = `${args.storage.s3Prefix}/${args.input.versionId}`;
-    const fileCount = args.input.files.length;
-    const uploadVerification = await get(
-      verifyUploadedStorageFiles(
-        {
-          bucket: args.bucket,
-          s3Key,
-          fileCount,
-        },
-        signal,
-      ),
-    );
-    if (uploadVerification.kind !== "verified") {
-      switch (uploadVerification.kind) {
+): Computed<Promise<VerifiedStorageCommit | CommitStorageResponse>> {
+  return computed(
+    async (get): Promise<VerifiedStorageCommit | CommitStorageResponse> => {
+      if (args.version?.fileCount === 0) {
+        return {
+          archiveSize: args.version.archiveSize,
+          existingBeforeTransaction: true,
+          s3Key: args.version.s3Key,
+        };
+      }
+
+      const s3Key =
+        args.version?.s3Key ??
+        `${args.storage.s3Prefix}/${args.input.versionId}`;
+      const verification = await get(
+        verifyUploadedStorageFiles(
+          {
+            bucket: args.bucket,
+            s3Key,
+            fileCount: args.version?.fileCount ?? args.input.files.length,
+          },
+          signal,
+        ),
+      );
+      signal.throwIfAborted();
+
+      if (args.version) {
+        return verification.kind === "verified"
+          ? {
+              archiveSize: verification.archiveSize,
+              existingBeforeTransaction: true,
+              s3Key,
+            }
+          : s3FilesMissingConflict();
+      }
+
+      switch (verification.kind) {
+        case "verified": {
+          return {
+            archiveSize: verification.archiveSize,
+            existingBeforeTransaction: false,
+            s3Key,
+          };
+        }
         case "missing-manifest": {
           return badRequestMessage(
             "Manifest not uploaded - upload failed or incomplete",
@@ -715,61 +681,277 @@ function commitNewStorageVersion(
           );
         }
       }
-    }
-
-    const size = totalSize(args.input.files);
-    await insertStorageVersionAndUpdateHead({
-      db: args.db,
-      storageId: args.storage.id,
-      s3Key,
-      input: args.input,
-      size,
-      archiveSize: uploadVerification.archiveSize,
-      fileCount,
-    });
-    signal.throwIfAborted();
-
-    return {
-      status: 200,
-      body: {
-        success: true,
-        versionId: args.input.versionId,
-        storageName: args.storage.name,
-        size,
-        fileCount,
-      },
-    };
-  });
+    },
+  );
 }
 
-async function recordStorageLineage(args: {
-  readonly db: Db;
-  readonly storageId: string;
+async function terminalStorageCommitAlreadySucceeded(args: {
+  readonly tx: Tx;
+  readonly storage: StorageRow;
+  readonly version: StorageVersionRow | undefined;
+  readonly verification: VerifiedStorageCommit;
+  readonly input: CommitStorageForStorageInput;
+}): Promise<boolean> {
+  const version = args.version;
+  const sandboxAuth = args.input.sandboxAuth;
+  const parentVersionId = args.input.parentVersionId;
+  const size = totalSize(args.input.files);
+  const fileCount = args.input.files.length;
+  if (
+    !version ||
+    !sandboxAuth ||
+    !parentVersionId ||
+    version.s3Key !== args.verification.s3Key ||
+    Number(version.size) !== size ||
+    version.archiveSize !== args.verification.archiveSize ||
+    version.fileCount !== fileCount ||
+    version.message !== (args.input.message ?? null) ||
+    version.createdBy !== "agent" ||
+    args.storage.headVersionId !== args.input.versionId ||
+    Number(args.storage.size) !== size ||
+    args.storage.fileCount !== fileCount
+  ) {
+    return false;
+  }
+
+  const [lineage] = await args.tx
+    .select({ id: storageVersionLineage.id })
+    .from(storageVersionLineage)
+    .where(
+      and(
+        eq(storageVersionLineage.storageId, args.storage.id),
+        eq(storageVersionLineage.versionId, args.input.versionId),
+        eq(storageVersionLineage.parentVersionId, parentVersionId),
+        eq(storageVersionLineage.runId, sandboxAuth.runId),
+      ),
+    )
+    .limit(1);
+  return lineage !== undefined;
+}
+
+function storageCommitSuccess(args: {
+  readonly storage: StorageRow;
   readonly versionId: string;
-  readonly parentVersionId: string | undefined;
-  readonly runId: string | undefined;
+  readonly size: number;
+  readonly fileCount: number;
+  readonly deduplicated: boolean;
+}): CommitStorageResponse {
+  return {
+    status: 200,
+    body: {
+      success: true,
+      versionId: args.versionId,
+      storageName: args.storage.name,
+      size: args.size,
+      fileCount: args.fileCount,
+      ...(args.deduplicated ? { deduplicated: true } : {}),
+    },
+  };
+}
+
+async function recordVerifiedNewStorageLineage(args: {
+  readonly tx: Tx;
+  readonly storageId: string;
+  readonly input: CommitStorageForStorageInput;
+  readonly verification: VerifiedStorageCommit;
 }): Promise<void> {
-  const parentVersionId = args.parentVersionId;
-  const runId = args.runId;
-  if (!parentVersionId || !runId) {
+  const sandboxAuth = args.input.sandboxAuth;
+  const parentVersionId = args.input.parentVersionId;
+  if (
+    args.verification.existingBeforeTransaction ||
+    !sandboxAuth ||
+    !parentVersionId
+  ) {
     return;
   }
 
-  await tapError(
-    args.db.insert(storageVersionLineage).values({
-      storageId: args.storageId,
-      versionId: args.versionId,
-      parentVersionId,
-      runId,
-    }),
-    (error) => {
-      L.error(
-        `Failed to record lineage for ${args.versionId}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-    },
-  );
+  await args.tx.insert(storageVersionLineage).values({
+    storageId: args.storageId,
+    versionId: args.input.versionId,
+    parentVersionId,
+    runId: sandboxAuth.runId,
+  });
+}
+
+async function commitActiveStorageVersion(args: {
+  readonly tx: Tx;
+  readonly storage: StorageRow;
+  readonly version: StorageVersionRow | undefined;
+  readonly input: CommitStorageForStorageInput;
+  readonly verification: VerifiedStorageCommit;
+}): Promise<CommitStorageResponse> {
+  if (args.version) {
+    if (args.version.archiveSize !== args.verification.archiveSize) {
+      await args.tx
+        .update(storageVersions)
+        .set({ archiveSize: args.verification.archiveSize })
+        .where(
+          and(
+            eq(storageVersions.id, args.version.id),
+            eq(storageVersions.storageId, args.storage.id),
+          ),
+        );
+    }
+    if (args.storage.headVersionId !== args.input.versionId) {
+      await args.tx
+        .update(storages)
+        .set({
+          headVersionId: args.input.versionId,
+          updatedAt: nowDate(),
+        })
+        .where(eq(storages.id, args.storage.id));
+    }
+    await recordVerifiedNewStorageLineage({
+      tx: args.tx,
+      storageId: args.storage.id,
+      input: args.input,
+      verification: args.verification,
+    });
+    return storageCommitSuccess({
+      storage: args.storage,
+      versionId: args.input.versionId,
+      size: Number(args.version.size),
+      fileCount: args.version.fileCount,
+      deduplicated: true,
+    });
+  }
+
+  const size = totalSize(args.input.files);
+  const fileCount = args.input.files.length;
+  const [insertedVersion] = await args.tx
+    .insert(storageVersions)
+    .values({
+      id: args.input.versionId,
+      storageId: args.storage.id,
+      s3Key: args.verification.s3Key,
+      size,
+      archiveSize: args.verification.archiveSize,
+      fileCount,
+      message: args.input.message ?? null,
+      createdBy: args.input.runId ? "agent" : "user",
+    })
+    .onConflictDoNothing()
+    .returning({ id: storageVersions.id });
+
+  let committedVersion = insertedVersion;
+  if (!committedVersion) {
+    const [updatedVersion] = await args.tx
+      .update(storageVersions)
+      .set({ archiveSize: args.verification.archiveSize })
+      .where(
+        and(
+          eq(storageVersions.storageId, args.storage.id),
+          eq(storageVersions.id, args.input.versionId),
+        ),
+      )
+      .returning({ id: storageVersions.id });
+    committedVersion = updatedVersion;
+  }
+  if (!committedVersion) {
+    throw new Error(`Version ${args.input.versionId} not found after insert`);
+  }
+
+  await args.tx
+    .update(storages)
+    .set({
+      headVersionId: args.input.versionId,
+      size,
+      fileCount,
+      updatedAt: nowDate(),
+    })
+    .where(eq(storages.id, args.storage.id));
+  await recordVerifiedNewStorageLineage({
+    tx: args.tx,
+    storageId: args.storage.id,
+    input: args.input,
+    verification: args.verification,
+  });
+
+  return storageCommitSuccess({
+    storage: args.storage,
+    versionId: args.input.versionId,
+    size,
+    fileCount,
+    deduplicated: false,
+  });
+}
+
+async function commitVerifiedStorageVersion(
+  args: {
+    readonly db: Db;
+    readonly input: CommitStorageForStorageInput;
+    readonly verification: VerifiedStorageCommit;
+  },
+  signal: AbortSignal,
+): Promise<CommitStorageResponse> {
+  return await args.db.transaction(async (tx) => {
+    const mounted = args.input.sandboxAuth
+      ? await lockMountedWritebackStorage(
+          {
+            tx,
+            auth: args.input.sandboxAuth,
+            storageId: args.input.storageId,
+          },
+          signal,
+        )
+      : undefined;
+    if (mounted && "status" in mounted) {
+      return mounted;
+    }
+
+    const [userStorage] = mounted
+      ? []
+      : await tx
+          .select(storageRowSelection())
+          .from(storages)
+          .where(eq(storages.id, args.input.storageId))
+          .limit(1);
+    signal.throwIfAborted();
+    const storage = mounted?.storage ?? userStorage;
+    if (!storage) {
+      return notFound("Storage not found");
+    }
+
+    const [version] = await tx
+      .select()
+      .from(storageVersions)
+      .where(
+        and(
+          eq(storageVersions.storageId, storage.id),
+          eq(storageVersions.id, args.input.versionId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (mounted && !sandboxStorageRunIsActive(mounted.runStatus)) {
+      const alreadySucceeded = await terminalStorageCommitAlreadySucceeded({
+        tx,
+        storage,
+        version,
+        verification: args.verification,
+        input: args.input,
+      });
+      signal.throwIfAborted();
+      return alreadySucceeded && version
+        ? storageCommitSuccess({
+            storage,
+            versionId: args.input.versionId,
+            size: Number(version.size),
+            fileCount: version.fileCount,
+            deduplicated: true,
+          })
+        : notFound("Active agent run not found");
+    }
+
+    return await commitActiveStorageVersion({
+      tx,
+      storage,
+      version,
+      input: args.input,
+      verification: args.verification,
+    });
+  });
 }
 
 export const prepareStorageUploadForStorage$ = command(
@@ -883,46 +1065,30 @@ export const commitStorageUploadForStorage$ = command(
     });
     signal.throwIfAborted();
 
-    if (existingVersion) {
-      return await get(
-        commitExistingStorageVersion(
-          {
-            db: writeDb,
-            bucket,
-            storage,
-            version: existingVersion,
-            input: args,
-          },
-          signal,
-        ),
-      );
-    }
-
-    const response = await get(
-      commitNewStorageVersion(
+    const verification = await get(
+      verifyStorageCommit(
         {
-          db: writeDb,
           bucket,
           storage,
+          version: existingVersion,
           input: args,
         },
         signal,
       ),
     );
     signal.throwIfAborted();
-
-    if (response.status === 200) {
-      await recordStorageLineage({
-        db: writeDb,
-        storageId: storage.id,
-        versionId: args.versionId,
-        parentVersionId: args.parentVersionId,
-        runId: args.runId,
-      });
-      signal.throwIfAborted();
+    if ("status" in verification) {
+      return verification;
     }
 
-    return response;
+    return await commitVerifiedStorageVersion(
+      {
+        db: writeDb,
+        input: args,
+        verification,
+      },
+      signal,
+    );
   },
 );
 
@@ -933,7 +1099,7 @@ export const prepareStorageUploadForAuth$ = command(
     signal: AbortSignal,
   ): Promise<PrepareStorageResponse> => {
     const writeDb = set(writeDb$);
-    const storage = await resolveStorageForPrepare(
+    const mounted = await resolveStorageForPrepare(
       {
         db: writeDb,
         input: args,
@@ -942,12 +1108,41 @@ export const prepareStorageUploadForAuth$ = command(
     );
     signal.throwIfAborted();
 
-    if ("status" in storage) {
-      return storage;
+    if ("status" in mounted) {
+      return mounted;
+    }
+    if (!sandboxStorageRunIsActive(mounted.runStatus)) {
+      return notFound("Active agent run not found");
     }
 
-    const upload: PrepareStorageForStorageInput = args;
-    return await set(prepareStorageUploadForStorage$, upload, signal);
+    const response = await set(
+      prepareStorageUploadForStorage$,
+      {
+        storageId: args.storageId,
+        files: args.files,
+        force: args.force,
+        runId: args.runId,
+        baseVersion: args.baseVersion,
+        changes: args.changes,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    if (response.status !== 200) {
+      return response;
+    }
+
+    const admitted = await writeDb.transaction(async (tx) => {
+      const current = await lockMountedWritebackStorage(
+        { tx, auth: args.auth, storageId: args.storageId },
+        signal,
+      );
+      return !(
+        "status" in current || !sandboxStorageRunIsActive(current.runStatus)
+      );
+    });
+    signal.throwIfAborted();
+    return admitted ? response : notFound("Active agent run not found");
   },
 );
 
@@ -958,7 +1153,7 @@ export const commitStorageUploadForAuth$ = command(
     signal: AbortSignal,
   ): Promise<CommitStorageResponse> => {
     const writeDb = set(writeDb$);
-    const storage = await resolveStorageForCommit(
+    const mounted = await resolveStorageForCommit(
       {
         db: writeDb,
         input: args,
@@ -967,11 +1162,22 @@ export const commitStorageUploadForAuth$ = command(
     );
     signal.throwIfAborted();
 
-    if ("status" in storage) {
-      return storage;
+    if ("status" in mounted) {
+      return mounted;
     }
 
-    const upload: CommitStorageForStorageInput = args;
-    return await set(commitStorageUploadForStorage$, upload, signal);
+    return await set(
+      commitStorageUploadForStorage$,
+      {
+        storageId: args.storageId,
+        versionId: args.versionId,
+        files: args.files,
+        runId: args.runId,
+        parentVersionId: args.parentVersionId,
+        message: args.message,
+        sandboxAuth: args.auth,
+      },
+      signal,
+    );
   },
 );

--- a/turbo/apps/api/src/signals/services/storage-write.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-write.service.ts
@@ -592,7 +592,6 @@ function verifyUploadedStorageFiles(
 
 interface VerifiedStorageCommit {
   readonly archiveSize: number;
-  readonly existingBeforeTransaction: boolean;
   readonly s3Key: string;
 }
 
@@ -635,7 +634,6 @@ function verifyStorageCommit(
       if (args.version?.fileCount === 0) {
         return {
           archiveSize: args.version.archiveSize,
-          existingBeforeTransaction: true,
           s3Key: args.version.s3Key,
         };
       }
@@ -659,7 +657,6 @@ function verifyStorageCommit(
         return verification.kind === "verified"
           ? {
               archiveSize: verification.archiveSize,
-              existingBeforeTransaction: true,
               s3Key,
             }
           : s3FilesMissingConflict();
@@ -669,7 +666,6 @@ function verifyStorageCommit(
         case "verified": {
           return {
             archiveSize: verification.archiveSize,
-            existingBeforeTransaction: false,
             s3Key,
           };
         }
@@ -753,19 +749,14 @@ function storageCommitSuccess(args: {
   };
 }
 
-async function recordVerifiedNewStorageLineage(args: {
+async function recordStorageLineage(args: {
   readonly tx: Tx;
   readonly storageId: string;
   readonly input: CommitStorageForStorageInput;
-  readonly verification: VerifiedStorageCommit;
 }): Promise<void> {
   const sandboxAuth = args.input.sandboxAuth;
   const parentVersionId = args.input.parentVersionId;
-  if (
-    args.verification.existingBeforeTransaction ||
-    !sandboxAuth ||
-    !parentVersionId
-  ) {
+  if (!sandboxAuth || !parentVersionId) {
     return;
   }
 
@@ -801,15 +792,16 @@ async function commitActiveStorageVersion(args: {
         .update(storages)
         .set({
           headVersionId: args.input.versionId,
+          size: Number(args.version.size),
+          fileCount: args.version.fileCount,
           updatedAt: nowDate(),
         })
         .where(eq(storages.id, args.storage.id));
     }
-    await recordVerifiedNewStorageLineage({
+    await recordStorageLineage({
       tx: args.tx,
       storageId: args.storage.id,
       input: args.input,
-      verification: args.verification,
     });
     return storageCommitSuccess({
       storage: args.storage,
@@ -864,11 +856,10 @@ async function commitActiveStorageVersion(args: {
       updatedAt: nowDate(),
     })
     .where(eq(storages.id, args.storage.id));
-  await recordVerifiedNewStorageLineage({
+  await recordStorageLineage({
     tx: args.tx,
     storageId: args.storage.id,
     input: args.input,
-    verification: args.verification,
   });
 
   return storageCommitSuccess({

--- a/turbo/apps/api/src/signals/services/storage-write.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-write.service.ts
@@ -394,23 +394,6 @@ async function resolveStorageForPrepare(
   );
 }
 
-async function resolveStorageForCommit(
-  args: {
-    readonly db: Db;
-    readonly input: CommitStorageInput;
-  },
-  signal: AbortSignal,
-): Promise<MountedWritebackStorage | StorageErrorResponse> {
-  return await findMountedWritebackStorage(
-    {
-      db: args.db,
-      auth: args.input.auth,
-      storageId: args.input.storageId,
-    },
-    signal,
-  );
-}
-
 function resolvePreparedFiles(
   args: {
     readonly db: Db;
@@ -613,6 +596,31 @@ interface VerifiedStorageCommit {
   readonly s3Key: string;
 }
 
+function terminalStorageCommitPersistedStateMatches(args: {
+  readonly storage: StorageRow;
+  readonly version: StorageVersionRow | undefined;
+  readonly input: CommitStorageForStorageInput;
+}): boolean {
+  const version = args.version;
+  const sandboxAuth = args.input.sandboxAuth;
+  const parentVersionId = args.input.parentVersionId;
+  const size = totalSize(args.input.files);
+  const fileCount = args.input.files.length;
+  return (
+    version !== undefined &&
+    sandboxAuth !== undefined &&
+    parentVersionId !== undefined &&
+    version.s3Key === `${args.storage.s3Prefix}/${args.input.versionId}` &&
+    Number(version.size) === size &&
+    version.fileCount === fileCount &&
+    version.message === (args.input.message ?? null) &&
+    version.createdBy === "agent" &&
+    args.storage.headVersionId === args.input.versionId &&
+    Number(args.storage.size) === size &&
+    args.storage.fileCount === fileCount
+  );
+}
+
 function verifyStorageCommit(
   args: {
     readonly bucket: string;
@@ -695,21 +703,17 @@ async function terminalStorageCommitAlreadySucceeded(args: {
   const version = args.version;
   const sandboxAuth = args.input.sandboxAuth;
   const parentVersionId = args.input.parentVersionId;
-  const size = totalSize(args.input.files);
-  const fileCount = args.input.files.length;
   if (
     !version ||
     !sandboxAuth ||
     !parentVersionId ||
+    !terminalStorageCommitPersistedStateMatches({
+      storage: args.storage,
+      version,
+      input: args.input,
+    }) ||
     version.s3Key !== args.verification.s3Key ||
-    Number(version.size) !== size ||
-    version.archiveSize !== args.verification.archiveSize ||
-    version.fileCount !== fileCount ||
-    version.message !== (args.input.message ?? null) ||
-    version.createdBy !== "agent" ||
-    args.storage.headVersionId !== args.input.versionId ||
-    Number(args.storage.size) !== size ||
-    args.storage.fileCount !== fileCount
+    version.archiveSize !== args.verification.archiveSize
   ) {
     return false;
   }
@@ -1153,10 +1157,11 @@ export const commitStorageUploadForAuth$ = command(
     signal: AbortSignal,
   ): Promise<CommitStorageResponse> => {
     const writeDb = set(writeDb$);
-    const mounted = await resolveStorageForCommit(
+    const mounted = await findMountedWritebackStorage(
       {
         db: writeDb,
-        input: args,
+        auth: args.auth,
+        storageId: args.storageId,
       },
       signal,
     );
@@ -1166,18 +1171,60 @@ export const commitStorageUploadForAuth$ = command(
       return mounted;
     }
 
-    return await set(
-      commitStorageUploadForStorage$,
-      {
-        storageId: args.storageId,
+    const commitInput: CommitStorageForStorageInput = {
+      storageId: args.storageId,
+      versionId: args.versionId,
+      files: args.files,
+      runId: args.runId,
+      parentVersionId: args.parentVersionId,
+      message: args.message,
+      sandboxAuth: args.auth,
+    };
+    const terminalRetry = !sandboxStorageRunIsActive(mounted.runStatus);
+    if (terminalRetry) {
+      const parentVersionId = args.parentVersionId;
+      const version = await findStorageVersion({
+        db: writeDb,
+        storageId: mounted.storage.id,
         versionId: args.versionId,
-        files: args.files,
-        runId: args.runId,
-        parentVersionId: args.parentVersionId,
-        message: args.message,
-        sandboxAuth: args.auth,
-      },
+      });
+      signal.throwIfAborted();
+      if (
+        !parentVersionId ||
+        !terminalStorageCommitPersistedStateMatches({
+          storage: mounted.storage,
+          version,
+          input: commitInput,
+        })
+      ) {
+        return notFound("Active agent run not found");
+      }
+
+      const [lineage] = await writeDb
+        .select({ id: storageVersionLineage.id })
+        .from(storageVersionLineage)
+        .where(
+          and(
+            eq(storageVersionLineage.storageId, mounted.storage.id),
+            eq(storageVersionLineage.versionId, args.versionId),
+            eq(storageVersionLineage.parentVersionId, parentVersionId),
+            eq(storageVersionLineage.runId, args.auth.runId),
+          ),
+        )
+        .limit(1);
+      signal.throwIfAborted();
+      if (!lineage) {
+        return notFound("Active agent run not found");
+      }
+    }
+
+    const response = await set(
+      commitStorageUploadForStorage$,
+      commitInput,
       signal,
     );
+    return terminalRetry && response.status !== 200
+      ? notFound("Active agent run not found")
+      : response;
   },
 );

--- a/turbo/packages/api-contracts/src/contracts/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-cron-cleanup-sandboxes-state.ts
@@ -25,6 +25,7 @@ export const testCronCleanupSandboxesStateActionBodySchema = z
       "get-queue-entry",
       "get-queue-marker-revoker",
       "get-export-job",
+      "transition-run-terminal",
     ]),
   })
   .passthrough();

--- a/turbo/packages/api-contracts/src/contracts/test-storage-fixture.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-storage-fixture.ts
@@ -44,6 +44,27 @@ const downloadResponseSchema = z.union([
     size: z.literal(0),
   }),
 ]);
+const writebackStateSchema = z.object({
+  storage: z
+    .object({
+      headVersionId: z.string().nullable(),
+      size: z.number(),
+      fileCount: z.number(),
+      updatedAt: z.string(),
+    })
+    .nullable(),
+  version: z
+    .object({
+      archiveSize: z.number(),
+      size: z.number(),
+      fileCount: z.number(),
+      message: z.string().nullable(),
+      createdBy: z.string(),
+      createdAt: z.string(),
+    })
+    .nullable(),
+  lineageCount: z.number(),
+});
 
 export const testStorageStateActionBodySchema = z.discriminatedUnion("action", [
   z.object({
@@ -81,6 +102,13 @@ export const testStorageStateActionBodySchema = z.discriminatedUnion("action", [
     storageOwner: storageOwnerSchema,
     versionId: z.string().optional(),
   }),
+  z.object({
+    action: z.literal("inspect-writeback"),
+    storageId: z.string().uuid(),
+    versionId: z.string().min(1),
+    runId: z.string().uuid(),
+    parentVersionId: z.string().min(1),
+  }),
 ]);
 
 export const testStorageStateActionResponseSchema = z.object({
@@ -98,6 +126,7 @@ export const testStorageStateActionResponseSchema = z.object({
     )
     .optional(),
   download: downloadResponseSchema.optional(),
+  writeback: writebackStateSchema.optional(),
 });
 
 export const testStorageFixtureContract = c.router({


### PR DESCRIPTION
## Summary

- gate sandbox storage prepare/commit and firewall credential responses to `pending` or `running` runs
- serialize the final privileged admission against timeout through the exact `agent_runs` row lock
- keep S3 verification outside the storage mutation transaction and perform firewall final admission after KMS/provider resolution without holding the run-row lock across external work
- make storage version, head, aggregate, and lineage writes atomic, including deduplicated HEAD moves to existing versions
- reject unproven terminal storage callbacks before S3; preserve a narrow write-free retry only when persisted metadata, head state, and run lineage prove the exact operation already committed

## Compatibility and exclusions

- reuses existing storage `404` and firewall `403/FORBIDDEN` responses; request and success contracts are unchanged
- does not revoke credentials already served from the Runner/mitm process-local cache
- does not change Guest or Runner behavior, token formats, schemas, active-input settlement, or hard sandbox cancellation; those remain in #30250

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm check-types` (pre-commit hook, all Turbo workspaces)
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts --silent=passed-only` (63 passed, including no-S3 terminal rejection and deduplicated exact retry)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts --silent=passed-only` (60 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "keeps a committed artifact head after initial empty artifact creation" --silent=passed-only` (1 passed)

The full `pnpm vitest run --maxWorkers=4 --silent=passed-only` run passed both affected API suites and 715 other files. Three unrelated files failed locally: one CLI suite loaded developer API-origin overrides before its test stubs (72/72 passed when those overrides were unset), and two API suites encountered pre-existing shared test-database fixture collisions.

Closes #30249

Parent: #30246
