### PR TITLE
perf(platform): render skeleton before app startup

### DIFF
--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -306,6 +306,42 @@ function clerkBootstrap(html) {
   return bootstrap;
 }
 
+function assertBootstrapAvatar(html) {
+  assert.doesNotMatch(html, /app-bootstrap-skeleton__avatar-placeholder/u);
+  for (const layer of ["head", "face", "hair"]) {
+    assert.equal(
+      tagAttribute(
+        html,
+        "img",
+        "data-app-bootstrap-avatar-layer",
+        layer,
+        "src",
+      ),
+      null,
+    );
+    assert.equal(
+      tagAttribute(
+        html,
+        "img",
+        "data-app-bootstrap-avatar-layer",
+        layer,
+        "decoding",
+      ),
+      "async",
+    );
+    assert.equal(
+      tagAttribute(
+        html,
+        "img",
+        "data-app-bootstrap-avatar-layer",
+        layer,
+        "fetchpriority",
+      ),
+      "low",
+    );
+  }
+}
+
 async function requestAppPage(origin, apiOrigin = "") {
   const response = await worker.fetch(
     new Request(`${origin}/settings/profile`),
@@ -360,11 +396,7 @@ assert.ok(
     "https://static.vm0.io/platform/icon.svg",
   ),
 );
-assert.equal(tagAttribute(vm0Page.html, "img", "alt", "", "src"), null);
-assert.match(
-  vm0Page.html,
-  /class="app-bootstrap-skeleton__avatar-placeholder"/u,
-);
+assertBootstrapAvatar(vm0Page.html);
 assert.equal(clerkBootstrap(vm0Page.html), expectedClerkBootstrap);
 
 const okouPage = await requestAppPage("https://app.okou.ai");
@@ -409,11 +441,7 @@ assert.ok(
     (href) => href === "https://static.okou.io",
   ),
 );
-assert.equal(tagAttribute(okouPage.html, "img", "alt", "", "src"), null);
-assert.match(
-  okouPage.html,
-  /class="app-bootstrap-skeleton__avatar-placeholder"/u,
-);
+assertBootstrapAvatar(okouPage.html);
 assert.equal(clerkBootstrap(okouPage.html), expectedClerkBootstrap);
 
 const okouPreview = await requestAppPage(

--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -360,9 +360,10 @@ assert.ok(
     "https://static.vm0.io/platform/icon.svg",
   ),
 );
-assert.equal(
-  tagAttribute(vm0Page.html, "img", "alt", "", "src"),
-  "https://static.vm0.io/platform/icon.svg",
+assert.equal(tagAttribute(vm0Page.html, "img", "alt", "", "src"), null);
+assert.match(
+  vm0Page.html,
+  /class="app-bootstrap-skeleton__avatar-placeholder"/u,
 );
 assert.equal(clerkBootstrap(vm0Page.html), expectedClerkBootstrap);
 
@@ -408,9 +409,10 @@ assert.ok(
     (href) => href === "https://static.okou.io",
   ),
 );
-assert.equal(
-  tagAttribute(okouPage.html, "img", "alt", "", "src"),
-  "https://static.okou.io/platform/icon.svg",
+assert.equal(tagAttribute(okouPage.html, "img", "alt", "", "src"), null);
+assert.match(
+  okouPage.html,
+  /class="app-bootstrap-skeleton__avatar-placeholder"/u,
 );
 assert.equal(clerkBootstrap(okouPage.html), expectedClerkBootstrap);
 

--- a/.github/scripts/tests/verify-okou-app-assets-test.sh
+++ b/.github/scripts/tests/verify-okou-app-assets-test.sh
@@ -17,6 +17,7 @@ fail() {
 
 printf 'javascript\n' > "${assets_directory}/app-AbCd1234.js"
 printf '{}\n' > "${assets_directory}/app-AbCd1234.js.map"
+printf 'bootstrap\n' > "${assets_directory}/bootstrap-after-first-paint-123456789abc.js"
 printf 'vendor\n' > "${assets_directory}/vendor-EfGh5678.js"
 printf '{}\n' > "${assets_directory}/vendor-EfGh5678.js.map"
 printf 'runtime\n' > "${assets_directory}/rolldown-runtime-IjKl9012.js"
@@ -50,15 +51,16 @@ output="$({
 grep -Fq 'Skipping unhashed source map: runtime.js.map' <<< "$output" ||
   fail "unhashed source map was not reported as skipped"
 grep -Fq \
-  'App bundle layout: app=app-AbCd1234.js vendor=vendor-EfGh5678.js runtime=rolldown-runtime-IjKl9012.js worker=shared-database-worker-MnOp3456.js' \
+  'App bundle layout: app=app-AbCd1234.js after-first-paint=bootstrap-after-first-paint-123456789abc.js vendor=vendor-EfGh5678.js runtime=rolldown-runtime-IjKl9012.js worker=shared-database-worker-MnOp3456.js' \
   <<< "$output" || fail "bundle layout was not reported"
 grep -Fq \
-  'Verified 8 immutable app assets on https://static.test/okou-app/assets' \
+  'Verified 9 immutable app assets on https://static.test/okou-app/assets' \
   <<< "$output" || fail "verification summary is incorrect"
 
 for relative_path in \
   app-AbCd1234.js \
   app-AbCd1234.js.map \
+  bootstrap-after-first-paint-123456789abc.js \
   vendor-EfGh5678.js \
   vendor-EfGh5678.js.map \
   rolldown-runtime-IjKl9012.js \
@@ -95,7 +97,7 @@ if PATH="${fake_bin}:$PATH" \
   fail "missing Rolldown runtime did not fail layout verification"
 fi
 grep -Fq \
-  'Expected exactly one app, vendor, Rolldown runtime, and SharedWorker JavaScript asset' \
+  'Expected exactly one app, after-first-paint bootstrap, vendor, Rolldown runtime, and SharedWorker JavaScript asset' \
   "${test_root}/layout-failure.log" || fail "layout failure was not identified"
 
 echo "verify okou app assets tests passed"

--- a/.github/scripts/tests/verify-okou-app-runtime-test.sh
+++ b/.github/scripts/tests/verify-okou-app-runtime-test.sh
@@ -32,20 +32,20 @@ cat > "$html_source" <<'HTML'
 <!doctype html>
 <meta name="okou-app-git-commit-sha" content="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
 <meta name="okou-app-version" content="0.812.5">
-<link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/app-AbCd1234.js" data-vm0-app-entry="">
-<link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/rolldown-runtime-IjKl9012.js">
-<link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/vendor-EfGh5678.js">
-<link rel="preload" as="script" crossorigin href="https://static.test/okou-app/assets/bootstrap-after-first-paint-123456789abc.js" integrity="sha384-dGVzdA==" data-vm0-after-first-paint-entry="">
+<link crossorigin href="https://static.test/okou-app/assets/app-AbCd1234.js" data-vm0-app-entry="">
+<link crossorigin href="https://static.test/okou-app/assets/rolldown-runtime-IjKl9012.js" data-vm0-app-module-preload="">
+<link crossorigin href="https://static.test/okou-app/assets/vendor-EfGh5678.js" data-vm0-app-module-preload="">
+<link crossorigin href="https://static.test/okou-app/assets/bootstrap-after-first-paint-123456789abc.js" data-vm0-after-first-paint-entry="">
 HTML
 
 cat > "$old_html_source" <<'HTML'
 <!doctype html>
 <meta name="okou-app-git-commit-sha" content="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb">
 <meta name="okou-app-version" content="0.812.4">
-<link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/app-Old12345.js" data-vm0-app-entry="">
-<link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/rolldown-runtime-Old12345.js">
-<link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/vendor-Old12345.js">
-<link rel="preload" as="script" crossorigin href="https://static.test/okou-app/assets/bootstrap-after-first-paint-Old12345.js" integrity="sha384-dGVzdA==" data-vm0-after-first-paint-entry="">
+<link crossorigin href="https://static.test/okou-app/assets/app-Old12345.js" data-vm0-app-entry="">
+<link crossorigin href="https://static.test/okou-app/assets/rolldown-runtime-Old12345.js" data-vm0-app-module-preload="">
+<link crossorigin href="https://static.test/okou-app/assets/vendor-Old12345.js" data-vm0-app-module-preload="">
+<link crossorigin href="https://static.test/okou-app/assets/bootstrap-after-first-paint-Old12345.js" data-vm0-after-first-paint-entry="">
 HTML
 
 cat > "${fake_bin}/curl" <<'BASH'

--- a/.github/scripts/tests/verify-okou-app-runtime-test.sh
+++ b/.github/scripts/tests/verify-okou-app-runtime-test.sh
@@ -21,6 +21,7 @@ fail() {
 
 for file_name in \
   app-AbCd1234.js \
+  bootstrap-after-first-paint-123456789abc.js \
   vendor-EfGh5678.js \
   rolldown-runtime-IjKl9012.js \
   shared-database-worker-MnOp3456.js; do
@@ -34,6 +35,7 @@ cat > "$html_source" <<'HTML'
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/app-AbCd1234.js" data-vm0-app-entry="">
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/rolldown-runtime-IjKl9012.js">
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/vendor-EfGh5678.js">
+<link rel="preload" as="script" crossorigin href="https://static.test/okou-app/assets/bootstrap-after-first-paint-123456789abc.js" data-vm0-after-first-paint-entry="">
 HTML
 
 cat > "$old_html_source" <<'HTML'
@@ -43,6 +45,7 @@ cat > "$old_html_source" <<'HTML'
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/app-Old12345.js" data-vm0-app-entry="">
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/rolldown-runtime-Old12345.js">
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/vendor-Old12345.js">
+<link rel="preload" as="script" crossorigin href="https://static.test/okou-app/assets/bootstrap-after-first-paint-Old12345.js" data-vm0-after-first-paint-entry="">
 HTML
 
 cat > "${fake_bin}/curl" <<'BASH'
@@ -103,11 +106,12 @@ output="$({
 } 2>&1)"
 
 grep -Fq \
-  'Verified app runtime: app=https://static.test/okou-app/assets/app-AbCd1234.js vendor=https://static.test/okou-app/assets/vendor-EfGh5678.js runtime=https://static.test/okou-app/assets/rolldown-runtime-IjKl9012.js worker=https://app.test/okou-app/assets/shared-database-worker-MnOp3456.js' \
+  'Verified app runtime: app=https://static.test/okou-app/assets/app-AbCd1234.js after-first-paint=https://static.test/okou-app/assets/bootstrap-after-first-paint-123456789abc.js vendor=https://static.test/okou-app/assets/vendor-EfGh5678.js runtime=https://static.test/okou-app/assets/rolldown-runtime-IjKl9012.js worker=https://app.test/okou-app/assets/shared-database-worker-MnOp3456.js' \
   <<< "$output" || fail "runtime verification summary is incorrect"
 for expected_url in \
   https://app.test/sign-up \
   https://static.test/okou-app/assets/app-AbCd1234.js \
+  https://static.test/okou-app/assets/bootstrap-after-first-paint-123456789abc.js \
   https://static.test/okou-app/assets/vendor-EfGh5678.js \
   https://static.test/okou-app/assets/rolldown-runtime-IjKl9012.js \
   https://app.test/okou-app/assets/shared-database-worker-MnOp3456.js; do

--- a/.github/scripts/tests/verify-okou-app-runtime-test.sh
+++ b/.github/scripts/tests/verify-okou-app-runtime-test.sh
@@ -35,7 +35,7 @@ cat > "$html_source" <<'HTML'
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/app-AbCd1234.js" data-vm0-app-entry="">
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/rolldown-runtime-IjKl9012.js">
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/vendor-EfGh5678.js">
-<link rel="preload" as="script" crossorigin href="https://static.test/okou-app/assets/bootstrap-after-first-paint-123456789abc.js" data-vm0-after-first-paint-entry="">
+<link rel="preload" as="script" crossorigin href="https://static.test/okou-app/assets/bootstrap-after-first-paint-123456789abc.js" integrity="sha384-dGVzdA==" data-vm0-after-first-paint-entry="">
 HTML
 
 cat > "$old_html_source" <<'HTML'
@@ -45,7 +45,7 @@ cat > "$old_html_source" <<'HTML'
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/app-Old12345.js" data-vm0-app-entry="">
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/rolldown-runtime-Old12345.js">
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/vendor-Old12345.js">
-<link rel="preload" as="script" crossorigin href="https://static.test/okou-app/assets/bootstrap-after-first-paint-Old12345.js" data-vm0-after-first-paint-entry="">
+<link rel="preload" as="script" crossorigin href="https://static.test/okou-app/assets/bootstrap-after-first-paint-Old12345.js" integrity="sha384-dGVzdA==" data-vm0-after-first-paint-entry="">
 HTML
 
 cat > "${fake_bin}/curl" <<'BASH'

--- a/.github/scripts/tests/verify-okou-app-runtime-test.sh
+++ b/.github/scripts/tests/verify-okou-app-runtime-test.sh
@@ -11,6 +11,7 @@ curl_log="${test_root}/curl.log"
 sleep_log="${test_root}/sleep.log"
 html_source="${test_root}/index.html"
 old_html_source="${test_root}/old-index.html"
+blocking_html_source="${test_root}/blocking-index.html"
 mkdir -p "$assets_directory" "$fake_bin"
 
 fail() {
@@ -30,7 +31,7 @@ cat > "$html_source" <<'HTML'
 <!doctype html>
 <meta name="okou-app-git-commit-sha" content="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
 <meta name="okou-app-version" content="0.812.5">
-<script type="module" crossorigin src="https://static.test/okou-app/assets/app-AbCd1234.js"></script>
+<link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/app-AbCd1234.js" data-vm0-app-entry="">
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/rolldown-runtime-IjKl9012.js">
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/vendor-EfGh5678.js">
 HTML
@@ -39,9 +40,9 @@ cat > "$old_html_source" <<'HTML'
 <!doctype html>
 <meta name="okou-app-git-commit-sha" content="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb">
 <meta name="okou-app-version" content="0.812.4">
-<script type="module" crossorigin src="https://static.test/okou-app/assets/app-AbCd1234.js"></script>
-<link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/rolldown-runtime-IjKl9012.js">
-<link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/vendor-EfGh5678.js">
+<link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/app-Old12345.js" data-vm0-app-entry="">
+<link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/rolldown-runtime-Old12345.js">
+<link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/vendor-Old12345.js">
 HTML
 
 cat > "${fake_bin}/curl" <<'BASH'
@@ -221,6 +222,24 @@ if PATH="${fake_bin}:$PATH" \
 fi
 grep -Fq 'SharedWorker same-origin proxy returned HTTP 200' \
   "${test_root}/worker-failure.log" || fail "worker failure was not identified"
+
+cp "$html_source" "$blocking_html_source"
+printf '%s\n' \
+  '<script type="module" src="https://static.test/okou-app/assets/app-AbCd1234.js"></script>' \
+  >> "$blocking_html_source"
+if PATH="${fake_bin}:$PATH" \
+  MOCK_CURL_LOG="$curl_log" \
+  MOCK_HTML_SOURCE="$blocking_html_source" \
+  MOCK_SLEEP_LOG="$sleep_log" \
+  bash "$script" \
+    https://app.test \
+    https://static.test/okou-app/assets \
+    "$assets_directory" > "${test_root}/blocking-html-failure.log" 2>&1; then
+  fail "static app module script did not fail HTML verification"
+fi
+grep -Fq 'Expected deferred app execution without static module scripts' \
+  "${test_root}/blocking-html-failure.log" ||
+  fail "static app module failure was not identified"
 
 sed -i '/vendor-EfGh5678/d' "$html_source"
 : > "$curl_log"

--- a/.github/scripts/verify-okou-app-assets.sh
+++ b/.github/scripts/verify-okou-app-assets.sh
@@ -20,6 +20,7 @@ sorted_assets="$(mktemp)"
 trap 'rm -f "$layout_files" "$pending_assets" "$sorted_assets"' EXIT
 
 declare -a app_files=()
+declare -a after_first_paint_files=()
 declare -a vendor_files=()
 declare -a runtime_files=()
 declare -a worker_files=()
@@ -27,6 +28,7 @@ find "$OKOU_APP_ASSETS_DIRECTORY" -type f -name '*.js' -print0 > "$layout_files"
 while IFS= read -r -d '' source_path; do
   relative_path="${source_path#"$OKOU_APP_ASSETS_DIRECTORY"/}"
   case "$relative_path" in
+    bootstrap-after-first-paint-*.js) after_first_paint_files+=("$relative_path") ;;
     vendor-*.js) vendor_files+=("$relative_path") ;;
     rolldown-runtime-*.js) runtime_files+=("$relative_path") ;;
     shared-database-worker-*.js) worker_files+=("$relative_path") ;;
@@ -36,21 +38,24 @@ done < "$layout_files"
 
 if ((
   ${#app_files[@]} != 1 ||
+  ${#after_first_paint_files[@]} != 1 ||
   ${#vendor_files[@]} != 1 ||
   ${#runtime_files[@]} != 1 ||
   ${#worker_files[@]} != 1
 )); then
-  echo "Expected exactly one app, vendor, Rolldown runtime, and SharedWorker JavaScript asset" >&2
-  printf 'app=%s vendor=%s runtime=%s worker=%s\n' \
+  echo "Expected exactly one app, after-first-paint bootstrap, vendor, Rolldown runtime, and SharedWorker JavaScript asset" >&2
+  printf 'app=%s after-first-paint=%s vendor=%s runtime=%s worker=%s\n' \
     "${app_files[*]:-none}" \
+    "${after_first_paint_files[*]:-none}" \
     "${vendor_files[*]:-none}" \
     "${runtime_files[*]:-none}" \
     "${worker_files[*]:-none}" >&2
   exit 1
 fi
 
-printf 'App bundle layout: app=%s vendor=%s runtime=%s worker=%s\n' \
+printf 'App bundle layout: app=%s after-first-paint=%s vendor=%s runtime=%s worker=%s\n' \
   "${app_files[0]}" \
+  "${after_first_paint_files[0]}" \
   "${vendor_files[0]}" \
   "${runtime_files[0]}" \
   "${worker_files[0]}"

--- a/.github/scripts/verify-okou-app-runtime.sh
+++ b/.github/scripts/verify-okou-app-runtime.sh
@@ -101,6 +101,7 @@ COMMIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 class AppDocumentParser(HTMLParser):
     def __init__(self) -> None:
         super().__init__()
+        self.app_entry_preloads: list[str] = []
         self.module_scripts: list[str] = []
         self.module_preloads: list[str] = []
         self.runtime_metadata: dict[str, list[str | None]] = {
@@ -118,7 +119,10 @@ class AppDocumentParser(HTMLParser):
         if tag == "link" and attributes.get("rel") == "modulepreload":
             href = attributes.get("href")
             if href:
-                self.module_preloads.append(href)
+                if "data-vm0-app-entry" in attributes:
+                    self.app_entry_preloads.append(href)
+                else:
+                    self.module_preloads.append(href)
         if tag == "meta" and attributes.get("name") in RUNTIME_META_NAMES:
             name = attributes["name"]
             if name is not None:
@@ -158,11 +162,17 @@ if observed_metadata != expected_metadata:
         f"Expected runtime build metadata {expected_metadata}, got {observed_metadata}"
     )
 
-expected_script = [sys.argv[3]]
+expected_app_entry = [sys.argv[3]]
 expected_preloads = {sys.argv[4], sys.argv[5]}
-if parser.module_scripts != expected_script:
+if parser.app_entry_preloads != expected_app_entry:
     raise RuntimeError(
-        f"Expected one CDN app module script {expected_script}, got {parser.module_scripts}"
+        f"Expected one deferred CDN app module preload {expected_app_entry}, "
+        f"got {parser.app_entry_preloads}"
+    )
+if parser.module_scripts:
+    raise RuntimeError(
+        f"Expected deferred app execution without static module scripts, "
+        f"got {parser.module_scripts}"
     )
 if len(parser.module_preloads) != 2 or set(parser.module_preloads) != expected_preloads:
     raise RuntimeError(

--- a/.github/scripts/verify-okou-app-runtime.sh
+++ b/.github/scripts/verify-okou-app-runtime.sh
@@ -32,6 +32,7 @@ probe_evidence="$(mktemp)"
 trap 'rm -f "$layout_files" "$document_body" "$curl_error" "$probe_evidence"' EXIT
 
 declare -a app_files=()
+declare -a after_first_paint_files=()
 declare -a vendor_files=()
 declare -a runtime_files=()
 declare -a worker_files=()
@@ -39,6 +40,7 @@ find "$assets_directory" -type f -name '*.js' -print0 > "$layout_files"
 while IFS= read -r -d '' source_path; do
   relative_path="${source_path#"$assets_directory"/}"
   case "$relative_path" in
+    bootstrap-after-first-paint-*.js) after_first_paint_files+=("$relative_path") ;;
     vendor-*.js) vendor_files+=("$relative_path") ;;
     rolldown-runtime-*.js) runtime_files+=("$relative_path") ;;
     shared-database-worker-*.js) worker_files+=("$relative_path") ;;
@@ -48,15 +50,17 @@ done < "$layout_files"
 
 if ((
   ${#app_files[@]} != 1 ||
+  ${#after_first_paint_files[@]} != 1 ||
   ${#vendor_files[@]} != 1 ||
   ${#runtime_files[@]} != 1 ||
   ${#worker_files[@]} != 1
 )); then
-  echo "Expected exactly one app, vendor, Rolldown runtime, and SharedWorker JavaScript asset" >&2
+  echo "Expected exactly one app, after-first-paint bootstrap, vendor, Rolldown runtime, and SharedWorker JavaScript asset" >&2
   exit 1
 fi
 
 app_asset_url="${public_assets_url}/${app_files[0]}"
+after_first_paint_asset_url="${public_assets_url}/${after_first_paint_files[0]}"
 vendor_asset_url="${public_assets_url}/${vendor_files[0]}"
 runtime_asset_url="${public_assets_url}/${runtime_files[0]}"
 worker_asset_url="${app_url}/okou-app/assets/${worker_files[0]}"
@@ -85,6 +89,7 @@ for ((attempt = 1; attempt <= document_max_attempts; attempt++)); do
       "$document_body" \
       "$canonical_document" \
       "$app_asset_url" \
+      "$after_first_paint_asset_url" \
       "$runtime_asset_url" \
       "$vendor_asset_url" 2>"$probe_evidence" <<'PY'
 from html.parser import HTMLParser
@@ -102,6 +107,7 @@ class AppDocumentParser(HTMLParser):
     def __init__(self) -> None:
         super().__init__()
         self.app_entry_preloads: list[str] = []
+        self.after_first_paint_preloads: list[str] = []
         self.module_scripts: list[str] = []
         self.module_preloads: list[str] = []
         self.runtime_metadata: dict[str, list[str | None]] = {
@@ -123,6 +129,15 @@ class AppDocumentParser(HTMLParser):
                     self.app_entry_preloads.append(href)
                 else:
                     self.module_preloads.append(href)
+        if (
+            tag == "link"
+            and attributes.get("rel") == "preload"
+            and attributes.get("as") == "script"
+            and "data-vm0-after-first-paint-entry" in attributes
+        ):
+            href = attributes.get("href")
+            if href:
+                self.after_first_paint_preloads.append(href)
         if tag == "meta" and attributes.get("name") in RUNTIME_META_NAMES:
             name = attributes["name"]
             if name is not None:
@@ -163,7 +178,8 @@ if observed_metadata != expected_metadata:
     )
 
 expected_app_entry = [sys.argv[3]]
-expected_preloads = {sys.argv[4], sys.argv[5]}
+expected_after_first_paint_entry = [sys.argv[4]]
+expected_preloads = {sys.argv[5], sys.argv[6]}
 if parser.app_entry_preloads != expected_app_entry:
     raise RuntimeError(
         f"Expected one deferred CDN app module preload {expected_app_entry}, "
@@ -173,6 +189,12 @@ if parser.module_scripts:
     raise RuntimeError(
         f"Expected deferred app execution without static module scripts, "
         f"got {parser.module_scripts}"
+    )
+if parser.after_first_paint_preloads != expected_after_first_paint_entry:
+    raise RuntimeError(
+        "Expected one deferred after-first-paint script preload "
+        f"{expected_after_first_paint_entry}, "
+        f"got {parser.after_first_paint_preloads}"
     )
 if len(parser.module_preloads) != 2 or set(parser.module_preloads) != expected_preloads:
     raise RuntimeError(
@@ -222,6 +244,7 @@ done
 
 for asset_url in \
   "$app_asset_url" \
+  "$after_first_paint_asset_url" \
   "$vendor_asset_url" \
   "$runtime_asset_url"; do
   curl \
@@ -259,8 +282,9 @@ if [[ "$worker_status" != "206" ]]; then
   exit 1
 fi
 
-printf 'Verified app runtime: app=%s vendor=%s runtime=%s worker=%s\n' \
+printf 'Verified app runtime: app=%s after-first-paint=%s vendor=%s runtime=%s worker=%s\n' \
   "$app_asset_url" \
+  "$after_first_paint_asset_url" \
   "$vendor_asset_url" \
   "$runtime_asset_url" \
   "$worker_asset_url"

--- a/.github/scripts/verify-okou-app-runtime.sh
+++ b/.github/scripts/verify-okou-app-runtime.sh
@@ -107,7 +107,7 @@ class AppDocumentParser(HTMLParser):
     def __init__(self) -> None:
         super().__init__()
         self.app_entry_preloads: list[str] = []
-        self.after_first_paint_preloads: list[str] = []
+        self.after_first_paint_preloads: list[tuple[str, str | None]] = []
         self.module_scripts: list[str] = []
         self.module_preloads: list[str] = []
         self.runtime_metadata: dict[str, list[str | None]] = {
@@ -137,7 +137,9 @@ class AppDocumentParser(HTMLParser):
         ):
             href = attributes.get("href")
             if href:
-                self.after_first_paint_preloads.append(href)
+                self.after_first_paint_preloads.append(
+                    (href, attributes.get("integrity"))
+                )
         if tag == "meta" and attributes.get("name") in RUNTIME_META_NAMES:
             name = attributes["name"]
             if name is not None:
@@ -190,12 +192,21 @@ if parser.module_scripts:
         f"Expected deferred app execution without static module scripts, "
         f"got {parser.module_scripts}"
     )
-if parser.after_first_paint_preloads != expected_after_first_paint_entry:
+observed_after_first_paint_entries = [
+    href for href, _integrity in parser.after_first_paint_preloads
+]
+if observed_after_first_paint_entries != expected_after_first_paint_entry:
     raise RuntimeError(
         "Expected one deferred after-first-paint script preload "
         f"{expected_after_first_paint_entry}, "
-        f"got {parser.after_first_paint_preloads}"
+        f"got {observed_after_first_paint_entries}"
     )
+if not all(
+    integrity is not None
+    and re.fullmatch(r"sha384-[A-Za-z0-9+/]+={0,2}", integrity)
+    for _href, integrity in parser.after_first_paint_preloads
+):
+    raise RuntimeError("Expected SHA-384 integrity on the after-first-paint preload")
 if len(parser.module_preloads) != 2 or set(parser.module_preloads) != expected_preloads:
     raise RuntimeError(
         f"Expected CDN runtime/vendor modulepreloads {sorted(expected_preloads)}, "

--- a/.github/scripts/verify-okou-app-runtime.sh
+++ b/.github/scripts/verify-okou-app-runtime.sh
@@ -107,7 +107,8 @@ class AppDocumentParser(HTMLParser):
     def __init__(self) -> None:
         super().__init__()
         self.app_entry_preloads: list[str] = []
-        self.after_first_paint_preloads: list[tuple[str, str | None]] = []
+        self.after_first_paint_preloads: list[str] = []
+        self.active_module_preloads: list[str] = []
         self.module_scripts: list[str] = []
         self.module_preloads: list[str] = []
         self.runtime_metadata: dict[str, list[str | None]] = {
@@ -122,24 +123,21 @@ class AppDocumentParser(HTMLParser):
             source = attributes.get("src")
             if source:
                 self.module_scripts.append(source)
-        if tag == "link" and attributes.get("rel") == "modulepreload":
+        if tag == "link":
             href = attributes.get("href")
-            if href:
-                if "data-vm0-app-entry" in attributes:
-                    self.app_entry_preloads.append(href)
-                else:
-                    self.module_preloads.append(href)
+            if href and "data-vm0-app-entry" in attributes:
+                self.app_entry_preloads.append(href)
+            if href and "data-vm0-app-module-preload" in attributes:
+                self.module_preloads.append(href)
+            if href and attributes.get("rel") == "modulepreload":
+                self.active_module_preloads.append(href)
         if (
             tag == "link"
-            and attributes.get("rel") == "preload"
-            and attributes.get("as") == "script"
             and "data-vm0-after-first-paint-entry" in attributes
         ):
             href = attributes.get("href")
             if href:
-                self.after_first_paint_preloads.append(
-                    (href, attributes.get("integrity"))
-                )
+                self.after_first_paint_preloads.append(href)
         if tag == "meta" and attributes.get("name") in RUNTIME_META_NAMES:
             name = attributes["name"]
             if name is not None:
@@ -192,21 +190,17 @@ if parser.module_scripts:
         f"Expected deferred app execution without static module scripts, "
         f"got {parser.module_scripts}"
     )
-observed_after_first_paint_entries = [
-    href for href, _integrity in parser.after_first_paint_preloads
-]
-if observed_after_first_paint_entries != expected_after_first_paint_entry:
+if parser.active_module_preloads:
+    raise RuntimeError(
+        "Expected module resource discovery after first paint, "
+        f"got {parser.active_module_preloads}"
+    )
+if parser.after_first_paint_preloads != expected_after_first_paint_entry:
     raise RuntimeError(
         "Expected one deferred after-first-paint script preload "
         f"{expected_after_first_paint_entry}, "
-        f"got {observed_after_first_paint_entries}"
+        f"got {parser.after_first_paint_preloads}"
     )
-if not all(
-    integrity is not None
-    and re.fullmatch(r"sha384-[A-Za-z0-9+/]+={0,2}", integrity)
-    for _href, integrity in parser.after_first_paint_preloads
-):
-    raise RuntimeError("Expected SHA-384 integrity on the after-first-paint preload")
 if len(parser.module_preloads) != 2 or set(parser.module_preloads) != expected_preloads:
     raise RuntimeError(
         f"Expected CDN runtime/vendor modulepreloads {sorted(expected_preloads)}, "

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -27,6 +27,11 @@
     <link vite-ignore rel="manifest" href="/manifest.webmanifest" />
     <link rel="preconnect" href="https://cdn.vm0.io" crossorigin />
     <link rel="preconnect" href="https://static.vm0.io" crossorigin />
+    <link
+      rel="preconnect"
+      href="https://static.cloudflareinsights.com"
+      crossorigin
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -256,177 +256,6 @@
         border-right: 2px solid currentColor;
         visibility: hidden;
       }
-
-      @keyframes app-bootstrap-skeleton-hide-static {
-        0%,
-        99.9% {
-          opacity: 1;
-        }
-        100% {
-          opacity: 0;
-        }
-      }
-
-      @keyframes app-bootstrap-skeleton-show-typewriter {
-        0%,
-        99.9% {
-          visibility: hidden;
-        }
-        100% {
-          visibility: visible;
-        }
-      }
-
-      @keyframes app-bootstrap-skeleton-type {
-        from {
-          width: 0;
-        }
-        to {
-          width: 100%;
-        }
-      }
-
-      @keyframes app-bootstrap-skeleton-blink {
-        0%,
-        100% {
-          border-color: transparent;
-        }
-        50% {
-          border-color: currentColor;
-        }
-      }
-
-      .browser-upgrade {
-        background: #ffffff;
-        box-sizing: border-box;
-        color: #14171d;
-        display: flex;
-        font-family:
-          system-ui,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          sans-serif;
-        align-items: center;
-        justify-content: center;
-        min-height: 100vh;
-        overflow: hidden;
-        padding: 24px;
-        position: relative;
-        width: 100%;
-      }
-
-      .browser-upgrade * {
-        box-sizing: border-box;
-      }
-
-      .browser-upgrade::before {
-        background-image: radial-gradient(
-          ellipse 120% 80% at 50% -20%,
-          rgba(248, 249, 251, 0.9),
-          transparent 50%
-        );
-        background-size: 100% 100%;
-        content: "";
-        inset: 0;
-        position: absolute;
-        z-index: 0;
-      }
-
-      [data-browser-supported="true"] .browser-upgrade {
-        display: none;
-      }
-
-      .browser-upgrade__center {
-        position: relative;
-        width: 100%;
-        z-index: 1;
-      }
-
-      .browser-upgrade__panel {
-        background: #ffffff;
-        border: 0.7px solid #dce1e8;
-        border-radius: 16px;
-        box-shadow:
-          0 2px 12px rgba(113, 120, 133, 0.04),
-          0 0 0 0.5px rgba(113, 120, 133, 0.02);
-        display: flex;
-        flex-direction: column;
-        gap: 24px;
-        align-items: center;
-        margin: 0 auto;
-        max-width: 384px;
-        padding: 32px;
-        text-align: center;
-      }
-
-      .browser-upgrade__icon {
-        align-items: center;
-        display: flex;
-        height: 40px;
-        justify-content: center;
-        width: 40px;
-      }
-
-      .browser-upgrade__icon svg {
-        display: block;
-        height: 40px;
-        width: 40px;
-      }
-
-      .browser-upgrade__copy {
-        display: flex;
-        flex-direction: column;
-        gap: 6px;
-      }
-
-      .browser-upgrade h1 {
-        color: #14171d;
-        font-size: 16px;
-        font-weight: 600;
-        letter-spacing: 0;
-        line-height: 24px;
-        margin: 0;
-      }
-
-      .browser-upgrade p {
-        color: #5d6572;
-        font-size: 14px;
-        line-height: 22px;
-        margin: 0;
-      }
-
-      .browser-upgrade__actions {
-        width: 100%;
-      }
-
-      .browser-upgrade a {
-        background: #ed4e01;
-        border: 1px solid #ed4e01;
-        border-radius: 8px;
-        box-sizing: border-box;
-        color: #ffffff;
-        display: inline-block;
-        font-size: 14px;
-        font-weight: 600;
-        line-height: 20px;
-        min-height: 40px;
-        padding: 9px 14px;
-        text-align: center;
-        text-decoration: none;
-        width: 100%;
-      }
-
-      .browser-upgrade a:hover {
-        background: #d94600;
-        border-color: #d94600;
-      }
-
-      @media (max-width: 520px) {
-        .browser-upgrade__panel {
-          padding: 24px 20px;
-        }
-      }
     </style>
     <script>
       (function () {
@@ -603,6 +432,178 @@
         }, 100);
       })();
     </script>
+    <style data-vm0-post-skeleton-styles="">
+      @keyframes app-bootstrap-skeleton-hide-static {
+        0%,
+        99.9% {
+          opacity: 1;
+        }
+        100% {
+          opacity: 0;
+        }
+      }
+
+      @keyframes app-bootstrap-skeleton-show-typewriter {
+        0%,
+        99.9% {
+          visibility: hidden;
+        }
+        100% {
+          visibility: visible;
+        }
+      }
+
+      @keyframes app-bootstrap-skeleton-type {
+        from {
+          width: 0;
+        }
+        to {
+          width: 100%;
+        }
+      }
+
+      @keyframes app-bootstrap-skeleton-blink {
+        0%,
+        100% {
+          border-color: transparent;
+        }
+        50% {
+          border-color: currentColor;
+        }
+      }
+
+      .browser-upgrade {
+        background: #ffffff;
+        box-sizing: border-box;
+        color: #14171d;
+        display: flex;
+        font-family:
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        overflow: hidden;
+        padding: 24px;
+        position: relative;
+        width: 100%;
+      }
+
+      .browser-upgrade * {
+        box-sizing: border-box;
+      }
+
+      .browser-upgrade::before {
+        background-image: radial-gradient(
+          ellipse 120% 80% at 50% -20%,
+          rgba(248, 249, 251, 0.9),
+          transparent 50%
+        );
+        background-size: 100% 100%;
+        content: "";
+        inset: 0;
+        position: absolute;
+        z-index: 0;
+      }
+
+      [data-browser-supported="true"] .browser-upgrade {
+        display: none;
+      }
+
+      .browser-upgrade__center {
+        position: relative;
+        width: 100%;
+        z-index: 1;
+      }
+
+      .browser-upgrade__panel {
+        background: #ffffff;
+        border: 0.7px solid #dce1e8;
+        border-radius: 16px;
+        box-shadow:
+          0 2px 12px rgba(113, 120, 133, 0.04),
+          0 0 0 0.5px rgba(113, 120, 133, 0.02);
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+        align-items: center;
+        margin: 0 auto;
+        max-width: 384px;
+        padding: 32px;
+        text-align: center;
+      }
+
+      .browser-upgrade__icon {
+        align-items: center;
+        display: flex;
+        height: 40px;
+        justify-content: center;
+        width: 40px;
+      }
+
+      .browser-upgrade__icon svg {
+        display: block;
+        height: 40px;
+        width: 40px;
+      }
+
+      .browser-upgrade__copy {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+
+      .browser-upgrade h1 {
+        color: #14171d;
+        font-size: 16px;
+        font-weight: 600;
+        letter-spacing: 0;
+        line-height: 24px;
+        margin: 0;
+      }
+
+      .browser-upgrade p {
+        color: #5d6572;
+        font-size: 14px;
+        line-height: 22px;
+        margin: 0;
+      }
+
+      .browser-upgrade__actions {
+        width: 100%;
+      }
+
+      .browser-upgrade a {
+        background: #ed4e01;
+        border: 1px solid #ed4e01;
+        border-radius: 8px;
+        box-sizing: border-box;
+        color: #ffffff;
+        display: inline-block;
+        font-size: 14px;
+        font-weight: 600;
+        line-height: 20px;
+        min-height: 40px;
+        padding: 9px 14px;
+        text-align: center;
+        text-decoration: none;
+        width: 100%;
+      }
+
+      .browser-upgrade a:hover {
+        background: #d94600;
+        border-color: #d94600;
+      }
+
+      @media (max-width: 520px) {
+        .browser-upgrade__panel {
+          padding: 24px 20px;
+        }
+      }
+    </style>
     <script data-vm0-app-entry="" type="module" src="/src/main.ts"></script>
     <div class="browser-upgrade" role="status" aria-live="polite">
       <div class="browser-upgrade__center">

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -27,11 +27,6 @@
     <link vite-ignore rel="manifest" href="/manifest.webmanifest" />
     <link rel="preconnect" href="https://cdn.vm0.io" crossorigin />
     <link rel="preconnect" href="https://static.vm0.io" crossorigin />
-    <link
-      rel="preconnect"
-      href="https://static.cloudflareinsights.com"
-      crossorigin
-    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -6,58 +6,294 @@
   data-app-head-managed="true"
 >
   <head>
+    <script>
+      window.__appBootstrapStart = performance.now();
+    </script>
     <title>AI Agents for Real Work — Your Trustworthy AI Teammate | VM0</title>
     <meta charset="UTF-8" />
     <meta name="vm0-api-origin" content="" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="https://static.vm0.io/platform/icon.svg"
+      integrity="sha384-ccZJ/dPMsNHiW8WF8/yNp+aD3sIwf2+1wy7fqvURH5oNrFX0sfNYTaXwTjyMhIjE"
+    />
+    <link
+      rel="icon"
+      type="image/x-icon"
+      href="https://static.vm0.io/platform/favicon.ico"
+      integrity="sha384-Pe0cByX3KRkasDxciKVerqZSvuElddhe0ri32ym8ia9G/4BZcn2EhPYZI1n4jV3B"
+    />
+    <link vite-ignore rel="manifest" href="/manifest.webmanifest" />
+    <link rel="preconnect" href="https://cdn.vm0.io" crossorigin />
+    <link rel="preconnect" href="https://static.vm0.io" crossorigin />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="https://static.vm0.io/platform/apple-touch-icon.png"
+      integrity="sha384-zSbBEIKCuNnaTseqd2LFjJVhGDe+8P6ONra73YN0hk+HENpXlwMzMINQY+VBXrch"
     />
-    <script data-vm0-clerk-bootstrap="">
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="black-translucent"
+    />
+    <meta name="application-name" content="VM0" />
+    <meta name="apple-mobile-web-app-title" content="VM0" />
+    <meta
+      name="description"
+      content="VM0, your trustworthy AI teammate for real work. An AI agent that connects to 100+ tools to run reports, triage, outreach, and research in Slack or the web."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="VM0" />
+    <meta property="og:title" content="VM0 - Your Trustworthy AI Teammate" />
+    <meta
+      property="og:description"
+      content="VM0, your trustworthy AI teammate for real work. An AI agent that connects to 100+ tools to run reports, triage, outreach, and research in Slack or the web."
+    />
+    <meta
+      property="og:image"
+      content="https://static.vm0.io/web/og-image.png"
+    />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta
+      property="og:image:alt"
+      content="VM0 - Your Trustworthy AI Teammate"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@okou_ai" />
+    <meta name="twitter:creator" content="@okou_ai" />
+    <meta name="twitter:title" content="VM0 - Your Trustworthy AI Teammate" />
+    <meta
+      name="twitter:description"
+      content="VM0 is an AI agent that connects to 100+ tools and does the work. Reports, triage, outreach, research. In Slack or on the web."
+    />
+    <meta
+      name="twitter:image"
+      content="https://static.vm0.io/web/og-image.png"
+    />
+    <meta name="google" content="notranslate" />
+    <meta
+      name="theme-color"
+      content="#ffffff"
+      media="(prefers-color-scheme: light)"
+    />
+    <meta
+      name="theme-color"
+      content="#19191b"
+      media="(prefers-color-scheme: dark)"
+    />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+    />
+    <script>
+      // Inline theme detection — mirrors signals/theme.ts resolveTheme() + applyTheme()
       (function () {
-        var hostname = location.hostname.toLowerCase();
-        var production =
-          hostname === "vm0.ai" ||
-          hostname.endsWith(".vm0.ai") ||
-          hostname === "okou.ai" ||
-          hostname.endsWith(".okou.ai");
-        var satellite =
-          hostname === "app.okou.ai" || hostname.endsWith(".app.okou.ai");
-        var publishableKey = production
-          ? "%VITE_CLERK_PUBLISHABLE_KEY_PROD%"
-          : "%VITE_CLERK_PUBLISHABLE_KEY_PREVIEW%";
-        var scriptUrl = satellite
-          ? "__VM0_CLERK_SATELLITE_SCRIPT_URL__"
-          : production
-            ? "__VM0_CLERK_PRODUCTION_SCRIPT_URL__"
-            : "__VM0_CLERK_PREVIEW_SCRIPT_URL__";
-
-        var script = document.createElement("script");
-        script.async = false;
-        script.defer = true;
-        script.crossOrigin = "anonymous";
-        script.dataset.clerkJsScript = "";
-        script.dataset.clerkPublishableKey = publishableKey;
-        if (satellite) {
-          script.dataset.clerkDomain = "app.okou.ai";
-        }
-        script.onerror = function () {
-          script.remove();
-        };
-        script.src = scriptUrl;
-        script.type = "text/javascript";
-        document.head.appendChild(script);
+        var p = localStorage.getItem("theme");
+        var t =
+          p === "dark" || p === "light"
+            ? p
+            : window.matchMedia("(prefers-color-scheme: dark)").matches
+              ? "dark"
+              : "light";
+        document.documentElement.dataset.theme = t;
+        if (t === "dark") document.documentElement.classList.add("dark");
       })();
     </script>
     <style>
+      :root {
+        --zero-viewport-height: 100dvh;
+      }
+
+      @supports (height: 100lvh) {
+        @media (display-mode: standalone) {
+          :root {
+            --zero-viewport-height: 100lvh;
+          }
+        }
+      }
+
+      html,
       body {
         margin: 0;
       }
 
+      html,
+      body,
+      #root {
+        width: 100%;
+        height: var(--zero-viewport-height);
+        min-height: var(--zero-viewport-height);
+        overflow: hidden;
+      }
+
       #root {
         display: none;
+        position: fixed;
+        top: 0;
+        right: 0;
+        left: 0;
+      }
+
+      [data-browser-supported="true"] #root {
+        display: block;
+      }
+
+      #app-bootstrap-skeleton {
+        position: fixed;
+        inset: 0;
+        /* Fixed insets follow WebKit's reachable layout viewport. Avoid the
+           standalone viewport unit, which can resolve after first paint. */
+        z-index: 60;
+        box-sizing: border-box;
+        display: none;
+        align-items: center;
+        justify-content: center;
+        background: #fdfdfe;
+        color: rgba(20, 23, 29, 0.7);
+        font-family:
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
+        opacity: 1;
+        transition: opacity 300ms ease;
+      }
+
+      [data-browser-supported="true"] #app-bootstrap-skeleton {
+        display: flex;
+      }
+
+      [data-theme="dark"] #app-bootstrap-skeleton {
+        background: #19191b;
+        color: rgba(232, 233, 237, 0.7);
+      }
+
+      #app-bootstrap-skeleton.app-bootstrap-skeleton--hidden {
+        pointer-events: none;
+        opacity: 0;
+      }
+
+      .app-bootstrap-skeleton__content {
+        position: fixed;
+        top: var(--app-bootstrap-skeleton-center-y, 50dvh);
+        left: 50%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 20px;
+        transform: translate(-50%, -50%);
+      }
+
+      .app-bootstrap-skeleton__avatar {
+        position: relative;
+        width: 64px;
+        height: 64px;
+        overflow: hidden;
+        border-radius: 9999px;
+      }
+
+      .app-bootstrap-skeleton__avatar-placeholder,
+      .app-bootstrap-skeleton__avatar-layers {
+        position: absolute;
+        inset: 0;
+      }
+
+      .app-bootstrap-skeleton__avatar-placeholder {
+        display: block;
+        width: 64px;
+        height: 64px;
+      }
+
+      .app-bootstrap-skeleton__avatar-layers {
+        transform: scale(1.25);
+      }
+
+      .app-bootstrap-skeleton__avatar img {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+
+      .app-bootstrap-skeleton__message {
+        position: relative;
+        height: 24px;
+        font-size: 16px;
+        font-weight: 500;
+        line-height: 24px;
+      }
+
+      .app-bootstrap-skeleton__message p {
+        margin: 0;
+        white-space: nowrap;
+      }
+
+      .app-bootstrap-skeleton__message-spacer {
+        visibility: hidden;
+      }
+
+      .app-bootstrap-skeleton__message-static {
+        position: absolute;
+        top: 0;
+        left: 50%;
+        transform: translateX(-50%);
+      }
+
+      .app-bootstrap-skeleton__message-typewriter {
+        position: absolute;
+        inset: 0;
+        width: 0;
+        overflow: hidden;
+        border-right: 2px solid currentColor;
+        visibility: hidden;
+      }
+
+      @keyframes app-bootstrap-skeleton-hide-static {
+        0%,
+        99.9% {
+          opacity: 1;
+        }
+        100% {
+          opacity: 0;
+        }
+      }
+
+      @keyframes app-bootstrap-skeleton-show-typewriter {
+        0%,
+        99.9% {
+          visibility: hidden;
+        }
+        100% {
+          visibility: visible;
+        }
+      }
+
+      @keyframes app-bootstrap-skeleton-type {
+        from {
+          width: 0;
+        }
+        to {
+          width: 100%;
+        }
+      }
+
+      @keyframes app-bootstrap-skeleton-blink {
+        0%,
+        100% {
+          border-color: transparent;
+        }
+        50% {
+          border-color: currentColor;
+        }
       }
 
       .browser-upgrade {
@@ -66,7 +302,6 @@
         color: #14171d;
         display: flex;
         font-family:
-          "Noto Sans",
           system-ui,
           -apple-system,
           BlinkMacSystemFont,
@@ -96,10 +331,6 @@
         inset: 0;
         position: absolute;
         z-index: 0;
-      }
-
-      [data-browser-supported="true"] #root {
-        display: block;
       }
 
       [data-browser-supported="true"] .browser-upgrade {
@@ -137,7 +368,7 @@
         width: 40px;
       }
 
-      .browser-upgrade__icon img {
+      .browser-upgrade__icon svg {
         display: block;
         height: 40px;
         width: 40px;
@@ -198,616 +429,11 @@
       }
     </style>
     <script>
-      // Resolve locale before any visible pre-bundle UI is constructed.
-      (function () {
-        var orgId = sessionStorage.getItem("clerk-active-org-id");
-        var cacheKey = orgId ? "vm0:locale:" + orgId : null;
-        var cached = cacheKey ? localStorage.getItem(cacheKey) : null;
-        // Prefer the workspace cache. Signed-out and first-time visitors use a
-        // supported browser language, with English as the fallback.
-        var browserLocale = /^ja(?:-|$)/i.test(navigator.language)
-          ? "ja-JP"
-          : /^ko(?:-|$)/i.test(navigator.language)
-            ? "ko-KR"
-            : /^id(?:-|$)/i.test(navigator.language)
-              ? "id-ID"
-              : /^de(?:-|$)/i.test(navigator.language)
-                ? "de-DE"
-                : /^es(?:-|$)/i.test(navigator.language)
-                  ? "es-ES"
-                  : /^it(?:-|$)/i.test(navigator.language)
-                    ? "it-IT"
-                    : /^fr(?:-|$)/i.test(navigator.language)
-                      ? "fr-FR"
-                      : /^hi(?:-|$)/i.test(navigator.language)
-                        ? "hi-IN"
-                        : /^pt(?:-|$)/i.test(navigator.language)
-                          ? "pt-BR"
-                          : "en-US";
-        var locale =
-          cached === "en-US" ||
-          cached === "pt-BR" ||
-          cached === "ja-JP" ||
-          cached === "ko-KR" ||
-          cached === "id-ID" ||
-          cached === "de-DE" ||
-          cached === "es-ES" ||
-          cached === "it-IT" ||
-          cached === "fr-FR" ||
-          cached === "hi-IN"
-            ? cached
-            : browserLocale;
-        var copyByLocale = {
-          "en-US": {
-            browserUpgrade: {
-              browser: {
-                actionLabel: "Update browser",
-                description:
-                  "{{assistantName}} does not support your current browser version. Update your browser to continue.",
-                title: "Update your browser to continue",
-              },
-              chrome: {
-                actionLabel: "Update Chrome",
-                description:
-                  "{{assistantName}} does not support your current browser version. Update Chrome to continue.",
-                title: "Update Chrome to continue",
-              },
-              chromium: {
-                actionLabel: "Update Chromium",
-                description:
-                  "{{assistantName}} does not support your current browser version. Update Chromium to continue.",
-                title: "Update Chromium to continue",
-              },
-              ios: {
-                actionLabel: "Update iOS",
-                description:
-                  "{{assistantName}} does not support your current browser version. Update iOS to continue.",
-                title: "Update iOS to continue",
-              },
-              safari: {
-                actionLabel: "Update Safari",
-                description:
-                  "{{assistantName}} does not support your current browser version. Update Safari to continue.",
-                title: "Update Safari to continue",
-              },
-            },
-            loading: {
-              ariaLabel: "Loading your workspace",
-              messages: [
-                "Warming up the neurons...",
-                "Brewing some ideas...",
-                "Getting things ready...",
-                "Almost there...",
-                "Loading your workspace...",
-                "Tuning the instruments...",
-                "Connecting the dots...",
-                "Spinning up the team...",
-              ],
-            },
-            metadata: {
-              description:
-                "{{assistantName}} is your AI coworker from {{brandName}}. Text {{assistantName}} or chat on the web — research, email, docs, Slack, GitHub, Notion, and 100+ tools.",
-              title: "{{assistantName}} — Your AI coworker from {{brandName}}",
-            },
-          },
-          "fr-FR": {
-            browserUpgrade: {
-              browser: {
-                actionLabel: "Mettre à jour le navigateur",
-                description:
-                  "{{assistantName}} ne prend pas en charge la version actuelle de votre navigateur. Mettez à jour votre navigateur pour continuer.",
-                title: "Mettez à jour votre navigateur pour continuer",
-              },
-              chrome: {
-                actionLabel: "Mettre à jour Chrome",
-                description:
-                  "{{assistantName}} ne prend pas en charge la version actuelle de votre navigateur. Mettez à jour Chrome pour continuer.",
-                title: "Mettez à jour Chrome pour continuer",
-              },
-              chromium: {
-                actionLabel: "Mettre à jour Chromium",
-                description:
-                  "{{assistantName}} ne prend pas en charge la version actuelle de votre navigateur. Mettez à jour Chromium pour continuer.",
-                title: "Mettez à jour Chromium pour continuer",
-              },
-              ios: {
-                actionLabel: "Mettre à jour iOS",
-                description:
-                  "{{assistantName}} ne prend pas en charge la version actuelle de votre navigateur. Mettez à jour iOS pour continuer.",
-                title: "Mettez à jour iOS pour continuer",
-              },
-              safari: {
-                actionLabel: "Mettre à jour Safari",
-                description:
-                  "{{assistantName}} ne prend pas en charge la version actuelle de votre navigateur. Mettez à jour Safari pour continuer.",
-                title: "Mettez à jour Safari pour continuer",
-              },
-            },
-            loading: {
-              ariaLabel: "Chargement de votre espace de travail",
-              messages: [
-                "Initialisation des neurones...",
-                "Quelques idées sont en préparation...",
-                "Préparation en cours...",
-                "Presque prêt...",
-                "Chargement de votre espace de travail...",
-                "Accordage des instruments...",
-                "Connexion des idées...",
-                "Mise en place de l’équipe...",
-              ],
-            },
-            metadata: {
-              description:
-                "{{assistantName}} est votre coéquipier IA créé par {{brandName}}. Envoyez un message à {{assistantName}} ou discutez sur le web — recherche, e-mails, documents, Slack, GitHub, Notion et plus de 100 outils.",
-              title:
-                "{{assistantName}} — Votre coéquipier IA créé par {{brandName}}",
-            },
-          },
-          "pt-BR": {
-            browserUpgrade: {
-              browser: {
-                actionLabel: "Atualizar navegador",
-                description:
-                  "O {{assistantName}} não oferece suporte à versão atual do seu navegador. Atualize o navegador para continuar.",
-                title: "Atualize seu navegador para continuar",
-              },
-              chrome: {
-                actionLabel: "Atualizar Chrome",
-                description:
-                  "O {{assistantName}} não oferece suporte à versão atual do seu navegador. Atualize o Chrome para continuar.",
-                title: "Atualize o Chrome para continuar",
-              },
-              chromium: {
-                actionLabel: "Atualizar Chromium",
-                description:
-                  "O {{assistantName}} não oferece suporte à versão atual do seu navegador. Atualize o Chromium para continuar.",
-                title: "Atualize o Chromium para continuar",
-              },
-              ios: {
-                actionLabel: "Atualizar iOS",
-                description:
-                  "O {{assistantName}} não oferece suporte à versão atual do seu navegador. Atualize o iOS para continuar.",
-                title: "Atualize o iOS para continuar",
-              },
-              safari: {
-                actionLabel: "Atualizar Safari",
-                description:
-                  "O {{assistantName}} não oferece suporte à versão atual do seu navegador. Atualize o Safari para continuar.",
-                title: "Atualize o Safari para continuar",
-              },
-            },
-            loading: {
-              ariaLabel: "Carregando seu espaço de trabalho",
-              messages: [
-                "Aquecendo os neurônios...",
-                "Preparando algumas ideias...",
-                "Preparando tudo...",
-                "Quase lá...",
-                "Carregando seu espaço de trabalho...",
-                "Ajustando os instrumentos...",
-                "Ligando os pontos...",
-                "Reunindo a equipe...",
-              ],
-            },
-            metadata: {
-              description:
-                "{{assistantName}} é seu colega de IA da {{brandName}}. Envie uma mensagem para o {{assistantName}} ou converse pela web — pesquise, envie e-mails, crie documentos e use Slack, GitHub, Notion e mais de 100 ferramentas.",
-              title: "{{assistantName}} — Seu colega de IA da {{brandName}}",
-            },
-          },
-          "ja-JP": {
-            browserUpgrade: {
-              browser: {
-                actionLabel: "ブラウザを更新",
-                description:
-                  "現在のブラウザのバージョンは{{assistantName}}でサポートされていません。続行するにはブラウザを更新してください。",
-                title: "続行するにはブラウザを更新してください",
-              },
-              chrome: {
-                actionLabel: "Chromeを更新",
-                description:
-                  "現在のブラウザのバージョンは{{assistantName}}でサポートされていません。続行するにはChromeを更新してください。",
-                title: "続行するにはChromeを更新してください",
-              },
-              chromium: {
-                actionLabel: "Chromiumを更新",
-                description:
-                  "現在のブラウザのバージョンは{{assistantName}}でサポートされていません。続行するにはChromiumを更新してください。",
-                title: "続行するにはChromiumを更新してください",
-              },
-              ios: {
-                actionLabel: "iOSを更新",
-                description:
-                  "現在のブラウザのバージョンは{{assistantName}}でサポートされていません。続行するにはiOSを更新してください。",
-                title: "続行するにはiOSを更新してください",
-              },
-              safari: {
-                actionLabel: "Safariを更新",
-                description:
-                  "現在のブラウザのバージョンは{{assistantName}}でサポートされていません。続行するにはSafariを更新してください。",
-                title: "続行するにはSafariを更新してください",
-              },
-            },
-            loading: {
-              ariaLabel: "ワークスペースを読み込み中",
-              messages: [
-                "ニューラルネットワークを準備しています...",
-                "アイデアを練っています...",
-                "準備しています...",
-                "もうすぐです...",
-                "ワークスペースを読み込んでいます...",
-                "楽器を調整しています...",
-                "点と点をつないでいます...",
-                "チームを立ち上げています...",
-              ],
-            },
-            metadata: {
-              description:
-                "{{assistantName}}は{{brandName}}のAIコワーカーです。{{assistantName}}にメッセージを送るか、Webでチャットできます。リサーチ、メール、ドキュメント、Slack、GitHub、Notionなど、100以上のツールを利用できます。",
-              title: "{{assistantName}} — {{brandName}}のAIコワーカー",
-            },
-          },
-          "ko-KR": {
-            browserUpgrade: {
-              browser: {
-                actionLabel: "브라우저 업데이트",
-                description:
-                  "{{assistantName}}는 현재 브라우저 버전을 지원하지 않습니다. 계속하려면 브라우저를 업데이트하세요.",
-                title: "계속하려면 브라우저를 업데이트하세요",
-              },
-              chrome: {
-                actionLabel: "Chrome 업데이트",
-                description:
-                  "{{assistantName}}는 현재 Chrome 버전을 지원하지 않습니다. 계속하려면 Chrome을 업데이트하세요.",
-                title: "계속하려면 Chrome을 업데이트하세요",
-              },
-              chromium: {
-                actionLabel: "Chromium 업데이트",
-                description:
-                  "{{assistantName}}는 현재 Chromium 버전을 지원하지 않습니다. 계속하려면 Chromium을 업데이트하세요.",
-                title: "계속하려면 Chromium을 업데이트하세요",
-              },
-              ios: {
-                actionLabel: "iOS 업데이트",
-                description:
-                  "{{assistantName}}는 현재 iOS 버전을 지원하지 않습니다. 계속하려면 iOS를 업데이트하세요.",
-                title: "계속하려면 iOS를 업데이트하세요",
-              },
-              safari: {
-                actionLabel: "Safari 업데이트",
-                description:
-                  "{{assistantName}}는 현재 Safari 버전을 지원하지 않습니다. 계속하려면 Safari를 업데이트하세요.",
-                title: "계속하려면 Safari를 업데이트하세요",
-              },
-            },
-            loading: {
-              ariaLabel: "워크스페이스를 불러오는 중",
-              messages: [
-                "뉴런을 예열하는 중...",
-                "아이디어를 구상 중...",
-                "준비 중...",
-                "거의 완료되었습니다...",
-                "워크스페이스를 불러오는 중...",
-                "도구를 조율하는 중...",
-                "연결 중...",
-                "팀을 구성하는 중...",
-              ],
-            },
-            metadata: {
-              description:
-                "{{assistantName}}는 {{brandName}}의 AI 팀원입니다. {{assistantName}}에 텍스트를 보내거나 웹에서 채팅하세요 — 리서치, 이메일, 문서, Slack, GitHub, Notion 및 100개 이상의 도구를 지원합니다.",
-              title: "{{assistantName}} — {{brandName}}의 AI 팀원",
-            },
-          },
-          "id-ID": {
-            browserUpgrade: {
-              browser: {
-                actionLabel: "Perbarui browser",
-                description:
-                  "{{assistantName}} tidak mendukung versi browser Anda saat ini. Perbarui browser Anda untuk melanjutkan.",
-                title: "Perbarui browser Anda untuk melanjutkan",
-              },
-              chrome: {
-                actionLabel: "Perbarui Chrome",
-                description:
-                  "{{assistantName}} tidak mendukung versi Chrome Anda saat ini. Perbarui Chrome untuk melanjutkan.",
-                title: "Perbarui Chrome untuk melanjutkan",
-              },
-              chromium: {
-                actionLabel: "Perbarui Chromium",
-                description:
-                  "{{assistantName}} tidak mendukung versi Chromium Anda saat ini. Perbarui Chromium untuk melanjutkan.",
-                title: "Perbarui Chromium untuk melanjutkan",
-              },
-              ios: {
-                actionLabel: "Perbarui iOS",
-                description:
-                  "{{assistantName}} tidak mendukung versi iOS Anda saat ini. Perbarui iOS untuk melanjutkan.",
-                title: "Perbarui iOS untuk melanjutkan",
-              },
-              safari: {
-                actionLabel: "Perbarui Safari",
-                description:
-                  "{{assistantName}} tidak mendukung versi Safari Anda saat ini. Perbarui Safari untuk melanjutkan.",
-                title: "Perbarui Safari untuk melanjutkan",
-              },
-            },
-            loading: {
-              ariaLabel: "Memuat ruang kerja Anda",
-              messages: [
-                "Sedang memanaskan neuron...",
-                "Sedang meracik ide...",
-                "Sedang menyiapkan semuanya...",
-                "Hampir sampai...",
-                "Memuat ruang kerja Anda...",
-                "Sedang menyetel instrumen...",
-                "Sedang menghubungkan titik-titik...",
-                "Sedang menyiapkan tim...",
-              ],
-            },
-            metadata: {
-              description:
-                "{{assistantName}} adalah rekan kerja AI Anda dari {{brandName}}. Kirim pesan ke {{assistantName}} atau chat di web — riset, email, dokumen, Slack, GitHub, Notion, dan 100+ alat.",
-              title:
-                "{{assistantName}} — Rekan kerja AI Anda dari {{brandName}}",
-            },
-          },
-          "de-DE": {
-            browserUpgrade: {
-              browser: {
-                actionLabel: "Browser aktualisieren",
-                description:
-                  "{{assistantName}} unterstützt Ihre aktuelle Browserversion nicht. Aktualisieren Sie Ihren Browser, um fortzufahren.",
-                title: "Aktualisieren Sie Ihren Browser, um fortzufahren",
-              },
-              chrome: {
-                actionLabel: "Chrome aktualisieren",
-                description:
-                  "{{assistantName}} unterstützt Ihre aktuelle Browserversion nicht. Aktualisieren Sie Chrome, um fortzufahren.",
-                title: "Aktualisieren Sie Chrome, um fortzufahren",
-              },
-              chromium: {
-                actionLabel: "Chromium aktualisieren",
-                description:
-                  "{{assistantName}} unterstützt Ihre aktuelle Browserversion nicht. Aktualisieren Sie Chromium, um fortzufahren.",
-                title: "Aktualisieren Sie Chromium, um fortzufahren",
-              },
-              ios: {
-                actionLabel: "iOS aktualisieren",
-                description:
-                  "{{assistantName}} unterstützt Ihre aktuelle Browserversion nicht. Aktualisieren Sie iOS, um fortzufahren.",
-                title: "Aktualisieren Sie iOS, um fortzufahren",
-              },
-              safari: {
-                actionLabel: "Safari aktualisieren",
-                description:
-                  "{{assistantName}} unterstützt Ihre aktuelle Browserversion nicht. Aktualisieren Sie Safari, um fortzufahren.",
-                title: "Aktualisieren Sie Safari, um fortzufahren",
-              },
-            },
-            loading: {
-              ariaLabel: "Ihr Arbeitsbereich wird geladen",
-              messages: [
-                "Neuronen werden aufgewärmt...",
-                "Ideen werden entwickelt...",
-                "Alles wird vorbereitet...",
-                "Fast geschafft...",
-                "Ihr Arbeitsbereich wird geladen...",
-                "Instrumente werden gestimmt...",
-                "Punkte werden verbunden...",
-                "Das Team wird zusammengestellt...",
-              ],
-            },
-            metadata: {
-              description:
-                "{{assistantName}} ist Ihr KI-Kollege von {{brandName}}. Schreiben Sie {{assistantName}} oder chatten Sie im Web — für Recherche, E-Mails, Dokumente, Slack, GitHub, Notion und über 100 weitere Tools.",
-              title: "{{assistantName}} — Ihr KI-Kollege von {{brandName}}",
-            },
-          },
-          "es-ES": {
-            browserUpgrade: {
-              browser: {
-                actionLabel: "Actualizar navegador",
-                description:
-                  "{{assistantName}} no es compatible con la versión actual de tu navegador. Actualiza el navegador para continuar.",
-                title: "Actualiza tu navegador para continuar",
-              },
-              chrome: {
-                actionLabel: "Actualizar Chrome",
-                description:
-                  "{{assistantName}} no es compatible con la versión actual de tu navegador. Actualiza Chrome para continuar.",
-                title: "Actualiza Chrome para continuar",
-              },
-              chromium: {
-                actionLabel: "Actualizar Chromium",
-                description:
-                  "{{assistantName}} no es compatible con la versión actual de tu navegador. Actualiza Chromium para continuar.",
-                title: "Actualiza Chromium para continuar",
-              },
-              ios: {
-                actionLabel: "Actualizar iOS",
-                description:
-                  "{{assistantName}} no es compatible con la versión actual de tu navegador. Actualiza iOS para continuar.",
-                title: "Actualiza iOS para continuar",
-              },
-              safari: {
-                actionLabel: "Actualizar Safari",
-                description:
-                  "{{assistantName}} no es compatible con la versión actual de tu navegador. Actualiza Safari para continuar.",
-                title: "Actualiza Safari para continuar",
-              },
-            },
-            loading: {
-              ariaLabel: "Cargando tu espacio de trabajo",
-              messages: [
-                "Activando las neuronas...",
-                "Preparando algunas ideas...",
-                "Dejándolo todo listo...",
-                "Ya casi está...",
-                "Cargando tu espacio de trabajo...",
-                "Afinando los instrumentos...",
-                "Conectando los puntos...",
-                "Reuniendo al equipo...",
-              ],
-            },
-            metadata: {
-              description:
-                "{{assistantName}} es tu compañero de IA de {{brandName}}. Escríbele a {{assistantName}} o chatea en la web: investiga, envía correos, crea documentos y usa Slack, GitHub, Notion y más de 100 herramientas.",
-              title: "{{assistantName}} — Tu compañero de IA de {{brandName}}",
-            },
-          },
-          "it-IT": {
-            browserUpgrade: {
-              browser: {
-                actionLabel: "Aggiorna browser",
-                description:
-                  "{{assistantName}} non supporta la versione attuale del tuo browser. Aggiorna il browser per continuare.",
-                title: "Aggiorna il browser per continuare",
-              },
-              chrome: {
-                actionLabel: "Aggiorna Chrome",
-                description:
-                  "{{assistantName}} non supporta la versione attuale del tuo browser. Aggiorna Chrome per continuare.",
-                title: "Aggiorna Chrome per continuare",
-              },
-              chromium: {
-                actionLabel: "Aggiorna Chromium",
-                description:
-                  "{{assistantName}} non supporta la versione attuale del tuo browser. Aggiorna Chromium per continuare.",
-                title: "Aggiorna Chromium per continuare",
-              },
-              ios: {
-                actionLabel: "Aggiorna iOS",
-                description:
-                  "{{assistantName}} non supporta la versione attuale del tuo browser. Aggiorna iOS per continuare.",
-                title: "Aggiorna iOS per continuare",
-              },
-              safari: {
-                actionLabel: "Aggiorna Safari",
-                description:
-                  "{{assistantName}} non supporta la versione attuale del tuo browser. Aggiorna Safari per continuare.",
-                title: "Aggiorna Safari per continuare",
-              },
-            },
-            loading: {
-              ariaLabel: "Caricamento dell'area di lavoro",
-              messages: [
-                "Riscaldamento dei neuroni...",
-                "Preparando qualche idea...",
-                "Preparando tutto...",
-                "Ci siamo quasi...",
-                "Caricamento dell'area di lavoro...",
-                "Accordando gli strumenti...",
-                "Unendo i puntini...",
-                "Radunando il team...",
-              ],
-            },
-            metadata: {
-              description:
-                "{{assistantName}} è il tuo collega AI di {{brandName}}. Scrivi a {{assistantName}} o chatta sul web — ricerca, email, documenti, Slack, GitHub, Notion e oltre 100 strumenti.",
-              title: "{{assistantName}} — Il tuo collega AI di {{brandName}}",
-            },
-          },
-          "hi-IN": {
-            browserUpgrade: {
-              browser: {
-                actionLabel: "ब्राउज़र अपडेट करें",
-                description:
-                  "{{assistantName}} आपके वर्तमान ब्राउज़र संस्करण का समर्थन नहीं करता है। जारी रखने के लिए अपना ब्राउज़र अपडेट करें।",
-                title: "जारी रखने के लिए अपना ब्राउज़र अपडेट करें",
-              },
-              chrome: {
-                actionLabel: "Chrome को अपडेट करें",
-                description:
-                  "{{assistantName}} आपके वर्तमान ब्राउज़र संस्करण का समर्थन नहीं करता है। जारी रखने के लिए Chrome को अपडेट करें।",
-                title: "जारी रखने के लिए Chrome को अपडेट करें",
-              },
-              chromium: {
-                actionLabel: "Chromium को अपडेट करें",
-                description:
-                  "{{assistantName}} आपके वर्तमान ब्राउज़र संस्करण का समर्थन नहीं करता है। जारी रखने के लिए Chromium को अपडेट करें।",
-                title: "जारी रखने के लिए Chromium को अपडेट करें",
-              },
-              ios: {
-                actionLabel: "iOS को अपडेट करें",
-                description:
-                  "{{assistantName}} आपके वर्तमान ब्राउज़र संस्करण का समर्थन नहीं करता है। जारी रखने के लिए iOS को अपडेट करें।",
-                title: "जारी रखने के लिए iOS को अपडेट करें",
-              },
-              safari: {
-                actionLabel: "Safari को अपडेट करें",
-                description:
-                  "{{assistantName}} आपके वर्तमान ब्राउज़र संस्करण का समर्थन नहीं करता है। जारी रखने के लिए Safari को अपडेट करें।",
-                title: "जारी रखने के लिए Safari को अपडेट करें",
-              },
-            },
-            loading: {
-              ariaLabel: "आपका वर्कस्पेस लोड हो रहा है",
-              messages: [
-                "न्यूरॉन्स को सक्रिय कर रहे हैं...",
-                "कुछ नए विचार तैयार कर रहे हैं...",
-                "सब कुछ तैयार कर रहे हैं...",
-                "बस लगभग तैयार...",
-                "आपका वर्कस्पेस लोड हो रहा है...",
-                "उपकरणों को ट्यून कर रहे हैं...",
-                "कड़ियाँ जोड़ रहे हैं...",
-                "टीम को तैयार कर रहे हैं...",
-              ],
-            },
-            metadata: {
-              description:
-                "{{assistantName}}, {{brandName}} से आपका AI सहकर्मी है। {{assistantName}} को टेक्स्ट करें या वेब पर चैट करें — रिसर्च, ईमेल, दस्तावेज़, Slack, GitHub, Notion और 100+ टूल।",
-              title: "{{assistantName}} — {{brandName}} से आपका AI सहकर्मी",
-            },
-          },
-        };
-
-        var selectedCopy = copyByLocale[locale];
-        var brandName = document.documentElement.dataset.appBrandName;
-        if (brandName !== "VM0" && brandName !== "Okou") {
-          throw new Error("Invalid app brand name");
-        }
-        var assistantName = brandName === "Okou" ? "Okou" : "Zero";
-        var interpolateBrandCopy = function (value) {
-          return value
-            .replace(/\{\{assistantName\}\}/g, assistantName)
-            .replace(/\{\{brandName\}\}/g, brandName);
-        };
-        var browserUpgradeTargets = [
-          "browser",
-          "chrome",
-          "chromium",
-          "ios",
-          "safari",
-        ];
-        for (var i = 0; i < browserUpgradeTargets.length; i += 1) {
-          var target = selectedCopy.browserUpgrade[browserUpgradeTargets[i]];
-          target.description = interpolateBrandCopy(target.description);
-        }
-        selectedCopy.metadata.description = interpolateBrandCopy(
-          selectedCopy.metadata.description,
-        );
-        selectedCopy.metadata.title = interpolateBrandCopy(
-          selectedCopy.metadata.title,
-        );
-
-        window.__vm0PreBundleCopy = selectedCopy;
-        document.documentElement.lang = locale;
-        if (cacheKey) localStorage.setItem(cacheKey, locale);
-      })();
-    </script>
-    <script>
       (function () {
         var ua = navigator.userAgent || "";
         var supported = true;
-        var copy = window.__vm0PreBundleCopy.browserUpgrade;
         var upgradeTargetKind = "browser";
-        var upgradeTarget = {
-          actionLabel: copy.browser.actionLabel,
-          actionUrl: "https://www.google.com/chrome/",
-          description: copy.browser.description,
-          title: copy.browser.title,
-        };
+        var actionUrl = "https://www.google.com/chrome/";
         var iosPattern = /\b(?:iPhone|iPad|iPod)\b.*\bOS (\d+)(?:_(\d+))?/;
         var iosMatch = iosPattern.exec(ua);
         var chromiumMatch = /\bChromium\/(\d+)/.exec(ua);
@@ -815,12 +441,7 @@
 
         if (iosMatch) {
           upgradeTargetKind = "ios";
-          upgradeTarget = {
-            actionLabel: copy.ios.actionLabel,
-            actionUrl: "https://support.apple.com/HT204204",
-            description: copy.ios.description,
-            title: copy.ios.title,
-          };
+          actionUrl = "https://support.apple.com/HT204204";
           var iosMajor = parseInt(iosMatch[1], 10);
           var iosMinor = iosMatch[2] ? parseInt(iosMatch[2], 10) : 0;
           if (!isNaN(iosMajor) && !isNaN(iosMinor)) {
@@ -831,16 +452,10 @@
           !/\b(?:Edg|OPR|SamsungBrowser)\//.test(ua)
         ) {
           var chromiumBrowser = !!chromiumMatch;
-          var chromiumCopy = chromiumBrowser ? copy.chromium : copy.chrome;
           upgradeTargetKind = chromiumBrowser ? "chromium" : "chrome";
-          upgradeTarget = {
-            actionLabel: chromiumCopy.actionLabel,
-            actionUrl: chromiumBrowser
-              ? "https://www.chromium.org/getting-involved/download-chromium/"
-              : "https://www.google.com/chrome/",
-            description: chromiumCopy.description,
-            title: chromiumCopy.title,
-          };
+          actionUrl = chromiumBrowser
+            ? "https://www.chromium.org/getting-involved/download-chromium/"
+            : "https://www.google.com/chrome/";
           var chromeMajor = parseInt(
             chromiumBrowser ? chromiumMatch[1] : chromeMatch[1],
             10,
@@ -855,12 +470,7 @@
             !/\b(?:Chrome|CriOS|Chromium|Edg|OPR|FxiOS)\//.test(ua)
           ) {
             upgradeTargetKind = "safari";
-            upgradeTarget = {
-              actionLabel: copy.safari.actionLabel,
-              actionUrl: "https://support.apple.com/safari",
-              description: copy.safari.description,
-              title: copy.safari.title,
-            };
+            actionUrl = "https://support.apple.com/safari";
             var safariMajor = parseInt(safariMatch[1], 10);
             var safariMinor = safariMatch[2] ? parseInt(safariMatch[2], 10) : 0;
             if (!isNaN(safariMajor) && !isNaN(safariMinor)) {
@@ -870,8 +480,8 @@
           }
         }
 
-        window.__vm0BrowserUpgrade = upgradeTarget;
         window.__vm0BrowserSupported = supported;
+        document.documentElement.dataset.browserUpgradeActionUrl = actionUrl;
         document.documentElement.dataset.browserUpgradeTarget =
           upgradeTargetKind;
         document.documentElement.setAttribute(
@@ -880,384 +490,34 @@
         );
       })();
     </script>
-    <script>
-      (function () {
-        var hostname = window.location.hostname;
-        var isProductionHost =
-          hostname === "vm0.ai" ||
-          hostname.endsWith(".vm0.ai") ||
-          hostname === "okou.ai" ||
-          hostname.endsWith(".okou.ai");
-        if (!isProductionHost) return;
-
-        window.dataLayer = window.dataLayer || [];
-        window.gtag = function () {
-          window.dataLayer.push(arguments);
-        };
-        window.gtag("js", new Date());
-        window.gtag("config", "AW-18144854014");
-        window.gtag("config", "AW-18407336975");
-
-        var initialized = false;
-
-        function loadMarketingScripts() {
-          var gtagScript = document.createElement("script");
-          gtagScript.async = true;
-          gtagScript.src =
-            "https://www.googletagmanager.com/gtag/js?id=AW-18144854014";
-          document.head.appendChild(gtagScript);
-        }
-
-        function scheduleMarketingScripts() {
-          if (initialized) return;
-          initialized = true;
-
-          if (typeof window.requestIdleCallback === "function") {
-            window.requestIdleCallback(loadMarketingScripts, {
-              timeout: 1500,
-            });
-            return;
-          }
-
-          window.setTimeout(loadMarketingScripts, 0);
-        }
-
-        // Keep vendor work outside the first-content critical path. The
-        // 30-second guard exceeds the observed mobile P90 startup window and
-        // still bounds bootstraps that never reach real app content.
-        window.addEventListener(
-          "vm0:app-first-content-visible",
-          scheduleMarketingScripts,
-          { once: true },
-        );
-        window.setTimeout(scheduleMarketingScripts, 30000);
-      })();
-    </script>
-    <script>
-      // Mark <head> parse start as early as possible so we can measure the
-      // total white-screen duration up to the first `hideAppSkeleton$` call.
-      window.__appBootstrapStart = performance.now();
-    </script>
-    <link
-      rel="icon"
-      type="image/svg+xml"
-      href="https://static.vm0.io/platform/icon.svg"
-      integrity="sha384-ccZJ/dPMsNHiW8WF8/yNp+aD3sIwf2+1wy7fqvURH5oNrFX0sfNYTaXwTjyMhIjE"
-    />
-    <link
-      rel="icon"
-      type="image/x-icon"
-      href="https://static.vm0.io/platform/favicon.ico"
-      integrity="sha384-Pe0cByX3KRkasDxciKVerqZSvuElddhe0ri32ym8ia9G/4BZcn2EhPYZI1n4jV3B"
-    />
-    <link vite-ignore rel="manifest" href="/manifest.webmanifest" />
-    <link rel="preconnect" href="https://cdn.vm0.io" crossorigin />
-    <link rel="preconnect" href="https://static.vm0.io" crossorigin />
-    <link
-      rel="apple-touch-icon"
-      sizes="180x180"
-      href="https://static.vm0.io/platform/apple-touch-icon.png"
-      integrity="sha384-zSbBEIKCuNnaTseqd2LFjJVhGDe+8P6ONra73YN0hk+HENpXlwMzMINQY+VBXrch"
-    />
-    <meta name="mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta
-      name="apple-mobile-web-app-status-bar-style"
-      content="black-translucent"
-    />
-    <meta name="application-name" content="VM0" />
-    <meta name="apple-mobile-web-app-title" content="VM0" />
-    <meta
-      name="description"
-      content="VM0, your trustworthy AI teammate for real work. An AI agent that connects to 100+ tools to run reports, triage, outreach, and research in Slack or the web."
-    />
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="VM0" />
-    <meta property="og:title" content="VM0 - Your Trustworthy AI Teammate" />
-    <meta
-      property="og:description"
-      content="VM0, your trustworthy AI teammate for real work. An AI agent that connects to 100+ tools to run reports, triage, outreach, and research in Slack or the web."
-    />
-    <meta
-      property="og:image"
-      content="https://static.vm0.io/web/og-image.png"
-    />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
-    <meta
-      property="og:image:alt"
-      content="VM0 - Your Trustworthy AI Teammate"
-    />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@okou_ai" />
-    <meta name="twitter:creator" content="@okou_ai" />
-    <meta name="twitter:title" content="VM0 - Your Trustworthy AI Teammate" />
-    <meta
-      name="twitter:description"
-      content="VM0 is an AI agent that connects to 100+ tools and does the work. Reports, triage, outreach, research. In Slack or on the web."
-    />
-    <meta
-      name="twitter:image"
-      content="https://static.vm0.io/web/og-image.png"
-    />
-    <script>
-      (function () {
-        if (document.documentElement.dataset.appHeadManaged === "true") return;
-
-        var copy = window.__vm0PreBundleCopy.metadata;
-        var metadata = [
-          ['meta[name="description"]', copy.description],
-          ['meta[property="og:description"]', copy.description],
-          ['meta[property="og:image:alt"]', copy.title],
-          ['meta[property="og:title"]', copy.title],
-          ['meta[name="twitter:description"]', copy.description],
-          ['meta[name="twitter:title"]', copy.title],
-        ];
-        for (var i = 0; i < metadata.length; i += 1) {
-          var element = document.querySelector(metadata[i][0]);
-          if (element) element.setAttribute("content", metadata[i][1]);
-        }
-      })();
-    </script>
-    <meta name="google" content="notranslate" />
-    <meta
-      name="theme-color"
-      content="#ffffff"
-      media="(prefers-color-scheme: light)"
-    />
-    <meta
-      name="theme-color"
-      content="#19191b"
-      media="(prefers-color-scheme: dark)"
-    />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
-    />
-    <script>
-      // Inline theme detection — mirrors signals/theme.ts resolveTheme() + applyTheme()
-      (function () {
-        var p = localStorage.getItem("theme");
-        var t =
-          p === "dark" || p === "light"
-            ? p
-            : window.matchMedia("(prefers-color-scheme: dark)").matches
-              ? "dark"
-              : "light";
-        document.documentElement.dataset.theme = t;
-        if (t === "dark") document.documentElement.classList.add("dark");
-      })();
-    </script>
-    <script type="module" src="/src/main.ts"></script>
   </head>
   <body>
-    <div class="browser-upgrade" role="status" aria-live="polite">
-      <div class="browser-upgrade__center">
-        <div class="browser-upgrade__panel">
-          <div class="browser-upgrade__icon" aria-hidden="true">
-            <img src="https://static.vm0.io/platform/icon.svg" alt="" />
-          </div>
-          <div class="browser-upgrade__copy">
-            <h1 id="browser-upgrade-title">Update your browser to continue</h1>
-            <p id="browser-upgrade-description">
-              Zero does not support your current browser version. Update your
-              browser to continue.
-            </p>
-          </div>
-          <div class="browser-upgrade__actions">
-            <a
-              id="browser-upgrade-action"
-              href="https://www.google.com/chrome/"
-            >
-              Update browser
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
-    <script>
-      (function () {
-        var target = window.__vm0BrowserUpgrade;
-        if (!target) return;
-
-        var title = document.getElementById("browser-upgrade-title");
-        var description = document.getElementById(
-          "browser-upgrade-description",
-        );
-        var action = document.getElementById("browser-upgrade-action");
-
-        if (title) title.textContent = target.title;
-        if (description) description.textContent = target.description;
-        if (action) {
-          action.textContent = target.actionLabel;
-          action.href = target.actionUrl;
-        }
-      })();
-    </script>
-    <div id="root"></div>
     <div
       id="app-bootstrap-skeleton"
       role="status"
       aria-live="polite"
       aria-label="Loading your workspace"
     >
-      <style>
-        :root {
-          --zero-viewport-height: 100dvh;
-        }
-        @supports (height: 100lvh) {
-          @media (display-mode: standalone) {
-            :root {
-              --zero-viewport-height: 100lvh;
-            }
-          }
-        }
-        html,
-        body {
-          margin: 0;
-        }
-        html,
-        body,
-        #root {
-          width: 100%;
-          height: var(--zero-viewport-height);
-          min-height: var(--zero-viewport-height);
-          overflow: hidden;
-        }
-        #root {
-          position: fixed;
-          top: 0;
-          right: 0;
-          left: 0;
-        }
-        #app-bootstrap-skeleton {
-          position: fixed;
-          inset: 0;
-          /* Fixed insets follow WebKit's reachable layout viewport. Avoid the
-             standalone viewport unit, which can resolve after first paint. */
-          z-index: 60;
-          box-sizing: border-box;
-          display: none;
-          align-items: center;
-          justify-content: center;
-          background: #fdfdfe;
-          color: rgba(20, 23, 29, 0.7);
-          font-family:
-            system-ui,
-            -apple-system,
-            BlinkMacSystemFont,
-            "Segoe UI",
-            sans-serif;
-          opacity: 1;
-          transition: opacity 300ms ease;
-        }
-        [data-browser-supported="true"] #app-bootstrap-skeleton {
-          display: flex;
-        }
-        [data-theme="dark"] #app-bootstrap-skeleton {
-          background: #19191b;
-          color: rgba(232, 233, 237, 0.7);
-        }
-        #app-bootstrap-skeleton.app-bootstrap-skeleton--hidden {
-          pointer-events: none;
-          opacity: 0;
-        }
-        .app-bootstrap-skeleton__content {
-          position: fixed;
-          top: var(--app-bootstrap-skeleton-center-y, 50dvh);
-          left: 50%;
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-          gap: 20px;
-          transform: translate(-50%, -50%);
-        }
-        .app-bootstrap-skeleton__avatar {
-          position: relative;
-          width: 64px;
-          height: 64px;
-          overflow: hidden;
-          border-radius: 9999px;
-        }
-        .app-bootstrap-skeleton__avatar-layers {
-          position: absolute;
-          inset: 0;
-          transform: scale(1.25);
-        }
-        .app-bootstrap-skeleton__avatar img {
-          position: absolute;
-          inset: 0;
-          width: 100%;
-          height: 100%;
-          object-fit: cover;
-        }
-        .app-bootstrap-skeleton__message {
-          position: relative;
-          height: 24px;
-          font-size: 16px;
-          font-weight: 500;
-          line-height: 24px;
-        }
-        .app-bootstrap-skeleton__message p {
-          margin: 0;
-          white-space: nowrap;
-        }
-        .app-bootstrap-skeleton__message-spacer {
-          visibility: hidden;
-        }
-        .app-bootstrap-skeleton__message-static {
-          position: absolute;
-          top: 0;
-          left: 50%;
-          transform: translateX(-50%);
-        }
-        .app-bootstrap-skeleton__message-typewriter {
-          position: absolute;
-          inset: 0;
-          width: 0;
-          overflow: hidden;
-          border-right: 2px solid currentColor;
-          visibility: hidden;
-        }
-        @keyframes app-bootstrap-skeleton-hide-static {
-          0%,
-          99.9% {
-            opacity: 1;
-          }
-          100% {
-            opacity: 0;
-          }
-        }
-        @keyframes app-bootstrap-skeleton-show-typewriter {
-          0%,
-          99.9% {
-            visibility: hidden;
-          }
-          100% {
-            visibility: visible;
-          }
-        }
-        @keyframes app-bootstrap-skeleton-type {
-          from {
-            width: 0;
-          }
-          to {
-            width: 100%;
-          }
-        }
-        @keyframes app-bootstrap-skeleton-blink {
-          0%,
-          100% {
-            border-color: transparent;
-          }
-          50% {
-            border-color: currentColor;
-          }
-        }
-      </style>
       <div class="app-bootstrap-skeleton__content">
         <div class="app-bootstrap-skeleton__avatar" aria-hidden="true">
+          <svg
+            class="app-bootstrap-skeleton__avatar-placeholder"
+            viewBox="0 0 64 64"
+            aria-hidden="true"
+          >
+            <circle cx="32" cy="32" r="32" fill="#fee8dc" />
+            <path d="M18 46c2-9 7-14 14-14s12 5 14 14" fill="#ed4e01" />
+            <circle cx="32" cy="25" r="12" fill="#f6b996" />
+            <circle cx="28" cy="24" r="1.5" fill="#14171d" />
+            <circle cx="36" cy="24" r="1.5" fill="#14171d" />
+            <path
+              d="M28 29c2.5 2 5.5 2 8 0"
+              fill="none"
+              stroke="#14171d"
+              stroke-linecap="round"
+              stroke-width="1.5"
+            />
+          </svg>
           <div class="app-bootstrap-skeleton__avatar-layers">
             <img data-app-bootstrap-avatar-layer="head" alt="" />
             <img data-app-bootstrap-avatar-layer="face" alt="" />
@@ -1279,179 +539,1075 @@
     </div>
     <script>
       (function () {
-        if (window.__vm0BrowserSupported !== true) return;
+        var callbacks = [];
+        var ready = false;
 
-        var skeleton = document.getElementById("app-bootstrap-skeleton");
-        // iOS standalone can expand the fixed containing viewport one frame
-        // after launch. Pin the content to the initially reachable viewport
-        // so that later geometry resolution cannot visibly recenter it.
-        var viewportHeight =
-          window.visualViewport && window.visualViewport.height > 0
-            ? window.visualViewport.height
-            : window.innerHeight;
-        if (viewportHeight > 0) {
-          skeleton.style.setProperty(
-            "--app-bootstrap-skeleton-center-y",
-            viewportHeight / 2 + "px",
-          );
-        }
-        var loadingCopy = window.__vm0PreBundleCopy.loading;
-        var messages = loadingCopy.messages;
-        skeleton.setAttribute("aria-label", loadingCopy.ariaLabel);
-        var avatarPresets = [
-          {
-            rotation: 1,
-            skin: 0,
-            hairStyle: 1,
-            hairColor: 5,
-            expression: 1,
-            intensity: "h",
-          },
-          {
-            rotation: 2,
-            skin: 1,
-            hairStyle: 3,
-            hairColor: 3,
-            expression: 1,
-            intensity: "m",
-          },
-          {
-            rotation: 4,
-            skin: 2,
-            hairStyle: 5,
-            hairColor: 4,
-            expression: 3,
-            intensity: "d",
-          },
-          {
-            rotation: 3,
-            skin: 3,
-            hairStyle: 4,
-            hairColor: 1,
-            expression: 4,
-            intensity: "h",
-          },
-          {
-            rotation: 5,
-            skin: 4,
-            hairStyle: 2,
-            hairColor: 2,
-            expression: 5,
-            intensity: "m",
-          },
-        ];
-        var staticAssetBase =
-          document.documentElement.getAttribute("data-app-brand-name") ===
-          "Okou"
-            ? "https://static.okou.io"
-            : "https://static.vm0.io";
-        var avatarAssetBase =
-          staticAssetBase + "/platform/views/zero-page/assets/avatar-svg/";
-        var avatar =
-          avatarPresets[Math.floor(Math.random() * avatarPresets.length)];
-        var messageIndex = Math.floor(Math.random() * messages.length);
-        var staticMessage = skeleton.querySelector(
-          ".app-bootstrap-skeleton__message-static",
-        );
-        var spacerMessage = skeleton.querySelector(
-          ".app-bootstrap-skeleton__message-spacer",
-        );
-        var typewriterMessage = skeleton.querySelector(
-          ".app-bootstrap-skeleton__message-typewriter",
-        );
-
-        skeleton.querySelector('[data-app-bootstrap-avatar-layer="head"]').src =
-          avatarAssetBase +
-          "head-r" +
-          avatar.rotation +
-          "-s" +
-          avatar.skin +
-          ".svg";
-        skeleton.querySelector('[data-app-bootstrap-avatar-layer="face"]').src =
-          avatarAssetBase +
-          "face-r" +
-          avatar.rotation +
-          "-f" +
-          avatar.expression +
-          "-" +
-          avatar.intensity +
-          ".svg";
-        skeleton.querySelector('[data-app-bootstrap-avatar-layer="hair"]').src =
-          avatarAssetBase +
-          "hair-r" +
-          avatar.rotation +
-          "-h" +
-          avatar.hairStyle +
-          "-c" +
-          avatar.hairColor +
-          ".svg";
-
-        function typewriterAnimation(message, delay) {
-          return (
-            "app-bootstrap-skeleton-show-typewriter " +
-            delay +
-            "ms forwards, app-bootstrap-skeleton-type 1.5s steps(" +
-            message.length +
-            ") " +
-            delay +
-            "ms forwards, app-bootstrap-skeleton-blink 0.6s step-end " +
-            delay +
-            "ms infinite"
-          );
-        }
-
-        function setMessages(isFirst) {
-          var currentMessage = messages[messageIndex % messages.length];
-          var nextMessage = messages[(messageIndex + 1) % messages.length];
-          var nextTypewriterMessage = typewriterMessage.cloneNode(true);
-
-          staticMessage.textContent = currentMessage;
-          staticMessage.style.display = isFirst ? "block" : "none";
-          staticMessage.style.animation = isFirst
-            ? "app-bootstrap-skeleton-hide-static 800ms forwards"
-            : "none";
-          spacerMessage.textContent = nextMessage;
-          nextTypewriterMessage.textContent = nextMessage;
-          nextTypewriterMessage.style.animation = typewriterAnimation(
-            nextMessage,
-            isFirst ? 800 : 0,
-          );
-          typewriterMessage.replaceWith(nextTypewriterMessage);
-          typewriterMessage = nextTypewriterMessage;
-        }
-
-        setMessages(true);
-
-        var cycles = 0;
-        var interval = window.setInterval(function () {
-          if (!document.getElementById("app-bootstrap-skeleton")) {
-            window.clearInterval(interval);
+        window.__vm0AfterFirstPaint = function (callback) {
+          if (ready) {
+            callback();
             return;
           }
+          callbacks.push(callback);
+        };
 
-          messageIndex += 1;
-          setMessages(false);
-          cycles += 1;
-          if (cycles >= 3) {
-            window.clearInterval(interval);
+        function flushCallbacks(firstPaintObserved) {
+          if (ready) return;
+          ready = true;
+          if (firstPaintObserved) {
+            window.__appBootstrapFirstPaintUpperBound = performance.now();
           }
-        }, 4000);
+          for (var i = 0; i < callbacks.length; i += 1) {
+            callbacks[i]();
+          }
+          callbacks.length = 0;
+        }
+
+        if (document.visibilityState === "visible") {
+          window.requestAnimationFrame(function () {
+            window.requestAnimationFrame(function () {
+              flushCallbacks(true);
+            });
+          });
+          return;
+        }
+
+        window.setTimeout(function () {
+          flushCallbacks(false);
+        }, 100);
+      })();
+    </script>
+    <script data-vm0-app-entry="" type="module" src="/src/main.ts"></script>
+    <div class="browser-upgrade" role="status" aria-live="polite">
+      <div class="browser-upgrade__center">
+        <div class="browser-upgrade__panel">
+          <div class="browser-upgrade__icon" aria-hidden="true">
+            <svg viewBox="0 0 40 40" aria-hidden="true">
+              <rect width="40" height="40" rx="10" fill="#fff1e9" />
+              <path
+                d="M13 20a7 7 0 0 1 12-5M27 20a7 7 0 0 1-12 5"
+                fill="none"
+                stroke="#ed4e01"
+                stroke-linecap="round"
+                stroke-width="2.5"
+              />
+              <path d="m24 11 1 4-4 1M16 29l-1-4 4-1" fill="#ed4e01" />
+            </svg>
+          </div>
+          <div class="browser-upgrade__copy">
+            <h1 id="browser-upgrade-title">Update your browser to continue</h1>
+            <p id="browser-upgrade-description">
+              Zero does not support your current browser version. Update your
+              browser to continue.
+            </p>
+          </div>
+          <div class="browser-upgrade__actions">
+            <a
+              id="browser-upgrade-action"
+              href="https://www.google.com/chrome/"
+            >
+              Update browser
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script>
+      (function () {
+        var action = document.getElementById("browser-upgrade-action");
+        var actionUrl =
+          document.documentElement.dataset.browserUpgradeActionUrl;
+        if (action && actionUrl) action.href = actionUrl;
+      })();
+    </script>
+    <div id="root"></div>
+    <link
+      rel="preload"
+      as="style"
+      data-vm0-font-stylesheet=""
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
+    />
+    <script data-vm0-clerk-bootstrap="">
+      (function () {
+        var hostname = location.hostname.toLowerCase();
+        var production =
+          hostname === "vm0.ai" ||
+          hostname.endsWith(".vm0.ai") ||
+          hostname === "okou.ai" ||
+          hostname.endsWith(".okou.ai");
+        var satellite =
+          hostname === "app.okou.ai" || hostname.endsWith(".app.okou.ai");
+        var publishableKey = production
+          ? "%VITE_CLERK_PUBLISHABLE_KEY_PROD%"
+          : "%VITE_CLERK_PUBLISHABLE_KEY_PREVIEW%";
+        var scriptUrl = satellite
+          ? "__VM0_CLERK_SATELLITE_SCRIPT_URL__"
+          : production
+            ? "__VM0_CLERK_PRODUCTION_SCRIPT_URL__"
+            : "__VM0_CLERK_PREVIEW_SCRIPT_URL__";
+
+        var preconnect = document.createElement("link");
+        preconnect.rel = "preconnect";
+        preconnect.href = new URL(scriptUrl).origin;
+        preconnect.crossOrigin = "anonymous";
+        document.head.appendChild(preconnect);
+
+        window.__vm0AfterFirstPaint(function () {
+          if (window.__vm0BrowserSupported !== true) return;
+
+          var script = document.createElement("script");
+          script.async = false;
+          script.defer = true;
+          script.crossOrigin = "anonymous";
+          script.dataset.clerkJsScript = "";
+          script.dataset.clerkPublishableKey = publishableKey;
+          if (satellite) {
+            script.dataset.clerkDomain = "app.okou.ai";
+          }
+          script.onerror = function () {
+            script.remove();
+          };
+          script.src = scriptUrl;
+          script.type = "text/javascript";
+          document.head.appendChild(script);
+        });
       })();
     </script>
     <script>
-      (function () {
-        var hostname = window.location.hostname.toLowerCase();
-        if (hostname !== "app.vm0.ai" && hostname !== "app.okou.ai") return;
+      window.__vm0AfterFirstPaint(function () {
+        // Resolve locale before Clerk and the application entry start.
+        (function () {
+          var orgId = sessionStorage.getItem("clerk-active-org-id");
+          var cacheKey = orgId ? "vm0:locale:" + orgId : null;
+          var cached = cacheKey ? localStorage.getItem(cacheKey) : null;
+          // Prefer the workspace cache. Signed-out and first-time visitors use a
+          // supported browser language, with English as the fallback.
+          var browserLocale = /^ja(?:-|$)/i.test(navigator.language)
+            ? "ja-JP"
+            : /^ko(?:-|$)/i.test(navigator.language)
+              ? "ko-KR"
+              : /^id(?:-|$)/i.test(navigator.language)
+                ? "id-ID"
+                : /^de(?:-|$)/i.test(navigator.language)
+                  ? "de-DE"
+                  : /^es(?:-|$)/i.test(navigator.language)
+                    ? "es-ES"
+                    : /^it(?:-|$)/i.test(navigator.language)
+                      ? "it-IT"
+                      : /^fr(?:-|$)/i.test(navigator.language)
+                        ? "fr-FR"
+                        : /^hi(?:-|$)/i.test(navigator.language)
+                          ? "hi-IN"
+                          : /^pt(?:-|$)/i.test(navigator.language)
+                            ? "pt-BR"
+                            : "en-US";
+          var locale =
+            cached === "en-US" ||
+            cached === "pt-BR" ||
+            cached === "ja-JP" ||
+            cached === "ko-KR" ||
+            cached === "id-ID" ||
+            cached === "de-DE" ||
+            cached === "es-ES" ||
+            cached === "it-IT" ||
+            cached === "fr-FR" ||
+            cached === "hi-IN"
+              ? cached
+              : browserLocale;
+          var copyByLocale = {
+            "en-US": {
+              browserUpgrade: {
+                browser: {
+                  actionLabel: "Update browser",
+                  description:
+                    "{{assistantName}} does not support your current browser version. Update your browser to continue.",
+                  title: "Update your browser to continue",
+                },
+                chrome: {
+                  actionLabel: "Update Chrome",
+                  description:
+                    "{{assistantName}} does not support your current browser version. Update Chrome to continue.",
+                  title: "Update Chrome to continue",
+                },
+                chromium: {
+                  actionLabel: "Update Chromium",
+                  description:
+                    "{{assistantName}} does not support your current browser version. Update Chromium to continue.",
+                  title: "Update Chromium to continue",
+                },
+                ios: {
+                  actionLabel: "Update iOS",
+                  description:
+                    "{{assistantName}} does not support your current browser version. Update iOS to continue.",
+                  title: "Update iOS to continue",
+                },
+                safari: {
+                  actionLabel: "Update Safari",
+                  description:
+                    "{{assistantName}} does not support your current browser version. Update Safari to continue.",
+                  title: "Update Safari to continue",
+                },
+              },
+              loading: {
+                ariaLabel: "Loading your workspace",
+                messages: [
+                  "Warming up the neurons...",
+                  "Brewing some ideas...",
+                  "Getting things ready...",
+                  "Almost there...",
+                  "Loading your workspace...",
+                  "Tuning the instruments...",
+                  "Connecting the dots...",
+                  "Spinning up the team...",
+                ],
+              },
+              metadata: {
+                description:
+                  "{{assistantName}} is your AI coworker from {{brandName}}. Text {{assistantName}} or chat on the web — research, email, docs, Slack, GitHub, Notion, and 100+ tools.",
+                title:
+                  "{{assistantName}} — Your AI coworker from {{brandName}}",
+              },
+            },
+            "fr-FR": {
+              browserUpgrade: {
+                browser: {
+                  actionLabel: "Mettre à jour le navigateur",
+                  description:
+                    "{{assistantName}} ne prend pas en charge la version actuelle de votre navigateur. Mettez à jour votre navigateur pour continuer.",
+                  title: "Mettez à jour votre navigateur pour continuer",
+                },
+                chrome: {
+                  actionLabel: "Mettre à jour Chrome",
+                  description:
+                    "{{assistantName}} ne prend pas en charge la version actuelle de votre navigateur. Mettez à jour Chrome pour continuer.",
+                  title: "Mettez à jour Chrome pour continuer",
+                },
+                chromium: {
+                  actionLabel: "Mettre à jour Chromium",
+                  description:
+                    "{{assistantName}} ne prend pas en charge la version actuelle de votre navigateur. Mettez à jour Chromium pour continuer.",
+                  title: "Mettez à jour Chromium pour continuer",
+                },
+                ios: {
+                  actionLabel: "Mettre à jour iOS",
+                  description:
+                    "{{assistantName}} ne prend pas en charge la version actuelle de votre navigateur. Mettez à jour iOS pour continuer.",
+                  title: "Mettez à jour iOS pour continuer",
+                },
+                safari: {
+                  actionLabel: "Mettre à jour Safari",
+                  description:
+                    "{{assistantName}} ne prend pas en charge la version actuelle de votre navigateur. Mettez à jour Safari pour continuer.",
+                  title: "Mettez à jour Safari pour continuer",
+                },
+              },
+              loading: {
+                ariaLabel: "Chargement de votre espace de travail",
+                messages: [
+                  "Initialisation des neurones...",
+                  "Quelques idées sont en préparation...",
+                  "Préparation en cours...",
+                  "Presque prêt...",
+                  "Chargement de votre espace de travail...",
+                  "Accordage des instruments...",
+                  "Connexion des idées...",
+                  "Mise en place de l’équipe...",
+                ],
+              },
+              metadata: {
+                description:
+                  "{{assistantName}} est votre coéquipier IA créé par {{brandName}}. Envoyez un message à {{assistantName}} ou discutez sur le web — recherche, e-mails, documents, Slack, GitHub, Notion et plus de 100 outils.",
+                title:
+                  "{{assistantName}} — Votre coéquipier IA créé par {{brandName}}",
+              },
+            },
+            "pt-BR": {
+              browserUpgrade: {
+                browser: {
+                  actionLabel: "Atualizar navegador",
+                  description:
+                    "O {{assistantName}} não oferece suporte à versão atual do seu navegador. Atualize o navegador para continuar.",
+                  title: "Atualize seu navegador para continuar",
+                },
+                chrome: {
+                  actionLabel: "Atualizar Chrome",
+                  description:
+                    "O {{assistantName}} não oferece suporte à versão atual do seu navegador. Atualize o Chrome para continuar.",
+                  title: "Atualize o Chrome para continuar",
+                },
+                chromium: {
+                  actionLabel: "Atualizar Chromium",
+                  description:
+                    "O {{assistantName}} não oferece suporte à versão atual do seu navegador. Atualize o Chromium para continuar.",
+                  title: "Atualize o Chromium para continuar",
+                },
+                ios: {
+                  actionLabel: "Atualizar iOS",
+                  description:
+                    "O {{assistantName}} não oferece suporte à versão atual do seu navegador. Atualize o iOS para continuar.",
+                  title: "Atualize o iOS para continuar",
+                },
+                safari: {
+                  actionLabel: "Atualizar Safari",
+                  description:
+                    "O {{assistantName}} não oferece suporte à versão atual do seu navegador. Atualize o Safari para continuar.",
+                  title: "Atualize o Safari para continuar",
+                },
+              },
+              loading: {
+                ariaLabel: "Carregando seu espaço de trabalho",
+                messages: [
+                  "Aquecendo os neurônios...",
+                  "Preparando algumas ideias...",
+                  "Preparando tudo...",
+                  "Quase lá...",
+                  "Carregando seu espaço de trabalho...",
+                  "Ajustando os instrumentos...",
+                  "Ligando os pontos...",
+                  "Reunindo a equipe...",
+                ],
+              },
+              metadata: {
+                description:
+                  "{{assistantName}} é seu colega de IA da {{brandName}}. Envie uma mensagem para o {{assistantName}} ou converse pela web — pesquise, envie e-mails, crie documentos e use Slack, GitHub, Notion e mais de 100 ferramentas.",
+                title: "{{assistantName}} — Seu colega de IA da {{brandName}}",
+              },
+            },
+            "ja-JP": {
+              browserUpgrade: {
+                browser: {
+                  actionLabel: "ブラウザを更新",
+                  description:
+                    "現在のブラウザのバージョンは{{assistantName}}でサポートされていません。続行するにはブラウザを更新してください。",
+                  title: "続行するにはブラウザを更新してください",
+                },
+                chrome: {
+                  actionLabel: "Chromeを更新",
+                  description:
+                    "現在のブラウザのバージョンは{{assistantName}}でサポートされていません。続行するにはChromeを更新してください。",
+                  title: "続行するにはChromeを更新してください",
+                },
+                chromium: {
+                  actionLabel: "Chromiumを更新",
+                  description:
+                    "現在のブラウザのバージョンは{{assistantName}}でサポートされていません。続行するにはChromiumを更新してください。",
+                  title: "続行するにはChromiumを更新してください",
+                },
+                ios: {
+                  actionLabel: "iOSを更新",
+                  description:
+                    "現在のブラウザのバージョンは{{assistantName}}でサポートされていません。続行するにはiOSを更新してください。",
+                  title: "続行するにはiOSを更新してください",
+                },
+                safari: {
+                  actionLabel: "Safariを更新",
+                  description:
+                    "現在のブラウザのバージョンは{{assistantName}}でサポートされていません。続行するにはSafariを更新してください。",
+                  title: "続行するにはSafariを更新してください",
+                },
+              },
+              loading: {
+                ariaLabel: "ワークスペースを読み込み中",
+                messages: [
+                  "ニューラルネットワークを準備しています...",
+                  "アイデアを練っています...",
+                  "準備しています...",
+                  "もうすぐです...",
+                  "ワークスペースを読み込んでいます...",
+                  "楽器を調整しています...",
+                  "点と点をつないでいます...",
+                  "チームを立ち上げています...",
+                ],
+              },
+              metadata: {
+                description:
+                  "{{assistantName}}は{{brandName}}のAIコワーカーです。{{assistantName}}にメッセージを送るか、Webでチャットできます。リサーチ、メール、ドキュメント、Slack、GitHub、Notionなど、100以上のツールを利用できます。",
+                title: "{{assistantName}} — {{brandName}}のAIコワーカー",
+              },
+            },
+            "ko-KR": {
+              browserUpgrade: {
+                browser: {
+                  actionLabel: "브라우저 업데이트",
+                  description:
+                    "{{assistantName}}는 현재 브라우저 버전을 지원하지 않습니다. 계속하려면 브라우저를 업데이트하세요.",
+                  title: "계속하려면 브라우저를 업데이트하세요",
+                },
+                chrome: {
+                  actionLabel: "Chrome 업데이트",
+                  description:
+                    "{{assistantName}}는 현재 Chrome 버전을 지원하지 않습니다. 계속하려면 Chrome을 업데이트하세요.",
+                  title: "계속하려면 Chrome을 업데이트하세요",
+                },
+                chromium: {
+                  actionLabel: "Chromium 업데이트",
+                  description:
+                    "{{assistantName}}는 현재 Chromium 버전을 지원하지 않습니다. 계속하려면 Chromium을 업데이트하세요.",
+                  title: "계속하려면 Chromium을 업데이트하세요",
+                },
+                ios: {
+                  actionLabel: "iOS 업데이트",
+                  description:
+                    "{{assistantName}}는 현재 iOS 버전을 지원하지 않습니다. 계속하려면 iOS를 업데이트하세요.",
+                  title: "계속하려면 iOS를 업데이트하세요",
+                },
+                safari: {
+                  actionLabel: "Safari 업데이트",
+                  description:
+                    "{{assistantName}}는 현재 Safari 버전을 지원하지 않습니다. 계속하려면 Safari를 업데이트하세요.",
+                  title: "계속하려면 Safari를 업데이트하세요",
+                },
+              },
+              loading: {
+                ariaLabel: "워크스페이스를 불러오는 중",
+                messages: [
+                  "뉴런을 예열하는 중...",
+                  "아이디어를 구상 중...",
+                  "준비 중...",
+                  "거의 완료되었습니다...",
+                  "워크스페이스를 불러오는 중...",
+                  "도구를 조율하는 중...",
+                  "연결 중...",
+                  "팀을 구성하는 중...",
+                ],
+              },
+              metadata: {
+                description:
+                  "{{assistantName}}는 {{brandName}}의 AI 팀원입니다. {{assistantName}}에 텍스트를 보내거나 웹에서 채팅하세요 — 리서치, 이메일, 문서, Slack, GitHub, Notion 및 100개 이상의 도구를 지원합니다.",
+                title: "{{assistantName}} — {{brandName}}의 AI 팀원",
+              },
+            },
+            "id-ID": {
+              browserUpgrade: {
+                browser: {
+                  actionLabel: "Perbarui browser",
+                  description:
+                    "{{assistantName}} tidak mendukung versi browser Anda saat ini. Perbarui browser Anda untuk melanjutkan.",
+                  title: "Perbarui browser Anda untuk melanjutkan",
+                },
+                chrome: {
+                  actionLabel: "Perbarui Chrome",
+                  description:
+                    "{{assistantName}} tidak mendukung versi Chrome Anda saat ini. Perbarui Chrome untuk melanjutkan.",
+                  title: "Perbarui Chrome untuk melanjutkan",
+                },
+                chromium: {
+                  actionLabel: "Perbarui Chromium",
+                  description:
+                    "{{assistantName}} tidak mendukung versi Chromium Anda saat ini. Perbarui Chromium untuk melanjutkan.",
+                  title: "Perbarui Chromium untuk melanjutkan",
+                },
+                ios: {
+                  actionLabel: "Perbarui iOS",
+                  description:
+                    "{{assistantName}} tidak mendukung versi iOS Anda saat ini. Perbarui iOS untuk melanjutkan.",
+                  title: "Perbarui iOS untuk melanjutkan",
+                },
+                safari: {
+                  actionLabel: "Perbarui Safari",
+                  description:
+                    "{{assistantName}} tidak mendukung versi Safari Anda saat ini. Perbarui Safari untuk melanjutkan.",
+                  title: "Perbarui Safari untuk melanjutkan",
+                },
+              },
+              loading: {
+                ariaLabel: "Memuat ruang kerja Anda",
+                messages: [
+                  "Sedang memanaskan neuron...",
+                  "Sedang meracik ide...",
+                  "Sedang menyiapkan semuanya...",
+                  "Hampir sampai...",
+                  "Memuat ruang kerja Anda...",
+                  "Sedang menyetel instrumen...",
+                  "Sedang menghubungkan titik-titik...",
+                  "Sedang menyiapkan tim...",
+                ],
+              },
+              metadata: {
+                description:
+                  "{{assistantName}} adalah rekan kerja AI Anda dari {{brandName}}. Kirim pesan ke {{assistantName}} atau chat di web — riset, email, dokumen, Slack, GitHub, Notion, dan 100+ alat.",
+                title:
+                  "{{assistantName}} — Rekan kerja AI Anda dari {{brandName}}",
+              },
+            },
+            "de-DE": {
+              browserUpgrade: {
+                browser: {
+                  actionLabel: "Browser aktualisieren",
+                  description:
+                    "{{assistantName}} unterstützt Ihre aktuelle Browserversion nicht. Aktualisieren Sie Ihren Browser, um fortzufahren.",
+                  title: "Aktualisieren Sie Ihren Browser, um fortzufahren",
+                },
+                chrome: {
+                  actionLabel: "Chrome aktualisieren",
+                  description:
+                    "{{assistantName}} unterstützt Ihre aktuelle Browserversion nicht. Aktualisieren Sie Chrome, um fortzufahren.",
+                  title: "Aktualisieren Sie Chrome, um fortzufahren",
+                },
+                chromium: {
+                  actionLabel: "Chromium aktualisieren",
+                  description:
+                    "{{assistantName}} unterstützt Ihre aktuelle Browserversion nicht. Aktualisieren Sie Chromium, um fortzufahren.",
+                  title: "Aktualisieren Sie Chromium, um fortzufahren",
+                },
+                ios: {
+                  actionLabel: "iOS aktualisieren",
+                  description:
+                    "{{assistantName}} unterstützt Ihre aktuelle Browserversion nicht. Aktualisieren Sie iOS, um fortzufahren.",
+                  title: "Aktualisieren Sie iOS, um fortzufahren",
+                },
+                safari: {
+                  actionLabel: "Safari aktualisieren",
+                  description:
+                    "{{assistantName}} unterstützt Ihre aktuelle Browserversion nicht. Aktualisieren Sie Safari, um fortzufahren.",
+                  title: "Aktualisieren Sie Safari, um fortzufahren",
+                },
+              },
+              loading: {
+                ariaLabel: "Ihr Arbeitsbereich wird geladen",
+                messages: [
+                  "Neuronen werden aufgewärmt...",
+                  "Ideen werden entwickelt...",
+                  "Alles wird vorbereitet...",
+                  "Fast geschafft...",
+                  "Ihr Arbeitsbereich wird geladen...",
+                  "Instrumente werden gestimmt...",
+                  "Punkte werden verbunden...",
+                  "Das Team wird zusammengestellt...",
+                ],
+              },
+              metadata: {
+                description:
+                  "{{assistantName}} ist Ihr KI-Kollege von {{brandName}}. Schreiben Sie {{assistantName}} oder chatten Sie im Web — für Recherche, E-Mails, Dokumente, Slack, GitHub, Notion und über 100 weitere Tools.",
+                title: "{{assistantName}} — Ihr KI-Kollege von {{brandName}}",
+              },
+            },
+            "es-ES": {
+              browserUpgrade: {
+                browser: {
+                  actionLabel: "Actualizar navegador",
+                  description:
+                    "{{assistantName}} no es compatible con la versión actual de tu navegador. Actualiza el navegador para continuar.",
+                  title: "Actualiza tu navegador para continuar",
+                },
+                chrome: {
+                  actionLabel: "Actualizar Chrome",
+                  description:
+                    "{{assistantName}} no es compatible con la versión actual de tu navegador. Actualiza Chrome para continuar.",
+                  title: "Actualiza Chrome para continuar",
+                },
+                chromium: {
+                  actionLabel: "Actualizar Chromium",
+                  description:
+                    "{{assistantName}} no es compatible con la versión actual de tu navegador. Actualiza Chromium para continuar.",
+                  title: "Actualiza Chromium para continuar",
+                },
+                ios: {
+                  actionLabel: "Actualizar iOS",
+                  description:
+                    "{{assistantName}} no es compatible con la versión actual de tu navegador. Actualiza iOS para continuar.",
+                  title: "Actualiza iOS para continuar",
+                },
+                safari: {
+                  actionLabel: "Actualizar Safari",
+                  description:
+                    "{{assistantName}} no es compatible con la versión actual de tu navegador. Actualiza Safari para continuar.",
+                  title: "Actualiza Safari para continuar",
+                },
+              },
+              loading: {
+                ariaLabel: "Cargando tu espacio de trabajo",
+                messages: [
+                  "Activando las neuronas...",
+                  "Preparando algunas ideas...",
+                  "Dejándolo todo listo...",
+                  "Ya casi está...",
+                  "Cargando tu espacio de trabajo...",
+                  "Afinando los instrumentos...",
+                  "Conectando los puntos...",
+                  "Reuniendo al equipo...",
+                ],
+              },
+              metadata: {
+                description:
+                  "{{assistantName}} es tu compañero de IA de {{brandName}}. Escríbele a {{assistantName}} o chatea en la web: investiga, envía correos, crea documentos y usa Slack, GitHub, Notion y más de 100 herramientas.",
+                title:
+                  "{{assistantName}} — Tu compañero de IA de {{brandName}}",
+              },
+            },
+            "it-IT": {
+              browserUpgrade: {
+                browser: {
+                  actionLabel: "Aggiorna browser",
+                  description:
+                    "{{assistantName}} non supporta la versione attuale del tuo browser. Aggiorna il browser per continuare.",
+                  title: "Aggiorna il browser per continuare",
+                },
+                chrome: {
+                  actionLabel: "Aggiorna Chrome",
+                  description:
+                    "{{assistantName}} non supporta la versione attuale del tuo browser. Aggiorna Chrome per continuare.",
+                  title: "Aggiorna Chrome per continuare",
+                },
+                chromium: {
+                  actionLabel: "Aggiorna Chromium",
+                  description:
+                    "{{assistantName}} non supporta la versione attuale del tuo browser. Aggiorna Chromium per continuare.",
+                  title: "Aggiorna Chromium per continuare",
+                },
+                ios: {
+                  actionLabel: "Aggiorna iOS",
+                  description:
+                    "{{assistantName}} non supporta la versione attuale del tuo browser. Aggiorna iOS per continuare.",
+                  title: "Aggiorna iOS per continuare",
+                },
+                safari: {
+                  actionLabel: "Aggiorna Safari",
+                  description:
+                    "{{assistantName}} non supporta la versione attuale del tuo browser. Aggiorna Safari per continuare.",
+                  title: "Aggiorna Safari per continuare",
+                },
+              },
+              loading: {
+                ariaLabel: "Caricamento dell'area di lavoro",
+                messages: [
+                  "Riscaldamento dei neuroni...",
+                  "Preparando qualche idea...",
+                  "Preparando tutto...",
+                  "Ci siamo quasi...",
+                  "Caricamento dell'area di lavoro...",
+                  "Accordando gli strumenti...",
+                  "Unendo i puntini...",
+                  "Radunando il team...",
+                ],
+              },
+              metadata: {
+                description:
+                  "{{assistantName}} è il tuo collega AI di {{brandName}}. Scrivi a {{assistantName}} o chatta sul web — ricerca, email, documenti, Slack, GitHub, Notion e oltre 100 strumenti.",
+                title: "{{assistantName}} — Il tuo collega AI di {{brandName}}",
+              },
+            },
+            "hi-IN": {
+              browserUpgrade: {
+                browser: {
+                  actionLabel: "ब्राउज़र अपडेट करें",
+                  description:
+                    "{{assistantName}} आपके वर्तमान ब्राउज़र संस्करण का समर्थन नहीं करता है। जारी रखने के लिए अपना ब्राउज़र अपडेट करें।",
+                  title: "जारी रखने के लिए अपना ब्राउज़र अपडेट करें",
+                },
+                chrome: {
+                  actionLabel: "Chrome को अपडेट करें",
+                  description:
+                    "{{assistantName}} आपके वर्तमान ब्राउज़र संस्करण का समर्थन नहीं करता है। जारी रखने के लिए Chrome को अपडेट करें।",
+                  title: "जारी रखने के लिए Chrome को अपडेट करें",
+                },
+                chromium: {
+                  actionLabel: "Chromium को अपडेट करें",
+                  description:
+                    "{{assistantName}} आपके वर्तमान ब्राउज़र संस्करण का समर्थन नहीं करता है। जारी रखने के लिए Chromium को अपडेट करें।",
+                  title: "जारी रखने के लिए Chromium को अपडेट करें",
+                },
+                ios: {
+                  actionLabel: "iOS को अपडेट करें",
+                  description:
+                    "{{assistantName}} आपके वर्तमान ब्राउज़र संस्करण का समर्थन नहीं करता है। जारी रखने के लिए iOS को अपडेट करें।",
+                  title: "जारी रखने के लिए iOS को अपडेट करें",
+                },
+                safari: {
+                  actionLabel: "Safari को अपडेट करें",
+                  description:
+                    "{{assistantName}} आपके वर्तमान ब्राउज़र संस्करण का समर्थन नहीं करता है। जारी रखने के लिए Safari को अपडेट करें।",
+                  title: "जारी रखने के लिए Safari को अपडेट करें",
+                },
+              },
+              loading: {
+                ariaLabel: "आपका वर्कस्पेस लोड हो रहा है",
+                messages: [
+                  "न्यूरॉन्स को सक्रिय कर रहे हैं...",
+                  "कुछ नए विचार तैयार कर रहे हैं...",
+                  "सब कुछ तैयार कर रहे हैं...",
+                  "बस लगभग तैयार...",
+                  "आपका वर्कस्पेस लोड हो रहा है...",
+                  "उपकरणों को ट्यून कर रहे हैं...",
+                  "कड़ियाँ जोड़ रहे हैं...",
+                  "टीम को तैयार कर रहे हैं...",
+                ],
+              },
+              metadata: {
+                description:
+                  "{{assistantName}}, {{brandName}} से आपका AI सहकर्मी है। {{assistantName}} को टेक्स्ट करें या वेब पर चैट करें — रिसर्च, ईमेल, दस्तावेज़, Slack, GitHub, Notion और 100+ टूल।",
+                title: "{{assistantName}} — {{brandName}} से आपका AI सहकर्मी",
+              },
+            },
+          };
 
-        var instatusScript = document.createElement("script");
-        instatusScript.src =
-          "https://api.dashboard.instatus.com/widget?host=status.vm0.ai&code=02c0ef5a&locale=en";
-        instatusScript.integrity =
-          "sha384-ZW3eZwADOMdlg2fdvESPD7jguK16IC/edxNFakKs81D2lkNdi3BXRmx/g331lkD3";
-        instatusScript.crossOrigin = "anonymous";
-        instatusScript.defer = true;
-        document.body.appendChild(instatusScript);
-      })();
+          var selectedCopy = copyByLocale[locale];
+          var brandName = document.documentElement.dataset.appBrandName;
+          if (brandName !== "VM0" && brandName !== "Okou") {
+            throw new Error("Invalid app brand name");
+          }
+          var assistantName = brandName === "Okou" ? "Okou" : "Zero";
+          var interpolateBrandCopy = function (value) {
+            return value
+              .replace(/\{\{assistantName\}\}/g, assistantName)
+              .replace(/\{\{brandName\}\}/g, brandName);
+          };
+          var browserUpgradeTargets = [
+            "browser",
+            "chrome",
+            "chromium",
+            "ios",
+            "safari",
+          ];
+          for (var i = 0; i < browserUpgradeTargets.length; i += 1) {
+            var target = selectedCopy.browserUpgrade[browserUpgradeTargets[i]];
+            target.description = interpolateBrandCopy(target.description);
+          }
+          selectedCopy.metadata.description = interpolateBrandCopy(
+            selectedCopy.metadata.description,
+          );
+          selectedCopy.metadata.title = interpolateBrandCopy(
+            selectedCopy.metadata.title,
+          );
+
+          window.__vm0PreBundleCopy = selectedCopy;
+          document.documentElement.lang = locale;
+          if (cacheKey) localStorage.setItem(cacheKey, locale);
+
+          var upgradeTargetKind =
+            document.documentElement.dataset.browserUpgradeTarget;
+          var upgradeCopy = upgradeTargetKind
+            ? selectedCopy.browserUpgrade[upgradeTargetKind]
+            : null;
+          if (upgradeCopy) {
+            var configuredActionUrl =
+              document.documentElement.dataset.browserUpgradeActionUrl;
+            window.__vm0BrowserUpgrade = {
+              actionLabel: upgradeCopy.actionLabel,
+              actionUrl: configuredActionUrl
+                ? configuredActionUrl
+                : "https://www.google.com/chrome/",
+              description: upgradeCopy.description,
+              title: upgradeCopy.title,
+            };
+          }
+        })();
+      });
+    </script>
+    <script>
+      window.__vm0AfterFirstPaint(function () {
+        (function () {
+          var hostname = window.location.hostname;
+          var isProductionHost =
+            hostname === "vm0.ai" ||
+            hostname.endsWith(".vm0.ai") ||
+            hostname === "okou.ai" ||
+            hostname.endsWith(".okou.ai");
+          if (!isProductionHost) return;
+
+          window.dataLayer = window.dataLayer || [];
+          window.gtag = function () {
+            window.dataLayer.push(arguments);
+          };
+          window.gtag("js", new Date());
+          window.gtag("config", "AW-18144854014");
+          window.gtag("config", "AW-18407336975");
+
+          var initialized = false;
+
+          function loadMarketingScripts() {
+            var gtagScript = document.createElement("script");
+            gtagScript.async = true;
+            gtagScript.src =
+              "https://www.googletagmanager.com/gtag/js?id=AW-18144854014";
+            document.head.appendChild(gtagScript);
+          }
+
+          function scheduleMarketingScripts() {
+            if (initialized) return;
+            initialized = true;
+
+            if (typeof window.requestIdleCallback === "function") {
+              window.requestIdleCallback(loadMarketingScripts, {
+                timeout: 1500,
+              });
+              return;
+            }
+
+            window.setTimeout(loadMarketingScripts, 0);
+          }
+
+          // Keep vendor work outside the first-content critical path. The
+          // 30-second guard exceeds the observed mobile P90 startup window and
+          // still bounds bootstraps that never reach real app content.
+          window.addEventListener(
+            "vm0:app-first-content-visible",
+            scheduleMarketingScripts,
+            { once: true },
+          );
+          window.setTimeout(scheduleMarketingScripts, 30000);
+        })();
+      });
+    </script>
+    <script>
+      window.__vm0AfterFirstPaint(function () {
+        (function () {
+          if (document.documentElement.dataset.appHeadManaged === "true")
+            return;
+
+          var copy = window.__vm0PreBundleCopy.metadata;
+          var metadata = [
+            ['meta[name="description"]', copy.description],
+            ['meta[property="og:description"]', copy.description],
+            ['meta[property="og:image:alt"]', copy.title],
+            ['meta[property="og:title"]', copy.title],
+            ['meta[name="twitter:description"]', copy.description],
+            ['meta[name="twitter:title"]', copy.title],
+          ];
+          for (var i = 0; i < metadata.length; i += 1) {
+            var element = document.querySelector(metadata[i][0]);
+            if (element) element.setAttribute("content", metadata[i][1]);
+          }
+        })();
+      });
+    </script>
+    <script>
+      window.__vm0AfterFirstPaint(function () {
+        if (window.__vm0BrowserSupported !== true) return;
+
+        var fontStylesheet = document.querySelector(
+          'link[data-vm0-font-stylesheet=""]',
+        );
+        if (fontStylesheet) {
+          fontStylesheet.rel = "stylesheet";
+          fontStylesheet.removeAttribute("as");
+        }
+
+        var appStylesheet = document.querySelector(
+          'link[data-vm0-app-stylesheet=""]',
+        );
+        if (appStylesheet) {
+          appStylesheet.rel = "stylesheet";
+          appStylesheet.removeAttribute("as");
+        }
+
+        var appEntry = document.querySelector('link[data-vm0-app-entry=""]');
+        if (!appEntry) return;
+
+        var appScript = document.createElement("script");
+        appScript.type = "module";
+        appScript.src = appEntry.href;
+        if (appEntry.hasAttribute("crossorigin")) {
+          appScript.crossOrigin = appEntry.getAttribute("crossorigin") || "";
+        }
+        appEntry.after(appScript);
+      });
+    </script>
+    <script>
+      window.__vm0AfterFirstPaint(function () {
+        (function () {
+          var target = window.__vm0BrowserUpgrade;
+          if (!target) return;
+
+          var title = document.getElementById("browser-upgrade-title");
+          var description = document.getElementById(
+            "browser-upgrade-description",
+          );
+          var action = document.getElementById("browser-upgrade-action");
+
+          if (title) title.textContent = target.title;
+          if (description) description.textContent = target.description;
+          if (action) {
+            action.textContent = target.actionLabel;
+            action.href = target.actionUrl;
+          }
+        })();
+      });
+    </script>
+    <script>
+      window.__vm0AfterFirstPaint(function () {
+        (function () {
+          if (window.__vm0BrowserSupported !== true) return;
+
+          var skeleton = document.getElementById("app-bootstrap-skeleton");
+          // iOS standalone can expand the fixed containing viewport one frame
+          // after launch. Pin the content to the initially reachable viewport
+          // so that later geometry resolution cannot visibly recenter it.
+          var viewportHeight =
+            window.visualViewport && window.visualViewport.height > 0
+              ? window.visualViewport.height
+              : window.innerHeight;
+          if (viewportHeight > 0) {
+            skeleton.style.setProperty(
+              "--app-bootstrap-skeleton-center-y",
+              viewportHeight / 2 + "px",
+            );
+          }
+          var loadingCopy = window.__vm0PreBundleCopy.loading;
+          var messages = loadingCopy.messages;
+          skeleton.setAttribute("aria-label", loadingCopy.ariaLabel);
+          var avatarPresets = [
+            {
+              rotation: 1,
+              skin: 0,
+              hairStyle: 1,
+              hairColor: 5,
+              expression: 1,
+              intensity: "h",
+            },
+            {
+              rotation: 2,
+              skin: 1,
+              hairStyle: 3,
+              hairColor: 3,
+              expression: 1,
+              intensity: "m",
+            },
+            {
+              rotation: 4,
+              skin: 2,
+              hairStyle: 5,
+              hairColor: 4,
+              expression: 3,
+              intensity: "d",
+            },
+            {
+              rotation: 3,
+              skin: 3,
+              hairStyle: 4,
+              hairColor: 1,
+              expression: 4,
+              intensity: "h",
+            },
+            {
+              rotation: 5,
+              skin: 4,
+              hairStyle: 2,
+              hairColor: 2,
+              expression: 5,
+              intensity: "m",
+            },
+          ];
+          var staticAssetBase =
+            document.documentElement.getAttribute("data-app-brand-name") ===
+            "Okou"
+              ? "https://static.okou.io"
+              : "https://static.vm0.io";
+          var avatarAssetBase =
+            staticAssetBase + "/platform/views/zero-page/assets/avatar-svg/";
+          var avatar =
+            avatarPresets[Math.floor(Math.random() * avatarPresets.length)];
+          var messageIndex = Math.floor(Math.random() * messages.length);
+          var staticMessage = skeleton.querySelector(
+            ".app-bootstrap-skeleton__message-static",
+          );
+          var spacerMessage = skeleton.querySelector(
+            ".app-bootstrap-skeleton__message-spacer",
+          );
+          var typewriterMessage = skeleton.querySelector(
+            ".app-bootstrap-skeleton__message-typewriter",
+          );
+
+          skeleton.querySelector(
+            '[data-app-bootstrap-avatar-layer="head"]',
+          ).src =
+            avatarAssetBase +
+            "head-r" +
+            avatar.rotation +
+            "-s" +
+            avatar.skin +
+            ".svg";
+          skeleton.querySelector(
+            '[data-app-bootstrap-avatar-layer="face"]',
+          ).src =
+            avatarAssetBase +
+            "face-r" +
+            avatar.rotation +
+            "-f" +
+            avatar.expression +
+            "-" +
+            avatar.intensity +
+            ".svg";
+          skeleton.querySelector(
+            '[data-app-bootstrap-avatar-layer="hair"]',
+          ).src =
+            avatarAssetBase +
+            "hair-r" +
+            avatar.rotation +
+            "-h" +
+            avatar.hairStyle +
+            "-c" +
+            avatar.hairColor +
+            ".svg";
+
+          function typewriterAnimation(message, delay) {
+            return (
+              "app-bootstrap-skeleton-show-typewriter " +
+              delay +
+              "ms forwards, app-bootstrap-skeleton-type 1.5s steps(" +
+              message.length +
+              ") " +
+              delay +
+              "ms forwards, app-bootstrap-skeleton-blink 0.6s step-end " +
+              delay +
+              "ms infinite"
+            );
+          }
+
+          function setMessages(isFirst) {
+            var currentMessage = messages[messageIndex % messages.length];
+            var nextMessage = messages[(messageIndex + 1) % messages.length];
+            var nextTypewriterMessage = typewriterMessage.cloneNode(true);
+
+            staticMessage.textContent = currentMessage;
+            staticMessage.style.display = isFirst ? "block" : "none";
+            staticMessage.style.animation = isFirst
+              ? "app-bootstrap-skeleton-hide-static 800ms forwards"
+              : "none";
+            spacerMessage.textContent = nextMessage;
+            nextTypewriterMessage.textContent = nextMessage;
+            nextTypewriterMessage.style.animation = typewriterAnimation(
+              nextMessage,
+              isFirst ? 800 : 0,
+            );
+            typewriterMessage.replaceWith(nextTypewriterMessage);
+            typewriterMessage = nextTypewriterMessage;
+          }
+
+          setMessages(true);
+
+          var cycles = 0;
+          var interval = window.setInterval(function () {
+            if (!document.getElementById("app-bootstrap-skeleton")) {
+              window.clearInterval(interval);
+              return;
+            }
+
+            messageIndex += 1;
+            setMessages(false);
+            cycles += 1;
+            if (cycles >= 3) {
+              window.clearInterval(interval);
+            }
+          }, 4000);
+        })();
+      });
+    </script>
+    <script>
+      window.__vm0AfterFirstPaint(function () {
+        (function () {
+          var hostname = window.location.hostname.toLowerCase();
+          if (hostname !== "app.vm0.ai" && hostname !== "app.okou.ai") return;
+
+          var instatusScript = document.createElement("script");
+          instatusScript.src =
+            "https://api.dashboard.instatus.com/widget?host=status.vm0.ai&code=02c0ef5a&locale=en";
+          instatusScript.integrity =
+            "sha384-ZW3eZwADOMdlg2fdvESPD7jguK16IC/edxNFakKs81D2lkNdi3BXRmx/g331lkD3";
+          instatusScript.crossOrigin = "anonymous";
+          instatusScript.defer = true;
+          document.body.appendChild(instatusScript);
+        })();
+      });
     </script>
   </body>
 </html>

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -648,8 +648,6 @@
     </script>
     <div id="root"></div>
     <link
-      rel="preload"
-      as="style"
       data-vm0-font-stylesheet=""
       href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
     />

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -361,6 +361,70 @@
         </div>
       </div>
     </div>
+    <script data-vm0-avatar-bootstrap="">
+      (function () {
+        if (window.__vm0BrowserSupported !== true) return;
+
+        var skeleton = document.getElementById("app-bootstrap-skeleton");
+        var avatarPresets = [
+          [1, 0, 1, 5, 1, "h"],
+          [2, 1, 3, 3, 1, "m"],
+          [4, 2, 5, 4, 3, "d"],
+          [3, 3, 4, 1, 4, "h"],
+          [5, 4, 2, 2, 5, "m"],
+        ];
+        var avatar =
+          avatarPresets[Math.floor(Math.random() * avatarPresets.length)];
+        var staticAssetBase =
+          document.documentElement.getAttribute("data-app-brand-name") ===
+          "Okou"
+            ? "https://static.okou.io"
+            : "https://static.vm0.io";
+        var avatarAssetBase =
+          staticAssetBase + "/platform/views/zero-page/assets/avatar-svg/";
+        var avatarSources = [
+          avatarAssetBase + "head-r" + avatar[0] + "-s" + avatar[1] + ".svg",
+          avatarAssetBase +
+            "face-r" +
+            avatar[0] +
+            "-f" +
+            avatar[4] +
+            "-" +
+            avatar[5] +
+            ".svg",
+          avatarAssetBase +
+            "hair-r" +
+            avatar[0] +
+            "-h" +
+            avatar[2] +
+            "-c" +
+            avatar[3] +
+            ".svg",
+        ];
+        var avatarLayers = skeleton.querySelectorAll(
+          "[data-app-bootstrap-avatar-layer]",
+        );
+        var loadedAvatarLayers = 0;
+
+        for (var i = 0; i < avatarLayers.length; i += 1) {
+          avatarLayers[i].addEventListener(
+            "load",
+            function () {
+              loadedAvatarLayers += 1;
+              if (loadedAvatarLayers === avatarLayers.length) {
+                skeleton
+                  .querySelector(".app-bootstrap-skeleton__avatar-layers")
+                  .classList.add(
+                    "app-bootstrap-skeleton__avatar-layers--ready",
+                  );
+              }
+            },
+            { once: true },
+          );
+          avatarLayers[i].src = avatarSources[i];
+        }
+      })();
+    </script>
     <script>
       (function () {
         var callbacks = [];
@@ -1468,77 +1532,6 @@
           var loadingCopy = window.__vm0PreBundleCopy.loading;
           var messages = loadingCopy.messages;
           skeleton.setAttribute("aria-label", loadingCopy.ariaLabel);
-          var avatarPresets = [
-            {
-              rotation: 1,
-              skin: 0,
-              hairStyle: 1,
-              hairColor: 5,
-              expression: 1,
-              intensity: "h",
-            },
-            {
-              rotation: 2,
-              skin: 1,
-              hairStyle: 3,
-              hairColor: 3,
-              expression: 1,
-              intensity: "m",
-            },
-            {
-              rotation: 4,
-              skin: 2,
-              hairStyle: 5,
-              hairColor: 4,
-              expression: 3,
-              intensity: "d",
-            },
-            {
-              rotation: 3,
-              skin: 3,
-              hairStyle: 4,
-              hairColor: 1,
-              expression: 4,
-              intensity: "h",
-            },
-            {
-              rotation: 5,
-              skin: 4,
-              hairStyle: 2,
-              hairColor: 2,
-              expression: 5,
-              intensity: "m",
-            },
-          ];
-          var staticAssetBase =
-            document.documentElement.getAttribute("data-app-brand-name") ===
-            "Okou"
-              ? "https://static.okou.io"
-              : "https://static.vm0.io";
-          var avatarAssetBase =
-            staticAssetBase + "/platform/views/zero-page/assets/avatar-svg/";
-          var avatar =
-            avatarPresets[Math.floor(Math.random() * avatarPresets.length)];
-          var avatarLayers = skeleton.querySelectorAll(
-            "[data-app-bootstrap-avatar-layer]",
-          );
-          var loadedAvatarLayers = 0;
-          for (var i = 0; i < avatarLayers.length; i += 1) {
-            avatarLayers[i].addEventListener(
-              "load",
-              function () {
-                loadedAvatarLayers += 1;
-                if (loadedAvatarLayers === avatarLayers.length) {
-                  skeleton
-                    .querySelector(".app-bootstrap-skeleton__avatar-layers")
-                    .classList.add(
-                      "app-bootstrap-skeleton__avatar-layers--ready",
-                    );
-                }
-              },
-              { once: true },
-            );
-          }
           var messageIndex = Math.floor(Math.random() * messages.length);
           var staticMessage = skeleton.querySelector(
             ".app-bootstrap-skeleton__message-static",
@@ -1549,38 +1542,6 @@
           var typewriterMessage = skeleton.querySelector(
             ".app-bootstrap-skeleton__message-typewriter",
           );
-
-          skeleton.querySelector(
-            '[data-app-bootstrap-avatar-layer="head"]',
-          ).src =
-            avatarAssetBase +
-            "head-r" +
-            avatar.rotation +
-            "-s" +
-            avatar.skin +
-            ".svg";
-          skeleton.querySelector(
-            '[data-app-bootstrap-avatar-layer="face"]',
-          ).src =
-            avatarAssetBase +
-            "face-r" +
-            avatar.rotation +
-            "-f" +
-            avatar.expression +
-            "-" +
-            avatar.intensity +
-            ".svg";
-          skeleton.querySelector(
-            '[data-app-bootstrap-avatar-layer="hair"]',
-          ).src =
-            avatarAssetBase +
-            "hair-r" +
-            avatar.rotation +
-            "-h" +
-            avatar.hairStyle +
-            "-c" +
-            avatar.hairColor +
-            ".svg";
 
           function typewriterAnimation(message, delay) {
             return (

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -200,20 +200,18 @@
         border-radius: 9999px;
       }
 
-      .app-bootstrap-skeleton__avatar-placeholder,
       .app-bootstrap-skeleton__avatar-layers {
         position: absolute;
         inset: 0;
       }
 
-      .app-bootstrap-skeleton__avatar-placeholder {
-        display: block;
-        width: 64px;
-        height: 64px;
+      .app-bootstrap-skeleton__avatar-layers {
+        opacity: 0;
+        transform: scale(1.25);
       }
 
-      .app-bootstrap-skeleton__avatar-layers {
-        transform: scale(1.25);
+      .app-bootstrap-skeleton__avatar-layers--ready {
+        opacity: 1;
       }
 
       .app-bootstrap-skeleton__avatar img {
@@ -329,28 +327,25 @@
     >
       <div class="app-bootstrap-skeleton__content">
         <div class="app-bootstrap-skeleton__avatar" aria-hidden="true">
-          <svg
-            class="app-bootstrap-skeleton__avatar-placeholder"
-            viewBox="0 0 64 64"
-            aria-hidden="true"
-          >
-            <circle cx="32" cy="32" r="32" fill="#fee8dc" />
-            <path d="M18 46c2-9 7-14 14-14s12 5 14 14" fill="#ed4e01" />
-            <circle cx="32" cy="25" r="12" fill="#f6b996" />
-            <circle cx="28" cy="24" r="1.5" fill="#14171d" />
-            <circle cx="36" cy="24" r="1.5" fill="#14171d" />
-            <path
-              d="M28 29c2.5 2 5.5 2 8 0"
-              fill="none"
-              stroke="#14171d"
-              stroke-linecap="round"
-              stroke-width="1.5"
-            />
-          </svg>
           <div class="app-bootstrap-skeleton__avatar-layers">
-            <img data-app-bootstrap-avatar-layer="head" alt="" />
-            <img data-app-bootstrap-avatar-layer="face" alt="" />
-            <img data-app-bootstrap-avatar-layer="hair" alt="" />
+            <img
+              data-app-bootstrap-avatar-layer="head"
+              alt=""
+              decoding="async"
+              fetchpriority="low"
+            />
+            <img
+              data-app-bootstrap-avatar-layer="face"
+              alt=""
+              decoding="async"
+              fetchpriority="low"
+            />
+            <img
+              data-app-bootstrap-avatar-layer="hair"
+              alt=""
+              decoding="async"
+              fetchpriority="low"
+            />
           </div>
         </div>
         <div class="app-bootstrap-skeleton__message">
@@ -1524,6 +1519,26 @@
             staticAssetBase + "/platform/views/zero-page/assets/avatar-svg/";
           var avatar =
             avatarPresets[Math.floor(Math.random() * avatarPresets.length)];
+          var avatarLayers = skeleton.querySelectorAll(
+            "[data-app-bootstrap-avatar-layer]",
+          );
+          var loadedAvatarLayers = 0;
+          for (var i = 0; i < avatarLayers.length; i += 1) {
+            avatarLayers[i].addEventListener(
+              "load",
+              function () {
+                loadedAvatarLayers += 1;
+                if (loadedAvatarLayers === avatarLayers.length) {
+                  skeleton
+                    .querySelector(".app-bootstrap-skeleton__avatar-layers")
+                    .classList.add(
+                      "app-bootstrap-skeleton__avatar-layers--ready",
+                    );
+                }
+              },
+              { once: true },
+            );
+          }
           var messageIndex = Math.floor(Math.random() * messages.length);
           var staticMessage = skeleton.querySelector(
             ".app-bootstrap-skeleton__message-static",

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -1321,6 +1321,8 @@
     <script>
       window.__vm0AfterFirstPaint(function () {
         (function () {
+          if (window.__vm0BrowserSupported !== true) return;
+
           var hostname = window.location.hostname;
           var isProductionHost =
             hostname === "vm0.ai" ||
@@ -1620,6 +1622,8 @@
     <script>
       window.__vm0AfterFirstPaint(function () {
         (function () {
+          if (window.__vm0BrowserSupported !== true) return;
+
           var hostname = window.location.hostname.toLowerCase();
           if (hostname !== "app.vm0.ai" && hostname !== "app.okou.ai") return;
 

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -540,6 +540,7 @@
     <script>
       (function () {
         var callbacks = [];
+        var paintObserver = null;
         var ready = false;
 
         window.__vm0AfterFirstPaint = function (callback) {
@@ -553,6 +554,7 @@
         function flushCallbacks(firstPaintObserved) {
           if (ready) return;
           ready = true;
+          if (paintObserver) paintObserver.disconnect();
           if (firstPaintObserved) {
             window.__appBootstrapFirstPaintUpperBound = performance.now();
           }
@@ -563,9 +565,34 @@
         }
 
         if (document.visibilityState === "visible") {
+          var observingFirstContentfulPaint = false;
+          if (typeof PerformanceObserver === "function") {
+            try {
+              paintObserver = new PerformanceObserver(function (list) {
+                var entries = list.getEntries();
+                for (var i = 0; i < entries.length; i += 1) {
+                  if (entries[i].name === "first-contentful-paint") {
+                    flushCallbacks(true);
+                    return;
+                  }
+                }
+              });
+              paintObserver.observe({ buffered: true, type: "paint" });
+              observingFirstContentfulPaint = true;
+            } catch {
+              paintObserver = null;
+            }
+          }
+
           window.requestAnimationFrame(function () {
             window.requestAnimationFrame(function () {
-              flushCallbacks(true);
+              if (!observingFirstContentfulPaint) {
+                flushCallbacks(true);
+                return;
+              }
+              window.setTimeout(function () {
+                flushCallbacks(true);
+              }, 250);
             });
           });
           return;

--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -100,6 +100,7 @@
     "msw": "^2.13.2",
     "oxlint": "^1.75.0",
     "oxlint-tsgolint": "7.0.2001",
+    "parse5": "7.3.0",
     "tailwindcss": "^4.3.3",
     "typescript": "^6.0.3",
     "unicode-emoji-json": "^0.9.0",

--- a/turbo/apps/platform/scripts/check-build-hash-stability.node.mjs
+++ b/turbo/apps/platform/scripts/check-build-hash-stability.node.mjs
@@ -20,6 +20,8 @@ const VERSION_META_NAME = "okou-app-version";
 const VENDOR_FILE_PATTERN = /^vendor-[^/]+\.js$/u;
 const RUNTIME_FILE_PATTERN = /^rolldown-runtime-[^/]+\.js$/u;
 const WORKER_FILE_PATTERN = /^shared-database-worker-[^/]+\.js$/u;
+const AFTER_FIRST_PAINT_FILE_PATTERN =
+  /^bootstrap-after-first-paint-[a-f0-9]{12}\.js$/u;
 const MERMAID_LITE_MODULE_PATH =
   "/packages/mermaid-lite/dist/mermaid.esm.min.mjs";
 const BASELINE_COMMIT_SHA = "1111111111111111111111111111111111111111";
@@ -181,8 +183,15 @@ async function describeBuild(outputDirectory) {
     WORKER_FILE_PATTERN,
     "SharedWorker JavaScript file",
   );
+  const afterFirstPaintFile = exactlyOne(
+    javaScriptFiles,
+    AFTER_FIRST_PAINT_FILE_PATTERN,
+    "after-first-paint bootstrap JavaScript file",
+  );
   const appFiles = javaScriptFiles.filter((fileName) => {
-    return ![vendorFile, runtimeFile, workerFile].includes(fileName);
+    return ![vendorFile, runtimeFile, workerFile, afterFirstPaintFile].includes(
+      fileName,
+    );
   });
   assert.equal(
     appFiles.length,
@@ -194,6 +203,7 @@ async function describeBuild(outputDirectory) {
 
   const artifacts = {
     app: await describeFile(assetsDirectory, appFile),
+    afterFirstPaint: await describeFile(assetsDirectory, afterFirstPaintFile),
     vendor: await describeFile(assetsDirectory, vendorFile),
     runtime: await describeFile(assetsDirectory, runtimeFile),
     worker: await describeFile(assetsDirectory, workerFile),
@@ -309,7 +319,13 @@ try {
   });
   const builds = [baseline, versionChange, canonical];
 
-  for (const label of ["app", "vendor", "runtime", "worker"]) {
+  for (const label of [
+    "app",
+    "afterFirstPaint",
+    "vendor",
+    "runtime",
+    "worker",
+  ]) {
     assertStable(builds, label);
   }
   assert.deepEqual(baseline.runtimeMetadata, {
@@ -324,10 +340,10 @@ try {
     commitSha: appCommitSha,
     version: appVersion,
   });
-  for (const label of ["vendor", "runtime", "worker"]) {
+  for (const label of ["afterFirstPaint", "vendor", "runtime", "worker"]) {
     assertStable([canonical, appMutation], label);
   }
-  for (const label of ["runtime", "worker"]) {
+  for (const label of ["afterFirstPaint", "runtime", "worker"]) {
     assertStable([canonical, mermaidMutation], label);
   }
   assert.notEqual(
@@ -386,9 +402,15 @@ try {
           },
         },
         verifiedStable: {
-          appMutation: ["vendor", "runtime", "worker"],
-          mermaidMutation: ["runtime", "worker"],
-          metadataChanges: ["app", "vendor", "runtime", "worker"],
+          appMutation: ["afterFirstPaint", "vendor", "runtime", "worker"],
+          mermaidMutation: ["afterFirstPaint", "runtime", "worker"],
+          metadataChanges: [
+            "app",
+            "afterFirstPaint",
+            "vendor",
+            "runtime",
+            "worker",
+          ],
         },
         verifiedInvalidated: {
           appMutation: ["app"],

--- a/turbo/apps/platform/scripts/check-single-bundle.node.ts
+++ b/turbo/apps/platform/scripts/check-single-bundle.node.ts
@@ -72,6 +72,7 @@ await test("extracts post-paint callbacks behind one preloaded entry", () => {
     /<link crossorigin href="__VM0_AFTER_FIRST_PAINT_ENTRY_URL__" data-vm0-after-first-paint-entry="">/u,
   );
   assert.match(extracted.html, /data-vm0-after-first-paint-loader=""/u);
+  assert.match(extracted.html, /window\.__vm0BrowserSupported !== true/u);
   assert.match(
     extracted.html,
     /modulePreloads\[index\]\.rel = "modulepreload"/u,

--- a/turbo/apps/platform/scripts/check-single-bundle.node.ts
+++ b/turbo/apps/platform/scripts/check-single-bundle.node.ts
@@ -6,7 +6,10 @@ import test from "node:test";
 
 import { build } from "vite";
 
-import { deferApplicationEntryResources } from "./deferred-entry-html.ts";
+import {
+  deferApplicationEntryResources,
+  extractAfterFirstPaintBootstrap,
+} from "./deferred-entry-html.ts";
 import {
   RAW_JAVASCRIPT_OUTPUT_LIMIT_BYTES,
   VENDOR_MODULE_PATTERN,
@@ -57,6 +60,30 @@ await test("fails closed when the deferred app entry is missing", () => {
   }, /Expected exactly one deferred app entry, found 0/u);
 });
 
+await test("extracts post-paint callbacks behind one preloaded entry", () => {
+  const extracted = extractAfterFirstPaintBootstrap(`
+    <script>window.__vm0AfterFirstPaint(function () { window.first = true; });</script>
+    <main>skeleton</main>
+    <script>window.__vm0AfterFirstPaint(function () { window.second = true; });</script>
+  `);
+
+  assert.match(
+    extracted.html,
+    /<link rel="preload" as="script" crossorigin href="__VM0_AFTER_FIRST_PAINT_ENTRY_URL__" data-vm0-after-first-paint-entry="">/u,
+  );
+  assert.match(extracted.html, /data-vm0-after-first-paint-loader=""/u);
+  assert.doesNotMatch(extracted.html, /window\.first = true/u);
+  assert.doesNotMatch(extracted.html, /window\.second = true/u);
+  assert.match(extracted.source, /window\.first = true/u);
+  assert.match(extracted.source, /window\.second = true/u);
+});
+
+await test("fails closed when post-paint callbacks are missing", () => {
+  assert.throws(() => {
+    extractAfterFirstPaintBootstrap("<main>missing callbacks</main>");
+  }, /Expected deferred after-first-paint bootstrap callbacks/u);
+});
+
 function applicationChunk() {
   return {
     code: "entry",
@@ -100,6 +127,14 @@ function workerAsset() {
   };
 }
 
+function afterFirstPaintBootstrapAsset() {
+  return {
+    fileName: "assets/bootstrap-after-first-paint-123456789abc.js",
+    source: "bootstrap",
+    type: "asset" as const,
+  };
+}
+
 function validApplicationOutputs() {
   return [applicationChunk(), vendorChunk(), runtimeChunk(), workerAsset()];
 }
@@ -107,9 +142,16 @@ function validApplicationOutputs() {
 await test("requires the fixed app, vendor, runtime, and worker layout", () => {
   assert.deepEqual(applicationBundleViolations(validApplicationOutputs()), []);
   assert.deepEqual(
+    applicationBundleViolations([
+      ...validApplicationOutputs(),
+      afterFirstPaintBootstrapAsset(),
+    ]),
+    [],
+  );
+  assert.deepEqual(
     applicationBundleViolations(validApplicationOutputs().slice(0, 3)),
     [
-      `Expected exactly one app entry, one vendor chunk, one Rolldown runtime chunk, and one shared database worker asset, but generated: ${APP_FILE} (chunk), ${VENDOR_FILE} (chunk), ${RUNTIME_FILE} (chunk)`,
+      `Expected exactly one app entry, one vendor chunk, one Rolldown runtime chunk, one shared database worker asset, and at most one after-first-paint bootstrap asset, but generated: ${APP_FILE} (chunk), ${VENDOR_FILE} (chunk), ${RUNTIME_FILE} (chunk)`,
     ],
   );
   assert.deepEqual(
@@ -118,7 +160,7 @@ await test("requires the fixed app, vendor, runtime, and worker layout", () => {
       { code: "lazy", fileName: "assets/lazy-Extra001.js", type: "chunk" },
     ]),
     [
-      `Expected exactly one app entry, one vendor chunk, one Rolldown runtime chunk, and one shared database worker asset, but generated: ${APP_FILE} (chunk), ${VENDOR_FILE} (chunk), ${RUNTIME_FILE} (chunk), assets/shared-database-worker-Worker01.js (asset), assets/lazy-Extra001.js (chunk)`,
+      `Expected exactly one app entry, one vendor chunk, one Rolldown runtime chunk, one shared database worker asset, and at most one after-first-paint bootstrap asset, but generated: ${APP_FILE} (chunk), ${VENDOR_FILE} (chunk), ${RUNTIME_FILE} (chunk), assets/shared-database-worker-Worker01.js (asset), assets/lazy-Extra001.js (chunk)`,
     ],
   );
 });

--- a/turbo/apps/platform/scripts/check-single-bundle.node.ts
+++ b/turbo/apps/platform/scripts/check-single-bundle.node.ts
@@ -32,7 +32,7 @@ await test("defers app execution and resource discovery until first paint", () =
     <link rel="stylesheet" crossorigin href="/assets/app-AppHash1.css">
     <link rel="stylesheet" href="https://fonts.example/font.css">
     <link rel="modulepreload" crossorigin href="/assets/vendor-Vendor01.js">
-    <script data-vm0-app-entry="" type="module" crossorigin src="/assets/app-AppHash1.js"></script>
+    <SCRIPT data-vm0-app-entry="" type="module" crossorigin src="/assets/app-AppHash1.js"></SCRIPT >
   `);
 
   assert.match(
@@ -62,7 +62,7 @@ await test("fails closed when the deferred app entry is missing", () => {
 
 await test("extracts post-paint callbacks behind one preloaded entry", () => {
   const extracted = extractAfterFirstPaintBootstrap(`
-    <script>window.__vm0AfterFirstPaint(function () { window.first = true; });</script>
+    <SCRIPT>window.__vm0AfterFirstPaint(function () { window.first = true; });</SCRIPT >
     <main>skeleton</main>
     <script>window.__vm0AfterFirstPaint(function () { window.second = true; });</script>
   `);

--- a/turbo/apps/platform/scripts/check-single-bundle.node.ts
+++ b/turbo/apps/platform/scripts/check-single-bundle.node.ts
@@ -72,7 +72,7 @@ await test("extracts post-paint callbacks behind one preloaded entry", () => {
     /<link crossorigin href="__VM0_AFTER_FIRST_PAINT_ENTRY_URL__" data-vm0-after-first-paint-entry="">/u,
   );
   assert.match(extracted.html, /data-vm0-after-first-paint-loader=""/u);
-  assert.match(extracted.html, /window\.__vm0BrowserSupported !== true/u);
+  assert.match(extracted.html, /window\.__vm0BrowserSupported === true/u);
   assert.match(
     extracted.html,
     /modulePreloads\[index\]\.rel = "modulepreload"/u,

--- a/turbo/apps/platform/scripts/check-single-bundle.node.ts
+++ b/turbo/apps/platform/scripts/check-single-bundle.node.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 
 import { build } from "vite";
 
+import { deferApplicationEntryResources } from "./deferred-entry-html.ts";
 import {
   RAW_JAVASCRIPT_OUTPUT_LIMIT_BYTES,
   VENDOR_MODULE_PATTERN,
@@ -22,6 +23,39 @@ import {
 const APP_FILE = "assets/index-AppHash1.js";
 const VENDOR_FILE = "assets/vendor-Vendor01.js";
 const RUNTIME_FILE = "assets/rolldown-runtime-Runtime1.js";
+
+await test("defers app execution and styles without delaying resource discovery", () => {
+  const html = deferApplicationEntryResources(`
+    <link rel="stylesheet" crossorigin href="/assets/app-AppHash1.css">
+    <link rel="stylesheet" href="https://fonts.example/font.css">
+    <link rel="modulepreload" crossorigin href="/assets/vendor-Vendor01.js">
+    <script data-vm0-app-entry="" type="module" crossorigin src="/assets/app-AppHash1.js"></script>
+  `);
+
+  assert.match(
+    html,
+    /<link rel="modulepreload" crossorigin href="\/assets\/app-AppHash1\.js" data-vm0-app-entry="">/u,
+  );
+  assert.match(
+    html,
+    /<link rel="preload" as="style" crossorigin href="\/assets\/app-AppHash1\.css" data-vm0-app-stylesheet="">/u,
+  );
+  assert.match(
+    html,
+    /<link rel="modulepreload" crossorigin href="\/assets\/vendor-Vendor01\.js">/u,
+  );
+  assert.match(
+    html,
+    /<link rel="stylesheet" href="https:\/\/fonts\.example\/font\.css">/u,
+  );
+  assert.doesNotMatch(html, /<script[^>]+src="\/assets\/app-AppHash1\.js"/u);
+});
+
+await test("fails closed when the deferred app entry is missing", () => {
+  assert.throws(() => {
+    deferApplicationEntryResources("<main>missing app entry</main>");
+  }, /Expected exactly one deferred app entry, found 0/u);
+});
 
 function applicationChunk() {
   return {

--- a/turbo/apps/platform/scripts/check-single-bundle.node.ts
+++ b/turbo/apps/platform/scripts/check-single-bundle.node.ts
@@ -69,9 +69,10 @@ await test("extracts post-paint callbacks behind one preloaded entry", () => {
 
   assert.match(
     extracted.html,
-    /<link rel="preload" as="script" crossorigin href="__VM0_AFTER_FIRST_PAINT_ENTRY_URL__" data-vm0-after-first-paint-entry="">/u,
+    /<link rel="preload" as="script" crossorigin href="__VM0_AFTER_FIRST_PAINT_ENTRY_URL__" integrity="__VM0_AFTER_FIRST_PAINT_ENTRY_INTEGRITY__" data-vm0-after-first-paint-entry="">/u,
   );
   assert.match(extracted.html, /data-vm0-after-first-paint-loader=""/u);
+  assert.match(extracted.html, /script\.integrity = entry\.integrity/u);
   assert.doesNotMatch(extracted.html, /window\.first = true/u);
   assert.doesNotMatch(extracted.html, /window\.second = true/u);
   assert.match(extracted.source, /window\.first = true/u);

--- a/turbo/apps/platform/scripts/check-single-bundle.node.ts
+++ b/turbo/apps/platform/scripts/check-single-bundle.node.ts
@@ -37,15 +37,15 @@ await test("defers app execution and resource discovery until first paint", () =
 
   assert.match(
     html,
-    /<link crossorigin href="\/assets\/app-AppHash1\.js" data-vm0-app-entry="">/u,
+    /<link crossorigin="" href="\/assets\/app-AppHash1\.js" data-vm0-app-entry="">/u,
   );
   assert.match(
     html,
-    /<link crossorigin href="\/assets\/app-AppHash1\.css" data-vm0-app-stylesheet="">/u,
+    /<link crossorigin="" href="\/assets\/app-AppHash1\.css" data-vm0-app-stylesheet="">/u,
   );
   assert.match(
     html,
-    /<link crossorigin href="\/assets\/vendor-Vendor01\.js" data-vm0-app-module-preload="">/u,
+    /<link crossorigin="" href="\/assets\/vendor-Vendor01\.js" data-vm0-app-module-preload="">/u,
   );
   assert.match(
     html,

--- a/turbo/apps/platform/scripts/check-single-bundle.node.ts
+++ b/turbo/apps/platform/scripts/check-single-bundle.node.ts
@@ -27,7 +27,7 @@ const APP_FILE = "assets/index-AppHash1.js";
 const VENDOR_FILE = "assets/vendor-Vendor01.js";
 const RUNTIME_FILE = "assets/rolldown-runtime-Runtime1.js";
 
-await test("defers app execution and styles without delaying resource discovery", () => {
+await test("defers app execution and resource discovery until first paint", () => {
   const html = deferApplicationEntryResources(`
     <link rel="stylesheet" crossorigin href="/assets/app-AppHash1.css">
     <link rel="stylesheet" href="https://fonts.example/font.css">
@@ -37,15 +37,15 @@ await test("defers app execution and styles without delaying resource discovery"
 
   assert.match(
     html,
-    /<link rel="modulepreload" crossorigin href="\/assets\/app-AppHash1\.js" data-vm0-app-entry="">/u,
+    /<link crossorigin href="\/assets\/app-AppHash1\.js" data-vm0-app-entry="">/u,
   );
   assert.match(
     html,
-    /<link rel="preload" as="style" crossorigin href="\/assets\/app-AppHash1\.css" data-vm0-app-stylesheet="">/u,
+    /<link crossorigin href="\/assets\/app-AppHash1\.css" data-vm0-app-stylesheet="">/u,
   );
   assert.match(
     html,
-    /<link rel="modulepreload" crossorigin href="\/assets\/vendor-Vendor01\.js">/u,
+    /<link crossorigin href="\/assets\/vendor-Vendor01\.js" data-vm0-app-module-preload="">/u,
   );
   assert.match(
     html,
@@ -69,10 +69,14 @@ await test("extracts post-paint callbacks behind one preloaded entry", () => {
 
   assert.match(
     extracted.html,
-    /<link rel="preload" as="script" crossorigin href="__VM0_AFTER_FIRST_PAINT_ENTRY_URL__" integrity="__VM0_AFTER_FIRST_PAINT_ENTRY_INTEGRITY__" data-vm0-after-first-paint-entry="">/u,
+    /<link crossorigin href="__VM0_AFTER_FIRST_PAINT_ENTRY_URL__" data-vm0-after-first-paint-entry="">/u,
   );
   assert.match(extracted.html, /data-vm0-after-first-paint-loader=""/u);
-  assert.match(extracted.html, /script\.integrity = entry\.integrity/u);
+  assert.match(
+    extracted.html,
+    /modulePreloads\[index\]\.rel = "modulepreload"/u,
+  );
+  assert.match(extracted.html, /appStylesheet\.rel = "preload"/u);
   assert.doesNotMatch(extracted.html, /window\.first = true/u);
   assert.doesNotMatch(extracted.html, /window\.second = true/u);
   assert.match(extracted.source, /window\.first = true/u);

--- a/turbo/apps/platform/scripts/deferred-entry-html.ts
+++ b/turbo/apps/platform/scripts/deferred-entry-html.ts
@@ -1,7 +1,17 @@
-import type { Plugin } from "vite";
+import { createHash } from "node:crypto";
+
+import type { Plugin, ResolvedConfig } from "vite";
 
 const APP_ENTRY_ATTRIBUTE = "data-vm0-app-entry";
 const APP_STYLESHEET_ATTRIBUTE = "data-vm0-app-stylesheet";
+const AFTER_FIRST_PAINT_ENTRY_ATTRIBUTE = "data-vm0-after-first-paint-entry";
+const AFTER_FIRST_PAINT_ENTRY_PLACEHOLDER =
+  "__VM0_AFTER_FIRST_PAINT_ENTRY_URL__";
+
+type ExtractedAfterFirstPaintBootstrap = {
+  readonly html: string;
+  readonly source: string;
+};
 
 function tagAttributes(tag: string): ReadonlyMap<string, string | undefined> {
   const attributes = new Map<string, string | undefined>();
@@ -82,13 +92,82 @@ export function deferApplicationEntryResources(html: string): string {
   });
 }
 
+export function extractAfterFirstPaintBootstrap(
+  html: string,
+): ExtractedAfterFirstPaintBootstrap {
+  const callbacks: string[] = [];
+  let insertedEntrypoint = false;
+  const extractedHtml = html.replace(
+    /<script>([\s\S]*?)<\/script>/gu,
+    (tag, source: string) => {
+      if (!/^\s*window\.__vm0AfterFirstPaint\(function \(\) \{/u.test(source)) {
+        return tag;
+      }
+      callbacks.push(source.trim());
+      if (insertedEntrypoint) {
+        return "";
+      }
+      insertedEntrypoint = true;
+      return `<link rel="preload" as="script" crossorigin href="${AFTER_FIRST_PAINT_ENTRY_PLACEHOLDER}" ${AFTER_FIRST_PAINT_ENTRY_ATTRIBUTE}="">
+    <script data-vm0-after-first-paint-loader="">
+      window.__vm0AfterFirstPaint(function () {
+        var entry = document.querySelector(
+          'link[${AFTER_FIRST_PAINT_ENTRY_ATTRIBUTE}=""]',
+        );
+        if (!entry) return;
+
+        var script = document.createElement("script");
+        script.src = entry.href;
+        script.crossOrigin = "anonymous";
+        document.head.appendChild(script);
+      });
+    </script>`;
+    },
+  );
+  if (callbacks.length === 0) {
+    throw new Error("Expected deferred after-first-paint bootstrap callbacks");
+  }
+
+  return {
+    html: extractedHtml,
+    source: `"use strict";\n${callbacks.join("\n")}\n`,
+  };
+}
+
+function assetUrl(config: ResolvedConfig, fileName: string): string {
+  return `${config.base.replace(/\/?$/u, "/")}${fileName}`;
+}
+
 export function deferredApplicationEntryHtmlPlugin(): Plugin {
+  let resolvedConfig: ResolvedConfig | undefined;
   return {
     name: "platform-deferred-application-entry-html",
+    configResolved(config) {
+      resolvedConfig = config;
+    },
     transformIndexHtml: {
       order: "post",
       handler(html) {
-        return deferApplicationEntryResources(html);
+        const deferredHtml = deferApplicationEntryResources(html);
+        if (resolvedConfig?.command !== "build") {
+          return deferredHtml;
+        }
+        const extracted = extractAfterFirstPaintBootstrap(deferredHtml);
+        const digest = createHash("sha256")
+          .update(extracted.source)
+          .digest("hex")
+          .slice(0, 12);
+        const fileName = `assets/bootstrap-after-first-paint-${digest}.js`;
+        this.emitFile({
+          type: "asset",
+          fileName,
+          source: extracted.source,
+        });
+        const entryUrl = assetUrl(resolvedConfig, fileName);
+        return extracted.html.replace(
+          AFTER_FIRST_PAINT_ENTRY_PLACEHOLDER,
+          entryUrl,
+        );
       },
     },
   };

--- a/turbo/apps/platform/scripts/deferred-entry-html.ts
+++ b/turbo/apps/platform/scripts/deferred-entry-html.ts
@@ -50,7 +50,7 @@ function inertResourceTag(
 export function deferApplicationEntryResources(html: string): string {
   let applicationEntries = 0;
   const deferredEntryHtml = html.replace(
-    /<script\b[^>]*>\s*<\/script>/gu,
+    /<script\b[^>]*>\s*<\/script\s*>/giu,
     (tag) => {
       const href = attributeValue(tag, "src");
       const isSourceEntry = hasAttribute(tag, APP_ENTRY_ATTRIBUTE);
@@ -99,7 +99,7 @@ export function extractAfterFirstPaintBootstrap(
   const callbacks: string[] = [];
   let insertedEntrypoint = false;
   const extractedHtml = html.replace(
-    /<script>([\s\S]*?)<\/script>/gu,
+    /<script\s*>([\s\S]*?)<\/script\s*>/giu,
     (tag, source: string) => {
       if (!/^\s*window\.__vm0AfterFirstPaint\(function \(\) \{/u.test(source)) {
         return tag;

--- a/turbo/apps/platform/scripts/deferred-entry-html.ts
+++ b/turbo/apps/platform/scripts/deferred-entry-html.ts
@@ -3,12 +3,11 @@ import { createHash } from "node:crypto";
 import { transformWithEsbuild, type Plugin, type ResolvedConfig } from "vite";
 
 const APP_ENTRY_ATTRIBUTE = "data-vm0-app-entry";
+const APP_MODULE_PRELOAD_ATTRIBUTE = "data-vm0-app-module-preload";
 const APP_STYLESHEET_ATTRIBUTE = "data-vm0-app-stylesheet";
 const AFTER_FIRST_PAINT_ENTRY_ATTRIBUTE = "data-vm0-after-first-paint-entry";
 const AFTER_FIRST_PAINT_ENTRY_PLACEHOLDER =
   "__VM0_AFTER_FIRST_PAINT_ENTRY_URL__";
-const AFTER_FIRST_PAINT_INTEGRITY_PLACEHOLDER =
-  "__VM0_AFTER_FIRST_PAINT_ENTRY_INTEGRITY__";
 
 type ExtractedAfterFirstPaintBootstrap = {
   readonly html: string;
@@ -37,18 +36,15 @@ function hasAttribute(tag: string, name: string): boolean {
   return tagAttributes(tag).has(name);
 }
 
-function preloadTag(
+function inertResourceTag(
   sourceTag: string,
   href: string,
-  relation: "modulepreload" | "preload",
-  as: "style" | undefined,
   marker: string,
 ): string {
   const crossorigin = hasAttribute(sourceTag, "crossorigin")
     ? " crossorigin"
     : "";
-  const resourceType = as === undefined ? "" : ` as="${as}"`;
-  return `<link rel="${relation}"${resourceType}${crossorigin} href="${href}" ${marker}="">`;
+  return `<link${crossorigin} href="${href}" ${marker}="">`;
 }
 
 export function deferApplicationEntryResources(html: string): string {
@@ -67,13 +63,7 @@ export function deferApplicationEntryResources(html: string): string {
         throw new Error("Deferred app entry is missing its source URL");
       }
       applicationEntries += 1;
-      return preloadTag(
-        tag,
-        href,
-        "modulepreload",
-        undefined,
-        APP_ENTRY_ATTRIBUTE,
-      );
+      return inertResourceTag(tag, href, APP_ENTRY_ATTRIBUTE);
     },
   );
   if (applicationEntries !== 1) {
@@ -85,6 +75,13 @@ export function deferApplicationEntryResources(html: string): string {
   return deferredEntryHtml.replace(/<link\b[^>]*>/gu, (tag) => {
     const href = attributeValue(tag, "href");
     if (
+      attributeValue(tag, "rel") === "modulepreload" &&
+      href?.endsWith(".js") &&
+      hasAttribute(tag, "crossorigin")
+    ) {
+      return inertResourceTag(tag, href, APP_MODULE_PRELOAD_ATTRIBUTE);
+    }
+    if (
       attributeValue(tag, "rel") !== "stylesheet" ||
       href === undefined ||
       !href.endsWith(".css") ||
@@ -92,7 +89,7 @@ export function deferApplicationEntryResources(html: string): string {
     ) {
       return tag;
     }
-    return preloadTag(tag, href, "preload", "style", APP_STYLESHEET_ATTRIBUTE);
+    return inertResourceTag(tag, href, APP_STYLESHEET_ATTRIBUTE);
   });
 }
 
@@ -112,9 +109,32 @@ export function extractAfterFirstPaintBootstrap(
         return "";
       }
       insertedEntrypoint = true;
-      return `<link rel="preload" as="script" crossorigin href="${AFTER_FIRST_PAINT_ENTRY_PLACEHOLDER}" integrity="${AFTER_FIRST_PAINT_INTEGRITY_PLACEHOLDER}" ${AFTER_FIRST_PAINT_ENTRY_ATTRIBUTE}="">
+      return `<link crossorigin href="${AFTER_FIRST_PAINT_ENTRY_PLACEHOLDER}" ${AFTER_FIRST_PAINT_ENTRY_ATTRIBUTE}="">
     <script data-vm0-after-first-paint-loader="">
       window.__vm0AfterFirstPaint(function () {
+        var modulePreloads = document.querySelectorAll(
+          'link[${APP_ENTRY_ATTRIBUTE}=""], link[${APP_MODULE_PRELOAD_ATTRIBUTE}=""]',
+        );
+        for (var index = 0; index < modulePreloads.length; index += 1) {
+          modulePreloads[index].rel = "modulepreload";
+        }
+
+        var appStylesheet = document.querySelector(
+          'link[${APP_STYLESHEET_ATTRIBUTE}=""]',
+        );
+        if (appStylesheet) {
+          appStylesheet.rel = "preload";
+          appStylesheet.as = "style";
+        }
+
+        var fontStylesheet = document.querySelector(
+          'link[data-vm0-font-stylesheet=""]',
+        );
+        if (fontStylesheet) {
+          fontStylesheet.rel = "preload";
+          fontStylesheet.as = "style";
+        }
+
         var entry = document.querySelector(
           'link[${AFTER_FIRST_PAINT_ENTRY_ATTRIBUTE}=""]',
         );
@@ -123,7 +143,6 @@ export function extractAfterFirstPaintBootstrap(
         var script = document.createElement("script");
         script.src = entry.href;
         script.crossOrigin = "anonymous";
-        script.integrity = entry.integrity;
         document.head.appendChild(script);
       });
     </script>`;
@@ -194,7 +213,7 @@ async function minifyInlineBootstrap(html: string): Promise<string> {
     sourceOffset = match.index + fullMatch.length;
   }
   parts.push(html.slice(sourceOffset));
-  return parts.join("");
+  return parts.join("").replace(/>\s+</gu, "><").trim();
 }
 
 function assetUrl(config: ResolvedConfig, fileName: string): string {
@@ -233,9 +252,6 @@ export function deferredApplicationEntryHtmlPlugin(): Plugin {
           .digest("hex")
           .slice(0, 12);
         const fileName = `assets/bootstrap-after-first-paint-${digest}.js`;
-        const integrity = `sha384-${createHash("sha384")
-          .update(minifiedSource)
-          .digest("base64")}`;
         this.emitFile({
           type: "asset",
           fileName,
@@ -243,9 +259,7 @@ export function deferredApplicationEntryHtmlPlugin(): Plugin {
         });
         const entryUrl = assetUrl(resolvedConfig, fileName);
         return await minifyInlineBootstrap(
-          extracted.html
-            .replace(AFTER_FIRST_PAINT_ENTRY_PLACEHOLDER, entryUrl)
-            .replace(AFTER_FIRST_PAINT_INTEGRITY_PLACEHOLDER, integrity),
+          extracted.html.replace(AFTER_FIRST_PAINT_ENTRY_PLACEHOLDER, entryUrl),
         );
       },
     },

--- a/turbo/apps/platform/scripts/deferred-entry-html.ts
+++ b/turbo/apps/platform/scripts/deferred-entry-html.ts
@@ -1,0 +1,84 @@
+import type { Plugin } from "vite";
+
+const APP_ENTRY_ATTRIBUTE = "data-vm0-app-entry";
+const APP_STYLESHEET_ATTRIBUTE = "data-vm0-app-stylesheet";
+
+function attributeValue(tag: string, name: string): string | undefined {
+  const match = new RegExp(`\\s${name}="([^"]*)"`, "u").exec(tag);
+  return match?.[1];
+}
+
+function hasAttribute(tag: string, name: string): boolean {
+  return new RegExp(`\\s${name}(?:="[^"]*")?(?=\\s|/?>)`, "u").test(tag);
+}
+
+function preloadTag(
+  sourceTag: string,
+  href: string,
+  relation: "modulepreload" | "preload",
+  as: "style" | undefined,
+  marker: string,
+): string {
+  const crossorigin = hasAttribute(sourceTag, "crossorigin")
+    ? " crossorigin"
+    : "";
+  const resourceType = as === undefined ? "" : ` as="${as}"`;
+  return `<link rel="${relation}"${resourceType}${crossorigin} href="${href}" ${marker}="">`;
+}
+
+export function deferApplicationEntryResources(html: string): string {
+  let applicationEntries = 0;
+  const deferredEntryHtml = html.replace(
+    /<script\b[^>]*>\s*<\/script>/gu,
+    (tag) => {
+      const href = attributeValue(tag, "src");
+      const isSourceEntry = hasAttribute(tag, APP_ENTRY_ATTRIBUTE);
+      const isBuiltEntry =
+        attributeValue(tag, "type") === "module" && href?.endsWith(".js");
+      if (!isSourceEntry && !isBuiltEntry) {
+        return tag;
+      }
+      if (href === undefined) {
+        throw new Error("Deferred app entry is missing its source URL");
+      }
+      applicationEntries += 1;
+      return preloadTag(
+        tag,
+        href,
+        "modulepreload",
+        undefined,
+        APP_ENTRY_ATTRIBUTE,
+      );
+    },
+  );
+  if (applicationEntries !== 1) {
+    throw new Error(
+      `Expected exactly one deferred app entry, found ${applicationEntries}`,
+    );
+  }
+
+  return deferredEntryHtml.replace(/<link\b[^>]*>/gu, (tag) => {
+    const href = attributeValue(tag, "href");
+    if (
+      attributeValue(tag, "rel") !== "stylesheet" ||
+      href === undefined ||
+      !href.endsWith(".css") ||
+      !hasAttribute(tag, "crossorigin")
+    ) {
+      return tag;
+    }
+    return preloadTag(tag, href, "preload", "style", APP_STYLESHEET_ATTRIBUTE);
+  });
+}
+
+export function deferredApplicationEntryHtmlPlugin(): Plugin {
+  return {
+    name: "platform-deferred-application-entry-html",
+    transformIndexHtml: {
+      order: "post",
+      handler(html) {
+        return deferApplicationEntryResources(html);
+      },
+    },
+  };
+}

--- a/turbo/apps/platform/scripts/deferred-entry-html.ts
+++ b/turbo/apps/platform/scripts/deferred-entry-html.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 
+import { parse, type DefaultTreeAdapterTypes } from "parse5";
 import { transformWithEsbuild, type Plugin, type ResolvedConfig } from "vite";
 
 const APP_ENTRY_ATTRIBUTE = "data-vm0-app-entry";
@@ -16,81 +17,187 @@ type ExtractedAfterFirstPaintBootstrap = {
 
 type InlineBlockKind = "script" | "style";
 
-function tagAttributes(tag: string): ReadonlyMap<string, string | undefined> {
-  const attributes = new Map<string, string | undefined>();
-  const pattern = /\s([A-Za-z_:][A-Za-z0-9:._-]*)(?:="([^"]*)")?/gu;
-  for (const match of tag.matchAll(pattern)) {
-    const name = match[1];
-    if (name !== undefined) {
-      attributes.set(name, match[2]);
+type HtmlElement = DefaultTreeAdapterTypes.Element;
+type HtmlNode = DefaultTreeAdapterTypes.Node;
+
+type HtmlReplacement = {
+  readonly endOffset: number;
+  readonly replacement: string;
+  readonly startOffset: number;
+};
+
+function isElement(node: HtmlNode): node is HtmlElement {
+  return "tagName" in node;
+}
+
+function htmlElements(html: string): readonly HtmlElement[] {
+  const document = parse(html, { sourceCodeLocationInfo: true });
+  const elements: HtmlElement[] = [];
+  const visit = (node: HtmlNode): void => {
+    if (isElement(node) && node.sourceCodeLocation !== undefined) {
+      elements.push(node);
     }
+    if ("childNodes" in node) {
+      for (const child of node.childNodes) {
+        visit(child);
+      }
+    }
+  };
+  visit(document);
+  return elements;
+}
+
+function attributeValue(
+  element: HtmlElement,
+  name: string,
+): string | undefined {
+  return element.attrs.find((attribute) => {
+    return attribute.name === name;
+  })?.value;
+}
+
+function hasAttribute(element: HtmlElement, name: string): boolean {
+  return element.attrs.some((attribute) => {
+    return attribute.name === name;
+  });
+}
+
+function escapeAttribute(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function applyHtmlReplacements(
+  html: string,
+  replacements: readonly HtmlReplacement[],
+): string {
+  const sorted = [...replacements].sort(
+    (left, right) => {
+      return right.startOffset - left.startOffset;
+    },
+  );
+  let earliestOffset = html.length;
+  let output = html;
+  for (const replacement of sorted) {
+    if (
+      replacement.startOffset < 0 ||
+      replacement.endOffset < replacement.startOffset ||
+      replacement.endOffset > earliestOffset
+    ) {
+      throw new Error("Invalid or overlapping HTML replacement");
+    }
+    output =
+      output.slice(0, replacement.startOffset) +
+      replacement.replacement +
+      output.slice(replacement.endOffset);
+    earliestOffset = replacement.startOffset;
   }
-  return attributes;
-}
-
-function attributeValue(tag: string, name: string): string | undefined {
-  return tagAttributes(tag).get(name);
-}
-
-function hasAttribute(tag: string, name: string): boolean {
-  return tagAttributes(tag).has(name);
+  return output;
 }
 
 function inertResourceTag(
-  sourceTag: string,
+  sourceElement: HtmlElement,
   href: string,
   marker: string,
 ): string {
-  const crossorigin = hasAttribute(sourceTag, "crossorigin")
+  const crossorigin = hasAttribute(sourceElement, "crossorigin")
     ? " crossorigin"
     : "";
-  return `<link${crossorigin} href="${href}" ${marker}="">`;
+  return `<link${crossorigin} href="${escapeAttribute(href)}" ${marker}="">`;
+}
+
+function deferredApplicationScriptReplacement(
+  html: string,
+  element: HtmlElement,
+): HtmlReplacement | undefined {
+  const location = element.sourceCodeLocation;
+  if (
+    element.tagName !== "script" ||
+    location?.startTag === undefined ||
+    location.endTag === undefined ||
+    html
+      .slice(location.startTag.endOffset, location.endTag.startOffset)
+      .trim() !== ""
+  ) {
+    return undefined;
+  }
+  const href = attributeValue(element, "src");
+  const isSourceEntry = hasAttribute(element, APP_ENTRY_ATTRIBUTE);
+  const isBuiltEntry =
+    attributeValue(element, "type") === "module" && href?.endsWith(".js");
+  if (!isSourceEntry && !isBuiltEntry) {
+    return undefined;
+  }
+  if (href === undefined) {
+    throw new Error("Deferred app entry is missing its source URL");
+  }
+  return {
+    endOffset: location.endOffset,
+    replacement: inertResourceTag(element, href, APP_ENTRY_ATTRIBUTE),
+    startOffset: location.startOffset,
+  };
+}
+
+function deferredApplicationLinkReplacement(
+  element: HtmlElement,
+): HtmlReplacement | undefined {
+  const location = element.sourceCodeLocation;
+  if (element.tagName !== "link" || location?.startTag === undefined) {
+    return undefined;
+  }
+  const href = attributeValue(element, "href");
+  let marker: string | undefined;
+  if (
+    attributeValue(element, "rel") === "modulepreload" &&
+    href?.endsWith(".js") &&
+    hasAttribute(element, "crossorigin")
+  ) {
+    marker = APP_MODULE_PRELOAD_ATTRIBUTE;
+  } else if (
+    attributeValue(element, "rel") === "stylesheet" &&
+    href?.endsWith(".css") &&
+    hasAttribute(element, "crossorigin")
+  ) {
+    marker = APP_STYLESHEET_ATTRIBUTE;
+  }
+  if (href === undefined || marker === undefined) {
+    return undefined;
+  }
+  return {
+    endOffset: location.startTag.endOffset,
+    replacement: inertResourceTag(element, href, marker),
+    startOffset: location.startTag.startOffset,
+  };
 }
 
 export function deferApplicationEntryResources(html: string): string {
   let applicationEntries = 0;
-  const deferredEntryHtml = html.replace(
-    /<script\b[^>]*>\s*<\/script\s*>/giu,
-    (tag) => {
-      const href = attributeValue(tag, "src");
-      const isSourceEntry = hasAttribute(tag, APP_ENTRY_ATTRIBUTE);
-      const isBuiltEntry =
-        attributeValue(tag, "type") === "module" && href?.endsWith(".js");
-      if (!isSourceEntry && !isBuiltEntry) {
-        return tag;
-      }
-      if (href === undefined) {
-        throw new Error("Deferred app entry is missing its source URL");
-      }
+  const replacements: HtmlReplacement[] = [];
+  for (const element of htmlElements(html)) {
+    const scriptReplacement = deferredApplicationScriptReplacement(
+      html,
+      element,
+    );
+    if (scriptReplacement !== undefined) {
       applicationEntries += 1;
-      return inertResourceTag(tag, href, APP_ENTRY_ATTRIBUTE);
-    },
-  );
+      replacements.push(scriptReplacement);
+      continue;
+    }
+    const linkReplacement = deferredApplicationLinkReplacement(element);
+    if (linkReplacement !== undefined) {
+      replacements.push(linkReplacement);
+    }
+  }
   if (applicationEntries !== 1) {
     throw new Error(
       `Expected exactly one deferred app entry, found ${applicationEntries}`,
     );
   }
 
-  return deferredEntryHtml.replace(/<link\b[^>]*>/gu, (tag) => {
-    const href = attributeValue(tag, "href");
-    if (
-      attributeValue(tag, "rel") === "modulepreload" &&
-      href?.endsWith(".js") &&
-      hasAttribute(tag, "crossorigin")
-    ) {
-      return inertResourceTag(tag, href, APP_MODULE_PRELOAD_ATTRIBUTE);
-    }
-    if (
-      attributeValue(tag, "rel") !== "stylesheet" ||
-      href === undefined ||
-      !href.endsWith(".css") ||
-      !hasAttribute(tag, "crossorigin")
-    ) {
-      return tag;
-    }
-    return inertResourceTag(tag, href, APP_STYLESHEET_ATTRIBUTE);
-  });
+  return applyHtmlReplacements(html, replacements);
 }
 
 export function extractAfterFirstPaintBootstrap(
@@ -98,18 +205,40 @@ export function extractAfterFirstPaintBootstrap(
 ): ExtractedAfterFirstPaintBootstrap {
   const callbacks: string[] = [];
   let insertedEntrypoint = false;
-  const extractedHtml = html.replace(
-    /<script\s*>([\s\S]*?)<\/script\s*>/giu,
-    (tag, source: string) => {
-      if (!/^\s*window\.__vm0AfterFirstPaint\(function \(\) \{/u.test(source)) {
-        return tag;
-      }
-      callbacks.push(source.trim());
-      if (insertedEntrypoint) {
-        return "";
-      }
-      insertedEntrypoint = true;
-      return `<link crossorigin href="${AFTER_FIRST_PAINT_ENTRY_PLACEHOLDER}" ${AFTER_FIRST_PAINT_ENTRY_ATTRIBUTE}="">
+  const replacements: HtmlReplacement[] = [];
+  for (const element of htmlElements(html)) {
+    const location = element.sourceCodeLocation;
+    if (
+      element.tagName !== "script" ||
+      element.attrs.length !== 0 ||
+      location?.startTag === undefined ||
+      location.endTag === undefined
+    ) {
+      continue;
+    }
+    const source = html.slice(
+      location.startTag.endOffset,
+      location.endTag.startOffset,
+    );
+    if (
+      !source
+        .trimStart()
+        .startsWith("window.__vm0AfterFirstPaint(function () {")
+    ) {
+      continue;
+    }
+    callbacks.push(source.trim());
+    let replacement = "";
+    if (insertedEntrypoint) {
+      replacements.push({
+        endOffset: location.endOffset,
+        replacement,
+        startOffset: location.startOffset,
+      });
+      continue;
+    }
+    insertedEntrypoint = true;
+    replacement = `<link crossorigin href="${AFTER_FIRST_PAINT_ENTRY_PLACEHOLDER}" ${AFTER_FIRST_PAINT_ENTRY_ATTRIBUTE}="">
     <script data-vm0-after-first-paint-loader="">
       window.__vm0AfterFirstPaint(function () {
         if (window.__vm0BrowserSupported === true) {
@@ -148,32 +277,35 @@ export function extractAfterFirstPaintBootstrap(
         document.head.appendChild(script);
       });
     </script>`;
-    },
-  );
+    replacements.push({
+      endOffset: location.endOffset,
+      replacement,
+      startOffset: location.startOffset,
+    });
+  }
   if (callbacks.length === 0) {
     throw new Error("Expected deferred after-first-paint bootstrap callbacks");
   }
 
   return {
-    html: extractedHtml,
+    html: applyHtmlReplacements(html, replacements),
     source: `"use strict";\n${callbacks.join("\n")}\n`,
   };
 }
 
 async function minifyInlineBlock(
   kind: InlineBlockKind,
-  attributes: string,
+  element: HtmlElement,
   source: string,
 ): Promise<string> {
   if (source.trim() === "") {
     return source;
   }
   if (kind === "script") {
-    const sourceTag = `<script${attributes}>`;
-    if (hasAttribute(sourceTag, "src")) {
+    if (hasAttribute(element, "src")) {
       return source;
     }
-    const type = attributeValue(sourceTag, "type");
+    const type = attributeValue(element, "type");
     if (type !== undefined && type !== "module" && type !== "text/javascript") {
       return source;
     }
@@ -192,30 +324,50 @@ async function minifyInlineBlock(
 }
 
 async function minifyInlineBootstrap(html: string): Promise<string> {
-  const pattern = /<(script|style)([^>]*)>([\s\S]*?)<\/\1>/gu;
-  const parts: string[] = [];
-  let sourceOffset = 0;
-  for (const match of html.matchAll(pattern)) {
-    const fullMatch = match[0];
-    const kind = match[1] as InlineBlockKind | undefined;
-    const attributes = match[2];
-    const source = match[3];
-    if (
-      fullMatch === undefined ||
-      kind === undefined ||
-      attributes === undefined ||
-      source === undefined ||
-      match.index === undefined
-    ) {
+  const replacements: HtmlReplacement[] = [];
+  for (const element of htmlElements(html)) {
+    if (element.tagName !== "script" && element.tagName !== "style") {
       continue;
     }
-    parts.push(html.slice(sourceOffset, match.index));
-    const minified = await minifyInlineBlock(kind, attributes, source);
-    parts.push(`<${kind}${attributes}>${minified}</${kind}>`);
-    sourceOffset = match.index + fullMatch.length;
+    const location = element.sourceCodeLocation;
+    if (location?.startTag === undefined || location.endTag === undefined) {
+      continue;
+    }
+    const source = html.slice(
+      location.startTag.endOffset,
+      location.endTag.startOffset,
+    );
+    const minified = await minifyInlineBlock(element.tagName, element, source);
+    replacements.push({
+      endOffset: location.endTag.startOffset,
+      replacement: minified,
+      startOffset: location.startTag.endOffset,
+    });
   }
-  parts.push(html.slice(sourceOffset));
-  return parts.join("").replace(/>\s+</gu, "><").trim();
+  const minified = applyHtmlReplacements(html, replacements);
+  const whitespaceReplacements: HtmlReplacement[] = [];
+  const document = parse(minified, { sourceCodeLocationInfo: true });
+  const visit = (node: HtmlNode): void => {
+    if (
+      node.nodeName === "#text" &&
+      node.value.trim() === "" &&
+      node.sourceCodeLocation !== undefined &&
+      node.sourceCodeLocation !== null
+    ) {
+      whitespaceReplacements.push({
+        endOffset: node.sourceCodeLocation.endOffset,
+        replacement: "",
+        startOffset: node.sourceCodeLocation.startOffset,
+      });
+    }
+    if ("childNodes" in node) {
+      for (const child of node.childNodes) {
+        visit(child);
+      }
+    }
+  };
+  visit(document);
+  return applyHtmlReplacements(minified, whitespaceReplacements).trim();
 }
 
 function assetUrl(config: ResolvedConfig, fileName: string): string {

--- a/turbo/apps/platform/scripts/deferred-entry-html.ts
+++ b/turbo/apps/platform/scripts/deferred-entry-html.ts
@@ -1,6 +1,12 @@
 import { createHash } from "node:crypto";
 
-import { parse, type DefaultTreeAdapterTypes } from "parse5";
+import {
+  defaultTreeAdapter,
+  html as htmlConstants,
+  parse,
+  serializeOuter,
+  type DefaultTreeAdapterTypes,
+} from "parse5";
 import { transformWithEsbuild, type Plugin, type ResolvedConfig } from "vite";
 
 const APP_ENTRY_ATTRIBUTE = "data-vm0-app-entry";
@@ -62,23 +68,13 @@ function hasAttribute(element: HtmlElement, name: string): boolean {
   });
 }
 
-function escapeAttribute(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;");
-}
-
 function applyHtmlReplacements(
   html: string,
   replacements: readonly HtmlReplacement[],
 ): string {
-  const sorted = [...replacements].sort(
-    (left, right) => {
-      return right.startOffset - left.startOffset;
-    },
-  );
+  const sorted = [...replacements].sort((left, right) => {
+    return right.startOffset - left.startOffset;
+  });
   let earliestOffset = html.length;
   let output = html;
   for (const replacement of sorted) {
@@ -103,10 +99,20 @@ function inertResourceTag(
   href: string,
   marker: string,
 ): string {
-  const crossorigin = hasAttribute(sourceElement, "crossorigin")
-    ? " crossorigin"
-    : "";
-  return `<link${crossorigin} href="${escapeAttribute(href)}" ${marker}="">`;
+  const attributes = [];
+  if (hasAttribute(sourceElement, "crossorigin")) {
+    attributes.push({
+      name: "crossorigin",
+      value: attributeValue(sourceElement, "crossorigin") ?? "",
+    });
+  }
+  attributes.push({ name: "href", value: href }, { name: marker, value: "" });
+  const link = defaultTreeAdapter.createElement(
+    "link",
+    htmlConstants.NS.HTML,
+    attributes,
+  );
+  return serializeOuter(link);
 }
 
 function deferredApplicationScriptReplacement(

--- a/turbo/apps/platform/scripts/deferred-entry-html.ts
+++ b/turbo/apps/platform/scripts/deferred-entry-html.ts
@@ -112,29 +112,29 @@ export function extractAfterFirstPaintBootstrap(
       return `<link crossorigin href="${AFTER_FIRST_PAINT_ENTRY_PLACEHOLDER}" ${AFTER_FIRST_PAINT_ENTRY_ATTRIBUTE}="">
     <script data-vm0-after-first-paint-loader="">
       window.__vm0AfterFirstPaint(function () {
-        if (window.__vm0BrowserSupported !== true) return;
+        if (window.__vm0BrowserSupported === true) {
+          var modulePreloads = document.querySelectorAll(
+            'link[${APP_ENTRY_ATTRIBUTE}=""], link[${APP_MODULE_PRELOAD_ATTRIBUTE}=""]',
+          );
+          for (var index = 0; index < modulePreloads.length; index += 1) {
+            modulePreloads[index].rel = "modulepreload";
+          }
 
-        var modulePreloads = document.querySelectorAll(
-          'link[${APP_ENTRY_ATTRIBUTE}=""], link[${APP_MODULE_PRELOAD_ATTRIBUTE}=""]',
-        );
-        for (var index = 0; index < modulePreloads.length; index += 1) {
-          modulePreloads[index].rel = "modulepreload";
-        }
+          var appStylesheet = document.querySelector(
+            'link[${APP_STYLESHEET_ATTRIBUTE}=""]',
+          );
+          if (appStylesheet) {
+            appStylesheet.rel = "preload";
+            appStylesheet.as = "style";
+          }
 
-        var appStylesheet = document.querySelector(
-          'link[${APP_STYLESHEET_ATTRIBUTE}=""]',
-        );
-        if (appStylesheet) {
-          appStylesheet.rel = "preload";
-          appStylesheet.as = "style";
-        }
-
-        var fontStylesheet = document.querySelector(
-          'link[data-vm0-font-stylesheet=""]',
-        );
-        if (fontStylesheet) {
-          fontStylesheet.rel = "preload";
-          fontStylesheet.as = "style";
+          var fontStylesheet = document.querySelector(
+            'link[data-vm0-font-stylesheet=""]',
+          );
+          if (fontStylesheet) {
+            fontStylesheet.rel = "preload";
+            fontStylesheet.as = "style";
+          }
         }
 
         var entry = document.querySelector(

--- a/turbo/apps/platform/scripts/deferred-entry-html.ts
+++ b/turbo/apps/platform/scripts/deferred-entry-html.ts
@@ -112,6 +112,8 @@ export function extractAfterFirstPaintBootstrap(
       return `<link crossorigin href="${AFTER_FIRST_PAINT_ENTRY_PLACEHOLDER}" ${AFTER_FIRST_PAINT_ENTRY_ATTRIBUTE}="">
     <script data-vm0-after-first-paint-loader="">
       window.__vm0AfterFirstPaint(function () {
+        if (window.__vm0BrowserSupported !== true) return;
+
         var modulePreloads = document.querySelectorAll(
           'link[${APP_ENTRY_ATTRIBUTE}=""], link[${APP_MODULE_PRELOAD_ATTRIBUTE}=""]',
         );

--- a/turbo/apps/platform/scripts/deferred-entry-html.ts
+++ b/turbo/apps/platform/scripts/deferred-entry-html.ts
@@ -1,17 +1,21 @@
 import { createHash } from "node:crypto";
 
-import type { Plugin, ResolvedConfig } from "vite";
+import { transformWithEsbuild, type Plugin, type ResolvedConfig } from "vite";
 
 const APP_ENTRY_ATTRIBUTE = "data-vm0-app-entry";
 const APP_STYLESHEET_ATTRIBUTE = "data-vm0-app-stylesheet";
 const AFTER_FIRST_PAINT_ENTRY_ATTRIBUTE = "data-vm0-after-first-paint-entry";
 const AFTER_FIRST_PAINT_ENTRY_PLACEHOLDER =
   "__VM0_AFTER_FIRST_PAINT_ENTRY_URL__";
+const AFTER_FIRST_PAINT_INTEGRITY_PLACEHOLDER =
+  "__VM0_AFTER_FIRST_PAINT_ENTRY_INTEGRITY__";
 
 type ExtractedAfterFirstPaintBootstrap = {
   readonly html: string;
   readonly source: string;
 };
+
+type InlineBlockKind = "script" | "style";
 
 function tagAttributes(tag: string): ReadonlyMap<string, string | undefined> {
   const attributes = new Map<string, string | undefined>();
@@ -108,7 +112,7 @@ export function extractAfterFirstPaintBootstrap(
         return "";
       }
       insertedEntrypoint = true;
-      return `<link rel="preload" as="script" crossorigin href="${AFTER_FIRST_PAINT_ENTRY_PLACEHOLDER}" ${AFTER_FIRST_PAINT_ENTRY_ATTRIBUTE}="">
+      return `<link rel="preload" as="script" crossorigin href="${AFTER_FIRST_PAINT_ENTRY_PLACEHOLDER}" integrity="${AFTER_FIRST_PAINT_INTEGRITY_PLACEHOLDER}" ${AFTER_FIRST_PAINT_ENTRY_ATTRIBUTE}="">
     <script data-vm0-after-first-paint-loader="">
       window.__vm0AfterFirstPaint(function () {
         var entry = document.querySelector(
@@ -119,6 +123,7 @@ export function extractAfterFirstPaintBootstrap(
         var script = document.createElement("script");
         script.src = entry.href;
         script.crossOrigin = "anonymous";
+        script.integrity = entry.integrity;
         document.head.appendChild(script);
       });
     </script>`;
@@ -134,6 +139,64 @@ export function extractAfterFirstPaintBootstrap(
   };
 }
 
+async function minifyInlineBlock(
+  kind: InlineBlockKind,
+  attributes: string,
+  source: string,
+): Promise<string> {
+  if (source.trim() === "") {
+    return source;
+  }
+  if (kind === "script") {
+    const sourceTag = `<script${attributes}>`;
+    if (hasAttribute(sourceTag, "src")) {
+      return source;
+    }
+    const type = attributeValue(sourceTag, "type");
+    if (type !== undefined && type !== "module" && type !== "text/javascript") {
+      return source;
+    }
+  }
+  const transformed = await transformWithEsbuild(
+    source,
+    kind === "script" ? "inline-bootstrap.js" : "inline-bootstrap.css",
+    {
+      legalComments: "none",
+      loader: kind === "script" ? "js" : "css",
+      minify: true,
+      target: "es2020",
+    },
+  );
+  return transformed.code.trim();
+}
+
+async function minifyInlineBootstrap(html: string): Promise<string> {
+  const pattern = /<(script|style)([^>]*)>([\s\S]*?)<\/\1>/gu;
+  const parts: string[] = [];
+  let sourceOffset = 0;
+  for (const match of html.matchAll(pattern)) {
+    const fullMatch = match[0];
+    const kind = match[1] as InlineBlockKind | undefined;
+    const attributes = match[2];
+    const source = match[3];
+    if (
+      fullMatch === undefined ||
+      kind === undefined ||
+      attributes === undefined ||
+      source === undefined ||
+      match.index === undefined
+    ) {
+      continue;
+    }
+    parts.push(html.slice(sourceOffset, match.index));
+    const minified = await minifyInlineBlock(kind, attributes, source);
+    parts.push(`<${kind}${attributes}>${minified}</${kind}>`);
+    sourceOffset = match.index + fullMatch.length;
+  }
+  parts.push(html.slice(sourceOffset));
+  return parts.join("");
+}
+
 function assetUrl(config: ResolvedConfig, fileName: string): string {
   return `${config.base.replace(/\/?$/u, "/")}${fileName}`;
 }
@@ -147,26 +210,42 @@ export function deferredApplicationEntryHtmlPlugin(): Plugin {
     },
     transformIndexHtml: {
       order: "post",
-      handler(html) {
+      async handler(html) {
         const deferredHtml = deferApplicationEntryResources(html);
         if (resolvedConfig?.command !== "build") {
           return deferredHtml;
         }
         const extracted = extractAfterFirstPaintBootstrap(deferredHtml);
+        const minifiedSource = (
+          await transformWithEsbuild(
+            extracted.source,
+            "bootstrap-after-first-paint.js",
+            {
+              legalComments: "none",
+              loader: "js",
+              minify: true,
+              target: "es2020",
+            },
+          )
+        ).code.trim();
         const digest = createHash("sha256")
-          .update(extracted.source)
+          .update(minifiedSource)
           .digest("hex")
           .slice(0, 12);
         const fileName = `assets/bootstrap-after-first-paint-${digest}.js`;
+        const integrity = `sha384-${createHash("sha384")
+          .update(minifiedSource)
+          .digest("base64")}`;
         this.emitFile({
           type: "asset",
           fileName,
-          source: extracted.source,
+          source: minifiedSource,
         });
         const entryUrl = assetUrl(resolvedConfig, fileName);
-        return extracted.html.replace(
-          AFTER_FIRST_PAINT_ENTRY_PLACEHOLDER,
-          entryUrl,
+        return await minifyInlineBootstrap(
+          extracted.html
+            .replace(AFTER_FIRST_PAINT_ENTRY_PLACEHOLDER, entryUrl)
+            .replace(AFTER_FIRST_PAINT_INTEGRITY_PLACEHOLDER, integrity),
         );
       },
     },

--- a/turbo/apps/platform/scripts/deferred-entry-html.ts
+++ b/turbo/apps/platform/scripts/deferred-entry-html.ts
@@ -3,13 +3,24 @@ import type { Plugin } from "vite";
 const APP_ENTRY_ATTRIBUTE = "data-vm0-app-entry";
 const APP_STYLESHEET_ATTRIBUTE = "data-vm0-app-stylesheet";
 
+function tagAttributes(tag: string): ReadonlyMap<string, string | undefined> {
+  const attributes = new Map<string, string | undefined>();
+  const pattern = /\s([A-Za-z_:][A-Za-z0-9:._-]*)(?:="([^"]*)")?/gu;
+  for (const match of tag.matchAll(pattern)) {
+    const name = match[1];
+    if (name !== undefined) {
+      attributes.set(name, match[2]);
+    }
+  }
+  return attributes;
+}
+
 function attributeValue(tag: string, name: string): string | undefined {
-  const match = new RegExp(`\\s${name}="([^"]*)"`, "u").exec(tag);
-  return match?.[1];
+  return tagAttributes(tag).get(name);
 }
 
 function hasAttribute(tag: string, name: string): boolean {
-  return new RegExp(`\\s${name}(?:="[^"]*")?(?=\\s|/?>)`, "u").test(tag);
+  return tagAttributes(tag).has(name);
 }
 
 function preloadTag(

--- a/turbo/apps/platform/scripts/single-bundle.ts
+++ b/turbo/apps/platform/scripts/single-bundle.ts
@@ -4,6 +4,8 @@ export const RAW_JAVASCRIPT_OUTPUT_LIMIT_BYTES = 8_500_000;
 
 const SHARED_DATABASE_WORKER_FILE_PATTERN =
   /^assets\/shared-database-worker-[^/]+\.js$/u;
+const AFTER_FIRST_PAINT_BOOTSTRAP_FILE_PATTERN =
+  /^assets\/bootstrap-after-first-paint-[a-f0-9]{12}\.js$/u;
 const VENDOR_FILE_PATTERN = /^assets\/vendor-[^/]+\.js$/u;
 const ROLLDOWN_RUNTIME_FILE_PATTERN = /^assets\/rolldown-runtime-[^/]+\.js$/u;
 
@@ -238,6 +240,14 @@ export function applicationBundleViolations(
       );
     },
   );
+  const afterFirstPaintBootstrapAssets = javaScriptOutputs.filter(
+    (output): output is GeneratedAsset => {
+      return (
+        output.type === "asset" &&
+        AFTER_FIRST_PAINT_BOOTSTRAP_FILE_PATTERN.test(output.fileName)
+      );
+    },
+  );
   const vendorChunks = applicationChunks.filter((chunk) => {
     return VENDOR_FILE_PATTERN.test(chunk.fileName);
   });
@@ -254,24 +264,24 @@ export function applicationBundleViolations(
   const vendorChunk = vendorChunks[0];
   const runtimeChunk = runtimeChunks[0];
   const workerAsset = workerAssets[0];
-  if (
-    javaScriptOutputs.length !== 4 ||
-    applicationChunks.length !== 3 ||
-    appChunks.length !== 1 ||
-    vendorChunks.length !== 1 ||
-    runtimeChunks.length !== 1 ||
-    workerAssets.length !== 1 ||
-    !appChunk ||
-    !vendorChunk ||
-    !runtimeChunk ||
-    !workerAsset ||
-    appChunk.isEntry !== true ||
-    vendorChunk.isEntry === true ||
-    runtimeChunk.isEntry === true
-  ) {
-    return [
-      `Expected exactly one app entry, one vendor chunk, one Rolldown runtime chunk, and one shared database worker asset, but generated: ${outputDescription(javaScriptOutputs)}`,
-    ];
+  const layoutViolation = `Expected exactly one app entry, one vendor chunk, one Rolldown runtime chunk, one shared database worker asset, and at most one after-first-paint bootstrap asset, but generated: ${outputDescription(javaScriptOutputs)}`;
+  if (!appChunk || !vendorChunk || !runtimeChunk || !workerAsset) {
+    return [layoutViolation];
+  }
+  const hasExpectedLayout = [
+    javaScriptOutputs.length === 4 + afterFirstPaintBootstrapAssets.length,
+    applicationChunks.length === 3,
+    appChunks.length === 1,
+    vendorChunks.length === 1,
+    runtimeChunks.length === 1,
+    workerAssets.length === 1,
+    afterFirstPaintBootstrapAssets.length <= 1,
+    appChunk.isEntry === true,
+    vendorChunk.isEntry !== true,
+    runtimeChunk.isEntry !== true,
+  ].every(Boolean);
+  if (!hasExpectedLayout) {
+    return [layoutViolation];
   }
 
   const allowedStaticImports = new Set(

--- a/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
@@ -88,11 +88,24 @@ function executeClerkBootstrap(html: string): void {
     "location",
     `${clerkBootstrapSource(html)}\n//# sourceURL=platform-clerk-bootstrap-test.js`,
   ) as ClerkBootstrapScript;
-  executeEntrypointScript(window, document, location);
+  const previousAfterFirstPaint = window.__vm0AfterFirstPaint;
+  window.__vm0AfterFirstPaint ??= (callback) => {
+    callback();
+  };
+  try {
+    executeEntrypointScript(window, document, location);
+  } finally {
+    if (previousAfterFirstPaint === undefined) {
+      Reflect.deleteProperty(window, "__vm0AfterFirstPaint");
+    } else {
+      window.__vm0AfterFirstPaint = previousAfterFirstPaint;
+    }
+  }
 }
 
 function captureClerkBootstrapScript(url: string): HTMLScriptElement {
   context.mocks.browser.url(url);
+  window.__vm0BrowserSupported = true;
   let clerkScript: HTMLScriptElement | undefined;
   const appendSpy = vi
     .spyOn(document.head, "appendChild")
@@ -108,6 +121,7 @@ function captureClerkBootstrapScript(url: string): HTMLScriptElement {
 
   executeClerkBootstrap(builtIndexHtml());
   appendSpy.mockRestore();
+  Reflect.deleteProperty(window, "__vm0BrowserSupported");
   if (!clerkScript) {
     throw new Error("Clerk bootstrap did not create the core script");
   }
@@ -218,13 +232,18 @@ async function completeEarlyClerkScript(
 }
 
 describe("platform Clerk entrypoint", () => {
-  it("declares the Clerk bootstrap before the app module", () => {
+  it("discovers the paintable skeleton before Clerk and the app module", () => {
     const html = builtIndexHtml();
     const parsedDocument = new DOMParser().parseFromString(html, "text/html");
+    const skeleton = parsedDocument.getElementById("app-bootstrap-skeleton");
     const bootstrap = parsedDocument.querySelector(CLERK_BOOTSTRAP_SELECTOR);
     const mainScript = parsedDocument.querySelector(
       'script[type="module"][src="/src/main.ts"]',
     );
+    const externalSkeletonImages = skeleton?.querySelectorAll("img[src]");
+    if (!(skeleton instanceof HTMLDivElement)) {
+      throw new Error("Built index.html does not contain the app skeleton");
+    }
     if (!(bootstrap instanceof HTMLScriptElement)) {
       throw new Error("Built index.html does not contain the Clerk bootstrap");
     }
@@ -232,10 +251,70 @@ describe("platform Clerk entrypoint", () => {
       throw new Error("Built index.html does not contain the app module");
     }
 
-    expect(bootstrap.compareDocumentPosition(mainScript)).toBe(
+    expect(skeleton.compareDocumentPosition(mainScript)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
+    expect(skeleton.compareDocumentPosition(bootstrap)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(externalSkeletonImages).toHaveLength(0);
+    expect(skeleton.querySelector("svg")).not.toBeNull();
+    expect(
+      parsedDocument.querySelector(
+        'link[data-vm0-font-stylesheet][rel="preload"][as="style"]',
+      ),
+    ).not.toBeNull();
+    expect(html.indexOf("data-vm0-clerk-bootstrap")).toBeLessThan(
+      html.indexOf("var appEntry ="),
+    );
     expect(html).not.toContain("@clerk/ui");
+  });
+
+  it("preconnects immediately and starts the Clerk core after first paint", () => {
+    context.mocks.browser.url("https://app.vm0.ai/");
+    window.__vm0BrowserSupported = true;
+    let afterFirstPaint: (() => void) | undefined;
+    window.__vm0AfterFirstPaint = (callback) => {
+      afterFirstPaint = callback;
+    };
+    const appendedNodes: Node[] = [];
+    const appendSpy = vi
+      .spyOn(document.head, "appendChild")
+      .mockImplementation(<T extends Node>(node: T): T => {
+        appendedNodes.push(node);
+        return node;
+      });
+
+    try {
+      executeClerkBootstrap(builtIndexHtml());
+      expect(
+        appendedNodes.filter((node) => {
+          return node instanceof HTMLLinkElement && node.rel === "preconnect";
+        }),
+      ).toHaveLength(1);
+      expect(
+        appendedNodes.filter((node) => {
+          return node instanceof HTMLScriptElement;
+        }),
+      ).toHaveLength(0);
+      if (afterFirstPaint === undefined) {
+        throw new Error("Clerk bootstrap did not register its paint callback");
+      }
+
+      afterFirstPaint();
+
+      const clerkScripts = appendedNodes.filter((node) => {
+        return (
+          node instanceof HTMLScriptElement &&
+          node.dataset.clerkJsScript !== undefined
+        );
+      });
+      expect(clerkScripts).toHaveLength(1);
+    } finally {
+      appendSpy.mockRestore();
+      Reflect.deleteProperty(window, "__vm0AfterFirstPaint");
+      Reflect.deleteProperty(window, "__vm0BrowserSupported");
+    }
   });
 
   it.each([

--- a/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
@@ -251,6 +251,9 @@ describe("platform Clerk entrypoint", () => {
       'script[type="module"][src="/src/main.ts"]',
     );
     const externalSkeletonImages = skeleton?.querySelectorAll("img[src]");
+    const avatarLayers = skeleton?.querySelectorAll(
+      "[data-app-bootstrap-avatar-layer]",
+    );
     if (!(skeleton instanceof HTMLDivElement)) {
       throw new Error("Built index.html does not contain the app skeleton");
     }
@@ -285,7 +288,12 @@ describe("platform Clerk entrypoint", () => {
       "@keyframes app-bootstrap-skeleton-type",
     );
     expect(externalSkeletonImages).toHaveLength(0);
-    expect(skeleton.querySelector("svg")).not.toBeNull();
+    expect(avatarLayers).toHaveLength(3);
+    for (const avatarLayer of avatarLayers ?? []) {
+      expect(avatarLayer.getAttribute("decoding")).toBe("async");
+      expect(avatarLayer.getAttribute("fetchpriority")).toBe("low");
+    }
+    expect(skeleton.querySelector("svg")).toBeNull();
     expect(
       parsedDocument.querySelector(
         "link[data-vm0-font-stylesheet]:not([rel]):not([as])",

--- a/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
@@ -275,7 +275,7 @@ describe("platform Clerk entrypoint", () => {
     expect(skeleton.querySelector("svg")).not.toBeNull();
     expect(
       parsedDocument.querySelector(
-        'link[data-vm0-font-stylesheet][rel="preload"][as="style"]',
+        'link[data-vm0-font-stylesheet]:not([rel]):not([as])',
       ),
     ).not.toBeNull();
     expect(html.indexOf("data-vm0-clerk-bootstrap")).toBeLessThan(

--- a/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
@@ -275,7 +275,7 @@ describe("platform Clerk entrypoint", () => {
     expect(skeleton.querySelector("svg")).not.toBeNull();
     expect(
       parsedDocument.querySelector(
-        'link[data-vm0-font-stylesheet]:not([rel]):not([as])',
+        "link[data-vm0-font-stylesheet]:not([rel]):not([as])",
       ),
     ).not.toBeNull();
     expect(html.indexOf("data-vm0-clerk-bootstrap")).toBeLessThan(

--- a/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
@@ -237,6 +237,13 @@ describe("platform Clerk entrypoint", () => {
     const parsedDocument = new DOMParser().parseFromString(html, "text/html");
     const skeleton = parsedDocument.getElementById("app-bootstrap-skeleton");
     const bootstrap = parsedDocument.querySelector(CLERK_BOOTSTRAP_SELECTOR);
+    const paintScheduler = [...parsedDocument.querySelectorAll("script")].find(
+      (script) => {
+        return script.textContent.includes(
+          "__appBootstrapFirstPaintUpperBound",
+        );
+      },
+    );
     const mainScript = parsedDocument.querySelector(
       'script[type="module"][src="/src/main.ts"]',
     );
@@ -247,6 +254,9 @@ describe("platform Clerk entrypoint", () => {
     if (!(bootstrap instanceof HTMLScriptElement)) {
       throw new Error("Built index.html does not contain the Clerk bootstrap");
     }
+    if (!(paintScheduler instanceof HTMLScriptElement)) {
+      throw new Error("Built index.html does not contain the paint scheduler");
+    }
     if (!(mainScript instanceof HTMLScriptElement)) {
       throw new Error("Built index.html does not contain the app module");
     }
@@ -255,6 +265,10 @@ describe("platform Clerk entrypoint", () => {
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
     expect(skeleton.compareDocumentPosition(bootstrap)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(paintScheduler.textContent).toContain("first-contentful-paint");
+    expect(skeleton.compareDocumentPosition(paintScheduler)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
     expect(externalSkeletonImages).toHaveLength(0);

--- a/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
@@ -244,6 +244,9 @@ describe("platform Clerk entrypoint", () => {
         );
       },
     );
+    const postSkeletonStyles = parsedDocument.querySelector(
+      "style[data-vm0-post-skeleton-styles]",
+    );
     const mainScript = parsedDocument.querySelector(
       'script[type="module"][src="/src/main.ts"]',
     );
@@ -256,6 +259,9 @@ describe("platform Clerk entrypoint", () => {
     }
     if (!(paintScheduler instanceof HTMLScriptElement)) {
       throw new Error("Built index.html does not contain the paint scheduler");
+    }
+    if (!(postSkeletonStyles instanceof HTMLStyleElement)) {
+      throw new Error("Built index.html does not contain post-skeleton styles");
     }
     if (!(mainScript instanceof HTMLScriptElement)) {
       throw new Error("Built index.html does not contain the app module");
@@ -270,6 +276,13 @@ describe("platform Clerk entrypoint", () => {
     expect(paintScheduler.textContent).toContain("first-contentful-paint");
     expect(skeleton.compareDocumentPosition(paintScheduler)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(skeleton.compareDocumentPosition(postSkeletonStyles)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(postSkeletonStyles.textContent).toContain(".browser-upgrade");
+    expect(postSkeletonStyles.textContent).toContain(
+      "@keyframes app-bootstrap-skeleton-type",
     );
     expect(externalSkeletonImages).toHaveLength(0);
     expect(skeleton.querySelector("svg")).not.toBeNull();

--- a/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
@@ -244,6 +244,9 @@ describe("platform Clerk entrypoint", () => {
         );
       },
     );
+    const avatarBootstrap = parsedDocument.querySelector(
+      "script[data-vm0-avatar-bootstrap]",
+    );
     const postSkeletonStyles = parsedDocument.querySelector(
       "style[data-vm0-post-skeleton-styles]",
     );
@@ -263,6 +266,9 @@ describe("platform Clerk entrypoint", () => {
     if (!(paintScheduler instanceof HTMLScriptElement)) {
       throw new Error("Built index.html does not contain the paint scheduler");
     }
+    if (!(avatarBootstrap instanceof HTMLScriptElement)) {
+      throw new Error("Built index.html does not contain the avatar bootstrap");
+    }
     if (!(postSkeletonStyles instanceof HTMLStyleElement)) {
       throw new Error("Built index.html does not contain post-skeleton styles");
     }
@@ -279,6 +285,15 @@ describe("platform Clerk entrypoint", () => {
     expect(paintScheduler.textContent).toContain("first-contentful-paint");
     expect(skeleton.compareDocumentPosition(paintScheduler)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(skeleton.compareDocumentPosition(avatarBootstrap)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(avatarBootstrap.compareDocumentPosition(paintScheduler)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(avatarBootstrap.textContent).toContain(
+      "avatarLayers[i].src = avatarSources[i]",
     );
     expect(skeleton.compareDocumentPosition(postSkeletonStyles)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,

--- a/turbo/apps/platform/src/__tests__/instatus-widget.test.ts
+++ b/turbo/apps/platform/src/__tests__/instatus-widget.test.ts
@@ -52,7 +52,19 @@ function loadInstatusScripts(hostname: string): HTMLScriptElement[] {
     `${getInstatusLoaderSource()}\n//# sourceURL=platform-instatus-widget-test.js`,
   ) as EntrypointScript;
 
-  executeEntrypointScript(window, document);
+  const previousAfterFirstPaint = window.__vm0AfterFirstPaint;
+  window.__vm0AfterFirstPaint = (callback) => {
+    callback();
+  };
+  try {
+    executeEntrypointScript(window, document);
+  } finally {
+    if (previousAfterFirstPaint === undefined) {
+      Reflect.deleteProperty(window, "__vm0AfterFirstPaint");
+    } else {
+      window.__vm0AfterFirstPaint = previousAfterFirstPaint;
+    }
+  }
   return appendedScripts;
 }
 

--- a/turbo/apps/platform/src/__tests__/instatus-widget.test.ts
+++ b/turbo/apps/platform/src/__tests__/instatus-widget.test.ts
@@ -35,7 +35,10 @@ function getInstatusLoaderSource(): string {
   return source;
 }
 
-function loadInstatusScripts(hostname: string): HTMLScriptElement[] {
+function loadInstatusScripts(
+  hostname: string,
+  browserSupported = true,
+): HTMLScriptElement[] {
   context.mocks.browser.url(`https://${hostname}/`);
   const appendedScripts: HTMLScriptElement[] = [];
   vi.spyOn(document.body, "appendChild").mockImplementation(
@@ -53,6 +56,8 @@ function loadInstatusScripts(hostname: string): HTMLScriptElement[] {
   ) as EntrypointScript;
 
   const previousAfterFirstPaint = window.__vm0AfterFirstPaint;
+  const previousBrowserSupported = window.__vm0BrowserSupported;
+  window.__vm0BrowserSupported = browserSupported;
   window.__vm0AfterFirstPaint = (callback) => {
     callback();
   };
@@ -63,6 +68,11 @@ function loadInstatusScripts(hostname: string): HTMLScriptElement[] {
       Reflect.deleteProperty(window, "__vm0AfterFirstPaint");
     } else {
       window.__vm0AfterFirstPaint = previousAfterFirstPaint;
+    }
+    if (previousBrowserSupported === undefined) {
+      Reflect.deleteProperty(window, "__vm0BrowserSupported");
+    } else {
+      window.__vm0BrowserSupported = previousBrowserSupported;
     }
   }
   return appendedScripts;
@@ -90,5 +100,9 @@ describe("platform Instatus widget", () => {
     "app.vm0.ai.evil.example",
   ])("does not load on the non-production hostname %s", (hostname) => {
     expect(loadInstatusScripts(hostname)).toStrictEqual([]);
+  });
+
+  it("does not load on an unsupported browser", () => {
+    expect(loadInstatusScripts("app.vm0.ai", false)).toStrictEqual([]);
   });
 });

--- a/turbo/apps/platform/src/__tests__/marketing-scripts.test.ts
+++ b/turbo/apps/platform/src/__tests__/marketing-scripts.test.ts
@@ -87,7 +87,7 @@ function executeMarketingEntrypoint(hostname: string): MarketingHarness {
     },
   );
 
-  const afterFirstPaintCallbacks: Array<() => void> = [];
+  const afterFirstPaintCallbacks: (() => void)[] = [];
   const previousAfterFirstPaint = window.__vm0AfterFirstPaint;
   window.__vm0AfterFirstPaint = (callback) => {
     afterFirstPaintCallbacks.push(callback);

--- a/turbo/apps/platform/src/__tests__/marketing-scripts.test.ts
+++ b/turbo/apps/platform/src/__tests__/marketing-scripts.test.ts
@@ -49,7 +49,10 @@ function marketingEntrypointSource(): string {
   return source;
 }
 
-function executeMarketingEntrypoint(hostname: string): MarketingHarness {
+function executeMarketingEntrypoint(
+  hostname: string,
+  browserSupported = true,
+): MarketingHarness {
   const marketingWindow = window as MarketingWindow;
   context.mocks.browser.url(`https://${hostname}/`);
   vi.stubGlobal("dataLayer", undefined);
@@ -115,8 +118,18 @@ function executeMarketingEntrypoint(hostname: string): MarketingHarness {
       return fallback?.delay;
     },
     flushFirstPaint: () => {
-      for (const callback of afterFirstPaintCallbacks.splice(0)) {
-        callback();
+      const previousBrowserSupported = window.__vm0BrowserSupported;
+      window.__vm0BrowserSupported = browserSupported;
+      try {
+        for (const callback of afterFirstPaintCallbacks.splice(0)) {
+          callback();
+        }
+      } finally {
+        if (previousBrowserSupported === undefined) {
+          Reflect.deleteProperty(window, "__vm0BrowserSupported");
+        } else {
+          window.__vm0BrowserSupported = previousBrowserSupported;
+        }
       }
       fallback = scheduledTimeouts.find(({ delay }) => {
         return delay === MARKETING_FALLBACK_DELAY_MS;
@@ -204,6 +217,16 @@ describe("platform marketing scripts", () => {
 
     window.dispatchEvent(new Event(APP_FIRST_CONTENT_VISIBLE_EVENT));
     harness.flushIdleCallbacks();
+  });
+
+  it("does not initialize on an unsupported browser", () => {
+    const harness = executeMarketingEntrypoint("app.vm0.ai", false);
+    harness.flushFirstPaint();
+
+    expect(harness.fallbackDelay).toBeUndefined();
+    expect(harness.marketingWindow.dataLayer).toBeUndefined();
+    expect(harness.marketingWindow.gtag).toBeUndefined();
+    expect(harness.requestedScriptUrls).toStrictEqual([]);
   });
 
   it.each(["localhost", "pr-29576-app.vm6.ai", "app.vm0.ai.example.com"])(

--- a/turbo/apps/platform/src/__tests__/marketing-scripts.test.ts
+++ b/turbo/apps/platform/src/__tests__/marketing-scripts.test.ts
@@ -28,6 +28,7 @@ interface MarketingHarness {
   readonly fallbackDelay: number | undefined;
   readonly marketingWindow: MarketingWindow;
   readonly requestedScriptUrls: string[];
+  readonly flushFirstPaint: () => void;
   readonly flushIdleCallbacks: () => void;
   readonly runFallback: () => void;
 }
@@ -86,19 +87,41 @@ function executeMarketingEntrypoint(hostname: string): MarketingHarness {
     },
   );
 
+  const afterFirstPaintCallbacks: Array<() => void> = [];
+  const previousAfterFirstPaint = window.__vm0AfterFirstPaint;
+  window.__vm0AfterFirstPaint = (callback) => {
+    afterFirstPaintCallbacks.push(callback);
+  };
+
   const executeEntrypointScript = new Function(
     "window",
     "document",
     `${marketingEntrypointSource()}\n//# sourceURL=platform-marketing-entrypoint-test.js`,
   ) as MarketingEntrypointScript;
-  executeEntrypointScript(window, document);
+  try {
+    executeEntrypointScript(window, document);
+  } finally {
+    if (previousAfterFirstPaint === undefined) {
+      Reflect.deleteProperty(window, "__vm0AfterFirstPaint");
+    } else {
+      window.__vm0AfterFirstPaint = previousAfterFirstPaint;
+    }
+  }
 
-  const fallback = scheduledTimeouts.find(({ delay }) => {
-    return delay === MARKETING_FALLBACK_DELAY_MS;
-  });
+  let fallback: ScheduledTimeout | undefined;
 
   return {
-    fallbackDelay: fallback?.delay,
+    get fallbackDelay() {
+      return fallback?.delay;
+    },
+    flushFirstPaint: () => {
+      for (const callback of afterFirstPaintCallbacks.splice(0)) {
+        callback();
+      }
+      fallback = scheduledTimeouts.find(({ delay }) => {
+        return delay === MARKETING_FALLBACK_DELAY_MS;
+      });
+    },
     flushIdleCallbacks: () => {
       for (const callback of idleCallbacks.splice(0)) {
         callback({
@@ -124,6 +147,10 @@ describe("platform marketing scripts", () => {
   it("loads Google Ads after first app content", () => {
     const harness = executeMarketingEntrypoint("app.vm0.ai");
 
+    expect(harness.marketingWindow.dataLayer).toBeUndefined();
+    expect(harness.requestedScriptUrls).toStrictEqual([]);
+    harness.flushFirstPaint();
+
     expect(
       harness.marketingWindow.dataLayer?.map((entry) => {
         return [...entry];
@@ -142,6 +169,7 @@ describe("platform marketing scripts", () => {
 
   it("waits 30 seconds before falling back when content never becomes ready", () => {
     const harness = executeMarketingEntrypoint("app.vm0.ai");
+    harness.flushFirstPaint();
 
     expect(harness.fallbackDelay).toBe(MARKETING_FALLBACK_DELAY_MS);
     expect(harness.requestedScriptUrls).toStrictEqual([]);
@@ -155,6 +183,7 @@ describe("platform marketing scripts", () => {
 
   it("loads Google Ads once across duplicate readiness and fallback signals", () => {
     const harness = executeMarketingEntrypoint("app.vm0.ai");
+    harness.flushFirstPaint();
 
     window.dispatchEvent(new Event(APP_FIRST_CONTENT_VISIBLE_EVENT));
     window.dispatchEvent(new Event(APP_FIRST_CONTENT_VISIBLE_EVENT));
@@ -166,6 +195,7 @@ describe("platform marketing scripts", () => {
 
   it("does not request scripts when only the app skeleton is visible", () => {
     const harness = executeMarketingEntrypoint("app.vm0.ai");
+    harness.flushFirstPaint();
 
     window.dispatchEvent(new Event(APP_SKELETON_VISIBLE_EVENT));
     harness.flushIdleCallbacks();
@@ -180,6 +210,7 @@ describe("platform marketing scripts", () => {
     "does not initialize or request scripts on %s",
     (hostname) => {
       const harness = executeMarketingEntrypoint(hostname);
+      harness.flushFirstPaint();
 
       window.dispatchEvent(new Event(APP_SKELETON_VISIBLE_EVENT));
       window.dispatchEvent(new Event(APP_FIRST_CONTENT_VISIBLE_EVENT));

--- a/turbo/apps/platform/src/global.d.ts
+++ b/turbo/apps/platform/src/global.d.ts
@@ -36,6 +36,7 @@ declare global {
     _vm0: VM0Global | undefined;
     __vm0BrowserSupported?: boolean;
     __vm0BrowserUpgrade?: VM0BrowserUpgradeCopy & { actionUrl: string };
+    __vm0AfterFirstPaint?: (callback: () => void) => void;
     __vm0PreBundleCopy?: VM0PreBundleCopy;
     /**
      * Set inline in `index.html` at the start of `<head>` parsing. Used by
@@ -43,6 +44,8 @@ declare global {
      * the first time the app skeleton is dismissed.
      */
     __appBootstrapStart?: number;
+    /** Upper bound recorded immediately after the first visible paint. */
+    __appBootstrapFirstPaintUpperBound?: number;
     /** Set when the entry module graph has finished evaluating. */
     __appBootstrapModuleReady?: number;
   }

--- a/turbo/apps/platform/src/lib/posthog.ts
+++ b/turbo/apps/platform/src/lib/posthog.ts
@@ -9,6 +9,12 @@ const POSTHOG_KEY = RUNTIME_CONFIG.postHogKey;
 
 export const AUTH_V2_DIAGNOSTIC_EVENT = "auth_v2_diagnostic";
 const AUTH_V2_DIAGNOSTIC_DISTINCT_ID = "auth-v2";
+export const APP_FIRST_SKELETON_PAINT_EVENT = "app_first_skeleton_paint";
+const APP_FIRST_SKELETON_PAINT_DISTINCT_ID = "app-bootstrap";
+
+type FirstSkeletonPaintMetric =
+  | "after-first-paint-upper-bound"
+  | "first-contentful-paint";
 
 export type AuthV2DiagnosticFlow = "sign-in" | "sign-up" | "unknown";
 
@@ -162,13 +168,54 @@ function authV2DiagnosticErrorCategory(
   }
 }
 
+function finiteNonNegativeNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+function firstSkeletonPaintMetric(value: unknown): FirstSkeletonPaintMetric {
+  return value === "first-contentful-paint"
+    ? value
+    : "after-first-paint-upper-bound";
+}
+
 function sanitizePostHogCaptureResult(
   captureResult: CaptureResult | null,
 ): CaptureResult | null {
-  if (
-    captureResult === null ||
-    captureResult.event !== AUTH_V2_DIAGNOSTIC_EVENT
-  ) {
+  if (captureResult === null) {
+    return null;
+  }
+  if (captureResult.event === APP_FIRST_SKELETON_PAINT_EVENT) {
+    const properties = captureResult.properties;
+    const sanitizedProperties: Record<string, boolean | number | string> = {
+      $process_person_profile: false,
+      distinct_id: APP_FIRST_SKELETON_PAINT_DISTINCT_ID,
+      paint_metric: firstSkeletonPaintMetric(properties.paint_metric),
+      public_brand: RUNTIME_CONFIG.publicBrand,
+      token: POSTHOG_KEY ?? "",
+    };
+    for (const name of [
+      "navigation_response_end_ms",
+      "navigation_response_start_ms",
+      "response_end_to_skeleton_paint_ms",
+      "skeleton_paint_ms",
+    ]) {
+      const value = finiteNonNegativeNumber(properties[name]);
+      if (value !== undefined) {
+        sanitizedProperties[name] = value;
+      }
+    }
+    return {
+      event: APP_FIRST_SKELETON_PAINT_EVENT,
+      properties: sanitizedProperties,
+      ...(captureResult.timestamp
+        ? { timestamp: captureResult.timestamp }
+        : {}),
+      uuid: captureResult.uuid,
+    };
+  }
+  if (captureResult.event !== AUTH_V2_DIAGNOSTIC_EVENT) {
     return captureResult;
   }
   const properties = captureResult.properties;
@@ -222,6 +269,68 @@ export function initPostHog(): void {
         }
         return { ...properties, public_brand: RUNTIME_CONFIG.publicBrand };
       },
+    });
+  });
+}
+
+function navigationTimingEntry(): PerformanceNavigationTiming | undefined {
+  return performance
+    .getEntriesByType("navigation")
+    .find((entry): entry is PerformanceNavigationTiming => {
+      return (
+        entry.entryType === "navigation" &&
+        "responseStart" in entry &&
+        "responseEnd" in entry
+      );
+    });
+}
+
+function firstContentfulPaintTime(): number | undefined {
+  return performance.getEntriesByType("paint").find((entry) => {
+    return entry.name === "first-contentful-paint";
+  })?.startTime;
+}
+
+/**
+ * Capture an anonymous, allowlisted measurement of the navigation response and
+ * the first frame that can contain the inline bootstrap skeleton.
+ */
+export function captureFirstSkeletonPaint(): void {
+  const navigation = navigationTimingEntry();
+  if (!navigation) {
+    return;
+  }
+  const responseStart = finiteNonNegativeNumber(navigation.responseStart);
+  const responseEnd = finiteNonNegativeNumber(navigation.responseEnd);
+  const firstContentfulPaint = finiteNonNegativeNumber(
+    firstContentfulPaintTime(),
+  );
+  const firstPaintUpperBound = finiteNonNegativeNumber(
+    window.__appBootstrapFirstPaintUpperBound,
+  );
+  const skeletonPaint = firstContentfulPaint ?? firstPaintUpperBound;
+  if (
+    responseStart === undefined ||
+    responseEnd === undefined ||
+    skeletonPaint === undefined ||
+    responseEnd < responseStart ||
+    skeletonPaint < responseEnd
+  ) {
+    return;
+  }
+
+  runPostHog(() => {
+    posthog.capture(APP_FIRST_SKELETON_PAINT_EVENT, {
+      navigation_response_end_ms: Math.round(responseEnd),
+      navigation_response_start_ms: Math.round(responseStart),
+      paint_metric:
+        firstContentfulPaint === undefined
+          ? "after-first-paint-upper-bound"
+          : "first-contentful-paint",
+      response_end_to_skeleton_paint_ms: Math.round(
+        skeletonPaint - responseEnd,
+      ),
+      skeleton_paint_ms: Math.round(skeletonPaint),
     });
   });
 }

--- a/turbo/apps/platform/src/main.ts
+++ b/turbo/apps/platform/src/main.ts
@@ -1,6 +1,6 @@
 import "./lib/preview-bypass-cookie-bootstrap.ts";
 import { initSentry } from "./lib/sentry.ts";
-import { initPostHog } from "./lib/posthog.ts";
+import { captureFirstSkeletonPaint, initPostHog } from "./lib/posthog.ts";
 import { initPlausible } from "./lib/plausible.ts";
 import { setupVisualViewportKeyboardState } from "./lib/visual-viewport-keyboard.ts";
 import "./polyfill.ts";
@@ -20,6 +20,7 @@ function startApplication(): void {
   // Initialize Sentry before bootstrap so errors during startup are captured
   initSentry();
   initPostHog();
+  captureFirstSkeletonPaint();
 
   async function main() {
     const store = createStore();

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-locale.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-locale.test.ts
@@ -117,11 +117,15 @@ function executeMetadataEntrypoint(): void {
 const context = testContext();
 
 function bindBootstrapStateToSignal(): void {
+  window.__vm0AfterFirstPaint = (callback) => {
+    callback();
+  };
   context.signal.addEventListener(
     "abort",
     () => {
       Reflect.deleteProperty(window, "__vm0BrowserSupported");
       Reflect.deleteProperty(window, "__vm0BrowserUpgrade");
+      Reflect.deleteProperty(window, "__vm0AfterFirstPaint");
       Reflect.deleteProperty(window, "__vm0PreBundleCopy");
       delete document.documentElement.dataset.appBrandName;
       delete document.documentElement.dataset.appHeadManaged;
@@ -676,10 +680,10 @@ describe("bootstrap locale", () => {
     context.mocks.browser.language("en-US");
     context.store.set(activeOrgIdStorage.set$, TEST_ORG_ID);
     context.store.set(testLocaleStorage.set$, "id-ID");
-    executeLocaleEntrypoint();
     executeBrowserCompatibilityEntrypoint(
       "Mozilla/5.0 Chrome/100.0.0.0 Safari/537.36",
     );
+    executeLocaleEntrypoint();
 
     const metadata = document.createElement("meta");
     metadata.name = "description";
@@ -861,10 +865,10 @@ describe("bootstrap locale", () => {
   it("uses cached Spanish across pre-bundle UI and i18next", async () => {
     context.store.set(activeOrgIdStorage.set$, TEST_ORG_ID);
     context.store.set(testLocaleStorage.set$, "es-ES");
-    executeLocaleEntrypoint();
     executeBrowserCompatibilityEntrypoint(
       "Mozilla/5.0 Chrome/100.0.0.0 Safari/537.36",
     );
+    executeLocaleEntrypoint();
 
     const metadata = document.createElement("meta");
     metadata.name = "description";
@@ -996,10 +1000,10 @@ describe("bootstrap locale", () => {
     context.mocks.browser.language("en-US");
     context.store.set(activeOrgIdStorage.set$, TEST_ORG_ID);
     context.store.set(testLocaleStorage.set$, "hi-IN");
-    executeLocaleEntrypoint();
     executeBrowserCompatibilityEntrypoint(
       "Mozilla/5.0 Chrome/100.0.0.0 Safari/537.36",
     );
+    executeLocaleEntrypoint();
 
     const metadata = document.createElement("meta");
     metadata.name = "description";

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-phase-telemetry.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-phase-telemetry.test.ts
@@ -4,8 +4,11 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { detachedSetupPage, setupPage } from "../../__tests__/page-helper.ts";
 import {
+  APP_FIRST_SKELETON_PAINT_EVENT,
   BOOTSTRAP_PHASE_TIMING_EVENT,
   type BootstrapThreadMetadataSource,
+  captureFirstSkeletonPaint,
+  initPostHog,
 } from "../../lib/posthog.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { detachedNavigateTo$ } from "../route.ts";
@@ -20,7 +23,21 @@ type Identify = (
   distinctId: string,
   properties?: Record<string, unknown>,
 ) => void;
-type Init = (key: string, config?: Record<string, unknown>) => void;
+interface CapturedPostHogEvent {
+  readonly event: string;
+  readonly properties: Record<string, unknown>;
+  readonly timestamp?: string;
+  readonly uuid: string;
+  readonly [property: string]: unknown;
+}
+
+type BeforeSend = (
+  event: CapturedPostHogEvent | null,
+) => CapturedPostHogEvent | null;
+type Init = (
+  key: string,
+  config?: { readonly before_send?: BeforeSend },
+) => void;
 type Register = (properties: Record<string, unknown>) => void;
 type Reset = () => void;
 type Unregister = (property: string) => void;
@@ -99,6 +116,95 @@ function mockEmptyThreadMetadata(): void {
 }
 
 describe("bootstrap phase telemetry", () => {
+  it("captures response-to-skeleton paint from navigation and FCP entries", () => {
+    const navigationEntry = {
+      entryType: "navigation",
+      name: "https://private.example/path?token=private",
+      responseEnd: 86.6,
+      responseStart: 41.2,
+    } as PerformanceNavigationTiming;
+    const paintEntry = {
+      entryType: "paint",
+      name: "first-contentful-paint",
+      startTime: 98.4,
+    } as PerformanceEntry;
+    const entriesSpy = vi
+      .spyOn(performance, "getEntriesByType")
+      .mockImplementation((entryType) => {
+        if (entryType === "navigation") {
+          return [navigationEntry];
+        }
+        if (entryType === "paint") {
+          return [paintEntry];
+        }
+        return [];
+      });
+
+    try {
+      captureFirstSkeletonPaint();
+    } finally {
+      entriesSpy.mockRestore();
+    }
+
+    expect(posthog.capture).toHaveBeenCalledWith(
+      APP_FIRST_SKELETON_PAINT_EVENT,
+      {
+        navigation_response_end_ms: 87,
+        navigation_response_start_ms: 41,
+        paint_metric: "first-contentful-paint",
+        response_end_to_skeleton_paint_ms: 12,
+        skeleton_paint_ms: 98,
+      },
+    );
+    expect(JSON.stringify(posthog.capture.mock.lastCall)).not.toContain(
+      "private.example",
+    );
+  });
+
+  it("strips identifiers, URLs, and arbitrary paint properties at ingest", () => {
+    initPostHog();
+    const [, config] = posthog.init.mock.lastCall ?? [];
+    const beforeSend = config?.before_send;
+    if (!beforeSend) {
+      throw new Error("PostHog before_send was not configured");
+    }
+
+    const sanitized = beforeSend({
+      event: APP_FIRST_SKELETON_PAINT_EVENT,
+      properties: {
+        $current_url: "https://private.example/path?token=private",
+        arbitrary_payload: { secret: "private" },
+        distinct_id: "user_private",
+        navigation_response_end_ms: 87,
+        navigation_response_start_ms: 41,
+        paint_metric: "first-contentful-paint",
+        response_end_to_skeleton_paint_ms: 12,
+        skeleton_paint_ms: 98,
+        token: "attacker_private",
+      },
+      timestamp: "2026-08-31T00:00:00.000Z",
+      uuid: "event_public_uuid",
+    });
+
+    expect(sanitized).toStrictEqual({
+      event: APP_FIRST_SKELETON_PAINT_EVENT,
+      properties: {
+        $process_person_profile: false,
+        distinct_id: "app-bootstrap",
+        navigation_response_end_ms: 87,
+        navigation_response_start_ms: 41,
+        paint_metric: "first-contentful-paint",
+        public_brand: "vm0",
+        response_end_to_skeleton_paint_ms: 12,
+        skeleton_paint_ms: 98,
+        token: "phc_bootstrap_phase_telemetry_test",
+      },
+      timestamp: "2026-08-31T00:00:00.000Z",
+      uuid: "event_public_uuid",
+    });
+    expect(JSON.stringify(sanitized)).not.toContain("private");
+  });
+
   it("captures bounded bootstrap and cold thread metadata phases", async () => {
     mockEmptyThreadMetadata();
 

--- a/turbo/apps/platform/src/signals/__tests__/signup-attribution-conversion.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/signup-attribution-conversion.test.ts
@@ -84,7 +84,19 @@ function executeMarketingEntrypoint(): WindowWithMarketingQueue {
     "document",
     `${marketingEntrypointSource()}\n//# sourceURL=platform-marketing-entrypoint-test.js`,
   ) as MarketingEntrypointScript;
-  executeEntrypointScript(window, document);
+  const previousAfterFirstPaint = window.__vm0AfterFirstPaint;
+  window.__vm0AfterFirstPaint = (callback) => {
+    callback();
+  };
+  try {
+    executeEntrypointScript(window, document);
+  } finally {
+    if (previousAfterFirstPaint === undefined) {
+      Reflect.deleteProperty(window, "__vm0AfterFirstPaint");
+    } else {
+      window.__vm0AfterFirstPaint = previousAfterFirstPaint;
+    }
+  }
   // The marketing entrypoint has already attempted to schedule its external
   // script load. Restore real timers before bootstrapping Clerk and routes.
   timeout.mockRestore();

--- a/turbo/apps/platform/src/signals/__tests__/signup-attribution-conversion.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/signup-attribution-conversion.test.ts
@@ -85,9 +85,11 @@ function executeMarketingEntrypoint(): WindowWithMarketingQueue {
     `${marketingEntrypointSource()}\n//# sourceURL=platform-marketing-entrypoint-test.js`,
   ) as MarketingEntrypointScript;
   const previousAfterFirstPaint = window.__vm0AfterFirstPaint;
+  const previousBrowserSupported = window.__vm0BrowserSupported;
   window.__vm0AfterFirstPaint = (callback) => {
     callback();
   };
+  window.__vm0BrowserSupported = true;
   try {
     executeEntrypointScript(window, document);
   } finally {
@@ -95,6 +97,11 @@ function executeMarketingEntrypoint(): WindowWithMarketingQueue {
       Reflect.deleteProperty(window, "__vm0AfterFirstPaint");
     } else {
       window.__vm0AfterFirstPaint = previousAfterFirstPaint;
+    }
+    if (previousBrowserSupported === undefined) {
+      Reflect.deleteProperty(window, "__vm0BrowserSupported");
+    } else {
+      window.__vm0BrowserSupported = previousBrowserSupported;
     }
   }
   // The marketing entrypoint has already attempted to schedule its external

--- a/turbo/apps/platform/vite.config.ts
+++ b/turbo/apps/platform/vite.config.ts
@@ -8,6 +8,7 @@ import { defineConfig, type Plugin } from "vite";
 import { devArtifactFetchProxy } from "./dev-artifact-fetch-proxy.ts";
 import platformPackage from "./package.json";
 import { clerkCoreHtmlPlugin } from "./scripts/clerk-html.ts";
+import { deferredApplicationEntryHtmlPlugin } from "./scripts/deferred-entry-html.ts";
 import {
   VENDOR_MODULE_PATTERN,
   applicationJavaScriptBundlePlugin,
@@ -73,6 +74,7 @@ export default defineConfig(({ command }) => ({
     devArtifactFetchProxy(),
     clerkCoreHtmlPlugin(),
     runtimeBuildInfoHtmlPlugin,
+    deferredApplicationEntryHtmlPlugin(),
     applicationJavaScriptBundlePlugin(),
     // Sentry source map upload (production builds only)
     process.env.SENTRY_AUTH_TOKEN &&

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -761,6 +761,9 @@ importers:
       oxlint-tsgolint:
         specifier: 7.0.2001
         version: 7.0.2001
+      parse5:
+        specifier: 7.3.0
+        version: 7.3.0
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3


### PR DESCRIPTION
## Summary

- place the bootstrap skeleton, system-font critical CSS, theme selection, and browser-support gate before Clerk, localization/bootstrap work, Google Fonts, and application startup
- keep the first paint independent of external resources; immediately request the real three-layer avatar with async decoding after the skeleton DOM, reveal it only when complete, and use no placeholder avatar
- activate Clerk, app CSS, Google Fonts, and the app/module-preload graph only after observed skeleton FCP while preserving Clerk's single-runtime ordering
- externalize post-paint bootstrap callbacks, keep unsupported browsers on the upgrade UI without activating app/font/Clerk/avatar resources, and retain PWA/iOS viewport behavior
- add anonymous, allowlisted `app_first_skeleton_paint` telemetry for navigation response timing and skeleton paint while keeping `app_first_skeleton_hide` compatible
- enforce the deferred entry/runtime topology in build and Pages verification scripts

## Production baseline

The original production investigation on v0.812.5 measured five fresh-Chrome `/_/skeleton` samples:

- responseEnd P50: ~100 ms
- skeleton FCP P50: 592 ms
- responseEnd -> skeleton FCP P50: ~501 ms (390-918 ms)
- detailed trace: responseEnd 94 ms, skeleton discovery ~645 ms, skeleton FCP 668 ms

The same comparison protocol remeasured current production commit `a2660022` at 409.0 ms responseEnd -> FCP P50.

## Preview measurements

Preview: `https://pr-30484-app.omby.ai`, exact merge ref `bb8bb60998b1cbbb1ed58265a9ebe97072f3a079` containing head `71dfcaac45ee50da068d488f68b905587d0813c8`.

Protocol: independent new Chrome profiles per run, one second on `about:blank` so browser-process/root-compositor startup is excluded consistently, then a cold navigation with no page cache or storage reuse. Times are navigation-relative milliseconds.

| Metric (P50) | Production | PR preview | Delta |
| --- | ---: | ---: | ---: |
| `/_/skeleton` responseEnd -> FCP | 409.0 | 77.2 (10 runs) | -331.8 (-81.1%) |
| `/_/skeleton` FCP | 528.0 | 168.0 (10 runs) | -360.0 |
| `/_/skeleton` app module ready | 1282.0 | 1363.9 (10 runs) | +81.9 |
| `/sign-in` responseEnd -> FCP | 444.4 | 98.0 (5 runs) | -346.4 (-78.0%) |
| `/sign-in` app module ready | 1484.4 | 1451.5 (5 runs) | -32.9 |
| `/sign-in` skeleton hide | 2486.1 | 1487.5 (5 runs) | -998.6 |
| `/sign-in` first app content | 2485.8 | 1613.4 (5 runs) | -872.4 |
| `/sign-in` Clerk core response end | 430.9 | 478.6 (5 runs) | +47.7 |

The ten final `/_/skeleton` responseEnd -> FCP samples were **329.0, 71.7, 52.4, 49.1, 91.9, 81.6, 86.6, 80.1, 61.9, and 74.3 ms** (P50 77.2 ms). Nine of ten were at or below 91.9 ms; the 329 ms sample was a cold infrastructure outlier. In every sampled route, app and Clerk activation began after FCP.

A separate A/B under simultaneous browser-process startup measured the previous post-paint-avatar head at 215.4 ms P50 and the final immediate-real-avatar head at 216.8 ms P50. This confirms that starting the async SVG requests immediately does not measurably move first paint; the cold-process trace attributed that protocol's extra delay to Chrome root-surface initialization after the document had already painted.

## Visual and functional QA

- final exact-preview cold-navigation recording: https://cdn.vm0.io/artifacts/z0r0li0dqd.webm
- light and dark skeleton frames render with the real layered avatar and correct theme colors
- supported Chrome: skeleton is the first contentful UI; app, Clerk, font, and post-paint bootstrap activation starts after FCP
- unsupported Chrome 100: upgrade UI is visible, skeleton/root stay hidden, and avatar/app/font/Clerk resources remain inactive
- signed-out `/sign-in`: skeleton hides/removes cleanly and the complete Clerk form becomes visible
- mobile 390x844: exact viewport coverage, centered content, and no overflow
- PWA/iOS standalone viewport and safe-area behavior are covered by the focused entrypoint test
- authenticated shell: unavailable in this runner because no reusable authenticated Chrome profile exists

## Verification

- `pnpm --filter @okouai/app lint`
- `pnpm --filter @okouai/app check-types`
- `pnpm --filter @okouai/app lint:build-config` (16 checks)
- focused Clerk/locale/skeleton/telemetry/safe-area/Instatus Vitest set (61 passed)
- focused Clerk avatar/bootstrap ordering test (9 passed)
- `bash .github/scripts/tests/verify-okou-app-runtime-test.sh`
- `bash .github/scripts/tests/verify-okou-app-assets-test.sh`
- Pages Worker runtime test
- production hash-stability build for app, post-paint, vendor, runtime, and worker assets
- exact-head CI: Turbo, Security, CodeQL, Crates, Desktop, Runner Image, and Codecov passed

No full local Vitest run or local development server was used.

## Retained tradeoffs

- the first paint reserves the avatar's 64x64 layout box but shows no fake image; on a slow static-asset connection the real avatar appears after the text, once all three async SVG layers have loaded
- synthetic `/_/skeleton` app-module-ready P50 moved by +81.9 ms versus the five-run production comparison, while real `/sign-in` module ready improved by 32.9 ms and first app content improved by 872.4 ms
- brand localization and typewriter animation enhance after first paint, so the first frame uses safe English default copy
