### PR TITLE
refactor: remove teams integration feature switch

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/teams-connect-page.ts
+++ b/turbo/apps/platform/src/signals/okou-page/teams-connect-page.ts
@@ -1,25 +1,15 @@
 import { command } from "ccstate";
 import { createElement } from "react";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { i18n } from "../../i18n/index.ts";
 import { TeamsConnectPage } from "../../views/okou-page/teams-connect-page.tsx";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
-import { detachedNavigateTo$ } from "../route.ts";
-import { ROUTES } from "../route-paths.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "./onboard-guard.ts";
 import { initTeamsConnectPage$ } from "./teams-connect-signals.ts";
 
 export const setupTeamsConnectPage$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    const features = get(featureSwitch$);
-    if (!features[FeatureSwitchKey.TeamsIntegration]) {
-      set(detachedNavigateTo$, ROUTES.home, { replace: true });
-      return;
-    }
-
+  async ({ set }, signal: AbortSignal) => {
     if (await set(onboardGuard$, signal)) {
       return;
     }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/teams-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/teams-connect-page.test.tsx
@@ -1,5 +1,4 @@
 import { teamsConnectContract } from "@okouai/api-contracts/contracts/teams-connect";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -13,7 +12,6 @@ function setupTeamsPage(path: string): void {
   detachedSetupPage({
     context,
     path,
-    featureSwitches: { [FeatureSwitchKey.TeamsIntegration]: true },
   });
 }
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/works-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/works-page.test.tsx
@@ -117,7 +117,6 @@ function mockFeishuAPI(overrides: Partial<FeishuConnectStatus> = {}): void {
 
 function setupWorksPage(
   options: {
-    teamsEnabled?: boolean;
     feishuEnabled?: boolean;
     strapiEnabled?: boolean;
   } = {},
@@ -126,7 +125,6 @@ function setupWorksPage(
     context,
     path: "/works",
     featureSwitches: {
-      [FeatureSwitchKey.TeamsIntegration]: options.teamsEnabled ?? false,
       [FeatureSwitchKey.FeishuIntegration]: options.feishuEnabled ?? false,
       [FeatureSwitchKey.StrapiIntegration]: options.strapiEnabled ?? false,
     },
@@ -283,7 +281,7 @@ describe("works page", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Slack")).toBeInTheDocument();
-      expect(screen.queryByText("Microsoft Teams")).not.toBeInTheDocument();
+      expect(screen.getByText("Microsoft Teams")).toBeInTheDocument();
       expect(screen.queryByText("Feishu")).not.toBeInTheDocument();
       expect(screen.queryByText("Strapi")).not.toBeInTheDocument();
       expect(screen.getByText("GitHub")).toBeInTheDocument();
@@ -407,7 +405,7 @@ describe("works page", () => {
     });
   });
 
-  it("shows Microsoft Teams status when the Teams integration is enabled", async () => {
+  it("shows Microsoft Teams status", async () => {
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
     mockTeamsAPI({
       isConnected: true,
@@ -417,7 +415,7 @@ describe("works page", () => {
       teamName: "Core Team",
     });
 
-    setupWorksPage({ teamsEnabled: true });
+    setupWorksPage();
 
     await waitFor(() => {
       expect(screen.getByText("Microsoft Teams")).toBeInTheDocument();
@@ -1114,7 +1112,7 @@ describe("works page", () => {
       teamName: null,
     });
 
-    setupWorksPage({ teamsEnabled: true });
+    setupWorksPage();
 
     await waitFor(() => {
       expect(screen.getByText("Microsoft Teams")).toBeInTheDocument();
@@ -1130,7 +1128,7 @@ describe("works page", () => {
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
     mockTeamsAPI({ isConnected: false, isInstalled: false, isAdmin: true });
 
-    setupWorksPage({ teamsEnabled: true });
+    setupWorksPage();
 
     const installButton = await screen.findByTestId("teams-install-button");
     expect(installButton).toHaveTextContent("Install in Teams");
@@ -1155,7 +1153,7 @@ describe("works page", () => {
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
     mockTeamsAPI({ isConnected: false, isInstalled: true, isAdmin: true });
 
-    setupWorksPage({ teamsEnabled: true });
+    setupWorksPage();
 
     const connectButton = await screen.findByTestId("teams-connect-button");
     expect(connectButton).toHaveTextContent("Connect");
@@ -1168,7 +1166,7 @@ describe("works page", () => {
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
     mockTeamsAPI({ isConnected: false, isInstalled: true, isAdmin: true });
 
-    setupWorksPage({ teamsEnabled: true });
+    setupWorksPage();
 
     click(await screen.findByLabelText("More Microsoft Teams options"));
     click(await screen.findByLabelText("Uninstall Microsoft Teams"));

--- a/turbo/apps/platform/src/views/okou-page/works-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/works-page.tsx
@@ -898,7 +898,6 @@ export function WorksPage() {
   const { t } = useTranslation();
   const assistantName = useGet(assistantName$);
   const features = useGet(featureSwitch$);
-  const teamsEnabled = features[FeatureSwitchKey.TeamsIntegration] ?? false;
   const feishuEnabled = features[FeatureSwitchKey.FeishuIntegration] ?? false;
   const strapiEnabled = features[FeatureSwitchKey.StrapiIntegration] ?? false;
   const displayNameLoadable = useLoadable(currentChatAgentDisplayName$);
@@ -933,7 +932,7 @@ export function WorksPage() {
       <main className="flex-1 overflow-auto px-4 sm:px-6 pt-3 pb-8">
         <div className="mx-auto max-w-[900px] flex flex-col gap-4">
           <SlackCard displayName={displayName} />
-          {teamsEnabled ? <TeamsCard displayName={displayName} /> : null}
+          <TeamsCard displayName={displayName} />
           <GithubCard />
           {feishuEnabled ? <FeishuCard /> : null}
           {strapiEnabled ? <StrapiCard /> : null}

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -11,7 +11,6 @@ import {
 describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
-    expect(isFeatureEnabled(FeatureSwitchKey.TeamsIntegration, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.MetaAdsConnector, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.ChatForward, {})).toBe(true);
   });

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -59,7 +59,6 @@ export enum FeatureSwitchKey {
   PersonalModelProviderAccounts = "personalModelProviderAccounts",
   ConnectorAccounts = "connectorAccounts",
   ConcurrencyMemberUsage = "concurrencyMemberUsage",
-  TeamsIntegration = "teamsIntegration",
   FeishuIntegration = "feishuIntegration",
   StrapiIntegration = "strapiIntegration",
   WorkflowConnectorReadiness = "workflowConnectorReadiness",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -414,12 +414,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.TeamsIntegration]: {
-    maintainer: "linghan@vm0.ai",
-    description:
-      "Show standalone Microsoft Teams integration settings, connect flows, and Works page entry points.",
-    enabled: true,
-  },
   [FeatureSwitchKey.FeishuIntegration]: {
     maintainer: "linghan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- remove the `teamsIntegration` feature-switch key and registry entry
- keep the fully rolled out Microsoft Teams behavior permanently enabled
- render the Teams card unconditionally and allow the Teams connect page without a feature-switch guard
- remove the obsolete switch overrides and disabled-state assertion from the affected tests

## Terminal state and evidence

- Terminal state: `fully-rolled-out`
- Decision basis: the user explicitly requested a full rollout cleanup; commit `285dd56871` / PR #25137 already enabled the switch globally on `main`
- Introducing commit: `242e261462` / PR #19570
- Commit comparison: the introducing commit added two switch-controlled fallbacks: hiding the Works-page Teams card and redirecting the Teams connect page home. Its parent had no Teams settings UI. The permanent enabled behavior therefore retains the Teams UI and removes only those disabled-state branches.

## Behavior retained and removed

Retained:

- Microsoft Teams card and status/actions on the Works page
- Microsoft Teams browser connect/settings page
- existing Teams API, signals, assets, translations, mocks, and product-behavior tests

Removed:

- `FeatureSwitchKey.TeamsIntegration` and its registry metadata
- the Works-page conditional rendering fallback
- the Teams connect-page redirect used only when the switch was off
- switch-specific test overrides, the disabled-card assertion, and the globally-enabled registry assertion

## Repository sweep

- Exact searches: `FeatureSwitchKey.TeamsIntegration`, `teamsIntegration`, `teamsEnabled`
- Variant searches: `teamsintegration`, `teams_integration`, `teams-integration`, the registry description, and Teams/feature/switch proximity patterns
- Remaining variant matches are product terms or unrelated Teams agent/model switching behavior, not feature-switch consumers

## Knip

- Baseline: `pnpm knip` reported only 50 existing configuration hints
- After: `pnpm knip` reported the same 50 configuration hints, with no new unused files, exports, types, or dependencies

## Tests and verification

- `pnpm exec prettier --write` on all changed files
- `pnpm turbo run lint check-types --filter=@okouai/core --filter=@okouai/app --concurrency=2`
- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts --maxWorkers=1 --silent=passed-only` (27 passed)
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/teams-connect-page.test.tsx src/views/okou-page/__tests__/works-page.test.tsx --maxWorkers=2 --silent=passed-only` (27 passed)
- `git diff --check`
- exact-key and second-round repository searches described above

Full repository-wide checks remain delegated to the PR pipeline.
