### PR TITLE
fix: presign first-party provider references

### DIFF
--- a/turbo/apps/api/src/lib/__tests__/presigned-url-redaction.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/presigned-url-redaction.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { redactPresignedUrls } from "../presigned-url-redaction";
+
+describe("redactPresignedUrls", () => {
+  it("redacts an AWS-compatible presigned URL embedded in provider text", () => {
+    const value = JSON.stringify({
+      error:
+        "download failed: https://r2.example.com/bucket/reference.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=secret&X-Amz-Signature=signature",
+    });
+
+    expect(redactPresignedUrls(value)).toBe(
+      '{"error":"download failed: [redacted presigned URL]"}',
+    );
+  });
+
+  it("preserves ordinary public URLs", () => {
+    const value =
+      "download failed: https://example.com/reference.png?version=latest";
+
+    expect(redactPresignedUrls(value)).toBe(value);
+  });
+});

--- a/turbo/apps/api/src/lib/presigned-url-redaction.ts
+++ b/turbo/apps/api/src/lib/presigned-url-redaction.ts
@@ -1,0 +1,12 @@
+const URL_PATTERN = /\bhttps?:\/\/[^\s"'<>\\]+/giu;
+const PRESIGNED_QUERY_PARAMETER_PATTERN =
+  /(?:^|&)(?:X-Amz-[A-Za-z0-9-]+|AWSAccessKeyId|Signature)=/iu;
+
+export function redactPresignedUrls(value: string): string {
+  return value.replace(URL_PATTERN, (url) => {
+    const query = url.split("?", 2)[1];
+    return query && PRESIGNED_QUERY_PARAMETER_PATTERN.test(query)
+      ? "[redacted presigned URL]"
+      : url;
+  });
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/avatar-video.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/avatar-video.test.ts
@@ -9,6 +9,7 @@ import { beforeEach, describe, expect, it, onTestFinished } from "vitest";
 import { createAppWithRoutes } from "../../../app-factory-core";
 import { testContext } from "../../../__tests__/test-context";
 import { mockEnv } from "../../../lib/env";
+import { buildArtifactKey, buildFileUrlFromKey } from "../../../lib/file-url";
 import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { signSandboxJwtForTests } from "../../auth/tokens";
@@ -32,6 +33,7 @@ import { seedCompose$, seedRun$ } from "./helpers/usage-state";
 const context = testContext();
 const store = createStore();
 const mocks = createRouteMocks(context);
+const TEST_BUCKET = "test-user-artifacts";
 
 const JOGGAI_CREATE_URL = "https://api.jogg.ai/v2/create_video_from_avatar";
 const JOGGAI_AVATARS_URL = "https://api.jogg.ai/v2/avatars/public";
@@ -598,6 +600,12 @@ describe("JoggAI built-in avatar video routes", () => {
 
   it("maps audio input without exposing private JoggAI resources", async () => {
     const fixture = await seedAvatarVideoFixture();
+    const audioKey = buildArtifactKey(
+      fixture.userId,
+      randomUUID(),
+      "voice.mp3",
+    );
+    const audioUrl = buildFileUrlFromKey(audioKey, "vm0");
     let observedBody: unknown = null;
     server.use(
       http.post(JOGGAI_CREATE_URL, async ({ request }) => {
@@ -619,7 +627,7 @@ describe("JoggAI built-in avatar video routes", () => {
       body: JSON.stringify({
         avatarId: 82,
         voiceId: "en-US-AvaNeural",
-        audioUrl: "https://example.com/voice.mp3",
+        audioUrl,
       }),
     });
 
@@ -629,11 +637,20 @@ describe("JoggAI built-in avatar video routes", () => {
       voice: {
         type: "audio",
         voice_id: "en-US-AvaNeural",
-        audio_url: "https://example.com/voice.mp3",
+        audio_url: expect.any(String),
       },
       aspect_ratio: "portrait",
       screen_style: 1,
       caption: true,
     });
+    const providerAudioUrl = asRecord(asRecord(observedBody).voice).audio_url;
+    if (typeof providerAudioUrl !== "string") {
+      throw new Error("Expected JoggAI audio URL");
+    }
+    const signedAudioUrl = new URL(providerAudioUrl);
+    expect(signedAudioUrl.origin).toBe("https://r2.example.com");
+    expect(signedAudioUrl.searchParams.get("object")).toBe(
+      `${TEST_BUCKET}/${audioKey}`,
+    );
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
@@ -2,6 +2,7 @@ import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 
 import {
+  HeadObjectCommand,
   PutObjectCommand,
   type PutObjectCommandInput,
 } from "@aws-sdk/client-s3";
@@ -10,8 +11,10 @@ import { HttpResponse, http } from "msw";
 import { onTestFinished } from "vitest";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
+import { apiTestS3PresignedUrl } from "../../../__tests__/mocks";
 import { testContext } from "../../../__tests__/test-context";
 import { mockEnv } from "../../../lib/env";
+import { buildArtifactKeyV2, buildFileUrlFromKey } from "../../../lib/file-url";
 import { clearMockNow, mockNow, now, nowDate } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { signSandboxJwtForTests } from "../../auth/tokens";
@@ -38,6 +41,9 @@ import { createRouteMocks } from "./helpers/route-test";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { setRunImageModelFixture } from "../../../test-fixtures/run-image-model";
 import { removeBuiltInGenerationPublicBrandFixture } from "../../../test-fixtures/built-in-generation";
+import { upsertOrgPlanEntitlementFixture } from "../../../test-fixtures/org-plan-entitlement";
+import { hostedTextFile } from "./helpers/api-bdd-host-files";
+import { createHostMapsBddApi } from "./helpers/api-bdd-host-maps";
 
 const context = testContext();
 const store = createStore();
@@ -1672,8 +1678,38 @@ describe("POST /api/image-io/generate", () => {
       sourceUrl: BYTEPLUS_SEEDREAM_5_PRO_LOW_MEDIA_URL,
     });
 
+    const hostApi = createHostMapsBddApi(context);
+    hostApi.captureHostedSitesS3();
+    await upsertOrgPlanEntitlementFixture({
+      orgId: fixture.orgId,
+      restrictedVm0Models: false,
+    });
+    const site = `seedream-reference-${randomUUID().slice(0, 8)}`;
+    const hostActor = {
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      orgRole: "org:admin" as const,
+      email: `${fixture.userId}@example.test`,
+    };
+    const hosted = await hostApi.prepareHostedSite(hostActor, {
+      site,
+      artifactKind: "hosted-site",
+      spaFallback: false,
+      files: [
+        hostedTextFile("/index.html", "<main>Reference image</main>"),
+        hostedTextFile("/img4.jpeg", "reference", "image/jpeg"),
+      ],
+    });
+    await hostApi.completeHostedSite(hostActor, hosted.deploymentId);
+    context.mocks.s3.getSignedUrl.mockImplementation(
+      (_client: unknown, command: unknown) => {
+        return Promise.resolve(apiTestS3PresignedUrl(command));
+      },
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const hostedImageUrl = `${hosted.url}/img4.jpeg`;
     const sourceImageUrls = [
-      MOCKUP_IMAGE_URL,
+      hostedImageUrl,
       SECOND_MOCKUP_IMAGE_URL,
       THIRD_MOCKUP_IMAGE_URL,
     ];
@@ -1717,25 +1753,38 @@ describe("POST /api/image-io/generate", () => {
       "Bearer test-byteplus-key",
       "Bearer test-byteplus-key",
     ]);
-    expect(observedBodies).toStrictEqual([
-      {
-        model: "dola-seedream-5-0-pro-260628",
-        prompt: "a precise editorial portrait",
-        size: "1.5K",
-        output_format: "jpeg",
-        response_format: "url",
-        watermark: false,
-      },
-      {
-        model: "dola-seedream-5-0-pro-260628",
-        prompt: "combine these references into a campaign image",
-        image: sourceImageUrls,
-        size: "2K",
-        output_format: "jpeg",
-        response_format: "url",
-        watermark: false,
-      },
-    ]);
+    expect(observedBodies[0]).toStrictEqual({
+      model: "dola-seedream-5-0-pro-260628",
+      prompt: "a precise editorial portrait",
+      size: "1.5K",
+      output_format: "jpeg",
+      response_format: "url",
+      watermark: false,
+    });
+    expect(observedBodies[1]).toMatchObject({
+      model: "dola-seedream-5-0-pro-260628",
+      prompt: "combine these references into a campaign image",
+      size: "2K",
+      output_format: "jpeg",
+      response_format: "url",
+      watermark: false,
+    });
+    const providerSourceImageUrls = (
+      observedBodies[1] as { readonly image?: unknown }
+    ).image;
+    expect(Array.isArray(providerSourceImageUrls)).toBeTruthy();
+    if (!Array.isArray(providerSourceImageUrls)) {
+      throw new Error("Expected BytePlus image references");
+    }
+    expect(providerSourceImageUrls.slice(1)).toStrictEqual(
+      sourceImageUrls.slice(1),
+    );
+    const signedHostedUrl = new URL(String(providerSourceImageUrls[0]));
+    expect(signedHostedUrl.origin).toBe("https://r2.example.com");
+    expect(signedHostedUrl.searchParams.get("sig")).toBe("bdd");
+    expect(signedHostedUrl.searchParams.get("object")).toMatch(
+      /^test-hosted-sites\/sites\/.+\/img4\.jpeg$/u,
+    );
     await expect(orgCredits(fixture)).resolves.toBe(823);
   });
 
@@ -2611,8 +2660,18 @@ describe("POST /api/image-io/generate", () => {
     });
     expect(falCalls).toBe(0);
 
+    const ownedArtifactKey = buildArtifactKeyV2(randomUUID(), "reference.png");
+    const ownedArtifactUrl = buildFileUrlFromKey(ownedArtifactKey, "vm0");
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      if (command instanceof HeadObjectCommand) {
+        return Promise.resolve({
+          Metadata: { "user-id": encodeURIComponent(fixture.userId) },
+        });
+      }
+      return Promise.resolve({});
+    });
     const sourceImageUrls = [
-      MOCKUP_IMAGE_URL,
+      ownedArtifactUrl,
       SECOND_MOCKUP_IMAGE_URL,
       THIRD_MOCKUP_IMAGE_URL,
     ];
@@ -2655,9 +2714,31 @@ describe("POST /api/image-io/generate", () => {
       model: "alibaba/qwen-image-3/text-to-image",
       billingCategory: "output_image.1k",
       sourceUrl: FAL_QWEN_IMAGE_3_MEDIA_URL,
+      sourceImageUrls,
     });
     expect(falCalls).toBe(1);
-    expect(observedBody).toMatchObject({ image_urls: sourceImageUrls });
+    const providerImageUrls = (
+      observedBody as unknown as Record<string, unknown>
+    )["image_urls"];
+    expect(Array.isArray(providerImageUrls)).toBeTruthy();
+    if (!Array.isArray(providerImageUrls)) {
+      throw new Error("Expected Fal image references");
+    }
+    expect(providerImageUrls.slice(1)).toStrictEqual(sourceImageUrls.slice(1));
+    const signedArtifactUrl = new URL(String(providerImageUrls[0]));
+    expect(signedArtifactUrl.origin).toBe("https://r2.example.com");
+    expect(signedArtifactUrl.searchParams.get("object")).toBe(
+      `${TEST_BUCKET}/${ownedArtifactKey}`,
+    );
+    const headObjectInputs = context.mocks.s3.send.mock.calls.flatMap(
+      ([command]) => {
+        return command instanceof HeadObjectCommand ? [command.input] : [];
+      },
+    );
+    expect(headObjectInputs).toContainEqual({
+      Bucket: TEST_BUCKET,
+      Key: ownedArtifactKey,
+    });
     await expect(orgCredits(fixture)).resolves.toBe(
       1000 - FAL_QWEN_IMAGE_3_STANDARD_TIER_CREDITS,
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/image-recognition.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-recognition.test.ts
@@ -12,6 +12,7 @@ import { onTestFinished } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
+import { apiTestS3PresignedUrl } from "../../../__tests__/mocks";
 import { buildArtifactKey } from "../../../lib/file-url";
 import { mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
@@ -119,6 +120,11 @@ async function seedActor(): Promise<RecognitionActor> {
 }
 
 function setStoredObjects(objects: readonly StoredObject[]): void {
+  context.mocks.s3.getSignedUrl.mockImplementation(
+    (_client: unknown, command: unknown) => {
+      return Promise.resolve(apiTestS3PresignedUrl(command));
+    },
+  );
   mocks.s3.listObjects(
     objects.map((object) => {
       return {
@@ -277,7 +283,9 @@ describe("POST /api/recognize", () => {
             {
               type: "image_url",
               image_url: {
-                url: expect.stringContaining(fileId),
+                url: expect.stringMatching(
+                  new RegExp(`^https://r2\\.example\\.com/.+${fileId}`, "u"),
+                ),
               },
             },
           ],

--- a/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
@@ -13,6 +13,7 @@ import type { OrgTier } from "@okouai/api-contracts/contracts/orgs";
 import { createAppWithRoutes } from "../../../app-factory-core";
 import { testContext } from "../../../__tests__/test-context";
 import { mockEnv } from "../../../lib/env";
+import { buildArtifactKey, buildFileUrlFromKey } from "../../../lib/file-url";
 import { server } from "../../../mocks/server";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { now } from "../../../lib/time";
@@ -222,6 +223,20 @@ interface VideoFixture {
   readonly orgId: string;
   readonly pricingResolution: UsagePricingFixture["resolution"];
   readonly userId: string;
+}
+
+function ownedArtifactReference(userId: string, filename: string) {
+  const key = buildArtifactKey(userId, randomUUID(), filename);
+  return { key, url: buildFileUrlFromKey(key, "vm0") };
+}
+
+function expectPresignedArtifactReference(value: unknown, key: string): void {
+  if (typeof value !== "string") {
+    throw new Error("Expected a provider reference URL");
+  }
+  const url = new URL(value);
+  expect(url.origin).toBe("https://r2.example.com");
+  expect(url.searchParams.get("object")).toBe(`${TEST_BUCKET}/${key}`);
 }
 
 const VIDEO_PRICING_ROWS = VIDEO_PRICING_DEFAULTS.map((row) => {
@@ -1742,6 +1757,26 @@ describe("POST /api/video-io/generate", () => {
 
   it("submits multimodal Dreamina references and charges with-video pricing", async () => {
     const fixture = await seedVideoFixture({ credits: 10_000 });
+    const firstFrameReference = ownedArtifactReference(
+      fixture.userId,
+      "first.png",
+    );
+    const lastFrameReference = ownedArtifactReference(
+      fixture.userId,
+      "last.png",
+    );
+    const imageReference = ownedArtifactReference(
+      fixture.userId,
+      "reference.png",
+    );
+    const videoReference = ownedArtifactReference(
+      fixture.userId,
+      "reference.mp4",
+    );
+    const audioReference = ownedArtifactReference(
+      fixture.userId,
+      "reference.mp3",
+    );
     const { composeId } = await store.set(
       seedCompose$,
       { orgId: fixture.orgId, userId: fixture.userId },
@@ -1789,11 +1824,11 @@ describe("POST /api/video-io/generate", () => {
         duration: "6s",
         resolution: "1080p",
         aspectRatio: "16:9",
-        imageUrls: ["https://example.com/reference.png"],
-        videoUrls: ["https://example.com/reference.mp4"],
-        audioUrls: ["https://example.com/reference.mp3"],
-        firstFrameImageUrl: "https://example.com/first.png",
-        lastFrameImageUrl: "https://example.com/last.png",
+        imageUrls: [imageReference.url],
+        videoUrls: [videoReference.url],
+        audioUrls: [audioReference.url],
+        firstFrameImageUrl: firstFrameReference.url,
+        lastFrameImageUrl: lastFrameReference.url,
         seed: 42,
       }),
     });
@@ -1835,31 +1870,55 @@ describe("POST /api/video-io/generate", () => {
         },
         {
           type: "image_url",
-          image_url: { url: "https://example.com/first.png" },
+          image_url: { url: expect.any(String) },
           role: "first_frame",
         },
         {
           type: "image_url",
-          image_url: { url: "https://example.com/last.png" },
+          image_url: { url: expect.any(String) },
           role: "last_frame",
         },
         {
           type: "image_url",
-          image_url: { url: "https://example.com/reference.png" },
+          image_url: { url: expect.any(String) },
           role: "reference_image",
         },
         {
           type: "video_url",
-          video_url: { url: "https://example.com/reference.mp4" },
+          video_url: { url: expect.any(String) },
           role: "reference_video",
         },
         {
           type: "audio_url",
-          audio_url: { url: "https://example.com/reference.mp3" },
+          audio_url: { url: expect.any(String) },
           role: "reference_audio",
         },
       ],
     });
+    const providerContent = asRecord(observedBody).content;
+    if (!Array.isArray(providerContent)) {
+      throw new Error("Expected BytePlus content array");
+    }
+    expectPresignedArtifactReference(
+      asRecord(asRecord(providerContent[1]).image_url).url,
+      firstFrameReference.key,
+    );
+    expectPresignedArtifactReference(
+      asRecord(asRecord(providerContent[2]).image_url).url,
+      lastFrameReference.key,
+    );
+    expectPresignedArtifactReference(
+      asRecord(asRecord(providerContent[3]).image_url).url,
+      imageReference.key,
+    );
+    expectPresignedArtifactReference(
+      asRecord(asRecord(providerContent[4]).video_url).url,
+      videoReference.key,
+    );
+    expectPresignedArtifactReference(
+      asRecord(asRecord(providerContent[5]).audio_url).url,
+      audioReference.key,
+    );
 
     const statusResponse = await app.request(
       `/api/built-in-generations/${generationId}`,
@@ -1882,6 +1941,10 @@ describe("POST /api/video-io/generate", () => {
 
   it("generates MiniMax H3 with full references and charges every billed usage component", async () => {
     const fixture = await seedVideoFixture();
+    const ownedImageReference = ownedArtifactReference(
+      fixture.userId,
+      "minimax-reference.png",
+    );
     const { composeId } = await store.set(
       seedCompose$,
       { orgId: fixture.orgId, userId: fixture.userId },
@@ -1897,9 +1960,12 @@ describe("POST /api/video-io/generate", () => {
       },
       context.signal,
     );
-    const referenceImageUrls = Array.from({ length: 7 }, (_, index) => {
-      return `https://example.com/reference-${index + 1}.png`;
-    });
+    const referenceImageUrls = [
+      ownedImageReference.url,
+      ...Array.from({ length: 6 }, (_, index) => {
+        return `https://example.com/reference-${index + 2}.png`;
+      }),
+    ];
     const referenceAudioUrls = [
       "https://example.com/reference-1.mp3",
       "https://example.com/reference-2.mp3",
@@ -1985,6 +2051,21 @@ describe("POST /api/video-io/generate", () => {
     expect(completionResponse.status).toBe(200);
 
     expect(observedAuthorization).toBe("Bearer test-minimax-key");
+    const providerContent = asRecord(observedBody).content;
+    if (!Array.isArray(providerContent)) {
+      throw new Error("Expected MiniMax content array");
+    }
+    const signedOwnedImageUrl = asRecord(
+      asRecord(providerContent[1]).image_url,
+    ).url;
+    expectPresignedArtifactReference(
+      signedOwnedImageUrl,
+      ownedImageReference.key,
+    );
+    const providerReferenceImageUrls = [
+      String(signedOwnedImageUrl),
+      ...referenceImageUrls.slice(1),
+    ];
     expect(observedBody).toStrictEqual({
       model: MINIMAX_H3_MODEL,
       content: [
@@ -1992,7 +2073,7 @@ describe("POST /api/video-io/generate", () => {
           type: "text",
           text: "preserve the character and follow the reference soundtrack",
         },
-        ...referenceImageUrls.map((url) => {
+        ...providerReferenceImageUrls.map((url) => {
           return {
             type: "image_url",
             image_url: { url },

--- a/turbo/apps/api/src/signals/routes/avatar-video.ts
+++ b/turbo/apps/api/src/signals/routes/avatar-video.ts
@@ -38,6 +38,7 @@ import {
   isRunBuiltInAdmissionError,
   startRunBuiltInAdmission$,
 } from "../services/run-built-in-admission.service";
+import { resolveProviderReferenceUrls$ } from "../services/provider-reference-url.service";
 
 const generateBody$ = bodyResultOf(avatarVideoContract.generate);
 const avatarsQuery$ = queryOf(avatarVideoContract.avatars);
@@ -78,6 +79,8 @@ const submitAvatarVideoJob$ = command(
     { set },
     args: {
       readonly generationId: string;
+      readonly orgId: string;
+      readonly userId: string;
       readonly options: AvatarVideoOptions;
     },
     signal: AbortSignal,
@@ -96,7 +99,27 @@ const submitAvatarVideoJob$ = command(
       return response;
     }
 
-    const handle = await submitJoggAiAvatarVideo(args.options, apiKey, signal);
+    const providerOptions = args.options.audioUrl
+      ? {
+          ...args.options,
+          audioUrl: (
+            await set(
+              resolveProviderReferenceUrls$,
+              {
+                orgId: args.orgId,
+                userId: args.userId,
+                urls: [args.options.audioUrl],
+              },
+              signal,
+            )
+          )[0],
+        }
+      : args.options;
+    const handle = await submitJoggAiAvatarVideo(
+      providerOptions,
+      apiKey,
+      signal,
+    );
     signal.throwIfAborted();
     if (isAvatarVideoErrorResponse(handle)) {
       await set(
@@ -202,7 +225,12 @@ const postGenerateInner$ = command(
     );
     const submitError = await set(
       submitAvatarVideoJob$,
-      { generationId, options },
+      {
+        generationId,
+        orgId: auth.orgId,
+        userId: auth.userId,
+        options,
+      },
       signal,
     );
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/image-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/image-io-generate.ts
@@ -35,6 +35,7 @@ import {
   submitFalImageQueueGeneration,
   type ImageOptions,
   type ImagePricing,
+  type ImageProviderReferences,
 } from "../services/image-generation.service";
 import {
   builtInGenerationRequestWithInternal,
@@ -51,6 +52,7 @@ import {
   startRunBuiltInAdmission$,
   type RunBuiltInAdmission,
 } from "../services/run-built-in-admission.service";
+import { resolveProviderReferenceUrls$ } from "../services/provider-reference-url.service";
 
 const L = logger("ImageGeneration");
 const imageBody$ = bodyResultOf(imageIoGenerateContract.post);
@@ -168,6 +170,31 @@ function acceptedImageResponse(
   };
 }
 
+const resolveImageProviderReferences$ = command(
+  async (
+    { set },
+    args: Pick<ImageJobArgs, "orgId" | "userId" | "options">,
+    signal: AbortSignal,
+  ): Promise<ImageProviderReferences> => {
+    const sourceCount = args.options.sourceImageUrls.length;
+    const urls = [
+      ...args.options.sourceImageUrls,
+      ...(args.options.maskImageUrl ? [args.options.maskImageUrl] : []),
+    ];
+    const resolved = await set(
+      resolveProviderReferenceUrls$,
+      { orgId: args.orgId, userId: args.userId, urls },
+      signal,
+    );
+    return {
+      sourceImageUrls: resolved.slice(0, sourceCount),
+      maskImageUrl: args.options.maskImageUrl
+        ? resolved[sourceCount]
+        : undefined,
+    };
+  },
+);
+
 const submitImageProviderWebhookJob$ = command(
   async (
     { set },
@@ -183,8 +210,10 @@ const submitImageProviderWebhookJob$ = command(
         "NOT_CONFIGURED",
       );
     }
+    const references = await set(resolveImageProviderReferences$, args, signal);
     const handle = await submitFalImageQueueGeneration(
       args.options,
+      references,
       falKey,
       falBuiltInGenerationWebhookUrl({ generationId: args.generationId }),
       signal,
@@ -240,8 +269,10 @@ const executeBytePlusImageProviderJob$ = command(
       return;
     }
 
+    const references = await set(resolveImageProviderReferences$, args, signal);
     const generation = await generateBytePlusImage(
       args.options,
+      references,
       apiKey,
       signal,
     );

--- a/turbo/apps/api/src/signals/routes/video-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/video-io-generate.ts
@@ -56,6 +56,7 @@ import {
   isRunBuiltInAdmissionError,
   startRunBuiltInAdmission$,
 } from "../services/run-built-in-admission.service";
+import { resolveProviderReferenceUrls$ } from "../services/provider-reference-url.service";
 import type { AuthContext } from "../../types/auth";
 
 const videoBody$ = bodyResultOf(videoIoGenerateContract.post);
@@ -165,6 +166,8 @@ interface GenerationErrorResponse {
 
 interface VideoJobArgs {
   readonly generationId: string;
+  readonly orgId: string;
+  readonly userId: string;
   readonly options: VideoOptions;
 }
 
@@ -237,6 +240,45 @@ function acceptedVideoResponse(
   };
 }
 
+const resolveVideoProviderOptions$ = command(
+  async (
+    { set },
+    args: Pick<VideoJobArgs, "orgId" | "userId" | "options">,
+    signal: AbortSignal,
+  ): Promise<VideoOptions> => {
+    const { options } = args;
+    const urls = [
+      ...(options.firstFrameImageUrl ? [options.firstFrameImageUrl] : []),
+      ...(options.lastFrameImageUrl ? [options.lastFrameImageUrl] : []),
+      ...options.referenceImageUrls,
+      ...options.inputVideoUrls,
+      ...options.referenceAudioUrls,
+    ];
+    const resolved = await set(
+      resolveProviderReferenceUrls$,
+      { orgId: args.orgId, userId: args.userId, urls },
+      signal,
+    );
+    let index = 0;
+    const next = (): string => {
+      const value = resolved[index];
+      index += 1;
+      if (!value) {
+        throw new Error("Expected a resolved provider reference URL");
+      }
+      return value;
+    };
+    return {
+      ...options,
+      firstFrameImageUrl: options.firstFrameImageUrl ? next() : undefined,
+      lastFrameImageUrl: options.lastFrameImageUrl ? next() : undefined,
+      referenceImageUrls: options.referenceImageUrls.map(next),
+      inputVideoUrls: options.inputVideoUrls.map(next),
+      referenceAudioUrls: options.referenceAudioUrls.map(next),
+    };
+  },
+);
+
 const submitMiniMaxVideoProviderJob$ = command(
   async (
     { set },
@@ -297,6 +339,11 @@ const submitVideoProviderWebhookJob$ = command(
   ): Promise<GenerationErrorResponse | null> => {
     await set(markBuiltInGenerationRunning$, args.generationId, signal);
     const provider = videoProviderForModel(args.options.model);
+    const providerOptions = await set(
+      resolveVideoProviderOptions$,
+      args,
+      signal,
+    );
     if (provider === "fal") {
       const apiKey = env("FAL_KEY");
       if (!apiKey) {
@@ -312,7 +359,7 @@ const submitVideoProviderWebhookJob$ = command(
         return response;
       }
       const handle = await submitFalVideoGeneration(
-        args.options,
+        providerOptions,
         apiKey,
         signal,
         falBuiltInGenerationWebhookUrl({
@@ -346,7 +393,11 @@ const submitVideoProviderWebhookJob$ = command(
     }
 
     if (provider === "minimax") {
-      return await set(submitMiniMaxVideoProviderJob$, args, signal);
+      return await set(
+        submitMiniMaxVideoProviderJob$,
+        { ...args, options: providerOptions },
+        signal,
+      );
     }
 
     const apiKey = env("BYTEPLUS_API_KEY");
@@ -363,7 +414,7 @@ const submitVideoProviderWebhookJob$ = command(
       return response;
     }
     const handle = await submitBytePlusVideoGeneration(
-      args.options,
+      providerOptions,
       apiKey,
       signal,
       bytePlusBuiltInGenerationWebhookUrl({
@@ -503,6 +554,8 @@ const postVideoInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     submitVideoProviderWebhookJob$,
     {
       generationId,
+      orgId: auth.orgId,
+      userId: auth.userId,
       options,
     },
     signal,

--- a/turbo/apps/api/src/signals/services/artifact-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-storage.service.ts
@@ -10,6 +10,8 @@ import {
   buildArtifactPrefix,
   buildArtifactPrefixV2,
   buildFileUrlFromKey,
+  isArtifactKeyV2,
+  publicArtifactsBaseUrlForBrand,
   sanitizeArtifactFilename,
 } from "../../lib/file-url";
 import { inferMimetype } from "../../lib/mimetype";
@@ -20,13 +22,15 @@ import {
   type S3ObjectHead,
   tryListMultipartS3Parts,
 } from "../external/s3";
-import { safeUriComponentDecode } from "../utils";
+import { safeUriComponentDecode, safeUrlParse } from "../utils";
 
 const MAX_ARTIFACT_KEY_ATTEMPTS = 5;
 const ARTIFACT_ID_METADATA_KEY = "artifact-id";
 const ARTIFACT_FILENAME_METADATA_KEY = "filename";
 const ARTIFACT_USER_ID_METADATA_KEY = "user-id";
 const ARTIFACT_PUBLIC_BRAND_METADATA_KEY = "public-brand";
+const CLOUDFLARE_IMAGE_RESIZE_PATH_PREFIX = "/cdn-cgi/image/";
+const PUBLIC_ARTIFACT_PATH_PREFIX = "/artifacts/";
 
 export interface ArtifactObjectLocation {
   readonly id: string;
@@ -53,6 +57,76 @@ export interface ResolvedArtifactObject {
   readonly size: number;
   readonly lastModified: Date | undefined;
 }
+
+function publicArtifactPath(pathname: string): string | null {
+  if (pathname.startsWith(PUBLIC_ARTIFACT_PATH_PREFIX)) {
+    return pathname;
+  }
+  if (!pathname.startsWith(CLOUDFLARE_IMAGE_RESIZE_PATH_PREFIX)) {
+    return null;
+  }
+  const artifactStart = pathname.indexOf(
+    PUBLIC_ARTIFACT_PATH_PREFIX,
+    CLOUDFLARE_IMAGE_RESIZE_PATH_PREFIX.length,
+  );
+  return artifactStart === -1 ? null : pathname.slice(artifactStart);
+}
+
+function publicArtifactKeyFromUrl(value: string): string | null {
+  const url = safeUrlParse(value);
+  if (!url) {
+    return null;
+  }
+  const allowedOrigins = new Set([
+    new URL(publicArtifactsBaseUrlForBrand("vm0")).origin,
+    new URL(publicArtifactsBaseUrlForBrand("okou")).origin,
+  ]);
+  if (!allowedOrigins.has(url.origin)) {
+    return null;
+  }
+  const path = publicArtifactPath(url.pathname);
+  return path?.replace(/^\/+/, "") ?? null;
+}
+
+function isOwnedLegacyArtifactKey(key: string, userId: string): boolean {
+  const segments = key.split("/");
+  return (
+    segments.length === 4 &&
+    segments[0] === "artifacts" &&
+    segments[1] === encodeURIComponent(userId) &&
+    Boolean(segments[2]) &&
+    Boolean(segments[3])
+  );
+}
+
+export const resolveOwnedPublicArtifactKey$ = command(
+  async (
+    { get },
+    args: { readonly userId: string; readonly url: string },
+    signal: AbortSignal,
+  ): Promise<string | null> => {
+    const key = publicArtifactKeyFromUrl(args.url);
+    if (!key) {
+      return null;
+    }
+    if (isOwnedLegacyArtifactKey(key, args.userId)) {
+      return key;
+    }
+    if (!isArtifactKeyV2(key)) {
+      return null;
+    }
+
+    const head = await get(
+      s3ObjectHead(env("R2_USER_ARTIFACTS_BUCKET_NAME"), key),
+    );
+    signal.throwIfAborted();
+    return head.kind === "found" &&
+      head.metadata[ARTIFACT_USER_ID_METADATA_KEY] ===
+        encodeURIComponent(args.userId)
+      ? key
+      : null;
+  },
+);
 
 interface ResolvedArtifactMultipartUpload {
   readonly key: string;

--- a/turbo/apps/api/src/signals/services/avatar-video.service.ts
+++ b/turbo/apps/api/src/signals/services/avatar-video.service.ts
@@ -12,6 +12,7 @@ import { usagePricing } from "@okouai/db/schema/usage-pricing";
 import { and, eq } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
+import { redactPresignedUrls } from "../../lib/presigned-url-redaction";
 import {
   resolveUsagePricingProvider,
   usagePricingResolution$,
@@ -334,7 +335,8 @@ function joggAiEnvelopeError(
   if (responseStatus >= 200 && responseStatus < 300 && code === 0) {
     return null;
   }
-  const message = optionalString(body.msg);
+  const rawMessage = optionalString(body.msg);
+  const message = rawMessage ? redactPresignedUrls(rawMessage) : undefined;
   L.warn("JoggAI API request failed", {
     status: responseStatus,
     providerCode: code,

--- a/turbo/apps/api/src/signals/services/image-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/image-generation.service.ts
@@ -14,6 +14,7 @@ import { and, eq, inArray } from "drizzle-orm";
 
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
+import { redactPresignedUrls } from "../../lib/presigned-url-redaction";
 import { safeJsonParse } from "../utils";
 import {
   canonicalUsagePricingProvider,
@@ -1695,10 +1696,18 @@ function falQualityInput(
   return modelConfig.supportsQuality ? { quality: options.quality } : {};
 }
 
-function falImageInput(options: ImageOptions): Record<string, unknown> {
+export interface ImageProviderReferences {
+  readonly sourceImageUrls: readonly string[];
+  readonly maskImageUrl: string | undefined;
+}
+
+function falImageInput(
+  options: ImageOptions,
+  references: ImageProviderReferences,
+): Record<string, unknown> {
   const modelConfig = IMAGE_MODEL_CONFIGS[options.model];
   if (modelConfig.promptless) {
-    return falSourceImageInput(modelConfig, options.sourceImageUrls);
+    return falSourceImageInput(modelConfig, references.sourceImageUrls);
   }
   return {
     prompt: options.prompt,
@@ -1728,10 +1737,10 @@ function falImageInput(options: ImageOptions): Record<string, unknown> {
       ? { enhance_prompt: options.enhancePrompt }
       : {}),
     ...(options.sourceImageUrls.length > 0
-      ? falSourceImageInput(modelConfig, options.sourceImageUrls)
+      ? falSourceImageInput(modelConfig, references.sourceImageUrls)
       : {}),
-    ...(modelConfig.supportsMaskImage && options.maskImageUrl
-      ? { mask_image_url: options.maskImageUrl }
+    ...(modelConfig.supportsMaskImage && references.maskImageUrl
+      ? { mask_image_url: references.maskImageUrl }
       : {}),
     ...(modelConfig.supportsInputFidelity && options.inputFidelity
       ? { input_fidelity: options.inputFidelity }
@@ -1756,11 +1765,12 @@ async function readImageProviderErrorBody(
 ): Promise<string> {
   const body = await response.text();
   signal.throwIfAborted();
-  return body.slice(0, 4000);
+  return redactPresignedUrls(body).slice(0, 4000);
 }
 
 export async function submitFalImageQueueGeneration(
   options: ImageOptions,
+  references: ImageProviderReferences,
   falKey: string,
   webhookUrl: string,
   signal: AbortSignal,
@@ -1771,7 +1781,7 @@ export async function submitFalImageQueueGeneration(
   const response = await fetch(queueUrl, {
     method: "POST",
     headers: falHeaders(falKey),
-    body: JSON.stringify(falImageInput(options)),
+    body: JSON.stringify(falImageInput(options, references)),
     signal,
   });
 
@@ -1857,11 +1867,14 @@ function bytePlusImageSize(options: ImageOptions): string {
   return options.size === "auto" ? "2K" : options.size;
 }
 
-function bytePlusImageInput(options: ImageOptions): Record<string, unknown> {
+function bytePlusImageInput(
+  options: ImageOptions,
+  references: ImageProviderReferences,
+): Record<string, unknown> {
   const sourceImages =
-    options.sourceImageUrls.length === 1
-      ? options.sourceImageUrls[0]
-      : options.sourceImageUrls;
+    references.sourceImageUrls.length === 1
+      ? references.sourceImageUrls[0]
+      : references.sourceImageUrls;
   return {
     model: options.model,
     prompt: options.prompt,
@@ -1908,13 +1921,14 @@ function parseBytePlusImageResult(
 
 export async function generateBytePlusImage(
   options: ImageOptions,
+  references: ImageProviderReferences,
   apiKey: string,
   signal: AbortSignal,
 ): Promise<ParsedImageGeneration | ErrorResponse> {
   const response = await fetch(BYTEPLUS_IMAGE_GENERATIONS_URL, {
     method: "POST",
     headers: bytePlusHeaders(apiKey),
-    body: JSON.stringify(bytePlusImageInput(options)),
+    body: JSON.stringify(bytePlusImageInput(options, references)),
     signal,
   });
   if (!response.ok) {

--- a/turbo/apps/api/src/signals/services/image-recognition.service.ts
+++ b/turbo/apps/api/src/signals/services/image-recognition.service.ts
@@ -29,6 +29,7 @@ import {
   checkOpenRouterUsagePricing$,
   recordOpenRouterUsage$,
 } from "./openrouter-usage.service";
+import { resolveProviderReferenceUrls$ } from "./provider-reference-url.service";
 
 const IMAGE_RECOGNITION_MODEL = "xiaomi/mimo-v2.5";
 const IMAGE_RECOGNITION_OPERATION = "image-recognition";
@@ -198,9 +199,23 @@ export const imageRecognition$ = command(
       return notConfigured("Image recognition pricing is not configured");
     }
 
+    const [providerImageUrl] = await set(
+      resolveProviderReferenceUrls$,
+      {
+        orgId: args.auth.orgId,
+        userId: args.auth.userId,
+        urls: [artifact.url],
+      },
+      requestSignal,
+    );
+    signal.throwIfAborted();
+    requestSignal.throwIfAborted();
+    if (!providerImageUrl) {
+      throw new Error("Expected a resolved image recognition URL");
+    }
     const content: OpenRouterContentPart[] = [
       { type: "text", text: args.body.prompt },
-      { type: "image_url", image_url: { url: artifact.url } },
+      { type: "image_url", image_url: { url: providerImageUrl } },
     ];
     const operationId = randomUUID();
     const generated = await settle(

--- a/turbo/apps/api/src/signals/services/provider-reference-url.service.ts
+++ b/turbo/apps/api/src/signals/services/provider-reference-url.service.ts
@@ -1,0 +1,250 @@
+import { command } from "ccstate";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
+import {
+  hostedDeployments,
+  hostedSites,
+  type HostedSiteManifest,
+} from "@okouai/db/schema/hosted-site";
+import { and, eq, isNull } from "drizzle-orm";
+
+import { env } from "../../lib/env";
+import { db$, type ReadonlyDb } from "../external/db";
+import {
+  generateHostedSitesPresignedGetUrl,
+  generatePresignedGetUrl,
+} from "../external/s3";
+import { safeUriComponentDecode, safeUrlParse } from "../utils";
+import { resolveOwnedPublicArtifactKey$ } from "./artifact-storage.service";
+
+const PROVIDER_REFERENCE_URL_TTL_SECONDS = 60 * 60;
+const IMMUTABLE_DEPLOYMENT_HOST_PATTERN =
+  /^dpl-([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/u;
+const PUBLIC_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/u;
+
+interface ProviderReferenceUrlsArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly urls: readonly string[];
+}
+
+interface HostedSiteUrlTarget {
+  readonly publicBrand: PublicBrand;
+  readonly publicSlug: string;
+  readonly path: string;
+}
+
+interface HostedSiteDeploymentTarget {
+  readonly manifest: HostedSiteManifest;
+  readonly r2Prefix: string;
+}
+
+function hostDomain(publicBrand: PublicBrand): string {
+  return publicBrand === "okou"
+    ? env("OKOU_PUBLIC_HOST_DOMAIN")
+    : env("ZERO_HOST_DOMAIN");
+}
+
+function hostScheme(publicBrand: PublicBrand): string {
+  return publicBrand === "okou"
+    ? env("OKOU_HOST_SCHEME")
+    : env("ZERO_HOST_SCHEME");
+}
+
+function publicSlugFromHostname(
+  hostname: string,
+  domain: string,
+): string | null {
+  const suffix = `.${domain.toLowerCase()}`;
+  if (!hostname.endsWith(suffix)) {
+    return null;
+  }
+  const publicSlug = hostname.slice(0, -suffix.length);
+  return PUBLIC_SLUG_PATTERN.test(publicSlug) ? publicSlug : null;
+}
+
+function normalizeHostedSitePath(pathname: string): string | null {
+  const decoded = safeUriComponentDecode(pathname);
+  if (
+    !decoded ||
+    !decoded.startsWith("/") ||
+    decoded.startsWith("//") ||
+    decoded.includes("\\") ||
+    decoded.includes("\0")
+  ) {
+    return null;
+  }
+  const segments = decoded.split("/").filter(Boolean);
+  if (
+    segments.some((segment) => {
+      return segment === "." || segment === "..";
+    })
+  ) {
+    return null;
+  }
+  return segments.length === 0 ? "/index.html" : `/${segments.join("/")}`;
+}
+
+function hostedSiteUrlTarget(value: string): HostedSiteUrlTarget | null {
+  const url = safeUrlParse(value);
+  if (!url || url.port) {
+    return null;
+  }
+  const path = normalizeHostedSitePath(url.pathname);
+  if (!path) {
+    return null;
+  }
+  const hostname = url.hostname.toLowerCase();
+  const matches = (["vm0", "okou"] as const).flatMap((publicBrand) => {
+    if (url.protocol !== `${hostScheme(publicBrand)}:`) {
+      return [];
+    }
+    const publicSlug = publicSlugFromHostname(
+      hostname,
+      hostDomain(publicBrand),
+    );
+    return publicSlug ? [{ publicBrand, publicSlug, path }] : [];
+  });
+  return matches.length === 1 ? (matches[0] ?? null) : null;
+}
+
+async function loadHostedSiteDeployment(
+  db: ReadonlyDb,
+  orgId: string,
+  target: HostedSiteUrlTarget,
+): Promise<HostedSiteDeploymentTarget | null> {
+  const deploymentId = IMMUTABLE_DEPLOYMENT_HOST_PATTERN.exec(
+    target.publicSlug,
+  )?.[1];
+  if (deploymentId) {
+    const [deployment] = await db
+      .select({
+        manifest: hostedDeployments.manifest,
+        r2Prefix: hostedDeployments.r2Prefix,
+        siteId: hostedDeployments.siteId,
+      })
+      .from(hostedDeployments)
+      .where(
+        and(
+          eq(hostedDeployments.id, deploymentId),
+          eq(hostedDeployments.orgId, orgId),
+          eq(hostedDeployments.publicBrand, target.publicBrand),
+          eq(hostedDeployments.status, "ready"),
+        ),
+      )
+      .limit(1);
+    if (!deployment) {
+      return null;
+    }
+    const [site] = await db
+      .select({ id: hostedSites.id })
+      .from(hostedSites)
+      .where(
+        and(
+          eq(hostedSites.id, deployment.siteId),
+          eq(hostedSites.orgId, orgId),
+          eq(hostedSites.publicBrand, target.publicBrand),
+          isNull(hostedSites.deletedAt),
+        ),
+      )
+      .limit(1);
+    return site ? deployment : null;
+  }
+
+  const [site] = await db
+    .select({
+      id: hostedSites.id,
+      activeDeploymentId: hostedSites.activeDeploymentId,
+    })
+    .from(hostedSites)
+    .where(
+      and(
+        eq(hostedSites.publicSlug, target.publicSlug),
+        eq(hostedSites.orgId, orgId),
+        eq(hostedSites.publicBrand, target.publicBrand),
+        isNull(hostedSites.deletedAt),
+      ),
+    )
+    .limit(1);
+  if (!site?.activeDeploymentId) {
+    return null;
+  }
+  const [deployment] = await db
+    .select({
+      manifest: hostedDeployments.manifest,
+      r2Prefix: hostedDeployments.r2Prefix,
+    })
+    .from(hostedDeployments)
+    .where(
+      and(
+        eq(hostedDeployments.id, site.activeDeploymentId),
+        eq(hostedDeployments.siteId, site.id),
+        eq(hostedDeployments.orgId, orgId),
+        eq(hostedDeployments.publicBrand, target.publicBrand),
+        eq(hostedDeployments.status, "ready"),
+      ),
+    )
+    .limit(1);
+  return deployment ?? null;
+}
+
+export const resolveProviderReferenceUrls$ = command(
+  async (
+    { get, set },
+    args: ProviderReferenceUrlsArgs,
+    signal: AbortSignal,
+  ): Promise<readonly string[]> => {
+    const db = get(db$);
+    const resolved: string[] = [];
+    for (const url of args.urls) {
+      const artifactKey = await set(
+        resolveOwnedPublicArtifactKey$,
+        { userId: args.userId, url },
+        signal,
+      );
+      if (artifactKey) {
+        resolved.push(
+          await get(
+            generatePresignedGetUrl(
+              env("R2_USER_ARTIFACTS_BUCKET_NAME"),
+              artifactKey,
+              PROVIDER_REFERENCE_URL_TTL_SECONDS,
+              undefined,
+              true,
+            ),
+          ),
+        );
+        signal.throwIfAborted();
+        continue;
+      }
+
+      const hostedTarget = hostedSiteUrlTarget(url);
+      const hostedBucket = env("R2_HOSTED_SITES_BUCKET_NAME");
+      if (!hostedTarget || !hostedBucket) {
+        resolved.push(url);
+        continue;
+      }
+      const deployment = await loadHostedSiteDeployment(
+        db,
+        args.orgId,
+        hostedTarget,
+      );
+      signal.throwIfAborted();
+      if (!deployment?.manifest.files[hostedTarget.path]) {
+        resolved.push(url);
+        continue;
+      }
+      resolved.push(
+        await get(
+          generateHostedSitesPresignedGetUrl(
+            hostedBucket,
+            `${deployment.r2Prefix}${hostedTarget.path}`,
+            PROVIDER_REFERENCE_URL_TTL_SECONDS,
+            true,
+          ),
+        ),
+      );
+      signal.throwIfAborted();
+    }
+    return resolved;
+  },
+);

--- a/turbo/apps/api/src/signals/services/video-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/video-generation.service.ts
@@ -26,6 +26,7 @@ import {
 import { and, eq, inArray } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
+import { redactPresignedUrls } from "../../lib/presigned-url-redaction";
 import {
   canonicalUsagePricingProvider,
   resolveUsagePricingProvider,
@@ -1366,9 +1367,10 @@ async function readProviderErrorBodyForLog(
   if (!body) {
     return undefined;
   }
-  return body.length > PROVIDER_ERROR_BODY_LOG_MAX_LENGTH
-    ? `${body.slice(0, PROVIDER_ERROR_BODY_LOG_MAX_LENGTH)}...`
-    : body;
+  const redactedBody = redactPresignedUrls(body);
+  return redactedBody.length > PROVIDER_ERROR_BODY_LOG_MAX_LENGTH
+    ? `${redactedBody.slice(0, PROVIDER_ERROR_BODY_LOG_MAX_LENGTH)}...`
+    : redactedBody;
 }
 
 export async function submitBytePlusVideoGeneration(


### PR DESCRIPTION
## Summary

- Resolve owned vm0/Okou artifact CDN and hosted-site references to one-hour R2 presigned GET URLs at external provider boundaries.
- Apply the transient references across Fal and BytePlus image generation, Fal/BytePlus/MiniMax video generation, JoggAI avatar audio, and OpenRouter image recognition.
- Preserve original URLs in persisted generation requests/results and redact presigned URLs from provider error logs.

## Why

Third-party providers can receive a CDN/WAF `403` while fetching an otherwise-public first-party reference URL. Sending a short-lived raw R2 URL bypasses browser-oriented CDN challenge behavior without proxying image, video, or audio bytes through the API server.

## Safety

- Only known vm0/Okou artifact and hosted-site origins are considered.
- Artifact ownership is checked against the current user; hosted sites are scoped to the current organization and a ready deployment manifest.
- Unknown, external, or unresolvable URLs remain unchanged.
- Presigned URLs are provider-only transient values and are not persisted.
- Provider error logging redacts AWS-compatible signature query parameters.
- No paid provider generation was invoked during verification.

## Verification

- `pnpm format`
- API lint plus repository lint for all other packages
- `pnpm knip`
- API layered type checks, platform type check, and all remaining package type checks
- Focused Vitest suites for image generation, video generation, avatar video, image recognition, and presigned-URL redaction (80 tests)

One existing video test exceeded its 5-second timeout when the five suites ran concurrently after the final rebase; the video suite passed 31/31 when rerun independently.
