### PR TITLE
fix: support atomic guest checkpoint completion

### DIFF
--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -453,6 +453,172 @@ pub mod webhooks {
             }
         }
 
+        /// DTOs for atomically completing agent runs.
+        pub mod complete {
+            /// Outcome of the sandbox reuse decision.
+            #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+            pub enum RequestSandboxReuseResult {
+                /// An idle sandbox was reused.
+                #[serde(rename = "reused")]
+                Reused,
+                /// Legacy outcome from the removed feature gate.
+                #[serde(rename = "featureDisabled")]
+                FeatureDisabled,
+                /// Legacy outcome for an unavailable reuse identity.
+                #[serde(rename = "noSessionId")]
+                NoSessionId,
+                /// The run had no sandbox reuse key.
+                #[serde(rename = "noReuseKey")]
+                NoReuseKey,
+                /// No matching idle sandbox was available.
+                #[serde(rename = "poolMiss")]
+                PoolMiss,
+                /// The idle sandbox profile did not match.
+                #[serde(rename = "profileMismatch")]
+                ProfileMismatch,
+                /// The idle sandbox device limits did not match.
+                #[serde(rename = "deviceLimitMismatch")]
+                DeviceLimitMismatch,
+                /// The selected idle sandbox could not be unparked.
+                #[serde(rename = "unparkFailed")]
+                UnparkFailed,
+            }
+
+            /// Final outcome of workspace reuse preparation.
+            #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+            pub enum RequestWorkspaceReuseResult {
+                /// A cached workspace was reused.
+                #[serde(rename = "reused")]
+                Reused,
+                /// The workspace remained in a reused sandbox.
+                #[serde(rename = "sandboxReused")]
+                SandboxReused,
+                /// No matching workspace cache was available.
+                #[serde(rename = "cacheMiss")]
+                CacheMiss,
+                /// The run had no workspace reuse key.
+                #[serde(rename = "noReuseKey")]
+                NoReuseKey,
+                /// The cached workspace directory was invalid.
+                #[serde(rename = "invalidWorkingDir")]
+                InvalidWorkingDir,
+                /// The cached workspace was locked by another run.
+                #[serde(rename = "lockBusy")]
+                LockBusy,
+                /// The cached workspace metadata was invalid.
+                #[serde(rename = "invalidMetadata")]
+                InvalidMetadata,
+                /// Workspace reuse was disabled by disk pressure.
+                #[serde(rename = "diskPressure")]
+                DiskPressure,
+                /// Workspace reuse was not configured.
+                #[serde(rename = "notConfigured")]
+                NotConfigured,
+                /// Workspace preparation fell back after sandbox setup.
+                #[serde(rename = "sandboxPrepareFallback")]
+                SandboxPrepareFallback,
+            }
+
+            /// Reason a final checkpoint intentionally omits resumable CLI agent session history.
+            #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+            pub enum RequestCheckpointCliAgentSessionHistoryDisposition {
+                /// The native history exceeded the bounded checkpoint limit.
+                #[serde(rename = "discarded_oversized")]
+                DiscardedOversized,
+                /// The native history was unavailable or unusable.
+                #[serde(rename = "unavailable")]
+                Unavailable,
+            }
+
+            /// Policy used when a final checkpoint artifact root is missing.
+            #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+            pub enum RequestCheckpointArtifactSnapshotMissingRootPolicy {
+                /// Treat a missing artifact root as an error.
+                #[serde(rename = "fail")]
+                Fail,
+                /// Preserve the parent artifact version when the root is missing.
+                #[serde(rename = "preserveParentVersion")]
+                PreserveParentVersion,
+            }
+
+            /// Artifact version captured by a final checkpoint.
+            #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+            #[serde(rename_all = "camelCase")]
+            pub struct RequestCheckpointArtifactSnapshot {
+                /// User-facing artifact name referenced by the run.
+                pub name: String,
+                /// Artifact version selected for the checkpoint.
+                pub version: String,
+                /// Guest filesystem path where the artifact is mounted.
+                pub mount_path: String,
+                /// Optional policy retained when the artifact mount root is missing.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub missing_root_policy: Option<RequestCheckpointArtifactSnapshotMissingRootPolicy>,
+            }
+
+            /// Volume versions captured by a final checkpoint.
+            #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+            #[serde(rename_all = "camelCase")]
+            pub struct RequestCheckpointVolumeVersionsSnapshot {
+                /// Volume names mapped to their captured versions.
+                pub versions: std::collections::BTreeMap<String, String>,
+            }
+
+            /// Final checkpoint metadata included with completion.
+            #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+            #[serde(rename_all = "camelCase")]
+            pub struct RequestCheckpoint {
+                /// CLI agent implementation that produced the session.
+                pub cli_agent_type: String,
+                /// CLI agent session identifier being checkpointed.
+                pub cli_agent_session_id: String,
+                /// Optional SHA-256 hash of uploaded CLI agent session history.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub cli_agent_session_history_hash: Option<String>,
+                /// Optional reason resumable session history was omitted.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub cli_agent_session_history_disposition:
+                    Option<RequestCheckpointCliAgentSessionHistoryDisposition>,
+                /// Optional artifact versions captured by the checkpoint.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub artifact_snapshots: Option<Vec<RequestCheckpointArtifactSnapshot>>,
+                /// Optional volume versions captured by the checkpoint.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub volume_versions_snapshot: Option<RequestCheckpointVolumeVersionsSnapshot>,
+            }
+
+            /// Request body for completing an agent run.
+            #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+            #[serde(rename_all = "camelCase")]
+            pub struct Request {
+                /// Agent run identifier bound to the sandbox token.
+                pub run_id: String,
+                /// Process exit code reported by the caller.
+                pub exit_code: i32,
+                /// Optional process failure description.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub error: Option<String>,
+                /// Highest contiguous agent event sequence delivered before completion.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub last_event_sequence: Option<u32>,
+                /// Optional sandbox identifier used by the run.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub sandbox_id: Option<String>,
+                /// Optional outcome of the sandbox reuse decision.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub sandbox_reuse_result: Option<RequestSandboxReuseResult>,
+                /// Optional outcome of the workspace reuse decision.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub workspace_reuse_result: Option<RequestWorkspaceReuseResult>,
+                /// Optional active-input delivery receipts recovered during completion.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub active_input_delivery_ids: Option<Vec<String>>,
+                /// Optional final checkpoint persisted atomically with completion.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub checkpoint: Option<RequestCheckpoint>,
+            }
+        }
+
         /// Sandbox storage upload DTOs shared by guest agents and webhook handlers.
         pub mod storages {
             /// File metadata entry used to compute and commit content-addressed storage uploads.

--- a/docs/active-input-delivery.md
+++ b/docs/active-input-delivery.md
@@ -96,6 +96,31 @@ state in one short transaction. Realtime publication, callbacks, usage work,
 and queue drain run only after commit. A first late finalization drains the
 thread without replaying the run's ordinary terminal callbacks or billing work.
 
+### Final Checkpoint Completion
+
+The Guest may include final checkpoint metadata in
+`/api/webhooks/agent/complete`. Session history and artifact bytes are uploaded
+before that request; completion carries only their validated identities and
+storage snapshots. The API then persists the checkpoint, promotes the eligible
+canonical AgentSession conversation, settles active-input delivery, and applies
+the terminal run state in the same database transaction.
+
+The nested checkpoint omits `runId`; the completion request's outer `runId` and
+sandbox authorization remain authoritative. Invalid checkpoint metadata rejects
+the combined request without partially finalizing delivery or changing the run
+status. Repeating a committed combined request is idempotent, and a later
+checkpoint-less Runner completion observes the first terminal result.
+
+The standalone checkpoint route and checkpoint-less completion remain supported
+for older Guests. Runner completion timing and payloads are unchanged. The API
+release that accepts the combined request must reach production, and preceding
+API handlers must drain, before a Guest starts sending it. While combined Guests
+can execute, that API release is the rollback floor.
+
+This compatibility boundary does not make timeout immutable and does not change
+legacy standalone checkpoint admission. Those changes require the later timeout
+rollout after the old active-run cohort drains.
+
 ## Compatibility
 
 `activeInputDeliveryIds` is optional, contains at most 1,024 unique canonical

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -6005,6 +6005,27 @@ describe("CHAT-02: model-first provider policies", () => {
       readThreadSessionConversation(context, run.threadId),
     ).resolves.toStrictEqual(canonicalConversation);
     expect(modelCalls).toBe(5);
+
+    const conversationClear = await holdThreadSessionConversationClearFixture({
+      threadId: run.threadId,
+      signal: context.signal,
+    });
+    conversationClear.release();
+    await conversationClear.done;
+    const repeatedCombinedH2 = await webhooks.requestAgentComplete(
+      {
+        runId: run.runId,
+        exitCode: 0,
+        checkpoint: {
+          cliAgentType: "pi",
+          cliAgentSessionId: run.threadId,
+          cliAgentSessionHistoryHash: h2Hash,
+        },
+      },
+      claimed.sandboxHeaders,
+      [200],
+    );
+    expect(repeatedCombinedH2.body).toStrictEqual(combinedH2.body);
   }, 90_000);
 
   it("routes DeepSeek V4 Flash through the native Responses adapter", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -2510,8 +2510,25 @@ describe("CHAT-02: queueing and recalling messages", () => {
       throw new Error("Expected terminal input to be reserved");
     }
 
-    await completeChatRunOk(active.runId, claimed.sandboxHeaders, {
-      activeInputDeliveryIds: [reserved.deliveryId],
+    const history = `bdd combined delivery history ${active.runId}`;
+    const historyHash = createHash("sha256").update(history).digest("hex");
+    const completed = await webhooks.requestAgentComplete(
+      {
+        runId: active.runId,
+        exitCode: 0,
+        activeInputDeliveryIds: [reserved.deliveryId],
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-combined-delivery-${active.runId}`,
+          cliAgentSessionHistoryHash: historyHash,
+        },
+      },
+      claimed.sandboxHeaders,
+      [200],
+    );
+    expect(completed.body).toStrictEqual({
+      success: true,
+      status: "completed",
     });
     await flushWaitUntilForTest();
 
@@ -5607,6 +5624,25 @@ describe("CHAT-02: model-first provider policies", () => {
       `${env("R2_USER_STORAGES_BUCKET_NAME")}/blobs/${h2Hash}.blob`,
       Buffer.from(h2, "utf8"),
     );
+    const combinedH2 = await webhooks.requestAgentComplete(
+      {
+        runId: run.runId,
+        exitCode: 0,
+        checkpoint: {
+          cliAgentType: "pi",
+          cliAgentSessionId: run.threadId,
+          cliAgentSessionHistoryHash: h2Hash,
+        },
+      },
+      claimed.sandboxHeaders,
+      [200],
+    );
+    expect(combinedH2.body).toStrictEqual({
+      success: true,
+      status: "completed",
+    });
+    await waitForRunStatus(actor, run.runId, "completed");
+    await flushWaitUntilForTest();
     const committedH2 = await webhooks.requestAgentCheckpoint(
       {
         runId: run.runId,
@@ -5623,13 +5659,6 @@ describe("CHAT-02: model-first provider policies", () => {
         `Expected H2 checkpoint success: ${committedH2Body.error.message}`,
       );
     }
-    await webhooks.requestAgentComplete(
-      { runId: run.runId, exitCode: 0 },
-      claimed.sandboxHeaders,
-      [200],
-    );
-    await waitForRunStatus(actor, run.runId, "completed");
-    await flushWaitUntilForTest();
     expect(modelCalls).toBe(1);
     expect(checkpointObjects.has(manifestKey)).toBeFalsy();
     expect(
@@ -5746,12 +5775,16 @@ describe("CHAT-02: model-first provider policies", () => {
       `${env("R2_USER_STORAGES_BUCKET_NAME")}/blobs/${invalidH2Hash}.blob`,
       invalidH2,
     );
-    const invalidCheckpoint = await webhooks.requestAgentCheckpoint(
+    const invalidCheckpoint = await webhooks.requestAgentComplete(
       {
         runId: failedHandoff.runId,
-        cliAgentType: "pi",
-        cliAgentSessionId: run.threadId,
-        cliAgentSessionHistoryHash: invalidH2Hash,
+        exitCode: 1,
+        error: "reject invalid native checkpoint",
+        checkpoint: {
+          cliAgentType: "pi",
+          cliAgentSessionId: run.threadId,
+          cliAgentSessionHistoryHash: invalidH2Hash,
+        },
       },
       failedClaim.sandboxHeaders,
       [400],
@@ -5772,12 +5805,15 @@ describe("CHAT-02: model-first provider policies", () => {
     await flushWaitUntilForTest();
     expect(modelCalls).toBe(2);
     expect(checkpointObjects.has(failedManifestKey)).toBeFalsy();
-    const lateFailedH2 = await webhooks.requestAgentCheckpoint(
+    const lateFailedH2 = await webhooks.requestAgentComplete(
       {
         runId: failedHandoff.runId,
-        cliAgentType: "pi",
-        cliAgentSessionId: run.threadId,
-        cliAgentSessionHistoryHash: h2Hash,
+        exitCode: 1,
+        checkpoint: {
+          cliAgentType: "pi",
+          cliAgentSessionId: run.threadId,
+          cliAgentSessionHistoryHash: h2Hash,
+        },
       },
       failedClaim.sandboxHeaders,
       [400],
@@ -5841,12 +5877,15 @@ describe("CHAT-02: model-first provider policies", () => {
       cancelledHandoff.runId,
       cancelledClaim.sandboxHeaders,
     );
-    const lateCancelledH2 = await webhooks.requestAgentCheckpoint(
+    const lateCancelledH2 = await webhooks.requestAgentComplete(
       {
         runId: cancelledHandoff.runId,
-        cliAgentType: "pi",
-        cliAgentSessionId: run.threadId,
-        cliAgentSessionHistoryHash: h2Hash,
+        exitCode: 1,
+        checkpoint: {
+          cliAgentType: "pi",
+          cliAgentSessionId: run.threadId,
+          cliAgentSessionHistoryHash: h2Hash,
+        },
       },
       cancelledClaim.sandboxHeaders,
       [400],

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -6006,6 +6006,53 @@ describe("CHAT-02: model-first provider policies", () => {
     ).resolves.toStrictEqual(canonicalConversation);
     expect(modelCalls).toBe(5);
 
+    const reportedFailureHandoff = await sendChatRun(actor, {
+      agentId,
+      threadId: run.threadId,
+      prompt: "retry one atomically reported Pi failure",
+    });
+    const reportedFailureManifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${reportedFailureHandoff.runId}/manifest.json`;
+    await expect
+      .poll(() => {
+        return checkpointObjects.has(reportedFailureManifestKey);
+      })
+      .toBe(true);
+    const reportedFailureClaim = await claimChatRun(
+      runnerGroup,
+      reportedFailureHandoff.runId,
+    );
+    const reportedFailureBody = {
+      runId: reportedFailureHandoff.runId,
+      exitCode: 1,
+      error: "guest reported Pi failure",
+      checkpoint: {
+        cliAgentType: "pi",
+        cliAgentSessionId: run.threadId,
+        cliAgentSessionHistoryHash: h2Hash,
+      },
+    } as const;
+    const reportedFailure = await webhooks.requestAgentComplete(
+      reportedFailureBody,
+      reportedFailureClaim.sandboxHeaders,
+      [200],
+    );
+    expect(reportedFailure.body).toStrictEqual({
+      success: true,
+      status: "failed",
+    });
+    await waitForRunStatus(actor, reportedFailureHandoff.runId, "failed");
+    await flushWaitUntilForTest();
+    const repeatedReportedFailure = await webhooks.requestAgentComplete(
+      reportedFailureBody,
+      reportedFailureClaim.sandboxHeaders,
+      [200],
+    );
+    expect(repeatedReportedFailure.body).toStrictEqual(reportedFailure.body);
+    await expect(
+      readThreadSessionConversation(context, run.threadId),
+    ).resolves.toStrictEqual(canonicalConversation);
+    expect(modelCalls).toBe(6);
+
     const conversationClear = await holdThreadSessionConversationClearFixture({
       threadId: run.threadId,
       signal: context.signal,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
@@ -569,6 +569,31 @@ export function createWebhookCallbackApi(context: TestContext) {
       statuses: readonly (200 | 400 | 401 | 404 | 500)[],
       signal?: AbortSignal,
     ) {
+      const historyHash = body.checkpoint?.cliAgentSessionHistoryHash;
+      if (historyHash !== undefined) {
+        const sessionHistoryBlob = registerKnownSessionHistoryBlob(
+          context,
+          body.runId,
+          historyHash,
+        );
+        if (sessionHistoryBlob && statuses.includes(200)) {
+          await accept(
+            setupApp({ context, routes: webhooksAgentCheckpointsRoutes })(
+              webhookCheckpointsPrepareHistoryContract,
+            ).prepare({
+              headers,
+              body: {
+                runId: body.runId,
+                hash: historyHash,
+                rawSize: sessionHistoryBlob.byteLength,
+                encodedSize: sessionHistoryBlob.byteLength,
+                encoding: "identity",
+              },
+            }),
+            [200],
+          );
+        }
+      }
       const client = signal
         ? setupAppWithRoutes({
             context,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -18239,17 +18239,18 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
         );
       }
 
-      const recovery = await webhooks.requestAgentComplete(
-        {
-          runId: run.runId,
-          exitCode: 1,
-          error: "guest reported failure",
-          checkpoint: {
-            cliAgentType: "claude-code",
-            cliAgentSessionId,
-            cliAgentSessionHistoryHash: historyHash,
-          },
+      const recoveryBody = {
+        runId: run.runId,
+        exitCode: 1,
+        error: "guest reported failure",
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId,
+          cliAgentSessionHistoryHash: historyHash,
         },
+      } as const;
+      const recovery = await webhooks.requestAgentComplete(
+        recoveryBody,
         sandboxHeaders,
         [200],
       );
@@ -18273,7 +18274,45 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
         sessionId: cliAgentSessionId,
         historyRef: { kind: "blob", hash: historyHash },
       });
-      await api.requestCancelRun(actor, continued.runId, [200]);
+      const successorHistory = `bdd ${ordering} successor history ${continued.runId}`;
+      const successorHistoryHash = createHash("sha256")
+        .update(successorHistory)
+        .digest("hex");
+      const successorCliAgentSessionId = `bdd-${ordering}-successor-${continued.runId}`;
+      mockSessionHistoryBlob(successorHistoryHash, successorHistory);
+      await webhooks.requestAgentComplete(
+        {
+          runId: continued.runId,
+          exitCode: 0,
+          checkpoint: {
+            cliAgentType: "claude-code",
+            cliAgentSessionId: successorCliAgentSessionId,
+            cliAgentSessionHistoryHash: successorHistoryHash,
+          },
+        },
+        { authorization: `Bearer ${continuedClaim.sandboxToken}` },
+        [200],
+      );
+
+      const repeatedAfterSuccessor = await webhooks.requestAgentComplete(
+        recoveryBody,
+        sandboxHeaders,
+        [200],
+      );
+      expect(repeatedAfterSuccessor.body).toStrictEqual(recovery.body);
+
+      const afterRetry = await api.createRun(actor, {
+        agentId,
+        sessionId: run.sessionId,
+        prompt: `resume the ${ordering} successor`,
+        modelProvider: "anthropic-api-key",
+      });
+      const afterRetryClaim = await api.claimRunnerJob(afterRetry.runId);
+      expect(afterRetryClaim.resumeSession).toMatchObject({
+        sessionId: successorCliAgentSessionId,
+        historyRef: { kind: "blob", hash: successorHistoryHash },
+      });
+      await api.requestCancelRun(actor, afterRetry.runId, [200]);
     },
   );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -18166,7 +18166,45 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
         sessionId: cliAgentSessionId,
         historyRef: { kind: "blob", hash: historyHash },
       });
-      await api.requestCancelRun(actor, continued.runId, [200]);
+      const successorHistory = `bdd successor ${cliAgentType} history ${continued.runId}`;
+      const successorHistoryHash = createHash("sha256")
+        .update(successorHistory)
+        .digest("hex");
+      const successorCliAgentSessionId = `bdd-successor-${cliAgentType}-${continued.runId}`;
+      mockSessionHistoryBlob(successorHistoryHash, successorHistory);
+      await webhooks.requestAgentComplete(
+        {
+          runId: continued.runId,
+          exitCode: 0,
+          checkpoint: {
+            cliAgentType,
+            cliAgentSessionId: successorCliAgentSessionId,
+            cliAgentSessionHistoryHash: successorHistoryHash,
+          },
+        },
+        { authorization: `Bearer ${continuedClaim.sandboxToken}` },
+        [200],
+      );
+
+      const repeatedAfterSuccessor = await webhooks.requestAgentComplete(
+        body,
+        sandboxHeaders,
+        [200],
+      );
+      expect(repeatedAfterSuccessor.body).toStrictEqual(completed.body);
+
+      const afterRetry = await api.createRun(actor, {
+        agentId,
+        sessionId: run.sessionId,
+        prompt: `resume successor ${cliAgentType} checkpoint`,
+        modelProvider: "anthropic-api-key",
+      });
+      const afterRetryClaim = await api.claimRunnerJob(afterRetry.runId);
+      expect(afterRetryClaim.resumeSession).toMatchObject({
+        sessionId: successorCliAgentSessionId,
+        historyRef: { kind: "blob", hash: successorHistoryHash },
+      });
+      await api.requestCancelRun(actor, afterRetry.runId, [200]);
     },
   );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -81,6 +81,7 @@ import { readStorageS3PrefixFixture } from "../../../test-fixtures/storage";
 import {
   readRunIdentityMismatchWriteCountsFixture,
   readRunModelRuntimeRouteFixture,
+  readSessionHistoryBlobRefCountFixture,
   setRunModelProviderFixture,
   setRunModelRuntimeRouteFixture,
 } from "../../../test-fixtures/agent-runs";
@@ -17985,33 +17986,28 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
     const historyHash = createHash("sha256")
       .update(`bdd snapshot history ${created.runId}`)
       .digest("hex");
-    const checkpoint = await webhooks.requestAgentCheckpoint(
+    const completion = await webhooks.requestAgentComplete(
       {
         runId: created.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-snapshot-cli-${created.runId}`,
-        cliAgentSessionHistoryHash: historyHash,
-        artifactSnapshots,
-        volumeVersionsSnapshot: {
-          versions: { [cacheVolume]: cachePrepared.versionId },
+        exitCode: 0,
+        lastEventSequence: 3,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-snapshot-cli-${created.runId}`,
+          cliAgentSessionHistoryHash: historyHash,
+          artifactSnapshots,
+          volumeVersionsSnapshot: {
+            versions: { [cacheVolume]: cachePrepared.versionId },
+          },
         },
       },
       sandboxHeaders,
       [200],
     );
-    if (checkpoint.status !== 200) {
-      throw new Error("Expected the snapshot checkpoint to succeed");
-    }
-    expect(checkpoint.body.artifacts).toStrictEqual(artifactSnapshots);
-    expect(checkpoint.body.volumes).toStrictEqual({
-      [cacheVolume]: cachePrepared.versionId,
+    expect(completion.body).toStrictEqual({
+      success: true,
+      status: "completed",
     });
-
-    await webhooks.requestAgentComplete(
-      { runId: created.runId, exitCode: 0, lastEventSequence: 3 },
-      sandboxHeaders,
-      [200],
-    );
 
     const completed = await api.readRun(actor, created.runId);
     expect(completed.status).toBe("completed");
@@ -18060,6 +18056,273 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
 });
 
 describe("RUN-03: sandbox completion reports against missing checkpoints and settled runs", () => {
+  it.each(["claude-code", "codex"] as const)(
+    "atomically completes a run with a %s checkpoint",
+    async (cliAgentType) => {
+      const api = createRunsApi(context);
+      const webhooks = createWebhookCallbackApi(context);
+      const { actor, agentId } = await entitledRunActor();
+      const run = await api.createRun(actor, {
+        agentId,
+        prompt: `complete with ${cliAgentType} checkpoint`,
+        modelProvider: "anthropic-api-key",
+      });
+      const claim = await api.claimRunnerJob(run.runId);
+      const history = `bdd combined ${cliAgentType} history ${run.runId}`;
+      const historyHash = createHash("sha256").update(history).digest("hex");
+      const cliAgentSessionId = `bdd-combined-${cliAgentType}-${run.runId}`;
+      mockSessionHistoryBlob(historyHash, history);
+      const sandboxHeaders = {
+        authorization: `Bearer ${claim.sandboxToken}`,
+      };
+      const body = {
+        runId: run.runId,
+        exitCode: 0,
+        lastEventSequence: 0,
+        checkpoint: {
+          cliAgentType,
+          cliAgentSessionId,
+          cliAgentSessionHistoryHash: historyHash,
+        },
+      } as const;
+
+      const completed = await webhooks.requestAgentComplete(
+        body,
+        sandboxHeaders,
+        [200],
+      );
+      expect(completed.body).toStrictEqual({
+        success: true,
+        status: "completed",
+      });
+      const settled = await api.readRun(actor, run.runId);
+      expect(settled.status).toBe("completed");
+      expect(settled.result).toMatchObject({
+        checkpointId: expect.any(String),
+        agentSessionId: run.sessionId,
+        conversationId: expect.any(String),
+      });
+
+      const repeated = await webhooks.requestAgentComplete(
+        body,
+        sandboxHeaders,
+        [200],
+      );
+      expect(repeated.body).toStrictEqual(completed.body);
+      await expect(
+        readSessionHistoryBlobRefCountFixture(historyHash),
+      ).resolves.toBe(1);
+      const conflictingCheckpoint = await webhooks.requestAgentComplete(
+        {
+          ...body,
+          checkpoint: {
+            ...body.checkpoint,
+            cliAgentSessionId: `${cliAgentSessionId}-conflict`,
+          },
+        },
+        sandboxHeaders,
+        [400],
+      );
+      expectApiError(conflictingCheckpoint.body);
+      expect(conflictingCheckpoint.body.error.message).toContain(
+        "Final checkpoint does not exactly match",
+      );
+      await expect(
+        readSessionHistoryBlobRefCountFixture(historyHash),
+      ).resolves.toBe(1);
+      const runnerDuplicate = await webhooks.requestAgentComplete(
+        {
+          runId: run.runId,
+          exitCode: 1,
+          error: "late runner failure",
+          lastEventSequence: 0,
+        },
+        sandboxHeaders,
+        [200],
+      );
+      expect(runnerDuplicate.body).toStrictEqual(completed.body);
+      const stillSettled = await api.readRun(actor, run.runId);
+      expect(stillSettled.result).toStrictEqual(settled.result);
+      expect(stillSettled.error ?? null).toBeNull();
+
+      const continued = await api.createRun(actor, {
+        agentId,
+        sessionId: run.sessionId,
+        prompt: `resume combined ${cliAgentType} checkpoint`,
+        modelProvider: "anthropic-api-key",
+      });
+      const continuedClaim = await api.claimRunnerJob(continued.runId);
+      expect(continuedClaim.resumeSession).toMatchObject({
+        sessionId: cliAgentSessionId,
+        historyRef: { kind: "blob", hash: historyHash },
+      });
+      await api.requestCancelRun(actor, continued.runId, [200]);
+    },
+  );
+
+  it.each(["combined-first", "runner-first"] as const)(
+    "preserves generic failure recovery when completion is %s",
+    async (ordering) => {
+      const api = createRunsApi(context);
+      const webhooks = createWebhookCallbackApi(context);
+      const { actor, agentId } = await entitledRunActor();
+      const run = await api.createRun(actor, {
+        agentId,
+        prompt: `recover a ${ordering} failure`,
+        modelProvider: "anthropic-api-key",
+      });
+      const claim = await api.claimRunnerJob(run.runId);
+      const history = `bdd ${ordering} recovery history ${run.runId}`;
+      const historyHash = createHash("sha256").update(history).digest("hex");
+      const cliAgentSessionId = `bdd-${ordering}-cli-${run.runId}`;
+      mockSessionHistoryBlob(historyHash, history);
+      const sandboxHeaders = {
+        authorization: `Bearer ${claim.sandboxToken}`,
+      };
+      if (ordering === "runner-first") {
+        await webhooks.requestAgentComplete(
+          {
+            runId: run.runId,
+            exitCode: 1,
+            error: "runner reported failure",
+          },
+          sandboxHeaders,
+          [200],
+        );
+      }
+
+      const recovery = await webhooks.requestAgentComplete(
+        {
+          runId: run.runId,
+          exitCode: 1,
+          error: "guest reported failure",
+          checkpoint: {
+            cliAgentType: "claude-code",
+            cliAgentSessionId,
+            cliAgentSessionHistoryHash: historyHash,
+          },
+        },
+        sandboxHeaders,
+        [200],
+      );
+      expect(recovery.body).toStrictEqual({ success: true, status: "failed" });
+      const failed = await api.readRun(actor, run.runId);
+      expect(failed.status).toBe("failed");
+      expect(failed.error).toBe(
+        ordering === "runner-first"
+          ? "runner reported failure"
+          : "guest reported failure",
+      );
+
+      const continued = await api.createRun(actor, {
+        agentId,
+        sessionId: run.sessionId,
+        prompt: `resume ${ordering} recovery`,
+        modelProvider: "anthropic-api-key",
+      });
+      const continuedClaim = await api.claimRunnerJob(continued.runId);
+      expect(continuedClaim.resumeSession).toMatchObject({
+        sessionId: cliAgentSessionId,
+        historyRef: { kind: "blob", hash: historyHash },
+      });
+      await api.requestCancelRun(actor, continued.runId, [200]);
+    },
+  );
+
+  it("preserves generic cancellation recovery in a combined request", async () => {
+    const api = createRunsApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "cancel before combined recovery",
+      modelProvider: "anthropic-api-key",
+    });
+    const claim = await api.claimRunnerJob(run.runId);
+    const history = `bdd cancellation recovery ${run.runId}`;
+    const historyHash = createHash("sha256").update(history).digest("hex");
+    const cliAgentSessionId = `bdd-cancel-recovery-${run.runId}`;
+    mockSessionHistoryBlob(historyHash, history);
+    const sandboxHeaders = { authorization: `Bearer ${claim.sandboxToken}` };
+    await api.requestCancelRun(actor, run.runId, [200]);
+
+    const recovery = await webhooks.requestAgentComplete(
+      {
+        runId: run.runId,
+        exitCode: 1,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId,
+          cliAgentSessionHistoryHash: historyHash,
+        },
+      },
+      sandboxHeaders,
+      [200],
+    );
+    expect(recovery.body).toStrictEqual({ success: true, status: "failed" });
+    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+      status: "cancelled",
+    });
+
+    const continued = await api.createRun(actor, {
+      agentId,
+      sessionId: run.sessionId,
+      prompt: "resume cancellation recovery",
+      modelProvider: "anthropic-api-key",
+    });
+    const continuedClaim = await api.claimRunnerJob(continued.runId);
+    expect(continuedClaim.resumeSession).toMatchObject({
+      sessionId: cliAgentSessionId,
+      historyRef: { kind: "blob", hash: historyHash },
+    });
+    await api.requestCancelRun(actor, continued.runId, [200]);
+  });
+
+  it("rejects a combined checkpoint after timeout without partial persistence", async () => {
+    const api = createRunsApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "time out before combined completion",
+      modelProvider: "anthropic-api-key",
+    });
+    const claim = await api.claimRunnerJob(run.runId);
+    const history = `bdd timed out combined history ${run.runId}`;
+    const historyHash = createHash("sha256").update(history).digest("hex");
+    mockSessionHistoryBlob(historyHash, history);
+    const sandboxHeaders = { authorization: `Bearer ${claim.sandboxToken}` };
+    await timeoutRunWithoutCallbacksFixture({ runId: run.runId });
+
+    const rejected = await webhooks.requestAgentComplete(
+      {
+        runId: run.runId,
+        exitCode: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-timeout-combined-${run.runId}`,
+          cliAgentSessionHistoryHash: historyHash,
+        },
+      },
+      sandboxHeaders,
+      [400],
+    );
+    expectApiError(rejected.body);
+    expect(rejected.body.error.message).toContain("run status is timeout");
+    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+      status: "timeout",
+    });
+
+    const fallback = await webhooks.requestAgentComplete(
+      { runId: run.runId, exitCode: 0 },
+      sandboxHeaders,
+      [200],
+    );
+    expect(fallback.body).toStrictEqual({ success: true, status: "failed" });
+    const failed = await api.readRun(actor, run.runId);
+    expect(failed.error).toBe("Checkpoint for run not found");
+  });
+
   it("keeps claim auth valid through timeout completion and final telemetry", async () => {
     const api = createRunsApi(context);
     const webhooks = createWebhookCallbackApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -18112,6 +18112,16 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
       await expect(
         readSessionHistoryBlobRefCountFixture(historyHash),
       ).resolves.toBe(1);
+      const conflictingExitDuplicate = await webhooks.requestAgentComplete(
+        {
+          ...body,
+          exitCode: 1,
+          error: "response-loss retry reported a failure",
+        },
+        sandboxHeaders,
+        [200],
+      );
+      expect(conflictingExitDuplicate.body).toStrictEqual(completed.body);
       const conflictingCheckpoint = await webhooks.requestAgentComplete(
         {
           ...body,

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-complete.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-complete.ts
@@ -35,7 +35,7 @@ const completeAgentRunRoute$ = command(
     const result = await set(completeAgentRun$, { auth, body }, signal);
     signal.throwIfAborted();
 
-    if (result.sideEffects) {
+    if (result.status === 200 && result.sideEffects) {
       waitUntil(
         tapError(
           set(

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -966,8 +966,7 @@ async function completedGenericCheckpointRetryResponse(
     existing?.type === body.cliAgentType &&
     existing.sessionId === body.cliAgentSessionId &&
     existing.historyHash === (body.cliAgentSessionHistoryHash ?? null) &&
-    isDeepStrictEqual(existing.storageMounts, storageMounts) &&
-    run.agentSessionConversationId === existing.conversationId;
+    isDeepStrictEqual(existing.storageMounts, storageMounts);
   if (!exactRetry) {
     return badRequestMessage(
       "[CHECKPOINT_ALREADY_COMMITTED] Final checkpoint does not exactly match the completed run",

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -50,17 +50,40 @@ import {
 import { lockAgentRunCheckpointLifecycle } from "./agent-run-checkpoint-lifecycle-lock.service";
 import { safeSync, settle } from "../utils";
 
-type CheckpointCreateBody = z.infer<
+export type AgentCheckpointBody = z.infer<
   typeof webhookCheckpointsContract.create.body
 >;
 type PrepareHistoryBody = z.infer<
   typeof webhookCheckpointsPrepareHistoryContract.prepare.body
 >;
 
+export interface AgentCheckpointInput {
+  readonly auth: SandboxAuth;
+  readonly body: AgentCheckpointBody;
+}
+
 interface CheckpointAuthInput<TBody> {
   readonly auth: SandboxAuth;
   readonly body: TBody;
 }
+
+export interface PreparedAgentCheckpoint {
+  readonly piValidation?: {
+    readonly chatThreadId: string | null;
+    readonly runSessionId: string;
+  };
+}
+
+export type AgentCheckpointErrorResponse =
+  | ReturnType<typeof badRequestMessage>
+  | ReturnType<typeof notFound>;
+
+type AgentCheckpointPreparation =
+  | { readonly ok: true; readonly prepared: PreparedAgentCheckpoint }
+  | {
+      readonly ok: false;
+      readonly response: AgentCheckpointErrorResponse;
+    };
 
 interface CheckpointRunContext {
   readonly agentSessionConversationId: string | null;
@@ -94,14 +117,14 @@ function piCheckpointError(code: string, message: string): never {
 }
 
 function responseArtifacts(
-  snapshots: CheckpointCreateBody["artifactSnapshots"],
-): CheckpointCreateBody["artifactSnapshots"] | undefined {
+  snapshots: AgentCheckpointBody["artifactSnapshots"],
+): AgentCheckpointBody["artifactSnapshots"] | undefined {
   return snapshots && snapshots.length > 0 ? snapshots : undefined;
 }
 
 function checkpointStorageMounts(args: {
   readonly runStorageMounts: readonly PersistedStorageMount[] | null;
-  readonly artifactSnapshots: CheckpointCreateBody["artifactSnapshots"];
+  readonly artifactSnapshots: AgentCheckpointBody["artifactSnapshots"];
 }): PersistedStorageMount[] {
   if (args.runStorageMounts === null) {
     throw new Error("Agent run is missing canonical Storage mounts");
@@ -141,7 +164,7 @@ function checkpointStorageMounts(args: {
 
 async function loadCheckpointRunContext(
   db: Db,
-  input: CheckpointAuthInput<CheckpointCreateBody>,
+  input: AgentCheckpointInput,
 ): Promise<CheckpointRunContext | undefined> {
   const [run] = await db
     .select({
@@ -169,7 +192,7 @@ async function loadCheckpointRunContext(
 
 async function lockCheckpointRunContext(
   tx: Tx,
-  input: CheckpointAuthInput<CheckpointCreateBody>,
+  input: AgentCheckpointInput,
 ): Promise<CheckpointRunContext | undefined> {
   const [run] = await tx
     .select({
@@ -630,7 +653,7 @@ const validatePiH2$ = command(async function validatePiH2(
   { set },
   db: Db,
   run: CheckpointRunContext,
-  body: CheckpointCreateBody,
+  body: AgentCheckpointBody,
   signal: AbortSignal,
 ): Promise<string | null> {
   if (body.cliAgentType !== "pi") {
@@ -666,7 +689,7 @@ interface CheckpointSuccessIdentity {
 
 function checkpointSuccessResponse(
   identity: CheckpointSuccessIdentity,
-  body: CheckpointCreateBody,
+  body: AgentCheckpointBody,
 ) {
   return {
     status: 200 as const,
@@ -680,6 +703,10 @@ function checkpointSuccessResponse(
   };
 }
 
+type AgentCheckpointResponse =
+  | ReturnType<typeof checkpointSuccessResponse>
+  | AgentCheckpointErrorResponse;
+
 function isActivePiCheckpointStatus(status: RunStatus): boolean {
   return status === "pending" || status === "running";
 }
@@ -690,7 +717,7 @@ function isPiCheckpointRun(run: CheckpointRunContext): boolean {
 
 function piCheckpointTypeError(
   run: CheckpointRunContext,
-  body: CheckpointCreateBody,
+  body: AgentCheckpointBody,
 ): string | null {
   if (isPiCheckpointRun(run) === (body.cliAgentType === "pi")) {
     return null;
@@ -708,7 +735,7 @@ function checkpointRunStateError(status: RunStatus): string {
   return `[CHECKPOINT_RUN_TERMINAL] Checkpoint cannot become canonical while the run status is ${status}`;
 }
 
-interface ExistingPiCheckpoint {
+interface ExistingCheckpoint {
   readonly checkpointId: string;
   readonly conversationId: string;
   readonly historyHash: string | null;
@@ -717,10 +744,10 @@ interface ExistingPiCheckpoint {
   readonly type: string | null;
 }
 
-async function loadExistingPiCheckpoint(
+async function loadExistingCheckpoint(
   tx: Tx,
   runId: string,
-): Promise<ExistingPiCheckpoint | undefined> {
+): Promise<ExistingCheckpoint | undefined> {
   const [existing] = await tx
     .select({
       checkpointId: checkpoints.id,
@@ -754,7 +781,7 @@ type PiCheckpointAdmission =
 async function admitPiCheckpoint(
   tx: Tx,
   run: CheckpointRunContext,
-  body: CheckpointCreateBody,
+  body: AgentCheckpointBody,
   storageMounts: readonly PersistedStorageMount[],
 ): Promise<PiCheckpointAdmission> {
   const active = isActivePiCheckpointStatus(run.status);
@@ -762,7 +789,7 @@ async function admitPiCheckpoint(
     return { kind: "error", message: piCheckpointRunStateError(run.status) };
   }
 
-  const existing = await loadExistingPiCheckpoint(tx, body.runId);
+  const existing = await loadExistingCheckpoint(tx, body.runId);
   if (!existing) {
     return active
       ? { kind: "write" }
@@ -799,7 +826,7 @@ async function admitPiCheckpoint(
 async function persistAgentCheckpoint(
   tx: Tx,
   run: CheckpointRunContext,
-  body: CheckpointCreateBody,
+  body: AgentCheckpointBody,
   options: {
     storageMounts: PersistedStorageMount[];
     deferSessionPromotion: boolean;
@@ -926,94 +953,184 @@ async function persistAgentCheckpoint(
   );
 }
 
-async function commitAgentCheckpoint(
-  db: Db,
-  input: CheckpointAuthInput<CheckpointCreateBody>,
-  piValidated: boolean,
+async function completedGenericCheckpointRetryResponse(
+  tx: Tx,
+  run: CheckpointRunContext,
+  body: AgentCheckpointBody,
+  storageMounts: readonly PersistedStorageMount[],
   signal: AbortSignal,
-) {
-  return await db.transaction(async (tx) => {
-    await lockAgentRunCheckpointLifecycle(tx, input.body.runId);
-    signal.throwIfAborted();
-    const run = await lockCheckpointRunContext(tx, input);
-    signal.throwIfAborted();
-    if (!run) {
-      return notFound("Agent run not found");
-    }
+): Promise<AgentCheckpointResponse> {
+  const existing = await loadExistingCheckpoint(tx, body.runId);
+  signal.throwIfAborted();
+  const exactRetry =
+    existing?.type === body.cliAgentType &&
+    existing.sessionId === body.cliAgentSessionId &&
+    existing.historyHash === (body.cliAgentSessionHistoryHash ?? null) &&
+    isDeepStrictEqual(existing.storageMounts, storageMounts) &&
+    run.agentSessionConversationId === existing.conversationId;
+  if (!exactRetry) {
+    return badRequestMessage(
+      "[CHECKPOINT_ALREADY_COMMITTED] Final checkpoint does not exactly match the completed run",
+    );
+  }
+  return checkpointSuccessResponse(
+    {
+      agentSessionId: run.sessionId,
+      checkpointId: existing.checkpointId,
+      conversationId: existing.conversationId,
+    },
+    body,
+  );
+}
 
-    const storageMounts = checkpointStorageMounts({
-      runStorageMounts: run.storageMounts,
-      artifactSnapshots: input.body.artifactSnapshots,
-    });
-    const typeError = piCheckpointTypeError(run, input.body);
-    if (typeError) {
-      return badRequestMessage(typeError);
-    }
-    const piRun = isPiCheckpointRun(run);
-    if (!piRun && run.status === "timeout") {
-      return badRequestMessage(checkpointRunStateError(run.status));
-    }
-    if (piRun) {
-      const admission = await admitPiCheckpoint(
-        tx,
-        run,
-        input.body,
-        storageMounts,
-      );
-      signal.throwIfAborted();
-      if (admission.kind === "error") {
-        return badRequestMessage(admission.message);
-      }
-      if (admission.kind === "response") {
-        return admission.response;
-      }
-      if (!piValidated) {
-        return badRequestMessage(
-          "[PI_H2_RUN_STATE_CHANGED] Pi H2 must be retried after the run became active",
-        );
-      }
-    }
+export async function persistAgentCheckpointInTransaction(
+  tx: Tx,
+  input: AgentCheckpointInput,
+  prepared: PreparedAgentCheckpoint,
+  signal: AbortSignal,
+  options: {
+    readonly requireExactGenericCompletedRetry?: boolean;
+  } = {},
+): Promise<AgentCheckpointResponse> {
+  const run = await lockCheckpointRunContext(tx, input);
+  signal.throwIfAborted();
+  if (!run) {
+    return notFound("Agent run not found");
+  }
 
-    return await persistAgentCheckpoint(
+  const storageMounts = checkpointStorageMounts({
+    runStorageMounts: run.storageMounts,
+    artifactSnapshots: input.body.artifactSnapshots,
+  });
+  const typeError = piCheckpointTypeError(run, input.body);
+  if (typeError) {
+    return badRequestMessage(typeError);
+  }
+  const piRun = isPiCheckpointRun(run);
+  if (!piRun && run.status === "timeout") {
+    return badRequestMessage(checkpointRunStateError(run.status));
+  }
+  if (
+    !piRun &&
+    run.status === "completed" &&
+    options.requireExactGenericCompletedRetry
+  ) {
+    return await completedGenericCheckpointRetryResponse(
       tx,
       run,
       input.body,
-      {
-        storageMounts,
-        deferSessionPromotion: piRun,
-      },
+      storageMounts,
+      signal,
+    );
+  }
+  if (piRun) {
+    const admission = await admitPiCheckpoint(
+      tx,
+      run,
+      input.body,
+      storageMounts,
+    );
+    signal.throwIfAborted();
+    if (admission.kind === "error") {
+      return badRequestMessage(admission.message);
+    }
+    if (admission.kind === "response") {
+      return admission.response;
+    }
+    if (
+      !prepared.piValidation ||
+      prepared.piValidation.chatThreadId !== run.chatThreadId ||
+      prepared.piValidation.runSessionId !== run.sessionId
+    ) {
+      return badRequestMessage(
+        "[PI_H2_RUN_STATE_CHANGED] Pi H2 must be retried after the run became active",
+      );
+    }
+  }
+
+  return await persistAgentCheckpoint(
+    tx,
+    run,
+    input.body,
+    {
+      storageMounts,
+      deferSessionPromotion: piRun,
+    },
+    signal,
+  );
+}
+
+export const prepareAgentCheckpointPersistence$ = command(
+  async (
+    { set },
+    input: AgentCheckpointInput,
+    signal: AbortSignal,
+  ): Promise<AgentCheckpointPreparation> => {
+    const db = set(writeDb$);
+    const run = await loadCheckpointRunContext(db, input);
+    signal.throwIfAborted();
+
+    if (!run) {
+      return { ok: false, response: notFound("Agent run not found") };
+    }
+
+    const typeError = piCheckpointTypeError(run, input.body);
+    if (typeError) {
+      return { ok: false, response: badRequestMessage(typeError) };
+    }
+    const piNeedsValidation =
+      isPiCheckpointRun(run) && isActivePiCheckpointStatus(run.status);
+    if (piNeedsValidation) {
+      const piError = await set(validatePiH2$, db, run, input.body, signal);
+      if (piError) {
+        return { ok: false, response: badRequestMessage(piError) };
+      }
+    }
+
+    return {
+      ok: true,
+      prepared: piNeedsValidation
+        ? {
+            piValidation: {
+              chatThreadId: run.chatThreadId,
+              runSessionId: run.sessionId,
+            },
+          }
+        : {},
+    };
+  },
+);
+
+async function commitAgentCheckpoint(
+  db: Db,
+  input: AgentCheckpointInput,
+  prepared: PreparedAgentCheckpoint,
+  signal: AbortSignal,
+): Promise<AgentCheckpointResponse> {
+  return await db.transaction(async (tx) => {
+    await lockAgentRunCheckpointLifecycle(tx, input.body.runId);
+    signal.throwIfAborted();
+    return await persistAgentCheckpointInTransaction(
+      tx,
+      input,
+      prepared,
       signal,
     );
   });
 }
 
 export const createAgentCheckpoint$ = command(
-  async (
-    { set },
-    input: CheckpointAuthInput<CheckpointCreateBody>,
-    signal: AbortSignal,
-  ) => {
+  async ({ set }, input: AgentCheckpointInput, signal: AbortSignal) => {
     const db = set(writeDb$);
-    const run = await loadCheckpointRunContext(db, input);
-    signal.throwIfAborted();
-
-    if (!run) {
-      return notFound("Agent run not found");
+    const preparation = await set(
+      prepareAgentCheckpointPersistence$,
+      input,
+      signal,
+    );
+    if (!preparation.ok) {
+      return preparation.response;
     }
 
-    const typeError = piCheckpointTypeError(run, input.body);
-    if (typeError) {
-      return badRequestMessage(typeError);
-    }
-    const piRun = isPiCheckpointRun(run);
-    const piNeedsValidation = piRun && isActivePiCheckpointStatus(run.status);
-    if (piNeedsValidation) {
-      const piError = await set(validatePiH2$, db, run, input.body, signal);
-      if (piError) {
-        return badRequestMessage(piError);
-      }
-    }
-
-    return await commitAgentCheckpoint(db, input, piNeedsValidation, signal);
+    return await commitAgentCheckpoint(db, input, preparation.prepared, signal);
   },
 );

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -703,8 +703,12 @@ function checkpointSuccessResponse(
   };
 }
 
+type AgentCheckpointSuccessResponse = ReturnType<
+  typeof checkpointSuccessResponse
+>;
+
 type AgentCheckpointResponse =
-  | ReturnType<typeof checkpointSuccessResponse>
+  | AgentCheckpointSuccessResponse
   | AgentCheckpointErrorResponse;
 
 function isActivePiCheckpointStatus(status: RunStatus): boolean {
@@ -953,13 +957,13 @@ async function persistAgentCheckpoint(
   );
 }
 
-async function completedGenericCheckpointRetryResponse(
+async function exactCheckpointRetryResponse(
   tx: Tx,
   run: CheckpointRunContext,
   body: AgentCheckpointBody,
   storageMounts: readonly PersistedStorageMount[],
   signal: AbortSignal,
-): Promise<AgentCheckpointResponse> {
+): Promise<AgentCheckpointSuccessResponse | undefined> {
   const existing = await loadExistingCheckpoint(tx, body.runId);
   signal.throwIfAborted();
   const exactRetry =
@@ -968,9 +972,7 @@ async function completedGenericCheckpointRetryResponse(
     existing.historyHash === (body.cliAgentSessionHistoryHash ?? null) &&
     isDeepStrictEqual(existing.storageMounts, storageMounts);
   if (!exactRetry) {
-    return badRequestMessage(
-      "[CHECKPOINT_ALREADY_COMMITTED] Final checkpoint does not exactly match the completed run",
-    );
+    return undefined;
   }
   return checkpointSuccessResponse(
     {
@@ -988,7 +990,7 @@ export async function persistAgentCheckpointInTransaction(
   prepared: PreparedAgentCheckpoint,
   signal: AbortSignal,
   options: {
-    readonly requireExactGenericCompletedRetry?: boolean;
+    readonly combinedCompletion?: true;
   } = {},
 ): Promise<AgentCheckpointResponse> {
   const run = await lockCheckpointRunContext(tx, input);
@@ -1010,17 +1012,25 @@ export async function persistAgentCheckpointInTransaction(
     return badRequestMessage(checkpointRunStateError(run.status));
   }
   if (
-    !piRun &&
-    run.status === "completed" &&
-    options.requireExactGenericCompletedRetry
+    options.combinedCompletion &&
+    (run.status === "completed" ||
+      (!piRun && (run.status === "failed" || run.status === "cancelled")))
   ) {
-    return await completedGenericCheckpointRetryResponse(
+    const exactRetry = await exactCheckpointRetryResponse(
       tx,
       run,
       input.body,
       storageMounts,
       signal,
     );
+    if (exactRetry) {
+      return exactRetry;
+    }
+    if (run.status === "completed") {
+      return badRequestMessage(
+        "[CHECKPOINT_ALREADY_COMMITTED] Final checkpoint does not exactly match the completed run",
+      );
+    }
   }
   if (piRun) {
     const admission = await admitPiCheckpoint(

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -1014,7 +1014,8 @@ export async function persistAgentCheckpointInTransaction(
   if (
     options.combinedCompletion &&
     (run.status === "completed" ||
-      (!piRun && (run.status === "failed" || run.status === "cancelled")))
+      run.status === "failed" ||
+      run.status === "cancelled")
   ) {
     const exactRetry = await exactCheckpointRetryResponse(
       tx,

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -152,8 +152,8 @@ function checkpointInputForCompletion(
   return {
     auth: input.auth,
     body: {
-      runId: input.body.runId,
       ...input.body.checkpoint,
+      runId: input.body.runId,
     },
   };
 }

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -38,6 +38,13 @@ import { projectLegacyCheckpointStorage } from "./storage-legacy-projection.serv
 import { maybeEmitRunUsageEvent$ } from "./chat-usage-event.service";
 import { processOrgUsageEvents$ } from "./credit-usage.service";
 import { lockAgentRunCheckpointLifecycle } from "./agent-run-checkpoint-lifecycle-lock.service";
+import {
+  type AgentCheckpointErrorResponse,
+  type AgentCheckpointInput,
+  type PreparedAgentCheckpoint,
+  persistAgentCheckpointInTransaction,
+  prepareAgentCheckpointPersistence$,
+} from "./agent-webhook-checkpoints.service";
 
 type WebhookCompleteBody = z.infer<
   typeof webhookCompleteContract.complete.body
@@ -86,21 +93,18 @@ export type DispatchCompleteSideEffectsInput = CompleteSideEffectsInput & {
   readonly apiStartTime?: number;
 };
 
-interface CompletionResponse {
-  readonly status: 200 | 404;
-  readonly body:
-    | {
-        readonly success: true;
-        readonly status: TerminalStatus;
-      }
-    | {
-        readonly error: {
-          readonly message: string;
-          readonly code: "NOT_FOUND";
-        };
-      };
+interface CompletionSuccessResponse {
+  readonly status: 200;
+  readonly body: {
+    readonly success: true;
+    readonly status: TerminalStatus;
+  };
   readonly sideEffects?: CompleteSideEffectsInput;
 }
+
+type CompletionResponse =
+  | CompletionSuccessResponse
+  | AgentCheckpointErrorResponse;
 
 interface RunRecord {
   readonly cancellationRecoveryCompleted: boolean | null;
@@ -131,9 +135,28 @@ interface CompletionCommit {
 type CompletionTransactionResult =
   | { readonly kind: "not-found" }
   | { readonly kind: "retry"; readonly chatThreadId: string | null }
+  | {
+      readonly kind: "response";
+      readonly response: AgentCheckpointErrorResponse;
+    }
   | { readonly kind: "committed"; readonly commit: CompletionCommit };
 
 const L = logger("webhook:complete");
+
+function checkpointInputForCompletion(
+  input: CompleteAgentRunInput,
+): AgentCheckpointInput | null {
+  if (!input.body.checkpoint) {
+    return null;
+  }
+  return {
+    auth: input.auth,
+    body: {
+      runId: input.body.runId,
+      ...input.body.checkpoint,
+    },
+  };
+}
 
 function buildRunResult(
   checkpoint: Pick<
@@ -369,12 +392,25 @@ function noActiveInputFinalization(): FinalizeActiveInputDeliveryResult {
   };
 }
 
+interface CompletionTransitionContext {
+  readonly checkpointInput: AgentCheckpointInput | null;
+  readonly checkpointPreparation: PreparedAgentCheckpoint | null;
+  readonly expectedChatThreadId: string | null;
+  readonly legacyPrepared: PreparedCompletion | null;
+}
+
 async function completeAgentRunTransition(
   tx: Tx,
   input: CompleteAgentRunInput,
-  prepared: PreparedCompletion | null,
-  expectedChatThreadId: string | null,
+  context: CompletionTransitionContext,
+  signal: AbortSignal,
 ): Promise<CompletionTransactionResult> {
+  const {
+    checkpointInput,
+    checkpointPreparation,
+    expectedChatThreadId,
+    legacyPrepared,
+  } = context;
   const threadLocked =
     expectedChatThreadId === null
       ? false
@@ -389,6 +425,30 @@ async function completeAgentRunTransition(
   if (expectedChatThreadId !== null && !threadLocked) {
     throw new Error("Agent run retained a missing chat thread");
   }
+  if (checkpointInput) {
+    if (!checkpointPreparation) {
+      throw new Error("Included agent checkpoint was not prepared");
+    }
+    const checkpointResult = await persistAgentCheckpointInTransaction(
+      tx,
+      checkpointInput,
+      checkpointPreparation,
+      signal,
+      { requireExactGenericCompletedRetry: true },
+    );
+    if (checkpointResult.status !== 200) {
+      return { kind: "response", response: checkpointResult };
+    }
+  }
+  const canTransition =
+    run.status === "pending" ||
+    run.status === "running" ||
+    run.status === "timeout";
+  const prepared =
+    checkpointInput && canTransition
+      ? await prepareCompletion(tx, input, run.sessionId, signal)
+      : legacyPrepared;
+  signal.throwIfAborted();
   if (input.body.lastEventSequence !== undefined) {
     await persistLastEventSequence(
       tx,
@@ -407,10 +467,6 @@ async function completeAgentRunTransition(
             input.body.activeInputDeliveryIds ?? [],
           ),
         });
-  const canTransition =
-    run.status === "pending" ||
-    run.status === "running" ||
-    run.status === "timeout";
   if (canTransition) {
     if (!prepared) {
       throw new Error("Active agent run completion was not prepared");
@@ -672,25 +728,44 @@ export const completeAgentRun$ = command(
     if (!initialRun) {
       return notFound("Agent run not found");
     }
-    const shouldPrepare =
-      initialRun.status === "pending" ||
-      initialRun.status === "running" ||
-      initialRun.status === "timeout";
+    const checkpointInput = checkpointInputForCompletion(input);
+    let checkpointPreparation: PreparedAgentCheckpoint | null = null;
+    if (checkpointInput) {
+      const preparation = await set(
+        prepareAgentCheckpointPersistence$,
+        checkpointInput,
+        signal,
+      );
+      if (!preparation.ok) {
+        return preparation.response;
+      }
+      checkpointPreparation = preparation.prepared;
+    }
+    const shouldPrepareLegacyCompletion =
+      !checkpointInput &&
+      (initialRun.status === "pending" ||
+        initialRun.status === "running" ||
+        initialRun.status === "timeout");
     let expectedChatThreadId = initialRun.chatThreadId;
     let commit: CompletionCommit;
     while (true) {
       const result = await db.transaction(async (tx) => {
         await lockAgentRunCheckpointLifecycle(tx, input.body.runId);
         signal.throwIfAborted();
-        const prepared = shouldPrepare
+        const legacyPrepared = shouldPrepareLegacyCompletion
           ? await prepareCompletion(tx, input, initialRun.sessionId, signal)
           : null;
         signal.throwIfAborted();
         return await completeAgentRunTransition(
           tx,
           input,
-          prepared,
-          expectedChatThreadId,
+          {
+            checkpointInput,
+            checkpointPreparation,
+            expectedChatThreadId,
+            legacyPrepared,
+          },
+          signal,
         );
       });
       signal.throwIfAborted();
@@ -700,6 +775,9 @@ export const completeAgentRun$ = command(
       }
       if (result.kind === "not-found") {
         return deletedRunCompletionResponse(initialRun);
+      }
+      if (result.kind === "response") {
+        return result.response;
       }
       commit = result.commit;
       break;

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -434,7 +434,7 @@ async function completeAgentRunTransition(
       checkpointInput,
       checkpointPreparation,
       signal,
-      { requireExactGenericCompletedRetry: true },
+      { combinedCompletion: true },
     );
     if (checkpointResult.status !== 200) {
       return { kind: "response", response: checkpointResult };

--- a/turbo/apps/api/src/test-fixtures/agent-runs.ts
+++ b/turbo/apps/api/src/test-fixtures/agent-runs.ts
@@ -40,6 +40,20 @@ import { projectLegacyWritebackArtifacts } from "../signals/services/storage-leg
 
 const store = createStore();
 
+export async function readSessionHistoryBlobRefCountFixture(
+  hash: string,
+): Promise<number> {
+  const [blob] = await db()
+    .select({ refCount: blobs.refCount })
+    .from(blobs)
+    .where(eq(blobs.hash, hash))
+    .limit(1);
+  if (!blob) {
+    throw new Error("Expected the Session history Blob fixture to exist");
+  }
+  return blob.refCount;
+}
+
 export async function clearRunLaunchSnapshotFixture(
   runId: string,
 ): Promise<void> {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
@@ -19,17 +19,28 @@ const storageId = "00000000-0000-4000-8000-000000000000";
 const manifestHash = "a".repeat(64);
 
 describe("agent checkpoint session history", () => {
-  const baseBody = {
-    runId: "00000000-0000-4000-8000-000000000000",
+  const runId = "00000000-0000-4000-8000-000000000000";
+  const checkpointMetadata = {
     cliAgentType: "codex",
     cliAgentSessionId: "00000000-0000-4000-8000-000000000001",
   };
+  const baseBody = { runId, ...checkpointMetadata };
 
   it("accepts exactly one uploaded hash or historyless disposition", () => {
     expect(
       webhookCheckpointsContract.create.body.safeParse({
         ...baseBody,
         cliAgentSessionHistoryHash: manifestHash,
+      }).success,
+    ).toBe(true);
+    expect(
+      webhookCompleteContract.complete.body.safeParse({
+        runId,
+        exitCode: 0,
+        checkpoint: {
+          ...checkpointMetadata,
+          cliAgentSessionHistoryHash: manifestHash,
+        },
       }).success,
     ).toBe(true);
     expect(
@@ -47,24 +58,48 @@ describe("agent checkpoint session history", () => {
   });
 
   it("rejects missing, conflicting, and unknown history dispositions", () => {
-    const invalidBodies = [
-      baseBody,
+    const invalidMetadata = [
+      checkpointMetadata,
       {
-        ...baseBody,
+        ...checkpointMetadata,
         cliAgentSessionHistoryHash: manifestHash,
         cliAgentSessionHistoryDisposition: "discarded_oversized",
       },
       {
-        ...baseBody,
+        ...checkpointMetadata,
         cliAgentSessionHistoryDisposition: "unknown",
       },
     ];
 
-    for (const body of invalidBodies) {
+    for (const checkpoint of invalidMetadata) {
       expect(
-        webhookCheckpointsContract.create.body.safeParse(body).success,
+        webhookCheckpointsContract.create.body.safeParse({
+          runId,
+          ...checkpoint,
+        }).success,
+      ).toBe(false);
+      expect(
+        webhookCompleteContract.complete.body.safeParse({
+          runId,
+          exitCode: 0,
+          checkpoint,
+        }).success,
       ).toBe(false);
     }
+  });
+
+  it("keeps the outer completion run ID authoritative", () => {
+    expect(
+      webhookCompleteContract.complete.body.safeParse({
+        runId,
+        exitCode: 0,
+        checkpoint: {
+          runId,
+          ...checkpointMetadata,
+          cliAgentSessionHistoryDisposition: "unavailable",
+        },
+      }).success,
+    ).toBe(false);
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -435,6 +435,72 @@ const activeInputDeliveryIdsSchema = z
     });
   });
 
+/**
+ * Artifact snapshots schema — canonical
+ * `Array<{name, version, mountPath, missingRootPolicy?}>` form. Legacy
+ * `Record<name, version>` support was removed in #10913 after the DB
+ * migration and guest-agent writer flip completed.
+ */
+const artifactSnapshotsSchema = z.array(
+  z.object({
+    name: z.string(),
+    version: z.string(),
+    mountPath: z.string(),
+    missingRootPolicy: artifactMissingRootPolicySchema.optional(),
+  }),
+);
+
+/**
+ * Volume versions snapshot schema
+ */
+const volumeVersionsSnapshotSchema = z.object({
+  versions: z.record(z.string(), z.string()),
+});
+
+const checkpointMetadataShape = {
+  cliAgentType: z.string().min(1, "cliAgentType is required"),
+  cliAgentSessionId: z.string().min(1, "cliAgentSessionId is required"),
+  cliAgentSessionHistoryHash: sha256HexSchema.optional(),
+  cliAgentSessionHistoryDisposition: z
+    .enum(["discarded_oversized", "unavailable"])
+    .optional(),
+  // Multi-artifact snapshots are folded into canonical checkpoint mounts
+  // and projected back into the legacy response shape.
+  artifactSnapshots: artifactSnapshotsSchema.optional(),
+  volumeVersionsSnapshot: volumeVersionsSnapshotSchema.optional(),
+} as const;
+
+function requireCheckpointHistory(
+  body: {
+    readonly cliAgentSessionHistoryHash?: string;
+    readonly cliAgentSessionHistoryDisposition?: string;
+  },
+  context: z.RefinementCtx,
+): void {
+  const hasHash = body.cliAgentSessionHistoryHash !== undefined;
+  const hasDisposition = body.cliAgentSessionHistoryDisposition !== undefined;
+  if (hasHash === hasDisposition) {
+    context.addIssue({
+      code: "custom",
+      path: ["cliAgentSessionHistoryHash"],
+      message: "Exactly one session history hash or disposition is required",
+    });
+  }
+}
+
+const webhookCheckpointMetadataSchema = z
+  .object(checkpointMetadataShape)
+  .strict()
+  .superRefine(requireCheckpointHistory);
+
+const webhookCheckpointCreateBodySchema = z
+  .object({
+    runId: z.string().min(1, "runId is required"),
+    ...checkpointMetadataShape,
+  })
+  .strict()
+  .superRefine(requireCheckpointHistory);
+
 const webhookCompleteBodySchema = z
   .object({
     runId: z.string().min(1, "runId is required"),
@@ -448,6 +514,7 @@ const webhookCompleteBodySchema = z
     sandboxReuseResult: sandboxReuseResultSchema.optional(),
     workspaceReuseResult: workspaceReuseResultSchema.optional(),
     activeInputDeliveryIds: activeInputDeliveryIdsSchema.optional(),
+    checkpoint: webhookCheckpointMetadataSchema.optional(),
   })
   .superRefine((body, context) => {
     const workspaceResult = body.workspaceReuseResult;
@@ -482,28 +549,6 @@ const agentEventSchema = z
     sequenceNumber: eventSequenceNumberSchema,
   })
   .passthrough();
-
-/**
- * Artifact snapshots schema — canonical
- * `Array<{name, version, mountPath, missingRootPolicy?}>` form. Legacy
- * `Record<name, version>` support was removed in #10913 after the DB
- * migration and guest-agent writer flip completed.
- */
-const artifactSnapshotsSchema = z.array(
-  z.object({
-    name: z.string(),
-    version: z.string(),
-    mountPath: z.string(),
-    missingRootPolicy: artifactMissingRootPolicySchema.optional(),
-  }),
-);
-
-/**
- * Volume versions snapshot schema
- */
-const volumeVersionsSnapshotSchema = z.object({
-  versions: z.record(z.string(), z.string()),
-});
 
 const firewallAuthErrorSchema = z.object({
   error: z.object({
@@ -675,34 +720,7 @@ export const webhookCheckpointsContract = c.router({
     method: "POST",
     path: "/api/webhooks/agent/checkpoints",
     headers: authHeadersSchema,
-    body: z
-      .object({
-        runId: z.string().min(1, "runId is required"),
-        cliAgentType: z.string().min(1, "cliAgentType is required"),
-        cliAgentSessionId: z.string().min(1, "cliAgentSessionId is required"),
-        cliAgentSessionHistoryHash: sha256HexSchema.optional(),
-        cliAgentSessionHistoryDisposition: z
-          .enum(["discarded_oversized", "unavailable"])
-          .optional(),
-        // Multi-artifact snapshots are folded into canonical checkpoint mounts
-        // and projected back into the legacy response shape.
-        artifactSnapshots: artifactSnapshotsSchema.optional(),
-        volumeVersionsSnapshot: volumeVersionsSnapshotSchema.optional(),
-      })
-      .strict()
-      .superRefine((body, ctx) => {
-        const hasHash = body.cliAgentSessionHistoryHash !== undefined;
-        const hasDisposition =
-          body.cliAgentSessionHistoryDisposition !== undefined;
-        if (hasHash === hasDisposition) {
-          ctx.addIssue({
-            code: "custom",
-            path: ["cliAgentSessionHistoryHash"],
-            message:
-              "Exactly one session history hash or disposition is required",
-          });
-        }
-      }),
+    body: webhookCheckpointCreateBodySchema,
     responses: {
       200: z.object({
         checkpointId: z.string(),

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
@@ -103,6 +103,11 @@ const expectedBindings = [
     direction: "request",
   },
   {
+    rustModulePath: ["webhooks", "agent", "complete"],
+    rustTypeName: "Request",
+    direction: "request",
+  },
+  {
     rustModulePath: ["webhooks", "agent", "storages"],
     rustTypeName: "FileEntryWithHash",
     direction: "request",
@@ -238,6 +243,7 @@ describe("Rust type bindings", () => {
     expect(secondRender).toBe(firstRender);
     expect(firstRender).toContain("pub mod webhooks {");
     expect(firstRender).toContain("pub mod checkpoints {");
+    expect(firstRender).toContain("pub mod complete {");
     expect(firstRender).toContain("pub mod prepare_history {");
     expect(firstRender).toContain("pub mod prepare {");
     expect(firstRender).toContain("pub struct FileEntryWithHash {");
@@ -319,6 +325,10 @@ describe("Rust type bindings", () => {
     expect(firstRender).toContain(
       "pub versions: std::collections::BTreeMap<String, String>,",
     );
+    expect(firstRender).toContain("pub struct RequestCheckpoint {");
+    expect(firstRender).toContain("pub checkpoint: Option<RequestCheckpoint>,");
+    expect(firstRender).toContain("pub exit_code: i32,");
+    expect(firstRender).toContain("pub last_event_sequence: Option<u32>,");
     expect(firstRender).toContain("pub enum SessionHistoryEncoding {");
     expect(firstRender).toContain(
       "pub encoding: Option<SessionHistoryEncoding>,",

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -15,6 +15,7 @@ import { fileEntryWithHashSchema } from "../contracts/storages";
 import {
   webhookCheckpointsContract,
   webhookCheckpointsPrepareHistoryContract,
+  webhookCompleteContract,
   webhookStoragesCommitContract,
   webhookStoragesPrepareContract,
 } from "../contracts/webhooks";
@@ -94,6 +95,10 @@ export const rustTypeModuleDocs = [
   {
     rustModulePath: ["webhooks", "agent", "checkpoints", "prepare_history"],
     rustDoc: ["DTOs for preparing direct session-history uploads."],
+  },
+  {
+    rustModulePath: ["webhooks", "agent", "complete"],
+    rustDoc: ["DTOs for atomically completing agent runs."],
   },
   {
     rustModulePath: ["webhooks", "agent", "storages"],
@@ -494,6 +499,142 @@ export const rustTypeBindings = [
           conversationId: ["Conversation captured by the checkpoint."],
           artifacts: ["Optional artifact versions captured by the checkpoint."],
           volumes: ["Optional volume versions captured by the checkpoint."],
+        },
+      },
+    ],
+  },
+  {
+    schema: webhookCompleteContract.complete.body,
+    rustModulePath: ["webhooks", "agent", "complete"],
+    rustTypeName: "Request",
+    direction: "request",
+    fieldTypeOverrides: {
+      exitCode: "i32",
+      lastEventSequence: "u32",
+    },
+    declarations: [
+      {
+        rustTypeName: "RequestSandboxReuseResult",
+        rustDoc: ["Outcome of the sandbox reuse decision."],
+        variants: {
+          reused: ["An idle sandbox was reused."],
+          featureDisabled: ["Legacy outcome from the removed feature gate."],
+          noSessionId: ["Legacy outcome for an unavailable reuse identity."],
+          noReuseKey: ["The run had no sandbox reuse key."],
+          poolMiss: ["No matching idle sandbox was available."],
+          profileMismatch: ["The idle sandbox profile did not match."],
+          deviceLimitMismatch: [
+            "The idle sandbox device limits did not match.",
+          ],
+          unparkFailed: ["The selected idle sandbox could not be unparked."],
+        },
+      },
+      {
+        rustTypeName: "RequestWorkspaceReuseResult",
+        rustDoc: ["Final outcome of workspace reuse preparation."],
+        variants: {
+          reused: ["A cached workspace was reused."],
+          sandboxReused: ["The workspace remained in a reused sandbox."],
+          cacheMiss: ["No matching workspace cache was available."],
+          noReuseKey: ["The run had no workspace reuse key."],
+          invalidWorkingDir: ["The cached workspace directory was invalid."],
+          lockBusy: ["The cached workspace was locked by another run."],
+          invalidMetadata: ["The cached workspace metadata was invalid."],
+          diskPressure: ["Workspace reuse was disabled by disk pressure."],
+          notConfigured: ["Workspace reuse was not configured."],
+          sandboxPrepareFallback: [
+            "Workspace preparation fell back after sandbox setup.",
+          ],
+        },
+      },
+      {
+        rustTypeName: "RequestCheckpoint",
+        rustDoc: ["Final checkpoint metadata included with completion."],
+        fields: {
+          cliAgentType: ["CLI agent implementation that produced the session."],
+          cliAgentSessionId: [
+            "CLI agent session identifier being checkpointed.",
+          ],
+          cliAgentSessionHistoryHash: [
+            "Optional SHA-256 hash of uploaded CLI agent session history.",
+          ],
+          cliAgentSessionHistoryDisposition: [
+            "Optional reason resumable session history was omitted.",
+          ],
+          artifactSnapshots: [
+            "Optional artifact versions captured by the checkpoint.",
+          ],
+          volumeVersionsSnapshot: [
+            "Optional volume versions captured by the checkpoint.",
+          ],
+        },
+      },
+      {
+        rustTypeName: "RequestCheckpointCliAgentSessionHistoryDisposition",
+        rustDoc: [
+          "Reason a final checkpoint intentionally omits resumable CLI agent session history.",
+        ],
+        variants: {
+          discarded_oversized: [
+            "The native history exceeded the bounded checkpoint limit.",
+          ],
+          unavailable: ["The native history was unavailable or unusable."],
+        },
+      },
+      {
+        rustTypeName: "RequestCheckpointArtifactSnapshot",
+        rustDoc: ["Artifact version captured by a final checkpoint."],
+        fields: {
+          name: ["User-facing artifact name referenced by the run."],
+          version: ["Artifact version selected for the checkpoint."],
+          mountPath: ["Guest filesystem path where the artifact is mounted."],
+          missingRootPolicy: [
+            "Optional policy retained when the artifact mount root is missing.",
+          ],
+        },
+      },
+      {
+        rustTypeName: "RequestCheckpointArtifactSnapshotMissingRootPolicy",
+        rustDoc: [
+          "Policy used when a final checkpoint artifact root is missing.",
+        ],
+        variants: {
+          fail: ["Treat a missing artifact root as an error."],
+          preserveParentVersion: [
+            "Preserve the parent artifact version when the root is missing.",
+          ],
+        },
+      },
+      {
+        rustTypeName: "RequestCheckpointVolumeVersionsSnapshot",
+        rustDoc: ["Volume versions captured by a final checkpoint."],
+        fields: {
+          versions: ["Volume names mapped to their captured versions."],
+        },
+      },
+      {
+        rustTypeName: "Request",
+        rustDoc: ["Request body for completing an agent run."],
+        fields: {
+          runId: ["Agent run identifier bound to the sandbox token."],
+          exitCode: ["Process exit code reported by the caller."],
+          error: ["Optional process failure description."],
+          lastEventSequence: [
+            "Highest contiguous agent event sequence delivered before completion.",
+          ],
+          sandboxId: ["Optional sandbox identifier used by the run."],
+          sandboxReuseResult: [
+            "Optional outcome of the sandbox reuse decision.",
+          ],
+          workspaceReuseResult: [
+            "Optional outcome of the workspace reuse decision.",
+          ],
+          activeInputDeliveryIds: [
+            "Optional active-input delivery receipts recovered during completion.",
+          ],
+          checkpoint: [
+            "Optional final checkpoint persisted atomically with completion.",
+          ],
         },
       },
     ],


### PR DESCRIPTION
## Summary

- add optional final checkpoint metadata to the existing agent completion contract and generated Rust request types
- reuse checkpoint validation and persistence inside the completion transaction so checkpoint identity, session promotion, delivery settlement, and terminal state commit atomically
- preserve standalone checkpoint, checkpoint-less Guest/Runner completion, duplicate completion, cancellation recovery, Pi admission, and current timeout behavior

## Scope

- API compatibility release only; Guest and Runner request timing and payloads are unchanged
- no database migration, pending-promotion marker, timeout immutability, or new acknowledgement protocol
- API deployment and old-handler drain remain required before the combined Guest caller in #30348 can ship

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/webhooks.test.ts src/rust-bindings/__tests__/types.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (186 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts` (131 tests)
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` against a fresh migrated database (3,648 tests)
- `pnpm knip`
- `cargo fmt --check`
- `cargo check -p api-contracts`
- `cargo test -p api-contracts`
- staged pre-commit hooks, including full Turbo type checks, Cargo docs, Clippy, and formatting

Closes #30346

Parent: #30250

Delivery parent: #30246
