### PR TITLE
fix(mitm-addon): accept zero-digit qvalue fractions

### DIFF
--- a/crates/runner/mitm-addon/src/response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/src/response_encoding_negotiation.py
@@ -14,7 +14,7 @@ _STREAM_DECODABLE_ENCODINGS = body_decoding.stream_decodable_content_encodings()
 _INVALID_Q_VALUE = Decimal(-1)
 _MIN_Q_VALUE = Decimal(0)
 _MAX_Q_VALUE = Decimal(1)
-_Q_VALUE_PATTERN = re.compile(r"(?:0(?:\.[0-9]{1,3})?|1(?:\.0{1,3})?)")
+_Q_VALUE_PATTERN = re.compile(r"(?:0(?:\.[0-9]{0,3})?|1(?:\.0{0,3})?)")
 _HTTP_OWS_CHARS = " \t"
 
 

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -51,6 +51,26 @@ _BROWSER_USER_AGENT = (
             id="drops-safe-q-zero",
         ),
         pytest.param(
+            [("Accept-Encoding", "gzip;q=1., zstd")],
+            ["gzip;q=1."],
+            id="accepts-q-one-zero-digit-fraction",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "gzip;q=0., gzip;q=1, zstd")],
+            ["identity"],
+            id="rejects-q-zero-zero-digit-fraction",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "gzip;q=0.5, identity;q=0., zstd")],
+            ["gzip;q=0.5, identity;q=0"],
+            id="preserves-identity-zero-digit-fraction-rejection",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "gzip, *;q=0., zstd")],
+            ["gzip, identity;q=0"],
+            id="preserves-wildcard-zero-digit-fraction-rejection",
+        ),
+        pytest.param(
             [("Accept-Encoding", "gzip, identity;q=0, zstd")],
             ["gzip, identity;q=0"],
             id="preserves-explicit-identity-rejection-with-safe-coding",


### PR DESCRIPTION
## Summary

- accept RFC-valid `q=0.` and `q=1.` values during request-side `Accept-Encoding` normalization
- preserve supported-coding rejection and explicit identity rejection for zero-digit fractions
- cover the boundary through the existing public normalizer test matrix

## Scope

This keeps the existing parser, numeric validation, invalid-value handling, and output formatting unchanged. It does not change APIs, persisted data, queue payloads, deployment protocols, or migrations.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_response_encoding_negotiation.py -q` (71 passed)
- `uv run --no-sync python -m pytest tests/` (7,225 passed)
- `lefthook run pre-commit`

Closes #30208
