### PR TITLE
fix(runner): validate dns readiness responses

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2824,6 +2824,7 @@ dependencies = [
  "libc",
  "nbd-cow",
  "nix",
+ "proptest",
  "reqwest",
  "rustix",
  "sandbox",

--- a/crates/sandbox-fc/Cargo.toml
+++ b/crates/sandbox-fc/Cargo.toml
@@ -31,6 +31,7 @@ rustix = { workspace = true, features = ["process"] }
 
 [dev-dependencies]
 clap = { workspace = true, features = ["derive"] }
+proptest.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 tracing-test-support.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/sandbox-fc/src/network/readiness.rs
+++ b/crates/sandbox-fc/src/network/readiness.rs
@@ -33,9 +33,12 @@ pub(super) type DnsReadinessProbe = Arc<dyn Fn(String) -> DnsReadinessFuture + S
 const DNS_RESPONSE_MAX_BYTES: usize = 512;
 const DNS_QUERY_FLAGS_RECURSION_DESIRED: u16 = 0x0100;
 const DNS_RESPONSE_FLAG: u16 = 0x8000;
+const DNS_RESPONSE_OPCODE_MASK: u16 = 0x7800;
+const DNS_RESPONSE_TRUNCATED_FLAG: u16 = 0x0200;
 const DNS_RESPONSE_CODE_MASK: u16 = 0x000f;
 const DNS_TYPE_A: u16 = 1;
 const DNS_CLASS_IN: u16 = 1;
+const DNS_NAME_MAX_BYTES: usize = 255;
 /// Deadline for the blocking UDP probe on the candidate namespace.
 ///
 /// The async wait adds `PROBE_THREAD_GRACE` so the one-shot thread can publish
@@ -315,7 +318,8 @@ fn probe_dns_endpoint(
                     sleep_before_retry(deadline);
                     continue;
                 };
-                match validate_dns_response(response, transaction_id, DNS_READINESS_IPV4) {
+                match validate_dns_response(response, transaction_id, hostname, DNS_READINESS_IPV4)
+                {
                     Ok(()) => return Ok(attempts),
                     Err(error) => last_error = error.with_attempts(attempts),
                 }
@@ -367,6 +371,7 @@ fn build_dns_query(transaction_id: u16, hostname: &str) -> Result<Vec<u8>, DnsRe
 fn validate_dns_response(
     response: &[u8],
     transaction_id: u16,
+    expected_hostname: &str,
     expected_ip: Ipv4Addr,
 ) -> Result<(), DnsReadinessError> {
     let mut cursor = 0;
@@ -379,6 +384,8 @@ fn validate_dns_response(
 
     if response_id != transaction_id
         || flags & DNS_RESPONSE_FLAG == 0
+        || flags & DNS_RESPONSE_OPCODE_MASK != 0
+        || flags & DNS_RESPONSE_TRUNCATED_FLAG != 0
         || flags & DNS_RESPONSE_CODE_MASK != 0
         || question_count != 1
         || answer_count == 0
@@ -388,11 +395,19 @@ fn validate_dns_response(
         ));
     }
 
-    skip_dns_name(response, &mut cursor)?;
-    skip_bytes(response, &mut cursor, 4)?;
+    let question_name = read_dns_name(response, &mut cursor)?;
+    let question_type = read_u16(response, &mut cursor)?;
+    let question_class = read_u16(response, &mut cursor)?;
+    if !dns_name_matches(&question_name, expected_hostname)
+        || question_type != DNS_TYPE_A
+        || question_class != DNS_CLASS_IN
+    {
+        return Err(invalid_response());
+    }
 
+    let mut found_expected_answer = false;
     for _ in 0..answer_count {
-        skip_dns_name(response, &mut cursor)?;
+        let owner_name = read_dns_name(response, &mut cursor)?;
         let record_type = read_u16(response, &mut cursor)?;
         let class = read_u16(response, &mut cursor)?;
         skip_bytes(response, &mut cursor, 4)?;
@@ -403,15 +418,18 @@ fn validate_dns_response(
         if record_type == DNS_TYPE_A
             && class == DNS_CLASS_IN
             && data_len == 4
+            && dns_name_matches(&owner_name, expected_hostname)
             && response.get(data_start..cursor) == Some(expected_octets.as_ref())
         {
-            return Ok(());
+            found_expected_answer = true;
         }
     }
 
-    Err(DnsReadinessError::stage(
-        DnsReadinessStage::ValidateResponse,
-    ))
+    if found_expected_answer {
+        Ok(())
+    } else {
+        Err(invalid_response())
+    }
 }
 
 fn read_u16(response: &[u8], cursor: &mut usize) -> Result<u16, DnsReadinessError> {
@@ -432,22 +450,64 @@ fn skip_bytes(response: &[u8], cursor: &mut usize, count: usize) -> Result<(), D
     Ok(())
 }
 
-fn skip_dns_name(response: &[u8], cursor: &mut usize) -> Result<(), DnsReadinessError> {
+fn read_dns_name<'a>(
+    response: &'a [u8],
+    cursor: &mut usize,
+) -> Result<Vec<&'a [u8]>, DnsReadinessError> {
+    let mut labels = Vec::new();
+    let mut position = *cursor;
+    let mut encoded_end = None;
+    let mut expanded_len = 1_usize;
+
     loop {
-        let length = *response.get(*cursor).ok_or_else(invalid_response)?;
-        *cursor += 1;
+        let length = *response.get(position).ok_or_else(invalid_response)?;
         if length == 0 {
-            return Ok(());
+            let end = position.checked_add(1).ok_or_else(invalid_response)?;
+            *cursor = encoded_end.unwrap_or(end);
+            return Ok(labels);
         }
         if length & 0xc0 == 0xc0 {
-            skip_bytes(response, cursor, 1)?;
-            return Ok(());
+            let pointer_position = position;
+            let pointer = read_u16(response, &mut position)?;
+            let target = usize::from(pointer & 0x3fff);
+            if target >= pointer_position {
+                return Err(invalid_response());
+            }
+            if encoded_end.is_none() {
+                encoded_end = Some(position);
+            }
+            position = target;
+            continue;
         }
         if length & 0xc0 != 0 {
             return Err(invalid_response());
         }
-        skip_bytes(response, cursor, usize::from(length))?;
+
+        let label_start = position.checked_add(1).ok_or_else(invalid_response)?;
+        let label_end = label_start
+            .checked_add(usize::from(length))
+            .ok_or_else(invalid_response)?;
+        let label = response
+            .get(label_start..label_end)
+            .ok_or_else(invalid_response)?;
+        expanded_len = expanded_len
+            .checked_add(1 + label.len())
+            .ok_or_else(invalid_response)?;
+        if expanded_len > DNS_NAME_MAX_BYTES {
+            return Err(invalid_response());
+        }
+        labels.push(label);
+        position = label_end;
     }
+}
+
+fn dns_name_matches(labels: &[&[u8]], expected_name: &str) -> bool {
+    let mut expected_labels = expected_name.split('.');
+    labels.iter().all(|label| {
+        expected_labels
+            .next()
+            .is_some_and(|expected| label.eq_ignore_ascii_case(expected.as_bytes()))
+    }) && expected_labels.next().is_none()
 }
 
 fn invalid_response() -> DnsReadinessError {
@@ -459,24 +519,81 @@ mod tests {
     use super::*;
     use std::sync::mpsc;
 
-    const TEST_SERVER_WAIT_TIMEOUT: Duration = Duration::from_secs(1);
+    use proptest::prelude::*;
+    use proptest::test_runner::{Config as ProptestConfig, RngSeed};
 
-    fn response_for_query(query: &[u8], answer: Ipv4Addr) -> Vec<u8> {
+    const TEST_SERVER_WAIT_TIMEOUT: Duration = Duration::from_secs(1);
+    const PROPERTY_CASES: u32 = 256;
+    const PROPERTY_SEED: u64 = 0xD05E_3041_9000_0001;
+
+    fn property_config() -> ProptestConfig {
+        ProptestConfig {
+            cases: PROPERTY_CASES,
+            rng_seed: RngSeed::Fixed(PROPERTY_SEED),
+            ..ProptestConfig::default()
+        }
+    }
+
+    fn response_for_query_with_answers(query: &[u8], answer_count: u16) -> Vec<u8> {
         let mut response = Vec::new();
         response.extend_from_slice(query.get(..2).unwrap());
         response.extend_from_slice(&0x8180_u16.to_be_bytes());
         response.extend_from_slice(&1_u16.to_be_bytes());
-        response.extend_from_slice(&1_u16.to_be_bytes());
+        response.extend_from_slice(&answer_count.to_be_bytes());
         response.extend_from_slice(&0_u16.to_be_bytes());
         response.extend_from_slice(&0_u16.to_be_bytes());
         response.extend_from_slice(query.get(12..).unwrap());
-        response.extend_from_slice(&[0xc0, 0x0c]);
-        response.extend_from_slice(&DNS_TYPE_A.to_be_bytes());
-        response.extend_from_slice(&DNS_CLASS_IN.to_be_bytes());
-        response.extend_from_slice(&0_u32.to_be_bytes());
-        response.extend_from_slice(&4_u16.to_be_bytes());
-        response.extend_from_slice(&answer.octets());
         response
+    }
+
+    fn append_answer(
+        response: &mut Vec<u8>,
+        owner: &[u8],
+        record_type: u16,
+        class: u16,
+        data: &[u8],
+    ) {
+        response.extend_from_slice(owner);
+        response.extend_from_slice(&record_type.to_be_bytes());
+        response.extend_from_slice(&class.to_be_bytes());
+        response.extend_from_slice(&0_u32.to_be_bytes());
+        response.extend_from_slice(&u16::try_from(data.len()).unwrap().to_be_bytes());
+        response.extend_from_slice(data);
+    }
+
+    fn response_for_query_with_owner(query: &[u8], owner: &[u8], answer: Ipv4Addr) -> Vec<u8> {
+        let mut response = response_for_query_with_answers(query, 1);
+        append_answer(
+            &mut response,
+            owner,
+            DNS_TYPE_A,
+            DNS_CLASS_IN,
+            &answer.octets(),
+        );
+        response
+    }
+
+    fn response_for_query(query: &[u8], answer: Ipv4Addr) -> Vec<u8> {
+        response_for_query_with_owner(query, &[0xc0, 0x0c], answer)
+    }
+
+    fn question_name(query: &[u8]) -> &[u8] {
+        query.get(12..query.len() - 4).unwrap()
+    }
+
+    fn pointer_to(offset: usize) -> [u8; 2] {
+        (0xc000_u16 | u16::try_from(offset).unwrap()).to_be_bytes()
+    }
+
+    fn write_u16(packet: &mut [u8], offset: usize, value: u16) {
+        packet
+            .get_mut(offset..offset + 2)
+            .unwrap()
+            .copy_from_slice(&value.to_be_bytes());
+    }
+
+    fn validate_readiness_response(response: &[u8]) -> Result<(), DnsReadinessError> {
+        validate_dns_response(response, 0x1234, DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4)
     }
 
     #[test]
@@ -501,7 +618,33 @@ mod tests {
         let query = build_dns_query(0x1234, DNS_READINESS_HOSTNAME).unwrap();
         let response = response_for_query(&query, DNS_READINESS_IPV4);
 
-        validate_dns_response(&response, 0x1234, DNS_READINESS_IPV4).unwrap();
+        validate_readiness_response(&response).unwrap();
+    }
+
+    #[test]
+    fn response_validation_accepts_case_insensitive_uncompressed_names() {
+        let query = build_dns_query(0x1234, "VM0-READINESS.INVALID").unwrap();
+        let response =
+            response_for_query_with_owner(&query, question_name(&query), DNS_READINESS_IPV4);
+
+        validate_readiness_response(&response).unwrap();
+    }
+
+    #[test]
+    fn response_validation_accepts_nested_backward_pointer() {
+        let query = build_dns_query(0x1234, DNS_READINESS_HOSTNAME).unwrap();
+        let mut response = response_for_query_with_answers(&query, 2);
+        let first_owner_offset = response.len();
+        append_answer(&mut response, &[0xc0, 0x0c], 16, DNS_CLASS_IN, &[]);
+        append_answer(
+            &mut response,
+            &pointer_to(first_owner_offset),
+            DNS_TYPE_A,
+            DNS_CLASS_IN,
+            &DNS_READINESS_IPV4.octets(),
+        );
+
+        validate_readiness_response(&response).unwrap();
     }
 
     #[test]
@@ -509,17 +652,174 @@ mod tests {
         let query = build_dns_query(0x1234, DNS_READINESS_HOSTNAME).unwrap();
         let response = response_for_query(&query, Ipv4Addr::new(192, 0, 2, 2));
 
-        assert!(validate_dns_response(&response, 0x4321, DNS_READINESS_IPV4).is_err());
-        assert!(validate_dns_response(&response, 0x1234, DNS_READINESS_IPV4).is_err());
+        assert!(
+            validate_dns_response(
+                &response,
+                0x4321,
+                DNS_READINESS_HOSTNAME,
+                DNS_READINESS_IPV4
+            )
+            .is_err()
+        );
+        assert!(validate_readiness_response(&response).is_err());
     }
 
     #[test]
-    fn response_validation_rejects_truncated_name() {
+    fn response_validation_rejects_mismatched_question_fields() {
         let query = build_dns_query(0x1234, DNS_READINESS_HOSTNAME).unwrap();
-        let mut response = response_for_query(&query, DNS_READINESS_IPV4);
-        response.truncate(13);
+        let response = response_for_query(&query, DNS_READINESS_IPV4);
 
-        assert!(validate_dns_response(&response, 0x1234, DNS_READINESS_IPV4).is_err());
+        let mut wrong_name = response.clone();
+        *wrong_name.get_mut(13).unwrap() = b'x';
+        assert!(validate_readiness_response(&wrong_name).is_err());
+
+        let mut wrong_type = response.clone();
+        write_u16(&mut wrong_type, query.len() - 4, 28);
+        assert!(validate_readiness_response(&wrong_type).is_err());
+
+        let mut wrong_class = response;
+        write_u16(&mut wrong_class, query.len() - 2, 3);
+        assert!(validate_readiness_response(&wrong_class).is_err());
+    }
+
+    #[test]
+    fn response_validation_rejects_mismatched_answer_owner() {
+        let query = build_dns_query(0x1234, DNS_READINESS_HOSTNAME).unwrap();
+        let other_query = build_dns_query(0x1234, "other.invalid").unwrap();
+        let response =
+            response_for_query_with_owner(&query, question_name(&other_query), DNS_READINESS_IPV4);
+
+        assert!(validate_readiness_response(&response).is_err());
+    }
+
+    #[test]
+    fn response_validation_rejects_invalid_headers_counts_and_record_length() {
+        let query = build_dns_query(0x1234, DNS_READINESS_HOSTNAME).unwrap();
+        let response = response_for_query(&query, DNS_READINESS_IPV4);
+
+        for flags in [0x0180, 0x8980, 0x8380, 0x8182] {
+            let mut invalid = response.clone();
+            write_u16(&mut invalid, 2, flags);
+            assert!(validate_readiness_response(&invalid).is_err());
+        }
+
+        for (offset, count) in [(4, 0), (4, 2), (6, 0), (6, 2)] {
+            let mut invalid = response.clone();
+            write_u16(&mut invalid, offset, count);
+            assert!(validate_readiness_response(&invalid).is_err());
+        }
+
+        let mut invalid_length = response;
+        write_u16(&mut invalid_length, query.len() + 10, 5);
+        assert!(validate_readiness_response(&invalid_length).is_err());
+    }
+
+    #[test]
+    fn response_validation_rejects_malformed_names_and_pointers() {
+        let query = build_dns_query(0x1234, DNS_READINESS_HOSTNAME).unwrap();
+
+        let mut question_self_pointer = response_for_query(&query, DNS_READINESS_IPV4);
+        question_self_pointer
+            .get_mut(12..14)
+            .unwrap()
+            .copy_from_slice(&pointer_to(12));
+        assert!(validate_readiness_response(&question_self_pointer).is_err());
+
+        for owner in [pointer_to(query.len()), pointer_to(511), [0x40, 0x00]] {
+            let response = response_for_query_with_owner(&query, &owner, DNS_READINESS_IPV4);
+            assert!(validate_readiness_response(&response).is_err());
+        }
+
+        let mut truncated_pointer = response_for_query(&query, DNS_READINESS_IPV4);
+        truncated_pointer.truncate(query.len() + 1);
+        assert!(validate_readiness_response(&truncated_pointer).is_err());
+
+        let long_label = "a".repeat(63);
+        let overlong_hostname = std::iter::repeat_n(long_label.as_str(), 4)
+            .collect::<Vec<_>>()
+            .join(".");
+        let overlong_query = build_dns_query(0x1234, &overlong_hostname).unwrap();
+        let overlong_response = response_for_query(&overlong_query, DNS_READINESS_IPV4);
+        assert!(
+            validate_dns_response(
+                &overlong_response,
+                0x1234,
+                &overlong_hostname,
+                DNS_READINESS_IPV4
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn response_validation_rejects_every_strict_truncation() {
+        let query = build_dns_query(0x1234, DNS_READINESS_HOSTNAME).unwrap();
+        let response = response_for_query(&query, DNS_READINESS_IPV4);
+
+        for length in 0..response.len() {
+            assert!(
+                validate_readiness_response(response.get(..length).unwrap()).is_err(),
+                "accepted response truncated to {length} bytes"
+            );
+        }
+    }
+
+    proptest! {
+        #![proptest_config(property_config())]
+
+        #[test]
+        fn response_validation_never_panics_for_bounded_bytes(
+            response in proptest::collection::vec(any::<u8>(), 0..=DNS_RESPONSE_MAX_BYTES),
+        ) {
+            let _ = validate_readiness_response(&response);
+        }
+
+        #[test]
+        fn response_validation_never_panics_for_single_byte_mutations(
+            index in any::<usize>(),
+            value in any::<u8>(),
+        ) {
+            let query = build_dns_query(0x1234, DNS_READINESS_HOSTNAME).unwrap();
+            let mut response = response_for_query(&query, DNS_READINESS_IPV4);
+            let response_len = response.len();
+            *response.get_mut(index % response_len).unwrap() = value;
+
+            let _ = validate_readiness_response(&response);
+        }
+    }
+
+    #[test]
+    fn endpoint_probe_rejects_controlled_invalid_response() {
+        let server = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)).unwrap();
+        server
+            .set_read_timeout(Some(TEST_SERVER_WAIT_TIMEOUT))
+            .unwrap();
+        let destination = match server.local_addr().unwrap() {
+            std::net::SocketAddr::V4(address) => address,
+            std::net::SocketAddr::V6(_) => panic!("test server should use IPv4"),
+        };
+        let server_thread = std::thread::spawn(move || -> io::Result<()> {
+            let mut query = [0_u8; DNS_RESPONSE_MAX_BYTES];
+            let (size, peer) = server.recv_from(&mut query)?;
+            let mut response = response_for_query(&query[..size], DNS_READINESS_IPV4);
+            write_u16(&mut response, size - 4, 28);
+            server.send_to(&response, peer)?;
+            Ok(())
+        });
+
+        let result = probe_dns_endpoint(
+            destination,
+            Duration::from_millis(30),
+            DNS_READINESS_HOSTNAME,
+        );
+        let server_result = server_thread.join().unwrap_or_else(|_| {
+            panic!("invalid-response DNS test server at {destination} panicked")
+        });
+
+        server_result.unwrap_or_else(|error| {
+            panic!("invalid-response DNS test server at {destination} failed: {error}")
+        });
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/sandbox-fc/src/network/readiness.rs
+++ b/crates/sandbox-fc/src/network/readiness.rs
@@ -457,6 +457,7 @@ fn read_dns_name<'a>(
     let mut labels = Vec::new();
     let mut position = *cursor;
     let mut encoded_end = None;
+    let mut pointer_limit = position;
     let mut expanded_len = 1_usize;
 
     loop {
@@ -467,12 +468,12 @@ fn read_dns_name<'a>(
             return Ok(labels);
         }
         if length & 0xc0 == 0xc0 {
-            let pointer_position = position;
             let pointer = read_u16(response, &mut position)?;
             let target = usize::from(pointer & 0x3fff);
-            if target >= pointer_position {
+            if target >= pointer_limit {
                 return Err(invalid_response());
             }
+            pointer_limit = target;
             if encoded_end.is_none() {
                 encoded_end = Some(position);
             }
@@ -729,6 +730,12 @@ mod tests {
             let response = response_for_query_with_owner(&query, &owner, DNS_READINESS_IPV4);
             assert!(validate_readiness_response(&response).is_err());
         }
+
+        let answer_offset = query.len();
+        let mut label_cycle = vec![1, b'a'];
+        label_cycle.extend_from_slice(&pointer_to(answer_offset));
+        let response = response_for_query_with_owner(&query, &label_cycle, DNS_READINESS_IPV4);
+        assert!(validate_readiness_response(&response).is_err());
 
         let mut truncated_pointer = response_for_query(&query, DNS_READINESS_IPV4);
         truncated_pointer.truncate(query.len() + 1);


### PR DESCRIPTION
## Summary

- bind DNS readiness responses to the queried hostname, `A` / `IN` question, direct answer owner, and expected IPv4 value
- decode uncompressed names and bounded backward compression pointers while rejecting malformed, cyclic, truncated, and overlong inputs
- reject truncated or nonstandard-opcode responses and validate the complete declared answer section before reporting readiness
- add deterministic parser and loopback endpoint regressions plus fixed-seed bounded property coverage

## Explicit exclusions

- this remains a readiness-specific parser; it does not add general DNS resolution or CNAME-chain support
- authority and additional sections remain outside the direct readiness-answer contract

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p sandbox-fc --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc` (822 unit tests, 1 integration test)
- `cargo check --manifest-path crates/Cargo.toml -p sandbox-fc --locked`

Closes #30419
