### PR TITLE
chore(api): refresh shared worker preview qa marker

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createProductionApp } from "./production-bootstrap";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed for #27599 rollback rotation on 2026-08-18)
+// (no-op API release marker refreshed for SharedWorker preview QA on 2026-08-31)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
## Purpose

Provision an isolated App/API PR Preview for reproducing the systematic SharedWorker browser E2E failure with staging-browser and agent-browser.

## Change

- Refresh the existing behavior-neutral API preview marker.
- Runtime behavior is unchanged.

## Validation

- `git diff --check`

## Important

This PR is a preview-only QA fixture. It must not be merged as a product change.