### PR TITLE
feat(runner): report operator environment alias states

### DIFF
--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -1,4 +1,5 @@
-//! Tracing layer that ships WARN+ events to Axiom.
+//! Tracing layer that ships WARN+ events and the dedicated Runner operator
+//! environment alias-state event to Axiom.
 //!
 //! Disabled at construction when `AXIOM_TOKEN_TELEMETRY` or
 //! `AXIOM_DATASET_SUFFIX` is unset. Dual-write: the existing fmt subscriber
@@ -68,6 +69,7 @@ const SERVICE_NAME: &str = "runner";
 const AXIOM_TOKEN_ENV: &str = "AXIOM_TOKEN_TELEMETRY";
 const AXIOM_SUFFIX_ENV: &str = "AXIOM_DATASET_SUFFIX";
 const ADDON_LOG_TARGET: &str = "mitmdump_addon";
+pub(crate) const OPERATOR_ENV_ALIAS_STATES_TARGET: &str = "runner::operator_env::alias_states";
 /// Target used for this layer's own diagnostics. Dispatcher diagnostics
 /// (non-success ingest responses, HTTP errors) remain visible to local
 /// logging, while the Axiom per-layer filter keeps any observed diagnostics
@@ -236,7 +238,10 @@ pub(crate) struct AxiomLayer {
 }
 
 fn should_ingest(metadata: &Metadata<'_>) -> bool {
-    metadata.target() != INTERNAL_TARGET && *metadata.level() <= tracing::Level::WARN
+    metadata.target() != INTERNAL_TARGET
+        && (*metadata.level() <= tracing::Level::WARN
+            || (*metadata.level() == tracing::Level::INFO
+                && metadata.target() == OPERATOR_ENV_ALIAS_STATES_TARGET))
 }
 
 fn ingest_filter() -> FilterFn<fn(&Metadata<'_>) -> bool> {

--- a/crates/runner/src/axiom_layer/tests.rs
+++ b/crates/runner/src/axiom_layer/tests.rs
@@ -13,9 +13,9 @@ use std::time::Duration;
 
 use super::{
     ADDON_LOG_TARGET, AxiomGuard, AxiomLayer, BATCH_INTERVAL, BATCH_SIZE, CHANNEL_CAP,
-    ERROR_SOURCE_MAX_DEPTH, FLUSH_DEADLINE, INTERNAL_TARGET, Msg, TEXT_FIELD_MAX_BYTES,
-    TRUNCATION_MARKER, init_from_env_values, init_with_base_url, init_with_base_url_and_hostname,
-    with_ingest_filter,
+    ERROR_SOURCE_MAX_DEPTH, FLUSH_DEADLINE, INTERNAL_TARGET, Msg, OPERATOR_ENV_ALIAS_STATES_TARGET,
+    TEXT_FIELD_MAX_BYTES, TRUNCATION_MARKER, init_from_env_values, init_with_base_url,
+    init_with_base_url_and_hostname, with_ingest_filter,
 };
 use httpmock::Method::POST;
 use httpmock::MockServer;
@@ -346,6 +346,76 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
         !has_event_with_message(&events, "info is below threshold, should not be ingested"),
         "INFO event should not be ingested: {events:#?}",
     );
+}
+
+#[tokio::test]
+async fn only_dedicated_operator_environment_info_target_is_ingested() {
+    let server = MockServer::start_async().await;
+    let (ingest, captured) = capture_axiom_ingest(&server).await;
+    let (layer, guard) = init_with_base_url_and_hostname(
+        &server.base_url(),
+        "test-token",
+        "test",
+        Some("runner-host-1".to_string()),
+    )
+    .expect("init must succeed");
+    let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
+
+    {
+        let _sub = tracing::subscriber::set_default(subscriber);
+        tracing::info!(
+            target: OPERATOR_ENV_ALIAS_STATES_TARGET,
+            api_url_alias_state = "equal_dual",
+            runner_token_alias_state = "canonical_only",
+            "runner operator environment alias states"
+        );
+        tracing::info!(target: "runner::operator_env", "unrelated operator info");
+        tracing::info!(
+            target: "runner::operator_env::alias_states::other",
+            "nearby target info"
+        );
+        tracing::event!(
+            target: OPERATOR_ENV_ALIAS_STATES_TARGET,
+            tracing::Level::DEBUG,
+            "dedicated target debug"
+        );
+        tracing::warn!("ordinary warning");
+        tracing::warn!(target: INTERNAL_TARGET, "internal warning");
+    }
+    guard.shutdown().await;
+
+    ingest.assert_calls_async(1).await;
+    let events = captured.events();
+    assert_eq!(events.len(), 2, "unexpected ingested events: {events:#?}");
+
+    let alias_states = event_with_message(&events, "runner operator environment alias states");
+    assert_eq!(alias_states["level"], json!("info"));
+    assert_eq!(
+        alias_states["context"],
+        json!(OPERATOR_ENV_ALIAS_STATES_TARGET)
+    );
+    assert_eq!(alias_states["runner_hostname"], json!("runner-host-1"));
+    assert_eq!(
+        alias_states["runner_version"],
+        json!(env!("CARGO_PKG_VERSION"))
+    );
+    assert_eq!(alias_states["api_url_alias_state"], json!("equal_dual"));
+    assert_eq!(
+        alias_states["runner_token_alias_state"],
+        json!("canonical_only")
+    );
+    event_with_message(&events, "ordinary warning");
+    for message in [
+        "unrelated operator info",
+        "nearby target info",
+        "dedicated target debug",
+        "internal warning",
+    ] {
+        assert!(
+            !has_event_with_message(&events, message),
+            "filtered event {message:?} reached ingest: {events:#?}",
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -453,20 +453,7 @@ async fn run_start_with_home(
         server.token = token;
     }
 
-    // Validate required server fields
-    if server.url.is_empty() {
-        return Err(RunnerError::Config(format!(
-            "server.url is required (set in config or via --api-url / {} / {})",
-            crate::operator_api_url::CANONICAL_ENV,
-            crate::operator_api_url::LEGACY_ENV
-        )));
-    }
-    server.url = config::normalize_api_base_url(&server.url)?;
-    if server.token.is_empty() {
-        return Err(RunnerError::Config(
-            "server.token is required (set in config or via --token / OKOU_RUNNER_TOKEN / VM0_RUNNER_TOKEN)".into(),
-        ));
-    }
+    let server = validate_server_config_for_start(server)?;
 
     let runner_host_env = crate::host_env::read_runner_host_env()?;
     let config::SandboxConfig {
@@ -977,6 +964,33 @@ async fn run_start_with_home(
         tracing::warn!(error = %e, "failed to remove live runner instance record");
     }
     run_result
+}
+
+fn validate_server_config_for_start(
+    mut server: config::ServerConfig,
+) -> RunnerResult<config::ServerConfig> {
+    if server.url.is_empty() {
+        return Err(RunnerError::Config(format!(
+            "server.url is required (set in config or via --api-url / {} / {})",
+            crate::operator_api_url::CANONICAL_ENV,
+            crate::operator_api_url::LEGACY_ENV
+        )));
+    }
+    server.url = config::normalize_api_base_url(&server.url)?;
+    if server.token.is_empty() {
+        return Err(RunnerError::Config(
+            "server.token is required (set in config or via --token / OKOU_RUNNER_TOKEN / VM0_RUNNER_TOKEN)".into(),
+        ));
+    }
+
+    info!(
+        target: crate::axiom_layer::OPERATOR_ENV_ALIAS_STATES_TARGET,
+        api_url_alias_state = crate::operator_api_url::environment_alias_state_label(),
+        runner_token_alias_state = crate::runner_token::environment_alias_state_label(),
+        "runner operator environment alias states"
+    );
+
+    Ok(server)
 }
 
 struct RunConfig {

--- a/crates/runner/src/cmd/start/tests/mod.rs
+++ b/crates/runner/src/cmd/start/tests/mod.rs
@@ -2,5 +2,6 @@ mod budget;
 mod failure_recovery;
 mod idle_reuse;
 mod main_loop;
+mod server_config;
 mod support;
 mod teardown_timer;

--- a/crates/runner/src/cmd/start/tests/server_config.rs
+++ b/crates/runner/src/cmd/start/tests/server_config.rs
@@ -1,0 +1,101 @@
+use super::super::*;
+use tracing::Level;
+use tracing_subscriber::prelude::*;
+use tracing_test_support::{CapturedEvent, CapturedEvents};
+
+const EVENT_MESSAGE: &str = "runner operator environment alias states";
+
+fn capture_validation(
+    server: config::ServerConfig,
+) -> (RunnerResult<config::ServerConfig>, Vec<CapturedEvent>) {
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+    captured.clear();
+
+    let result = validate_server_config_for_start(server);
+    (result, captured.entries())
+}
+
+fn alias_state_events(events: &[CapturedEvent]) -> Vec<&CapturedEvent> {
+    events
+        .iter()
+        .filter(|event| {
+            event
+                .fields
+                .get("message")
+                .is_some_and(|message| message == EVENT_MESSAGE)
+        })
+        .collect()
+}
+
+#[test]
+fn successful_server_validation_emits_one_value_free_alias_state_event() {
+    const URL: &str = "https://Operator-URL.Example.Test/base/";
+
+    let (result, events) = capture_validation(config::ServerConfig {
+        url: URL.to_string(),
+        token: "present".to_string(),
+    });
+    let server = result.expect("valid server configuration should resolve");
+    assert_eq!(server.url, "https://operator-url.example.test/base");
+
+    let alias_events = alias_state_events(&events);
+    assert_eq!(alias_events.len(), 1, "captured events: {events:#?}");
+    let event = alias_events[0];
+    assert_eq!(event.level, Level::INFO);
+    assert_eq!(
+        event.fields.keys().map(String::as_str).collect::<Vec<_>>(),
+        ["api_url_alias_state", "message", "runner_token_alias_state",],
+        "alias-state event must contain only fixed fields: {event:#?}",
+    );
+    assert!(
+        [
+            "absent",
+            "canonical_only",
+            "legacy_only",
+            "equal_dual",
+            "conflicting_dual",
+        ]
+        .contains(
+            &event
+                .fields
+                .get("api_url_alias_state")
+                .unwrap_or_else(|| panic!("missing API URL state: {event:#?}"))
+                .as_str(),
+        ),
+        "unexpected API URL state: {event:#?}",
+    );
+    assert!(
+        ["absent", "canonical_only", "legacy_only", "dual_present",].contains(
+            &event
+                .fields
+                .get("runner_token_alias_state")
+                .unwrap_or_else(|| panic!("missing Runner token state: {event:#?}"))
+                .as_str(),
+        ),
+        "unexpected Runner token state: {event:#?}",
+    );
+}
+
+#[test]
+fn invalid_server_configuration_emits_no_alias_state_event() {
+    for server in [
+        config::ServerConfig {
+            url: "not-an-absolute-url".to_string(),
+            token: "present".to_string(),
+        },
+        config::ServerConfig {
+            url: "https://api.example.test".to_string(),
+            token: String::new(),
+        },
+    ] {
+        let (result, events) = capture_validation(server);
+        assert!(result.is_err());
+        assert!(
+            alias_state_events(&events).is_empty(),
+            "validation failure emitted an alias-state event: {events:#?}",
+        );
+    }
+}

--- a/crates/runner/src/operator_api_url.rs
+++ b/crates/runner/src/operator_api_url.rs
@@ -1,5 +1,51 @@
+use std::ffi::OsStr;
+
 pub(crate) const CANONICAL_ENV: &str = guest_contracts::env::CANONICAL_API_URL_ENV;
 pub(crate) const LEGACY_ENV: &str = guest_contracts::env::API_URL_ENV;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EnvironmentAliasState {
+    Absent,
+    CanonicalOnly,
+    LegacyOnly,
+    EqualDual,
+    ConflictingDual,
+}
+
+impl EnvironmentAliasState {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Absent => "absent",
+            Self::CanonicalOnly => "canonical_only",
+            Self::LegacyOnly => "legacy_only",
+            Self::EqualDual => "equal_dual",
+            Self::ConflictingDual => "conflicting_dual",
+        }
+    }
+}
+
+fn classify_environment_aliases(
+    canonical: Option<&OsStr>,
+    legacy: Option<&OsStr>,
+) -> EnvironmentAliasState {
+    match (canonical, legacy) {
+        (None, None) => EnvironmentAliasState::Absent,
+        (Some(_), None) => EnvironmentAliasState::CanonicalOnly,
+        (None, Some(_)) => EnvironmentAliasState::LegacyOnly,
+        (Some(canonical), Some(legacy)) if canonical == legacy => EnvironmentAliasState::EqualDual,
+        (Some(_), Some(_)) => EnvironmentAliasState::ConflictingDual,
+    }
+}
+
+fn environment_alias_state() -> EnvironmentAliasState {
+    let canonical = std::env::var_os(CANONICAL_ENV);
+    let legacy = std::env::var_os(LEGACY_ENV);
+    classify_environment_aliases(canonical.as_deref(), legacy.as_deref())
+}
+
+pub(crate) fn environment_alias_state_label() -> &'static str {
+    environment_alias_state().label()
+}
 
 /// Select the Runner operator environment source that Clap binds to `--api-url`.
 ///
@@ -17,11 +63,43 @@ pub(crate) fn clap_environment_name() -> &'static str {
 }
 
 pub(crate) fn environment_aliases_conflict() -> bool {
-    match (
-        std::env::var_os(CANONICAL_ENV),
-        std::env::var_os(LEGACY_ENV),
-    ) {
-        (Some(canonical), Some(legacy)) => canonical != legacy,
-        _ => false,
+    environment_alias_state() == EnvironmentAliasState::ConflictingDual
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_complete_environment_alias_matrix() {
+        let canonical = OsStr::new("canonical");
+        let legacy = OsStr::new("legacy");
+        let equal = OsStr::new("equal");
+
+        for (canonical, legacy, expected) in [
+            (None, None, EnvironmentAliasState::Absent),
+            (Some(canonical), None, EnvironmentAliasState::CanonicalOnly),
+            (None, Some(legacy), EnvironmentAliasState::LegacyOnly),
+            (Some(equal), Some(equal), EnvironmentAliasState::EqualDual),
+            (
+                Some(canonical),
+                Some(legacy),
+                EnvironmentAliasState::ConflictingDual,
+            ),
+        ] {
+            assert_eq!(classify_environment_aliases(canonical, legacy), expected);
+        }
+
+        assert_eq!(EnvironmentAliasState::Absent.label(), "absent");
+        assert_eq!(
+            EnvironmentAliasState::CanonicalOnly.label(),
+            "canonical_only"
+        );
+        assert_eq!(EnvironmentAliasState::LegacyOnly.label(), "legacy_only");
+        assert_eq!(EnvironmentAliasState::EqualDual.label(), "equal_dual");
+        assert_eq!(
+            EnvironmentAliasState::ConflictingDual.label(),
+            "conflicting_dual"
+        );
     }
 }

--- a/crates/runner/src/runner_token.rs
+++ b/crates/runner/src/runner_token.rs
@@ -1,6 +1,49 @@
 pub(crate) const CANONICAL_ENV: &str = "OKOU_RUNNER_TOKEN";
 pub(crate) const LEGACY_ENV: &str = "VM0_RUNNER_TOKEN";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EnvironmentAliasState {
+    Absent,
+    CanonicalOnly,
+    LegacyOnly,
+    DualPresent,
+}
+
+impl EnvironmentAliasState {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Absent => "absent",
+            Self::CanonicalOnly => "canonical_only",
+            Self::LegacyOnly => "legacy_only",
+            Self::DualPresent => "dual_present",
+        }
+    }
+}
+
+fn classify_environment_alias_presence(
+    canonical_present: bool,
+    legacy_present: bool,
+) -> EnvironmentAliasState {
+    // Token bytes must never cross this telemetry boundary; classify presence only.
+    match (canonical_present, legacy_present) {
+        (false, false) => EnvironmentAliasState::Absent,
+        (true, false) => EnvironmentAliasState::CanonicalOnly,
+        (false, true) => EnvironmentAliasState::LegacyOnly,
+        (true, true) => EnvironmentAliasState::DualPresent,
+    }
+}
+
+fn environment_alias_state() -> EnvironmentAliasState {
+    classify_environment_alias_presence(
+        std::env::var_os(CANONICAL_ENV).is_some(),
+        std::env::var_os(LEGACY_ENV).is_some(),
+    )
+}
+
+pub(crate) fn environment_alias_state_label() -> &'static str {
+    environment_alias_state().label()
+}
+
 /// Select the one environment source that Clap binds to the sensitive token
 /// argument. This is Stage 1 compatibility for runner process configuration.
 /// Remove the legacy alias only after #28914 moves CI and external secret
@@ -15,5 +58,39 @@ pub(crate) fn clap_environment_name() -> &'static str {
 }
 
 pub(crate) fn environment_aliases_conflict() -> bool {
-    std::env::var_os(CANONICAL_ENV).is_some() && std::env::var_os(LEGACY_ENV).is_some()
+    environment_alias_state() == EnvironmentAliasState::DualPresent
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_complete_presence_only_matrix() {
+        for (canonical_present, legacy_present, expected, label) in [
+            (false, false, EnvironmentAliasState::Absent, "absent"),
+            (
+                true,
+                false,
+                EnvironmentAliasState::CanonicalOnly,
+                "canonical_only",
+            ),
+            (
+                false,
+                true,
+                EnvironmentAliasState::LegacyOnly,
+                "legacy_only",
+            ),
+            (
+                true,
+                true,
+                EnvironmentAliasState::DualPresent,
+                "dual_present",
+            ),
+        ] {
+            let state = classify_environment_alias_presence(canonical_present, legacy_present);
+            assert_eq!(state, expected);
+            assert_eq!(state.label(), label);
+        }
+    }
 }

--- a/docs/runner-host-configuration.md
+++ b/docs/runner-host-configuration.md
@@ -3,9 +3,10 @@
 ## Diagnostic Host Attribution
 
 `runner.yaml` may contain an optional `hostname` used only to identify the
-physical runner in claims, sandbox telemetry, and Runner Axiom warning/error
-events. Production automation writes the exact Ansible `inventory_hostname`;
-it does not derive the value from DNS or the operating system at runtime.
+physical runner in claims, sandbox telemetry, Runner Axiom warning/error
+events, and the dedicated operator-environment alias-state event. Production
+automation writes the exact Ansible `inventory_hostname`; it does not derive
+the value from DNS or the operating system at runtime.
 
 The value must be non-empty and no longer than 255 JavaScript string units
 (UTF-16 code units). `runner config --hostname <value>` validates and preserves
@@ -46,6 +47,38 @@ serving API instances drained. The current schema no longer contains
 telemetry/Axiom dimensions, and distinct hostnames on two hosts running one
 version. Remove any historical query fallback only after its bounded
 observation window expires.
+
+## Runner Start Operator-Environment Alias Telemetry
+
+After `runner start` has normalized its effective server URL successfully and
+proved its effective token is non-empty, it emits exactly one informational
+`runner operator environment alias states` event. Its dedicated tracing target,
+serialized to the Axiom `context` field, is
+`runner::operator_env::alias_states`. The Runner Axiom filter admits this exact
+informational target in addition to its existing warning-and-error traffic;
+unrelated informational, debug, and trace events remain local.
+
+The event classifies only the live `runner start` process environment. It
+contains two fixed, value-free fields:
+
+| Field                      | Classifications                                                                |
+| -------------------------- | ------------------------------------------------------------------------------ |
+| `api_url_alias_state`      | `absent`, `canonical_only`, `legacy_only`, `equal_dual`, or `conflicting_dual` |
+| `runner_token_alias_state` | `absent`, `canonical_only`, `legacy_only`, or `dual_present`                   |
+
+For the API URL pair, a dual state distinguishes equal values from
+conflicting values. Token classification inspects presence only; it never
+compares the two token values. The event never includes URL or token values,
+lengths, hashes, prefixes, suffixes, command arguments, environment dumps,
+configuration contents, or error representations. `runner_hostname` and
+`runner_version` are added automatically by the Axiom layer.
+
+This event does not prove that arbitrary external `runner config` invocations
+have stopped using a legacy alias. Removing either legacy reader still requires
+a current source and configuration inventory, evidence from every intended
+Runner host, supported rollback ancestry, and an explicit compatibility
+decision. A failed URL or token validation emits no event, so missing expected
+host coverage is not legacy-drain evidence.
 
 The runner reads host-local overrides from `/etc/vm0-runner/host.env` once
 during startup. A missing file is equivalent to an empty file: the runner uses


### PR DESCRIPTION
## Summary

- classify the live Runner operator API URL aliases with fixed value-free states
- classify Runner token aliases from presence booleans only, without inspecting token bytes
- emit one post-validation startup INFO event and allowlist only its exact Axiom target
- document the event's evidence boundary and compatibility requirements

## Compatibility and safety

- preserves every legacy reader, precedence rule, conflict rule, explicit flag behavior, `runner.yaml` fallback, URL normalization, local-provider behavior, and rollback path
- emits no URL or token values, lengths, hashes, prefixes, suffixes, arguments, environment dumps, configuration contents, or error representations
- leaves unrelated INFO/DEBUG/TRACE events local and keeps all internal Axiom-layer events excluded
- does not modify `.github/actions/**` or `.github/workflows/**`

## Just-in-time evidence

- refreshed base: `main@5c9f0267b8588f7fe43e059ac4274cf559aa74df`
- fully paginated inventory: 28 open PRs, 29 changed-file pages, 558/558 declared/fetched files, zero mismatches
- the only blast-radius overlap is PR #25722 adding unrelated Cloudflare Access constants to `crates/guest-contracts/src/env.rs`

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `npx --yes --package=prettier@3.8.1 prettier --check docs/runner-host-configuration.md`
- `git diff origin/main...HEAD --check`
- `./scripts/check-file-size.sh <focused changed files>`
- `CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `CARGO_BUILD_JOBS=1 cargo check --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `CARGO_BUILD_JOBS=1 cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`

A focused `cargo test` attempt reached the final Runner test-binary link and was killed by the local 4 GB cgroup (`exit 137`; `memory.peak=4005113856`; `oom_kill=4`), so no test executed locally. Strict all-target compilation passed; protected PR CI remains authoritative for test execution.

Closes #30401

Parent: #28914
