### PR TITLE
fix(platform): align pinned agent shortcuts with sidebar navigation

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/nav.ts
+++ b/turbo/apps/platform/src/signals/okou-page/nav.ts
@@ -5,8 +5,6 @@ import { localStorageSignals } from "../external/local-storage.ts";
 import { openQueueDrawer$ } from "../queue-page/queue-drawer-state.ts";
 import { setupGlobalShortcut } from "../../lib/setup-global-shortcut.ts";
 import { currentChatAgentId$ } from "../agent-chat.ts";
-import { activeRoute$ } from "../active-route.ts";
-import { eventDrivenChatThreads$ } from "../chat-page/chat-thread-event-sourcing.ts";
 import { setChatShortcutHelpOpen$ } from "../chat-page/chat-shortcut-help.ts";
 import {
   openAgentListDialog$,
@@ -61,39 +59,6 @@ function adjacentPinnedAgentId(
   ]!.agentId;
 }
 
-const firstChatThreadIdForAgent$ = command(
-  async ({ get }, agentId: string, signal: AbortSignal) => {
-    const threads = await get(eventDrivenChatThreads$);
-    signal.throwIfAborted();
-    for (const thread of threads) {
-      if (thread.agentId === agentId) {
-        return thread.id;
-      }
-    }
-    return null;
-  },
-);
-
-const navigateToAgentChat$ = command(({ set }, agentId: string) => {
-  set(detachedNavigateTo$, "/agents/:agentId/chat", {
-    pathParams: { agentId },
-  });
-});
-
-const navigateToPinnedAgent$ = command(
-  async ({ get, set }, agentId: string, signal: AbortSignal) => {
-    if (get(activeRoute$) === "chat") {
-      const threadId = await set(firstChatThreadIdForAgent$, agentId, signal);
-      signal.throwIfAborted();
-      if (threadId) {
-        set(navigateToChat$, threadId);
-        return;
-      }
-    }
-    set(navigateToAgentChat$, agentId);
-  },
-);
-
 const navigateAdjacentPinnedAgent$ = command(
   async (
     { get, set },
@@ -111,7 +76,9 @@ const navigateAdjacentPinnedAgent$ = command(
     if (!targetAgentId) {
       return;
     }
-    await set(navigateToPinnedAgent$, targetAgentId, signal);
+    set(detachedNavigateTo$, "/agents/:agentId/chat", {
+      pathParams: { agentId: targetAgentId },
+    });
   },
 );
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -2563,7 +2563,7 @@ describe("zero sidebar", () => {
     });
   });
 
-  it("keeps the chat list owner without carrying rows across agent scopes", async () => {
+  it("keeps the chat list owner when switching to a pinned agent chat", async () => {
     prepareAgents();
     const supportUnreadGate = context.mocks.deferred<void>();
     context.mocks.data.userPreferences({
@@ -2638,7 +2638,7 @@ describe("zero sidebar", () => {
     });
 
     await waitFor(() => {
-      expect(pathname()).toBe(`/chats/${INCIDENT_THREAD_ID}`);
+      expect(pathname()).toBe(`/agents/${SUPPORT_AGENT_ID}/chat`);
       expect(
         within(sidebar()).queryByText("Research kickoff"),
       ).not.toBeInTheDocument();
@@ -2654,7 +2654,7 @@ describe("zero sidebar", () => {
     });
   });
 
-  it("falls back to the pinned agent chat when the next pinned agent has no thread", async () => {
+  it("opens the pinned agent chat even when the next agent has a thread", async () => {
     prepareAgents();
     context.mocks.data.userPreferences({
       pinnedAgentIds: [RESEARCH_AGENT_ID, SUPPORT_AGENT_ID],
@@ -2666,7 +2666,14 @@ describe("zero sidebar", () => {
         agent: { id: RESEARCH_AGENT_ID, avatarUrl: null },
       },
     );
-    mockSidebarThreadStory([researchThread]);
+    const supportThread = createThread(
+      INCIDENT_THREAD_ID,
+      "Support escalation",
+      {
+        agent: { id: SUPPORT_AGENT_ID, avatarUrl: null },
+      },
+    );
+    mockSidebarThreadStory([researchThread, supportThread]);
 
     setupSidebarPage({ context, path: `/chats/${RESEARCH_THREAD_ID}` });
 


### PR DESCRIPTION
## Summary

- route Ctrl+Shift+[ and Ctrl+Shift+] agent switches to `/agents/:agentId/chat`
- remove the existing-thread lookup so keyboard switching matches pinned agent card navigation
- cover switching from a chat thread when the target agent already has a thread

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx --maxWorkers=1 -t 'keeps the chat list owner when switching to a pinned agent chat|opens the pinned agent chat even when the next agent has a thread'` (2 passed)
