### PR TITLE
fix(email): enforce okou branding for product mail

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-drain-email-outbox-scoped.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-drain-email-outbox-scoped.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import { beforeEach, describe, expect, it, onTestFinished } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
-import { mockOptionalEnv } from "../../../lib/env";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { nowDate } from "../../../lib/time";
 import { createDeferredPromise } from "../../utils";
 import { createEmailOutboxStateApi } from "./helpers/email-outbox-state";
@@ -42,6 +42,7 @@ beforeEach(() => {
     data: { id: `resend-${randomUUID()}` },
     error: null,
   });
+  mockEnv("RESEND_FROM_DOMAIN", "vm0.bot");
   mockOptionalEnv("EMAIL_OUTBOX_DRAIN_DELAY_MS", "0");
 });
 
@@ -67,6 +68,7 @@ describe("scoped email outbox drain", () => {
     expect(context.mocks.resend.send).toHaveBeenCalledTimes(1);
     expect(context.mocks.resend.send).toHaveBeenCalledWith(
       expect.objectContaining({
+        from: "Okou <okou@okou.io>",
         to: dueItem.toAddress,
         subject: dueItem.subject,
       }),

--- a/turbo/apps/api/src/signals/routes/__tests__/email.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/email.test.ts
@@ -101,7 +101,8 @@ beforeEach(() => {
   resendMocks.send.mockResolvedValue({ data: { id: "resend-test-id" } });
   mockEnv("RESEND_API_KEY", "test-resend-key");
   mockEnv("RESEND_WEBHOOK_SECRET", INBOUND_SECRET);
-  mockEnv("RESEND_FROM_DOMAIN", "mail.example.com");
+  mockEnv("RESEND_FROM_DOMAIN", "vm0.bot");
+  mockEnv("APP_URL", "https://app.vm0.ai");
   mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
   // Resend pacing is not part of these transactional delivery assertions.
   mockOptionalEnv("EMAIL_OUTBOX_DRAIN_DELAY_MS", "0");
@@ -178,15 +179,42 @@ describe("low-credit email delivery", () => {
       to: actor.email,
       subject: "Your credit balance is running low",
     });
+    expect(item).toMatchObject({
+      from_address: "Okou Team <support@okou.io>",
+      public_brand: "okou",
+      headers: {
+        "List-Unsubscribe": expect.stringContaining(
+          "<https://api.okou.ai/api/email/unsubscribe?token=",
+        ),
+        "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+      },
+      template: {
+        template: "credit-low-balance",
+        props: {
+          billingUrl:
+            "https://app.okou.ai/?settings=billing&billingView=credits",
+          unsubscribeUrl: expect.stringContaining(
+            "https://app.okou.ai/email/unsubscribe?token=",
+          ),
+        },
+      },
+    });
     const drained = await email.drainEmailOutboxItems([item.id]);
 
     expect(drained).toBe(1);
     expect(resendMocks.send).toHaveBeenCalledTimes(1);
     expect(context.mocks.resend.send).toHaveBeenCalledWith(
       expect.objectContaining({
-        from: "VM0 Team <support@mail.example.com>",
+        from: "Okou Team <support@okou.io>",
         to: actor.email,
         subject: "Your credit balance is running low",
+        html: expect.stringContaining("https://app.okou.ai/"),
+        headers: {
+          "List-Unsubscribe": expect.stringContaining(
+            "<https://api.okou.ai/api/email/unsubscribe?token=",
+          ),
+          "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+        },
       }),
     );
   });
@@ -222,6 +250,24 @@ describe("POST /api/email/inbound", () => {
 
     const locator = await email.enqueueDataExportEmail(controlActor);
     const item = await email.findEmailOutboxItem(locator);
+    expect(item).toMatchObject({
+      from_address: "Okou <okou@okou.io>",
+      public_brand: "okou",
+      headers: {
+        "List-Unsubscribe": expect.stringContaining(
+          "<https://api.okou.ai/api/email/unsubscribe?token=",
+        ),
+        "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+      },
+      template: {
+        template: "data-export-ready",
+        props: {
+          unsubscribeUrl: expect.stringContaining(
+            "https://app.okou.ai/email/unsubscribe?token=",
+          ),
+        },
+      },
+    });
     const drained = await email.drainEmailOutboxItems([item.id]);
 
     expect(drained).toBe(1);
@@ -233,6 +279,10 @@ describe("POST /api/email/inbound", () => {
     if (!sent) {
       throw new Error("Expected a data-export email");
     }
+    expect(sent).toMatchObject({
+      from: "Okou <okou@okou.io>",
+      html: expect.stringContaining("https://app.okou.ai/email/unsubscribe"),
+    });
     if (
       typeof sent !== "object" ||
       sent === null ||
@@ -247,7 +297,7 @@ describe("POST /api/email/inbound", () => {
       throw new Error("Expected a one-click unsubscribe header");
     }
     const oneClickUrl = new URL(oneClickHeader.slice(1, -1));
-    expect(oneClickUrl.origin).toBe("https://api.vm0.ai");
+    expect(oneClickUrl.origin).toBe("https://api.okou.ai");
     expect(oneClickUrl.pathname).toBe("/api/email/unsubscribe");
     expect(oneClickUrl.searchParams.get("token")).toBeTruthy();
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/official-automation-result-email.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-automation-result-email.test.ts
@@ -345,7 +345,7 @@ describe.sequential("Official Automation result email callbacks", () => {
     await flushWaitUntilForTest();
   });
 
-  it("retries independently of Run success, preserves brand, and sends bounded Markdown multipart output", async () => {
+  it("retries independently of Run success and renders bounded Okou Markdown multipart output for a VM0 snapshot", async () => {
     const scenario = await setupScenario();
     const runId = await startRun(scenario, "https://app.okou.ai");
     const longPlainText = `LONG_PLAIN_TEXT_${"x".repeat(160)}`;
@@ -398,7 +398,7 @@ describe.sequential("Official Automation result email callbacks", () => {
     const resultCallbackId = await seedResultCallback({
       runId,
       automationId: scenario.automationId,
-      publicBrand: "okou",
+      publicBrand: "vm0",
       workflowName: 'Official <script> & " result',
     });
 
@@ -428,7 +428,7 @@ describe.sequential("Official Automation result email callbacks", () => {
       }),
     ).resolves.toStrictEqual({ items: [], claim: null });
 
-    mockEnv("RESEND_FROM_DOMAIN", "mail.example.com");
+    mockEnv("RESEND_FROM_DOMAIN", "vm0.bot");
     const redrive = await accept(
       executionClient().dispatchCallbacks({
         body: { run_id: runId, status: "completed", dispatch_count: 8 },
@@ -454,13 +454,14 @@ describe.sequential("Official Automation result email callbacks", () => {
     const item = source.items[0]!;
     expect(source.claim?.email_outbox_id).toBe(item.id);
     expect(item).toMatchObject({
-      from_address: "Okou <okou@mail.example.com>",
+      from_address: "Okou <okou@okou.io>",
       to_addresses: scenario.actor.email,
       public_brand: "okou",
       status: "pending",
       source_run_id: runId,
       source_workflow_automation_id: scenario.automationId,
       headers: {
+        "List-Unsubscribe": `<https://api.okou.ai/api/email/unsubscribe?token=${unsubscribeToken(scenario.actor.userId)}>`,
         "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
       },
     });
@@ -489,9 +490,13 @@ describe.sequential("Official Automation result email callbacks", () => {
     expect(context.mocks.resend.send).toHaveBeenCalledTimes(1);
     const send = context.mocks.resend.send.mock.calls[0]?.[0];
     expect(send).toMatchObject({
-      from: "Okou <okou@mail.example.com>",
+      from: "Okou <okou@okou.io>",
       to: scenario.actor.email,
       subject: 'Official <script> & " result completed',
+      headers: {
+        "List-Unsubscribe": `<https://api.okou.ai/api/email/unsubscribe?token=${unsubscribeToken(scenario.actor.userId)}>`,
+        "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+      },
     });
     const html =
       typeof send === "object" &&
@@ -542,6 +547,9 @@ describe.sequential("Official Automation result email callbacks", () => {
       expect(html).not.toContain(`href="${unsafeDestination}`);
     }
     expect(html).toContain("[Result truncated]");
+    expect(html).toContain("Okou");
+    expect(html).not.toContain("Zero");
+    expect(html).not.toContain("VM0");
     expect(html).toContain(`https://app.okou.ai/activities/${runId}`);
     expect(html).toContain(
       "This result was sent by an Official Workflow automation.<br>",

--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -5871,12 +5871,10 @@ describe.sequential("Official Workflow Run admission", () => {
     const producerRuns: {
       readonly runId: string;
       readonly automationId: string;
-      readonly publicBrand: "vm0" | "okou";
     }[] = [
       {
         runId: explicit.body.runId,
         automationId: loopAutomation.id,
-        publicBrand: "okou",
       },
     ];
     await completeSuccessfulRun(
@@ -5904,7 +5902,6 @@ describe.sequential("Official Workflow Run admission", () => {
     producerRuns.push({
       runId: scheduledRun.runId,
       automationId: loopAutomation.id,
-      publicBrand: "vm0",
     });
     await completeSuccessfulRun(
       runnerGroup,
@@ -5931,7 +5928,6 @@ describe.sequential("Official Workflow Run admission", () => {
     producerRuns.push({
       runId: onceRun.runId,
       automationId: onceAutomation.id,
-      publicBrand: "vm0",
     });
     await completeSuccessfulRun(
       runnerGroup,
@@ -5982,7 +5978,6 @@ describe.sequential("Official Workflow Run admission", () => {
     producerRuns.push({
       runId: webhookRun.runId,
       automationId: webhookAutomation.id,
-      publicBrand: "vm0",
     });
     await completeSuccessfulRun(
       runnerGroup,
@@ -6020,7 +6015,7 @@ describe.sequential("Official Workflow Run admission", () => {
       expect(source.claim).not.toBeNull();
       expect(source.items).toStrictEqual([
         expect.objectContaining({
-          public_brand: producer.publicBrand,
+          public_brand: "okou",
           source_run_id: producer.runId,
           source_workflow_automation_id: producer.automationId,
           status: "pending",
@@ -6032,7 +6027,7 @@ describe.sequential("Official Workflow Run admission", () => {
     }
   });
 
-  it("preserves session and agent-token brands across Official result callback retry", async () => {
+  it("uses Okou email brand for session and agent-token launches across Official result callback retry", async () => {
     const scenario = await installResultEmailLoopScenario(
       "api-test-result-brand",
       true,
@@ -6116,7 +6111,7 @@ describe.sequential("Official Workflow Run admission", () => {
     expect(source.claim).not.toBeNull();
     expect(source.items).toStrictEqual([
       expect.objectContaining({
-        public_brand: "vm0",
+        public_brand: "okou",
         source_run_id: agentRun.body.runId,
         source_workflow_automation_id: scenario.automation.id,
       }),

--- a/turbo/apps/api/src/signals/routes/__tests__/run-cron.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-cron.bdd.test.ts
@@ -486,7 +486,7 @@ describe("SCHED-02 and OPS-01: email outbox drain cron", () => {
     expect(drain).toBe(1);
     expect(context.mocks.resend.send).toHaveBeenCalledWith(
       expect.objectContaining({
-        from: "Zero <vm0@mail.example.com>",
+        from: "Okou <okou@mail.example.com>",
         to,
         subject,
         html: expect.stringContaining("Your data export is ready"),

--- a/turbo/apps/api/src/signals/services/credit-low-balance-alert.service.ts
+++ b/turbo/apps/api/src/signals/services/credit-low-balance-alert.service.ts
@@ -5,7 +5,6 @@ import { orgCache } from "@okouai/db/schema/org-cache";
 import { orgMembersCache } from "@okouai/db/schema/org-members-cache";
 import { users } from "@okouai/db/schema/user";
 import { and, eq, inArray, notInArray, sql } from "drizzle-orm";
-import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import { appUrlForPublicBrand } from "@okouai/core/public-brand";
 
 import { env } from "../../lib/env";
@@ -25,6 +24,7 @@ import {
   buildUnsubscribeHeaders,
   buildUnsubscribeUrl,
   CREDIT_LOW_BALANCE_EMAIL_SUBJECT,
+  EMAIL_PUBLIC_BRAND,
   getUserEmail,
   type EmailTemplate,
 } from "./email-common.service";
@@ -34,15 +34,14 @@ type OrganizationMembership = ClerkOrganizationMembership;
 export const LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS = 5000;
 
 const L = logger("CreditLowBalanceAlert");
-function billingCreditsUrl(publicBrand: PublicBrand): string {
-  return `${appUrlForPublicBrand(env("APP_URL"), publicBrand)}/?settings=billing&billingView=credits`;
+function billingCreditsUrl(): string {
+  return `${appUrlForPublicBrand(env("APP_URL"), EMAIL_PUBLIC_BRAND)}/?settings=billing&billingView=credits`;
 }
 
 export interface CreditLowBalanceAlertArgs {
   readonly orgId: string;
   readonly remainingCredits: number;
   readonly thresholdCredits: number;
-  readonly publicBrand?: PublicBrand;
 }
 
 interface Recipient {
@@ -273,15 +272,11 @@ export const enqueueCreditLowBalanceAlert$ = command(
 
     const orgName = await orgDisplayName(db, args.orgId);
     signal.throwIfAborted();
-    const publicBrand = args.publicBrand ?? "vm0";
-    const billingUrl = billingCreditsUrl(publicBrand);
+    const billingUrl = billingCreditsUrl();
 
     await db.insert(emailOutbox).values(
       deliverableRecipients.map((recipient) => {
-        const unsubscribeUrl = buildUnsubscribeUrl(
-          recipient.userId,
-          publicBrand,
-        );
+        const unsubscribeUrl = buildUnsubscribeUrl(recipient.userId);
         const template = {
           template: "credit-low-balance",
           props: {
@@ -293,19 +288,19 @@ export const enqueueCreditLowBalanceAlert$ = command(
           },
         } satisfies EmailTemplate;
         return {
-          fromAddress: buildTeamFromAddress("support", publicBrand),
+          fromAddress: buildTeamFromAddress(),
           toAddresses: recipient.email,
           ccAddresses: null,
           subject: CREDIT_LOW_BALANCE_EMAIL_SUBJECT,
-          publicBrand,
+          publicBrand: EMAIL_PUBLIC_BRAND,
           replyTo: null,
           headers: buildUnsubscribeHeaders(
-            buildOneClickUnsubscribeUrl(recipient.userId, publicBrand),
+            buildOneClickUnsubscribeUrl(recipient.userId),
           ),
           template,
           status: "pending",
           attempts: 0,
-        };
+        } as const;
       }),
     );
   },

--- a/turbo/apps/api/src/signals/services/email-common.service.ts
+++ b/turbo/apps/api/src/signals/services/email-common.service.ts
@@ -44,6 +44,9 @@ const MAX_ATTEMPTS = 3;
 const BACKOFF_BASE_MS = 1000;
 const MAX_OUTBOX_BATCH_SIZE = 120;
 const OUTBOX_DRAIN_DELAY_MS = 500;
+// Email is single-branded even while the rest of the product retains the
+// dual PublicBrand compatibility contract.
+export const EMAIL_PUBLIC_BRAND = "okou" satisfies PublicBrand;
 
 // Inter-send pacing for Resend rate limits. Overridable so environments
 // without a real provider (tests drain a shared outbox backlog) can disable
@@ -127,13 +130,11 @@ export type EmailTemplate = z.output<typeof emailTemplateSchema>;
 const emailAddressesSchema = z.union([z.string(), z.array(z.string())]);
 const outboxRowSchema = z.object({
   id: z.string(),
-  from_address: z.string(),
   to_addresses: emailAddressesSchema,
   cc_addresses: emailAddressesSchema.nullable(),
   subject: z.string(),
   reply_to: z.string().nullable(),
   headers: z.record(z.string(), z.string()).nullable(),
-  public_brand: z.enum(["vm0", "okou"]),
   template: emailTemplateSchema,
   attempts: z.int(),
 });
@@ -142,13 +143,11 @@ type OutboxRow = z.output<typeof outboxRowSchema>;
 function outboxRowSelection() {
   return {
     id: emailOutbox.id,
-    from_address: emailOutbox.fromAddress,
     to_addresses: emailOutbox.toAddresses,
     cc_addresses: emailOutbox.ccAddresses,
     subject: emailOutbox.subject,
     reply_to: emailOutbox.replyTo,
     headers: emailOutbox.headers,
-    public_brand: emailOutbox.publicBrand,
     template: emailOutbox.template,
     attempts: emailOutbox.attempts,
   };
@@ -162,17 +161,16 @@ function getResendClient(): Resend {
   return new Resend(apiKey);
 }
 
-function apiUrl(publicBrand: PublicBrand): string {
-  return apiUrlForPublicBrand(apiBackendUrl() ?? webUrl(), publicBrand);
+function apiUrl(): string {
+  return apiUrlForPublicBrand(apiBackendUrl() ?? webUrl(), EMAIL_PUBLIC_BRAND);
 }
 
-function appUrl(publicBrand: PublicBrand): string {
-  return appUrlForPublicBrand(env("APP_URL"), publicBrand);
+function appUrl(): string {
+  return appUrlForPublicBrand(env("APP_URL"), EMAIL_PUBLIC_BRAND);
 }
 
 function officialAutomationResultUnsubscribeUrl(
   headers: Readonly<Record<string, string>> | undefined,
-  publicBrand: PublicBrand,
 ): string {
   const listUnsubscribe = headers?.["List-Unsubscribe"];
   if (
@@ -200,31 +198,25 @@ function officialAutomationResultUnsubscribeUrl(
     );
   }
 
-  const unsubscribeUrl = new URL(`${appUrl(publicBrand)}/email/unsubscribe`);
+  const unsubscribeUrl = new URL(`${appUrl()}/email/unsubscribe`);
   unsubscribeUrl.searchParams.set("token", token);
   return unsubscribeUrl.toString();
 }
 
-function getFromDomain(publicBrand: PublicBrand): string {
+function getFromDomain(): string {
   const domain = env("RESEND_FROM_DOMAIN");
   if (!domain) {
     throw new Error("RESEND_FROM_DOMAIN is not configured");
   }
-  return fromDomainForPublicBrand(domain, publicBrand);
+  return fromDomainForPublicBrand(domain, EMAIL_PUBLIC_BRAND);
 }
 
-export function buildFromAddress(
-  localPart: string,
-  publicBrand: PublicBrand = "vm0",
-): string {
-  return `${publicBrandPresentation(publicBrand).assistantName} <${localPart}@${getFromDomain(publicBrand)}>`;
+export function buildFromAddress(): string {
+  return `${publicBrandPresentation(EMAIL_PUBLIC_BRAND).assistantName} <okou@${getFromDomain()}>`;
 }
 
-export function buildTeamFromAddress(
-  localPart: string,
-  publicBrand: PublicBrand = "vm0",
-): string {
-  return `${publicBrandPresentation(publicBrand).brandName} Team <${localPart}@${getFromDomain(publicBrand)}>`;
+export function buildTeamFromAddress(): string {
+  return `${publicBrandPresentation(EMAIL_PUBLIC_BRAND).brandName} Team <support@${getFromDomain()}>`;
 }
 
 function generateUnsubscribeToken(userId: string): string {
@@ -236,20 +228,14 @@ function generateUnsubscribeToken(userId: string): string {
   return `${userId}.${hmac}`;
 }
 
-export function buildUnsubscribeUrl(
-  userId: string,
-  publicBrand: PublicBrand = "vm0",
-): string {
-  return `${appUrl(publicBrand)}/email/unsubscribe?token=${generateUnsubscribeToken(
+export function buildUnsubscribeUrl(userId: string): string {
+  return `${appUrl()}/email/unsubscribe?token=${generateUnsubscribeToken(
     userId,
   )}`;
 }
 
-export function buildOneClickUnsubscribeUrl(
-  userId: string,
-  publicBrand: PublicBrand = "vm0",
-): string {
-  return `${apiUrl(publicBrand)}/api/email/unsubscribe?token=${generateUnsubscribeToken(
+export function buildOneClickUnsubscribeUrl(userId: string): string {
+  return `${apiUrl()}/api/email/unsubscribe?token=${generateUnsubscribeToken(
     userId,
   )}`;
 }
@@ -296,7 +282,6 @@ interface RenderedEmailTemplate {
 
 function renderTemplate(
   template: EmailTemplate,
-  publicBrand: PublicBrand,
   headers: Readonly<Record<string, string>> | undefined,
 ): RenderedEmailTemplate {
   switch (template.template) {
@@ -339,8 +324,8 @@ function renderTemplate(
     case "official-automation-result": {
       const rendered = renderOfficialAutomationResultEmail(
         template.props,
-        publicBrand,
-        officialAutomationResultUnsubscribeUrl(headers, publicBrand),
+        EMAIL_PUBLIC_BRAND,
+        officialAutomationResultUnsubscribeUrl(headers),
       );
       if (rendered.fallback) {
         log.warn("Official Automation result email used fallback renderer", {
@@ -354,27 +339,35 @@ function renderTemplate(
   }
 }
 
+function fromAddressForTemplate(template: EmailTemplate): string {
+  // Resolve the sender at delivery so legacy or malformed outbox snapshots
+  // cannot bypass the user-facing email brand policy.
+  switch (template.template) {
+    case "credit-low-balance": {
+      return buildTeamFromAddress();
+    }
+    case "data-export-ready":
+    case "official-automation-result": {
+      return buildFromAddress();
+    }
+  }
+}
+
 async function sendEmailDirect(options: {
-  readonly from: string;
   readonly to: string | readonly string[];
   readonly subject: string;
   readonly template: EmailTemplate;
   readonly cc?: string | readonly string[];
   readonly replyTo?: string;
   readonly headers?: Record<string, string>;
-  readonly publicBrand: PublicBrand;
 }): Promise<
   | { readonly ok: true; readonly resendId: string }
   | { readonly ok: false; readonly error: string }
 > {
   const resend = getResendClient();
-  const rendered = renderTemplate(
-    options.template,
-    options.publicBrand,
-    options.headers,
-  );
+  const rendered = renderTemplate(options.template, options.headers);
   const { data, error } = await resend.emails.send({
-    from: options.from,
+    from: fromAddressForTemplate(options.template),
     to: typeof options.to === "string" ? options.to : [...options.to],
     subject: options.subject,
     ...rendered,
@@ -452,14 +445,12 @@ async function processOutboxItem(
   }
 
   const result = await sendEmailDirect({
-    from: row.from_address,
     to: row.to_addresses,
     subject: row.subject,
     template: row.template,
     cc: row.cc_addresses ?? undefined,
     replyTo: row.reply_to ?? undefined,
     headers: row.headers ?? undefined,
-    publicBrand: row.public_brand,
   });
 
   if (!result.ok) {

--- a/turbo/apps/api/src/signals/services/internal-workflow-automation-result-email-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-workflow-automation-result-email-callback.service.ts
@@ -17,6 +17,7 @@ import {
   buildFromAddress,
   buildOneClickUnsubscribeUrl,
   buildUnsubscribeHeaders,
+  EMAIL_PUBLIC_BRAND,
   getUserEmail,
   OFFICIAL_AUTOMATION_RESULT_EMAIL_SUBJECT_MAX_CHARACTERS,
   OFFICIAL_AUTOMATION_RESULT_EMAIL_TEXT_MAX_CHARACTERS,
@@ -166,8 +167,7 @@ export async function handleWorkflowAutomationResultEmailInternalCallback(
   }
 
   const output = await getRunOutputText(db, envelope.runId, signal);
-  const publicBrand = payload.data.publicBrand;
-  const productUrl = appUrlForPublicBrand(env("APP_URL"), publicBrand);
+  const productUrl = appUrlForPublicBrand(env("APP_URL"), EMAIL_PUBLIC_BRAND);
   const manageUrl = await workflowAutomationManageUrl(
     db,
     {
@@ -220,16 +220,11 @@ export async function handleWorkflowAutomationResultEmailInternalCallback(
 
     await tx.insert(emailOutbox).values({
       id: claim.emailOutboxId,
-      fromAddress: buildFromAddress(
-        publicBrand === "okou" ? "okou" : "zero",
-        publicBrand,
-      ),
+      fromAddress: buildFromAddress(),
       toAddresses: userEmail,
       subject: resultEmailSubject(payload.data.workflowName),
-      headers: buildUnsubscribeHeaders(
-        buildOneClickUnsubscribeUrl(run.userId, publicBrand),
-      ),
-      publicBrand,
+      headers: buildUnsubscribeHeaders(buildOneClickUnsubscribeUrl(run.userId)),
+      publicBrand: EMAIL_PUBLIC_BRAND,
       template: {
         template: "official-automation-result",
         props: {

--- a/turbo/apps/api/src/signals/services/user-export.service.ts
+++ b/turbo/apps/api/src/signals/services/user-export.service.ts
@@ -55,6 +55,7 @@ import {
   buildOneClickUnsubscribeUrl,
   buildUnsubscribeHeaders,
   buildUnsubscribeUrl,
+  EMAIL_PUBLIC_BRAND,
 } from "./email-common.service";
 import {
   normalizeSessionHistoryBlobEncoding,
@@ -1093,7 +1094,6 @@ function enqueueExportReadyEmail(
     readonly downloadUrl: string;
     readonly expiresAt: Date;
     readonly artifactCount: number;
-    readonly publicBrand: PublicBrand;
   },
   signal: AbortSignal,
 ): Computed<Promise<void>> {
@@ -1107,11 +1107,8 @@ function enqueueExportReadyEmail(
     signal.throwIfAborted();
 
     const email = await get(getCachedUserEmail(runtime, args.userId, signal));
-    const unsubscribeUrl = buildUnsubscribeUrl(args.userId, args.publicBrand);
-    const oneClickUnsubscribeUrl = buildOneClickUnsubscribeUrl(
-      args.userId,
-      args.publicBrand,
-    );
+    const unsubscribeUrl = buildUnsubscribeUrl(args.userId);
+    const oneClickUnsubscribeUrl = buildOneClickUnsubscribeUrl(args.userId);
     const formattedExpiry = args.expiresAt.toLocaleDateString("en-US", {
       year: "numeric",
       month: "long",
@@ -1119,13 +1116,10 @@ function enqueueExportReadyEmail(
     });
 
     await runtime.db.insert(emailOutbox).values({
-      fromAddress: buildFromAddress(
-        args.publicBrand === "okou" ? "okou" : "vm0",
-        args.publicBrand,
-      ),
+      fromAddress: buildFromAddress(),
       toAddresses: email,
       subject: DATA_EXPORT_READY_SUBJECT,
-      publicBrand: args.publicBrand,
+      publicBrand: EMAIL_PUBLIC_BRAND,
       headers: buildUnsubscribeHeaders(oneClickUnsubscribeUrl),
       template: {
         template: "data-export-ready",
@@ -1213,7 +1207,6 @@ const runExportJob$ = command(async function runExportJob(
         downloadUrl,
         expiresAt,
         artifactCount: 0,
-        publicBrand: args.publicBrand,
       },
       signal,
     ),


### PR DESCRIPTION
## Summary

- centralize the user-facing email policy on Okou at the shared outbox render/send boundary
- persist Okou senders, presentation, CTA/manage links, and unsubscribe headers in every current production outbox producer
- cover legacy sender snapshots, Official explicit/scheduled/once/webhook and token paths, data exports, and low-credit alerts
- preserve the #30443 safe Markdown multipart renderer and its URL, HTML, image, 8,000-character, and 96 KiB boundaries
- preserve the #30591 Official Workflow automation deep-link footer: "This result was sent by an Official Workflow automation." and "Manage this automation · Unsubscribe"

## Production outbox evidence

MaskDB live read at 2026-09-01T04:07:44Z returned zero rows across `pending`, `sending`, and `failed`. No active legacy-branded backlog exists, so this change intentionally adds no migration.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm format`
- `pnpm exec prettier --check <nine changed email files>`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm --filter api run lint`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-drain-email-outbox-scoped.test.ts src/signals/routes/__tests__/email.test.ts src/signals/routes/__tests__/official-automation-result-email.test.ts src/signals/routes/__tests__/official-workflows.test.ts src/signals/routes/__tests__/run-cron.bdd.test.ts` (65 tests)
- `git diff --check`

Closes #30404
