### PR TITLE
test(mitm-addon): cover nested decode boundary

### DIFF
--- a/crates/runner/mitm-addon/tests/test_path_security.py
+++ b/crates/runner/mitm-addon/tests/test_path_security.py
@@ -39,7 +39,7 @@ def test_has_unsafe_path_blocks_dot_segments(path):
         pytest.param(path_security._MAX_PERCENT_DECODE_PASSES + 1, id="over-limit"),
     ],
 )
-def test_has_unsafe_path_blocks_nested_dot_segments_at_decode_limit(decode_passes):
+def test_has_unsafe_path_blocks_nested_dot_segments_at_decode_limit(decode_passes: int):
     encoded = "%2e"
     for _ in range(decode_passes - 1):
         encoded = urllib.parse.quote(encoded, safe="")

--- a/crates/runner/mitm-addon/tests/test_path_security.py
+++ b/crates/runner/mitm-addon/tests/test_path_security.py
@@ -25,11 +25,26 @@ import path_security
         "/api/%252e%252e%253bmatrix=1/admin",
         "/api/%252e%252e%252fadmin",
         "/api/%252f..",
-        "/api/%25252525252e%25252525252e/admin",
     ],
 )
 def test_has_unsafe_path_blocks_dot_segments(path):
     assert path_security.has_unsafe_path(path) is True
+
+
+@pytest.mark.parametrize(
+    "decode_passes",
+    [
+        pytest.param(path_security._MAX_PERCENT_DECODE_PASSES - 1, id="below-limit"),
+        pytest.param(path_security._MAX_PERCENT_DECODE_PASSES, id="at-limit"),
+        pytest.param(path_security._MAX_PERCENT_DECODE_PASSES + 1, id="over-limit"),
+    ],
+)
+def test_has_unsafe_path_blocks_nested_dot_segments_at_decode_limit(decode_passes):
+    encoded = "%2e"
+    for _ in range(decode_passes - 1):
+        encoded = urllib.parse.quote(encoded, safe="")
+
+    assert path_security.has_unsafe_path(f"/api/{encoded}/admin") is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- replace the isolated over-limit dot-segment literal with a configured decode-boundary matrix
- cover unsafe materialization below, exactly at, and one pass beyond the nested decode limit
- preserve the existing safe-character-at-the-limit control

## Scope

This is a test-only change. It does not modify path validation behavior, expose new production APIs, change dependencies, or alter runtime compatibility.

## Testing

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_path_security.py` (78 passed)
- `uv run --no-sync python -m pytest tests/` (7223 passed)

Closes #30209
