### PR TITLE
perf(platform): include mermaid lite in vendor chunk

### DIFF
--- a/turbo/apps/platform/scripts/check-build-hash-stability.node.mjs
+++ b/turbo/apps/platform/scripts/check-build-hash-stability.node.mjs
@@ -2,10 +2,11 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { once } from "node:events";
-import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 import {
   brotliCompressSync,
   constants as zlibConstants,
@@ -16,6 +17,8 @@ const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/u;
 const VENDOR_FILE_PATTERN = /^vendor-[^/]+\.js$/u;
 const RUNTIME_FILE_PATTERN = /^rolldown-runtime-[^/]+\.js$/u;
 const WORKER_FILE_PATTERN = /^shared-database-worker-[^/]+\.js$/u;
+const MERMAID_LITE_MODULE_PATH =
+  "/packages/mermaid-lite/dist/mermaid.esm.min.mjs";
 const BASELINE_COMMIT_SHA = "1111111111111111111111111111111111111111";
 const ALTERNATE_COMMIT_SHA = "2222222222222222222222222222222222222222";
 
@@ -41,6 +44,54 @@ const alternateVersion = `${appVersion}-bundle-stability`;
 const sourceMaps = process.argv.includes("--sourcemap");
 const temporaryRoot = await mkdtemp(
   path.join(tmpdir(), "okou-app-hash-stability-"),
+);
+const mutationConfigFile = path.join(temporaryRoot, "vite-mutation.config.mjs");
+
+await writeFile(
+  mutationConfigFile,
+  `import baseConfig from ${JSON.stringify(
+    pathToFileURL(path.join(appDirectory, "vite.config.ts")).href,
+  )};
+
+const mutationTargets = {
+  app: "/apps/platform/src/main.ts",
+  mermaid: ${JSON.stringify(MERMAID_LITE_MODULE_PATH)},
+};
+
+export default (environment) => {
+  const config =
+    typeof baseConfig === "function" ? baseConfig(environment) : baseConfig;
+  const mutation = process.env.OKOU_BUILD_HASH_MUTATION;
+  const target = mutationTargets[mutation];
+  if (!target) {
+    throw new Error(\`Unknown build hash mutation: \${mutation}\`);
+  }
+  return {
+    ...config,
+    plugins: [
+      {
+        enforce: "pre",
+        name: "okou-build-hash-mutation",
+        transform(code, id) {
+          const moduleId = id.replaceAll("\\\\", "/").split("?", 1)[0];
+          if (!moduleId.endsWith(target)) {
+            return;
+          }
+          return {
+            code:
+              code +
+              "\\nglobalThis.__okouBuildHashMutation = " +
+              JSON.stringify(mutation) +
+              ";",
+            map: null,
+          };
+        },
+      },
+      ...(config.plugins ?? []),
+    ],
+  };
+};
+`,
 );
 
 function digest(content) {
@@ -123,11 +174,29 @@ async function describeBuild(outputDirectory) {
       const mapFile = `${result[label].fileName}.map`;
       assert.ok(files.includes(mapFile), `Expected source map: ${mapFile}`);
     }
+    const vendorSourceMap = JSON.parse(
+      await readFile(
+        path.join(assetsDirectory, `${result.vendor.fileName}.map`),
+        "utf8",
+      ),
+    );
+    assert.ok(
+      vendorSourceMap.sources.some((source) => {
+        return source.replaceAll("\\", "/").endsWith(MERMAID_LITE_MODULE_PATH);
+      }),
+      "Expected the vendor source map to include the generated Mermaid module",
+    );
   }
   return result;
 }
 
-async function runBuild({ commitSha, label, outputDirectory, version }) {
+async function runBuild({
+  commitSha,
+  label,
+  mutation,
+  outputDirectory,
+  version,
+}) {
   await rm(outputDirectory, { force: true, recursive: true });
   const arguments_ = [
     "exec",
@@ -139,6 +208,9 @@ async function runBuild({ commitSha, label, outputDirectory, version }) {
     "--logLevel",
     "warn",
   ];
+  if (mutation) {
+    arguments_.push("--config", mutationConfigFile);
+  }
   if (sourceMaps) {
     arguments_.push("--sourcemap");
   }
@@ -148,6 +220,7 @@ async function runBuild({ commitSha, label, outputDirectory, version }) {
       ...process.env,
       OKOU_APP_GIT_COMMIT_SHA: commitSha,
       OKOU_APP_VERSION: version,
+      OKOU_BUILD_HASH_MUTATION: mutation ?? "",
       SENTRY_AUTH_TOKEN: "",
     },
     stdio: "inherit",
@@ -182,6 +255,20 @@ try {
     outputDirectory: path.join(temporaryRoot, "version-change"),
     version: alternateVersion,
   });
+  const appMutation = await runBuild({
+    commitSha: appCommitSha,
+    label: "app-only mutation",
+    mutation: "app",
+    outputDirectory: path.join(temporaryRoot, "app-mutation"),
+    version: appVersion,
+  });
+  const mermaidMutation = await runBuild({
+    commitSha: appCommitSha,
+    label: "Mermaid mutation",
+    mutation: "mermaid",
+    outputDirectory: path.join(temporaryRoot, "mermaid-mutation"),
+    version: appVersion,
+  });
   const canonical = await runBuild({
     commitSha: appCommitSha,
     label: "canonical",
@@ -193,10 +280,22 @@ try {
   for (const label of ["vendor", "runtime"]) {
     assertStable(builds, label);
   }
+  for (const label of ["vendor", "runtime", "worker"]) {
+    assertStable([canonical, appMutation], label);
+  }
+  for (const label of ["runtime", "worker"]) {
+    assertStable([canonical, mermaidMutation], label);
+  }
   assert.notEqual(baseline.app.fileName, canonical.app.fileName);
   assert.notEqual(baseline.app.sha256, canonical.app.sha256);
   assert.notEqual(versionChange.app.fileName, canonical.app.fileName);
   assert.notEqual(versionChange.app.sha256, canonical.app.sha256);
+  assert.notEqual(appMutation.app.fileName, canonical.app.fileName);
+  assert.notEqual(appMutation.app.sha256, canonical.app.sha256);
+  assert.notEqual(mermaidMutation.vendor.fileName, canonical.vendor.fileName);
+  assert.notEqual(mermaidMutation.vendor.sha256, canonical.vendor.sha256);
+  assert.notEqual(mermaidMutation.app.fileName, canonical.app.fileName);
+  assert.notEqual(mermaidMutation.app.sha256, canonical.app.sha256);
 
   process.stdout.write(
     `${JSON.stringify(
@@ -212,13 +311,31 @@ try {
             version: appVersion,
             artifacts: canonical,
           },
+          appMutation: {
+            commitSha: appCommitSha,
+            version: appVersion,
+            artifacts: appMutation,
+          },
+          mermaidMutation: {
+            commitSha: appCommitSha,
+            version: appVersion,
+            artifacts: mermaidMutation,
+          },
           versionChange: {
             commitSha: appCommitSha,
             version: alternateVersion,
             artifacts: versionChange,
           },
         },
-        verifiedStable: ["vendor", "runtime"],
+        verifiedStable: {
+          appMutation: ["vendor", "runtime", "worker"],
+          mermaidMutation: ["runtime", "worker"],
+          metadataChanges: ["vendor", "runtime"],
+        },
+        verifiedInvalidated: {
+          appMutation: ["app"],
+          mermaidMutation: ["app", "vendor"],
+        },
       },
       null,
       2,

--- a/turbo/apps/platform/scripts/check-production-minification.node.mjs
+++ b/turbo/apps/platform/scripts/check-production-minification.node.mjs
@@ -5,7 +5,7 @@ import { URL } from "node:url";
 
 import { loadConfigFromFile } from "vite";
 
-await test("production build emits one node_modules vendor group with isolated metadata", async () => {
+await test("production build emits one deterministic vendor group with isolated metadata", async () => {
   const loaded = await loadConfigFromFile(
     { command: "build", mode: "production" },
     new URL("../vite.config.ts", import.meta.url).pathname,
@@ -23,6 +23,20 @@ await test("production build emits one node_modules vendor group with isolated m
   assert.equal(
     vendorGroup.test.test("/repo/node_modules/react/index.js"),
     true,
+  );
+  assert.equal(
+    vendorGroup.test.test(
+      "/repo/packages/mermaid-lite/dist/mermaid.esm.min.mjs",
+    ),
+    true,
+  );
+  assert.equal(
+    vendorGroup.test.test("/repo/packages/mermaid-lite/src/index.ts"),
+    false,
+  );
+  assert.equal(
+    vendorGroup.test.test("/repo/packages/core/src/resource-registry.ts"),
+    false,
   );
   assert.equal(vendorGroup.test.test("/repo/src/main.ts"), false);
   assert.equal(

--- a/turbo/apps/platform/scripts/check-single-bundle.node.ts
+++ b/turbo/apps/platform/scripts/check-single-bundle.node.ts
@@ -8,6 +8,7 @@ import { build } from "vite";
 
 import {
   RAW_JAVASCRIPT_OUTPUT_LIMIT_BYTES,
+  VENDOR_MODULE_PATTERN,
   applicationBundleViolations,
   applicationJavaScriptBundlePlugin,
   singleWorkerBundleViolations,
@@ -42,6 +43,7 @@ function vendorChunk() {
       "/repo/node_modules/react/index.js",
       "/repo/node_modules/rehype-prism-plus/dist/common.es.js",
       "/repo/node_modules/refractor/lib/common.js",
+      "/repo/packages/mermaid-lite/dist/mermaid.esm.min.mjs",
     ],
     type: "chunk" as const,
   };
@@ -140,6 +142,42 @@ await test("keeps third-party modules only in vendor and rejects extra edges", (
   );
 });
 
+await test("keeps only the generated Mermaid workspace module in vendor", () => {
+  const missingMermaid = applicationBundleViolations([
+    applicationChunk(),
+    {
+      ...vendorChunk(),
+      moduleIds: vendorChunk().moduleIds.filter((moduleId) => {
+        return !moduleId.includes("/packages/mermaid-lite/");
+      }),
+    },
+    runtimeChunk(),
+    workerAsset(),
+  ]);
+  assert.ok(
+    missingMermaid.some((violation) => {
+      return violation.includes("expected exactly one /packages/mermaid-lite/");
+    }),
+  );
+
+  const unrelatedWorkspaceModule =
+    "/repo/packages/core/src/presentation-template-items.ts";
+  assert.deepEqual(
+    applicationBundleViolations([
+      applicationChunk(),
+      {
+        ...vendorChunk(),
+        moduleIds: [...vendorChunk().moduleIds, unrelatedWorkspaceModule],
+      },
+      runtimeChunk(),
+      workerAsset(),
+    ]),
+    [
+      `${VENDOR_FILE}: only node_modules and /packages/mermaid-lite/dist/mermaid.esm.min.mjs may be emitted in the vendor chunk: ${unrelatedWorkspaceModule}`,
+    ],
+  );
+});
+
 await test("allows Prism common and rejects non-common entries", () => {
   assert.deepEqual(applicationBundleViolations(validApplicationOutputs()), []);
 
@@ -204,17 +242,19 @@ await test("emits the fixed page topology and one external worker", async () => 
   const root = await mkdtemp(path.join(tmpdir(), "okou-app-bundles-"));
   const sourceDirectory = path.join(root, "src");
   const vendorDirectory = path.join(root, "node_modules", "fixture-vendor");
+  const mermaidDirectory = path.join(root, "packages", "mermaid-lite", "dist");
 
   try {
     await mkdir(sourceDirectory, { recursive: true });
     await mkdir(vendorDirectory, { recursive: true });
+    await mkdir(mermaidDirectory, { recursive: true });
     await writeFile(
       path.join(root, "index.html"),
       '<script type="module" src="/src/main.js"></script>',
     );
     await writeFile(
       path.join(sourceDirectory, "main.js"),
-      'import SharedDatabaseWorker from "./shared-database-worker.js?sharedworker"; import localeUrl from "./locale.json?url"; import vendor from "fixture-vendor"; new SharedDatabaseWorker({ name: "test" }); console.log(localeUrl, vendor.value);',
+      'import SharedDatabaseWorker from "./shared-database-worker.js?sharedworker"; import localeUrl from "./locale.json?url"; import mermaid from "../packages/mermaid-lite/dist/mermaid.esm.min.mjs"; import vendor from "fixture-vendor"; new SharedDatabaseWorker({ name: "test" }); console.log(localeUrl, mermaid.value, vendor.value);',
     );
     await writeFile(
       path.join(sourceDirectory, "shared-database-worker.js"),
@@ -232,6 +272,10 @@ await test("emits the fixed page topology and one external worker", async () => 
       path.join(vendorDirectory, "index.cjs"),
       'module.exports = { value: "vendor-static" };',
     );
+    await writeFile(
+      path.join(mermaidDirectory, "mermaid.esm.min.mjs"),
+      'export default { value: "mermaid-static" };',
+    );
 
     const result = await build({
       configFile: false,
@@ -244,7 +288,7 @@ await test("emits the fixed page topology and one external worker", async () => 
         rolldownOptions: {
           output: {
             codeSplitting: {
-              groups: [{ name: "vendor", test: /[\\/]node_modules[\\/]/u }],
+              groups: [{ name: "vendor", test: VENDOR_MODULE_PATTERN }],
             },
           },
         },
@@ -269,6 +313,25 @@ await test("emits the fixed page topology and one external worker", async () => 
         return item.type === "chunk" && item.isEntry;
       }).length,
       1,
+    );
+    const emittedVendorChunk = javaScriptOutputs.find((item) => {
+      return (
+        item.type === "chunk" &&
+        /^assets\/vendor-[^/]+\.js$/u.test(item.fileName)
+      );
+    });
+    assert.ok(emittedVendorChunk?.type === "chunk");
+    assert.ok(
+      emittedVendorChunk.moduleIds.some((moduleId) => {
+        return moduleId.endsWith(
+          "/packages/mermaid-lite/dist/mermaid.esm.min.mjs",
+        );
+      }),
+    );
+    assert.ok(
+      emittedVendorChunk.moduleIds.every((moduleId) => {
+        return !moduleId.endsWith("/src/main.js");
+      }),
     );
     for (const pattern of [
       /^assets\/vendor-[^/]+\.js$/u,

--- a/turbo/apps/platform/scripts/single-bundle.ts
+++ b/turbo/apps/platform/scripts/single-bundle.ts
@@ -7,6 +7,12 @@ const SHARED_DATABASE_WORKER_FILE_PATTERN =
 const VENDOR_FILE_PATTERN = /^assets\/vendor-[^/]+\.js$/u;
 const ROLLDOWN_RUNTIME_FILE_PATTERN = /^assets\/rolldown-runtime-[^/]+\.js$/u;
 
+const MERMAID_LITE_MODULE_PATH =
+  "/packages/mermaid-lite/dist/mermaid.esm.min.mjs";
+
+export const VENDOR_MODULE_PATTERN =
+  /(?:[\\/]node_modules[\\/]|[\\/]packages[\\/]mermaid-lite[\\/]dist[\\/]mermaid\.esm\.min\.mjs$)/u;
+
 const FORBIDDEN_BUNDLED_PACKAGES = [
   "@base-org",
   "@clerk/clerk-js",
@@ -63,6 +69,14 @@ function normalizeModuleId(moduleId: string): string {
 
 function isNodeModule(moduleId: string): boolean {
   return normalizeModuleId(moduleId).includes("/node_modules/");
+}
+
+function isMermaidLiteModule(moduleId: string): boolean {
+  return normalizeModuleId(moduleId).endsWith(MERMAID_LITE_MODULE_PATH);
+}
+
+function isVirtualModule(moduleId: string): boolean {
+  return moduleId.startsWith("\0");
 }
 
 function bundledPackage(moduleId: string): string | undefined {
@@ -144,6 +158,47 @@ function chunkViolations(
   return violations;
 }
 
+function mermaidLiteVendorViolations(
+  appChunk: GeneratedChunk,
+  vendorChunk: GeneratedChunk,
+  runtimeChunk: GeneratedChunk,
+): string[] {
+  const violations: string[] = [];
+  const mermaidLiteModules = (vendorChunk.moduleIds ?? []).filter(
+    isMermaidLiteModule,
+  );
+  if (mermaidLiteModules.length !== 1) {
+    violations.push(
+      `${vendorChunk.fileName}: expected exactly one ${MERMAID_LITE_MODULE_PATH} module, found ${mermaidLiteModules.length}`,
+    );
+  }
+  const unrelatedVendorModules = (vendorChunk.moduleIds ?? []).filter(
+    (moduleId) => {
+      return (
+        !isNodeModule(moduleId) &&
+        !isMermaidLiteModule(moduleId) &&
+        !isVirtualModule(moduleId)
+      );
+    },
+  );
+  if (unrelatedVendorModules.length > 0) {
+    violations.push(
+      `${vendorChunk.fileName}: only node_modules and ${MERMAID_LITE_MODULE_PATH} may be emitted in the vendor chunk: ${unrelatedVendorModules.join(", ")}`,
+    );
+  }
+  for (const chunk of [appChunk, runtimeChunk]) {
+    const misplacedMermaidLiteModules = (chunk.moduleIds ?? []).filter(
+      isMermaidLiteModule,
+    );
+    if (misplacedMermaidLiteModules.length > 0) {
+      violations.push(
+        `${chunk.fileName}: ${MERMAID_LITE_MODULE_PATH} must be emitted only in the vendor chunk: ${misplacedMermaidLiteModules.join(", ")}`,
+      );
+    }
+  }
+  return violations;
+}
+
 export function applicationBundleViolations(
   outputs: readonly GeneratedOutput[],
 ): string[] {
@@ -216,6 +271,9 @@ export function applicationBundleViolations(
       `${vendorChunk.fileName}: vendor chunk has no node_modules`,
     );
   }
+  violations.push(
+    ...mermaidLiteVendorViolations(appChunk, vendorChunk, runtimeChunk),
+  );
 
   const rawBytes = javaScriptOutputs.reduce((total, output) => {
     if (output.type === "chunk") {

--- a/turbo/apps/platform/vite.config.ts
+++ b/turbo/apps/platform/vite.config.ts
@@ -9,6 +9,7 @@ import { devArtifactFetchProxy } from "./dev-artifact-fetch-proxy.ts";
 import platformPackage from "./package.json";
 import { clerkCoreHtmlPlugin } from "./scripts/clerk-html.ts";
 import {
+  VENDOR_MODULE_PATTERN,
   applicationJavaScriptBundlePlugin,
   singleWorkerJavaScriptBundlePlugin,
 } from "./scripts/single-bundle.ts";
@@ -80,14 +81,14 @@ export default defineConfig(({ command }) => ({
     sourcemap: !!process.env.SENTRY_AUTH_TOKEN,
     rolldownOptions: {
       output: {
-        // Keep all third-party modules in one cache-stable vendor chunk. The
-        // application entry and Rolldown runtime remain separate generated
-        // chunks, while the SharedWorker is emitted as its own asset.
+        // Keep third-party modules and the pinned generated Mermaid package in
+        // one cache-stable vendor chunk. The application entry and Rolldown
+        // runtime remain separate chunks, while the SharedWorker is an asset.
         codeSplitting: {
           groups: [
             {
               name: "vendor",
-              test: /[\\/]node_modules[\\/]/u,
+              test: VENDOR_MODULE_PATTERN,
             },
           ],
         },


### PR DESCRIPTION
## Summary

- include the exact generated `@okouai/mermaid-lite` ESM artifact in the existing deterministic vendor group alongside `node_modules`
- keep the fixed eager topology unchanged: one entry script, vendor/runtime modulepreloads, one SharedWorker asset, and no dynamic imports
- enforce that Mermaid is present in vendor and that no other filesystem-backed workspace module can leak into it
- extend the production hash matrix so an app-only edit preserves vendor bytes while a Mermaid artifact edit invalidates vendor

## Controlled production build

Measured from base `59721d7915e4013364c4a317728a5ed1a879cebd` with gzip-9 and Brotli-11:

| Initial page JavaScript | Before raw / gzip / Brotli | After raw / gzip / Brotli |
| --- | ---: | ---: |
| App entry | 4,299,929 / 1,069,980 / 818,115 B | 3,418,418 / 844,303 / 638,232 B |
| Vendor | 2,021,284 / 617,208 / 516,542 B | 2,900,967 / 842,865 / 685,329 B |
| Rolldown runtime | 694 / 422 / 373 B | 694 / 422 / 373 B |
| Total | 6,321,907 / 1,687,610 / 1,335,030 B | 6,320,079 / 1,687,590 / 1,323,934 B |

- initial page-JS requests remain **3**: entry plus runtime and vendor modulepreloads
- every page chunk reports `dynamicImports: []`
- preload order remains runtime, then vendor; vendor imports only the runtime
- SharedWorker remains a separate non-page asset at 452,805 raw / 126,152 gzip / 109,052 Brotli bytes
- JavaScript source maps remain three files; total map bytes change from 24,187,503 to 24,189,663 (+2,160 B)

## Hash evidence

- canonical vendor: `vendor-DVqZ5LI5.js`, SHA-256 `6c176e0467dde3ab7d22773446267096fdd5e5e2547eb179230236af20bc062e`
- synthetic app-only edit: vendor, runtime, and worker names and bytes are identical; only the app entry changes
- synthetic Mermaid artifact edit: vendor becomes `vendor-Kma208A4.js`; runtime and worker remain byte-identical, while the entry changes because its static vendor filename changes
- SHA/version-only builds continue to keep vendor and runtime byte-identical
- the vendor source map contains the Mermaid generated source; two independent `sentry-cli sourcemaps inject` runs produced byte-identical trees and the same vendor debug ID (`d93581da-194a-57f0-aced-7af1a05463f3`)

## Verification

- `pnpm --filter @okouai/app lint:build-config`
- `pnpm --filter @okouai/app check-types`
- targeted Prettier, ESLint, and Oxlint checks for the five changed build/test files
- `pnpm --filter @okouai/app run build:verify-hashes -- --sourcemap`
- two local Sentry source-map injection passes followed by a byte-for-byte directory diff

No full Vitest suite, dev server, staging browser, merge automation, or route lazy loading was used.

## Risk

- Mermaid now shares vendor invalidation with npm dependencies by design; conversely, a Mermaid upgrade invalidates the combined vendor chunk.
- This is a cache-boundary change, not an execution deferral: Mermaid remains statically eager and keeps its current module evaluation behavior.
- The exact generated artifact path is deliberately enforced; moving or expanding that package requires an explicit topology update.
- The controller-owned exact-head staging regression gate remains pending before merge.
