### PR TITLE
docs(rust): explain exec frame write safety invariants

### DIFF
--- a/crates/vsock-host/src/exec_operation/frame.rs
+++ b/crates/vsock-host/src/exec_operation/frame.rs
@@ -1,3 +1,44 @@
+//! Frame writes are serialized through the shared writer so that operation state and frame bytes
+//! cross their safety boundaries in a fixed order.
+//!
+//! ## Frame-write safety contract
+//!
+//! Each guarded frame write has three states:
+//!
+//! - `NOT_STARTED`: the writer lock is not held yet, or the pre-write decision is still running.
+//!   Dropping the write in this state means no frame bytes could have been emitted.
+//! - `STARTED`: the pre-write decision returned `Write` and the writer is about to, or is already,
+//!   awaiting `write_all`. The write may be partial, so a dropped future or write error poisons
+//!   the connection rather than allowing it to be reused.
+//! - `COMPLETED`: `write_all` returned successfully. Dropping the guard after this state does not
+//!   poison the connection.
+//!
+//! The pre-write callback runs after `Shared::writer` has been acquired and before the
+//! `STARTED` transition. It is therefore the serialized admission point for route and operation
+//! state changes, write observers, and cancellation decisions. A callback that returns `Skip`
+//! exits while the writer is still serialized, without crossing `STARTED`, emitting frame bytes,
+//! or publishing a write-start notification.
+//!
+//! `send_exec_cancel_frame_for_wait_with_write_start` uses that admission point to revalidate the
+//! route immediately before cancellation can be written. When the route is still cancellable, it
+//! marks the host cancellation and sends `write_started_tx` from the callback before returning
+//! `Write`; the generic writer has not yet stored `STARTED` or called `write_all`. When the
+//! operation is already terminal, the callback returns `AlreadyTerminal` as `Skip`, so the stale
+//! cancel frame is not written. Moving either the route revalidation or this notification outside
+//! the writer lock would break the ordering against a terminal result or a reused wire sequence.
+//!
+//! The cancellation and drop regression surface is covered by the named tests in
+//! `crates/vsock-host/src/tests/exec_operation/cancel.rs`, including
+//! `exec_cancel_writer_lock_timeout_before_write_does_not_poison_or_send_frame`,
+//! `exec_cancel_terminal_result_wins_while_cancel_write_is_blocked`,
+//! `exec_write_observer_fires_at_frame_write_boundary`, and
+//! `exec_operation_frame_write_guard_started_drop_poisons_connection`. Supervised cancellation
+//! and route-reuse cases are covered in
+//! `crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs`, including
+//! `supervised_exec_cancel_and_wait_terminal_result_wins_while_cancel_write_is_blocked`,
+//! `supervised_exec_cancel_and_wait_writer_lock_timeout_before_write_cleans_registration`, and
+//! `stale_cancel_handle_does_not_cancel_reused_wire_sequence`.
+
 use std::io;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
@@ -19,17 +60,34 @@ use super::{
     EXEC_OPERATION_FRAME_WRITE_SLOW_THRESHOLD, EXEC_OPERATION_FRAME_WRITE_STARTED,
 };
 
+/// Poisons the connection if a frame write is dropped after its write boundary.
+///
+/// The guard is created before waiting for the serialized writer lock. The guarded operation
+/// stores `STARTED` immediately before `write_all` and `COMPLETED` only after a successful
+/// `write_all`. Its `Drop` implementation consequently treats a dropped `STARTED` write as
+/// potentially partial, while a write dropped before `STARTED` or after `COMPLETED` does not
+/// poison the connection.
 pub(in crate::exec_operation) struct ExecOperationFrameWriteGuard {
     pub(in crate::exec_operation) shared: Arc<Shared>,
     pub(in crate::exec_operation) state: Arc<AtomicU8>,
 }
 
+/// Admission result for a cancel frame.
+///
+/// `AlreadyTerminal` means that route admission or the serialized pre-write check observed that
+/// the operation no longer accepts cancellation. It is a successful no-frame outcome, not proof
+/// that a cancel frame was written.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(in crate::exec_operation) enum ExecCancelFrameWriteOutcome {
     Sent,
     AlreadyTerminal,
 }
 
+/// Decision returned by the serialized pre-write callback.
+///
+/// `Skip` must be decided while the shared writer lock is held. It returns before the write-start
+/// state transition, so the frame-write guard can be dropped without poisoning and no bytes can be
+/// emitted by this frame attempt.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum FrameWriteDecision {
     Write,
@@ -102,6 +160,18 @@ fn mark_exec_operation_host_cancel_requested_for_wait(
     }
 }
 
+/// Admit and write a cancel frame while preserving the cancel-and-wait race boundary.
+///
+/// The route reservation is followed by a serialized pre-write check. That check must remain
+/// inside the shared writer lock so a terminal result cannot be separated from the decision to
+/// write a cancel frame for the same route. `AlreadyTerminal` becomes `Skip`, which leaves the
+/// frame-write state at `NOT_STARTED` and emits no cancel frame.
+///
+/// When cancellation is admitted, the callback marks the host cancellation and sends
+/// `write_started_tx` before returning `Write`. The notification therefore occurs before the
+/// generic writer stores `STARTED` and before `write_all` can emit bytes; it is not a completion
+/// notification. The reservation, state transition, notification, and `Write` decision must keep
+/// this ordering.
 pub(in crate::exec_operation) async fn send_exec_cancel_frame_for_wait_with_write_start(
     shared: &Arc<Shared>,
     route_id: RouteId,
@@ -243,6 +313,11 @@ pub(in crate::exec_operation) async fn write_frame(
     .await
 }
 
+/// Write an exec-start frame through the serialized frame-write lifecycle.
+///
+/// Admission and write observers run in the pre-write callback while the writer lock is held and
+/// before the guarded write crosses `STARTED`. They therefore describe the write boundary rather
+/// than successful completion.
 pub(in crate::exec_operation) async fn write_exec_start_frame(
     shared: &Arc<Shared>,
     route_id: RouteId,
@@ -270,6 +345,11 @@ pub(in crate::exec_operation) async fn write_exec_start_frame(
     .await
 }
 
+/// Run a pre-write callback and then write a typed frame while holding the writer serialization.
+///
+/// The callback runs after the writer lock is acquired and before the write-start state transition.
+/// Callers use this point for state admission and observers that must be ordered before any frame
+/// bytes are emitted.
 pub(in crate::exec_operation) async fn write_frame_with_pre_write(
     shared: &Arc<Shared>,
     msg_type: u8,
@@ -287,6 +367,11 @@ pub(in crate::exec_operation) async fn write_frame_with_pre_write(
     Ok(())
 }
 
+/// Run a pre-write callback and then write already encoded frame data.
+///
+/// The callback has the same serialized pre-write contract as
+/// `write_frame_with_pre_write`; the encoded-data form keeps the state transition and poisoning
+/// behavior in the shared writer implementation below.
 pub(in crate::exec_operation) async fn write_encoded_frame_with_pre_write(
     shared: &Arc<Shared>,
     data: &[u8],
@@ -314,6 +399,13 @@ async fn write_frame_with_pre_write_decision(
     write_encoded_frame_with_pre_write_decision(shared, &data, diagnostic, pre_write).await
 }
 
+/// Perform the serialized frame write and enforce its cancellation safety boundaries.
+///
+/// The writer lock is acquired before `pre_write` is called. A `Skip` decision returns while that
+/// lock is held and before `STARTED` is stored. For a `Write` decision, `STARTED` is stored
+/// immediately before `write_all`; `COMPLETED` is stored only after `write_all` succeeds. Keep the
+/// frame-write guard alive across the whole operation so dropping a future during the possible
+/// partial-write window poisons the connection.
 async fn write_encoded_frame_with_pre_write_decision(
     shared: &Arc<Shared>,
     data: &[u8],


### PR DESCRIPTION
## Summary

- Document the exec frame-write lifecycle and connection-poisoning contract.
- Explain serialized pre-write admission, cancel route revalidation, `AlreadyTerminal`/`Skip`, and write-start notification ordering.
- Cross-reference the existing one-shot and supervised cancellation/drop regression tests.

## Scope

- Documentation-only change in `crates/vsock-host/src/exec_operation/frame.rs`.
- No runtime behavior, protocol, route reservation, notification timing, or test logic changed.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo check --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-host --no-deps`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host` (387 passed)

Closes #30445
