### PR TITLE
perf(platform): load google fonts from document head

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -9,6 +9,12 @@
     <title>AI Agents for Real Work — Your Trustworthy AI Teammate | VM0</title>
     <meta charset="UTF-8" />
     <meta name="vm0-api-origin" content="" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
+    />
     <script data-vm0-clerk-bootstrap="">
       (function () {
         var hostname = location.hostname.toLowerCase();

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -1,6 +1,3 @@
-/* Import Noto Sans and JetBrains Mono from Google Fonts - must be first */
-@import url("https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap");
-
 @import "tailwindcss";
 @import "@okouai/ui/styles/globals.css";
 


### PR DESCRIPTION
## Summary

- load the existing Google Fonts stylesheet directly from the document head
- preconnect to the Google Fonts stylesheet and font asset origins
- remove the external CSS import while preserving the same families, weights, and display=swap behavior

## Why

The CSS import makes Google Fonts discovery wait for the application stylesheet. A document-head stylesheet link lets the browser discover it during HTML parsing and request it alongside the application CSS.

## Validation

- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- staged workspace, platform, and API type checks
- pnpm --filter @okouai/app exec vitest run src/views/css/__tests__/entrypoint-safe-area.test.ts
- production Vite build with test Clerk publishable keys
- verified the built HTML contains one Google Fonts stylesheet and both preconnects, while the built CSS contains no Google Fonts import