### PR TITLE
fix(platform): prevent stale feature switch hydration

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-feature-switch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-feature-switch.test.ts
@@ -4,6 +4,12 @@ import { describe, expect, it } from "vitest";
 
 import { setupPage } from "../../__tests__/page-helper.ts";
 import {
+  emitMockedClerkEvent,
+  mockClerkSessionTransitioning,
+  mockOrganization,
+  mockUser,
+} from "../../__tests__/mock-auth.ts";
+import {
   featureSwitch$,
   imageRecognitionAvailable$,
 } from "../external/feature-switch.ts";
@@ -70,5 +76,148 @@ describe("bootstrap feature switch hydration", () => {
     expect(
       context.store.get(featureSwitch$)[FeatureSwitchKey.AhrefsConnector],
     ).toBeFalsy();
+  });
+
+  it("cancels hydration when the SSO callback clears the identity", async () => {
+    const requestStarted = context.mocks.deferred<void>();
+    context.mocks.api(featureSwitchesContract.get, ({ never }) => {
+      requestStarted.resolve(undefined);
+      return never();
+    });
+
+    const setup = setupPage({
+      context,
+      path: "/sign-up/sso-callback",
+      cachedFeatureSwitches: { [FeatureSwitchKey.AhrefsConnector]: false },
+      withoutRender: true,
+    });
+    await requestStarted.promise;
+
+    mockUser(null, null);
+    mockOrganization({ activeOrg: null, memberships: [] });
+    emitMockedClerkEvent();
+
+    await setup;
+    expect(
+      context.store.get(featureSwitch$)[FeatureSwitchKey.AhrefsConnector],
+    ).toBeFalsy();
+  });
+
+  it("does not apply a response after an unannounced user change", async () => {
+    const requestStarted = context.mocks.deferred<void>();
+    const releaseResponse = context.mocks.deferred<void>();
+    context.mocks.api(featureSwitchesContract.get, async ({ respond }) => {
+      requestStarted.resolve(undefined);
+      await releaseResponse.promise;
+      return respond(200, {
+        switches: { [FeatureSwitchKey.AhrefsConnector]: true },
+        effectiveSwitches: { [FeatureSwitchKey.AhrefsConnector]: true },
+      });
+    });
+
+    const setup = setupPage({
+      context,
+      path: "/error",
+      cachedFeatureSwitches: { [FeatureSwitchKey.AhrefsConnector]: false },
+      withoutRender: true,
+    });
+    await requestStarted.promise;
+
+    mockUser(
+      { id: "replacement-user", fullName: "Replacement User" },
+      { token: "replacement-token" },
+    );
+    releaseResponse.resolve(undefined);
+
+    await setup;
+    expect(
+      context.store.get(featureSwitch$)[FeatureSwitchKey.AhrefsConnector],
+    ).toBeFalsy();
+  });
+
+  it("keeps an org refresh request stale after the organization returns", async () => {
+    const requestStarted = context.mocks.deferred<void>();
+    context.mocks.api(featureSwitchesContract.get, ({ never }) => {
+      requestStarted.resolve(undefined);
+      return never();
+    });
+
+    const setup = setupPage({
+      context,
+      path: "/error",
+      cachedFeatureSwitches: { [FeatureSwitchKey.AhrefsConnector]: false },
+      org: {
+        activeOrg: { id: "org_A", name: "Org A" },
+        memberships: [{ id: "org_A" }],
+      },
+      withoutRender: true,
+    });
+    await requestStarted.promise;
+
+    mockOrganization({ activeOrg: null, memberships: [{ id: "org_A" }] });
+    emitMockedClerkEvent();
+    mockOrganization({
+      activeOrg: { id: "org_A", name: "Org A" },
+      memberships: [{ id: "org_A" }],
+    });
+    emitMockedClerkEvent();
+
+    await setup;
+    expect(
+      context.store.get(featureSwitch$)[FeatureSwitchKey.AhrefsConnector],
+    ).toBeFalsy();
+  });
+
+  it("cancels hydration while the Clerk session is transitioning", async () => {
+    const requestStarted = context.mocks.deferred<void>();
+    context.mocks.api(featureSwitchesContract.get, ({ never }) => {
+      requestStarted.resolve(undefined);
+      return never();
+    });
+
+    const setup = setupPage({
+      context,
+      path: "/error",
+      cachedFeatureSwitches: { [FeatureSwitchKey.AhrefsConnector]: false },
+      withoutRender: true,
+    });
+    await requestStarted.promise;
+
+    mockClerkSessionTransitioning(true);
+    mockClerkSessionTransitioning(false);
+
+    await setup;
+    expect(
+      context.store.get(featureSwitch$)[FeatureSwitchKey.AhrefsConnector],
+    ).toBeFalsy();
+  });
+
+  it("keeps hydration active for a Clerk event with the same identity", async () => {
+    const requestStarted = context.mocks.deferred<void>();
+    const releaseResponse = context.mocks.deferred<void>();
+    context.mocks.api(featureSwitchesContract.get, async ({ respond }) => {
+      requestStarted.resolve(undefined);
+      await releaseResponse.promise;
+      return respond(200, {
+        switches: { [FeatureSwitchKey.AhrefsConnector]: true },
+        effectiveSwitches: { [FeatureSwitchKey.AhrefsConnector]: true },
+      });
+    });
+
+    const setup = setupPage({
+      context,
+      path: "/error",
+      cachedFeatureSwitches: { [FeatureSwitchKey.AhrefsConnector]: false },
+      withoutRender: true,
+    });
+    await requestStarted.promise;
+
+    emitMockedClerkEvent();
+    releaseResponse.resolve(undefined);
+
+    await setup;
+    expect(
+      context.store.get(featureSwitch$)[FeatureSwitchKey.AhrefsConnector],
+    ).toBeTruthy();
   });
 });

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -1,4 +1,5 @@
 import { command, computed } from "ccstate";
+import type { BrowserClerk as Clerk } from "@clerk/shared/types";
 import { getAllFeatureStates } from "@okouai/core/feature-switch";
 import { featureSwitchesContract } from "@okouai/api-contracts/contracts/feature-switches";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
@@ -12,6 +13,53 @@ import {
   featureSwitchCacheState$,
   setFeatureSwitchLocalStorage$,
 } from "./feature-switch-state.ts";
+import {
+  completeOnLocalAbort,
+  createChildAbortController,
+  withCleanup,
+} from "../utils.ts";
+
+type FeatureSwitchClerk = Pick<
+  Clerk,
+  "addListener" | "organization" | "session" | "user"
+>;
+
+interface FeatureSwitchIdentity {
+  readonly email: string | undefined;
+  readonly orgId: string;
+  readonly sessionId: string;
+  readonly userId: string;
+}
+
+function readFeatureSwitchIdentity(
+  clerk: FeatureSwitchClerk,
+): FeatureSwitchIdentity | null {
+  const user = clerk.user;
+  const organization = clerk.organization;
+  const session = clerk.session;
+  if (!user || !organization || !session) {
+    return null;
+  }
+  return {
+    email: user.primaryEmailAddress?.emailAddress,
+    orgId: organization.id,
+    sessionId: session.id,
+    userId: user.id,
+  };
+}
+
+function isSameFeatureSwitchIdentity(
+  left: FeatureSwitchIdentity,
+  right: FeatureSwitchIdentity | null,
+): boolean {
+  return (
+    right !== null &&
+    left.email === right.email &&
+    left.orgId === right.orgId &&
+    left.sessionId === right.sessionId &&
+    left.userId === right.userId
+  );
+}
 
 // Pinned to the API backend: feature switches bootstrap before the platform API
 // client is available.
@@ -63,18 +111,14 @@ export const customConnectorMcpEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.CustomConnectorMcp] ?? false;
 });
 
-export const reloadFeatureSwitch$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    const clerk = await get(clerk$);
+const hydrateFeatureSwitch$ = command(
+  async (
+    { get, set },
+    clerk: FeatureSwitchClerk,
+    identity: FeatureSwitchIdentity,
+    signal: AbortSignal,
+  ) => {
     signal.throwIfAborted();
-    if (!clerk.user || !clerk.organization) {
-      set(writeConnectionDiagnostic$, {
-        action: "set-enabled",
-        enabled: false,
-      });
-      return;
-    }
-
     const client = get(apiFeatureSwitchClient$);
     const result = await accept(
       client.get({ fetchOptions: { signal } }),
@@ -82,10 +126,16 @@ export const reloadFeatureSwitch$ = command(
     );
     signal.throwIfAborted();
 
+    if (
+      !isSameFeatureSwitchIdentity(identity, readFeatureSwitchIdentity(clerk))
+    ) {
+      return;
+    }
+
     const combined = getAllFeatureStates({
-      userId: clerk.user.id,
-      email: clerk.user.primaryEmailAddress?.emailAddress,
-      orgId: clerk.organization.id,
+      userId: identity.userId,
+      email: identity.email,
+      orgId: identity.orgId,
     });
     applySwitches(
       combined,
@@ -97,6 +147,45 @@ export const reloadFeatureSwitch$ = command(
       action: "set-enabled",
       enabled: combined[FeatureSwitchKey.OkouDebug],
     });
+  },
+);
+
+export const reloadFeatureSwitch$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+    const identity = readFeatureSwitchIdentity(clerk);
+    if (!identity) {
+      set(writeConnectionDiagnostic$, {
+        action: "set-enabled",
+        enabled: false,
+      });
+      return;
+    }
+
+    const requestController = createChildAbortController(signal);
+    const abortIfIdentityChanged = () => {
+      if (
+        !isSameFeatureSwitchIdentity(identity, readFeatureSwitchIdentity(clerk))
+      ) {
+        requestController.abort();
+      }
+    };
+    const unsubscribe = clerk.addListener(abortIfIdentityChanged, {
+      skipInitialEmit: true,
+    });
+    abortIfIdentityChanged();
+    await withCleanup(
+      completeOnLocalAbort(
+        set(hydrateFeatureSwitch$, clerk, identity, requestController.signal),
+        requestController.signal,
+        signal,
+      ),
+      () => {
+        unsubscribe();
+        requestController.abort();
+      },
+    );
   },
 );
 


### PR DESCRIPTION
## Summary

- snapshot the active Clerk user, organization, email, and session before feature-switch hydration
- cancel the in-flight hydration when Clerk identity changes, while preserving parent cancellation and normal API failures
- revalidate the identity immediately before writing the effective switches to local storage
- cover the SSO callback clear, user replacement, mobile organization ABA, session transition, and unchanged-identity event paths

## Root cause

`reloadFeatureSwitch$` checked `clerk.user` and `clerk.organization` before the API request, then dereferenced the same mutable Clerk object after awaiting the response. During `/sign-up/sso-callback`, Clerk can clear or replace that identity, causing PLATFORM-95 or allowing a stale response to be cached for another identity.

Sentry: https://vm0.sentry.io/issues/7679389481/

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/signals/__tests__/bootstrap-feature-switch.test.ts --maxWorkers=1 --silent=passed-only` (8 passed)
- `pnpm --filter @okouai/app exec vitest run src/signals/__tests__/auth-org-switch.test.ts --maxWorkers=1 --silent=passed-only` (1 passed)
- `pnpm --filter @okouai/app exec vitest run src/signals/__tests__/api-client-headers.test.ts --maxWorkers=1 --silent=passed-only` (13 passed)
