### PR TITLE
fix(api): report byteplus image failure detail

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
@@ -1561,6 +1561,117 @@ describe("POST /api/image-io/generate", () => {
     await expect(orgCredits(fixture)).resolves.toBe(1000);
   });
 
+  it("reports the BytePlus failure detail when a reference image is unreachable", async () => {
+    const fixture = await seedImageFixture({ credits: 1000 });
+    const pricingFixture = await createScopedImagePricing({
+      configured: SEEDREAM_5_PRO_IMAGE_PRICING,
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    server.use(
+      http.post(BYTEPLUS_IMAGE_GENERATIONS_URL, () => {
+        return HttpResponse.json(
+          {
+            error: {
+              code: "InvalidParameter",
+              message:
+                "The parameter `image` specified in the request are not valid: Error while downloading: https://refs.sites.vm0.io/img4.jpeg, status code: 403.",
+              param: "image",
+              type: "BadRequest",
+            },
+          },
+          { status: 400 },
+        );
+      }),
+    );
+
+    const app = createImageIoTestApp(pricingFixture.resolution);
+    const response = await app.request("/api/image-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        prompt: "restyle this reference",
+        model: "seedream5-pro",
+        size: "2K",
+        imageUrls: ["https://refs.sites.vm0.io/img4.jpeg"],
+      }),
+    });
+
+    expect(response.status).toBe(202);
+    const generationId = readAcceptedGenerationId(
+      await response.json(),
+      "image",
+      fixture.userId,
+    );
+    await flushWaitUntilForTest();
+
+    const statusResponse = await app.request(
+      `/api/built-in-generations/${generationId}`,
+      { headers: authHeaders() },
+    );
+    expect(statusResponse.status).toBe(200);
+    await expect(statusResponse.json()).resolves.toMatchObject({
+      generationId,
+      type: "image",
+      status: "failed",
+      error: {
+        message:
+          "BytePlus image generation failed: The parameter `image` specified in the request are not valid: Error while downloading: https://refs.sites.vm0.io/img4.jpeg, status code: 403. (image)",
+        code: "BYTEPLUS_INVALID_PARAMETER",
+      },
+    });
+    await expect(orgCredits(fixture)).resolves.toBe(1000);
+  });
+
+  it("falls back to a generic message when BytePlus returns an unparsable error", async () => {
+    const fixture = await seedImageFixture({ credits: 1000 });
+    const pricingFixture = await createScopedImagePricing({
+      configured: SEEDREAM_5_PRO_IMAGE_PRICING,
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    server.use(
+      http.post(BYTEPLUS_IMAGE_GENERATIONS_URL, () => {
+        return new HttpResponse("upstream unavailable", { status: 502 });
+      }),
+    );
+
+    const app = createImageIoTestApp(pricingFixture.resolution);
+    const response = await app.request("/api/image-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        prompt: "a precise editorial portrait",
+        model: "seedream5-pro",
+        size: "2K",
+      }),
+    });
+
+    expect(response.status).toBe(202);
+    const generationId = readAcceptedGenerationId(
+      await response.json(),
+      "image",
+      fixture.userId,
+    );
+    await flushWaitUntilForTest();
+
+    const statusResponse = await app.request(
+      `/api/built-in-generations/${generationId}`,
+      { headers: authHeaders() },
+    );
+    expect(statusResponse.status).toBe(200);
+    await expect(statusResponse.json()).resolves.toMatchObject({
+      generationId,
+      type: "image",
+      status: "failed",
+      error: {
+        message: "Image generation failed",
+        code: "BYTEPLUS_IMAGE_REQUEST_FAILED",
+      },
+    });
+    await expect(orgCredits(fixture)).resolves.toBe(1000);
+  });
+
   it("rejects a Qwen Image 3 size above the provider's pixel cap", async () => {
     const fixture = await seedImageFixture({ credits: 1000 });
     mocks.clerk.session(fixture.userId, fixture.orgId);

--- a/turbo/apps/api/src/signals/services/image-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/image-generation.service.ts
@@ -1893,6 +1893,49 @@ function parseBytePlusImageFile(value: unknown): BytePlusImageFile | null {
   };
 }
 
+interface BytePlusImageProviderError {
+  readonly message: string;
+  readonly code: string | undefined;
+}
+
+/**
+ * BytePlus reports actionable failures in a single `error` object: an
+ * unreachable reference image, a rejected prompt, an out-of-range aspect
+ * ratio. Callers can only act on those when the detail reaches the generation
+ * record, so keep the provider message instead of collapsing every failure
+ * into one generic string.
+ */
+function readBytePlusImageProviderError(
+  value: unknown,
+): BytePlusImageProviderError | null {
+  if (!isRecord(value) || !isRecord(value.error)) {
+    return null;
+  }
+  const { message, code, param } = value.error;
+  if (typeof message !== "string" || message.length === 0) {
+    return null;
+  }
+  return {
+    message:
+      typeof param === "string" && param.length > 0
+        ? `${message} (${param})`
+        : message,
+    code: typeof code === "string" ? code : undefined,
+  };
+}
+
+function normalizeBytePlusImageErrorCode(value: string | undefined): string {
+  const normalized = value
+    ?.trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toUpperCase();
+  return normalized
+    ? `BYTEPLUS_${normalized}`
+    : "BYTEPLUS_IMAGE_REQUEST_FAILED";
+}
+
 function parseBytePlusImageResult(
   value: unknown,
 ): BytePlusImageResult | ErrorResponse {
@@ -1924,9 +1967,14 @@ export async function generateBytePlusImage(
       status: response.status,
       body: responseBody,
     });
+    const providerError = readBytePlusImageProviderError(
+      safeJsonParse(responseBody),
+    );
     return badGateway(
-      "Image generation failed",
-      "BYTEPLUS_IMAGE_REQUEST_FAILED",
+      providerError
+        ? `BytePlus image generation failed: ${providerError.message}`
+        : "Image generation failed",
+      normalizeBytePlusImageErrorCode(providerError?.code),
     );
   }
 


### PR DESCRIPTION
## Problem

Every rejected BytePlus image request reached the user as the same four words.

`generateBytePlusImage` logged the provider's error body and then returned a
single hard-coded message:

```ts
L.error("BytePlus image generation request failed", { model, status, body });
return badGateway("Image generation failed", "BYTEPLUS_IMAGE_REQUEST_FAILED");
```

The discarded detail was specific and, in several cases, directly actionable by
the caller. Real production failures from the last three months:

| What BytePlus reported | What the caller saw |
| --- | --- |
| `Error while downloading: https://….sites.vm0.io/img4.jpeg, status code: 403` | Image generation failed |
| `input text may be related to copyright restrictions` | Image generation failed |
| `expected the aspect ratio to be between 0.40 and 2.50, but received 2.60` | Image generation failed |
| `expected the height to be at least 300px, but received a 546x210px image` | Image generation failed |

The last two are input problems the caller could have fixed unaided. Instead,
every one of these required an operator to open Axiom and read
`vm0-web-logs-prod` to learn what had happened.

## Change

Parse the provider `error` object and carry its message and code into the
generation record.

This is not a new mechanism. `video-generation.service.ts` already does exactly
this for the same provider (`readVideoProviderError`,
`normalizeBytePlusErrorCode`, `bytePlusProviderErrorResponse`); the image path
was simply never given the same treatment. The new helpers mirror that shape,
narrowed to the one payload BytePlus actually returns.

- `InvalidParameter` → `BYTEPLUS_INVALID_PARAMETER`
- `InputTextSensitiveContentDetected.PolicyViolation` →
  `BYTEPLUS_INPUT_TEXT_SENSITIVE_CONTENT_DETECTED_POLICY_VIOLATION`
- `param` is appended as `(image)`, matching the video service

Bodies that are absent, non-JSON, or truncated by the existing 4000-character
cap keep the previous generic message and `BYTEPLUS_IMAGE_REQUEST_FAILED`
code, so nothing regresses when the provider returns something unexpected.

## Scope

Message and code only. The `ErrorResponse` status is unchanged, because the
BytePlus image path is asynchronous — `image-io-generate.ts` reads
`generation.body.error` into `failBuiltInGenerationJob$` and drops the status —
so mapping upstream statuses would add an unread value.

The video service is already correct and is untouched.

## Tests

Two integration tests at the route boundary, using the real production error
payload:

- an unreachable reference image surfaces the provider message and
  `BYTEPLUS_INVALID_PARAMETER`
- a non-JSON upstream body falls back to the previous generic message and code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
