### PR TITLE
fix(runner): preserve exact-reuse timezone outcomes

### DIFF
--- a/crates/guest-reseed/Cargo.toml
+++ b/crates/guest-reseed/Cargo.toml
@@ -2,7 +2,7 @@
 name = "guest-reseed"
 version = "0.3.7"
 edition.workspace = true
-description = "Inject entropy and force CRNG reseed after Firecracker snapshot restore"
+description = "Repair snapshot-sensitive guest state and apply guest timezones"
 
 [dependencies]
 libc.workspace = true

--- a/crates/guest-reseed/src/lib.rs
+++ b/crates/guest-reseed/src/lib.rs
@@ -1,12 +1,12 @@
-//! Inject host-provided entropy and force a kernel CRNG reseed after a
-//! Firecracker snapshot restore.
+//! Repair snapshot-sensitive guest state and apply the guest timezone.
 //!
 //! On ARM64 with Linux 6.1, VMGenID does not automatically reseed the CRNG
 //! after snapshot restore because the kernel driver supports ACPI but not
 //! DeviceTree until Linux 6.10. This crate accepts fresh host entropy through
 //! stdin, writes it to `/dev/urandom`, and forces an immediate reseed through
 //! the `RNDRESEEDCRNG` ioctl so restored VMs do not share identical random
-//! output.
+//! output. Its timezone-only mode applies the canonical guest timezone policy
+//! without changing the clock or reading entropy.
 
 use std::ffi::{OsStr, OsString};
 use std::fs;
@@ -25,6 +25,7 @@ const RNDRESEEDCRNG: libc::Ioctl = 0x5207;
 const MAX_ENTROPY_BYTES: usize = 64 * 1024;
 const RESTORE_ENTROPY_BYTES: usize = 256;
 const RESTORE_MODE_ARG: &str = "--restore-state";
+const TIMEZONE_MODE_ARG: &str = "--sync-timezone";
 const CLOCK_SYNC_FAILED_MARKER: &str = "guest clock sync failed";
 const RESEED_FAILED_MARKER: &str = "guest-reseed failed";
 const TIMEZONE_SYNC_FAILED_MARKER: &str = "guest timezone sync failed";
@@ -228,6 +229,19 @@ fn parse_restore_args(args: &[OsString]) -> Result<RestoreArgs, &'static str> {
     }
 }
 
+fn parse_timezone_args(args: &[OsString]) -> Result<&str, &'static str> {
+    let [mode, timezone] = args else {
+        return Err("timezone is missing or invalid");
+    };
+    if mode != TIMEZONE_MODE_ARG {
+        return Err("timezone is missing or invalid");
+    }
+    timezone
+        .to_str()
+        .filter(|timezone| is_safe_timezone_name(timezone))
+        .ok_or("timezone is missing or invalid")
+}
+
 /// Runs the `guest-reseed` CLI.
 ///
 /// `args` must contain the command-line arguments after the executable name,
@@ -244,9 +258,15 @@ fn parse_restore_args(args: &[OsString]) -> Result<RestoreArgs, &'static str> {
 ///   <none|best-effort|required> [timezone] < entropy-bytes
 /// ```
 ///
+/// The timezone-only operation uses:
+///
+/// ```text
+/// guest-reseed --sync-timezone <timezone>
+/// ```
+///
 /// Entropy-only input must contain between 1 and 65,536 bytes. Restore input
-/// must contain exactly 256 bytes. `stderr` receives usage and runtime
-/// diagnostics.
+/// must contain exactly 256 bytes. Timezone-only mode does not read input.
+/// `stderr` receives usage and runtime diagnostics.
 ///
 /// Valid input is written to `/dev/urandom`, then the kernel CRNG is force-
 /// reseeded through the `RNDRESEEDCRNG` ioctl. This operation requires
@@ -255,6 +275,8 @@ fn parse_restore_args(args: &[OsString]) -> Result<RestoreArgs, &'static str> {
 /// Restore mode sets the realtime clock, reseeds the CRNG, then optionally
 /// applies the timezone. Required timezone failures return non-zero;
 /// best-effort application failures emit a marker and return success.
+/// Timezone-only mode uses the same best-effort marker contract without
+/// setting the clock or reseeding the CRNG.
 ///
 /// Returns process-style exit codes: `0` for success and `1` for argument,
 /// input, clock, reseed, or required-timezone failures.
@@ -290,6 +312,21 @@ where
     if args.is_empty() {
         return run_entropy_only(input, &mut stderr, reseed_fn);
     }
+    if args
+        .first()
+        .and_then(|arg| arg.to_str())
+        .is_some_and(|arg| arg == TIMEZONE_MODE_ARG)
+    {
+        let timezone = match parse_timezone_args(&args) {
+            Ok(timezone) => timezone,
+            Err(error) => {
+                let _ = writeln!(stderr, "guest-reseed: {error}");
+                let _ = writeln!(stderr, "usage: guest-reseed --sync-timezone <timezone>");
+                return 1;
+            }
+        };
+        return report_timezone_result(timezone_fn(timezone), false, &mut stderr);
+    }
 
     let restore = match parse_restore_args(&args) {
         Ok(restore) => restore,
@@ -321,23 +358,23 @@ where
     let Some(timezone) = restore.timezone.as_deref() else {
         return 0;
     };
-    match timezone_fn(timezone) {
+    report_timezone_result(
+        timezone_fn(timezone),
+        restore.timezone_mode == RestoreTimezoneMode::Required,
+        &mut stderr,
+    )
+}
+
+fn report_timezone_result(result: io::Result<bool>, required: bool, mut stderr: impl Write) -> i32 {
+    match result {
         Ok(true) => 0,
-        Ok(false) if restore.timezone_mode == RestoreTimezoneMode::BestEffort => {
-            let _ = writeln!(stderr, "{TIMEZONE_UNAVAILABLE_MARKER}");
-            0
-        }
         Ok(false) => {
             let _ = writeln!(stderr, "{TIMEZONE_UNAVAILABLE_MARKER}");
-            1
-        }
-        Err(error) if restore.timezone_mode == RestoreTimezoneMode::BestEffort => {
-            let _ = writeln!(stderr, "{TIMEZONE_SYNC_FAILED_MARKER}: {error}");
-            0
+            i32::from(required)
         }
         Err(error) => {
             let _ = writeln!(stderr, "{TIMEZONE_SYNC_FAILED_MARKER}: {error}");
-            1
+            i32::from(required)
         }
     }
 }
@@ -486,6 +523,106 @@ mod tests {
             String::from_utf8(stderr).unwrap(),
             "usage: guest-reseed < entropy-bytes\n"
         );
+    }
+
+    #[test]
+    fn timezone_mode_only_applies_timezone() {
+        let clock_called = Cell::new(false);
+        let reseed_called = Cell::new(false);
+        let timezone = RefCell::new(None);
+        let mut stderr = Vec::new();
+
+        let code = run_with_operations(
+            &b""[..],
+            &mut stderr,
+            [TIMEZONE_MODE_ARG, "Asia/Shanghai"],
+            |_, _| {
+                clock_called.set(true);
+                Ok(())
+            },
+            |_| {
+                reseed_called.set(true);
+                Ok(())
+            },
+            |received| {
+                timezone.replace(Some(received.to_owned()));
+                Ok(true)
+            },
+        );
+
+        assert_eq!(code, 0);
+        assert!(!clock_called.get());
+        assert!(!reseed_called.get());
+        assert_eq!(timezone.into_inner().as_deref(), Some("Asia/Shanghai"));
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn timezone_mode_reports_best_effort_outcomes() {
+        for (timezone_result, marker) in [
+            (Ok(false), TIMEZONE_UNAVAILABLE_MARKER),
+            (
+                Err(io::Error::other("write denied")),
+                TIMEZONE_SYNC_FAILED_MARKER,
+            ),
+        ] {
+            let mut stderr = Vec::new();
+            let code = run_with_operations(
+                &b""[..],
+                &mut stderr,
+                [TIMEZONE_MODE_ARG, "UTC"],
+                |_, _| Ok(()),
+                |_| Ok(()),
+                |_| timezone_result,
+            );
+            let stderr = String::from_utf8(stderr).unwrap();
+
+            assert_eq!(code, 0, "stderr={stderr}");
+            assert!(stderr.contains(marker), "stderr={stderr}");
+        }
+    }
+
+    #[test]
+    fn timezone_mode_rejects_invalid_arguments_before_operations() {
+        let cases: &[&[&str]] = &[
+            &[TIMEZONE_MODE_ARG],
+            &[TIMEZONE_MODE_ARG, "UTC", "extra"],
+            &[TIMEZONE_MODE_ARG, "../UTC"],
+            &[TIMEZONE_MODE_ARG, "UTC;id"],
+        ];
+
+        for args in cases {
+            let clock_called = Cell::new(false);
+            let reseed_called = Cell::new(false);
+            let timezone_called = Cell::new(false);
+            let mut stderr = Vec::new();
+            let code = run_with_operations(
+                &b""[..],
+                &mut stderr,
+                args.iter().copied(),
+                |_, _| {
+                    clock_called.set(true);
+                    Ok(())
+                },
+                |_| {
+                    reseed_called.set(true);
+                    Ok(())
+                },
+                |_| {
+                    timezone_called.set(true);
+                    Ok(true)
+                },
+            );
+
+            assert_eq!(code, 1, "args={args:?}");
+            assert!(!clock_called.get(), "args={args:?}");
+            assert!(!reseed_called.get(), "args={args:?}");
+            assert!(!timezone_called.get(), "args={args:?}");
+            assert!(
+                String::from_utf8(stderr).unwrap().contains("usage:"),
+                "args={args:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/guest-reseed/src/main.rs
+++ b/crates/guest-reseed/src/main.rs
@@ -12,14 +12,17 @@
 //! Usage: guest-reseed < entropy-bytes
 //!        guest-reseed --restore-state <seconds> <nanoseconds>
 //!          <none|best-effort|required> [timezone] < entropy-bytes
+//!        guest-reseed --sync-timezone <timezone>
 //!
 //! Entropy-only mode accepts no arguments and reads 1 through 65,536 raw bytes
 //! from stdin. Restore mode reads exactly 256 raw bytes.
+//! Timezone-only mode does not read stdin, set the clock, or reseed the CRNG.
 //!
 //! Entropy is written to /dev/urandom, then the CRNG is force-reseeded via the
 //! RNDRESEEDCRNG ioctl. Restore mode also needs permission to set realtime and
 //! update `/etc`. The command returns 0 on success and 1 for argument, input,
-//! clock, reseed, or required-timezone failures; stderr receives diagnostics.
+//! clock, reseed, or required-timezone failures. Best-effort timezone outcomes
+//! return 0 with bounded stderr markers when unavailable or failed.
 
 fn main() {
     std::process::exit(guest_reseed::run_cli(

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -31,9 +31,10 @@ use super::ownership::{OwnershipTransitions, RunSandbox};
 use super::{OuterJobPanicPoint, maybe_panic_outer_job};
 use crate::config::ProfileConfig;
 use crate::executor::{
-    ExactReuseSpeculationTiming, RunnerPreSpawnOperationTiming, RunnerPreSpawnPhase,
-    RunnerPreSpawnTiming, SessionHistoryRestorePlanInput, build_session_history_restore_plan,
-    restore_guest_state_with_intent, try_sync_guest_timezone_intent, validate_resume_session_id,
+    ExactReuseSpeculationTiming, GuestTimezoneSyncOutcome, RunnerPreSpawnOperationTiming,
+    RunnerPreSpawnPhase, RunnerPreSpawnTiming, SessionHistoryRestorePlanInput,
+    build_session_history_restore_plan, restore_guest_state_with_intent,
+    try_sync_guest_timezone_intent, validate_resume_session_id,
 };
 use crate::guest_timezone::{GuestTimezoneAssumption, GuestTimezoneIntent};
 use crate::idle_pool::{
@@ -1894,6 +1895,7 @@ async fn activate_speculated_exact(
     let claimed_timezone = GuestTimezoneIntent::from_context(context);
     let assumption = sandbox.guest_timezone_intent().compare(&claimed_timezone);
     let mut correction_duration = None;
+    let mut correction_succeeded = false;
     let guest_state_prepared = match assumption {
         GuestTimezoneAssumption::Match => true,
         GuestTimezoneAssumption::Mismatch => {
@@ -1907,7 +1909,9 @@ async fn activate_speculated_exact(
             .await;
             correction_duration = Some(correction_started_at.elapsed());
             match corrected {
-                Ok(Ok(())) => {}
+                Ok(Ok(outcome)) => {
+                    correction_succeeded = outcome == GuestTimezoneSyncOutcome::Applied;
+                }
                 Ok(Err(error)) => {
                     speculation_timing.timezone_correction =
                         correction_duration.map(|duration| RunnerPreSpawnOperationTiming {
@@ -1963,7 +1967,7 @@ async fn activate_speculated_exact(
     speculation_timing.timezone_correction =
         correction_duration.map(|duration| RunnerPreSpawnOperationTiming {
             duration,
-            succeeded: true,
+            succeeded: correction_succeeded,
         });
     speculation_timing.timezone_assumption = Some(assumption);
     pre_spawn_timing.record_exact_reuse_speculation(speculation_timing);

--- a/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
@@ -1,9 +1,9 @@
 use super::super::super::*;
 use super::super::support::{
     SpeculativeIdleSeedSpec, context_with_session, mock_run_config, mock_run_config_with_overrides,
-    seed_idle_pool_with_speculative_timezone, shutdown, status_idle_reuse_keys_and_active_runs,
-    test_profiles, test_runner_identity, wait_budget_count, wait_cancel_handle,
-    wait_cancel_token_removed, wait_discover_entered, wait_idle_pool_len,
+    mock_run_config_with_overrides_and_api_url, seed_idle_pool_with_speculative_timezone, shutdown,
+    status_idle_reuse_keys_and_active_runs, test_profiles, test_runner_identity, wait_budget_count,
+    wait_cancel_handle, wait_cancel_token_removed, wait_discover_entered, wait_idle_pool_len,
     wait_idle_pool_reuse_keys,
 };
 use std::sync::Arc;
@@ -11,6 +11,9 @@ use std::sync::Arc;
 use guest_contracts::reuse_preparation::{
     REUSE_PREPARATION_EXIT_CLEANUP_FAILED, ReusePreparationRequest,
 };
+use tracing::Level;
+use tracing_subscriber::prelude::*;
+use tracing_test_support::CapturedEvents;
 
 use crate::guest_timezone::GuestTimezoneIntent;
 use crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher;
@@ -54,7 +57,7 @@ fn timezone_correction_commands(overrides: &sandbox_mock::MockSandboxOverrides) 
     overrides
         .exec_calls()
         .into_iter()
-        .filter(|call| call.cmd.contains("/etc/timezone") && !call.cmd.contains("guest-reseed"))
+        .filter(|call| call.cmd.starts_with("/sbin/guest-reseed --sync-timezone "))
         .map(|call| call.cmd)
         .collect()
 }
@@ -215,7 +218,10 @@ async fn assert_timezone_transition_with(
     match expected_correction_zone {
         Some(zone) => {
             assert_eq!(corrections.len(), 1);
-            assert!(corrections[0].contains(&format!("/usr/share/zoneinfo/{zone}")));
+            assert_eq!(
+                corrections[0],
+                format!("/sbin/guest-reseed --sync-timezone {zone}")
+            );
         }
         None => assert!(corrections.is_empty()),
     }
@@ -266,21 +272,149 @@ async fn exact_reuse_verifies_configured_and_default_timezone_transitions() {
     assert_timezone_transition(GuestTimezoneIntent::Default, None, "UTC", None).await;
 }
 
-#[tokio::test]
-async fn embedded_timezone_correction_failure_remains_best_effort() {
-    assert_timezone_transition_with(
-        GuestTimezoneIntent::Configured("Asia/Shanghai".into()),
-        Some("Europe/London"),
-        "Asia/Shanghai",
-        Some("Europe/London"),
-        |overrides| {
-            overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
-                pattern: "/usr/share/zoneinfo/Europe/London".into(),
-                exit_code: 1,
-                stdout: Vec::new(),
-                stderr: b"simulated timezone setup failure".to_vec(),
-            });
+async fn assert_timezone_correction_failure_remains_best_effort(
+    exit_code: i32,
+    stderr: &[u8],
+    expected_stderr: &str,
+    expected_exit_code: Option<&str>,
+) {
+    use httpmock::prelude::*;
+
+    let server = MockServer::start_async().await;
+    let telemetry_mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/telemetry")
+                .body_matches(
+                    r#""action_type":"runner_exact_reuse_timezone_correction","duration_ms":[0-9]+,"success":false,"error":"speculative_timezone_correction_failed""#,
+                );
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"success":true,"id":"ok"}"#);
+        })
+        .await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
+        pattern: "/sbin/guest-reseed --sync-timezone Europe/London".into(),
+        exit_code,
+        stdout: b"timezone stdout".to_vec(),
+        stderr: stderr.to_vec(),
+    });
+    let (config, env) = mock_run_config_with_overrides_and_api_url(
+        test_profiles(),
+        2,
+        4096,
+        1,
+        Arc::clone(&overrides),
+        &server.base_url(),
+    );
+    let budget = Arc::clone(&config.capacity.budget);
+    let reuse_key = RunId::new_v4().to_string();
+    let generation_run_id = RunId::new_v4();
+    let sandbox_id = seed_idle_pool_with_speculative_timezone(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        SpeculativeIdleSeedSpec {
+            reuse_key: &reuse_key,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id: generation_run_id,
+            guest_timezone_intent: GuestTimezoneIntent::Configured("Asia/Shanghai".into()),
+            timing: None,
         },
+    )
+    .await;
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider.set_claim_result(
+        run_id,
+        Some(claimed_context(run_id, &reuse_key, Some("Europe/London"))),
+    );
+    env.handle
+        .discover_tx
+        .send(exact_generation_candidate(
+            run_id,
+            &reuse_key,
+            generation_run_id,
+        ))
+        .unwrap();
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(30))
+        .await
+        .expect("timezone correction failure should remain best effort");
+    assert_eq!(completion.sandbox_id, Some(sandbox_id));
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    assert_eq!(overrides.destroy_call_count(), 0);
+
+    shutdown(&env, run_handle).await;
+    telemetry_mock.assert_calls_async(1).await;
+
+    let run_id = run_id.to_string();
+    let events = captured.entries();
+    let event = events
+        .iter()
+        .find(|event| {
+            event.level == Level::WARN
+                && event.fields.get("message").map(String::as_str)
+                    == Some("failed to set guest timezone")
+                && event.fields.get("run_id").map(String::as_str) == Some(run_id.as_str())
+        })
+        .unwrap_or_else(|| panic!("missing timezone warning; events={events:#?}"));
+    assert_eq!(
+        event.fields.get("tz").map(String::as_str),
+        Some("Europe/London")
+    );
+    assert_eq!(
+        event.fields.get("termination").map(String::as_str),
+        Some("exited")
+    );
+    assert_eq!(
+        event.fields.get("exit_code").map(String::as_str),
+        expected_exit_code
+    );
+    assert!(
+        event
+            .fields
+            .get("stderr_excerpt")
+            .is_some_and(|value| value.contains(expected_stderr)),
+        "event={event:#?}"
+    );
+    assert!(
+        event
+            .fields
+            .get("stdout_excerpt")
+            .is_some_and(|value| value.contains("timezone stdout")),
+        "event={event:#?}"
+    );
+}
+
+#[tokio::test]
+async fn unavailable_timezone_correction_remains_best_effort_and_reports_failure() {
+    assert_timezone_correction_failure_remains_best_effort(
+        0,
+        b"guest timezone unavailable",
+        "guest timezone unavailable",
+        None,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn nonzero_timezone_correction_remains_best_effort_and_reports_failure() {
+    assert_timezone_correction_failure_remains_best_effort(
+        2,
+        b"simulated timezone setup failure",
+        "simulated timezone setup failure",
+        Some("2"),
     )
     .await;
 }
@@ -1262,7 +1396,7 @@ async fn timezone_correction_panic_destroys_before_fresh_fallback() {
         Some("Europe/London"),
         |overrides| {
             overrides.add_exec_panic_matcher(
-                "/usr/share/zoneinfo/Europe/London",
+                "/sbin/guest-reseed --sync-timezone Europe/London",
                 "simulated timezone correction panic",
             );
         },

--- a/crates/runner/src/executor/guest_state.rs
+++ b/crates/runner/src/executor/guest_state.rs
@@ -15,6 +15,8 @@ use crate::ids::RunId;
 use crate::types::ExecutionContext;
 
 const ENTROPY_SIZE: usize = 256;
+const GUEST_RESEED_PATH: &str = "/sbin/guest-reseed";
+const TIMEZONE_SYNC_MODE_ARG: &str = "--sync-timezone";
 const TIMEZONE_SYNC_FAILED_MARKER: &str = "guest timezone sync failed";
 const TIMEZONE_UNAVAILABLE_MARKER: &str = "guest timezone unavailable";
 
@@ -22,6 +24,14 @@ const TIMEZONE_UNAVAILABLE_MARKER: &str = "guest timezone unavailable";
 enum GuestTimezone<'a> {
     BestEffort { name: &'a str, run_id: RunId },
     Required { name: &'a str },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum GuestTimezoneSyncOutcome {
+    Applied,
+    Unavailable,
+    Failed,
+    NotRequested,
 }
 
 fn helper_exec_exit_code(result: &sandbox::ExecResult) -> Option<i32> {
@@ -54,18 +64,8 @@ pub(crate) fn is_shell_safe_guest_timezone_name(tz: &str) -> bool {
     is_shell_safe_name(tz)
 }
 
-fn timezone_sync_body(tz: &str) -> String {
-    format!(
-        "echo '{tz}' > /etc/timezone && \
-         ln -sf /usr/share/zoneinfo/{tz} /etc/localtime && \
-         sed -i '/^TZ=/d' /etc/environment && \
-         echo 'TZ={tz}' >> /etc/environment"
-    )
-}
-
 fn timezone_sync_command(tz: &str) -> String {
-    let body = timezone_sync_body(tz);
-    format!("if test -f /usr/share/zoneinfo/{tz}; then {body}; fi")
+    format!("{GUEST_RESEED_PATH} {TIMEZONE_SYNC_MODE_ARG} {tz}")
 }
 
 fn stderr_contains_marker(result: &sandbox::ExecResult, marker: &str) -> bool {
@@ -75,25 +75,58 @@ fn stderr_contains_marker(result: &sandbox::ExecResult, marker: &str) -> bool {
         .any(|window| window == marker.as_bytes())
 }
 
-fn log_embedded_timezone_failure(run_id: RunId, tz: &str, result: &sandbox::ExecResult) {
-    if !stderr_contains_marker(result, TIMEZONE_SYNC_FAILED_MARKER)
-        && !stderr_contains_marker(result, TIMEZONE_UNAVAILABLE_MARKER)
+fn classify_timezone_sync_result(result: &sandbox::ExecResult) -> GuestTimezoneSyncOutcome {
+    if !helper_exec_succeeded(result) || stderr_contains_marker(result, TIMEZONE_SYNC_FAILED_MARKER)
     {
+        GuestTimezoneSyncOutcome::Failed
+    } else if stderr_contains_marker(result, TIMEZONE_UNAVAILABLE_MARKER) {
+        GuestTimezoneSyncOutcome::Unavailable
+    } else {
+        GuestTimezoneSyncOutcome::Applied
+    }
+}
+
+fn log_timezone_sync_failure(
+    run_id: RunId,
+    tz: &str,
+    result: &sandbox::ExecResult,
+    outcome: GuestTimezoneSyncOutcome,
+) {
+    if matches!(
+        outcome,
+        GuestTimezoneSyncOutcome::Applied | GuestTimezoneSyncOutcome::NotRequested
+    ) {
         return;
     }
-
     let stderr_excerpt =
         format_command_output_excerpt("stderr", &result.stderr, result.stderr_truncated);
     let stdout_excerpt =
         format_command_output_excerpt("stdout", &result.stdout, result.stdout_truncated);
-    tracing::warn!(
-        run_id = %run_id,
-        tz = %tz,
-        termination = helper_exec_termination_label(result),
-        stderr_excerpt = %stderr_excerpt.as_deref().unwrap_or(""),
-        stdout_excerpt = %stdout_excerpt.as_deref().unwrap_or(""),
-        "failed to set guest timezone"
-    );
+    let exit_code = if helper_exec_succeeded(result) {
+        None
+    } else {
+        helper_exec_exit_code(result)
+    };
+    if let Some(exit_code) = exit_code {
+        tracing::warn!(
+            run_id = %run_id,
+            tz = %tz,
+            termination = helper_exec_termination_label(result),
+            exit_code,
+            stderr_excerpt = %stderr_excerpt.as_deref().unwrap_or(""),
+            stdout_excerpt = %stdout_excerpt.as_deref().unwrap_or(""),
+            "failed to set guest timezone"
+        );
+    } else {
+        tracing::warn!(
+            run_id = %run_id,
+            tz = %tz,
+            termination = helper_exec_termination_label(result),
+            stderr_excerpt = %stderr_excerpt.as_deref().unwrap_or(""),
+            stdout_excerpt = %stdout_excerpt.as_deref().unwrap_or(""),
+            "failed to set guest timezone"
+        );
+    }
 }
 
 /// Restores snapshot-sensitive guest state in one fixed operation before the
@@ -180,7 +213,8 @@ async fn restore_guest_state_inner(
         )));
     }
     if let Some(GuestTimezone::BestEffort { name, run_id }) = timezone {
-        log_embedded_timezone_failure(run_id, name, &result);
+        let outcome = classify_timezone_sync_result(&result);
+        log_timezone_sync_failure(run_id, name, &result, outcome);
     }
 
     Ok(())
@@ -221,13 +255,13 @@ pub(crate) async fn try_sync_guest_timezone_intent(
     sandbox: &dyn Sandbox,
     run_id: RunId,
     intent: &GuestTimezoneIntent,
-) -> RunnerResult<()> {
+) -> RunnerResult<GuestTimezoneSyncOutcome> {
     let Some(tz) = intent.guest_name() else {
-        return Ok(());
+        return Ok(GuestTimezoneSyncOutcome::NotRequested);
     };
     let cmd = timezone_sync_command(tz);
     // Best-effort: don't fail the run if timezone setup fails.
-    match sandbox
+    let result = match sandbox
         .exec_with_diagnostic_label(
             &ExecRequest {
                 cmd: &cmd,
@@ -242,37 +276,13 @@ pub(crate) async fn try_sync_guest_timezone_intent(
         )
         .await
     {
-        Ok(result) if !helper_exec_succeeded(&result) => {
-            let stderr_excerpt =
-                format_command_output_excerpt("stderr", &result.stderr, result.stderr_truncated);
-            let stdout_excerpt =
-                format_command_output_excerpt("stdout", &result.stdout, result.stdout_truncated);
-            if let Some(exit_code) = helper_exec_exit_code(&result) {
-                tracing::warn!(
-                    run_id = %run_id,
-                    tz = %tz,
-                    termination = helper_exec_termination_label(&result),
-                    exit_code,
-                    stderr_excerpt = %stderr_excerpt.as_deref().unwrap_or(""),
-                    stdout_excerpt = %stdout_excerpt.as_deref().unwrap_or(""),
-                    "failed to set guest timezone"
-                );
-            } else {
-                tracing::warn!(
-                    run_id = %run_id,
-                    tz = %tz,
-                    termination = helper_exec_termination_label(&result),
-                    stderr_excerpt = %stderr_excerpt.as_deref().unwrap_or(""),
-                    stdout_excerpt = %stdout_excerpt.as_deref().unwrap_or(""),
-                    "failed to set guest timezone"
-                );
-            }
-        }
-        Ok(_) => {}
+        Ok(result) => result,
         Err(e) => {
             tracing::warn!(run_id = %run_id, tz = %tz, error = %e, "failed to set guest timezone");
             return Err(e.into());
         }
-    }
-    Ok(())
+    };
+    let outcome = classify_timezone_sync_result(&result);
+    log_timezone_sync_failure(run_id, tz, &result, outcome);
+    Ok(outcome)
 }

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -47,7 +47,7 @@ mod workspace_session_history_materializer;
 pub(crate) use crate::restored_session_identity::RestoredSessionIdentity;
 pub(crate) use cli_framework::effective_cli_framework;
 pub(crate) use guest_state::{
-    is_shell_safe_guest_timezone_name, restore_guest_state_with_intent,
+    GuestTimezoneSyncOutcome, is_shell_safe_guest_timezone_name, restore_guest_state_with_intent,
     restore_guest_state_with_timezone, try_sync_guest_timezone_intent,
 };
 pub(crate) use session_history_cpu::SessionHistoryCpuPool;

--- a/crates/runner/src/executor/tests/agent_run_tests/guest_setup.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/guest_setup.rs
@@ -40,10 +40,7 @@ async fn run_in_sandbox_folds_timezone_sync_into_fixed_restore_operation() {
     let exec_calls = sandbox.exec_calls();
     let standalone_timezone_calls = exec_calls
         .iter()
-        .filter(|call| {
-            call.cmd
-                .starts_with("if test -f /usr/share/zoneinfo/Asia/Shanghai")
-        })
+        .filter(|call| call.cmd == "/sbin/guest-reseed --sync-timezone Asia/Shanghai")
         .collect::<Vec<_>>();
     assert!(
         standalone_timezone_calls.is_empty(),
@@ -78,9 +75,9 @@ async fn run_in_sandbox_runs_standalone_timezone_sync_without_restore_exec() {
 
     let exec_calls = sandbox.exec_calls();
     assert!(
-        exec_calls.iter().any(|call| call
-            .cmd
-            .starts_with("if test -f /usr/share/zoneinfo/Asia/Shanghai")),
+        exec_calls
+            .iter()
+            .any(|call| call.cmd == "/sbin/guest-reseed --sync-timezone Asia/Shanghai"),
         "fresh path should keep standalone timezone sync; calls: {exec_calls:?}"
     );
     assert!(sandbox.guest_state_restore_calls().is_empty());

--- a/crates/runner/src/executor/tests/guest_state_tests.rs
+++ b/crates/runner/src/executor/tests/guest_state_tests.rs
@@ -4,10 +4,12 @@ use tracing::Level;
 use tracing_subscriber::prelude::*;
 
 use super::super::guest_state::{
-    restore_guest_state, restore_guest_state_with_timezone, sync_guest_timezone,
+    GuestTimezoneSyncOutcome, restore_guest_state, restore_guest_state_with_timezone,
+    sync_guest_timezone, try_sync_guest_timezone_intent,
 };
 use super::support::{CapturedEvent, CapturedEvents, minimal_context, sandbox_exec_error};
 use crate::error::RunnerError;
+use crate::guest_timezone::GuestTimezoneIntent;
 use crate::ids::RunId;
 use crate::types::ExecutionContext;
 
@@ -330,29 +332,56 @@ async fn sync_guest_timezone_accepts_common_timezone_name_shapes() {
 
         let calls = sandbox.exec_calls();
         assert_eq!(calls.len(), 1, "timezone {tz:?} should call guest exec");
-        assert!(
-            calls[0]
-                .cmd
-                .starts_with(&format!("if test -f /usr/share/zoneinfo/{tz}; then ")),
-            "unexpected timezone command: {}",
-            calls[0].cmd
+        assert_eq!(
+            calls[0].cmd,
+            format!("/sbin/guest-reseed --sync-timezone {tz}")
         );
-        assert!(
-            calls[0]
-                .cmd
-                .contains(&format!("echo '{tz}' > /etc/timezone")),
-            "unexpected timezone command: {}",
-            calls[0].cmd
-        );
-        assert!(
-            calls[0]
-                .cmd
-                .contains(&format!("echo 'TZ={tz}' >> /etc/environment")),
-            "unexpected timezone command: {}",
-            calls[0].cmd
-        );
-        assert!(calls[0].cmd.ends_with(" fi"));
+        assert!(!calls[0].cmd.contains("/etc/timezone"));
     }
+}
+
+#[tokio::test]
+async fn try_sync_guest_timezone_preserves_completed_outcomes() {
+    for (result, expected) in [
+        (
+            ExecResult::new(0, Vec::new(), Vec::new()),
+            GuestTimezoneSyncOutcome::Applied,
+        ),
+        (
+            ExecResult::new(0, Vec::new(), b"guest timezone unavailable".to_vec()),
+            GuestTimezoneSyncOutcome::Unavailable,
+        ),
+        (
+            ExecResult::new(
+                0,
+                Vec::new(),
+                b"guest timezone sync failed: write denied".to_vec(),
+            ),
+            GuestTimezoneSyncOutcome::Failed,
+        ),
+        (
+            ExecResult::new(2, Vec::new(), b"unexpected helper failure".to_vec()),
+            GuestTimezoneSyncOutcome::Failed,
+        ),
+    ] {
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_exec_result(Ok(result));
+        let intent = GuestTimezoneIntent::Configured("Asia/Shanghai".into());
+
+        let outcome = try_sync_guest_timezone_intent(&sandbox, RunId::nil(), &intent)
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, expected);
+    }
+
+    let sandbox = MockSandbox::new("test");
+    let outcome =
+        try_sync_guest_timezone_intent(&sandbox, RunId::nil(), &GuestTimezoneIntent::Unknown)
+            .await
+            .unwrap();
+    assert_eq!(outcome, GuestTimezoneSyncOutcome::NotRequested);
+    assert!(sandbox.exec_calls().is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- add a timezone-only `guest-reseed` mode that reuses the canonical guest timezone filesystem policy
- preserve applied, unavailable, failed, and not-requested timezone correction outcomes in the runner
- report exact-reuse correction telemetry as successful only when the timezone was actually applied
- keep completed correction failures best-effort while emitting bounded warning diagnostics

## Exclusions

- no API, queue payload, or vsock protocol changes
- no change to exact-reuse fallback behavior for completed timezone correction failures
- no new telemetry action or error category

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-reseed --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-reseed --all-features --no-deps`
- `cargo test -p guest-reseed`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner executor::tests::guest_state_tests`
- `cargo test -p runner cmd::start::tests::main_loop::exact_reuse_speculation`
- `cargo test -p runner executor::tests::telemetry_tests`
- `cargo test -p runner executor::tests::agent_run_tests::guest_setup`
- `cargo test -p runner`

Closes #30421
