### PR TITLE
feat(chrome-recorder): add the okou tab recording extension

### DIFF
--- a/.github/release-please-workspace-exclusions.json
+++ b/.github/release-please-workspace-exclusions.json
@@ -1,5 +1,6 @@
 {
   "crates/xtask": "Development-only Rust task runner",
+  "turbo/apps/chrome-recorder": "Unpublished Chrome extension bundle distributed through the Chrome Web Store",
   "turbo/packages/api-services": "Unshipped package with no workspace consumer",
   "turbo/packages/eslint-config": "Development-only lint configuration",
   "turbo/packages/eslint-rules": "Development-only lint rules",

--- a/turbo/apps/chrome-recorder/README.md
+++ b/turbo/apps/chrome-recorder/README.md
@@ -1,0 +1,95 @@
+# Okou Screen Recorder
+
+Manifest V3 Chrome extension that records a browser tab with Okou's controls
+rendered inside the page being recorded.
+
+## Local build
+
+```bash
+pnpm --dir turbo --filter @okouai/chrome-recorder build
+```
+
+Load `turbo/apps/chrome-recorder/dist` from `chrome://extensions` with **Load
+unpacked**.
+
+## User flow
+
+1. Click the Okou toolbar action.
+2. The extension checks the Okou sign-in state through the `__session` and
+   `__client_uat` cookies on the Okou origin. When no session exists it opens
+   `app.okou.ai` and marks the action; sign in and click the action again.
+3. Chrome's native share picker opens. Only the **Chrome Tab** surface is
+   accepted — window and full-screen capture are refused, because the page
+   controls and DOM blur exist only inside a tab.
+4. The chosen page shows the ready panel: microphone, tab audio, **Blur
+   elements**, and **Start recording**.
+5. **Start recording** runs a `3 · 2 · 1` countdown inside the page. Capture
+   begins only after it finishes, so the countdown never lands in the file.
+6. The recording controller stays in the page: elapsed time, pause, resume,
+   finish, and discard. Chrome's own **Stop sharing** finishes immediately.
+7. The finished WebM is written to the extension's IndexedDB, a new Okou tab
+   opens with `?okouRecorderSession=<id>`, and the recording is handed to the
+   application. The extension copy is deleted once the application acknowledges
+   it.
+
+## Architecture
+
+| Context            | File                    | Responsibility                                                               |
+| ------------------ | ----------------------- | ---------------------------------------------------------------------------- |
+| Service worker     | `src/service-worker.ts` | Sign-in check, session state, tab routing, opening the Okou handoff tab      |
+| Offscreen document | `src/offscreen.ts`      | `getDisplayMedia`, microphone mixing, `MediaRecorder`, storing the result    |
+| Content script     | `src/content.ts`        | Overlay lifecycle in the recorded tab, handoff bridge on the Okou tab        |
+| Overlay            | `src/overlay.ts`        | Ready panel, blur mode, countdown, recording controller                      |
+| Blur               | `src/blur-manager.ts`   | Element selection and blur persistence                                       |
+| Handoff frame      | `src/handoff.ts`        | Reads the recording from extension IndexedDB and posts it to the application |
+
+Capture lives in the offscreen document rather than the content script so the
+stream and `MediaRecorder` survive navigation inside the recorded tab.
+
+## Element blur
+
+Blur is applied to the pixels before they reach `MediaRecorder`, so the video
+file itself is redacted; there is no post-processing step and no unblurred copy.
+
+Selecting an element sets an inline `filter: blur(10px) !important` on that
+element, so the blur travels with it while the page scrolls. Pages also destroy
+and rebuild those nodes — virtualized lists, infinite scroll, SPA re-renders —
+so each selection additionally stores a selector, preferring `id` and stable
+test/ARIA attributes and falling back to a structural path. A `MutationObserver`
+on `childList`, `style`, and `class`, plus a capture-phase `scroll` listener,
+re-applies the blur to every current match and drops detached nodes.
+
+Known limits: the extension cannot reach `chrome://` pages, the Chrome Web
+Store, or native applications, and elements rendered inside a single `canvas` or
+`<video>` cannot be selected individually.
+
+## Application handoff
+
+`packages/core/src/browser-recorder-protocol.ts` holds the contract shared with
+the Okou application. The recording lives in extension-origin IndexedDB, which
+page scripts cannot read, so `handoff.html` is loaded as a hidden
+extension-origin iframe and the content script relays structured-clone messages
+between it and the application:
+
+1. Application → `handoff:ready`
+2. Extension → `handoff:recording` (or `handoff:error`)
+3. Application → `handoff:complete`, after which the extension deletes its copy
+
+The application side of this exchange — receiving `handoff:recording`, opening
+the source dialog, and uploading — is not implemented yet.
+
+## Verification
+
+`pnpm --dir turbo --filter @okouai/chrome-recorder test` covers the blur manager
+and the overlay state machine in `happy-dom`.
+
+Verified by hand in Chromium 151 with the unpacked build loaded: the service
+worker starts, `chrome.cookies` reads the Okou sign-in state with no Okou tab
+open, `getDisplayMedia` succeeds from the offscreen document without a user
+gesture, the ready panel renders in the recorded page, clicking an element
+blurs it, the blur re-applies to a recycled node after a scroll re-render, and
+the countdown sends `start` to the service worker.
+
+Not verified: headless Chromium resolves every `getDisplayMedia` call to a
+synthetic monitor, so the `displaySurface === "browser"` guard that refuses
+non-tab capture has not been exercised against a real tab selection.

--- a/turbo/apps/chrome-recorder/package.json
+++ b/turbo/apps/chrome-recorder/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@okouai/chrome-recorder",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsup && node scripts/copy-static.mjs",
+    "check-types": "tsc --noEmit",
+    "lint": "oxlint src --deny-warnings",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@okouai/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@okouai/typescript-config": "workspace:*",
+    "@types/chrome": "^0.1.6",
+    "happy-dom": "^20.11.1",
+    "oxlint": "^1.75.0",
+    "tsup": "^8.5.1",
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
+  }
+}

--- a/turbo/apps/chrome-recorder/public/handoff.html
+++ b/turbo/apps/chrome-recorder/public/handoff.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Okou recording handoff</title>
+  </head>
+  <body>
+    <script src="handoff.js"></script>
+  </body>
+</html>

--- a/turbo/apps/chrome-recorder/public/manifest.json
+++ b/turbo/apps/chrome-recorder/public/manifest.json
@@ -1,0 +1,42 @@
+{
+  "manifest_version": 3,
+  "name": "Okou Screen Recorder",
+  "description": "Record a Chrome tab with on-page countdown, controls, and private element blur, then continue in Okou.",
+  "version": "0.1.0",
+  "minimum_chrome_version": "116",
+  "permissions": ["cookies", "offscreen", "storage", "tabs"],
+  "host_permissions": ["http://*/*", "https://*/*"],
+  "background": {
+    "service_worker": "service-worker.js"
+  },
+  "action": {
+    "default_icon": "icon-192.png",
+    "default_title": "Start an Okou recording"
+  },
+  "icons": {
+    "192": "icon-192.png"
+  },
+  "content_scripts": [
+    {
+      "matches": ["http://*/*", "https://*/*"],
+      "js": ["content.js"],
+      "run_at": "document_start"
+    }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["handoff.html"],
+      "matches": [
+        "https://app.okou.ai/*",
+        "https://app.vm0.ai/*",
+        "https://staging-app.vm7.ai/*",
+        "https://*.vm6.ai/*",
+        "http://localhost/*",
+        "http://127.0.0.1/*"
+      ]
+    }
+  ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
+  }
+}

--- a/turbo/apps/chrome-recorder/public/offscreen.html
+++ b/turbo/apps/chrome-recorder/public/offscreen.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Okou recorder runtime</title>
+  </head>
+  <body>
+    <script src="offscreen.js"></script>
+  </body>
+</html>

--- a/turbo/apps/chrome-recorder/scripts/copy-static.mjs
+++ b/turbo/apps/chrome-recorder/scripts/copy-static.mjs
@@ -1,0 +1,23 @@
+import { copyFile, mkdir } from "node:fs/promises";
+
+const output = new URL("../dist/", import.meta.url);
+await mkdir(output, { recursive: true });
+
+await Promise.all([
+  copyFile(
+    new URL("../public/manifest.json", import.meta.url),
+    new URL("manifest.json", output),
+  ),
+  copyFile(
+    new URL("../public/offscreen.html", import.meta.url),
+    new URL("offscreen.html", output),
+  ),
+  copyFile(
+    new URL("../public/handoff.html", import.meta.url),
+    new URL("handoff.html", output),
+  ),
+  copyFile(
+    new URL("../../platform/public/icons/icon-192.png", import.meta.url),
+    new URL("icon-192.png", output),
+  ),
+]);

--- a/turbo/apps/chrome-recorder/src/blur-manager.test.ts
+++ b/turbo/apps/chrome-recorder/src/blur-manager.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BlurManager, selectorForElement } from "./blur-manager.ts";
+
+function flushFrame(): void {
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    callback(0);
+    return 1;
+  });
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("BlurManager", () => {
+  it("attaches blur to the element so it travels with page scroll", () => {
+    const element = document.createElement("section");
+    element.id = "private-account";
+    document.body.append(element);
+    const manager = new BlurManager(() => {});
+
+    expect(manager.add(element)).toBe(true);
+    expect(element.style.getPropertyValue("filter")).toBe("blur(10px)");
+    expect(element.hasAttribute("data-okou-recorder-blurred")).toBe(true);
+
+    manager.destroy();
+    expect(element.style.getPropertyValue("filter")).toBe("");
+    expect(element.hasAttribute("data-okou-recorder-blurred")).toBe(false);
+  });
+
+  it("blurs the recycled node when a virtualized list re-renders on scroll", () => {
+    flushFrame();
+    const original = document.createElement("div");
+    original.setAttribute("data-testid", "account-balance");
+    document.body.append(original);
+    const manager = new BlurManager(() => {});
+    manager.add(original);
+
+    const recycled = document.createElement("div");
+    recycled.setAttribute("data-testid", "account-balance");
+    original.replaceWith(recycled);
+    window.dispatchEvent(new Event("scroll"));
+
+    expect(recycled.style.getPropertyValue("filter")).toBe("blur(10px)");
+    manager.destroy();
+  });
+
+  it("restores blur when the page overwrites the inline filter", () => {
+    flushFrame();
+    const element = document.createElement("div");
+    element.id = "customer-card";
+    document.body.append(element);
+    const manager = new BlurManager(() => {});
+    manager.add(element);
+
+    element.style.removeProperty("filter");
+    window.dispatchEvent(new Event("scroll"));
+
+    expect(element.style.getPropertyValue("filter")).toBe("blur(10px)");
+    manager.destroy();
+  });
+
+  it("reports the selection count and undoes the last selection", () => {
+    const counts: number[] = [];
+    const first = document.createElement("div");
+    first.id = "first";
+    const second = document.createElement("div");
+    second.id = "second";
+    document.body.append(first, second);
+    const manager = new BlurManager((count) => {
+      counts.push(count);
+    });
+
+    manager.add(first);
+    manager.add(second);
+    expect(manager.add(second)).toBe(false);
+    manager.undo();
+
+    expect(counts).toEqual([1, 2, 1]);
+    expect(second.style.getPropertyValue("filter")).toBe("");
+    expect(first.style.getPropertyValue("filter")).toBe("blur(10px)");
+    manager.destroy();
+  });
+
+  it("prefers stable attributes over positional selectors", () => {
+    const element = document.createElement("div");
+    element.setAttribute("data-testid", "customer-email");
+    document.body.append(element);
+
+    expect(selectorForElement(element)).toBe(
+      'div[data-testid="customer-email"]',
+    );
+  });
+
+  it("falls back to a structural selector when no stable attribute exists", () => {
+    const wrapper = document.createElement("section");
+    wrapper.id = "invoices";
+    const row = document.createElement("div");
+    wrapper.append(document.createElement("div"), row);
+    document.body.append(wrapper);
+
+    expect(selectorForElement(row)).toBe("#invoices > div:nth-of-type(2)");
+  });
+});

--- a/turbo/apps/chrome-recorder/src/blur-manager.ts
+++ b/turbo/apps/chrome-recorder/src/blur-manager.ts
@@ -1,0 +1,242 @@
+const BLUR_ATTRIBUTE = "data-okou-recorder-blurred";
+const BLUR_FILTER = "blur(10px)";
+
+interface OriginalElementStyle {
+  readonly attributeValue: string | null;
+  readonly filterPriority: string;
+  readonly filterValue: string;
+}
+
+interface BlurRecord {
+  readonly appliedElements: Map<HTMLElement, OriginalElementStyle>;
+  readonly selector: string;
+}
+
+function cssIdentifier(value: string): string {
+  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+    return CSS.escape(value);
+  }
+  return value.replaceAll(/[^a-zA-Z0-9_-]/gu, (character) => {
+    return `\\${character.codePointAt(0)?.toString(16) ?? "20"} `;
+  });
+}
+
+function cssString(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+}
+
+function uniqueSelector(element: HTMLElement): string | null {
+  if (element.id) {
+    const selector = `#${cssIdentifier(element.id)}`;
+    if (document.querySelectorAll(selector).length === 1) {
+      return selector;
+    }
+  }
+  for (const attribute of [
+    "data-testid",
+    "data-test",
+    "data-qa",
+    "aria-label",
+    "name",
+  ]) {
+    const value = element.getAttribute(attribute);
+    if (!value) {
+      continue;
+    }
+    const selector = `${element.localName}[${attribute}="${cssString(value)}"]`;
+    if (document.querySelectorAll(selector).length === 1) {
+      return selector;
+    }
+  }
+  return null;
+}
+
+export function selectorForElement(element: HTMLElement): string {
+  const stable = uniqueSelector(element);
+  if (stable) {
+    return stable;
+  }
+  const segments: string[] = [];
+  let current: HTMLElement | null = element;
+  while (current && current !== document.body) {
+    const parent: HTMLElement | null = current.parentElement;
+    if (!parent) {
+      break;
+    }
+    const localName = current.localName;
+    const siblings = [...parent.children].filter((candidate) => {
+      return candidate.localName === localName;
+    });
+    const index = siblings.indexOf(current) + 1;
+    segments.unshift(`${localName}:nth-of-type(${Math.max(1, index)})`);
+    const parentStable = uniqueSelector(parent);
+    if (parentStable) {
+      segments.unshift(parentStable);
+      return segments.join(" > ");
+    }
+    current = parent;
+  }
+  return segments.length > 0
+    ? `body > ${segments.join(" > ")}`
+    : element.localName;
+}
+
+function restoreElement(
+  element: HTMLElement,
+  original: OriginalElementStyle,
+): void {
+  if (original.filterValue) {
+    element.style.setProperty(
+      "filter",
+      original.filterValue,
+      original.filterPriority,
+    );
+  } else {
+    element.style.removeProperty("filter");
+  }
+  if (original.attributeValue === null) {
+    element.removeAttribute(BLUR_ATTRIBUTE);
+  } else {
+    element.setAttribute(BLUR_ATTRIBUTE, original.attributeValue);
+  }
+}
+
+/**
+ * Keeps every selected element blurred for the whole recording.
+ *
+ * The blur is an inline `filter` on the element itself, so it travels with the
+ * element while the page scrolls. Virtualized lists, infinite scroll, and SPA
+ * re-renders destroy and rebuild those nodes, so the manager also stores a
+ * selector per selection and re-applies the blur to every current match after
+ * DOM mutations, style overwrites, and scroll.
+ */
+export class BlurManager {
+  readonly #onChange: (count: number) => void;
+  readonly #records: BlurRecord[] = [];
+  readonly #observer: MutationObserver;
+  readonly #onScroll: () => void;
+  #reapplyFrame: number | null = null;
+
+  constructor(onChange: (count: number) => void) {
+    this.#onChange = onChange;
+    this.#observer = new MutationObserver(() => {
+      this.#scheduleReapply();
+    });
+    this.#observer.observe(document.documentElement, {
+      attributeFilter: ["class", "style"],
+      attributes: true,
+      childList: true,
+      subtree: true,
+    });
+    this.#onScroll = () => {
+      this.#scheduleReapply();
+    };
+    window.addEventListener("scroll", this.#onScroll, {
+      capture: true,
+      passive: true,
+    });
+  }
+
+  get count(): number {
+    return this.#records.length;
+  }
+
+  has(element: HTMLElement): boolean {
+    return this.#records.some((record) => {
+      return record.appliedElements.has(element);
+    });
+  }
+
+  add(element: HTMLElement): boolean {
+    if (
+      element === document.body ||
+      element === document.documentElement ||
+      this.has(element)
+    ) {
+      return false;
+    }
+    const record: BlurRecord = {
+      appliedElements: new Map(),
+      selector: selectorForElement(element),
+    };
+    this.#apply(record, element);
+    this.#records.push(record);
+    this.#onChange(this.count);
+    return true;
+  }
+
+  undo(): void {
+    const record = this.#records.pop();
+    if (!record) {
+      return;
+    }
+    this.#restore(record);
+    this.#onChange(this.count);
+  }
+
+  clear(): void {
+    for (const record of this.#records) {
+      this.#restore(record);
+    }
+    this.#records.length = 0;
+    this.#onChange(0);
+  }
+
+  destroy(): void {
+    this.#observer.disconnect();
+    window.removeEventListener("scroll", this.#onScroll, { capture: true });
+    if (this.#reapplyFrame !== null) {
+      cancelAnimationFrame(this.#reapplyFrame);
+      this.#reapplyFrame = null;
+    }
+    this.clear();
+  }
+
+  #apply(record: BlurRecord, element: HTMLElement): void {
+    if (!record.appliedElements.has(element)) {
+      record.appliedElements.set(element, {
+        attributeValue: element.getAttribute(BLUR_ATTRIBUTE),
+        filterPriority: element.style.getPropertyPriority("filter"),
+        filterValue: element.style.getPropertyValue("filter"),
+      });
+    }
+    if (element.getAttribute(BLUR_ATTRIBUTE) !== "") {
+      element.setAttribute(BLUR_ATTRIBUTE, "");
+    }
+    // Writing an unchanged value would retrigger the attribute observer and
+    // spin the reapply loop forever.
+    if (element.style.getPropertyValue("filter") !== BLUR_FILTER) {
+      element.style.setProperty("filter", BLUR_FILTER, "important");
+    }
+  }
+
+  #restore(record: BlurRecord): void {
+    for (const [element, original] of record.appliedElements) {
+      restoreElement(element, original);
+    }
+    record.appliedElements.clear();
+  }
+
+  #scheduleReapply(): void {
+    if (this.#reapplyFrame !== null) {
+      return;
+    }
+    this.#reapplyFrame = requestAnimationFrame(() => {
+      this.#reapplyFrame = null;
+      for (const record of this.#records) {
+        for (const [element] of record.appliedElements) {
+          if (element.isConnected) {
+            this.#apply(record, element);
+          } else {
+            record.appliedElements.delete(element);
+          }
+        }
+        for (const match of document.querySelectorAll<HTMLElement>(
+          record.selector,
+        )) {
+          this.#apply(record, match);
+        }
+      }
+    });
+  }
+}

--- a/turbo/apps/chrome-recorder/src/content.ts
+++ b/turbo/apps/chrome-recorder/src/content.ts
@@ -1,0 +1,209 @@
+import {
+  isOkouAppUrl,
+  isOkouRecorderPageMessage,
+  OKOU_RECORDER_CHANNEL,
+  OKOU_RECORDER_PROTOCOL_VERSION,
+  okouRecorderSessionId,
+  type OkouRecorderPageMessage,
+} from "@okouai/core/browser-recorder-protocol";
+
+import {
+  extensionMessage,
+  isRuntimeMessage,
+  type ContentMessage,
+  type WorkerMessage,
+} from "./messages.ts";
+import { RecorderOverlay } from "./overlay.ts";
+
+let overlay: RecorderOverlay | null = null;
+let sessionId: string | null = null;
+
+function notifyWorker(message: WorkerMessage): void {
+  void chrome.runtime.sendMessage(message);
+}
+
+function sendCommand(
+  action: Extract<
+    WorkerMessage,
+    { readonly type: "content:command" }
+  >["action"],
+): void {
+  if (!sessionId) {
+    return;
+  }
+  notifyWorker(
+    extensionMessage({
+      action,
+      recipient: "worker",
+      sessionId,
+      type: "content:command",
+    }),
+  );
+}
+
+function ensureOverlay(): RecorderOverlay {
+  if (overlay) {
+    return overlay;
+  }
+  overlay = new RecorderOverlay({
+    onCancel: () => {
+      sendCommand("cancel");
+    },
+    onFinish: () => {
+      sendCommand("finish");
+    },
+    onMicrophone: (enabled) => {
+      if (!sessionId) {
+        return;
+      }
+      notifyWorker(
+        extensionMessage({
+          enabled,
+          recipient: "worker",
+          sessionId,
+          type: "content:microphone",
+        }),
+      );
+    },
+    onPause: () => {
+      sendCommand("pause");
+    },
+    onResume: () => {
+      sendCommand("resume");
+    },
+    onStart: () => {
+      sendCommand("start");
+    },
+  });
+  return overlay;
+}
+
+function teardownOverlay(): void {
+  overlay?.destroy();
+  overlay = null;
+  sessionId = null;
+}
+
+function handleContentMessage(message: ContentMessage): void {
+  switch (message.type) {
+    case "worker:prepare": {
+      sessionId = message.sessionId;
+      ensureOverlay().prepare(message.state);
+      break;
+    }
+    case "worker:state": {
+      if (message.sessionId === sessionId) {
+        ensureOverlay().update(message.state);
+      }
+      break;
+    }
+    case "worker:error": {
+      if (message.sessionId === sessionId) {
+        ensureOverlay().showError(message.code);
+      }
+      break;
+    }
+    case "worker:cleanup": {
+      if (message.sessionId === sessionId) {
+        teardownOverlay();
+      }
+      break;
+    }
+  }
+}
+
+chrome.runtime.onMessage.addListener((value, _sender, sendResponse) => {
+  if (!isRuntimeMessage(value) || value.recipient !== "content") {
+    return false;
+  }
+  handleContentMessage(value);
+  sendResponse({ ok: true });
+  return false;
+});
+
+// A navigation inside the recorded tab destroys the overlay, so ask the worker
+// to re-send the live session state as soon as the new document loads.
+notifyWorker(
+  extensionMessage({
+    recipient: "worker",
+    type: "content:mounted",
+  }),
+);
+
+/**
+ * Bridges the finished recording from the extension into the Okou application.
+ *
+ * The recording lives in the extension's own IndexedDB, which page scripts
+ * cannot read. `handoff.html` is loaded as a hidden extension-origin iframe;
+ * this content script relays its structured-clone messages to the application
+ * and relays the application's acknowledgement back so the extension copy is
+ * deleted.
+ */
+function startHandoff(handoffSessionId: string): void {
+  const frame = document.createElement("iframe");
+  frame.src = `${chrome.runtime.getURL("handoff.html")}#${handoffSessionId}`;
+  frame.setAttribute("aria-hidden", "true");
+  frame.style.display = "none";
+
+  let frameLoaded = false;
+  let pendingReady = false;
+
+  const toFrame = (message: OkouRecorderPageMessage): void => {
+    frame.contentWindow?.postMessage(message, "*");
+  };
+
+  frame.addEventListener("load", () => {
+    frameLoaded = true;
+    if (pendingReady) {
+      toFrame({
+        channel: OKOU_RECORDER_CHANNEL,
+        sessionId: handoffSessionId,
+        source: "platform",
+        type: "handoff:ready",
+        version: OKOU_RECORDER_PROTOCOL_VERSION,
+      });
+    }
+  });
+
+  window.addEventListener("message", (event: MessageEvent<unknown>) => {
+    const message: unknown = event.data;
+    if (
+      !isOkouRecorderPageMessage(message) ||
+      ("sessionId" in message && message.sessionId !== handoffSessionId)
+    ) {
+      return;
+    }
+    if (event.source === frame.contentWindow) {
+      if (
+        message.type === "handoff:recording" ||
+        message.type === "handoff:error"
+      ) {
+        window.postMessage(message, location.origin);
+      }
+      return;
+    }
+    if (event.source !== window || message.source !== "platform") {
+      return;
+    }
+    if (message.type === "handoff:ready") {
+      pendingReady = true;
+      if (frameLoaded) {
+        toFrame(message);
+      }
+      return;
+    }
+    if (message.type === "handoff:complete") {
+      toFrame(message);
+      frame.remove();
+    }
+  });
+
+  document.documentElement.append(frame);
+}
+
+if (isOkouAppUrl(location.href)) {
+  const handoffSessionId = okouRecorderSessionId(new URL(location.href));
+  if (handoffSessionId) {
+    startHandoff(handoffSessionId);
+  }
+}

--- a/turbo/apps/chrome-recorder/src/handoff.ts
+++ b/turbo/apps/chrome-recorder/src/handoff.ts
@@ -1,0 +1,79 @@
+import {
+  isOkouRecorderPageMessage,
+  OKOU_RECORDER_CHANNEL,
+  OKOU_RECORDER_PROTOCOL_VERSION,
+  type OkouRecorderPageMessage,
+} from "@okouai/core/browser-recorder-protocol";
+
+import { extensionMessage } from "./messages.ts";
+import { deleteRecording, readRecording } from "./recording-store.ts";
+
+const sessionId = location.hash.slice(1);
+const parentOrigin = document.referrer
+  ? new URL(document.referrer).origin
+  : null;
+
+function toParent(message: OkouRecorderPageMessage): void {
+  if (!parentOrigin) {
+    return;
+  }
+  window.parent.postMessage(message, parentOrigin);
+}
+
+async function deliverRecording(): Promise<void> {
+  const recording = await readRecording(sessionId);
+  if (!recording) {
+    toParent({
+      channel: OKOU_RECORDER_CHANNEL,
+      code: "recording-missing",
+      sessionId,
+      source: "extension",
+      type: "handoff:error",
+      version: OKOU_RECORDER_PROTOCOL_VERSION,
+    });
+    return;
+  }
+  toParent({
+    channel: OKOU_RECORDER_CHANNEL,
+    recording: {
+      blob: recording.blob,
+      contentType: recording.contentType,
+      durationSeconds: recording.durationSeconds,
+      name: recording.name,
+    },
+    sessionId,
+    source: "extension",
+    type: "handoff:recording",
+    version: OKOU_RECORDER_PROTOCOL_VERSION,
+  });
+}
+
+async function completeHandoff(): Promise<void> {
+  await deleteRecording(sessionId);
+  await chrome.runtime.sendMessage(
+    extensionMessage({
+      recipient: "worker",
+      sessionId,
+      type: "handoff:consumed",
+    }),
+  );
+}
+
+window.addEventListener("message", (event: MessageEvent<unknown>) => {
+  const message: unknown = event.data;
+  if (
+    event.origin !== parentOrigin ||
+    !isOkouRecorderPageMessage(message) ||
+    message.source !== "platform" ||
+    message.sessionId !== sessionId
+  ) {
+    return;
+  }
+  if (message.type === "handoff:ready") {
+    void deliverRecording();
+    return;
+  }
+  if (message.type === "handoff:complete") {
+    void completeHandoff();
+  }
+});

--- a/turbo/apps/chrome-recorder/src/messages.ts
+++ b/turbo/apps/chrome-recorder/src/messages.ts
@@ -1,0 +1,165 @@
+const EXTENSION_MESSAGE_CHANNEL = "okou-recorder-internal";
+const EXTENSION_MESSAGE_VERSION = 1;
+
+export type RecorderSessionStatus =
+  | "finalizing"
+  | "paused"
+  | "ready"
+  | "recording";
+
+export interface RecorderStateSnapshot {
+  readonly elapsedSeconds: number;
+  readonly microphone: boolean;
+  readonly status: RecorderSessionStatus;
+  readonly tabAudio: boolean;
+}
+
+interface ExtensionMessageBase {
+  readonly channel: typeof EXTENSION_MESSAGE_CHANNEL;
+  readonly version: typeof EXTENSION_MESSAGE_VERSION;
+}
+
+export type WorkerMessage =
+  | (ExtensionMessageBase & {
+      readonly recipient: "worker";
+      readonly type: "content:mounted";
+    })
+  | (ExtensionMessageBase & {
+      readonly action: "cancel" | "finish" | "pause" | "resume" | "start";
+      readonly recipient: "worker";
+      readonly sessionId: string;
+      readonly type: "content:command";
+    })
+  | (ExtensionMessageBase & {
+      readonly enabled: boolean;
+      readonly recipient: "worker";
+      readonly sessionId: string;
+      readonly type: "content:microphone";
+    })
+  | (ExtensionMessageBase & {
+      readonly recipient: "worker";
+      readonly sessionId: string;
+      readonly state: RecorderStateSnapshot;
+      readonly type: "offscreen:state";
+    })
+  | (ExtensionMessageBase & {
+      readonly durationSeconds: number;
+      readonly recipient: "worker";
+      readonly sessionId: string;
+      readonly type: "offscreen:completed";
+    })
+  | (ExtensionMessageBase & {
+      readonly code:
+        | "capture-ended"
+        | "capture-failed"
+        | "microphone-permission";
+      readonly recipient: "worker";
+      readonly sessionId: string;
+      readonly type: "offscreen:error";
+    })
+  | (ExtensionMessageBase & {
+      readonly recipient: "worker";
+      readonly sessionId: string;
+      readonly type: "handoff:consumed";
+    });
+
+export type ContentMessage =
+  | (ExtensionMessageBase & {
+      readonly recipient: "content";
+      readonly sessionId: string;
+      readonly state: RecorderStateSnapshot;
+      readonly type: "worker:prepare";
+    })
+  | (ExtensionMessageBase & {
+      readonly recipient: "content";
+      readonly sessionId: string;
+      readonly state: RecorderStateSnapshot;
+      readonly type: "worker:state";
+    })
+  | (ExtensionMessageBase & {
+      readonly recipient: "content";
+      readonly sessionId: string;
+      readonly type: "worker:cleanup";
+    })
+  | (ExtensionMessageBase & {
+      readonly code:
+        | "capture-ended"
+        | "capture-failed"
+        | "microphone-permission";
+      readonly recipient: "content";
+      readonly sessionId: string;
+      readonly type: "worker:error";
+    });
+
+export type OffscreenMessage =
+  | (ExtensionMessageBase & {
+      readonly recipient: "offscreen";
+      readonly sessionId: string;
+      readonly type: "worker:select-source";
+    })
+  | (ExtensionMessageBase & {
+      readonly action: "cancel" | "finish" | "pause" | "resume" | "start";
+      readonly recipient: "offscreen";
+      readonly sessionId: string;
+      readonly type: "worker:command";
+    })
+  | (ExtensionMessageBase & {
+      readonly enabled: boolean;
+      readonly recipient: "offscreen";
+      readonly sessionId: string;
+      readonly type: "worker:microphone";
+    });
+
+type RuntimeMessage = ContentMessage | OffscreenMessage | WorkerMessage;
+
+export type CaptureSelection =
+  | {
+      readonly ok: true;
+      readonly tabAudio: boolean;
+    }
+  | {
+      readonly ok: false;
+      readonly reason: "cancelled" | "failed" | "tab-required";
+    };
+
+type MessageBody = RuntimeMessage extends infer T
+  ? T extends RuntimeMessage
+    ? Omit<T, "channel" | "version">
+    : never
+  : never;
+
+export function extensionMessage<T extends MessageBody>(
+  message: T,
+): ExtensionMessageBase & T {
+  return {
+    ...message,
+    channel: EXTENSION_MESSAGE_CHANNEL,
+    version: EXTENSION_MESSAGE_VERSION,
+  };
+}
+
+export function isRuntimeMessage(value: unknown): value is RuntimeMessage {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const message = value as Readonly<Record<string, unknown>>;
+  return (
+    message.channel === EXTENSION_MESSAGE_CHANNEL &&
+    message.version === EXTENSION_MESSAGE_VERSION &&
+    typeof message.recipient === "string" &&
+    typeof message.type === "string"
+  );
+}
+
+export function isCaptureSelection(value: unknown): value is CaptureSelection {
+  if (typeof value !== "object" || value === null || !("ok" in value)) {
+    return false;
+  }
+  const selection = value as Readonly<Record<string, unknown>>;
+  return selection.ok === true
+    ? typeof selection.tabAudio === "boolean"
+    : selection.ok === false &&
+        ["cancelled", "failed", "tab-required"].includes(
+          String(selection.reason),
+        );
+}

--- a/turbo/apps/chrome-recorder/src/offscreen.ts
+++ b/turbo/apps/chrome-recorder/src/offscreen.ts
@@ -1,0 +1,415 @@
+import {
+  extensionMessage,
+  isRuntimeMessage,
+  type CaptureSelection,
+  type OffscreenMessage,
+  type RecorderSessionStatus,
+  type RecorderStateSnapshot,
+  type WorkerMessage,
+} from "./messages.ts";
+import { saveRecording } from "./recording-store.ts";
+
+interface OkouCaptureController {
+  setFocusBehavior(behavior: "focus-captured-surface"): void;
+}
+
+type OkouCaptureControllerConstructor = new () => OkouCaptureController;
+
+interface OkouDisplayMediaOptions extends DisplayMediaStreamOptions {
+  readonly controller?: OkouCaptureController;
+  readonly selfBrowserSurface?: "exclude";
+  readonly surfaceSwitching?: "exclude";
+}
+
+interface CaptureRuntime {
+  audioContext: AudioContext | null;
+  chunks: Blob[];
+  displayStream: MediaStream | null;
+  elapsedMs: number;
+  finalizing: boolean;
+  microphoneStream: MediaStream | null;
+  recorder: MediaRecorder | null;
+  recordingStream: MediaStream | null;
+  segmentStartedAt: number;
+  sessionId: string | null;
+  status: RecorderSessionStatus;
+  tabAudio: boolean;
+}
+
+const runtime: CaptureRuntime = {
+  audioContext: null,
+  chunks: [],
+  displayStream: null,
+  elapsedMs: 0,
+  finalizing: false,
+  microphoneStream: null,
+  recorder: null,
+  recordingStream: null,
+  segmentStartedAt: 0,
+  sessionId: null,
+  status: "ready",
+  tabAudio: false,
+};
+
+function captureController(): OkouCaptureController | undefined {
+  const constructor = (
+    globalThis as typeof globalThis & {
+      readonly CaptureController?: OkouCaptureControllerConstructor;
+    }
+  ).CaptureController;
+  if (!constructor) {
+    return undefined;
+  }
+  const controller = new constructor();
+  controller.setFocusBehavior("focus-captured-surface");
+  return controller;
+}
+
+function stopTracks(stream: MediaStream | null): void {
+  for (const track of stream?.getTracks() ?? []) {
+    track.stop();
+  }
+}
+
+function elapsedMilliseconds(): number {
+  return (
+    runtime.elapsedMs +
+    (runtime.status === "recording"
+      ? Math.max(0, Date.now() - runtime.segmentStartedAt)
+      : 0)
+  );
+}
+
+function stateSnapshot(): RecorderStateSnapshot {
+  return {
+    elapsedSeconds: elapsedMilliseconds() / 1000,
+    microphone: runtime.microphoneStream !== null,
+    status: runtime.status,
+    tabAudio: runtime.tabAudio,
+  };
+}
+
+async function publishState(): Promise<void> {
+  if (!runtime.sessionId) {
+    return;
+  }
+  await chrome.runtime.sendMessage(
+    extensionMessage({
+      recipient: "worker",
+      sessionId: runtime.sessionId,
+      state: stateSnapshot(),
+      type: "offscreen:state",
+    }),
+  );
+}
+
+async function publishError(
+  code: Extract<WorkerMessage, { readonly type: "offscreen:error" }>["code"],
+): Promise<void> {
+  if (!runtime.sessionId) {
+    return;
+  }
+  await chrome.runtime.sendMessage(
+    extensionMessage({
+      code,
+      recipient: "worker",
+      sessionId: runtime.sessionId,
+      type: "offscreen:error",
+    }),
+  );
+}
+
+async function releaseCapture(): Promise<void> {
+  stopTracks(runtime.recordingStream);
+  stopTracks(runtime.microphoneStream);
+  stopTracks(runtime.displayStream);
+  runtime.recordingStream = null;
+  runtime.microphoneStream = null;
+  runtime.displayStream = null;
+  if (runtime.audioContext) {
+    await runtime.audioContext.close();
+    runtime.audioContext = null;
+  }
+  runtime.chunks = [];
+  runtime.recorder = null;
+  runtime.elapsedMs = 0;
+  runtime.segmentStartedAt = 0;
+  runtime.finalizing = false;
+  runtime.sessionId = null;
+  runtime.status = "ready";
+  runtime.tabAudio = false;
+}
+
+function recorderMimeType(): string | undefined {
+  return [
+    "video/webm;codecs=vp9,opus",
+    "video/webm;codecs=vp8,opus",
+    "video/webm",
+  ].find((contentType) => {
+    return MediaRecorder.isTypeSupported(contentType);
+  });
+}
+
+async function selectSource(sessionId: string): Promise<CaptureSelection> {
+  if (runtime.sessionId) {
+    await releaseCapture();
+  }
+  runtime.sessionId = sessionId;
+  const controller = captureController();
+  const options: OkouDisplayMediaOptions = {
+    audio: true,
+    controller,
+    selfBrowserSurface: "exclude",
+    surfaceSwitching: "exclude",
+    video: { frameRate: { ideal: 30, max: 30 } },
+  };
+
+  try {
+    const displayStream = await navigator.mediaDevices.getDisplayMedia(options);
+    const videoTrack = displayStream.getVideoTracks()[0];
+    if (!videoTrack || videoTrack.getSettings().displaySurface !== "browser") {
+      stopTracks(displayStream);
+      await releaseCapture();
+      return { ok: false, reason: "tab-required" };
+    }
+    runtime.displayStream = displayStream;
+    runtime.tabAudio = displayStream.getAudioTracks().length > 0;
+    runtime.status = "ready";
+    videoTrack.addEventListener(
+      "ended",
+      () => {
+        void finishRecording("capture-ended");
+      },
+      { once: true },
+    );
+    return { ok: true, tabAudio: runtime.tabAudio };
+  } catch (error) {
+    await releaseCapture();
+    const name =
+      error instanceof Error || error instanceof DOMException ? error.name : "";
+    return {
+      ok: false,
+      reason: name === "NotAllowedError" ? "cancelled" : "failed",
+    };
+  }
+}
+
+async function setMicrophone(enabled: boolean): Promise<void> {
+  if (runtime.status !== "ready") {
+    return;
+  }
+  if (!enabled) {
+    stopTracks(runtime.microphoneStream);
+    runtime.microphoneStream = null;
+    await publishState();
+    return;
+  }
+  if (runtime.microphoneStream) {
+    return;
+  }
+  try {
+    runtime.microphoneStream = await navigator.mediaDevices.getUserMedia({
+      audio: { echoCancellation: true, noiseSuppression: true },
+      video: false,
+    });
+    await publishState();
+  } catch {
+    await publishError("microphone-permission");
+  }
+}
+
+function combinedRecordingStream(): MediaStream {
+  const displayStream = runtime.displayStream;
+  if (!displayStream) {
+    throw new Error("A display stream is required before recording");
+  }
+  const microphoneStream = runtime.microphoneStream;
+  if (!microphoneStream) {
+    return displayStream;
+  }
+
+  const audioTracks = [
+    ...displayStream.getAudioTracks(),
+    ...microphoneStream.getAudioTracks(),
+  ];
+  if (audioTracks.length === 0) {
+    return new MediaStream(displayStream.getVideoTracks());
+  }
+  const context = new AudioContext();
+  runtime.audioContext = context;
+  const destination = context.createMediaStreamDestination();
+  for (const audioTrack of audioTracks) {
+    context
+      .createMediaStreamSource(new MediaStream([audioTrack]))
+      .connect(destination);
+  }
+  return new MediaStream([
+    ...displayStream.getVideoTracks(),
+    ...destination.stream.getAudioTracks(),
+  ]);
+}
+
+async function finalizeRecording(
+  sessionId: string,
+  recorder: MediaRecorder,
+): Promise<void> {
+  if (runtime.sessionId !== sessionId) {
+    return;
+  }
+  const durationSeconds = elapsedMilliseconds() / 1000;
+  const contentType = recorder.mimeType || "video/webm";
+  const blob = new Blob(runtime.chunks, { type: contentType });
+  if (blob.size === 0) {
+    await publishError("capture-failed");
+    await releaseCapture();
+    return;
+  }
+  await saveRecording({
+    blob,
+    contentType,
+    createdAt: Date.now(),
+    durationSeconds,
+    name: "Okou recording.webm",
+    sessionId,
+  });
+  await chrome.runtime.sendMessage(
+    extensionMessage({
+      durationSeconds,
+      recipient: "worker",
+      sessionId,
+      type: "offscreen:completed",
+    }),
+  );
+  await releaseCapture();
+}
+
+async function startRecording(): Promise<void> {
+  if (
+    runtime.status !== "ready" ||
+    !runtime.sessionId ||
+    !runtime.displayStream
+  ) {
+    return;
+  }
+  const sessionId = runtime.sessionId;
+  const recordingStream = combinedRecordingStream();
+  runtime.recordingStream = recordingStream;
+  runtime.chunks = [];
+  const contentType = recorderMimeType();
+  const recorder = contentType
+    ? new MediaRecorder(recordingStream, { mimeType: contentType })
+    : new MediaRecorder(recordingStream);
+  runtime.recorder = recorder;
+  recorder.addEventListener("dataavailable", (event) => {
+    if (event.data.size > 0) {
+      runtime.chunks.push(event.data);
+    }
+  });
+  recorder.addEventListener(
+    "stop",
+    () => {
+      void finalizeRecording(sessionId, recorder);
+    },
+    { once: true },
+  );
+  runtime.elapsedMs = 0;
+  runtime.segmentStartedAt = Date.now();
+  runtime.status = "recording";
+  recorder.start(1000);
+  await publishState();
+}
+
+async function pauseRecording(): Promise<void> {
+  if (
+    runtime.status !== "recording" ||
+    runtime.recorder?.state !== "recording"
+  ) {
+    return;
+  }
+  runtime.elapsedMs = elapsedMilliseconds();
+  runtime.recorder.pause();
+  runtime.status = "paused";
+  await publishState();
+}
+
+async function resumeRecording(): Promise<void> {
+  if (runtime.status !== "paused" || runtime.recorder?.state !== "paused") {
+    return;
+  }
+  runtime.segmentStartedAt = Date.now();
+  runtime.recorder.resume();
+  runtime.status = "recording";
+  await publishState();
+}
+
+async function finishRecording(
+  reason: "cancel" | "capture-ended" | "finish",
+): Promise<void> {
+  if (!runtime.sessionId || runtime.finalizing) {
+    return;
+  }
+  const recorder = runtime.recorder;
+  if (!recorder || recorder.state === "inactive") {
+    if (reason === "capture-ended") {
+      await publishError("capture-ended");
+    }
+    await releaseCapture();
+    return;
+  }
+  runtime.finalizing = true;
+  if (runtime.status === "recording") {
+    runtime.elapsedMs = elapsedMilliseconds();
+  }
+  runtime.status = "finalizing";
+  await publishState();
+  recorder.stop();
+  stopTracks(runtime.displayStream);
+  stopTracks(runtime.microphoneStream);
+}
+
+async function handleMessage(message: OffscreenMessage): Promise<unknown> {
+  switch (message.type) {
+    case "worker:select-source": {
+      return await selectSource(message.sessionId);
+    }
+    case "worker:microphone": {
+      if (message.sessionId === runtime.sessionId) {
+        await setMicrophone(message.enabled);
+      }
+      return { ok: true };
+    }
+    case "worker:command": {
+      if (message.sessionId !== runtime.sessionId) {
+        return { ok: false };
+      }
+      switch (message.action) {
+        case "start": {
+          await startRecording();
+          break;
+        }
+        case "pause": {
+          await pauseRecording();
+          break;
+        }
+        case "resume": {
+          await resumeRecording();
+          break;
+        }
+        case "cancel":
+        case "finish": {
+          await finishRecording(message.action);
+          break;
+        }
+      }
+      return { ok: true };
+    }
+  }
+}
+
+chrome.runtime.onMessage.addListener((value, _sender, sendResponse) => {
+  if (!isRuntimeMessage(value) || value.recipient !== "offscreen") {
+    return false;
+  }
+  void handleMessage(value).then(sendResponse);
+  return true;
+});

--- a/turbo/apps/chrome-recorder/src/overlay-styles.ts
+++ b/turbo/apps/chrome-recorder/src/overlay-styles.ts
@@ -1,0 +1,278 @@
+export const OVERLAY_STYLES = `
+:host {
+  all: initial;
+}
+
+.layer {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483647;
+  pointer-events: none;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Inter,
+    "Helvetica Neue", Arial, sans-serif;
+  color: #0b0b0c;
+}
+
+.layer[data-mode="hidden"] {
+  display: none;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+  border: 0;
+  background: none;
+  color: inherit;
+}
+
+.panel {
+  position: absolute;
+  left: 50%;
+  bottom: 28px;
+  transform: translateX(-50%);
+  width: 360px;
+  pointer-events: auto;
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow:
+    0 1px 2px rgba(11, 11, 12, 0.08),
+    0 24px 48px -12px rgba(11, 11, 12, 0.28);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6b6b70;
+}
+
+.brand-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #ff4f0a;
+}
+
+.source {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.source-title {
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.source-origin {
+  font-size: 12px;
+  color: #6b6b70;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: #f4f4f5;
+  font-size: 13px;
+  font-weight: 500;
+  width: 100%;
+  text-align: left;
+}
+
+.option[data-interactive="false"] {
+  cursor: default;
+  color: #6b6b70;
+}
+
+.option-value {
+  font-size: 12px;
+  font-weight: 600;
+  color: #6b6b70;
+}
+
+.option[data-active="true"] .option-value {
+  color: #ff4f0a;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.primary {
+  flex: 1;
+  padding: 11px 16px;
+  border-radius: 10px;
+  background: #0b0b0c;
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.secondary {
+  padding: 11px 14px;
+  border-radius: 10px;
+  background: #f4f4f5;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.notice {
+  font-size: 12px;
+  line-height: 1.45;
+  color: #b3350a;
+  background: #fff1ea;
+  border-radius: 8px;
+  padding: 9px 11px;
+}
+
+.notice[hidden] {
+  display: none;
+}
+
+.blur-bar {
+  position: absolute;
+  left: 50%;
+  bottom: 28px;
+  transform: translateX(-50%);
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 999px;
+  background: #0b0b0c;
+  color: #ffffff;
+  box-shadow: 0 20px 40px -12px rgba(11, 11, 12, 0.5);
+  font-size: 13px;
+}
+
+.blur-hint {
+  padding: 0 6px 0 8px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.blur-count {
+  color: #a1a1a6;
+}
+
+.pill-button {
+  padding: 7px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.pill-button[data-active="true"] {
+  background: #ff4f0a;
+}
+
+.pill-button[disabled] {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.pill-button.confirm {
+  background: #ffffff;
+  color: #0b0b0c;
+  font-weight: 600;
+}
+
+.highlight {
+  position: fixed;
+  border: 2px dashed #ff4f0a;
+  border-radius: 6px;
+  background: rgba(255, 79, 10, 0.12);
+  pointer-events: none;
+  display: none;
+}
+
+.highlight[data-visible="true"] {
+  display: block;
+}
+
+.countdown {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.countdown-value {
+  font-size: 132px;
+  font-weight: 700;
+  line-height: 1;
+  color: #ffffff;
+  text-shadow: 0 12px 48px rgba(11, 11, 12, 0.55);
+}
+
+.controller {
+  position: absolute;
+  left: 50%;
+  bottom: 28px;
+  transform: translateX(-50%);
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 999px;
+  background: rgba(11, 11, 12, 0.94);
+  color: #ffffff;
+  box-shadow: 0 20px 40px -12px rgba(11, 11, 12, 0.5);
+}
+
+.recording-dot {
+  width: 10px;
+  height: 10px;
+  margin-left: 4px;
+  border-radius: 50%;
+  background: #ff3b30;
+}
+
+.controller[data-status="paused"] .recording-dot {
+  background: #a1a1a6;
+}
+
+.elapsed {
+  font-variant-numeric: tabular-nums;
+  font-size: 14px;
+  font-weight: 600;
+  min-width: 52px;
+  text-align: center;
+}
+`;

--- a/turbo/apps/chrome-recorder/src/overlay.test.ts
+++ b/turbo/apps/chrome-recorder/src/overlay.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { RecorderStateSnapshot } from "./messages.ts";
+import { formatElapsed, OVERLAY_HOST_ID, RecorderOverlay } from "./overlay.ts";
+
+const READY: RecorderStateSnapshot = {
+  elapsedSeconds: 0,
+  microphone: false,
+  status: "ready",
+  tabAudio: true,
+};
+
+function callbacks() {
+  return {
+    onCancel: vi.fn(),
+    onFinish: vi.fn(),
+    onMicrophone: vi.fn(),
+    onPause: vi.fn(),
+    onResume: vi.fn(),
+    onStart: vi.fn(),
+  };
+}
+
+function shadow(): ShadowRoot {
+  const host = document.getElementById(OVERLAY_HOST_ID);
+  if (!host?.shadowRoot) {
+    throw new Error("The overlay host is not mounted");
+  }
+  return host.shadowRoot;
+}
+
+function click(selector: string): void {
+  const button = shadow().querySelector<HTMLElement>(selector);
+  if (!button) {
+    throw new Error(`No overlay element matches ${selector}`);
+  }
+  button.click();
+}
+
+function text(selector: string): string {
+  return shadow().querySelector(selector)?.textContent ?? "";
+}
+
+let overlay: RecorderOverlay | null = null;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  overlay?.destroy();
+  overlay = null;
+  vi.useRealTimers();
+  document.body.replaceChildren();
+});
+
+describe("RecorderOverlay", () => {
+  it("starts capture only after the on-page countdown reaches zero", () => {
+    const handlers = callbacks();
+    overlay = new RecorderOverlay(handlers);
+    overlay.prepare(READY);
+    expect(overlay.mode).toBe("ready");
+
+    click(".primary");
+    expect(overlay.mode).toBe("countdown");
+    expect(text(".countdown-value")).toBe("3");
+    expect(handlers.onStart).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(800);
+    expect(text(".countdown-value")).toBe("2");
+    vi.advanceTimersByTime(1600);
+
+    expect(handlers.onStart).toHaveBeenCalledTimes(1);
+    expect(overlay.mode).toBe("recording");
+  });
+
+  it("shows the tab audio state and toggles the microphone through the worker", () => {
+    const handlers = callbacks();
+    overlay = new RecorderOverlay(handlers);
+    overlay.prepare(READY);
+
+    expect(text("[data-option='tab-audio'] .option-value")).toBe("On");
+    click("[data-option='microphone']");
+    expect(handlers.onMicrophone).toHaveBeenCalledWith(true);
+
+    overlay.update({ ...READY, microphone: true });
+    click("[data-option='microphone']");
+    expect(handlers.onMicrophone).toHaveBeenLastCalledWith(false);
+  });
+
+  it("swaps the controller between pause and resume and keeps time running", () => {
+    const handlers = callbacks();
+    overlay = new RecorderOverlay(handlers);
+    overlay.prepare(READY);
+
+    overlay.update({ ...READY, elapsedSeconds: 8, status: "recording" });
+    expect(overlay.mode).toBe("recording");
+    expect(text(".elapsed")).toBe("00:08");
+
+    vi.advanceTimersByTime(2000);
+    expect(text(".elapsed")).toBe("00:10");
+
+    click(".controller .pill-button");
+    expect(handlers.onPause).toHaveBeenCalledTimes(1);
+
+    overlay.update({ ...READY, elapsedSeconds: 10, status: "paused" });
+    vi.advanceTimersByTime(3000);
+    expect(text(".elapsed")).toBe("00:10");
+
+    click(".controller .pill-button");
+    expect(handlers.onResume).toHaveBeenCalledTimes(1);
+  });
+
+  it("blurs a picked element and reports the count on the ready panel", () => {
+    const target = document.createElement("div");
+    target.id = "customer-email";
+    document.body.append(target);
+    vi.spyOn(document, "elementFromPoint").mockReturnValue(target);
+
+    overlay = new RecorderOverlay(callbacks());
+    overlay.prepare(READY);
+    click("[data-option='blur']");
+    expect(overlay.mode).toBe("blur");
+
+    document.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, clientX: 10, clientY: 10 }),
+    );
+
+    expect(target.style.getPropertyValue("filter")).toBe("blur(10px)");
+    expect(overlay.blurCount).toBe(1);
+    expect(text(".blur-count")).toBe("1 blurred");
+
+    click(".pill-button.confirm");
+    expect(overlay.mode).toBe("ready");
+    expect(text("[data-option='blur'] .option-value")).toBe("1 blurred");
+  });
+
+  it("explains why a recording stopped", () => {
+    overlay = new RecorderOverlay(callbacks());
+    overlay.prepare(READY);
+    overlay.showError("microphone-permission");
+
+    expect(text(".notice")).toContain("Chrome blocked microphone access");
+  });
+});
+
+describe("formatElapsed", () => {
+  it("renders minutes and seconds with a stable width", () => {
+    expect(formatElapsed(0)).toBe("00:00");
+    expect(formatElapsed(9.8)).toBe("00:09");
+    expect(formatElapsed(605)).toBe("10:05");
+  });
+});

--- a/turbo/apps/chrome-recorder/src/overlay.ts
+++ b/turbo/apps/chrome-recorder/src/overlay.ts
@@ -1,0 +1,463 @@
+import { BlurManager } from "./blur-manager.ts";
+import { OVERLAY_STYLES } from "./overlay-styles.ts";
+import type { RecorderStateSnapshot } from "./messages.ts";
+
+export const OVERLAY_HOST_ID = "okou-recorder-overlay";
+const COUNTDOWN_SECONDS = 3;
+const COUNTDOWN_STEP_MS = 800;
+
+type OverlayMode = "blur" | "countdown" | "hidden" | "ready" | "recording";
+
+interface OverlayCallbacks {
+  readonly onCancel: () => void;
+  readonly onFinish: () => void;
+  readonly onMicrophone: (enabled: boolean) => void;
+  readonly onPause: () => void;
+  readonly onResume: () => void;
+  readonly onStart: () => void;
+}
+
+const ERROR_MESSAGES: Readonly<Record<string, string>> = {
+  "capture-ended": "Screen sharing stopped, so the recording was finished.",
+  "capture-failed": "Chrome could not produce a recording for this tab.",
+  "microphone-permission":
+    "Chrome blocked microphone access. Allow it in site settings, then try again.",
+};
+
+function element<K extends keyof HTMLElementTagNameMap>(
+  tagName: K,
+  className: string,
+  textContent?: string,
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tagName);
+  node.className = className;
+  if (textContent !== undefined) {
+    node.textContent = textContent;
+  }
+  return node;
+}
+
+export function formatElapsed(seconds: number): string {
+  const total = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(total / 60);
+  return `${String(minutes).padStart(2, "0")}:${String(total % 60).padStart(2, "0")}`;
+}
+
+/**
+ * Renders the recorder controls inside the page being recorded.
+ *
+ * Everything lives in a closed-styled shadow root so page CSS cannot reach it,
+ * and the root layer is `pointer-events: none` so element picking can read the
+ * page through it with `document.elementFromPoint`.
+ */
+export class RecorderOverlay {
+  readonly #blur: BlurManager;
+  readonly #callbacks: OverlayCallbacks;
+  readonly #host: HTMLElement;
+  readonly #layer: HTMLElement;
+  readonly #root: ShadowRoot;
+
+  readonly #panel: HTMLElement;
+  readonly #sourceTitle: HTMLElement;
+  readonly #sourceOrigin: HTMLElement;
+  readonly #microphoneOption: HTMLButtonElement;
+  readonly #microphoneValue: HTMLElement;
+  readonly #tabAudioOption: HTMLElement;
+  readonly #tabAudioValue: HTMLElement;
+  readonly #blurOption: HTMLButtonElement;
+  readonly #blurOptionValue: HTMLElement;
+  readonly #notice: HTMLElement;
+
+  readonly #blurBar: HTMLElement;
+  readonly #blurCount: HTMLElement;
+  readonly #blurUndo: HTMLButtonElement;
+  readonly #blurNavigate: HTMLButtonElement;
+  readonly #highlight: HTMLElement;
+
+  readonly #countdown: HTMLElement;
+  readonly #countdownValue: HTMLElement;
+
+  readonly #controller: HTMLElement;
+  readonly #elapsed: HTMLElement;
+  readonly #pauseResume: HTMLButtonElement;
+
+  #mode: OverlayMode = "hidden";
+  #microphone = false;
+  #picking = false;
+  #countdownTimer: number | null = null;
+  #tickTimer: number | null = null;
+  #elapsedSeconds = 0;
+
+  constructor(callbacks: OverlayCallbacks) {
+    this.#callbacks = callbacks;
+    this.#blur = new BlurManager((count) => {
+      this.#renderBlurCount(count);
+    });
+
+    this.#host = document.createElement("div");
+    this.#host.id = OVERLAY_HOST_ID;
+    this.#root = this.#host.attachShadow({ mode: "open" });
+    const sheet = new CSSStyleSheet();
+    sheet.replaceSync(OVERLAY_STYLES);
+    this.#root.adoptedStyleSheets = [sheet];
+
+    this.#layer = element("div", "layer");
+    this.#layer.dataset.mode = "hidden";
+    this.#root.append(this.#layer);
+
+    this.#sourceTitle = element("div", "source-title");
+    this.#sourceOrigin = element("div", "source-origin");
+    this.#microphoneValue = element("span", "option-value", "Off");
+    this.#microphoneOption = element("button", "option");
+    this.#tabAudioValue = element("span", "option-value", "Off");
+    this.#tabAudioOption = element("div", "option");
+    this.#blurOptionValue = element("span", "option-value", "None");
+    this.#blurOption = element("button", "option");
+    this.#notice = element("div", "notice");
+    this.#panel = this.#buildPanel();
+
+    this.#blurCount = element("span", "blur-count", "0 blurred");
+    this.#blurUndo = element("button", "pill-button", "Undo");
+    this.#blurNavigate = element("button", "pill-button", "Navigate");
+    this.#blurBar = this.#buildBlurBar();
+    this.#highlight = element("div", "highlight");
+
+    this.#countdownValue = element("div", "countdown-value");
+    this.#countdown = element("div", "countdown");
+    this.#countdown.append(this.#countdownValue);
+
+    this.#elapsed = element("span", "elapsed", "00:00");
+    this.#pauseResume = element("button", "pill-button", "Pause");
+    this.#controller = this.#buildController();
+
+    this.#layer.append(
+      this.#highlight,
+      this.#panel,
+      this.#blurBar,
+      this.#countdown,
+      this.#controller,
+    );
+  }
+
+  get mode(): OverlayMode {
+    return this.#mode;
+  }
+
+  get blurCount(): number {
+    return this.#blur.count;
+  }
+
+  mount(): void {
+    if (!this.#host.isConnected) {
+      document.documentElement.append(this.#host);
+    }
+  }
+
+  prepare(state: RecorderStateSnapshot): void {
+    this.mount();
+    this.#microphone = state.microphone;
+    this.#sourceTitle.textContent = document.title || location.hostname;
+    this.#sourceOrigin.textContent = location.hostname;
+    this.#renderOptions(state);
+    this.#renderState(state);
+  }
+
+  update(state: RecorderStateSnapshot): void {
+    this.#microphone = state.microphone;
+    this.#renderOptions(state);
+    this.#renderState(state);
+  }
+
+  showError(code: string): void {
+    this.#notice.textContent = ERROR_MESSAGES[code] ?? code;
+    this.#notice.hidden = false;
+  }
+
+  destroy(): void {
+    this.#stopCountdown();
+    this.#stopTicking();
+    this.#stopPicking();
+    this.#blur.destroy();
+    this.#host.remove();
+    this.#mode = "hidden";
+  }
+
+  #buildPanel(): HTMLElement {
+    const panel = element("div", "panel");
+    const brand = element("div", "brand");
+    brand.append(element("span", "brand-dot"), document.createTextNode("Okou"));
+
+    const source = element("div", "source");
+    source.append(this.#sourceTitle, this.#sourceOrigin);
+
+    this.#microphoneOption.dataset.option = "microphone";
+    this.#microphoneOption.append(
+      document.createTextNode("Microphone"),
+      this.#microphoneValue,
+    );
+    this.#microphoneOption.addEventListener("click", () => {
+      this.#callbacks.onMicrophone(!this.#microphone);
+    });
+
+    this.#tabAudioOption.dataset.interactive = "false";
+    this.#tabAudioOption.dataset.option = "tab-audio";
+    this.#tabAudioOption.append(
+      document.createTextNode("Tab audio"),
+      this.#tabAudioValue,
+    );
+
+    this.#blurOption.dataset.option = "blur";
+    this.#blurOption.append(
+      document.createTextNode("Blur elements"),
+      this.#blurOptionValue,
+    );
+    this.#blurOption.addEventListener("click", () => {
+      this.#enterBlurMode();
+    });
+
+    const options = element("div", "options");
+    options.append(
+      this.#microphoneOption,
+      this.#tabAudioOption,
+      this.#blurOption,
+    );
+
+    const start = element("button", "primary", "Start recording");
+    start.addEventListener("click", () => {
+      this.#startCountdown();
+    });
+    const cancel = element("button", "secondary", "Cancel");
+    cancel.addEventListener("click", () => {
+      this.#callbacks.onCancel();
+    });
+    const actions = element("div", "actions");
+    actions.append(start, cancel);
+
+    this.#notice.hidden = true;
+    panel.append(brand, source, options, this.#notice, actions);
+    return panel;
+  }
+
+  #buildBlurBar(): HTMLElement {
+    const bar = element("div", "blur-bar");
+    const hint = element("span", "blur-hint", "Click an element to blur it");
+
+    this.#blurUndo.addEventListener("click", () => {
+      this.#blur.undo();
+    });
+    this.#blurNavigate.dataset.active = "false";
+    this.#blurNavigate.addEventListener("click", () => {
+      if (this.#picking) {
+        this.#stopPicking();
+        this.#blurNavigate.dataset.active = "true";
+      } else {
+        this.#startPicking();
+        this.#blurNavigate.dataset.active = "false";
+      }
+    });
+    const done = element("button", "pill-button confirm", "Done");
+    done.addEventListener("click", () => {
+      this.#exitBlurMode();
+    });
+
+    bar.append(hint, this.#blurCount, this.#blurUndo, this.#blurNavigate, done);
+    return bar;
+  }
+
+  #buildController(): HTMLElement {
+    const controller = element("div", "controller");
+    controller.dataset.status = "recording";
+
+    this.#pauseResume.addEventListener("click", () => {
+      if (this.#pauseResume.textContent === "Pause") {
+        this.#callbacks.onPause();
+      } else {
+        this.#callbacks.onResume();
+      }
+    });
+    const finish = element("button", "pill-button confirm", "Finish");
+    finish.addEventListener("click", () => {
+      this.#callbacks.onFinish();
+    });
+    const discard = element("button", "pill-button", "Discard");
+    discard.addEventListener("click", () => {
+      this.#callbacks.onCancel();
+    });
+
+    controller.append(
+      element("span", "recording-dot"),
+      this.#elapsed,
+      this.#pauseResume,
+      finish,
+      discard,
+    );
+    return controller;
+  }
+
+  #setMode(mode: OverlayMode): void {
+    this.#mode = mode;
+    this.#layer.dataset.mode = mode;
+    this.#panel.hidden = mode !== "ready";
+    this.#blurBar.hidden = mode !== "blur";
+    this.#countdown.hidden = mode !== "countdown";
+    this.#controller.hidden = mode !== "recording";
+    if (mode !== "blur") {
+      this.#stopPicking();
+    }
+  }
+
+  #renderOptions(state: RecorderStateSnapshot): void {
+    this.#microphoneOption.dataset.active = String(state.microphone);
+    this.#microphoneValue.textContent = state.microphone ? "On" : "Off";
+    this.#tabAudioOption.dataset.active = String(state.tabAudio);
+    this.#tabAudioValue.textContent = state.tabAudio ? "On" : "Off";
+    this.#renderBlurCount(this.#blur.count);
+  }
+
+  #renderBlurCount(count: number): void {
+    this.#blurOptionValue.textContent =
+      count === 0 ? "None" : `${count} blurred`;
+    this.#blurCount.textContent = `${count} blurred`;
+    this.#blurUndo.disabled = count === 0;
+    this.#blurOption.dataset.active = String(count > 0);
+  }
+
+  #renderState(state: RecorderStateSnapshot): void {
+    this.#elapsedSeconds = state.elapsedSeconds;
+    this.#elapsed.textContent = formatElapsed(state.elapsedSeconds);
+    this.#controller.dataset.status = state.status;
+    this.#pauseResume.textContent =
+      state.status === "paused" ? "Resume" : "Pause";
+    this.#pauseResume.disabled = state.status === "finalizing";
+
+    if (state.status === "ready") {
+      if (this.#mode !== "blur" && this.#mode !== "countdown") {
+        this.#setMode("ready");
+      }
+      this.#stopTicking();
+      return;
+    }
+    this.#setMode("recording");
+    if (state.status === "recording") {
+      this.#startTicking();
+    } else {
+      this.#stopTicking();
+    }
+  }
+
+  #startTicking(): void {
+    if (this.#tickTimer !== null) {
+      return;
+    }
+    this.#tickTimer = window.setInterval(() => {
+      this.#elapsedSeconds += 1;
+      this.#elapsed.textContent = formatElapsed(this.#elapsedSeconds);
+    }, 1000);
+  }
+
+  #stopTicking(): void {
+    if (this.#tickTimer !== null) {
+      window.clearInterval(this.#tickTimer);
+      this.#tickTimer = null;
+    }
+  }
+
+  #enterBlurMode(): void {
+    this.#setMode("blur");
+    this.#startPicking();
+  }
+
+  #exitBlurMode(): void {
+    this.#setMode("ready");
+  }
+
+  #startCountdown(): void {
+    this.#setMode("countdown");
+    let remaining = COUNTDOWN_SECONDS;
+    this.#countdownValue.textContent = String(remaining);
+    this.#countdownTimer = window.setInterval(() => {
+      remaining -= 1;
+      if (remaining > 0) {
+        this.#countdownValue.textContent = String(remaining);
+        return;
+      }
+      this.#stopCountdown();
+      this.#setMode("recording");
+      this.#callbacks.onStart();
+    }, COUNTDOWN_STEP_MS);
+  }
+
+  #stopCountdown(): void {
+    if (this.#countdownTimer !== null) {
+      window.clearInterval(this.#countdownTimer);
+      this.#countdownTimer = null;
+    }
+  }
+
+  readonly #onPointerMove = (event: MouseEvent): void => {
+    const target = this.#elementUnderPointer(event);
+    if (!target) {
+      this.#highlight.dataset.visible = "false";
+      return;
+    }
+    const box = target.getBoundingClientRect();
+    this.#highlight.dataset.visible = "true";
+    this.#highlight.style.left = `${box.left}px`;
+    this.#highlight.style.top = `${box.top}px`;
+    this.#highlight.style.width = `${box.width}px`;
+    this.#highlight.style.height = `${box.height}px`;
+  };
+
+  readonly #onPointerDown = (event: MouseEvent): void => {
+    const target = this.#elementUnderPointer(event);
+    if (!target) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    this.#blur.add(target);
+    this.#highlight.dataset.visible = "false";
+  };
+
+  readonly #onKeyDown = (event: KeyboardEvent): void => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      this.#exitBlurMode();
+    }
+  };
+
+  #elementUnderPointer(event: MouseEvent): HTMLElement | null {
+    const target = document.elementFromPoint(event.clientX, event.clientY);
+    if (
+      !(target instanceof HTMLElement) ||
+      target === this.#host ||
+      target === document.body ||
+      target === document.documentElement ||
+      this.#blur.has(target)
+    ) {
+      return null;
+    }
+    return target;
+  }
+
+  #startPicking(): void {
+    if (this.#picking) {
+      return;
+    }
+    this.#picking = true;
+    document.addEventListener("mousemove", this.#onPointerMove, true);
+    document.addEventListener("click", this.#onPointerDown, true);
+    document.addEventListener("keydown", this.#onKeyDown, true);
+  }
+
+  #stopPicking(): void {
+    if (!this.#picking) {
+      return;
+    }
+    this.#picking = false;
+    this.#highlight.dataset.visible = "false";
+    document.removeEventListener("mousemove", this.#onPointerMove, true);
+    document.removeEventListener("click", this.#onPointerDown, true);
+    document.removeEventListener("keydown", this.#onKeyDown, true);
+  }
+}

--- a/turbo/apps/chrome-recorder/src/recording-store.ts
+++ b/turbo/apps/chrome-recorder/src/recording-store.ts
@@ -1,0 +1,85 @@
+interface StoredRecording {
+  readonly blob: Blob;
+  readonly contentType: string;
+  readonly createdAt: number;
+  readonly durationSeconds: number;
+  readonly name: string;
+  readonly sessionId: string;
+}
+
+const DATABASE_NAME = "okou-screen-recorder";
+const DATABASE_VERSION = 1;
+const RECORDINGS_STORE = "recordings";
+
+function openDatabase(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DATABASE_NAME, DATABASE_VERSION);
+    request.addEventListener("upgradeneeded", () => {
+      const database = request.result;
+      if (!database.objectStoreNames.contains(RECORDINGS_STORE)) {
+        database.createObjectStore(RECORDINGS_STORE, {
+          keyPath: "sessionId",
+        });
+      }
+    });
+    request.addEventListener("success", () => {
+      resolve(request.result);
+    });
+    request.addEventListener("error", () => {
+      reject(request.error ?? new Error("Could not open the recording store"));
+    });
+  });
+}
+
+function transactionCompletion(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.addEventListener("complete", () => {
+      resolve();
+    });
+    transaction.addEventListener("abort", () => {
+      reject(
+        transaction.error ?? new Error("The recording transaction aborted"),
+      );
+    });
+    transaction.addEventListener("error", () => {
+      reject(
+        transaction.error ?? new Error("The recording transaction failed"),
+      );
+    });
+  });
+}
+
+export async function saveRecording(recording: StoredRecording): Promise<void> {
+  const database = await openDatabase();
+  const transaction = database.transaction(RECORDINGS_STORE, "readwrite");
+  transaction.objectStore(RECORDINGS_STORE).put(recording);
+  await transactionCompletion(transaction);
+  database.close();
+}
+
+export async function readRecording(
+  sessionId: string,
+): Promise<StoredRecording | null> {
+  const database = await openDatabase();
+  const transaction = database.transaction(RECORDINGS_STORE, "readonly");
+  const request = transaction.objectStore(RECORDINGS_STORE).get(sessionId);
+  const value = await new Promise<StoredRecording | null>((resolve, reject) => {
+    request.addEventListener("success", () => {
+      resolve((request.result as StoredRecording | undefined) ?? null);
+    });
+    request.addEventListener("error", () => {
+      reject(request.error ?? new Error("Could not read the recording"));
+    });
+  });
+  await transactionCompletion(transaction);
+  database.close();
+  return value;
+}
+
+export async function deleteRecording(sessionId: string): Promise<void> {
+  const database = await openDatabase();
+  const transaction = database.transaction(RECORDINGS_STORE, "readwrite");
+  transaction.objectStore(RECORDINGS_STORE).delete(sessionId);
+  await transactionCompletion(transaction);
+  database.close();
+}

--- a/turbo/apps/chrome-recorder/src/service-worker.ts
+++ b/turbo/apps/chrome-recorder/src/service-worker.ts
@@ -1,0 +1,464 @@
+import { OKOU_RECORDER_SESSION_QUERY } from "@okouai/core/browser-recorder-protocol";
+
+import {
+  extensionMessage,
+  isCaptureSelection,
+  isRuntimeMessage,
+  type CaptureSelection,
+  type ContentMessage,
+  type OffscreenMessage,
+  type RecorderStateSnapshot,
+  type WorkerMessage,
+} from "./messages.ts";
+
+interface StoredSession {
+  readonly appOrigin: string;
+  readonly sessionId: string;
+  readonly state: RecorderStateSnapshot;
+  readonly targetTabId: number;
+}
+
+const ACTIVE_SESSION_KEY = "active-recorder-session";
+const OKOU_APP_ORIGIN = "https://app.okou.ai";
+// Checked in order so a local or preview sign-in wins over production while
+// the feature is being developed against a non-production deployment.
+const OKOU_APP_ORIGINS = [
+  "http://localhost:3002",
+  "https://staging-app.vm7.ai",
+  OKOU_APP_ORIGIN,
+] as const;
+
+async function activeSession(): Promise<StoredSession | null> {
+  const stored: unknown = await chrome.storage.session.get(ACTIVE_SESSION_KEY);
+  const value = (stored as Readonly<Record<string, unknown>>)[
+    ACTIVE_SESSION_KEY
+  ];
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+  const session = value as Readonly<Record<string, unknown>>;
+  if (
+    typeof session.appOrigin !== "string" ||
+    typeof session.sessionId !== "string" ||
+    typeof session.targetTabId !== "number" ||
+    typeof session.state !== "object" ||
+    session.state === null
+  ) {
+    return null;
+  }
+  return value as StoredSession;
+}
+
+async function saveActiveSession(session: StoredSession): Promise<void> {
+  await chrome.storage.session.set({ [ACTIVE_SESSION_KEY]: session });
+}
+
+async function clearActiveSession(): Promise<void> {
+  await chrome.storage.session.remove(ACTIVE_SESSION_KEY);
+  await chrome.action.setBadgeText({ text: "" });
+}
+
+async function ensureOffscreenDocument(): Promise<void> {
+  const documentUrl = chrome.runtime.getURL("offscreen.html");
+  const contexts = await chrome.runtime.getContexts({
+    contextTypes: [chrome.runtime.ContextType.OFFSCREEN_DOCUMENT],
+    documentUrls: [documentUrl],
+  });
+  if (contexts.length > 0) {
+    return;
+  }
+  await chrome.offscreen.createDocument({
+    justification:
+      "Keep the user-selected tab capture and MediaRecorder alive across navigation.",
+    reasons: [chrome.offscreen.Reason.DISPLAY_MEDIA],
+    url: "offscreen.html",
+  });
+}
+
+/**
+ * Resolves the Okou deployment the user is currently signed in to.
+ *
+ * Clerk keeps a `__session` JWT and a `__client_uat` sign-in timestamp on the
+ * application origin. Reading them through `chrome.cookies` verifies the login
+ * before Chrome's share picker opens, and works with no Okou tab open.
+ */
+async function signedInAppOrigin(): Promise<string | null> {
+  for (const origin of OKOU_APP_ORIGINS) {
+    const session = await chrome.cookies.get({
+      name: "__session",
+      url: origin,
+    });
+    if (session && session.value.length > 0) {
+      return origin;
+    }
+    const signedInAt = await chrome.cookies.get({
+      name: "__client_uat",
+      url: origin,
+    });
+    if (signedInAt && signedInAt.value !== "0") {
+      return origin;
+    }
+  }
+  return null;
+}
+
+async function focusTab(tab: chrome.tabs.Tab): Promise<void> {
+  if (!tab.id) {
+    return;
+  }
+  await chrome.tabs.update(tab.id, { active: true });
+  if (tab.windowId !== chrome.windows.WINDOW_ID_NONE) {
+    await chrome.windows.update(tab.windowId, { focused: true });
+  }
+}
+
+/**
+ * Reports a dead end on the toolbar action.
+ *
+ * Recording is refused before any page controls exist, so the action badge is
+ * the only surface left to explain why nothing happened.
+ */
+async function reportBlocked(title: string): Promise<void> {
+  await chrome.action.setBadgeBackgroundColor({ color: "#ff4f0a" });
+  await chrome.action.setBadgeText({ text: "!" });
+  await chrome.action.setTitle({ title });
+}
+
+async function openLoginPreflight(): Promise<void> {
+  await chrome.tabs.create({ active: true, url: `${OKOU_APP_ORIGIN}/` });
+  await reportBlocked("Sign in to Okou, then click the recorder again");
+}
+
+async function selectCaptureSource(
+  sessionId: string,
+): Promise<CaptureSelection> {
+  await ensureOffscreenDocument();
+  const response: unknown = await chrome.runtime.sendMessage(
+    extensionMessage({
+      recipient: "offscreen",
+      sessionId,
+      type: "worker:select-source",
+    }),
+  );
+  return isCaptureSelection(response)
+    ? response
+    : { ok: false, reason: "failed" };
+}
+
+function isInjectableTab(
+  tab: chrome.tabs.Tab | undefined,
+): tab is chrome.tabs.Tab & {
+  readonly id: number;
+  readonly url: string;
+} {
+  if (!tab?.id || !tab.url) {
+    return false;
+  }
+  const url = new URL(tab.url);
+  return url.protocol === "http:" || url.protocol === "https:";
+}
+
+async function sendToTarget(
+  tabId: number,
+  message: ContentMessage,
+): Promise<boolean> {
+  try {
+    await chrome.tabs.sendMessage(tabId, message);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function sendOffscreen(message: OffscreenMessage): Promise<void> {
+  await ensureOffscreenDocument();
+  await chrome.runtime.sendMessage(message);
+}
+
+async function cancelSession(session: StoredSession): Promise<void> {
+  await sendOffscreen(
+    extensionMessage({
+      action: "cancel",
+      recipient: "offscreen",
+      sessionId: session.sessionId,
+      type: "worker:command",
+    }),
+  );
+  await sendToTarget(
+    session.targetTabId,
+    extensionMessage({
+      recipient: "content",
+      sessionId: session.sessionId,
+      type: "worker:cleanup",
+    }),
+  );
+  await clearActiveSession();
+}
+
+async function beginCapture(): Promise<void> {
+  const existing = await activeSession();
+  if (existing) {
+    const target = await chrome.tabs.get(existing.targetTabId);
+    await focusTab(target);
+    return;
+  }
+
+  const appOrigin = await signedInAppOrigin();
+  if (!appOrigin) {
+    await openLoginPreflight();
+    return;
+  }
+
+  await chrome.action.setBadgeText({ text: "" });
+  await chrome.action.setTitle({ title: "Start an Okou recording" });
+  const sessionId = crypto.randomUUID();
+  const selection = await selectCaptureSource(sessionId);
+  if (!selection.ok) {
+    if (selection.reason === "tab-required") {
+      await reportBlocked(
+        "Okou records a Chrome tab. Choose the Chrome Tab option and pick a tab.",
+      );
+    }
+    if (selection.reason === "failed") {
+      await reportBlocked("Chrome could not start capturing this tab");
+    }
+    return;
+  }
+
+  const [target] = await chrome.tabs.query({
+    active: true,
+    lastFocusedWindow: true,
+  });
+  if (!isInjectableTab(target)) {
+    await sendOffscreen(
+      extensionMessage({
+        action: "cancel",
+        recipient: "offscreen",
+        sessionId,
+        type: "worker:command",
+      }),
+    );
+    await reportBlocked(
+      "Okou controls need a regular http or https tab, not a Chrome page",
+    );
+    return;
+  }
+
+  const state: RecorderStateSnapshot = {
+    elapsedSeconds: 0,
+    microphone: false,
+    status: "ready",
+    tabAudio: selection.tabAudio,
+  };
+  const session: StoredSession = {
+    appOrigin,
+    sessionId,
+    state,
+    targetTabId: target.id,
+  };
+  await saveActiveSession(session);
+  const prepared = await sendToTarget(
+    target.id,
+    extensionMessage({
+      recipient: "content",
+      sessionId,
+      state,
+      type: "worker:prepare",
+    }),
+  );
+  if (!prepared) {
+    await cancelSession(session);
+    return;
+  }
+  await chrome.action.setBadgeBackgroundColor({ color: "#ef4444" });
+  await chrome.action.setBadgeText({ text: "REC" });
+}
+
+async function handleContentMessage(
+  message: Extract<
+    WorkerMessage,
+    { readonly type: "content:command" | "content:microphone" }
+  >,
+  sender: chrome.runtime.MessageSender,
+): Promise<void> {
+  const session = await activeSession();
+  if (!session || sender.tab?.id !== session.targetTabId) {
+    return;
+  }
+  if (message.type === "content:microphone") {
+    await sendOffscreen(
+      extensionMessage({
+        enabled: message.enabled,
+        recipient: "offscreen",
+        sessionId: session.sessionId,
+        type: "worker:microphone",
+      }),
+    );
+    return;
+  }
+  await sendOffscreen(
+    extensionMessage({
+      action: message.action,
+      recipient: "offscreen",
+      sessionId: session.sessionId,
+      type: "worker:command",
+    }),
+  );
+  if (message.action === "cancel") {
+    await sendToTarget(
+      session.targetTabId,
+      extensionMessage({
+        recipient: "content",
+        sessionId: session.sessionId,
+        type: "worker:cleanup",
+      }),
+    );
+    await clearActiveSession();
+  }
+}
+
+async function restoreTarget(
+  sender: chrome.runtime.MessageSender,
+): Promise<void> {
+  const session = await activeSession();
+  if (!session || sender.tab?.id !== session.targetTabId) {
+    return;
+  }
+  await sendToTarget(
+    session.targetTabId,
+    extensionMessage({
+      recipient: "content",
+      sessionId: session.sessionId,
+      state: session.state,
+      type: "worker:prepare",
+    }),
+  );
+}
+
+async function updateTargetState(
+  message: Extract<WorkerMessage, { readonly type: "offscreen:state" }>,
+): Promise<void> {
+  const session = await activeSession();
+  if (!session || session.sessionId !== message.sessionId) {
+    return;
+  }
+  const updated = { ...session, state: message.state };
+  await saveActiveSession(updated);
+  await sendToTarget(
+    session.targetTabId,
+    extensionMessage({
+      recipient: "content",
+      sessionId: session.sessionId,
+      state: message.state,
+      type: "worker:state",
+    }),
+  );
+}
+
+async function completeRecording(
+  message: Extract<WorkerMessage, { readonly type: "offscreen:completed" }>,
+): Promise<void> {
+  const session = await activeSession();
+  if (!session || session.sessionId !== message.sessionId) {
+    return;
+  }
+  await sendToTarget(
+    session.targetTabId,
+    extensionMessage({
+      recipient: "content",
+      sessionId: session.sessionId,
+      type: "worker:cleanup",
+    }),
+  );
+  await clearActiveSession();
+  const url = new URL(session.appOrigin);
+  url.searchParams.set(OKOU_RECORDER_SESSION_QUERY, message.sessionId);
+  await chrome.tabs.create({ active: true, url: url.href });
+}
+
+async function handleOffscreenError(
+  message: Extract<WorkerMessage, { readonly type: "offscreen:error" }>,
+): Promise<void> {
+  const session = await activeSession();
+  if (!session || session.sessionId !== message.sessionId) {
+    return;
+  }
+  await sendToTarget(
+    session.targetTabId,
+    extensionMessage({
+      code: message.code,
+      recipient: "content",
+      sessionId: session.sessionId,
+      type: "worker:error",
+    }),
+  );
+  if (message.code !== "microphone-permission") {
+    await sendToTarget(
+      session.targetTabId,
+      extensionMessage({
+        recipient: "content",
+        sessionId: session.sessionId,
+        type: "worker:cleanup",
+      }),
+    );
+    await clearActiveSession();
+  }
+}
+
+async function handleWorkerMessage(
+  message: WorkerMessage,
+  sender: chrome.runtime.MessageSender,
+): Promise<void> {
+  switch (message.type) {
+    case "content:command":
+    case "content:microphone": {
+      await handleContentMessage(message, sender);
+      break;
+    }
+    case "content:mounted": {
+      await restoreTarget(sender);
+      break;
+    }
+    case "offscreen:state": {
+      await updateTargetState(message);
+      break;
+    }
+    case "offscreen:completed": {
+      await completeRecording(message);
+      break;
+    }
+    case "offscreen:error": {
+      await handleOffscreenError(message);
+      break;
+    }
+    case "handoff:consumed": {
+      if (!(await activeSession())) {
+        await chrome.offscreen.closeDocument();
+      }
+      break;
+    }
+  }
+}
+
+chrome.action.onClicked.addListener(() => {
+  void beginCapture();
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  void (async () => {
+    const session = await activeSession();
+    if (session?.targetTabId === tabId) {
+      await cancelSession(session);
+    }
+  })();
+});
+
+chrome.runtime.onMessage.addListener((value, sender, sendResponse) => {
+  if (!isRuntimeMessage(value) || value.recipient !== "worker") {
+    return false;
+  }
+  void handleWorkerMessage(value, sender).then(() => {
+    sendResponse({ ok: true });
+  });
+  return true;
+});

--- a/turbo/apps/chrome-recorder/tsconfig.json
+++ b/turbo/apps/chrome-recorder/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@okouai/typescript-config/base.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "types": ["chrome", "vitest/globals"]
+  },
+  "include": ["src/**/*", "vitest.config.ts", "tsup.config.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/turbo/apps/chrome-recorder/tsup.config.ts
+++ b/turbo/apps/chrome-recorder/tsup.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  clean: true,
+  dts: false,
+  entry: {
+    content: "src/content.ts",
+    handoff: "src/handoff.ts",
+    offscreen: "src/offscreen.ts",
+    "service-worker": "src/service-worker.ts",
+  },
+  format: ["iife"],
+  minify: false,
+  outExtension: () => {
+    return { js: ".js" };
+  },
+  outDir: "dist",
+  platform: "browser",
+  sourcemap: true,
+  splitting: false,
+  target: "chrome116",
+});

--- a/turbo/apps/chrome-recorder/vitest.config.ts
+++ b/turbo/apps/chrome-recorder/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "happy-dom",
+    globals: true,
+  },
+});

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -61,6 +61,19 @@
       "ignoreDependencies": ["eslint", "oxlint", "wrangler"],
       "ignoreBinaries": ["eslint", "oxlint", "wrangler"]
     },
+    "apps/chrome-recorder": {
+      "entry": [
+        "src/content.ts",
+        "src/handoff.ts",
+        "src/offscreen.ts",
+        "src/service-worker.ts",
+        "src/**/*.{test,spec}.ts",
+        "scripts/copy-static.mjs"
+      ],
+      "project": ["src/**/*.ts", "scripts/*.mjs", "*.config.ts"],
+      "ignoreDependencies": ["oxlint"],
+      "ignoreBinaries": ["oxlint"]
+    },
     "apps/desktop": {
       "entry": [
         "forge.config.js",

--- a/turbo/packages/core/src/browser-recorder-protocol.test.ts
+++ b/turbo/packages/core/src/browser-recorder-protocol.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isOkouAppUrl,
+  isOkouRecorderPageMessage,
+  OKOU_RECORDER_CHANNEL,
+  OKOU_RECORDER_PROTOCOL_VERSION,
+  okouRecorderSessionId,
+} from "./browser-recorder-protocol";
+
+describe("browser recorder protocol", () => {
+  it("accepts a recording handoff with a Blob", () => {
+    expect(
+      isOkouRecorderPageMessage({
+        channel: OKOU_RECORDER_CHANNEL,
+        recording: {
+          blob: new Blob(["recording"], { type: "video/webm" }),
+          contentType: "video/webm",
+          durationSeconds: 12.5,
+          name: "Okou recording.webm",
+        },
+        sessionId: "session-1",
+        source: "extension",
+        type: "handoff:recording",
+        version: OKOU_RECORDER_PROTOCOL_VERSION,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects messages from the wrong protocol version", () => {
+    expect(
+      isOkouRecorderPageMessage({
+        channel: OKOU_RECORDER_CHANNEL,
+        sessionId: "session-1",
+        source: "platform",
+        type: "handoff:ready",
+        version: 2,
+      }),
+    ).toBe(false);
+  });
+
+  it.each([
+    "https://app.okou.ai/",
+    "https://app.vm0.ai/agents",
+    "https://staging-app.vm7.ai/",
+    "https://pr-123-app.vm6.ai/",
+    "http://localhost:3002/",
+  ])("recognizes an Okou application URL: %s", (url) => {
+    expect(isOkouAppUrl(url)).toBe(true);
+  });
+
+  it.each([
+    "https://app.okou.ai.evil.example/",
+    "https://okou.ai/",
+    "https://example.com/",
+  ])("rejects a non-application URL: %s", (url) => {
+    expect(isOkouAppUrl(url)).toBe(false);
+  });
+
+  it("reads only bounded non-empty handoff session identifiers", () => {
+    expect(
+      okouRecorderSessionId(
+        new URL("https://app.okou.ai/?okouRecorderSession=session-1"),
+      ),
+    ).toBe("session-1");
+    expect(
+      okouRecorderSessionId(
+        new URL("https://app.okou.ai/?okouRecorderSession="),
+      ),
+    ).toBeNull();
+  });
+});

--- a/turbo/packages/core/src/browser-recorder-protocol.ts
+++ b/turbo/packages/core/src/browser-recorder-protocol.ts
@@ -1,0 +1,125 @@
+export const OKOU_RECORDER_CHANNEL = "okou-recorder";
+export const OKOU_RECORDER_PROTOCOL_VERSION = 1;
+export const OKOU_RECORDER_SESSION_QUERY = "okouRecorderSession";
+
+export type OkouRecorderPageMessage =
+  | {
+      readonly channel: typeof OKOU_RECORDER_CHANNEL;
+      readonly sessionId: string;
+      readonly source: "platform";
+      readonly type: "handoff:ready";
+      readonly version: typeof OKOU_RECORDER_PROTOCOL_VERSION;
+    }
+  | {
+      readonly channel: typeof OKOU_RECORDER_CHANNEL;
+      readonly recording: {
+        readonly blob: Blob;
+        readonly contentType: string;
+        readonly durationSeconds: number;
+        readonly name: string;
+      };
+      readonly sessionId: string;
+      readonly source: "extension";
+      readonly type: "handoff:recording";
+      readonly version: typeof OKOU_RECORDER_PROTOCOL_VERSION;
+    }
+  | {
+      readonly channel: typeof OKOU_RECORDER_CHANNEL;
+      readonly code: "recording-missing";
+      readonly sessionId: string;
+      readonly source: "extension";
+      readonly type: "handoff:error";
+      readonly version: typeof OKOU_RECORDER_PROTOCOL_VERSION;
+    }
+  | {
+      readonly channel: typeof OKOU_RECORDER_CHANNEL;
+      readonly sessionId: string;
+      readonly source: "platform";
+      readonly type: "handoff:complete";
+      readonly version: typeof OKOU_RECORDER_PROTOCOL_VERSION;
+    };
+
+type UnknownRecord = Readonly<Record<string, unknown>>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null;
+}
+
+function isIdentifier(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= 128;
+}
+
+function isRecording(
+  value: unknown,
+): value is Extract<
+  OkouRecorderPageMessage,
+  { readonly type: "handoff:recording" }
+>["recording"] {
+  return (
+    isRecord(value) &&
+    value.blob instanceof Blob &&
+    typeof value.contentType === "string" &&
+    typeof value.durationSeconds === "number" &&
+    Number.isFinite(value.durationSeconds) &&
+    value.durationSeconds >= 0 &&
+    typeof value.name === "string" &&
+    value.name.length > 0
+  );
+}
+
+export function isOkouRecorderPageMessage(
+  value: unknown,
+): value is OkouRecorderPageMessage {
+  if (
+    !isRecord(value) ||
+    value.channel !== OKOU_RECORDER_CHANNEL ||
+    value.version !== OKOU_RECORDER_PROTOCOL_VERSION
+  ) {
+    return false;
+  }
+
+  switch (value.type) {
+    case "handoff:ready":
+    case "handoff:complete": {
+      return value.source === "platform" && isIdentifier(value.sessionId);
+    }
+    case "handoff:recording": {
+      return (
+        value.source === "extension" &&
+        isIdentifier(value.sessionId) &&
+        isRecording(value.recording)
+      );
+    }
+    case "handoff:error": {
+      return (
+        value.source === "extension" &&
+        value.code === "recording-missing" &&
+        isIdentifier(value.sessionId)
+      );
+    }
+    default: {
+      return false;
+    }
+  }
+}
+
+export function okouRecorderSessionId(url: URL): string | null {
+  const sessionId = url.searchParams.get(OKOU_RECORDER_SESSION_QUERY);
+  return isIdentifier(sessionId) ? sessionId : null;
+}
+
+export function isOkouAppUrl(value: string): boolean {
+  const url = new URL(value);
+  if (url.protocol === "https:") {
+    return (
+      url.hostname === "app.okou.ai" ||
+      url.hostname === "app.vm0.ai" ||
+      url.hostname === "staging-app.vm7.ai" ||
+      /^pr-\d+-app\.vm6\.ai$/u.test(url.hostname)
+    );
+  }
+  return (
+    url.protocol === "http:" &&
+    (url.hostname === "localhost" || url.hostname === "127.0.0.1")
+  );
+}

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -112,7 +112,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(vite@8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
 
   apps/api:
     dependencies:
@@ -311,7 +311,35 @@ importers:
         version: 8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(vite@8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
+
+  apps/chrome-recorder:
+    dependencies:
+      '@okouai/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+    devDependencies:
+      '@okouai/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      '@types/chrome':
+        specifier: ^0.1.6
+        version: 0.1.43
+      happy-dom:
+        specifier: ^20.11.1
+        version: 20.11.1
+      oxlint:
+        specifier: ^1.75.0
+        version: 1.75.0(oxlint-tsgolint@7.0.2001)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@swc/core@1.15.46)(jiti@2.7.0)(postcss@8.5.25)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
 
   apps/cli:
     devDependencies:
@@ -401,7 +429,7 @@ importers:
         version: 8.10.0
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(vite@8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
       yaml:
         specifier: '>=2.8.3'
         version: 2.9.0
@@ -501,7 +529,7 @@ importers:
         version: 8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(vite@8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
 
   apps/host-worker:
     devDependencies:
@@ -778,7 +806,7 @@ importers:
         version: 8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(vite@8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/api-contracts:
     dependencies:
@@ -815,7 +843,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(vite@8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/api-services:
     devDependencies:
@@ -839,7 +867,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(vite@8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/connectors:
     dependencies:
@@ -879,7 +907,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(vite@8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/core:
     dependencies:
@@ -913,7 +941,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(vite@8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/db:
     dependencies:
@@ -974,7 +1002,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(vite@8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/eslint-config:
     devDependencies:
@@ -998,7 +1026,7 @@ importers:
         version: 7.0.1(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-turbo:
         specifier: ^2.8.14
-        version: 2.8.21(eslint@9.39.4(jiti@2.7.0))(turbo@2.10.12)
+        version: 2.8.21(eslint@9.39.4(jiti@2.7.0))(turbo@2.10.11)
       globals:
         specifier: ^16.3.0
         version: 16.5.0
@@ -1044,7 +1072,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(vite@8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/mermaid-lite: {}
 
@@ -1080,7 +1108,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(vite@8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/proxy: {}
 
@@ -1172,7 +1200,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(vite@8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
 
 packages:
 
@@ -4321,18 +4349,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-64@2.10.12':
-    resolution: {integrity: sha512-9nKgKoF6ZOUsM+or0OtNf+TTJSfGvDNP7ZFv/ZGWVwOSCkumyctQiTeHwB4UNljHTnC41AqylgbunLDHoccNrA==}
-    cpu: [x64]
-    os: [darwin]
-
   '@turbo/darwin-arm64@2.10.11':
     resolution: {integrity: sha512-R0a0CvGAeYYsBgPIgFNB3agGXh6qukjduNhFlwVVX1Ss2IdBJLXmgjytNGmo084bLKS0B6UdLRwKhXMHKKaObQ==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@turbo/darwin-arm64@2.10.12':
-    resolution: {integrity: sha512-H4Elb1jqTZVeIC9bbcNwjSzemZ6RegoTOVHeuV5Osirt2Z8UguTyisMEkvZjPVZgMeN9J4ERZBFad40tFnkb7w==}
     cpu: [arm64]
     os: [darwin]
 
@@ -4341,18 +4359,8 @@ packages:
     cpu: [x64]
     os: [android, linux]
 
-  '@turbo/linux-64@2.10.12':
-    resolution: {integrity: sha512-lr7KIotukvjZwEXiFSYAeOH3BWzjFVBbSzTbv0fuGFsNukYyH0+g1hB5ecqnJkgkYU+KHEMG1edOhnjiKON1wQ==}
-    cpu: [x64]
-    os: [android, linux]
-
   '@turbo/linux-arm64@2.10.11':
     resolution: {integrity: sha512-eSP9+jjsSCBs2x0QpJZlp49dSD1EIMwXH7PsMIhdWk7w6IThhuKJ+jL95JQ2IW7tRjRmdh8gKcKQtrHLD5R5lA==}
-    cpu: [arm64]
-    os: [android, linux]
-
-  '@turbo/linux-arm64@2.10.12':
-    resolution: {integrity: sha512-f0pZDTtvzB5SuNwuXBaKbZHUCMCukgc8nMlHEuvLmj91Fzec+MEbr3cAvGNor5htEDqZnO6Lxt9N/GPI/77oGA==}
     cpu: [arm64]
     os: [android, linux]
 
@@ -4361,18 +4369,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-64@2.10.12':
-    resolution: {integrity: sha512-SDOueJRjS/QcykWf2KCRtTLmIl5YMKsLbXkXQGhDwcTXvKXZiS5ih5lBl/gkwZIpYFjqA/rAlfMzlAFcVHNe0g==}
-    cpu: [x64]
-    os: [win32]
-
   '@turbo/windows-arm64@2.10.11':
     resolution: {integrity: sha512-m8tJkIrTrbQ9O1uHxV0GUq623Zg1678xGna8eMsy4KbygUX/wVFgdZDYV/AxyoyaW/U7nyKoBvaDVwm22p9xqA==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@turbo/windows-arm64@2.10.12':
-    resolution: {integrity: sha512-0i0mVUa4kKk+/B3RwEwPMf9CB+T7ul56hn5FFHNA4VUNTOoLBEd6aNf3FaKfCatDNZ6cicCEf6if9QUTVyzzcA==}
     cpu: [arm64]
     os: [win32]
 
@@ -4393,6 +4391,9 @@ packages:
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/chrome@0.1.43':
+    resolution: {integrity: sha512-ukH/HhmR6ht+UTX3PLUWJxgJ/RQcK2Foj4lBzsF24SIWsXgqhGuXqjd8FFuwioPP7d/JUKLM4g8GZxw3F4HTcA==}
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
@@ -4417,6 +4418,15 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/filesystem@0.0.36':
+    resolution: {integrity: sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==}
+
+  '@types/filewriter@0.0.33':
+    resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
+
+  '@types/har-format@1.2.16':
+    resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
   '@types/hast@3.0.5':
     resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
@@ -8732,10 +8742,6 @@ packages:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -8840,10 +8846,6 @@ packages:
 
   turbo@2.10.11:
     resolution: {integrity: sha512-yQfwQVoRXwOuyX1LxiJFBFNg6VfuYh+/RyZLd82+isgyLkBXw3S5XRRzvcck1FAjSCG5sVyLd+O1eDMvYa3J7g==}
-    hasBin: true
-
-  turbo@2.10.12:
-    resolution: {integrity: sha512-AswgMPnpOoaVZHrrSBejETzEbuIA69OVGwfkHwfrY0A23VjWXBANzgq9+OymWOHAIArB7D1+1z498WY8fGg1Jw==}
     hasBin: true
 
   type-check@0.4.0:
@@ -9054,7 +9056,7 @@ packages:
     peerDependencies:
       '@types/node': 24.3.0
       '@vitejs/devtools': ^0.1.18
-      esbuild: '>=0.28.1'
+      esbuild: 0.28.1
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -9106,7 +9108,6 @@ packages:
       '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -12636,37 +12637,19 @@ snapshots:
   '@turbo/darwin-64@2.10.11':
     optional: true
 
-  '@turbo/darwin-64@2.10.12':
-    optional: true
-
   '@turbo/darwin-arm64@2.10.11':
-    optional: true
-
-  '@turbo/darwin-arm64@2.10.12':
     optional: true
 
   '@turbo/linux-64@2.10.11':
     optional: true
 
-  '@turbo/linux-64@2.10.12':
-    optional: true
-
   '@turbo/linux-arm64@2.10.11':
-    optional: true
-
-  '@turbo/linux-arm64@2.10.12':
     optional: true
 
   '@turbo/windows-64@2.10.11':
     optional: true
 
-  '@turbo/windows-64@2.10.12':
-    optional: true
-
   '@turbo/windows-arm64@2.10.11':
-    optional: true
-
-  '@turbo/windows-arm64@2.10.12':
     optional: true
 
   '@tybys/wasm-util@0.10.1':
@@ -12698,6 +12681,11 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/chrome@0.1.43':
+    dependencies:
+      '@types/filesystem': 0.0.36
+      '@types/har-format': 1.2.16
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 24.3.0
@@ -12725,6 +12713,14 @@ snapshots:
   '@types/estree@1.0.8': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/filesystem@0.0.36':
+    dependencies:
+      '@types/filewriter': 0.0.33
+
+  '@types/filewriter@0.0.33': {}
+
+  '@types/har-format@1.2.16': {}
 
   '@types/hast@3.0.5':
     dependencies:
@@ -12989,7 +12985,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(vite@8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -13036,7 +13032,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(vite@8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -14253,11 +14249,11 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-turbo@2.8.21(eslint@9.39.4(jiti@2.7.0))(turbo@2.10.12):
+  eslint-plugin-turbo@2.8.21(eslint@9.39.4(jiti@2.7.0))(turbo@2.10.11):
     dependencies:
       dotenv: 16.0.3
       eslint: 9.39.4(jiti@2.7.0)
-      turbo: 2.10.12
+      turbo: 2.10.11
 
   eslint-scope@5.1.1:
     dependencies:
@@ -17669,11 +17665,6 @@ snapshots:
 
   tinyexec@1.2.4: {}
 
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -17752,7 +17743,7 @@ snapshots:
       source-map: 0.7.6
       sucrase: 3.35.1
       tinyexec: 0.3.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
       '@swc/core': 1.15.46
@@ -17779,15 +17770,6 @@ snapshots:
       '@turbo/linux-arm64': 2.10.11
       '@turbo/windows-64': 2.10.11
       '@turbo/windows-arm64': 2.10.11
-
-  turbo@2.10.12:
-    optionalDependencies:
-      '@turbo/darwin-64': 2.10.12
-      '@turbo/darwin-arm64': 2.10.12
-      '@turbo/linux-64': 2.10.12
-      '@turbo/linux-arm64': 2.10.12
-      '@turbo/windows-64': 2.10.12
-      '@turbo/windows-arm64': 2.10.12
 
   type-check@0.4.0:
     dependencies:
@@ -18031,7 +18013,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(vite@8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(vite@8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
@@ -18060,7 +18042,18 @@ snapshots:
       '@vitest/ui': 4.1.10(vitest@4.1.10)
       happy-dom: 20.11.1
     transitivePeerDependencies:
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
       - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   w3c-keyname@2.2.8: {}
 


### PR DESCRIPTION
Adds a Manifest V3 Chrome extension that records a browser tab with Okou's controls rendered inside the page being recorded.

## Flow

Toolbar action → Okou sign-in check → Chrome's native share picker → in-page ready panel → `3 · 2 · 1` countdown → in-page recording controller → new Okou tab with the finished recording.

The sign-in check reads the Clerk `__session` / `__client_uat` cookies on the Okou origin through `chrome.cookies`, so it needs no open Okou tab and no application change. Capture runs in an offscreen document so the stream and `MediaRecorder` survive navigation inside the recorded tab. Only the **Chrome Tab** surface is accepted — the page controls and DOM blur exist only inside a tab — and the toolbar action now explains every refusal instead of failing silently.

## Element blur

Blur reaches `MediaRecorder` rather than a post-processing step, so no unblurred copy of the video ever exists.

A selection sets an inline `filter: blur(10px) !important` on the element, so the blur travels with it while the page scrolls. Pages also destroy and rebuild those nodes — virtualized lists, infinite scroll, SPA re-renders — so each selection additionally stores a selector (preferring `id` and stable test/ARIA attributes, falling back to a structural path) and is re-applied on DOM mutations, inline style overwrites, and scroll.

## Scope

`packages/core/src/browser-recorder-protocol.ts` holds the handoff contract shared with the application. The application side — receiving `handoff:recording`, opening the source dialog, uploading — is **not** in this PR.

## Verification

12 unit tests cover the blur manager and the overlay state machine. Additionally exercised against a real Chromium 151 with the unpacked build loaded: the service worker starts, `chrome.cookies` reads the sign-in state with no Okou tab open, `getDisplayMedia` succeeds from the offscreen document without a user gesture, the ready panel renders in the recorded page, clicking an element blurs it, the blur re-applies to a recycled node after a scroll re-render, and the countdown sends `start` to the service worker.

Not verified: headless Chromium resolves every `getDisplayMedia` call to a synthetic monitor, so the `displaySurface === "browser"` guard has not been exercised against a real tab selection.

## Status

Opened for review of the approach and then closed immediately — not intended to merge as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
