### PR TITLE
fix(guest-agent): atomically persist checkpoint completion

### DIFF
--- a/crates/guest-agent/src/checkpoint/mod.rs
+++ b/crates/guest-agent/src/checkpoint/mod.rs
@@ -1,18 +1,19 @@
-//! Checkpoint creation — reads session history and calls checkpoint API.
+//! Checkpoint preparation and post-completion local reconciliation.
 
 mod artifact;
 mod session_history;
 
-use crate::constants;
 use crate::env;
 use crate::error::AgentError;
 use crate::http::HttpClient;
 use crate::run_context::GuestRuntime;
 use crate::session_metadata::CapturedSessionMetadata;
-use api_contracts::generated::types::webhooks::agent::checkpoints;
+use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
+use api_contracts::generated::types::webhooks::agent::{checkpoints, complete};
+use guest_common::log_info;
 use guest_common::telemetry::record_sandbox_op;
-use guest_common::{log_error, log_info, log_warn};
 use std::borrow::Cow;
+use std::time::{Duration, Instant};
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
@@ -42,28 +43,6 @@ impl CheckpointMode {
     }
 }
 
-/// Log the message, record a failed `sandbox_op`, and build a matching
-/// `Checkpoint` error. Success-path checkpoint failures are run-fatal and
-/// logged as errors; recovery checkpoint skips are best-effort and stay warn.
-fn fail(
-    mode: CheckpointMode,
-    op: &str,
-    start: std::time::Instant,
-    msg: impl Into<String>,
-) -> AgentError {
-    let msg = msg.into();
-    record_failure(mode, op, start, &msg);
-    AgentError::Checkpoint(msg)
-}
-
-fn record_failure(mode: CheckpointMode, op: &str, start: std::time::Instant, msg: &str) {
-    match mode {
-        CheckpointMode::Success => log_error!(LOG_TAG, "{msg}"),
-        CheckpointMode::Recovery => log_warn!(LOG_TAG, "{msg}"),
-    }
-    record_sandbox_op(op, start.elapsed(), false, Some(msg));
-}
-
 struct CheckpointInputs<'a> {
     run_id: &'a str,
     framework: env::Framework,
@@ -91,97 +70,197 @@ impl<'a> CheckpointInputs<'a> {
     }
 }
 
-/// Create a checkpoint after a successful run using the explicit runtime snapshot.
-pub async fn create_checkpoint_for_runtime(
-    runtime: &GuestRuntime,
-    session_metadata: &CapturedSessionMetadata,
-) -> Result<(), AgentError> {
-    let inputs = CheckpointInputs::from_runtime(runtime, session_metadata);
-    create_checkpoint_with_inputs(&runtime.http, &inputs).await
+/// Checkpoint metadata and local state awaiting atomic completion acknowledgement.
+pub struct PreparedCheckpoint {
+    request: complete::RequestCheckpoint,
+    mode: CheckpointMode,
+    uploaded_history: Option<session_history::UploadedCheckpointSessionHistory>,
+    framework: env::Framework,
+    final_session_history_identity_file: String,
+    total_started_at: Instant,
 }
 
-/// Create a checkpoint with bounded session-history limits for integration tests.
+impl PreparedCheckpoint {
+    pub(crate) fn request(&self) -> &complete::RequestCheckpoint {
+        &self.request
+    }
+
+    pub(crate) fn acknowledge(self, api_elapsed: Duration) {
+        record_sandbox_op("checkpoint_api_call", api_elapsed, true, None);
+        if let Some(uploaded_history) = self.uploaded_history
+            && session_history::reconcile_live_history_after_checkpoint(
+                uploaded_history.live_history,
+            )
+        {
+            session_history::write_final_session_history_identity(
+                self.mode,
+                &uploaded_history.cli_agent_session_id,
+                &uploaded_history.history_hash,
+                uploaded_history.history_size,
+                &uploaded_history.history_source,
+                self.framework,
+                &self.final_session_history_identity_file,
+            );
+        }
+        log_info!(LOG_TAG, "{} persisted successfully", self.mode.log_label());
+        record_sandbox_op(
+            self.mode.total_op(),
+            self.total_started_at.elapsed(),
+            true,
+            None,
+        );
+    }
+
+    pub(crate) fn record_persistence_failure(self, api_elapsed: Duration) {
+        record_sandbox_op("checkpoint_api_call", api_elapsed, false, None);
+        record_sandbox_op(
+            self.mode.total_op(),
+            self.total_started_at.elapsed(),
+            false,
+            None,
+        );
+    }
+}
+
+/// Prepare a checkpoint after a successful run using the explicit runtime snapshot.
+pub async fn prepare_checkpoint_for_runtime(
+    runtime: &GuestRuntime,
+    session_metadata: &CapturedSessionMetadata,
+) -> Result<PreparedCheckpoint, AgentError> {
+    let inputs = CheckpointInputs::from_runtime(runtime, session_metadata);
+    prepare_checkpoint_with_inputs(&runtime.http, &inputs).await
+}
+
+/// Prepare a checkpoint with bounded session-history limits for integration tests.
 #[doc(hidden)]
-pub async fn create_checkpoint_for_runtime_with_history_limits_for_test(
+pub async fn prepare_checkpoint_for_runtime_with_history_limits_for_test(
     runtime: &GuestRuntime,
     session_metadata: &CapturedSessionMetadata,
     candidate_max_bytes: u64,
     checkpoint_max_bytes: u64,
-) -> Result<(), AgentError> {
+) -> Result<PreparedCheckpoint, AgentError> {
     let mut inputs = CheckpointInputs::from_runtime(runtime, session_metadata);
     inputs.session_history_limits =
         session_history::CheckpointSessionHistoryLimits::BoundedForTest {
             candidate_max_bytes,
             checkpoint_max_bytes,
         };
-    create_checkpoint_with_inputs(&runtime.http, &inputs).await
+    prepare_checkpoint_with_inputs(&runtime.http, &inputs).await
 }
 
-/// Create a best-effort recovery checkpoint using the explicit runtime snapshot.
-pub async fn create_recovery_checkpoint_for_runtime(
+/// Prepare a best-effort recovery checkpoint using the explicit runtime snapshot.
+pub async fn prepare_recovery_checkpoint_for_runtime(
     runtime: &GuestRuntime,
     session_metadata: &CapturedSessionMetadata,
-) -> Result<(), AgentError> {
+) -> Result<PreparedCheckpoint, AgentError> {
     let inputs = CheckpointInputs::from_runtime(runtime, session_metadata);
-    create_recovery_checkpoint_with_inputs(&runtime.http, &inputs).await
+    prepare_recovery_checkpoint_with_inputs(&runtime.http, &inputs).await
 }
 
-/// Create a recovery checkpoint with bounded session-history limits for integration tests.
+/// Prepare a recovery checkpoint with bounded session-history limits for integration tests.
 #[doc(hidden)]
-pub async fn create_recovery_checkpoint_for_runtime_with_history_limits_for_test(
+pub async fn prepare_recovery_checkpoint_for_runtime_with_history_limits_for_test(
     runtime: &GuestRuntime,
     session_metadata: &CapturedSessionMetadata,
     candidate_max_bytes: u64,
     checkpoint_max_bytes: u64,
-) -> Result<(), AgentError> {
+) -> Result<PreparedCheckpoint, AgentError> {
     let mut inputs = CheckpointInputs::from_runtime(runtime, session_metadata);
     inputs.session_history_limits =
         session_history::CheckpointSessionHistoryLimits::BoundedForTest {
             candidate_max_bytes,
             checkpoint_max_bytes,
         };
-    create_recovery_checkpoint_with_inputs(&runtime.http, &inputs).await
+    prepare_recovery_checkpoint_with_inputs(&runtime.http, &inputs).await
 }
 
-async fn create_checkpoint_with_inputs(
+async fn prepare_checkpoint_with_inputs(
     http: &HttpClient,
     inputs: &CheckpointInputs<'_>,
-) -> Result<(), AgentError> {
-    let start = std::time::Instant::now();
-    let result = create_checkpoint_impl(http, CheckpointMode::Success, inputs).await;
-    record_sandbox_op(
-        CheckpointMode::Success.total_op(),
-        start.elapsed(),
-        result.is_ok(),
-        None,
-    );
-    result
+) -> Result<PreparedCheckpoint, AgentError> {
+    prepare_checkpoint_for_mode(http, CheckpointMode::Success, inputs).await
 }
 
-async fn create_recovery_checkpoint_with_inputs(
+async fn prepare_recovery_checkpoint_with_inputs(
     http: &HttpClient,
     inputs: &CheckpointInputs<'_>,
-) -> Result<(), AgentError> {
-    let start = std::time::Instant::now();
-    let result = create_checkpoint_impl(http, CheckpointMode::Recovery, inputs).await;
-    record_sandbox_op(
-        CheckpointMode::Recovery.total_op(),
-        start.elapsed(),
-        result.is_ok(),
-        None,
-    );
-    result
+) -> Result<PreparedCheckpoint, AgentError> {
+    prepare_checkpoint_for_mode(http, CheckpointMode::Recovery, inputs).await
 }
 
-async fn create_checkpoint_impl(
+async fn prepare_checkpoint_for_mode(
     http: &HttpClient,
     mode: CheckpointMode,
     inputs: &CheckpointInputs<'_>,
-) -> Result<(), AgentError> {
-    log_info!(LOG_TAG, "Creating {}...", mode.log_label());
+) -> Result<PreparedCheckpoint, AgentError> {
+    let total_started_at = Instant::now();
+    let result = prepare_checkpoint_impl(http, mode, inputs).await;
+    if result.is_err() {
+        record_sandbox_op(mode.total_op(), total_started_at.elapsed(), false, None);
+    }
+    result.map(|prepared| PreparedCheckpoint {
+        request: prepared.request,
+        mode,
+        uploaded_history: prepared.uploaded_history,
+        framework: inputs.framework,
+        final_session_history_identity_file: inputs.final_session_history_identity_file.to_string(),
+        total_started_at,
+    })
+}
+
+struct PreparedCheckpointParts {
+    request: complete::RequestCheckpoint,
+    uploaded_history: Option<session_history::UploadedCheckpointSessionHistory>,
+}
+
+fn completion_history_disposition(
+    disposition: checkpoints::RequestCliAgentSessionHistoryDisposition,
+) -> complete::RequestCheckpointCliAgentSessionHistoryDisposition {
+    match disposition {
+        checkpoints::RequestCliAgentSessionHistoryDisposition::DiscardedOversized => {
+            complete::RequestCheckpointCliAgentSessionHistoryDisposition::DiscardedOversized
+        }
+        checkpoints::RequestCliAgentSessionHistoryDisposition::Unavailable => {
+            complete::RequestCheckpointCliAgentSessionHistoryDisposition::Unavailable
+        }
+    }
+}
+
+fn completion_missing_root_policy(
+    policy: ArtifactEntryMissingRootPolicy,
+) -> complete::RequestCheckpointArtifactSnapshotMissingRootPolicy {
+    match policy {
+        ArtifactEntryMissingRootPolicy::Fail => {
+            complete::RequestCheckpointArtifactSnapshotMissingRootPolicy::Fail
+        }
+        ArtifactEntryMissingRootPolicy::PreserveParentVersion => {
+            complete::RequestCheckpointArtifactSnapshotMissingRootPolicy::PreserveParentVersion
+        }
+    }
+}
+
+fn completion_artifact_snapshot(
+    snapshot: checkpoints::ArtifactSnapshot,
+) -> complete::RequestCheckpointArtifactSnapshot {
+    complete::RequestCheckpointArtifactSnapshot {
+        name: snapshot.name,
+        version: snapshot.version,
+        mount_path: snapshot.mount_path,
+        missing_root_policy: snapshot
+            .missing_root_policy
+            .map(completion_missing_root_policy),
+    }
+}
+
+async fn prepare_checkpoint_impl(
+    http: &HttpClient,
+    mode: CheckpointMode,
+    inputs: &CheckpointInputs<'_>,
+) -> Result<PreparedCheckpointParts, AgentError> {
+    log_info!(LOG_TAG, "Preparing {}...", mode.log_label());
 
     // History upload and artifact snapshots are independent pre-requisites
-    // of the final checkpoint API call, so run them concurrently. The history
+    // of the final combined completion, so run them concurrently. The history
     // path performs blocking local preparation before web API work; the
     // artifact path performs blocking file preparation before VAS work. Wait
     // for both results even after one fails so a started blocking operation is
@@ -196,105 +275,55 @@ async fn create_checkpoint_impl(
     let artifact_snapshots = artifact_snapshots?;
 
     let cli_agent_type = inputs.framework.agent_type();
-    let (payload, uploaded_history) = match checkpoint_history {
+    let (
+        cli_agent_session_id,
+        cli_agent_session_history_hash,
+        cli_agent_session_history_disposition,
+        uploaded_history,
+    ) = match checkpoint_history {
         session_history::CheckpointSessionHistory::Uploaded(history) => {
-            let payload = checkpoints::Request {
-                run_id: inputs.run_id.to_string(),
-                cli_agent_type: cli_agent_type.to_string(),
-                cli_agent_session_id: history.cli_agent_session_id.clone(),
-                cli_agent_session_history_hash: Some(history.history_hash.clone()),
-                cli_agent_session_history_disposition: None,
-                artifact_snapshots,
-                volume_versions_snapshot: None,
-            };
-            (payload, Some(history))
+            let session_id = history.cli_agent_session_id.clone();
+            let history_hash = history.history_hash.clone();
+            (session_id, Some(history_hash), None, Some(history))
         }
         session_history::CheckpointSessionHistory::DiscardedOversized {
             cli_agent_session_id,
-        } => {
-            let payload = checkpoints::Request {
-                run_id: inputs.run_id.to_string(),
-                cli_agent_type: cli_agent_type.to_string(),
-                cli_agent_session_id,
-                cli_agent_session_history_hash: None,
-                cli_agent_session_history_disposition: Some(
-                    checkpoints::RequestCliAgentSessionHistoryDisposition::DiscardedOversized,
-                ),
-                artifact_snapshots,
-                volume_versions_snapshot: None,
-            };
-            (payload, None)
-        }
+        } => (
+            cli_agent_session_id,
+            None,
+            Some(completion_history_disposition(
+                checkpoints::RequestCliAgentSessionHistoryDisposition::DiscardedOversized,
+            )),
+            None,
+        ),
         session_history::CheckpointSessionHistory::Unavailable {
             cli_agent_session_id,
-        } => {
-            let payload = checkpoints::Request {
-                run_id: inputs.run_id.to_string(),
-                cli_agent_type: cli_agent_type.to_string(),
-                cli_agent_session_id,
-                cli_agent_session_history_hash: None,
-                cli_agent_session_history_disposition: Some(
-                    checkpoints::RequestCliAgentSessionHistoryDisposition::Unavailable,
-                ),
-                artifact_snapshots,
-                volume_versions_snapshot: None,
-            };
-            (payload, None)
-        }
+        } => (
+            cli_agent_session_id,
+            None,
+            Some(completion_history_disposition(
+                checkpoints::RequestCliAgentSessionHistoryDisposition::Unavailable,
+            )),
+            None,
+        ),
     };
-
-    log_info!(LOG_TAG, "Calling checkpoint API...");
-    let api_start = std::time::Instant::now();
-    let url = http.checkpoint_url()?;
-    let result = match http
-        .post_json(url, &payload, constants::HTTP_MAX_ATTEMPTS)
-        .await
-    {
-        Ok(v) => v,
-        Err(e) => {
-            record_sandbox_op("checkpoint_api_call", api_start.elapsed(), false, None);
-            return Err(e);
-        }
+    let request = complete::RequestCheckpoint {
+        cli_agent_type: cli_agent_type.to_string(),
+        cli_agent_session_id,
+        cli_agent_session_history_hash,
+        cli_agent_session_history_disposition,
+        artifact_snapshots: artifact_snapshots.map(|snapshots| {
+            snapshots
+                .into_iter()
+                .map(completion_artifact_snapshot)
+                .collect()
+        }),
+        volume_versions_snapshot: None,
     };
-
-    let response = result.ok_or_else(|| {
-        fail(
-            mode,
-            "checkpoint_api_call",
-            api_start,
-            "Invalid checkpoint API response",
-        )
-    })?;
-    let response = serde_json::from_value::<checkpoints::Response>(response).map_err(|_| {
-        fail(
-            mode,
-            "checkpoint_api_call",
-            api_start,
-            "Invalid checkpoint API response",
-        )
-    })?;
-
-    if let Some(uploaded_history) = uploaded_history
-        && session_history::reconcile_live_history_after_checkpoint(uploaded_history.live_history)
-    {
-        session_history::write_final_session_history_identity(
-            mode,
-            &uploaded_history.cli_agent_session_id,
-            &uploaded_history.history_hash,
-            uploaded_history.history_size,
-            &uploaded_history.history_source,
-            inputs.framework,
-            inputs.final_session_history_identity_file.as_ref(),
-        );
-    }
-    log_info!(
-        LOG_TAG,
-        "{} created successfully: {}",
-        mode.log_label(),
-        response.checkpoint_id
-    );
-    record_sandbox_op("checkpoint_api_call", api_start.elapsed(), true, None);
-    Ok(())
+    Ok(PreparedCheckpointParts {
+        request,
+        uploaded_history,
+    })
 }
 
 #[cfg(test)]
@@ -353,7 +382,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn checkpoint_missing_mount_fails_before_final_checkpoint_api_call() {
+    async fn checkpoint_missing_mount_fails_before_final_completion() {
         let server = MockServer::start();
         let dir = tempfile::tempdir().unwrap();
         let guest_paths = crate::paths::GuestPaths::from_runtime_dir(dir.path().join("runtime"));
@@ -373,11 +402,6 @@ mod tests {
             when.method(POST)
                 .path("/api/webhooks/agent/storages/commit");
             then.status(200).json_body(json!({"unreachable": true}));
-        });
-        let checkpoint = server.mock(|when, then| {
-            when.method(POST).path("/api/webhooks/agent/checkpoints");
-            then.status(200)
-                .json_body(json!({"checkpointId": "unreachable", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
         });
         let http = HttpClient::with_api_config(
             server.base_url(),
@@ -409,9 +433,10 @@ mod tests {
                 .into(),
         };
 
-        let err = create_checkpoint_impl(&http, CheckpointMode::Success, &inputs)
+        let err = prepare_checkpoint_impl(&http, CheckpointMode::Success, &inputs)
             .await
-            .unwrap_err();
+            .err()
+            .expect("missing artifact mount should fail checkpoint preparation");
 
         assert!(
             err.to_string().contains("Failed to walk artifact files"),
@@ -419,7 +444,6 @@ mod tests {
         );
         prepare.assert_calls(0);
         commit.assert_calls(0);
-        checkpoint.assert_calls(0);
     }
 
     #[tokio::test]
@@ -468,18 +492,6 @@ mod tests {
             when.method(PUT).path("/test/session-history-upload");
             then.respond_with(move |req| session_history_upload_response(req, &expected_upload));
         });
-        let checkpoint = server.mock(|when, then| {
-            when.method(POST)
-                .path("/api/webhooks/agent/checkpoints")
-                .json_body(json!({
-                    "runId": "checkpoint-codex-zstd-reuse",
-                    "cliAgentType": "codex",
-                    "cliAgentSessionId": thread_id,
-                    "cliAgentSessionHistoryHash": history_hash,
-                }));
-            then.status(200)
-                .json_body(json!({"checkpointId": "checkpoint-codex-zstd", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
-        });
         let http = HttpClient::with_api_config(
             server.base_url(),
             "test-token",
@@ -512,12 +524,17 @@ mod tests {
                 .into(),
         };
 
-        create_checkpoint_impl(&http, CheckpointMode::Success, &inputs)
+        let prepared = prepare_checkpoint_impl(&http, CheckpointMode::Success, &inputs)
             .await
             .unwrap();
 
         prepare.assert_calls(1);
         upload.assert_calls(1);
-        checkpoint.assert_calls(1);
+        assert_eq!(prepared.request.cli_agent_type, "codex");
+        assert_eq!(prepared.request.cli_agent_session_id, thread_id);
+        assert_eq!(
+            prepared.request.cli_agent_session_history_hash.as_deref(),
+            Some(history_hash.as_str())
+        );
     }
 }

--- a/crates/guest-agent/src/complete.rs
+++ b/crates/guest-agent/src/complete.rs
@@ -35,6 +35,8 @@ struct CompletePayload<'a> {
     run_id: &'a str,
     exit_code: i32,
     #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     last_event_sequence: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     sandbox_id: Option<&'a str>,
@@ -72,6 +74,7 @@ fn as_optional_slice(values: &[String]) -> Option<&[String]> {
 pub async fn report_checkpoint_for_run(
     runtime: &GuestRuntime,
     exit_code: i32,
+    error: Option<&str>,
     last_event_sequence: Option<u32>,
     active_input_delivery_ids: &[String],
     checkpoint: PreparedCheckpoint,
@@ -82,6 +85,7 @@ pub async fn report_checkpoint_for_run(
         payload_for_runtime(
             runtime,
             exit_code,
+            error,
             last_event_sequence,
             active_input_delivery_ids,
             Some(checkpoint.request()),
@@ -147,6 +151,7 @@ pub async fn report_user_cancellation_for_run(
 fn payload_for_runtime<'a>(
     runtime: &'a GuestRuntime,
     exit_code: i32,
+    error: Option<&'a str>,
     last_event_sequence: Option<u32>,
     active_input_delivery_ids: &'a [String],
     checkpoint: Option<&'a complete::RequestCheckpoint>,
@@ -155,6 +160,7 @@ fn payload_for_runtime<'a>(
     CompletePayload {
         run_id: &config.run_id,
         exit_code,
+        error,
         last_event_sequence,
         sandbox_id: as_optional(&config.sandbox_id),
         sandbox_reuse_result: as_optional(&config.sandbox_reuse_result),
@@ -176,6 +182,7 @@ fn checkpointless_payload_for_run<'a>(
     CompletePayload {
         run_id,
         exit_code,
+        error: None,
         last_event_sequence,
         sandbox_id: as_optional(sandbox_id),
         sandbox_reuse_result: as_optional(sandbox_reuse_result),
@@ -204,6 +211,7 @@ mod tests {
         let payload = CompletePayload {
             run_id: "run-123",
             exit_code: 0,
+            error: None,
             last_event_sequence: None,
             sandbox_id: None,
             sandbox_reuse_result: None,
@@ -220,6 +228,7 @@ mod tests {
         let payload = CompletePayload {
             run_id: "run-123",
             exit_code: 0,
+            error: None,
             last_event_sequence: None,
             sandbox_id: Some("abc"),
             sandbox_reuse_result: Some("reused"),
@@ -240,6 +249,7 @@ mod tests {
         let payload = CompletePayload {
             run_id: "run-123",
             exit_code: 0,
+            error: None,
             last_event_sequence: None,
             sandbox_id: None,
             sandbox_reuse_result: Some("poolMiss"),
@@ -257,6 +267,7 @@ mod tests {
         let payload = CompletePayload {
             run_id: "run-123",
             exit_code: 0,
+            error: None,
             last_event_sequence: None,
             sandbox_id: Some("sid"),
             sandbox_reuse_result: None,
@@ -281,6 +292,7 @@ mod tests {
         let payload = CompletePayload {
             run_id: "run-123",
             exit_code: 0,
+            error: None,
             last_event_sequence: Some(7),
             sandbox_id: None,
             sandbox_reuse_result: None,

--- a/crates/guest-agent/src/complete.rs
+++ b/crates/guest-agent/src/complete.rs
@@ -2,13 +2,13 @@
 //!
 //! The runner also posts `/complete` after it observes the VM exit, but by
 //! then the run has incurred `final_telemetry`, VM teardown, stop/destroy,
-//! and host observation delays. The guest calls it after a successful
-//! checkpoint, or after a cancelled run's recovery attempt has returned. The
-//! runner's subsequent call is absorbed by the route's idempotency check.
+//! and host observation delays. The guest calls it with a prepared checkpoint
+//! after successful execution or recovery. The runner's subsequent call is
+//! absorbed by the route's idempotency check.
 //!
-//! Fire-and-forget semantics: a failure is logged and swallowed because the
-//! runner's fallback is the correctness guarantee. One attempt (matching
-//! telemetry) so a flaky network does not tie up VM shutdown.
+//! Checkpoint-bearing completion uses the checkpoint retry budget and returns
+//! failures to the caller. Checkpoint-less cancellation fallback remains
+//! fire-and-forget because the runner is its correctness guarantee.
 //!
 //! Trust model: sandbox and workspace metadata are relayed from
 //! runner-set env vars and included in the payload for analytics only. The
@@ -17,9 +17,15 @@
 //! could skew these values with no way for the runner to correct them. Do
 //! not treat these fields as authoritative for security decisions.
 
+use crate::checkpoint::PreparedCheckpoint;
+use crate::constants;
+use crate::error::AgentError;
 use crate::http::HttpClient;
+use crate::run_context::GuestRuntime;
+use api_contracts::generated::types::webhooks::agent::complete;
 use guest_common::{log_info, log_warn};
 use serde::Serialize;
+use std::time::Instant;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
@@ -38,6 +44,8 @@ struct CompletePayload<'a> {
     workspace_reuse_result: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     active_input_delivery_ids: Option<&'a [String]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    checkpoint: Option<&'a complete::RequestCheckpoint>,
 }
 
 fn as_optional(value: &str) -> Option<&str> {
@@ -48,8 +56,7 @@ fn as_optional_slice(values: &[String]) -> Option<&[String]> {
     (!values.is_empty()).then_some(values)
 }
 
-/// Report a successful run to the host after
-/// `checkpoint::create_checkpoint_for_runtime()` succeeds.
+/// Atomically persist a prepared checkpoint and complete the run.
 ///
 /// Sandbox and workspace reuse fields are relayed analytics values;
 /// empty strings are serialized as absent so an unset env var is equivalent
@@ -59,30 +66,41 @@ fn as_optional_slice(values: &[String]) -> Option<&[String]> {
 /// events webhook POST succeeded. The host persists it on the run, and clients
 /// use it as a terminal event-drain watermark after observing terminal status.
 ///
-/// Fire-and-forget. Returns `()` and never propagates errors — the runner's
-/// fallback call covers any failure here.
-pub async fn report_success_for_run(
-    http: &HttpClient,
-    run_id: &str,
-    sandbox_id: &str,
-    sandbox_reuse_result: &str,
-    workspace_reuse_result: &str,
+/// This uses the checkpoint request's retry budget and propagates failure so a
+/// successful execution can return nonzero rather than silently lose
+/// persistence. Recovery callers may handle the same error as best-effort.
+pub async fn report_checkpoint_for_run(
+    runtime: &GuestRuntime,
+    exit_code: i32,
     last_event_sequence: Option<u32>,
     active_input_delivery_ids: &[String],
-) {
-    report_payload(
-        http,
-        payload_for_run(
-            run_id,
-            0,
-            sandbox_id,
-            sandbox_reuse_result,
-            workspace_reuse_result,
+    checkpoint: PreparedCheckpoint,
+) -> Result<(), AgentError> {
+    let api_started_at = Instant::now();
+    let result = report_payload(
+        &runtime.http,
+        payload_for_runtime(
+            runtime,
+            exit_code,
             last_event_sequence,
             active_input_delivery_ids,
+            Some(checkpoint.request()),
         ),
+        constants::HTTP_MAX_ATTEMPTS,
     )
     .await;
+    let api_elapsed = api_started_at.elapsed();
+    match result {
+        Ok(()) => {
+            checkpoint.acknowledge(api_elapsed);
+            log_info!(LOG_TAG, "Complete webhook acknowledged");
+            Ok(())
+        }
+        Err(error) => {
+            checkpoint.record_persistence_failure(api_elapsed);
+            Err(error)
+        }
+    }
 }
 
 /// Report an explicit user cancellation after its recovery-checkpoint attempt.
@@ -98,9 +116,13 @@ pub async fn report_user_cancellation_for_run(
     last_event_sequence: Option<u32>,
     active_input_delivery_ids: &[String],
 ) {
-    report_payload(
+    if !http.has_api() {
+        return;
+    }
+
+    if let Err(error) = report_payload(
         http,
-        payload_for_run(
+        checkpointless_payload_for_run(
             run_id,
             1,
             sandbox_id,
@@ -109,11 +131,40 @@ pub async fn report_user_cancellation_for_run(
             last_event_sequence,
             active_input_delivery_ids,
         ),
+        1,
     )
-    .await;
+    .await
+    {
+        log_warn!(
+            LOG_TAG,
+            "Complete webhook failed (runner will retry): {error}"
+        );
+        return;
+    }
+    log_info!(LOG_TAG, "Complete webhook acknowledged");
 }
 
-fn payload_for_run<'a>(
+fn payload_for_runtime<'a>(
+    runtime: &'a GuestRuntime,
+    exit_code: i32,
+    last_event_sequence: Option<u32>,
+    active_input_delivery_ids: &'a [String],
+    checkpoint: Option<&'a complete::RequestCheckpoint>,
+) -> CompletePayload<'a> {
+    let config = &runtime.config;
+    CompletePayload {
+        run_id: &config.run_id,
+        exit_code,
+        last_event_sequence,
+        sandbox_id: as_optional(&config.sandbox_id),
+        sandbox_reuse_result: as_optional(&config.sandbox_reuse_result),
+        workspace_reuse_result: as_optional(&config.workspace_reuse_result),
+        active_input_delivery_ids: as_optional_slice(active_input_delivery_ids),
+        checkpoint,
+    }
+}
+
+fn checkpointless_payload_for_run<'a>(
     run_id: &'a str,
     exit_code: i32,
     sandbox_id: &'a str,
@@ -130,27 +181,18 @@ fn payload_for_run<'a>(
         sandbox_reuse_result: as_optional(sandbox_reuse_result),
         workspace_reuse_result: as_optional(workspace_reuse_result),
         active_input_delivery_ids: as_optional_slice(active_input_delivery_ids),
+        checkpoint: None,
     }
 }
 
-async fn report_payload(http: &HttpClient, payload: CompletePayload<'_>) {
-    if !http.has_api() {
-        return;
-    }
-
-    // 1 attempt — the runner's fallback is the safety net. Retrying from the
-    // guest just delays VM exit without improving the outcome.
-    let url = match http.complete_url() {
-        Ok(url) => url,
-        Err(e) => {
-            log_warn!(LOG_TAG, "Complete webhook skipped: {e}");
-            return;
-        }
-    };
-    match http.post_json(url, &payload, 1).await {
-        Ok(_) => log_info!(LOG_TAG, "Complete webhook acknowledged"),
-        Err(e) => log_warn!(LOG_TAG, "Complete webhook failed (runner will retry): {e}"),
-    }
+async fn report_payload(
+    http: &HttpClient,
+    payload: CompletePayload<'_>,
+    max_attempts: u32,
+) -> Result<(), AgentError> {
+    let url = http.complete_url()?;
+    http.post_json(url, &payload, max_attempts).await?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -167,6 +209,7 @@ mod tests {
             sandbox_reuse_result: None,
             workspace_reuse_result: None,
             active_input_delivery_ids: None,
+            checkpoint: None,
         };
         let json = serde_json::to_string(&payload).unwrap();
         assert_eq!(json, r#"{"runId":"run-123","exitCode":0}"#);
@@ -182,6 +225,7 @@ mod tests {
             sandbox_reuse_result: Some("reused"),
             workspace_reuse_result: Some("sandboxReused"),
             active_input_delivery_ids: None,
+            checkpoint: None,
         };
         let json = serde_json::to_string(&payload).unwrap();
         assert!(json.contains(r#""sandboxId":"abc""#));
@@ -201,6 +245,7 @@ mod tests {
             sandbox_reuse_result: Some("poolMiss"),
             workspace_reuse_result: None,
             active_input_delivery_ids: None,
+            checkpoint: None,
         };
         let json = serde_json::to_string(&payload).unwrap();
         assert!(!json.contains("sandboxId"));
@@ -217,6 +262,7 @@ mod tests {
             sandbox_reuse_result: None,
             workspace_reuse_result: Some("cacheMiss"),
             active_input_delivery_ids: None,
+            checkpoint: None,
         };
         let json = serde_json::to_string(&payload).unwrap();
         assert!(json.contains(r#""sandboxId":"sid""#));
@@ -240,6 +286,7 @@ mod tests {
             sandbox_reuse_result: None,
             workspace_reuse_result: None,
             active_input_delivery_ids: None,
+            checkpoint: None,
         };
         let json = serde_json::to_string(&payload).unwrap();
         assert_eq!(

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -116,7 +116,6 @@ struct ApiHttpConfig {
 #[derive(Clone)]
 struct ApiUrls {
     events: String,
-    checkpoint: String,
     complete: String,
     heartbeat: String,
     telemetry: String,
@@ -305,10 +304,6 @@ impl HttpClient {
         Ok(&self.api_config()?.urls.events)
     }
 
-    pub(crate) fn checkpoint_url(&self) -> Result<&str, AgentError> {
-        Ok(&self.api_config()?.urls.checkpoint)
-    }
-
     pub(crate) fn complete_url(&self) -> Result<&str, AgentError> {
         Ok(&self.api_config()?.urls.complete)
     }
@@ -379,7 +374,6 @@ impl ApiUrls {
     fn new(base_url: &str) -> Self {
         Self {
             events: urls::events_url(base_url),
-            checkpoint: urls::checkpoint_url(base_url),
             complete: urls::complete_url(base_url),
             heartbeat: urls::heartbeat_url(base_url),
             telemetry: urls::telemetry_url(base_url),

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -825,6 +825,7 @@ async fn complete_execution(
                 let result = complete::report_checkpoint_for_run(
                     runtime,
                     0,
+                    None,
                     state.last_event_sequence,
                     state.active_input_delivery_ids,
                     checkpoint,
@@ -895,6 +896,7 @@ async fn complete_execution(
                         match complete::report_checkpoint_for_run(
                             runtime,
                             exit_code,
+                            state.failure_message,
                             state.last_event_sequence,
                             state.active_input_delivery_ids,
                             checkpoint,
@@ -1982,7 +1984,7 @@ mod tests {
             when.method(POST)
                 .path("/api/webhooks/agent/complete")
                 .json_body_includes(
-                    r#"{"exitCode":1,"checkpoint":{"cliAgentSessionId":"recovery-session-from-main"}}"#,
+                    r#"{"exitCode":1,"error":"You've hit your usage limit.","checkpoint":{"cliAgentSessionId":"recovery-session-from-main"}}"#,
                 );
             then.status(200)
                 .header("Content-Type", "application/json")

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -790,6 +790,13 @@ async fn complete_execution(
         log_info!(LOG_TAG, "✗ Execution failed ({}s)", cli_elapsed.as_secs());
     }
 
+    let user_cancelled = state
+        .failure_diagnostic
+        .as_ref()
+        .and_then(|diagnostic| diagnostic.cli_termination.as_ref())
+        .is_some_and(|termination| termination.reason == CliTerminationReason::UserCancellation);
+    let mut guest_completion_reported = false;
+
     // Checkpoint on success (skip when no API — local/test mode). The
     // pre-checkpoint flush runs in `tokio::join!` with the snapshot work so
     // its ~1s upload overlaps the ~4s checkpoint. The EOF-consuming final
@@ -805,41 +812,48 @@ async fn complete_execution(
             let session_metadata = state.session_metadata.ok_or_else(|| {
                 AgentError::Checkpoint("No valid CLI session ID was captured".to_string())
             })?;
-            checkpoint::create_checkpoint_for_runtime(runtime, session_metadata).await
+            checkpoint::prepare_checkpoint_for_runtime(runtime, session_metadata).await
         };
         let (cp_result, _) = tokio::join!(checkpoint, telemetry.flush(UploadMode::Live),);
         match cp_result {
-            Ok(()) => {
-                log_info!(
-                    LOG_TAG,
-                    "✓ Checkpoint complete ({}s)",
-                    cp_start.elapsed().as_secs()
-                );
-
-                // Checkpoint row is in the DB — the complete route's only
-                // hard dependency is satisfied. Fire /complete now so the
-                // host's `last_event_to_complete` timestamp isn't stretched
-                // by VM teardown + runner fallback (which used to be the
-                // only trigger). Runner still posts /complete after VM
+            Ok(checkpoint) => {
+                // Persist the prepared checkpoint and terminal state together
+                // before returning to the top-level final telemetry pass. The
+                // runner still posts a checkpoint-less /complete after VM
                 // exit; its call is idempotency-short-circuited.
-                //
-                // Serialize /complete before returning to the top-level final
-                // telemetry pass so the ack log line lands in the file before
-                // the telemetry uploader snapshots its EOF. The
-                // ~hundreds-of-ms we pay for serialization is invisible to
-                // users because the host's status transition already happened
-                // the moment /complete returned.
                 log_info!(LOG_TAG, "▷ Cleanup");
-                complete::report_success_for_run(
-                    http,
-                    &config.run_id,
-                    &config.sandbox_id,
-                    &config.sandbox_reuse_result,
-                    &config.workspace_reuse_result,
+                let result = complete::report_checkpoint_for_run(
+                    runtime,
+                    0,
                     state.last_event_sequence,
                     state.active_input_delivery_ids,
+                    checkpoint,
                 )
                 .await;
+                match result {
+                    Ok(()) => {
+                        guest_completion_reported = true;
+                        log_info!(
+                            LOG_TAG,
+                            "✓ Checkpoint complete ({}s)",
+                            cp_start.elapsed().as_secs()
+                        );
+                    }
+                    Err(e) => {
+                        record_persistence_failure(
+                            PersistenceFailure {
+                                label: "Checkpoint",
+                                error: &e,
+                                elapsed: cp_start.elapsed(),
+                                cli_exit_code,
+                                wrote_failure_diagnostic,
+                            },
+                            runtime,
+                            state.session_metadata,
+                        );
+                        exit_code = 1;
+                    }
+                }
             }
             Err(e) => {
                 record_persistence_failure(
@@ -874,10 +888,28 @@ async fn complete_execution(
         if http.has_api() {
             if let Some(session_metadata) = state.session_metadata {
                 log_info!(LOG_TAG, "Attempting best-effort recovery checkpoint");
-                match checkpoint::create_recovery_checkpoint_for_runtime(runtime, session_metadata)
+                match checkpoint::prepare_recovery_checkpoint_for_runtime(runtime, session_metadata)
                     .await
                 {
-                    Ok(()) => log_info!(LOG_TAG, "Recovery checkpoint created"),
+                    Ok(checkpoint) => {
+                        match complete::report_checkpoint_for_run(
+                            runtime,
+                            exit_code,
+                            state.last_event_sequence,
+                            state.active_input_delivery_ids,
+                            checkpoint,
+                        )
+                        .await
+                        {
+                            Ok(()) => {
+                                guest_completion_reported = true;
+                                log_info!(LOG_TAG, "Recovery checkpoint created");
+                            }
+                            Err(e) => {
+                                log_warn!(LOG_TAG, "Recovery checkpoint skipped: {e}");
+                            }
+                        }
+                    }
                     Err(e) => log_warn!(LOG_TAG, "Recovery checkpoint skipped: {e}"),
                 }
             } else {
@@ -891,12 +923,7 @@ async fn complete_execution(
         log_info!(LOG_TAG, "▷ Cleanup");
     }
 
-    if state
-        .failure_diagnostic
-        .as_ref()
-        .and_then(|diagnostic| diagnostic.cli_termination.as_ref())
-        .is_some_and(|termination| termination.reason == CliTerminationReason::UserCancellation)
-    {
+    if user_cancelled && !guest_completion_reported {
         complete::report_user_cancellation_for_run(
             http,
             &config.run_id,
@@ -1534,6 +1561,18 @@ mod tests {
     }
 
     #[test]
+    fn complete_execution_treats_combined_report_failure_as_checkpoint_failure() {
+        let _test_state_guard = lock_test_state();
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(
+                complete_execution_treats_combined_report_failure_as_checkpoint_failure_inner(),
+            );
+    }
+
+    #[test]
     fn complete_execution_keeps_workload_resource_counters_out_of_messages() {
         let _test_state_guard = lock_test_state();
         tokio::runtime::Builder::new_current_thread()
@@ -1754,6 +1793,75 @@ mod tests {
         }
     }
 
+    async fn complete_execution_treats_combined_report_failure_as_checkpoint_failure_inner() {
+        let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
+        server.reset_async().await;
+        let _env_guard = unsafe { set_test_env(server, Some("/combined-checkpoint-failure")) };
+        let guest_paths = test_guest_paths();
+
+        let cleanup_paths = run_scoped_cleanup_paths(&guest_paths, true);
+        for path in &cleanup_paths {
+            let _ = std::fs::remove_file(path);
+        }
+
+        let complete_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/complete")
+                .json_body_includes(
+                    r#"{"exitCode":0,"checkpoint":{"cliAgentSessionId":"combined-failure-session"}}"#,
+                );
+            then.status(500);
+        });
+        let _telemetry_mock = server.mock(|when, then| {
+            when.method(POST).path("/api/webhooks/agent/telemetry");
+            then.status(200)
+                .header("Content-Type", "application/json")
+                .json_body(json!({}));
+        });
+
+        let config = test_guest_config(server, Some("/combined-checkpoint-failure"));
+        let masker = Arc::new(masker::SecretMasker::from_config(&config));
+        let http = test_http_client(server);
+        let telemetry =
+            Telemetry::spawn_for_paths(config.run_id.clone(), &guest_paths, masker, http.clone());
+        let runtime = test_guest_runtime(config, http);
+        let session_metadata =
+            session_metadata::CapturedSessionMetadata::for_test("combined-failure-session", None);
+        let exit_code = complete_execution(
+            0,
+            0,
+            Duration::ZERO,
+            CompletionState {
+                last_event_sequence: None,
+                failure_message: None,
+                failure_diagnostic: None,
+                active_input_delivery_ids: &[],
+                session_metadata: Some(&session_metadata),
+            },
+            &telemetry,
+            &runtime,
+        )
+        .await;
+        telemetry.shutdown().await;
+
+        assert_eq!(exit_code, 1);
+        complete_mock.assert_calls_async(3).await;
+        let error = std::fs::read_to_string(guest_paths.checkpoint_error_file()).unwrap();
+        assert!(
+            error.contains("POST failed after 3 attempts"),
+            "got: {error}"
+        );
+        let diagnostic: FailureDiagnostic =
+            serde_json::from_slice(&std::fs::read(guest_paths.failure_diagnostic_file()).unwrap())
+                .unwrap();
+        assert_eq!(diagnostic.failure_class, FailureClass::CheckpointFailed);
+        assert_eq!(diagnostic.cli_exit_code, Some(0));
+
+        for path in cleanup_paths {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
     async fn complete_execution_keeps_success_when_history_is_unavailable_inner() {
         let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
         server.reset_async().await;
@@ -1770,19 +1878,15 @@ mod tests {
                 .path("/api/webhooks/agent/checkpoints/prepare-history");
             then.status(500);
         });
-        let checkpoint_mock = server.mock(|when, then| {
-            when.method(POST)
-                .path("/api/webhooks/agent/checkpoints")
-                .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
-            then.status(200)
-                .header("Content-Type", "application/json")
-                .json_body(json!({"checkpointId": "historyless-checkpoint", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
-        });
         let complete_mock = server.mock(|when, then| {
-            when.method(POST).path("/api/webhooks/agent/complete");
+            when.method(POST)
+                .path("/api/webhooks/agent/complete")
+                .json_body_includes(
+                    r#"{"exitCode":0,"checkpoint":{"cliAgentSessionHistoryDisposition":"unavailable"}}"#,
+                );
             then.status(200)
                 .header("Content-Type", "application/json")
-                .json_body(json!({}));
+                .json_body(json!({"success": true, "status": "completed"}));
         });
         let _telemetry_mock = server.mock(|when, then| {
             when.method(POST).path("/api/webhooks/agent/telemetry");
@@ -1818,7 +1922,6 @@ mod tests {
 
         assert_eq!(exit_code, 0);
         assert_eq!(prepare_mock.calls_async().await, 0);
-        assert_eq!(checkpoint_mock.calls_async().await, 1);
         assert_eq!(complete_mock.calls_async().await, 1);
 
         for path in cleanup_paths {
@@ -1875,13 +1978,15 @@ mod tests {
                 .body(history.as_str());
             then.status(200);
         });
-        let checkpoint_mock = server.mock(|when, then| {
+        let complete_mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/api/webhooks/agent/checkpoints")
-                .json_body_includes(r#"{"cliAgentSessionId":"recovery-session-from-main"}"#);
+                .path("/api/webhooks/agent/complete")
+                .json_body_includes(
+                    r#"{"exitCode":1,"checkpoint":{"cliAgentSessionId":"recovery-session-from-main"}}"#,
+                );
             then.status(200)
                 .header("Content-Type", "application/json")
-                .json_body(json!({"checkpointId": "checkpoint-from-main", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+                .json_body(json!({"success": true, "status": "failed"}));
         });
         let _telemetry_mock = server.mock(|when, then| {
             when.method(POST).path("/api/webhooks/agent/telemetry");
@@ -1932,7 +2037,7 @@ mod tests {
         assert_eq!(diagnostic, failure_diagnostic);
         prepare_mock.assert_calls_async(1).await;
         upload_mock.assert_calls_async(1).await;
-        checkpoint_mock.assert_calls_async(1).await;
+        complete_mock.assert_calls_async(1).await;
 
         for path in cleanup_paths {
             let _ = std::fs::remove_file(path);

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1539,7 +1539,17 @@ mod tests {
             .enable_all()
             .build()
             .unwrap()
-            .block_on(complete_execution_creates_recovery_checkpoint_after_cli_failure_inner());
+            .block_on(complete_execution_after_cli_failure_inner(200, 1));
+    }
+
+    #[test]
+    fn complete_execution_keeps_cli_failure_when_recovery_report_fails() {
+        let _test_state_guard = lock_test_state();
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(complete_execution_after_cli_failure_inner(500, 3));
     }
 
     #[test]
@@ -1931,7 +1941,10 @@ mod tests {
         }
     }
 
-    async fn complete_execution_creates_recovery_checkpoint_after_cli_failure_inner() {
+    async fn complete_execution_after_cli_failure_inner(
+        completion_status: u16,
+        expected_completion_calls: usize,
+    ) {
         let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
         server.reset_async().await;
         let _env_guard = unsafe { set_test_env(server, Some("plain prompt")) };
@@ -1986,7 +1999,7 @@ mod tests {
                 .json_body_includes(
                     r#"{"exitCode":1,"error":"You've hit your usage limit.","checkpoint":{"cliAgentSessionId":"recovery-session-from-main"}}"#,
                 );
-            then.status(200)
+            then.status(completion_status)
                 .header("Content-Type", "application/json")
                 .json_body(json!({"success": true, "status": "failed"}));
         });
@@ -2039,7 +2052,9 @@ mod tests {
         assert_eq!(diagnostic, failure_diagnostic);
         prepare_mock.assert_calls_async(1).await;
         upload_mock.assert_calls_async(1).await;
-        complete_mock.assert_calls_async(1).await;
+        complete_mock
+            .assert_calls_async(expected_completion_calls)
+            .await;
 
         for path in cleanup_paths {
             let _ = std::fs::remove_file(path);

--- a/crates/guest-agent/src/urls.rs
+++ b/crates/guest-agent/src/urls.rs
@@ -6,10 +6,6 @@ pub(crate) fn events_url(base_url: &str) -> String {
     routes::webhooks::agent::events::SEND.url(base_url)
 }
 
-pub(crate) fn checkpoint_url(base_url: &str) -> String {
-    routes::webhooks::agent::checkpoints::CREATE.url(base_url)
-}
-
 pub(crate) fn complete_url(base_url: &str) -> String {
     routes::webhooks::agent::complete::COMPLETE.url(base_url)
 }

--- a/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
+++ b/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
@@ -188,7 +188,8 @@ async fn unchanged_artifact_checkpoint_records_content_hash_timing()
     let checkpoint =
         guest_agent::checkpoint::prepare_checkpoint_for_runtime(&runtime, &session_metadata)
             .await?;
-    guest_agent::complete::report_checkpoint_for_run(&runtime, 0, None, &[], checkpoint).await?;
+    guest_agent::complete::report_checkpoint_for_run(&runtime, 0, None, None, &[], checkpoint)
+        .await?;
 
     history_prepare.assert_calls_async(1).await;
     storage_prepare.assert_calls_async(0).await;

--- a/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
+++ b/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
@@ -29,7 +29,8 @@ fn checkpoint_request_has_artifact_snapshot(
         return false;
     };
     let Some(snapshots) = body
-        .get("artifactSnapshots")
+        .get("checkpoint")
+        .and_then(|checkpoint| checkpoint.get("artifactSnapshots"))
         .and_then(|value| value.as_array())
     else {
         return false;
@@ -169,9 +170,9 @@ async fn unchanged_artifact_checkpoint_records_content_hash_timing()
     });
     let expected_version = version_id.clone();
     let expected_mount_path = mount_path.to_string_lossy().into_owned();
-    let checkpoint = server.mock(|when, then| {
+    let complete = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
+            .path("/api/webhooks/agent/complete")
             .is_true(move |req| {
                 checkpoint_request_has_artifact_snapshot(
                     req,
@@ -181,15 +182,18 @@ async fn unchanged_artifact_checkpoint_records_content_hash_timing()
             });
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-with-unchanged-artifact", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "completed"}));
     });
 
-    guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime, &session_metadata).await?;
+    let checkpoint =
+        guest_agent::checkpoint::prepare_checkpoint_for_runtime(&runtime, &session_metadata)
+            .await?;
+    guest_agent::complete::report_checkpoint_for_run(&runtime, 0, None, &[], checkpoint).await?;
 
     history_prepare.assert_calls_async(1).await;
     storage_prepare.assert_calls_async(0).await;
     storage_commit.assert_calls_async(0).await;
-    checkpoint.assert_calls_async(1).await;
+    complete.assert_calls_async(1).await;
 
     let sandbox_ops = std::fs::read_to_string(runtime.paths.sandbox_ops_file())?;
     assert!(sandbox_ops.contains(r#""action_type":"artifact_content_hash_compute""#));

--- a/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
+++ b/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
@@ -24,6 +24,7 @@ fn checkpoint_request_has_artifact_snapshot(
     req: &HttpMockRequest,
     expected_version: &str,
     expected_mount_path: &str,
+    expected_missing_mount_path: &str,
 ) -> bool {
     let Ok(body) = serde_json::from_slice::<serde_json::Value>(req.body_ref()) else {
         return false;
@@ -36,12 +37,28 @@ fn checkpoint_request_has_artifact_snapshot(
         return false;
     };
 
-    snapshots.iter().any(|snapshot| {
+    let unchanged_snapshot_matches = snapshots.iter().any(|snapshot| {
         snapshot.get("name").and_then(|value| value.as_str()) == Some("workspace")
             && snapshot.get("version").and_then(|value| value.as_str()) == Some(expected_version)
             && snapshot.get("mountPath").and_then(|value| value.as_str())
                 == Some(expected_mount_path)
-    })
+            && snapshot
+                .get("missingRootPolicy")
+                .and_then(|value| value.as_str())
+                == Some("fail")
+    });
+    let preserved_snapshot_matches = snapshots.iter().any(|snapshot| {
+        snapshot.get("name").and_then(|value| value.as_str()) == Some("memory")
+            && snapshot.get("version").and_then(|value| value.as_str())
+                == Some("preserved-memory-version")
+            && snapshot.get("mountPath").and_then(|value| value.as_str())
+                == Some(expected_missing_mount_path)
+            && snapshot
+                .get("missingRootPolicy")
+                .and_then(|value| value.as_str())
+                == Some("preserveParentVersion")
+    });
+    unchanged_snapshot_matches && preserved_snapshot_matches
 }
 
 struct SandboxOpsOverrideGuard;
@@ -77,6 +94,7 @@ fn test_runtime(
     api_url: &str,
 ) -> Result<GuestRuntime, Box<dyn std::error::Error>> {
     let runtime_dir = temp_dir.join("runtime");
+    let missing_mount_path = temp_dir.join("missing-memory");
     let paths = GuestPaths::from_runtime_dir(&runtime_dir);
     let run_payload_file = write_run_payload(
         &runtime_dir,
@@ -87,6 +105,14 @@ fn test_runtime(
                     "mountPath": mount_path.to_string_lossy(),
                     "storageId": STORAGE_ID,
                     "versionId": version_id,
+                    "missingRootPolicy": "fail",
+                },
+                {
+                    "name": "memory",
+                    "mountPath": missing_mount_path.to_string_lossy(),
+                    "storageId": "memory-storage-id",
+                    "versionId": "preserved-memory-version",
+                    "missingRootPolicy": "preserveParentVersion",
                 }
             ])
             .to_string(),
@@ -170,6 +196,11 @@ async fn unchanged_artifact_checkpoint_records_content_hash_timing()
     });
     let expected_version = version_id.clone();
     let expected_mount_path = mount_path.to_string_lossy().into_owned();
+    let expected_missing_mount_path = temp_dir
+        .path()
+        .join("missing-memory")
+        .to_string_lossy()
+        .into_owned();
     let complete = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/complete")
@@ -178,6 +209,7 @@ async fn unchanged_artifact_checkpoint_records_content_hash_timing()
                     req,
                     &expected_version,
                     &expected_mount_path,
+                    &expected_missing_mount_path,
                 )
             });
         then.status(200)

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -257,8 +257,15 @@ fn recovery_checkpoint_resolves_history_from_codex_sessions_root() -> TestResult
             &session_metadata,
         )
         .await?;
-        guest_agent::complete::report_checkpoint_for_run(&guest_runtime, 1, None, &[], checkpoint)
-            .await
+        guest_agent::complete::report_checkpoint_for_run(
+            &guest_runtime,
+            1,
+            None,
+            None,
+            &[],
+            checkpoint,
+        )
+        .await
     })?;
     prepare_mock.assert_calls(1);
     upload_mock.assert_calls(1);

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -219,13 +219,15 @@ fn recovery_checkpoint_resolves_history_from_codex_sessions_root() -> TestResult
             .body(history.as_str());
         then.status(200);
     });
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(format!(r#"{{"cliAgentSessionId":"{thread_id}"}}"#));
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(format!(
+                r#"{{"exitCode":1,"checkpoint":{{"cliAgentSessionId":"{thread_id}"}}}}"#
+            ));
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "codex-derived-checkpoint", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "failed"}));
     });
 
     let config = fixture.config(&server.base_url(), "test-token")?;
@@ -249,15 +251,18 @@ fn recovery_checkpoint_resolves_history_from_codex_sessions_root() -> TestResult
             },
         ),
     );
-    runtime.block_on(
-        guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(
+    runtime.block_on(async {
+        let checkpoint = guest_agent::checkpoint::prepare_recovery_checkpoint_for_runtime(
             &guest_runtime,
             &session_metadata,
-        ),
-    )?;
+        )
+        .await?;
+        guest_agent::complete::report_checkpoint_for_run(&guest_runtime, 1, None, &[], checkpoint)
+            .await
+    })?;
     prepare_mock.assert_calls(1);
     upload_mock.assert_calls(1);
-    checkpoint_mock.assert_calls(1);
+    complete_mock.assert_calls(1);
     Ok(())
 }
 

--- a/crates/guest-agent/tests/event_delivery_failure_recovery.rs
+++ b/crates/guest-agent/tests/event_delivery_failure_recovery.rs
@@ -123,13 +123,15 @@ async fn run_event_failure_case(
             .header("Content-Type", "application/octet-stream");
         then.status(200);
     });
-    let checkpoint = server.mock(|when, then| {
+    let complete = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(format!(r#"{{"cliAgentSessionId":"{THREAD_ID}"}}"#));
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(format!(
+                r#"{{"exitCode":1,"checkpoint":{{"cliAgentSessionId":"{THREAD_ID}"}}}}"#
+            ));
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "event-delivery-recovery-checkpoint", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "failed"}));
     });
 
     let output = common::command_output_with_timeout(
@@ -185,7 +187,7 @@ async fn run_event_failure_case(
     assert!(events.calls_async().await >= 3);
     prepare.assert_calls_async(1).await;
     upload.assert_calls_async(1).await;
-    checkpoint.assert_calls_async(1).await;
+    complete.assert_calls_async(1).await;
 
     let paths = guest_agent::paths::GuestPaths::from_runtime_dir(runtime_dir.clone());
     let diagnostic: FailureDiagnostic =

--- a/crates/guest-agent/tests/execution_timeout_recovery.rs
+++ b/crates/guest-agent/tests/execution_timeout_recovery.rs
@@ -69,13 +69,16 @@ async fn execution_timeout_checkpoints_the_resumable_session_before_exit()
             .header("Content-Type", "application/octet-stream");
         then.status(200);
     });
-    let checkpoint = server.mock(|when, then| {
+    let complete = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(format!(r#"{{"cliAgentSessionId":"{THREAD_ID}"}}"#));
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(format!(
+                r#"{{"exitCode":{},"checkpoint":{{"cliAgentSessionId":"{THREAD_ID}"}}}}"#,
+                AGENT_EXECUTION_TIMEOUT_EXIT_CODE
+            ));
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "execution-timeout-recovery-checkpoint", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "failed"}));
     });
 
     let output = common::command_output_with_timeout(
@@ -147,7 +150,7 @@ async fn execution_timeout_checkpoints_the_resumable_session_before_exit()
     );
     prepare.assert_calls_async(1).await;
     upload.assert_calls_async(1).await;
-    checkpoint.assert_calls_async(1).await;
+    complete.assert_calls_async(1).await;
 
     let paths = guest_agent::paths::GuestPaths::from_runtime_dir(runtime_dir);
     let diagnostic: FailureDiagnostic =

--- a/crates/guest-agent/tests/integration_cases/checkpoint/recovery.rs
+++ b/crates/guest-agent/tests/integration_cases/checkpoint/recovery.rs
@@ -33,25 +33,28 @@ async fn recovery_checkpoint_uploads_valid_session_history() {
             .body(history.as_str());
         then.status(200);
     });
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(r#"{"cliAgentSessionId":"recovery-session"}"#);
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(r#"{"checkpoint":{"cliAgentSessionId":"recovery-session"}}"#);
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-recovery", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "failed"}));
     });
 
-    let result = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(
+    let result = guest_agent::checkpoint::prepare_recovery_checkpoint_for_runtime(
         &runtime,
         &checkpoint_session_metadata(&runtime),
     )
     .await;
 
-    assert!(result.is_ok());
+    let checkpoint = result.unwrap();
+    report_prepared_checkpoint(&runtime, 1, checkpoint)
+        .await
+        .unwrap();
     prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(1).await;
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(1).await;
     assert!(
         !std::path::Path::new(runtime.paths.final_session_history_identity_file()).exists(),
         "recovery checkpoint must not write final session history identity metadata"
@@ -75,20 +78,22 @@ async fn recovery_checkpoint_does_not_prune_eligible_claude_history() {
             .path("/api/webhooks/agent/checkpoints/prepare-history");
         then.status(200);
     });
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(
+                r#"{"checkpoint":{"cliAgentSessionHistoryDisposition":"unavailable"}}"#,
+            );
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-invalid-claude-history", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "failed"}));
     });
 
     create_bounded_recovery_checkpoint(&runtime).await.unwrap();
     assert_eq!(std::fs::metadata(&history_path).unwrap().len(), source_size);
     assert!(!std::path::Path::new(runtime.paths.final_session_history_identity_file()).exists());
     prepare_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(1).await;
 }
 
 #[tokio::test]
@@ -109,20 +114,22 @@ async fn recovery_checkpoint_does_not_prune_eligible_codex_history() {
             .path("/api/webhooks/agent/checkpoints/prepare-history");
         then.status(200);
     });
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(
+                r#"{"checkpoint":{"cliAgentSessionHistoryDisposition":"unavailable"}}"#,
+            );
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-invalid-codex-history", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "failed"}));
     });
 
     create_bounded_recovery_checkpoint(&runtime).await.unwrap();
     assert_eq!(std::fs::metadata(&history_path).unwrap().len(), source_size);
     assert!(!std::path::Path::new(runtime.paths.final_session_history_identity_file()).exists());
     prepare_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(1).await;
 
     let source_history = std::fs::read(&history_path).unwrap();
     let encoded_history = zstd_session_history_for_test(&source_history).unwrap();
@@ -137,7 +144,7 @@ async fn recovery_checkpoint_does_not_prune_eligible_codex_history() {
     );
     assert!(!std::path::Path::new(runtime.paths.final_session_history_identity_file()).exists());
     prepare_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(2).await;
+    complete_mock.assert_calls_async(2).await;
 }
 
 async fn assert_recovery_checkpoint_ignores_legacy_history_marker(
@@ -174,25 +181,30 @@ async fn assert_recovery_checkpoint_ignores_legacy_history_marker(
             .body(history.as_str());
         then.status(200);
     });
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(format!(r#"{{"cliAgentSessionId":"{session_id}"}}"#));
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(format!(
+                r#"{{"checkpoint":{{"cliAgentSessionId":"{session_id}"}}}}"#
+            ));
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-derived-history", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "failed"}));
     });
 
-    let result = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(
+    let result = guest_agent::checkpoint::prepare_recovery_checkpoint_for_runtime(
         &runtime,
         &checkpoint_session_metadata(&runtime),
     )
     .await;
 
-    assert!(result.is_ok());
+    let checkpoint = result.map_err(|error| error.to_string())?;
+    report_prepared_checkpoint(&runtime, 1, checkpoint)
+        .await
+        .map_err(|error| error.to_string())?;
     prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(1).await;
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(1).await;
     assert_eq!(
         std::fs::read_to_string(legacy_marker)
             .map_err(|e| format!("read adversarial legacy marker: {e}"))?,
@@ -227,28 +239,33 @@ async fn recovery_checkpoint_continues_without_partial_jsonl_history() {
             .path("/api/webhooks/agent/checkpoints/prepare-history");
         then.status(200);
     });
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(
+                r#"{"checkpoint":{"cliAgentSessionHistoryDisposition":"unavailable"}}"#,
+            );
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-partial-history", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "failed"}));
     });
 
-    let result = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(
+    let result = guest_agent::checkpoint::prepare_recovery_checkpoint_for_runtime(
         &runtime,
         &checkpoint_session_metadata(&runtime),
     )
     .await;
 
-    assert!(result.is_ok());
+    let checkpoint = result.unwrap();
+    report_prepared_checkpoint(&runtime, 1, checkpoint)
+        .await
+        .unwrap();
     assert!(
         !std::path::Path::new(runtime.paths.checkpoint_error_file()).exists(),
         "recovery checkpoint must not write the success-path checkpoint error file"
     );
     prepare_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(1).await;
 }
 
 #[tokio::test]
@@ -270,28 +287,33 @@ async fn recovery_checkpoint_continues_without_non_utf8_session_history() {
             .path("/api/webhooks/agent/checkpoints/prepare-history");
         then.status(200);
     });
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(
+                r#"{"checkpoint":{"cliAgentSessionHistoryDisposition":"unavailable"}}"#,
+            );
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-non-utf8-history", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "failed"}));
     });
 
-    let result = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(
+    let result = guest_agent::checkpoint::prepare_recovery_checkpoint_for_runtime(
         &runtime,
         &checkpoint_session_metadata(&runtime),
     )
     .await;
 
-    assert!(result.is_ok());
+    let checkpoint = result.unwrap();
+    report_prepared_checkpoint(&runtime, 1, checkpoint)
+        .await
+        .unwrap();
     assert!(
         !std::path::Path::new(runtime.paths.checkpoint_error_file()).exists(),
         "recovery checkpoint must not write the success-path checkpoint error file"
     );
     prepare_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(1).await;
 }
 
 #[tokio::test]
@@ -307,18 +329,20 @@ async fn recovery_checkpoint_skips_when_session_id_is_missing() {
             .path("/api/webhooks/agent/checkpoints/prepare-history");
         then.status(200);
     });
-    let checkpoint_mock = server.mock(|when, then| {
-        when.method(POST).path("/api/webhooks/agent/checkpoints");
+    let complete_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/complete");
         then.status(200);
     });
 
-    let result = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(
+    let result = guest_agent::checkpoint::prepare_recovery_checkpoint_for_runtime(
         &runtime,
         &checkpoint_session_metadata(&runtime),
     )
     .await;
 
-    let err = result.unwrap_err();
+    let err = result
+        .err()
+        .expect("missing session ID should fail recovery preparation");
     assert!(
         err.to_string().contains("Session ID is empty"),
         "expected recovery checkpoint to fail on missing session ID, got: {err}"
@@ -328,7 +352,7 @@ async fn recovery_checkpoint_skips_when_session_id_is_missing() {
         "recovery checkpoint must not write the success-path checkpoint error file"
     );
     prepare_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(0).await;
+    complete_mock.assert_calls_async(0).await;
 }
 
 #[tokio::test]
@@ -345,28 +369,33 @@ async fn recovery_checkpoint_continues_when_derived_history_is_missing() {
             .path("/api/webhooks/agent/checkpoints/prepare-history");
         then.status(200);
     });
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(
+                r#"{"checkpoint":{"cliAgentSessionHistoryDisposition":"unavailable"}}"#,
+            );
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-missing-history", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "failed"}));
     });
 
-    let result = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(
+    let result = guest_agent::checkpoint::prepare_recovery_checkpoint_for_runtime(
         &runtime,
         &checkpoint_session_metadata(&runtime),
     )
     .await;
 
-    assert!(result.is_ok());
+    let checkpoint = result.unwrap();
+    report_prepared_checkpoint(&runtime, 1, checkpoint)
+        .await
+        .unwrap();
     assert!(
         !std::path::Path::new(runtime.paths.checkpoint_error_file()).exists(),
         "recovery checkpoint must not write the success-path checkpoint error file"
     );
     prepare_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(1).await;
 }
 
 #[tokio::test]
@@ -383,26 +412,31 @@ async fn recovery_checkpoint_continues_without_invalid_history_source() {
             .path("/api/webhooks/agent/checkpoints/prepare-history");
         then.status(200);
     });
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(
+                r#"{"checkpoint":{"cliAgentSessionHistoryDisposition":"unavailable"}}"#,
+            );
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-invalid-history-source", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "failed"}));
     });
 
-    let result = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(
+    let result = guest_agent::checkpoint::prepare_recovery_checkpoint_for_runtime(
         &runtime,
         &checkpoint_session_metadata(&runtime),
     )
     .await;
 
-    assert!(result.is_ok());
+    let checkpoint = result.unwrap();
+    report_prepared_checkpoint(&runtime, 1, checkpoint)
+        .await
+        .unwrap();
     assert!(
         !std::path::Path::new(runtime.paths.checkpoint_error_file()).exists(),
         "recovery checkpoint must not write the success-path checkpoint error file"
     );
     prepare_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(1).await;
 }

--- a/crates/guest-agent/tests/integration_cases/checkpoint/success.rs
+++ b/crates/guest-agent/tests/integration_cases/checkpoint/success.rs
@@ -94,6 +94,7 @@ async fn pi_checkpoint_reports_full_combined_completion_payload() {
     guest_agent::complete::report_checkpoint_for_run(
         &runtime,
         0,
+        None,
         Some(42),
         &active_input_delivery_ids,
         checkpoint,

--- a/crates/guest-agent/tests/integration_cases/checkpoint/success.rs
+++ b/crates/guest-agent/tests/integration_cases/checkpoint/success.rs
@@ -44,6 +44,68 @@ fn assert_session_history_prune_operation(
 }
 
 #[tokio::test]
+async fn pi_checkpoint_reports_full_combined_completion_payload() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let mut runtime = runtime_from_process_env().unwrap();
+    runtime.config.framework = guest_agent::env::Framework::Pi;
+    runtime.config.workspace_reuse_result = "sandboxReused".to_string();
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let session_id = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    guest_agent::paths::write_private(session_id_file(), session_id).unwrap();
+    let active_input_delivery_ids = vec!["11111111-1111-4111-8111-111111111111".to_string()];
+
+    let standalone_checkpoint = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/checkpoints");
+        then.status(200);
+    });
+    let complete = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(
+                json!({
+                    "runId": "test-run-001",
+                    "exitCode": 0,
+                    "lastEventSequence": 42,
+                    "sandboxId": "00000000-0000-4000-8000-000000000abc",
+                    "sandboxReuseResult": "reused",
+                    "workspaceReuseResult": "sandboxReused",
+                    "activeInputDeliveryIds": ["11111111-1111-4111-8111-111111111111"],
+                    "checkpoint": {
+                        "cliAgentType": "pi",
+                        "cliAgentSessionId": session_id,
+                        "cliAgentSessionHistoryDisposition": "unavailable"
+                    }
+                })
+                .to_string(),
+            );
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"success": true, "status": "completed"}));
+    });
+
+    let session_metadata =
+        guest_agent::session_metadata::CapturedSessionMetadata::for_test(session_id, None);
+    let checkpoint =
+        guest_agent::checkpoint::prepare_checkpoint_for_runtime(&runtime, &session_metadata)
+            .await
+            .unwrap();
+    guest_agent::complete::report_checkpoint_for_run(
+        &runtime,
+        0,
+        Some(42),
+        &active_input_delivery_ids,
+        checkpoint,
+    )
+    .await
+    .unwrap();
+
+    standalone_checkpoint.assert_calls_async(0).await;
+    complete.assert_calls_async(1).await;
+}
+
+#[tokio::test]
 async fn success_checkpoint_preserves_small_codex_history() {
     let api = SharedApiMock::new().await;
     let server = api.server();
@@ -68,26 +130,29 @@ async fn success_checkpoint_preserves_small_codex_history() {
             .header("Content-Type", "application/json")
             .json_body(json!({"existing": true}));
     });
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
+            .path("/api/webhooks/agent/complete")
             .json_body_includes(format!(
-                r#"{{"cliAgentSessionHistoryHash":"{history_hash}"}}"#
+                r#"{{"checkpoint":{{"cliAgentSessionHistoryHash":"{history_hash}"}}}}"#
             ));
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-unpruned-codex", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "completed"}));
     });
 
-    guest_agent::checkpoint::create_checkpoint_for_runtime(
+    let checkpoint = guest_agent::checkpoint::prepare_checkpoint_for_runtime(
         &runtime,
         &checkpoint_session_metadata(&runtime),
     )
     .await
     .unwrap();
+    report_prepared_checkpoint(&runtime, 0, checkpoint)
+        .await
+        .unwrap();
 
     prepare_mock.assert_calls_async(1).await;
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(1).await;
     assert_eq!(std::fs::read(&history_path).unwrap(), history);
     assert_session_history_prune_operation(
         &runtime,
@@ -128,28 +193,26 @@ async fn checkpoint_rejects_mistyped_prepare_response_before_upload() {
         when.method(PUT).path(upload_path);
         then.status(200);
     });
-    let checkpoint_mock = server.mock(|when, then| {
-        when.method(POST).path("/api/webhooks/agent/checkpoints");
-        then.status(200).json_body(json!({
-            "checkpointId": "unreachable",
-            "agentSessionId": "test-agent-session",
-            "conversationId": "test-conversation",
-        }));
+    let complete_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/complete");
+        then.status(200)
+            .json_body(json!({"success": true, "status": "completed"}));
     });
 
-    let error = guest_agent::checkpoint::create_checkpoint_for_runtime(
+    let error = guest_agent::checkpoint::prepare_checkpoint_for_runtime(
         &runtime,
         &checkpoint_session_metadata(&runtime),
     )
     .await
-    .unwrap_err();
+    .err()
+    .expect("mistyped prepare response should fail checkpoint preparation");
 
     let message = error.to_string();
     assert!(message.contains("Invalid prepare-history response"));
     assert!(!message.contains(sensitive_response_value));
     prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(0).await;
+    complete_mock.assert_calls_async(0).await;
 }
 
 #[tokio::test]
@@ -179,21 +242,19 @@ async fn checkpoint_rejects_prepare_response_without_upload_url() {
         when.method(PUT);
         then.status(200);
     });
-    let checkpoint_mock = server.mock(|when, then| {
-        when.method(POST).path("/api/webhooks/agent/checkpoints");
-        then.status(200).json_body(json!({
-            "checkpointId": "unreachable",
-            "agentSessionId": "test-agent-session",
-            "conversationId": "test-conversation",
-        }));
+    let complete_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/complete");
+        then.status(200)
+            .json_body(json!({"success": true, "status": "completed"}));
     });
 
-    let error = guest_agent::checkpoint::create_checkpoint_for_runtime(
+    let error = guest_agent::checkpoint::prepare_checkpoint_for_runtime(
         &runtime,
         &checkpoint_session_metadata(&runtime),
     )
     .await
-    .unwrap_err();
+    .err()
+    .expect("missing upload URL should fail checkpoint preparation");
 
     assert!(
         error
@@ -202,7 +263,7 @@ async fn checkpoint_rejects_prepare_response_without_upload_url() {
     );
     prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(0).await;
+    complete_mock.assert_calls_async(0).await;
 }
 
 #[tokio::test]
@@ -228,15 +289,17 @@ async fn success_checkpoint_discards_oversized_claude_history_without_compact_bo
         then.status(500);
     });
     let expected_session_id = session_id.to_string();
-    let checkpoint_mock = server.mock(move |when, then| {
-        when.method(POST).path("/api/webhooks/agent/checkpoints");
+    let complete_mock = server.mock(move |when, then| {
+        when.method(POST).path("/api/webhooks/agent/complete");
         then.respond_with(move |request| {
             let body = serde_json::from_slice::<Value>(request.body_ref()).unwrap();
-            if body["cliAgentSessionId"] == expected_session_id
-                && body["cliAgentSessionHistoryDisposition"] == "discarded_oversized"
-                && body.get("cliAgentSessionHistoryHash").is_none()
+            if body["checkpoint"]["cliAgentSessionId"] == expected_session_id
+                && body["checkpoint"]["cliAgentSessionHistoryDisposition"] == "discarded_oversized"
+                && body["checkpoint"]
+                    .get("cliAgentSessionHistoryHash")
+                    .is_none()
             {
-                json_http_response(200, json!({"checkpointId": "checkpoint-discarded-claude", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}))
+                json_http_response(200, json!({"success": true, "status": "completed"}))
             } else {
                 http_status(400)
             }
@@ -246,7 +309,7 @@ async fn success_checkpoint_discards_oversized_claude_history_without_compact_bo
     create_bounded_checkpoint(&runtime).await.unwrap();
 
     prepare_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(1).await;
     assert_eq!(std::fs::read(history_path).unwrap(), history);
     assert_session_history_prune_operation(
         &runtime,
@@ -277,20 +340,22 @@ async fn success_checkpoint_discards_codex_history_that_jumps_past_hard_limit() 
             .path("/api/webhooks/agent/checkpoints/prepare-history");
         then.status(500);
     });
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(r#"{"cliAgentType":"codex"}"#)
-            .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"discarded_oversized"}"#);
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(r#"{"checkpoint":{"cliAgentType":"codex"}}"#)
+            .json_body_includes(
+                r#"{"checkpoint":{"cliAgentSessionHistoryDisposition":"discarded_oversized"}}"#,
+            );
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-discarded-codex", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "completed"}));
     });
 
     create_bounded_checkpoint(&runtime).await.unwrap();
 
     prepare_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(1).await;
     assert_eq!(std::fs::read(history_path).unwrap(), history);
     assert_session_history_prune_operation(
         &runtime,
@@ -324,19 +389,21 @@ async fn success_checkpoint_discards_codex_history_with_oversized_canonical_cand
             .path("/api/webhooks/agent/checkpoints/prepare-history");
         then.status(500);
     });
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"discarded_oversized"}"#);
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(
+                r#"{"checkpoint":{"cliAgentSessionHistoryDisposition":"discarded_oversized"}}"#,
+            );
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-discarded-candidate", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "completed"}));
     });
 
     create_bounded_checkpoint(&runtime).await.unwrap();
 
     prepare_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(1).await;
     assert_eq!(std::fs::read(history_path).unwrap(), history);
     assert_session_history_prune_operation(
         &runtime,
@@ -358,18 +425,20 @@ async fn checkpoint_continues_when_codex_history_is_missing() {
     let home = tempfile::tempdir().unwrap();
     use_test_codex_home(&mut runtime, home.path());
     guest_agent::paths::write_private(session_id_file(), session_id).unwrap();
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(
+                r#"{"checkpoint":{"cliAgentSessionHistoryDisposition":"unavailable"}}"#,
+            );
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-history-unavailable", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "completed"}));
     });
 
     create_bounded_checkpoint(&runtime).await.unwrap();
 
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(1).await;
     let operations = std::fs::read_to_string(runtime.paths.sandbox_ops_file()).unwrap();
     assert!(operations.lines().any(|line| {
         let operation: Value = serde_json::from_str(line).unwrap();
@@ -379,7 +448,7 @@ async fn checkpoint_continues_when_codex_history_is_missing() {
 }
 
 #[tokio::test]
-async fn checkpoint_rejects_create_response_missing_required_identity() {
+async fn combined_checkpoint_accepts_terminal_acknowledgement_without_checkpoint_identity() {
     let api = SharedApiMock::new().await;
     let server = api.server();
     let mut runtime = runtime_from_process_env().unwrap();
@@ -389,26 +458,19 @@ async fn checkpoint_rejects_create_response_missing_required_identity() {
     let home = tempfile::tempdir().unwrap();
     use_test_codex_home(&mut runtime, home.path());
     guest_agent::paths::write_private(session_id_file(), session_id).unwrap();
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(
+                r#"{"checkpoint":{"cliAgentSessionHistoryDisposition":"unavailable"}}"#,
+            );
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({
-                "checkpointId": "checkpoint-invalid-response",
-                "conversationId": "test-conversation",
-            }));
+            .json_body(json!({"success": true, "status": "completed"}));
     });
 
-    let error = create_bounded_checkpoint(&runtime).await.unwrap_err();
-
-    assert!(
-        error
-            .to_string()
-            .contains("Invalid checkpoint API response")
-    );
-    checkpoint_mock.assert_calls_async(1).await;
+    create_bounded_checkpoint(&runtime).await.unwrap();
+    complete_mock.assert_calls_async(1).await;
 }
 
 #[tokio::test]
@@ -423,13 +485,15 @@ async fn success_checkpoint_reports_invalid_local_history_as_unavailable() {
             .path("/api/webhooks/agent/checkpoints/prepare-history");
         then.status(400);
     });
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(
+                r#"{"checkpoint":{"cliAgentSessionHistoryDisposition":"unavailable"}}"#,
+            );
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-invalid-local-history", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "completed"}));
     });
 
     let cases: [(&str, &[u8]); 2] = [
@@ -454,7 +518,7 @@ async fn success_checkpoint_reports_invalid_local_history_as_unavailable() {
     }
 
     prepare_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(2).await;
+    complete_mock.assert_calls_async(2).await;
 }
 
 #[tokio::test]
@@ -482,19 +546,21 @@ async fn success_checkpoint_reports_invalid_reused_zstd_history_as_unavailable()
             .path("/api/webhooks/agent/checkpoints/prepare-history");
         then.status(400);
     });
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(
+                r#"{"checkpoint":{"cliAgentSessionHistoryDisposition":"unavailable"}}"#,
+            );
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-invalid-zstd-history", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "completed"}));
     });
 
     create_bounded_checkpoint(&runtime).await.unwrap();
 
     prepare_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(1).await;
     assert!(!std::path::Path::new(runtime.paths.final_session_history_identity_file()).exists());
 }
 
@@ -546,18 +612,20 @@ async fn success_checkpoint_reconciles_claude_compact_generation_after_commit() 
         then.respond_with(move |req| upload_validation_response(req, &upload_body, &upload_len));
     });
     let checkpoint_history_path = history_path.clone();
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(format!(r#"{{"cliAgentSessionId":"{session_id}"}}"#))
+            .path("/api/webhooks/agent/complete")
             .json_body_includes(format!(
-                r#"{{"cliAgentSessionHistoryHash":"{history_hash}"}}"#
+                r#"{{"checkpoint":{{"cliAgentSessionId":"{session_id}"}}}}"#
+            ))
+            .json_body_includes(format!(
+                r#"{{"checkpoint":{{"cliAgentSessionHistoryHash":"{history_hash}"}}}}"#
             ));
         then.respond_with(move |_| {
             if std::fs::metadata(&checkpoint_history_path)
                 .is_ok_and(|metadata| metadata.len() == source_size)
             {
-                json_http_response(200, json!({"checkpointId": "checkpoint-pruned-claude", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}))
+                json_http_response(200, json!({"success": true, "status": "completed"}))
             } else {
                 http_status(500)
             }
@@ -568,7 +636,7 @@ async fn success_checkpoint_reconciles_claude_compact_generation_after_commit() 
 
     prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(1).await;
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(1).await;
     assert_eq!(std::fs::read(&history_path).unwrap(), candidate);
 
     let identity_bytes =
@@ -637,19 +705,21 @@ async fn success_checkpoint_reconciles_codex_compact_generation_after_commit() {
         });
     });
     let checkpoint_history_path = history_path.clone();
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(format!(r#"{{"cliAgentSessionId":"{session_id}"}}"#))
-            .json_body_includes(r#"{"cliAgentType":"codex"}"#)
+            .path("/api/webhooks/agent/complete")
             .json_body_includes(format!(
-                r#"{{"cliAgentSessionHistoryHash":"{history_hash}"}}"#
+                r#"{{"checkpoint":{{"cliAgentSessionId":"{session_id}"}}}}"#
+            ))
+            .json_body_includes(r#"{"checkpoint":{"cliAgentType":"codex"}}"#)
+            .json_body_includes(format!(
+                r#"{{"checkpoint":{{"cliAgentSessionHistoryHash":"{history_hash}"}}}}"#
             ));
         then.respond_with(move |_| {
             if std::fs::metadata(&checkpoint_history_path)
                 .is_ok_and(|metadata| metadata.len() == source_size)
             {
-                json_http_response(200, json!({"checkpointId": "checkpoint-pruned-codex", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}))
+                json_http_response(200, json!({"success": true, "status": "completed"}))
             } else {
                 http_status(500)
             }
@@ -660,7 +730,7 @@ async fn success_checkpoint_reconciles_codex_compact_generation_after_commit() {
 
     prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(1).await;
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(1).await;
     assert_eq!(std::fs::read(&history_path).unwrap(), candidate);
 
     let identity_bytes =
@@ -705,11 +775,11 @@ async fn success_checkpoint_omits_identity_when_live_history_replacement_fails()
     });
     let replacement_history_path = history_path.clone();
     let replacement_moved_dir = moved_history_dir.clone();
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
+            .path("/api/webhooks/agent/complete")
             .json_body_includes(format!(
-                r#"{{"cliAgentSessionHistoryHash":"{history_hash}"}}"#
+                r#"{{"checkpoint":{{"cliAgentSessionHistoryHash":"{history_hash}"}}}}"#
             ));
         then.respond_with(move |_| {
             let history_parent = replacement_history_path.parent().unwrap();
@@ -720,17 +790,14 @@ async fn success_checkpoint_omits_identity_when_live_history_replacement_fails()
                 &replacement_history_path,
             )
             .unwrap();
-            json_http_response(
-                200,
-                json!({"checkpointId": "checkpoint-pruned-unreconciled", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}),
-            )
+            json_http_response(200, json!({"success": true, "status": "completed"}))
         });
     });
 
     create_bounded_checkpoint(&runtime).await.unwrap();
 
     prepare_mock.assert_calls_async(1).await;
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(1).await;
     assert_eq!(std::fs::metadata(&history_path).unwrap().len(), source_size);
     assert!(!std::path::Path::new(runtime.paths.final_session_history_identity_file()).exists());
     std::fs::remove_dir_all(moved_history_dir).unwrap();
@@ -757,24 +824,20 @@ async fn success_checkpoint_keeps_live_history_when_compact_commit_fails() {
             .header("Content-Type", "application/json")
             .json_body(json!({"existing": true}));
     });
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
+            .path("/api/webhooks/agent/complete")
             .json_body_includes(format!(
-                r#"{{"cliAgentSessionHistoryHash":"{history_hash}"}}"#
+                r#"{{"checkpoint":{{"cliAgentSessionHistoryHash":"{history_hash}"}}}}"#
             ));
-        then.status(200).header("Content-Type", "application/json");
+        then.status(500).header("Content-Type", "application/json");
     });
 
     let error = create_bounded_checkpoint(&runtime).await.unwrap_err();
 
-    assert!(
-        error
-            .to_string()
-            .contains("Invalid checkpoint API response")
-    );
+    assert!(error.to_string().contains("POST failed after 3 attempts"));
     prepare_mock.assert_calls_async(1).await;
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(3).await;
     assert_eq!(std::fs::metadata(&history_path).unwrap().len(), source_size);
     assert!(!std::path::Path::new(runtime.paths.final_session_history_identity_file()).exists());
 }
@@ -818,28 +881,29 @@ async fn success_checkpoint_writes_large_final_identity_metadata()
             .header("Content-Type", "application/octet-stream");
         then.respond_with(move |req| upload_zstd_validation_response(req, &upload_body));
     });
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(r#"{"cliAgentSessionId":"success-large-session"}"#)
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(r#"{"checkpoint":{"cliAgentSessionId":"success-large-session"}}"#)
             .json_body_includes(format!(
-                r#"{{"cliAgentSessionHistoryHash":"{history_hash}"}}"#
+                r#"{{"checkpoint":{{"cliAgentSessionHistoryHash":"{history_hash}"}}}}"#
             ));
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-success-large", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "completed"}));
     });
 
-    let result = guest_agent::checkpoint::create_checkpoint_for_runtime(
+    let result = guest_agent::checkpoint::prepare_checkpoint_for_runtime(
         &runtime,
         &checkpoint_session_metadata(&runtime),
     )
     .await;
 
-    assert!(result.is_ok());
+    let checkpoint = result.unwrap();
+    report_prepared_checkpoint(&runtime, 0, checkpoint).await?;
     prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(1).await;
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(1).await;
 
     let identity_bytes =
         std::fs::read(runtime.paths.final_session_history_identity_file()).unwrap();
@@ -898,20 +962,22 @@ async fn success_checkpoint_propagates_zstd_prepare_bad_request()
         when.method(PUT);
         then.status(200);
     });
-    let checkpoint_mock = server.mock(|when, then| {
-        when.method(POST).path("/api/webhooks/agent/checkpoints");
+    let complete_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/complete");
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "unexpected", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "completed"}));
     });
 
-    let result = guest_agent::checkpoint::create_checkpoint_for_runtime(
+    let result = guest_agent::checkpoint::prepare_checkpoint_for_runtime(
         &runtime,
         &checkpoint_session_metadata(&runtime),
     )
     .await;
 
-    let err = result.unwrap_err();
+    let err = result
+        .err()
+        .expect("mismatched existing blob should fail checkpoint preparation");
     assert!(
         err.to_string()
             .contains("Session history encoded size does not match the existing blob"),
@@ -919,7 +985,7 @@ async fn success_checkpoint_propagates_zstd_prepare_bad_request()
     );
     zstd_prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(0).await;
+    complete_mock.assert_calls_async(0).await;
     Ok(())
 }
 
@@ -957,20 +1023,22 @@ async fn success_checkpoint_rejects_missing_zstd_encoding_acknowledgement()
         when.method(PUT).path("/test/zstd-unack-history-upload");
         then.status(200);
     });
-    let checkpoint_mock = server.mock(|when, then| {
-        when.method(POST).path("/api/webhooks/agent/checkpoints");
+    let complete_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/complete");
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "unexpected", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "completed"}));
     });
 
-    let result = guest_agent::checkpoint::create_checkpoint_for_runtime(
+    let result = guest_agent::checkpoint::prepare_checkpoint_for_runtime(
         &runtime,
         &checkpoint_session_metadata(&runtime),
     )
     .await;
 
-    let err = result.unwrap_err();
+    let err = result
+        .err()
+        .expect("missing zstd acknowledgement should fail checkpoint preparation");
     assert!(
         err.to_string()
             .contains("Prepare-history response did not acknowledge zstd"),
@@ -978,7 +1046,7 @@ async fn success_checkpoint_rejects_missing_zstd_encoding_acknowledgement()
     );
     zstd_prepare_mock.assert_calls_async(1).await;
     zstd_upload_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(0).await;
+    complete_mock.assert_calls_async(0).await;
     Ok(())
 }
 
@@ -1019,20 +1087,22 @@ async fn success_checkpoint_rejects_new_zstd_with_mismatched_encoding_acknowledg
             .path("/test/zstd-new-mismatched-ack-upload");
         then.status(200);
     });
-    let checkpoint_mock = server.mock(|when, then| {
-        when.method(POST).path("/api/webhooks/agent/checkpoints");
+    let complete_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/complete");
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "unexpected", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "completed"}));
     });
 
-    let result = guest_agent::checkpoint::create_checkpoint_for_runtime(
+    let result = guest_agent::checkpoint::prepare_checkpoint_for_runtime(
         &runtime,
         &checkpoint_session_metadata(&runtime),
     )
     .await;
 
-    let err = result.unwrap_err();
+    let err = result
+        .err()
+        .expect("mismatched zstd acknowledgement should fail checkpoint preparation");
     assert!(
         err.to_string()
             .contains("Prepare-history response did not acknowledge zstd"),
@@ -1040,7 +1110,7 @@ async fn success_checkpoint_rejects_new_zstd_with_mismatched_encoding_acknowledg
     );
     zstd_prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(0).await;
+    complete_mock.assert_calls_async(0).await;
     Ok(())
 }
 
@@ -1079,28 +1149,31 @@ async fn success_checkpoint_accepts_existing_gzip_for_zstd_history()
         when.method(PUT);
         then.status(200);
     });
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(r#"{"cliAgentSessionId":"zstd-existing-gzip-session"}"#)
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(
+                r#"{"checkpoint":{"cliAgentSessionId":"zstd-existing-gzip-session"}}"#,
+            )
             .json_body_includes(format!(
-                r#"{{"cliAgentSessionHistoryHash":"{history_hash}"}}"#
+                r#"{{"checkpoint":{{"cliAgentSessionHistoryHash":"{history_hash}"}}}}"#
             ));
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-existing-gzip", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "completed"}));
     });
 
-    let result = guest_agent::checkpoint::create_checkpoint_for_runtime(
+    let result = guest_agent::checkpoint::prepare_checkpoint_for_runtime(
         &runtime,
         &checkpoint_session_metadata(&runtime),
     )
     .await;
 
-    assert!(result.is_ok());
+    let checkpoint = result.unwrap();
+    report_prepared_checkpoint(&runtime, 0, checkpoint).await?;
     prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(1).await;
     Ok(())
 }
 
@@ -1139,20 +1212,22 @@ async fn success_checkpoint_propagates_zstd_auth_failure() -> Result<(), Box<dyn
         when.method(PUT);
         then.status(200);
     });
-    let checkpoint_mock = server.mock(|when, then| {
-        when.method(POST).path("/api/webhooks/agent/checkpoints");
+    let complete_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/complete");
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "unexpected", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "completed"}));
     });
 
-    let result = guest_agent::checkpoint::create_checkpoint_for_runtime(
+    let result = guest_agent::checkpoint::prepare_checkpoint_for_runtime(
         &runtime,
         &checkpoint_session_metadata(&runtime),
     )
     .await;
 
-    let err = result.unwrap_err();
+    let err = result
+        .err()
+        .expect("authorization failure should fail checkpoint preparation");
     assert!(
         err.to_string()
             .contains("unauthorized checkpoint history prepare"),
@@ -1160,7 +1235,7 @@ async fn success_checkpoint_propagates_zstd_auth_failure() -> Result<(), Box<dyn
     );
     zstd_prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(0).await;
+    complete_mock.assert_calls_async(0).await;
     Ok(())
 }
 
@@ -1241,27 +1316,30 @@ async fn success_checkpoint_uses_explicit_runtime_after_process_env_changes() {
             .body(history.as_str());
         then.status(200);
     });
-    let checkpoint_mock = server.mock(|when, then| {
+    let complete_mock = server.mock(|when, then| {
         when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
+            .path("/api/webhooks/agent/complete")
             .json_body_includes(r#"{"runId":"captured-run"}"#)
-            .json_body_includes(r#"{"cliAgentType":"claude-code"}"#)
-            .json_body_includes(r#"{"cliAgentSessionId":"captured-session"}"#);
+            .json_body_includes(r#"{"checkpoint":{"cliAgentType":"claude-code"}}"#)
+            .json_body_includes(r#"{"checkpoint":{"cliAgentSessionId":"captured-session"}}"#);
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-explicit-runtime", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
+            .json_body(json!({"success": true, "status": "completed"}));
     });
 
-    let result = guest_agent::checkpoint::create_checkpoint_for_runtime(
+    let result = guest_agent::checkpoint::prepare_checkpoint_for_runtime(
         &runtime,
         &checkpoint_session_metadata(&runtime),
     )
     .await;
 
-    assert!(result.is_ok());
+    let checkpoint = result.unwrap();
+    report_prepared_checkpoint(&runtime, 0, checkpoint)
+        .await
+        .unwrap();
     prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(1).await;
-    checkpoint_mock.assert_calls_async(1).await;
+    complete_mock.assert_calls_async(1).await;
     assert!(
         std::path::Path::new(&final_identity_file).exists(),
         "final identity should be written under explicit runtime paths"

--- a/crates/guest-agent/tests/integration_cases/checkpoint/support.rs
+++ b/crates/guest-agent/tests/integration_cases/checkpoint/support.rs
@@ -19,26 +19,39 @@ pub(super) async fn create_bounded_checkpoint(
     runtime: &guest_agent::run_context::GuestRuntime,
 ) -> Result<(), guest_agent::error::AgentError> {
     let session_metadata = checkpoint_session_metadata(runtime);
-    guest_agent::checkpoint::create_checkpoint_for_runtime_with_history_limits_for_test(
-        runtime,
-        &session_metadata,
-        CHECKPOINT_TEST_CANDIDATE_MAX_BYTES,
-        CHECKPOINT_TEST_MAX_BYTES,
-    )
-    .await
+    let checkpoint =
+        guest_agent::checkpoint::prepare_checkpoint_for_runtime_with_history_limits_for_test(
+            runtime,
+            &session_metadata,
+            CHECKPOINT_TEST_CANDIDATE_MAX_BYTES,
+            CHECKPOINT_TEST_MAX_BYTES,
+        )
+        .await?;
+    report_prepared_checkpoint(runtime, 0, checkpoint).await
 }
 
 pub(super) async fn create_bounded_recovery_checkpoint(
     runtime: &guest_agent::run_context::GuestRuntime,
 ) -> Result<(), guest_agent::error::AgentError> {
     let session_metadata = checkpoint_session_metadata(runtime);
-    guest_agent::checkpoint::create_recovery_checkpoint_for_runtime_with_history_limits_for_test(
-        runtime,
-        &session_metadata,
-        CHECKPOINT_TEST_CANDIDATE_MAX_BYTES,
-        CHECKPOINT_TEST_MAX_BYTES,
-    )
-    .await
+    let checkpoint =
+        guest_agent::checkpoint::prepare_recovery_checkpoint_for_runtime_with_history_limits_for_test(
+            runtime,
+            &session_metadata,
+            CHECKPOINT_TEST_CANDIDATE_MAX_BYTES,
+            CHECKPOINT_TEST_MAX_BYTES,
+        )
+        .await?;
+    report_prepared_checkpoint(runtime, 1, checkpoint).await
+}
+
+pub(super) async fn report_prepared_checkpoint(
+    runtime: &guest_agent::run_context::GuestRuntime,
+    exit_code: i32,
+    checkpoint: guest_agent::checkpoint::PreparedCheckpoint,
+) -> Result<(), guest_agent::error::AgentError> {
+    guest_agent::complete::report_checkpoint_for_run(runtime, exit_code, None, &[], checkpoint)
+        .await
 }
 
 pub(super) fn checkpoint_session_metadata(

--- a/crates/guest-agent/tests/integration_cases/checkpoint/support.rs
+++ b/crates/guest-agent/tests/integration_cases/checkpoint/support.rs
@@ -50,8 +50,15 @@ pub(super) async fn report_prepared_checkpoint(
     exit_code: i32,
     checkpoint: guest_agent::checkpoint::PreparedCheckpoint,
 ) -> Result<(), guest_agent::error::AgentError> {
-    guest_agent::complete::report_checkpoint_for_run(runtime, exit_code, None, &[], checkpoint)
-        .await
+    guest_agent::complete::report_checkpoint_for_run(
+        runtime,
+        exit_code,
+        None,
+        None,
+        &[],
+        checkpoint,
+    )
+    .await
 }
 
 pub(super) fn checkpoint_session_metadata(

--- a/crates/guest-agent/tests/integration_cases/complete.rs
+++ b/crates/guest-agent/tests/integration_cases/complete.rs
@@ -1,7 +1,6 @@
 use crate::support::*;
 use httpmock::prelude::*;
 use serde_json::json;
-use std::time::Duration;
 
 const TEST_RUN_ID: &str = "test-run-001";
 const TEST_SANDBOX_ID: &str = "00000000-0000-4000-8000-000000000abc";
@@ -12,14 +11,13 @@ const TEST_DELIVERY_ID: &str = "b1e2ad6d-930a-4d51-aa40-7952d54f978b";
 // =========================================================================
 // Complete webhook
 //
-// The guest calls /complete right after the checkpoint row lands — the host
-// transitions the run to `completed` seconds earlier than waiting for the
-// runner's fallback after VM teardown. The runner's POST still fires on VM
-// exit and is absorbed by the route's idempotency check.
+// Checkpoint-less completion is retained only for explicit cancellation when
+// recovery preparation or combined reporting cannot be acknowledged. The
+// runner's POST still fires on VM exit and is absorbed by idempotency.
 // =========================================================================
 
 #[tokio::test]
-async fn complete_report_success_posts_full_payload_when_metadata_present() {
+async fn cancellation_fallback_posts_full_payload_when_metadata_present() {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
@@ -29,7 +27,7 @@ async fn complete_report_success_posts_full_payload_when_metadata_present() {
             .header("Authorization", "Bearer test-token-abc123")
             .json_body(json!({
                 "runId": TEST_RUN_ID,
-                "exitCode": 0,
+                "exitCode": 1,
                 "lastEventSequence": 7,
                 "sandboxId": TEST_SANDBOX_ID,
                 "sandboxReuseResult": TEST_SANDBOX_REUSE_RESULT,
@@ -42,7 +40,7 @@ async fn complete_report_success_posts_full_payload_when_metadata_present() {
         }));
     });
 
-    guest_agent::complete::report_success_for_run(
+    guest_agent::complete::report_user_cancellation_for_run(
         &http_client!(),
         TEST_RUN_ID,
         TEST_SANDBOX_ID,
@@ -61,7 +59,7 @@ async fn complete_report_success_posts_full_payload_when_metadata_present() {
 /// payload carries only `runId` + `exitCode`. Matches the
 /// `skip_serializing_if = "Option::is_none"` contract end-to-end.
 #[tokio::test]
-async fn complete_report_success_omits_metadata_when_env_absent() {
+async fn cancellation_fallback_omits_metadata_when_env_absent() {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
@@ -70,12 +68,12 @@ async fn complete_report_success_omits_metadata_when_env_absent() {
             .path("/api/webhooks/agent/complete")
             .json_body(json!({
                 "runId": TEST_RUN_ID,
-                "exitCode": 0,
+                "exitCode": 1,
             }));
         then.status(200).json_body(json!({"success": true}));
     });
 
-    guest_agent::complete::report_success_for_run(
+    guest_agent::complete::report_user_cancellation_for_run(
         &http_client!(),
         TEST_RUN_ID,
         "",
@@ -90,7 +88,7 @@ async fn complete_report_success_omits_metadata_when_env_absent() {
 }
 
 #[tokio::test]
-async fn complete_report_success_swallows_server_error() {
+async fn cancellation_fallback_swallows_server_error() {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
@@ -101,7 +99,7 @@ async fn complete_report_success_swallows_server_error() {
 
     // 1 attempt — no retry, no panic. Fire-and-forget semantics mean the
     // runner fallback is the correctness guarantee.
-    guest_agent::complete::report_success_for_run(
+    guest_agent::complete::report_user_cancellation_for_run(
         &http_client!(),
         TEST_RUN_ID,
         TEST_SANDBOX_ID,
@@ -121,7 +119,7 @@ async fn complete_report_success_swallows_server_error() {
 /// error still swallows cleanly and the runner fallback will be the only
 /// call that actually transitions the run.
 #[tokio::test]
-async fn complete_report_success_swallows_4xx_auth_error() {
+async fn cancellation_fallback_swallows_4xx_auth_error() {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
@@ -132,7 +130,7 @@ async fn complete_report_success_swallows_4xx_auth_error() {
         }));
     });
 
-    guest_agent::complete::report_success_for_run(
+    guest_agent::complete::report_user_cancellation_for_run(
         &http_client!(),
         TEST_RUN_ID,
         TEST_SANDBOX_ID,
@@ -142,46 +140,6 @@ async fn complete_report_success_swallows_4xx_auth_error() {
         &[],
     )
     .await;
-
-    mock.assert_calls_async(1).await;
-}
-
-#[tokio::test]
-async fn complete_report_user_cancellation_posts_nonzero_and_swallows_server_error() {
-    let api = SharedApiMock::new().await;
-    let server = api.server();
-
-    let mock = server.mock(|when, then| {
-        when.method(POST)
-            .path("/api/webhooks/agent/complete")
-            .json_body(json!({
-                "runId": TEST_RUN_ID,
-                "exitCode": 1,
-                "lastEventSequence": 9,
-                "sandboxId": TEST_SANDBOX_ID,
-                "sandboxReuseResult": TEST_SANDBOX_REUSE_RESULT,
-                "workspaceReuseResult": TEST_WORKSPACE_REUSE_RESULT,
-            }));
-        then.status(500);
-    });
-
-    let result = tokio::time::timeout(
-        Duration::from_secs(2),
-        guest_agent::complete::report_user_cancellation_for_run(
-            &http_client!(),
-            TEST_RUN_ID,
-            TEST_SANDBOX_ID,
-            TEST_SANDBOX_REUSE_RESULT,
-            TEST_WORKSPACE_REUSE_RESULT,
-            Some(9),
-            &[],
-        ),
-    )
-    .await;
-    assert!(
-        result.is_ok(),
-        "failed cancellation completion must not hang guest shutdown"
-    );
 
     mock.assert_calls_async(1).await;
 }

--- a/crates/guest-agent/tests/no_api_mode.rs
+++ b/crates/guest-agent/tests/no_api_mode.rs
@@ -88,7 +88,7 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
 
     let complete_log_path = tmp.path().join("complete-system.log");
     let complete_log_guard = SystemLogOverrideGuard::set(&complete_log_path);
-    guest_agent::complete::report_success_for_run(
+    guest_agent::complete::report_user_cancellation_for_run(
         &http,
         &runtime.config.run_id,
         "sandbox-no-api",

--- a/crates/guest-agent/tests/user_cancellation_recovery.rs
+++ b/crates/guest-agent/tests/user_cancellation_recovery.rs
@@ -26,31 +26,45 @@ struct Scenario {
     run_id: &'static str,
     thread_id: &'static str,
     endpoint_nonce: &'static [u8; 16],
-    checkpoint_status: u16,
+    combined_completion_status: u16,
+    combined_completion_attempts: usize,
+    fallback_completion_attempts: usize,
+    expected_request_order: &'static [&'static str],
     recovery_log: &'static str,
 }
 
 #[tokio::test]
-async fn user_cancellation_checkpoints_before_reporting_completion()
+async fn user_cancellation_reports_checkpoint_with_completion()
 -> Result<(), Box<dyn std::error::Error>> {
     run_scenario(Scenario {
         run_id: SUCCESS_RUN_ID,
         thread_id: SUCCESS_THREAD_ID,
         endpoint_nonce: b"cancel-success01",
-        checkpoint_status: 200,
+        combined_completion_status: 200,
+        combined_completion_attempts: 1,
+        fallback_completion_attempts: 0,
+        expected_request_order: &["combined_complete"],
         recovery_log: "Recovery checkpoint created",
     })
     .await
 }
 
 #[tokio::test]
-async fn user_cancellation_reports_completion_after_recovery_failure()
+async fn user_cancellation_falls_back_after_combined_completion_failure()
 -> Result<(), Box<dyn std::error::Error>> {
     run_scenario(Scenario {
         run_id: FAILURE_RUN_ID,
         thread_id: FAILURE_THREAD_ID,
         endpoint_nonce: b"cancel-failure01",
-        checkpoint_status: 400,
+        combined_completion_status: 500,
+        combined_completion_attempts: 3,
+        fallback_completion_attempts: 1,
+        expected_request_order: &[
+            "combined_complete",
+            "combined_complete",
+            "combined_complete",
+            "fallback_complete",
+        ],
         recovery_log: "Recovery checkpoint skipped:",
     })
     .await
@@ -111,37 +125,46 @@ async fn run_scenario(scenario: Scenario) -> Result<(), Box<dyn std::error::Erro
             .header("Content-Type", "application/octet-stream");
         then.status(200);
     });
-    let checkpoint_order = Arc::clone(&request_order);
-    let checkpoint = server.mock(move |when, then| {
-        when.method(POST)
-            .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(format!(
-                r#"{{"cliAgentSessionId":"{}"}}"#,
-                scenario.thread_id
-            ));
-        then.respond_with(move |_| {
-            checkpoint_order
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner)
-                .push("checkpoint");
-            HttpMockResponse::builder()
-                .status(scenario.checkpoint_status)
-                .header("Content-Type", "application/json")
-                .body(r#"{"checkpointId":"user-cancellation-recovery-checkpoint","agentSessionId":"test-agent-session","conversationId":"test-conversation"}"#)
-                .build()
-        });
-    });
-    let complete_order = Arc::clone(&request_order);
-    let complete = server.mock(move |when, then| {
+    let combined_complete_order = Arc::clone(&request_order);
+    let combined_complete = server.mock(move |when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/complete")
             .header("Authorization", "Bearer test-token")
-            .json_body_includes(format!(r#"{{"runId":"{}","exitCode":1}}"#, scenario.run_id));
+            .json_body_includes(format!(
+                r#"{{"runId":"{}","exitCode":1,"checkpoint":{{"cliAgentSessionId":"{}"}}}}"#,
+                scenario.run_id, scenario.thread_id
+            ));
         then.respond_with(move |_| {
-            complete_order
+            combined_complete_order
                 .lock()
                 .unwrap_or_else(PoisonError::into_inner)
-                .push("complete");
+                .push("combined_complete");
+            HttpMockResponse::builder()
+                .status(scenario.combined_completion_status)
+                .header("Content-Type", "application/json")
+                .body(r#"{"success":true,"status":"failed"}"#)
+                .build()
+        });
+    });
+    let fallback_complete_order = Arc::clone(&request_order);
+    let fallback_complete = server.mock(move |when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/complete")
+            .header("Authorization", "Bearer test-token")
+            .is_true(move |request| {
+                let Ok(body) = serde_json::from_slice::<serde_json::Value>(request.body_ref())
+                else {
+                    return false;
+                };
+                body.get("runId").and_then(serde_json::Value::as_str) == Some(scenario.run_id)
+                    && body.get("exitCode").and_then(serde_json::Value::as_i64) == Some(1)
+                    && body.get("checkpoint").is_none()
+            });
+        then.respond_with(move |_| {
+            fallback_complete_order
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .push("fallback_complete");
             HttpMockResponse::builder()
                 .status(200)
                 .header("Content-Type", "application/json")
@@ -267,28 +290,28 @@ async fn run_scenario(scenario: Scenario) -> Result<(), Box<dyn std::error::Erro
     );
     prepare.assert_calls_async(1).await;
     upload.assert_calls_async(1).await;
-    checkpoint.assert_calls_async(1).await;
-    complete.assert_calls_async(1).await;
+    combined_complete
+        .assert_calls_async(scenario.combined_completion_attempts)
+        .await;
+    fallback_complete
+        .assert_calls_async(scenario.fallback_completion_attempts)
+        .await;
     assert_eq!(
         request_order
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .as_slice(),
-        ["checkpoint", "complete"],
-        "recovery checkpoint request must arrive before /complete"
+        scenario.expected_request_order,
+        "checkpoint-less cancellation completion may only follow failed combined attempts"
     );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let recovery_index = stderr
+    stderr
         .find(scenario.recovery_log)
         .ok_or_else(|| std::io::Error::other(format!("missing recovery log:\n{stderr}")))?;
-    let complete_index = stderr
+    stderr
         .find("Complete webhook acknowledged")
         .ok_or_else(|| std::io::Error::other(format!("missing completion log:\n{stderr}")))?;
-    assert!(
-        recovery_index < complete_index,
-        "recovery must finish before /complete:\n{stderr}"
-    );
 
     let paths = guest_agent::paths::GuestPaths::from_runtime_dir(runtime_dir);
     let diagnostic: FailureDiagnostic =

--- a/docs/active-input-delivery.md
+++ b/docs/active-input-delivery.md
@@ -98,12 +98,13 @@ thread without replaying the run's ordinary terminal callbacks or billing work.
 
 ### Final Checkpoint Completion
 
-The Guest may include final checkpoint metadata in
+The bundled Guest prepares final checkpoint metadata and sends it in
 `/api/webhooks/agent/complete`. Session history and artifact bytes are uploaded
-before that request; completion carries only their validated identities and
-storage snapshots. The API then persists the checkpoint, promotes the eligible
-canonical AgentSession conversation, settles active-input delivery, and applies
-the terminal run state in the same database transaction.
+before that request; completion carries their validated identities and storage
+snapshots together with the event watermark, active-input delivery IDs, and
+sandbox reuse metadata. The API then persists the checkpoint, promotes the
+eligible canonical AgentSession conversation, settles active-input delivery,
+and applies the terminal run state in the same database transaction.
 
 The nested checkpoint omits `runId`; the completion request's outer `runId` and
 sandbox authorization remain authoritative. Invalid checkpoint metadata rejects
@@ -111,11 +112,26 @@ the combined request without partially finalizing delivery or changing the run
 status. Repeating a committed combined request is idempotent, and a later
 checkpoint-less Runner completion observes the first terminal result.
 
+Successful execution and successful recovery send one combined completion and
+do not post the prepared checkpoint to the standalone route. Combined reporting
+uses the checkpoint retry budget. Mandatory success-path failure produces a
+nonzero Guest result, while recovery remains best-effort. Explicit cancellation
+still sends one checkpoint-less completion when checkpoint preparation or the
+combined request is not acknowledged. Local session-history reconciliation
+happens only after the combined request is acknowledged.
+
 The standalone checkpoint route and checkpoint-less completion remain supported
-for older Guests. Runner completion timing and payloads are unchanged. The API
-release that accepts the combined request must reach production, and preceding
-API handlers must drain, before a Guest starts sending it. While combined Guests
-can execute, that API release is the rollback floor.
+for outgoing Guests and the unchanged Runner fallback. Runner completion timing
+and payloads are unchanged. The API release that accepts the combined request
+must reach production, and preceding API handlers must drain, before a Guest
+starts sending it. While combined Guests can execute, that API release is the
+rollback floor.
+
+After the combined Guest/Runner artifact reaches production, record its traffic
+promotion boundary, stop the outgoing Runner target from claiming new work, and
+wait for its existing Guest runs to drain. The later immutable-timeout rollout
+must wait at least 7,200 seconds after that cutover and confirm that no
+pre-cutover `pending` or `running` cohort remains.
 
 This compatibility boundary does not make timeout immutable and does not change
 legacy standalone checkpoint admission. Those changes require the later timeout


### PR DESCRIPTION
## Summary

- prepare Guest checkpoint history and artifact metadata without posting the standalone checkpoint
- persist checkpoint metadata and terminal run state atomically through `/api/webhooks/agent/complete`
- reconcile local session history only after the combined completion is acknowledged
- preserve mandatory success retries, best-effort recovery, failure details, and a single checkpoint-less cancellation fallback
- document the deployment compatibility boundary and drain gate

## Scope

- Runner completion behavior is unchanged and remains the checkpoint-less fallback
- the standalone checkpoint API remains available for outgoing Guests
- immutable timeout enforcement is deferred to the later delivery slice

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent -p api-contracts -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p guest-agent -p api-contracts -p runner --no-deps`
- `cargo test -p guest-agent`
- `cargo test -p api-contracts`
- `cargo test -p runner api_provider_complete_`
- `cargo test -p runner api_provider_claim_carries_sandbox_token_to_completion`
- `cargo test -p runner main_loop_discover_claim_execute_complete`
- pre-commit workspace Rust formatting, Clippy, Rustdoc, file-size, and commitlint hooks

Closes #30348

Parent delivery issue: #30250
