### PR TITLE
test(runner): cover response negotiation lifecycle

### DIFF
--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
@@ -534,6 +534,9 @@ async def test_unrelated_same_run_policy_change_keeps_equivalent_authorization(
     assert flow.request.headers["Authorization"] == _RESOLVED_AUTHORIZATION
     assert flow.request.query["managed"] == "resolved-for-old-authorization"
     assert flow.metadata[metadata_keys.SANDBOX_RUN_ID] == _ORIGINAL_RUN_ID
+    assert (
+        flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] == "rewritten_stream_decodable"
+    )
 
 
 async def test_different_same_run_allow_decision_fails_closed_without_old_credentials(

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -263,6 +263,16 @@ def test_normalize_accept_encoding_for_body_inspection(
             id="unsafe-coding-removed",
         ),
         pytest.param(
+            [("Accept-Encoding", "gzip;q=bogus, br")],
+            "rewritten_stream_decodable",
+            id="malformed-coding-rewritten",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "br, zstd, *;q=0.5, identity;q=0")],
+            "rewritten_stream_decodable",
+            id="wildcard-expanded",
+        ),
+        pytest.param(
             [("Accept-Encoding", "br, identity;q=0")],
             "preserved_client_constraints",
             id="all-safe-representations-rejected",
@@ -808,6 +818,7 @@ async def test_model_provider_websocket_upgrade_injects_auth_and_keeps_accept_en
     assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == ""
     assert flow.request.headers["Authorization"] == "Bearer x"
     assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, zstd, br"
+    assert metadata_keys.RESPONSE_ENCODING_NEGOTIATION not in flow.metadata
 
 
 @pytest.mark.parametrize(
@@ -844,6 +855,7 @@ async def test_response_bodyless_usage_inspected_methods_keep_accept_encoding(
 
     assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, zstd, br"
     assert flow.request.headers["Authorization"] == "Bearer x"
+    assert metadata_keys.RESPONSE_ENCODING_NEGOTIATION not in flow.metadata
 
 
 @pytest.mark.parametrize(
@@ -1076,3 +1088,4 @@ async def test_browser_passthrough_keeps_accept_encoding_for_parser_connector(
 
     auth_fetch.assert_not_called()
     assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, zstd, br"
+    assert metadata_keys.RESPONSE_ENCODING_NEGOTIATION not in flow.metadata


### PR DESCRIPTION
## Summary

- cover malformed and wildcard `Accept-Encoding` inputs in the typed negotiation-outcome matrix
- verify response-inspection negotiation metadata survives firewall-auth revalidation
- verify WebSocket, bodyless, and browser-pass-through requests do not retain negotiation metadata

## Explicit exclusions

- no production behavior or logging changes
- no Brotli streaming decoder or decompression-boundary changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/test_response_encoding_negotiation.py tests/test_request_handler_firewall_auth_revalidation.py` (93 passed)
- `uv run --no-sync python -m pytest tests/` (7,241 passed)

A first full-suite run observed one missing asynchronous proxy-log row in an unchanged model-provider failure test. The isolated test passed immediately, and the complete suite passed on the next run.

Relates to #30375
