### PR TITLE
chore(desktop): stop publishing the zero desktop release line

### DIFF
--- a/.github/scripts/build-okou-desktop-artifact.sh
+++ b/.github/scripts/build-okou-desktop-artifact.sh
@@ -1,17 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ "$#" -lt 4 || "$#" -gt 5 ]]; then
-  echo "Usage: $0 <commit-sha> <desktop-version> <zero-app-directory> <output-directory> [okou-app-directory]" >&2
+if [[ "$#" -ne 4 ]]; then
+  echo "Usage: $0 <commit-sha> <desktop-version> <okou-app-directory> <output-directory>" >&2
   exit 1
 fi
 
 commit_sha="$1"
 desktop_version="$2"
-app_dir="${3%/}"
+okou_app_dir="${3%/}"
 output_dir="$4"
-okou_app_dir="${5:-}"
-okou_app_dir="${okou_app_dir%/}"
 
 if [[ ! "$commit_sha" =~ ^[0-9a-f]{40}$ ]]; then
   echo "Desktop artifact commit must be a full lowercase SHA-1: $commit_sha" >&2
@@ -21,11 +19,7 @@ if [[ ! "$desktop_version" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-+][0-9A-Za-z.-]+)?$ ]]
   echo "Desktop artifact version must be a semantic version: $desktop_version" >&2
   exit 1
 fi
-if [[ ! -d "$app_dir" || "$(basename "$app_dir")" != "Zero Computer Use.app" ]]; then
-  echo "Desktop artifact requires a Zero Computer Use.app directory: $app_dir" >&2
-  exit 1
-fi
-if [[ -n "$okou_app_dir" && (! -d "$okou_app_dir" || "$(basename "$okou_app_dir")" != "Okou.app") ]]; then
+if [[ ! -d "$okou_app_dir" || "$(basename "$okou_app_dir")" != "Okou.app" ]]; then
   echo "Desktop artifact requires an Okou.app directory: $okou_app_dir" >&2
   exit 1
 fi
@@ -33,32 +27,20 @@ fi
 mkdir -p "$output_dir"
 output_dir="$(cd "$output_dir" && pwd -P)"
 rm -f \
-  "$output_dir/app.tar.gz" \
   "$output_dir/okou-app.tar.gz" \
   "$output_dir/manifest.json" \
   "$output_dir/ready.json"
 
-COPYFILE_DISABLE=1 tar -czf "$output_dir/app.tar.gz" \
-  -C "$(dirname "$app_dir")" \
-  "$(basename "$app_dir")"
+COPYFILE_DISABLE=1 tar -czf "$output_dir/okou-app.tar.gz" \
+  -C "$(dirname "$okou_app_dir")" \
+  "$(basename "$okou_app_dir")"
 
-archive_sha256="$(shasum -a 256 "$output_dir/app.tar.gz" | cut -d ' ' -f 1)"
-archive_size="$(wc -c < "$output_dir/app.tar.gz" | tr -d '[:space:]')"
-okou_archive_sha256=""
-okou_archive_size=0
-if [[ -n "$okou_app_dir" ]]; then
-  COPYFILE_DISABLE=1 tar -czf "$output_dir/okou-app.tar.gz" \
-    -C "$(dirname "$okou_app_dir")" \
-    "$(basename "$okou_app_dir")"
-  okou_archive_sha256="$(shasum -a 256 "$output_dir/okou-app.tar.gz" | cut -d ' ' -f 1)"
-  okou_archive_size="$(wc -c < "$output_dir/okou-app.tar.gz" | tr -d '[:space:]')"
-fi
+okou_archive_sha256="$(shasum -a 256 "$output_dir/okou-app.tar.gz" | cut -d ' ' -f 1)"
+okou_archive_size="$(wc -c < "$output_dir/okou-app.tar.gz" | tr -d '[:space:]')"
 
 jq -n \
   --arg commit_sha "$commit_sha" \
   --arg desktop_version "$desktop_version" \
-  --arg archive_sha256 "$archive_sha256" \
-  --argjson archive_size "$archive_size" \
   --arg okou_archive_sha256 "$okou_archive_sha256" \
   --argjson okou_archive_size "$okou_archive_size" \
   '{
@@ -67,21 +49,13 @@ jq -n \
     desktopVersion: $desktop_version,
     platform: "darwin",
     arch: "arm64",
-    appName: "Zero Computer Use.app",
-    archive: {
-      path: "app.tar.gz",
-      sha256: $archive_sha256,
-      size: $archive_size
+    okouAppName: "Okou.app",
+    okouArchive: {
+      path: "okou-app.tar.gz",
+      sha256: $okou_archive_sha256,
+      size: $okou_archive_size
     }
-  }
-  | if $okou_archive_sha256 == "" then . else . + {
-      okouAppName: "Okou.app",
-      okouArchive: {
-        path: "okou-app.tar.gz",
-        sha256: $okou_archive_sha256,
-        size: $okou_archive_size
-      }
-    } end' > "$output_dir/manifest.json"
+  }' > "$output_dir/manifest.json"
 
 manifest_sha256="$(shasum -a 256 "$output_dir/manifest.json" | cut -d ' ' -f 1)"
 jq -n \
@@ -91,8 +65,7 @@ jq -n \
   > "$output_dir/ready.json"
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-verify_args=("$output_dir" "$commit_sha" "$desktop_version")
-if [[ -n "$okou_app_dir" ]]; then
-  verify_args+=(--require-okou)
-fi
-bash "$script_dir/verify-okou-desktop-artifact.sh" "${verify_args[@]}"
+bash "$script_dir/verify-okou-desktop-artifact.sh" \
+  "$output_dir" \
+  "$commit_sha" \
+  "$desktop_version"

--- a/.github/scripts/fetch-okou-desktop-artifact.sh
+++ b/.github/scripts/fetch-okou-desktop-artifact.sh
@@ -48,7 +48,7 @@ copy_with_retry() {
   done
 }
 
-for filename in app.tar.gz manifest.json ready.json; do
+for filename in manifest.json ready.json; do
   if ! copy_with_retry \
     "$artifact_uri/$filename" \
     "$destination/$filename"; then
@@ -58,15 +58,13 @@ for filename in app.tar.gz manifest.json ready.json; do
 done
 
 okou_archive_path="$(jq -r '.okouArchive.path // ""' "$destination/manifest.json")"
-if [[ -n "$okou_archive_path" ]]; then
-  if [[ "$okou_archive_path" != "okou-app.tar.gz" ]]; then
-    echo "Desktop artifact manifest contains an unexpected Okou archive path: $okou_archive_path" >&2
-    exit 1
-  fi
-  if ! copy_with_retry \
-    "$artifact_uri/$okou_archive_path" \
-    "$destination/$okou_archive_path"; then
-    echo "Desktop artifact download failed: $artifact_uri/$okou_archive_path" >&2
-    exit 1
-  fi
+if [[ "$okou_archive_path" != "okou-app.tar.gz" ]]; then
+  echo "Desktop artifact manifest contains an unexpected Okou archive path: ${okou_archive_path:-<missing>}" >&2
+  exit 1
+fi
+if ! copy_with_retry \
+  "$artifact_uri/$okou_archive_path" \
+  "$destination/$okou_archive_path"; then
+  echo "Desktop artifact download failed: $artifact_uri/$okou_archive_path" >&2
+  exit 1
 fi

--- a/.github/scripts/tests/deploy-desktop-workflow-test.sh
+++ b/.github/scripts/tests/deploy-desktop-workflow-test.sh
@@ -86,7 +86,6 @@ ruby -e '
   raise "Desktop promotion must verify the canonical R2 artifact" unless download.include?("verify-okou-desktop-artifact.sh")
   raise "Desktop promotion must address artifacts by release_target" unless download.include?(ARGV[5])
   raise "Desktop promotion must extract the Okou app archive" unless download.include?("okou-app.tar.gz")
-  raise "Desktop promotion must not extract a Zero app archive" if download.include?("Zero Computer Use.app")
 
   promote_text = release_text.split("  promote-desktop-release:\n", 2).fetch(1).split(/\n  [a-zA-Z0-9_-]+:\n/, 2).first
   dollar = 36.chr
@@ -129,15 +128,12 @@ ruby -e '
   raise "Desktop promotion must publish Okou artifacts" unless promote_text.include?("Okou-darwin-arm64-")
   raise "Desktop promotion must smoke-test Okou installation" unless promote_text.include?("okou-install-smoke")
   raise "Desktop promotion must smoke-test Okou updates" unless promote_text.include?("okou-update-smoke")
-  raise "Desktop promotion must not publish the retired Zero release line" if promote_text.include?("RELEASE_TAG: desktop-v")
-  raise "Desktop promotion must not build Zero release artifacts" if promote_text.include?("Zero-darwin-arm64-")
 
   publish = release.fetch("publish-desktop-update-manifest")
   raise "Desktop manifest must wait for promotion" unless Array(publish.fetch("needs")).include?("promote-desktop-release")
   publish_text = publish.fetch("steps").find { |step| step["name"] == "Publish Desktop update manifest" }.fetch("run")
   raise "Desktop manifests must publish the Okou feed" unless publish_text.include?("ai-okou-desktop-update-manifest.json")
   raise "Desktop manifests must publish under the Okou mutable tag" unless publish_text.include?("ai-okou-desktop-updates")
-  raise "Desktop manifests must no longer publish the retired Zero feed" if publish_text.include?("--product zero") || publish_text.include?("manifest_tag=desktop-updates")
 ' \
   "$desktop_workflow" \
   "$release_workflow" \

--- a/.github/scripts/tests/deploy-desktop-workflow-test.sh
+++ b/.github/scripts/tests/deploy-desktop-workflow-test.sh
@@ -85,7 +85,8 @@ ruby -e '
   raise "Desktop promotion must fetch the canonical R2 artifact" unless download.include?("fetch-okou-desktop-artifact.sh")
   raise "Desktop promotion must verify the canonical R2 artifact" unless download.include?("verify-okou-desktop-artifact.sh")
   raise "Desktop promotion must address artifacts by release_target" unless download.include?(ARGV[5])
-  raise "Desktop promotion must require the Okou app archive" unless download.include?("--require-okou")
+  raise "Desktop promotion must extract the Okou app archive" unless download.include?("okou-app.tar.gz")
+  raise "Desktop promotion must not extract a Zero app archive" if download.include?("Zero Computer Use.app")
 
   promote_text = release_text.split("  promote-desktop-release:\n", 2).fetch(1).split(/\n  [a-zA-Z0-9_-]+:\n/, 2).first
   dollar = 36.chr
@@ -128,13 +129,15 @@ ruby -e '
   raise "Desktop promotion must publish Okou artifacts" unless promote_text.include?("Okou-darwin-arm64-")
   raise "Desktop promotion must smoke-test Okou installation" unless promote_text.include?("okou-install-smoke")
   raise "Desktop promotion must smoke-test Okou updates" unless promote_text.include?("okou-update-smoke")
+  raise "Desktop promotion must not publish the retired Zero release line" if promote_text.include?("RELEASE_TAG: desktop-v")
+  raise "Desktop promotion must not build Zero release artifacts" if promote_text.include?("Zero-darwin-arm64-")
 
   publish = release.fetch("publish-desktop-update-manifest")
   raise "Desktop manifest must wait for promotion" unless Array(publish.fetch("needs")).include?("promote-desktop-release")
   publish_text = publish.fetch("steps").find { |step| step["name"] == "Publish Desktop update manifest" }.fetch("run")
-  raise "Desktop manifests must preserve the Zero feed" unless publish_text.include?("desktop-update-manifest.json")
   raise "Desktop manifests must publish the Okou feed" unless publish_text.include?("ai-okou-desktop-update-manifest.json")
   raise "Desktop manifests must publish under the Okou mutable tag" unless publish_text.include?("ai-okou-desktop-updates")
+  raise "Desktop manifests must no longer publish the retired Zero feed" if publish_text.include?("--product zero") || publish_text.include?("manifest_tag=desktop-updates")
 ' \
   "$desktop_workflow" \
   "$release_workflow" \

--- a/.github/scripts/tests/fetch-okou-desktop-artifact-test.sh
+++ b/.github/scripts/tests/fetch-okou-desktop-artifact-test.sh
@@ -8,7 +8,6 @@ trap 'rm -rf "$tmp_dir"' EXIT
 
 source_dir="${tmp_dir}/source"
 mkdir -p "$source_dir" "${tmp_dir}/bin"
-printf 'archive\n' > "$source_dir/app.tar.gz"
 printf 'okou archive\n' > "$source_dir/okou-app.tar.gz"
 printf '{"version":1,"okouArchive":{"path":"okou-app.tar.gz"}}\n' > "$source_dir/manifest.json"
 printf '{"version":1}\n' > "$source_dir/ready.json"
@@ -33,7 +32,7 @@ if [[ -n "${MOCK_AWS_TRANSIENT_FAILURES:-}" ]]; then
   fi
 fi
 
-if [[ "$filename" == "app.tar.gz" && "${MOCK_ARCHIVE_PRESENT:-true}" != "true" ]]; then
+if [[ "$filename" == "okou-app.tar.gz" && "${MOCK_ARCHIVE_PRESENT:-true}" != "true" ]]; then
   echo "fatal error: An error occurred (404) when calling HeadObject" >&2
   exit 1
 fi
@@ -52,12 +51,12 @@ destination="${tmp_dir}/destination"
 mkdir -p "$destination"
 MOCK_AWS_LOG="${tmp_dir}/fetch.log" \
   bash "$script" "$r2_endpoint" "$artifact_uri" "$destination"
-cmp "$source_dir/app.tar.gz" "$destination/app.tar.gz"
 cmp "$source_dir/okou-app.tar.gz" "$destination/okou-app.tar.gz"
 cmp "$source_dir/manifest.json" "$destination/manifest.json"
 cmp "$source_dir/ready.json" "$destination/ready.json"
-if (( "$(grep -c 's3 cp' "${tmp_dir}/fetch.log")" != 4 )); then
-  echo "Expected exactly four Desktop artifact object copies" >&2
+test ! -e "$destination/app.tar.gz"
+if (( "$(grep -c 's3 cp' "${tmp_dir}/fetch.log")" != 3 )); then
+  echo "Expected exactly three Desktop artifact object copies" >&2
   exit 1
 fi
 if grep -q -- '--recursive' "${tmp_dir}/fetch.log"; then
@@ -74,7 +73,7 @@ if MOCK_ARCHIVE_PRESENT=false \
   echo "Expected a missing Desktop archive to fail" >&2
   exit 1
 fi
-if (( "$(grep -c 's3 cp' "${tmp_dir}/missing.log")" != 1 )); then
+if (( "$(grep -c 's3 cp' "${tmp_dir}/missing.log")" != 3 )); then
   echo "Expected a missing Desktop archive to fail without retrying" >&2
   exit 1
 fi
@@ -87,22 +86,23 @@ MOCK_AWS_TRANSIENT_FAILURES=2 \
   MOCK_AWS_LOG="${tmp_dir}/retry.log" \
   bash "$script" "$r2_endpoint" "$artifact_uri" "$retry_destination" \
     >/dev/null 2>&1
-test -f "$retry_destination/app.tar.gz"
-if (( "$(grep -c 's3 cp' "${tmp_dir}/retry.log")" != 6 )); then
-  echo "Expected two retries followed by all four object copies" >&2
+test -f "$retry_destination/okou-app.tar.gz"
+if (( "$(grep -c 's3 cp' "${tmp_dir}/retry.log")" != 5 )); then
+  echo "Expected two retries followed by all three object copies" >&2
   exit 1
 fi
 
 legacy_source_dir="${tmp_dir}/legacy-source"
 legacy_destination="${tmp_dir}/legacy-destination"
 mkdir -p "$legacy_source_dir" "$legacy_destination"
-cp "$source_dir/app.tar.gz" "$source_dir/ready.json" "$legacy_source_dir/"
+printf 'archive\n' > "$legacy_source_dir/app.tar.gz"
+cp "$source_dir/ready.json" "$legacy_source_dir/"
 printf '{"version":1}\n' > "$legacy_source_dir/manifest.json"
-MOCK_SOURCE_DIR="$legacy_source_dir" \
+if MOCK_SOURCE_DIR="$legacy_source_dir" \
   MOCK_AWS_LOG="${tmp_dir}/legacy.log" \
-  bash "$script" "$r2_endpoint" "$artifact_uri" "$legacy_destination"
-if (( "$(grep -c 's3 cp' "${tmp_dir}/legacy.log")" != 3 )); then
-  echo "Expected a legacy Zero-only artifact to use three object copies" >&2
+  bash "$script" "$r2_endpoint" "$artifact_uri" "$legacy_destination" \
+    >/dev/null 2>&1; then
+  echo "Expected a legacy Zero-only artifact to fail" >&2
   exit 1
 fi
 test ! -e "$legacy_destination/okou-app.tar.gz"

--- a/.github/scripts/tests/fetch-okou-desktop-artifact-test.sh
+++ b/.github/scripts/tests/fetch-okou-desktop-artifact-test.sh
@@ -54,7 +54,6 @@ MOCK_AWS_LOG="${tmp_dir}/fetch.log" \
 cmp "$source_dir/okou-app.tar.gz" "$destination/okou-app.tar.gz"
 cmp "$source_dir/manifest.json" "$destination/manifest.json"
 cmp "$source_dir/ready.json" "$destination/ready.json"
-test ! -e "$destination/app.tar.gz"
 if (( "$(grep -c 's3 cp' "${tmp_dir}/fetch.log")" != 3 )); then
   echo "Expected exactly three Desktop artifact object copies" >&2
   exit 1
@@ -92,20 +91,19 @@ if (( "$(grep -c 's3 cp' "${tmp_dir}/retry.log")" != 5 )); then
   exit 1
 fi
 
-legacy_source_dir="${tmp_dir}/legacy-source"
-legacy_destination="${tmp_dir}/legacy-destination"
-mkdir -p "$legacy_source_dir" "$legacy_destination"
-printf 'archive\n' > "$legacy_source_dir/app.tar.gz"
-cp "$source_dir/ready.json" "$legacy_source_dir/"
-printf '{"version":1}\n' > "$legacy_source_dir/manifest.json"
-if MOCK_SOURCE_DIR="$legacy_source_dir" \
-  MOCK_AWS_LOG="${tmp_dir}/legacy.log" \
-  bash "$script" "$r2_endpoint" "$artifact_uri" "$legacy_destination" \
+undeclared_source_dir="${tmp_dir}/undeclared-source"
+undeclared_destination="${tmp_dir}/undeclared-destination"
+mkdir -p "$undeclared_source_dir" "$undeclared_destination"
+cp "$source_dir/okou-app.tar.gz" "$source_dir/ready.json" "$undeclared_source_dir/"
+printf '{"version":1}\n' > "$undeclared_source_dir/manifest.json"
+if MOCK_SOURCE_DIR="$undeclared_source_dir" \
+  MOCK_AWS_LOG="${tmp_dir}/undeclared.log" \
+  bash "$script" "$r2_endpoint" "$artifact_uri" "$undeclared_destination" \
     >/dev/null 2>&1; then
-  echo "Expected a legacy Zero-only artifact to fail" >&2
+  echo "Expected a manifest without an Okou archive to fail" >&2
   exit 1
 fi
-test ! -e "$legacy_destination/okou-app.tar.gz"
+test ! -e "$undeclared_destination/okou-app.tar.gz"
 
 if MOCK_AWS_LOG="${tmp_dir}/absent.log" \
   bash "$script" "$r2_endpoint" "$artifact_uri" "${tmp_dir}/absent" \

--- a/.github/scripts/tests/okou-desktop-artifact-test.sh
+++ b/.github/scripts/tests/okou-desktop-artifact-test.sh
@@ -10,16 +10,16 @@ trap 'rm -rf "$tmp_dir"' EXIT
 commit_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 desktop_version="1.2.3"
 okou_app_dir="${tmp_dir}/package/Okou.app"
-zero_app_dir="${tmp_dir}/package/Zero Computer Use.app"
+other_app_dir="${tmp_dir}/package/Other.app"
 artifact_dir="${tmp_dir}/artifact"
 mkdir -p \
   "$okou_app_dir/Contents/MacOS" \
   "$okou_app_dir/Contents/Frameworks/Example.framework/Versions/A" \
-  "$zero_app_dir/Contents/MacOS"
+  "$other_app_dir/Contents/MacOS"
 printf '#!/usr/bin/env bash\nexit 0\n' > "$okou_app_dir/Contents/MacOS/Okou"
-printf '#!/usr/bin/env bash\nexit 0\n' > "$zero_app_dir/Contents/MacOS/Zero Computer Use"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$other_app_dir/Contents/MacOS/Other"
 chmod +x "$okou_app_dir/Contents/MacOS/Okou"
-chmod +x "$zero_app_dir/Contents/MacOS/Zero Computer Use"
+chmod +x "$other_app_dir/Contents/MacOS/Other"
 ln -s A "$okou_app_dir/Contents/Frameworks/Example.framework/Versions/Current"
 
 bash "$build_script" \
@@ -34,11 +34,8 @@ jq -e \
   '.commitSha == $commit_sha
     and .desktopVersion == $desktop_version
     and .okouAppName == "Okou.app"
-    and .okouArchive.path == "okou-app.tar.gz"
-    and (has("appName") | not)
-    and (has("archive") | not)' \
+    and .okouArchive.path == "okou-app.tar.gz"' \
   "$artifact_dir/manifest.json" >/dev/null
-test ! -e "$artifact_dir/app.tar.gz"
 
 extracted_dir="${tmp_dir}/extracted"
 mkdir -p "$extracted_dir"
@@ -49,9 +46,9 @@ test -L "$extracted_dir/Okou.app/Contents/Frameworks/Example.framework/Versions/
 if bash "$build_script" \
   "$commit_sha" \
   "$desktop_version" \
-  "$zero_app_dir" \
-  "${tmp_dir}/zero-artifact" >/dev/null 2>&1; then
-  echo "Expected the retired Zero app directory to be rejected" >&2
+  "$other_app_dir" \
+  "${tmp_dir}/other-artifact" >/dev/null 2>&1; then
+  echo "Expected an app directory that is not Okou.app to be rejected" >&2
   exit 1
 fi
 

--- a/.github/scripts/tests/okou-desktop-artifact-test.sh
+++ b/.github/scripts/tests/okou-desktop-artifact-test.sh
@@ -9,72 +9,65 @@ trap 'rm -rf "$tmp_dir"' EXIT
 
 commit_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 desktop_version="1.2.3"
-app_dir="${tmp_dir}/package/Zero Computer Use.app"
 okou_app_dir="${tmp_dir}/package/Okou.app"
+zero_app_dir="${tmp_dir}/package/Zero Computer Use.app"
 artifact_dir="${tmp_dir}/artifact"
 mkdir -p \
-  "$app_dir/Contents/MacOS" \
-  "$app_dir/Contents/Frameworks/Example.framework/Versions/A" \
-  "$okou_app_dir/Contents/MacOS"
-printf '#!/usr/bin/env bash\nexit 0\n' > "$app_dir/Contents/MacOS/Zero Computer Use"
+  "$okou_app_dir/Contents/MacOS" \
+  "$okou_app_dir/Contents/Frameworks/Example.framework/Versions/A" \
+  "$zero_app_dir/Contents/MacOS"
 printf '#!/usr/bin/env bash\nexit 0\n' > "$okou_app_dir/Contents/MacOS/Okou"
-chmod +x "$app_dir/Contents/MacOS/Zero Computer Use"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$zero_app_dir/Contents/MacOS/Zero Computer Use"
 chmod +x "$okou_app_dir/Contents/MacOS/Okou"
-ln -s A "$app_dir/Contents/Frameworks/Example.framework/Versions/Current"
+chmod +x "$zero_app_dir/Contents/MacOS/Zero Computer Use"
+ln -s A "$okou_app_dir/Contents/Frameworks/Example.framework/Versions/Current"
 
 bash "$build_script" \
   "$commit_sha" \
   "$desktop_version" \
-  "$app_dir" \
-  "$artifact_dir" \
-  "$okou_app_dir"
-bash "$verify_script" "$artifact_dir" "$commit_sha" "$desktop_version" --require-okou
+  "$okou_app_dir" \
+  "$artifact_dir"
+bash "$verify_script" "$artifact_dir" "$commit_sha" "$desktop_version"
 jq -e \
   --arg commit_sha "$commit_sha" \
   --arg desktop_version "$desktop_version" \
   '.commitSha == $commit_sha
     and .desktopVersion == $desktop_version
     and .okouAppName == "Okou.app"
-    and .okouArchive.path == "okou-app.tar.gz"' \
+    and .okouArchive.path == "okou-app.tar.gz"
+    and (has("appName") | not)
+    and (has("archive") | not)' \
   "$artifact_dir/manifest.json" >/dev/null
+test ! -e "$artifact_dir/app.tar.gz"
 
 extracted_dir="${tmp_dir}/extracted"
 mkdir -p "$extracted_dir"
-tar -xzf "$artifact_dir/app.tar.gz" -C "$extracted_dir"
 tar -xzf "$artifact_dir/okou-app.tar.gz" -C "$extracted_dir"
-test -x "$extracted_dir/Zero Computer Use.app/Contents/MacOS/Zero Computer Use"
 test -x "$extracted_dir/Okou.app/Contents/MacOS/Okou"
-test -L "$extracted_dir/Zero Computer Use.app/Contents/Frameworks/Example.framework/Versions/Current"
+test -L "$extracted_dir/Okou.app/Contents/Frameworks/Example.framework/Versions/Current"
 
-legacy_artifact_dir="${tmp_dir}/legacy-artifact"
-bash "$build_script" \
+if bash "$build_script" \
   "$commit_sha" \
   "$desktop_version" \
-  "$app_dir" \
-  "$legacy_artifact_dir"
-bash "$verify_script" "$legacy_artifact_dir" "$commit_sha" "$desktop_version"
-if bash "$verify_script" \
-  "$legacy_artifact_dir" \
-  "$commit_sha" \
-  "$desktop_version" \
-  --require-okou >/dev/null 2>&1; then
-  echo "Expected a legacy Zero-only artifact to fail the Okou requirement" >&2
+  "$zero_app_dir" \
+  "${tmp_dir}/zero-artifact" >/dev/null 2>&1; then
+  echo "Expected the retired Zero app directory to be rejected" >&2
   exit 1
 fi
 
 tampered_dir="${tmp_dir}/tampered"
 cp -a "$artifact_dir" "$tampered_dir"
-printf 'tampered\n' >> "$tampered_dir/app.tar.gz"
-if bash "$verify_script" "$tampered_dir" "$commit_sha" "$desktop_version" --require-okou >/dev/null 2>&1; then
-  echo "Expected a tampered Desktop archive to fail" >&2
+printf 'tampered\n' >> "$tampered_dir/okou-app.tar.gz"
+if bash "$verify_script" "$tampered_dir" "$commit_sha" "$desktop_version" >/dev/null 2>&1; then
+  echo "Expected a tampered Okou Desktop archive to fail" >&2
   exit 1
 fi
 
-tampered_okou_dir="${tmp_dir}/tampered-okou"
-cp -a "$artifact_dir" "$tampered_okou_dir"
-printf 'tampered\n' >> "$tampered_okou_dir/okou-app.tar.gz"
-if bash "$verify_script" "$tampered_okou_dir" "$commit_sha" "$desktop_version" --require-okou >/dev/null 2>&1; then
-  echo "Expected a tampered Okou Desktop archive to fail" >&2
+missing_dir="${tmp_dir}/missing"
+cp -a "$artifact_dir" "$missing_dir"
+rm -f "$missing_dir/okou-app.tar.gz"
+if bash "$verify_script" "$missing_dir" "$commit_sha" "$desktop_version" >/dev/null 2>&1; then
+  echo "Expected a missing Okou Desktop archive to fail" >&2
   exit 1
 fi
 
@@ -92,19 +85,19 @@ unsafe_dir="${tmp_dir}/unsafe"
 unsafe_source="${tmp_dir}/unsafe-source"
 mkdir -p "$unsafe_dir" "$unsafe_source/Other.app"
 printf 'unexpected\n' > "$unsafe_source/Other.app/file"
-tar -czf "$unsafe_dir/app.tar.gz" -C "$unsafe_source" Other.app
-unsafe_archive_sha="$(shasum -a 256 "$unsafe_dir/app.tar.gz" | cut -d ' ' -f 1)"
-unsafe_archive_size="$(wc -c < "$unsafe_dir/app.tar.gz" | tr -d '[:space:]')"
+tar -czf "$unsafe_dir/okou-app.tar.gz" -C "$unsafe_source" Other.app
+unsafe_archive_sha="$(shasum -a 256 "$unsafe_dir/okou-app.tar.gz" | cut -d ' ' -f 1)"
+unsafe_archive_size="$(wc -c < "$unsafe_dir/okou-app.tar.gz" | tr -d '[:space:]')"
 jq \
   --arg archive_sha "$unsafe_archive_sha" \
   --argjson archive_size "$unsafe_archive_size" \
-  '.archive.sha256 = $archive_sha | .archive.size = $archive_size' \
-  "$legacy_artifact_dir/manifest.json" > "$unsafe_dir/manifest.json"
+  '.okouArchive.sha256 = $archive_sha | .okouArchive.size = $archive_size' \
+  "$artifact_dir/manifest.json" > "$unsafe_dir/manifest.json"
 unsafe_manifest_sha="$(shasum -a 256 "$unsafe_dir/manifest.json" | cut -d ' ' -f 1)"
 jq \
   --arg manifest_sha "$unsafe_manifest_sha" \
   '.manifestSha256 = $manifest_sha' \
-  "$legacy_artifact_dir/ready.json" > "$unsafe_dir/ready.json"
+  "$artifact_dir/ready.json" > "$unsafe_dir/ready.json"
 if bash "$verify_script" "$unsafe_dir" "$commit_sha" "$desktop_version" >/dev/null 2>&1; then
   echo "Expected an archive with another top-level path to fail" >&2
   exit 1

--- a/.github/scripts/tests/resolve-production-rollback-target-test.sh
+++ b/.github/scripts/tests/resolve-production-rollback-target-test.sh
@@ -460,11 +460,9 @@ ruby -e '
   expected_target = "$" + "{{ needs.release-please.outputs.release_target }}"
   expected_tags = "$" + "{{ needs.release-please.outputs.release_tags }}"
   workflow_source = "$" + "{{ github.sha }}"
-  desktop_target = "desktop-v" + "$" + "{{ needs.release-please.outputs.desktop_version }}"
   checkout_ref_exceptions = {
     "queue-production-deploy" => "main",
     "refresh-release-pull-request" => "main",
-    "publish-desktop-update-manifest" => desktop_target,
     "update-rollback-dashboard" => workflow_source,
   }
   release.each do |job_name, job|

--- a/.github/scripts/verify-okou-desktop-artifact.sh
+++ b/.github/scripts/verify-okou-desktop-artifact.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ "$#" -lt 3 || "$#" -gt 4 || ("$#" -eq 4 && "$4" != "--require-okou") ]]; then
-  echo "Usage: $0 <artifact-directory> <expected-commit-sha> <expected-desktop-version> [--require-okou]" >&2
+if [[ "$#" -ne 3 ]]; then
+  echo "Usage: $0 <artifact-directory> <expected-commit-sha> <expected-desktop-version>" >&2
   exit 1
 fi
 
 artifact_dir="$1"
 expected_commit_sha="$2"
 expected_desktop_version="$3"
-require_okou="${4:-}"
 manifest_path="$artifact_dir/manifest.json"
 ready_path="$artifact_dir/ready.json"
 
@@ -22,7 +21,7 @@ if [[ ! "$expected_desktop_version" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-+][0-9A-Za-z.
   exit 1
 fi
 
-for artifact_path in "$artifact_dir/app.tar.gz" "$manifest_path" "$ready_path"; do
+for artifact_path in "$artifact_dir/okou-app.tar.gz" "$manifest_path" "$ready_path"; do
   if [[ ! -f "$artifact_path" ]]; then
     echo "Desktop artifact is missing $(basename "$artifact_path")" >&2
     exit 1
@@ -37,10 +36,10 @@ jq -e \
     and .desktopVersion == $desktop_version
     and .platform == "darwin"
     and .arch == "arm64"
-    and .appName == "Zero Computer Use.app"
-    and .archive.path == "app.tar.gz"
-    and (.archive.sha256 | type == "string" and test("^[0-9a-f]{64}$"))
-    and (.archive.size | type == "number" and . > 0)' \
+    and .okouAppName == "Okou.app"
+    and .okouArchive.path == "okou-app.tar.gz"
+    and (.okouArchive.sha256 | type == "string" and test("^[0-9a-f]{64}$"))
+    and (.okouArchive.size | type == "number" and . > 0)' \
   "$manifest_path" >/dev/null
 
 verify_archive() {
@@ -93,26 +92,9 @@ verify_archive() {
 }
 
 verify_archive \
-  "$artifact_dir/app.tar.gz" \
-  "Zero Computer Use.app" \
-  '.archive'
-
-has_okou_archive="$(jq -r 'has("okouAppName") or has("okouArchive")' "$manifest_path")"
-if [[ "$has_okou_archive" == "true" ]]; then
-  jq -e \
-    '.okouAppName == "Okou.app"
-      and .okouArchive.path == "okou-app.tar.gz"
-      and (.okouArchive.sha256 | type == "string" and test("^[0-9a-f]{64}$"))
-      and (.okouArchive.size | type == "number" and . > 0)' \
-    "$manifest_path" >/dev/null
-  verify_archive \
-    "$artifact_dir/okou-app.tar.gz" \
-    "Okou.app" \
-    '.okouArchive'
-elif [[ "$require_okou" == "--require-okou" ]]; then
-  echo "Desktop artifact does not contain the required Okou app archive" >&2
-  exit 1
-fi
+  "$artifact_dir/okou-app.tar.gz" \
+  "Okou.app" \
+  '.okouArchive'
 
 manifest_sha256="$(shasum -a 256 "$manifest_path" | cut -d ' ' -f 1)"
 jq -e \

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -732,9 +732,8 @@ jobs:
           bash .github/scripts/build-okou-desktop-artifact.sh \
             "$ARTIFACT_SHA" \
             "$DESKTOP_VERSION" \
-            "turbo/apps/desktop/out/Zero Computer Use-darwin-arm64/Zero Computer Use.app" \
-            /tmp/okou-desktop-artifact \
-            "turbo/apps/desktop/out/Okou-darwin-arm64/Okou.app"
+            "turbo/apps/desktop/out/Okou-darwin-arm64/Okou.app" \
+            /tmp/okou-desktop-artifact
 
       - name: Upload canonical Desktop artifact
         if: steps.existing.outputs.exists != 'true'
@@ -750,14 +749,6 @@ jobs:
           aws s3 rm "$artifact_uri/" \
             --endpoint-url "$r2_endpoint" \
             --recursive
-
-          aws s3api put-object \
-            --endpoint-url "$r2_endpoint" \
-            --bucket "$R2_BUCKET_NAME" \
-            --key "${ARTIFACT_PREFIX}/app.tar.gz" \
-            --body /tmp/okou-desktop-artifact/app.tar.gz \
-            --content-type application/gzip \
-            --cache-control "$cache_control"
 
           aws s3api put-object \
             --endpoint-url "$r2_endpoint" \

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -317,7 +317,6 @@ jobs:
       contents: write
     env:
       DESKTOP_VERSION: ${{ needs.release-please.outputs.desktop_version }}
-      RELEASE_TAG: desktop-v${{ needs.release-please.outputs.desktop_version }}
       OKOU_RELEASE_TAG: okou-desktop-v${{ needs.release-please.outputs.desktop_version }}
       RELEASE_TARGET: ${{ needs.release-please.outputs.release_target }}
       OKOU_DESKTOP_SIGNING_IDENTITY: "Developer ID Application: Max & Zoe, Inc. (C5UWSXYB67)"
@@ -356,7 +355,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Desktop App* promoting signed macOS Apple silicon release...\n📦 Version: `${{ needs.release-please.outputs.desktop_version }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/desktop-v${{ needs.release-please.outputs.desktop_version }}|View Release>"
+                  text: "*Desktop App* promoting signed macOS Apple silicon release...\n📦 Version: `${{ needs.release-please.outputs.desktop_version }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/okou-desktop-v${{ needs.release-please.outputs.desktop_version }}|View Release>"
 
       - name: Record start time
         id: timer
@@ -366,15 +365,11 @@ jobs:
         run: pnpm install --frozen-lockfile --strict-peer-dependencies --filter @okouai/desktop...
 
       - name: Verify Desktop release inputs
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if ! [[ "$DESKTOP_VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::Desktop version must look like a semantic version, received: $DESKTOP_VERSION"
             exit 1
           fi
-
-          gh release view "$RELEASE_TAG" --repo "${{ github.repository }}" >/dev/null
 
           package_version=$(node -p "require('./apps/desktop/package.json').version")
           if [ "$package_version" != "$DESKTOP_VERSION" ]; then
@@ -414,7 +409,6 @@ jobs:
           artifact_uri="s3://${R2_BUCKET_NAME}/okou-desktop/${ARTIFACT_SHA}"
           ready_key="okou-desktop/${ARTIFACT_SHA}/ready.json"
           artifact_dir="$(mktemp -d)"
-          zero_package_dir="$PWD/apps/desktop/out/Zero Computer Use-darwin-arm64"
           okou_package_dir="$PWD/apps/desktop/out/Okou-darwin-arm64"
           error_log="$(mktemp)"
 
@@ -450,27 +444,17 @@ jobs:
           bash ../.github/scripts/verify-okou-desktop-artifact.sh \
             "$artifact_dir" \
             "$ARTIFACT_SHA" \
-            "$DESKTOP_VERSION" \
-            --require-okou
+            "$DESKTOP_VERSION"
 
-          rm -rf "$zero_package_dir" "$okou_package_dir"
-          mkdir -p "$zero_package_dir" "$okou_package_dir"
-          tar -xzf "$artifact_dir/app.tar.gz" -C "$zero_package_dir"
+          rm -rf "$okou_package_dir"
+          mkdir -p "$okou_package_dir"
           tar -xzf "$artifact_dir/okou-app.tar.gz" -C "$okou_package_dir"
-          zero_app_dir="$zero_package_dir/Zero Computer Use.app"
           okou_app_dir="$okou_package_dir/Okou.app"
-          if [ ! -d "$zero_app_dir" ]; then
-            echo "Canonical Desktop artifact did not contain Zero Computer Use.app" >&2
-            exit 1
-          fi
           if [ ! -d "$okou_app_dir" ]; then
             echo "Canonical Desktop artifact did not contain Okou.app" >&2
             exit 1
           fi
-          {
-            echo "zero_app_dir=$zero_app_dir"
-            echo "okou_app_dir=$okou_app_dir"
-          } >> "$GITHUB_OUTPUT"
+          echo "okou_app_dir=$okou_app_dir" >> "$GITHUB_OUTPUT"
 
       - name: Validate macOS release secrets
         run: |
@@ -537,94 +521,61 @@ jobs:
           OKOU_DESKTOP_NOTARIZE_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           OKOU_DESKTOP_NOTARIZE_API_ISSUER: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
         run: |
-          create_product_artifacts() {
-            local product="$1"
-            local app_dir="$2"
-            local artifact_name="$3"
-            local volume_name="$4"
-            local background_svg="${5:-}"
-            local zip_artifact_path="apps/desktop/out/${artifact_name}-darwin-arm64-$DESKTOP_VERSION.zip"
-            local dmg_artifact_path="apps/desktop/out/${artifact_name}-darwin-arm64-$DESKTOP_VERSION.dmg"
-            local background_args=()
+          app_dir="${{ steps.desktop-app.outputs.okou_app_dir }}"
+          zip_artifact_path="apps/desktop/out/Okou-darwin-arm64-$DESKTOP_VERSION.zip"
+          dmg_artifact_path="apps/desktop/out/Okou-darwin-arm64-$DESKTOP_VERSION.dmg"
 
-            if [ -n "$background_svg" ]; then
-              background_args=(--background-svg "$background_svg")
-            fi
-
-            node apps/desktop/scripts/sign-and-notarize-packaged-app.mjs \
-              --app "$app_dir" \
-              --product "$product"
-            ditto -c -k --sequesterRsrc --keepParent \
-              "$app_dir" \
-              "$zip_artifact_path"
-            node apps/desktop/scripts/create-styled-dmg.mjs \
-              --app "$app_dir" \
-              --out "$dmg_artifact_path" \
-              --volume-name "$volume_name" \
-              "${background_args[@]}"
-            codesign --force --sign "$OKOU_DESKTOP_SIGNING_IDENTITY" --timestamp "$dmg_artifact_path"
-            xcrun notarytool submit "$dmg_artifact_path" \
-              --key "$OKOU_DESKTOP_NOTARIZE_API_KEY_PATH" \
-              --key-id "$OKOU_DESKTOP_NOTARIZE_API_KEY_ID" \
-              --issuer "$OKOU_DESKTOP_NOTARIZE_API_ISSUER" \
-              --wait
-            xcrun stapler staple "$dmg_artifact_path"
-          }
-
-          create_product_artifacts \
-            zero \
-            "${{ steps.desktop-app.outputs.zero_app_dir }}" \
-            Zero \
-            "Zero Computer Use"
-          create_product_artifacts \
-            okou \
-            "${{ steps.desktop-app.outputs.okou_app_dir }}" \
-            Okou \
-            "Okou" \
-            apps/desktop/assets/dmg-background-okou.svg
+          node apps/desktop/scripts/sign-and-notarize-packaged-app.mjs \
+            --app "$app_dir" \
+            --product okou
+          ditto -c -k --sequesterRsrc --keepParent \
+            "$app_dir" \
+            "$zip_artifact_path"
+          node apps/desktop/scripts/create-styled-dmg.mjs \
+            --app "$app_dir" \
+            --out "$dmg_artifact_path" \
+            --volume-name "Okou" \
+            --background-svg apps/desktop/assets/dmg-background-okou.svg
+          codesign --force --sign "$OKOU_DESKTOP_SIGNING_IDENTITY" --timestamp "$dmg_artifact_path"
+          xcrun notarytool submit "$dmg_artifact_path" \
+            --key "$OKOU_DESKTOP_NOTARIZE_API_KEY_PATH" \
+            --key-id "$OKOU_DESKTOP_NOTARIZE_API_KEY_ID" \
+            --issuer "$OKOU_DESKTOP_NOTARIZE_API_ISSUER" \
+            --wait
+          xcrun stapler staple "$dmg_artifact_path"
 
           {
-            echo "zero_zip_path=apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.zip"
-            echo "zero_dmg_path=apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.dmg"
-            echo "okou_zip_path=apps/desktop/out/Okou-darwin-arm64-$DESKTOP_VERSION.zip"
-            echo "okou_dmg_path=apps/desktop/out/Okou-darwin-arm64-$DESKTOP_VERSION.dmg"
+            echo "okou_zip_path=$zip_artifact_path"
+            echo "okou_dmg_path=$dmg_artifact_path"
           } >> "$GITHUB_OUTPUT"
 
       - name: Verify signed and notarized macOS artifacts
         run: |
-          verify_product_artifacts() {
-            local product="$1"
-            local app_name="$2"
-            local artifact_name="$3"
-            local bundle_id="$4"
-            local auth_scheme="$5"
-            local app_dir="apps/desktop/out/${app_name}-darwin-arm64/${app_name}.app"
-            local plist="$app_dir/Contents/Info.plist"
-            local runtime_config="$app_dir/Contents/Resources/app/desktop-runtime-config.json"
-            local zip_artifact_path="apps/desktop/out/${artifact_name}-darwin-arm64-$DESKTOP_VERSION.zip"
-            local dmg_artifact_path="apps/desktop/out/${artifact_name}-darwin-arm64-$DESKTOP_VERSION.dmg"
-            local dmg_mount="$RUNNER_TEMP/${product}-desktop-dmg"
+          app_name="Okou"
+          bundle_id="ai.okou.desktop"
+          auth_scheme="ai.okou.desktop"
+          app_dir="apps/desktop/out/${app_name}-darwin-arm64/${app_name}.app"
+          plist="$app_dir/Contents/Info.plist"
+          runtime_config="$app_dir/Contents/Resources/app/desktop-runtime-config.json"
+          zip_artifact_path="apps/desktop/out/${app_name}-darwin-arm64-$DESKTOP_VERSION.zip"
+          dmg_artifact_path="apps/desktop/out/${app_name}-darwin-arm64-$DESKTOP_VERSION.dmg"
+          dmg_mount="$RUNNER_TEMP/okou-desktop-dmg"
 
-            if [ ! -f "$zip_artifact_path" ] || [ ! -f "$dmg_artifact_path" ]; then
-              echo "Missing $app_name release artifacts"
-              find apps/desktop/out -maxdepth 5 -type f -print || true
-              exit 1
-            fi
-            if [ ! -d "$app_dir" ]; then
-              echo "No packaged app found: $app_dir"
-              find apps/desktop/out -maxdepth 4 -type d -print || true
-              exit 1
-            fi
-            if [ "$product" = "zero" ] && [ -e "$runtime_config" ]; then
-              echo "Zero production artifact should not contain Desktop runtime config"
-              exit 1
-            fi
-            if [ "$product" = "okou" ]; then
-              if [ ! -f "$runtime_config" ]; then
-                echo "Okou production artifact should contain Desktop runtime config"
-                exit 1
-              fi
-              RUNTIME_CONFIG="$runtime_config" node <<'NODE'
+          if [ ! -f "$zip_artifact_path" ] || [ ! -f "$dmg_artifact_path" ]; then
+            echo "Missing $app_name release artifacts"
+            find apps/desktop/out -maxdepth 5 -type f -print || true
+            exit 1
+          fi
+          if [ ! -d "$app_dir" ]; then
+            echo "No packaged app found: $app_dir"
+            find apps/desktop/out -maxdepth 4 -type d -print || true
+            exit 1
+          fi
+          if [ ! -f "$runtime_config" ]; then
+            echo "Okou production artifact should contain Desktop runtime config"
+            exit 1
+          fi
+          RUNTIME_CONFIG="$runtime_config" node <<'NODE'
           const fs = require("node:fs");
 
           const config = JSON.parse(
@@ -637,108 +588,84 @@ jobs:
             throw new Error(`Unexpected Okou runtime config: ${JSON.stringify(config)}`);
           }
           NODE
-            fi
 
-            minimum_system_version=$(/usr/libexec/PlistBuddy -c "Print :LSMinimumSystemVersion" "$plist" 2>/dev/null || true)
-            if [ "$minimum_system_version" != "14.0" ]; then
-              echo "::error::Expected LSMinimumSystemVersion 14.0, found ${minimum_system_version:-missing}"
-              exit 1
-            fi
-            /usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist" | grep -qx "$app_name"
-            /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$plist" | grep -qx "$app_name"
-            /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$plist" | grep -qx "$app_name"
-            /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$plist" | grep -qx "$bundle_id"
-            /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLSchemes:0" "$plist" | grep -qx "$auth_scheme"
-            file "$app_dir/Contents/MacOS/$app_name" | grep -q "arm64"
-            file "$app_dir/Contents/Resources/native/computer-use-helper" | grep -q "arm64"
-            codesign --verify --deep --strict --verbose=2 "$app_dir"
-            codesign --display --verbose=4 "$app_dir" 2>&1 | grep -F "Authority=$OKOU_DESKTOP_SIGNING_IDENTITY"
-            xcrun stapler validate "$app_dir"
-            unzip -l "$zip_artifact_path" | grep -q "$app_name.app/Contents/MacOS/$app_name"
-            codesign --verify --verbose=2 "$dmg_artifact_path"
-            codesign --display --verbose=4 "$dmg_artifact_path" 2>&1 | grep -F "Authority=$OKOU_DESKTOP_SIGNING_IDENTITY"
-            xcrun stapler validate "$dmg_artifact_path"
-            hdiutil verify "$dmg_artifact_path"
-
-            (
-              rm -rf "$dmg_mount"
-              mkdir -p "$dmg_mount"
-              hdiutil attach "$dmg_artifact_path" -nobrowse -readonly -mountpoint "$dmg_mount"
-              trap 'hdiutil detach "$dmg_mount"' EXIT
-
-              mounted_app="$dmg_mount/$app_name.app"
-              if [ ! -d "$mounted_app" ]; then
-                echo "DMG should contain $app_name.app"
-                find "$dmg_mount" -maxdepth 2 -print || true
-                exit 1
-              fi
-              mounted_plist="$mounted_app/Contents/Info.plist"
-              mounted_minimum_system_version=$(/usr/libexec/PlistBuddy -c "Print :LSMinimumSystemVersion" "$mounted_plist" 2>/dev/null || true)
-              if [ "$mounted_minimum_system_version" != "14.0" ]; then
-                echo "::error::Expected mounted app LSMinimumSystemVersion 14.0, found ${mounted_minimum_system_version:-missing}"
-                exit 1
-              fi
-              if [ ! -L "$dmg_mount/Applications" ] || [ "$(readlink "$dmg_mount/Applications")" != "/Applications" ]; then
-                echo "DMG Applications symlink should point to /Applications"
-                exit 1
-              fi
-              if [ ! -f "$dmg_mount/.background/background.png" ]; then
-                echo "DMG should contain the Finder background image"
-                find "$dmg_mount" -maxdepth 3 -print || true
-                exit 1
-              fi
-              background_info="$(sips -g pixelWidth -g pixelHeight -g dpiWidth -g dpiHeight "$dmg_mount/.background/background.png")"
-              echo "$background_info"
-              echo "$background_info" | grep -q "pixelWidth: 1320"
-              echo "$background_info" | grep -q "pixelHeight: 800"
-              echo "$background_info" | grep -q "dpiWidth: 144.000"
-              echo "$background_info" | grep -q "dpiHeight: 144.000"
-              codesign --verify --deep --strict --verbose=2 "$mounted_app"
-              xcrun stapler validate "$mounted_app"
-
-              if [ "$product" = "okou" ]; then
-                install_dir="$RUNNER_TEMP/okou-install-smoke/Applications"
-                installed_app="$install_dir/Okou.app"
-                update_dir="$RUNNER_TEMP/okou-update-smoke"
-                rm -rf "$install_dir" "$update_dir"
-                mkdir -p "$install_dir" "$update_dir"
-
-                ditto "$mounted_app" "$installed_app"
-                OKOU_DESKTOP_PRODUCT=okou \
-                OKOU_DESKTOP_PLATFORM_URL=https://app.okou.ai \
-                OKOU_DESKTOP_SMOKE_APP_PATH="$installed_app" \
-                node apps/desktop/scripts/smoke-test-packaged-app.js
-
-                unzip -q "$zip_artifact_path" -d "$update_dir"
-                rm -rf "$installed_app"
-                ditto "$update_dir/Okou.app" "$installed_app"
-                OKOU_DESKTOP_PRODUCT=okou \
-                OKOU_DESKTOP_PLATFORM_URL=https://app.okou.ai \
-                OKOU_DESKTOP_SMOKE_APP_PATH="$installed_app" \
-                node apps/desktop/scripts/smoke-test-packaged-app.js
-              fi
-            )
-          }
-
-          verify_product_artifacts \
-            zero \
-            "Zero Computer Use" \
-            Zero \
-            ai.vm0.zero.desktop \
-            ai.vm0.zero.desktop
-          verify_product_artifacts \
-            okou \
-            "Okou" \
-            Okou \
-            ai.okou.desktop \
-            ai.okou.desktop
-
-          zero_bundle_id=$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "${{ steps.desktop-app.outputs.zero_app_dir }}/Contents/Info.plist")
-          okou_bundle_id=$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "${{ steps.desktop-app.outputs.okou_app_dir }}/Contents/Info.plist")
-          if [ "$zero_bundle_id" = "$okou_bundle_id" ]; then
-            echo "Zero and Okou release artifacts must keep independent identities"
+          minimum_system_version=$(/usr/libexec/PlistBuddy -c "Print :LSMinimumSystemVersion" "$plist" 2>/dev/null || true)
+          if [ "$minimum_system_version" != "14.0" ]; then
+            echo "::error::Expected LSMinimumSystemVersion 14.0, found ${minimum_system_version:-missing}"
             exit 1
           fi
+          /usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist" | grep -qx "$app_name"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$plist" | grep -qx "$app_name"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$plist" | grep -qx "$app_name"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$plist" | grep -qx "$bundle_id"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLSchemes:0" "$plist" | grep -qx "$auth_scheme"
+          file "$app_dir/Contents/MacOS/$app_name" | grep -q "arm64"
+          file "$app_dir/Contents/Resources/native/computer-use-helper" | grep -q "arm64"
+          codesign --verify --deep --strict --verbose=2 "$app_dir"
+          codesign --display --verbose=4 "$app_dir" 2>&1 | grep -F "Authority=$OKOU_DESKTOP_SIGNING_IDENTITY"
+          xcrun stapler validate "$app_dir"
+          unzip -l "$zip_artifact_path" | grep -q "$app_name.app/Contents/MacOS/$app_name"
+          codesign --verify --verbose=2 "$dmg_artifact_path"
+          codesign --display --verbose=4 "$dmg_artifact_path" 2>&1 | grep -F "Authority=$OKOU_DESKTOP_SIGNING_IDENTITY"
+          xcrun stapler validate "$dmg_artifact_path"
+          hdiutil verify "$dmg_artifact_path"
+
+          (
+            rm -rf "$dmg_mount"
+            mkdir -p "$dmg_mount"
+            hdiutil attach "$dmg_artifact_path" -nobrowse -readonly -mountpoint "$dmg_mount"
+            trap 'hdiutil detach "$dmg_mount"' EXIT
+
+            mounted_app="$dmg_mount/$app_name.app"
+            if [ ! -d "$mounted_app" ]; then
+              echo "DMG should contain $app_name.app"
+              find "$dmg_mount" -maxdepth 2 -print || true
+              exit 1
+            fi
+            mounted_plist="$mounted_app/Contents/Info.plist"
+            mounted_minimum_system_version=$(/usr/libexec/PlistBuddy -c "Print :LSMinimumSystemVersion" "$mounted_plist" 2>/dev/null || true)
+            if [ "$mounted_minimum_system_version" != "14.0" ]; then
+              echo "::error::Expected mounted app LSMinimumSystemVersion 14.0, found ${mounted_minimum_system_version:-missing}"
+              exit 1
+            fi
+            if [ ! -L "$dmg_mount/Applications" ] || [ "$(readlink "$dmg_mount/Applications")" != "/Applications" ]; then
+              echo "DMG Applications symlink should point to /Applications"
+              exit 1
+            fi
+            if [ ! -f "$dmg_mount/.background/background.png" ]; then
+              echo "DMG should contain the Finder background image"
+              find "$dmg_mount" -maxdepth 3 -print || true
+              exit 1
+            fi
+            background_info="$(sips -g pixelWidth -g pixelHeight -g dpiWidth -g dpiHeight "$dmg_mount/.background/background.png")"
+            echo "$background_info"
+            echo "$background_info" | grep -q "pixelWidth: 1320"
+            echo "$background_info" | grep -q "pixelHeight: 800"
+            echo "$background_info" | grep -q "dpiWidth: 144.000"
+            echo "$background_info" | grep -q "dpiHeight: 144.000"
+            codesign --verify --deep --strict --verbose=2 "$mounted_app"
+            xcrun stapler validate "$mounted_app"
+
+            install_dir="$RUNNER_TEMP/okou-install-smoke/Applications"
+            installed_app="$install_dir/Okou.app"
+            update_dir="$RUNNER_TEMP/okou-update-smoke"
+            rm -rf "$install_dir" "$update_dir"
+            mkdir -p "$install_dir" "$update_dir"
+
+            ditto "$mounted_app" "$installed_app"
+            OKOU_DESKTOP_PRODUCT=okou \
+            OKOU_DESKTOP_PLATFORM_URL=https://app.okou.ai \
+            OKOU_DESKTOP_SMOKE_APP_PATH="$installed_app" \
+            node apps/desktop/scripts/smoke-test-packaged-app.js
+
+            unzip -q "$zip_artifact_path" -d "$update_dir"
+            rm -rf "$installed_app"
+            ditto "$update_dir/Okou.app" "$installed_app"
+            OKOU_DESKTOP_PRODUCT=okou \
+            OKOU_DESKTOP_PLATFORM_URL=https://app.okou.ai \
+            OKOU_DESKTOP_SMOKE_APP_PATH="$installed_app" \
+            node apps/desktop/scripts/smoke-test-packaged-app.js
+          )
 
       - name: Upload Desktop artifacts to GitHub Releases
         env:
@@ -762,11 +689,6 @@ jobs:
               --latest=false
           fi
 
-          gh release upload "$RELEASE_TAG" \
-            "${{ steps.desktop-artifacts.outputs.zero_zip_path }}" \
-            "${{ steps.desktop-artifacts.outputs.zero_dmg_path }}" \
-            --repo "${{ github.repository }}" \
-            --clobber
           gh release upload "$OKOU_RELEASE_TAG" \
             "${{ steps.desktop-artifacts.outputs.okou_zip_path }}" \
             "${{ steps.desktop-artifacts.outputs.okou_dmg_path }}" \
@@ -798,7 +720,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Desktop App* ✅ Published signed macOS Apple silicon artifacts\n📦 Version: `${{ needs.release-please.outputs.desktop_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n0️⃣ <${{ github.server_url }}/${{ github.repository }}/releases/tag/desktop-v${{ needs.release-please.outputs.desktop_version }}|Zero Release>\n🟠 <${{ github.server_url }}/${{ github.repository }}/releases/tag/okou-desktop-v${{ needs.release-please.outputs.desktop_version }}|Okou Release>\n⬇️ <${{ github.server_url }}/${{ github.repository }}/releases/download/okou-desktop-v${{ needs.release-please.outputs.desktop_version }}/Okou-darwin-arm64-${{ needs.release-please.outputs.desktop_version }}.dmg|Download Okou macOS DMG>\n🔄 <${{ github.server_url }}/${{ github.repository }}/releases/download/okou-desktop-v${{ needs.release-please.outputs.desktop_version }}/Okou-darwin-arm64-${{ needs.release-please.outputs.desktop_version }}.zip|Okou auto-update ZIP>"
+                  text: "*Desktop App* ✅ Published signed macOS Apple silicon artifacts\n📦 Version: `${{ needs.release-please.outputs.desktop_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🟠 <${{ github.server_url }}/${{ github.repository }}/releases/tag/okou-desktop-v${{ needs.release-please.outputs.desktop_version }}|Okou Release>\n⬇️ <${{ github.server_url }}/${{ github.repository }}/releases/download/okou-desktop-v${{ needs.release-please.outputs.desktop_version }}/Okou-darwin-arm64-${{ needs.release-please.outputs.desktop_version }}.dmg|Download Okou macOS DMG>\n🔄 <${{ github.server_url }}/${{ github.repository }}/releases/download/okou-desktop-v${{ needs.release-please.outputs.desktop_version }}/Okou-darwin-arm64-${{ needs.release-please.outputs.desktop_version }}.zip|Okou auto-update ZIP>"
 
       - name: Notify Slack - Failure
         if: ${{ failure() && steps.slack-start.outputs.ts }}
@@ -814,7 +736,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Desktop App* ❌ Release failed\n📦 Version: `${{ needs.release-please.outputs.desktop_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/desktop-v${{ needs.release-please.outputs.desktop_version }}|View Release>\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
+                  text: "*Desktop App* ❌ Release failed\n📦 Version: `${{ needs.release-please.outputs.desktop_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/okou-desktop-v${{ needs.release-please.outputs.desktop_version }}|View Release>\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
 
       - name: Delete temporary keychain
         if: ${{ always() && steps.signing-certificate.outputs.keychain_path != '' }}
@@ -833,105 +755,72 @@ jobs:
       contents: write
     env:
       DESKTOP_VERSION: ${{ needs.release-please.outputs.desktop_version }}
-      ZERO_RELEASE_TAG: desktop-v${{ needs.release-please.outputs.desktop_version }}
       OKOU_RELEASE_TAG: okou-desktop-v${{ needs.release-please.outputs.desktop_version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          ref: desktop-v${{ needs.release-please.outputs.desktop_version }}
+          ref: ${{ needs.release-please.outputs.release_target }}
 
       - name: Verify Desktop release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          verify_release_assets() {
-            local release_tag="$1"
-            local artifact_name="$2"
-            local release_assets
-            local asset_name
+          release_assets="$(gh release view "$OKOU_RELEASE_TAG" \
+            --repo "${{ github.repository }}" \
+            --json assets \
+            --jq '.assets[].name')"
 
-            release_assets="$(gh release view "$release_tag" \
-              --repo "${{ github.repository }}" \
-              --json assets \
-              --jq '.assets[].name')"
-
-            for extension in zip dmg; do
-              asset_name="$artifact_name-darwin-arm64-$DESKTOP_VERSION.$extension"
-              if ! printf '%s\n' "$release_assets" | grep -qx "$asset_name"; then
-                echo "::error::Missing Desktop release asset: $asset_name"
-                printf '%s\n' "$release_assets"
-                exit 1
-              fi
-            done
-          }
-
-          verify_release_assets "$ZERO_RELEASE_TAG" Zero
-          verify_release_assets "$OKOU_RELEASE_TAG" Okou
+          for extension in zip dmg; do
+            asset_name="Okou-darwin-arm64-$DESKTOP_VERSION.$extension"
+            if ! printf '%s\n' "$release_assets" | grep -qx "$asset_name"; then
+              echo "::error::Missing Desktop release asset: $asset_name"
+              printf '%s\n' "$release_assets"
+              exit 1
+            fi
+          done
 
       - name: Publish Desktop update manifest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          publish_manifest() {
-            local product="$1"
-            local artifact_name="$2"
-            local release_tag="$3"
-            local manifest_tag="$4"
-            local manifest_filename="$5"
-            local manifest_title="$6"
-            local manifest_dir="apps/desktop/out/update-manifest/$product"
-            local manifest_path="$manifest_dir/$manifest_filename"
-            local zip_url
+          manifest_tag=ai-okou-desktop-updates
+          manifest_filename=ai-okou-desktop-update-manifest.json
+          manifest_dir="apps/desktop/out/update-manifest/okou"
+          manifest_path="$manifest_dir/$manifest_filename"
 
-            mkdir -p "$manifest_dir"
-            if gh release view "$manifest_tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-              if gh release view "$manifest_tag" \
-                --repo "${{ github.repository }}" \
-                --json assets \
-                --jq '.assets[].name' | grep -qx "$manifest_filename"; then
-                gh release download "$manifest_tag" \
-                  --repo "${{ github.repository }}" \
-                  --pattern "$manifest_filename" \
-                  --dir "$manifest_dir" \
-                  --clobber
-              fi
-            else
-              gh release create "$manifest_tag" \
-                --repo "${{ github.repository }}" \
-                --title "$manifest_title" \
-                --notes "Mutable manifest used by the $artifact_name desktop auto-update feed." \
-                --latest=false
-            fi
-
-            zip_url="https://github.com/${{ github.repository }}/releases/download/$release_tag/${artifact_name}-darwin-arm64-$DESKTOP_VERSION.zip"
-            node apps/desktop/scripts/update-desktop-release-manifest.mjs \
-              --manifest "$manifest_path" \
-              --product "$product" \
-              --version "$DESKTOP_VERSION" \
-              --zip-url "$zip_url" \
-              --channel stable \
-              --platform darwin \
-              --arch arm64
-
-            gh release upload "$manifest_tag" "$manifest_path" \
+          mkdir -p "$manifest_dir"
+          if gh release view "$manifest_tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            if gh release view "$manifest_tag" \
               --repo "${{ github.repository }}" \
-              --clobber
-          }
+              --json assets \
+              --jq '.assets[].name' | grep -qx "$manifest_filename"; then
+              gh release download "$manifest_tag" \
+                --repo "${{ github.repository }}" \
+                --pattern "$manifest_filename" \
+                --dir "$manifest_dir" \
+                --clobber
+            fi
+          else
+            gh release create "$manifest_tag" \
+              --repo "${{ github.repository }}" \
+              --title "Okou Desktop Updates" \
+              --notes "Mutable manifest used by the Okou desktop auto-update feed." \
+              --latest=false
+          fi
 
-          publish_manifest \
-            zero \
-            Zero \
-            "$ZERO_RELEASE_TAG" \
-            desktop-updates \
-            desktop-update-manifest.json \
-            "Desktop Updates"
-          publish_manifest \
-            okou \
-            Okou \
-            "$OKOU_RELEASE_TAG" \
-            ai-okou-desktop-updates \
-            ai-okou-desktop-update-manifest.json \
-            "Okou Desktop Updates"
+          zip_url="https://github.com/${{ github.repository }}/releases/download/$OKOU_RELEASE_TAG/Okou-darwin-arm64-$DESKTOP_VERSION.zip"
+          node apps/desktop/scripts/update-desktop-release-manifest.mjs \
+            --manifest "$manifest_path" \
+            --product okou \
+            --version "$DESKTOP_VERSION" \
+            --zip-url "$zip_url" \
+            --channel stable \
+            --platform darwin \
+            --arch arm64
+
+          gh release upload "$manifest_tag" "$manifest_path" \
+            --repo "${{ github.repository }}" \
+            --clobber
 
   detect-host-worker-deploy-inputs:
     needs: release-please


### PR DESCRIPTION
Closes #30390. Part of #26364.

The Zero Desktop hard stop went live on 2026-08-31T02:26Z and is verified on both brand hosts. Installed Zero builds block themselves on launch, Zero Desktop traffic went to zero within half an hour, and the one external Computer Use host went offline at 02:29:44Z. Publishing `desktop-v*` now produces a signed, notarized artifact that no user can install, so this stops producing it. Okou is unaffected.

## What changed

`.github/workflows/release-please.yml` — `promote-desktop-release`:

- Dropped the `RELEASE_TAG: desktop-v${version}` env and the `gh release view "$RELEASE_TAG"` input check. `desktop_release_created` already gates the job and the `apps/desktop/package.json` version match still runs.
- `Download canonical Desktop app` extracts only `Okou.app`.
- `Sign and notarize macOS artifacts` signs, zips, builds, signs, notarizes and staples only the Okou DMG. `zero_zip_path` / `zero_dmg_path` are gone; `okou_zip_path` / `okou_dmg_path` are unchanged.
- `Verify signed and notarized macOS artifacts` keeps every Okou check verbatim — Info.plist identity, arm64 slices, `codesign`, `stapler`, DMG mount, Finder background geometry, and both the install and update smoke tests. The Zero half and the two now-single-call product helpers are inlined away.
- `Upload Desktop artifacts to GitHub Releases` no longer uploads to `desktop-v${version}`. The `okou-desktop-v${version}` create and upload are untouched.
- Slack start/failure links now point at the Okou release; the success message drops the Zero release link.

`.github/workflows/release-please.yml` — `publish-desktop-update-manifest`:

- Removed the `ZERO_RELEASE_TAG` env and `verify_release_assets "$ZERO_RELEASE_TAG" Zero`.
- Removed the `publish_manifest zero` call, which was a forced consequence of dropping `ZERO_RELEASE_TAG`, and the safer outcome: republishing the Zero feed would have pointed `desktop-updates/desktop-update-manifest.json` at a ZIP that no longer exists. The asset now stays frozen at the last published Zero release instead of 404ing.
- The checkout ref moves from the `desktop-v${version}` tag to `needs.release-please.outputs.release_target`. Same commit, and it removes the last `desktop-v` reference plus a checkout-ref exception in `resolve-production-rollback-target-test.sh`.

`.github/scripts/build-okou-desktop-artifact.sh` — inverted as the issue asks: `<okou-app-directory>` is now a required positional and the Zero positional is gone. The canonical R2 artifact therefore carries `okou-app.tar.gz` / `okouAppName` / `okouArchive` only. Every caller is updated:

- `verify-okou-desktop-artifact.sh` requires the Okou archive unconditionally; the `--require-okou` opt-in flag is removed.
- `fetch-okou-desktop-artifact.sh` fetches `manifest.json`, `ready.json`, then the manifest-declared Okou archive (3 objects instead of 4), and fails on a manifest without one.
- `.github/workflows/desktop.yml` passes the Okou app directory and stops uploading `app.tar.gz` to R2.

## Explicitly not touched

- The `okou-desktop-v*` line. `/api/desktop/updates/stable/darwin/arm64/dmg` still 302s to the Okou DMG, which is the Download Okou button on the hard-stop screen blocked users see right now.
- `/api/desktop/migration-policy` and its route. `desktop-zero-migration.ts:91` and `:277` both fall back to `soft` on any failure, so removing the endpoint would silently undo the hard stop.
- `.github/workflows/desktop-migration-policy.yml` and `validate-desktop-migration-policy.sh` — the rollback mechanism.
- The two `desktop-updates` rows in `MIGRATED_BRANDED_PATHS`.
- `release-please-config.json`. release-please still cuts the `desktop-v${version}` tag and changelog release for the `turbo/apps/desktop` package; the Okou line derives its version from it. Only the artifact publishing stops.
- `desktop.yml`'s `Build canonical unsigned Desktop app` still builds and smoke-tests the default (Zero) product. That step also drives `pnpm -F @okouai/desktop upload:sentry` for production sourcemaps, so removing it is a separate Sentry-affecting change rather than part of retiring the release line. Its packaged output is simply no longer collected into the artifact.

## Verification

Ran locally on the branch:

- `.github/scripts/tests/okou-desktop-artifact-test.sh` — rewritten for the new signature: build/verify round trip, symlink preservation, manifest shape, an app directory that is not `Okou.app` is rejected, tampered and missing archives fail, wrong commit and wrong version fail, and an archive with a foreign top-level path fails.
- `.github/scripts/tests/fetch-okou-desktop-artifact-test.sh` — 3 object copies, retry accounting, a missing archive fails without retrying, and a manifest that declares no Okou archive fails closed.
- `.github/scripts/tests/deploy-desktop-workflow-test.sh` — the `--require-okou` assertion becomes a positive assertion that promotion extracts the Okou archive, and the Zero-feed assertion is deleted with the behavior it covered. No "stays removed" tombstones were added (`docs/fallback.md` §1).
- `.github/scripts/tests/resolve-production-rollback-target-test.sh`.
- Full `.github/scripts/tests/*.sh` sweep diffed against `main`: no new failures (the remaining ones are sandbox tooling gaps — missing `ansible-playbook`, `zstd`, `cargo`, no process substitution).
- `shellcheck` clean on all six changed shell files, `.github/scripts/check-workflow-shell-compatibility.sh` passes, `bash -n` passes on every extracted `run` block in both changed jobs, and `actionlint` output is byte-identical to `main` apart from line-number shifts.

The end-to-end proof the issue asks for is the next desktop release itself: `gh release view okou-desktop-v<next>` should carry both Okou assets, and `desktop-v<next>` should carry none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
