### PR TITLE
fix: preserve codex per-turn token usage

### DIFF
--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -1111,8 +1111,8 @@ sudo "$BIN_DIR/runner" exec --timeout 75 \
   || fail "Claude compact-generation compatibility"
 echo "PASS: Claude compact-generation compatibility"
 
-# Test 9: verify the bundled Codex resumes and appends a native compact
-# generation under the same thread ID. Model requests terminate on loopback.
+# Test 9: verify successful usage notifications and that the bundled Codex
+# resumes and appends a native compact generation under the same thread ID.
 echo "--- Test: Codex compact-generation compatibility ---"
 CODEX_COMPACT_SMOKE=$(cat <<'PY'
 import json
@@ -1130,6 +1130,7 @@ compacting_turn_token = "CODEX-COMPACTING-TURN-TOKEN"
 candidate_turn_token = "CODEX-COMPACT-CANDIDATE-TURN-TOKEN"
 append_token = "CODEX-COMPACT-APPEND-TOKEN"
 legacy_seed_token = "CODEX-LEGACY-SEED-TOKEN"
+usage_token = "CODEX-TOKEN-USAGE-TOKEN"
 # [sync:codex-app-server-compatibility-params] Keep in sync with initialize in
 # codex_app_server.rs, thread/turn params in codex_app_server_backend.rs, and
 # IGNORED_NOTIFICATION_METHODS in codex_app_server_events.rs.
@@ -1160,6 +1161,59 @@ class Handler(BaseHTTPRequestHandler):
         length = int(self.headers.get("content-length", "0"))
         payload = json.loads(self.rfile.read(length))
         requests.append((self.path, payload))
+        if usage_token in json.dumps(payload.get("input", [])):
+            events = [
+                {
+                    "type": "response.created",
+                    "response": {"id": "resp-token-usage"},
+                },
+                {
+                    "type": "response.output_item.done",
+                    "item": {
+                        "type": "message",
+                        "role": "assistant",
+                        "id": "msg-token-usage",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "token usage probe complete",
+                            }
+                        ],
+                    },
+                },
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp-token-usage",
+                        "usage": {
+                            "input_tokens": 30,
+                            "input_tokens_details": {
+                                "cached_tokens": 11,
+                                "cache_write_tokens": 2,
+                            },
+                            "output_tokens": 7,
+                            "output_tokens_details": {
+                                "reasoning_tokens": 3,
+                            },
+                            "total_tokens": 37,
+                        },
+                    },
+                },
+            ]
+            body = "".join(
+                "event: "
+                + event["type"]
+                + "\ndata: "
+                + json.dumps(event, separators=(",", ":"))
+                + "\n\n"
+                for event in events
+            ).encode()
+            self.send_response(200)
+            self.send_header("content-type", "text/event-stream")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
         body = json.dumps(
             {
                 "error": {
@@ -1375,6 +1429,61 @@ def response_request_for_prompt(prompt):
         f"found {len(matching_requests)} among {len(requests)} requests"
     )
     return matching_requests[0]
+
+
+def probe_token_usage(codex_home, port):
+    write_config(codex_home, port)
+    requests.clear()
+    result = run_codex_app_server(codex_home, usage_token)
+    response_request_for_prompt(usage_token)
+    messages = result["messages"]
+    turn_response = next(
+        message
+        for message in messages
+        if message.get("id") == 3
+    )
+    turn_id = turn_response["result"]["turn"]["id"]
+    usage_notifications = [
+        (index, message)
+        for index, message in enumerate(messages)
+        if (
+            message.get("method") == "thread/tokenUsage/updated"
+            and message.get("params", {}).get("threadId")
+            == result["thread_id"]
+            and message.get("params", {}).get("turnId") == turn_id
+        )
+    ]
+    assert usage_notifications, (
+        "Codex did not emit thread/tokenUsage/updated on success\n"
+        + app_server_output(result)
+    )
+    usage_index, usage_message = usage_notifications[-1]
+    expected_usage = {
+        "inputTokens": 30,
+        "cachedInputTokens": 11,
+        "cacheWriteInputTokens": 2,
+        "outputTokens": 7,
+        "reasoningOutputTokens": 3,
+        "totalTokens": 37,
+    }
+    token_usage = usage_message["params"]["tokenUsage"]
+    assert token_usage["total"] == expected_usage, token_usage
+    assert token_usage["last"] == expected_usage, token_usage
+    completion_index, completion = next(
+        (index, message)
+        for index, message in enumerate(messages)
+        if (
+            message.get("method") == "turn/completed"
+            and message.get("params", {}).get("threadId")
+            == result["thread_id"]
+            and message.get("params", {}).get("turn", {}).get("id")
+            == turn_id
+        )
+    )
+    assert usage_index < completion_index, (
+        "token usage notification must precede turn completion"
+    )
+    assert "usage" not in completion.get("params", {}), completion
 
 
 def zstd_compress(history_bytes):
@@ -1697,6 +1806,8 @@ with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
         server_thread.start()
         root = Path(temp_root)
         port = server.server_port
+
+        probe_token_usage(root / "usage" / ".codex", port)
 
         seed_home = root / "seed" / ".codex"
         write_config(seed_home, port)

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -257,6 +257,7 @@ async fn run_codex_app_server(
         CliEventIngestor::new_with_session_metadata(runtime, codex_startup, session_metadata, 0);
     let mut output_timing = CodexOutputTiming::default();
     let resume_thread_id = resume_thread_id_from_runtime(runtime)?;
+    let can_replay_historical_usage = resume_thread_id.is_some();
     let mut client = CodexAppServerClient::spawn(codex_app_server_config(
         runtime,
         workload_containment.cloned(),
@@ -283,7 +284,7 @@ async fn run_codex_app_server(
         let thread_identity = thread_identity_from_response(&thread_response)?;
         validate_resumed_thread_id(&thread_identity.canonical_id, resume_thread_id.as_deref())?;
         let mut notification_state = CodexNotificationState {
-            allow_historical_usage: true,
+            allow_historical_usage: can_replay_historical_usage,
             ..CodexNotificationState::default()
         };
 
@@ -339,7 +340,7 @@ async fn run_codex_app_server(
         let turn_id = turn_id_from_response(&turn_response)?;
         let mut active_input_open = active_input.is_enabled();
         let mut turn_started_observed = false;
-        notification_state.allow_historical_usage = true;
+        notification_state.allow_historical_usage = can_replay_historical_usage;
 
         let exit_code = loop {
             let event = next_codex_run_event(
@@ -990,8 +991,8 @@ fn prepare_notification_ingest(
     if let Some(update) = codex_token_usage_update(&notification)
         .map_err(|error| AgentError::Execution(error.to_string()))?
     {
-        if active_turn_id.is_empty()
-            || (notification_state.allow_historical_usage && update.turn_id != active_turn_id)
+        if notification_state.allow_historical_usage
+            && (active_turn_id.is_empty() || update.turn_id != active_turn_id)
         {
             validate_scope(
                 Some(&update.thread_id),

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -19,8 +19,9 @@ use super::codex_app_server::{
     CodexAppServerClient, CodexAppServerConfig, CodexAppServerError, ServerNotification,
 };
 use super::codex_app_server_events::{
-    CodexOutputItemKind, CodexOutputItemStart, IGNORED_NOTIFICATION_METHODS,
-    codex_output_item_start, notification_thread_id, notification_to_codex_event,
+    CodexOutputItemKind, CodexOutputItemStart, CodexTurnUsageTracker, IGNORED_NOTIFICATION_METHODS,
+    codex_output_item_start, codex_token_usage_update, notification_thread_id,
+    notification_to_codex_event,
 };
 use super::event_delivery::{EventDeliveryRuntime, EventDeliverySender};
 use super::{
@@ -51,6 +52,14 @@ struct PreparedNotificationIngest {
     emitted_thread_started: bool,
     active_input_ready: bool,
     terminal_exit_code: Option<i32>,
+}
+
+#[derive(Default)]
+struct CodexNotificationState {
+    thread_started_emitted: bool,
+    secondary_thread_notification_logged: bool,
+    turn_usage: CodexTurnUsageTracker,
+    allow_historical_usage: bool,
 }
 
 struct ThreadIdentity {
@@ -273,8 +282,10 @@ async fn run_codex_app_server(
         .await?;
         let thread_identity = thread_identity_from_response(&thread_response)?;
         validate_resumed_thread_id(&thread_identity.canonical_id, resume_thread_id.as_deref())?;
-        let mut thread_started_emitted = false;
-        let mut secondary_thread_notification_logged = false;
+        let mut notification_state = CodexNotificationState {
+            allow_historical_usage: true,
+            ..CodexNotificationState::default()
+        };
 
         while let Some(notification) = client.pop_notification() {
             let mut sink = EventIngestSink {
@@ -288,17 +299,17 @@ async fn run_codex_app_server(
             let ingest_result = ingest_notification(
                 notification,
                 &mut sink,
-                thread_started_emitted,
                 &thread_identity.canonical_id,
                 "",
                 None,
-                &mut secondary_thread_notification_logged,
+                &mut notification_state,
             )
             .await?;
-            thread_started_emitted = thread_started_emitted || ingest_result.emitted_thread_started;
+            notification_state.thread_started_emitted =
+                notification_state.thread_started_emitted || ingest_result.emitted_thread_started;
         }
 
-        if !thread_started_emitted {
+        if !notification_state.thread_started_emitted {
             let mut sink = EventIngestSink {
                 ingestor: &mut ingestor,
                 output_timing: &mut output_timing,
@@ -312,7 +323,7 @@ async fn run_codex_app_server(
                 &mut sink,
             )
             .await?;
-            thread_started_emitted = true;
+            notification_state.thread_started_emitted = true;
         }
 
         let turn_response = race_with_heartbeat(
@@ -328,6 +339,7 @@ async fn run_codex_app_server(
         let turn_id = turn_id_from_response(&turn_response)?;
         let mut active_input_open = active_input.is_enabled();
         let mut turn_started_observed = false;
+        notification_state.allow_historical_usage = true;
 
         let exit_code = loop {
             let event = next_codex_run_event(
@@ -358,9 +370,8 @@ async fn run_codex_app_server(
                         notification,
                         &mut sink,
                         &active_input,
-                        &mut thread_started_emitted,
                         &notification_scope,
-                        &mut secondary_thread_notification_logged,
+                        &mut notification_state,
                     )
                     .await?;
                     turn_started_observed =
@@ -401,9 +412,8 @@ async fn run_codex_app_server(
                         &mut client,
                         &mut sink,
                         &active_input,
-                        &mut thread_started_emitted,
                         &notification_scope,
-                        &mut secondary_thread_notification_logged,
+                        &mut notification_state,
                     )
                     .await?
                     {
@@ -827,19 +837,18 @@ async fn drain_queued_notifications(
     client: &mut CodexAppServerClient,
     sink: &mut EventIngestSink<'_, '_>,
     active_input: &ActiveInputWriter,
-    thread_started_emitted: &mut bool,
     scope: &CodexTurnScope<'_>,
-    secondary_thread_notification_logged: &mut bool,
+    notification_state: &mut CodexNotificationState,
 ) -> Result<Option<i32>, AgentError> {
     let mut prepared_notifications = Vec::new();
-    let mut prepared_thread_started_emitted = *thread_started_emitted;
+    let mut prepared_thread_started_emitted = notification_state.thread_started_emitted;
     while let Some(notification) = client.pop_notification() {
         let prepared = prepare_notification_ingest(
             notification,
             prepared_thread_started_emitted,
             scope.thread_id,
             scope.turn_id,
-            secondary_thread_notification_logged,
+            notification_state,
         )?;
         prepared_thread_started_emitted =
             prepared_thread_started_emitted || prepared.emitted_thread_started;
@@ -855,7 +864,8 @@ async fn drain_queued_notifications(
         if let Some(event) = prepared.event {
             ingest_event(event, sink).await?;
         }
-        *thread_started_emitted = *thread_started_emitted || prepared.emitted_thread_started;
+        notification_state.thread_started_emitted =
+            notification_state.thread_started_emitted || prepared.emitted_thread_started;
         if let Some(exit_code) = prepared.terminal_exit_code {
             return Ok(Some(exit_code));
         }
@@ -867,16 +877,15 @@ async fn ingest_run_notification(
     notification: ServerNotification,
     sink: &mut EventIngestSink<'_, '_>,
     active_input: &ActiveInputWriter,
-    thread_started_emitted: &mut bool,
     scope: &CodexTurnScope<'_>,
-    secondary_thread_notification_logged: &mut bool,
+    notification_state: &mut CodexNotificationState,
 ) -> Result<NotificationIngestResult, AgentError> {
     let prepared = prepare_notification_ingest(
         notification,
-        *thread_started_emitted,
+        notification_state.thread_started_emitted,
         scope.thread_id,
         scope.turn_id,
-        secondary_thread_notification_logged,
+        notification_state,
     )?;
     record_output_item_start(prepared.output_item_start.as_ref(), sink);
     // Close before any ingest await so the control path cannot accept input
@@ -892,7 +901,8 @@ async fn ingest_run_notification(
     if let Some(event) = prepared.event {
         ingest_event(event, sink).await?;
     }
-    *thread_started_emitted = *thread_started_emitted || prepared.emitted_thread_started;
+    notification_state.thread_started_emitted =
+        notification_state.thread_started_emitted || prepared.emitted_thread_started;
     Ok(result)
 }
 
@@ -927,18 +937,17 @@ fn heartbeat_error(result: Result<HeartbeatStatus, oneshot::error::RecvError>) -
 async fn ingest_notification(
     notification: ServerNotification,
     sink: &mut EventIngestSink<'_, '_>,
-    thread_started_emitted: bool,
     expected_thread_id: &str,
     active_turn_id: &str,
     terminal_active_input: Option<&ActiveInputWriter>,
-    secondary_thread_notification_logged: &mut bool,
+    notification_state: &mut CodexNotificationState,
 ) -> Result<NotificationIngestResult, AgentError> {
     let prepared = prepare_notification_ingest(
         notification,
-        thread_started_emitted,
+        notification_state.thread_started_emitted,
         expected_thread_id,
         active_turn_id,
-        secondary_thread_notification_logged,
+        notification_state,
     )?;
     record_output_item_start(prepared.output_item_start.as_ref(), sink);
     if prepared.terminal_exit_code.is_some()
@@ -962,18 +971,47 @@ fn prepare_notification_ingest(
     thread_started_emitted: bool,
     expected_thread_id: &str,
     active_turn_id: &str,
-    secondary_thread_notification_logged: &mut bool,
+    notification_state: &mut CodexNotificationState,
 ) -> Result<PreparedNotificationIngest, AgentError> {
     if let Some(secondary_thread_id) =
         secondary_notification_thread_id(&notification, expected_thread_id)
     {
-        if !*secondary_thread_notification_logged {
+        if !notification_state.secondary_thread_notification_logged {
             log_info!(
                 LOG_TAG,
                 "Ignoring codex app-server notification for secondary thread: method={} thread_id={secondary_thread_id}",
                 notification.method
             );
-            *secondary_thread_notification_logged = true;
+            notification_state.secondary_thread_notification_logged = true;
+        }
+        return Ok(PreparedNotificationIngest::default());
+    }
+
+    if let Some(update) = codex_token_usage_update(&notification)
+        .map_err(|error| AgentError::Execution(error.to_string()))?
+    {
+        if active_turn_id.is_empty()
+            || (notification_state.allow_historical_usage && update.turn_id != active_turn_id)
+        {
+            validate_scope(
+                Some(&update.thread_id),
+                None,
+                expected_thread_id,
+                active_turn_id,
+            )?;
+            notification_state.turn_usage.observe_replay(update);
+        } else {
+            validate_scope(
+                Some(&update.thread_id),
+                Some(&update.turn_id),
+                expected_thread_id,
+                active_turn_id,
+            )?;
+            notification_state
+                .turn_usage
+                .observe_current(update)
+                .map_err(|error| AgentError::Execution(error.to_string()))?;
+            notification_state.allow_historical_usage = false;
         }
         return Ok(PreparedNotificationIngest::default());
     }
@@ -988,7 +1026,7 @@ fn prepare_notification_ingest(
             active_turn_id,
         )?;
     }
-    let Some(event) = notification_to_codex_event(&notification)
+    let Some(mut event) = notification_to_codex_event(&notification)
         .map_err(|error| AgentError::Execution(error.to_string()))?
     else {
         return Ok(PreparedNotificationIngest {
@@ -997,6 +1035,20 @@ fn prepare_notification_ingest(
         });
     };
     validate_event_scope(&event, expected_thread_id, active_turn_id)?;
+    if !active_turn_id.is_empty() && event_turn_id(&event).is_some() {
+        notification_state.allow_historical_usage = false;
+    }
+    if event.get("type").and_then(Value::as_str) == Some("turn.completed")
+        && let Some(usage) = notification_state
+            .turn_usage
+            .usage()
+            .map_err(|error| AgentError::Execution(error.to_string()))?
+    {
+        let event = event.as_object_mut().ok_or_else(|| {
+            AgentError::Execution("normalized codex event is not an object".to_string())
+        })?;
+        event.insert("usage".to_string(), usage);
+    }
     if is_duplicate_thread_started(&event, thread_started_emitted, expected_thread_id) {
         return Ok(PreparedNotificationIngest {
             output_item_start,

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -27,6 +27,7 @@
 //! app-server representation.
 
 use guest_contracts::epoch_milliseconds::is_plausible_epoch_milliseconds;
+use serde::Deserialize;
 use serde_json::{Map, Value, json};
 
 use super::codex_app_server::ServerNotification;
@@ -69,6 +70,116 @@ pub(super) struct CodexOutputItemStart {
     pub(super) turn_id: String,
     pub(super) started_at_ms: u64,
     pub(super) kind: CodexOutputItemKind,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct CodexTokenUsage {
+    input_tokens: i64,
+    cached_input_tokens: i64,
+    cache_write_input_tokens: i64,
+    output_tokens: i64,
+    reasoning_output_tokens: i64,
+    total_tokens: i64,
+}
+
+impl CodexTokenUsage {
+    fn is_non_negative(self) -> bool {
+        self.input_tokens >= 0
+            && self.cached_input_tokens >= 0
+            && self.cache_write_input_tokens >= 0
+            && self.output_tokens >= 0
+            && self.reasoning_output_tokens >= 0
+            && self.total_tokens >= 0
+    }
+
+    fn checked_sub(self, baseline: Self, method: &str) -> Result<Self, CodexAppServerEventError> {
+        let difference = |latest: i64, prior: i64| {
+            latest
+                .checked_sub(prior)
+                .filter(|value| *value >= 0)
+                .ok_or_else(|| invalid_field_for_method(method, "tokenUsage.total"))
+        };
+        Ok(Self {
+            input_tokens: difference(self.input_tokens, baseline.input_tokens)?,
+            cached_input_tokens: difference(
+                self.cached_input_tokens,
+                baseline.cached_input_tokens,
+            )?,
+            cache_write_input_tokens: difference(
+                self.cache_write_input_tokens,
+                baseline.cache_write_input_tokens,
+            )?,
+            output_tokens: difference(self.output_tokens, baseline.output_tokens)?,
+            reasoning_output_tokens: difference(
+                self.reasoning_output_tokens,
+                baseline.reasoning_output_tokens,
+            )?,
+            total_tokens: difference(self.total_tokens, baseline.total_tokens)?,
+        })
+    }
+
+    fn into_value(self) -> Value {
+        json!({
+            "input_tokens": self.input_tokens,
+            "cached_input_tokens": self.cached_input_tokens,
+            "cache_write_input_tokens": self.cache_write_input_tokens,
+            "output_tokens": self.output_tokens,
+            "reasoning_output_tokens": self.reasoning_output_tokens,
+            "total_tokens": self.total_tokens,
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct CodexTokenUsageUpdate {
+    pub(super) thread_id: String,
+    pub(super) turn_id: String,
+    total: CodexTokenUsage,
+    last: CodexTokenUsage,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct CodexTurnUsageTracker {
+    baseline: Option<CodexTokenUsage>,
+    latest: Option<CodexTokenUsage>,
+}
+
+impl CodexTurnUsageTracker {
+    pub(super) fn observe_replay(&mut self, update: CodexTokenUsageUpdate) {
+        self.baseline = Some(update.total);
+    }
+
+    pub(super) fn observe_current(
+        &mut self,
+        update: CodexTokenUsageUpdate,
+    ) -> Result<(), CodexAppServerEventError> {
+        let baseline = match self.baseline {
+            Some(baseline) => baseline,
+            None => {
+                let baseline = update
+                    .total
+                    .checked_sub(update.last, "thread/tokenUsage/updated")?;
+                self.baseline = Some(baseline);
+                baseline
+            }
+        };
+        update
+            .total
+            .checked_sub(baseline, "thread/tokenUsage/updated")?;
+        self.latest = Some(update.total);
+        Ok(())
+    }
+
+    pub(super) fn usage(&self) -> Result<Option<Value>, CodexAppServerEventError> {
+        let (Some(baseline), Some(latest)) = (self.baseline, self.latest) else {
+            return Ok(None);
+        };
+        latest
+            .checked_sub(baseline, "thread/tokenUsage/updated")
+            .map(CodexTokenUsage::into_value)
+            .map(Some)
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -146,8 +257,14 @@ pub(super) fn notification_thread_id(notification: &ServerNotification) -> Optio
     let params = notification.params.as_ref()?;
     let thread_id = match notification.method.as_str() {
         "thread/started" => params.pointer("/thread/id"),
-        "turn/started" | "turn/completed" | "turn/plan/updated" | "item/started"
-        | "item/completed" | "error" | "warning" => params.get("threadId"),
+        "turn/started"
+        | "turn/completed"
+        | "turn/plan/updated"
+        | "item/started"
+        | "item/completed"
+        | "thread/tokenUsage/updated"
+        | "error"
+        | "warning" => params.get("threadId"),
         _ => None,
     }?;
     thread_id.as_str().filter(|thread_id| !thread_id.is_empty())
@@ -220,6 +337,43 @@ pub(super) fn notification_to_codex_event(
     }
 }
 
+pub(super) fn codex_token_usage_update(
+    notification: &ServerNotification,
+) -> Result<Option<CodexTokenUsageUpdate>, CodexAppServerEventError> {
+    if notification.method != "thread/tokenUsage/updated" {
+        return Ok(None);
+    }
+
+    let params = required_params_object(notification)?;
+    let thread_id =
+        required_non_empty_string_key(params, &notification.method, "threadId", "threadId")?;
+    let turn_id = required_non_empty_string_key(params, &notification.method, "turnId", "turnId")?;
+    let token_usage =
+        required_object_key(params, &notification.method, "tokenUsage", "tokenUsage")?;
+    let total = required_token_usage(
+        required_object_key(
+            token_usage,
+            &notification.method,
+            "total",
+            "tokenUsage.total",
+        )?,
+        &notification.method,
+        "tokenUsage.total",
+    )?;
+    let last = required_token_usage(
+        required_object_key(token_usage, &notification.method, "last", "tokenUsage.last")?,
+        &notification.method,
+        "tokenUsage.last",
+    )?;
+
+    Ok(Some(CodexTokenUsageUpdate {
+        thread_id: thread_id.to_string(),
+        turn_id: turn_id.to_string(),
+        total,
+        last,
+    }))
+}
+
 fn map_thread_started(
     notification: &ServerNotification,
 ) -> Result<Value, CodexAppServerEventError> {
@@ -287,8 +441,20 @@ fn map_turn_completed(
         "turn".to_string(),
         normalize_turn(turn, &notification.method, status)?,
     );
-    copy_optional_field(&mut event, "usage", params, "usage");
     Ok(Value::Object(event))
+}
+
+fn required_token_usage(
+    usage: &Map<String, Value>,
+    method: &str,
+    field: &'static str,
+) -> Result<CodexTokenUsage, CodexAppServerEventError> {
+    let usage = serde_json::from_value::<CodexTokenUsage>(Value::Object(usage.clone()))
+        .map_err(|_error| invalid_field_for_method(method, field))?;
+    usage
+        .is_non_negative()
+        .then_some(usage)
+        .ok_or_else(|| invalid_field_for_method(method, field))
 }
 
 fn map_turn_plan_updated(
@@ -1217,7 +1383,7 @@ mod tests {
     }
 
     #[test]
-    fn successful_turn_completed_stays_turn_completed() {
+    fn turn_completed_does_not_read_non_contract_usage() {
         let event = mapped_event(
             "turn/completed",
             json!({
@@ -1246,9 +1412,47 @@ mod tests {
                     "started_at": 10,
                     "completed_at": 20,
                     "duration_ms": 1000
-                },
-                "usage": {"input_tokens": 1}
+                }
             })
+        );
+    }
+
+    #[test]
+    fn token_usage_update_rejects_negative_count() {
+        let error = codex_token_usage_update(&notification(
+            "thread/tokenUsage/updated",
+            json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "tokenUsage": {
+                    "total": {
+                        "inputTokens": -1,
+                        "cachedInputTokens": 0,
+                        "cacheWriteInputTokens": 0,
+                        "outputTokens": 0,
+                        "reasoningOutputTokens": 0,
+                        "totalTokens": 0
+                    },
+                    "last": {
+                        "inputTokens": 0,
+                        "cachedInputTokens": 0,
+                        "cacheWriteInputTokens": 0,
+                        "outputTokens": 0,
+                        "reasoningOutputTokens": 0,
+                        "totalTokens": 0
+                    },
+                    "modelContextWindow": 258400
+                }
+            }),
+        ))
+        .expect_err("negative token usage should fail");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::InvalidField {
+                method: "thread/tokenUsage/updated".to_string(),
+                field: "tokenUsage.total"
+            }
         );
     }
 

--- a/crates/guest-agent/tests/codex_app_server_backend.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend.rs
@@ -101,6 +101,7 @@ async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_start
         events[2].pointer("/item/text").and_then(Value::as_str),
         Some("guest-mock-codex app-server response: drive the app-server backend")
     );
+    assert_eq!(events[3]["usage"], common::expected_codex_turn_usage());
 
     let sandbox_ops = read_sandbox_ops(&runtime.paths)?;
     let output_item_started = sandbox_ops

--- a/crates/guest-agent/tests/codex_app_server_backend_resume_usage_no_replay.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_resume_usage_no_replay.rs
@@ -1,7 +1,4 @@
-//! Resume-path integration coverage for Codex app-server execution.
-//!
-//! This is separate from `codex_app_server_backend.rs` because `guest_agent::env`
-//! uses resume-session process env setup that must stay isolated.
+//! Legacy-style resume coverage when Codex does not replay historical usage.
 
 mod common;
 
@@ -10,21 +7,20 @@ use serde_json::Value;
 use std::time::Duration;
 
 #[tokio::test]
-async fn codex_app_server_backend_resumes_existing_thread_id()
+async fn codex_app_server_backend_derives_resume_usage_without_replay()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
-    let resume_thread_id = "0193ABCDEF01723489ABCDEF01234567";
-    let canonical_resume_thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
+    let resume_thread_id = "0193abcdef01723489abcdef01234567";
 
     unsafe {
         common::setup_codex_app_server_env(
             &mock,
             tmp.path(),
             common::CodexAppServerEnvConfig {
-                run_id: "codex-app-server-backend-resume-test",
-                prompt: "drive the app-server resume backend",
-                scenario: Some("runtime-turn-usage-resume-replay"),
+                run_id: "codex-app-server-backend-resume-usage-no-replay-test",
+                prompt: "derive resumed turn usage without replay",
+                scenario: Some("runtime-turn-usage-resume-no-replay"),
                 resume_session_id: Some(resume_thread_id),
             },
         )?;
@@ -36,8 +32,8 @@ async fn codex_app_server_backend_resumes_existing_thread_id()
     }
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
-
     let masker = SecretMasker::from_raw("");
+
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
         common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
@@ -47,36 +43,12 @@ async fn codex_app_server_backend_resumes_existing_thread_id()
 
     assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
     assert!(cli_result.failure_diagnostic.is_none());
-
     let events = read_agent_log_events(&runtime.paths)?;
-    assert_eq!(
-        events[0].get("type").and_then(Value::as_str),
-        Some("thread.started")
-    );
-    assert_eq!(
-        events[0].get("thread_id").and_then(Value::as_str),
-        Some(canonical_resume_thread_id)
-    );
     let completed = events
         .iter()
         .find(|event| event.get("type").and_then(Value::as_str) == Some("turn.completed"))
         .ok_or("missing turn.completed event")?;
     assert_eq!(completed["usage"], common::expected_codex_turn_usage());
-
-    let stored_id = std::fs::read_to_string(runtime.paths.session_id_file())?;
-    assert_eq!(stored_id, canonical_resume_thread_id);
-
-    let session_events = common::read_codex_session_history_events_for_runtime(&runtime)?;
-    let input_event = session_events
-        .iter()
-        .find(|event| event.get("type").and_then(Value::as_str) == Some("mock.app_server.input"))
-        .ok_or("missing mock app-server input event")?;
-    assert_eq!(
-        input_event
-            .get("thread_request_excludes_turns")
-            .and_then(Value::as_bool),
-        Some(true)
-    );
 
     Ok(())
 }

--- a/crates/guest-agent/tests/codex_app_server_backend_secondary_thread.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_secondary_thread.rs
@@ -86,6 +86,10 @@ async fn codex_app_server_backend_ignores_secondary_thread_notifications()
     assert!(events.iter().all(|event| {
         event.get("thread_id").and_then(Value::as_str) != Some(SECONDARY_THREAD_ID)
     }));
+    assert_eq!(
+        events.last().ok_or("missing terminal event")?["usage"],
+        common::expected_codex_turn_usage()
+    );
 
     let sandbox_ops = std::fs::read_to_string(runtime.paths.sandbox_ops_file()).unwrap_or_default();
     assert!(!sandbox_ops.contains("api_to_codex_output_item_started"));

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -21,7 +21,7 @@ pub(crate) mod process_session;
 mod system_log;
 
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
-use serde_json::Value;
+use serde_json::{Value, json};
 use shell_quote::quote_shell_arg;
 use std::collections::HashMap;
 use std::ffi::{CString, OsStr};
@@ -1274,6 +1274,17 @@ pub fn read_codex_session_history_events_for_runtime(
         .lines()
         .map(|line| serde_json::from_str(line).map_err(Into::into))
         .collect()
+}
+
+pub fn expected_codex_turn_usage() -> Value {
+    json!({
+        "input_tokens": 12,
+        "cached_input_tokens": 3,
+        "cache_write_input_tokens": 3,
+        "output_tokens": 24,
+        "reasoning_output_tokens": 7,
+        "total_tokens": 36
+    })
 }
 
 /// Configure the process environment for one mock-Claude CLI integration-test

--- a/crates/guest-mock-codex/src/app_server/handlers.rs
+++ b/crates/guest-mock-codex/src/app_server/handlers.rs
@@ -1,12 +1,14 @@
 use super::messages::{
     agent_message_item_started_notification, assistant_item_completed_notification,
-    initialize_response, large_server_notification, large_warning_notification,
-    reasoning_item_started_notification, server_notification, server_notification_with_index,
+    historical_token_usage_notification, initialize_response, large_server_notification,
+    large_warning_notification, reasoning_item_started_notification,
+    secondary_token_usage_notification, server_notification, server_notification_with_index,
     server_request, thread_response, thread_started_notification, turn,
     turn_completed_notification, turn_failed_notification, turn_started_notification,
     warning_notification, write_error, write_json_line, write_oversized_delivery_notifications,
-    write_split_json_line_prefix, write_success, write_turn_completion_notifications,
-    write_turn_notifications, write_turn_start_notifications,
+    write_resumed_turn_notifications, write_split_json_line_prefix, write_success,
+    write_turn_completion_notifications, write_turn_notifications, write_turn_start_notifications,
+    write_turn_usage_notifications,
 };
 use super::persistence::{InputEventContext, persist_input_events, session_rollout_timestamp};
 use super::scenario::Scenario;
@@ -235,6 +237,9 @@ impl AppServerState {
             thread_id
         };
         write_success(output, id, thread_response(response_thread_id, true))?;
+        if self.scenario == Scenario::RuntimeTurnUsageResumeReplay {
+            write_json_line(output, &historical_token_usage_notification(thread_id))?;
+        }
         Ok(ServerAction::Continue)
     }
 
@@ -374,11 +379,27 @@ impl AppServerState {
         }
         if matches!(
             self.scenario,
-            Scenario::RuntimeTurnComplete | Scenario::RuntimeTurnCompleteWithoutThreadStarted
+            Scenario::RuntimeTurnComplete
+                | Scenario::RuntimeTurnCompleteWithoutThreadStarted
+                | Scenario::RuntimeTurnUsageResumeNoReplay
+                | Scenario::RuntimeTurnUsageResumeReplay
         ) {
             match turn_output {
                 MockTurnOutput::Complete(response_text) => {
-                    write_turn_notifications(output, &thread_id, &turn_id, &response_text)?;
+                    if matches!(
+                        self.scenario,
+                        Scenario::RuntimeTurnUsageResumeNoReplay
+                            | Scenario::RuntimeTurnUsageResumeReplay
+                    ) {
+                        write_resumed_turn_notifications(
+                            output,
+                            &thread_id,
+                            &turn_id,
+                            &response_text,
+                        )?;
+                    } else {
+                        write_turn_notifications(output, &thread_id, &turn_id, &response_text)?;
+                    }
                 }
                 MockTurnOutput::Checkpoint {
                     checkpoint_text,
@@ -410,6 +431,7 @@ impl AppServerState {
         }
         if self.scenario == Scenario::RuntimeTurnFailed {
             write_json_line(output, &turn_started_notification(&thread_id, &turn_id))?;
+            write_turn_usage_notifications(output, &thread_id, &turn_id)?;
             write_json_line(output, &turn_failed_notification(&thread_id, &turn_id))?;
         }
         if self.scenario == Scenario::RuntimeEventFlood {
@@ -638,6 +660,10 @@ fn write_secondary_thread_notifications<W: Write>(
     write_json_line(output, &warning_notification(SECONDARY_THREAD_ID, 1))?;
     write_json_line(
         output,
+        &secondary_token_usage_notification(SECONDARY_THREAD_ID, turn_id),
+    )?;
+    write_json_line(
+        output,
         &assistant_item_completed_notification(
             SECONDARY_THREAD_ID,
             turn_id,
@@ -648,6 +674,7 @@ fn write_secondary_thread_notifications<W: Write>(
         output,
         &turn_completed_notification(SECONDARY_THREAD_ID, turn_id),
     )?;
+    write_turn_usage_notifications(output, thread_id, turn_id)?;
     write_json_line(output, &turn_completed_notification(thread_id, turn_id))
 }
 

--- a/crates/guest-mock-codex/src/app_server/messages.rs
+++ b/crates/guest-mock-codex/src/app_server/messages.rs
@@ -6,6 +6,72 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
 const LARGE_NOTIFICATION_MESSAGE_BYTES: usize = 17 * 1024 * 1024;
+const HISTORICAL_TURN_ID: &str = "00000000-0000-4000-8000-000000000099";
+
+#[derive(Clone, Copy)]
+struct MockTokenUsage {
+    input_tokens: i64,
+    cached_input_tokens: i64,
+    cache_write_input_tokens: i64,
+    output_tokens: i64,
+    reasoning_output_tokens: i64,
+    total_tokens: i64,
+}
+
+impl MockTokenUsage {
+    const fn add(self, other: Self) -> Self {
+        Self {
+            input_tokens: self.input_tokens + other.input_tokens,
+            cached_input_tokens: self.cached_input_tokens + other.cached_input_tokens,
+            cache_write_input_tokens: self.cache_write_input_tokens
+                + other.cache_write_input_tokens,
+            output_tokens: self.output_tokens + other.output_tokens,
+            reasoning_output_tokens: self.reasoning_output_tokens + other.reasoning_output_tokens,
+            total_tokens: self.total_tokens + other.total_tokens,
+        }
+    }
+}
+
+const EMPTY_USAGE: MockTokenUsage = MockTokenUsage {
+    input_tokens: 0,
+    cached_input_tokens: 0,
+    cache_write_input_tokens: 0,
+    output_tokens: 0,
+    reasoning_output_tokens: 0,
+    total_tokens: 0,
+};
+const HISTORICAL_USAGE: MockTokenUsage = MockTokenUsage {
+    input_tokens: 100,
+    cached_input_tokens: 20,
+    cache_write_input_tokens: 5,
+    output_tokens: 50,
+    reasoning_output_tokens: 10,
+    total_tokens: 150,
+};
+const FIRST_RESPONSE_USAGE: MockTokenUsage = MockTokenUsage {
+    input_tokens: 7,
+    cached_input_tokens: 2,
+    cache_write_input_tokens: 1,
+    output_tokens: 11,
+    reasoning_output_tokens: 3,
+    total_tokens: 18,
+};
+const SECOND_RESPONSE_USAGE: MockTokenUsage = MockTokenUsage {
+    input_tokens: 5,
+    cached_input_tokens: 1,
+    cache_write_input_tokens: 2,
+    output_tokens: 13,
+    reasoning_output_tokens: 4,
+    total_tokens: 18,
+};
+const SECONDARY_USAGE: MockTokenUsage = MockTokenUsage {
+    input_tokens: 900,
+    cached_input_tokens: 300,
+    cache_write_input_tokens: 200,
+    output_tokens: 700,
+    reasoning_output_tokens: 400,
+    total_tokens: 1600,
+};
 
 pub(super) fn initialize_response() -> Value {
     json!({
@@ -299,12 +365,7 @@ pub(super) fn turn_completed_notification(thread_id: &str, turn_id: &str) -> Val
         "method": "turn/completed",
         "params": {
             "threadId": thread_id,
-            "turn": completed_turn(turn_id),
-            "usage": {
-                "inputTokens": 7,
-                "outputTokens": 11,
-                "totalTokens": 18
-            }
+            "turn": completed_turn(turn_id)
         }
     })
 }
@@ -325,14 +386,22 @@ pub(super) fn turn_failed_notification(thread_id: &str, turn_id: &str) -> Value 
                 "startedAt": 1,
                 "completedAt": 3,
                 "durationMs": 2
-            },
-            "usage": {
-                "inputTokens": 7,
-                "outputTokens": 0,
-                "totalTokens": 7
             }
         }
     })
+}
+
+pub(super) fn historical_token_usage_notification(thread_id: &str) -> Value {
+    token_usage_updated_notification(
+        thread_id,
+        HISTORICAL_TURN_ID,
+        HISTORICAL_USAGE,
+        HISTORICAL_USAGE,
+    )
+}
+
+pub(super) fn secondary_token_usage_notification(thread_id: &str, turn_id: &str) -> Value {
+    token_usage_updated_notification(thread_id, turn_id, SECONDARY_USAGE, SECONDARY_USAGE)
 }
 
 pub(super) fn warning_notification(thread_id: &str, index: usize) -> Value {
@@ -367,6 +436,22 @@ pub(super) fn write_turn_notifications<W: Write>(
 ) -> io::Result<()> {
     write_turn_start_notifications(output, thread_id, turn_id)?;
     write_turn_completion_notifications(output, thread_id, turn_id, response_text)
+}
+
+pub(super) fn write_resumed_turn_notifications<W: Write>(
+    output: &mut W,
+    thread_id: &str,
+    turn_id: &str,
+    response_text: &str,
+) -> io::Result<()> {
+    write_turn_start_notifications(output, thread_id, turn_id)?;
+    write_turn_completion_notifications_with_baseline(
+        output,
+        thread_id,
+        turn_id,
+        response_text,
+        HISTORICAL_USAGE,
+    )
 }
 
 pub(super) fn write_turn_start_notifications<W: Write>(
@@ -411,11 +496,89 @@ pub(super) fn write_turn_completion_notifications<W: Write>(
     turn_id: &str,
     response_text: &str,
 ) -> io::Result<()> {
+    write_turn_completion_notifications_with_baseline(
+        output,
+        thread_id,
+        turn_id,
+        response_text,
+        EMPTY_USAGE,
+    )
+}
+
+fn write_turn_completion_notifications_with_baseline<W: Write>(
+    output: &mut W,
+    thread_id: &str,
+    turn_id: &str,
+    response_text: &str,
+    baseline: MockTokenUsage,
+) -> io::Result<()> {
     write_json_line(
         output,
         &assistant_item_completed_notification(thread_id, turn_id, response_text),
     )?;
+    write_turn_usage_notifications_with_baseline(output, thread_id, turn_id, baseline)?;
     write_json_line(output, &turn_completed_notification(thread_id, turn_id))
+}
+
+pub(super) fn write_turn_usage_notifications<W: Write>(
+    output: &mut W,
+    thread_id: &str,
+    turn_id: &str,
+) -> io::Result<()> {
+    write_turn_usage_notifications_with_baseline(output, thread_id, turn_id, EMPTY_USAGE)
+}
+
+fn write_turn_usage_notifications_with_baseline<W: Write>(
+    output: &mut W,
+    thread_id: &str,
+    turn_id: &str,
+    baseline: MockTokenUsage,
+) -> io::Result<()> {
+    let first_total = baseline.add(FIRST_RESPONSE_USAGE);
+    let first =
+        token_usage_updated_notification(thread_id, turn_id, first_total, FIRST_RESPONSE_USAGE);
+    write_json_line(output, &first)?;
+    write_json_line(output, &first)?;
+    write_json_line(
+        output,
+        &token_usage_updated_notification(
+            thread_id,
+            turn_id,
+            first_total.add(SECOND_RESPONSE_USAGE),
+            SECOND_RESPONSE_USAGE,
+        ),
+    )
+}
+
+fn token_usage_updated_notification(
+    thread_id: &str,
+    turn_id: &str,
+    total: MockTokenUsage,
+    last: MockTokenUsage,
+) -> Value {
+    json!({
+        "method": "thread/tokenUsage/updated",
+        "params": {
+            "threadId": thread_id,
+            "turnId": turn_id,
+            "tokenUsage": {
+                "total": token_usage_breakdown(total),
+                "last": token_usage_breakdown(last),
+                "modelContextWindow": 258400
+            }
+        }
+    })
+}
+
+fn token_usage_breakdown(usage: MockTokenUsage) -> Value {
+    json!({
+        "inputTokens": usage.input_tokens,
+        "cachedInputTokens": usage.cached_input_tokens,
+        "cacheWriteInputTokens": usage.cache_write_input_tokens,
+        "outputTokens": usage.output_tokens,
+        "reasoningOutputTokens": usage.reasoning_output_tokens,
+        "totalTokens": usage.total_tokens
+    })
 }
 
 pub(super) fn server_request(id: Value) -> Value {

--- a/crates/guest-mock-codex/src/app_server/scenario.rs
+++ b/crates/guest-mock-codex/src/app_server/scenario.rs
@@ -34,6 +34,8 @@ pub(super) enum Scenario {
     RuntimeTurnStartedBeforeSteer,
     WaitOnTurnSteerResponse,
     RuntimeTurnCompleteWithoutThreadStarted,
+    RuntimeTurnUsageResumeNoReplay,
+    RuntimeTurnUsageResumeReplay,
     RuntimeEventFlood,
     RuntimeLargeEventFlood,
     RuntimeOversizedDelivery,
@@ -91,6 +93,8 @@ impl Scenario {
                 "runtime-turn-complete-without-thread-started" => {
                     Ok(Self::RuntimeTurnCompleteWithoutThreadStarted)
                 }
+                "runtime-turn-usage-resume-no-replay" => Ok(Self::RuntimeTurnUsageResumeNoReplay),
+                "runtime-turn-usage-resume-replay" => Ok(Self::RuntimeTurnUsageResumeReplay),
                 "runtime-event-flood" => Ok(Self::RuntimeEventFlood),
                 "runtime-large-event-flood" => Ok(Self::RuntimeLargeEventFlood),
                 "runtime-oversized-delivery" => Ok(Self::RuntimeOversizedDelivery),

--- a/crates/guest-mock-codex/tests/integration/app_server.rs
+++ b/crates/guest-mock-codex/tests/integration/app_server.rs
@@ -547,6 +547,9 @@ fn app_server_turn_steer_can_complete_runtime_turn_after_success() -> std::io::R
             "item/started",
             "item/started",
             "item/completed",
+            "thread/tokenUsage/updated",
+            "thread/tokenUsage/updated",
+            "thread/tokenUsage/updated",
             "turn/completed",
         ]
     );
@@ -746,13 +749,21 @@ fn app_server_checkpointed_shell_emits_output_before_continuing() -> std::io::Re
 
     std::fs::write(release_file, "continue")?;
     let completed_item = server.read_required()?;
-    let completed_turn = server.read_required()?;
     assert_eq!(completed_item["method"], "item/completed");
     assert_eq!(
         completed_item["params"]["item"]["text"],
         "continuation-finished"
     );
-    assert_eq!(completed_turn["method"], "turn/completed");
+    let mut usage_notifications = 0;
+    loop {
+        let notification = server.read_required()?;
+        match notification["method"].as_str() {
+            Some("thread/tokenUsage/updated") => usage_notifications += 1,
+            Some("turn/completed") => break,
+            method => panic!("unexpected completion notification: {method:?}"),
+        }
+    }
+    assert_eq!(usage_notifications, 3);
 
     assert_eq!(server.close_and_wait()?, 0);
     Ok(())
@@ -886,9 +897,17 @@ fn app_server_can_start_runtime_turn_before_steer_completion() -> std::io::Resul
     assert_eq!(steered["result"]["turnId"], turn_id);
 
     let item_completed_notification = server.read_required()?;
-    let turn_completed_notification = server.read_required()?;
     assert_eq!(item_completed_notification["method"], "item/completed");
-    assert_eq!(turn_completed_notification["method"], "turn/completed");
+    let mut usage_notifications = 0;
+    loop {
+        let notification = server.read_required()?;
+        match notification["method"].as_str() {
+            Some("thread/tokenUsage/updated") => usage_notifications += 1,
+            Some("turn/completed") => break,
+            method => panic!("unexpected completion notification: {method:?}"),
+        }
+    }
+    assert_eq!(usage_notifications, 3);
     assert_eq!(server.close_and_wait()?, 0);
     Ok(())
 }


### PR DESCRIPTION
## Summary

- consume Codex `thread/tokenUsage/updated` notifications and restore per-turn usage on normalized terminal events
- derive the historical baseline for fresh, paginated-resume, and legacy/no-replay runs without double-counting repeated snapshots
- update the Codex mock and pinned runner behavior probe to use the official successful notification shape and ordering

## Scope

- preserves input, cached-input, cache-write-input, output, reasoning-output, and total token fields
- filters secondary-thread usage before it can affect the primary turn
- leaves the platform UI, user flow, proxy-side model observations, and billing unchanged

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent -p guest-mock-codex --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-agent -p guest-mock-codex --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-codex`
- `bash -n .github/scripts/runner-behavior-exec.sh`
- local success-path probe against Codex 0.150.1; the pinned 0.151 full runner behavior probe runs in CI

Closes #30319

Parent context: #30318
