### PR TITLE
test(python): assert accepted absolute-form requests open upstream

### DIFF
--- a/crates/runner/mitm-addon/tests/test_mitmproxy_authority_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_authority_framing.py
@@ -354,9 +354,15 @@ async def test_matching_http1_absolute_form_authority_is_forwardable_with_auth(
             command for command in header_commands if isinstance(command, HttpRequestHook)
         )
         await addon_context.master.addons.invoke_addon(mitm_addon, request_hook)
-        list(http_layer.handle_event(events.HookCompleted(request_hook, None)))
+        request_commands = list(http_layer.handle_event(events.HookCompleted(request_hook, None)))
 
     assert flow.response is None
+    assert flow.error is None
+    open_connections = [
+        command for command in request_commands if isinstance(command, commands.OpenConnection)
+    ]
+    assert len(open_connections) == 1
+    assert open_connections[0].connection.address == ("203.0.113.10", 443)
     assert flow.request.authority == "API.GITHUB.COM.:443"
     assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.github.com/repos"
     assert flow.request.headers["Authorization"] == "Bearer managed-secret"


### PR DESCRIPTION
## Summary

- retain the real mitmproxy commands emitted after the accepted absolute-form request hook completes
- assert the accepted flow remains error-free and emits exactly one upstream connection attempt to the trusted transparent-proxy destination
- preserve the existing absolute-form target, Host, Authorization, and rejection-path assertions

## Scope

This is a test-only change. It does not modify addon runtime behavior, shared test helpers, dependencies, TLS handling, or deployment contracts. The test intentionally stops at upstream transport connection initiation because HTTPS connection completion enters mitmproxy's TLS handshake before HTTP bytes are emitted.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_mitmproxy_authority_framing.py` (5 passed)
- `uv run --no-sync python -m pytest tests/` (7,227 passed)

Closes #30313
