### PR TITLE
perf(runner): benchmark exact default-seed prepared baseline

### DIFF
--- a/.github/scripts/runner-storage-baseline-benchmark-remote.sh
+++ b/.github/scripts/runner-storage-baseline-benchmark-remote.sh
@@ -1,0 +1,932 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BIN_DIR=${1:?Missing Runner binary directory}
+SERVICE=${2:?Missing Runner service name}
+GROUP=${3:?Missing Runner group}
+RUNNER_DIR=${4:?Missing Runner directory}
+SOURCE_REVISION=${5:?Missing vm0-skills source revision}
+SAMPLES=${6:?Missing sample count}
+REPORT=${7:?Missing report script path}
+
+PROFILE=vm0/default
+UNIT="vm0-runner-${SERVICE}.service"
+GROUP_DIR="/var/lib/vm0-runner/groups/${GROUP}"
+SKILLS_ROOT=/home/user/.claude/skills
+SOURCE_URL=https://github.com/vm0-ai/vm0-skills.git
+BENCHMARK_DIR=""
+SERVER_PID=""
+BENCHMARK_SERVICE_STARTED=false
+ORIGINAL_SERVICE_RESTARTED=false
+RAW_SAMPLES=""
+TELEMETRY=""
+LAST_RUN_ID=""
+LAST_SANDBOX_ID=""
+LAST_SUBMIT_ERROR=""
+CGROUP_PATH=""
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+if [[ ! "$SOURCE_REVISION" =~ ^[0-9a-f]{40}$ ]]; then
+  fail "Source revision must be a full lowercase 40-character Git commit"
+fi
+case "$SAMPLES" in
+  ''|*[!0-9]*) fail "Sample count must be an integer" ;;
+esac
+if [ "$SAMPLES" -lt 1 ] || [ "$SAMPLES" -gt 100 ]; then
+  fail "Sample count must be between 1 and 100"
+fi
+if [ ! -x "$REPORT" ]; then
+  fail "Report script is not executable: $REPORT"
+fi
+
+wait_for_unit_inactive() {
+  local attempt
+  for attempt in $(seq 1 60); do
+    if ! sudo systemctl is-active --quiet "$UNIT"; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
+restart_original_service() {
+  if [ "$ORIGINAL_SERVICE_RESTARTED" = true ]; then
+    return
+  fi
+  sudo "$BIN_DIR/runner" service stop --name "$SERVICE" --force >/dev/null 2>&1 || true
+  wait_for_unit_inactive || true
+  sudo "$BIN_DIR/runner" service start --name "$SERVICE" \
+    --config "$RUNNER_DIR/runner.yaml" \
+    --local \
+    --env USE_MOCK_CLAUDE=true >/dev/null
+  sudo "$BIN_DIR/runner" service wait-running --name "$SERVICE" --timeout-secs 120 >/dev/null
+  ORIGINAL_SERVICE_RESTARTED=true
+}
+
+cleanup() {
+  local status=$?
+  if [ "$BENCHMARK_SERVICE_STARTED" = true ]; then
+    sudo "$BIN_DIR/runner" service stop --name "$SERVICE" --force >/dev/null 2>&1 || true
+    wait_for_unit_inactive || true
+  fi
+  if [ -n "$SERVER_PID" ]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+  if [ -n "$BENCHMARK_DIR" ] && [[ "$BENCHMARK_DIR" == /tmp/vm0-storage-baseline.* ]]; then
+    rm -rf "$BENCHMARK_DIR"
+  fi
+  restart_original_service || true
+  return "$status"
+}
+trap cleanup EXIT
+
+BENCHMARK_DIR=$(mktemp -d /tmp/vm0-storage-baseline.XXXXXX)
+SOURCE_DIR="$BENCHMARK_DIR/source"
+ARCHIVE_DIR="$BENCHMARK_DIR/archives"
+MANIFEST="$BENCHMARK_DIR/storage-manifest.json"
+MOUNTS="$BENCHMARK_DIR/mounts.jsonl"
+CHECKSUMS="$BENCHMARK_DIR/checksums"
+TELEMETRY="$BENCHMARK_DIR/telemetry.jsonl"
+RAW_SAMPLES="$BENCHMARK_DIR/samples.jsonl"
+PORT_FILE="$BENCHMARK_DIR/server.port"
+SERVER_LOG="$BENCHMARK_DIR/server.log"
+mkdir -p "$ARCHIVE_DIR"
+: > "$TELEMETRY"
+: > "$RAW_SAMPLES"
+
+echo "=== Reproducing default-seed fixture ==="
+git init -q "$SOURCE_DIR"
+git -C "$SOURCE_DIR" remote add origin "$SOURCE_URL"
+git -C "$SOURCE_DIR" fetch -q --depth=1 origin "$SOURCE_REVISION"
+RESOLVED_REVISION=$(git -C "$SOURCE_DIR" rev-parse FETCH_HEAD)
+[ "$RESOLVED_REVISION" = "$SOURCE_REVISION" ] \
+  || fail "Fetched source revision does not match the requested commit"
+git -C "$SOURCE_DIR" checkout -q --detach FETCH_HEAD
+
+for skill in computer-use gen workflow-setup; do
+  [ -d "$SOURCE_DIR/$skill" ] || fail "Source revision is missing seed skill: $skill"
+  tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
+    -C "$SOURCE_DIR/$skill" -cf - . \
+    | gzip -n > "$ARCHIVE_DIR/$skill.tar.gz"
+  while IFS= read -r -d '' source_file; do
+    relative_path=${source_file#"$SOURCE_DIR/$skill/"}
+    checksum=$(sha256sum "$source_file" | awk '{print $1}')
+    printf '%s  %s/%s/%s\n' "$checksum" "$SKILLS_ROOT" "$skill" "$relative_path" \
+      >> "$CHECKSUMS"
+  done < <(find "$SOURCE_DIR/$skill" -type f -print0 | sort -z)
+done
+TREE_DIGEST=$(sha256sum "$CHECKSUMS" | awk '{print $1}')
+RUNNER_DIGEST=$(sudo sha256sum "$BIN_DIR/runner" | awk '{print $1}')
+CONFIG_DIGEST=$(sudo sha256sum "$RUNNER_DIR/runner.yaml" | awk '{print $1}')
+ROOTFS_HASH=$(sudo awk '$1 == "rootfs_hash:" {print $2; exit}' "$RUNNER_DIR/runner.yaml")
+SNAPSHOT_HASH=$(sudo awk '$1 == "snapshot_hash:" {print $2; exit}' "$RUNNER_DIR/runner.yaml")
+[ -n "$ROOTFS_HASH" ] || fail "Runner config omitted rootfs_hash"
+[ -n "$SNAPSHOT_HASH" ] || fail "Runner config omitted snapshot_hash"
+DESCRIPTOR_DIGEST=$(printf '%s\n' \
+  "$SOURCE_REVISION" \
+  "$TREE_DIGEST" \
+  claude-code \
+  "$PROFILE" \
+  "$RUNNER_DIGEST" \
+  "$ROOTFS_HASH" \
+  "$SNAPSHOT_HASH" \
+  | sha256sum | awk '{print $1}')
+
+python3 - "$ARCHIVE_DIR" "$TELEMETRY" "$PORT_FILE" >"$SERVER_LOG" 2>&1 <<'PY' &
+import http.server
+import json
+import pathlib
+import sys
+import threading
+
+archive_dir = pathlib.Path(sys.argv[1]).resolve()
+telemetry_path = pathlib.Path(sys.argv[2])
+port_path = pathlib.Path(sys.argv[3])
+write_lock = threading.Lock()
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, format_string, *args):
+        return
+
+    def do_GET(self):
+        prefix = "/archives/"
+        if not self.path.startswith(prefix):
+            self.send_error(404)
+            return
+        name = self.path[len(prefix):]
+        if not name or "/" in name or name in {".", ".."}:
+            self.send_error(404)
+            return
+        path = archive_dir / name
+        if not path.is_file():
+            self.send_error(404)
+            return
+        body = path.read_bytes()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/gzip")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        if self.path != "/api/webhooks/agent/telemetry":
+            self.send_error(404)
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        if length < 1 or length > 8 * 1024 * 1024:
+            self.send_error(413)
+            return
+        body = self.rfile.read(length)
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            self.send_error(400)
+            return
+        encoded = json.dumps(payload, separators=(",", ":"))
+        with write_lock:
+            with telemetry_path.open("a", encoding="utf-8") as output:
+                output.write(encoded + "\n")
+        response = b"{}"
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(response)
+
+
+server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+port_path.write_text(str(server.server_port), encoding="utf-8")
+server.serve_forever()
+PY
+SERVER_PID=$!
+
+for _ in $(seq 1 100); do
+  [ -s "$PORT_FILE" ] && break
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    cat "$SERVER_LOG" >&2
+    fail "Fixture server exited before publishing its port"
+  fi
+  sleep 0.05
+done
+[ -s "$PORT_FILE" ] || fail "Fixture server did not publish its port"
+FIXTURE_PORT=$(<"$PORT_FILE")
+FIXTURE_URL="http://127.0.0.1:${FIXTURE_PORT}"
+
+for skill in computer-use gen workflow-setup; do
+  archive="$ARCHIVE_DIR/$skill.tar.gz"
+  size=$(stat -c %s "$archive")
+  jq -cn \
+    --arg name "$skill" \
+    --arg storage_id "default-seed-fixture-$skill" \
+    --arg version_id "$SOURCE_REVISION" \
+    --arg mount_path "$SKILLS_ROOT/$skill" \
+    --arg archive_url "$FIXTURE_URL/archives/$skill.tar.gz" \
+    --argjson archive_size "$size" \
+    '{
+      name: $name,
+      storageId: $storage_id,
+      versionId: $version_id,
+      mountPath: $mount_path,
+      archiveUrl: $archive_url,
+      archiveSize: $archive_size,
+      baselineCandidate: true
+    }' >> "$MOUNTS"
+done
+jq -s '{storageMounts: .}' "$MOUNTS" > "$MANIFEST"
+chmod 0600 "$MANIFEST"
+
+disk_bytes() {
+  local mode=$1
+  shift
+  local option=()
+  if [ "$mode" = logical ]; then
+    option=(--apparent-size)
+  fi
+  sudo du "${option[@]}" -s -B1 "$@" 2>/dev/null | awk '{sum += $1} END {print sum + 0}'
+}
+
+FIXTURE_LOGICAL_BYTES=$(disk_bytes logical "$BENCHMARK_DIR")
+FIXTURE_ALLOCATED_BYTES=$(disk_bytes allocated "$BENCHMARK_DIR")
+
+echo "=== Starting isolated local Runner telemetry boundary ==="
+sudo "$BIN_DIR/runner" service stop --name "$SERVICE" --force >/dev/null 2>&1 || true
+wait_for_unit_inactive || fail "Runner service did not stop before benchmark"
+sudo "$BIN_DIR/runner" service start --name "$SERVICE" \
+  --config "$RUNNER_DIR/runner.yaml" \
+  --local \
+  --env USE_MOCK_CLAUDE=true \
+  --env "OKOU_API_BACKEND_URL=$FIXTURE_URL"
+BENCHMARK_SERVICE_STARTED=true
+sudo "$BIN_DIR/runner" service wait-running --name "$SERVICE" --timeout-secs 120 >/dev/null
+CGROUP_PATH=$(sudo systemctl show "$UNIT" --property=ControlGroup --value)
+[ -n "$CGROUP_PATH" ] || fail "Runner service cgroup is unavailable"
+
+cpu_usage_usec() {
+  sudo awk '$1 == "usage_usec" {print $2}' "/sys/fs/cgroup${CGROUP_PATH}/cpu.stat"
+}
+
+wait_for_telemetry() {
+  local run_id=$1
+  local attempt
+  for attempt in $(seq 1 200); do
+    if jq -s -e --arg run_id "$run_id" \
+      'any(.[]; .runId == $run_id and (.sandboxOperations | length) > 0)' \
+      "$TELEMETRY" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.05
+  done
+  return 1
+}
+
+operations_for_run() {
+  local run_id=$1
+  "$REPORT" --operations "$TELEMETRY" "$run_id"
+}
+
+operation_duration() {
+  local operations=$1
+  local action=$2
+  jq -r --arg action "$action" \
+    '[.[] | select(.action_type == $action)] | last | .duration_ms // empty' \
+    <<<"$operations"
+}
+
+operation_reuse_result() {
+  local operations=$1
+  jq -r \
+    '[.[] | select(.action_type == "api_to_spawn")] | last | .sandbox_reuse_result // empty' \
+    <<<"$operations"
+}
+
+sandbox_for_thread() {
+  local chat_thread_id=$1
+  local reuse_key="thread:$chat_thread_id"
+  local sandbox_id
+  local attempt
+
+  for attempt in $(seq 1 100); do
+    sandbox_id=$(sudo jq -r --arg reuse_key "$reuse_key" \
+      '.idle_sandboxes[]? | select(.reuse_key == $reuse_key) | .sandbox_id' \
+      "$RUNNER_DIR/status.json" 2>/dev/null || true)
+    if [ -n "$sandbox_id" ]; then
+      printf '%s\n' "$sandbox_id"
+      return 0
+    fi
+    sleep 0.05
+  done
+  return 1
+}
+
+record_completed_sample() {
+  local cohort=$1
+  local chat_thread_id=$2
+  local expected_reuse=$3
+  local attestation_ms=$4
+  local cpu_usec=$5
+  local submit_status=$6
+  local submit_output=$7
+  local submit_json
+  local operations
+  local reuse_result
+  local api_to_spawn_ms
+  local storage_apply_ms
+  local storage_cache_populate_ms
+  local storage_guest_download_ms
+  local sandbox_create_ms
+  local agent_spawn_ms
+
+  LAST_RUN_ID=""
+  LAST_SANDBOX_ID=""
+  LAST_SUBMIT_ERROR=""
+  if [ "$submit_status" -ne 0 ]; then
+    LAST_SUBMIT_ERROR=submit_failed
+    jq -cn --arg cohort "$cohort" --arg error_code "$LAST_SUBMIT_ERROR" \
+      '{kind:"sample",cohort:$cohort,success:false,error_code:$error_code}' >> "$RAW_SAMPLES"
+    return 1
+  fi
+  submit_json=$(awk '/^\{/{line=$0} END{print line}' <<<"$submit_output")
+  LAST_RUN_ID=$(jq -r '.run_id // empty' <<<"$submit_json" 2>/dev/null || true)
+  if [ -z "$LAST_RUN_ID" ]; then
+    LAST_SUBMIT_ERROR=missing_run_id
+    jq -cn --arg cohort "$cohort" --arg error_code "$LAST_SUBMIT_ERROR" \
+      '{kind:"sample",cohort:$cohort,success:false,error_code:$error_code}' >> "$RAW_SAMPLES"
+    return 1
+  fi
+  if ! wait_for_telemetry "$LAST_RUN_ID"; then
+    LAST_SUBMIT_ERROR=telemetry_missing
+    jq -cn --arg cohort "$cohort" --arg run_id "$LAST_RUN_ID" --arg error_code "$LAST_SUBMIT_ERROR" \
+      '{kind:"sample",cohort:$cohort,success:false,run_id:$run_id,error_code:$error_code}' \
+      >> "$RAW_SAMPLES"
+    return 1
+  fi
+  operations=$(operations_for_run "$LAST_RUN_ID")
+  reuse_result=$(operation_reuse_result "$operations")
+  if [ "$reuse_result" != "$expected_reuse" ]; then
+    LAST_SUBMIT_ERROR=unexpected_reuse_result
+    jq -cn \
+      --arg cohort "$cohort" \
+      --arg run_id "$LAST_RUN_ID" \
+      --arg error_code "$LAST_SUBMIT_ERROR" \
+      --arg expected_reuse "$expected_reuse" \
+      --arg actual_reuse "$reuse_result" \
+      '{kind:"sample",cohort:$cohort,success:false,run_id:$run_id,error_code:$error_code,expected_reuse:$expected_reuse,actual_reuse:$actual_reuse}' \
+      >> "$RAW_SAMPLES"
+    return 1
+  fi
+
+  api_to_spawn_ms=$(operation_duration "$operations" api_to_spawn)
+  storage_apply_ms=$(operation_duration "$operations" runner_storage_manifest_apply)
+  storage_cache_populate_ms=$(operation_duration "$operations" runner_storage_manifest_cache_populate)
+  storage_guest_download_ms=$(operation_duration "$operations" runner_storage_manifest_guest_download)
+  sandbox_create_ms=$(operation_duration "$operations" sandbox_create)
+  agent_spawn_ms=$(operation_duration "$operations" runner_agent_start_process)
+  [ -n "$api_to_spawn_ms" ] || fail "api_to_spawn telemetry missing for $LAST_RUN_ID"
+  [ -n "$storage_apply_ms" ] || fail "storage apply telemetry missing for $LAST_RUN_ID"
+  [ -n "$agent_spawn_ms" ] || fail "real agent spawn telemetry missing for $LAST_RUN_ID"
+  if [ "$cohort" = fresh ] || [ "$cohort" = validation ]; then
+    [ -n "$storage_guest_download_ms" ] \
+      || fail "fresh sample omitted guest storage application for $LAST_RUN_ID"
+    [ -n "$sandbox_create_ms" ] \
+      || fail "fresh sample omitted sandbox creation for $LAST_RUN_ID"
+  fi
+  if [ "$cohort" = prepared ] && [ -n "$storage_guest_download_ms" ]; then
+    fail "prepared sample unexpectedly downloaded storage for $LAST_RUN_ID"
+  fi
+  if ! LAST_SANDBOX_ID=$(sandbox_for_thread "$chat_thread_id"); then
+    fail "reusable sandbox was not published for $LAST_RUN_ID"
+  fi
+
+  jq -cn \
+    --arg cohort "$cohort" \
+    --arg run_id "$LAST_RUN_ID" \
+    --arg sandbox_id "$LAST_SANDBOX_ID" \
+    --argjson api_to_spawn_ms "$api_to_spawn_ms" \
+    --argjson storage_apply_ms "$storage_apply_ms" \
+    --argjson storage_cache_populate_ms "${storage_cache_populate_ms:-null}" \
+    --argjson storage_guest_download_ms "${storage_guest_download_ms:-null}" \
+    --argjson sandbox_create_ms "${sandbox_create_ms:-null}" \
+    --argjson agent_spawn_ms "$agent_spawn_ms" \
+    --argjson cpu_usec "$cpu_usec" \
+    --argjson attestation_ms "${attestation_ms:-null}" \
+    '{
+      kind:"sample",
+      cohort:$cohort,
+      success:true,
+      run_id:$run_id,
+      sandbox_id:$sandbox_id,
+      api_to_spawn_ms:$api_to_spawn_ms,
+      storage_apply_ms:$storage_apply_ms,
+      storage_cache_populate_ms:$storage_cache_populate_ms,
+      storage_guest_download_ms:$storage_guest_download_ms,
+      sandbox_create_ms:$sandbox_create_ms,
+      agent_spawn_ms:$agent_spawn_ms,
+      cpu_usec:$cpu_usec,
+      attestation_ms:$attestation_ms,
+      candidate_ready_proxy_ms: (
+        $api_to_spawn_ms + (if $attestation_ms == null then 0 else $attestation_ms end)
+      )
+    }' >> "$RAW_SAMPLES"
+}
+
+record_sample() {
+  local cohort=$1
+  local manifest=$2
+  local chat_thread_id=$3
+  local session_id=$4
+  local expected_reuse=$5
+  local attestation_ms=${6:-}
+  local prompt=${7:-true}
+  local cpu_before
+  local cpu_after
+  local submit_output
+  local submit_status=0
+
+  cpu_before=$(cpu_usage_usec)
+  if submit_output=$(sudo "$BIN_DIR/runner" local submit \
+    --group "$GROUP" \
+    --profile "$PROFILE" \
+    --chat-thread-id "$chat_thread_id" \
+    --session-id "$session_id" \
+    --feature-flag sandboxReuse=true \
+    --storage-manifest "$manifest" \
+    --timeout 120 \
+    --prompt "$prompt" 2>&1); then
+    submit_status=0
+  else
+    submit_status=$?
+  fi
+  cpu_after=$(cpu_usage_usec)
+  record_completed_sample "$cohort" "$chat_thread_id" "$expected_reuse" \
+    "$attestation_ms" "$((cpu_after - cpu_before))" "$submit_status" "$submit_output"
+}
+
+CHECKSUMS_BASE64=$(base64 -w0 "$CHECKSUMS")
+ATTEST_COMMAND='test "$(cat /tmp/vm0-default-seed-baseline-descriptor 2>/dev/null)" = "$EXPECTED_DESCRIPTOR" && printf %s "$EXPECTED_CHECKSUMS" | base64 -d | sha256sum -c - >/dev/null'
+
+attest_candidate() {
+  local sandbox_id=$1
+  local started_ns
+  local finished_ns
+  local output
+  local status=0
+  local attempt
+  started_ns=$(date +%s%N)
+  for attempt in $(seq 1 10); do
+    if output=$(sudo timeout 4 "$BIN_DIR/runner" exec --timeout 2 \
+      --sandbox "$sandbox_id" -- \
+      env \
+      "EXPECTED_DESCRIPTOR=$DESCRIPTOR_DIGEST" \
+      "EXPECTED_CHECKSUMS=$CHECKSUMS_BASE64" \
+      bash -lc "$ATTEST_COMMAND" 2>&1); then
+      status=0
+    else
+      status=$?
+    fi
+    if [ "$status" -eq 0 ]; then
+      finished_ns=$(date +%s%N)
+      ATTESTATION_MS=$(((finished_ns - started_ns) / 1000000))
+      return 0
+    fi
+    if [ "$status" -eq 1 ] \
+      && ! grep -Eq 'error: (exec failed|sandbox operation gate|config error)' <<<"$output"; then
+      finished_ns=$(date +%s%N)
+      ATTESTATION_MS=$(((finished_ns - started_ns) / 1000000))
+      echo "Prepared candidate attestation command failed for $sandbox_id:" >&2
+      printf '%s\n' "$output" | tail -c 4096 >&2
+      return 1
+    fi
+    sleep 0.1
+  done
+  finished_ns=$(date +%s%N)
+  ATTESTATION_MS=$(((finished_ns - started_ns) / 1000000))
+  echo "Prepared candidate attestation transport failed for $sandbox_id:" >&2
+  printf '%s\n' "$output" | tail -c 4096 >&2
+  return 2
+}
+
+release_candidate_gate() {
+  local sandbox_id=$1
+  local release_path=$2
+  local attempt
+
+  for attempt in $(seq 1 20); do
+    if sudo timeout 4 "$BIN_DIR/runner" exec --timeout 2 \
+      --sandbox "$sandbox_id" -- touch "$release_path" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+wait_for_agent_spawn() {
+  local run_id=$1
+  local submit_pid=$2
+  local deadline=$((SECONDS + 115))
+
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if sudo journalctl -u "$UNIT" --since '2 minutes ago' --no-pager -o cat \
+      --grep "agent startup timing run_id=$run_id" 2>/dev/null \
+      | grep -Fq "agent startup timing run_id=$run_id"; then
+      return 0
+    fi
+    if ! kill -0 "$submit_pid" 2>/dev/null; then
+      return 1
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
+run_candidate_gate() {
+  local candidate_sandbox_id=$1
+  local chat_thread_id=$2
+  local session_id=$3
+  local release_path="/tmp/vm0-default-seed-baseline-release-$session_id"
+  local output_file="$BENCHMARK_DIR/$session_id.submit"
+  local submit_pid
+  local cpu_before
+  local cpu_after
+  local started_ns
+  local finished_ns
+  local attempt
+  local active=false
+  local submit_json
+  local completed_run_id
+  local operations
+  local published_sandbox_id
+  local attestation_status=0
+
+  GATE_ATTESTED=false
+  GATE_ATTESTATION_MS=""
+  GATE_OUTPUT=""
+  GATE_STATUS=0
+  GATE_ERROR=""
+  GATE_ELAPSED_MS=""
+  cpu_before=$(cpu_usage_usec)
+  started_ns=$(date +%s%N)
+  sudo "$BIN_DIR/runner" local submit \
+    --group "$GROUP" \
+    --profile "$PROFILE" \
+    --chat-thread-id "$chat_thread_id" \
+    --session-id "$session_id" \
+    --feature-flag sandboxReuse=true \
+    --storage-manifest "$MANIFEST" \
+    --timeout 120 \
+    --prompt "for _ in \$(seq 1 600); do [ -e '$release_path' ] && exit 0; sleep 0.05; done; exit 98" \
+    >"$output_file" 2>&1 &
+  submit_pid=$!
+
+  for attempt in $(seq 1 200); do
+    GATE_RUN_ID=$(sudo jq -r --arg sandbox_id "$candidate_sandbox_id" \
+      '.active_runs[]? | select(.sandbox_id == $sandbox_id) | .run_id' \
+      "$RUNNER_DIR/status.json" 2>/dev/null || true)
+    if [ -n "$GATE_RUN_ID" ]; then
+      active=true
+      break
+    fi
+    if ! kill -0 "$submit_pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.05
+  done
+  if [ "$active" != true ]; then
+    wait "$submit_pid" 2>/dev/null || true
+    cat "$output_file" >&2
+    fail "Prepared candidate did not become active: $candidate_sandbox_id"
+  fi
+  if ! wait_for_agent_spawn "$GATE_RUN_ID" "$submit_pid"; then
+    if wait "$submit_pid"; then
+      GATE_STATUS=0
+    else
+      GATE_STATUS=$?
+    fi
+    cpu_after=$(cpu_usage_usec)
+    finished_ns=$(date +%s%N)
+    GATE_CPU_USEC=$((cpu_after - cpu_before))
+    GATE_ELAPSED_MS=$(((finished_ns - started_ns) / 1000000))
+    GATE_OUTPUT=$(<"$output_file")
+    rm -f "$output_file"
+    GATE_ERROR=candidate_agent_spawn_unavailable
+    return 2
+  fi
+
+  ATTESTATION_MS=""
+  if attest_candidate "$candidate_sandbox_id"; then
+    attestation_status=0
+  else
+    attestation_status=$?
+  fi
+  case "$attestation_status" in
+    0) GATE_ATTESTED=true ;;
+    1) ;;
+    *) fail "Prepared candidate attestation could not reach the guest" ;;
+  esac
+  GATE_ATTESTATION_MS=$ATTESTATION_MS
+  release_candidate_gate "$candidate_sandbox_id" "$release_path" \
+    || fail "Prepared candidate gate could not release its controlled job"
+
+  if wait "$submit_pid"; then
+    GATE_STATUS=0
+  else
+    GATE_STATUS=$?
+  fi
+  cpu_after=$(cpu_usage_usec)
+  finished_ns=$(date +%s%N)
+  GATE_CPU_USEC=$((cpu_after - cpu_before))
+  GATE_ELAPSED_MS=$(((finished_ns - started_ns) / 1000000))
+  GATE_OUTPUT=$(<"$output_file")
+  rm -f "$output_file"
+  [ "$GATE_STATUS" -eq 0 ] || fail "Prepared candidate gate job failed"
+
+  submit_json=$(awk '/^\{/{line=$0} END{print line}' <<<"$GATE_OUTPUT")
+  completed_run_id=$(jq -r '.run_id // empty' <<<"$submit_json" 2>/dev/null || true)
+  [ -n "$completed_run_id" ] || fail "Prepared candidate gate omitted its run ID"
+  [ "$completed_run_id" = "$GATE_RUN_ID" ] \
+    || fail "Prepared candidate gate completed a different run"
+  wait_for_telemetry "$GATE_RUN_ID" || fail "Prepared candidate gate telemetry is missing"
+  operations=$(operations_for_run "$GATE_RUN_ID")
+  [ "$(operation_reuse_result "$operations")" = reused ] \
+    || fail "Prepared candidate gate did not reuse the expected sandbox"
+  published_sandbox_id=$(sandbox_for_thread "$chat_thread_id") \
+    || fail "Prepared candidate was not returned to the idle pool"
+  [ "$published_sandbox_id" = "$candidate_sandbox_id" ] \
+    || fail "Prepared candidate gate changed sandbox identity"
+  [ "$GATE_ATTESTED" = true ]
+}
+
+assert_candidate_rejected_then_fresh() {
+  local name=$1
+  local mutation=$2
+  local candidate_sandbox_id=$3
+  local candidate_thread=$4
+  local fallback_manifest=${5:-$MANIFEST}
+  local fallback_thread
+  local gate_status
+
+  record_sample warmup "$MANIFEST" "$candidate_thread" \
+    "storage-baseline-mutate-$name" reused "" "$mutation" \
+    || fail "Could not create invalid prepared candidate: $name"
+  [ "$LAST_SANDBOX_ID" = "$candidate_sandbox_id" ] \
+    || fail "Invalidation changed prepared sandbox identity: $name"
+  if run_candidate_gate "$candidate_sandbox_id" "$candidate_thread" \
+    "storage-baseline-reject-$name"; then
+    gate_status=0
+  else
+    gate_status=$?
+  fi
+  [ "$gate_status" -ne 0 ] || fail "Invalid prepared candidate was accepted: $name"
+  [ "$gate_status" -eq 1 ] \
+    || fail "Invalid prepared candidate could not be checked: $name"
+  fallback_thread=$(cat /proc/sys/kernel/random/uuid)
+  record_sample validation "$fallback_manifest" "$fallback_thread" \
+    "storage-baseline-validation-$name" poolMiss "" true \
+    || fail "Fresh fallback failed for invalid candidate: $name"
+  jq -cn --arg case "$name" --arg run_id "$LAST_RUN_ID" \
+    '{kind:"validation",case:$case,prepared_candidate_rejected:true,fresh_complete_path:true,run_id:$run_id}' \
+    >> "$RAW_SAMPLES"
+}
+
+jq -cn \
+  --arg source_revision "$SOURCE_REVISION" \
+  --arg tree_digest "$TREE_DIGEST" \
+  --arg descriptor_digest "$DESCRIPTOR_DIGEST" \
+  --arg runner_digest "$RUNNER_DIGEST" \
+  --arg config_digest "$CONFIG_DIGEST" \
+  --arg rootfs_hash "$ROOTFS_HASH" \
+  --arg snapshot_hash "$SNAPSHOT_HASH" \
+  --arg profile "$PROFILE" \
+  --argjson samples "$SAMPLES" \
+  --argjson fixture_logical_bytes "$FIXTURE_LOGICAL_BYTES" \
+  --argjson fixture_allocated_bytes "$FIXTURE_ALLOCATED_BYTES" \
+  '{
+    kind:"metadata",
+    source_revision:$source_revision,
+    tree_digest:$tree_digest,
+    descriptor_digest:$descriptor_digest,
+    runner_digest:$runner_digest,
+    config_digest:$config_digest,
+    rootfs_hash:$rootfs_hash,
+    snapshot_hash:$snapshot_hash,
+    profile:$profile,
+    samples_per_cohort:$samples,
+    fixture_logical_bytes:$fixture_logical_bytes,
+    fixture_allocated_bytes:$fixture_allocated_bytes
+  }' >> "$RAW_SAMPLES"
+
+echo "=== Warming exact source archives ==="
+CACHE_WARM_THREAD=$(cat /proc/sys/kernel/random/uuid)
+record_sample warmup "$MANIFEST" "$CACHE_WARM_THREAD" storage-baseline-cache-warm poolMiss "" true \
+  || fail "Archive-cache warmup failed: $LAST_SUBMIT_ERROR"
+
+echo "=== Sampling current fresh staging path ==="
+for index in $(seq 1 "$SAMPLES"); do
+  thread_id=$(cat /proc/sys/kernel/random/uuid)
+  record_sample fresh "$MANIFEST" "$thread_id" "storage-baseline-fresh-$index" poolMiss "" true \
+    || fail "Fresh sample $index failed: $LAST_SUBMIT_ERROR"
+done
+
+echo "=== Preparing exact reusable sandbox ==="
+PREPARED_THREAD=$(cat /proc/sys/kernel/random/uuid)
+PREPARE_PROMPT="printf '%s\\n' '$DESCRIPTOR_DIGEST' > /tmp/vm0-default-seed-baseline-descriptor"
+record_sample warmup "$MANIFEST" "$PREPARED_THREAD" storage-baseline-prepared poolMiss "" "$PREPARE_PROMPT" \
+  || fail "Prepared baseline construction failed: $LAST_SUBMIT_ERROR"
+PREPARED_SANDBOX_ID=$LAST_SANDBOX_ID
+
+echo "=== Sampling exact prepared path ==="
+for index in $(seq 1 "$SAMPLES"); do
+  if run_candidate_gate "$PREPARED_SANDBOX_ID" "$PREPARED_THREAD" \
+    "storage-baseline-prepared-$index"; then
+    gate_status=0
+  else
+    gate_status=$?
+  fi
+  if [ "$gate_status" -eq 2 ]; then
+    jq -cn \
+      --arg run_id "$GATE_RUN_ID" \
+      --arg error_code "$GATE_ERROR" \
+      --argjson cpu_usec "$GATE_CPU_USEC" \
+      --argjson candidate_gate_elapsed_ms "$GATE_ELAPSED_MS" \
+      '{kind:"sample",cohort:"prepared",success:false,run_id:$run_id,error_code:$error_code,cpu_usec:$cpu_usec,candidate_gate_elapsed_ms:$candidate_gate_elapsed_ms}' \
+      >> "$RAW_SAMPLES"
+    break
+  fi
+  [ "$gate_status" -eq 0 ] \
+    || fail "Prepared candidate attestation failed before sample $index"
+  record_completed_sample prepared "$PREPARED_THREAD" reused \
+    "$GATE_ATTESTATION_MS" "$GATE_CPU_USEC" "$GATE_STATUS" "$GATE_OUTPUT" \
+    || fail "Prepared sample $index failed: $LAST_SUBMIT_ERROR"
+  PREPARED_SANDBOX_ID=$LAST_SANDBOX_ID
+done
+
+prepare_validation_candidate() {
+  local name=$1
+  VALIDATION_THREAD=$(cat /proc/sys/kernel/random/uuid)
+  record_sample warmup "$MANIFEST" "$VALIDATION_THREAD" \
+    "storage-baseline-candidate-$name" poolMiss "" "$PREPARE_PROMPT" \
+    || fail "Could not prepare validation candidate: $name"
+  VALIDATION_SANDBOX_ID=$LAST_SANDBOX_ID
+}
+
+echo "=== Verifying prepared candidate invalidation ==="
+prepare_validation_candidate missing-marker
+assert_candidate_rejected_then_fresh missing-marker \
+  'rm -f /tmp/vm0-default-seed-baseline-descriptor' \
+  "$VALIDATION_SANDBOX_ID" "$VALIDATION_THREAD"
+prepare_validation_candidate stale-descriptor
+assert_candidate_rejected_then_fresh stale-descriptor \
+  'printf "%s\n" stale > /tmp/vm0-default-seed-baseline-descriptor' \
+  "$VALIDATION_SANDBOX_ID" "$VALIDATION_THREAD"
+prepare_validation_candidate incomplete-tree
+assert_candidate_rejected_then_fresh incomplete-tree \
+  "find '$SKILLS_ROOT/computer-use' -type f -print -quit | xargs -r rm -f" \
+  "$VALIDATION_SANDBOX_ID" "$VALIDATION_THREAD"
+prepare_validation_candidate corrupt-tree
+assert_candidate_rejected_then_fresh corrupt-tree \
+  "find '$SKILLS_ROOT/gen' -type f -print -quit | xargs -r sh -c 'printf corrupt >> \"\$1\"' sh" \
+  "$VALIDATION_SANDBOX_ID" "$VALIDATION_THREAD"
+
+CHANGED_MANIFEST="$BENCHMARK_DIR/storage-manifest-changed.json"
+jq --arg version_id "${SOURCE_REVISION}-changed" \
+  '.storageMounts[0].versionId = $version_id' "$MANIFEST" > "$CHANGED_MANIFEST"
+chmod 0600 "$CHANGED_MANIFEST"
+prepare_validation_candidate mismatched-descriptor
+assert_candidate_rejected_then_fresh mismatched-descriptor \
+  'printf "%s\n" mismatched-environment > /tmp/vm0-default-seed-baseline-descriptor' \
+  "$VALIDATION_SANDBOX_ID" "$VALIDATION_THREAD" "$CHANGED_MANIFEST"
+
+expect_current_archive_failure() {
+  local name=$1
+  local manifest=$2
+  local thread_id
+  local output
+  local status=0
+  local run_id
+  local operations
+  thread_id=$(cat /proc/sys/kernel/random/uuid)
+  if output=$(sudo "$BIN_DIR/runner" local submit \
+    --group "$GROUP" \
+    --profile "$PROFILE" \
+    --chat-thread-id "$thread_id" \
+    --session-id "storage-baseline-current-$name" \
+    --feature-flag sandboxReuse=true \
+    --storage-manifest "$manifest" \
+    --timeout 120 \
+    --prompt true 2>&1); then
+    status=0
+  else
+    status=$?
+  fi
+  [ "$status" -ne 0 ] || fail "Invalid current archive unexpectedly succeeded: $name"
+  run_id=$(awk '/^\{/{line=$0} END{print line}' <<<"$output" | jq -r '.run_id // empty' 2>/dev/null || true)
+  [ -n "$run_id" ] || fail "Invalid current archive result omitted run ID: $name"
+  wait_for_telemetry "$run_id" || fail "Invalid current archive telemetry missing: $name"
+  operations=$(operations_for_run "$run_id")
+  jq -e 'any(.[]; .action_type == "runner_storage_manifest_apply" and .success == false)' \
+    <<<"$operations" >/dev/null \
+    || fail "Invalid current archive did not fail storage application: $name"
+  jq -cn --arg case "$name" --arg run_id "$run_id" \
+    '{kind:"validation",case:$case,current_complete_path_failed_closed:true,run_id:$run_id}' \
+    >> "$RAW_SAMPLES"
+}
+
+echo "=== Verifying invalid current archives fail closed ==="
+MISSING_MANIFEST="$BENCHMARK_DIR/storage-manifest-missing.json"
+jq --arg url "$FIXTURE_URL/archives/missing.tar.gz" --arg version missing-current \
+  '.storageMounts[0].archiveUrl = $url | .storageMounts[0].versionId = $version | .storageMounts[0].archiveSize = 1' \
+  "$MANIFEST" > "$MISSING_MANIFEST"
+chmod 0600 "$MISSING_MANIFEST"
+expect_current_archive_failure missing-current-archive "$MISSING_MANIFEST"
+
+printf 'not a gzip archive\n' > "$ARCHIVE_DIR/corrupt.tar.gz"
+CORRUPT_SIZE=$(stat -c %s "$ARCHIVE_DIR/corrupt.tar.gz")
+CORRUPT_MANIFEST="$BENCHMARK_DIR/storage-manifest-corrupt.json"
+jq --arg url "$FIXTURE_URL/archives/corrupt.tar.gz" --arg version corrupt-current \
+  --argjson size "$CORRUPT_SIZE" \
+  '.storageMounts[0].archiveUrl = $url | .storageMounts[0].versionId = $version | .storageMounts[0].archiveSize = $size' \
+  "$MANIFEST" > "$CORRUPT_MANIFEST"
+chmod 0600 "$CORRUPT_MANIFEST"
+expect_current_archive_failure corrupt-current-archive "$CORRUPT_MANIFEST"
+
+echo "=== Verifying cancellation and queue cleanup ==="
+CANCEL_THREAD=$(cat /proc/sys/kernel/random/uuid)
+if timeout --signal=INT --kill-after=15s 1s \
+  sudo "$BIN_DIR/runner" local submit \
+    --group "$GROUP" \
+    --profile "$PROFILE" \
+    --chat-thread-id "$CANCEL_THREAD" \
+    --session-id storage-baseline-cancel \
+    --feature-flag sandboxReuse=true \
+    --storage-manifest "$MANIFEST" \
+    --timeout 120 \
+    --prompt 'sleep 30' >"$BENCHMARK_DIR/cancel.out" 2>&1; then
+  CANCEL_STATUS=0
+else
+  CANCEL_STATUS=$?
+fi
+[ "$CANCEL_STATUS" -ne 0 ] || fail "Cancellation probe unexpectedly completed normally"
+for _ in $(seq 1 100); do
+  if ! sudo find "$GROUP_DIR" -type f \( -name '*.job' -o -name '*.claim' -o -name '*.cancel' \) \
+    -print -quit 2>/dev/null | grep -q .; then
+    break
+  fi
+  sleep 0.1
+done
+if sudo find "$GROUP_DIR" -type f \( -name '*.job' -o -name '*.claim' -o -name '*.cancel' \) \
+  -print -quit 2>/dev/null | grep -q .; then
+  fail "Cancellation left local queue ownership files"
+fi
+jq -cn --argjson exit_status "$CANCEL_STATUS" \
+  '{kind:"validation",case:"cancellation",terminal:true,queue_clean:true,exit_status:$exit_status}' \
+  >> "$RAW_SAMPLES"
+
+MEMORY_CURRENT_BYTES=$(sudo cat "/sys/fs/cgroup${CGROUP_PATH}/memory.current")
+MEMORY_PEAK_BYTES=$(sudo cat "/sys/fs/cgroup${CGROUP_PATH}/memory.peak")
+RUNNER_LOGICAL_BYTES=$(disk_bytes logical "$RUNNER_DIR" "$GROUP_DIR")
+RUNNER_ALLOCATED_BYTES=$(disk_bytes allocated "$RUNNER_DIR" "$GROUP_DIR")
+jq -cn \
+  --argjson memory_current_bytes "$MEMORY_CURRENT_BYTES" \
+  --argjson memory_peak_bytes "$MEMORY_PEAK_BYTES" \
+  --argjson runner_logical_bytes "$RUNNER_LOGICAL_BYTES" \
+  --argjson runner_allocated_bytes "$RUNNER_ALLOCATED_BYTES" \
+  '{
+    kind:"resources",
+    memory_current_bytes:$memory_current_bytes,
+    memory_peak_bytes:$memory_peak_bytes,
+    runner_logical_bytes:$runner_logical_bytes,
+    runner_allocated_bytes:$runner_allocated_bytes
+  }' >> "$RAW_SAMPLES"
+
+echo "=== Stopping benchmark service and verifying cleanup ==="
+sudo "$BIN_DIR/runner" service stop --name "$SERVICE" --force >/dev/null
+wait_for_unit_inactive || fail "Runner service did not stop after benchmark"
+BENCHMARK_SERVICE_STARTED=false
+if sudo find "$GROUP_DIR" -type f \( -name '*.job' -o -name '*.claim' -o -name '*.cancel' \) \
+  -print -quit 2>/dev/null | grep -q .; then
+  fail "Benchmark cleanup left local queue ownership files"
+fi
+RAW_OUTPUT=$(cat "$RAW_SAMPLES")
+SUMMARY_OUTPUT=$("$REPORT" "$RAW_SAMPLES")
+
+kill "$SERVER_PID" >/dev/null 2>&1 || true
+wait "$SERVER_PID" >/dev/null 2>&1 || true
+SERVER_PID=""
+rm -rf "$BENCHMARK_DIR"
+BENCHMARK_DIR=""
+restart_original_service
+
+echo "=== Storage baseline raw samples ==="
+printf '%s\n' "$RAW_OUTPUT"
+jq -cn \
+  '{kind:"cleanup",service_stopped:true,queue_clean:true,fixture_removed:true,fixture_server_stopped:true,original_service_restarted:true}'
+echo "=== Storage baseline summary ==="
+printf '%s\n' "$SUMMARY_OUTPUT"
+trap - EXIT

--- a/.github/scripts/runner-storage-baseline-benchmark-remote.sh
+++ b/.github/scripts/runner-storage-baseline-benchmark-remote.sh
@@ -111,6 +111,9 @@ git -C "$SOURCE_DIR" checkout -q --detach FETCH_HEAD
 
 for skill in computer-use gen workflow-setup; do
   [ -d "$SOURCE_DIR/$skill" ] || fail "Source revision is missing seed skill: $skill"
+  unexpected_entry=$(find "$SOURCE_DIR/$skill" ! -type d ! -type f -print -quit)
+  [ -z "$unexpected_entry" ] \
+    || fail "Source seed skill contains a non-regular entry: $unexpected_entry"
   tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
     -C "$SOURCE_DIR/$skill" -cf - . \
     | gzip -n > "$ARCHIVE_DIR/$skill.tar.gz"
@@ -121,6 +124,7 @@ for skill in computer-use gen workflow-setup; do
       >> "$CHECKSUMS"
   done < <(find "$SOURCE_DIR/$skill" -type f -print0 | sort -z)
 done
+EXPECTED_FILE_COUNT=$(wc -l < "$CHECKSUMS")
 TREE_DIGEST=$(sha256sum "$CHECKSUMS" | awk '{print $1}')
 RUNNER_DIGEST=$(sudo sha256sum "$BIN_DIR/runner" | awk '{print $1}')
 CONFIG_DIGEST=$(sudo sha256sum "$RUNNER_DIR/runner.yaml" | awk '{print $1}')
@@ -329,7 +333,7 @@ record_completed_sample() {
   local cohort=$1
   local chat_thread_id=$2
   local expected_reuse=$3
-  local attestation_ms=$4
+  local candidate_gate_overhead_ms=$4
   local cpu_usec=$5
   local submit_status=$6
   local submit_output=$7
@@ -415,7 +419,7 @@ record_completed_sample() {
     --argjson sandbox_create_ms "${sandbox_create_ms:-null}" \
     --argjson agent_spawn_ms "$agent_spawn_ms" \
     --argjson cpu_usec "$cpu_usec" \
-    --argjson attestation_ms "${attestation_ms:-null}" \
+    --argjson candidate_gate_overhead_ms "${candidate_gate_overhead_ms:-null}" \
     '{
       kind:"sample",
       cohort:$cohort,
@@ -429,9 +433,9 @@ record_completed_sample() {
       sandbox_create_ms:$sandbox_create_ms,
       agent_spawn_ms:$agent_spawn_ms,
       cpu_usec:$cpu_usec,
-      attestation_ms:$attestation_ms,
+      candidate_gate_overhead_ms:$candidate_gate_overhead_ms,
       candidate_ready_proxy_ms: (
-        $api_to_spawn_ms + (if $attestation_ms == null then 0 else $attestation_ms end)
+        $api_to_spawn_ms + (if $candidate_gate_overhead_ms == null then 0 else $candidate_gate_overhead_ms end)
       )
     }' >> "$RAW_SAMPLES"
 }
@@ -442,7 +446,7 @@ record_sample() {
   local chat_thread_id=$3
   local session_id=$4
   local expected_reuse=$5
-  local attestation_ms=${6:-}
+  local candidate_gate_overhead_ms=${6:-}
   local prompt=${7:-true}
   local cpu_before
   local cpu_after
@@ -465,176 +469,47 @@ record_sample() {
   fi
   cpu_after=$(cpu_usage_usec)
   record_completed_sample "$cohort" "$chat_thread_id" "$expected_reuse" \
-    "$attestation_ms" "$((cpu_after - cpu_before))" "$submit_status" "$submit_output"
+    "$candidate_gate_overhead_ms" "$((cpu_after - cpu_before))" "$submit_status" "$submit_output"
 }
 
 CHECKSUMS_BASE64=$(base64 -w0 "$CHECKSUMS")
-ATTEST_COMMAND='test "$(cat /tmp/vm0-default-seed-baseline-descriptor 2>/dev/null)" = "$EXPECTED_DESCRIPTOR" && printf %s "$EXPECTED_CHECKSUMS" | base64 -d | sha256sum -c - >/dev/null'
-
-attest_candidate() {
-  local sandbox_id=$1
-  local started_ns
-  local finished_ns
-  local output
-  local status=0
-  local attempt
-  started_ns=$(date +%s%N)
-  for attempt in $(seq 1 10); do
-    if output=$(sudo timeout 4 "$BIN_DIR/runner" exec --timeout 2 \
-      --sandbox "$sandbox_id" -- \
-      env \
-      "EXPECTED_DESCRIPTOR=$DESCRIPTOR_DIGEST" \
-      "EXPECTED_CHECKSUMS=$CHECKSUMS_BASE64" \
-      bash -lc "$ATTEST_COMMAND" 2>&1); then
-      status=0
-    else
-      status=$?
-    fi
-    if [ "$status" -eq 0 ]; then
-      finished_ns=$(date +%s%N)
-      ATTESTATION_MS=$(((finished_ns - started_ns) / 1000000))
-      return 0
-    fi
-    if [ "$status" -eq 1 ] \
-      && ! grep -Eq 'error: (exec failed|sandbox operation gate|config error)' <<<"$output"; then
-      finished_ns=$(date +%s%N)
-      ATTESTATION_MS=$(((finished_ns - started_ns) / 1000000))
-      echo "Prepared candidate attestation command failed for $sandbox_id:" >&2
-      printf '%s\n' "$output" | tail -c 4096 >&2
-      return 1
-    fi
-    sleep 0.1
-  done
-  finished_ns=$(date +%s%N)
-  ATTESTATION_MS=$(((finished_ns - started_ns) / 1000000))
-  echo "Prepared candidate attestation transport failed for $sandbox_id:" >&2
-  printf '%s\n' "$output" | tail -c 4096 >&2
-  return 2
-}
-
-release_candidate_gate() {
-  local sandbox_id=$1
-  local release_path=$2
-  local attempt
-
-  for attempt in $(seq 1 20); do
-    if sudo timeout 4 "$BIN_DIR/runner" exec --timeout 2 \
-      --sandbox "$sandbox_id" -- touch "$release_path" >/dev/null 2>&1; then
-      return 0
-    fi
-    sleep 0.1
-  done
-  return 1
-}
-
-wait_for_agent_spawn() {
-  local run_id=$1
-  local submit_pid=$2
-  local deadline=$((SECONDS + 115))
-
-  while [ "$SECONDS" -lt "$deadline" ]; do
-    if sudo journalctl -u "$UNIT" --since '2 minutes ago' --no-pager -o cat \
-      --grep "agent startup timing run_id=$run_id" 2>/dev/null \
-      | grep -Fq "agent startup timing run_id=$run_id"; then
-      return 0
-    fi
-    if ! kill -0 "$submit_pid" 2>/dev/null; then
-      return 1
-    fi
-    sleep 0.25
-  done
-  return 1
-}
+ATTEST_PROMPT='test "$(cat /tmp/vm0-default-seed-baseline-descriptor 2>/dev/null)" = "$EXPECTED_DESCRIPTOR" || exit 91; test -z "$(find /home/user/.claude/skills/computer-use /home/user/.claude/skills/gen /home/user/.claude/skills/workflow-setup ! -type d ! -type f -print -quit)" || exit 92; actual_count=$(find /home/user/.claude/skills/computer-use /home/user/.claude/skills/gen /home/user/.claude/skills/workflow-setup -type f -print | wc -l); [ "$actual_count" -eq "$EXPECTED_FILE_COUNT" ] || exit 93; printf %s "$EXPECTED_CHECKSUMS" | base64 -d | sha256sum -c - >/dev/null || exit 94'
 
 run_candidate_gate() {
   local candidate_sandbox_id=$1
   local chat_thread_id=$2
   local session_id=$3
-  local release_path="/tmp/vm0-default-seed-baseline-release-$session_id"
-  local output_file="$BENCHMARK_DIR/$session_id.submit"
-  local submit_pid
   local cpu_before
   local cpu_after
   local started_ns
   local finished_ns
-  local attempt
-  local active=false
   local submit_json
-  local completed_run_id
+  local job_exit_code
   local operations
+  local reuse_result
+  local api_to_spawn_ms
   local published_sandbox_id
-  local attestation_status=0
 
   GATE_ATTESTED=false
-  GATE_ATTESTATION_MS=""
+  GATE_OVERHEAD_MS=""
   GATE_OUTPUT=""
   GATE_STATUS=0
   GATE_ERROR=""
   GATE_ELAPSED_MS=""
   cpu_before=$(cpu_usage_usec)
   started_ns=$(date +%s%N)
-  sudo "$BIN_DIR/runner" local submit \
+  if GATE_OUTPUT=$(sudo "$BIN_DIR/runner" local submit \
     --group "$GROUP" \
     --profile "$PROFILE" \
     --chat-thread-id "$chat_thread_id" \
     --session-id "$session_id" \
     --feature-flag sandboxReuse=true \
     --storage-manifest "$MANIFEST" \
+    --env "EXPECTED_DESCRIPTOR=$DESCRIPTOR_DIGEST" \
+    --env "EXPECTED_CHECKSUMS=$CHECKSUMS_BASE64" \
+    --env "EXPECTED_FILE_COUNT=$EXPECTED_FILE_COUNT" \
     --timeout 120 \
-    --prompt "for _ in \$(seq 1 600); do [ -e '$release_path' ] && exit 0; sleep 0.05; done; exit 98" \
-    >"$output_file" 2>&1 &
-  submit_pid=$!
-
-  for attempt in $(seq 1 200); do
-    GATE_RUN_ID=$(sudo jq -r --arg sandbox_id "$candidate_sandbox_id" \
-      '.active_runs[]? | select(.sandbox_id == $sandbox_id) | .run_id' \
-      "$RUNNER_DIR/status.json" 2>/dev/null || true)
-    if [ -n "$GATE_RUN_ID" ]; then
-      active=true
-      break
-    fi
-    if ! kill -0 "$submit_pid" 2>/dev/null; then
-      break
-    fi
-    sleep 0.05
-  done
-  if [ "$active" != true ]; then
-    wait "$submit_pid" 2>/dev/null || true
-    cat "$output_file" >&2
-    fail "Prepared candidate did not become active: $candidate_sandbox_id"
-  fi
-  if ! wait_for_agent_spawn "$GATE_RUN_ID" "$submit_pid"; then
-    if wait "$submit_pid"; then
-      GATE_STATUS=0
-    else
-      GATE_STATUS=$?
-    fi
-    cpu_after=$(cpu_usage_usec)
-    finished_ns=$(date +%s%N)
-    GATE_CPU_USEC=$((cpu_after - cpu_before))
-    GATE_ELAPSED_MS=$(((finished_ns - started_ns) / 1000000))
-    GATE_OUTPUT=$(<"$output_file")
-    rm -f "$output_file"
-    GATE_ERROR=candidate_agent_spawn_unavailable
-    return 2
-  fi
-
-  ATTESTATION_MS=""
-  if attest_candidate "$candidate_sandbox_id"; then
-    attestation_status=0
-  else
-    attestation_status=$?
-  fi
-  case "$attestation_status" in
-    0) GATE_ATTESTED=true ;;
-    1) ;;
-    *) fail "Prepared candidate attestation could not reach the guest" ;;
-  esac
-  GATE_ATTESTATION_MS=$ATTESTATION_MS
-  release_candidate_gate "$candidate_sandbox_id" "$release_path" \
-    || fail "Prepared candidate gate could not release its controlled job"
-
-  if wait "$submit_pid"; then
+    --prompt "$ATTEST_PROMPT" 2>&1); then
     GATE_STATUS=0
   else
     GATE_STATUS=$?
@@ -643,24 +518,53 @@ run_candidate_gate() {
   finished_ns=$(date +%s%N)
   GATE_CPU_USEC=$((cpu_after - cpu_before))
   GATE_ELAPSED_MS=$(((finished_ns - started_ns) / 1000000))
-  GATE_OUTPUT=$(<"$output_file")
-  rm -f "$output_file"
-  [ "$GATE_STATUS" -eq 0 ] || fail "Prepared candidate gate job failed"
 
   submit_json=$(awk '/^\{/{line=$0} END{print line}' <<<"$GATE_OUTPUT")
-  completed_run_id=$(jq -r '.run_id // empty' <<<"$submit_json" 2>/dev/null || true)
-  [ -n "$completed_run_id" ] || fail "Prepared candidate gate omitted its run ID"
-  [ "$completed_run_id" = "$GATE_RUN_ID" ] \
-    || fail "Prepared candidate gate completed a different run"
-  wait_for_telemetry "$GATE_RUN_ID" || fail "Prepared candidate gate telemetry is missing"
+  GATE_RUN_ID=$(jq -r '.run_id // empty' <<<"$submit_json" 2>/dev/null || true)
+  job_exit_code=$(jq -r '.exit_code // empty' <<<"$submit_json" 2>/dev/null || true)
+  if [ -z "$GATE_RUN_ID" ] || [ -z "$job_exit_code" ]; then
+    GATE_ERROR=candidate_result_unavailable
+    return 2
+  fi
+  if ! wait_for_telemetry "$GATE_RUN_ID"; then
+    GATE_ERROR=candidate_telemetry_unavailable
+    return 2
+  fi
   operations=$(operations_for_run "$GATE_RUN_ID")
-  [ "$(operation_reuse_result "$operations")" = reused ] \
-    || fail "Prepared candidate gate did not reuse the expected sandbox"
-  published_sandbox_id=$(sandbox_for_thread "$chat_thread_id") \
-    || fail "Prepared candidate was not returned to the idle pool"
-  [ "$published_sandbox_id" = "$candidate_sandbox_id" ] \
-    || fail "Prepared candidate gate changed sandbox identity"
-  [ "$GATE_ATTESTED" = true ]
+  reuse_result=$(operation_reuse_result "$operations")
+  if [ "$reuse_result" != reused ]; then
+    GATE_ERROR=candidate_not_reused
+    return 2
+  fi
+  api_to_spawn_ms=$(operation_duration "$operations" api_to_spawn)
+  if [ -z "$api_to_spawn_ms" ]; then
+    GATE_ERROR=candidate_agent_spawn_unavailable
+    return 2
+  fi
+  case "$job_exit_code" in
+    91) GATE_ERROR=candidate_descriptor_rejected; return 1 ;;
+    92) GATE_ERROR=candidate_entry_type_rejected; return 1 ;;
+    93) GATE_ERROR=candidate_file_set_rejected; return 1 ;;
+    94) GATE_ERROR=candidate_checksum_rejected; return 1 ;;
+  esac
+  if [ "$GATE_STATUS" -ne 0 ] || [ "$job_exit_code" -ne 0 ]; then
+    GATE_ERROR=candidate_execution_failed
+    return 2
+  fi
+  if [ "$GATE_ELAPSED_MS" -gt "$api_to_spawn_ms" ]; then
+    GATE_OVERHEAD_MS=$((GATE_ELAPSED_MS - api_to_spawn_ms))
+  else
+    GATE_OVERHEAD_MS=0
+  fi
+  if ! published_sandbox_id=$(sandbox_for_thread "$chat_thread_id"); then
+    GATE_ERROR=candidate_not_republished
+    return 2
+  fi
+  if [ "$published_sandbox_id" != "$candidate_sandbox_id" ]; then
+    GATE_ERROR=candidate_identity_changed
+    return 2
+  fi
+  GATE_ATTESTED=true
 }
 
 assert_candidate_rejected_then_fresh() {
@@ -760,9 +664,9 @@ for index in $(seq 1 "$SAMPLES"); do
     break
   fi
   [ "$gate_status" -eq 0 ] \
-    || fail "Prepared candidate attestation failed before sample $index"
+    || fail "Prepared candidate attestation failed before sample $index: $GATE_ERROR"
   record_completed_sample prepared "$PREPARED_THREAD" reused \
-    "$GATE_ATTESTATION_MS" "$GATE_CPU_USEC" "$GATE_STATUS" "$GATE_OUTPUT" \
+    "$GATE_OVERHEAD_MS" "$GATE_CPU_USEC" "$GATE_STATUS" "$GATE_OUTPUT" \
     || fail "Prepared sample $index failed: $LAST_SUBMIT_ERROR"
   PREPARED_SANDBOX_ID=$LAST_SANDBOX_ID
 done
@@ -792,6 +696,10 @@ assert_candidate_rejected_then_fresh incomplete-tree \
 prepare_validation_candidate corrupt-tree
 assert_candidate_rejected_then_fresh corrupt-tree \
   "find '$SKILLS_ROOT/gen' -type f -print -quit | xargs -r sh -c 'printf corrupt >> \"\$1\"' sh" \
+  "$VALIDATION_SANDBOX_ID" "$VALIDATION_THREAD"
+prepare_validation_candidate unexpected-file
+assert_candidate_rejected_then_fresh unexpected-file \
+  "touch '$SKILLS_ROOT/workflow-setup/.vm0-unexpected'" \
   "$VALIDATION_SANDBOX_ID" "$VALIDATION_THREAD"
 
 CHANGED_MANIFEST="$BENCHMARK_DIR/storage-manifest-changed.json"

--- a/.github/scripts/runner-storage-baseline-report.sh
+++ b/.github/scripts/runner-storage-baseline-report.sh
@@ -67,7 +67,7 @@ jq -s '
           sandbox_create_ms: distribution($successful; "sandbox_create_ms"),
           agent_spawn_ms: distribution($successful; "agent_spawn_ms"),
           cpu_usec: distribution($successful; "cpu_usec"),
-          attestation_ms: distribution($successful; "attestation_ms"),
+          candidate_gate_overhead_ms: distribution($successful; "candidate_gate_overhead_ms"),
           candidate_ready_proxy_ms: distribution($successful; "candidate_ready_proxy_ms"),
           at_or_below_1s: at_or_below_1s($successful; "api_to_spawn_ms"),
           candidate_ready_at_or_below_1s: at_or_below_1s($successful; "candidate_ready_proxy_ms")
@@ -109,6 +109,6 @@ jq -s '
         ),
         failure_free: ($fresh.failures == 0 and $prepared.failures == 0)
       },
-      interpretation: "Prepared exact reuse also avoids sandbox creation; observed api_to_spawn is not a storage-only estimate. candidate_gate_adjusted_delta adds measured harness attestation after spawn as a conservative ready proxy, not a production timing boundary."
+      interpretation: "Prepared exact reuse also avoids sandbox creation; observed api_to_spawn is not a storage-only estimate. candidate_gate_adjusted_delta uses paired controlled-turn completion as a conservative ready proxy, not a production timing boundary."
     }
 ' "$RAW_SAMPLES"

--- a/.github/scripts/runner-storage-baseline-report.sh
+++ b/.github/scripts/runner-storage-baseline-report.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = --operations ]; then
+  TELEMETRY=${2:?Missing telemetry JSONL path}
+  RUN_ID=${3:?Missing run ID}
+  jq -cs --arg run_id "$RUN_ID" \
+    '[.[] | select(.runId == $run_id) | (.sandboxOperations // [])[]]' \
+    "$TELEMETRY"
+  exit 0
+fi
+
+RAW_SAMPLES=${1:?Usage: runner-storage-baseline-report.sh <samples.jsonl>}
+
+if [ ! -s "$RAW_SAMPLES" ]; then
+  echo "Storage baseline sample file is empty: $RAW_SAMPLES" >&2
+  exit 1
+fi
+
+jq -s '
+  def nearest_rank($values; $percent):
+    ($values | sort) as $sorted
+    | if ($sorted | length) == 0 then null
+      else $sorted[((($sorted | length) * $percent / 100) | ceil) - 1]
+      end;
+
+  def distribution($records; $field):
+    [$records[] | .[$field] | select(type == "number")] as $values
+    | if ($values | length) == 0 then null
+      else (($values | add) / ($values | length)) as $mean
+      | {
+        count: ($values | length),
+        min: ($values | min),
+        max: ($values | max),
+        mean: $mean,
+        stddev: ($values | map(. - $mean | . * .) | add / length | sqrt),
+        range: (($values | max) - ($values | min)),
+        p50: nearest_rank($values; 50),
+        p90: nearest_rank($values; 90),
+        p95: nearest_rank($values; 95),
+        p99: nearest_rank($values; 99)
+      }
+      end;
+
+  def at_or_below_1s($records; $field):
+    [$records[] | .[$field] | select(type == "number")] as $values
+    | if ($values | length) == 0 then null
+      else {
+        count: ([$values[] | select(. <= 1000)] | length),
+        fraction: (([$values[] | select(. <= 1000)] | length) / ($values | length))
+      }
+      end;
+
+  def cohort($name):
+    [ .[] | select(.kind == "sample" and .cohort == $name) ] as $records
+    | if ($records | length) == 0 then error("missing sample cohort: \($name)")
+      else [$records[] | select(.success == true)] as $successful
+      | {
+          cohort: $name,
+          samples: ($records | length),
+          successes: ($successful | length),
+          failures: ([$records[] | select(.success != true)] | length),
+          api_to_spawn_ms: distribution($successful; "api_to_spawn_ms"),
+          storage_apply_ms: distribution($successful; "storage_apply_ms"),
+          storage_cache_populate_ms: distribution($successful; "storage_cache_populate_ms"),
+          storage_guest_download_ms: distribution($successful; "storage_guest_download_ms"),
+          sandbox_create_ms: distribution($successful; "sandbox_create_ms"),
+          agent_spawn_ms: distribution($successful; "agent_spawn_ms"),
+          cpu_usec: distribution($successful; "cpu_usec"),
+          attestation_ms: distribution($successful; "attestation_ms"),
+          candidate_ready_proxy_ms: distribution($successful; "candidate_ready_proxy_ms"),
+          at_or_below_1s: at_or_below_1s($successful; "api_to_spawn_ms"),
+          candidate_ready_at_or_below_1s: at_or_below_1s($successful; "candidate_ready_proxy_ms")
+        }
+      end;
+
+  cohort("fresh") as $fresh
+  | cohort("prepared") as $prepared
+  | {
+      schema_version: 2,
+      fresh: $fresh,
+      prepared: $prepared,
+      observed_total_path_delta: {
+        p90_ms: (
+          if $fresh.api_to_spawn_ms.p90 == null or $prepared.api_to_spawn_ms.p90 == null
+          then null
+          else $fresh.api_to_spawn_ms.p90 - $prepared.api_to_spawn_ms.p90
+          end
+        ),
+        at_or_below_1s_percentage_points: (
+          if $fresh.at_or_below_1s.fraction == null or $prepared.at_or_below_1s.fraction == null
+          then null
+          else 100 * ($prepared.at_or_below_1s.fraction - $fresh.at_or_below_1s.fraction)
+          end
+        )
+      },
+      candidate_gate_adjusted_delta: {
+        p90_ms: (
+          if $fresh.candidate_ready_proxy_ms.p90 == null or $prepared.candidate_ready_proxy_ms.p90 == null
+          then null
+          else $fresh.candidate_ready_proxy_ms.p90 - $prepared.candidate_ready_proxy_ms.p90
+          end
+        ),
+        at_or_below_1s_percentage_points: (
+          if $fresh.candidate_ready_at_or_below_1s.fraction == null or $prepared.candidate_ready_at_or_below_1s.fraction == null
+          then null
+          else 100 * ($prepared.candidate_ready_at_or_below_1s.fraction - $fresh.candidate_ready_at_or_below_1s.fraction)
+          end
+        ),
+        failure_free: ($fresh.failures == 0 and $prepared.failures == 0)
+      },
+      interpretation: "Prepared exact reuse also avoids sandbox creation; observed api_to_spawn is not a storage-only estimate. candidate_gate_adjusted_delta adds measured harness attestation after spawn as a conservative ready proxy, not a production timing boundary."
+    }
+' "$RAW_SAMPLES"

--- a/.github/scripts/tests/dev-runner-test.sh
+++ b/.github/scripts/tests/dev-runner-test.sh
@@ -6,6 +6,8 @@ DEV_RUNNER="${REPO_ROOT}/scripts/dev-runner.sh"
 TARGET_HELPER="${REPO_ROOT}/.github/scripts/runner-image-target.sh"
 GUEST_HELPER="${REPO_ROOT}/.github/scripts/runner-guest-binaries.sh"
 GUEST_INVENTORY="${REPO_ROOT}/crates/runner/guest-binaries.json"
+STORAGE_BASELINE_WORKER="${REPO_ROOT}/.github/scripts/runner-storage-baseline-benchmark-remote.sh"
+STORAGE_BASELINE_REPORT="${REPO_ROOT}/.github/scripts/runner-storage-baseline-report.sh"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
@@ -28,6 +30,8 @@ setup_test_root() {
   ln -s "$TARGET_HELPER" "${root}/.github/scripts/runner-image-target.sh"
   ln -s "$GUEST_HELPER" "${root}/.github/scripts/runner-guest-binaries.sh"
   ln -s "$GUEST_INVENTORY" "${root}/crates/runner/guest-binaries.json"
+  ln -s "$STORAGE_BASELINE_WORKER" "${root}/.github/scripts/runner-storage-baseline-benchmark-remote.sh"
+  ln -s "$STORAGE_BASELINE_REPORT" "${root}/.github/scripts/runner-storage-baseline-report.sh"
   touch "${root}/.certs/vm0-metal-local.pem"
 
   cat >"${root}/scripts/.env.local" <<'ENV'
@@ -55,6 +59,12 @@ case "$command" in
     ;;
   "sudo install -m 755 /dev/stdin "*)
     cat >/dev/null
+    ;;
+  "sudo tee "*"storage-baseline-"*" >/dev/null && sudo chmod 0755 "*)
+    cat >/dev/null
+    ;;
+  "sudo "*"storage-baseline-benchmark.sh"*)
+    printf '%s\n' 'storage baseline benchmark invoked'
     ;;
   *" setup")
     ;;
@@ -147,6 +157,20 @@ run_deploy() {
     "$@" "${root}/scripts/dev-runner.sh" deploy
 }
 
+run_storage_baseline_benchmark() {
+  local name=$1
+  shift
+  local root="${TMPDIR}/${name}"
+  setup_test_root "$root"
+
+  REMOTE_ARCH=x86_64 \
+    CF_SSH_LOG="${root}/cf-ssh.log" \
+    SERVICE_STOP_LOG="${root}/service-stop.log" \
+    CARGO_LOG="${root}/cargo.log" \
+    PATH="${root}/bin:$PATH" \
+    "${root}/scripts/dev-runner.sh" storage-baseline-benchmark "$@"
+}
+
 run_deploy arm64-success aarch64 env >"${TMPDIR}/arm64-success.out" 2>"${TMPDIR}/arm64-success.err"
 grep -q -- "--target aarch64-unknown-linux-musl" "${TMPDIR}/arm64-success/cargo.log" || fail "expected ARM64 cargo target"
 grep -q "service stop" "${TMPDIR}/arm64-success/service-stop.log" || fail "expected ARM64 service stop"
@@ -209,5 +233,25 @@ fi
 [ ! -f "${TMPDIR}/unsupported/cargo.log" ] || fail "unsupported architecture should fail before cargo"
 [ ! -f "${TMPDIR}/unsupported/service-stop.log" ] || fail "unsupported architecture should fail before service stop"
 grep -q "unsupported remote architecture for dev-host: ppc64le" "${TMPDIR}/unsupported.err" || fail "expected unsupported architecture error"
+
+SOURCE_REVISION=dc9bfc7a3c2faf607e2520d80c233792bf8f9249
+run_storage_baseline_benchmark storage-baseline 7 "$SOURCE_REVISION" \
+  >"${TMPDIR}/storage-baseline.out" 2>"${TMPDIR}/storage-baseline.err"
+grep -q 'storage baseline benchmark invoked' "${TMPDIR}/storage-baseline.out" \
+  || fail "expected storage baseline worker output"
+grep -q "storage-baseline-benchmark.sh.*'$SOURCE_REVISION'.*'7'.*storage-baseline-report.sh" \
+  "${TMPDIR}/storage-baseline/cf-ssh.log" \
+  || fail "expected bounded storage baseline worker invocation"
+[ "$(grep -c 'sudo tee.*storage-baseline-' "${TMPDIR}/storage-baseline/cf-ssh.log")" -eq 2 ] \
+  || fail "expected storage baseline worker and report uploads"
+
+if run_storage_baseline_benchmark storage-baseline-invalid 0 "$SOURCE_REVISION" \
+  >"${TMPDIR}/storage-baseline-invalid.out" 2>"${TMPDIR}/storage-baseline-invalid.err"; then
+  fail "expected invalid storage baseline sample count to fail"
+fi
+grep -q 'sample count must be between 1 and 100' "${TMPDIR}/storage-baseline-invalid.err" \
+  || fail "expected invalid storage baseline sample diagnostic"
+[ ! -s "${TMPDIR}/storage-baseline-invalid/cf-ssh.log" ] \
+  || fail "invalid storage baseline input should fail before SSH"
 
 echo "dev-runner-test: ok"

--- a/.github/scripts/tests/runner-storage-baseline-benchmark-test.sh
+++ b/.github/scripts/tests/runner-storage-baseline-benchmark-test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
+WORKER="$REPO_ROOT/.github/scripts/runner-storage-baseline-benchmark-remote.sh"
+REVISION=dc9bfc7a3c2faf607e2520d80c233792bf8f9249
+
+tmp=$(mktemp -d)
+cleanup() {
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+assert_fails_with() {
+  local expected=$1
+  shift
+  local status=0
+
+  set +e
+  bash "$WORKER" "$@" >"$tmp/out" 2>"$tmp/err"
+  status=$?
+  set -e
+  if [ "$status" -eq 0 ]; then
+    echo "worker input unexpectedly succeeded: $*" >&2
+    exit 1
+  fi
+  if ! grep -Fq "$expected" "$tmp/err"; then
+    echo "worker error did not contain: $expected" >&2
+    cat "$tmp/err" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with \
+  'Source revision must be a full lowercase 40-character Git commit' \
+  /bin service vm0/group /runner not-a-revision 1 /bin/true
+assert_fails_with \
+  'Sample count must be an integer' \
+  /bin service vm0/group /runner "$REVISION" nope /bin/true
+assert_fails_with \
+  'Sample count must be between 1 and 100' \
+  /bin service vm0/group /runner "$REVISION" 0 /bin/true
+assert_fails_with \
+  'Sample count must be between 1 and 100' \
+  /bin service vm0/group /runner "$REVISION" 101 /bin/true
+assert_fails_with \
+  'Report script is not executable' \
+  /bin service vm0/group /runner "$REVISION" 1 "$tmp/missing-report"
+
+echo "runner-storage-baseline-benchmark-test: ok"

--- a/.github/scripts/tests/runner-storage-baseline-report-test.sh
+++ b/.github/scripts/tests/runner-storage-baseline-report-test.sh
@@ -26,7 +26,7 @@ for value in 700 900 1100 1300; do
       sandbox_create_ms: 400,
       agent_spawn_ms: 10,
       cpu_usec: 1000,
-      attestation_ms: null,
+      candidate_gate_overhead_ms: null,
       candidate_ready_proxy_ms: $value
     }' >> "$raw"
 done
@@ -44,7 +44,7 @@ for value in 600 700 800 900; do
       sandbox_create_ms: null,
       agent_spawn_ms: 8,
       cpu_usec: 500,
-      attestation_ms: 12,
+      candidate_gate_overhead_ms: 12,
       candidate_ready_proxy_ms: ($value + 12)
     }' >> "$raw"
 done
@@ -65,7 +65,7 @@ jq -e '
   and .prepared.failures == 1
   and .prepared.api_to_spawn_ms.p90 == 900
   and .prepared.at_or_below_1s.fraction == 1
-  and .prepared.attestation_ms.p95 == 12
+  and .prepared.candidate_gate_overhead_ms.p95 == 12
   and .prepared.candidate_ready_proxy_ms.p90 == 912
   and .observed_total_path_delta.p90_ms == 400
   and .observed_total_path_delta.at_or_below_1s_percentage_points == 50

--- a/.github/scripts/tests/runner-storage-baseline-report-test.sh
+++ b/.github/scripts/tests/runner-storage-baseline-report-test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
+REPORT="$REPO_ROOT/.github/scripts/runner-storage-baseline-report.sh"
+
+tmp=$(mktemp -d)
+cleanup() {
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+raw="$tmp/samples.jsonl"
+for value in 700 900 1100 1300; do
+  jq -cn \
+    --argjson value "$value" \
+    '{
+      kind: "sample",
+      cohort: "fresh",
+      success: true,
+      api_to_spawn_ms: $value,
+      storage_apply_ms: 300,
+      storage_cache_populate_ms: 80,
+      storage_guest_download_ms: 200,
+      sandbox_create_ms: 400,
+      agent_spawn_ms: 10,
+      cpu_usec: 1000,
+      attestation_ms: null,
+      candidate_ready_proxy_ms: $value
+    }' >> "$raw"
+done
+for value in 600 700 800 900; do
+  jq -cn \
+    --argjson value "$value" \
+    '{
+      kind: "sample",
+      cohort: "prepared",
+      success: true,
+      api_to_spawn_ms: $value,
+      storage_apply_ms: 0,
+      storage_cache_populate_ms: null,
+      storage_guest_download_ms: null,
+      sandbox_create_ms: null,
+      agent_spawn_ms: 8,
+      cpu_usec: 500,
+      attestation_ms: 12,
+      candidate_ready_proxy_ms: ($value + 12)
+    }' >> "$raw"
+done
+jq -cn '{kind:"sample",cohort:"prepared",success:false,error:"bounded failure"}' >> "$raw"
+
+bash "$REPORT" "$raw" > "$tmp/report.json"
+
+jq -e '
+  .schema_version == 2
+  and .fresh.samples == 4
+  and .fresh.api_to_spawn_ms.p50 == 900
+  and .fresh.api_to_spawn_ms.p90 == 1300
+  and (.fresh.api_to_spawn_ms.stddev | type) == "number"
+  and .fresh.at_or_below_1s.count == 2
+  and .fresh.at_or_below_1s.fraction == 0.5
+  and .prepared.samples == 5
+  and .prepared.successes == 4
+  and .prepared.failures == 1
+  and .prepared.api_to_spawn_ms.p90 == 900
+  and .prepared.at_or_below_1s.fraction == 1
+  and .prepared.attestation_ms.p95 == 12
+  and .prepared.candidate_ready_proxy_ms.p90 == 912
+  and .observed_total_path_delta.p90_ms == 400
+  and .observed_total_path_delta.at_or_below_1s_percentage_points == 50
+  and .candidate_gate_adjusted_delta.p90_ms == 388
+  and .candidate_gate_adjusted_delta.at_or_below_1s_percentage_points == 50
+  and (.candidate_gate_adjusted_delta.failure_free | not)
+' "$tmp/report.json" >/dev/null
+
+: > "$tmp/empty.jsonl"
+if bash "$REPORT" "$tmp/empty.jsonl" >"$tmp/empty.out" 2>"$tmp/empty.err"; then
+  echo "empty report input unexpectedly succeeded" >&2
+  exit 1
+fi
+grep -Fq 'sample file is empty' "$tmp/empty.err"
+
+jq -cn '{kind:"sample",cohort:"fresh",success:true,api_to_spawn_ms:1}' \
+  > "$tmp/missing.jsonl"
+if bash "$REPORT" "$tmp/missing.jsonl" >"$tmp/missing.out" 2>"$tmp/missing.err"; then
+  echo "missing prepared cohort unexpectedly succeeded" >&2
+  exit 1
+fi
+grep -Fq 'missing sample cohort: prepared' "$tmp/missing.err"
+
+cat > "$tmp/telemetry.jsonl" <<'JSONL'
+{"runId":"target","event":"guest-payload-without-operations"}
+{"runId":"other","sandboxOperations":[{"action_type":"ignored"}]}
+{"runId":"target","sandboxOperations":[{"action_type":"api_to_spawn","duration_ms":42}]}
+JSONL
+bash "$REPORT" --operations "$tmp/telemetry.jsonl" target > "$tmp/operations.json"
+jq -e '
+  length == 1
+  and .[0].action_type == "api_to_spawn"
+  and .[0].duration_ms == 42
+' "$tmp/operations.json" >/dev/null
+
+echo "runner-storage-baseline-report-test: ok"

--- a/crates/runner/src/cmd/local/mod.rs
+++ b/crates/runner/src/cmd/local/mod.rs
@@ -19,7 +19,7 @@ pub struct LocalArgs {
 #[derive(Subcommand)]
 enum LocalCommand {
     /// Submit a job to a locally running runner
-    Submit(submit::SubmitArgs),
+    Submit(Box<submit::SubmitArgs>),
     /// Cancel a running job
     Cancel(cancel::CancelArgs),
 }
@@ -27,7 +27,7 @@ enum LocalCommand {
 /// Dispatch `runner local` to the selected local file-queue subcommand.
 pub async fn run_local(args: LocalArgs) -> RunnerResult<ExitCode> {
     match args.command {
-        LocalCommand::Submit(args) => submit::run_submit(args).await,
+        LocalCommand::Submit(args) => submit::run_submit(*args).await,
         LocalCommand::Cancel(args) => cancel::run_cancel(args).await,
     }
 }

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -5,12 +5,14 @@
 //! the job.
 
 use std::collections::{HashMap, HashSet};
+use std::io::Read;
 use std::io::Write;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::time::Duration;
 
+use api_contracts::generated::types::runners::storage::StorageMountEntry;
 use clap::Args;
 use tokio::signal::unix::{Signal, SignalKind, signal};
 use uuid::Uuid;
@@ -34,6 +36,12 @@ const MAX_LOCAL_SUBMIT_TIMEOUT_SECS: u64 = 24 * 60 * 60;
 
 /// Grace period after Ctrl+C to wait for the runner to write a `.result` file.
 const CANCEL_GRACE: Duration = Duration::from_secs(10);
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LocalStorageManifestInput {
+    storage_mounts: Vec<StorageMountEntry>,
+}
 
 #[derive(Args)]
 pub struct SubmitArgs {
@@ -70,6 +78,9 @@ pub struct SubmitArgs {
     /// Delayed active input for local smoke tests (repeatable, format: after=1s,text=hello)
     #[arg(long = "active-input")]
     active_inputs: Vec<String>,
+    /// Canonical storage manifest JSON for an operator-controlled local job
+    #[arg(long)]
+    storage_manifest: Option<PathBuf>,
 }
 
 /// Detect the system timezone from the `TZ` env var or a timezone file.
@@ -364,6 +375,7 @@ impl SubmitPlan {
             secret_env,
             timeout,
             active_inputs,
+            storage_manifest,
         } = args;
 
         crate::group::validate_or_err(&group)?;
@@ -393,6 +405,10 @@ impl SubmitPlan {
 
         let job_id = RunId::new_v4();
         let active_inputs = Self::parse_active_inputs(&active_inputs, timeout)?;
+        let storage_mounts = storage_manifest
+            .as_deref()
+            .map(Self::read_storage_manifest)
+            .transpose()?;
         let request = JobRequest {
             job_id,
             prompt,
@@ -406,6 +422,8 @@ impl SubmitPlan {
             session_id,
             feature_flags,
             active_input: (!active_inputs.is_empty()).then_some(true),
+            storage_mounts,
+            submitted_at_ms: Some(chrono::Utc::now().timestamp_millis().max(0) as u64),
         };
 
         let request_json = serde_json::to_vec(&request)
@@ -427,6 +445,56 @@ impl SubmitPlan {
             request_json,
             active_inputs,
         })
+    }
+
+    fn read_storage_manifest(path: &Path) -> RunnerResult<Vec<StorageMountEntry>> {
+        let file = std::fs::File::open(path).map_err(|error| {
+            RunnerError::Config(format!(
+                "open local storage manifest {}: {error}",
+                path.display()
+            ))
+        })?;
+        let metadata = file.metadata().map_err(|error| {
+            RunnerError::Config(format!(
+                "stat local storage manifest {}: {error}",
+                path.display()
+            ))
+        })?;
+        if metadata.len() > local_queue::LOCAL_JOB_MAX_BYTES as u64 {
+            return Err(RunnerError::Config(format!(
+                "local storage manifest {} exceeds {} bytes (got {} bytes)",
+                path.display(),
+                local_queue::LOCAL_JOB_MAX_BYTES,
+                metadata.len()
+            )));
+        }
+
+        let read_limit = local_queue::LOCAL_JOB_MAX_BYTES + 1;
+        let mut bytes = Vec::with_capacity(metadata.len() as usize);
+        file.take(read_limit as u64)
+            .read_to_end(&mut bytes)
+            .map_err(|error| {
+                RunnerError::Config(format!(
+                    "read local storage manifest {}: {error}",
+                    path.display()
+                ))
+            })?;
+        if bytes.len() > local_queue::LOCAL_JOB_MAX_BYTES {
+            return Err(RunnerError::Config(format!(
+                "local storage manifest {} exceeds {} bytes",
+                path.display(),
+                local_queue::LOCAL_JOB_MAX_BYTES
+            )));
+        }
+
+        let manifest: LocalStorageManifestInput =
+            serde_json::from_slice(&bytes).map_err(|error| {
+                RunnerError::Config(format!(
+                    "parse local storage manifest {}: {error}",
+                    path.display()
+                ))
+            })?;
+        Ok(manifest.storage_mounts)
     }
 
     fn parse_active_inputs(

--- a/crates/runner/src/cmd/local/submit/tests/completed_cleanup.rs
+++ b/crates/runner/src/cmd/local/submit/tests/completed_cleanup.rs
@@ -29,6 +29,7 @@ async fn submit_returns_failure_for_nonzero_job_response() {
             secret_env: vec![],
             timeout: 5,
             active_inputs: vec![],
+            storage_manifest: None,
         },
         home,
         42,

--- a/crates/runner/src/cmd/local/submit/tests/queue_publication.rs
+++ b/crates/runner/src/cmd/local/submit/tests/queue_publication.rs
@@ -84,6 +84,7 @@ fn submit_plan_creates_private_queue_dirs_and_job_file() {
             secret_env: vec![],
             timeout: 5,
             active_inputs: vec![],
+            storage_manifest: None,
         },
         home,
     )
@@ -126,6 +127,7 @@ fn submit_plan_tightens_existing_permissive_queue_dirs() {
             secret_env: vec![],
             timeout: 5,
             active_inputs: vec![],
+            storage_manifest: None,
         },
         home,
     )

--- a/crates/runner/src/cmd/local/submit/tests/request.rs
+++ b/crates/runner/src/cmd/local/submit/tests/request.rs
@@ -23,6 +23,7 @@ async fn submit_defaults_profile_and_writes_default_partition() {
             secret_env: vec![],
             timeout: 5,
             active_inputs: vec![],
+            storage_manifest: None,
         },
         home,
     )
@@ -58,6 +59,7 @@ async fn submit_writes_non_default_profile_partition() {
             secret_env: vec![],
             timeout: 5,
             active_inputs: vec![],
+            storage_manifest: None,
         },
         home,
     )
@@ -87,6 +89,7 @@ async fn submit_serializes_feature_flags_and_identity_fields() {
             secret_env: vec![],
             timeout: 5,
             active_inputs: vec![],
+            storage_manifest: None,
         },
         home,
     )
@@ -125,6 +128,7 @@ async fn submit_keeps_session_only_job_without_reuse_key() {
             secret_env: vec![],
             timeout: 5,
             active_inputs: vec![],
+            storage_manifest: None,
         },
         home,
     )
@@ -134,6 +138,52 @@ async fn submit_keeps_session_only_job_without_reuse_key() {
     assert_eq!(code, ExitCode::SUCCESS);
     assert_eq!(request.session_id.as_deref(), Some("sess-123"));
     assert!(request.reuse_key.is_none());
+}
+
+#[tokio::test]
+async fn submit_serializes_canonical_storage_manifest_and_timestamp() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = dir.path().join("storage-manifest.json");
+    std::fs::write(
+        &manifest_path,
+        serde_json::to_vec(&serde_json::json!({
+            "storageMounts": [{
+                "name": "computer-use",
+                "storageId": "fixture-storage",
+                "versionId": "fixture-version",
+                "mountPath": "/home/user/.claude/skills/computer-use",
+                "archiveUrl": "https://example.test/computer-use.tar.gz",
+                "archiveSize": 123,
+                "baselineCandidate": true
+            }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let mut args = submit_args_for_test();
+    args.storage_manifest = Some(manifest_path);
+    let before_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+
+    let (code, request) =
+        run_submit_and_write_success(args, HomePaths::with_root(dir.path().to_path_buf()))
+            .await
+            .unwrap();
+    let after_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+
+    assert_eq!(code, ExitCode::SUCCESS);
+    let mounts = request.storage_mounts.unwrap();
+    assert_eq!(mounts.len(), 1);
+    assert_eq!(mounts[0].name, "computer-use");
+    assert_eq!(
+        mounts[0].mount_path,
+        "/home/user/.claude/skills/computer-use"
+    );
+    assert_eq!(mounts[0].baseline_candidate, Some(true));
+    assert!(
+        request
+            .submitted_at_ms
+            .is_some_and(|value| (before_ms..=after_ms).contains(&value))
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/cmd/local/submit/tests/support.rs
+++ b/crates/runner/src/cmd/local/submit/tests/support.rs
@@ -158,6 +158,7 @@ pub(super) fn submit_args_for_test() -> SubmitArgs {
         secret_env: vec![],
         timeout: 1,
         active_inputs: vec![],
+        storage_manifest: None,
     }
 }
 

--- a/crates/runner/src/cmd/local/submit/tests/validation.rs
+++ b/crates/runner/src/cmd/local/submit/tests/validation.rs
@@ -27,6 +27,7 @@ async fn rejects_invalid_profile_name() {
         secret_env: vec![],
         timeout: 1,
         active_inputs: vec![],
+        storage_manifest: None,
     };
     let dir = tempfile::tempdir().unwrap();
     let home = HomePaths::with_root(dir.path().to_path_buf());
@@ -51,6 +52,7 @@ async fn accepts_valid_profile_name() {
         secret_env: vec![],
         timeout: 0,
         active_inputs: vec![],
+        storage_manifest: None,
     };
     // Should pass validation and fail later (HomePaths or timeout), not on profile.
     let dir = tempfile::tempdir().unwrap();
@@ -75,6 +77,7 @@ async fn rejects_feature_flag_missing_equals() {
         secret_env: vec![],
         timeout: 1,
         active_inputs: vec![],
+        storage_manifest: None,
     };
     let dir = tempfile::tempdir().unwrap();
     let home = HomePaths::with_root(dir.path().to_path_buf());
@@ -96,6 +99,7 @@ async fn rejects_feature_flag_non_boolean() {
         secret_env: vec![],
         timeout: 1,
         active_inputs: vec![],
+        storage_manifest: None,
     };
     let dir = tempfile::tempdir().unwrap();
     let home = HomePaths::with_root(dir.path().to_path_buf());
@@ -122,6 +126,7 @@ async fn timeout_message_includes_group_and_profile() {
         secret_env: vec![],
         timeout: 0,
         active_inputs: vec![],
+        storage_manifest: None,
     };
 
     let err = run_submit_with_home(args, home).await.unwrap_err();
@@ -223,6 +228,55 @@ async fn serialized_job_over_size_limit_is_rejected_before_publication() {
 }
 
 #[tokio::test]
+async fn malformed_storage_manifest_is_rejected_before_publication() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = dir.path().join("storage-manifest.json");
+    std::fs::write(&manifest_path, b"not json").unwrap();
+    let mut args = submit_args_for_test();
+    args.storage_manifest = Some(manifest_path);
+
+    let error = run_submit_with_home(args, HomePaths::with_root(dir.path().to_path_buf()))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, RunnerError::Config(_)), "got: {error:?}");
+    assert!(
+        error.to_string().contains("parse local storage manifest"),
+        "got: {error}"
+    );
+    let job_dir = local_queue::profile_jobs_dir(
+        &dir.path().join("groups/test/group"),
+        crate::profile::DEFAULT_PROFILE,
+    )
+    .unwrap();
+    assert!(std::fs::read_dir(job_dir).unwrap().next().is_none());
+}
+
+#[tokio::test]
+async fn oversized_storage_manifest_is_rejected_before_publication() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = dir.path().join("storage-manifest.json");
+    let manifest_file = std::fs::File::create(&manifest_path).unwrap();
+    manifest_file
+        .set_len(local_queue::LOCAL_JOB_MAX_BYTES as u64 + 1)
+        .unwrap();
+    let mut args = submit_args_for_test();
+    args.storage_manifest = Some(manifest_path);
+
+    let error = run_submit_with_home(args, HomePaths::with_root(dir.path().to_path_buf()))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, RunnerError::Config(_)), "got: {error:?}");
+    assert!(
+        error
+            .to_string()
+            .contains(&local_queue::LOCAL_JOB_MAX_BYTES.to_string()),
+        "got: {error}"
+    );
+}
+
+#[tokio::test]
 async fn timeout_removes_unclaimed_job_from_queue() {
     let dir = tempfile::tempdir().unwrap();
     let home = HomePaths::with_root(dir.path().to_path_buf());
@@ -240,6 +294,7 @@ async fn timeout_removes_unclaimed_job_from_queue() {
         secret_env: vec![],
         timeout: 0,
         active_inputs: vec![],
+        storage_manifest: None,
     };
 
     let err = run_submit_with_home(args, home).await.unwrap_err();

--- a/crates/runner/src/local_queue/state.rs
+++ b/crates/runner/src/local_queue/state.rs
@@ -1062,6 +1062,8 @@ mod tests {
             session_id: Some("session-123".into()),
             feature_flags: None,
             active_input: None,
+            storage_mounts: None,
+            submitted_at_ms: None,
         };
         std::fs::write(&job_path, serde_json::to_vec(&request).unwrap()).unwrap();
         job_path

--- a/crates/runner/src/local_queue/types.rs
+++ b/crates/runner/src/local_queue/types.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use api_contracts::generated::types::runners::storage::StorageMountEntry;
+
 use crate::ids::RunId;
 
 /// Job request written by `runner local submit` as a `{job_id}.job` file.
@@ -28,6 +30,12 @@ pub(crate) struct JobRequest {
     pub(crate) feature_flags: Option<HashMap<String, bool>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) active_input: Option<bool>,
+    /// Canonical storage mounts supplied by an operator-controlled local job.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) storage_mounts: Option<Vec<StorageMountEntry>>,
+    /// Epoch-millisecond time when local submit constructed the queue request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) submitted_at_ms: Option<u64>,
 }
 
 /// Job response written by the runner as a `{job_id}.result` file.

--- a/crates/runner/src/provider/local/mod.rs
+++ b/crates/runner/src/provider/local/mod.rs
@@ -20,6 +20,7 @@ use tracing::{info, warn};
 use super::{ClaimedJob, CompletionAuth, CompletionReportTiming, JobCandidate, JobProvider};
 use crate::local_queue::{LocalClaimResult, LocalDiscoveredJob, LocalQueue};
 use crate::run_cancellation::RunCancellationRegistry;
+use crate::storage_manifest::StorageManifest;
 use crate::types::{CompleteRequest, ExecutionContext, HeartbeatState};
 use cancel::{LocalCancelScanner, LocalCancelWatcher};
 use watch::{QueueFileKind, RECONCILE_INTERVAL, ensure_watcher, next_change_or_pending};
@@ -259,6 +260,26 @@ impl JobProvider for LocalProvider {
             }
         };
 
+        let storage_manifest = match req.storage_mounts {
+            Some(storage_mounts) => match StorageManifest::from_storage_mounts(storage_mounts) {
+                Ok(manifest) => Some(manifest),
+                Err(error) => {
+                    let error = format!("invalid local storage manifest: {error}");
+                    warn!(run_id = %run_id, error = %error, "local: claimed job has invalid storage manifest");
+                    let queue = self.queue.clone();
+                    if let Err(cleanup_error) = tokio::task::spawn_blocking(move || {
+                        queue.fail_claimed_job_sync(run_id, error);
+                    })
+                    .await
+                    {
+                        warn!(run_id = %run_id, error = %cleanup_error, "local: invalid storage manifest cleanup failed");
+                    }
+                    return None;
+                }
+            },
+            None => None,
+        };
+
         let environment_merge = merge_local_environments(req.environment, req.secret_environment);
         let context = ExecutionContext {
             run_id,
@@ -267,7 +288,7 @@ impl JobProvider for LocalProvider {
             append_system_prompt: None,
             vars: req.vars,
             sandbox_token: String::new(),
-            storage_manifest: None,
+            storage_manifest,
             environment: environment_merge.environment,
             platform_environment: None,
             resume_session: req
@@ -281,7 +302,7 @@ impl JobProvider for LocalProvider {
             secret_connector_metadata_map: None,
             cli_agent_type: req.cli_agent_type,
             real_agent_in_preview: None,
-            api_start_time: None,
+            api_start_time: req.submitted_at_ms,
             user_timezone: req.user_timezone,
             capture_network_bodies: None,
             firewalls: None,

--- a/crates/runner/src/provider/local/tests/claim.rs
+++ b/crates/runner/src/provider/local/tests/claim.rs
@@ -1,4 +1,85 @@
 use super::support::*;
+use api_contracts::generated::types::runners::storage::StorageMountEntry;
+
+fn storage_mount(name: &str, mount_path: &str) -> StorageMountEntry {
+    StorageMountEntry {
+        name: name.to_owned(),
+        storage_id: format!("{name}-storage"),
+        version_id: format!("{name}-version"),
+        mount_path: mount_path.to_owned(),
+        archive_url: Some(format!("https://example.test/{name}.tar.gz")),
+        archive_size: Some(123),
+        empty: None,
+        baseline_candidate: Some(true),
+        instructions_target_filename: None,
+        missing_root_policy: None,
+        writeback: None,
+    }
+}
+
+#[tokio::test]
+async fn claim_maps_local_storage_manifest_and_timestamp_into_context() {
+    let dir = tempfile::tempdir().unwrap();
+    let provider = default_provider(dir.path(), CancellationToken::new(), empty_cancel_tokens());
+    let run_id = RunId::new_v4();
+    let submitted_at_ms = 1_900_000_000_000;
+    write_job_with_storage_manifest(
+        dir.path(),
+        run_id,
+        vec![storage_mount(
+            "computer-use",
+            "/home/user/.claude/skills/computer-use",
+        )],
+        Some(submitted_at_ms),
+    );
+
+    let candidate = provider.discover().await.unwrap();
+    let claimed = provider.claim(candidate).await.unwrap();
+    let context = claimed.context();
+
+    assert_eq!(context.api_start_time, Some(submitted_at_ms));
+    let manifest = context.storage_manifest.as_ref().unwrap();
+    assert_eq!(manifest.storages.len(), 1);
+    assert_eq!(manifest.storages[0].name, "computer-use");
+    assert_eq!(
+        manifest.storages[0].mount_path,
+        "/home/user/.claude/skills/computer-use"
+    );
+    assert!(manifest.storages[0].baseline_candidate);
+}
+
+#[tokio::test]
+async fn claim_terminally_fails_invalid_local_storage_manifest() {
+    let dir = tempfile::tempdir().unwrap();
+    let provider = default_provider(dir.path(), CancellationToken::new(), empty_cancel_tokens());
+    let run_id = RunId::new_v4();
+    let mount_path = "/home/user/.claude/skills/computer-use";
+    write_job_with_storage_manifest(
+        dir.path(),
+        run_id,
+        vec![
+            storage_mount("computer-use", mount_path),
+            storage_mount("gen", mount_path),
+        ],
+        None,
+    );
+
+    let candidate = provider.discover().await.unwrap();
+    assert!(provider.claim(candidate).await.is_none());
+
+    let result = read_result(dir.path(), run_id);
+    assert_ne!(result.exit_code, 0);
+    assert!(
+        result
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("duplicate mountPath")),
+        "got: {:?}",
+        result.error
+    );
+    assert!(!local_queue::claim_path(dir.path(), run_id).exists());
+    assert!(provider.find_unclaimed_job().is_none());
+}
 
 #[tokio::test]
 async fn claim_attaches_active_input_source_when_requested() {

--- a/crates/runner/src/provider/local/tests/support.rs
+++ b/crates/runner/src/provider/local/tests/support.rs
@@ -14,6 +14,7 @@ pub(super) use crate::local_queue::JobResponse;
 pub(super) use crate::provider::{CompletionAuth, JobCandidate, JobProvider};
 use crate::run_cancellation::{RunCancellationRegistration, RunCancellationRegistry};
 use crate::types::CompleteRequest;
+use api_contracts::generated::types::runners::storage::StorageMountEntry;
 pub(super) use tokio_util::sync::CancellationToken;
 
 pub(super) trait LocalProviderTestExt {
@@ -209,6 +210,8 @@ struct JobOptions<'a> {
     reuse_key: Option<&'a str>,
     session_id: Option<&'a str>,
     active_input: Option<bool>,
+    storage_mounts: Option<Vec<StorageMountEntry>>,
+    submitted_at_ms: Option<u64>,
 }
 
 fn write_job_in_partition_with_options(
@@ -242,8 +245,29 @@ fn job_request_json(job_id: RunId, prompt: &str, options: JobOptions<'_>) -> Vec
         session_id: options.session_id.map(String::from),
         feature_flags: None,
         active_input: options.active_input,
+        storage_mounts: options.storage_mounts,
+        submitted_at_ms: options.submitted_at_ms,
     };
     serde_json::to_vec(&req).unwrap()
+}
+
+pub(super) fn write_job_with_storage_manifest(
+    dir: &std::path::Path,
+    job_id: RunId,
+    storage_mounts: Vec<StorageMountEntry>,
+    submitted_at_ms: Option<u64>,
+) {
+    write_job_in_partition_with_options(
+        dir,
+        crate::profile::DEFAULT_PROFILE,
+        job_id,
+        "hello with storage",
+        JobOptions {
+            storage_mounts: Some(storage_mounts),
+            submitted_at_ms,
+            ..JobOptions::default()
+        },
+    );
 }
 
 pub(super) fn write_job_with_environments(
@@ -265,6 +289,8 @@ pub(super) fn write_job_with_environments(
         session_id: None,
         feature_flags: None,
         active_input: None,
+        storage_mounts: None,
+        submitted_at_ms: None,
     };
     let json = serde_json::to_vec(&req).unwrap();
     let job_dir = local_queue::profile_jobs_dir(dir, crate::profile::DEFAULT_PROFILE).unwrap();

--- a/crates/runner/src/storage_manifest.rs
+++ b/crates/runner/src/storage_manifest.rs
@@ -51,6 +51,14 @@ impl<'de> Deserialize<'de> for StorageManifest {
     }
 }
 
+impl StorageManifest {
+    pub(crate) fn from_storage_mounts(
+        storage_mounts: Vec<StorageMountEntry>,
+    ) -> Result<Self, String> {
+        normalize_storage_mounts(storage_mounts)
+    }
+}
+
 fn normalize_storage_mounts(
     storage_mounts: Vec<StorageMountEntry>,
 ) -> Result<StorageManifest, String> {

--- a/docs/runner-default-seed-baseline-benchmark.md
+++ b/docs/runner-default-seed-baseline-benchmark.md
@@ -15,8 +15,8 @@ complete and unmodified.
 The descriptor contains:
 
 - the full `vm0-ai/vm0-skills` source commit;
-- a deterministic checksum list and digest for `computer-use`, `gen`, and
-  `workflow-setup`;
+- a deterministic exact path-and-checksum manifest and digest for
+  `computer-use`, `gen`, and `workflow-setup`;
 - the `claude-code` framework and its exact guest mount paths;
 - the Runner profile;
 - the Runner binary digest;
@@ -24,13 +24,17 @@ The descriptor contains:
 - a digest of the complete descriptor.
 
 Changing any input invalidates the candidate. A parked sandbox intentionally
-rejects `runner exec`, so the harness starts a controlled reuse turn whose mock
-agent blocks without performing benchmark work. It waits for the Runner's real
-agent-spawn boundary, checks the descriptor marker and every seed file with
-`runner exec`, and only then releases that controlled turn. The attestation
-duration is recorded separately and added to a candidate-ready comparison
-proxy. This ordering avoids competing with the Runner's own pre-spawn vsock
-operations.
+rejects `runner exec`, and normal guest operations are not reliably available
+after the agent connection starts. The harness therefore starts a controlled
+reuse turn whose mock agent performs the attestation as its only command. A
+dedicated exit code distinguishes an expected candidate rejection from a
+Runner lifecycle failure. The fixture rejects non-regular source entries, and
+attestation requires the retained file set to match exactly before checking
+content.
+
+The candidate-ready comparison uses the controlled turn's measured completion
+time. Its post-spawn component includes attestation and Runner finalization, so
+it is a conservative paired overhead rather than an isolated checksum timer.
 
 The controlled checker is the only process allowed to observe an invalid
 candidate. Missing, stale, incomplete, corrupt, or mismatched state rejects the
@@ -66,12 +70,12 @@ The worker runs three phases:
 2. The fresh cohort repeatedly uses a new reuse key, a cold sandbox, and the
    complete manifest with the same warm host archive cache.
 3. The prepared cohort constructs one exact sandbox and repeatedly resumes it
-   for controlled, blocking turns. Each turn reaches real agent spawn, is
-   attested before release, and uses the unchanged complete manifest. Exact
-   storage fingerprints make the storage plan no-work; the independent tree
-   attestation determines whether the candidate may be accepted. The cohort
-   stops and records a failure if the same candidate can no longer reach the
-   real-spawn boundary.
+   for controlled attestation-only turns. Each turn reaches real agent spawn
+   and uses the unchanged complete manifest. Exact storage fingerprints make
+   the storage plan no-work; the mock agent's independent tree attestation
+   determines whether the candidate may be accepted. The cohort stops and
+   records a failure if the same candidate can no longer complete the
+   controlled turn.
 
 Each successful sample records the complete local-submit-to-real-guest-spawn
 `api_to_spawn` duration. This has the same Runner telemetry action name but its
@@ -82,7 +86,7 @@ also records:
 - sandbox creation when present;
 - the real guest-agent process spawn boundary;
 - service CPU delta;
-- candidate attestation duration;
+- conservative post-spawn candidate-gate overhead;
 - service current and peak memory;
 - fixture and Runner logical and allocated disk; and
 - terminal failure, cancellation, queue cleanup, and service cleanup evidence.
@@ -90,9 +94,9 @@ also records:
 The report calculates p50, p90, p95, and p99 directly from complete per-sample
 durations with nearest-rank percentiles. It also reports the fraction at or below
 one second, sample range, mean, and failure count. In addition to the observed
-`api_to_spawn` distribution, it reports a candidate-ready proxy computed per
-sample as observed spawn plus that sample's attestation. It never sums or
-subtracts independently aggregated component percentiles.
+`api_to_spawn` distribution, it reports the paired controlled-turn completion
+time as a candidate-ready proxy. It never sums or subtracts independently
+aggregated component percentiles.
 
 Exact prepared reuse avoids sandbox creation as well as storage application.
 The reported whole-path difference is therefore relevant to a
@@ -108,6 +112,7 @@ each invalidation probe and verifies:
 - a stale descriptor uses the fresh complete path;
 - a deleted seed file uses the fresh complete path;
 - a modified seed file uses the fresh complete path;
+- an unexpected seed file uses the fresh complete path;
 - a changed fixture version/environment descriptor uses the fresh complete
   path;
 - a missing current archive fails the complete path closed;
@@ -116,7 +121,7 @@ each invalidation probe and verifies:
   cancel ownership files.
 
 Separate candidates prevent a measured sandbox's lifecycle failure or prior
-mutation from contaminating the correctness probes. The first five cases have a
+mutation from contaminating the correctness probes. The first six cases have a
 valid current manifest and test rejection of prepared state. The missing and
 corrupt archive cases are different: the current authority itself is
 unavailable, so the run fails instead of granting the rejected prepared files.

--- a/docs/runner-default-seed-baseline-benchmark.md
+++ b/docs/runner-default-seed-baseline-benchmark.md
@@ -1,0 +1,161 @@
+# Default-seed prepared baseline benchmark
+
+This benchmark compares the current complete default-seed storage path with one
+exact prepared sandbox on the same metal Runner. It is a local experiment. It
+does not add a production baseline, pool, claim selector, API field, persisted
+authority, or cross-thread reuse rule.
+
+## Candidate ownership
+
+The benchmark harness owns the candidate descriptor. The Runner's existing
+storage fingerprints are not a candidate attestation: they record which storage
+versions were last applied but do not prove that retained guest files remain
+complete and unmodified.
+
+The descriptor contains:
+
+- the full `vm0-ai/vm0-skills` source commit;
+- a deterministic checksum list and digest for `computer-use`, `gen`, and
+  `workflow-setup`;
+- the `claude-code` framework and its exact guest mount paths;
+- the Runner profile;
+- the Runner binary digest;
+- the rootfs and snapshot identities; and
+- a digest of the complete descriptor.
+
+Changing any input invalidates the candidate. A parked sandbox intentionally
+rejects `runner exec`, so the harness starts a controlled reuse turn whose mock
+agent blocks without performing benchmark work. It waits for the Runner's real
+agent-spawn boundary, checks the descriptor marker and every seed file with
+`runner exec`, and only then releases that controlled turn. The attestation
+duration is recorded separately and added to a candidate-ready comparison
+proxy. This ordering avoids competing with the Runner's own pre-spawn vsock
+operations.
+
+The controlled checker is the only process allowed to observe an invalid
+candidate. Missing, stale, incomplete, corrupt, or mismatched state rejects the
+candidate; the harness creates a new reuse key and supplies the valid complete
+manifest for the subsequent workload-shaped run. No production or arbitrary
+workload is dispatched against the rejected state.
+
+This validation is intentionally local and relatively expensive. It occurs
+after the measured real-spawn boundary because the current Runner has no
+pre-workload candidate-attestation hook. A future production design would need
+an authoritative immutable or revalidated representation before granting the
+candidate and must include that validation cost.
+
+## Fixture
+
+The worker fetches an explicit full Git commit from the public
+`vm0-ai/vm0-skills` repository. It creates deterministic gzip-compressed tar
+archives with sorted entries, epoch timestamps, and normalized numeric
+ownership. The source commit is the fixture version; it is not a production VAS
+version ID.
+
+An isolated loopback server exposes the three archives and captures only this
+Runner service's telemetry. The worker restarts the local Runner with its API
+URL pointed at that sink, then restores the ordinary local development service
+configuration during cleanup. Experiment telemetry is not sent to the normal
+API.
+
+## Paths and measurements
+
+The worker runs three phases:
+
+1. A cache warmup applies the complete manifest to a fresh sandbox.
+2. The fresh cohort repeatedly uses a new reuse key, a cold sandbox, and the
+   complete manifest with the same warm host archive cache.
+3. The prepared cohort constructs one exact sandbox and repeatedly resumes it
+   for controlled, blocking turns. Each turn reaches real agent spawn, is
+   attested before release, and uses the unchanged complete manifest. Exact
+   storage fingerprints make the storage plan no-work; the independent tree
+   attestation determines whether the candidate may be accepted. The cohort
+   stops and records a failure if the same candidate can no longer reach the
+   real-spawn boundary.
+
+Each successful sample records the complete local-submit-to-real-guest-spawn
+`api_to_spawn` duration. This has the same Runner telemetry action name but its
+start is the local queue publish boundary, not an HTTP API request. The worker
+also records:
+
+- storage apply, host cache/staging, and guest application;
+- sandbox creation when present;
+- the real guest-agent process spawn boundary;
+- service CPU delta;
+- candidate attestation duration;
+- service current and peak memory;
+- fixture and Runner logical and allocated disk; and
+- terminal failure, cancellation, queue cleanup, and service cleanup evidence.
+
+The report calculates p50, p90, p95, and p99 directly from complete per-sample
+durations with nearest-rank percentiles. It also reports the fraction at or below
+one second, sample range, mean, and failure count. In addition to the observed
+`api_to_spawn` distribution, it reports a candidate-ready proxy computed per
+sample as observed spawn plus that sample's attestation. It never sums or
+subtracts independently aggregated component percentiles.
+
+Exact prepared reuse avoids sandbox creation as well as storage application.
+The reported whole-path difference is therefore relevant to a
+prepared-pool-style direction and is not a storage-only causal estimate. Storage
+and sandbox components remain separate in the output.
+
+## Failure and invalidation probes
+
+After the measured cohorts, the worker builds a separate exact candidate for
+each invalidation probe and verifies:
+
+- a missing candidate marker uses the fresh complete path;
+- a stale descriptor uses the fresh complete path;
+- a deleted seed file uses the fresh complete path;
+- a modified seed file uses the fresh complete path;
+- a changed fixture version/environment descriptor uses the fresh complete
+  path;
+- a missing current archive fails the complete path closed;
+- a corrupt current archive fails the complete path closed; and
+- cancellation reaches a terminal state without leaving local job, claim, or
+  cancel ownership files.
+
+Separate candidates prevent a measured sandbox's lifecycle failure or prior
+mutation from contaminating the correctness probes. The first five cases have a
+valid current manifest and test rejection of prepared state. The missing and
+corrupt archive cases are different: the current authority itself is
+unavailable, so the run fails instead of granting the rejected prepared files.
+
+## Running on the configured metal host
+
+Prepare and deploy the local Runner first:
+
+```bash
+scripts/dev-runner.sh deploy-local
+```
+
+Then run the benchmark. The default is 20 samples per measured cohort and the
+checked-in known source revision. Both may be explicit:
+
+```bash
+scripts/dev-runner.sh storage-baseline-benchmark \
+  20 \
+  dc9bfc7a3c2faf607e2520d80c233792bf8f9249
+```
+
+The sample count must be between 1 and 100, and the source revision must be a
+full lowercase 40-character commit. The command emits raw JSONL records followed
+by one JSON summary. Capture that foreground output in ignored `codex-work/`
+storage when evidence must be retained for an issue.
+
+The worker always uses the deployed Runner binary, profile configuration,
+rootfs, and snapshot already present on that host. It records their identities
+in the metadata record so results from different revisions are not combined.
+
+## Interpreting the gate
+
+Compare the complete sample distributions with the parent gate: at least 25 ms
+p90, two percentage points at the one-second boundary, or a material tail
+improvement, with no material CPU, memory, disk, failure, cancellation, or
+cleanup regression. A cohort that cannot complete its requested repeated
+same-candidate samples is not failure-free even if its successful-sample
+percentiles are faster.
+
+A pass supports only a separate production-behavior issue. It does not make the
+benchmark's local manifest, guest attestation, or retained sandbox a production
+authority. A miss supports keeping complete per-run storage application.

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 # Usage:
 #   scripts/dev-runner.sh deploy   Build, upload, and start the runner
 #   scripts/dev-runner.sh remove   Stop and uninstall the runner
+#   scripts/dev-runner.sh storage-baseline-benchmark [samples] [source-revision]
 #
 # Set RUNNER_TARGET_TRIPLE to force a supported runner target. When unset,
 # deploy derives the target from the remote host architecture.
@@ -221,6 +222,46 @@ cmd_deploy_local() {
   LOCAL_MODE=1 cmd_deploy
 }
 
+cmd_storage_baseline_benchmark() {
+  local samples="${2:-20}"
+  local source_revision="${3:-dc9bfc7a3c2faf607e2520d80c233792bf8f9249}"
+  local worker_source="$PROJECT_ROOT/.github/scripts/runner-storage-baseline-benchmark-remote.sh"
+  local report_source="$PROJECT_ROOT/.github/scripts/runner-storage-baseline-report.sh"
+  local worker_remote="$RUNNER_DIR/storage-baseline-benchmark.sh"
+  local report_remote="$RUNNER_DIR/storage-baseline-report.sh"
+
+  case "$samples" in
+    ''|*[!0-9]*)
+      log "Error: storage baseline sample count must be an integer"
+      return 2
+      ;;
+  esac
+  if [ "$samples" -lt 1 ] || [ "$samples" -gt 100 ]; then
+    log "Error: storage baseline sample count must be between 1 and 100"
+    return 2
+  fi
+  if [[ ! "$source_revision" =~ ^[0-9a-f]{40}$ ]]; then
+    log "Error: storage baseline source revision must be a full lowercase 40-character Git commit"
+    return 2
+  fi
+
+  log "Staging storage baseline benchmark on $HOST..."
+  ssh_cmd "sudo tee '$worker_remote' >/dev/null && sudo chmod 0755 '$worker_remote'" \
+    < "$worker_source"
+  ssh_cmd "sudo tee '$report_remote' >/dev/null && sudo chmod 0755 '$report_remote'" \
+    < "$report_source"
+
+  log "Running $samples samples per cohort from vm0-skills@$source_revision..."
+  ssh_cmd "sudo '$worker_remote' \
+    '$REMOTE_BIN_DIR' \
+    '$RUNNER_SERVICE_SUFFIX' \
+    '$RUNNER_GROUP' \
+    '$RUNNER_DIR' \
+    '$source_revision' \
+    '$samples' \
+    '$report_remote'"
+}
+
 cmd_exec() {
   RUN_ID="${2:?Usage: $0 exec <run-id> <command...>}"
   COMMAND="${3:?Usage: $0 exec <run-id> <command...>}"
@@ -245,11 +286,12 @@ COMMAND="${1:-}"
 case "$COMMAND" in
   deploy) cmd_deploy ;;
   deploy-local) cmd_deploy_local ;;
+  storage-baseline-benchmark) cmd_storage_baseline_benchmark "$@" ;;
   submit) cmd_submit "$@" ;;
   exec) cmd_exec "$@" ;;
   remove) cmd_remove ;;
   *)
-    log "Usage: $0 {deploy|deploy-local|submit|exec|remove}"
+    log "Usage: $0 {deploy|deploy-local|storage-baseline-benchmark|submit|exec|remove}"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

- add an operator-only local queue storage manifest and submission timestamp so the existing Runner path can be measured without changing production APIs, protocols, claim selection, or persisted authority
- add a deterministic exact default-seed metal benchmark, report generator, invalidation and cleanup probes, shell coverage, and operating documentation
- record the controlled result: raw prepared spawn is faster, but exact candidate validation makes the paired ready path slower and the same candidate fails on its seventh attempt, so the parent gate is missed and no production baseline behavior is proposed

## Controlled metal result

- source fixture: `vm0-ai/vm0-skills@dc9bfc7a3c2faf607e2520d80c233792bf8f9249`
- current fresh path: 20/20 successful; `api_to_spawn` p50/p90/p95/p99 = 377/426/426/529 ms
- same prepared candidate: 6 successful samples followed by one bounded `candidate_not_reused` lifecycle failure after 65.236 seconds
- successful prepared samples: raw `api_to_spawn` p90 = 83 ms, but paired exact-gate completion p90 = 659 ms
- candidate-gate-adjusted p90 difference = -233 ms, so the controlled ready path is slower even before counting the material failure
- missing, stale, incomplete, corrupt, unexpected, and mismatched state, current-archive failure, cancellation, service restoration, and queue cleanup probes passed

The result supports retaining the complete per-run storage path. It does not create a production child because the gate requires a net tail improvement without a material failure regression.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-features` (3376 passed, 26 ignored; guest inventory passed)
- focused local-submit and local-provider integration tests
- `.github/scripts/tests/runner-storage-baseline-report-test.sh`
- `.github/scripts/tests/runner-storage-baseline-benchmark-test.sh`
- `bash .github/scripts/tests/dev-runner-test.sh`
- `bash -n .github/scripts/runner-storage-baseline-report.sh .github/scripts/runner-storage-baseline-benchmark-remote.sh scripts/dev-runner.sh`
- representative aarch64 metal smoke and formal 20-sample benchmark with the deterministic guest-owned attestation gate

Closes #30353
Relates to #29819
