### PR TITLE
fix(runner): retry unpublished status snapshots

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -80,7 +80,7 @@ use crate::resource_budget::ResourceBudget;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::run_cancellation::{RunCancellationRegistration, RunCancellationRegistry};
 use crate::runner_process_identity::RunnerProcessIdentity;
-use crate::status::{StatusTracker, remove_stale_status_file};
+use crate::status::{StatusResult, StatusTracker, remove_stale_status_file};
 use crate::workspace_image_cache::{
     WorkspaceCacheChange, WorkspaceCacheWatcher, WorkspaceImageCache,
 };
@@ -237,6 +237,19 @@ fn workspace_cache_gc_future(cache: WorkspaceImageCache) -> WorkspaceCacheGcFutu
 async fn next_workspace_cache_gc(
     future: &mut Option<WorkspaceCacheGcFuture>,
 ) -> RunnerResult<Option<u64>> {
+    match future {
+        Some(future) => future.await,
+        None => std::future::pending().await,
+    }
+}
+
+type StatusRetryFuture = BoxFuture<'static, StatusResult<()>>;
+
+fn status_retry_future(status: Arc<StatusTracker>) -> StatusRetryFuture {
+    Box::pin(async move { status.retry_unpublished_snapshot().await })
+}
+
+async fn next_status_retry(future: &mut Option<StatusRetryFuture>) -> StatusResult<()> {
     match future {
         Some(future) => future.await,
         None => std::future::pending().await,
@@ -1957,6 +1970,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     workspace_cache_reconciliation_tick
         .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut workspace_cache_gc_fut = None;
+    let mut status_retry_fut = None;
     let mut draining_idle_pool_drained = false;
     let mut pending_finalizing_candidate = None;
     let mut terminal_error = None;
@@ -2187,6 +2201,12 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     ),
                 }
             }
+            result = next_status_retry(&mut status_retry_fut) => {
+                status_retry_fut = None;
+                if let Err(error) = result {
+                    warn!(%error, "failed to retry unpublished runner status");
+                }
+            }
             _ = workspace_cache_gc_tick.tick() => {
                 if workspace_cache_gc_fut.is_none()
                     && let Some(cache) = exec_config.workspace_cache.clone()
@@ -2287,6 +2307,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             _ = heartbeat_tick.tick() => {
                 let live_mode = *mode_rx.borrow();
                 heartbeat.request(live_mode)?;
+                if status_retry_fut.is_none() {
+                    status_retry_fut = Some(status_retry_future(Arc::clone(&shared.status)));
+                }
                 #[cfg(test)]
                 test_hooks
                     .test_observer
@@ -2380,6 +2403,11 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
 
     let phase = teardown.phase_start("heartbeat_drain");
     heartbeat.drain().await;
+    if let Some(retry) = status_retry_fut.take()
+        && let Err(error) = retry.await
+    {
+        warn!(%error, "failed to finish runner status retry during teardown");
+    }
     let final_heartbeat_sequence = heartbeat.into_next_snapshot_sequence();
     teardown.phase_complete("heartbeat_drain", phase);
 
@@ -2477,6 +2505,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         )
         .await;
         teardown.phase_complete("orphan_reap_shutdown_final", phase);
+    }
+    if let Err(error) = shared.status.retry_unpublished_snapshot().await {
+        warn!(%error, "failed to publish final runner status snapshot");
     }
     // Wait for any in-flight destroy tasks (from capacity or profile-mismatch
     // eviction) so their factory Arcs are dropped before the

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -2506,9 +2506,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         .await;
         teardown.phase_complete("orphan_reap_shutdown_final", phase);
     }
-    if let Err(error) = shared.status.retry_unpublished_snapshot().await {
-        warn!(%error, "failed to publish final runner status snapshot");
-    }
     // Wait for any in-flight destroy tasks (from capacity or profile-mismatch
     // eviction) so their factory Arcs are dropped before the
     // factory shutdown ownership preflight.
@@ -2611,6 +2608,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     let phase = teardown.phase_start("status_stopped");
     if let Err(error) = shared.status.set_mode(RunnerMode::Stopped).await {
         warn!(%error, "failed to persist final stopped runner status");
+    }
+    if let Err(error) = shared.status.retry_unpublished_snapshot().await {
+        warn!(%error, "failed to publish final runner status snapshot");
     }
     teardown.phase_complete("status_stopped", phase);
     info!(total_teardown_ms = teardown.elapsed_ms(), "runner stopped");

--- a/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
@@ -3,8 +3,10 @@ use super::super::support::{
     MockRunEnv, assert_run_exits_within, minimal_context, mock_run_config,
     mock_run_config_with_delay, mock_run_config_with_overrides, push_job, shutdown, test_profiles,
     wait_budget_count, wait_budget_exhausted_reactor, wait_cancel_token, wait_cancel_token_removed,
-    wait_discover_entered, wait_status_mode,
+    wait_discover_entered, wait_status_idle_reuse_keys_and_active_runs, wait_status_mode,
 };
+use crate::status::StatusPersistenceError;
+use sandbox::SandboxId;
 use std::sync::Arc;
 
 async fn wait_for_blocked_routine_heartbeat(env: &MockRunEnv) {
@@ -36,6 +38,50 @@ async fn trigger_routine_heartbeat(
     env.start_observer
         .wait_routine_heartbeat_requested_after(cursor, expected_mode, Duration::from_secs(5))
         .await;
+}
+
+#[tokio::test]
+async fn routine_heartbeat_retries_unpublished_status() {
+    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let (heartbeat_trigger, heartbeat_trigger_rx) = tokio::sync::mpsc::unbounded_channel();
+    config.test_hooks.manual_routine_heartbeat_rx = Some(heartbeat_trigger_rx);
+    let status_parent = env._temp_dir.path().join("status-state");
+    let unavailable_parent = env._temp_dir.path().join("status-state-unavailable");
+    tokio::fs::create_dir(&status_parent).await.unwrap();
+    let status_path = status_parent.join("status.json");
+    let status = Arc::new(StatusTracker::new(status_path.clone(), 4, None, None));
+    config.shared.status = Arc::clone(&status);
+    let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+    let run_id = RunId::new_v4();
+    let sandbox_id = SandboxId::new_v4();
+    status.add_run(run_id, sandbox_id).await.unwrap();
+    wait_status_idle_reuse_keys_and_active_runs(
+        &status_path,
+        &[],
+        &[run_id.to_string()],
+        Duration::from_secs(5),
+    )
+    .await;
+
+    tokio::fs::rename(&status_parent, &unavailable_parent)
+        .await
+        .unwrap();
+    let error = status
+        .remove_run_if_matching(run_id, sandbox_id)
+        .await
+        .unwrap_err();
+    assert!(matches!(error, StatusPersistenceError::Write { .. }));
+    tokio::fs::rename(&unavailable_parent, &status_parent)
+        .await
+        .unwrap();
+
+    trigger_routine_heartbeat(&heartbeat_trigger, &env, RunnerMode::Running).await;
+    wait_status_idle_reuse_keys_and_active_runs(&status_path, &[], &[], Duration::from_secs(5))
+        .await;
+
+    shutdown(&env, run_handle).await;
 }
 
 // -----------------------------------------------------------------------

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -3,6 +3,7 @@ use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
@@ -112,10 +113,6 @@ struct StatusSnapshot {
     status: RunnerStatus,
 }
 
-struct PersistenceState {
-    published_generation: u64,
-}
-
 struct SerializedStatusSnapshot {
     generation: u64,
     json: String,
@@ -127,7 +124,8 @@ struct DelayedPersistenceState {
 }
 
 struct PersistenceCoordinator {
-    ordering: Arc<Mutex<PersistenceState>>,
+    ordering: Arc<Mutex<()>>,
+    published_generation: AtomicU64,
     delayed: std::sync::Mutex<DelayedPersistenceState>,
     #[cfg(test)]
     settled: tokio::sync::Notify,
@@ -138,7 +136,7 @@ type StatusWriteFuture = Pin<Box<dyn Future<Output = StatusResult<()>> + Send + 
 enum InFlightStatusWriteState {
     Active {
         write: StatusWriteFuture,
-        ordering: OwnedMutexGuard<PersistenceState>,
+        ordering: OwnedMutexGuard<()>,
     },
     Complete,
 }
@@ -154,9 +152,8 @@ struct InFlightStatusWrite {
 impl PersistenceCoordinator {
     fn new() -> Self {
         Self {
-            ordering: Arc::new(Mutex::new(PersistenceState {
-                published_generation: 0,
-            })),
+            ordering: Arc::new(Mutex::new(())),
+            published_generation: AtomicU64::new(0),
             delayed: std::sync::Mutex::new(DelayedPersistenceState {
                 active: false,
                 pending: None,
@@ -215,7 +212,7 @@ impl PersistenceCoordinator {
 impl InFlightStatusWrite {
     fn new(
         write: StatusWriteFuture,
-        ordering: OwnedMutexGuard<PersistenceState>,
+        ordering: OwnedMutexGuard<()>,
         persistence: Arc<PersistenceCoordinator>,
         path: PathBuf,
         generation: u64,
@@ -235,10 +232,10 @@ impl InFlightStatusWrite {
             InFlightStatusWriteState::Active { write, .. } => write.as_mut().await,
             InFlightStatusWriteState::Complete => return Ok(()),
         };
-        if result.is_ok()
-            && let InFlightStatusWriteState::Active { ordering, .. } = &mut self.state
-        {
-            ordering.published_generation = self.generation;
+        if result.is_ok() {
+            self.persistence
+                .published_generation
+                .store(self.generation, Ordering::Release);
         }
         self.state = InFlightStatusWriteState::Complete;
         result
@@ -274,7 +271,7 @@ impl Drop for InFlightStatusWrite {
 
 async fn continue_in_flight_status_write(
     write: StatusWriteFuture,
-    mut ordering: OwnedMutexGuard<PersistenceState>,
+    _ordering: OwnedMutexGuard<()>,
     persistence: Arc<PersistenceCoordinator>,
     path: PathBuf,
     generation: u64,
@@ -282,11 +279,13 @@ async fn continue_in_flight_status_write(
     if let Err(error) = write.await {
         warn!(generation, %error, "in-flight status persistence later failed");
     } else {
-        ordering.published_generation = generation;
+        persistence
+            .published_generation
+            .store(generation, Ordering::Release);
     }
     while let Some(pending) = persistence.take_pending_or_finish() {
         let pending_generation = pending.generation;
-        if ordering.published_generation >= pending_generation {
+        if persistence.published_generation.load(Ordering::Acquire) >= pending_generation {
             continue;
         }
         if let Err(source) =
@@ -302,7 +301,9 @@ async fn continue_in_flight_status_write(
                 "deferred status persistence failed"
             );
         } else {
-            ordering.published_generation = pending_generation;
+            persistence
+                .published_generation
+                .store(pending_generation, Ordering::Release);
         }
     }
 }
@@ -589,13 +590,36 @@ impl StatusTracker {
             let mut state = self.state.lock().await;
             let removed = matches!(state.active_runs.get(&run_id), Some(current) if current.sandbox_id == sandbox_id);
             if !removed {
-                return Ok(false);
+                None
+            } else {
+                state.active_runs.remove(&run_id);
+                Some(self.capture_changed_snapshot(&mut state))
             }
-            state.active_runs.remove(&run_id);
-            self.capture_changed_snapshot(&mut state)
+        };
+        let Some(snapshot) = snapshot else {
+            self.retry_unpublished_snapshot().await?;
+            return Ok(false);
         };
         self.persist_snapshot(snapshot).await?;
         Ok(true)
+    }
+
+    /// Publish the current whole status when requested state is newer than the
+    /// latest successful publication.
+    pub async fn retry_unpublished_snapshot(&self) -> StatusResult<()> {
+        let snapshot = {
+            let mut state = self.state.lock().await;
+            if self
+                .persistence
+                .published_generation
+                .load(Ordering::Acquire)
+                >= state.generation
+            {
+                return Ok(());
+            }
+            self.capture_changed_snapshot(&mut state)
+        };
+        self.persist_snapshot(snapshot).await
     }
 
     /// Replace the idle sandbox list only if the snapshot is at least as new as the
@@ -732,7 +756,7 @@ impl StatusTracker {
                 });
             }
         };
-        if ordering.published_generation >= serialized.generation {
+        if persistence.published_generation.load(Ordering::Acquire) >= serialized.generation {
             return Ok(());
         }
 
@@ -816,6 +840,17 @@ mod tests {
         serde_json::from_str(&content).unwrap()
     }
 
+    async fn assert_latest_generation_published(tracker: &StatusTracker) {
+        let requested_generation = tracker.state.lock().await.generation;
+        assert_eq!(
+            tracker
+                .persistence
+                .published_generation
+                .load(Ordering::Acquire),
+            requested_generation,
+        );
+    }
+
     #[tokio::test]
     async fn write_initial_creates_file() {
         let dir = tempfile::tempdir().unwrap();
@@ -830,6 +865,7 @@ mod tests {
         assert!(status["active_runs"].as_array().unwrap().is_empty());
         assert!(status["started_at"].as_str().is_some());
         assert!(status["updated_at"].as_str().is_some());
+        assert_latest_generation_published(&tracker).await;
     }
 
     #[tokio::test]
@@ -918,6 +954,7 @@ mod tests {
         tracker.set_mode(RunnerMode::Running).await.unwrap();
         let status = read_status(&path);
         assert_eq!(status["mode"], "running");
+        assert_latest_generation_published(&tracker).await;
     }
 
     #[tokio::test(start_paused = true)]
@@ -962,6 +999,7 @@ mod tests {
         );
         let status = read_status(&path);
         assert_eq!(status["mode"], "running");
+        assert_latest_generation_published(&tracker).await;
     }
 
     #[tokio::test]
@@ -1020,6 +1058,94 @@ mod tests {
         tracker.set_mode(RunnerMode::Running).await.unwrap();
         let status = read_status(&path);
         assert_eq!(status["mode"], "running");
+        assert_latest_generation_published(&tracker).await;
+    }
+
+    #[tokio::test]
+    async fn remove_run_if_matching_retries_failed_publication_without_another_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("status");
+        let unavailable_parent = dir.path().join("status-unavailable");
+        tokio::fs::create_dir(&parent).await.unwrap();
+        let path = parent.join("status.json");
+        let tracker = StatusTracker::new(path.clone(), 4, None, None);
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        tracker.add_run(run_id, sandbox_id).await.unwrap();
+
+        tokio::fs::rename(&parent, &unavailable_parent)
+            .await
+            .unwrap();
+        let error = tracker
+            .remove_run_if_matching(run_id, sandbox_id)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, StatusPersistenceError::Write { .. }));
+        tokio::fs::rename(&unavailable_parent, &parent)
+            .await
+            .unwrap();
+
+        assert!(
+            !tracker
+                .remove_run_if_matching(run_id, sandbox_id)
+                .await
+                .unwrap()
+        );
+
+        let status = read_status(&path);
+        assert!(status["active_runs"].as_array().unwrap().is_empty());
+        assert_latest_generation_published(&tracker).await;
+    }
+
+    #[tokio::test]
+    async fn failed_removal_retry_publishes_replacement_sandbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("status");
+        let unavailable_parent = dir.path().join("status-unavailable");
+        tokio::fs::create_dir(&parent).await.unwrap();
+        let path = parent.join("status.json");
+        let tracker = StatusTracker::new(path.clone(), 4, None, None);
+        let run_id = RunId::new_v4();
+        let old_sandbox_id = SandboxId::new_v4();
+        let current_sandbox_id = SandboxId::new_v4();
+        tracker.add_run(run_id, old_sandbox_id).await.unwrap();
+
+        tokio::fs::rename(&parent, &unavailable_parent)
+            .await
+            .unwrap();
+        let removal_error = tracker
+            .remove_run_if_matching(run_id, old_sandbox_id)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            removal_error,
+            StatusPersistenceError::Write { .. }
+        ));
+        let replacement_error = tracker
+            .add_run(run_id, current_sandbox_id)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            replacement_error,
+            StatusPersistenceError::Write { .. }
+        ));
+        tokio::fs::rename(&unavailable_parent, &parent)
+            .await
+            .unwrap();
+
+        assert!(
+            !tracker
+                .remove_run_if_matching(run_id, old_sandbox_id)
+                .await
+                .unwrap()
+        );
+
+        let status = read_status(&path);
+        let runs = status["active_runs"].as_array().unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0]["run_id"], run_id.to_string());
+        assert_eq!(runs[0]["sandbox_id"], current_sandbox_id.to_string());
+        assert_latest_generation_published(&tracker).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- track the highest successfully published runner-status generation separately from requested in-memory state
- retry the current whole snapshot when a matching removal is already absent, on routine heartbeats, and during teardown
- cover real filesystem write failures, replacement sandbox safety, and the heartbeat retry owner

## Scope

- no `status.json` schema change
- no API, queue, runner protocol, database, or migration change
- no dedicated timer, detached retry task, or unbounded retry loop

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-features status::tests:: -- --nocapture`
- `cargo test -p runner --all-features cmd::start::tests::main_loop::heartbeat::routine_heartbeat_retries_unpublished_status -- --nocapture`
- `cargo test -p runner --all-features`

Closes #30450
