### PR TITLE
test(rust): cover exec-control worker spawn failures

### DIFF
--- a/crates/vsock-guest/src/exec_control/forward.rs
+++ b/crates/vsock-guest/src/exec_control/forward.rs
@@ -2,7 +2,6 @@ use std::io;
 use std::os::unix::net::UnixStream;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
-use std::thread;
 use std::time::{Duration, Instant};
 
 use process_control_ipc::{ControlRequest, ControlResponseStatus};
@@ -10,6 +9,7 @@ use vsock_proto::{ExecControlNonce, ExecControlStatus, MSG_EXEC_CONTROL_RESULT};
 
 use crate::error::to_io_error;
 use crate::log::log;
+use crate::threading::{SystemThreadSpawner, ThreadSpawner};
 use crate::writer::GuestWriter;
 
 use super::sink::{ControlSinkState, ControlStreamLockError, PendingControlSlot};
@@ -50,15 +50,27 @@ pub(super) fn try_forward(
     request: OwnedExecControlRequest,
     writer: GuestWriter,
 ) -> Option<(ExecControlStatus, String)> {
+    try_forward_with_spawner(sink, request, writer, SystemThreadSpawner)
+}
+
+pub(super) fn try_forward_with_spawner<S>(
+    sink: Arc<ControlSinkState>,
+    request: OwnedExecControlRequest,
+    writer: GuestWriter,
+    spawner: S,
+) -> Option<(ExecControlStatus, String)>
+where
+    S: ThreadSpawner,
+{
     let pending_slot = match sink.reserve_pending_slot() {
         Ok(pending_slot) => pending_slot,
         Err(error) => return Some(error),
     };
 
-    match thread::Builder::new()
-        .name(THREAD_EXEC_CONTROL_FORWARD.to_owned())
-        .spawn(move || forward_control_request(sink, pending_slot, request, writer))
-    {
+    match spawner.spawn_unit(
+        THREAD_EXEC_CONTROL_FORWARD,
+        Box::new(move || forward_control_request(sink, pending_slot, request, writer)),
+    ) {
         Ok(_) => None,
         Err(error) => Some((
             ExecControlStatus::SinkError,

--- a/crates/vsock-guest/src/exec_control/tests/forwarding.rs
+++ b/crates/vsock-guest/src/exec_control/tests/forwarding.rs
@@ -1,3 +1,4 @@
+use std::io::Read;
 use std::os::unix::net::UnixStream;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -5,9 +6,14 @@ use std::time::Duration;
 
 use vsock_proto::{ExecControlStatus, MSG_EXEC_CONTROL_RESULT};
 
-use super::super::forward::{forward_control_request, try_forward};
+use crate::threading::test_support::FailingThreadSpawner;
+
+use super::super::forward::{forward_control_request, try_forward, try_forward_with_spawner};
 use super::super::sink::{ControlSinkInner, ControlSinkState};
-use super::super::{EXEC_REQUEST_TIMEOUT_DIAGNOSTIC, MAX_PENDING_CONTROL_REQUESTS};
+use super::super::{
+    EXEC_CONTROL_WORKER_START_ERROR_PREFIX, EXEC_REQUEST_TIMEOUT_DIAGNOSTIC,
+    MAX_PENDING_CONTROL_REQUESTS, THREAD_EXEC_CONTROL_FORWARD,
+};
 use super::support::{
     connected_sink, guest_writer_pair, owned_control_request, read_exec_control_result,
 };
@@ -83,6 +89,35 @@ fn exec_control_queue_full_rejects_without_leaking_pending_slots() {
 
     drop(pending_slots);
     assert_eq!(sink.pending.load(Ordering::Acquire), 0);
+}
+#[test]
+fn exec_control_worker_spawn_failure_releases_slot_without_forwarding_payload() {
+    let (sink, mut peer) = connected_sink();
+    peer.set_nonblocking(true).unwrap();
+    let (writer, _host) = guest_writer_pair();
+
+    let immediate = try_forward_with_spawner(
+        Arc::clone(&sink),
+        owned_control_request(31, 18, 5000, "msg-spawn-fails"),
+        writer,
+        FailingThreadSpawner::fail_once(THREAD_EXEC_CONTROL_FORWARD),
+    )
+    .expect("worker spawn failure should return an immediate result");
+
+    assert_eq!(immediate.0, ExecControlStatus::SinkError);
+    assert_eq!(
+        immediate.1,
+        format!(
+            "{EXEC_CONTROL_WORKER_START_ERROR_PREFIX}: injected thread spawn failure for {THREAD_EXEC_CONTROL_FORWARD}"
+        )
+    );
+    assert_eq!(sink.pending.load(Ordering::Acquire), 0);
+
+    let mut byte = [0u8];
+    let error = peer
+        .read(&mut byte)
+        .expect_err("failed forwarding worker should not send a control request");
+    assert_eq!(error.kind(), std::io::ErrorKind::WouldBlock);
 }
 #[test]
 fn pending_control_slot_holds_existing_slot_until_drop() {


### PR DESCRIPTION
## Summary

- route exec-control forwarding launches through the existing crate `ThreadSpawner` while preserving the production `SystemThreadSpawner` entry
- inject a deterministic named worker-launch failure after pending capacity is reserved
- verify the immediate `SinkError` diagnostic, pending-slot release, and absence of process-control request bytes

## Scope

- no public API or wire-protocol changes
- no migration, deployment compatibility, or documentation changes
- existing successful handler-level forwarding coverage remains unchanged

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo xtask check-rust-path-attributes`
- `cd crates && cargo test -p vsock-guest exec_control::tests::forwarding`
- `cd crates && cargo test -p vsock-guest`
- `cd crates && cargo clippy --all-targets --all-features`
- `cd crates && cargo clippy -p vsock-guest --release --no-default-features --all-targets`
- `cd crates && cargo doc --workspace --all-features --no-deps`

Closes #30471
