### PR TITLE
test(runner): remove dns reservation rebind race

### DIFF
--- a/crates/runner/src/dns/port.rs
+++ b/crates/runner/src/dns/port.rs
@@ -84,7 +84,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn reservation_holds_tcp_and_udp_until_drop() {
+    fn reservation_holds_tcp_and_udp_while_alive() {
         let reservation = reserve_port().unwrap();
         let port = reservation.port();
 
@@ -93,11 +93,6 @@ mod tests {
 
         let udp_error = std::net::UdpSocket::bind(("0.0.0.0", port)).unwrap_err();
         assert_eq!(udp_error.kind(), std::io::ErrorKind::AddrInUse);
-
-        drop(reservation);
-
-        let _tcp_listener = std::net::TcpListener::bind(("0.0.0.0", port)).unwrap();
-        let _udp_socket = std::net::UdpSocket::bind(("0.0.0.0", port)).unwrap();
     }
 
     fn bind_tcp_udp_pair() -> std::io::Result<(ReservedTcpPort, std::net::UdpSocket)> {


### PR DESCRIPTION
## Summary

- keep the DNS reservation test focused on the deterministic ownership boundary
- continue verifying that competing TCP and UDP binds fail while the production reservation is alive
- remove post-drop ephemeral-port rebind assertions that can race with parallel socket allocation

## Scope

This is a test-only correction in `crates/runner/src/dns/port.rs`. It does not change runner DNS allocation, socket ownership, dnsmasq handoff, runtime behavior, configuration, persistence, protocols, or deployment compatibility.

Closes #30386

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner dns::port::tests::reservation_holds_tcp_and_udp_while_alive -- --exact`
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner dns::port::tests`
- `cargo fmt --all --manifest-path crates/Cargo.toml -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner` (3377 passed, 26 ignored; guest inventory 1 passed)
- `git diff --check`
- repository pre-commit hooks (workspace Cargo fmt, docs, Clippy, file size, commitlint)
