### PR TITLE
fix(python): preserve capture fields on connection errors

### DIFF
--- a/crates/runner/mitm-addon/src/body_capture.py
+++ b/crates/runner/mitm-addon/src/body_capture.py
@@ -420,7 +420,12 @@ def _set_body_fields(
     log_entry[f"{side}_body_encoding"] = encoding
 
 
-def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
+def add_capture_fields(
+    flow: http.HTTPFlow,
+    log_entry: dict,
+    *,
+    response_incomplete: bool = False,
+) -> None:
     """Add capture-mode request/response fields to ``log_entry`` in place.
 
     # [NETWORK_LOG_FIELDS] — capture-only fields in the shared network log schema.
@@ -462,6 +467,11 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
 
     Request bodies prefer request streaming metadata when requestheaders()
     installed a safe capped stream before mitmproxy buffered the body.
+
+    ``response_incomplete`` marks response capture as semantically incomplete
+    when a terminal error interrupts delivery. It is separate from the stream
+    buffer's size-limit truncation state so an arbitrary interrupted UTF-8
+    prefix preserves its exact bytes.
 
     Response bodies prefer streaming metadata from
     ``response_streaming.configure_response_stream()`` because that path keeps a
@@ -560,7 +570,7 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
                 log_entry,
                 "response",
                 raw_response_body,
-                truncated=stream_truncated,
+                truncated=stream_truncated or response_incomplete,
             )
             return
 
@@ -581,7 +591,7 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
                 log_entry,
                 "response",
                 raw_response_body,
-                truncated=stream_truncated,
+                truncated=stream_truncated or response_incomplete,
             )
             return
         res_ct = response_dependency_headers.get("content-type", "")
@@ -591,5 +601,6 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
             "response",
             body,
             res_ct,
+            already_truncated=response_incomplete,
             truncated_at_limit=stream_truncated,
         )

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1959,6 +1959,9 @@ def _handle_error(flow: http.HTTPFlow) -> None:
         )
         log_entry["error"] = error_msg
 
+        if flow_metadata.should_capture_body(flow.metadata):
+            body_capture.add_capture_fields(flow, log_entry, response_incomplete=True)
+
         log_http_network_entry(network_log_path, log_entry, raw_url)
 
     # Report proxy-extracted usage for model provider responses.

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -241,10 +241,67 @@ class TestErrorHandler:
         assert entry["status"] == 0
         assert entry["request_size"] == len(b"partial request")
         assert entry["error"] == "connection reset by peer"
+        assert entry["request_headers"] == {
+            "Host": "***",
+            "Authorization": "***",
+        }
+        assert entry["request_body"] == "partial request"
+        assert entry["request_body_encoding"] == "utf-8"
+        assert entry["request_body_truncated"] is True
         assert "firewall_error" not in entry
         assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
         assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
         assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY not in flow.metadata
+
+    def test_error_captures_partial_streamed_response_before_cleanup(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        flow = real_flow(
+            with_response=False,
+            host="api.example.com",
+        )
+        log_path = tmp_path / "network.jsonl"
+        flow.metadata[metadata_keys.SANDBOX_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.SANDBOX_NETWORK_LOG_PATH] = str(log_path)
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.CAPTURE_BODY] = True
+        http_network_log.set_target(
+            flow,
+            url="https://api.example.com/",
+            host="api.example.com",
+            port=443,
+        )
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map(
+                {
+                    "content-type": "text/plain",
+                    "set-cookie": "session=secret",
+                }
+            ),
+        )
+
+        mitm_addon.responseheaders(flow)
+        assert response_stream(flow)(b"partial response") == b"partial response"
+        flow.error = Error("connection reset by peer")
+
+        with mitm_ctx():
+            mitm_addon.error(flow)
+
+        [entry] = read_jsonl_entries_after_flush(log_path)
+        assert entry["status"] == 0
+        assert entry["error"] == "connection reset by peer"
+        assert entry["response_headers"] == {
+            "content-type": "text/plain",
+            "set-cookie": "***",
+        }
+        assert entry["response_body"] == "partial response"
+        assert entry["response_body_encoding"] == "utf-8"
+        assert entry["response_body_truncated"] is True
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
+        assert flow.response.stream is False
 
     async def test_browser_connector_candidate_error_keeps_original_error(
         self, tmp_path, real_flow, mitm_ctx, headers
@@ -479,6 +536,18 @@ class TestErrorHandler:
         assert entry["latency_ms"] > 0
         assert_utc_millisecond_timestamp(entry["timestamp"])
         assert flow.metadata[metadata_keys.ORIGINAL_URL] == raw_url
+        assert {
+            "request_headers",
+            "request_headers_truncated",
+            "request_body",
+            "request_body_encoding",
+            "request_body_truncated",
+            "response_headers",
+            "response_headers_truncated",
+            "response_body",
+            "response_body_encoding",
+            "response_body_truncated",
+        }.isdisjoint(entry)
 
     def test_error_log_omits_url_when_json_escaping_exceeds_line_budget(
         self, tmp_path, real_flow, mitm_ctx

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -165,7 +165,6 @@ class TestErrorHandler:
         assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
         assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
         assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY not in flow.metadata
-        assert flow.request.stream is False
 
     def test_header_phase_connector_diagnostic_error_keeps_connection_error(
         self, tmp_path, real_flow, mitm_ctx
@@ -253,6 +252,7 @@ class TestErrorHandler:
         assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
         assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
         assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY not in flow.metadata
+        assert flow.request.stream is False
 
     def test_error_captures_partial_streamed_response_before_cleanup(
         self, tmp_path, real_flow, mitm_ctx

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -165,6 +165,7 @@ class TestErrorHandler:
         assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
         assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
         assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY not in flow.metadata
+        assert flow.request.stream is False
 
     def test_header_phase_connector_diagnostic_error_keeps_connection_error(
         self, tmp_path, real_flow, mitm_ctx
@@ -299,6 +300,7 @@ class TestErrorHandler:
         assert entry["response_body"] == "partial response"
         assert entry["response_body_encoding"] == "utf-8"
         assert entry["response_body_truncated"] is True
+        assert metadata_keys.RESPONSE_STREAM_STATE not in flow.metadata
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
         assert flow.response.stream is False


### PR DESCRIPTION
## Summary

- add the existing sanitized request/response capture fields to capture-enabled HTTP connection-error network entries
- represent interrupted response prefixes as incomplete without conflating interruption with the capture-size boundary
- cover partial request and response streams, capture-disabled compatibility, and terminal cleanup through the `error()` integration boundary

## Scope

- no shared schema, database, API, UI, CLI, runner protocol, or migration changes
- normal response capture behavior and existing sanitization/size limits remain unchanged

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (7,245 passed)

Closes #30473
