### PR TITLE
feat(mitm-addon): support brotli streaming usage inspection

### DIFF
--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -2,7 +2,7 @@
 
 Exports:
 
-- Bounded streaming usage decoding for gzip, deflate; one-shot
+- Bounded streaming usage decoding for gzip, deflate, br; one-shot
   decompression for gzip, deflate, br, zstd.
 - Request and response network-log capture decoding that hides failed bodies.
 - JSON usage decompression with diagnostic error classification.
@@ -42,7 +42,7 @@ _STREAM_ZLIB_WBITS_BY_ENCODING = {
     "gzip": 16 + zlib.MAX_WBITS,
     "deflate": zlib.MAX_WBITS,
 }
-_STREAM_DECODABLE_CONTENT_ENCODINGS = (*_STREAM_ZLIB_WBITS_BY_ENCODING, "identity")
+_STREAM_DECODABLE_CONTENT_ENCODINGS = (*_STREAM_ZLIB_WBITS_BY_ENCODING, "br", "identity")
 _SUPPORTED_ONE_SHOT_BODY_ENCODINGS = frozenset({"gzip", "deflate", "br", "zstd"})
 
 
@@ -193,8 +193,75 @@ def _create_zlib_stream_decode_session(
     return StreamDecodeSession(decode, finish_error)
 
 
+def _create_brotli_stream_decode_session(
+    feed: _StreamDecodeFeed,
+    *,
+    max_decoded_chunk: int,
+    should_continue: _StreamDecodeShouldContinue | None,
+) -> StreamDecodeSession:
+    obj = brotli.Decompressor()
+    compressed_bytes_seen = 0
+    decode_error: str | None = None
+    decoded_bytes_emitted = 0
+    inspection_stopped = False
+    saw_input = False
+
+    def decode(chunk: bytes) -> None:
+        nonlocal compressed_bytes_seen, decode_error, decoded_bytes_emitted
+        nonlocal inspection_stopped, saw_input
+        if decode_error is not None or inspection_stopped:
+            return
+        if chunk:
+            saw_input = True
+            compressed_bytes_seen += len(chunk)
+
+        pending_input = chunk
+        while True:
+            allowed_decoded_bytes = max(
+                STREAM_DECODE_EXPANSION_GRACE,
+                compressed_bytes_seen * STREAM_DECODE_MAX_EXPANSION_RATIO,
+            )
+            remaining_decoded_bytes = allowed_decoded_bytes - decoded_bytes_emitted
+            try:
+                decoded = obj.process(
+                    pending_input,
+                    output_buffer_limit=min(max_decoded_chunk, remaining_decoded_bytes + 1),
+                )
+            except brotli.error:
+                decode_error = INVALID_COMPRESSED_BODY
+                return
+            pending_input = b""
+
+            accepted = decoded[:remaining_decoded_bytes]
+            for offset in range(0, len(accepted), max_decoded_chunk):
+                decoded_chunk = accepted[offset : offset + max_decoded_chunk]
+                decoded_bytes_emitted += len(decoded_chunk)
+                feed(decoded_chunk)
+                if should_continue is not None and not should_continue():
+                    inspection_stopped = True
+                    return
+            if len(decoded) > remaining_decoded_bytes:
+                decode_error = DECODED_BODY_LIMIT_EXCEEDED
+                return
+            if obj.is_finished():
+                return
+            if not decoded and obj.can_accept_more_data():
+                return
+
+    def finish_error() -> str | None:
+        if decode_error is not None:
+            return decode_error
+        if inspection_stopped:
+            return None
+        if saw_input and not obj.is_finished():
+            return INCOMPLETE_COMPRESSED_BODY
+        return None
+
+    return StreamDecodeSession(decode, finish_error)
+
+
 def stream_decodable_content_encodings() -> tuple[str, ...]:
-    """Return ordered content codings supported by bounded streaming decode."""
+    """Return ordered content codings supported by streaming inspection."""
     return _STREAM_DECODABLE_CONTENT_ENCODINGS
 
 
@@ -203,8 +270,6 @@ def _stream_decode_skip_reason(encoding: str) -> str | None:
         return None
     if encoding == "zstd":
         return "zstd streaming output cannot be hard-bounded"
-    if encoding == "br":
-        return "brotli streaming output cannot be bounded"
     return "unsupported content encoding"
 
 
@@ -236,11 +301,20 @@ def create_stream_decode_session(
 
     Usage parsers are bounded-state scanners and may need to inspect long
     responses, so this helper does not enforce a fixed total decoded-byte cap.
-    For gzip and deflate, one response-scoped budget bounds cumulative decoded
-    output to the larger of the streaming grace or compressed bytes seen times
-    the maximum expansion ratio. The budget is shared across callbacks and
-    concatenated members. Each decoded parser chunk is bounded independently.
-    Returns None when a content encoding cannot be safely decoded incrementally.
+    For compressed encodings, one response-scoped budget bounds cumulative
+    decoded output to the larger of the streaming grace or compressed bytes
+    seen times the maximum expansion ratio. The budget is shared across
+    callbacks and concatenated zlib members. Each decoded parser chunk is
+    bounded independently.
+
+    Brotli 1.2's ``output_buffer_limit`` is a soft allocation threshold and a
+    call may return more bytes than requested. Supporting Brotli streaming
+    intentionally accepts that transient overshoot. Returned output is still
+    split before parser delivery and charged against the response-scoped
+    expansion budget, but this helper does not promise a byte-exact bound on
+    the Brotli binding's temporary output allocation.
+
+    Returns None when a content encoding cannot be decoded incrementally.
 
     The returned session exposes ``finish_error()`` so billing paths can reject
     parser state from compressed streams that never reached a valid frame/member
@@ -271,6 +345,12 @@ def create_stream_decode_session(
                 inspection_stopped = True
 
         return StreamDecodeSession(feed_until_stopped, _no_stream_decode_error)
+    if encoding == "br":
+        return _create_brotli_stream_decode_session(
+            feed,
+            max_decoded_chunk=max_decoded_chunk,
+            should_continue=should_continue,
+        )
     return _create_zlib_stream_decode_session(
         feed,
         encoding_label=encoding,

--- a/crates/runner/mitm-addon/src/body_limits.py
+++ b/crates/runner/mitm-addon/src/body_limits.py
@@ -24,18 +24,21 @@ DEFAULT_BODY_DECODE_LIMIT = _SMALL_BODY_LIMIT_BYTES
 # bodies from request stream buffers.
 REQUEST_BODY_BILLING_INSPECTION_LIMIT = STREAM_BUFFER_LIMIT
 
-# Maximum decoded chunk size fed to incremental usage parsers. This bounds
-# transient decompressor output independently of the response-level expansion
-# budget below.
+# Maximum decoded chunk size fed to incremental usage parsers. gzip/deflate
+# also enforce this as a hard decompressor output limit. Brotli 1.2 treats its
+# output_buffer_limit as a soft allocation threshold, so supporting br accepts
+# that the decoder may transiently return more; body_decoding slices that output
+# before parser delivery.
 STREAM_DECODE_CHUNK_LIMIT = 64 * 1024  # 64 KB
 
-# Initial decoded-output allowance for streaming gzip/deflate usage inspection.
+# Initial decoded-output allowance for streaming compressed usage inspection.
 # This permits small or initially bursty compressed bodies without imposing a
-# fixed total cap on long, low-ratio streams.
+# fixed total cap on long, low-ratio streams. It limits bytes delivered to
+# parsers, not Brotli's transient output allocation described above.
 STREAM_DECODE_EXPANSION_GRACE = 5 * 1024 * 1024  # 5 MB
 
 # Maximum cumulative decoded bytes allowed per compressed byte seen by a
-# streaming gzip/deflate response session, after the grace allowance is spent.
+# streaming compressed response session, after the grace allowance is spent.
 STREAM_DECODE_MAX_EXPANSION_RATIO = 100
 
 # Decompression cap for production model-provider and connector JSON usage

--- a/crates/runner/mitm-addon/src/response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/src/response_encoding_negotiation.py
@@ -32,7 +32,8 @@ def normalize_accept_encoding_for_body_inspection(
 
     The proxy inspects selected upstream responses for usage/billing.  For those
     requests, avoid negotiating encodings whose Python streaming decoders cannot
-    provide the needed bounded-output behavior.
+    provide the needed bounded-output behavior. Brotli participates under the
+    documented soft output-limit contract in ``body_decoding``.
 
     The helper preserves explicit requester rejections.  When ``identity`` and
     every supported compression coding are rejected, the original header remains

--- a/crates/runner/mitm-addon/tests/body_decode_helpers.py
+++ b/crates/runner/mitm-addon/tests/body_decode_helpers.py
@@ -30,6 +30,9 @@ def track_brotli_decompressor(monkeypatch):
         def is_finished(self) -> bool:
             return self._inner.is_finished()
 
+        def can_accept_more_data(self) -> bool:
+            return self._inner.can_accept_more_data()
+
     monkeypatch.setattr("body_decoding.brotli.Decompressor", CountingDecompressor)
     return stats
 

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -108,6 +108,7 @@ class TestStreamDecodeSession:
         compressed_by_encoding = {
             "gzip": gzip.compress(plaintext),
             "deflate": zlib.compress(plaintext),
+            "br": brotli.compress(plaintext),
         }
 
         for encoding, compressed in compressed_by_encoding.items():
@@ -134,6 +135,17 @@ class TestStreamDecodeSession:
         session.feed(compressed[:-1])
 
         assert b"".join(chunks) == plaintext
+        assert session.finish_error() == "incomplete compressed body"
+
+    def test_brotli_session_reports_truncated_stream(self, headers):
+        plaintext = b'{"model":"claude-sonnet-4-6","usage":{"input_tokens":42}}'
+        compressed = brotli.compress(plaintext)
+        chunks: list[bytes] = []
+        session = create_stream_decode_session(headers(("Content-Encoding", "br")), chunks.append)
+        assert session is not None
+
+        session.feed(compressed[:-1])
+
         assert session.finish_error() == "incomplete compressed body"
 
     @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
@@ -264,6 +276,33 @@ class TestStreamDecodeSession:
         assert len(chunks) > 1
         assert max(len(chunk) for chunk in chunks) <= STREAM_DECODE_CHUNK_LIMIT
         assert session.finish_error() is None
+
+    def test_brotli_high_ratio_output_is_chunked(self, headers):
+        plaintext = b"A" * (STREAM_DECODE_CHUNK_LIMIT * 3 + 123)
+        chunks: list[bytes] = []
+        session = create_stream_decode_session(headers(("Content-Encoding", "br")), chunks.append)
+        assert session is not None
+
+        session.feed(brotli.compress(plaintext))
+
+        assert b"".join(chunks) == plaintext
+        assert len(chunks) > 1
+        assert max(len(chunk) for chunk in chunks) <= STREAM_DECODE_CHUNK_LIMIT
+        assert session.finish_error() is None
+
+    def test_brotli_high_ratio_output_stops_at_expansion_budget(self, headers):
+        plaintext = b"A" * (8 * 1024 * 1024)
+        compressed = brotli.compress(plaintext)
+        assert len(compressed) * STREAM_DECODE_MAX_EXPANSION_RATIO < STREAM_DECODE_EXPANSION_GRACE
+        chunks: list[bytes] = []
+        session = create_stream_decode_session(headers(("Content-Encoding", "br")), chunks.append)
+        assert session is not None
+
+        session.feed(compressed)
+
+        assert b"".join(chunks) == plaintext[:STREAM_DECODE_EXPANSION_GRACE]
+        assert max(len(chunk) for chunk in chunks) <= STREAM_DECODE_CHUNK_LIMIT
+        assert session.finish_error() == "decoded body limit exceeded"
 
     @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
     def test_document_parser_termination_stops_zlib_traversal(self, headers, monkeypatch, encoding):
@@ -437,11 +476,22 @@ class TestStreamDecodeSession:
         assert chunks == []
         assert session.finish_error() == "invalid compressed body"
 
-    def test_brotli_unsafe_encoding_does_not_feed(self, headers):
+    def test_brotli_error_short_circuits(self, headers, monkeypatch):
+        stats = track_brotli_decompressor(monkeypatch)
         chunks: list[bytes] = []
         session = create_stream_decode_session(headers(("Content-Encoding", "br")), chunks.append)
-        assert session is None
+        assert session is not None
+
+        session.feed(b"not brotli at all")
+        calls_after_error = stats["calls"]
+        session.feed(b"more garbage")
+
         assert chunks == []
+        assert stats["calls"] == calls_after_error
+        assert session.finish_error() == "invalid compressed body"
+
+    def test_brotli_can_stream_decode_usage_is_true(self, headers):
+        assert can_stream_decode_usage(headers(("Content-Encoding", "br"))) is True
 
     def test_zstd_unsafe_encoding_does_not_feed(self, headers):
         chunks: list[bytes] = []

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -115,7 +115,7 @@ class TestXStreamPathRouting:
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
-    def test_brotli_stream_path_skips_response_body_parser(self, real_flow, mitm_ctx):
+    def test_brotli_stream_path_registers_response_body_parser(self, real_flow, mitm_ctx):
         flow = self._make_x_response_flow(real_flow, "/2/tweets/search/stream")
         assert flow.response is not None
         flow.response.headers = header_map(
@@ -126,8 +126,10 @@ class TestXStreamPathRouting:
             mitm_addon.responseheaders(flow)
 
         assert callable(response_stream(flow))
-        assert metadata_keys.X_NDJSON_STATE not in flow.metadata
-        assert "connector_response_finish" not in flow.metadata
+        assert metadata_keys.X_NDJSON_STATE in flow.metadata
+        assert "connector_response_finish" in flow.metadata
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
     def test_unregistered_parser_factory_does_not_require_original_url(self, real_flow):
         flow = self._make_x_response_flow(real_flow, "/2/tweets/search/stream")

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -1677,7 +1677,7 @@ def test_uninspectable_billable_success_is_not_reported_as_provider_failure(
         response_headers=header_map(
             {
                 "content-type": "text/event-stream",
-                "content-encoding": "br",
+                "content-encoding": "zstd",
             }
         ),
     )

--- a/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
@@ -587,10 +587,9 @@ class TestModelProviderJsonStreaming:
         MODEL_PROVIDER_JSON_CASES,
         ids=model_provider_json_case_id,
     )
-    def test_full_pipeline_brotli_model_json_uses_bounded_fallback(
+    def test_full_pipeline_brotli_model_json_streams_usage(
         self, tmp_path, real_flow, provider_case
     ):
-        """Brotli streaming decode is skipped, but bounded JSON fallback remains active."""
         flow = model_provider_flow(
             real_flow,
             tmp_path,
@@ -605,9 +604,11 @@ class TestModelProviderJsonStreaming:
         )
 
         mitm_addon.responseheaders(flow)
-        response_stream(flow)(compressed)
-        assert metadata_keys.STREAM_BUFFER in flow.metadata
-        assert metadata_keys.STREAM_BUFFER_STATE in flow.metadata
+        midpoint = len(compressed) // 2
+        response_stream(flow)(compressed[:midpoint])
+        response_stream(flow)(compressed[midpoint:])
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
         webhook = run_response(flow, self._usage_webhook_api)
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_parser_setup.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_parser_setup.py
@@ -68,7 +68,7 @@ class TestResponseHeadersModelJsonParser:
             "tokens.output": 7,
         }
 
-    def test_brotli_model_json_skips_incremental_parser(self, real_flow, mitm_ctx):
+    def test_brotli_model_json_uses_incremental_parser(self, real_flow, mitm_ctx):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.response = tutils.tresp(
             status_code=200,
@@ -82,7 +82,7 @@ class TestResponseHeadersModelJsonParser:
             mitm_addon.responseheaders(flow)
 
         assert callable(response_stream(flow))
-        assert "model_json_usage_finish" not in flow.metadata
+        assert "model_json_usage_finish" in flow.metadata
         assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
 
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage_openai_responses.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage_openai_responses.py
@@ -14,10 +14,6 @@ import body_decoding
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 from tests.flow_helpers import response_stream
-from tests.jsonl_log_helpers import (
-    jsonl_exists_after_flush,
-    read_jsonl_entries_after_flush,
-)
 from tests.model_provider_flow_helpers import RealFlowFactory, model_usage_source_entries
 from tests.model_provider_sse_usage_helpers import (
     assert_single_model_sse_parse_warning,
@@ -163,7 +159,7 @@ class TestOpenAIResponsesSseUsage:
         assert model_sse_parse_warnings(flow) == []
 
     @pytest.mark.parametrize("capture_body", [False, True])
-    def test_brotli_sse_is_rejected_without_body_capture(self, tmp_path, real_flow, capture_body):
+    def test_brotli_sse_reports_usage(self, tmp_path, real_flow, capture_body):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         assert flow.response is not None
         flow.response.headers["content-encoding"] = "br"
@@ -176,22 +172,21 @@ class TestOpenAIResponsesSseUsage:
         )
 
         mitm_addon.responseheaders(flow)
-        assert flow.response.status_code == 502
-        assert response_stream(flow)(brotli.compress(plaintext)) == b""
-        assert metadata_keys.STREAM_BUFFER not in flow.metadata
-        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
+        assert flow.response.status_code == 200
+        compressed = brotli.compress(plaintext)
+        midpoint = len(compressed) // 2
+        assert response_stream(flow)(compressed[:midpoint]) == compressed[:midpoint]
+        assert response_stream(flow)(compressed[midpoint:]) == compressed[midpoint:]
+        assert (metadata_keys.STREAM_BUFFER in flow.metadata) is capture_body
+        assert (metadata_keys.STREAM_BUFFER_STATE in flow.metadata) is capture_body
 
         webhook = run_response(flow, self._usage_webhook_api)
 
-        assert webhook.request_count == 0
-        proxy_log = Path(flow.metadata[metadata_keys.SANDBOX_PROXY_LOG_PATH])
-        entries = (
-            read_jsonl_entries_after_flush(proxy_log) if jsonl_exists_after_flush(proxy_log) else []
-        )
-        assert not any(
-            entry.get("message") == "Model provider JSON usage extraction failed"
-            for entry in entries
-        )
+        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
+            "tokens.input": 50,
+            "tokens.output": 20,
+        }
+        assert model_sse_parse_warnings(flow) == []
 
     def test_full_pipeline_model_sse_reports_response_incomplete_usage(self, tmp_path, real_flow):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)

--- a/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
+++ b/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
@@ -507,7 +507,7 @@ class TestOpenAIChatCompletionsUsage:
             "tokens.output": 5,
         }
 
-    def test_brotli_json_uses_buffered_fallback(
+    def test_brotli_json_uses_streaming_parser(
         self,
         tmp_path,
         real_flow,
@@ -525,9 +525,11 @@ class TestOpenAIChatCompletionsUsage:
         compressed = brotli.compress(body)
 
         mitm_addon.responseheaders(flow)
-        assert "model_json_usage_finish" not in flow.metadata
-        assert response_stream(flow)(compressed) == compressed
-        assert flow.metadata[metadata_keys.STREAM_BUFFER] == bytearray(compressed)
+        assert "model_json_usage_finish" in flow.metadata
+        midpoint = len(compressed) // 2
+        assert response_stream(flow)(compressed[:midpoint]) == compressed[:midpoint]
+        assert response_stream(flow)(compressed[midpoint:]) == compressed[midpoint:]
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
 
         webhook = _run_response(flow, self._usage_webhook_api)
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
@@ -822,7 +822,7 @@ async def test_billable_model_provider_rejects_uninspectable_response_and_drains
         sandbox_fields={"modelUsageProvider": "claude-sonnet-4-6"},
     )
     flow = _model_provider_tracking_flow(real_flow)
-    flow.request.headers["Accept-Encoding"] = "br, identity;q=0"
+    flow.request.headers["Accept-Encoding"] = "zstd, identity;q=0"
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url=usage_webhook_server.api_url),
@@ -830,7 +830,7 @@ async def test_billable_model_provider_rejects_uninspectable_response_and_drains
     ):
         await mitm_addon.request(flow)
 
-        assert flow.request.headers["Accept-Encoding"] == "br, identity;q=0"
+        assert flow.request.headers["Accept-Encoding"] == "zstd, identity;q=0"
         assert (
             flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION]
             == "preserved_client_constraints"
@@ -849,7 +849,7 @@ async def test_billable_model_provider_rejects_uninspectable_response_and_drains
             b"",
             {
                 "Content-Type": "text/event-stream",
-                "Content-Encoding": "br",
+                "Content-Encoding": "zstd",
             },
         )
         mitm_addon.responseheaders(flow)

--- a/crates/runner/mitm-addon/tests/test_response_encoding_inspection_risk.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_inspection_risk.py
@@ -67,14 +67,6 @@ class TestResponseEncodingInspectionRisk:
                 id="model-json-zstd",
             ),
             pytest.param(
-                "br",
-                "text/event-stream",
-                "brotli streaming output cannot be bounded",
-                True,
-                False,
-                id="model-sse-brotli",
-            ),
-            pytest.param(
                 "private-encoding-value",
                 "application/json",
                 "unsupported content encoding",
@@ -147,10 +139,11 @@ class TestResponseEncodingInspectionRisk:
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
+    @pytest.mark.parametrize("content_encoding", ["gzip", "br"])
     def test_stream_safe_model_response_keeps_parser_without_risk(
-        self, real_flow, tmp_path, mitm_ctx
+        self, real_flow, tmp_path, mitm_ctx, content_encoding: str
     ) -> None:
-        flow = self._model_flow(real_flow, tmp_path, content_encoding="gzip")
+        flow = self._model_flow(real_flow, tmp_path, content_encoding=content_encoding)
 
         with mitm_ctx():
             mitm_addon.responseheaders(flow)
@@ -283,20 +276,18 @@ class TestResponseEncodingInspectionRisk:
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
-    @pytest.mark.parametrize("content_encoding", ["br", "zstd"])
     def test_billable_connector_stream_rejects_non_streamable_encoding(
         self,
         real_flow,
         tmp_path,
         mitm_ctx,
-        content_encoding: str,
     ) -> None:
         flow = make_x_pipeline_flow(
             real_flow,
             tmp_path,
             path="/2/tweets/search/stream",
             rule="GET /2/tweets/search/stream",
-            content_encoding=content_encoding,
+            content_encoding="zstd",
         )
         flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] = "rewritten_stream_decodable"
 

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -42,8 +42,8 @@ _BROWSER_USER_AGENT = (
         ),
         pytest.param(
             [("Accept-Encoding", "gzip, zstd, br")],
-            ["gzip"],
-            id="drops-unsafe-keeps-gzip",
+            ["gzip, br"],
+            id="drops-zstd-keeps-stream-decodable-codings",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip;q=0, deflate;q=0.5, identity;q=1")],
@@ -82,8 +82,8 @@ _BROWSER_USER_AGENT = (
         ),
         pytest.param(
             [("Accept-Encoding", "zstd, br, *")],
-            ["identity"],
-            id="unsafe-only-falls-back-to-identity",
+            ["br"],
+            id="drops-zstd-and-wildcard-keeps-brotli",
         ),
         pytest.param(
             [("Accept-Encoding", "identity;q=0, zstd")],
@@ -97,27 +97,27 @@ _BROWSER_USER_AGENT = (
         ),
         pytest.param(
             [("Accept-Encoding", "zstd, br, *;q=0.5, identity;q=0")],
-            ["gzip;q=0.5, deflate;q=0.5, identity;q=0"],
+            ["br, gzip;q=0.5, deflate;q=0.5, identity;q=0"],
             id="wildcard-allows-safe-compression-when-identity-rejected",
         ),
         pytest.param(
             [("Accept-Encoding", "zstd, br, *, identity;q=0")],
-            ["gzip, deflate, identity;q=0"],
+            ["br, gzip, deflate, identity;q=0"],
             id="wildcard-default-q-allows-safe-compression-when-identity-rejected",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip;q=0, zstd, *;q=0.5, identity;q=0")],
-            ["deflate;q=0.5, identity;q=0"],
+            ["deflate;q=0.5, br;q=0.5, identity;q=0"],
             id="wildcard-safe-compression-respects-explicit-safe-rejection",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip;q=0.2, zstd, *;q=0.8, identity;q=0")],
-            ["gzip;q=0.2, deflate;q=0.8, identity;q=0"],
+            ["gzip;q=0.2, deflate;q=0.8, br;q=0.8, identity;q=0"],
             id="wildcard-adds-missing-safe-compression-after-explicit-safe-coding",
         ),
         pytest.param(
             [("Accept-Encoding", "deflate, br"), ("Accept-Encoding", "*;q=0.5, identity;q=0")],
-            ["deflate, gzip;q=0.5, identity;q=0"],
+            ["deflate, br, gzip;q=0.5, identity;q=0"],
             id="wildcard-adds-missing-safe-compression-across-header-fields",
         ),
         pytest.param(
@@ -127,8 +127,8 @@ _BROWSER_USER_AGENT = (
                     "gzip;q=0, deflate;q=0, zstd, *;q=0.5, identity;q=0",
                 )
             ],
-            ["gzip;q=0, deflate;q=0, zstd, *;q=0.5, identity;q=0"],
-            id="wildcard-keeps-original-when-all-safe-codings-rejected",
+            ["br;q=0.5, identity;q=0"],
+            id="wildcard-adds-brotli-when-zlib-codings-are-rejected",
         ),
         pytest.param(
             [("Accept-Encoding", "*;q=0.5, *;q=0, identity;q=0, zstd")],
@@ -137,7 +137,7 @@ _BROWSER_USER_AGENT = (
         ),
         pytest.param(
             [("Accept-Encoding", "GZip;q=1, zstd"), ("Accept-Encoding", "deflate;q=0.5, br")],
-            ["gzip;q=1, deflate;q=0.5"],
+            ["gzip;q=1, deflate;q=0.5, br"],
             id="case-insensitive-and-multiple-fields",
         ),
         pytest.param(
@@ -258,7 +258,7 @@ def test_normalize_accept_encoding_for_body_inspection(
             id="already-safe",
         ),
         pytest.param(
-            [("Accept-Encoding", "gzip, br")],
+            [("Accept-Encoding", "gzip, zstd")],
             "rewritten_stream_decodable",
             id="unsafe-coding-removed",
         ),
@@ -273,7 +273,12 @@ def test_normalize_accept_encoding_for_body_inspection(
             id="wildcard-expanded",
         ),
         pytest.param(
-            [("Accept-Encoding", "br, identity;q=0")],
+            [
+                (
+                    "Accept-Encoding",
+                    "gzip;q=0, deflate;q=0, br;q=0, identity;q=0",
+                )
+            ],
             "preserved_client_constraints",
             id="all-safe-representations-rejected",
         ),
@@ -297,7 +302,7 @@ def test_explicit_normalized_encodings_create_stream_decode_sessions(headers) ->
     request_headers = headers(
         (
             _ACCEPT_ENCODING,
-            ", ".join((*supported_encodings, "br", "zstd")),
+            ", ".join((*supported_encodings, "zstd")),
         )
     )
 
@@ -318,7 +323,7 @@ def test_explicit_normalized_encodings_create_stream_decode_sessions(headers) ->
 
 
 def test_wildcard_expansion_uses_stream_decoder_capability_order(headers) -> None:
-    request_headers = headers((_ACCEPT_ENCODING, "br, zstd, *;q=0.5, identity;q=0"))
+    request_headers = headers((_ACCEPT_ENCODING, "zstd, *;q=0.5, identity;q=0"))
 
     response_encoding_negotiation.normalize_accept_encoding_for_body_inspection(request_headers)
 
@@ -459,7 +464,7 @@ async def test_observable_model_provider_request_normalizes_accept_encoding_befo
         await mitm_addon.request(flow)
 
     auth_fetch.assert_awaited_once()
-    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip"
+    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, br"
     assert flow.request.headers["Authorization"] == "Bearer x"
     assert (
         flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] == "rewritten_stream_decodable"
@@ -621,7 +626,7 @@ async def test_header_phase_stream_safe_auth_normalizes_accept_encoding_before_a
     ):
         requestheaders_result = mitm_addon.requestheaders(flow)
         await await_requestheaders_result(requestheaders_result)
-        assert flow.request.headers[_ACCEPT_ENCODING] == "gzip"
+        assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, br"
         assert flow.request.headers["Authorization"] == "Bearer x"
         assert (
             flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION]
@@ -630,7 +635,7 @@ async def test_header_phase_stream_safe_auth_normalizes_accept_encoding_before_a
         await mitm_addon.request(flow)
 
     auth_fetch.assert_awaited_once()
-    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip"
+    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, br"
 
 
 async def test_header_phase_auth_fallback_restores_encoding_negotiation(
@@ -986,7 +991,7 @@ async def test_invalid_websocket_upgrade_normalizes_accept_encoding(
     ):
         await mitm_addon.request(flow)
 
-    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip"
+    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, br"
 
 
 async def test_invalid_websocket_upgrade_method_normalizes_accept_encoding(
@@ -1018,7 +1023,7 @@ async def test_invalid_websocket_upgrade_method_normalizes_accept_encoding(
     ):
         await mitm_addon.request(flow)
 
-    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip"
+    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, br"
 
 
 @pytest.mark.parametrize("http_version", ["HTTP/1.0", "HTTP/2.0", "HTTP/3"])
@@ -1053,7 +1058,7 @@ async def test_invalid_websocket_upgrade_http_version_normalizes_accept_encoding
     ):
         await mitm_addon.request(flow)
 
-    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip"
+    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, br"
 
 
 async def test_browser_passthrough_keeps_accept_encoding_for_parser_connector(

--- a/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
@@ -93,17 +93,40 @@ class TestXConnectorResponsePipeline:
         assert len(events) == len(by_category)
         assert by_category == {"posts.read": 1, "user.read": 1}
 
-    @pytest.mark.parametrize("encoding_case", ["br", "zstd"])
-    def test_full_response_pipeline_unsafe_compressed_x_json_uses_bounded_fallback(
-        self, tmp_path, real_flow, mitm_ctx, encoding_case
+    def test_full_response_pipeline_brotli_x_json_uses_incremental_parser(
+        self, tmp_path, real_flow, mitm_ctx
     ):
-        """Unsafe streaming encodings are skipped, but X JSON fallback remains active."""
-        flow = make_x_pipeline_flow(real_flow, tmp_path, content_encoding=encoding_case)
+        flow = make_x_pipeline_flow(real_flow, tmp_path, content_encoding="br")
+        payload = b'{"data":[{"id":"1"}],"includes":{"users":[{"id":"u1"}]}}'
+        compressed = _compress_body("br", payload)
+
+        with mitm_ctx():
+            mitm_addon.responseheaders(flow)
+        midpoint = len(compressed) // 2
+        response_stream(flow)(compressed[:midpoint])
+        response_stream(flow)(compressed[midpoint:])
+        response_stream(flow)(b"")
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
+
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.response(flow)
+            usage.flush_usage_events(trigger="test")
+
+        events = webhook.usage_events()
+        by_category = {event["category"]: event["quantity"] for event in events}
+        assert len(events) == len(by_category)
+        assert by_category == {"posts.read": 1, "user.read": 1}
+
+    def test_full_response_pipeline_zstd_x_json_uses_bounded_fallback(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        flow = make_x_pipeline_flow(real_flow, tmp_path, content_encoding="zstd")
         payload = b'{"data":[{"id":"1"}],"includes":{"users":[{"id":"u1"}]}}'
 
         with mitm_ctx():
             mitm_addon.responseheaders(flow)
-        response_stream(flow)(_compress_body(encoding_case, payload))
+        response_stream(flow)(_compress_body("zstd", payload))
         assert metadata_keys.STREAM_BUFFER in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE in flow.metadata
 
@@ -115,10 +138,10 @@ class TestXConnectorResponsePipeline:
         assert "connector_response_finish" not in flow.metadata
         assert metadata_keys.X_NDJSON_STATE not in flow.metadata
 
-    @pytest.mark.parametrize("encoding_case", ["br", "zstd"])
     def test_full_response_pipeline_bounds_buffered_x_json_fallback_work(
-        self, tmp_path, real_flow, mitm_ctx, encoding_case
+        self, tmp_path, real_flow, mitm_ctx
     ):
+        encoding_case = "zstd"
         flow = make_x_pipeline_flow(
             real_flow,
             tmp_path,
@@ -193,10 +216,10 @@ class TestXConnectorResponsePipeline:
         assert entry["body_truncated"] is False
         assert entry["parse_error"] == "work limit exceeded"
 
-    @pytest.mark.parametrize("encoding_case", ["br", "zstd"])
     def test_responseheaders_unsafe_compressed_x_stream_does_not_leave_parser_state(
-        self, tmp_path, real_flow, mitm_ctx, encoding_case
+        self, tmp_path, real_flow, mitm_ctx
     ):
+        encoding_case = "zstd"
         flow = make_x_stream_pipeline_flow(real_flow, tmp_path)
         assert flow.response is not None
         flow.response.headers["content-encoding"] = encoding_case

--- a/crates/runner/mitm-addon/tests/test_x_response_parsers.py
+++ b/crates/runner/mitm-addon/tests/test_x_response_parsers.py
@@ -3,6 +3,7 @@
 import gzip
 import zlib
 
+import brotli
 import pytest
 
 import flow_metadata_keys as metadata_keys
@@ -116,17 +117,22 @@ class TestNdjsonExtractor:
         assert state["data_count"] == 1
         assert "connector_response_finish" in flow.metadata
 
-    def test_decompresses_gzip_stream_before_parsing(self, real_flow):
+    @pytest.mark.parametrize("content_encoding", ["gzip", "br"])
+    def test_decompresses_stream_before_parsing(self, real_flow, content_encoding):
         ndjson_body = (
             b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n'
             b'{"data":{"id":"2"},"includes":{"users":[{"id":"u2"}]}}\n'
             b'{"data":{"id":"3"},"includes":{"users":[{"id":"u3"}]}}\n'
         )
-        compressed = gzip.compress(ndjson_body)
+        compressed = (
+            gzip.compress(ndjson_body)
+            if content_encoding == "gzip"
+            else brotli.compress(ndjson_body)
+        )
         flow = make_x_response_flow(
             real_flow,
             path="/2/tweets/search/stream",
-            content_encoding="gzip",
+            content_encoding=content_encoding,
         )
 
         mitm_addon.responseheaders(flow)


### PR DESCRIPTION
## Summary

- add incremental Brotli decoding for model-provider and connector usage parsers while preserving upstream wire bytes
- treat `br` as stream-decodable during response encoding negotiation and keep `zstd` on the existing unsupported/fallback paths
- enforce parser chunking, expansion-budget checks, invalid/incomplete stream handling, and document Brotli 1.2's soft output-limit contract

## Scope

- accepts that Brotli's decoder may transiently return more bytes than its requested `output_buffer_limit`; parser deliveries remain bounded and decoded output remains charged to the response expansion budget
- does not add zstd streaming inspection
- does not change wire response encoding or add logging

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync pytest -q` (`7243 passed`)

Closes #30462
