### PR TITLE
fix(e2e): restore sharedworker feature mocks

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -761,6 +761,17 @@ unless gate_script.include?("RUNNER_E2E_SKIP_ALLOWED=\"true\"") &&
     gate_script.include?("needs.prepare.outputs.turbo-runner-consumer-needed")
   raise "CI gate must restore the runner-specific E2E skip policy"
 end
+if gate_script.include?('[ "$result" = "cancelled" ]') ||
+    gate_script.include?("cancelled by concurrency group, allowed")
+  raise "CI gate must reject cancelled required jobs"
+end
+unless gate_script.include?(
+    '&& [ "$result" = "skipped" ]; then',
+  ) && gate_script.include?(
+    'echo "::error::$job: expected success or skipped, got $result"',
+  )
+  raise "CI gate must allow only intentional non-executed skips"
+end
 %w[
   cli-e2e-03-runner-prepare
   cli-e2e-03-runner-bootstrap

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -3054,8 +3054,6 @@ jobs:
               echo "✅ $job: $result"
             elif { [ "$allow_skip" = "skipped" ] || [ "$allow_skip" = "true" ]; } && [ "$result" = "skipped" ]; then
               echo "⏭️ $job: $result (allowed)"
-            elif [ "$allow_skip" = "true" ] && [ "$result" = "cancelled" ]; then
-              echo "⚠️ $job: $result (cancelled by concurrency group, allowed)"
             elif [ "$allow_skip" = "informational" ]; then
               echo "ℹ️ $job: $result (informational, not blocking)"
             else

--- a/e2e/playwright/fixtures.ts
+++ b/e2e/playwright/fixtures.ts
@@ -2,12 +2,20 @@ import { setupClerkTestingToken } from "@clerk/testing/playwright";
 import { expect, test as base } from "@playwright/test";
 
 import { resolveApiBackendUrl } from "./api-backend-url";
+import { SharedWorkerRoutes } from "./lib/shared-worker-routes";
+import { deriveAppUrl } from "./playwright.config";
 
 export { expect };
 
 const apiUrl = resolveApiBackendUrl();
+const sharedDatabaseWorkerScript =
+  /\/assets\/shared-database-worker-[^/?]+\.js(?:\?.*)?$/u;
 
-export const test = base.extend({
+interface WorkerRouteFixtures {
+  readonly sharedWorkerRoutes: SharedWorkerRoutes;
+}
+
+export const test = base.extend<WorkerRouteFixtures>({
   context: async ({ context }, use) => {
     // Every page load runs `clerk.load()`, which handshakes with the Clerk
     // Frontend API — including tests that only restore a saved storage
@@ -41,6 +49,19 @@ export const test = base.extend({
       await use(page);
     } finally {
       await page.unrouteAll({ behavior: "ignoreErrors" });
+    }
+  },
+  sharedWorkerRoutes: async ({ context }, use) => {
+    const routes = await SharedWorkerRoutes.install({
+      apiOrigin: apiUrl,
+      bridgeOrigin: deriveAppUrl(apiUrl),
+      context,
+      workerScript: sharedDatabaseWorkerScript,
+    });
+    try {
+      await use(routes);
+    } finally {
+      await routes.close();
     }
   },
 });

--- a/e2e/playwright/fixtures.ts
+++ b/e2e/playwright/fixtures.ts
@@ -2,6 +2,10 @@ import { setupClerkTestingToken } from "@clerk/testing/playwright";
 import { expect, test as base } from "@playwright/test";
 
 import { resolveApiBackendUrl } from "./api-backend-url";
+import {
+  installPreviewBypassCookie,
+  VERCEL_PROTECTION_BYPASS_NAME,
+} from "./lib/preview-bypass";
 import { SharedWorkerRoutes } from "./lib/shared-worker-routes";
 import { deriveAppUrl } from "./playwright.config";
 
@@ -28,11 +32,19 @@ export const test = base.extend<WorkerRouteFixtures>({
     const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
     if (apiUrl && bypassSecret) {
       const apiOrigin = new URL(apiUrl).origin;
+      // Playwright routing covers page requests but not native SharedWorker
+      // fetches. The production bridge reads this app-origin cookie and
+      // forwards the bypass through its worker heartbeat.
+      await installPreviewBypassCookie(
+        context,
+        deriveAppUrl(apiUrl),
+        bypassSecret,
+      );
       await context.route(`${apiOrigin}/**`, async (route) => {
         await route.continue({
           headers: {
             ...route.request().headers(),
-            "x-vercel-protection-bypass": bypassSecret,
+            [VERCEL_PROTECTION_BYPASS_NAME]: bypassSecret,
           },
         });
       });

--- a/e2e/playwright/lib/preview-bypass.test.ts
+++ b/e2e/playwright/lib/preview-bypass.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { BrowserContext } from "@playwright/test";
+
+import {
+  installPreviewBypassCookie,
+  previewBypassCookie,
+} from "./preview-bypass";
+
+test("builds an app-readable host-only preview bypass cookie", () => {
+  assert.deepEqual(
+    previewBypassCookie(
+      "https://pr-30474-app.omby.ai/path",
+      "preview secret/value",
+    ),
+    {
+      name: "x-vercel-protection-bypass",
+      value: "preview%20secret%2Fvalue",
+      url: "https://pr-30474-app.omby.ai",
+      sameSite: "Lax",
+      secure: true,
+    },
+  );
+});
+
+test("installs the preview bypass cookie before the browser uses the context", async () => {
+  const calls: Parameters<BrowserContext["addCookies"]>[0][] = [];
+  await installPreviewBypassCookie(
+    {
+      addCookies: (cookies) => {
+        calls.push(cookies);
+        return Promise.resolve();
+      },
+    },
+    "http://127.0.0.1:3000",
+    "local-secret",
+  );
+
+  assert.deepEqual(calls, [
+    [
+      {
+        name: "x-vercel-protection-bypass",
+        value: "local-secret",
+        url: "http://127.0.0.1:3000",
+        sameSite: "Lax",
+        secure: false,
+      },
+    ],
+  ]);
+});

--- a/e2e/playwright/lib/preview-bypass.ts
+++ b/e2e/playwright/lib/preview-bypass.ts
@@ -1,0 +1,28 @@
+import type { BrowserContext } from "@playwright/test";
+
+export const VERCEL_PROTECTION_BYPASS_NAME = "x-vercel-protection-bypass";
+
+type BrowserContextCookie = Parameters<BrowserContext["addCookies"]>[0][number];
+type CookieContext = Pick<BrowserContext, "addCookies">;
+
+export function previewBypassCookie(
+  appUrl: string,
+  bypassSecret: string,
+): BrowserContextCookie {
+  const appOrigin = new URL(appUrl);
+  return {
+    name: VERCEL_PROTECTION_BYPASS_NAME,
+    value: encodeURIComponent(bypassSecret),
+    url: appOrigin.origin,
+    sameSite: "Lax",
+    secure: appOrigin.protocol === "https:",
+  };
+}
+
+export async function installPreviewBypassCookie(
+  context: CookieContext,
+  appUrl: string,
+  bypassSecret: string,
+): Promise<void> {
+  await context.addCookies([previewBypassCookie(appUrl, bypassSecret)]);
+}

--- a/e2e/playwright/lib/shared-worker-routes.test.ts
+++ b/e2e/playwright/lib/shared-worker-routes.test.ts
@@ -1,0 +1,386 @@
+import assert from "node:assert/strict";
+import { createServer, type Server } from "node:http";
+import { test } from "node:test";
+
+import {
+  chromium,
+  type Browser,
+  type BrowserContext,
+  type Page,
+} from "@playwright/test";
+
+import { SharedWorkerRoutes } from "./shared-worker-routes";
+
+interface Harness {
+  readonly browser: Browser;
+  readonly origin: string;
+  readonly server: Server;
+}
+
+interface WorkerFetchResult {
+  readonly body?: unknown;
+  readonly error?: string;
+  readonly ok: boolean;
+  readonly source?: string | null;
+  readonly status?: number;
+}
+
+const workerScript = "**/shared-worker.js";
+
+test("intercepts a real SharedWorker after explicit readiness", async () => {
+  const harness = await createHarness();
+  const context = await harness.browser.newContext();
+  const page = await context.newPage();
+  const routes = await installRoutes(harness, context);
+  try {
+    await routes.route("/api/mocked", async (route) => {
+      assert.equal(await route.request().headerValue("x-test-request"), "yes");
+      await route.fulfill({
+        headers: { "x-test-source": "route" },
+        json: { source: "route" },
+        status: 201,
+      });
+    });
+    await page.goto(harness.origin);
+    await createWorker(page);
+    await routes.waitForReady();
+
+    assert.deepEqual(
+      await fetchFromWorker(page, "/api/mocked", {
+        "x-test-request": "yes",
+      }),
+      {
+        body: { source: "route" },
+        ok: true,
+        source: "route",
+        status: 201,
+      },
+    );
+    await page.reload();
+    assert.deepEqual(
+      (
+        await fetchFromWorker(page, "/api/mocked", {
+          "x-test-request": "yes",
+        })
+      ).body,
+      { source: "route" },
+    );
+  } finally {
+    await closeTestResources([routes], [context], harness);
+  }
+});
+
+test("passes unmatched SharedWorker requests through to the network", async () => {
+  const harness = await createHarness();
+  const context = await harness.browser.newContext();
+  const page = await context.newPage();
+  const routes = await installRoutes(harness, context);
+  try {
+    await page.goto(harness.origin);
+    await createWorker(page);
+    await routes.waitForReady();
+    assert.deepEqual(await fetchFromWorker(page, "/api/network"), {
+      body: { source: "network" },
+      ok: true,
+      source: "network",
+      status: 200,
+    });
+  } finally {
+    await closeTestResources([routes], [context], harness);
+  }
+});
+
+test("surfaces SharedWorker handler errors without waiting for a test timeout", async () => {
+  const harness = await createHarness();
+  const context = await harness.browser.newContext();
+  const page = await context.newPage();
+  const routes = await installRoutes(harness, context);
+  try {
+    await routes.route("/api/mocked", () => {
+      throw new Error("intentional handler failure");
+    });
+    await page.goto(harness.origin);
+    await createWorker(page);
+    await routes.waitForReady();
+
+    const result = await Promise.race([
+      fetchFromWorker(page, "/api/mocked"),
+      new Promise<WorkerFetchResult>((_resolve, reject) => {
+        setTimeout(() => {
+          reject(new Error("SharedWorker handler did not fail promptly"));
+        }, 2_000);
+      }),
+    ]);
+    assert.equal(result.ok, false);
+    assert.match(result.error ?? "", /intentional handler failure/u);
+    await assert.rejects(
+      routes.close(),
+      /SharedWorker route handler failed.*intentional handler failure/u,
+    );
+  } finally {
+    await closeTestResources([routes], [context], harness);
+  }
+});
+
+test("keeps SharedWorker route state isolated between browser contexts", async () => {
+  const harness = await createHarness();
+  const firstContext = await harness.browser.newContext();
+  const secondContext = await harness.browser.newContext();
+  const firstPage = await firstContext.newPage();
+  const secondPage = await secondContext.newPage();
+  const firstRoutes = await installRoutes(harness, firstContext);
+  const secondRoutes = await installRoutes(harness, secondContext);
+  try {
+    await firstRoutes.route("/api/mocked", async (route) => {
+      await route.fulfill({ json: { source: "first" } });
+    });
+    await secondRoutes.route("/api/mocked", async (route) => {
+      await route.fulfill({ json: { source: "second" } });
+    });
+    await Promise.all([
+      firstPage.goto(harness.origin),
+      secondPage.goto(harness.origin),
+    ]);
+    await Promise.all([createWorker(firstPage), createWorker(secondPage)]);
+    await Promise.all([
+      firstRoutes.waitForReady(),
+      secondRoutes.waitForReady(),
+    ]);
+
+    const [first, second] = await Promise.all([
+      fetchFromWorker(firstPage, "/api/mocked"),
+      fetchFromWorker(secondPage, "/api/mocked"),
+    ]);
+    assert.deepEqual(first.body, { source: "first" });
+    assert.deepEqual(second.body, { source: "second" });
+  } finally {
+    await closeTestResources(
+      [firstRoutes, secondRoutes],
+      [firstContext, secondContext],
+      harness,
+    );
+  }
+});
+
+test("restores native SharedWorker fetch during deterministic cleanup", async () => {
+  const harness = await createHarness();
+  const context = await harness.browser.newContext();
+  const page = await context.newPage();
+  const routes = await installRoutes(harness, context);
+  try {
+    await routes.route("/api/mocked", async (route) => {
+      await route.fulfill({ json: { source: "route" } });
+    });
+    await page.goto(harness.origin);
+    await createWorker(page);
+    await routes.waitForReady();
+    assert.deepEqual((await fetchFromWorker(page, "/api/mocked")).body, {
+      source: "route",
+    });
+
+    await routes.close();
+    assert.deepEqual(await fetchFromWorker(page, "/api/mocked"), {
+      body: { source: "network" },
+      ok: true,
+      source: "network",
+      status: 200,
+    });
+  } finally {
+    await closeTestResources([routes], [context], harness);
+  }
+});
+
+test("fails readiness quickly when the runtime worker is not intercepted", async () => {
+  const harness = await createHarness();
+  const context = await harness.browser.newContext();
+  const page = await context.newPage();
+  const routes = await SharedWorkerRoutes.install({
+    apiOrigin: harness.origin,
+    bridgeOrigin: harness.origin,
+    context,
+    workerScript: "**/different-worker.js",
+  });
+  try {
+    await page.goto(harness.origin);
+    await createWorker(page);
+    await assert.rejects(
+      routes.waitForReady(100),
+      /SharedWorker route bridge was not ready within 100ms/u,
+    );
+  } finally {
+    await closeTestResources([routes], [context], harness);
+  }
+});
+
+async function installRoutes(
+  harness: Harness,
+  context: BrowserContext,
+): Promise<SharedWorkerRoutes> {
+  return await SharedWorkerRoutes.install({
+    apiOrigin: harness.origin,
+    bridgeOrigin: harness.origin,
+    context,
+    workerScript,
+  });
+}
+
+async function createHarness(): Promise<Harness> {
+  const server = createServer((request, response) => {
+    const pathname = new URL(request.url ?? "/", "http://fixture").pathname;
+    if (pathname === "/shared-worker.js") {
+      response.writeHead(200, { "content-type": "text/javascript" });
+      response.end(`
+        addEventListener("connect", ({ ports: [port] }) => {
+          port.addEventListener("message", async (event) => {
+            try {
+              const response = await fetch(event.data.path, {
+                headers: event.data.headers,
+              });
+              port.postMessage({
+                body: await response.json(),
+                ok: true,
+                source: response.headers.get("x-test-source"),
+                status: response.status,
+              });
+            } catch (error) {
+              port.postMessage({
+                error: error instanceof Error ? error.message : String(error),
+                ok: false,
+              });
+            }
+          });
+          port.start();
+        });
+      `);
+      return;
+    }
+    if (pathname.startsWith("/api/")) {
+      response.writeHead(200, {
+        "content-type": "application/json",
+        "x-test-source": "network",
+      });
+      response.end(JSON.stringify({ source: "network" }));
+      return;
+    }
+    response.writeHead(200, { "content-type": "text/html" });
+    response.end("<!doctype html><title>SharedWorker route fixture</title>");
+  });
+  await listen(server);
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("SharedWorker fixture server has no TCP address");
+  }
+  return {
+    browser: await chromium.launch(),
+    origin: `http://127.0.0.1:${address.port}`,
+    server,
+  };
+}
+
+async function createWorker(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const worker = new SharedWorker("/shared-worker.js", {
+      name: "production-topology-fixture",
+    });
+    worker.port.start();
+  });
+}
+
+async function fetchFromWorker(
+  page: Page,
+  path: string,
+  headers: Readonly<Record<string, string>> = {},
+): Promise<WorkerFetchResult> {
+  const value: unknown = await page.evaluate(
+    async ({ requestHeaders, requestPath }) => {
+      const worker = new SharedWorker("/shared-worker.js", {
+        name: "production-topology-fixture",
+      });
+      worker.port.start();
+      return await new Promise<unknown>((resolve, reject) => {
+        worker.addEventListener("error", (event) => {
+          reject(new Error(event.message));
+        });
+        worker.port.addEventListener(
+          "message",
+          (event: MessageEvent<unknown>) => {
+            resolve(event.data);
+          },
+          { once: true },
+        );
+        worker.port.postMessage({
+          headers: requestHeaders,
+          path: requestPath,
+        });
+      });
+    },
+    { requestHeaders: headers, requestPath: path },
+  );
+  if (!isWorkerFetchResult(value)) {
+    throw new Error("SharedWorker returned an invalid fixture response");
+  }
+  return value;
+}
+
+function isWorkerFetchResult(value: unknown): value is WorkerFetchResult {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "ok" in value &&
+    typeof value.ok === "boolean"
+  );
+}
+
+async function closeHarness(harness: Harness): Promise<void> {
+  await harness.browser.close();
+  await new Promise<void>((resolve, reject) => {
+    harness.server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+    harness.server.closeAllConnections();
+  });
+}
+
+async function closeTestResources(
+  routes: readonly SharedWorkerRoutes[],
+  contexts: readonly BrowserContext[],
+  harness: Harness,
+): Promise<void> {
+  const failures: unknown[] = [];
+  for (const workerRoutes of routes) {
+    try {
+      await workerRoutes.close();
+    } catch (error: unknown) {
+      failures.push(error);
+    }
+  }
+  for (const context of contexts) {
+    try {
+      await context.close();
+    } catch (error: unknown) {
+      failures.push(error);
+    }
+  }
+  try {
+    await closeHarness(harness);
+  } catch (error: unknown) {
+    failures.push(error);
+  }
+  if (failures.length === 1) {
+    throw failures[0];
+  }
+  if (failures.length > 1) {
+    throw new AggregateError(failures, "SharedWorker test cleanup failed");
+  }
+}
+
+async function listen(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+}

--- a/e2e/playwright/lib/shared-worker-routes.test.ts
+++ b/e2e/playwright/lib/shared-worker-routes.test.ts
@@ -190,6 +190,22 @@ test("restores native SharedWorker fetch during deterministic cleanup", async ()
   }
 });
 
+test("closes cleanly after the runtime SharedWorker has stopped", async () => {
+  const harness = await createHarness();
+  const context = await harness.browser.newContext();
+  const page = await context.newPage();
+  const routes = await installRoutes(harness, context);
+  try {
+    await page.goto(harness.origin);
+    await createWorker(page);
+    await routes.waitForReady();
+    await terminateWorker(page);
+    await routes.close();
+  } finally {
+    await closeTestResources([routes], [context], harness);
+  }
+});
+
 test("fails readiness quickly when the runtime worker is not intercepted", async () => {
   const harness = await createHarness();
   const context = await harness.browser.newContext();
@@ -232,6 +248,11 @@ async function createHarness(): Promise<Harness> {
       response.end(`
         addEventListener("connect", ({ ports: [port] }) => {
           port.addEventListener("message", async (event) => {
+            if (event.data.terminate === true) {
+              port.postMessage({ terminated: true });
+              self.close();
+              return;
+            }
             try {
               const response = await fetch(event.data.path, {
                 headers: event.data.headers,
@@ -320,6 +341,33 @@ async function fetchFromWorker(
     throw new Error("SharedWorker returned an invalid fixture response");
   }
   return value;
+}
+
+async function terminateWorker(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const worker = new SharedWorker("/shared-worker.js", {
+      name: "production-topology-fixture",
+    });
+    worker.port.start();
+    await new Promise<void>((resolve) => {
+      worker.port.addEventListener(
+        "message",
+        (event: MessageEvent<unknown>) => {
+          const message = event.data;
+          if (
+            message &&
+            typeof message === "object" &&
+            "terminated" in message &&
+            message.terminated === true
+          ) {
+            resolve();
+          }
+        },
+        { once: true },
+      );
+      worker.port.postMessage({ terminate: true });
+    });
+  });
 }
 
 function isWorkerFetchResult(value: unknown): value is WorkerFetchResult {

--- a/e2e/playwright/lib/shared-worker-routes.ts
+++ b/e2e/playwright/lib/shared-worker-routes.ts
@@ -364,10 +364,17 @@ export class SharedWorkerRoutes {
           }
           const channel: unknown = Reflect.get(value, "channel");
           if (channel instanceof BroadcastChannel) {
-            await new Promise<void>((resolve, reject) => {
+            // Chromium may terminate a SharedWorker as soon as its final page
+            // port disappears. Probe first: no response means there is no
+            // runtime left to restore, while a live runtime must acknowledge
+            // the disposal handshake below.
+            const workerIsAlive = await new Promise<boolean>((resolve) => {
+              const probeId = crypto.randomUUID();
+              const listenerController = new AbortController();
               const timer = setTimeout(() => {
-                reject(new Error("SharedWorker route cleanup timed out"));
-              }, 2_000);
+                listenerController.abort();
+                resolve(false);
+              }, 500);
               channel.addEventListener(
                 "message",
                 (event: MessageEvent<unknown>) => {
@@ -376,15 +383,50 @@ export class SharedWorkerRoutes {
                     message &&
                     typeof message === "object" &&
                     "kind" in message &&
-                    message.kind === "disposed"
+                    message.kind === "probe-response" &&
+                    "probeId" in message &&
+                    message.probeId === probeId
                   ) {
                     clearTimeout(timer);
-                    resolve();
+                    listenerController.abort();
+                    resolve(true);
                   }
                 },
+                { signal: listenerController.signal },
               );
-              channel.postMessage({ kind: "dispose" });
+              channel.postMessage({ kind: "probe", probeId });
             });
+            if (workerIsAlive) {
+              await new Promise<void>((resolve, reject) => {
+                const disposeId = crypto.randomUUID();
+                const listenerController = new AbortController();
+                const timer = setTimeout(() => {
+                  listenerController.abort();
+                  reject(new Error("SharedWorker route cleanup timed out"));
+                }, 2_000);
+                channel.addEventListener(
+                  "message",
+                  (event: MessageEvent<unknown>) => {
+                    const message = event.data;
+                    if (
+                      message &&
+                      typeof message === "object" &&
+                      "kind" in message &&
+                      message.kind === "disposed" &&
+                      "disposeId" in message &&
+                      message.disposeId === disposeId
+                    ) {
+                      clearTimeout(timer);
+                      listenerController.abort();
+                      channel.postMessage({ kind: "close", disposeId });
+                      resolve();
+                    }
+                  },
+                  { signal: listenerController.signal },
+                );
+                channel.postMessage({ kind: "dispose", disposeId });
+              });
+            }
             channel.close();
           }
           Reflect.deleteProperty(globalThis, stateKey);
@@ -656,17 +698,36 @@ export class SharedWorkerRoutes {
   const channel = new BroadcastChannel(${channelName});
   const nativeFetch = globalThis.fetch.bind(globalThis);
   const pending = new Map();
+  let activeDisposeId = null;
   channel.addEventListener("message", (event) => {
     const message = event.data;
     if (!message || typeof message !== "object") return;
-    if (message.kind === "dispose") {
+    if (message.kind === "probe" && typeof message.probeId === "string") {
+      channel.postMessage({
+        kind: "probe-response",
+        probeId: message.probeId,
+      });
+      return;
+    }
+    if (message.kind === "dispose" && typeof message.disposeId === "string") {
+      activeDisposeId = message.disposeId;
       globalThis.fetch = nativeFetch;
       for (const entry of pending.values()) {
         entry.cleanup();
         entry.reject(new Error("SharedWorker routes were disposed"));
       }
       pending.clear();
-      channel.postMessage({ kind: "disposed" });
+      channel.postMessage({
+        kind: "disposed",
+        disposeId: message.disposeId,
+      });
+      return;
+    }
+    if (
+      message.kind === "close" &&
+      typeof message.disposeId === "string" &&
+      message.disposeId === activeDisposeId
+    ) {
       channel.close();
       return;
     }

--- a/e2e/playwright/lib/shared-worker-routes.ts
+++ b/e2e/playwright/lib/shared-worker-routes.ts
@@ -1,0 +1,732 @@
+import { randomUUID } from "node:crypto";
+
+import type {
+  BrowserContext,
+  Page,
+  Request as PlaywrightRequest,
+  Route as PlaywrightRoute,
+} from "@playwright/test";
+
+type WorkerScriptMatcher = Parameters<BrowserContext["route"]>[0];
+
+interface SerializedWorkerRequest {
+  readonly body: string | null;
+  readonly headers: readonly (readonly [string, string])[];
+  readonly method: string;
+  readonly url: string;
+}
+
+interface ContinueResult {
+  readonly action: "continue";
+}
+
+interface ErrorResult {
+  readonly action: "error";
+  readonly message: string;
+}
+
+interface FulfillResult {
+  readonly action: "fulfill";
+  readonly body: string | null;
+  readonly headers: readonly (readonly [string, string])[];
+  readonly status: number;
+}
+
+type DispatchResult = ContinueResult | ErrorResult | FulfillResult;
+
+interface ReadyMessage {
+  readonly kind: "ready";
+}
+
+interface RequestMessage {
+  readonly kind: "request";
+  readonly request: SerializedWorkerRequest;
+  readonly requestId: string;
+}
+
+type BridgeMessage = ReadyMessage | RequestMessage;
+
+export interface SharedWorkerFulfillOptions {
+  readonly body?: string;
+  readonly contentType?: string;
+  readonly headers?: Readonly<Record<string, string>>;
+  readonly json?: unknown;
+  readonly status?: number;
+}
+
+export interface SharedWorkerRequest {
+  headerValue(name: string): Promise<string | null>;
+  headers(): Readonly<Record<string, string>>;
+  method(): string;
+  postData(): string | null;
+  postDataJSON(): unknown;
+  url(): string;
+}
+
+export interface SharedWorkerRoute {
+  continue(): Promise<void>;
+  fulfill(options: SharedWorkerFulfillOptions): Promise<void>;
+  request(): SharedWorkerRequest;
+}
+
+export type SharedWorkerRouteMatcher =
+  | string
+  | ((url: URL, request: SharedWorkerRequest) => boolean);
+
+export type SharedWorkerRouteHandler = (
+  route: SharedWorkerRoute,
+) => Promise<void> | void;
+
+interface RouteEntry {
+  readonly handler: SharedWorkerRouteHandler;
+  readonly matcher: SharedWorkerRouteMatcher;
+}
+
+interface ResponseWaiter {
+  readonly matcher: SharedWorkerRouteMatcher;
+  readonly reject: (error: Error) => void;
+  readonly resolve: (request: SharedWorkerRequest) => void;
+  readonly timer: NodeJS.Timeout;
+}
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+}
+
+export interface SharedWorkerRoutesOptions {
+  readonly apiOrigin: string;
+  readonly bridgeOrigin: string;
+  readonly context: BrowserContext;
+  readonly workerScript: WorkerScriptMatcher;
+}
+
+const defaultWaitTimeoutMs = 10_000;
+
+function deferred<T>(): Deferred<T> {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve(value) {
+      if (!resolvePromise) {
+        throw new Error("Deferred resolver is unavailable");
+      }
+      resolvePromise(value);
+    },
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isHeaderEntries(
+  value: unknown,
+): value is readonly (readonly [string, string])[] {
+  return (
+    Array.isArray(value) &&
+    value.every((entry) => {
+      return (
+        Array.isArray(entry) &&
+        entry.length === 2 &&
+        typeof entry[0] === "string" &&
+        typeof entry[1] === "string"
+      );
+    })
+  );
+}
+
+function isSerializedWorkerRequest(
+  value: unknown,
+): value is SerializedWorkerRequest {
+  return (
+    isRecord(value) &&
+    (typeof value.body === "string" || value.body === null) &&
+    isHeaderEntries(value.headers) &&
+    typeof value.method === "string" &&
+    typeof value.url === "string"
+  );
+}
+
+function isBridgeMessage(value: unknown): value is BridgeMessage {
+  if (!isRecord(value) || typeof value.kind !== "string") {
+    return false;
+  }
+  return (
+    value.kind === "ready" ||
+    (value.kind === "request" &&
+      typeof value.requestId === "string" &&
+      isSerializedWorkerRequest(value.request))
+  );
+}
+
+function matches(
+  matcher: SharedWorkerRouteMatcher,
+  request: SharedWorkerRequest,
+): boolean {
+  const url = new URL(request.url());
+  return typeof matcher === "string"
+    ? url.pathname === matcher
+    : matcher(url, request);
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(message));
+    }, timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
+  });
+}
+
+class WorkerRequest implements SharedWorkerRequest {
+  readonly #body: string | null;
+  readonly #headers: Readonly<Record<string, string>>;
+  readonly #method: string;
+  readonly #url: string;
+
+  constructor(request: SerializedWorkerRequest) {
+    this.#body = request.body;
+    this.#headers = Object.freeze(Object.fromEntries(request.headers));
+    this.#method = request.method;
+    this.#url = request.url;
+  }
+
+  async headerValue(name: string): Promise<string | null> {
+    const requestedName = name.toLowerCase();
+    const entry = Object.entries(this.#headers).find(([headerName]) => {
+      return headerName.toLowerCase() === requestedName;
+    });
+    return entry?.[1] ?? null;
+  }
+
+  headers(): Readonly<Record<string, string>> {
+    return this.#headers;
+  }
+
+  method(): string {
+    return this.#method;
+  }
+
+  postData(): string | null {
+    return this.#body;
+  }
+
+  postDataJSON(): unknown {
+    if (this.#body === null) {
+      return null;
+    }
+    const value: unknown = JSON.parse(this.#body);
+    return value;
+  }
+
+  url(): string {
+    return this.#url;
+  }
+}
+
+class WorkerRoute implements SharedWorkerRoute {
+  readonly #request: SharedWorkerRequest;
+  #result: DispatchResult | undefined;
+
+  constructor(request: SharedWorkerRequest) {
+    this.#request = request;
+  }
+
+  async continue(): Promise<void> {
+    this.#setResult({ action: "continue" });
+  }
+
+  async fulfill(options: SharedWorkerFulfillOptions): Promise<void> {
+    if (options.body !== undefined && options.json !== undefined) {
+      throw new Error("SharedWorker route cannot fulfill with body and json");
+    }
+    const headers = new Headers(options.headers);
+    if (options.contentType !== undefined) {
+      headers.set("content-type", options.contentType);
+    }
+    let body = options.body ?? null;
+    if (options.json !== undefined) {
+      body = JSON.stringify(options.json);
+      if (!headers.has("content-type")) {
+        headers.set("content-type", "application/json");
+      }
+    }
+    this.#setResult({
+      action: "fulfill",
+      body,
+      headers: [...headers.entries()],
+      status: options.status ?? 200,
+    });
+  }
+
+  request(): SharedWorkerRequest {
+    return this.#request;
+  }
+
+  result(): DispatchResult {
+    if (!this.#result) {
+      throw new Error("SharedWorker route handler did not resolve the request");
+    }
+    return this.#result;
+  }
+
+  #setResult(result: DispatchResult): void {
+    if (this.#result) {
+      throw new Error("SharedWorker route request was already resolved");
+    }
+    this.#result = result;
+  }
+}
+
+/**
+ * Routes API fetches without replacing the production SharedWorker topology.
+ * The context serves the original worker URL with a fetch seam prepended to
+ * its real bundle. A same-origin control page stays alive across app
+ * navigations so worker requests cannot lose their response during reload.
+ */
+export class SharedWorkerRoutes {
+  readonly #apiOrigin: string;
+  readonly #bindingName = `__vm0SharedWorkerRoute_${randomUUID()}`;
+  readonly #bridgeUrl: string;
+  readonly #channelName = `vm0-playwright-shared-worker-${randomUUID()}`;
+  readonly #context: BrowserContext;
+  readonly #failures: Error[] = [];
+  readonly #ready = deferred<void>();
+  readonly #routes: RouteEntry[] = [];
+  readonly #scriptIntercepted = deferred<void>();
+  readonly #stateKey = `__vm0SharedWorkerRouteState_${randomUUID()}`;
+  readonly #waiters = new Set<ResponseWaiter>();
+  readonly #workerScript: WorkerScriptMatcher;
+  #bridgePage: Page | undefined;
+  #bridgeReady = false;
+  #closed = false;
+
+  private constructor(options: SharedWorkerRoutesOptions) {
+    this.#apiOrigin = new URL(options.apiOrigin).origin;
+    this.#bridgeUrl = new URL(
+      `/playwright/shared-worker-routes/${randomUUID()}`,
+      options.bridgeOrigin,
+    ).href;
+    this.#context = options.context;
+    this.#workerScript = options.workerScript;
+  }
+
+  static async install(
+    options: SharedWorkerRoutesOptions,
+  ): Promise<SharedWorkerRoutes> {
+    const routes = new SharedWorkerRoutes(options);
+    await routes.#install();
+    return routes;
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) {
+      return;
+    }
+    this.#closed = true;
+    const cleanupFailures: Error[] = [];
+
+    for (const waiter of this.#waiters) {
+      clearTimeout(waiter.timer);
+      waiter.reject(
+        new Error("SharedWorker routes closed before the response"),
+      );
+    }
+    this.#waiters.clear();
+
+    if (this.#bridgeReady && this.#bridgePage && !this.#bridgePage.isClosed()) {
+      try {
+        await this.#bridgePage.evaluate(async (stateKey) => {
+          const value: unknown = Reflect.get(globalThis, stateKey);
+          if (!value || typeof value !== "object") {
+            throw new Error("SharedWorker route page channel is unavailable");
+          }
+          const channel: unknown = Reflect.get(value, "channel");
+          if (channel instanceof BroadcastChannel) {
+            await new Promise<void>((resolve, reject) => {
+              const timer = setTimeout(() => {
+                reject(new Error("SharedWorker route cleanup timed out"));
+              }, 2_000);
+              channel.addEventListener(
+                "message",
+                (event: MessageEvent<unknown>) => {
+                  const message = event.data;
+                  if (
+                    message &&
+                    typeof message === "object" &&
+                    "kind" in message &&
+                    message.kind === "disposed"
+                  ) {
+                    clearTimeout(timer);
+                    resolve();
+                  }
+                },
+              );
+              channel.postMessage({ kind: "dispose" });
+            });
+            channel.close();
+          }
+          Reflect.deleteProperty(globalThis, stateKey);
+        }, this.#stateKey);
+      } catch (error: unknown) {
+        cleanupFailures.push(
+          new Error(
+            `Could not dispose SharedWorker routes: ${errorMessage(error)}`,
+          ),
+        );
+      }
+    }
+
+    if (this.#bridgePage && !this.#bridgePage.isClosed()) {
+      try {
+        await this.#bridgePage.close();
+      } catch (error: unknown) {
+        cleanupFailures.push(
+          new Error(
+            `Could not close SharedWorker bridge page: ${errorMessage(error)}`,
+          ),
+        );
+      }
+    }
+
+    try {
+      await this.#context.unroute(
+        this.#workerScript,
+        this.#interceptWorkerScript,
+      );
+    } catch (error: unknown) {
+      cleanupFailures.push(
+        new Error(
+          `Could not remove SharedWorker route: ${errorMessage(error)}`,
+        ),
+      );
+    }
+    try {
+      await this.#context.unroute(this.#bridgeUrl, this.#serveBridgePage);
+    } catch (error: unknown) {
+      cleanupFailures.push(
+        new Error(
+          `Could not remove SharedWorker bridge page route: ${errorMessage(error)}`,
+        ),
+      );
+    }
+
+    const failures = [...this.#failures, ...cleanupFailures];
+    this.#failures.length = 0;
+    if (failures.length === 1) {
+      throw failures[0];
+    }
+    if (failures.length > 1) {
+      throw new AggregateError(failures, "SharedWorker route failures");
+    }
+  }
+
+  async route(
+    matcher: SharedWorkerRouteMatcher,
+    handler: SharedWorkerRouteHandler,
+  ): Promise<void> {
+    if (this.#closed) {
+      throw new Error("Cannot register a closed SharedWorker route");
+    }
+    this.#routes.push({ handler, matcher });
+  }
+
+  async waitForReady(timeoutMs = defaultWaitTimeoutMs): Promise<void> {
+    await withTimeout(
+      Promise.all([this.#scriptIntercepted.promise, this.#ready.promise]).then(
+        () => undefined,
+      ),
+      timeoutMs,
+      `SharedWorker route bridge was not ready within ${timeoutMs}ms`,
+    );
+  }
+
+  waitForResponse(
+    matcher: SharedWorkerRouteMatcher,
+    timeoutMs = defaultWaitTimeoutMs,
+  ): Promise<SharedWorkerRequest> {
+    if (this.#closed) {
+      return Promise.reject(new Error("SharedWorker routes are closed"));
+    }
+    return new Promise<SharedWorkerRequest>((resolve, reject) => {
+      const waiter: ResponseWaiter = {
+        matcher,
+        reject,
+        resolve,
+        timer: setTimeout(() => {
+          this.#waiters.delete(waiter);
+          reject(
+            new Error(
+              `SharedWorker response was not observed within ${timeoutMs}ms`,
+            ),
+          );
+        }, timeoutMs),
+      };
+      this.#waiters.add(waiter);
+    });
+  }
+
+  async #dispatch(message: BridgeMessage): Promise<DispatchResult | null> {
+    if (message.kind === "ready") {
+      this.#bridgeReady = true;
+      this.#ready.resolve(undefined);
+      return null;
+    }
+    const request = new WorkerRequest(message.request);
+    if (this.#closed) {
+      return { action: "continue" };
+    }
+
+    try {
+      let entry: RouteEntry | undefined;
+      for (let index = this.#routes.length - 1; index >= 0; index -= 1) {
+        const candidate = this.#routes[index];
+        if (candidate && matches(candidate.matcher, request)) {
+          entry = candidate;
+          break;
+        }
+      }
+      let result: DispatchResult = { action: "continue" };
+      if (entry) {
+        const route = new WorkerRoute(request);
+        await entry.handler(route);
+        result = route.result();
+      }
+      this.#resolveWaiters(request);
+      return result;
+    } catch (error: unknown) {
+      const failure = new Error(
+        `SharedWorker route handler failed for ${request.method()} ${request.url()}: ${errorMessage(error)}`,
+        { cause: error },
+      );
+      this.#failures.push(failure);
+      this.#rejectWaiters(request, failure);
+      return { action: "error", message: failure.message };
+    }
+  }
+
+  async #install(): Promise<void> {
+    await this.#context.route(this.#bridgeUrl, this.#serveBridgePage);
+    this.#bridgePage = await this.#context.newPage();
+    await this.#bridgePage.exposeBinding(
+      this.#bindingName,
+      async (_source, message: unknown) => {
+        if (!isBridgeMessage(message)) {
+          throw new Error("SharedWorker bridge received an invalid message");
+        }
+        return await this.#dispatch(message);
+      },
+    );
+    await this.#bridgePage.goto(this.#bridgeUrl);
+    await this.#bridgePage.evaluate(
+      ({ bindingName, channelName, stateKey }) => {
+        const channel = new BroadcastChannel(channelName);
+        Reflect.set(globalThis, stateKey, { channel });
+        channel.addEventListener("message", (event: MessageEvent<unknown>) => {
+          const message = event.data;
+          if (
+            !message ||
+            typeof message !== "object" ||
+            !("kind" in message) ||
+            (message.kind !== "ready" && message.kind !== "request")
+          ) {
+            return;
+          }
+          const binding: unknown = Reflect.get(globalThis, bindingName);
+          if (typeof binding !== "function") {
+            throw new Error("SharedWorker route binding is unavailable");
+          }
+          const invoke = binding as (value: unknown) => Promise<unknown>;
+          Promise.resolve(invoke(message)).then(
+            (result: unknown) => {
+              if (message.kind === "request") {
+                channel.postMessage({
+                  kind: "response",
+                  requestId: Reflect.get(message, "requestId"),
+                  result,
+                });
+              }
+            },
+            (error: unknown) => {
+              if (message.kind === "request") {
+                channel.postMessage({
+                  kind: "response",
+                  requestId: Reflect.get(message, "requestId"),
+                  result: {
+                    action: "error",
+                    message:
+                      error instanceof Error ? error.message : String(error),
+                  },
+                });
+              }
+            },
+          );
+        });
+      },
+      {
+        bindingName: this.#bindingName,
+        channelName: this.#channelName,
+        stateKey: this.#stateKey,
+      },
+    );
+    await this.#context.route(this.#workerScript, this.#interceptWorkerScript);
+  }
+
+  readonly #serveBridgePage = async (route: PlaywrightRoute): Promise<void> => {
+    await route.fulfill({
+      body: "<!doctype html><title>SharedWorker route bridge</title>",
+      contentType: "text/html",
+    });
+  };
+
+  readonly #interceptWorkerScript = async (
+    route: PlaywrightRoute,
+  ): Promise<void> => {
+    const response = await route.fetch();
+    if (!response.ok()) {
+      throw new Error(
+        `SharedWorker script returned ${response.status()}: ${response.url()}`,
+      );
+    }
+    const contentType = response.headers()["content-type"]?.toLowerCase();
+    if (
+      contentType?.includes("javascript") !== true &&
+      contentType?.includes("ecmascript") !== true
+    ) {
+      throw new Error(
+        `SharedWorker script is not JavaScript: ${contentType ?? "missing"}`,
+      );
+    }
+    const body = await response.text();
+    await route.fulfill({
+      response,
+      body: `${this.#workerBridgeSource()}\n${body}`,
+    });
+    this.#scriptIntercepted.resolve(undefined);
+  };
+
+  #rejectWaiters(request: SharedWorkerRequest, error: Error): void {
+    for (const waiter of this.#waiters) {
+      if (!matches(waiter.matcher, request)) {
+        continue;
+      }
+      clearTimeout(waiter.timer);
+      this.#waiters.delete(waiter);
+      waiter.reject(error);
+    }
+  }
+
+  #resolveWaiters(request: SharedWorkerRequest): void {
+    for (const waiter of this.#waiters) {
+      if (!matches(waiter.matcher, request)) {
+        continue;
+      }
+      clearTimeout(waiter.timer);
+      this.#waiters.delete(waiter);
+      waiter.resolve(request);
+    }
+  }
+
+  #workerBridgeSource(): string {
+    const apiOrigin = JSON.stringify(this.#apiOrigin);
+    const channelName = JSON.stringify(this.#channelName);
+    return `;(() => {
+  const apiOrigin = ${apiOrigin};
+  const channel = new BroadcastChannel(${channelName});
+  const nativeFetch = globalThis.fetch.bind(globalThis);
+  const pending = new Map();
+  channel.addEventListener("message", (event) => {
+    const message = event.data;
+    if (!message || typeof message !== "object") return;
+    if (message.kind === "dispose") {
+      globalThis.fetch = nativeFetch;
+      for (const entry of pending.values()) {
+        entry.cleanup();
+        entry.reject(new Error("SharedWorker routes were disposed"));
+      }
+      pending.clear();
+      channel.postMessage({ kind: "disposed" });
+      channel.close();
+      return;
+    }
+    if (message.kind !== "response") return;
+    const entry = pending.get(message.requestId);
+    if (!entry) return;
+    pending.delete(message.requestId);
+    entry.cleanup();
+    if (message.result?.action === "error") {
+      entry.reject(new Error(message.result.message));
+      return;
+    }
+    entry.resolve(message.result);
+  });
+  globalThis.fetch = async (input, init) => {
+    const request = new Request(input, init);
+    const url = new URL(request.url);
+    if (url.origin !== apiOrigin || !url.pathname.startsWith("/api/")) {
+      return await nativeFetch(request);
+    }
+    const requestId = crypto.randomUUID();
+    const body = request.method === "GET" || request.method === "HEAD"
+      ? null
+      : await request.clone().text();
+    const result = await new Promise((resolve, reject) => {
+      const abort = () => {
+        pending.delete(requestId);
+        reject(request.signal.reason);
+      };
+      const cleanup = () => request.signal.removeEventListener("abort", abort);
+      if (request.signal.aborted) {
+        abort();
+        return;
+      }
+      request.signal.addEventListener("abort", abort, { once: true });
+      pending.set(requestId, { cleanup, reject, resolve });
+      channel.postMessage({
+        kind: "request",
+        requestId,
+        request: {
+          body,
+          headers: [...request.headers.entries()],
+          method: request.method,
+          url: request.url,
+        },
+      });
+    });
+    if (result.action === "continue") {
+      return await nativeFetch(request);
+    }
+    return new Response(result.body, {
+      headers: result.headers,
+      status: result.status,
+    });
+  };
+  channel.postMessage({ kind: "ready" });
+})();`;
+  }
+}
+
+export type SharedWorkerRequestHeaders =
+  | Pick<PlaywrightRequest, "headerValue">
+  | SharedWorkerRequest;

--- a/e2e/playwright/tests/agents.spec.ts
+++ b/e2e/playwright/tests/agents.spec.ts
@@ -1,6 +1,7 @@
 import type { Locator, Page } from "@playwright/test";
 import { resolveApiBackendUrl } from "../api-backend-url";
 import { expect, test } from "../fixtures";
+import type { SharedWorkerRoutes } from "../lib/shared-worker-routes";
 import { deriveAppUrl } from "../playwright.config";
 
 const appUrl = deriveAppUrl(resolveApiBackendUrl());
@@ -118,35 +119,65 @@ async function mockPinnedAgentGrid(
 
 async function mockUnreadThread(
   page: Page,
+  sharedWorkerRoutes: SharedWorkerRoutes,
   defaultAgentId: string,
 ): Promise<void> {
-  await page.route("**/api/chat-threads/snapshot", async (route) => {
-    await route.fulfill({
-      json: {
-        chatThreads: [
-          {
-            id: unreadThreadStory.id,
-            agentId: defaultAgentId,
-            title: unreadThreadStory.title,
-            sortAt: unreadThreadStory.createdAt,
-            createdAt: unreadThreadStory.createdAt,
-            updatedAt: unreadThreadStory.createdAt,
-            pinnedAt: null,
-            renamedAt: null,
-            selectedModel: null,
-            serviceTier: null,
-            computerUseHostId: null,
-          },
-        ],
-        latestEventId: null,
-        latestSeqId: null,
-      },
-    });
-  });
-  await page.route(
+  let createdEventSeqId: number | null = null;
+  await sharedWorkerRoutes.route(
+    "/api/chat-threads/snapshot",
+    async (route) => {
+      await route.fulfill({
+        json: {
+          chatThreads: [
+            {
+              id: unreadThreadStory.id,
+              agentId: defaultAgentId,
+              title: unreadThreadStory.title,
+              sortAt: unreadThreadStory.createdAt,
+              createdAt: unreadThreadStory.createdAt,
+              updatedAt: unreadThreadStory.createdAt,
+              pinnedAt: null,
+              renamedAt: null,
+              selectedModel: null,
+              serviceTier: null,
+              computerUseHostId: null,
+            },
+          ],
+          latestEventId: null,
+          latestSeqId: null,
+        },
+      });
+    },
+  );
+  await sharedWorkerRoutes.route(
     (url) => url.pathname === "/api/chat-threads/events",
     async (route) => {
-      await route.fulfill({ json: { events: [], hasMore: false } });
+      const requestUrl = new URL(route.request().url());
+      const rawSinceSeqId = requestUrl.searchParams.get("sinceSeqId");
+      const sinceSeqId = rawSinceSeqId === null ? 0 : Number(rawSinceSeqId);
+      if (!Number.isSafeInteger(sinceSeqId) || sinceSeqId < 0) {
+        throw new Error("Thread event cursor is invalid");
+      }
+      createdEventSeqId ??= sinceSeqId + 1;
+      const events =
+        sinceSeqId < createdEventSeqId
+          ? [
+              {
+                id: `d${unreadThreadStory.id.slice(1)}`,
+                seqId: createdEventSeqId,
+                kind: "created",
+                chatThreadId: unreadThreadStory.id,
+                agentId: defaultAgentId,
+                title: unreadThreadStory.title,
+                selectedModel: null,
+                serviceTier: null,
+                computerUseHostId: null,
+                cloudBrowserEnabled: false,
+                createdAt: unreadThreadStory.createdAt,
+              },
+            ]
+          : [];
+      await route.fulfill({ json: { events, hasMore: false } });
     },
   );
   await page.route("**/api/indicators", async (route) => {
@@ -333,6 +364,7 @@ test("onboarding workflow preview uses the shared dialog radius", async ({
 
 test("three-column rail and unread indicators preserve their visual hierarchy", async ({
   page,
+  sharedWorkerRoutes,
 }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.addInitScript(() => {
@@ -354,14 +386,14 @@ test("three-column rail and unread indicators preserve their visual hierarchy", 
     page,
     defaultAgentId,
   );
-  await mockUnreadThread(page, defaultAgentId);
+  await mockUnreadThread(page, sharedWorkerRoutes, defaultAgentId);
+  await sharedWorkerRoutes.waitForReady();
   await Promise.all([
     ...[
       "/api/feature-switches",
       "/api/onboarding/status",
       "/api/agents",
       "/api/user-preferences",
-      "/api/chat-threads/snapshot",
       "/api/indicators",
       "/api/chat-thread-unreads",
     ].map((pathname) => {
@@ -372,6 +404,7 @@ test("three-column rail and unread indicators preserve their visual hierarchy", 
         );
       });
     }),
+    sharedWorkerRoutes.waitForResponse("/api/chat-threads/events"),
     page.reload(),
   ]);
 

--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1,6 +1,10 @@
-import type { Locator, Page, Request, Response } from "@playwright/test";
+import type { Locator, Page, Response } from "@playwright/test";
 import { resolveApiBackendUrl } from "../api-backend-url";
 import { expect, test } from "../fixtures";
+import type {
+  SharedWorkerRequestHeaders,
+  SharedWorkerRoutes,
+} from "../lib/shared-worker-routes";
 import { deriveAppUrl } from "../playwright.config";
 
 const appUrl = deriveAppUrl(resolveApiBackendUrl());
@@ -60,7 +64,7 @@ function mockChatEventCursorId(seqId: number): string {
 }
 
 async function negotiatedChatEventHeaders(
-  request: Request,
+  request: SharedWorkerRequestHeaders,
 ): Promise<Record<string, string>> {
   const version = await request.headerValue(chatEventSchemaVersionHeader);
   if (version === null) {
@@ -114,35 +118,35 @@ async function waitForAgentDraftClear(
   await draftCleared;
 }
 
-function isChatThreadEventRowsResponse(
-  response: Response,
+async function navigateToMockChatThread(
+  page: Page,
+  sharedWorkerRoutes: SharedWorkerRoutes,
+  threadId: string,
+): Promise<void> {
+  await sharedWorkerRoutes.waitForReady();
+  const rowsLoaded = sharedWorkerRoutes.waitForResponse((url, request) => {
+    return isChatThreadEventRowsRequest(url, request.method(), threadId);
+  });
+  await page.goto(new URL(`/chats/${threadId}`, appUrl).href);
+  await rowsLoaded;
+}
+
+function isChatThreadEventRowsRequest(
+  url: URL,
+  method: string,
   threadId: string,
 ): boolean {
-  const request = response.request();
-  const url = new URL(response.url());
   const rawSinceSeqId = url.searchParams.get("sinceSeqId");
   const sinceEventId = url.searchParams.get("sinceEventId");
   const sinceSeqId = Number(rawSinceSeqId);
   return (
-    response.ok() &&
-    request.method() === "GET" &&
+    method === "GET" &&
     url.pathname === `/api/chat-threads/${threadId}/event-rows` &&
     rawSinceSeqId !== null &&
     Number.isSafeInteger(sinceSeqId) &&
     ((sinceSeqId === 0 && sinceEventId === null) ||
       (sinceSeqId > 0 && sinceEventId !== null))
   );
-}
-
-async function navigateToMockChatThread(
-  page: Page,
-  threadId: string,
-): Promise<void> {
-  const rowsLoaded = page.waitForResponse((response) => {
-    return isChatThreadEventRowsResponse(response, threadId);
-  });
-  await page.goto(new URL(`/chats/${threadId}`, appUrl).href);
-  await rowsLoaded;
 }
 
 async function clearComposerEditor(editor: Locator): Promise<void> {
@@ -448,21 +452,25 @@ function toMockChatEventRow(
 
 async function mockChatThread(
   page: Page,
+  sharedWorkerRoutes: SharedWorkerRoutes,
   options: MockChatThreadOptions,
 ): Promise<void> {
   const createdEventId = `d${options.threadId.slice(1)}`;
   let createdEventSeqId: number | null = null;
 
-  await page.route("**/api/chat-threads/snapshot", async (route) => {
-    await route.fulfill({
-      json: {
-        chatThreads: [],
-        latestEventId: null,
-        latestSeqId: null,
-      },
-    });
-  });
-  await page.route(
+  await sharedWorkerRoutes.route(
+    "/api/chat-threads/snapshot",
+    async (route) => {
+      await route.fulfill({
+        json: {
+          chatThreads: [],
+          latestEventId: null,
+          latestSeqId: null,
+        },
+      });
+    },
+  );
+  await sharedWorkerRoutes.route(
     (url) => url.pathname === "/api/chat-threads/events",
     async (route) => {
       const requestUrl = new URL(route.request().url());
@@ -498,7 +506,7 @@ async function mockChatThread(
       await route.fulfill({ json: { events, hasMore: false } });
     },
   );
-  await page.route(
+  await sharedWorkerRoutes.route(
     (url) =>
       url.pathname === `/api/chat-threads/${options.threadId}/event-rows`,
     async (route) => {
@@ -566,7 +574,7 @@ async function mockChatThread(
       });
     },
   );
-  await page.route(
+  await sharedWorkerRoutes.route(
     (url) =>
       url.pathname === `/api/chat-threads/${options.threadId}/event-snapshot`,
     async (route) => {
@@ -592,6 +600,7 @@ async function mockChatThread(
 
 async function mockResponsiveFollowupThread(
   page: Page,
+  sharedWorkerRoutes: SharedWorkerRoutes,
   agentId: string,
 ): Promise<void> {
   const createdAt = "2026-06-09T10:01:01Z";
@@ -632,7 +641,7 @@ async function mockResponsiveFollowupThread(
     },
   ];
 
-  await mockChatThread(page, {
+  await mockChatThread(page, sharedWorkerRoutes, {
     agentId,
     createdAt,
     events,
@@ -644,11 +653,12 @@ async function mockResponsiveFollowupThread(
 
 async function mockForwardLayoutThread(
   page: Page,
+  sharedWorkerRoutes: SharedWorkerRoutes,
   agentId: string,
 ): Promise<void> {
   const createdAt = "2026-08-13T08:00:01Z";
   const runId = "run-forward-layout";
-  await mockChatThread(page, {
+  await mockChatThread(page, sharedWorkerRoutes, {
     agentId,
     createdAt,
     selectedModel: null,
@@ -680,6 +690,7 @@ async function mockForwardLayoutThread(
 
 async function mockModelChangeThread(
   page: Page,
+  sharedWorkerRoutes: SharedWorkerRoutes,
   agentId: string,
 ): Promise<void> {
   const createdAt = "2026-08-06T09:02:01Z";
@@ -781,7 +792,7 @@ async function mockModelChangeThread(
       createdAt,
     },
   ];
-  await mockChatThread(page, {
+  await mockChatThread(page, sharedWorkerRoutes, {
     agentId,
     createdAt,
     events,
@@ -793,6 +804,7 @@ async function mockModelChangeThread(
 
 async function mockCardSpacingThread(
   page: Page,
+  sharedWorkerRoutes: SharedWorkerRoutes,
   agentId: string,
 ): Promise<void> {
   const createdAt = "2026-08-13T06:00:02Z";
@@ -824,7 +836,7 @@ async function mockCardSpacingThread(
       createdAt,
     },
   ];
-  await mockChatThread(page, {
+  await mockChatThread(page, sharedWorkerRoutes, {
     agentId,
     createdAt,
     events,
@@ -890,6 +902,7 @@ async function setupDelayedImageRoutes(
 
 async function mockDelayedImageLayoutThread(
   page: Page,
+  sharedWorkerRoutes: SharedWorkerRoutes,
   agentId: string,
   routes: DelayedImageRoutes,
 ): Promise<void> {
@@ -901,7 +914,7 @@ async function mockDelayedImageLayoutThread(
     },
   );
   const runId = "run-delayed-image-layout";
-  await mockChatThread(page, {
+  await mockChatThread(page, sharedWorkerRoutes, {
     agentId,
     createdAt: "2026-08-12T09:00:03Z",
     selectedModel: null,
@@ -1754,6 +1767,7 @@ test("chat composer keeps standard tool icons and Send inside on narrow screens"
 
 test("forward composer stays inside the modal on narrow screens", async ({
   page,
+  sharedWorkerRoutes,
 }) => {
   await page.setViewportSize({ width: 360, height: 780 });
   await page.goto(appUrl);
@@ -1764,8 +1778,12 @@ test("forward composer stays inside the modal on narrow screens", async ({
   if (!agentId) {
     throw new Error("Could not resolve the active agent from the chat URL");
   }
-  await mockForwardLayoutThread(page, agentId);
-  await navigateToMockChatThread(page, forwardLayoutThreadId);
+  await mockForwardLayoutThread(page, sharedWorkerRoutes, agentId);
+  await navigateToMockChatThread(
+    page,
+    sharedWorkerRoutes,
+    forwardLayoutThreadId,
+  );
 
   const assistantReply = page.getByText(
     "Keep the forward composer within the modal.",
@@ -1807,6 +1825,7 @@ test("forward composer stays inside the modal on narrow screens", async ({
 
 test("model change labels follow the divider at the right edge", async ({
   page,
+  sharedWorkerRoutes,
 }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto(appUrl);
@@ -1817,8 +1836,8 @@ test("model change labels follow the divider at the right edge", async ({
   if (!agentId) {
     throw new Error("Could not resolve the active agent from the chat URL");
   }
-  await mockModelChangeThread(page, agentId);
-  await navigateToMockChatThread(page, modelChangeThreadId);
+  await mockModelChangeThread(page, sharedWorkerRoutes, agentId);
+  await navigateToMockChatThread(page, sharedWorkerRoutes, modelChangeThreadId);
 
   await expectRightAlignedDivider(
     page.getByText("Model changed to Claude Sonnet 4.6", { exact: true }),
@@ -1830,6 +1849,7 @@ test("model change labels follow the divider at the right edge", async ({
 
 test("consecutive body cards keep a block gap between them", async ({
   page,
+  sharedWorkerRoutes,
 }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto(appUrl);
@@ -1840,8 +1860,8 @@ test("consecutive body cards keep a block gap between them", async ({
   if (!agentId) {
     throw new Error("Could not resolve the active agent from the chat URL");
   }
-  await mockCardSpacingThread(page, agentId);
-  await navigateToMockChatThread(page, cardSpacingThreadId);
+  await mockCardSpacingThread(page, sharedWorkerRoutes, agentId);
+  await navigateToMockChatThread(page, sharedWorkerRoutes, cardSpacingThreadId);
 
   const cards = page.getByTestId("computer-use-authorization-card");
   await expect(cards).toHaveCount(2);
@@ -1864,6 +1884,7 @@ test("consecutive body cards keep a block gap between them", async ({
 
 test("image preview frames stay fixed while delayed images load", async ({
   page,
+  sharedWorkerRoutes,
 }) => {
   await page.goto(appUrl);
   await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
@@ -1874,10 +1895,15 @@ test("image preview frames stay fixed while delayed images load", async ({
     throw new Error("Could not resolve the active agent from the chat URL");
   }
   const routes = await setupDelayedImageRoutes(page);
-  await mockDelayedImageLayoutThread(page, agentId, routes);
+  await mockDelayedImageLayoutThread(page, sharedWorkerRoutes, agentId, routes);
 
-  const rowsLoaded = page.waitForResponse((response) => {
-    return isChatThreadEventRowsResponse(response, imageLayoutThreadId);
+  await sharedWorkerRoutes.waitForReady();
+  const rowsLoaded = sharedWorkerRoutes.waitForResponse((url, request) => {
+    return isChatThreadEventRowsRequest(
+      url,
+      request.method(),
+      imageLayoutThreadId,
+    );
   });
   await page.goto(new URL(`/chats/${imageLayoutThreadId}`, appUrl).href, {
     waitUntil: "domcontentloaded",
@@ -1939,6 +1965,7 @@ test.describe("mobile follow-up card rail", () => {
 
   test("responsive follow-up rail aligns its edges and equalizes card heights", async ({
     page,
+    sharedWorkerRoutes,
   }) => {
     await enableResponsiveFollowupCards(page);
     await page.setViewportSize({ width: 390, height: 844 });
@@ -1951,8 +1978,12 @@ test.describe("mobile follow-up card rail", () => {
     if (!agentId) {
       throw new Error("Could not resolve the active agent from the chat URL");
     }
-    await mockResponsiveFollowupThread(page, agentId);
-    await navigateToMockChatThread(page, responsiveFollowupThreadId);
+    await mockResponsiveFollowupThread(page, sharedWorkerRoutes, agentId);
+    await navigateToMockChatThread(
+      page,
+      sharedWorkerRoutes,
+      responsiveFollowupThreadId,
+    );
 
     const rail = page.getByRole("group", { name: "Keep going" });
     const cards = responsiveFollowupPrompts.map((prompt) => {
@@ -2049,6 +2080,7 @@ test.describe("mobile follow-up card rail", () => {
 
 test("keeps the flat follow-up list in a narrow desktop window", async ({
   page,
+  sharedWorkerRoutes,
 }) => {
   await enableResponsiveFollowupCards(page);
   await page.setViewportSize({ width: 390, height: 844 });
@@ -2061,8 +2093,12 @@ test("keeps the flat follow-up list in a narrow desktop window", async ({
   if (!agentId) {
     throw new Error("Could not resolve the active agent from the chat URL");
   }
-  await mockResponsiveFollowupThread(page, agentId);
-  await navigateToMockChatThread(page, responsiveFollowupThreadId);
+  await mockResponsiveFollowupThread(page, sharedWorkerRoutes, agentId);
+  await navigateToMockChatThread(
+    page,
+    sharedWorkerRoutes,
+    responsiveFollowupThreadId,
+  );
 
   const list = page.getByRole("group", { name: "Keep going" });
   const rows = responsiveFollowupPrompts.map((prompt) => {


### PR DESCRIPTION
## Summary

- intercept the original production SharedWorker script URL and prepend a Playwright-only fetch seam without replacing its worker name, MessagePort topology, bundle, or runtime ownership
- route worker-owned chat snapshot/event fixtures through that seam while keeping indicators, drafts, metadata, mark-read, feature switches, and other page-owned endpoints page-scoped
- seed the existing app-origin preview-bypass cookie before navigation so production code can forward preview authorization from the page to native SharedWorker requests
- preserve all 30 lane tests and the real deployed-runner scenario, with focused coverage for readiness, interception, navigation, handler failures, passthrough, context isolation, deterministic cleanup, and the preview-cookie contract
- make the Turbo aggregate gate reject cancelled required browser jobs while retaining intentional non-executed skip and informational semantics

## Diagnosis

The closed runtime-bridge approach waited for a CDP SharedWorker target to move from `attached: true` to `attached: false` before installing its runtime bridge. Its focused fixture created that lifecycle, but the deployed preview did not prove or guarantee it. The bridge readiness promise therefore remained unresolved and reproduced the same four 120-second feature timeouts.

This change attaches at the deterministic network boundary where Chromium loads the actual SharedWorker main script. A same-origin control page remains alive across app navigation, so reload cannot destroy an in-flight bridge response. Teardown probes whether Chromium still owns the worker; a live worker must acknowledge native-fetch restoration, while an already-terminated owner requires no runtime disposal. It then removes both context routes and surfaces any handler error.

The first exact-head preview run then narrowed the unchanged real-runner timeout to authorization before realtime or catch-up logic. Request telemetry showed the page client receiving 200 responses while the SharedWorker client received 403 for `/api/realtime/token` and thread snapshot requests; no `/event-rows` request reached the preview API. Playwright's page routing injected the bypass header only into page requests, while native SharedWorker fetches were outside that route. The focused repair seeds the app-origin bypass cookie before navigation. Existing production code captures that cookie and forwards the bypass through its SharedWorker heartbeat, preserving the deployed authentication topology rather than adding a test-only runtime auth path.

## Verification

- `cd e2e && pnpm check-types`
- `cd e2e && pnpm exec tsx --test playwright/lib/shared-worker-routes.test.ts` — 7 passed
- `cd e2e && pnpm exec tsx --test playwright/lib/preview-bypass.test.ts` — 2 passed
- `bash .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `bash -n .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- repository Prettier, lint, Knip, and staged TypeScript checks
- exact-head deployed-preview features job [`99435723653`](https://github.com/vm0-ai/vm0/actions/runs/33375173627/job/99435723653) — raw log: `30 passed (1.2m)`

Closes #30454
