### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -1561,31 +1561,6 @@ describe("workflows routes", () => {
     expect(queryButtonByText("Install")).toBeNull();
   });
 
-  it("treats a pre-P4 catalog detail without lifecycle as active", async () => {
-    const { lifecycle: _lifecycle, ...legacyDefinition } =
-      officialCatalogDetail();
-    mockAgentPageApis();
-    context.mocks.data.onboardingStatus({ defaultAgentId: AGENT_ID });
-    context.mocks.data.userPreferences({ timezone: "UTC" });
-    mockWorkflowApis([officialSalesResearch()]);
-    context.mocks.api(officialWorkflowsContract.get, ({ respond }) => {
-      return respond(200, legacyDefinition);
-    });
-
-    detachedSetupPage({
-      context,
-      path: "/workflows/official/sales-research",
-      featureSwitches: { [FeatureSwitchKey.OfficialWorkflows]: true },
-    });
-
-    click(
-      await waitFor(() => {
-        return buttonByText("Install");
-      }),
-    );
-    await expect(screen.findByRole("dialog")).resolves.toBeInTheDocument();
-  });
-
   it("preselects the default Agent and installs every Blueprint with typed parameters", async () => {
     const definition = officialCatalogDetail();
     const installBodies: unknown[] = [];

--- a/turbo/apps/platform/src/views/workflows-page/official-workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/official-workflows-page.tsx
@@ -438,7 +438,7 @@ function OfficialWorkflowDefinitionPage() {
                   definition.description}
               </p>
             </div>
-            {(definition.lifecycle ?? "active") === "active" ? (
+            {definition.lifecycle === "active" ? (
               <Button
                 type="button"
                 className="zero-btn-morandi h-9 shrink-0 gap-2 rounded-lg"
@@ -479,7 +479,7 @@ function OfficialWorkflowDefinitionPage() {
         ) : null}
         {definition ? (
           <div className="mx-auto flex max-w-[900px] flex-col gap-4">
-            {(definition.lifecycle ?? "active") === "retired" ? (
+            {definition.lifecycle === "retired" ? (
               <Alert>
                 <AlertTitle>
                   {i18n.t(($) => {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/official-workflows.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/official-workflows.test.ts
@@ -42,7 +42,7 @@ const blueprint = {
 };
 
 describe("Official Workflow product contracts", () => {
-  it("represents retained retired catalog detail while preserving the rollback field window", () => {
+  it("represents retained retired catalog detail", () => {
     const detail = {
       name: "team-brief",
       revision: REVISION,
@@ -65,8 +65,8 @@ describe("Official Workflow product contracts", () => {
 
     const { lifecycle: _lifecycle, ...legacyDetail } = detail;
     expect(
-      officialWorkflowCatalogDetailSchema.parse(legacyDetail),
-    ).toStrictEqual(legacyDetail);
+      officialWorkflowCatalogDetailSchema.safeParse(legacyDetail).success,
+    ).toBe(false);
   });
 
   it("carries every declared parameter type in authoritative installation metadata", () => {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/official-workflows.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/official-workflows.test.ts
@@ -62,11 +62,6 @@ describe("Official Workflow product contracts", () => {
     expect(officialWorkflowCatalogDetailSchema.parse(detail)).toStrictEqual(
       detail,
     );
-
-    const { lifecycle: _lifecycle, ...legacyDetail } = detail;
-    expect(
-      officialWorkflowCatalogDetailSchema.safeParse(legacyDetail).success,
-    ).toBe(false);
   });
 
   it("carries every declared parameter type in authoritative installation metadata", () => {

--- a/turbo/packages/api-contracts/src/contracts/official-workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/official-workflows.ts
@@ -29,10 +29,7 @@ export type OfficialWorkflowCatalogSummary = z.infer<
 
 export const officialWorkflowCatalogDetailSchema =
   officialWorkflowCatalogSummarySchema.extend({
-    // New App -> old API fallback. Current APIs always return this field;
-    // remove the optional parser in #29991 after pre-P4 APIs are no longer
-    // serving or retained for rollback.
-    lifecycle: officialWorkflowLifecycleSchema.optional(),
+    lifecycle: officialWorkflowLifecycleSchema,
     workflow: officialWorkflowExecutableSchema,
   });
 export type OfficialWorkflowCatalogDetail = z.infer<


### PR DESCRIPTION
Removes the new-App-to-old-API `lifecycle` fallback on the Official Workflow catalog detail response. Partially addresses #29991.

## Cohort — Official Workflow catalog detail `lifecycle`

**Old boundary:** #29996 (P4) added `lifecycle` to the catalog detail response. During rollout a newly promoted App could still reach a pre-P4 API that omitted the field, so the contract kept it optional and the App defaulted it to `"active"` at both render sites.

**New boundary:** `lifecycle` is required on `officialWorkflowCatalogDetailSchema`, and the App reads `definition.lifecycle` directly.

Removed:
- `.optional()` and the rollout comment on `lifecycle` in `officialWorkflowCatalogDetailSchema`
- `(definition.lifecycle ?? "active")` at both call sites in `official-workflows-page.tsx`
- the `treats a pre-P4 catalog detail without lifecycle as active` Platform regression
- the legacy-shape half of the contract test, which asserted that a detail without `lifecycle` parses; it now asserts the opposite, so the tightened contract stays covered

**Window:** the consumer is a new App calling an older API, so the governing gate is the old API leaving service — canonical window 1 — plus the issue's requirement that it no longer be a retained rollback target.

**Rollout evidence (observed):**
- #29996 merged `2026-08-28T08:41:08Z` (`71ff589c65d`).
- First `api/production` deployment containing it: `c0578f6721`, `2026-08-28T11:02:21Z`, confirmed with `git merge-base --is-ancestor` walking the deployment list forward from oldest.
- **19 further `api/production` deployments** have been promoted since.
- Elapsed: **58.0 hours**.

**Source evidence that the current API always sets the field:** `catalogDetail` in `turbo/apps/api/src/signals/services/official-workflow-installation.service.ts` returns `lifecycle: definition.lifecycle` from the accepted catalog definition on its only success path, and throws when the accepted revision is missing. Both producers of `OfficialWorkflowCatalogDetail` — `listActiveOfficialWorkflows` and `getOfficialWorkflow` — go through it.

**Client-floor gate, with an important caveat:** `minimumSupportedVersion` was raised to `0.812.1` (#30336, in `api/production` at `2026-08-30T11:28:57Z`), which is above the `0.807.1` App version at the #29996 merge commit. However, the Axiom census below shows the floor does **not** immediately drain sub-floor App builds, so this PR does not rely on it. It does not need to: tightening a shared **response** schema only affects clients that ship the new bundle. An older App bundle carries its own older, permissive parser and simply ignores the now-always-present field.

**Axiom evidence (read-only), dataset `vm0-request-log-prod`, range `2026-08-30T11:28:57Z` → `2026-08-30T21:00:00Z`:** grouping `x_client_type == "App"` by `x_client_version` shows builds well below the new floor still transmitting at the end of the window — `0.784.0` (2151 requests, last `20:59:51Z`), `0.804.5` (2111, last `20:59:59Z`), `0.810.0` (1307, last `20:59:45Z`), plus `0.806.1`, `0.808.3`, `0.809.1`, `0.810.1`, `0.810.2`. Recorded here because it is evidence that constrains other candidates, and because it is the reason this PR rests on the API-drain gate rather than the floor.

**MaskDB:** not applicable. No schema, column, or persisted payload changes.

## Deliberately left in place

`officialWorkflowInstallationResponseSchema.definition` stays optional, even though #29991 groups it with `lifecycle`. The issue states that current APIs always return it, but on current `main` the install and get-installation routes in `turbo/apps/api/src/signals/routes/official-workflows.ts` build `body: { workflow: detail, ...(definition ? { definition } : {}) }`, and `getOfficialWorkflowInstallationDefinition` returns `null` whenever the accepted catalog has no entry for that definition name. That omission is live runtime behavior, not an expired rollout fallback, so requiring the field would need a route behavior change that is out of scope for compatibility cleanup. #29991 should stay open for it. The P1 `workflow.official` / `automation.official` optional fields in `workflows.ts` are likewise untouched, since their pre-P1 surface was not dated in this run.

## Other explicitly deferred candidates

- **AgentPhone brandless connect (`agentphone-connect-params.ts` `parseBrandState`, `agentphone.service.ts`).** Its gate is that the client floor excludes the pre-rollout Platform build. The floor now nominally does, but the census above shows App `0.784.0` — below the pre-rollout `0.788.0` — still issuing requests seconds before this run. Unlike a response-schema tightening, that path validates a **request** signature from those clients, so the observed traffic is a real blocker.
- **#29908 Official Workflow queue rollout markers.** Requires proving no pending unrevoked or runless marker rows remain, and removal changes queue rejection semantics.
- **#26519 / #28672 archive pins and the presentation-templates switch.** Open PR #30335 is already removing that switch.
- **Queued-launch-context brand reads** for Telegram, AgentPhone, and Feishu. MaskDB's projection still does not expose `public_brand` on the context tables, and `feishu_chat_ingress` is still absent.
- **#28571 multi-account connector exact-ID fallback.** Gated on the final rollout contraction, a product milestone.

## Checks (run once against the combined diff)

- `pnpm format`
- `pnpm -F @okouai/app lint`, `pnpm -F @okouai/api-contracts lint` (no new warnings)
- `pnpm -F @okouai/api-contracts check-types`, `pnpm -F @okouai/app check-types`, `pnpm -F api check-types`
- `pnpm knip` (no new unused files, exports, or dependencies)
- `pnpm -F @okouai/api-contracts exec vitest run` — 641 passing across 35 files
- `pnpm -F @okouai/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx` — 75 passing
- `pnpm -F api exec vitest run` on `official-workflows` + `cron-official-workflow-catalog` + `official-automation-result-email` — 56 passing against a local Postgres with `timezone=UTC`

Full coverage is left to the PR pipeline; no full local Vitest run and no local dev server.
