### PR TITLE
perf(python): avoid omitted connector union allocation

### DIFF
--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -474,8 +474,8 @@ def _classify_request(
         client_ip,
         frozenset(),
     )
-    if intent.status == "present" and intent.value in (
-        omitted_builtin_firewalls | omitted_custom_connector_ids
+    if intent.status == "present" and (
+        intent.value in omitted_builtin_firewalls or intent.value in omitted_custom_connector_ids
     ):
         return Allow(
             sandbox_info=sandbox_info,

--- a/crates/runner/mitm-addon/tests/test_request_classification_omitted_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_request_classification_omitted_connectors.py
@@ -155,10 +155,11 @@ def test_omitted_connector_lookup_allocation_does_not_scale_with_target_count(
             )
             assert isinstance(warm_classification, request_classification.Allow)
 
+            measured_flow = new_flow()
             tracemalloc.start()
             try:
                 classification = request_classification.classify_request(
-                    new_flow(),
+                    measured_flow,
                     registry_path=str(registry_path),
                     api_url=_API_URL,
                     tls_admission=None,

--- a/crates/runner/mitm-addon/tests/test_request_classification_omitted_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_request_classification_omitted_connectors.py
@@ -1,0 +1,172 @@
+"""Connector-intent classification for omitted runtime targets."""
+
+import tracemalloc
+
+import pytest
+
+import connector_intent
+import request_classification
+from tests.request_handler_helpers import (
+    _sandbox_without_firewalls,
+    _shared_route_sandbox,
+    _write_registry,
+)
+
+_API_URL = "https://api.vm0.ai"
+_CLIENT_IP = "10.200.0.5"
+_CONNECTOR_INTENT_HEADER = "X-VM0-Connector-Intent"
+
+
+@pytest.mark.parametrize(
+    ("omitted_builtin", "omitted_custom", "intent"),
+    [
+        (["removed-builtin"], [], "removed-builtin"),
+        ([], ["removed-custom"], "removed-custom"),
+        (["removed-overlap"], ["removed-overlap"], "removed-overlap"),
+    ],
+    ids=["builtin-only", "custom-only", "both"],
+)
+def test_omitted_connector_intent_returns_ordinary_allow(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    headers,
+    omitted_builtin,
+    omitted_custom,
+    intent,
+):
+    sandbox = _shared_route_sandbox(tmp_path)
+    sandbox["omittedBuiltinFirewalls"] = omitted_builtin
+    sandbox["omittedCustomConnectorIds"] = omitted_custom
+    registry_path = _write_registry(tmp_path, client_ip=_CLIENT_IP, sandbox_info=sandbox)
+    flow = real_flow(
+        with_response=False,
+        client_ip=_CLIENT_IP,
+        host="shared.example.com",
+        path="/items/123",
+        request_headers=headers(
+            ("Host", "shared.example.com"),
+            (_CONNECTOR_INTENT_HEADER, intent),
+        ),
+    )
+    connector_intent.capture_and_strip(flow)
+
+    with mitm_ctx(registry_path=str(registry_path), api_url=_API_URL):
+        classification = request_classification.classify_request(
+            flow,
+            registry_path=str(registry_path),
+            api_url=_API_URL,
+            tls_admission=None,
+        )
+
+    assert isinstance(classification, request_classification.Allow)
+
+
+@pytest.mark.parametrize(
+    ("intent_headers", "reason"),
+    [
+        (((_CONNECTOR_INTENT_HEADER, "not-omitted"),), "connector_intent_not_candidate"),
+        (
+            (
+                (_CONNECTOR_INTENT_HEADER, "first"),
+                (_CONNECTOR_INTENT_HEADER, "second"),
+            ),
+            "malformed_connector_intent",
+        ),
+        ((), "connector_intent_required"),
+    ],
+    ids=["present-no-match", "malformed", "absent"],
+)
+def test_non_omitted_intent_continues_to_firewall_classification(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    headers,
+    intent_headers,
+    reason,
+):
+    sandbox = _shared_route_sandbox(tmp_path)
+    sandbox["omittedBuiltinFirewalls"] = ["removed-builtin"]
+    sandbox["omittedCustomConnectorIds"] = ["removed-custom"]
+    registry_path = _write_registry(tmp_path, client_ip=_CLIENT_IP, sandbox_info=sandbox)
+    flow = real_flow(
+        with_response=False,
+        client_ip=_CLIENT_IP,
+        host="shared.example.com",
+        path="/items/123",
+        request_headers=headers(("Host", "shared.example.com"), *intent_headers),
+    )
+    connector_intent.capture_and_strip(flow)
+
+    with mitm_ctx(registry_path=str(registry_path), api_url=_API_URL):
+        classification = request_classification.classify_request(
+            flow,
+            registry_path=str(registry_path),
+            api_url=_API_URL,
+            tls_admission=None,
+        )
+
+    assert isinstance(classification, request_classification.FirewallAmbiguous)
+    assert classification.firewall_ambiguous.reason == reason
+
+
+def test_omitted_connector_lookup_allocation_does_not_scale_with_target_count(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    headers,
+):
+    peak_by_target_count: dict[int, int] = {}
+
+    for target_count in (1, 10_000):
+        registry_dir = tmp_path / f"targets-{target_count}"
+        registry_dir.mkdir()
+        omitted_custom = [f"omitted-{index}" for index in range(target_count)]
+        sandbox = _sandbox_without_firewalls(
+            registry_dir,
+            sandbox_fields={"omittedCustomConnectorIds": omitted_custom},
+        )
+        registry_path = _write_registry(
+            registry_dir,
+            client_ip=_CLIENT_IP,
+            sandbox_info=sandbox,
+        )
+
+        def new_flow():
+            flow = real_flow(
+                with_response=False,
+                client_ip=_CLIENT_IP,
+                host="target.example.com",
+                path="/items",
+                request_headers=headers(
+                    ("Host", "target.example.com"),
+                    (_CONNECTOR_INTENT_HEADER, "not-omitted"),
+                ),
+            )
+            connector_intent.capture_and_strip(flow)
+            return flow
+
+        with mitm_ctx(registry_path=str(registry_path), api_url=_API_URL):
+            warm_classification = request_classification.classify_request(
+                new_flow(),
+                registry_path=str(registry_path),
+                api_url=_API_URL,
+                tls_admission=None,
+            )
+            assert isinstance(warm_classification, request_classification.Allow)
+
+            tracemalloc.start()
+            try:
+                classification = request_classification.classify_request(
+                    new_flow(),
+                    registry_path=str(registry_path),
+                    api_url=_API_URL,
+                    tls_admission=None,
+                )
+                peak_by_target_count[target_count] = tracemalloc.get_traced_memory()[1]
+            finally:
+                tracemalloc.stop()
+
+        assert isinstance(classification, request_classification.Allow)
+
+    assert peak_by_target_count[10_000] <= peak_by_target_count[1] + 16 * 1024


### PR DESCRIPTION
## Summary

- replace per-request union construction with short-circuit membership in the existing Builtin and Custom omitted sets
- preserve ordinary allow behavior for omitted connector intents and downstream firewall behavior for other intent states
- add real-registry classifier integration coverage and a warmed allocation-scaling regression

## Scope

- no API, registry format, Rust/Python contract, migration, or feature-switch changes
- no combined omitted-target cache or retained index

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_request_classification_omitted_connectors.py -q` (7 passed)
- allocation regression repeated three additional times (passed)
- `uv run --no-sync python -m pytest tests/` (7234 passed)

Closes #30314
