### PR TITLE
fix(ci): gate api promotion on connector catalog readiness

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1414,8 +1414,87 @@ jobs:
             rm -rf .vercel/output
             cp -R turbo/apps/api/.vercel/output .vercel/output
           environment-file: ${{ steps.api-production-env.outputs.file }}
+          skip-domain: "true"
           skip-start: "true"
           skip-finish: "true"
+          skip-setup: "true"
+
+      - name: Check staged API health
+        shell: bash
+        env:
+          API_DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+          vercel curl /health --deployment "$API_DEPLOYMENT_URL" --token "$VERCEL_TOKEN" -- \
+            --fail \
+            --show-error \
+            --silent \
+            --max-time 20 \
+            --retry 3 \
+            --retry-delay 2 \
+            --retry-all-errors
+
+      - name: Reconcile staged connector catalog
+        shell: bash
+        env:
+          API_DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          response=""
+          for attempt in 1 2 3; do
+            if ! response=$(vercel curl /api/cron/sync-connector-catalog \
+              --deployment "$API_DEPLOYMENT_URL" \
+              --token "$VERCEL_TOKEN" \
+              -- \
+              --fail-with-body \
+              --show-error \
+              --silent \
+              --max-time 120 \
+              --header "Authorization: Bearer ${CRON_SECRET}"); then
+              echo "::warning::Connector catalog reconcile request failed (attempt ${attempt}/3)"
+            elif summary=$(jq -c '{
+              outcome,
+              state,
+              hasActive: (.active != null),
+              lastAttemptOutcome: .lastAttempt.outcome,
+              filtering: {
+                stale: .filtering.stale,
+                filteredAuthMethodCount: (.filtering.filteredAuthMethods | length)
+              }
+            }' <<< "$response"); then
+              echo "Connector catalog reconcile: ${summary}"
+
+              if jq -e '
+                .state == "current"
+                and .active != null
+                and .filtering.stale == false
+              ' <<< "$response" >/dev/null; then
+                exit 0
+              fi
+              echo "::warning::Connector catalog is not ready (attempt ${attempt}/3)"
+            else
+              echo "::warning::Connector catalog reconcile returned invalid JSON (attempt ${attempt}/3)"
+            fi
+
+            if [ "$attempt" -lt 3 ]; then
+              sleep 2
+            fi
+          done
+
+          echo "::error::Connector catalog reconcile did not produce a current accepted snapshot"
+          exit 1
+
+      - name: Promote API Production
+        uses: ./.github/actions/vercel-promote
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
+          vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_API }}
+          deployment-url: ${{ steps.deploy.outputs.url }}
           skip-setup: "true"
 
       - name: Verify production App and API domains

--- a/turbo/apps/api/src/__tests__/release-please-config.test.ts
+++ b/turbo/apps/api/src/__tests__/release-please-config.test.ts
@@ -223,6 +223,81 @@ describe("release-please API deployment graph", () => {
     expect(promoteApiProductionJob).toContain('skip-setup: "true"');
   });
 
+  it("stages and validates the API before production promotion", () => {
+    const workflow = readText(".github/workflows/release-please.yml");
+    const promoteApiProductionJob = workflowJobBlock(
+      workflow,
+      "promote-api-production",
+    );
+    const deployStep = promoteApiProductionJob.indexOf(
+      "- name: Deploy API Production",
+    );
+    const healthStep = promoteApiProductionJob.indexOf(
+      "- name: Check staged API health",
+    );
+    const reconcileStep = promoteApiProductionJob.indexOf(
+      "- name: Reconcile staged connector catalog",
+    );
+    const promoteStep = promoteApiProductionJob.indexOf(
+      "- name: Promote API Production",
+    );
+    const verifyDomainsStep = promoteApiProductionJob.indexOf(
+      "- name: Verify production App and API domains",
+    );
+
+    expect(deployStep).toBeGreaterThan(-1);
+    expect(healthStep).toBeGreaterThan(deployStep);
+    expect(reconcileStep).toBeGreaterThan(healthStep);
+    expect(promoteStep).toBeGreaterThan(reconcileStep);
+    expect(verifyDomainsStep).toBeGreaterThan(promoteStep);
+
+    const deployBlock = promoteApiProductionJob.slice(deployStep, healthStep);
+    expect(deployBlock).toContain('skip-domain: "true"');
+
+    const healthBlock = promoteApiProductionJob.slice(
+      healthStep,
+      reconcileStep,
+    );
+    expect(healthBlock).toContain(
+      `API_DEPLOYMENT_URL: \${{ steps.deploy.outputs.url }}`,
+    );
+    expect(healthBlock).toContain(
+      'vercel curl /health --deployment "$API_DEPLOYMENT_URL"',
+    );
+
+    const reconcileBlock = promoteApiProductionJob.slice(
+      reconcileStep,
+      promoteStep,
+    );
+    expect(reconcileBlock).toContain(
+      `API_DEPLOYMENT_URL: \${{ steps.deploy.outputs.url }}`,
+    );
+    expect(reconcileBlock).toContain(
+      "vercel curl /api/cron/sync-connector-catalog",
+    );
+    expect(reconcileBlock).toContain(
+      `--header "Authorization: Bearer \${CRON_SECRET}"`,
+    );
+    expect(reconcileBlock).toContain("hasActive: (.active != null)");
+    expect(reconcileBlock).toContain(
+      "lastAttemptOutcome: .lastAttempt.outcome",
+    );
+    expect(reconcileBlock).not.toContain("capabilityDigest:");
+    expect(reconcileBlock).toContain('.state == "current"');
+    expect(reconcileBlock).toContain(".active != null");
+    expect(reconcileBlock).toContain(".filtering.stale == false");
+
+    const promoteBlock = promoteApiProductionJob.slice(
+      promoteStep,
+      verifyDomainsStep,
+    );
+    expect(promoteBlock).toContain("uses: ./.github/actions/vercel-promote");
+    expect(promoteBlock).toContain(
+      `deployment-url: \${{ steps.deploy.outputs.url }}`,
+    );
+    expect(promoteBlock).toContain('skip-setup: "true"');
+  });
+
   it("keeps Vercel setup enabled for other deployment callers", () => {
     const action = readText(".github/actions/vercel-deploy/action.yml");
     const skipSetupInputStart = action.indexOf("  skip-setup:\n");


### PR DESCRIPTION
## Summary

- stage the production API deployment without assigning production domains
- check health and reconcile a current accepted connector catalog on the exact staged deployment
- promote that deployment only after readiness passes, then verify public production domains
- keep reconciliation logs low-cardinality and add workflow ordering regression coverage

## Behavior

The release job now follows:

`deploy staged → health → reconcile current catalog → promote → verify production domains`

If health, reconciliation, response validation, or promotion fails, the job exits before the new deployment becomes current. Catalog readiness requires `state == "current"`, a non-null active snapshot, and `filtering.stale == false`.

## Exclusions

- no connector catalog schema, identity, reader, or API response changes
- no preview workflow refactor
- no previous-generation fallback or request-triggered reconciliation
- runtime unavailable-state classification remains in #30382

## Validation

- `pnpm exec prettier --check ../.github/workflows/release-please.yml apps/api/src/__tests__/release-please-config.test.ts`
- `pnpm exec vitest run apps/api/src/__tests__/release-please-config.test.ts` (10 passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `actionlint .github/workflows/release-please.yml` (v1.7.12)
- pre-commit: full Turbo `check-types` (15/15), full Knip, Prettier, file-size check, commitlint
- `git diff --check`

Closes #30381

Parent delivery: #30373
