### PR TITLE
fix(e2e): intercept shared worker requests in browser tests

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -757,6 +757,10 @@ gate_step = jobs.fetch("ci-gate-turbo").fetch("steps").find do |step|
 end
 raise "missing Turbo CI gate validation" unless gate_step
 gate_script = gate_step.fetch("run")
+if gate_script.include?('[ "$result" = "cancelled" ]') ||
+    gate_script.include?("cancelled by concurrency group, allowed")
+  raise "CI gate must reject cancelled required jobs"
+end
 unless gate_script.include?("RUNNER_E2E_SKIP_ALLOWED=\"true\"") &&
     gate_script.include?("needs.prepare.outputs.turbo-runner-consumer-needed")
   raise "CI gate must restore the runner-specific E2E skip policy"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -3054,8 +3054,6 @@ jobs:
               echo "✅ $job: $result"
             elif { [ "$allow_skip" = "skipped" ] || [ "$allow_skip" = "true" ]; } && [ "$result" = "skipped" ]; then
               echo "⏭️ $job: $result (allowed)"
-            elif [ "$allow_skip" = "true" ] && [ "$result" = "cancelled" ]; then
-              echo "⚠️ $job: $result (cancelled by concurrency group, allowed)"
             elif [ "$allow_skip" = "informational" ]; then
               echo "ℹ️ $job: $result (informational, not blocking)"
             else

--- a/e2e/playwright/fixtures.ts
+++ b/e2e/playwright/fixtures.ts
@@ -1,5 +1,6 @@
 import { setupClerkTestingToken } from "@clerk/testing/playwright";
 import { expect, test as base } from "@playwright/test";
+import { SharedWorkerRoutes } from "./lib/shared-worker-routes";
 
 import { resolveApiBackendUrl } from "./api-backend-url";
 
@@ -7,7 +8,7 @@ export { expect };
 
 const apiUrl = resolveApiBackendUrl();
 
-export const test = base.extend({
+export const test = base.extend<{ sharedWorkerRoutes: SharedWorkerRoutes }>({
   context: async ({ context }, use) => {
     // Every page load runs `clerk.load()`, which handshakes with the Clerk
     // Frontend API — including tests that only restore a saved storage
@@ -41,6 +42,22 @@ export const test = base.extend({
       await use(page);
     } finally {
       await page.unrouteAll({ behavior: "ignoreErrors" });
+    }
+  },
+  sharedWorkerRoutes: async ({ browser, page }, use) => {
+    const apiUrl = process.env.VM0_API_BACKEND_URL;
+    if (!apiUrl) {
+      throw new Error("VM0_API_BACKEND_URL environment variable is required");
+    }
+    const routes = await SharedWorkerRoutes.create(
+      browser,
+      page,
+      new URL(apiUrl).origin,
+    );
+    try {
+      await use(routes);
+    } finally {
+      await routes.close();
     }
   },
 });

--- a/e2e/playwright/fixtures.ts
+++ b/e2e/playwright/fixtures.ts
@@ -45,9 +45,8 @@ export const test = base.extend<{ sharedWorkerRoutes: SharedWorkerRoutes }>({
     }
   },
   sharedWorkerRoutes: async ({ browser, page }, use) => {
-    const apiUrl = process.env.VM0_API_BACKEND_URL;
     if (!apiUrl) {
-      throw new Error("VM0_API_BACKEND_URL environment variable is required");
+      throw new Error("E2E API backend URL is required");
     }
     const routes = await SharedWorkerRoutes.create(
       browser,

--- a/e2e/playwright/lib/active-agent.ts
+++ b/e2e/playwright/lib/active-agent.ts
@@ -1,0 +1,12 @@
+import type { Page } from "@playwright/test";
+
+export async function waitForActiveAgentId(page: Page): Promise<string> {
+  await page.waitForURL(/\/agents\/[^/]+\/chat\/?$/, { timeout: 30_000 });
+  const agentId = new URL(page.url()).pathname.match(
+    /^\/agents\/([^/]+)\/chat\/?$/,
+  )?.[1];
+  if (!agentId) {
+    throw new Error("Could not resolve the active agent from the chat URL");
+  }
+  return agentId;
+}

--- a/e2e/playwright/lib/shared-worker-route-bridge.ts
+++ b/e2e/playwright/lib/shared-worker-route-bridge.ts
@@ -99,10 +99,6 @@ export function workerBridgeSource(
 ): string {
   return `(() => new Promise((resolveBridge) => {
     const installBridge = () => {
-      if (globalThis._vm0 === undefined) {
-        setTimeout(installBridge, 0);
-        return;
-      }
       const channel = new BroadcastChannel(${JSON.stringify(channelName)});
       const nativeFetch = globalThis.fetch.bind(globalThis);
       const pending = new Map();
@@ -143,6 +139,22 @@ export function workerBridgeSource(
       globalThis.fetch = routedFetch;
       resolveBridge();
     };
-    installBridge();
+    if (globalThis._vm0 !== undefined) {
+      installBridge();
+      return;
+    }
+    Object.defineProperty(globalThis, "_vm0", {
+      configurable: true,
+      get: () => undefined,
+      set: (value) => {
+        Object.defineProperty(globalThis, "_vm0", {
+          configurable: true,
+          enumerable: true,
+          value,
+          writable: true,
+        });
+        installBridge();
+      },
+    });
   }))()`;
 }

--- a/e2e/playwright/lib/shared-worker-route-bridge.ts
+++ b/e2e/playwright/lib/shared-worker-route-bridge.ts
@@ -11,6 +11,8 @@ export async function installPageBridge(
   channelName: string,
   bindingName: string,
 ): Promise<void> {
+  // Keep the injected code browser-native. Passing a transpiled callback can
+  // leak tsx's __name helper into the page, where that helper does not exist.
   await page.addInitScript({
     content: pageBridgeSource(channelName, bindingName),
   });
@@ -97,7 +99,7 @@ export function workerBridgeSource(
   channelName: string,
   apiOrigin: string,
 ): string {
-  return `(() => new Promise((resolveBridge) => {
+  return `(() => new Promise((resolveBridge, rejectBridge) => {
     const installBridge = () => {
       const channel = new BroadcastChannel(${JSON.stringify(channelName)});
       const nativeFetch = globalThis.fetch.bind(globalThis);
@@ -143,6 +145,9 @@ export function workerBridgeSource(
       installBridge();
       return;
     }
+    // The production worker assigns _vm0 after Sentry initialization and
+    // before accepting connections. Observe that assignment without polling,
+    // then restore the ordinary writable data property expected by the app.
     Object.defineProperty(globalThis, "_vm0", {
       configurable: true,
       get: () => undefined,
@@ -153,7 +158,11 @@ export function workerBridgeSource(
           value,
           writable: true,
         });
-        installBridge();
+        try {
+          installBridge();
+        } catch (error) {
+          rejectBridge(error);
+        }
       },
     });
   }))()`;

--- a/e2e/playwright/lib/shared-worker-route-bridge.ts
+++ b/e2e/playwright/lib/shared-worker-route-bridge.ts
@@ -1,0 +1,148 @@
+import type { Page } from "@playwright/test";
+
+export const WORKER_ROUTES_READY_EVENT = "vm0-shared-worker-routes-ready";
+
+const WORKER_ROUTES_READY_STORAGE_KEY = "vm0.sharedWorkerRoutes.ready";
+const ROUTE_REQUEST_TYPE = "vm0-shared-worker-route-request";
+const ROUTE_RESPONSE_TYPE = "vm0-shared-worker-route-response";
+
+export async function installPageBridge(
+  page: Page,
+  channelName: string,
+  bindingName: string,
+): Promise<void> {
+  await page.addInitScript({
+    content: pageBridgeSource(channelName, bindingName),
+  });
+}
+
+function pageBridgeSource(channelName: string, bindingName: string): string {
+  return `(() => {
+    if (window.frameElement !== null) return;
+    const channel = new BroadcastChannel(${JSON.stringify(channelName)});
+    channel.addEventListener("message", (event) => {
+      const value = event.data;
+      if (
+        typeof value !== "object" ||
+        value === null ||
+        value.type !== ${JSON.stringify(ROUTE_REQUEST_TYPE)} ||
+        typeof value.requestId !== "string" ||
+        !("request" in value)
+      ) return;
+      const binding = globalThis[${JSON.stringify(bindingName)}];
+      if (typeof binding !== "function") {
+        throw new Error("SharedWorker route binding is unavailable");
+      }
+      void Promise.resolve(binding(value.request)).then((response) => {
+        channel.postMessage({
+          type: ${JSON.stringify(ROUTE_RESPONSE_TYPE)},
+          requestId: value.requestId,
+          response,
+        });
+      });
+    });
+
+    const NativeSharedWorker = globalThis.SharedWorker;
+    let released = sessionStorage.getItem(${JSON.stringify(WORKER_ROUTES_READY_STORAGE_KEY)}) === "true";
+    const pendingMessages = [];
+    globalThis.addEventListener(
+      ${JSON.stringify(WORKER_ROUTES_READY_EVENT)},
+      () => {
+        released = true;
+        sessionStorage.setItem(${JSON.stringify(WORKER_ROUTES_READY_STORAGE_KEY)}, "true");
+        for (const send of pendingMessages.splice(0)) send();
+      },
+      { once: true },
+    );
+    const GatedSharedWorker = function (scriptURL, options) {
+      const worker = new NativeSharedWorker(scriptURL, options);
+      const port = worker.port;
+      const postMessage = port.postMessage.bind(port);
+      const gatedPort = {
+        addEventListener: port.addEventListener.bind(port),
+        close: port.close.bind(port),
+        postMessage: (message, transferOrOptions) => {
+          const send = () => {
+            if (transferOrOptions === undefined) postMessage(message);
+            else postMessage(message, transferOrOptions);
+          };
+          if (released) send();
+          else pendingMessages.push(send);
+        },
+        removeEventListener: port.removeEventListener.bind(port),
+        start: port.start.bind(port),
+      };
+      return new Proxy(worker, {
+        get: (target, property) => {
+          if (property === "port") return gatedPort;
+          const value = Reflect.get(target, property, target);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+        set: (target, property, value) => {
+          return Reflect.set(target, property, value, target);
+        },
+      });
+    };
+    Object.setPrototypeOf(GatedSharedWorker, NativeSharedWorker);
+    GatedSharedWorker.prototype = NativeSharedWorker.prototype;
+    Object.defineProperty(globalThis, "SharedWorker", {
+      configurable: true,
+      value: GatedSharedWorker,
+      writable: true,
+    });
+  })();`;
+}
+
+export function workerBridgeSource(
+  channelName: string,
+  apiOrigin: string,
+): string {
+  return `(() => new Promise((resolveBridge) => {
+    const installBridge = () => {
+      if (globalThis._vm0 === undefined) {
+        setTimeout(installBridge, 0);
+        return;
+      }
+      const channel = new BroadcastChannel(${JSON.stringify(channelName)});
+      const nativeFetch = globalThis.fetch.bind(globalThis);
+      const pending = new Map();
+      channel.addEventListener("message", (event) => {
+        const value = event.data;
+        if (value?.type !== ${JSON.stringify(ROUTE_RESPONSE_TYPE)}) return;
+        const resolve = pending.get(value.requestId);
+        if (!resolve) return;
+        pending.delete(value.requestId);
+        resolve(value.response);
+      });
+      const routedFetch = async (input, init) => {
+        const request = new Request(input, init);
+        const url = new URL(request.url);
+        if (url.origin !== ${JSON.stringify(apiOrigin)} || !url.pathname.startsWith("/api/")) {
+          return await nativeFetch(request);
+        }
+        const requestId = crypto.randomUUID();
+        const response = await new Promise((resolve) => {
+          pending.set(requestId, resolve);
+          channel.postMessage({
+            type: ${JSON.stringify(ROUTE_REQUEST_TYPE)},
+            requestId,
+            request: {
+              url: request.url,
+              method: request.method,
+              headers: Object.fromEntries(request.headers.entries()),
+            },
+          });
+        });
+        if (response.action === "continue") return await nativeFetch(request);
+        if (response.action === "fail") throw new TypeError("Failed to fetch");
+        return new Response(response.body, {
+          status: response.status,
+          headers: response.headers,
+        });
+      };
+      globalThis.fetch = routedFetch;
+      resolveBridge();
+    };
+    installBridge();
+  }))()`;
+}

--- a/e2e/playwright/lib/shared-worker-routes.test.ts
+++ b/e2e/playwright/lib/shared-worker-routes.test.ts
@@ -51,11 +51,11 @@ test("routes requests from a real SharedWorker and cleans up", async (context) =
 
             await page.goto(fixture.origin);
             const port = await connectSharedWorker(page, "success");
+            const result = fetchFromSharedWorker(port);
             await routes.waitForWorker();
-            const result = await fetchFromSharedWorker(port);
             await registration.handled;
 
-            assert.deepEqual(result, {
+            assert.deepEqual(await result, {
               mocked: { source: "worker-route" },
               passthrough: { source: "network-passthrough" },
             });

--- a/e2e/playwright/lib/shared-worker-routes.test.ts
+++ b/e2e/playwright/lib/shared-worker-routes.test.ts
@@ -63,6 +63,23 @@ test("routes requests from a real SharedWorker and cleans up", async (context) =
             assert.equal(fixture.requestCount("/api/mocked"), 0);
             assert.equal(fixture.requestCount("/api/passthrough"), 1);
 
+            const isolatedContext = await browser.newContext();
+            try {
+              const isolatedPage = await isolatedContext.newPage();
+              await isolatedPage.goto(fixture.origin);
+              const isolatedPort = await connectSharedWorker(
+                isolatedPage,
+                "isolated-context",
+              );
+              const isolatedResult = await fetchFromSharedWorker(isolatedPort);
+              assert.deepEqual(isolatedResult.mocked, {
+                source: "network-mocked",
+              });
+              assert.equal(fixture.requestCount("/api/mocked"), 1);
+            } finally {
+              await isolatedContext.close();
+            }
+
             let handlerCalled = false;
             routes.route(
               (url) => url.pathname === "/api/mocked",
@@ -95,7 +112,7 @@ test("routes requests from a real SharedWorker and cleans up", async (context) =
             const port = await connectSharedWorker(page, "after-cleanup");
             const result = await fetchFromSharedWorker(port);
             assert.deepEqual(result.mocked, { source: "network-mocked" });
-            assert.equal(fixture.requestCount("/api/mocked"), 1);
+            assert.equal(fixture.requestCount("/api/mocked"), 2);
           } finally {
             await cleanContext.close();
           }

--- a/e2e/playwright/lib/shared-worker-routes.test.ts
+++ b/e2e/playwright/lib/shared-worker-routes.test.ts
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import { createServer, type Server } from "node:http";
+import { test } from "node:test";
+
+import { chromium, type JSHandle, type Page } from "@playwright/test";
+
+import { SharedWorkerRoutes } from "./shared-worker-routes";
+
+interface WorkerFetchResult {
+  readonly mocked: Readonly<Record<string, unknown>>;
+  readonly passthrough: Readonly<Record<string, unknown>>;
+}
+
+interface WorkerFixture {
+  readonly origin: string;
+  readonly requestCount: (pathname: string) => number;
+}
+
+test("routes requests from a real SharedWorker and cleans up", async (context) => {
+  await withWorkerFixture(async (fixture) => {
+    await context.test(
+      "fulfills worker fetches and passes through others",
+      async () => {
+        const browser = await chromium.launch();
+        try {
+          const browserContext = await browser.newContext();
+          const page = await browserContext.newPage();
+          const routes = await SharedWorkerRoutes.create(
+            browser,
+            page,
+            fixture.origin,
+          );
+          let routesClosed = false;
+          try {
+            let pageRouteObserved = false;
+            await browserContext.route("**/api/mocked", async (route) => {
+              pageRouteObserved = true;
+              await route.fulfill({ json: { source: "page-route" } });
+            });
+            const registration = routes.route(
+              (url) => url.pathname === "/api/mocked",
+              async (route) => {
+                assert.equal(route.request().method(), "GET");
+                assert.equal(
+                  await route.request().headerValue("x-worker-route-test"),
+                  "present",
+                );
+                await route.fulfill({ json: { source: "worker-route" } });
+              },
+            );
+
+            await page.goto(fixture.origin);
+            const port = await connectSharedWorker(page, "success");
+            await routes.waitForWorker();
+            const result = await fetchFromSharedWorker(port);
+            await registration.handled;
+
+            assert.deepEqual(result, {
+              mocked: { source: "worker-route" },
+              passthrough: { source: "network-passthrough" },
+            });
+            assert.equal(pageRouteObserved, false);
+            assert.equal(fixture.requestCount("/api/mocked"), 0);
+            assert.equal(fixture.requestCount("/api/passthrough"), 1);
+
+            let handlerCalled = false;
+            routes.route(
+              (url) => url.pathname === "/api/mocked",
+              async () => {
+                handlerCalled = true;
+                throw new Error("worker route handler failed");
+              },
+            );
+            await assert.rejects(
+              fetchFromSharedWorker(port),
+              /Failed to fetch/u,
+            );
+            assert.equal(handlerCalled, true);
+            routesClosed = true;
+            await assert.rejects(
+              routes.close(),
+              /worker route handler failed/u,
+            );
+          } finally {
+            if (!routesClosed) {
+              await routes.close();
+            }
+            await browserContext.close();
+          }
+
+          const cleanContext = await browser.newContext();
+          try {
+            const page = await cleanContext.newPage();
+            await page.goto(fixture.origin);
+            const port = await connectSharedWorker(page, "after-cleanup");
+            const result = await fetchFromSharedWorker(port);
+            assert.deepEqual(result.mocked, { source: "network-mocked" });
+            assert.equal(fixture.requestCount("/api/mocked"), 1);
+          } finally {
+            await cleanContext.close();
+          }
+        } finally {
+          await browser.close();
+        }
+      },
+    );
+  });
+});
+
+async function connectSharedWorker(
+  page: Page,
+  name: string,
+): Promise<JSHandle<MessagePort>> {
+  return await page.evaluateHandle<MessagePort, string>((workerName) => {
+    return new Promise<MessagePort>((resolve) => {
+      const worker = new SharedWorker("/worker.js", { name: workerName });
+      worker.port.addEventListener(
+        "message",
+        () => {
+          resolve(worker.port);
+        },
+        { once: true },
+      );
+      worker.port.start();
+    });
+  }, name);
+}
+
+async function fetchFromSharedWorker(
+  port: JSHandle<MessagePort>,
+): Promise<WorkerFetchResult> {
+  return await port.evaluate<WorkerFetchResult>((workerPort) => {
+    return new Promise<WorkerFetchResult>((resolve, reject) => {
+      workerPort.addEventListener(
+        "message",
+        (
+          event: MessageEvent<WorkerFetchResult | { readonly error: string }>,
+        ) => {
+          if ("error" in event.data) {
+            reject(new Error(event.data.error));
+          } else {
+            resolve(event.data);
+          }
+        },
+        { once: true },
+      );
+      workerPort.postMessage("fetch");
+    });
+  });
+}
+
+async function withWorkerFixture<Result>(
+  use: (fixture: WorkerFixture) => Promise<Result>,
+): Promise<Result> {
+  const requestCounts = new Map<string, number>();
+  const server = createServer((request, response) => {
+    const pathname = new URL(request.url ?? "/", "http://fixture").pathname;
+    requestCounts.set(pathname, (requestCounts.get(pathname) ?? 0) + 1);
+    if (pathname === "/") {
+      response.writeHead(200, { "content-type": "text/html" });
+      response.end("<!doctype html><title>SharedWorker route fixture</title>");
+      return;
+    }
+    if (pathname === "/worker.js") {
+      response.writeHead(200, { "content-type": "text/javascript" });
+      response.end(`
+        onconnect = ({ ports: [port] }) => {
+          port.postMessage({ ready: true });
+          port.onmessage = () => {
+            Promise.all([
+              fetch("/api/mocked", {
+                headers: { "x-worker-route-test": "present" },
+              }).then((response) => response.json()),
+              fetch("/api/passthrough").then((response) => response.json()),
+            ])
+              .then(([mocked, passthrough]) => {
+                port.postMessage({ mocked, passthrough });
+              })
+              .catch((error) => {
+                port.postMessage({ error: String(error.message ?? error) });
+              });
+          };
+        };
+      `);
+      return;
+    }
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(
+      JSON.stringify({
+        source:
+          pathname === "/api/mocked" ? "network-mocked" : "network-passthrough",
+      }),
+    );
+  });
+  await listen(server);
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    await close(server);
+    throw new Error("SharedWorker fixture server has no TCP address");
+  }
+  try {
+    return await use({
+      origin: `http://127.0.0.1:${address.port}`,
+      requestCount: (pathname: string): number =>
+        requestCounts.get(pathname) ?? 0,
+    });
+  } finally {
+    await close(server);
+  }
+}
+
+async function listen(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+}
+
+async function close(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+    server.closeAllConnections();
+  });
+}

--- a/e2e/playwright/lib/shared-worker-routes.test.ts
+++ b/e2e/playwright/lib/shared-worker-routes.test.ts
@@ -2,13 +2,23 @@ import assert from "node:assert/strict";
 import { createServer, type Server } from "node:http";
 import { test } from "node:test";
 
-import { chromium, type JSHandle, type Page } from "@playwright/test";
+import { chromium, type Page } from "@playwright/test";
 
 import { SharedWorkerRoutes } from "./shared-worker-routes";
 
 interface WorkerFetchResult {
   readonly mocked: Readonly<Record<string, unknown>>;
   readonly passthrough: Readonly<Record<string, unknown>>;
+}
+
+interface WorkerClient {
+  readonly port: MessagePort;
+}
+
+declare global {
+  interface Window {
+    sharedWorkerRouteTestClients?: Map<string, WorkerClient>;
+  }
 }
 
 interface WorkerFixture {
@@ -50,15 +60,15 @@ test("routes requests from a real SharedWorker and cleans up", async (context) =
             );
 
             await page.goto(fixture.origin);
-            const port = await connectSharedWorker(page, "success");
-            const result = fetchFromSharedWorker(port);
+            await connectSharedWorker(page, "success");
+            const result = fetchFromSharedWorker(page, "success");
             await routes.waitForWorker();
-            await registration.handled;
-
-            assert.deepEqual(await result, {
+            const firstResult = await result;
+            assert.deepEqual(firstResult, {
               mocked: { source: "worker-route" },
               passthrough: { source: "network-passthrough" },
             });
+            await registration.handled;
             assert.equal(pageRouteObserved, false);
             assert.equal(fixture.requestCount("/api/mocked"), 0);
             assert.equal(fixture.requestCount("/api/passthrough"), 1);
@@ -67,11 +77,11 @@ test("routes requests from a real SharedWorker and cleans up", async (context) =
             try {
               const isolatedPage = await isolatedContext.newPage();
               await isolatedPage.goto(fixture.origin);
-              const isolatedPort = await connectSharedWorker(
+              await connectSharedWorker(isolatedPage, "isolated-context");
+              const isolatedResult = await fetchFromSharedWorker(
                 isolatedPage,
                 "isolated-context",
               );
-              const isolatedResult = await fetchFromSharedWorker(isolatedPort);
               assert.deepEqual(isolatedResult.mocked, {
                 source: "network-mocked",
               });
@@ -89,7 +99,7 @@ test("routes requests from a real SharedWorker and cleans up", async (context) =
               },
             );
             await assert.rejects(
-              fetchFromSharedWorker(port),
+              fetchFromSharedWorker(page, "success"),
               /Failed to fetch/u,
             );
             assert.equal(handlerCalled, true);
@@ -109,8 +119,8 @@ test("routes requests from a real SharedWorker and cleans up", async (context) =
           try {
             const page = await cleanContext.newPage();
             await page.goto(fixture.origin);
-            const port = await connectSharedWorker(page, "after-cleanup");
-            const result = await fetchFromSharedWorker(port);
+            await connectSharedWorker(page, "after-cleanup");
+            const result = await fetchFromSharedWorker(page, "after-cleanup");
             assert.deepEqual(result.mocked, { source: "network-mocked" });
             assert.equal(fixture.requestCount("/api/mocked"), 2);
           } finally {
@@ -124,31 +134,27 @@ test("routes requests from a real SharedWorker and cleans up", async (context) =
   });
 });
 
-async function connectSharedWorker(
-  page: Page,
-  name: string,
-): Promise<JSHandle<MessagePort>> {
-  return await page.evaluateHandle<MessagePort, string>((workerName) => {
-    return new Promise<MessagePort>((resolve) => {
-      const worker = new SharedWorker("/worker.js", { name: workerName });
-      worker.port.addEventListener(
-        "message",
-        () => {
-          resolve(worker.port);
-        },
-        { once: true },
-      );
-      worker.port.start();
-    });
+async function connectSharedWorker(page: Page, name: string): Promise<void> {
+  await page.evaluate((workerName) => {
+    const worker = new SharedWorker("/worker.js", { name: workerName });
+    const port = worker.port;
+    port.start();
+    window.sharedWorkerRouteTestClients ??= new Map<string, WorkerClient>();
+    window.sharedWorkerRouteTestClients.set(workerName, { port });
   }, name);
 }
 
 async function fetchFromSharedWorker(
-  port: JSHandle<MessagePort>,
+  page: Page,
+  name: string,
 ): Promise<WorkerFetchResult> {
-  return await port.evaluate<WorkerFetchResult>((workerPort) => {
+  return await page.evaluate<WorkerFetchResult, string>((workerName) => {
+    const workerClient = window.sharedWorkerRouteTestClients?.get(workerName);
+    if (!workerClient) {
+      throw new Error(`SharedWorker client ${workerName} is unavailable`);
+    }
     return new Promise<WorkerFetchResult>((resolve, reject) => {
-      workerPort.addEventListener(
+      workerClient.port.addEventListener(
         "message",
         (
           event: MessageEvent<WorkerFetchResult | { readonly error: string }>,
@@ -161,9 +167,9 @@ async function fetchFromSharedWorker(
         },
         { once: true },
       );
-      workerPort.postMessage("fetch");
+      workerClient.port.postMessage("fetch");
     });
-  });
+  }, name);
 }
 
 async function withWorkerFixture<Result>(
@@ -181,8 +187,8 @@ async function withWorkerFixture<Result>(
     if (pathname === "/worker.js") {
       response.writeHead(200, { "content-type": "text/javascript" });
       response.end(`
+        globalThis._vm0 = {};
         onconnect = ({ ports: [port] }) => {
-          port.postMessage({ ready: true });
           port.onmessage = () => {
             Promise.all([
               fetch("/api/mocked", {
@@ -191,7 +197,10 @@ async function withWorkerFixture<Result>(
               fetch("/api/passthrough").then((response) => response.json()),
             ])
               .then(([mocked, passthrough]) => {
-                port.postMessage({ mocked, passthrough });
+                port.postMessage({
+                  mocked,
+                  passthrough,
+                });
               })
               .catch((error) => {
                 port.postMessage({ error: String(error.message ?? error) });

--- a/e2e/playwright/lib/shared-worker-routes.ts
+++ b/e2e/playwright/lib/shared-worker-routes.ts
@@ -1,0 +1,419 @@
+import type { Browser, CDPSession, Page } from "@playwright/test";
+
+interface PendingChildCommand {
+  readonly sessionId: string;
+  readonly resolve: () => void;
+  readonly reject: (reason: unknown) => void;
+}
+
+interface PausedRequest {
+  readonly requestId: string;
+  readonly url: string;
+  readonly method: string;
+  readonly headers: Readonly<Record<string, string>>;
+}
+
+interface RouteEntry {
+  readonly matches: (url: URL) => boolean;
+  readonly handler: SharedWorkerRouteHandler;
+  readonly resolveHandled: (request: SharedWorkerRequest) => void;
+  handled: boolean;
+}
+
+export interface SharedWorkerRequest {
+  url(): string;
+  method(): string;
+  headerValue(name: string): Promise<string | null>;
+}
+
+interface SharedWorkerJsonFulfillOptions {
+  readonly status?: number;
+  readonly headers?: Readonly<Record<string, string>>;
+  readonly json: unknown;
+  readonly body?: never;
+}
+
+interface SharedWorkerBodyFulfillOptions {
+  readonly status?: number;
+  readonly headers?: Readonly<Record<string, string>>;
+  readonly body?: string;
+  readonly json?: never;
+}
+
+export type SharedWorkerFulfillOptions =
+  | SharedWorkerJsonFulfillOptions
+  | SharedWorkerBodyFulfillOptions;
+
+export interface SharedWorkerRoute {
+  request(): SharedWorkerRequest;
+  fulfill(options: SharedWorkerFulfillOptions): Promise<void>;
+}
+
+export type SharedWorkerRouteHandler = (
+  route: SharedWorkerRoute,
+) => Promise<void>;
+
+export interface SharedWorkerRouteRegistration {
+  readonly handled: Promise<SharedWorkerRequest>;
+}
+
+class WorkerRequest implements SharedWorkerRequest {
+  constructor(private readonly paused: PausedRequest) {}
+
+  url(): string {
+    return this.paused.url;
+  }
+
+  method(): string {
+    return this.paused.method;
+  }
+
+  async headerValue(name: string): Promise<string | null> {
+    const normalizedName = name.toLowerCase();
+    for (const [headerName, value] of Object.entries(this.paused.headers)) {
+      if (headerName.toLowerCase() === normalizedName) {
+        return value;
+      }
+    }
+    return null;
+  }
+}
+
+class WorkerRoute implements SharedWorkerRoute {
+  handled = false;
+
+  constructor(
+    private readonly workerRequest: SharedWorkerRequest,
+    private readonly fulfillRequest: (
+      options: SharedWorkerFulfillOptions,
+    ) => Promise<void>,
+  ) {}
+
+  request(): SharedWorkerRequest {
+    return this.workerRequest;
+  }
+
+  async fulfill(options: SharedWorkerFulfillOptions): Promise<void> {
+    if (this.handled) {
+      throw new Error("SharedWorker request was already handled");
+    }
+    this.handled = true;
+    await this.fulfillRequest(options);
+  }
+}
+
+export class SharedWorkerRoutes {
+  private readonly entries: RouteEntry[] = [];
+  private readonly pendingCommands = new Map<number, PendingChildCommand>();
+  private readonly attachingTargets = new Set<string>();
+  private readonly operations = new Set<Promise<void>>();
+  private readonly errors: Error[] = [];
+  private readonly workerReadyPromise: Promise<void>;
+  private readonly resolveWorkerReady: () => void;
+  private nextCommandId = 0;
+  private closed = false;
+
+  private constructor(
+    private readonly session: CDPSession,
+    private readonly apiPattern: string,
+    private readonly browserContextId: string,
+  ) {
+    let resolveWorkerReady!: () => void;
+    this.workerReadyPromise = new Promise<void>((resolve) => {
+      resolveWorkerReady = resolve;
+    });
+    this.resolveWorkerReady = resolveWorkerReady;
+    session.on("Target.targetCreated", ({ targetInfo }) => {
+      if (
+        targetInfo.type === "shared_worker" &&
+        targetInfo.browserContextId === this.browserContextId
+      ) {
+        this.run(this.attach(targetInfo.targetId));
+      }
+    });
+    session.on("Target.detachedFromTarget", ({ sessionId }) => {
+      this.rejectPendingCommands(
+        sessionId,
+        new Error("SharedWorker target detached"),
+      );
+    });
+    session.on("Target.receivedMessageFromTarget", ({ sessionId, message }) => {
+      try {
+        this.receiveChildMessage(sessionId, message);
+      } catch (error) {
+        this.errors.push(toError(error));
+      }
+    });
+  }
+
+  static async create(
+    browser: Browser,
+    page: Page,
+    apiOrigin: string,
+  ): Promise<SharedWorkerRoutes> {
+    const pageSession = await page.context().newCDPSession(page);
+    const { targetInfo } = await pageSession.send("Target.getTargetInfo");
+    await pageSession.detach();
+    if (!targetInfo.browserContextId) {
+      throw new Error("Playwright page has no Chromium browser context id");
+    }
+    const session = await browser.newBrowserCDPSession();
+    const routes = new SharedWorkerRoutes(
+      session,
+      `${new URL(apiOrigin).origin}/api/*`,
+      targetInfo.browserContextId,
+    );
+    await session.send("Target.setDiscoverTargets", { discover: true });
+    return routes;
+  }
+
+  async waitForWorker(): Promise<void> {
+    await this.workerReadyPromise;
+  }
+
+  route(
+    matches: (url: URL) => boolean,
+    handler: SharedWorkerRouteHandler,
+  ): SharedWorkerRouteRegistration {
+    let resolveHandled!: (request: SharedWorkerRequest) => void;
+    const handled = new Promise<SharedWorkerRequest>((resolve) => {
+      resolveHandled = resolve;
+    });
+    this.entries.unshift({
+      matches,
+      handler,
+      resolveHandled,
+      handled: false,
+    });
+    return { handled };
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    await Promise.all(this.operations);
+    await this.session.detach();
+    if (this.errors.length === 1) {
+      throw this.errors[0];
+    }
+    if (this.errors.length > 1) {
+      throw new AggregateError(
+        this.errors,
+        "SharedWorker route handling failed",
+      );
+    }
+  }
+
+  private run(operation: Promise<void>): void {
+    this.operations.add(operation);
+    void operation.then(
+      () => {
+        this.operations.delete(operation);
+      },
+      (error: unknown) => {
+        this.operations.delete(operation);
+        this.errors.push(toError(error));
+      },
+    );
+  }
+
+  private async attach(targetId: string): Promise<void> {
+    if (this.closed || this.attachingTargets.has(targetId)) {
+      return;
+    }
+    this.attachingTargets.add(targetId);
+    const { sessionId } = await this.session.send("Target.attachToTarget", {
+      targetId,
+      flatten: false,
+    });
+    this.attachingTargets.delete(targetId);
+    if (this.closed) {
+      await this.session.send("Target.detachFromTarget", { sessionId });
+      return;
+    }
+    await this.sendChildCommand(sessionId, "Fetch.enable", {
+      patterns: [{ urlPattern: this.apiPattern, requestStage: "Request" }],
+    });
+    this.resolveWorkerReady();
+  }
+
+  private receiveChildMessage(sessionId: string, message: string): void {
+    const value: unknown = JSON.parse(message);
+    if (!isRecord(value)) {
+      throw new Error("SharedWorker target sent a non-object message");
+    }
+    if ("id" in value) {
+      this.resolveChildCommand(value);
+      return;
+    }
+    if (value.method !== "Fetch.requestPaused") {
+      return;
+    }
+    const paused = parsePausedRequest(value.params);
+    this.run(this.handlePausedRequest(sessionId, paused));
+  }
+
+  private resolveChildCommand(value: Readonly<Record<string, unknown>>): void {
+    if (typeof value.id !== "number") {
+      throw new Error("SharedWorker target response has an invalid command id");
+    }
+    const pending = this.pendingCommands.get(value.id);
+    if (!pending) {
+      return;
+    }
+    this.pendingCommands.delete(value.id);
+    if ("error" in value) {
+      pending.reject(childCommandError(value.error));
+      return;
+    }
+    pending.resolve();
+  }
+
+  private async handlePausedRequest(
+    sessionId: string,
+    paused: PausedRequest,
+  ): Promise<void> {
+    const url = new URL(paused.url);
+    const entry = this.entries.find((candidate) => candidate.matches(url));
+    if (!entry) {
+      await this.sendChildCommand(sessionId, "Fetch.continueRequest", {
+        requestId: paused.requestId,
+      });
+      return;
+    }
+
+    const request = new WorkerRequest(paused);
+    const route = new WorkerRoute(request, async (options) => {
+      await this.fulfill(sessionId, paused.requestId, options);
+    });
+    try {
+      await entry.handler(route);
+      if (!route.handled) {
+        throw new Error(
+          "SharedWorker route handler did not handle its request",
+        );
+      }
+      if (!entry.handled) {
+        entry.handled = true;
+        entry.resolveHandled(request);
+      }
+    } catch (error) {
+      if (!route.handled) {
+        await this.sendChildCommand(sessionId, "Fetch.failRequest", {
+          requestId: paused.requestId,
+          errorReason: "Failed",
+        });
+      }
+      throw error;
+    }
+  }
+
+  private async fulfill(
+    sessionId: string,
+    requestId: string,
+    options: SharedWorkerFulfillOptions,
+  ): Promise<void> {
+    const headers = { ...options.headers };
+    const body =
+      "json" in options ? JSON.stringify(options.json) : (options.body ?? "");
+    if (body === undefined) {
+      throw new Error("SharedWorker JSON response is not serializable");
+    }
+    if (
+      "json" in options &&
+      !Object.keys(headers).some(
+        (name) => name.toLowerCase() === "content-type",
+      )
+    ) {
+      headers["content-type"] = "application/json";
+    }
+    await this.sendChildCommand(sessionId, "Fetch.fulfillRequest", {
+      requestId,
+      responseCode: options.status ?? 200,
+      responseHeaders: Object.entries(headers).map(([name, value]) => {
+        return { name, value };
+      }),
+      body: Buffer.from(body).toString("base64"),
+    });
+  }
+
+  private async sendChildCommand(
+    sessionId: string,
+    method: string,
+    params: Readonly<Record<string, unknown>>,
+  ): Promise<void> {
+    const id = ++this.nextCommandId;
+    let resolveCommand!: () => void;
+    let rejectCommand!: (reason: unknown) => void;
+    const command = new Promise<void>((resolve, reject) => {
+      resolveCommand = resolve;
+      rejectCommand = reject;
+    });
+    this.pendingCommands.set(id, {
+      sessionId,
+      resolve: resolveCommand,
+      reject: rejectCommand,
+    });
+    try {
+      await this.session.send("Target.sendMessageToTarget", {
+        sessionId,
+        message: JSON.stringify({ id, method, params }),
+      });
+    } catch (error) {
+      this.pendingCommands.delete(id);
+      rejectCommand(error);
+    }
+    await command;
+  }
+
+  private rejectPendingCommands(sessionId: string, reason: Error): void {
+    for (const [id, pending] of this.pendingCommands) {
+      if (pending.sessionId === sessionId) {
+        this.pendingCommands.delete(id);
+        pending.reject(reason);
+      }
+    }
+  }
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null;
+}
+
+function parsePausedRequest(value: unknown): PausedRequest {
+  if (!isRecord(value) || typeof value.requestId !== "string") {
+    throw new Error("SharedWorker target sent an invalid paused request");
+  }
+  const request = value.request;
+  if (
+    !isRecord(request) ||
+    typeof request.url !== "string" ||
+    typeof request.method !== "string" ||
+    !isRecord(request.headers)
+  ) {
+    throw new Error("SharedWorker target sent invalid request details");
+  }
+  const headers: Record<string, string> = {};
+  for (const [name, headerValue] of Object.entries(request.headers)) {
+    if (typeof headerValue !== "string") {
+      throw new Error("SharedWorker target sent an invalid request header");
+    }
+    headers[name] = headerValue;
+  }
+  return {
+    requestId: value.requestId,
+    url: request.url,
+    method: request.method,
+    headers,
+  };
+}
+
+function childCommandError(value: unknown): Error {
+  if (!isRecord(value) || typeof value.message !== "string") {
+    return new Error("SharedWorker target command failed");
+  }
+  return new Error(value.message);
+}
+
+function toError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}

--- a/e2e/playwright/lib/shared-worker-routes.ts
+++ b/e2e/playwright/lib/shared-worker-routes.ts
@@ -26,23 +26,11 @@ export interface SharedWorkerRequest {
   headerValue(name: string): Promise<string | null>;
 }
 
-interface SharedWorkerJsonFulfillOptions {
+export interface SharedWorkerFulfillOptions {
   readonly status?: number;
   readonly headers?: Readonly<Record<string, string>>;
   readonly json: unknown;
-  readonly body?: never;
 }
-
-interface SharedWorkerBodyFulfillOptions {
-  readonly status?: number;
-  readonly headers?: Readonly<Record<string, string>>;
-  readonly body?: string;
-  readonly json?: never;
-}
-
-export type SharedWorkerFulfillOptions =
-  | SharedWorkerJsonFulfillOptions
-  | SharedWorkerBodyFulfillOptions;
 
 export interface SharedWorkerRoute {
   request(): SharedWorkerRequest;
@@ -342,13 +330,11 @@ export class SharedWorkerRoutes {
     options: SharedWorkerFulfillOptions,
   ): Promise<void> {
     const headers = { ...options.headers };
-    const body =
-      "json" in options ? JSON.stringify(options.json) : (options.body ?? "");
+    const body = JSON.stringify(options.json);
     if (body === undefined) {
       throw new Error("SharedWorker JSON response is not serializable");
     }
     if (
-      "json" in options &&
       !Object.keys(headers).some(
         (name) => name.toLowerCase() === "content-type",
       )

--- a/e2e/playwright/lib/shared-worker-routes.ts
+++ b/e2e/playwright/lib/shared-worker-routes.ts
@@ -155,6 +155,9 @@ export class SharedWorkerRoutes {
     // API request cannot escape before the target session attaches.
     await page.addInitScript(
       ({ readyEvent, readyStorageKey }) => {
+        if (window.frameElement !== null) {
+          return;
+        }
         const NativeSharedWorker = globalThis.SharedWorker;
         let released = sessionStorage.getItem(readyStorageKey) === "true";
         const pendingMessages: Array<() => void> = [];

--- a/e2e/playwright/lib/shared-worker-routes.ts
+++ b/e2e/playwright/lib/shared-worker-routes.ts
@@ -110,6 +110,8 @@ export class SharedWorkerRoutes {
   private readonly errors: Error[] = [];
   private readonly workerReadyPromise: Promise<void>;
   private readonly resolveWorkerReady: () => void;
+  private workerReadyError: Error | undefined;
+  private workerReady = false;
   private nextCommandId = 0;
   private closed = false;
 
@@ -128,7 +130,12 @@ export class SharedWorkerRoutes {
         targetInfo.type === "shared_worker" &&
         targetInfo.browserContextId === this.browserContextId
       ) {
-        this.run(this.attach(targetInfo.targetId));
+        this.run(this.attach(targetInfo.targetId), (error) => {
+          if (!this.workerReady) {
+            this.workerReadyError = error;
+            this.resolveWorkerReady();
+          }
+        });
       }
     });
     session.on("Target.detachedFromTarget", ({ sessionId }) => {
@@ -179,6 +186,9 @@ export class SharedWorkerRoutes {
 
   async waitForWorker(): Promise<void> {
     await this.workerReadyPromise;
+    if (this.workerReadyError) {
+      throw this.workerReadyError;
+    }
   }
 
   route(
@@ -213,7 +223,10 @@ export class SharedWorkerRoutes {
     }
   }
 
-  private run(operation: Promise<void>): void {
+  private run(
+    operation: Promise<void>,
+    onError?: (error: Error) => void,
+  ): void {
     this.operations.add(operation);
     void operation.then(
       () => {
@@ -221,7 +234,9 @@ export class SharedWorkerRoutes {
       },
       (error: unknown) => {
         this.operations.delete(operation);
-        this.errors.push(toError(error));
+        const normalizedError = toError(error);
+        this.errors.push(normalizedError);
+        onError?.(normalizedError);
       },
     );
   }
@@ -243,6 +258,7 @@ export class SharedWorkerRoutes {
       await this.sendChildCommand(sessionId, "Fetch.enable", {
         patterns: [{ urlPattern: this.apiPattern, requestStage: "Request" }],
       });
+      this.workerReady = true;
       this.resolveWorkerReady();
     } finally {
       this.attachingTargets.delete(targetId);

--- a/e2e/playwright/lib/shared-worker-routes.ts
+++ b/e2e/playwright/lib/shared-worker-routes.ts
@@ -1,5 +1,8 @@
 import type { Browser, CDPSession, Page } from "@playwright/test";
 
+const WORKER_ROUTES_READY_EVENT = "vm0-shared-worker-routes-ready";
+const WORKER_ROUTES_READY_STORAGE_KEY = "vm0.sharedWorkerRoutes.ready";
+
 interface PendingChildCommand {
   readonly sessionId: string;
   readonly resolve: () => void;
@@ -105,6 +108,7 @@ export class SharedWorkerRoutes {
 
   private constructor(
     private readonly session: CDPSession,
+    private readonly page: Page,
     private readonly apiPattern: string,
     private readonly browserContextId: string,
   ) {
@@ -146,6 +150,67 @@ export class SharedWorkerRoutes {
     page: Page,
     apiOrigin: string,
   ): Promise<SharedWorkerRoutes> {
+    // Production sends its heartbeat as soon as the worker connects. Hold
+    // page-to-worker messages until Fetch interception is active so the first
+    // API request cannot escape before the target session attaches.
+    await page.addInitScript(
+      ({ readyEvent, readyStorageKey }) => {
+        const NativeSharedWorker = globalThis.SharedWorker;
+        let released = sessionStorage.getItem(readyStorageKey) === "true";
+        const pendingMessages: Array<() => void> = [];
+        globalThis.addEventListener(
+          readyEvent,
+          () => {
+            released = true;
+            sessionStorage.setItem(readyStorageKey, "true");
+            for (const send of pendingMessages.splice(0)) {
+              send();
+            }
+          },
+          { once: true },
+        );
+
+        const GatedSharedWorker = function (
+          scriptURL: string | URL,
+          options?: string | WorkerOptions,
+        ): SharedWorker {
+          const worker =
+            typeof options === "string"
+              ? new NativeSharedWorker(scriptURL, options)
+              : new NativeSharedWorker(scriptURL, options);
+          const postMessage = worker.port.postMessage.bind(worker.port);
+          worker.port.postMessage = (
+            message: unknown,
+            transferOrOptions?: Transferable[] | StructuredSerializeOptions,
+          ): void => {
+            const send = (): void => {
+              if (Array.isArray(transferOrOptions)) {
+                postMessage(message, transferOrOptions);
+              } else {
+                postMessage(message, transferOrOptions);
+              }
+            };
+            if (released) {
+              send();
+            } else {
+              pendingMessages.push(send);
+            }
+          };
+          return worker;
+        };
+        Object.setPrototypeOf(GatedSharedWorker, NativeSharedWorker);
+        GatedSharedWorker.prototype = NativeSharedWorker.prototype;
+        Object.defineProperty(globalThis, "SharedWorker", {
+          configurable: true,
+          value: GatedSharedWorker,
+          writable: true,
+        });
+      },
+      {
+        readyEvent: WORKER_ROUTES_READY_EVENT,
+        readyStorageKey: WORKER_ROUTES_READY_STORAGE_KEY,
+      },
+    );
     const pageSession = await page.context().newCDPSession(page);
     let browserContextId: string;
     try {
@@ -160,6 +225,7 @@ export class SharedWorkerRoutes {
     const session = await browser.newBrowserCDPSession();
     const routes = new SharedWorkerRoutes(
       session,
+      page,
       `${new URL(apiOrigin).origin}/api/*`,
       browserContextId,
     );
@@ -177,6 +243,9 @@ export class SharedWorkerRoutes {
     if (this.workerReadyError) {
       throw this.workerReadyError;
     }
+    await this.page.evaluate((readyEvent) => {
+      globalThis.dispatchEvent(new Event(readyEvent));
+    }, WORKER_ROUTES_READY_EVENT);
   }
 
   route(

--- a/e2e/playwright/lib/shared-worker-routes.ts
+++ b/e2e/playwright/lib/shared-worker-routes.ts
@@ -9,11 +9,11 @@ import {
 
 interface PendingChildCommand {
   readonly sessionId: string;
-  readonly resolve: () => void;
+  readonly resolve: (result: unknown) => void;
   readonly reject: (reason: unknown) => void;
 }
 
-interface PausedRequest {
+interface RouteRequestDetails {
   readonly url: string;
   readonly method: string;
   readonly headers: Readonly<Record<string, string>>;
@@ -69,19 +69,19 @@ export interface SharedWorkerRouteRegistration {
 }
 
 class WorkerRequest implements SharedWorkerRequest {
-  constructor(private readonly paused: PausedRequest) {}
+  constructor(private readonly details: RouteRequestDetails) {}
 
   url(): string {
-    return this.paused.url;
+    return this.details.url;
   }
 
   method(): string {
-    return this.paused.method;
+    return this.details.method;
   }
 
   async headerValue(name: string): Promise<string | null> {
     const normalizedName = name.toLowerCase();
-    for (const [headerName, value] of Object.entries(this.paused.headers)) {
+    for (const [headerName, value] of Object.entries(this.details.headers)) {
       if (headerName.toLowerCase() === normalizedName) {
         return value;
       }
@@ -319,11 +319,18 @@ export class SharedWorkerRoutes {
         "Runtime.runIfWaitingForDebugger",
         {},
       );
-      await this.sendChildCommand(sessionId, "Runtime.evaluate", {
-        awaitPromise: true,
-        expression: workerBridgeSource(this.channelName, this.apiOrigin),
-        returnByValue: true,
-      });
+      const evaluation = await this.sendChildCommand(
+        sessionId,
+        "Runtime.evaluate",
+        {
+          awaitPromise: true,
+          expression: workerBridgeSource(this.channelName, this.apiOrigin),
+          returnByValue: true,
+        },
+      );
+      if (isRecord(evaluation) && "exceptionDetails" in evaluation) {
+        throw childEvaluationError(evaluation.exceptionDetails);
+      }
       this.workerReady = true;
       this.resolveWorkerReady();
     } finally {
@@ -351,21 +358,21 @@ export class SharedWorkerRoutes {
       pending.reject(childCommandError(value.error));
       return;
     }
-    pending.resolve();
+    pending.resolve("result" in value ? value.result : undefined);
   }
 
   private async handleRequest(value: unknown): Promise<RouteResponse> {
     if (this.closed) {
       return { action: "continue" };
     }
-    const paused = parsePausedRequest(value);
+    const details = parseRouteRequest(value);
     const entry = this.entries.find((candidate) => {
-      return candidate.matches(new URL(paused.url));
+      return candidate.matches(new URL(details.url));
     });
     if (!entry) {
       return { action: "continue" };
     }
-    const request = new WorkerRequest(paused);
+    const request = new WorkerRequest(details);
     const route = new WorkerRoute(request);
     try {
       await entry.handler(route);
@@ -389,14 +396,14 @@ export class SharedWorkerRoutes {
     sessionId: string,
     method: string,
     params: Readonly<Record<string, unknown>>,
-  ): Promise<void> {
+  ): Promise<unknown> {
     if (this.closed) {
       throw this.closeError;
     }
     const id = ++this.nextCommandId;
-    let resolveCommand!: () => void;
+    let resolveCommand!: (result: unknown) => void;
     let rejectCommand!: (reason: unknown) => void;
-    const command = new Promise<void>((resolve, reject) => {
+    const command = new Promise<unknown>((resolve, reject) => {
       resolveCommand = resolve;
       rejectCommand = reject;
     });
@@ -414,7 +421,7 @@ export class SharedWorkerRoutes {
       this.pendingCommands.delete(id);
       rejectCommand(error);
     }
-    await command;
+    return await command;
   }
 
   private rejectPendingCommands(sessionId: string, reason: Error): void {
@@ -438,7 +445,7 @@ function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
   return typeof value === "object" && value !== null;
 }
 
-function parsePausedRequest(value: unknown): PausedRequest {
+function parseRouteRequest(value: unknown): RouteRequestDetails {
   if (
     !isRecord(value) ||
     typeof value.url !== "string" ||
@@ -466,6 +473,21 @@ function childCommandError(value: unknown): Error {
     return new Error("SharedWorker target command failed");
   }
   return new Error(value.message);
+}
+
+function childEvaluationError(value: unknown): Error {
+  if (isRecord(value)) {
+    if (
+      isRecord(value.exception) &&
+      typeof value.exception.description === "string"
+    ) {
+      return new Error(value.exception.description);
+    }
+    if (typeof value.text === "string") {
+      return new Error(value.text);
+    }
+  }
+  return new Error("SharedWorker bridge evaluation failed");
 }
 
 function toError(value: unknown): Error {

--- a/e2e/playwright/lib/shared-worker-routes.ts
+++ b/e2e/playwright/lib/shared-worker-routes.ts
@@ -1,7 +1,11 @@
+import { randomUUID } from "node:crypto";
 import type { Browser, CDPSession, Page } from "@playwright/test";
 
-const WORKER_ROUTES_READY_EVENT = "vm0-shared-worker-routes-ready";
-const WORKER_ROUTES_READY_STORAGE_KEY = "vm0.sharedWorkerRoutes.ready";
+import {
+  installPageBridge,
+  workerBridgeSource,
+  WORKER_ROUTES_READY_EVENT,
+} from "./shared-worker-route-bridge";
 
 interface PendingChildCommand {
   readonly sessionId: string;
@@ -10,7 +14,6 @@ interface PendingChildCommand {
 }
 
 interface PausedRequest {
-  readonly requestId: string;
   readonly url: string;
   readonly method: string;
   readonly headers: Readonly<Record<string, string>>;
@@ -22,6 +25,23 @@ interface RouteEntry {
   readonly resolveHandled: (request: SharedWorkerRequest) => void;
   handled: boolean;
 }
+
+interface ContinueResponse {
+  readonly action: "continue";
+}
+
+interface FailResponse {
+  readonly action: "fail";
+}
+
+interface FulfillResponse {
+  readonly action: "fulfill";
+  readonly status: number;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body: string;
+}
+
+type RouteResponse = ContinueResponse | FailResponse | FulfillResponse;
 
 export interface SharedWorkerRequest {
   url(): string;
@@ -71,36 +91,49 @@ class WorkerRequest implements SharedWorkerRequest {
 }
 
 class WorkerRoute implements SharedWorkerRoute {
-  handled = false;
+  response: FulfillResponse | undefined;
 
-  constructor(
-    private readonly workerRequest: SharedWorkerRequest,
-    private readonly fulfillRequest: (
-      options: SharedWorkerFulfillOptions,
-    ) => Promise<void>,
-  ) {}
+  constructor(private readonly workerRequest: SharedWorkerRequest) {}
 
   request(): SharedWorkerRequest {
     return this.workerRequest;
   }
 
   async fulfill(options: SharedWorkerFulfillOptions): Promise<void> {
-    if (this.handled) {
+    if (this.response) {
       throw new Error("SharedWorker request was already handled");
     }
-    this.handled = true;
-    await this.fulfillRequest(options);
+    const headers = { ...options.headers };
+    const body = JSON.stringify(options.json);
+    if (body === undefined) {
+      throw new Error("SharedWorker JSON response is not serializable");
+    }
+    if (
+      !Object.keys(headers).some(
+        (name) => name.toLowerCase() === "content-type",
+      )
+    ) {
+      headers["content-type"] = "application/json";
+    }
+    this.response = {
+      action: "fulfill",
+      status: options.status ?? 200,
+      headers,
+      body,
+    };
   }
 }
 
 export class SharedWorkerRoutes {
   private readonly entries: RouteEntry[] = [];
   private readonly pendingCommands = new Map<number, PendingChildCommand>();
+  private readonly candidateTargets = new Map<string, boolean>();
   private readonly attachingTargets = new Set<string>();
   private readonly operations = new Set<Promise<void>>();
   private readonly errors: Error[] = [];
   private readonly workerReadyPromise: Promise<void>;
   private readonly resolveWorkerReady: () => void;
+  private readonly closeError = new Error("SharedWorker routes closed");
   private workerReadyError: Error | undefined;
   private workerReady = false;
   private nextCommandId = 0;
@@ -109,8 +142,9 @@ export class SharedWorkerRoutes {
   private constructor(
     private readonly session: CDPSession,
     private readonly page: Page,
-    private readonly apiPattern: string,
+    private readonly apiOrigin: string,
     private readonly browserContextId: string,
+    private readonly channelName: string,
   ) {
     let resolveWorkerReady!: () => void;
     this.workerReadyPromise = new Promise<void>((resolve) => {
@@ -122,13 +156,30 @@ export class SharedWorkerRoutes {
         targetInfo.type === "shared_worker" &&
         targetInfo.browserContextId === this.browserContextId
       ) {
+        this.candidateTargets.set(targetInfo.targetId, targetInfo.attached);
+      }
+    });
+    session.on("Target.targetInfoChanged", ({ targetInfo }) => {
+      const sawAttached = this.candidateTargets.get(targetInfo.targetId);
+      if (sawAttached === undefined) {
+        return;
+      }
+      if (targetInfo.attached) {
+        this.candidateTargets.set(targetInfo.targetId, true);
+        return;
+      }
+      if (sawAttached) {
+        this.candidateTargets.delete(targetInfo.targetId);
         this.run(this.attach(targetInfo.targetId), (error) => {
-          if (!this.workerReady) {
+          if (!this.closed && !this.workerReady) {
             this.workerReadyError = error;
             this.resolveWorkerReady();
           }
         });
       }
+    });
+    session.on("Target.targetDestroyed", ({ targetId }) => {
+      this.candidateTargets.delete(targetId);
     });
     session.on("Target.detachedFromTarget", ({ sessionId }) => {
       this.rejectPendingCommands(
@@ -150,70 +201,8 @@ export class SharedWorkerRoutes {
     page: Page,
     apiOrigin: string,
   ): Promise<SharedWorkerRoutes> {
-    // Production sends its heartbeat as soon as the worker connects. Hold
-    // page-to-worker messages until Fetch interception is active so the first
-    // API request cannot escape before the target session attaches.
-    await page.addInitScript(
-      ({ readyEvent, readyStorageKey }) => {
-        if (window.frameElement !== null) {
-          return;
-        }
-        const NativeSharedWorker = globalThis.SharedWorker;
-        let released = sessionStorage.getItem(readyStorageKey) === "true";
-        const pendingMessages: Array<() => void> = [];
-        globalThis.addEventListener(
-          readyEvent,
-          () => {
-            released = true;
-            sessionStorage.setItem(readyStorageKey, "true");
-            for (const send of pendingMessages.splice(0)) {
-              send();
-            }
-          },
-          { once: true },
-        );
-
-        const GatedSharedWorker = function (
-          scriptURL: string | URL,
-          options?: string | WorkerOptions,
-        ): SharedWorker {
-          const worker =
-            typeof options === "string"
-              ? new NativeSharedWorker(scriptURL, options)
-              : new NativeSharedWorker(scriptURL, options);
-          const postMessage = worker.port.postMessage.bind(worker.port);
-          worker.port.postMessage = (
-            message: unknown,
-            transferOrOptions?: Transferable[] | StructuredSerializeOptions,
-          ): void => {
-            const send = (): void => {
-              if (Array.isArray(transferOrOptions)) {
-                postMessage(message, transferOrOptions);
-              } else {
-                postMessage(message, transferOrOptions);
-              }
-            };
-            if (released) {
-              send();
-            } else {
-              pendingMessages.push(send);
-            }
-          };
-          return worker;
-        };
-        Object.setPrototypeOf(GatedSharedWorker, NativeSharedWorker);
-        GatedSharedWorker.prototype = NativeSharedWorker.prototype;
-        Object.defineProperty(globalThis, "SharedWorker", {
-          configurable: true,
-          value: GatedSharedWorker,
-          writable: true,
-        });
-      },
-      {
-        readyEvent: WORKER_ROUTES_READY_EVENT,
-        readyStorageKey: WORKER_ROUTES_READY_STORAGE_KEY,
-      },
-    );
+    const channelName = `vm0-shared-worker-routes-${randomUUID()}`;
+    const routesBindingName = `__vm0RouteSharedWorkerRequest_${randomUUID().replaceAll("-", "")}`;
     const pageSession = await page.context().newCDPSession(page);
     let browserContextId: string;
     try {
@@ -229,10 +218,18 @@ export class SharedWorkerRoutes {
     const routes = new SharedWorkerRoutes(
       session,
       page,
-      `${new URL(apiOrigin).origin}/api/*`,
+      new URL(apiOrigin).origin,
       browserContextId,
+      channelName,
     );
     try {
+      await page.exposeBinding(
+        routesBindingName,
+        async (_source, value: unknown): Promise<RouteResponse> => {
+          return await routes.handleRequest(value);
+        },
+      );
+      await installPageBridge(page, channelName, routesBindingName);
       await session.send("Target.setDiscoverTargets", { discover: true });
     } catch (error) {
       await session.detach();
@@ -270,8 +267,9 @@ export class SharedWorkerRoutes {
 
   async close(): Promise<void> {
     this.closed = true;
-    await Promise.allSettled(this.operations);
+    this.rejectAllPendingCommands(this.closeError);
     await this.session.detach();
+    await Promise.allSettled(this.operations);
     if (this.errors.length === 1) {
       throw this.errors[0];
     }
@@ -295,7 +293,9 @@ export class SharedWorkerRoutes {
       (error: unknown) => {
         this.operations.delete(operation);
         const normalizedError = toError(error);
-        this.errors.push(normalizedError);
+        if (!this.closed) {
+          this.errors.push(normalizedError);
+        }
         onError?.(normalizedError);
       },
     );
@@ -312,11 +312,17 @@ export class SharedWorkerRoutes {
         flatten: false,
       });
       if (this.closed) {
-        await this.session.send("Target.detachFromTarget", { sessionId });
         return;
       }
-      await this.sendChildCommand(sessionId, "Fetch.enable", {
-        patterns: [{ urlPattern: this.apiPattern, requestStage: "Request" }],
+      await this.sendChildCommand(
+        sessionId,
+        "Runtime.runIfWaitingForDebugger",
+        {},
+      );
+      await this.sendChildCommand(sessionId, "Runtime.evaluate", {
+        awaitPromise: true,
+        expression: workerBridgeSource(this.channelName, this.apiOrigin),
+        returnByValue: true,
       });
       this.workerReady = true;
       this.resolveWorkerReady();
@@ -330,18 +336,9 @@ export class SharedWorkerRoutes {
     if (!isRecord(value)) {
       throw new Error("SharedWorker target sent a non-object message");
     }
-    if ("id" in value) {
-      this.resolveChildCommand(value);
+    if (!("id" in value)) {
       return;
     }
-    if (value.method !== "Fetch.requestPaused") {
-      return;
-    }
-    const paused = parsePausedRequest(value.params);
-    this.run(this.handlePausedRequest(sessionId, paused));
-  }
-
-  private resolveChildCommand(value: Readonly<Record<string, unknown>>): void {
     if (typeof value.id !== "number") {
       throw new Error("SharedWorker target response has an invalid command id");
     }
@@ -357,26 +354,22 @@ export class SharedWorkerRoutes {
     pending.resolve();
   }
 
-  private async handlePausedRequest(
-    sessionId: string,
-    paused: PausedRequest,
-  ): Promise<void> {
-    const url = new URL(paused.url);
-    const entry = this.entries.find((candidate) => candidate.matches(url));
-    if (!entry) {
-      await this.sendChildCommand(sessionId, "Fetch.continueRequest", {
-        requestId: paused.requestId,
-      });
-      return;
+  private async handleRequest(value: unknown): Promise<RouteResponse> {
+    if (this.closed) {
+      return { action: "continue" };
     }
-
-    const request = new WorkerRequest(paused);
-    const route = new WorkerRoute(request, async (options) => {
-      await this.fulfill(sessionId, paused.requestId, options);
+    const paused = parsePausedRequest(value);
+    const entry = this.entries.find((candidate) => {
+      return candidate.matches(new URL(paused.url));
     });
+    if (!entry) {
+      return { action: "continue" };
+    }
+    const request = new WorkerRequest(paused);
+    const route = new WorkerRoute(request);
     try {
       await entry.handler(route);
-      if (!route.handled) {
+      if (!route.response) {
         throw new Error(
           "SharedWorker route handler did not handle its request",
         );
@@ -385,42 +378,11 @@ export class SharedWorkerRoutes {
         entry.handled = true;
         entry.resolveHandled(request);
       }
+      return route.response;
     } catch (error) {
-      if (!route.handled) {
-        await this.sendChildCommand(sessionId, "Fetch.failRequest", {
-          requestId: paused.requestId,
-          errorReason: "Failed",
-        });
-      }
-      throw error;
+      this.errors.push(toError(error));
+      return { action: "fail" };
     }
-  }
-
-  private async fulfill(
-    sessionId: string,
-    requestId: string,
-    options: SharedWorkerFulfillOptions,
-  ): Promise<void> {
-    const headers = { ...options.headers };
-    const body = JSON.stringify(options.json);
-    if (body === undefined) {
-      throw new Error("SharedWorker JSON response is not serializable");
-    }
-    if (
-      !Object.keys(headers).some(
-        (name) => name.toLowerCase() === "content-type",
-      )
-    ) {
-      headers["content-type"] = "application/json";
-    }
-    await this.sendChildCommand(sessionId, "Fetch.fulfillRequest", {
-      requestId,
-      responseCode: options.status ?? 200,
-      responseHeaders: Object.entries(headers).map(([name, value]) => {
-        return { name, value };
-      }),
-      body: Buffer.from(body).toString("base64"),
-    });
   }
 
   private async sendChildCommand(
@@ -428,6 +390,9 @@ export class SharedWorkerRoutes {
     method: string,
     params: Readonly<Record<string, unknown>>,
   ): Promise<void> {
+    if (this.closed) {
+      throw this.closeError;
+    }
     const id = ++this.nextCommandId;
     let resolveCommand!: () => void;
     let rejectCommand!: (reason: unknown) => void;
@@ -460,6 +425,13 @@ export class SharedWorkerRoutes {
       }
     }
   }
+
+  private rejectAllPendingCommands(reason: Error): void {
+    for (const pending of this.pendingCommands.values()) {
+      pending.reject(reason);
+    }
+    this.pendingCommands.clear();
+  }
 }
 
 function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
@@ -467,29 +439,24 @@ function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
 }
 
 function parsePausedRequest(value: unknown): PausedRequest {
-  if (!isRecord(value) || typeof value.requestId !== "string") {
-    throw new Error("SharedWorker target sent an invalid paused request");
-  }
-  const request = value.request;
   if (
-    !isRecord(request) ||
-    typeof request.url !== "string" ||
-    typeof request.method !== "string" ||
-    !isRecord(request.headers)
+    !isRecord(value) ||
+    typeof value.url !== "string" ||
+    typeof value.method !== "string" ||
+    !isRecord(value.headers)
   ) {
-    throw new Error("SharedWorker target sent invalid request details");
+    throw new Error("SharedWorker route received invalid request details");
   }
   const headers: Record<string, string> = {};
-  for (const [name, headerValue] of Object.entries(request.headers)) {
+  for (const [name, headerValue] of Object.entries(value.headers)) {
     if (typeof headerValue !== "string") {
-      throw new Error("SharedWorker target sent an invalid request header");
+      throw new Error("SharedWorker route received an invalid request header");
     }
     headers[name] = headerValue;
   }
   return {
-    requestId: value.requestId,
-    url: request.url,
-    method: request.method,
+    url: value.url,
+    method: value.method,
     headers,
   };
 }

--- a/e2e/playwright/lib/shared-worker-routes.ts
+++ b/e2e/playwright/lib/shared-worker-routes.ts
@@ -152,18 +152,28 @@ export class SharedWorkerRoutes {
     apiOrigin: string,
   ): Promise<SharedWorkerRoutes> {
     const pageSession = await page.context().newCDPSession(page);
-    const { targetInfo } = await pageSession.send("Target.getTargetInfo");
-    await pageSession.detach();
-    if (!targetInfo.browserContextId) {
-      throw new Error("Playwright page has no Chromium browser context id");
+    let browserContextId: string;
+    try {
+      const { targetInfo } = await pageSession.send("Target.getTargetInfo");
+      if (!targetInfo.browserContextId) {
+        throw new Error("Playwright page has no Chromium browser context id");
+      }
+      browserContextId = targetInfo.browserContextId;
+    } finally {
+      await pageSession.detach();
     }
     const session = await browser.newBrowserCDPSession();
     const routes = new SharedWorkerRoutes(
       session,
       `${new URL(apiOrigin).origin}/api/*`,
-      targetInfo.browserContextId,
+      browserContextId,
     );
-    await session.send("Target.setDiscoverTargets", { discover: true });
+    try {
+      await session.send("Target.setDiscoverTargets", { discover: true });
+    } catch (error) {
+      await session.detach();
+      throw error;
+    }
     return routes;
   }
 
@@ -190,7 +200,7 @@ export class SharedWorkerRoutes {
 
   async close(): Promise<void> {
     this.closed = true;
-    await Promise.all(this.operations);
+    await Promise.allSettled(this.operations);
     await this.session.detach();
     if (this.errors.length === 1) {
       throw this.errors[0];
@@ -221,19 +231,22 @@ export class SharedWorkerRoutes {
       return;
     }
     this.attachingTargets.add(targetId);
-    const { sessionId } = await this.session.send("Target.attachToTarget", {
-      targetId,
-      flatten: false,
-    });
-    this.attachingTargets.delete(targetId);
-    if (this.closed) {
-      await this.session.send("Target.detachFromTarget", { sessionId });
-      return;
+    try {
+      const { sessionId } = await this.session.send("Target.attachToTarget", {
+        targetId,
+        flatten: false,
+      });
+      if (this.closed) {
+        await this.session.send("Target.detachFromTarget", { sessionId });
+        return;
+      }
+      await this.sendChildCommand(sessionId, "Fetch.enable", {
+        patterns: [{ urlPattern: this.apiPattern, requestStage: "Request" }],
+      });
+      this.resolveWorkerReady();
+    } finally {
+      this.attachingTargets.delete(targetId);
     }
-    await this.sendChildCommand(sessionId, "Fetch.enable", {
-      patterns: [{ urlPattern: this.apiPattern, requestStage: "Request" }],
-    });
-    this.resolveWorkerReady();
   }
 
   private receiveChildMessage(sessionId: string, message: string): void {

--- a/e2e/playwright/tests/agents.spec.ts
+++ b/e2e/playwright/tests/agents.spec.ts
@@ -1,6 +1,10 @@
 import type { Locator, Page } from "@playwright/test";
 import { resolveApiBackendUrl } from "../api-backend-url";
 import { expect, test } from "../fixtures";
+import type {
+  SharedWorkerRouteRegistration,
+  SharedWorkerRoutes,
+} from "../lib/shared-worker-routes";
 import { deriveAppUrl } from "../playwright.config";
 
 const appUrl = deriveAppUrl(resolveApiBackendUrl());
@@ -28,6 +32,10 @@ type PinnedAgentStoryControls = {
   readonly setGradientColorThemes: (enabled: boolean) => void;
   readonly setPinnedAgents: (agents: readonly PinnedAgentStoryEntry[]) => void;
 };
+interface UnreadThreadMocks {
+  readonly events: SharedWorkerRouteRegistration;
+  readonly snapshot: SharedWorkerRouteRegistration;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -118,32 +126,36 @@ async function mockPinnedAgentGrid(
 
 async function mockUnreadThread(
   page: Page,
+  sharedWorkerRoutes: SharedWorkerRoutes,
   defaultAgentId: string,
-): Promise<void> {
-  await page.route("**/api/chat-threads/snapshot", async (route) => {
-    await route.fulfill({
-      json: {
-        chatThreads: [
-          {
-            id: unreadThreadStory.id,
-            agentId: defaultAgentId,
-            title: unreadThreadStory.title,
-            sortAt: unreadThreadStory.createdAt,
-            createdAt: unreadThreadStory.createdAt,
-            updatedAt: unreadThreadStory.createdAt,
-            pinnedAt: null,
-            renamedAt: null,
-            selectedModel: null,
-            serviceTier: null,
-            computerUseHostId: null,
-          },
-        ],
-        latestEventId: null,
-        latestSeqId: null,
-      },
-    });
-  });
-  await page.route(
+): Promise<UnreadThreadMocks> {
+  const snapshot = sharedWorkerRoutes.route(
+    (url) => url.pathname === "/api/chat-threads/snapshot",
+    async (route) => {
+      await route.fulfill({
+        json: {
+          chatThreads: [
+            {
+              id: unreadThreadStory.id,
+              agentId: defaultAgentId,
+              title: unreadThreadStory.title,
+              sortAt: unreadThreadStory.createdAt,
+              createdAt: unreadThreadStory.createdAt,
+              updatedAt: unreadThreadStory.createdAt,
+              pinnedAt: null,
+              renamedAt: null,
+              selectedModel: null,
+              serviceTier: null,
+              computerUseHostId: null,
+            },
+          ],
+          latestEventId: null,
+          latestSeqId: null,
+        },
+      });
+    },
+  );
+  const events = sharedWorkerRoutes.route(
     (url) => url.pathname === "/api/chat-threads/events",
     async (route) => {
       await route.fulfill({ json: { events: [], hasMore: false } });
@@ -172,6 +184,7 @@ async function mockUnreadThread(
       });
     },
   );
+  return { events, snapshot };
 }
 
 async function visibleIndicatorStyle(locator: Locator): Promise<{
@@ -333,6 +346,7 @@ test("onboarding workflow preview uses the shared dialog radius", async ({
 
 test("three-column rail and unread indicators preserve their visual hierarchy", async ({
   page,
+  sharedWorkerRoutes,
 }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.addInitScript(() => {
@@ -343,6 +357,7 @@ test("three-column rail and unread indicators preserve their visual hierarchy", 
   });
   await page.goto(appUrl);
   await page.waitForURL(/\/agents\/[^/]+\/chat\/?$/, { timeout: 30_000 });
+  await sharedWorkerRoutes.waitForWorker();
   const defaultAgentId = new URL(page.url()).pathname.match(
     /^\/agents\/([^/]+)\/chat\/?$/,
   )?.[1];
@@ -354,14 +369,19 @@ test("three-column rail and unread indicators preserve their visual hierarchy", 
     page,
     defaultAgentId,
   );
-  await mockUnreadThread(page, defaultAgentId);
+  const unreadThreadMocks = await mockUnreadThread(
+    page,
+    sharedWorkerRoutes,
+    defaultAgentId,
+  );
   await Promise.all([
+    unreadThreadMocks.snapshot.handled,
+    unreadThreadMocks.events.handled,
     ...[
       "/api/feature-switches",
       "/api/onboarding/status",
       "/api/agents",
       "/api/user-preferences",
-      "/api/chat-threads/snapshot",
       "/api/indicators",
       "/api/chat-thread-unreads",
     ].map((pathname) => {

--- a/e2e/playwright/tests/agents.spec.ts
+++ b/e2e/playwright/tests/agents.spec.ts
@@ -1,6 +1,7 @@
 import type { Locator, Page } from "@playwright/test";
 import { resolveApiBackendUrl } from "../api-backend-url";
 import { expect, test } from "../fixtures";
+import { waitForActiveAgentId } from "../lib/active-agent";
 import type {
   SharedWorkerRouteRegistration,
   SharedWorkerRoutes,
@@ -127,17 +128,18 @@ async function mockPinnedAgentGrid(
 async function mockUnreadThread(
   page: Page,
   sharedWorkerRoutes: SharedWorkerRoutes,
-  defaultAgentId: string,
+  defaultAgentId: Promise<string>,
 ): Promise<UnreadThreadMocks> {
   const snapshot = sharedWorkerRoutes.route(
     (url) => url.pathname === "/api/chat-threads/snapshot",
     async (route) => {
+      const agentId = await defaultAgentId;
       await route.fulfill({
         json: {
           chatThreads: [
             {
               id: unreadThreadStory.id,
-              agentId: defaultAgentId,
+              agentId,
               title: unreadThreadStory.title,
               sortAt: unreadThreadStory.createdAt,
               createdAt: unreadThreadStory.createdAt,
@@ -162,9 +164,10 @@ async function mockUnreadThread(
     },
   );
   await page.route("**/api/indicators", async (route) => {
+    const agentId = await defaultAgentId;
     await route.fulfill({
       json: {
-        agents: { [defaultAgentId]: "unread" },
+        agents: { [agentId]: "unread" },
         threads: { [unreadThreadStory.id]: "unread" },
       },
     });
@@ -355,23 +358,18 @@ test("three-column rail and unread indicators preserve their visual hierarchy", 
     localStorage.setItem("theme", "light");
     localStorage.setItem("colorTheme", "blue-horizon");
   });
-  await page.goto(appUrl);
-  await page.waitForURL(/\/agents\/[^/]+\/chat\/?$/, { timeout: 30_000 });
-  await sharedWorkerRoutes.waitForWorker();
-  const defaultAgentId = new URL(page.url()).pathname.match(
-    /^\/agents\/([^/]+)\/chat\/?$/,
-  )?.[1];
-  if (!defaultAgentId) {
-    throw new Error("Could not resolve the default agent from the sidebar");
-  }
-
-  const { setGradientColorThemes, setPinnedAgents } = await mockPinnedAgentGrid(
-    page,
-    defaultAgentId,
-  );
+  const defaultAgentIdPromise = waitForActiveAgentId(page);
   const unreadThreadMocks = await mockUnreadThread(
     page,
     sharedWorkerRoutes,
+    defaultAgentIdPromise,
+  );
+  await page.goto(appUrl);
+  const defaultAgentId = await defaultAgentIdPromise;
+  await sharedWorkerRoutes.waitForWorker();
+
+  const { setGradientColorThemes, setPinnedAgents } = await mockPinnedAgentGrid(
+    page,
     defaultAgentId,
   );
   await Promise.all([

--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1,6 +1,7 @@
 import type { Locator, Page, Request, Response } from "@playwright/test";
 import { resolveApiBackendUrl } from "../api-backend-url";
 import { expect, test } from "../fixtures";
+import { waitForActiveAgentId } from "../lib/active-agent";
 import type {
   SharedWorkerRequest,
   SharedWorkerRouteRegistration,
@@ -122,8 +123,10 @@ async function waitForAgentDraftClear(
 async function navigateToMockChatThread(
   page: Page,
   threadId: string,
+  events: SharedWorkerRouteRegistration,
   eventRows: SharedWorkerRouteRegistration,
 ): Promise<void> {
+  await events.handled;
   await page.goto(new URL(`/chats/${threadId}`, appUrl).href);
   await eventRows.handled;
 }
@@ -396,7 +399,7 @@ async function mockModelPickerBoundary(page: Page): Promise<{
 }
 
 interface MockChatThreadOptions {
-  readonly agentId: string;
+  readonly agentId: Promise<string>;
   readonly createdAt: string;
   readonly events: readonly Readonly<Record<string, unknown>>[];
   readonly selectedModel: string | null;
@@ -406,6 +409,7 @@ interface MockChatThreadOptions {
 
 interface MockChatThreadRoutes {
   readonly eventRows: SharedWorkerRouteRegistration;
+  readonly events: SharedWorkerRouteRegistration;
 }
 
 function toMockChatEventRow(
@@ -458,7 +462,7 @@ async function mockChatThread(
       });
     },
   );
-  sharedWorkerRoutes.route(
+  const events = sharedWorkerRoutes.route(
     (url) => url.pathname === "/api/chat-threads/events",
     async (route) => {
       const requestUrl = new URL(route.request().url());
@@ -468,10 +472,8 @@ async function mockChatThread(
         throw new Error("Thread event cursor is invalid");
       }
 
-      // The initial real page can persist a thread-list cursor before these
-      // routes are installed. Deliver the synthetic thread through the
-      // incremental event stream so both cold and already-cached starts own a
-      // deterministic path to the same thread metadata.
+      // Anchor the synthetic event after the worker's current cursor so cold
+      // and already-cached starts reach the same thread metadata.
       createdEventSeqId ??= sinceSeqId + 1;
       const events =
         sinceSeqId < createdEventSeqId
@@ -481,7 +483,7 @@ async function mockChatThread(
                 seqId: createdEventSeqId,
                 kind: "created",
                 chatThreadId: options.threadId,
-                agentId: options.agentId,
+                agentId: await options.agentId,
                 title: options.title,
                 selectedModel: options.selectedModel,
                 serviceTier: null,
@@ -584,13 +586,13 @@ async function mockChatThread(
       });
     },
   );
-  return { eventRows };
+  return { eventRows, events };
 }
 
 async function mockResponsiveFollowupThread(
   page: Page,
   sharedWorkerRoutes: SharedWorkerRoutes,
-  agentId: string,
+  agentId: Promise<string>,
 ): Promise<MockChatThreadRoutes> {
   const createdAt = "2026-06-09T10:01:01Z";
   const runId = "run-responsive-followups";
@@ -643,7 +645,7 @@ async function mockResponsiveFollowupThread(
 async function mockForwardLayoutThread(
   page: Page,
   sharedWorkerRoutes: SharedWorkerRoutes,
-  agentId: string,
+  agentId: Promise<string>,
 ): Promise<MockChatThreadRoutes> {
   const createdAt = "2026-08-13T08:00:01Z";
   const runId = "run-forward-layout";
@@ -680,7 +682,7 @@ async function mockForwardLayoutThread(
 async function mockModelChangeThread(
   page: Page,
   sharedWorkerRoutes: SharedWorkerRoutes,
-  agentId: string,
+  agentId: Promise<string>,
 ): Promise<MockChatThreadRoutes> {
   const createdAt = "2026-08-06T09:02:01Z";
   const events = [
@@ -794,7 +796,7 @@ async function mockModelChangeThread(
 async function mockCardSpacingThread(
   page: Page,
   sharedWorkerRoutes: SharedWorkerRoutes,
-  agentId: string,
+  agentId: Promise<string>,
 ): Promise<MockChatThreadRoutes> {
   const createdAt = "2026-08-13T06:00:02Z";
   const runId = "run-card-spacing";
@@ -892,7 +894,7 @@ async function setupDelayedImageRoutes(
 async function mockDelayedImageLayoutThread(
   page: Page,
   sharedWorkerRoutes: SharedWorkerRoutes,
-  agentId: string,
+  agentId: Promise<string>,
   routes: DelayedImageRoutes,
 ): Promise<MockChatThreadRoutes> {
   await page.route(
@@ -1760,23 +1762,19 @@ test("forward composer stays inside the modal on narrow screens", async ({
 }) => {
   await enableChatForward(page);
   await page.setViewportSize({ width: 360, height: 780 });
-  await page.goto(appUrl);
-  await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
-  await sharedWorkerRoutes.waitForWorker();
-  const agentId = new URL(page.url()).pathname.match(
-    /^\/agents\/([^/]+)\/chat\/?$/,
-  )?.[1];
-  if (!agentId) {
-    throw new Error("Could not resolve the active agent from the chat URL");
-  }
+  const agentId = waitForActiveAgentId(page);
   const mockRoutes = await mockForwardLayoutThread(
     page,
     sharedWorkerRoutes,
     agentId,
   );
+  await page.goto(appUrl);
+  await agentId;
+  await sharedWorkerRoutes.waitForWorker();
   await navigateToMockChatThread(
     page,
     forwardLayoutThreadId,
+    mockRoutes.events,
     mockRoutes.eventRows,
   );
 
@@ -1823,23 +1821,19 @@ test("model change labels follow the divider at the right edge", async ({
   sharedWorkerRoutes,
 }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
-  await page.goto(appUrl);
-  await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
-  await sharedWorkerRoutes.waitForWorker();
-  const agentId = new URL(page.url()).pathname.match(
-    /^\/agents\/([^/]+)\/chat\/?$/,
-  )?.[1];
-  if (!agentId) {
-    throw new Error("Could not resolve the active agent from the chat URL");
-  }
+  const agentId = waitForActiveAgentId(page);
   const mockRoutes = await mockModelChangeThread(
     page,
     sharedWorkerRoutes,
     agentId,
   );
+  await page.goto(appUrl);
+  await agentId;
+  await sharedWorkerRoutes.waitForWorker();
   await navigateToMockChatThread(
     page,
     modelChangeThreadId,
+    mockRoutes.events,
     mockRoutes.eventRows,
   );
 
@@ -1856,23 +1850,19 @@ test("consecutive body cards keep a block gap between them", async ({
   sharedWorkerRoutes,
 }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
-  await page.goto(appUrl);
-  await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
-  await sharedWorkerRoutes.waitForWorker();
-  const agentId = new URL(page.url()).pathname.match(
-    /^\/agents\/([^/]+)\/chat\/?$/,
-  )?.[1];
-  if (!agentId) {
-    throw new Error("Could not resolve the active agent from the chat URL");
-  }
+  const agentId = waitForActiveAgentId(page);
   const mockRoutes = await mockCardSpacingThread(
     page,
     sharedWorkerRoutes,
     agentId,
   );
+  await page.goto(appUrl);
+  await agentId;
+  await sharedWorkerRoutes.waitForWorker();
   await navigateToMockChatThread(
     page,
     cardSpacingThreadId,
+    mockRoutes.events,
     mockRoutes.eventRows,
   );
 
@@ -1899,22 +1889,18 @@ test("image preview frames stay fixed while delayed images load", async ({
   page,
   sharedWorkerRoutes,
 }) => {
-  await page.goto(appUrl);
-  await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
-  await sharedWorkerRoutes.waitForWorker();
-  const agentId = new URL(page.url()).pathname.match(
-    /^\/agents\/([^/]+)\/chat\/?$/,
-  )?.[1];
-  if (!agentId) {
-    throw new Error("Could not resolve the active agent from the chat URL");
-  }
   const routes = await setupDelayedImageRoutes(page);
+  const agentId = waitForActiveAgentId(page);
   const mockRoutes = await mockDelayedImageLayoutThread(
     page,
     sharedWorkerRoutes,
     agentId,
     routes,
   );
+  await page.goto(appUrl);
+  await agentId;
+  await sharedWorkerRoutes.waitForWorker();
+  await mockRoutes.events.handled;
 
   await page.goto(new URL(`/chats/${imageLayoutThreadId}`, appUrl).href, {
     waitUntil: "domcontentloaded",
@@ -1980,24 +1966,19 @@ test.describe("mobile follow-up card rail", () => {
   }) => {
     await enableResponsiveFollowupCards(page);
     await page.setViewportSize({ width: 390, height: 844 });
-    await page.goto(appUrl);
-    await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
-    await sharedWorkerRoutes.waitForWorker();
-
-    const agentId = new URL(page.url()).pathname.match(
-      /^\/agents\/([^/]+)\/chat\/?$/,
-    )?.[1];
-    if (!agentId) {
-      throw new Error("Could not resolve the active agent from the chat URL");
-    }
+    const agentId = waitForActiveAgentId(page);
     const mockRoutes = await mockResponsiveFollowupThread(
       page,
       sharedWorkerRoutes,
       agentId,
     );
+    await page.goto(appUrl);
+    await agentId;
+    await sharedWorkerRoutes.waitForWorker();
     await navigateToMockChatThread(
       page,
       responsiveFollowupThreadId,
+      mockRoutes.events,
       mockRoutes.eventRows,
     );
 
@@ -2100,24 +2081,19 @@ test("keeps the flat follow-up list in a narrow desktop window", async ({
 }) => {
   await enableResponsiveFollowupCards(page);
   await page.setViewportSize({ width: 390, height: 844 });
-  await page.goto(appUrl);
-  await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
-  await sharedWorkerRoutes.waitForWorker();
-
-  const agentId = new URL(page.url()).pathname.match(
-    /^\/agents\/([^/]+)\/chat\/?$/,
-  )?.[1];
-  if (!agentId) {
-    throw new Error("Could not resolve the active agent from the chat URL");
-  }
+  const agentId = waitForActiveAgentId(page);
   const mockRoutes = await mockResponsiveFollowupThread(
     page,
     sharedWorkerRoutes,
     agentId,
   );
+  await page.goto(appUrl);
+  await agentId;
+  await sharedWorkerRoutes.waitForWorker();
   await navigateToMockChatThread(
     page,
     responsiveFollowupThreadId,
+    mockRoutes.events,
     mockRoutes.eventRows,
   );
 

--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1,6 +1,11 @@
 import type { Locator, Page, Request, Response } from "@playwright/test";
 import { resolveApiBackendUrl } from "../api-backend-url";
 import { expect, test } from "../fixtures";
+import type {
+  SharedWorkerRequest,
+  SharedWorkerRouteRegistration,
+  SharedWorkerRoutes,
+} from "../lib/shared-worker-routes";
 import { deriveAppUrl } from "../playwright.config";
 
 const appUrl = deriveAppUrl(resolveApiBackendUrl());
@@ -60,7 +65,7 @@ function mockChatEventCursorId(seqId: number): string {
 }
 
 async function negotiatedChatEventHeaders(
-  request: Request,
+  request: Request | SharedWorkerRequest,
 ): Promise<Record<string, string>> {
   const version = await request.headerValue(chatEventSchemaVersionHeader);
   if (version === null) {
@@ -114,35 +119,13 @@ async function waitForAgentDraftClear(
   await draftCleared;
 }
 
-function isChatThreadEventRowsResponse(
-  response: Response,
-  threadId: string,
-): boolean {
-  const request = response.request();
-  const url = new URL(response.url());
-  const rawSinceSeqId = url.searchParams.get("sinceSeqId");
-  const sinceEventId = url.searchParams.get("sinceEventId");
-  const sinceSeqId = Number(rawSinceSeqId);
-  return (
-    response.ok() &&
-    request.method() === "GET" &&
-    url.pathname === `/api/chat-threads/${threadId}/event-rows` &&
-    rawSinceSeqId !== null &&
-    Number.isSafeInteger(sinceSeqId) &&
-    ((sinceSeqId === 0 && sinceEventId === null) ||
-      (sinceSeqId > 0 && sinceEventId !== null))
-  );
-}
-
 async function navigateToMockChatThread(
   page: Page,
   threadId: string,
+  eventRows: SharedWorkerRouteRegistration,
 ): Promise<void> {
-  const rowsLoaded = page.waitForResponse((response) => {
-    return isChatThreadEventRowsResponse(response, threadId);
-  });
   await page.goto(new URL(`/chats/${threadId}`, appUrl).href);
-  await rowsLoaded;
+  await eventRows.handled;
 }
 
 async function clearComposerEditor(editor: Locator): Promise<void> {
@@ -421,6 +404,10 @@ interface MockChatThreadOptions {
   readonly title: string;
 }
 
+interface MockChatThreadRoutes {
+  readonly eventRows: SharedWorkerRouteRegistration;
+}
+
 function toMockChatEventRow(
   event: Readonly<Record<string, unknown>>,
   threadId: string,
@@ -453,21 +440,25 @@ function toMockChatEventRow(
 
 async function mockChatThread(
   page: Page,
+  sharedWorkerRoutes: SharedWorkerRoutes,
   options: MockChatThreadOptions,
-): Promise<void> {
+): Promise<MockChatThreadRoutes> {
   const createdEventId = `d${options.threadId.slice(1)}`;
   let createdEventSeqId: number | null = null;
 
-  await page.route("**/api/chat-threads/snapshot", async (route) => {
-    await route.fulfill({
-      json: {
-        chatThreads: [],
-        latestEventId: null,
-        latestSeqId: null,
-      },
-    });
-  });
-  await page.route(
+  sharedWorkerRoutes.route(
+    (url) => url.pathname === "/api/chat-threads/snapshot",
+    async (route) => {
+      await route.fulfill({
+        json: {
+          chatThreads: [],
+          latestEventId: null,
+          latestSeqId: null,
+        },
+      });
+    },
+  );
+  sharedWorkerRoutes.route(
     (url) => url.pathname === "/api/chat-threads/events",
     async (route) => {
       const requestUrl = new URL(route.request().url());
@@ -503,7 +494,7 @@ async function mockChatThread(
       await route.fulfill({ json: { events, hasMore: false } });
     },
   );
-  await page.route(
+  const eventRows = sharedWorkerRoutes.route(
     (url) =>
       url.pathname === `/api/chat-threads/${options.threadId}/event-rows`,
     async (route) => {
@@ -571,7 +562,7 @@ async function mockChatThread(
       });
     },
   );
-  await page.route(
+  sharedWorkerRoutes.route(
     (url) =>
       url.pathname === `/api/chat-threads/${options.threadId}/event-snapshot`,
     async (route) => {
@@ -593,12 +584,14 @@ async function mockChatThread(
       });
     },
   );
+  return { eventRows };
 }
 
 async function mockResponsiveFollowupThread(
   page: Page,
+  sharedWorkerRoutes: SharedWorkerRoutes,
   agentId: string,
-): Promise<void> {
+): Promise<MockChatThreadRoutes> {
   const createdAt = "2026-06-09T10:01:01Z";
   const runId = "run-responsive-followups";
   const events = [
@@ -637,7 +630,7 @@ async function mockResponsiveFollowupThread(
     },
   ];
 
-  await mockChatThread(page, {
+  return await mockChatThread(page, sharedWorkerRoutes, {
     agentId,
     createdAt,
     events,
@@ -649,11 +642,12 @@ async function mockResponsiveFollowupThread(
 
 async function mockForwardLayoutThread(
   page: Page,
+  sharedWorkerRoutes: SharedWorkerRoutes,
   agentId: string,
-): Promise<void> {
+): Promise<MockChatThreadRoutes> {
   const createdAt = "2026-08-13T08:00:01Z";
   const runId = "run-forward-layout";
-  await mockChatThread(page, {
+  return await mockChatThread(page, sharedWorkerRoutes, {
     agentId,
     createdAt,
     selectedModel: null,
@@ -685,8 +679,9 @@ async function mockForwardLayoutThread(
 
 async function mockModelChangeThread(
   page: Page,
+  sharedWorkerRoutes: SharedWorkerRoutes,
   agentId: string,
-): Promise<void> {
+): Promise<MockChatThreadRoutes> {
   const createdAt = "2026-08-06T09:02:01Z";
   const events = [
     {
@@ -786,7 +781,7 @@ async function mockModelChangeThread(
       createdAt,
     },
   ];
-  await mockChatThread(page, {
+  return await mockChatThread(page, sharedWorkerRoutes, {
     agentId,
     createdAt,
     events,
@@ -798,8 +793,9 @@ async function mockModelChangeThread(
 
 async function mockCardSpacingThread(
   page: Page,
+  sharedWorkerRoutes: SharedWorkerRoutes,
   agentId: string,
-): Promise<void> {
+): Promise<MockChatThreadRoutes> {
   const createdAt = "2026-08-13T06:00:02Z";
   const runId = "run-card-spacing";
   const events = [
@@ -829,7 +825,7 @@ async function mockCardSpacingThread(
       createdAt,
     },
   ];
-  await mockChatThread(page, {
+  return await mockChatThread(page, sharedWorkerRoutes, {
     agentId,
     createdAt,
     events,
@@ -895,9 +891,10 @@ async function setupDelayedImageRoutes(
 
 async function mockDelayedImageLayoutThread(
   page: Page,
+  sharedWorkerRoutes: SharedWorkerRoutes,
   agentId: string,
   routes: DelayedImageRoutes,
-): Promise<void> {
+): Promise<MockChatThreadRoutes> {
   await page.route(
     (url) =>
       url.pathname === `/api/chat-threads/${imageLayoutThreadId}/artifacts`,
@@ -906,7 +903,7 @@ async function mockDelayedImageLayoutThread(
     },
   );
   const runId = "run-delayed-image-layout";
-  await mockChatThread(page, {
+  return await mockChatThread(page, sharedWorkerRoutes, {
     agentId,
     createdAt: "2026-08-12T09:00:03Z",
     selectedModel: null,
@@ -1759,19 +1756,29 @@ test("chat composer keeps standard tool icons and Send inside on narrow screens"
 
 test("forward composer stays inside the modal on narrow screens", async ({
   page,
+  sharedWorkerRoutes,
 }) => {
   await enableChatForward(page);
   await page.setViewportSize({ width: 360, height: 780 });
   await page.goto(appUrl);
   await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
+  await sharedWorkerRoutes.waitForWorker();
   const agentId = new URL(page.url()).pathname.match(
     /^\/agents\/([^/]+)\/chat\/?$/,
   )?.[1];
   if (!agentId) {
     throw new Error("Could not resolve the active agent from the chat URL");
   }
-  await mockForwardLayoutThread(page, agentId);
-  await navigateToMockChatThread(page, forwardLayoutThreadId);
+  const mockRoutes = await mockForwardLayoutThread(
+    page,
+    sharedWorkerRoutes,
+    agentId,
+  );
+  await navigateToMockChatThread(
+    page,
+    forwardLayoutThreadId,
+    mockRoutes.eventRows,
+  );
 
   const assistantReply = page.getByText(
     "Keep the forward composer within the modal.",
@@ -1813,18 +1820,28 @@ test("forward composer stays inside the modal on narrow screens", async ({
 
 test("model change labels follow the divider at the right edge", async ({
   page,
+  sharedWorkerRoutes,
 }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto(appUrl);
   await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
+  await sharedWorkerRoutes.waitForWorker();
   const agentId = new URL(page.url()).pathname.match(
     /^\/agents\/([^/]+)\/chat\/?$/,
   )?.[1];
   if (!agentId) {
     throw new Error("Could not resolve the active agent from the chat URL");
   }
-  await mockModelChangeThread(page, agentId);
-  await navigateToMockChatThread(page, modelChangeThreadId);
+  const mockRoutes = await mockModelChangeThread(
+    page,
+    sharedWorkerRoutes,
+    agentId,
+  );
+  await navigateToMockChatThread(
+    page,
+    modelChangeThreadId,
+    mockRoutes.eventRows,
+  );
 
   await expectRightAlignedDivider(
     page.getByText("Model changed to Claude Sonnet 4.6", { exact: true }),
@@ -1836,18 +1853,28 @@ test("model change labels follow the divider at the right edge", async ({
 
 test("consecutive body cards keep a block gap between them", async ({
   page,
+  sharedWorkerRoutes,
 }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto(appUrl);
   await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
+  await sharedWorkerRoutes.waitForWorker();
   const agentId = new URL(page.url()).pathname.match(
     /^\/agents\/([^/]+)\/chat\/?$/,
   )?.[1];
   if (!agentId) {
     throw new Error("Could not resolve the active agent from the chat URL");
   }
-  await mockCardSpacingThread(page, agentId);
-  await navigateToMockChatThread(page, cardSpacingThreadId);
+  const mockRoutes = await mockCardSpacingThread(
+    page,
+    sharedWorkerRoutes,
+    agentId,
+  );
+  await navigateToMockChatThread(
+    page,
+    cardSpacingThreadId,
+    mockRoutes.eventRows,
+  );
 
   const cards = page.getByTestId("computer-use-authorization-card");
   await expect(cards).toHaveCount(2);
@@ -1870,9 +1897,11 @@ test("consecutive body cards keep a block gap between them", async ({
 
 test("image preview frames stay fixed while delayed images load", async ({
   page,
+  sharedWorkerRoutes,
 }) => {
   await page.goto(appUrl);
   await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
+  await sharedWorkerRoutes.waitForWorker();
   const agentId = new URL(page.url()).pathname.match(
     /^\/agents\/([^/]+)\/chat\/?$/,
   )?.[1];
@@ -1880,15 +1909,17 @@ test("image preview frames stay fixed while delayed images load", async ({
     throw new Error("Could not resolve the active agent from the chat URL");
   }
   const routes = await setupDelayedImageRoutes(page);
-  await mockDelayedImageLayoutThread(page, agentId, routes);
+  const mockRoutes = await mockDelayedImageLayoutThread(
+    page,
+    sharedWorkerRoutes,
+    agentId,
+    routes,
+  );
 
-  const rowsLoaded = page.waitForResponse((response) => {
-    return isChatThreadEventRowsResponse(response, imageLayoutThreadId);
-  });
   await page.goto(new URL(`/chats/${imageLayoutThreadId}`, appUrl).href, {
     waitUntil: "domcontentloaded",
   });
-  await rowsLoaded;
+  await mockRoutes.eventRows.handled;
 
   const user = delayedImagePreview(
     page,
@@ -1945,11 +1976,13 @@ test.describe("mobile follow-up card rail", () => {
 
   test("responsive follow-up rail aligns its edges and equalizes card heights", async ({
     page,
+    sharedWorkerRoutes,
   }) => {
     await enableResponsiveFollowupCards(page);
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto(appUrl);
     await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
+    await sharedWorkerRoutes.waitForWorker();
 
     const agentId = new URL(page.url()).pathname.match(
       /^\/agents\/([^/]+)\/chat\/?$/,
@@ -1957,8 +1990,16 @@ test.describe("mobile follow-up card rail", () => {
     if (!agentId) {
       throw new Error("Could not resolve the active agent from the chat URL");
     }
-    await mockResponsiveFollowupThread(page, agentId);
-    await navigateToMockChatThread(page, responsiveFollowupThreadId);
+    const mockRoutes = await mockResponsiveFollowupThread(
+      page,
+      sharedWorkerRoutes,
+      agentId,
+    );
+    await navigateToMockChatThread(
+      page,
+      responsiveFollowupThreadId,
+      mockRoutes.eventRows,
+    );
 
     const rail = page.getByRole("group", { name: "Keep going" });
     const cards = responsiveFollowupPrompts.map((prompt) => {
@@ -2055,11 +2096,13 @@ test.describe("mobile follow-up card rail", () => {
 
 test("keeps the flat follow-up list in a narrow desktop window", async ({
   page,
+  sharedWorkerRoutes,
 }) => {
   await enableResponsiveFollowupCards(page);
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto(appUrl);
   await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
+  await sharedWorkerRoutes.waitForWorker();
 
   const agentId = new URL(page.url()).pathname.match(
     /^\/agents\/([^/]+)\/chat\/?$/,
@@ -2067,8 +2110,16 @@ test("keeps the flat follow-up list in a narrow desktop window", async ({
   if (!agentId) {
     throw new Error("Could not resolve the active agent from the chat URL");
   }
-  await mockResponsiveFollowupThread(page, agentId);
-  await navigateToMockChatThread(page, responsiveFollowupThreadId);
+  const mockRoutes = await mockResponsiveFollowupThread(
+    page,
+    sharedWorkerRoutes,
+    agentId,
+  );
+  await navigateToMockChatThread(
+    page,
+    responsiveFollowupThreadId,
+    mockRoutes.eventRows,
+  );
 
   const list = page.getByRole("group", { name: "Keep going" });
   const rows = responsiveFollowupPrompts.map((prompt) => {


### PR DESCRIPTION
## Summary

- route matching API requests from the production-topology chat `SharedWorker` through a deterministic test bridge installed after worker initialization
- gate the page's first worker message until the bridge is ready, while preserving the native worker runtime, request construction, headers, MessagePort, and unmatched network traffic
- keep the worker/page endpoint ownership migration and make the Turbo aggregate gate reject cancelled required jobs

## Scope

- adds an E2E-only page/worker bridge with a unique `BroadcastChannel`, Playwright binding, browser-context target filtering, and explicit teardown
- keeps the typed `SharedWorkerRoutes` fulfillment, passthrough, handler failure, precedence, and first-request readiness API
- migrates worker-owned chat snapshot, event stream, event-row, and event-snapshot mocks away from page-scoped Playwright routes
- preserves page-scoped mocks for indicators, unreads, drafts, read state, metadata, feature switches, media, and other page-owned endpoints
- adds focused integration coverage against a real Chromium `SharedWorker`, including startup ordering, request headers, passthrough, handler failure, separate-context isolation, and post-cleanup native behavior
- leaves production App/API/runner code and the real deployed-runner test path unchanged

This supersedes the earlier CDP `Fetch` implementation. Repeated runs showed that a second target session could acknowledge `Fetch.enable` while requests still escaped during Playwright's own SharedWorker attach lifecycle. Target discovery is now used only to install the runtime bridge after the existing production initialization marker.

## Validation

- `cd e2e && ../turbo/node_modules/.bin/prettier --check playwright/fixtures.ts playwright/lib/shared-worker-route-bridge.ts playwright/lib/shared-worker-routes.ts playwright/lib/shared-worker-routes.test.ts playwright/tests/agents.spec.ts playwright/tests/chat.spec.ts`
- `cd e2e && pnpm check-types`
- focused real-SharedWorker integration test: 30 consecutive fresh-browser passes
- `cd e2e && pnpm test` after rebase onto current `main` (54 passed, 0 failed, 0 cancelled, 0 skipped)
- `bash -n .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `scripts/check-file-size.sh` for every changed file

The full workflow contract test cannot run in this development container because its script invokes Ruby and Ruby is not installed. CI will run it in the repository's standard workflow environment.

Closes #30364
