### PR TITLE
fix(runner): report only fail-closed response encoding risk

### DIFF
--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -40,6 +40,11 @@ Request context
   HTTP/1.1 request is a confirmed WebSocket upgrade handshake. Read by
   response streaming so only matching 101 responses defer model-provider usage
   release until ``websocket_end()``.
+- ``RESPONSE_ENCODING_NEGOTIATION``: fixed ``str`` outcome written when request
+  handling normalizes ``Accept-Encoding`` for response-body usage inspection.
+  Read only by the fail-closed response-encoding diagnostic, restored with an
+  abandoned header-phase request probe, preserved across firewall-auth
+  revalidation, and removed by terminal flow cleanup.
 
 Timing context
 --------------
@@ -210,6 +215,7 @@ SUPPRESS_REQUEST_BODY_CAPTURE: Final = "suppress_request_body_capture"
 CLI_AGENT_TYPE: Final = "cli_agent_type"
 BROWSER_USER_AGENT: Final = "browser_user_agent"
 WEBSOCKET_UPGRADE_REQUEST: Final = "websocket_upgrade_request"
+RESPONSE_ENCODING_NEGOTIATION: Final = "response_encoding_negotiation"
 
 # Timing metadata
 HTTP_REQUEST_START_MONOTONIC: Final = "http_request_start_monotonic"

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1175,6 +1175,7 @@ def _current_firewall_authorization_classification(
             metadata_keys.HTTP_REQUEST_START_MONOTONIC,
             metadata_keys.WEBSOCKET_UPGRADE_REQUEST,
             metadata_keys.AWS_SIGV4_REQUEST_INSPECTION,
+            metadata_keys.RESPONSE_ENCODING_NEGOTIATION,
         )
         if key in flow.metadata
     }
@@ -1518,8 +1519,10 @@ def _maybe_normalize_accept_encoding_for_body_inspection(
     if _is_websocket_upgrade_request(flow):
         flow.metadata[metadata_keys.WEBSOCKET_UPGRADE_REQUEST] = True
     if _expects_http_response_body_usage_inspection(flow, allow, sandbox_info):
-        response_encoding_negotiation.normalize_accept_encoding_for_body_inspection(
-            flow.request.headers
+        flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] = (
+            response_encoding_negotiation.normalize_accept_encoding_for_body_inspection(
+                flow.request.headers
+            )
         )
 
 
@@ -1683,6 +1686,7 @@ def _release_terminal_flow_state(
     flow.metadata.pop(metadata_keys.FIREWALL_AUTH_PROBE_FAILURE, None)
     release_aws_sigv4_request_inspection(flow)
     flow.metadata.pop(metadata_keys.WEBSOCKET_UPGRADE_REQUEST, None)
+    flow.metadata.pop(metadata_keys.RESPONSE_ENCODING_NEGOTIATION, None)
     request_streaming.release_request_stream_state(flow)
     connector_diagnostics.release_flow_state(flow)
     codex_model_catalog_cache.release_flow_state(flow)

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -45,6 +45,7 @@ REQUEST_HEADERS_PROBE_METADATA_KEYS = (
     metadata_keys.CLI_AGENT_TYPE,
     metadata_keys.BROWSER_USER_AGENT,
     metadata_keys.WEBSOCKET_UPGRADE_REQUEST,
+    metadata_keys.RESPONSE_ENCODING_NEGOTIATION,
     metadata_keys.ORIGINAL_URL,
     metadata_keys.TRUSTED_AUTHORITY_HOST,
     metadata_keys.NETWORK_LOG_TARGET,

--- a/crates/runner/mitm-addon/src/response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/src/response_encoding_negotiation.py
@@ -2,6 +2,7 @@
 
 import re
 from decimal import Decimal, InvalidOperation
+from typing import Literal
 
 from mitmproxy import http
 
@@ -17,8 +18,16 @@ _MAX_Q_VALUE = Decimal(1)
 _Q_VALUE_PATTERN = re.compile(r"(?:0(?:\.[0-9]{0,3})?|1(?:\.0{0,3})?)")
 _HTTP_OWS_CHARS = " \t"
 
+type ResponseEncodingNegotiationOutcome = Literal[
+    "already_stream_decodable",
+    "rewritten_stream_decodable",
+    "preserved_client_constraints",
+]
 
-def normalize_accept_encoding_for_body_inspection(headers: http.Headers) -> None:
+
+def normalize_accept_encoding_for_body_inspection(
+    headers: http.Headers,
+) -> ResponseEncodingNegotiationOutcome:
     """Best-effort restriction of Accept-Encoding for body inspection.
 
     The proxy inspects selected upstream responses for usage/billing.  For those
@@ -29,12 +38,13 @@ def normalize_accept_encoding_for_body_inspection(headers: http.Headers) -> None
     every supported compression coding are rejected, the original header remains
     unchanged and the actual response might not support bounded streaming
     inspection.  Callers must use the response's ``Content-Encoding`` to decide
-    whether incremental body inspection is available.
+    whether incremental body inspection is available. The return value records
+    whether the request was already safe, rewritten, or preserved by constraint.
     """
     values = headers.get_all(_ACCEPT_ENCODING)
     if not values:
         headers[_ACCEPT_ENCODING] = _IDENTITY
-        return
+        return "rewritten_stream_decodable"
 
     accepted_safe: dict[str, str | None] = {}
     rejected_safe: set[str] = set()
@@ -95,13 +105,16 @@ def normalize_accept_encoding_for_body_inspection(headers: http.Headers) -> None
         rewritten = ", ".join(
             _format_coding(name, q_text) for name, q_text in accepted_safe.items()
         )
-        _set_if_changed(headers, values, rewritten)
-        return
+        if _set_if_changed(headers, values, rewritten):
+            return "rewritten_stream_decodable"
+        return "already_stream_decodable"
 
     if identity_rejected:
-        return
+        return "preserved_client_constraints"
 
-    _set_if_changed(headers, values, _IDENTITY)
+    if _set_if_changed(headers, values, _IDENTITY):
+        return "rewritten_stream_decodable"
+    return "already_stream_decodable"
 
 
 def _parse_coding(raw_coding: str) -> tuple[str, Decimal | None]:
@@ -166,7 +179,8 @@ def _add_wildcard_safe_compression_encodings(
             accepted_safe[name] = wildcard_q_text
 
 
-def _set_if_changed(headers: http.Headers, original_values: list[str], value: str) -> None:
+def _set_if_changed(headers: http.Headers, original_values: list[str], value: str) -> bool:
     if len(original_values) == 1 and original_values[0] == value:
-        return
+        return False
     headers[_ACCEPT_ENCODING] = value
+    return True

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -155,23 +155,27 @@ def _anthropic_lifecycle_observer(
     return observe
 
 
-def _maybe_log_response_encoding_inspection_risk(
+def _log_response_encoding_fail_closed(
     flow: http.HTTPFlow,
     response: http.Response,
 ) -> None:
-    if not http_response_classification.can_have_body(flow, response):
-        return
     skip_reason = body_decoding.stream_decode_skip_reason(response.headers)
     if skip_reason is None:
-        return
+        raise RuntimeError("fail-closed response encoding is stream-decodable")
     log_usage_underbilling(
         flow_metadata.proxy_log_path(flow.metadata),
-        "Response encoding prevents incremental usage inspection",
+        "Response encoding has no bounded usage accounting path",
         "response_encoding_not_stream_decodable",
         "risk",
         run_id=flow_metadata.run_id(flow.metadata),
         firewall_name=flow_metadata.firewall_name(flow.metadata),
+        firewall_billable=flow_metadata.is_firewall_billable(flow.metadata),
         status_code=response.status_code,
+        inspection_disposition="fail_closed",
+        request_encoding_negotiation=flow.metadata.get(
+            metadata_keys.RESPONSE_ENCODING_NEGOTIATION,
+            "not_recorded",
+        ),
         decode_skip_reason=skip_reason,
     )
 
@@ -263,8 +267,6 @@ def _configure_response_inspection_stream(
                 )
             decode_session = _make_response_decode_session(parser_fn, response.headers)
             if decode_session is None:
-                if is_observable_model_provider:
-                    _maybe_log_response_encoding_inspection_risk(flow, response)
                 if failure_observer is not None:
                     model_provider_failure.register_response_finish(
                         flow,
@@ -344,8 +346,6 @@ def _configure_response_inspection_stream(
             should_continue=extractor.accepts_more_input,
         )
         if decode_session is None:
-            if is_observable_model_provider:
-                _maybe_log_response_encoding_inspection_risk(flow, response)
             if failure_observer is not None:
                 model_provider_failure.register_response_finish(
                     flow,
@@ -412,8 +412,6 @@ def _configure_response_inspection_stream(
             _HTTP_STATUS_OK_MIN <= response.status_code < _HTTP_STATUS_REDIRECT_MIN
             and usage.has_connector_response_parser(firewall_name)
         )
-        if requires_response_inspection:
-            _maybe_log_response_encoding_inspection_risk(flow, response)
         needs_buffered_fallback = (
             http_response_classification.can_have_body(flow, response)
             and body_decoding.can_decode_json_usage_body(response.headers)
@@ -512,6 +510,7 @@ def configure_response_stream(flow: http.HTTPFlow) -> None:
     failure_observer = model_provider_failure.configure_response_observer(flow)
     setup = _configure_response_inspection_stream(flow, failure_observer)
     if setup.reject_uninspectable:
+        _log_response_encoding_fail_closed(flow, flow.response)
         _reject_uninspectable_response(flow)
         return
 

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -172,10 +172,7 @@ def _log_response_encoding_fail_closed(
         firewall_billable=flow_metadata.is_firewall_billable(flow.metadata),
         status_code=response.status_code,
         inspection_disposition="fail_closed",
-        request_encoding_negotiation=flow.metadata.get(
-            metadata_keys.RESPONSE_ENCODING_NEGOTIATION,
-            "not_recorded",
-        ),
+        request_encoding_negotiation=flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION],
         decode_skip_reason=skip_reason,
     )
 

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -12,7 +12,9 @@ class TestXStreamPathRouting:
     """Tests for stream path routing through responseheaders (issue #9534)."""
 
     def _make_x_response_flow(self, real_flow, path: str):
-        return make_x_response_flow(real_flow, path=path)
+        flow = make_x_response_flow(real_flow, path=path)
+        flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] = "already_stream_decodable"
+        return flow
 
     @pytest.mark.parametrize(
         "path",

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -1682,6 +1682,7 @@ def test_uninspectable_billable_success_is_not_reported_as_provider_failure(
         ),
     )
     flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
+    flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] = "already_stream_decodable"
 
     model_provider_failure.admit_flow(flow)
     mitm_addon.responseheaders(flow)

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage_openai_responses.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage_openai_responses.py
@@ -37,7 +37,7 @@ def _openai_responses_sse_flow(
     *,
     model_usage_provider: str = "gpt-5.5",
 ) -> http.HTTPFlow:
-    return model_provider_sse_flow(
+    flow = model_provider_sse_flow(
         tmp_path,
         real_flow,
         host="api.openai.com",
@@ -46,6 +46,8 @@ def _openai_responses_sse_flow(
         cli_agent_type="codex",
         model_usage_provider=model_usage_provider,
     )
+    flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] = "already_stream_decodable"
+    return flow
 
 
 class TestOpenAIResponsesSseUsage:

--- a/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
@@ -18,6 +18,7 @@ import terminal_usage
 import usage
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
 from tests.flow_helpers import response_stream
+from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.pending_helpers import assert_pending
 from tests.request_handler_helpers import _single_firewall_sandbox, _write_registry
 from tests.requestheaders_helpers import await_requestheaders_result
@@ -830,6 +831,10 @@ async def test_billable_model_provider_rejects_uninspectable_response_and_drains
         await mitm_addon.request(flow)
 
         assert flow.request.headers["Accept-Encoding"] == "br, identity;q=0"
+        assert (
+            flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION]
+            == "preserved_client_constraints"
+        )
         usage.write_pending_snapshot(flush_request_id="before-response")
         assert_pending(
             usage_pending_path,
@@ -849,12 +854,23 @@ async def test_billable_model_provider_rejects_uninspectable_response_and_drains
         )
         mitm_addon.responseheaders(flow)
 
+        underbilling_entries = [
+            entry
+            for entry in read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+            if entry.get("type") == "usage_underbilling"
+        ]
+        [entry] = underbilling_entries
+        assert entry["reason"] == "response_encoding_not_stream_decodable"
+        assert entry["firewall_billable"] is True
+        assert entry["inspection_disposition"] == "fail_closed"
+        assert entry["request_encoding_negotiation"] == "preserved_client_constraints"
         assert flow.response.status_code == 502
         assert flow.response.content == b""
         stream = response_stream(flow)
         assert stream(b"uninspectable upstream bytes") == b""
         assert stream(b"") == b""
         mitm_addon.response(flow)
+        assert metadata_keys.RESPONSE_ENCODING_NEGOTIATION not in flow.metadata
         assert usage.flush_usage_events(trigger="test") == 0
 
     assert usage_webhook_server.request_count == 0

--- a/crates/runner/mitm-addon/tests/test_response_encoding_inspection_risk.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_inspection_risk.py
@@ -44,6 +44,7 @@ class TestResponseEncodingInspectionRisk:
                 metadata_keys.FIREWALL_NAME: "model-provider:anthropic-api-key",
                 metadata_keys.FIREWALL_BILLABLE: True,
                 metadata_keys.MODEL_USAGE_PROVIDER: "claude-sonnet-4-6",
+                metadata_keys.RESPONSE_ENCODING_NEGOTIATION: "rewritten_stream_decodable",
             }
         )
         return flow
@@ -104,15 +105,21 @@ class TestResponseEncodingInspectionRisk:
         with mitm_ctx():
             mitm_addon.responseheaders(flow)
 
-        [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
-        assert entry["type"] == "usage_underbilling"
-        assert entry["reason"] == "response_encoding_not_stream_decodable"
-        assert entry["underbilling_class"] == "risk"
-        assert entry["component"] == "mitm_addon"
-        assert entry["run_id"] == "run-encoding-risk"
-        assert entry["firewall_name"] == "model-provider:anthropic-api-key"
-        assert entry["status_code"] == 200
-        assert entry["decode_skip_reason"] == decode_skip_reason
+        if rejected:
+            [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+            assert entry["type"] == "usage_underbilling"
+            assert entry["reason"] == "response_encoding_not_stream_decodable"
+            assert entry["underbilling_class"] == "risk"
+            assert entry["component"] == "mitm_addon"
+            assert entry["run_id"] == "run-encoding-risk"
+            assert entry["firewall_name"] == "model-provider:anthropic-api-key"
+            assert entry["firewall_billable"] is True
+            assert entry["status_code"] == 200
+            assert entry["inspection_disposition"] == "fail_closed"
+            assert entry["request_encoding_negotiation"] == "rewritten_stream_decodable"
+            assert entry["decode_skip_reason"] == decode_skip_reason
+        else:
+            assert not jsonl_exists_after_flush(tmp_path / "proxy.jsonl")
         upstream_chunk = b"compressed-upstream"
         assert response_stream(flow)(upstream_chunk) == (b"" if rejected else upstream_chunk)
         assert flow.response is not None
@@ -126,6 +133,7 @@ class TestResponseEncodingInspectionRisk:
             tmp_path,
             content_encoding="private-encoding-value",
         )
+        flow.metadata.pop(metadata_keys.RESPONSE_ENCODING_NEGOTIATION)
 
         with mitm_ctx():
             mitm_addon.responseheaders(flow)
@@ -133,6 +141,7 @@ class TestResponseEncodingInspectionRisk:
         [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
         assert "private-encoding-value" not in str(entry)
         assert entry["decode_skip_reason"] == "unsupported content encoding"
+        assert entry["request_encoding_negotiation"] == "not_recorded"
         assert flow.response is not None
         assert flow.response.status_code == 502
         assert response_stream(flow)(b"unknown-encoding-body") == b""
@@ -164,8 +173,7 @@ class TestResponseEncodingInspectionRisk:
         with mitm_ctx():
             mitm_addon.responseheaders(flow)
 
-        [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
-        assert entry["reason"] == "response_encoding_not_stream_decodable"
+        assert not jsonl_exists_after_flush(tmp_path / "proxy.jsonl")
         assert flow.response is not None
         assert flow.response.status_code == 200
         upstream_chunk = b"non-billable-brotli"
@@ -186,9 +194,7 @@ class TestResponseEncodingInspectionRisk:
         with mitm_ctx():
             mitm_addon.responseheaders(flow)
 
-        [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
-        assert entry["reason"] == "response_encoding_not_stream_decodable"
-        assert entry["status_code"] == 429
+        assert not jsonl_exists_after_flush(tmp_path / "proxy.jsonl")
         assert flow.response.status_code == 429
         upstream_chunk = b"upstream-error-brotli"
         assert response_stream(flow)(upstream_chunk) == upstream_chunk
@@ -237,7 +243,7 @@ class TestResponseEncodingInspectionRisk:
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
-    def test_successful_billable_connector_logs_non_streamable_encoding_risk(
+    def test_successful_billable_connector_uses_bounded_fallback_without_encoding_risk(
         self, real_flow, tmp_path, mitm_ctx
     ) -> None:
         flow = make_x_pipeline_flow(real_flow, tmp_path, content_encoding="zstd")
@@ -245,13 +251,7 @@ class TestResponseEncodingInspectionRisk:
         with mitm_ctx():
             mitm_addon.responseheaders(flow)
 
-        [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
-        assert entry["type"] == "usage_underbilling"
-        assert entry["reason"] == "response_encoding_not_stream_decodable"
-        assert entry["underbilling_class"] == "risk"
-        assert entry["firewall_name"] == "x"
-        assert entry["status_code"] == 200
-        assert entry["decode_skip_reason"] == "zstd streaming output cannot be hard-bounded"
+        assert not jsonl_exists_after_flush(tmp_path / "proxy.jsonl")
         assert flow.response is not None
         assert flow.response.status_code == 200
         upstream_chunk = b"bounded-json-fallback"
@@ -274,6 +274,9 @@ class TestResponseEncodingInspectionRisk:
         [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
         assert entry["reason"] == "response_encoding_not_stream_decodable"
         assert entry["decode_skip_reason"] == "unsupported content encoding"
+        assert entry["firewall_billable"] is True
+        assert entry["inspection_disposition"] == "fail_closed"
+        assert entry["request_encoding_negotiation"] == "not_recorded"
         assert flow.response is not None
         assert flow.response.status_code == 502
         assert response_stream(flow)(b"unknown-connector-encoding") == b""
@@ -301,6 +304,9 @@ class TestResponseEncodingInspectionRisk:
 
         [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
         assert entry["reason"] == "response_encoding_not_stream_decodable"
+        assert entry["firewall_billable"] is True
+        assert entry["inspection_disposition"] == "fail_closed"
+        assert entry["request_encoding_negotiation"] == "not_recorded"
         assert flow.response is not None
         assert flow.response.status_code == 502
         assert response_stream(flow)(b"compressed-ndjson") == b""

--- a/crates/runner/mitm-addon/tests/test_response_encoding_inspection_risk.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_inspection_risk.py
@@ -133,7 +133,6 @@ class TestResponseEncodingInspectionRisk:
             tmp_path,
             content_encoding="private-encoding-value",
         )
-        flow.metadata.pop(metadata_keys.RESPONSE_ENCODING_NEGOTIATION)
 
         with mitm_ctx():
             mitm_addon.responseheaders(flow)
@@ -141,7 +140,7 @@ class TestResponseEncodingInspectionRisk:
         [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
         assert "private-encoding-value" not in str(entry)
         assert entry["decode_skip_reason"] == "unsupported content encoding"
-        assert entry["request_encoding_negotiation"] == "not_recorded"
+        assert entry["request_encoding_negotiation"] == "rewritten_stream_decodable"
         assert flow.response is not None
         assert flow.response.status_code == 502
         assert response_stream(flow)(b"unknown-encoding-body") == b""
@@ -267,6 +266,7 @@ class TestResponseEncodingInspectionRisk:
             tmp_path,
             content_encoding="private-encoding-value",
         )
+        flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] = "preserved_client_constraints"
 
         with mitm_ctx():
             mitm_addon.responseheaders(flow)
@@ -276,7 +276,7 @@ class TestResponseEncodingInspectionRisk:
         assert entry["decode_skip_reason"] == "unsupported content encoding"
         assert entry["firewall_billable"] is True
         assert entry["inspection_disposition"] == "fail_closed"
-        assert entry["request_encoding_negotiation"] == "not_recorded"
+        assert entry["request_encoding_negotiation"] == "preserved_client_constraints"
         assert flow.response is not None
         assert flow.response.status_code == 502
         assert response_stream(flow)(b"unknown-connector-encoding") == b""
@@ -298,6 +298,7 @@ class TestResponseEncodingInspectionRisk:
             rule="GET /2/tweets/search/stream",
             content_encoding=content_encoding,
         )
+        flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] = "rewritten_stream_decodable"
 
         with mitm_ctx():
             mitm_addon.responseheaders(flow)
@@ -306,7 +307,7 @@ class TestResponseEncodingInspectionRisk:
         assert entry["reason"] == "response_encoding_not_stream_decodable"
         assert entry["firewall_billable"] is True
         assert entry["inspection_disposition"] == "fail_closed"
-        assert entry["request_encoding_negotiation"] == "not_recorded"
+        assert entry["request_encoding_negotiation"] == "rewritten_stream_decodable"
         assert flow.response is not None
         assert flow.response.status_code == 502
         assert response_stream(flow)(b"compressed-ndjson") == b""

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -244,11 +244,42 @@ def test_normalize_accept_encoding_for_body_inspection(
 ) -> None:
     request_headers = headers(*header_pairs)
 
+    response_encoding_negotiation.normalize_accept_encoding_for_body_inspection(request_headers)
+    assert request_headers.get_all(_ACCEPT_ENCODING) == values
+
+
+@pytest.mark.parametrize(
+    ("header_pairs", "outcome"),
+    [
+        pytest.param([], "rewritten_stream_decodable", id="absent"),
+        pytest.param(
+            [("Accept-Encoding", "gzip")],
+            "already_stream_decodable",
+            id="already-safe",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "gzip, br")],
+            "rewritten_stream_decodable",
+            id="unsafe-coding-removed",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "br, identity;q=0")],
+            "preserved_client_constraints",
+            id="all-safe-representations-rejected",
+        ),
+    ],
+)
+def test_normalization_reports_bounded_negotiation_outcome(
+    headers,
+    header_pairs: list[tuple[str, str]],
+    outcome: response_encoding_negotiation.ResponseEncodingNegotiationOutcome,
+) -> None:
+    request_headers = headers(*header_pairs)
+
     assert (
         response_encoding_negotiation.normalize_accept_encoding_for_body_inspection(request_headers)
-        is None
+        == outcome
     )
-    assert request_headers.get_all(_ACCEPT_ENCODING) == values
 
 
 def test_explicit_normalized_encodings_create_stream_decode_sessions(headers) -> None:
@@ -341,6 +372,7 @@ def _connector_registry(
     path: str,
     billable: bool,
     capture_network_bodies: bool = False,
+    include_encrypted_secrets: bool = True,
 ) -> Path:
     sandbox_fields: dict[str, object] = {}
     if capture_network_bodies:
@@ -363,6 +395,7 @@ def _connector_registry(
                 "unknownPolicy": "deny",
             },
             billable_firewalls=[firewall_name] if billable else None,
+            include_encrypted_secrets=include_encrypted_secrets,
             sandbox_fields=sandbox_fields,
         ),
     )
@@ -418,6 +451,9 @@ async def test_observable_model_provider_request_normalizes_accept_encoding_befo
     auth_fetch.assert_awaited_once()
     assert flow.request.headers[_ACCEPT_ENCODING] == "gzip"
     assert flow.request.headers["Authorization"] == "Bearer x"
+    assert (
+        flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] == "rewritten_stream_decodable"
+    )
 
 
 async def test_observable_model_provider_without_accept_encoding_sets_identity(
@@ -444,6 +480,9 @@ async def test_observable_model_provider_without_accept_encoding_sets_identity(
         await mitm_addon.request(flow)
 
     assert flow.request.headers[_ACCEPT_ENCODING] == "identity"
+    assert (
+        flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] == "rewritten_stream_decodable"
+    )
 
 
 async def test_billable_connector_with_response_parser_normalizes_accept_encoding(
@@ -476,6 +515,9 @@ async def test_billable_connector_with_response_parser_normalizes_accept_encodin
         await mitm_addon.request(flow)
 
     assert flow.request.headers[_ACCEPT_ENCODING] == "deflate"
+    assert (
+        flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] == "rewritten_stream_decodable"
+    )
 
 
 async def test_billable_connector_without_response_parser_keeps_accept_encoding(
@@ -508,6 +550,7 @@ async def test_billable_connector_without_response_parser_keeps_accept_encoding(
         await mitm_addon.request(flow)
 
     assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, zstd, br"
+    assert metadata_keys.RESPONSE_ENCODING_NEGOTIATION not in flow.metadata
 
 
 async def test_non_observable_model_provider_keeps_accept_encoding(
@@ -534,6 +577,7 @@ async def test_non_observable_model_provider_keeps_accept_encoding(
         await mitm_addon.request(flow)
 
     assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, zstd, br"
+    assert metadata_keys.RESPONSE_ENCODING_NEGOTIATION not in flow.metadata
 
 
 async def test_header_phase_stream_safe_auth_normalizes_accept_encoding_before_auth(
@@ -569,10 +613,53 @@ async def test_header_phase_stream_safe_auth_normalizes_accept_encoding_before_a
         await await_requestheaders_result(requestheaders_result)
         assert flow.request.headers[_ACCEPT_ENCODING] == "gzip"
         assert flow.request.headers["Authorization"] == "Bearer x"
+        assert (
+            flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION]
+            == "rewritten_stream_decodable"
+        )
         await mitm_addon.request(flow)
 
     auth_fetch.assert_awaited_once()
     assert flow.request.headers[_ACCEPT_ENCODING] == "gzip"
+
+
+async def test_header_phase_auth_fallback_restores_encoding_negotiation(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    headers: Callable[..., http.Headers],
+    mitm_ctx,
+    fake_firewall_headers,
+) -> None:
+    reg_path = _connector_registry(
+        tmp_path,
+        firewall_name=_X_FIREWALL_NAME,
+        host=_X_HOST,
+        path=_X_PATH,
+        billable=True,
+        capture_network_bodies=True,
+        include_encrypted_secrets=False,
+    )
+    original_accept_encoding = "gzip, zstd, br"
+    flow = _request_flow(
+        real_flow,
+        headers,
+        host=_X_HOST,
+        path=_X_PATH,
+        method="GET",
+        accept_encoding=original_accept_encoding,
+        extra_headers=(("Content-Length", str(mitm_addon.STREAM_BUFFER_LIMIT + 1)),),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        requestheaders_result = mitm_addon.requestheaders(flow)
+        await await_requestheaders_result(requestheaders_result)
+
+    auth_fetch.assert_not_called()
+    assert flow.request.headers[_ACCEPT_ENCODING] == original_accept_encoding
+    assert metadata_keys.RESPONSE_ENCODING_NEGOTIATION not in flow.metadata
 
 
 async def test_header_phase_websocket_auth_fallback_restores_upgrade_marker(
@@ -628,6 +715,7 @@ async def test_header_phase_websocket_auth_fallback_restores_upgrade_marker(
 
     auth_fetch.assert_not_called()
     assert metadata_keys.WEBSOCKET_UPGRADE_REQUEST not in flow.metadata
+    assert metadata_keys.RESPONSE_ENCODING_NEGOTIATION not in flow.metadata
     assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
     assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, zstd, br"
 

--- a/crates/runner/mitm-addon/tests/x_flow_helpers.py
+++ b/crates/runner/mitm-addon/tests/x_flow_helpers.py
@@ -157,10 +157,12 @@ def make_x_stream_pipeline_flow(
     *,
     sandbox_value: str = "test-token",
 ) -> http.HTTPFlow:
-    return make_x_pipeline_flow(
+    flow = make_x_pipeline_flow(
         real_flow,
         tmp_path,
         path="/2/tweets/search/stream",
         sandbox_value=sandbox_value,
         rule="GET /2/tweets/search/stream",
     )
+    flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] = "already_stream_decodable"
+    return flow


### PR DESCRIPTION
## Summary

- retain a fixed `Accept-Encoding` negotiation outcome for response-body usage inspection across request probe, auth revalidation, and terminal cleanup
- emit the response-encoding `usage_underbilling` event only when the existing successful-billable fail-closed disposition is selected
- include bounded billability, inspection disposition, and request-negotiation fields while preserving empty-502 replacement and upstream body discard
- stop classifying non-billable observation gaps, non-2xx pass-through, and bounded terminal fallback as generic underbilling
- require the request-negotiation metadata invariant at fail-close logging instead of hiding missing state behind a default

## Explicit exclusions

- no Brotli streaming decoder or decompression-boundary change
- no new compatibility/observation log for non-billable pass-through
- no generic success event or second terminal state machine for bounded fallback; existing provider and connector accounting diagnostics remain authoritative

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/test_connector_usage.py tests/test_model_provider_failure_reporting.py tests/test_model_provider_sse_usage_openai_responses.py tests/test_x_connector_pipeline.py tests/test_response_encoding_negotiation.py tests/test_response_encoding_inspection_risk.py tests/test_request_handler_usage_tracking.py` (300 passed)
- `uv run --no-sync python -m pytest tests/` (7,232 passed)

Closes #30375
