### PR TITLE
test(platform): stabilize terminal activity event polling

### DIFF
--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-paged-events.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-paged-events.test.tsx
@@ -229,6 +229,7 @@ describe("activity paged events", () => {
   });
 
   it("polls until the terminal event watermark is visible and then stops", async () => {
+    const finalEventRequestStarted = context.mocks.deferred<void>();
     let requestCount = 0;
     const requestedSequences: (number | undefined)[] = [];
 
@@ -256,6 +257,7 @@ describe("activity paged events", () => {
             lastEventSequence: 1,
           } satisfies AgentEventsResponse);
         }
+        finalEventRequestStarted.resolve();
         return respond(200, {
           events: [makeAssistantEvent(1, "Final indexed event")],
           hasMore: false,
@@ -270,6 +272,7 @@ describe("activity paged events", () => {
       path: "/activities/a0000000-0000-4000-a000-000000000099",
     });
 
+    await finalEventRequestStarted.promise;
     const finalEvent = await screen.findByText("Final indexed event");
     expect(finalEvent).toBeInTheDocument();
     expect(screen.getByText("Running event")).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- wait for the third terminal-watermark event request before starting the DOM visibility assertion
- preserve the exact polling sequence, terminal event rendering, and previously rendered event coverage

## Root cause

The page-level test started Testing Library's default `findByText` observation window at page bootstrap, before the poller completed the three mocked event requests required by the scenario. The same test took 945 ms in a successful PR run and timed out under merge-queue coverage load before the final event became visible.

This is a test synchronization race. Production polling still reached the expected third request and no user-visible product race was demonstrated.

Failed job: https://github.com/vm0-ai/vm0/actions/runs/33361134441/job/99392612078

## Scope

Test-only synchronization change. This does not change production polling behavior, poll intervals, retries, timeouts, or coverage.

## Validation

- named Vitest case in 5 sequential fresh processes: 5/5 passed
- complete `activity-paged-events.test.tsx`: 8/8 passed
- named Vitest case with V8 coverage enabled
- `pnpm exec prettier --check apps/platform/src/views/activity-page/__tests__/activity-paged-events.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
