### PR TITLE
feat(cli): improve social download diagnostics

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
@@ -2609,15 +2609,64 @@ describe("managed SocialKit route", () => {
       expectedCode: "SOCIALKIT_DOWNLOAD_FAILED",
     },
     {
-      caseName: "unsafe provider message",
+      caseName: "oversized provider message",
+      providerFailure: {
+        status: "failed",
+        errorCode: "oversized_failure",
+        error: "x".repeat(501),
+        retryable: false,
+      },
+      expectedCode: "SOCIALKIT_DOWNLOAD_FAILED",
+    },
+    {
+      caseName: "provider URL",
       providerFailure: {
         status: "failed",
         errorCode: "private_failure",
-        error:
-          "Download failed at https://temporary.socialkit.test/file\nAuthorization: token=test-socialkit-key\n    at provider.js:1:2",
+        error: "Download failed at https://temporary.socialkit.test/file",
         retryable: false,
       },
       expectedCode: "SOCIALKIT_PROVIDER_private_failure",
+    },
+    {
+      caseName: "configured provider credential",
+      providerFailure: {
+        status: "failed",
+        errorCode: "credential_failure",
+        error: "Provider failed with test-socialkit-key",
+        retryable: false,
+      },
+      expectedCode: "SOCIALKIT_PROVIDER_credential_failure",
+    },
+    {
+      caseName: "credential assignment",
+      providerFailure: {
+        status: "failed",
+        errorCode: "authorization_failure",
+        error: "Authorization: Bearer different-provider-secret",
+        retryable: false,
+      },
+      expectedCode: "SOCIALKIT_PROVIDER_authorization_failure",
+    },
+    {
+      caseName: "stack frame",
+      providerFailure: {
+        status: "failed",
+        errorCode: "stack_failure",
+        error: "Provider failed at worker (/srv/provider.js:1:2)",
+        retryable: false,
+      },
+      expectedCode: "SOCIALKIT_PROVIDER_stack_failure",
+    },
+    {
+      caseName: "ASCII multiline provider message",
+      providerFailure: {
+        status: "failed",
+        errorCode: "multiline_failure",
+        error: "Provider failure\nwith hidden next line",
+        retryable: false,
+      },
+      expectedCode: "SOCIALKIT_PROVIDER_multiline_failure",
     },
     {
       caseName: "unicode multiline provider message",

--- a/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
@@ -2515,7 +2515,7 @@ describe("managed SocialKit route", () => {
     await expect(credits(actor)).resolves.toBe(creditsAfterFailure);
   });
 
-  it("marks provider download failures free and terminal", async () => {
+  it("preserves bounded provider download diagnostics", async () => {
     const actor = createBddApi(context).user();
     configureProvider();
     const pricing = await setupConfiguredPricing();
@@ -2533,6 +2533,11 @@ describe("managed SocialKit route", () => {
         return HttpResponse.json({
           jobId: providerJobId,
           status: "failed",
+          errorCode: "duration_limit_exceeded",
+          error: "Video exceeds the max_duration=60s limit",
+          retryable: false,
+          downloadUrl: "https://temporary.socialkit.test/private-video",
+          accessKey: "test-socialkit-key",
         });
       }),
     );
@@ -2560,14 +2565,124 @@ describe("managed SocialKit route", () => {
       [200],
     );
 
-    expect(failed.body.status).toBe("provider_failed");
-    expect(failed.body.billing).toBeNull();
-    expect(failed.body.error).toMatchObject({
-      billed: false,
-      retryable: false,
+    expect(failed.body).toMatchObject({
+      status: "provider_failed",
+      billing: null,
+      error: {
+        code: "SOCIALKIT_PROVIDER_duration_limit_exceeded",
+        message: "Video exceeds the max_duration=60s limit",
+        billed: false,
+        retryable: false,
+      },
     });
+    expect(JSON.stringify(failed.body)).not.toContain("downloadUrl");
+    expect(JSON.stringify(failed.body)).not.toContain("test-socialkit-key");
     await expect(credits(actor)).resolves.toBe(beforeCredits);
   });
+
+  it.each([
+    {
+      caseName: "legacy failure without diagnostics",
+      providerFailure: {
+        status: "failed",
+      },
+      expectedCode: "SOCIALKIT_DOWNLOAD_FAILED",
+    },
+    {
+      caseName: "malformed provider code",
+      providerFailure: {
+        status: "failed",
+        errorCode: "invalid provider code",
+        error: "The provider could not prepare the download",
+        retryable: false,
+      },
+      expectedCode: "SOCIALKIT_DOWNLOAD_FAILED",
+    },
+    {
+      caseName: "oversized provider code",
+      providerFailure: {
+        status: "failed",
+        errorCode: "x".repeat(129),
+        error: "The provider could not prepare the download",
+        retryable: false,
+      },
+      expectedCode: "SOCIALKIT_DOWNLOAD_FAILED",
+    },
+    {
+      caseName: "unsafe provider message",
+      providerFailure: {
+        status: "failed",
+        errorCode: "private_failure",
+        error:
+          "Download failed at https://temporary.socialkit.test/file\nAuthorization: token=test-socialkit-key\n    at provider.js:1:2",
+        retryable: false,
+      },
+      expectedCode: "SOCIALKIT_PROVIDER_private_failure",
+    },
+  ])(
+    "uses a safe fallback for $caseName",
+    async ({ providerFailure, expectedCode }) => {
+      const actor = createBddApi(context).user();
+      configureProvider();
+      const pricing = await setupConfiguredPricing();
+      await fundActor(actor);
+      const beforeCredits = await credits(actor);
+      const providerJobId = `provider-safe-fallback-${randomUUID()}`;
+      server.use(
+        http.post(`${SOCIALKIT_BASE}/v2/tiktok/download`, () => {
+          return HttpResponse.json({
+            jobId: providerJobId,
+            status: "queued",
+          });
+        }),
+        http.get(`${SOCIALKIT_BASE}/v2/downloads/${providerJobId}`, () => {
+          return HttpResponse.json({
+            jobId: providerJobId,
+            ...providerFailure,
+          });
+        }),
+      );
+      const socialClient = client(pricing.resolution)(socialContract);
+
+      const created = await accept(
+        socialClient.createDownload({
+          headers: authenticate(actor),
+          body: {
+            platform: "tiktok",
+            url: "https://www.tiktok.com/@public/video/1",
+            maxDuration: 60,
+            quality: "720p",
+            format: "mp4",
+          },
+        }),
+        [202],
+      );
+      await flushWaitUntilForTest();
+      const failed = await accept(
+        socialClient.getDownload({
+          headers: authenticate(actor),
+          params: { downloadId: created.body.downloadId },
+        }),
+        [200],
+      );
+
+      expect(failed.body).toMatchObject({
+        status: "provider_failed",
+        billing: null,
+        error: {
+          code: expectedCode,
+          message: "SocialKit could not prepare the download",
+          billed: false,
+          retryable: false,
+        },
+      });
+      const serialized = JSON.stringify(failed.body);
+      expect(serialized).not.toContain("temporary.socialkit.test");
+      expect(serialized).not.toContain("test-socialkit-key");
+      expect(serialized).not.toContain("provider.js");
+      await expect(credits(actor)).resolves.toBe(beforeCredits);
+    },
+  );
 
   it("rejects a ready response for a different platform without billing", async () => {
     const actor = createBddApi(context).user();

--- a/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
@@ -2669,11 +2669,31 @@ describe("managed SocialKit route", () => {
       expectedCode: "SOCIALKIT_PROVIDER_multiline_failure",
     },
     {
+      caseName: "C1 control provider message",
+      providerFailure: {
+        status: "failed",
+        errorCode: "control_failure",
+        error: "Provider failure\u0085with hidden next line",
+        retryable: false,
+      },
+      expectedCode: "SOCIALKIT_PROVIDER_control_failure",
+    },
+    {
       caseName: "unicode multiline provider message",
       providerFailure: {
         status: "failed",
         errorCode: "multiline_failure",
         error: "Provider failure\u2028with hidden next line",
+        retryable: false,
+      },
+      expectedCode: "SOCIALKIT_PROVIDER_multiline_failure",
+    },
+    {
+      caseName: "unicode paragraph separator provider message",
+      providerFailure: {
+        status: "failed",
+        errorCode: "multiline_failure",
+        error: "Provider failure\u2029with hidden next line",
         retryable: false,
       },
       expectedCode: "SOCIALKIT_PROVIDER_multiline_failure",

--- a/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
@@ -2619,6 +2619,16 @@ describe("managed SocialKit route", () => {
       },
       expectedCode: "SOCIALKIT_PROVIDER_private_failure",
     },
+    {
+      caseName: "unicode multiline provider message",
+      providerFailure: {
+        status: "failed",
+        errorCode: "multiline_failure",
+        error: "Provider failure\u2028with hidden next line",
+        retryable: false,
+      },
+      expectedCode: "SOCIALKIT_PROVIDER_multiline_failure",
+    },
   ])(
     "uses a safe fallback for $caseName",
     async ({ providerFailure, expectedCode }) => {

--- a/turbo/apps/api/src/signals/services/socialkit-download.service.ts
+++ b/turbo/apps/api/src/signals/services/socialkit-download.service.ts
@@ -58,7 +58,15 @@ const MAX_PROVIDER_RESPONSE_BYTES = 1024 * 1024;
 const MULTIPART_PART_BYTES = 8 * 1024 * 1024;
 const MAX_DOWNLOAD_BYTES = 2 * 1024 * 1024 * 1024;
 const MAX_ARTIFACT_FILENAME_STEM_CHARS = 120;
+const MAX_PROVIDER_FAILURE_CODE_CHARS = 128;
+const MAX_PROVIDER_FAILURE_MESSAGE_CHARS = 500;
 const INVALID_ARTIFACT_FILENAME_CHARS = String.raw`<>:"/\|?*`;
+const PROVIDER_FAILURE_CODE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/u;
+const PROVIDER_FAILURE_URL_PATTERN = /(?:[a-z][a-z0-9+.-]*:\/\/|www\.)/iu;
+const PROVIDER_FAILURE_CREDENTIAL_PATTERN =
+  /\b(?:access[ _-]?key|api[ _-]?key|authorization|password|token)\s*[:=]\s*\S+/iu;
+const PROVIDER_FAILURE_STACK_PATTERN =
+  /(?:\bat\s+(?:async\s+)?(?:\S+\s+\()?[^()\s]+:\d+:\d+\)?|\bFile\s+"[^"]+",\s+line\s+\d+)/u;
 const RECONCILE_BATCH_SIZE = 2;
 const USAGE_NAMESPACE = "42a65d9f-67d6-4bed-ae87-9f80ce1feb79";
 const ACTIVE_STATUSES = [
@@ -68,6 +76,17 @@ const ACTIVE_STATUSES = [
 ] as const;
 
 type DownloadJob = typeof socialKitDownloadJobs.$inferSelect;
+type DownloadJobError = NonNullable<DownloadJob["error"]>;
+
+const PROVIDER_DOWNLOAD_FAILED_ERROR = {
+  code: "SOCIALKIT_DOWNLOAD_FAILED",
+  message: "SocialKit could not prepare the download",
+} satisfies DownloadJobError;
+
+const INVALID_PROVIDER_RESPONSE_ERROR = {
+  code: "SOCIALKIT_INVALID_DOWNLOAD_RESPONSE",
+  message: "SocialKit returned invalid download metadata",
+} satisfies DownloadJobError;
 
 interface SocialKitDownloadErrorResponse {
   readonly status: 409 | 502 | 503;
@@ -119,6 +138,17 @@ const providerReadySchema = z.object({
   format: socialKitDownloadFormatSchema,
   title: z.unknown().optional(),
   thumbnail: z.unknown().optional(),
+});
+
+const providerFailedSchema = z.object({
+  status: z.literal("failed"),
+  errorCode: z
+    .string()
+    .min(1)
+    .max(MAX_PROVIDER_FAILURE_CODE_CHARS)
+    .regex(PROVIDER_FAILURE_CODE_PATTERN),
+  error: z.string().trim().min(1).max(MAX_PROVIDER_FAILURE_MESSAGE_CHARS),
+  retryable: z.boolean(),
 });
 
 const providerThumbnailSchema = z
@@ -213,6 +243,42 @@ function providerBody(value: unknown): unknown {
   return value;
 }
 
+function safeProviderFailureMessage(
+  message: string,
+  accessKey: string,
+): string | null {
+  const hasControlCharacter = [...message].some((character) => {
+    const codeUnit = character.charCodeAt(0);
+    return codeUnit <= 31 || (codeUnit >= 127 && codeUnit <= 159);
+  });
+  if (
+    hasControlCharacter ||
+    PROVIDER_FAILURE_URL_PATTERN.test(message) ||
+    PROVIDER_FAILURE_CREDENTIAL_PATTERN.test(message) ||
+    PROVIDER_FAILURE_STACK_PATTERN.test(message) ||
+    message.includes(accessKey)
+  ) {
+    return null;
+  }
+  return message;
+}
+
+function providerFailureError(
+  value: unknown,
+  accessKey: string,
+): DownloadJobError | null {
+  const parsed = providerFailedSchema.safeParse(value);
+  if (!parsed.success) {
+    return null;
+  }
+  return {
+    code: `SOCIALKIT_PROVIDER_${parsed.data.errorCode}`,
+    message:
+      safeProviderFailureMessage(parsed.data.error, accessKey) ??
+      PROVIDER_DOWNLOAD_FAILED_ERROR.message,
+  };
+}
+
 async function providerJson(
   url: string,
   init: RequestInit,
@@ -270,7 +336,10 @@ async function startProviderJob(
 
 type ProviderPollResult =
   | { readonly status: "processing" }
-  | { readonly status: "failed" }
+  | {
+      readonly status: "failed";
+      readonly error: DownloadJobError | null;
+    }
   | { readonly status: "invalid" }
   | {
       readonly status: "ready";
@@ -289,7 +358,7 @@ async function pollProviderJob(
   );
   if (!result.response.ok) {
     if (result.response.status === 404) {
-      return { status: "failed" };
+      return { status: "failed", error: null };
     }
     throw new Error(
       `SocialKit download status failed (${result.response.status})`,
@@ -304,7 +373,10 @@ async function pollProviderJob(
     return { status: "invalid" };
   }
   if (result.body.status === "failed") {
-    return { status: "failed" };
+    return {
+      status: "failed",
+      error: providerFailureError(result.body, accessKey),
+    };
   }
   if (result.body.status === "queued" || result.body.status === "processing") {
     return { status: "processing" };
@@ -1030,7 +1102,7 @@ async function recordProviderFailure(
   writeDb: Db,
   job: DownloadJob,
   signal: AbortSignal,
-  invalidResponse = false,
+  error: DownloadJobError,
 ): Promise<void> {
   if (job.creditsCharged !== null) {
     await deferClaimedJob(writeDb, job, signal);
@@ -1040,14 +1112,7 @@ async function recordProviderFailure(
     .update(socialKitDownloadJobs)
     .set({
       status: "provider_failed",
-      error: {
-        code: invalidResponse
-          ? "SOCIALKIT_INVALID_DOWNLOAD_RESPONSE"
-          : "SOCIALKIT_DOWNLOAD_FAILED",
-        message: invalidResponse
-          ? "SocialKit returned invalid download metadata"
-          : "SocialKit could not prepare the download",
-      },
+      error,
       claimExpiresAt: null,
       updatedAt: nowDate(),
       completedAt: nowDate(),
@@ -1116,17 +1181,32 @@ export const reconcileSocialKitDownload$ = command(
           return true;
         }
         if (poll.value.status === "failed") {
-          await recordProviderFailure(writeDb, job, signal);
+          await recordProviderFailure(
+            writeDb,
+            job,
+            signal,
+            poll.value.error ?? PROVIDER_DOWNLOAD_FAILED_ERROR,
+          );
           signal.throwIfAborted();
           return true;
         }
         if (poll.value.status === "invalid") {
-          await recordProviderFailure(writeDb, job, signal, true);
+          await recordProviderFailure(
+            writeDb,
+            job,
+            signal,
+            INVALID_PROVIDER_RESPONSE_ERROR,
+          );
           signal.throwIfAborted();
           return true;
         }
         if (!readyMetadataIsValid(job, poll.value.ready)) {
-          await recordProviderFailure(writeDb, job, signal, true);
+          await recordProviderFailure(
+            writeDb,
+            job,
+            signal,
+            INVALID_PROVIDER_RESPONSE_ERROR,
+          );
           signal.throwIfAborted();
           return true;
         }

--- a/turbo/apps/api/src/signals/services/socialkit-download.service.ts
+++ b/turbo/apps/api/src/signals/services/socialkit-download.service.ts
@@ -249,7 +249,12 @@ function safeProviderFailureMessage(
 ): string | null {
   const hasControlCharacter = [...message].some((character) => {
     const codeUnit = character.charCodeAt(0);
-    return codeUnit <= 31 || (codeUnit >= 127 && codeUnit <= 159);
+    return (
+      codeUnit <= 31 ||
+      (codeUnit >= 127 && codeUnit <= 159) ||
+      codeUnit === 0x20_28 ||
+      codeUnit === 0x20_29
+    );
   });
   if (
     hasControlCharacter ||

--- a/turbo/apps/cli/src/commands/social/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/social/__tests__/index.test.ts
@@ -121,6 +121,7 @@ function failedDownloadResponse(status: "provider_failed" | "artifact_failed") {
 }
 
 describe("okou social command", () => {
+  const originalExitCode = process.exitCode;
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
   const mockConsoleError = vi
     .spyOn(console, "error")
@@ -156,6 +157,7 @@ describe("okou social command", () => {
     mockConsoleError.mockClear();
     mockStderrWrite.mockClear();
     mockExit.mockClear();
+    process.exitCode = originalExitCode;
     vi.unstubAllEnvs();
     await fs.rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
   });
@@ -1013,19 +1015,74 @@ describe("okou social command", () => {
     {
       caseName: "a free provider failure",
       status: "provider_failed" as const,
-      message: "failed before billing",
+      billed: "no",
+      retryable: "no",
     },
     {
       caseName: "a billed artifact failure",
       status: "artifact_failed" as const,
-      message: "was billed but artifact materialization failed",
+      billed: "yes",
+      retryable: "yes",
     },
-  ])("reports $caseName accurately", async ({ status, message }) => {
+  ])(
+    "reports $caseName with complete diagnostics",
+    async ({ status, billed, retryable }) => {
+      server.use(
+        http.post("http://localhost:3000/api/social/downloads", () => {
+          return HttpResponse.json(failedDownloadResponse(status), {
+            status: 202,
+          });
+        }),
+      );
+
+      await expect(
+        socialCommand.parseAsync([
+          "node",
+          "cli",
+          "download",
+          "youtube",
+          "https://youtu.be/public-video",
+          "--max-duration",
+          "600",
+        ]),
+      ).rejects.toThrow("process.exit called");
+
+      const error = errorOutput();
+      expect(error).toContain(
+        "Download ID: 6bdc3449-41ef-4624-a525-45bce09c67f0",
+      );
+      expect(error).toContain(`Status: ${status}`);
+      expect(error).toContain("Platform: youtube");
+      expect(error).toContain("Requested quality: 720p");
+      expect(error).toContain("Requested format: mp4");
+      expect(error).toContain("Error code:");
+      expect(error).toContain("Error:");
+      expect(error).toContain(`Retryable: ${retryable}`);
+      expect(error).toContain(`Billed: ${billed}`);
+      if (status === "artifact_failed") {
+        expect(error).toContain(
+          "Resume: okou social download --resume 6bdc3449-41ef-4624-a525-45bce09c67f0",
+        );
+      } else {
+        expect(error).not.toContain("Resume:");
+      }
+      expect(mockExit).toHaveBeenCalledWith(1);
+    },
+  );
+
+  it("prints one compact terminal response for JSON failures", async () => {
+    const response = {
+      ...failedDownloadResponse("provider_failed"),
+      error: {
+        code: "SOCIALKIT_PROVIDER_duration_limit_exceeded",
+        message: "Video exceeds the requested duration limit",
+        retryable: false,
+        billed: false,
+      },
+    };
     server.use(
       http.post("http://localhost:3000/api/social/downloads", () => {
-        return HttpResponse.json(failedDownloadResponse(status), {
-          status: 202,
-        });
+        return HttpResponse.json(response, { status: 202 });
       }),
     );
 
@@ -1038,12 +1095,96 @@ describe("okou social command", () => {
         "https://youtu.be/public-video",
         "--max-duration",
         "600",
+        "--json",
       ]),
     ).rejects.toThrow("process.exit called");
 
-    expect(errorOutput()).toContain(message);
+    expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+    expect(output()).toBe(JSON.stringify(response));
+    expect(JSON.parse(output()) as unknown).toStrictEqual(response);
+    expect(errorOutput()).toContain(
+      "Error code: SOCIALKIT_PROVIDER_duration_limit_exceeded",
+    );
     expect(mockExit).toHaveBeenCalledWith(1);
   });
+
+  it("prints the exact corrected resume command for mixed arguments", async () => {
+    await expect(
+      socialCommand.parseAsync([
+        "node",
+        "cli",
+        "download",
+        "youtube",
+        "https://youtu.be/public-video",
+        "--resume",
+        "6bdc3449-41ef-4624-a525-45bce09c67f0",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(errorOutput()).toContain(
+      "use: okou social download --resume 6bdc3449-41ef-4624-a525-45bce09c67f0",
+    );
+  });
+
+  it.each([
+    { signal: "SIGINT" as const, exitCode: 130 },
+    { signal: "SIGTERM" as const, exitCode: 143 },
+  ])(
+    "prints recovery guidance and cleans up after $signal",
+    async ({ signal, exitCode }) => {
+      let statusRequestStarted = false;
+      const initialSigintListeners = process.listenerCount("SIGINT");
+      const initialSigtermListeners = process.listenerCount("SIGTERM");
+      server.use(
+        http.get(
+          "http://localhost:3000/api/social/downloads/6bdc3449-41ef-4624-a525-45bce09c67f0",
+          async ({ request }) => {
+            statusRequestStarted = true;
+            await new Promise<void>((resolve) => {
+              if (request.signal.aborted) {
+                resolve();
+                return;
+              }
+              request.signal.addEventListener(
+                "abort",
+                () => {
+                  resolve();
+                },
+                { once: true },
+              );
+            });
+            return HttpResponse.error();
+          },
+        ),
+      );
+
+      const command = socialCommand.parseAsync([
+        "node",
+        "cli",
+        "download",
+        "--resume",
+        "6bdc3449-41ef-4624-a525-45bce09c67f0",
+        "--json",
+      ]);
+      await vi.waitFor(() => {
+        expect(statusRequestStarted).toBeTruthy();
+      });
+      process.emit(signal, signal);
+      await command;
+
+      expect(output()).toBe("");
+      expect(errorOutput()).toContain(
+        `continues on the server after ${signal}`,
+      );
+      expect(errorOutput()).toContain(
+        "Resume: okou social download --resume 6bdc3449-41ef-4624-a525-45bce09c67f0",
+      );
+      expect(process.exitCode).toBe(exitCode);
+      expect(mockExit).not.toHaveBeenCalled();
+      expect(process.listenerCount("SIGINT")).toBe(initialSigintListeners);
+      expect(process.listenerCount("SIGTERM")).toBe(initialSigtermListeners);
+    },
+  );
 
   it("documents typed discovery, calls, billing, and security boundaries", () => {
     const tools = socialCommand.commands.find((command) => {
@@ -1069,13 +1210,19 @@ describe("okou social command", () => {
     const download = socialCommand.commands.find((command) => {
       return command.name() === "download";
     });
+    const downloadHelp = download?.helpInformation() ?? "";
     expect(socialHelp).toContain("Use Okou Social public data services");
     expect(tools?.helpInformation()).toContain(
       "List typed Okou Social tools and their schemas",
     );
     expect(call?.helpInformation()).toContain("Call a typed Okou Social tool");
-    expect(download?.helpInformation()).toContain("--max-duration");
-    expect(download?.helpInformation()).toContain("--resume");
+    expect(downloadHelp).toContain("--max-duration");
+    expect(downloadHelp).toContain("--resume");
+    expect(downloadHelp).toContain("default: 720p");
+    expect(downloadHelp).toContain("default: mp4");
+    expect(downloadHelp.replace(/\s+/gu, " ")).toContain(
+      "billing uses completed duration",
+    );
     expect(socialHelp).toContain("38 typed tools");
     expect(socialHelp).toContain("okou social tools --json");
     expect(socialHelp).toContain("youtube_summarize");

--- a/turbo/apps/cli/src/commands/social/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/social/__tests__/index.test.ts
@@ -1127,11 +1127,19 @@ describe("okou social command", () => {
   });
 
   it.each([
-    { signal: "SIGINT" as const, exitCode: 130 },
-    { signal: "SIGTERM" as const, exitCode: 143 },
+    {
+      signal: "SIGINT" as const,
+      secondSignal: "SIGTERM" as const,
+      exitCode: 130,
+    },
+    {
+      signal: "SIGTERM" as const,
+      secondSignal: "SIGINT" as const,
+      exitCode: 143,
+    },
   ])(
     "prints recovery guidance and cleans up after $signal",
-    async ({ signal, exitCode }) => {
+    async ({ signal, secondSignal, exitCode }) => {
       let statusRequestStarted = false;
       const initialSigintListeners = process.listenerCount("SIGINT");
       const initialSigtermListeners = process.listenerCount("SIGTERM");
@@ -1170,9 +1178,11 @@ describe("okou social command", () => {
         expect(statusRequestStarted).toBeTruthy();
       });
       process.emit(signal, signal);
+      process.emit(secondSignal, secondSignal);
       await command;
 
       expect(output()).toBe("");
+      expect(mockConsoleError).toHaveBeenCalledTimes(2);
       expect(errorOutput()).toContain(
         `continues on the server after ${signal}`,
       );

--- a/turbo/apps/cli/src/commands/social/index.ts
+++ b/turbo/apps/cli/src/commands/social/index.ts
@@ -1,3 +1,5 @@
+import { setTimeout as sleep } from "node:timers/promises";
+
 import {
   findManagedSocialKitTool,
   managedSocialKitToolCatalog,
@@ -39,6 +41,13 @@ interface SocialKitDownloadOptions {
   readonly quality?: string;
   readonly resume?: string;
 }
+
+type DownloadSignal = "SIGINT" | "SIGTERM";
+
+const DOWNLOAD_SIGNAL_EXIT_CODE: Readonly<Record<DownloadSignal, number>> = {
+  SIGINT: 130,
+  SIGTERM: 143,
+};
 
 type SocialKitCatalogRetrieval =
   | { readonly kind: "cursor" }
@@ -179,22 +188,94 @@ function positiveInteger(value: string): number {
   return parsed;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
+function resumeDownloadCommand(downloadId: string): string {
+  return `okou social download --resume ${downloadId}`;
+}
+
+function terminalDownloadError(response: SocialKitDownloadResponse): Error {
+  if (!response.error) {
+    return new Error(
+      `Okou Social download ${response.downloadId} returned ${response.status} without error details`,
+    );
+  }
+  const lines = [
+    "Okou Social download failed",
+    `  Download ID: ${response.downloadId}`,
+    `  Status: ${response.status}`,
+    `  Platform: ${response.platform}`,
+    `  Requested quality: ${response.quality}`,
+    `  Requested format: ${response.format}`,
+    `  Error code: ${response.error.code}`,
+    `  Error: ${response.error.message}`,
+    `  Retryable: ${response.error.retryable ? "yes" : "no"}`,
+    `  Billed: ${response.error.billed ? "yes" : "no"}`,
+  ];
+  if (response.status === "artifact_failed") {
+    lines.push(`  Resume: ${resumeDownloadCommand(response.downloadId)}`);
+  }
+  return new Error(lines.join("\n"));
+}
+
+function failDownload(
+  response: SocialKitDownloadResponse,
+  compact: boolean,
+): never {
+  if (compact) {
+    console.log(JSON.stringify(response));
+  }
+  throw terminalDownloadError(response);
+}
+
+async function withDownloadInterruption(
+  downloadId: string,
+  action: (signal: AbortSignal) => Promise<void>,
+): Promise<void> {
+  const controller = new AbortController();
+  let interruption: DownloadSignal | undefined;
+  const interrupt = (signal: DownloadSignal): void => {
+    if (interruption) {
+      return;
+    }
+    interruption = signal;
+    console.error(
+      `Okou Social download ${downloadId} continues on the server after ${signal}`,
+    );
+    console.error(`Resume: ${resumeDownloadCommand(downloadId)}`);
+    process.exitCode = DOWNLOAD_SIGNAL_EXIT_CODE[signal];
+    controller.abort();
+  };
+  const onSigint = (): void => {
+    interrupt("SIGINT");
+  };
+  const onSigterm = (): void => {
+    interrupt("SIGTERM");
+  };
+  process.once("SIGINT", onSigint);
+  process.once("SIGTERM", onSigterm);
+  try {
+    await action(controller.signal);
+  } catch (error) {
+    if (!interruption) {
+      throw error;
+    }
+  } finally {
+    process.removeListener("SIGINT", onSigint);
+    process.removeListener("SIGTERM", onSigterm);
+  }
 }
 
 async function waitForDownload(
   initial: SocialKitDownloadResponse,
   compact: boolean,
   retryArtifactFailures: boolean,
+  signal: AbortSignal,
 ): Promise<void> {
   let current = initial;
   let previousStatus: string | undefined;
   let pollImmediately =
     retryArtifactFailures && current.status === "artifact_failed";
   for (let attempt = 0; attempt < 900; attempt += 1) {
+    signal.throwIfAborted();
     if (current.status !== previousStatus) {
       console.error(
         `Okou Social download ${current.downloadId}: ${current.status}`,
@@ -206,24 +287,21 @@ async function waitForDownload(
       return;
     }
     if (current.status === "provider_failed") {
-      throw new Error(
-        `Okou Social download ${current.downloadId} failed before billing`,
-      );
+      failDownload(current, compact);
     }
     if (current.status === "artifact_failed" && !retryArtifactFailures) {
-      throw new Error(
-        `Okou Social download ${current.downloadId} was billed but artifact materialization failed; resume with --resume ${current.downloadId}`,
-      );
+      failDownload(current, compact);
     }
     if (pollImmediately) {
       pollImmediately = false;
     } else {
-      await sleep(2_000);
+      await sleep(2_000, undefined, { signal });
     }
-    current = await getSocialKitDownload(current.downloadId);
+    current = await getSocialKitDownload(current.downloadId, signal);
   }
+  signal.throwIfAborted();
   throw new Error(
-    `Okou Social download ${current.downloadId} is still running; resume with --resume ${current.downloadId}`,
+    `Okou Social download ${current.downloadId} is still running; resume with: ${resumeDownloadCommand(current.downloadId)}`,
   );
 }
 
@@ -482,11 +560,14 @@ const downloadCommand = new Command()
   .argument("[url]", "Public social media URL")
   .option(
     "--max-duration <seconds>",
-    "Maximum accepted media duration and billing bound",
+    "Required maximum accepted media duration; billing uses completed duration",
     positiveInteger,
   )
-  .option("--quality <quality>", "240p, 360p, 480p, 720p, or 1080p")
-  .option("--format <format>", "mp4 or m4a")
+  .option(
+    "--quality <quality>",
+    "240p, 360p, 480p, 720p, or 1080p (default: 720p)",
+  )
+  .option("--format <format>", "mp4 or m4a (default: mp4)")
   .option("--resume <download-id>", "Resume polling an existing download")
   .option("--json", "Print compact JSON")
   .action(
@@ -497,6 +578,7 @@ const downloadCommand = new Command()
         options: SocialKitDownloadOptions,
       ) => {
         if (options.resume) {
+          const downloadId = options.resume;
           if (
             platform ||
             url ||
@@ -505,14 +587,17 @@ const downloadCommand = new Command()
             options.format
           ) {
             throw new InvalidArgumentError(
-              "--resume cannot be combined with a new download request",
+              `--resume cannot be combined with a new download request; use: ${resumeDownloadCommand(downloadId)}`,
             );
           }
-          await waitForDownload(
-            await getSocialKitDownload(options.resume),
-            options.json === true,
-            true,
-          );
+          await withDownloadInterruption(downloadId, async (signal) => {
+            await waitForDownload(
+              await getSocialKitDownload(downloadId, signal),
+              options.json === true,
+              true,
+              signal,
+            );
+          });
           return;
         }
         if (!platform || !url || !options.maxDuration) {
@@ -533,11 +618,10 @@ const downloadCommand = new Command()
               "Okou Social download request is invalid",
           );
         }
-        await waitForDownload(
-          await createSocialKitDownload(parsed.data),
-          options.json === true,
-          false,
-        );
+        const created = await createSocialKitDownload(parsed.data);
+        await withDownloadInterruption(created.downloadId, async (signal) => {
+          await waitForDownload(created, options.json === true, false, signal);
+        });
       },
     ),
   );

--- a/turbo/apps/cli/src/lib/api/domains/social.ts
+++ b/turbo/apps/cli/src/lib/api/domains/social.ts
@@ -71,13 +71,19 @@ export async function createSocialKitDownload(
 
 export async function getSocialKitDownload(
   downloadId: string,
+  signal: AbortSignal,
 ): Promise<SocialKitDownloadResponse> {
   const config = await getClientConfig();
   const client = initClient(socialContract, config);
   const result = await client.getDownload({
     headers: {},
     params: { downloadId },
-    fetchOptions: { signal: AbortSignal.timeout(SOCIALKIT_API_TIMEOUT_MS) },
+    fetchOptions: {
+      signal: AbortSignal.any([
+        signal,
+        AbortSignal.timeout(SOCIALKIT_API_TIMEOUT_MS),
+      ]),
+    },
   });
   if (result.status === 200) {
     return result.body;


### PR DESCRIPTION
## Summary

- preserve bounded, safe SocialKit provider failure diagnostics in the existing download error fields
- print complete human-readable failures and one compact JSON terminal record, with exact resume guidance where applicable
- stop local polling cleanly on `SIGINT` or `SIGTERM` while the durable server-side download continues

## Compatibility

- keeps the public response shape, database schema, billing behavior, and job lifecycle unchanged
- remains compatible with generic errors returned by older API deployments and existing CLI consumers

## Fallbacks

- `socialkit-download.service.ts:providerFailureError` — missing or malformed external diagnostics retain the existing generic error pair; an unsafe message retains only the bounded namespaced code with the generic message. This is required handling for untrusted external provider data, not rollout compatibility, so it has no deployment removal gate while that payload remains provider-owned.

## Validation

- `pnpm format`
- focused API integration tests (69 passed)
- focused CLI integration tests (31 passed)
- focused API and CLI branch coverage inspection
- API and CLI lint
- API and CLI type checks
- `pnpm knip --workspace api --workspace @okouai/cli`
- full pre-commit formatting, Knip, type checks, file-size check, and commitlint

Closes #30356
