### PR TITLE
refactor: clear app and connector lint warnings

### DIFF
--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -16,7 +16,7 @@
     "lint:build-config": "node --test scripts/check-production-minification.node.mjs && tsx --test scripts/check-single-bundle.node.ts",
     "lint:localized-ui": "node --test scripts/check-localized-ui.node.mjs && node scripts/check-localized-ui.mjs",
     "lint:static-assets": "node scripts/check-static-assets.mjs",
-    "lint": "pnpm lint:static-assets && pnpm lint:emoji-data && pnpm lint:localized-ui && pnpm lint:build-config && pnpm i18n:check && oxlint && oxlint --type-aware -c ../../.oxlintrc.typeaware.json && eslint . --max-warnings 0",
+    "lint": "pnpm lint:static-assets && pnpm lint:emoji-data && pnpm lint:localized-ui && pnpm lint:build-config && pnpm i18n:check && oxlint --deny-warnings && oxlint --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings && eslint . --max-warnings 0",
     "check-types": "tsc -p tsconfig.production.json --noEmit && tsc -p tsconfig.tests.json --noEmit"
   },
   "dependencies": {

--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -1,7 +1,9 @@
 import type {
   Attribute,
   AttributeData,
+  BrowserClerk,
   ClerkAPIError,
+  CreateOrganizationParams,
   PasswordValidation,
 } from "@clerk/react/types";
 import { vi } from "vitest";
@@ -1056,6 +1058,10 @@ interface MockedUserProfileOptions {
   getContainer?: () => HTMLElement | null;
 }
 
+type MockedCreateOrganization = (
+  params: CreateOrganizationParams,
+) => Promise<{ readonly id: string }>;
+
 export const mockedClerk = {
   initialize,
   get loaded() {
@@ -1188,12 +1194,10 @@ export const mockedClerk = {
     };
   },
   handleRedirectCallback,
-  signOut: vi.fn(() => {
+  signOut: vi.fn<BrowserClerk["signOut"]>(() => {
     return Promise.resolve();
   }),
-  openSignIn: vi.fn(() => {
-    return Promise.resolve();
-  }),
+  openSignIn: vi.fn<BrowserClerk["openSignIn"]>(),
   openUserProfile: vi.fn<(options?: MockedUserProfileOptions) => void>(),
   closeUserProfile: vi.fn<() => void>(),
   load: mockedClerkLoad,
@@ -1210,18 +1214,20 @@ export const mockedClerk = {
       }
     };
   },
-  redirectToSignIn: vi.fn(),
+  redirectToSignIn: vi.fn<BrowserClerk["redirectToSignIn"]>(),
   buildSignInUrl: vi.fn<typeof defaultBuildSignInUrlImpl>(
     defaultBuildSignInUrlImpl,
   ),
   // Production-instance behavior: the URL passes through unchanged. Dev
   // instances append the __clerk_db_jwt session handoff parameter.
-  buildUrlWithAuth: vi.fn(defaultBuildUrlWithAuthImpl),
+  buildUrlWithAuth: vi.fn<typeof defaultBuildUrlWithAuthImpl>(
+    defaultBuildUrlWithAuthImpl,
+  ),
   buildUserProfileUrl: vi.fn<typeof defaultBuildUserProfileUrlImpl>(
     defaultBuildUserProfileUrlImpl,
   ),
   setActive: vi.fn<typeof defaultSetActiveImpl>(defaultSetActiveImpl),
-  createOrganization: vi.fn((_params: { name: string; slug: string }) => {
+  createOrganization: vi.fn<MockedCreateOrganization>(() => {
     return Promise.resolve({ id: "new-org-id" });
   }),
 };

--- a/turbo/apps/platform/src/__tests__/platform-runtime-environment.test.ts
+++ b/turbo/apps/platform/src/__tests__/platform-runtime-environment.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BrowserOptions } from "@sentry/browser";
-import type { PostHogConfig } from "posthog-js/dist/module.slim";
+import type { PostHog, PostHogConfig } from "posthog-js/dist/module.slim";
 import { isOkouProductionHostname } from "../lib/platform-host.ts";
 import { sentryLogContext } from "../lib/sentry-config.ts";
 import { initSharedDatabaseWorkerSentry } from "../shared-database/worker-sentry.ts";
@@ -25,8 +25,10 @@ const {
   sentryInit,
 } = vi.hoisted(() => {
   return {
-    browserSentryCaptureException: vi.fn(),
-    browserSentryCaptureMessage: vi.fn(),
+    browserSentryCaptureException:
+      vi.fn<typeof import("@sentry/browser").captureException>(),
+    browserSentryCaptureMessage:
+      vi.fn<typeof import("@sentry/browser").captureMessage>(),
     browserSentryInit: vi.fn<(options: BrowserOptions) => void>(),
     posthogInit:
       vi.fn<(key: string, config?: Partial<PostHogConfig>) => void>(),
@@ -37,10 +39,10 @@ const {
 vi.mock("posthog-js/dist/module.slim", () => {
   return {
     posthog: {
-      capture: vi.fn(),
-      identify: vi.fn(),
+      capture: vi.fn<PostHog["capture"]>(),
+      identify: vi.fn<PostHog["identify"]>(),
       init: posthogInit,
-      reset: vi.fn(),
+      reset: vi.fn<PostHog["reset"]>(),
     },
   };
 });
@@ -48,7 +50,7 @@ vi.mock("posthog-js/dist/module.slim", () => {
 vi.mock("@sentry/react", () => {
   return {
     init: sentryInit,
-    setUser: vi.fn(),
+    setUser: vi.fn<typeof import("@sentry/react").setUser>(),
   };
 });
 

--- a/turbo/apps/platform/src/lib/__tests__/preview-bypass-cookie.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/preview-bypass-cookie.test.ts
@@ -32,7 +32,7 @@ describe("preview bypass cookie", () => {
   });
 
   it("writes the cookie when the bypass query is present", () => {
-    const setCookie = vi.fn();
+    const setCookie = vi.fn<(cookie: string) => void>();
 
     expect(
       writePreviewBypassCookie(

--- a/turbo/apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, type Mock } from "vitest";
 import { animationFrame, timeout } from "signal-timers";
 
 import { testContext } from "../../signals/__tests__/test-helpers.ts";
@@ -59,7 +59,7 @@ function focusTextEntry(): HTMLTextAreaElement {
 
 function focusComposer(inExistingThread: boolean): {
   editor: HTMLDivElement;
-  scrollIntoView: ReturnType<typeof vi.fn>;
+  scrollIntoView: Mock<HTMLElement["scrollIntoView"]>;
 } {
   const container = document.createElement(
     inExistingThread ? "footer" : "section",
@@ -70,7 +70,7 @@ function focusComposer(inExistingThread: boolean): {
 
   const composer = document.createElement("div");
   composer.className = "zero-composer";
-  const scrollIntoView = vi.fn();
+  const scrollIntoView = vi.fn<HTMLElement["scrollIntoView"]>();
   Object.defineProperty(composer, "scrollIntoView", {
     configurable: true,
     value: scrollIntoView,

--- a/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
+++ b/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
@@ -552,11 +552,11 @@ function mockMatchMedia(matches: boolean | ((query: string) => boolean)): void {
       matches: typeof matches === "function" ? matches(query) : matches,
       media: query,
       onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
+      addListener: vi.fn<MediaQueryList["addListener"]>(),
+      removeListener: vi.fn<MediaQueryList["removeListener"]>(),
+      addEventListener: vi.fn<MediaQueryList["addEventListener"]>(),
+      removeEventListener: vi.fn<MediaQueryList["removeEventListener"]>(),
+      dispatchEvent: vi.fn<MediaQueryList["dispatchEvent"]>(),
     };
     return mediaQueryList;
   });

--- a/turbo/apps/platform/src/signals/okou-page/settings/workspace-settings-state.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/workspace-settings-state.ts
@@ -625,14 +625,12 @@ export const confirmInvitePurchase$ = command(
     const result = await accept(
       client.confirmPurchase({
         params: { purchaseId: preview.payment.purchaseId },
-        body: {
-          ...(preview.payment.paymentMethodPreviewToken
-            ? {
-                paymentMethodPreviewToken:
-                  preview.payment.paymentMethodPreviewToken,
-              }
-            : {}),
-        },
+        body: preview.payment.paymentMethodPreviewToken
+          ? {
+              paymentMethodPreviewToken:
+                preview.payment.paymentMethodPreviewToken,
+            }
+          : {},
         fetchOptions: { signal },
       }),
       [200],

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -228,6 +228,124 @@ async function submitIdentifier(
   });
 }
 
+function mockExpiredVerificationAttempt(): void {
+  mockedClerk.signInPrepareFirstFactor.mockResolvedValue(
+    currentSignInResource(),
+  );
+  mockedClerk.signInAttemptFirstFactor.mockRejectedValue({
+    errors: [
+      {
+        code: "verification_expired",
+        longMessage: "Sensitive provider detail must not be rendered.",
+      },
+    ],
+  });
+}
+
+async function openVerificationCodeStep(
+  method: string,
+  title: string,
+): Promise<HTMLElement> {
+  fireEvent.click(await waitForRoleElement("button", method));
+
+  const codeInput = await screen.findByLabelText("Verification code");
+  expect(screen.getByRole("heading", { level: 1, name: title })).toBeVisible();
+  expect(screen.getAllByRole("heading")).toHaveLength(1);
+  expect(roleElement("button", "Back")).toBeUndefined();
+  return codeInput;
+}
+
+async function recoverExpiredCodeWithOneResend(
+  codeInput: HTMLElement,
+): Promise<void> {
+  fireEvent.change(codeInput, { target: { value: "123456" } });
+  fireEvent.submit(containingForm(codeInput));
+
+  const alert = await screen.findByRole("alert");
+  expect(alert).toHaveTextContent(
+    "This verification code has expired. Request a new code.",
+  );
+  expect(document.activeElement).toBe(alert);
+  expectFieldErrorAssociation(codeInput, alert);
+  expect(
+    screen.queryByText("Sensitive provider detail must not be rendered."),
+  ).toBeNull();
+
+  fireEvent.change(codeInput, { target: { value: "654321" } });
+  await waitFor(() => {
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+  expect(codeInput).toHaveValue("654321");
+  expectNoFieldErrorAssociation(codeInput);
+
+  fireEvent.submit(containingForm(codeInput));
+  const retryAlert = await screen.findByRole("alert");
+  expect(document.activeElement).toBe(retryAlert);
+  expectFieldErrorAssociation(codeInput, retryAlert);
+
+  const resend = await waitForRoleElement(
+    "button",
+    "Didn't receive a code? Resend",
+  );
+  expect(resend).toBeEnabled();
+  fireEvent.click(resend);
+  fireEvent.click(resend);
+
+  await waitFor(() => {
+    expect(mockedClerk.signInPrepareFirstFactor).toHaveBeenCalledTimes(2);
+  });
+  await waitFor(() => {
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expectNoFieldErrorAssociation(codeInput);
+  });
+  expect(codeInput).toHaveValue("");
+}
+
+interface RestoredPreparedStepOptions {
+  readonly cooldownIdentity: string;
+  readonly factor: MockedSignInFactor;
+  readonly strategy: "email_code" | "reset_password_email_code";
+}
+
+async function setupRestoredPreparedStep(
+  options: RestoredPreparedStepOptions,
+): Promise<void> {
+  const startedAt = Date.parse("2026-08-25T08:00:00.000Z");
+  mockNow(startedAt + 1000, context.signal);
+  context.store.set(
+    signInResendCooldownStorage.set$,
+    JSON.stringify({
+      deadlineMs: startedAt + 30_000,
+      identity: options.cooldownIdentity,
+    }),
+  );
+  mockPreparedFirstFactor(options.strategy);
+  setupSignInPage({
+    identifier: "person@example.com",
+    status: "needs_first_factor",
+    supportedFirstFactors: [options.factor, passwordFactor()],
+  });
+
+  await expect(
+    screen.findByLabelText("Verification code"),
+  ).resolves.toBeVisible();
+  await expect(
+    waitForRoleElement("button", "Didn't receive a code? Resend (29)"),
+  ).resolves.toBeDisabled();
+  expect(mockedClerk.signInPrepareFirstFactor).not.toHaveBeenCalled();
+
+  fireEvent.click(screen.getByLabelText("Toggle theme"));
+  expect(mockedClerk.signInPrepareFirstFactor).not.toHaveBeenCalled();
+}
+
+async function editRestoredIdentifier(): Promise<void> {
+  fireEvent.click(await waitForRoleElement("button", "Edit identifier"));
+  await expect(screen.findByLabelText("Email address")).resolves.toHaveValue(
+    "person@example.com",
+  );
+  expect(mockedClerk.signInPrepareFirstFactor).not.toHaveBeenCalled();
+}
+
 describe("auth v2 sign-in flow", () => {
   it("shows the loading state until the low-level Clerk resource is ready", async () => {
     const clerkLoad = createDeferredPromise<void>(context.signal);
@@ -1548,170 +1666,77 @@ describe("auth v2 sign-in flow", () => {
     });
   });
 
-  it.each([
-    {
-      factors: [emailCodeFactor()],
-      method: "Email code to p***@example.com",
-      name: "email verification",
-      recovery: false,
-      title: "Check your email",
-    },
-    {
-      factors: [passwordFactor(), passwordResetFactor()],
-      method: "Reset your password",
-      name: "password reset",
-      recovery: true,
-      title: "Reset password",
-    },
-  ])("recovers an expired $name code with one resend", async (testCase) => {
-    mockedClerk.signInPrepareFirstFactor.mockResolvedValue(
-      currentSignInResource(),
-    );
-    mockedClerk.signInAttemptFirstFactor.mockRejectedValue({
-      errors: [
-        {
-          code: "verification_expired",
-          longMessage: "Sensitive provider detail must not be rendered.",
-        },
-      ],
-    });
-
+  it("recovers an expired email verification code with one resend", async () => {
+    mockExpiredVerificationAttempt();
     setupSignInPage({ status: "needs_identifier" });
-    await submitIdentifier("person@example.com", testCase.factors);
-    if (testCase.recovery) {
-      fireEvent.click(await waitForRoleElement("button", "Forgot password?"));
-      await expect(
-        screen.findByRole("heading", { name: "Forgot Password?" }),
-      ).resolves.toBeVisible();
-      expect(mockedClerk.signInPrepareFirstFactor).not.toHaveBeenCalled();
-    }
-    fireEvent.click(await waitForRoleElement("button", testCase.method));
+    await submitIdentifier("person@example.com", [emailCodeFactor()]);
 
-    const codeInput = await screen.findByLabelText("Verification code");
-    expect(
-      screen.getByRole("heading", { level: 1, name: testCase.title }),
-    ).toBeVisible();
-    expect(screen.getAllByRole("heading")).toHaveLength(1);
-    if (testCase.recovery) {
-      expect(roleElement("button", "Back")).toBeUndefined();
-      expect(roleElement("button", "Use another method")).toBeUndefined();
-    } else {
-      await expect(
-        waitForRoleElement("button", "Use another method"),
-      ).resolves.toBeVisible();
-      expect(roleElement("button", "Back")).toBeUndefined();
-    }
-    fireEvent.change(codeInput, { target: { value: "123456" } });
-    fireEvent.submit(containingForm(codeInput));
-
-    const alert = await screen.findByRole("alert");
-    expect(alert).toHaveTextContent(
-      "This verification code has expired. Request a new code.",
+    const codeInput = await openVerificationCodeStep(
+      "Email code to p***@example.com",
+      "Check your email",
     );
-    expect(document.activeElement).toBe(alert);
-    expectFieldErrorAssociation(codeInput, alert);
-    expect(
-      screen.queryByText("Sensitive provider detail must not be rendered."),
-    ).toBeNull();
+    await expect(
+      waitForRoleElement("button", "Use another method"),
+    ).resolves.toBeVisible();
 
-    fireEvent.change(codeInput, { target: { value: "654321" } });
-    await waitFor(() => {
-      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-    });
-    expect(codeInput).toHaveValue("654321");
-    expectNoFieldErrorAssociation(codeInput);
-
-    fireEvent.submit(containingForm(codeInput));
-    const retryAlert = await screen.findByRole("alert");
-    expect(document.activeElement).toBe(retryAlert);
-    expectFieldErrorAssociation(codeInput, retryAlert);
-
-    const resend = await waitForRoleElement(
-      "button",
-      "Didn't receive a code? Resend",
-    );
-    expect(resend).toBeEnabled();
-    fireEvent.click(resend);
-    fireEvent.click(resend);
-
-    await waitFor(() => {
-      expect(mockedClerk.signInPrepareFirstFactor).toHaveBeenCalledTimes(2);
-    });
-    await waitFor(() => {
-      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-      expectNoFieldErrorAssociation(codeInput);
-    });
-    expect(codeInput).toHaveValue("");
+    await recoverExpiredCodeWithOneResend(codeInput);
   });
 
-  it.each([
-    {
+  it("recovers an expired password reset code with one resend", async () => {
+    mockExpiredVerificationAttempt();
+    setupSignInPage({ status: "needs_identifier" });
+    await submitIdentifier("person@example.com", [
+      passwordFactor(),
+      passwordResetFactor(),
+    ]);
+
+    fireEvent.click(await waitForRoleElement("button", "Forgot password?"));
+    await expect(
+      screen.findByRole("heading", { name: "Forgot Password?" }),
+    ).resolves.toBeVisible();
+    expect(mockedClerk.signInPrepareFirstFactor).not.toHaveBeenCalled();
+
+    const codeInput = await openVerificationCodeStep(
+      "Reset your password",
+      "Reset password",
+    );
+    expect(roleElement("button", "Use another method")).toBeUndefined();
+
+    await recoverExpiredCodeWithOneResend(codeInput);
+  });
+
+  it("restores a prepared email-code step and its editable identifier without another initial dispatch", async () => {
+    await setupRestoredPreparedStep({
       cooldownIdentity: "email-code:email_primary",
       factor: emailCodeFactor(),
-      name: "email-code",
-      showsMethodChooser: true,
-      strategy: "email_code" as const,
-    },
-    {
+      strategy: "email_code",
+    });
+
+    fireEvent.click(await waitForRoleElement("button", "Use another method"));
+    await expect(
+      screen.findByRole("heading", { name: "Use another method" }),
+    ).resolves.toBeVisible();
+    fireEvent.click(await waitForRoleElement("button", "Back"));
+    await expect(
+      screen.findByLabelText("Verification code"),
+    ).resolves.toBeVisible();
+    expect(mockedClerk.signInPrepareFirstFactor).not.toHaveBeenCalled();
+
+    await editRestoredIdentifier();
+  });
+
+  it("restores a prepared password-reset-code step and its editable identifier without another initial dispatch", async () => {
+    await setupRestoredPreparedStep({
       cooldownIdentity: "password-reset:email_primary",
       factor: passwordResetFactor(),
-      name: "password-reset-code",
-      showsMethodChooser: false,
-      strategy: "reset_password_email_code" as const,
-    },
-  ])(
-    "restores a prepared $name step and its editable identifier without another initial dispatch",
-    async (testCase) => {
-      const startedAt = Date.parse("2026-08-25T08:00:00.000Z");
-      mockNow(startedAt + 1000, context.signal);
-      context.store.set(
-        signInResendCooldownStorage.set$,
-        JSON.stringify({
-          deadlineMs: startedAt + 30_000,
-          identity: testCase.cooldownIdentity,
-        }),
-      );
-      mockPreparedFirstFactor(testCase.strategy);
-      setupSignInPage({
-        identifier: "person@example.com",
-        status: "needs_first_factor",
-        supportedFirstFactors: [testCase.factor, passwordFactor()],
-      });
+      strategy: "reset_password_email_code",
+    });
 
-      await expect(
-        screen.findByLabelText("Verification code"),
-      ).resolves.toBeVisible();
-      await expect(
-        waitForRoleElement("button", "Didn't receive a code? Resend (29)"),
-      ).resolves.toBeDisabled();
-      expect(mockedClerk.signInPrepareFirstFactor).not.toHaveBeenCalled();
+    expect(roleElement("button", "Back")).toBeUndefined();
+    expect(roleElement("button", "Use another method")).toBeUndefined();
 
-      fireEvent.click(screen.getByLabelText("Toggle theme"));
-      expect(mockedClerk.signInPrepareFirstFactor).not.toHaveBeenCalled();
-      if (testCase.showsMethodChooser) {
-        fireEvent.click(
-          await waitForRoleElement("button", "Use another method"),
-        );
-        await expect(
-          screen.findByRole("heading", { name: "Use another method" }),
-        ).resolves.toBeVisible();
-        fireEvent.click(await waitForRoleElement("button", "Back"));
-        await expect(
-          screen.findByLabelText("Verification code"),
-        ).resolves.toBeVisible();
-        expect(mockedClerk.signInPrepareFirstFactor).not.toHaveBeenCalled();
-      } else {
-        expect(roleElement("button", "Back")).toBeUndefined();
-        expect(roleElement("button", "Use another method")).toBeUndefined();
-      }
-
-      fireEvent.click(await waitForRoleElement("button", "Edit identifier"));
-      await expect(
-        screen.findByLabelText("Email address"),
-      ).resolves.toHaveValue("person@example.com");
-      expect(mockedClerk.signInPrepareFirstFactor).not.toHaveBeenCalled();
-    },
-  );
+    await editRestoredIdentifier();
+  });
 
   it("keeps an edited restored identifier authoritative over a stale resource snapshot", async () => {
     const factors = [emailCodeFactor(), passwordFactor()];

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-diagnostics.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-diagnostics.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
+import type { PostHog } from "posthog-js/dist/module.slim";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -13,11 +14,6 @@ import {
 import { AUTH_V2_DIAGNOSTIC_EVENT } from "../../../../lib/posthog.ts";
 import { testContext } from "../../../../signals/__tests__/test-helpers.ts";
 
-type Capture = (
-  eventName: string,
-  properties?: Record<string, unknown>,
-) => void;
-
 const { apiOriginMarker, posthog } = vi.hoisted(() => {
   vi.stubEnv("VITE_POSTHOG_KEY", "phc_auth_v2_recovery_diagnostics_test");
   window.location.href = "https://app.vm0.ai/";
@@ -28,12 +24,12 @@ const { apiOriginMarker, posthog } = vi.hoisted(() => {
   return {
     apiOriginMarker,
     posthog: {
-      capture: vi.fn<Capture>(),
-      identify: vi.fn(),
-      init: vi.fn(),
-      register: vi.fn(),
-      reset: vi.fn(),
-      unregister: vi.fn(),
+      capture: vi.fn<PostHog["capture"]>(),
+      identify: vi.fn<PostHog["identify"]>(),
+      init: vi.fn<PostHog["init"]>(),
+      register: vi.fn<PostHog["register"]>(),
+      reset: vi.fn<PostHog["reset"]>(),
+      unregister: vi.fn<PostHog["unregister"]>(),
     },
   };
 });

--- a/turbo/apps/platform/src/views/components/__tests__/force-upgrade-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/force-upgrade-dialog.test.tsx
@@ -29,7 +29,7 @@ describe("force upgrade dialog", () => {
   });
 
   it("shows an update dialog and refreshes after confirmation", async () => {
-    const reload = vi.fn();
+    const reload = vi.fn<() => void>();
     context.store.set(forceUpgradeDialogOpen$, true);
 
     render(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
@@ -1075,7 +1075,7 @@ describe("chat composer models", () => {
 
   it("scrolls the slash workflow picker with keyboard selection", async () => {
     const user = userEvent.setup({ delay: null });
-    const scrollIntoView = vi.fn();
+    const scrollIntoView = vi.fn<HTMLElement["scrollIntoView"]>();
     Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
       configurable: true,
       value: scrollIntoView,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
@@ -2724,8 +2724,8 @@ describe("chat composer templates", () => {
     if (!illustrationTemplate) {
       throw new Error("Illustration template with four variants not found");
     }
-    const scrollIntoView = vi.fn();
-    const scrollTo = vi.fn();
+    const scrollIntoView = vi.fn<HTMLElement["scrollIntoView"]>();
+    const scrollTo = vi.fn<HTMLElement["scrollTo"]>();
     const rect = ({
       left,
       right,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-test-helpers.ts
@@ -552,8 +552,10 @@ export function mockUrlObjectMethods(
     URL,
     "revokeObjectURL",
   );
-  const createObjectURL = vi.fn(createObjectURLImplementation);
-  const revokeObjectURL = vi.fn();
+  const createObjectURL = vi.fn<typeof URL.createObjectURL>(
+    createObjectURLImplementation,
+  );
+  const revokeObjectURL = vi.fn<typeof URL.revokeObjectURL>();
   Object.defineProperties(URL, {
     createObjectURL: {
       configurable: true,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-history-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-history-navigation.test.tsx
@@ -44,6 +44,7 @@ import {
 } from "./chat-lifecycle-test-helpers.ts";
 
 const SHARED_DATABASE_REALTIME_CHANNEL = "user-org:test-user-123:org_default";
+type RenameRequest = (threadId: string, title: string) => void;
 
 describe("chat lifecycle", () => {
   it("renders new messages after a payload-less created event", async () => {
@@ -1063,7 +1064,7 @@ describe("chat lifecycle", () => {
       threadTitle: "Thread detail should stay pending",
     });
     lifecycle.setThreadList([thread]);
-    const renameRequest = vi.fn();
+    const renameRequest = vi.fn<RenameRequest>();
     let persistedRenameEvent: ChatThreadEvent | null = null;
 
     context.mocks.api(chatThreadByIdContract.get, ({ never }) => {
@@ -1262,7 +1263,7 @@ describe("chat lifecycle", () => {
   });
 
   it("adds an emoji to the current chat from the Shift+F2 picker", async () => {
-    const renameRequest = vi.fn();
+    const renameRequest = vi.fn<RenameRequest>();
     mockResizeObserver();
     mockKeyboardNavigationThreads({ currentDetailTitle: null });
     context.mocks.api(
@@ -1303,7 +1304,7 @@ describe("chat lifecycle", () => {
   });
 
   it("adds an emoji to the current chat directly with Ctrl+Shift+1", async () => {
-    const renameRequest = vi.fn();
+    const renameRequest = vi.fn<RenameRequest>();
     mockResizeObserver();
     mockKeyboardNavigationThreads({ currentDetailTitle: null });
     context.mocks.api(
@@ -1344,7 +1345,7 @@ describe("chat lifecycle", () => {
   });
 
   it("adds an emoji to the focused side chat directly with Ctrl+Shift+1", async () => {
-    const renameRequest = vi.fn();
+    const renameRequest = vi.fn<RenameRequest>();
     mockResizeObserver();
     mockKeyboardNavigationThreads({ currentDetailTitle: null });
     context.mocks.api(
@@ -1388,7 +1389,7 @@ describe("chat lifecycle", () => {
   });
 
   it("adds an emoji from the composer with Ctrl+Shift+1", async () => {
-    const renameRequest = vi.fn();
+    const renameRequest = vi.fn<RenameRequest>();
     mockResizeObserver();
     mockKeyboardNavigationThreads({ currentDetailTitle: null });
     context.mocks.api(
@@ -1428,7 +1429,7 @@ describe("chat lifecycle", () => {
   });
 
   it("clears the current chat emoji directly with Ctrl+Shift+0", async () => {
-    const renameRequest = vi.fn();
+    const renameRequest = vi.fn<RenameRequest>();
     mockResizeObserver();
     mockKeyboardNavigationThreads({
       currentTitle: "🔥 Current keyboard thread",
@@ -1469,7 +1470,7 @@ describe("chat lifecycle", () => {
 
   it("keeps shifted digit input editable in the chat composer", async () => {
     const user = userEvent.setup({ delay: null });
-    const renameRequest = vi.fn();
+    const renameRequest = vi.fn<RenameRequest>();
     mockResizeObserver();
     mockKeyboardNavigationThreads({ currentDetailTitle: null });
     context.mocks.api(
@@ -1554,7 +1555,7 @@ describe("chat lifecycle", () => {
   });
 
   it("replaces the current chat emoji from the Shift+F2 picker", async () => {
-    const renameRequest = vi.fn();
+    const renameRequest = vi.fn<RenameRequest>();
     mockResizeObserver();
     mockKeyboardNavigationThreads({
       currentTitle: "🔥   Current keyboard thread",
@@ -1597,7 +1598,7 @@ describe("chat lifecycle", () => {
   });
 
   it("clears the current chat emoji from the picker Remove button", async () => {
-    const renameRequest = vi.fn();
+    const renameRequest = vi.fn<RenameRequest>();
     mockResizeObserver();
     mockKeyboardNavigationThreads({
       currentTitle: "🔥 Current keyboard thread",
@@ -1635,7 +1636,7 @@ describe("chat lifecycle", () => {
   });
 
   it("does not clear the emoji when the chat has no other title text", async () => {
-    const renameRequest = vi.fn();
+    const renameRequest = vi.fn<RenameRequest>();
     mockResizeObserver();
     mockKeyboardNavigationThreads({ currentTitle: "🔥" });
     context.mocks.api(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-lifecycle-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-lifecycle-test-helpers.ts
@@ -1,5 +1,5 @@
 import { screen, waitFor, within } from "@testing-library/react";
-import { expect, vi } from "vitest";
+import { expect, vi, type Mock } from "vitest";
 import {
   chatThreadByIdContract,
   chatThreadArtifactsContract,
@@ -113,7 +113,7 @@ export function computerUsePermissions() {
 }
 
 interface PushBrowserMock {
-  readonly register: ReturnType<typeof vi.fn>;
+  readonly register: Mock<TestServiceWorkerContainer["register"]>;
 }
 
 type TestPushManager = Pick<PushManager, "getSubscription" | "subscribe">;
@@ -186,7 +186,7 @@ export function mockPushBrowserSupport(): PushBrowserMock {
     get permission() {
       return notificationPermission;
     },
-    requestPermission: vi.fn(() => {
+    requestPermission: vi.fn<typeof Notification.requestPermission>(() => {
       notificationPermission = "granted";
       return Promise.resolve(notificationPermission);
     }),
@@ -203,17 +203,17 @@ export function mockPushBrowserSupport(): PushBrowserMock {
     },
   } satisfies Pick<PushSubscription, "endpoint" | "getKey">;
   const pushManager: TestPushManager = {
-    getSubscription: vi.fn(() => {
+    getSubscription: vi.fn<PushManager["getSubscription"]>(() => {
       return Promise.resolve(null);
     }),
-    subscribe: vi.fn(() => {
+    subscribe: vi.fn<PushManager["subscribe"]>(() => {
       return Promise.resolve(subscription as PushSubscription);
     }),
   };
   const registration = {
     pushManager,
   } satisfies TestServiceWorkerRegistration;
-  const register = vi.fn(() => {
+  const register = vi.fn<TestServiceWorkerContainer["register"]>(() => {
     return Promise.resolve(registration);
   });
   const descriptor = Object.getOwnPropertyDescriptor(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -616,17 +616,10 @@ async function expectConnectorCardsVisible(expected: {
   readonly asana: boolean;
 }): Promise<void> {
   await waitFor(() => {
-    if (expected.github) {
-      expect(queryConnectorCardByLabel("GitHub")).toBeInTheDocument();
-    } else {
-      expect(queryConnectorCardByLabel("GitHub")).not.toBeInTheDocument();
-    }
-
-    if (expected.asana) {
-      expect(queryConnectorCardByLabel("Asana")).toBeInTheDocument();
-    } else {
-      expect(queryConnectorCardByLabel("Asana")).not.toBeInTheDocument();
-    }
+    expect({
+      github: queryConnectorCardByLabel("GitHub") !== null,
+      asana: queryConnectorCardByLabel("Asana") !== null,
+    }).toStrictEqual(expected);
   });
 }
 

--- a/turbo/packages/connectors/package.json
+++ b/turbo/packages/connectors/package.json
@@ -76,7 +76,7 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "oxlint && oxlint --type-aware -c ../../.oxlintrc.typeaware.json && eslint . --max-warnings 0",
+    "lint": "oxlint --deny-warnings && oxlint --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings && eslint . --max-warnings 0",
     "check-types": "tsc --noEmit"
   },
   "dependencies": {

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -2061,12 +2061,11 @@ function isAscii(value: string): boolean {
 function isIpv4NumberComponent(value: string): boolean {
   if (value === "") return false;
   if (value.toLowerCase().startsWith("0x")) {
-    return (
-      value.length > 2 &&
-      [...value.slice(2)].every((char) => {
-        return isHexDigit(char);
-      })
-    );
+    if (value.length <= 2) return false;
+    for (let index = 2; index < value.length; index += 1) {
+      if (!isHexDigit(value.charAt(index))) return false;
+    }
+    return true;
   }
   return UNICODE_DECIMAL_NUMBER_PATTERN.test(value);
 }


### PR DESCRIPTION
## Summary

- type App test mocks from their Clerk, PostHog, Sentry, DOM, and local callback boundaries
- split distinct sign-in recovery scenarios into explicit tests and compare connector-card visibility as one state
- remove redundant request-body and IPv4 parsing spreads without changing behavior
- make both regular and type-aware Oxlint fail on any future App or Connectors warning

This clears all 59 App warnings and the single Connectors warning present on `main`. Existing API warnings remain out of scope and are tracked in #30342.

## Validation

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged TypeScript checks for non-App/API packages, App, and API
- post-rebase App and Connectors lint and type checks
- 14 targeted Vitest files, 703 tests passed