### PR TITLE
test(vsock-guest): cover meminfo parsing with fixtures

### DIFF
--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -35,7 +35,7 @@ use crate::guest_storage_manifest::{
 };
 use crate::handlers::{MessageOutcome, handle_basic_message};
 use crate::log::log;
-use crate::memory_snapshot::read_memory_snapshot;
+use crate::memory_snapshot::MeminfoSource;
 use crate::process_containment::{ProcessContainmentMode, verify_exec_process_containment_empty};
 use crate::quiesce::{AcquireOperationError, OperationGuard, OperationState, QuiesceResult};
 use crate::writer::GuestWriter;
@@ -254,6 +254,7 @@ fn handle_memory_snapshot(
     seq: u32,
     payload: &[u8],
     operation_state: &OperationState,
+    meminfo_source: &MeminfoSource,
     writer: &GuestWriter,
 ) -> io::Result<()> {
     if !validate_empty_control_payload(
@@ -267,7 +268,7 @@ fn handle_memory_snapshot(
     if !operation_state.is_quiesced() {
         return send_error_response(seq, "guest operations are not fully quiesced", writer);
     }
-    match read_memory_snapshot() {
+    match meminfo_source.read_memory_snapshot() {
         Ok(snapshot) => {
             let payload = snapshot.encode_payload();
             let response = vsock_proto::encode(MSG_MEMORY_SNAPSHOT_RESULT, seq, &payload)
@@ -312,6 +313,7 @@ struct ConnectionDispatcher {
     exec_control_registry: ExecControlRegistry,
     operation_state: OperationState,
     guest_agent_program: GuestAgentProgram,
+    meminfo_source: MeminfoSource,
     process_containment_mode: ProcessContainmentMode,
     exec_drain_deadline: Duration,
 }
@@ -323,6 +325,17 @@ struct ConnectionPrograms {
     guest_storage_manifest: GuestStorageManifestProgram,
 }
 
+impl ConnectionPrograms {
+    fn production() -> Self {
+        Self {
+            guest_agent: GuestAgentProgram::production(),
+            guest_dns_readiness: GuestDnsReadinessProgram::production(),
+            guest_state_restore: GuestStateRestoreProgram::production(),
+            guest_storage_manifest: GuestStorageManifestProgram::production(),
+        }
+    }
+}
+
 impl ConnectionDispatcher {
     fn new(
         writer: GuestWriter,
@@ -330,6 +343,7 @@ impl ConnectionDispatcher {
         process_containment_mode: ProcessContainmentMode,
         exec_drain_deadline: Duration,
         programs: ConnectionPrograms,
+        meminfo_source: MeminfoSource,
     ) -> io::Result<Self> {
         let file_write_worker =
             FileWriteWorker::start(writer.clone(), Arc::clone(&connection_cancel))?;
@@ -362,6 +376,7 @@ impl ConnectionDispatcher {
             exec_control_registry: ExecControlRegistry::default(),
             operation_state: OperationState::default(),
             guest_agent_program: programs.guest_agent,
+            meminfo_source,
             process_containment_mode,
             exec_drain_deadline,
         })
@@ -711,7 +726,13 @@ impl ConnectionDispatcher {
     }
 
     fn handle_memory_snapshot(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
-        handle_memory_snapshot(msg.seq, msg.payload, &self.operation_state, &self.writer)
+        handle_memory_snapshot(
+            msg.seq,
+            msg.payload,
+            &self.operation_state,
+            &self.meminfo_source,
+            &self.writer,
+        )
     }
 
     fn handle_basic_message(&self, msg: BorrowedRawMessage<'_>) -> io::Result<DispatchOutcome> {
@@ -816,6 +837,21 @@ pub fn handle_connection_with_test_process_containment_and_exec_drain_deadline(
     )
 }
 
+/// Handles a host-side test connection with an explicit meminfo source file.
+#[doc(hidden)]
+pub fn handle_connection_with_test_memory_snapshot_path(
+    stream: UnixStream,
+    path: std::path::PathBuf,
+) -> io::Result<()> {
+    handle_connection_with_mode_and_program(
+        stream,
+        ProcessContainmentMode::TestNoop,
+        EXEC_OUTPUT_DRAIN_DEADLINE,
+        ConnectionPrograms::production(),
+        MeminfoSource::for_test(path),
+    )
+}
+
 /// Handles a host-side test connection with a test DNS readiness executable.
 ///
 /// This remains available without `test-support` so integration tests can
@@ -829,10 +865,11 @@ pub fn handle_connection_with_test_dns_readiness_program(
         stream,
         ProcessContainmentMode::TestNoop,
         EXEC_OUTPUT_DRAIN_DEADLINE,
-        GuestAgentProgram::production(),
-        GuestDnsReadinessProgram::for_test(program),
-        GuestStateRestoreProgram::production(),
-        GuestStorageManifestProgram::production(),
+        ConnectionPrograms {
+            guest_dns_readiness: GuestDnsReadinessProgram::for_test(program),
+            ..ConnectionPrograms::production()
+        },
+        MeminfoSource::production(),
     )
 }
 
@@ -846,10 +883,11 @@ pub fn handle_connection_with_test_storage_manifest_program(
         stream,
         ProcessContainmentMode::TestNoop,
         EXEC_OUTPUT_DRAIN_DEADLINE,
-        GuestAgentProgram::production(),
-        GuestDnsReadinessProgram::production(),
-        GuestStateRestoreProgram::production(),
-        GuestStorageManifestProgram::for_test(program),
+        ConnectionPrograms {
+            guest_storage_manifest: GuestStorageManifestProgram::for_test(program),
+            ..ConnectionPrograms::production()
+        },
+        MeminfoSource::production(),
     )
 }
 
@@ -863,10 +901,11 @@ pub fn handle_connection_with_test_guest_state_restore_program(
         stream,
         ProcessContainmentMode::TestNoop,
         EXEC_OUTPUT_DRAIN_DEADLINE,
-        GuestAgentProgram::production(),
-        GuestDnsReadinessProgram::production(),
-        GuestStateRestoreProgram::for_test(program),
-        GuestStorageManifestProgram::production(),
+        ConnectionPrograms {
+            guest_state_restore: GuestStateRestoreProgram::for_test(program),
+            ..ConnectionPrograms::production()
+        },
+        MeminfoSource::production(),
     )
 }
 
@@ -880,10 +919,11 @@ pub fn handle_connection_with_test_guest_agent_program(
         stream,
         ProcessContainmentMode::TestNoop,
         EXEC_OUTPUT_DRAIN_DEADLINE,
-        GuestAgentProgram::for_test(program),
-        GuestDnsReadinessProgram::production(),
-        GuestStateRestoreProgram::production(),
-        GuestStorageManifestProgram::production(),
+        ConnectionPrograms {
+            guest_agent: GuestAgentProgram::for_test(program),
+            ..ConnectionPrograms::production()
+        },
+        MeminfoSource::production(),
     )
 }
 
@@ -907,10 +947,8 @@ fn handle_connection_with_mode_and_exec_drain_deadline(
         stream,
         process_containment_mode,
         exec_drain_deadline,
-        GuestAgentProgram::production(),
-        GuestDnsReadinessProgram::production(),
-        GuestStateRestoreProgram::production(),
-        GuestStorageManifestProgram::production(),
+        ConnectionPrograms::production(),
+        MeminfoSource::production(),
     )
 }
 
@@ -918,19 +956,15 @@ fn handle_connection_with_mode_and_program(
     stream: UnixStream,
     process_containment_mode: ProcessContainmentMode,
     exec_drain_deadline: Duration,
-    guest_agent_program: GuestAgentProgram,
-    guest_dns_readiness_program: GuestDnsReadinessProgram,
-    guest_state_restore_program: GuestStateRestoreProgram,
-    guest_storage_manifest_program: GuestStorageManifestProgram,
+    programs: ConnectionPrograms,
+    meminfo_source: MeminfoSource,
 ) -> io::Result<()> {
     match handle_connection_with_outcome(
         stream,
         process_containment_mode,
         exec_drain_deadline,
-        guest_agent_program,
-        guest_dns_readiness_program,
-        guest_state_restore_program,
-        guest_storage_manifest_program,
+        programs,
+        meminfo_source,
     ) {
         Ok(_) => Ok(()),
         Err(failure) => Err(failure.error),
@@ -941,10 +975,8 @@ fn handle_connection_with_outcome(
     stream: UnixStream,
     process_containment_mode: ProcessContainmentMode,
     exec_drain_deadline: Duration,
-    guest_agent_program: GuestAgentProgram,
-    guest_dns_readiness_program: GuestDnsReadinessProgram,
-    guest_state_restore_program: GuestStateRestoreProgram,
-    guest_storage_manifest_program: GuestStorageManifestProgram,
+    programs: ConnectionPrograms,
+    meminfo_source: MeminfoSource,
 ) -> Result<ConnectionEnd, ConnectionFailure> {
     // Clone the stream to get separate reader and writer
     // This avoids deadlock: reader can block while worker threads write results.
@@ -972,12 +1004,8 @@ fn handle_connection_with_outcome(
         connection_cancel.clone(),
         process_containment_mode,
         exec_drain_deadline,
-        ConnectionPrograms {
-            guest_agent: guest_agent_program,
-            guest_dns_readiness: guest_dns_readiness_program,
-            guest_state_restore: guest_state_restore_program,
-            guest_storage_manifest: guest_storage_manifest_program,
-        },
+        programs,
+        meminfo_source,
     )
     .map_err(|error| session.failure(error))?;
     let mut buf = [0u8; READ_BUFFER_SIZE];
@@ -1125,10 +1153,8 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
                         stream,
                         process_containment_mode,
                         EXEC_OUTPUT_DRAIN_DEADLINE,
-                        GuestAgentProgram::production(),
-                        GuestDnsReadinessProgram::production(),
-                        GuestStateRestoreProgram::production(),
-                        GuestStorageManifestProgram::production(),
+                        ConnectionPrograms::production(),
+                        MeminfoSource::production(),
                     )
                 })
         } else {
@@ -1141,10 +1167,8 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
                         stream,
                         process_containment_mode,
                         EXEC_OUTPUT_DRAIN_DEADLINE,
-                        GuestAgentProgram::production(),
-                        GuestDnsReadinessProgram::production(),
-                        GuestStateRestoreProgram::production(),
-                        GuestStorageManifestProgram::production(),
+                        ConnectionPrograms::production(),
+                        MeminfoSource::production(),
                     )
                 })
         };

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -35,6 +35,7 @@ mod writer;
 pub use connection::handle_connection_with_test_dns_readiness_program;
 pub use connection::handle_connection_with_test_guest_agent_program;
 pub use connection::handle_connection_with_test_guest_state_restore_program;
+pub use connection::handle_connection_with_test_memory_snapshot_path;
 pub use connection::handle_connection_with_test_storage_manifest_program;
 pub use connection::{
     connect_unix, connect_vsock, handle_connection,

--- a/crates/vsock-guest/src/memory_snapshot.rs
+++ b/crates/vsock-guest/src/memory_snapshot.rs
@@ -1,9 +1,37 @@
 use std::io;
+use std::path::{Path, PathBuf};
 
 use vsock_proto::MemorySnapshot;
 
 const MEMINFO_PATH: &str = "/proc/meminfo";
 const KIB: u64 = 1024;
+
+pub(crate) enum MeminfoSource {
+    Production,
+    Test(PathBuf),
+}
+
+impl MeminfoSource {
+    pub(crate) fn production() -> Self {
+        Self::Production
+    }
+
+    pub(crate) fn for_test(path: PathBuf) -> Self {
+        Self::Test(path)
+    }
+
+    pub(crate) fn read_memory_snapshot(&self) -> io::Result<MemorySnapshot> {
+        let meminfo = std::fs::read_to_string(self.path())?;
+        parse_memory_snapshot(&meminfo)
+    }
+
+    fn path(&self) -> &Path {
+        match self {
+            Self::Production => Path::new(MEMINFO_PATH),
+            Self::Test(path) => path,
+        }
+    }
+}
 
 #[derive(Default)]
 struct MemorySnapshotFields {
@@ -25,11 +53,6 @@ struct MemorySnapshotFields {
     page_tables_bytes: Option<u64>,
     swap_total_bytes: Option<u64>,
     swap_free_bytes: Option<u64>,
-}
-
-pub(crate) fn read_memory_snapshot() -> io::Result<MemorySnapshot> {
-    let meminfo = std::fs::read_to_string(MEMINFO_PATH)?;
-    parse_memory_snapshot(&meminfo)
 }
 
 fn parse_memory_snapshot(meminfo: &str) -> io::Result<MemorySnapshot> {

--- a/crates/vsock-guest/tests/connection/quiesce.rs
+++ b/crates/vsock-guest/tests/connection/quiesce.rs
@@ -1,13 +1,66 @@
-use std::io::Write;
+use std::io::{Read, Write};
 
 use vsock_proto::{
     self, ExecOutputPolicy, ExecTermination, MSG_EXEC_START, MSG_MEMORY_SNAPSHOT,
     MSG_MEMORY_SNAPSHOT_RESULT, MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED,
     MSG_QUIESCE_OPERATIONS, MSG_RESUME_OPERATIONS, MSG_WRITE_FILE, MSG_WRITE_FILES,
-    MSG_WRITE_PRIVATE_FILES, WriteFileBatchEntry,
+    MSG_WRITE_PRIVATE_FILES, MemorySnapshot, WriteFileBatchEntry,
 };
 
 use super::support::*;
+
+const KIB: u64 = 1024;
+const VALID_MEMINFO: &str = concat!(
+    "MemTotal: 18000 kB\n",
+    "MemFree: 1701 kB\n",
+    "MemAvailable: 16002 kB\n",
+    "Buffers: 103 kB\n",
+    "Cached: 204 kB\n",
+    "AnonPages: 305 kB\n",
+    "Mapped: 406 kB\n",
+    "Dirty: 507 kB\n",
+    "Writeback: 608 kB\n",
+    "Shmem: 709 kB\n",
+    "Slab: 810 kB\n",
+    "SReclaimable: 411 kB\n",
+    "SUnreclaim: 399 kB\n",
+    "Unevictable: 914 kB\n",
+    "KernelStack: 1015 kB\n",
+    "PageTables: 1116 kB\n",
+    "SwapTotal: 1217 kB\n",
+    "SwapFree: 1118 kB\n",
+);
+
+fn expected_memory_snapshot() -> MemorySnapshot {
+    MemorySnapshot {
+        mem_total_bytes: 18_000 * KIB,
+        mem_free_bytes: 1_701 * KIB,
+        mem_available_bytes: 16_002 * KIB,
+        buffers_bytes: 103 * KIB,
+        cached_bytes: 204 * KIB,
+        anon_pages_bytes: 305 * KIB,
+        mapped_bytes: 406 * KIB,
+        dirty_bytes: 507 * KIB,
+        writeback_bytes: 608 * KIB,
+        shmem_bytes: 709 * KIB,
+        slab_bytes: 810 * KIB,
+        slab_reclaimable_bytes: 411 * KIB,
+        slab_unreclaimable_bytes: 399 * KIB,
+        unevictable_bytes: 914 * KIB,
+        kernel_stack_bytes: 1_015 * KIB,
+        page_tables_bytes: 1_116 * KIB,
+        swap_total_bytes: 1_217 * KIB,
+        swap_free_bytes: 1_118 * KIB,
+    }
+}
+
+fn request_memory_snapshot(stream: &mut (impl Read + Write), seq: u32) -> MemorySnapshot {
+    send_control_payload(stream, MSG_MEMORY_SNAPSHOT, seq, &[]);
+    let response = read_message(stream);
+    assert_eq!(response.msg_type, MSG_MEMORY_SNAPSHOT_RESULT);
+    assert_eq!(response.seq, seq);
+    vsock_proto::decode_memory_snapshot(&response.payload).unwrap()
+}
 
 fn assert_error_contains(stream: &mut impl std::io::Read, seq: u32, expected_fragment: &str) {
     let error = read_error_response(stream, seq);
@@ -121,6 +174,71 @@ fn memory_snapshot_requires_fully_quiesced_connection() {
     assert!(snapshot.swap_free_bytes <= snapshot.swap_total_bytes);
 
     finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn controlled_memory_snapshot_maps_all_meminfo_fields() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("meminfo");
+    std::fs::write(&path, VALID_MEMINFO).unwrap();
+    let (handle, mut host_stream) = start_guest_connection_with_memory_snapshot_path(path);
+
+    send_quiesce_operations(&mut host_stream, 301);
+    let quiesced = read_message(&mut host_stream);
+    assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
+
+    let snapshot = request_memory_snapshot(&mut host_stream, 302);
+    assert_eq!(snapshot, expected_memory_snapshot());
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn controlled_memory_snapshot_reports_parse_errors_and_recovers() {
+    let overflow_kib = u64::MAX / KIB + 1;
+    let cases = [
+        (
+            "missing-field",
+            VALID_MEMINFO.replacen("SwapFree: 1118 kB\n", "", 1),
+            "SwapFree is missing",
+        ),
+        (
+            "invalid-number",
+            VALID_MEMINFO.replacen("MemFree: 1701 kB", "MemFree: invalid kB", 1),
+            "MemFree has an invalid value",
+        ),
+        (
+            "extra-unit-token",
+            VALID_MEMINFO.replacen("MemAvailable: 16002 kB", "MemAvailable: 16002 kB extra", 1),
+            "MemAvailable has an invalid unit",
+        ),
+        (
+            "overflow",
+            VALID_MEMINFO.replacen("Buffers: 103 kB", &format!("Buffers: {overflow_kib} kB"), 1),
+            "Buffers byte value overflowed",
+        ),
+    ];
+
+    for (case, invalid_meminfo, expected_error) in cases {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join(format!("{case}.meminfo"));
+        std::fs::write(&path, invalid_meminfo).unwrap();
+        let (handle, mut host_stream) =
+            start_guest_connection_with_memory_snapshot_path(path.clone());
+
+        send_quiesce_operations(&mut host_stream, 303);
+        let quiesced = read_message(&mut host_stream);
+        assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
+
+        send_control_payload(&mut host_stream, MSG_MEMORY_SNAPSHOT, 304, &[]);
+        assert_error_contains(&mut host_stream, 304, expected_error);
+
+        std::fs::write(&path, VALID_MEMINFO).unwrap();
+        let snapshot = request_memory_snapshot(&mut host_stream, 305);
+        assert_eq!(snapshot, expected_memory_snapshot());
+
+        finish_guest_connection(handle, host_stream);
+    }
 }
 
 #[test]

--- a/crates/vsock-guest/tests/connection/support/connection.rs
+++ b/crates/vsock-guest/tests/connection/support/connection.rs
@@ -10,6 +10,7 @@ use vsock_guest::{
     handle_connection_with_test_dns_readiness_program,
     handle_connection_with_test_guest_agent_program,
     handle_connection_with_test_guest_state_restore_program,
+    handle_connection_with_test_memory_snapshot_path,
     handle_connection_with_test_process_containment,
     handle_connection_with_test_process_containment_and_exec_drain_deadline,
     handle_connection_with_test_storage_manifest_program,
@@ -40,6 +41,14 @@ pub(crate) fn start_guest_connection_with_exec_drain_deadline(
             stream,
             exec_drain_deadline,
         )
+    })
+}
+
+pub(crate) fn start_guest_connection_with_memory_snapshot_path(
+    path: std::path::PathBuf,
+) -> (GuestConnectionHandle, UnixStream) {
+    start_guest_connection_with_handler(move |stream| {
+        handle_connection_with_test_memory_snapshot_path(stream, path)
     })
 }
 

--- a/crates/vsock-guest/tests/connection/support/mod.rs
+++ b/crates/vsock-guest/tests/connection/support/mod.rs
@@ -11,6 +11,7 @@ pub(crate) use connection::{
     start_guest_connection_with_exec_drain_deadline,
     start_guest_connection_with_guest_agent_program,
     start_guest_connection_with_guest_state_restore_program,
+    start_guest_connection_with_memory_snapshot_path,
     start_guest_connection_with_storage_manifest_program, wait_for_guest_connection,
 };
 pub(crate) use exec::{


### PR DESCRIPTION
## Summary

- make the guest memory-snapshot source connection-owned while keeping `/proc/meminfo` as the production source
- add controlled connection coverage for all 18 meminfo field mappings and KiB-to-byte conversion
- cover missing, invalid numeric, invalid unit, and overflow diagnostics, then prove the same quiesced connection recovers with valid input

## Scope

- retains the existing live `/proc/meminfo` integration coverage
- does not change protocol messages, payloads, production source selection, or deployment compatibility

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p vsock-guest --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p vsock-guest --no-deps --all-features`
- `cargo test -p vsock-guest --all-features`
- repository pre-commit and commit-message hooks

Closes #30202
