### PR TITLE
test(runner): decouple draining heartbeat from virtual time

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1793,9 +1793,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     );
 
     // -----------------------------------------------------------------------
-    // Heartbeat interval — same first-tick delay as above. One integration
-    // test injects manual ticks so its coalescing assertions do not advance
-    // unrelated Runner timers.
+    // Heartbeat interval — same first-tick delay as above. Integration tests
+    // inject manual ticks so their assertions do not advance unrelated Runner
+    // timers.
     // -----------------------------------------------------------------------
     #[cfg(test)]
     let mut heartbeat_tick = match test_hooks.manual_routine_heartbeat_rx.take() {

--- a/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
@@ -350,16 +350,17 @@ async fn natural_shutdown_flushes_stopping_after_current_heartbeat() {
 /// parked in Draining mode. Silently dropping its `heartbeat_tick` branch
 /// would leave a draining runner looking dead to the server until it exits.
 ///
-/// Drain before the first tick (t >= 10s) so the runner transitions to
-/// Draining mode first; the tick observed after the time advance therefore
+/// Enter Draining before injecting a routine heartbeat so the observed tick
 /// had to be handled by the Draining-mode heartbeat branch.
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn heartbeat_fires_while_draining() {
     let gate = Arc::new(tokio::sync::Notify::new());
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         Arc::clone(&gate),
     ));
-    let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
+    let (mut config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
+    let (heartbeat_trigger, heartbeat_trigger_rx) = tokio::sync::mpsc::unbounded_channel();
+    config.test_hooks.manual_routine_heartbeat_rx = Some(heartbeat_trigger_rx);
     let status_path = env._temp_dir.path().join("status.json");
     let run_handle = tokio::spawn(run(config));
 
@@ -370,18 +371,17 @@ async fn heartbeat_fires_while_draining() {
     push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
     let _token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
 
-    // Enter Draining before the first heartbeat tick fires. `status.json`
+    // Enter Draining before triggering the routine heartbeat. `status.json`
     // is updated only after the main loop observes the mode transition.
     env.drain();
     wait_status_mode(&status_path, "draining", Duration::from_secs(5)).await;
     assert_eq!(*env.mode_tx.borrow(), RunnerMode::Draining);
     let before = env.handle.heartbeat_count();
 
-    // Advance past the first tick while Draining mode is active.
-    // A broken Draining path that dropped its `heartbeat_tick.tick()`
-    // branch would leave the count unchanged; `wait_heartbeat_past`
-    // returns false on timeout.
-    tokio::time::advance(HEARTBEAT_PERIOD + Duration::from_secs(5)).await;
+    // Trigger a routine heartbeat while Draining mode is active. A broken
+    // Draining path that dropped its `heartbeat_tick.tick()` branch would
+    // never acknowledge the trigger or advance the provider heartbeat count.
+    trigger_routine_heartbeat(&heartbeat_trigger, &env, RunnerMode::Draining).await;
     assert!(
         env.handle
             .wait_heartbeat_past(before, Duration::from_secs(5))


### PR DESCRIPTION
## Summary

- drive the draining heartbeat integration test through the existing manual routine-heartbeat source
- keep the real runner main loop, lifecycle transitions, status persistence, provider heartbeat, and hard-shutdown path
- update the manual-trigger maintenance comment to reflect use by multiple integration tests

## Why

The test advanced Tokio's paused clock by 15 seconds to trigger the production heartbeat interval. Runner status persistence uses the same Tokio clock for a five-second deadline around real filesystem I/O, so virtual time could expire the `Stopping` status write under unlucky scheduling. The old test reproduced locally during a 50-run loop after more than 20 passes.

The explicit trigger is sent only after the gated runner is observably `Draining`. It enters the same main-loop `heartbeat_tick.tick()` branch and the test still waits for the provider-visible heartbeat to complete.

## Validation

- target test: 100/100 consecutive post-change passes
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner --all-features cmd::start::tests::main_loop::heartbeat` (9 passed)
- `cargo test -p runner --all-targets --all-features` (3,371 passed, 26 ignored; guest inventory 1 passed)
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`
- `lefthook run pre-commit`

## Scope

Production heartbeat cadence, missed-tick behavior, lifecycle semantics, status persistence timeout, and persisted schema are unchanged. The manual receiver remains test-only, so there is no API, protocol, migration, rollout, or old/new runner compatibility impact.

Closes #30367
