### PR TITLE
fix(api): classify connector catalog unavailable errors

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { gunzipSync } from "node:zlib";
 
+import { EVENT } from "@axiomhq/logging";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
 import { cronConnectorCatalogContract } from "@okouai/api-contracts/contracts/cron";
 import { connectorsSlugCallbackContract } from "@okouai/api-contracts/contracts/connectors-slug-callback";
@@ -50,6 +51,8 @@ import { clearMockNow, mockNow, now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import {
   apiTestConnectorCatalogValidationAuthority,
+  clearApiTestConnectorCatalogExternalReaderIdentityReplacements,
+  corruptApiTestConnectorCatalogActiveSnapshotPayload,
   deleteApiTestConnectorCatalogCompatibility,
   deleteApiTestConnectorCatalogCompatibilityEvaluation,
   deleteApiTestConnectorCatalogRuntimeProjectionSet,
@@ -63,6 +66,7 @@ import {
   readApiTestConnectorCatalogRuntimeProjectionAuthority,
   readApiTestConnectorCatalogValidationAuthority,
   replaceApiTestConnectorCatalogStoredBytes,
+  setApiTestConnectorCatalogExternalReaderIdentityReplacements,
   setApiTestConnectorCatalogRuntimeProjectionAuthority,
   setApiTestConnectorCatalogValidationAuthority,
 } from "../../../test-fixtures/connector-catalog";
@@ -1469,6 +1473,57 @@ function runnerFirewallClient() {
   );
 }
 
+async function expectCatalogUnavailableRequestError(
+  reason: string,
+): Promise<void> {
+  const code = `CONNECTOR_CATALOG_UNAVAILABLE:${reason}`;
+  const response = await accept(
+    runnerFirewallClient().resolve({
+      headers: { authorization: OFFICIAL_RUNNER_AUTHORIZATION },
+      body: {},
+    }),
+    [500],
+  );
+
+  expect(response.body).toStrictEqual({ error: "Internal server error" });
+  const capturedError =
+    context.mocks.sentry.captureException.mock.calls.at(-1)?.[0];
+  expect(capturedError).toMatchObject({
+    name: "ExternalConnectorCatalogUnavailableError",
+    message: "Accepted external connector catalog is unavailable",
+    reason,
+    code,
+  });
+
+  const [message, fields] =
+    context.mocks.axiomLogging.error.mock.calls.at(-1) ?? [];
+  expect(message).toBe(
+    "Unhandled request error: Accepted external connector catalog is unavailable",
+  );
+  const logFields = fields as Record<PropertyKey, unknown>;
+  expect(logFields).toMatchObject({
+    type: "unhandled_request_error",
+    errorSummary: "Accepted external connector catalog is unavailable",
+    method: "POST",
+    route: "/api/runners/builtin-firewalls/resolve",
+    errorCode: code,
+    error: expect.objectContaining({
+      name: "ExternalConnectorCatalogUnavailableError",
+      message: "Accepted external connector catalog is unavailable",
+      reason,
+      code,
+    }),
+  });
+  expect(logFields[EVENT]).toMatchObject({
+    source: "api",
+    type: "unhandled_request_error",
+    errorSummary: "Accepted external connector catalog is unavailable",
+    method: "POST",
+    route: "/api/runners/builtin-firewalls/resolve",
+    errorCode: code,
+  });
+}
+
 interface VolumeStorageState {
   readonly s3_prefix: string;
   readonly size: number;
@@ -1646,6 +1701,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  clearApiTestConnectorCatalogExternalReaderIdentityReplacements();
   setApiVersion(DEFAULT_API_VERSION);
   clearMockNow();
 });
@@ -1699,6 +1755,53 @@ describe("connector catalog cron authentication and initial state", () => {
       unresolvedBridgeCredentials: 0,
     });
     expect(context.mocks.s3.send).not.toHaveBeenCalled();
+  });
+});
+
+describe("connector catalog unavailable request telemetry", () => {
+  it("classifies a missing current identity", async () => {
+    expect.hasAssertions();
+    configureSource();
+
+    await expectCatalogUnavailableRequestError("missing_current_identity");
+  });
+
+  it("classifies an invalid persisted compatibility evaluation", async () => {
+    expect.hasAssertions();
+    configureSource();
+    await installApiTestConnectorCatalog();
+    await invalidateApiTestConnectorCatalogCompatibility();
+
+    await expectCatalogUnavailableRequestError(
+      "invalid_compatibility_evaluation",
+    );
+  });
+
+  it("classifies a rejected persisted artifact", async () => {
+    expect.hasAssertions();
+    configureSource();
+    await installApiTestConnectorCatalog();
+    await corruptApiTestConnectorCatalogActiveSnapshotPayload();
+
+    await expectCatalogUnavailableRequestError(
+      "invalid_artifact:invalid-compression",
+    );
+  });
+
+  it("classifies a missing active snapshot after the identity retry", async () => {
+    expect.hasAssertions();
+    configureSource();
+    await installApiTestConnectorCatalog({
+      catalogVersion: "2026-08-31.identity-race-initial",
+    });
+    setApiTestConnectorCatalogExternalReaderIdentityReplacements([
+      "2026-08-31.identity-race-first-replacement",
+      "2026-08-31.identity-race-second-replacement",
+    ]);
+
+    await expectCatalogUnavailableRequestError(
+      "missing_active_snapshot_after_retry",
+    );
   });
 });
 

--- a/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
@@ -1,4 +1,5 @@
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
+import type { ConnectorCatalogSyncFailureCode } from "@okouai/api-contracts/contracts/connector-catalog-diagnostics";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import type { ConnectorResponse } from "@okouai/api-contracts/contracts/connector-schemas";
 import type { ConnectorSearchItem } from "@okouai/api-contracts/contracts/connectors";
@@ -24,7 +25,7 @@ import {
 import { and, eq } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
-import { singleton } from "../../lib/singleton";
+import { singleton, testOverride } from "../../lib/singleton";
 import type { ReadonlyDb } from "../external/db";
 import { onRejection, settle } from "../utils";
 import {
@@ -154,10 +155,44 @@ interface ConnectorCatalogDiscoveryRead {
   readonly referenceMetadata: readonly ConnectorCatalogReferenceMetadata[];
 }
 
+type ExternalConnectorCatalogUnavailableReason =
+  | "missing_current_identity"
+  | "missing_active_snapshot_after_retry"
+  | "invalid_compatibility_evaluation"
+  | `invalid_artifact:${ConnectorCatalogSyncFailureCode}`;
+
 export class ExternalConnectorCatalogUnavailableError extends Error {
-  constructor() {
+  readonly code: `CONNECTOR_CATALOG_UNAVAILABLE:${ExternalConnectorCatalogUnavailableReason}`;
+
+  constructor(readonly reason: ExternalConnectorCatalogUnavailableReason) {
     super("Accepted external connector catalog is unavailable");
     this.name = "ExternalConnectorCatalogUnavailableError";
+    this.code = `CONNECTOR_CATALOG_UNAVAILABLE:${reason}`;
+  }
+}
+
+type ConnectorCatalogExternalReaderIdentityReadHook = () => Promise<void>;
+
+const externalReaderIdentityReadHook = testOverride<
+  ConnectorCatalogExternalReaderIdentityReadHook | undefined
+>(() => {
+  return undefined;
+});
+
+export function setConnectorCatalogExternalReaderIdentityReadHookForTest(
+  hook: ConnectorCatalogExternalReaderIdentityReadHook,
+): void {
+  externalReaderIdentityReadHook.set(hook);
+}
+
+export function clearConnectorCatalogExternalReaderIdentityReadHookForTest(): void {
+  externalReaderIdentityReadHook.clear();
+}
+
+async function runExternalReaderIdentityReadHook(): Promise<void> {
+  const hook = externalReaderIdentityReadHook.get();
+  if (hook) {
+    await hook();
   }
 }
 
@@ -434,7 +469,9 @@ async function readCurrentCatalog(args: {
             failureCode: "invalid-compatibility-evaluation",
           },
         );
-        throw new ExternalConnectorCatalogUnavailableError();
+        throw new ExternalConnectorCatalogUnavailableError(
+          "invalid_compatibility_evaluation",
+        );
       }
       return parsed.data.filteredAuthMethods;
     },
@@ -485,7 +522,9 @@ async function loadCurrentCatalog(args: {
     ...identityLogFields(args.identity),
     failureCode,
   });
-  throw new ExternalConnectorCatalogUnavailableError();
+  throw new ExternalConnectorCatalogUnavailableError(
+    `invalid_artifact:${failureCode}`,
+  );
 }
 
 function deleteInFlightCatalog(
@@ -511,8 +550,11 @@ async function loadAcceptedConnectorCatalogSnapshotAttempt(
     ...(timing === undefined ? {} : { timing }),
   });
   if (!currentIdentity) {
-    throw new ExternalConnectorCatalogUnavailableError();
+    throw new ExternalConnectorCatalogUnavailableError(
+      "missing_current_identity",
+    );
   }
+  await runExternalReaderIdentityReadHook();
   const currentKey = identityKey(currentIdentity);
   const cache = preparedCatalogCache();
   if (cache.completed?.key === currentKey) {
@@ -572,7 +614,9 @@ export async function loadAcceptedConnectorCatalogSnapshot(
   // identity no longer has a row; retry once against the newly active identity.
   const second = await loadAcceptedConnectorCatalogSnapshotAttempt(db, timing);
   if (!second) {
-    throw new ExternalConnectorCatalogUnavailableError();
+    throw new ExternalConnectorCatalogUnavailableError(
+      "missing_active_snapshot_after_retry",
+    );
   }
   return second;
 }

--- a/turbo/apps/api/src/test-fixtures/connector-catalog.ts
+++ b/turbo/apps/api/src/test-fixtures/connector-catalog.ts
@@ -30,6 +30,10 @@ import {
   persistConnectorCatalogCompatibility,
 } from "../signals/services/connector-catalog-compatibility.service";
 import {
+  clearConnectorCatalogExternalReaderIdentityReadHookForTest,
+  setConnectorCatalogExternalReaderIdentityReadHookForTest,
+} from "../signals/services/connector-catalog-external-reader.service";
+import {
   CONNECTOR_CATALOG_RUNTIME_PROJECTION_VERSION,
   clearConnectorCatalogRuntimeProjectionIdentityReadHookForTest,
   persistConnectorCatalogRuntimeProjection,
@@ -245,6 +249,24 @@ export function setApiTestConnectorCatalogRuntimeProjectionIdentityReadHook(
 
 export function clearApiTestConnectorCatalogRuntimeProjectionIdentityReplacements(): void {
   clearConnectorCatalogRuntimeProjectionIdentityReadHookForTest();
+}
+
+export function setApiTestConnectorCatalogExternalReaderIdentityReplacements(
+  catalogVersions: readonly string[],
+): void {
+  let nextIndex = 0;
+  setConnectorCatalogExternalReaderIdentityReadHookForTest(async () => {
+    const catalogVersion = catalogVersions[nextIndex];
+    if (catalogVersion === undefined) {
+      return;
+    }
+    nextIndex += 1;
+    await installApiTestConnectorCatalog({ catalogVersion });
+  });
+}
+
+export function clearApiTestConnectorCatalogExternalReaderIdentityReplacements(): void {
+  clearConnectorCatalogExternalReaderIdentityReadHookForTest();
 }
 
 interface ApiTestConnectorCatalogIdentity {

--- a/turbo/apps/api/src/test-fixtures/connector-catalog.ts
+++ b/turbo/apps/api/src/test-fixtures/connector-catalog.ts
@@ -252,15 +252,13 @@ export function clearApiTestConnectorCatalogRuntimeProjectionIdentityReplacement
 }
 
 export function setApiTestConnectorCatalogExternalReaderIdentityReplacements(
-  catalogVersions: readonly string[],
+  catalogVersions: readonly [first: string, second: string],
 ): void {
-  let nextIndex = 0;
+  const [firstCatalogVersion, secondCatalogVersion] = catalogVersions;
+  let nextCatalogVersion = firstCatalogVersion;
   setConnectorCatalogExternalReaderIdentityReadHookForTest(async () => {
-    const catalogVersion = catalogVersions[nextIndex];
-    if (catalogVersion === undefined) {
-      return;
-    }
-    nextIndex += 1;
+    const catalogVersion = nextCatalogVersion;
+    nextCatalogVersion = secondCatalogVersion;
     await installApiTestConnectorCatalog({ catalogVersion });
   });
 }


### PR DESCRIPTION
## Summary

- require every expected external connector catalog unavailable branch to provide a closed reason
- expose a stable `CONNECTOR_CATALOG_UNAVAILABLE:<reason>` value through the existing root Axiom `errorCode`
- cover missing identity, invalid compatibility, rejected artifacts, and the terminal identity/payload race through the real runner firewall API boundary
- add a deterministic, resettable catalog-rotation fixture for the existing retry branch

## Behavior preserved

- HTTP status and response body remain the existing sanitized `500`
- Sentry capture, error severity, route, and method attribution remain unchanged
- no route catches, client retry changes, catalog synchronization, validation-authority, cache, database, frontend, CLI, or runner behavior changes
- unexpected database, programmer, evaluator, and invariant errors continue to propagate unchanged

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/connector-catalog-external-reader.service.ts apps/api/src/test-fixtures/connector-catalog.ts apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-connector-catalog.test.ts --silent=passed-only` (113 passed)
- `git diff --check`
- pre-commit hooks, including full-workspace Knip and Turbo type checking

Closes #30382
