### PR TITLE
docs(python): update stale model-provider usage integration path

### DIFF
--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -802,9 +802,15 @@ class TestModelProviderResponseHookUsage:
     def test_full_path_response_to_webhook(
         self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
     ):
-        """Integration: response() -> _maybe_report -> _enqueue -> _retry -> webhook.
+        """Integration test for the response hook's terminal model-usage lifecycle.
 
-        Verifies wiring between all intermediate layers through loopback HTTP.
+        The response hook reaches terminal one-shot reporting through
+        ``terminal_usage.report_model_provider_usage_once()``, which buffers
+        billing and model-observation payloads through the public ``usage``
+        facade. The explicit ``usage.flush_usage_events(trigger="test")`` call
+        admits those buffers to retry-capable webhook enqueue and delivery, and
+        this test verifies the successful loopback HTTP requests. It does not
+        trigger a delivery retry.
         """
         flow = real_flow(with_response=False, host="api.anthropic.com")
         log_path = str(tmp_path / "network.jsonl")


### PR DESCRIPTION
## Summary

- Update the model-provider response integration test docstring to match the current terminal reporting and webhook lifecycle.
- Document model-usage buffering, the explicit test flush, and retry-capable webhook enqueue/delivery.
- Clarify that the test verifies successful loopback delivery and does not trigger a retry failure.

## Scope

This PR changes only the docstring of `TestModelProviderResponseHookUsage.test_full_path_response_to_webhook`. It does not change production code, test setup, assertions, billing or observation behavior, webhook transport, or retry policy.

## Validation

- `uv run --no-sync python -m pytest tests/test_model_provider_usage.py::TestModelProviderResponseHookUsage::test_full_path_response_to_webhook`
- `uv run --no-sync ruff format --check tests/test_model_provider_usage.py`
- `uv run --no-sync ruff check tests/test_model_provider_usage.py`
- `git diff --check`

Closes #30414
