### PR TITLE
fix(runner): reject cleartext remote api urls

### DIFF
--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -326,6 +326,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_config_rejects_cleartext_remote_api_url_before_filesystem_setup() {
+        let mut args = args_with_valid_image_hashes();
+        args.api_url = "http://api.example.com".into();
+
+        let err = run_config(args).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("server.url"), "got: {msg}");
+        assert!(msg.contains("https"), "got: {msg}");
+        assert!(!msg.contains("api.example.com"), "got: {msg}");
+        assert!(
+            !msg.contains("rootfs not found"),
+            "API URL validation should happen before image checks: {msg}"
+        );
+    }
+
+    #[tokio::test]
     async fn run_config_rejects_mismatched_profile_arg_lengths() {
         let cases = [
             (

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -290,8 +290,9 @@ pub(crate) fn validate_runner_hostname(value: &str) -> RunnerResult<()> {
 
 /// Validate and normalize the runner API base URL.
 ///
-/// The URL is later copied into guest-visible config and log-adjacent paths,
-/// so reject components that can carry credentials or other sensitive values.
+/// The URL is used for authenticated requests and later copied into
+/// guest-visible config and log-adjacent paths, so require HTTPS outside the
+/// loopback development boundary and reject sensitive URL components.
 pub(crate) fn normalize_api_base_url(value: &str) -> RunnerResult<String> {
     let mut parsed = url::Url::parse(value)
         .map_err(|_| RunnerError::Config("server.url must be an absolute http(s) URL".into()))?;
@@ -336,6 +337,19 @@ pub(crate) fn normalize_api_base_url(value: &str) -> RunnerResult<String> {
         parsed
             .set_host(Some(&host))
             .map_err(|_| RunnerError::Config("server.url has an invalid host".into()))?;
+    }
+
+    let host_is_loopback = match parsed.host() {
+        Some(url::Host::Domain(host)) => host == "localhost",
+        Some(url::Host::Ipv4(address)) => address.is_loopback(),
+        Some(url::Host::Ipv6(address)) => address.is_loopback(),
+        None => false,
+    };
+    if parsed.scheme() == "http" && !host_is_loopback {
+        return Err(RunnerError::Config(
+            "server.url must use https unless its host is localhost or a loopback IP address"
+                .into(),
+        ));
     }
 
     Ok(parsed.as_str().trim_end_matches('/').to_string())

--- a/crates/runner/src/config/tests.rs
+++ b/crates/runner/src/config/tests.rs
@@ -188,13 +188,14 @@ fn normalize_api_base_url_accepts_http_https_and_preserves_path_prefix() {
         ("https://api.example.com", "https://api.example.com"),
         ("https://api.example.com/", "https://api.example.com"),
         ("http://localhost:3000/api/", "http://localhost:3000/api"),
+        ("http://LOCALHOST.:3000/api/", "http://localhost:3000/api"),
+        ("http://127.0.0.2:8080/base/", "http://127.0.0.2:8080/base"),
         ("https://faß.de/base", "https://xn--fa-hia.de/base"),
         ("https://xn--fa-hia.de/base", "https://xn--fa-hia.de/base"),
         (
             "https://api。example.com.:8443/base/",
             "https://api.example.com:8443/base",
         ),
-        ("http://192.0.2.10:8080/base", "http://192.0.2.10:8080/base"),
         (
             "https://api.example.com/prefix/v1",
             "https://api.example.com/prefix/v1",
@@ -208,6 +209,19 @@ fn normalize_api_base_url_accepts_http_https_and_preserves_path_prefix() {
 
     for (input, expected) in cases {
         assert_eq!(normalize_api_base_url(input).unwrap(), expected);
+    }
+}
+
+#[test]
+fn normalize_api_base_url_rejects_cleartext_remote_hosts() {
+    for input in [
+        "http://api.example.com",
+        "http://localhost.example.com",
+        "http://10.0.0.5:3000",
+        "http://192.0.2.10:8080/base",
+        "http://[2001:db8::1]:8080/base",
+    ] {
+        assert_invalid_api_base_url(input, "https");
     }
 }
 
@@ -407,6 +421,26 @@ async fn load_for_start_applies_api_url_override_before_server_url_validation() 
     let server = config.server.unwrap();
     assert_eq!(server.url, "https://api.example.com/prefix");
     assert_eq!(server.token, "secret");
+}
+
+#[tokio::test]
+async fn load_for_start_rejects_cleartext_remote_api_url_override() {
+    let fixture = ConfigFixture::new().await;
+    let yaml = fixture.yaml_with_default_profile(
+        r#"server:
+  url: https://api.example.com
+  token: secret
+"#,
+    );
+    let config_path = fixture.write_config(&yaml).await;
+
+    let error = load_for_start(&config_path, Some("http://api.example.com"))
+        .await
+        .unwrap_err();
+    let message = error.to_string();
+
+    assert!(message.contains("https"), "got: {message}");
+    assert!(!message.contains("api.example.com"), "got: {message}");
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -1251,7 +1251,7 @@ mod tests {
 
     fn http_client() -> HttpClient {
         HttpClient::new(HttpClientConfig {
-            api_url: "http://api.test".to_string(),
+            api_url: "http://localhost".to_string(),
             vercel_bypass: None,
             client_session_id: "runner-session-test".to_string(),
         })

--- a/crates/runner/src/http.rs
+++ b/crates/runner/src/http.rs
@@ -227,7 +227,7 @@ impl HttpClient {
     /// `config.vercel_bypass` is present, that value is attached as
     /// `x-vercel-protection-bypass` on authenticated requests.
     ///
-    /// Returns an error if the underlying HTTP client cannot be built.
+    /// Returns an error if the API URL is invalid or the underlying HTTP client cannot be built.
     pub fn new(config: HttpClientConfig) -> RunnerResult<Self> {
         let HttpClientConfig {
             api_url: raw_api_url,
@@ -484,6 +484,24 @@ mod tests {
             !message.contains("user:pass") && !message.contains("token=secret"),
             "error should not echo sensitive URL components: {message}"
         );
+    }
+
+    #[test]
+    fn new_rejects_cleartext_remote_api_url() {
+        let result = HttpClient::new(HttpClientConfig {
+            api_url: "http://api.vm0.dev".to_string(),
+            vercel_bypass: None,
+            client_session_id: "runner-session-test".to_string(),
+        });
+        let error = match result {
+            Ok(_) => panic!("expected cleartext remote API URL to be rejected"),
+            Err(error) => error,
+        };
+        let message = error.to_string();
+
+        assert!(message.contains("server.url"), "got: {message}");
+        assert!(message.contains("https"), "got: {message}");
+        assert!(!message.contains("api.vm0.dev"), "got: {message}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reject remote cleartext runner control-plane API URLs at the shared normalization boundary
- preserve HTTP for `localhost`, canonical IPv4 loopback addresses in `127.0.0.0/8`, and IPv6 `::1`
- cover persisted config, start overrides, command validation, and HTTP client construction

## Compatibility

- no API, queue, guest protocol, UI, or user-operation-flow changes
- newly deployed runners fail closed on existing remote HTTP control-plane configuration
- unrelated guest, connector, object-storage, and mock-server HTTP traffic is unchanged

## Validation

- `cargo fmt --all -- --check`
- `cargo xtask check-rust-path-attributes`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p runner`

Closes #30199
