### PR TITLE
fix(connectors): inject zoom oauth credentials

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -394,6 +394,7 @@ runs:
           GUMROAD
           MERCURY
           SPOTIFY
+          ZOOM
         )
         for prefix in "${oauth_client_config_prefixes[@]}"; do
           add_oauth_client_config "$prefix"

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -618,6 +618,8 @@ assert_env_value "$success_env_file" GH_OAUTH_CLIENT_ID "doppler-GH_OAUTH_CLIENT
 assert_env_value "$success_env_file" GH_OAUTH_CLIENT_SECRET "doppler-GH_OAUTH_CLIENT_SECRET"
 assert_env_value "$success_env_file" SLACK_OAUTH_CLIENT_ID "doppler-SLACK_OAUTH_CLIENT_ID"
 assert_env_value "$success_env_file" SLACK_OAUTH_CLIENT_SECRET "doppler-SLACK_OAUTH_CLIENT_SECRET"
+assert_env_value "$success_env_file" ZOOM_OAUTH_CLIENT_ID "doppler-ZOOM_OAUTH_CLIENT_ID"
+assert_env_value "$success_env_file" ZOOM_OAUTH_CLIENT_SECRET "doppler-ZOOM_OAUTH_CLIENT_SECRET"
 assert_env_value "$success_env_file" BOX_OAUTH_CLIENT_ID "doppler-BOX_OAUTH_CLIENT_ID"
 assert_env_value "$success_env_file" BOX_OAUTH_CLIENT_SECRET "doppler-BOX_OAUTH_CLIENT_SECRET"
 assert_env_value "$success_env_file" QUICKBOOKS_OAUTH_CLIENT_ID "doppler-QUICKBOOKS_OAUTH_CLIENT_ID"


### PR DESCRIPTION
## Summary

- inject the Zoom OAuth client ID and secret from Doppler into shared Web/API deployment environments
- cover both Zoom OAuth values in the environment renderer regression test

## Root cause

The connector catalog and Turbo environment allowlist already referenced `ZOOM_OAUTH_CLIENT_ID` and `ZOOM_OAUTH_CLIENT_SECRET`, but the shared deployment renderer omitted the `ZOOM` prefix. As a result, preview and production Vercel deployments did not receive the credentials.

## Operational readiness

- confirmed the existing Doppler `prd` Zoom OAuth values are populated
- populated the previously empty Doppler `dev` Zoom OAuth values from the established credential pair without logging secret values
- confirmed both keys are now populated in `dev` and `prd`

## Verification

- `bash .github/scripts/tests/web-api-env-action-test.sh`
- `bash -n .github/scripts/tests/web-api-env-action-test.sh`
- `pnpm exec prettier --check ../.github/actions/web-api-env/action.yml`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `git diff --check`
