### PR TITLE
refactor(api): serve the desktop migration policy from a constant

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
@@ -18,8 +18,6 @@ const DESKTOP_UPDATE_MANIFEST_URL =
   "https://github.com/vm0-ai/vm0/releases/download/desktop-updates/desktop-update-manifest.json";
 const OKOU_DESKTOP_UPDATE_MANIFEST_URL =
   "https://github.com/vm0-ai/vm0/releases/download/ai-okou-desktop-updates/ai-okou-desktop-update-manifest.json";
-const DESKTOP_ZERO_MIGRATION_POLICY_URL =
-  "https://github.com/vm0-ai/vm0/releases/download/desktop-migration-policy/desktop-migration-policy.json";
 
 interface DesktopUpdateRelease {
   readonly version: string;
@@ -125,51 +123,18 @@ describe("desktop update routes", () => {
     await accept(manifestStateClient().reset({ body: {} }), [200]);
   });
 
-  it.each(["off", "soft", "hard"] as const)(
-    "serves the no-store %s Zero migration policy",
-    async (mode) => {
-      server.use(
-        http.get(DESKTOP_ZERO_MIGRATION_POLICY_URL, () => {
-          return HttpResponse.json({ schemaVersion: 1, mode });
-        }),
-      );
+  it("serves the no-store hard Zero migration policy", async () => {
+    const response = await appRequest(
+      "http://api.test/api/desktop/migration-policy",
+    );
 
-      const response = await appRequest(
-        "http://api.test/api/desktop/migration-policy",
-      );
-
-      expect(response.status).toBe(200);
-      expect(response.headers.get("Cache-Control")).toBe("no-store");
-      await expect(response.json()).resolves.toStrictEqual({
-        schemaVersion: 1,
-        mode,
-      });
-    },
-  );
-
-  it.each([
-    HttpResponse.json({ schemaVersion: 2, mode: "hard" }),
-    new HttpResponse(null, { status: 503 }),
-  ])(
-    "defaults to soft coexistence for an unavailable policy",
-    async (mockResponse) => {
-      server.use(
-        http.get(DESKTOP_ZERO_MIGRATION_POLICY_URL, () => {
-          return mockResponse;
-        }),
-      );
-
-      const response = await appRequest(
-        "http://api.test/api/desktop/migration-policy",
-      );
-
-      expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toStrictEqual({
-        schemaVersion: 1,
-        mode: "soft",
-      });
-    },
-  );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    await expect(response.json()).resolves.toStrictEqual({
+      schemaVersion: 1,
+      mode: "hard",
+    });
+  });
 
   it("redirects the release page route to the current stable desktop release", async () => {
     mockDesktopUpdateManifest(

--- a/turbo/apps/api/src/signals/routes/desktop-updates.ts
+++ b/turbo/apps/api/src/signals/routes/desktop-updates.ts
@@ -4,7 +4,6 @@ import {
   DESKTOP_UPDATE_LINE_OKOU,
   DESKTOP_UPDATE_LINE_ZERO,
   desktopUpdatesContract,
-  desktopZeroMigrationPolicySchema,
   type DesktopZeroMigrationPolicy,
   type DesktopUpdateLine,
 } from "@okouai/api-contracts/contracts/desktop-updates";
@@ -14,7 +13,6 @@ import { notFound } from "../../lib/error";
 import { request$, setResHeader$ } from "../context/hono";
 import { pathParamsOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
-import { readBoundedResponseText, safeJsonParse, settle } from "../utils";
 import {
   loadDesktopDmgDownloadUrl,
   loadDesktopReleasePageUrl,
@@ -31,52 +29,32 @@ const productReleasePageParams$ = pathParamsOf(
 const productDmgDownloadParams$ = pathParamsOf(
   desktopUpdatesContract.productDmgDownload,
 );
-const DESKTOP_ZERO_MIGRATION_POLICY_URL =
-  "https://github.com/vm0-ai/vm0/releases/download/desktop-migration-policy/desktop-migration-policy.json";
-const SAFE_DESKTOP_ZERO_MIGRATION_POLICY = {
+
+/**
+ * The Zero Desktop migration policy this service serves.
+ *
+ * The policy used to be fetched from a GitHub release asset on every poll so
+ * that it could be flipped without a deploy. `hard` was activated and verified
+ * on 2026-08-31 and the owner confirmed it will not be rolled back, so the
+ * mechanism is gone and the policy now changes only by editing this constant
+ * and deploying.
+ *
+ * The endpoint itself has to stay: both this route and the desktop client fail
+ * open to `soft`, so removing it would silently un-block every installed Zero
+ * build that still polls.
+ */
+const DESKTOP_ZERO_MIGRATION_POLICY = {
   schemaVersion: 1,
-  mode: "soft",
+  mode: "hard",
 } as const satisfies DesktopZeroMigrationPolicy;
-const DESKTOP_ZERO_MIGRATION_POLICY_MAX_BYTES = 1024;
 
-async function fetchDesktopZeroMigrationPolicy(
-  signal: AbortSignal,
-): Promise<DesktopZeroMigrationPolicy> {
-  const fetched = await settle(
-    fetch(DESKTOP_ZERO_MIGRATION_POLICY_URL, {
-      headers: { Accept: "application/json" },
-      signal,
-    }),
-    signal,
-  );
-  if (!fetched.ok || !fetched.value.ok) {
-    return SAFE_DESKTOP_ZERO_MIGRATION_POLICY;
-  }
-  const body = await settle(
-    readBoundedResponseText(
-      fetched.value,
-      DESKTOP_ZERO_MIGRATION_POLICY_MAX_BYTES,
-    ),
-    signal,
-  );
-  if (!body.ok || body.value.kind !== "text") {
-    return SAFE_DESKTOP_ZERO_MIGRATION_POLICY;
-  }
-  const parsed = desktopZeroMigrationPolicySchema.safeParse(
-    safeJsonParse(body.value.text),
-  );
-  return parsed.success ? parsed.data : SAFE_DESKTOP_ZERO_MIGRATION_POLICY;
-}
-
-const getDesktopMigrationPolicy$ = command(
-  async ({ set }, signal: AbortSignal) => {
-    set(setResHeader$, "Cache-Control", "no-store");
-    return {
-      status: 200 as const,
-      body: await fetchDesktopZeroMigrationPolicy(signal),
-    };
-  },
-);
+const getDesktopMigrationPolicy$ = command(({ set }) => {
+  set(setResHeader$, "Cache-Control", "no-store");
+  return {
+    status: 200 as const,
+    body: DESKTOP_ZERO_MIGRATION_POLICY,
+  };
+});
 
 /**
  * The update line the release-page and DMG routes serve, taken from the


### PR DESCRIPTION
Closes #30395. Part of #26364.

## What changed

`/api/desktop/migration-policy` now returns `{"schemaVersion":1,"mode":"hard"}` from a constant in `turbo/apps/api/src/signals/routes/desktop-updates.ts` instead of fetching the policy from the `desktop-migration-policy` GitHub release asset on every poll.

Removed: `DESKTOP_ZERO_MIGRATION_POLICY_URL`, `SAFE_DESKTOP_ZERO_MIGRATION_POLICY`, `DESKTOP_ZERO_MIGRATION_POLICY_MAX_BYTES`, and `fetchDesktopZeroMigrationPolicy`. The handler no longer needs its `AbortSignal`, and the route no longer makes an outbound request. `Cache-Control: no-store`, the 200 status, and the response body shape are unchanged, so no client sees a difference.

## The trade being accepted

**This change turns the policy from a runtime switch into a code deploy.** The removed mechanism flipped the policy in about five minutes through a workflow run; from here the only way to change it is to edit the constant and ship a release. That is deliberate: `hard` was activated and verified on 2026-08-31, the owner confirmed there will be no rollback, and the fetch mechanism is being removed in exchange for losing the fast flip.

## Why the endpoint is not deleted

Both sides fail *open*, not closed. This route used to return `soft` on any fetch, read, or parse failure, and `apps/desktop/src/desktop-zero-migration.ts` defaults to `soft` on any failure at `:91` and `:277`. Deleting the route — or deleting the release asset it read — would silently revert every installed Zero build to `soft` and un-block the users the hard stop just stopped. The endpoint has to keep answering `hard` for as long as any installed Zero can poll it.

## Scope

`desktopZeroMigrationPolicySchema` and `DesktopZeroMigrationPolicy` stay in `api-contracts`; they are still used by the contract itself and by the desktop client. This file just stops parsing with the schema. `desktopUpdateLineFromRequestUrl` is untouched.

The workflow, the validation script and its test, the runbook, and the release asset are intentionally **not** deleted here. They must stop being read first, and that only takes effect once this deploys; a follow-up issue removes them.

## Tests

The two route tests that drove the fetch through MSW are replaced by one test asserting the constant, per the issue. No assertion was added that the removed fetch path stays removed (`docs/fallback.md` §1).

Verified locally in `apps/api`: `check-types`, `lint`, `knip --workspace apps/api`, prettier, and `vitest run src/signals/routes/__tests__/desktop-updates.test.ts` (17 passed).

## Post-deploy verification

`GET /api/desktop/migration-policy` returns `{"schemaVersion":1,"mode":"hard"}` with `cache-control: no-store` on both `api.okou.ai` and `api.vm0.ai`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
