### PR TITLE
fix(guest-agent): classify structured codex errors

### DIFF
--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -284,7 +284,11 @@ fn codex_error_failure_reason(error: Option<&Value>) -> Option<FailureReason> {
 
 fn codex_error_info_failure_reason(error: &Value) -> Option<FailureReason> {
     match codex_error_info_variant(error)? {
+        "contextWindowExceeded" => Some(FailureReason::ContextWindowExceeded),
         "rateLimitExceeded" | "serverOverloaded" => Some(FailureReason::ProviderOverloaded),
+        "responseStreamConnectionFailed" | "responseStreamDisconnected" => {
+            Some(FailureReason::ResponseConnectionLost)
+        }
         "usageLimitExceeded" => Some(FailureReason::UsageLimit),
         "cyberPolicy" | "misalignmentPolicyViolation" => Some(FailureReason::SafetyPolicyRefusal),
         _ => None,

--- a/crates/guest-agent/tests/codex_app_server_backend_structured_errors.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_structured_errors.rs
@@ -1,0 +1,97 @@
+//! Structured Codex app-server failure classification integration coverage.
+//!
+//! All cases run sequentially in one test because setup mutates process env and
+//! the current directory.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use guest_contracts::diagnostics::FailureReason;
+use std::time::Duration;
+
+struct StructuredErrorCase {
+    scenario: &'static str,
+    expected_reason: Option<FailureReason>,
+}
+
+#[tokio::test]
+async fn codex_app_server_classifies_supported_structured_errors()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock_codex()?;
+    let original_directory = std::env::current_dir()?;
+    let cases = [
+        StructuredErrorCase {
+            scenario: "runtime-turn-failed-context-window-exceeded",
+            expected_reason: Some(FailureReason::ContextWindowExceeded),
+        },
+        StructuredErrorCase {
+            scenario: "runtime-turn-failed-response-stream-connection-failed",
+            expected_reason: Some(FailureReason::ResponseConnectionLost),
+        },
+        StructuredErrorCase {
+            scenario: "runtime-turn-failed-response-stream-disconnected",
+            expected_reason: Some(FailureReason::ResponseConnectionLost),
+        },
+        StructuredErrorCase {
+            scenario: "runtime-turn-failed-internal-server-error",
+            expected_reason: None,
+        },
+        StructuredErrorCase {
+            scenario: "runtime-turn-failed-response-too-many-failed-attempts",
+            expected_reason: None,
+        },
+        StructuredErrorCase {
+            scenario: "runtime-turn-failed-unauthorized",
+            expected_reason: None,
+        },
+        StructuredErrorCase {
+            scenario: "runtime-turn-failed-unknown",
+            expected_reason: None,
+        },
+    ];
+
+    for (index, case) in cases.iter().enumerate() {
+        let tmp = tempfile::tempdir()?;
+        let run_id = format!("codex-structured-error-{index}");
+        unsafe {
+            common::setup_codex_app_server_env(
+                &mock,
+                tmp.path(),
+                common::CodexAppServerEnvConfig {
+                    run_id: &run_id,
+                    prompt: "exercise structured Codex error classification",
+                    scenario: Some(case.scenario),
+                    resume_session_id: None,
+                },
+            )?;
+        }
+        let runtime = common::guest_runtime_from_process_env()?;
+        let run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            common::execute_cli_for_runtime(
+                &runtime,
+                &SecretMasker::from_raw(""),
+                common::spawn_dummy_heartbeat(),
+            ),
+        )
+        .await
+        .expect("execute_cli should return promptly")?;
+
+        assert_eq!(result.exit_code, 1, "scenario: {}", case.scenario);
+        let diagnostic = result
+            .failure_diagnostic
+            .as_ref()
+            .unwrap_or_else(|| panic!("missing diagnostic for scenario: {}", case.scenario));
+        assert_eq!(
+            diagnostic.failure_reason, case.expected_reason,
+            "scenario: {}",
+            case.scenario
+        );
+
+        drop(run_files);
+        std::env::set_current_dir(&original_directory)?;
+    }
+
+    Ok(())
+}

--- a/crates/guest-mock-codex/src/app_server/handlers.rs
+++ b/crates/guest-mock-codex/src/app_server/handlers.rs
@@ -437,10 +437,13 @@ impl AppServerState {
                 "checkpointed shell prompts require a runtime turn-complete scenario",
             ));
         }
-        if self.scenario == Scenario::RuntimeTurnFailed {
+        if let Some(failure) = self.scenario.turn_failure() {
             write_json_line(output, &turn_started_notification(&thread_id, &turn_id))?;
             write_turn_usage_notifications(output, &thread_id, &turn_id)?;
-            write_json_line(output, &turn_failed_notification(&thread_id, &turn_id))?;
+            write_json_line(
+                output,
+                &turn_failed_notification(&thread_id, &turn_id, failure),
+            )?;
         }
         if self.scenario == Scenario::RuntimeEventFlood {
             write_json_line(output, &turn_started_notification(&thread_id, &turn_id))?;

--- a/crates/guest-mock-codex/src/app_server/messages.rs
+++ b/crates/guest-mock-codex/src/app_server/messages.rs
@@ -1,3 +1,4 @@
+use super::scenario::TurnFailure;
 use crate::session;
 use guest_contracts::managed_command::render_managed_shell_command;
 use serde_json::{Value, json};
@@ -389,7 +390,21 @@ pub(super) fn turn_interrupted_notification(thread_id: &str, turn_id: &str) -> V
     })
 }
 
-pub(super) fn turn_failed_notification(thread_id: &str, turn_id: &str) -> Value {
+pub(super) fn turn_failed_notification(
+    thread_id: &str,
+    turn_id: &str,
+    failure: TurnFailure,
+) -> Value {
+    let error = match turn_failure_error_info(failure) {
+        Some(codex_error_info) => json!({
+            "message": "mock codex primary failure",
+            "codexErrorInfo": codex_error_info
+        }),
+        None => json!({
+            "message": "mock codex primary failure"
+        }),
+    };
+
     json!({
         "method": "turn/completed",
         "params": {
@@ -399,15 +414,38 @@ pub(super) fn turn_failed_notification(thread_id: &str, turn_id: &str) -> Value 
                 "items": [],
                 "itemsView": "notLoaded",
                 "status": "failed",
-                "error": {
-                    "message": "mock codex primary failure"
-                },
+                "error": error,
                 "startedAt": 1,
                 "completedAt": 3,
                 "durationMs": 2
             }
         }
     })
+}
+
+fn turn_failure_error_info(failure: TurnFailure) -> Option<Value> {
+    match failure {
+        TurnFailure::Generic => None,
+        TurnFailure::ContextWindowExceeded => Some(json!("contextWindowExceeded")),
+        TurnFailure::InternalServerError => Some(json!("internalServerError")),
+        TurnFailure::ResponseStreamConnectionFailed => Some(json!({
+            "responseStreamConnectionFailed": {
+                "httpStatusCode": 502
+            }
+        })),
+        TurnFailure::ResponseStreamDisconnected => Some(json!({
+            "responseStreamDisconnected": {
+                "httpStatusCode": 502
+            }
+        })),
+        TurnFailure::ResponseTooManyFailedAttempts => Some(json!({
+            "responseTooManyFailedAttempts": {
+                "httpStatusCode": 401
+            }
+        })),
+        TurnFailure::Unauthorized => Some(json!("unauthorized")),
+        TurnFailure::Unknown => Some(json!("futureStructuredError")),
+    }
 }
 
 pub(super) fn historical_token_usage_notification(thread_id: &str) -> Value {

--- a/crates/guest-mock-codex/src/app_server/scenario.rs
+++ b/crates/guest-mock-codex/src/app_server/scenario.rs
@@ -29,6 +29,13 @@ pub(super) enum Scenario {
     ExitOnTurnSteer,
     RuntimeTurnComplete,
     RuntimeTurnFailed,
+    RuntimeTurnFailedContextWindowExceeded,
+    RuntimeTurnFailedInternalServerError,
+    RuntimeTurnFailedResponseStreamConnectionFailed,
+    RuntimeTurnFailedResponseStreamDisconnected,
+    RuntimeTurnFailedResponseTooManyFailedAttempts,
+    RuntimeTurnFailedUnauthorized,
+    RuntimeTurnFailedUnknown,
     RuntimeTurnCompleteAfterSteer,
     RuntimeTurnCompleteBeforeSteerResponse,
     RuntimeTurnStartedBeforeSteer,
@@ -87,6 +94,23 @@ impl Scenario {
                 "exit-on-turn-steer" => Ok(Self::ExitOnTurnSteer),
                 "runtime-turn-complete" => Ok(Self::RuntimeTurnComplete),
                 "runtime-turn-failed" => Ok(Self::RuntimeTurnFailed),
+                "runtime-turn-failed-context-window-exceeded" => {
+                    Ok(Self::RuntimeTurnFailedContextWindowExceeded)
+                }
+                "runtime-turn-failed-internal-server-error" => {
+                    Ok(Self::RuntimeTurnFailedInternalServerError)
+                }
+                "runtime-turn-failed-response-stream-connection-failed" => {
+                    Ok(Self::RuntimeTurnFailedResponseStreamConnectionFailed)
+                }
+                "runtime-turn-failed-response-stream-disconnected" => {
+                    Ok(Self::RuntimeTurnFailedResponseStreamDisconnected)
+                }
+                "runtime-turn-failed-response-too-many-failed-attempts" => {
+                    Ok(Self::RuntimeTurnFailedResponseTooManyFailedAttempts)
+                }
+                "runtime-turn-failed-unauthorized" => Ok(Self::RuntimeTurnFailedUnauthorized),
+                "runtime-turn-failed-unknown" => Ok(Self::RuntimeTurnFailedUnknown),
                 "runtime-turn-complete-after-steer" => Ok(Self::RuntimeTurnCompleteAfterSteer),
                 "runtime-turn-complete-before-steer-response" => {
                     Ok(Self::RuntimeTurnCompleteBeforeSteerResponse)
@@ -155,4 +179,38 @@ impl Scenario {
                 | Self::CompleteBeforeTurnInterrupt
         )
     }
+
+    pub(super) const fn turn_failure(self) -> Option<TurnFailure> {
+        match self {
+            Self::RuntimeTurnFailed => Some(TurnFailure::Generic),
+            Self::RuntimeTurnFailedContextWindowExceeded => {
+                Some(TurnFailure::ContextWindowExceeded)
+            }
+            Self::RuntimeTurnFailedInternalServerError => Some(TurnFailure::InternalServerError),
+            Self::RuntimeTurnFailedResponseStreamConnectionFailed => {
+                Some(TurnFailure::ResponseStreamConnectionFailed)
+            }
+            Self::RuntimeTurnFailedResponseStreamDisconnected => {
+                Some(TurnFailure::ResponseStreamDisconnected)
+            }
+            Self::RuntimeTurnFailedResponseTooManyFailedAttempts => {
+                Some(TurnFailure::ResponseTooManyFailedAttempts)
+            }
+            Self::RuntimeTurnFailedUnauthorized => Some(TurnFailure::Unauthorized),
+            Self::RuntimeTurnFailedUnknown => Some(TurnFailure::Unknown),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum TurnFailure {
+    Generic,
+    ContextWindowExceeded,
+    InternalServerError,
+    ResponseStreamConnectionFailed,
+    ResponseStreamDisconnected,
+    ResponseTooManyFailedAttempts,
+    Unauthorized,
+    Unknown,
 }


### PR DESCRIPTION
## Summary

- classify Codex `contextWindowExceeded` as `context_window_exceeded`
- classify Codex stream connection and disconnection variants as `response_connection_lost`
- exercise supported and intentionally generic structured variants through the Codex app-server integration boundary

## Scope

- preserves the legacy context-window message fallback for mixed-version deployments
- keeps ambiguous, authentication-unspecific, and unknown structured errors generic
- does not change UI behavior, API contracts, database state, or the guest-contract failure-reason enum

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent -p guest-mock-codex --all-targets --all-features`
- `cargo doc -p guest-agent -p guest-mock-codex --all-features --no-deps`
- `cargo test -p guest-agent --test codex_app_server_backend_structured_errors`
- `cargo test -p guest-agent -p guest-mock-codex`
- repository pre-commit Rust formatting, Clippy, documentation, and file-size checks

Closes #30323

Parent context: #30318
