### PR TITLE
refactor: route intro video recording progress through set-loop

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/intro-video.ts
+++ b/turbo/apps/platform/src/signals/okou-page/intro-video.ts
@@ -20,6 +20,7 @@ import {
   onRef,
   onRejection,
   resetSignal,
+  setLoop,
   settle,
   withCleanup,
 } from "../utils.ts";
@@ -557,22 +558,34 @@ function createRecordingProgressCommands(
   );
   const updateRecordingSeconds$ = command(
     async ({ set }, generation: number, signal: AbortSignal): Promise<void> => {
-      while (
-        generation === runtime.generation &&
-        runtime.recorder?.state === "recording"
-      ) {
-        await delay(250, { signal });
-        if (
-          generation !== runtime.generation ||
-          runtime.recorder?.state !== "recording"
-        ) {
-          return;
-        }
-        set(
-          internal.recordingSeconds$,
-          Math.max(0, Math.floor((now() - runtime.recordingStartedAt) / 1000)),
+      const recordingIsActive = () => {
+        return (
+          generation === runtime.generation &&
+          runtime.recorder?.state === "recording"
         );
-      }
+      };
+      let isFirstIteration = true;
+      await setLoop(
+        () => {
+          if (!recordingIsActive()) {
+            return true;
+          }
+          if (isFirstIteration) {
+            isFirstIteration = false;
+            return false;
+          }
+          set(
+            internal.recordingSeconds$,
+            Math.max(
+              0,
+              Math.floor((now() - runtime.recordingStartedAt) / 1000),
+            ),
+          );
+          return false;
+        },
+        250,
+        signal,
+      );
     },
   );
   return { runRecordingCountdown$, updateRecordingSeconds$ };


### PR DESCRIPTION
## Summary

- replace the intro-video recording progress command's manual recurring `while` loop with the shared `setLoop` primitive
- keep the first progress update after one 250 ms interval
- use the recording attempt's restartable lifecycle signal, which combines the attempt controller with its parent signal

## Behavior preserved

The loop still stops when the recording generation changes, the recorder leaves the `recording` state, or the owning signal aborts. Recording seconds continue to use the test-aware `now()` helper.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged workspace, Platform, and API type checks
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-start-cards.test.tsx` (11 passed)
- Platform loop/native-timer scans; no native timers or manual `while + delay` loops remain

Full validation is delegated to the PR pipeline.
