### PR TITLE
refactor: remove meta ads connector feature switch

### DIFF
--- a/turbo/apps/api/src/signals/services/connector-auth-method-feature-switches.ts
+++ b/turbo/apps/api/src/signals/services/connector-auth-method-feature-switches.ts
@@ -28,7 +28,6 @@ const FEATURE_SWITCH_BY_AUTH_METHOD = Object.freeze<
   "garmin-connect\0oauth": FeatureSwitchKey.GarminConnectConnector,
   "mailchimp\0oauth": FeatureSwitchKey.MailchimpConnector,
   "mercury\0oauth": FeatureSwitchKey.MercuryConnector,
-  "meta-ads\0oauth": FeatureSwitchKey.MetaAdsConnector,
   "neon\0oauth": FeatureSwitchKey.NeonConnector,
   "netsuite\0api-token": FeatureSwitchKey.NetSuiteConnector,
   "paypal\0api-token": FeatureSwitchKey.PayPalConnector,

--- a/turbo/apps/platform/src/mocks/handlers/connector-catalog-fixtures.ts
+++ b/turbo/apps/platform/src/mocks/handlers/connector-catalog-fixtures.ts
@@ -493,13 +493,13 @@ export const testConnectorCatalogDefinitions = (
       label: "Mailchimp",
       description: "Manage Mailchimp audiences and campaigns.",
       category: "marketing-content-growth",
+      featureSwitch: FeatureSwitchKey.MailchimpConnector,
     }),
     oauthConnector({
       connectorSlug: "meta-ads",
       label: "Meta Ads",
       description: "Manage Meta Ads campaigns and audiences.",
       category: "marketing-content-growth",
-      featureSwitch: FeatureSwitchKey.MetaAdsConnector,
     }),
     oauthConnector({
       connectorSlug: "tiktok-ads",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -876,11 +876,7 @@ describe("connectors page", () => {
       return respond(200, []);
     });
 
-    detachedSetupPage({
-      context,
-      path: "/connectors",
-      featureSwitches: { [FeatureSwitchKey.MetaAdsConnector]: true },
-    });
+    detachedSetupPage({ context, path: "/connectors" });
 
     await expect(
       screen.findByRole("heading", { name: "Conectores" }),
@@ -1328,11 +1324,7 @@ describe("connectors page", () => {
       },
     );
 
-    detachedSetupPage({
-      context,
-      path: "/connectors",
-      featureSwitches: { [FeatureSwitchKey.MetaAdsConnector]: true },
-    });
+    detachedSetupPage({ context, path: "/connectors" });
 
     await waitFor(() => {
       const card = connectorCardByLabel("Meta Ads");
@@ -2807,16 +2799,18 @@ describe("connectors page", () => {
     detachedSetupPage({
       context,
       path: "/connectors",
-      featureSwitches: { [FeatureSwitchKey.MetaAdsConnector]: false },
+      featureSwitches: { [FeatureSwitchKey.MailchimpConnector]: false },
     });
 
     const searchInput = await screen.findByPlaceholderText("Find connectors");
-    await fill(searchInput, "meta");
+    await fill(searchInput, "mailchimp");
 
     await expect(
       screen.findByText(/No connectors matching/),
     ).resolves.toBeInTheDocument();
-    expect(screen.queryByLabelText("Connect Meta Ads")).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Connect Mailchimp"),
+    ).not.toBeInTheDocument();
   });
 
   it("refreshes connector discovery when connector feature switches change", async () => {
@@ -2825,11 +2819,11 @@ describe("connectors page", () => {
     detachedSetupPage({
       context,
       path: "/connectors",
-      featureSwitches: { [FeatureSwitchKey.MetaAdsConnector]: false },
+      featureSwitches: { [FeatureSwitchKey.MailchimpConnector]: false },
     });
 
     const searchInput = await screen.findByPlaceholderText("Find connectors");
-    await fill(searchInput, "meta");
+    await fill(searchInput, "mailchimp");
 
     await expect(
       screen.findByText(/No connectors matching/),
@@ -2837,18 +2831,18 @@ describe("connectors page", () => {
 
     context.mocks.api(featureSwitchesContract.get, ({ respond }) => {
       return respond(200, {
-        switches: { [FeatureSwitchKey.MetaAdsConnector]: true },
-        effectiveSwitches: { [FeatureSwitchKey.MetaAdsConnector]: true },
+        switches: { [FeatureSwitchKey.MailchimpConnector]: true },
+        effectiveSwitches: { [FeatureSwitchKey.MailchimpConnector]: true },
       });
     });
     await context.store.set(
       setFeatureSwitch$,
-      { [FeatureSwitchKey.MetaAdsConnector]: true },
+      { [FeatureSwitchKey.MailchimpConnector]: true },
       context.signal,
     );
 
     await expect(
-      screen.findByLabelText("Connect Meta Ads"),
+      screen.findByLabelText("Connect Mailchimp"),
     ).resolves.toBeInTheDocument();
   });
 
@@ -3206,11 +3200,7 @@ describe("connectors page", () => {
       },
     );
 
-    detachedSetupPage({
-      context,
-      path: "/connectors",
-      featureSwitches: { [FeatureSwitchKey.MetaAdsConnector]: true },
-    });
+    detachedSetupPage({ context, path: "/connectors" });
 
     await fill(await screen.findByPlaceholderText("Find connectors"), "meta");
     click(await screen.findByLabelText("Connect Meta Ads"));

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -11,7 +11,6 @@ import {
 describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
-    expect(isFeatureEnabled(FeatureSwitchKey.MetaAdsConnector, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.ChatForward, {})).toBe(true);
   });
 

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -25,7 +25,6 @@ export enum FeatureSwitchKey {
   SupabaseConnector = "supabaseConnector",
   WebflowConnector = "webflowConnector",
   CloseConnector = "closeConnector",
-  MetaAdsConnector = "metaAdsConnector",
   PosthogConnector = "posthogConnector",
   PayPalConnector = "payPalConnector",
   RampConnector = "rampConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -143,11 +143,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the Webflow site management connector",
     enabled: false,
   },
-  [FeatureSwitchKey.MetaAdsConnector]: {
-    maintainer: "ethan@vm0.ai",
-    description: "Enable the Meta Ads Manager connector",
-    enabled: true,
-  },
   [FeatureSwitchKey.PosthogConnector]: {
     maintainer: "yuma@vm0.ai",
     description: "Enable the PostHog analytics connector",


### PR DESCRIPTION
## Summary

- retire `MetaAdsConnector` in the `fully-rolled-out` state
- remove the API auth-method rollout association so Meta Ads OAuth is always discoverable
- remove Meta Ads switch fixtures and overrides while preserving generic connector-gating coverage with Mailchimp

## Rollout decision and history

- Terminal state: `fully-rolled-out`
- Decision basis: the cleanup request explicitly states that Meta Ads is fully rolled out; `80d54798c68` already enabled the registry entry globally.
- Initial introduction: `f88722560e` added the Meta Ads connector and its original feature switch.
- Prior graduation: `d97041194d` removed the delivered switch and kept Meta Ads OAuth exposed unconditionally.
- Reintroduced gate: `b78dbd96dc` restored the switch to disable Meta Ads; its parent shows the ungated behavior being restored here.
- Current architecture: `6670ff6f17` moved connector auth-method gating into the API-owned association map, so the graduation must remove that map entry as well as the core registry.

## Behavior comparison

Kept permanently:

- Meta Ads catalog discovery and connector card
- Meta Ads OAuth start, callback, reconnect, localization, provider, and permission behavior

Removed:

- the `MetaAdsConnector` enum member and registry metadata
- the `meta-ads` OAuth association in `FEATURE_SWITCH_BY_AUTH_METHOD`
- Meta Ads switch state in platform catalog fixtures
- Meta Ads true and false test overrides and the core registry assertion

The two generic product tests for hiding a gated connector and refreshing discovery after a switch change now use the still-gated Mailchimp connector.

## Search and orphan review

Second-pass terms: `MetaAdsConnector`, `metaAdsConnector`, `META_ADS_CONNECTOR`, `meta_ads_connector`, `meta-ads-connector`, the old registry description, Meta Ads plus switch/feature associations, and the auth-method map key.

No switch-key or rollout-association matches remain. Remaining `meta-ads` and Meta Ads matches are the permanent connector implementation, OAuth tests, environment configuration, catalog artifacts, localization, onboarding content, changelogs, and provider registrations.

Knip baseline and after both exited 0 with the same 50 existing configuration hints and no unused files, exports, types, dependencies, or devDependencies.

## Validation

Passed:

- Prettier on all 6 changed files
- `git diff --check`
- targeted Oxlint, type-aware Oxlint, and ESLint for all changed files
- `@okouai/core` type-check
- API `check-types:gateways` followed by `check-types:core`
- platform production and test type-checks
- core feature-switch test: 27 passed
- platform affected connector-page tests: 5 passed
- exact-key and second-pass repository searches
- Knip before and after cleanup

Environment-blocked locally:

- API connector-catalog test file could not start because no local PostgreSQL server was available: `ECONNREFUSED ::1:5432` and `ECONNREFUSED 127.0.0.1:5432`; all 31 tests were skipped during suite setup. The PR pipeline is expected to run this coverage with its test database.