### PR TITLE
feat(cli): add aggregate connector doctor

### DIFF
--- a/turbo/apps/cli/src/commands/doctor/__tests__/connectors.test.ts
+++ b/turbo/apps/cli/src/commands/doctor/__tests__/connectors.test.ts
@@ -1,0 +1,705 @@
+import type {
+  WorkflowConnectorReadinessEntry,
+  WorkflowDetailResponse,
+  WorkflowSummary,
+} from "@okouai/api-contracts/contracts/workflows";
+import chalk from "chalk";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { server } from "../../../mocks/server";
+import { connectorsCommand } from "../connectors";
+
+const API_ORIGIN = "http://localhost:3000";
+const OWNER_USER_ID = "user-owner";
+const OTHER_USER_ID = "user-other";
+const AGENT_ID = "11111111-1111-1111-1111-111111111111";
+const ATTENTION_WORKFLOW_ID = "20000000-0000-4000-8000-000000000001";
+const UNKNOWN_WORKFLOW_ID = "20000000-0000-4000-8000-000000000002";
+const READY_WORKFLOW_ID = "20000000-0000-4000-8000-000000000003";
+const EMPTY_WORKFLOW_ID = "20000000-0000-4000-8000-000000000004";
+const OFFICIAL_WORKFLOW_ID = "20000000-0000-4000-8000-000000000005";
+const FOREIGN_WORKFLOW_ID = "20000000-0000-4000-8000-000000000006";
+const RAW_SECRET = "raw-secret-must-not-appear";
+
+interface JsonConnector {
+  readonly slug: string;
+  readonly label: string;
+  readonly reason: string;
+  readonly status: string;
+  readonly action: {
+    readonly kind: string;
+    readonly label: string;
+    readonly url: string;
+  } | null;
+}
+
+interface JsonWorkflow {
+  readonly id: string;
+  readonly name: string;
+  readonly displayName: string | null;
+  readonly agent: {
+    readonly id: string;
+    readonly name: string | null;
+    readonly displayName: string | null;
+  };
+  readonly official: {
+    readonly definitionName: string;
+    readonly installationState: string;
+    readonly definitionLifecycle: string;
+    readonly readOnly: boolean;
+  } | null;
+  readonly outcome: string;
+  readonly connectors: readonly JsonConnector[];
+  readonly error: {
+    readonly code: string;
+    readonly message: string;
+    readonly status: number | null;
+  } | null;
+}
+
+interface JsonReport {
+  readonly schemaVersion: number;
+  readonly summary: {
+    readonly checked: number;
+    readonly attention: number;
+    readonly unknown: number;
+    readonly ready: number;
+    readonly noConnectors: number;
+  };
+  readonly workflows: readonly JsonWorkflow[];
+}
+
+function encodeJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function okouToken(userId: string): string {
+  return `vm0_sandbox_${encodeJson({ alg: "HS256", typ: "JWT" })}.${encodeJson({
+    userId,
+    runId: "run-doctor",
+    orgId: "org-doctor",
+    scope: "okou",
+    capabilities: ["agent:read"],
+    iat: 1,
+    exp: 4_102_444_800,
+  })}.test-signature`;
+}
+
+function workflow(
+  id: string,
+  name: string,
+  overrides: Partial<WorkflowSummary> = {},
+): WorkflowSummary {
+  return {
+    id,
+    agentId: AGENT_ID,
+    agentName: "doctor-agent",
+    agentDisplayName: "Doctor Agent",
+    name,
+    displayName: null,
+    description: null,
+    visibility: "private",
+    ownerUserId: OWNER_USER_ID,
+    createdAt: "2026-08-31T00:00:00.000Z",
+    canManage: true,
+    canPublish: true,
+    official: null,
+    shadowedBy: null,
+    ...overrides,
+  };
+}
+
+function workflowDetail(summary: WorkflowSummary): WorkflowDetailResponse {
+  return {
+    ...summary,
+    createdByUserId: summary.ownerUserId,
+    updatedByUserId: summary.ownerUserId,
+    updatedAt: "2026-08-31T00:00:00.000Z",
+    instruction: "Run the workflow.",
+    files: null,
+    fileContents: null,
+    automations: [],
+  };
+}
+
+function mockWorkflowList(workflows: readonly WorkflowSummary[]): void {
+  server.use(
+    http.get(`${API_ORIGIN}/api/workflows`, () => {
+      return HttpResponse.json(workflows);
+    }),
+  );
+}
+
+function mockWorkflowDetail(summary: WorkflowSummary): void {
+  server.use(
+    http.get(`${API_ORIGIN}/api/workflows/${summary.id}`, () => {
+      return HttpResponse.json(workflowDetail(summary));
+    }),
+  );
+}
+
+function reportFromOutput(output: string): JsonReport {
+  return JSON.parse(output) as JsonReport;
+}
+
+describe("okou doctor connectors command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("OKOU_API_BACKEND_URL", API_ORIGIN);
+    vi.stubEnv("OKOU_APP_URL", API_ORIGIN);
+    vi.stubEnv("OKOU_TOKEN", okouToken(OWNER_USER_ID));
+    connectorsCommand.setOptionValue("agent", undefined);
+    connectorsCommand.setOptionValue("json", undefined);
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  function output(): string {
+    return mockConsoleLog.mock.calls.flat().join("\n");
+  }
+
+  async function run(args: readonly string[] = []): Promise<void> {
+    await connectorsCommand.parseAsync(["node", "cli", ...args]);
+  }
+
+  it("reports only owned workflows with stable outcomes and action links", async () => {
+    const attention = workflow(ATTENTION_WORKFLOW_ID, "attention-workflow", {
+      displayName: "Attention Workflow",
+      description: `Connector configuration ${RAW_SECRET}`,
+    });
+    const unknown = workflow(UNKNOWN_WORKFLOW_ID, "unknown-workflow");
+    const ready = workflow(READY_WORKFLOW_ID, "ready-workflow");
+    const empty = workflow(EMPTY_WORKFLOW_ID, "empty-workflow");
+    const official = workflow(OFFICIAL_WORKFLOW_ID, "official-workflow", {
+      official: {
+        definitionName: "official-workflow",
+        installationState: "installed",
+        definitionLifecycle: "active",
+        readOnly: true,
+      },
+    });
+    const foreign = workflow(FOREIGN_WORKFLOW_ID, "foreign-workflow", {
+      visibility: "public",
+      ownerUserId: OTHER_USER_ID,
+    });
+    mockWorkflowList([attention, unknown, ready, empty, official, foreign]);
+
+    const checkedWorkflowIds = new Set<string>();
+    server.use(
+      http.post(
+        `${API_ORIGIN}/api/workflows/:workflowId/connector-readiness`,
+        ({ params }) => {
+          const workflowId = String(params.workflowId);
+          checkedWorkflowIds.add(workflowId);
+          if (workflowId === ATTENTION_WORKFLOW_ID) {
+            return HttpResponse.json({
+              connectors: [
+                {
+                  connectorSlug: "gmail",
+                  label: "Gmail",
+                  reason: "The workflow reads Gmail messages.",
+                  status: "reconnect-required",
+                },
+                {
+                  connectorSlug: "notion",
+                  label: "Notion",
+                  reason: "The workflow updates Notion pages.",
+                  status: "scope-mismatch",
+                },
+                {
+                  connectorSlug: "slack",
+                  label: "Slack",
+                  reason: "The workflow posts to Slack.",
+                  status: "not-connected",
+                },
+                {
+                  connectorSlug: "github",
+                  label: "GitHub",
+                  reason: "The workflow reads GitHub issues.",
+                  status: "not-enabled-for-agent",
+                },
+                {
+                  connectorSlug: "google-drive",
+                  label: "Google Drive",
+                  reason: "The workflow reads Drive files.",
+                  status: "connected",
+                },
+              ] satisfies WorkflowConnectorReadinessEntry[],
+            });
+          }
+          if (workflowId === UNKNOWN_WORKFLOW_ID) {
+            return HttpResponse.json({
+              connectors: [
+                {
+                  connectorSlug: "linear",
+                  label: "Linear",
+                  reason: "The connector is referenced by an automation.",
+                  status: "unavailable",
+                },
+                {
+                  connectorSlug: "github",
+                  label: "GitHub",
+                  reason: "The workflow reads GitHub issues.",
+                  status: "connected",
+                },
+              ] satisfies WorkflowConnectorReadinessEntry[],
+            });
+          }
+          if (workflowId === READY_WORKFLOW_ID) {
+            return HttpResponse.json({
+              connectors: [
+                {
+                  connectorSlug: "github",
+                  label: "GitHub",
+                  reason: "The workflow reads GitHub issues.",
+                  status: "connected",
+                },
+              ] satisfies WorkflowConnectorReadinessEntry[],
+            });
+          }
+          if (workflowId === EMPTY_WORKFLOW_ID) {
+            return HttpResponse.json({ connectors: [] });
+          }
+          if (workflowId === OFFICIAL_WORKFLOW_ID) {
+            return HttpResponse.json(
+              {
+                error: {
+                  code: "CONFLICT",
+                  message: `Official workflow conflict ${RAW_SECRET}`,
+                },
+              },
+              { status: 409 },
+            );
+          }
+          throw new Error(`Unexpected readiness request for ${workflowId}`);
+        },
+      ),
+    );
+
+    await run(["--json"]);
+
+    const printed = output();
+    const report = reportFromOutput(printed);
+    expect(Object.keys(report)).toStrictEqual([
+      "schemaVersion",
+      "summary",
+      "workflows",
+    ]);
+    expect(report.schemaVersion).toBe(1);
+    expect(report.summary).toStrictEqual({
+      checked: 5,
+      attention: 1,
+      unknown: 2,
+      ready: 1,
+      noConnectors: 1,
+    });
+    expect(checkedWorkflowIds).toStrictEqual(
+      new Set([
+        ATTENTION_WORKFLOW_ID,
+        UNKNOWN_WORKFLOW_ID,
+        READY_WORKFLOW_ID,
+        EMPTY_WORKFLOW_ID,
+        OFFICIAL_WORKFLOW_ID,
+      ]),
+    );
+
+    const attentionResult = report.workflows.find((item) => {
+      return item.id === ATTENTION_WORKFLOW_ID;
+    });
+    expect(Object.keys(attentionResult ?? {})).toStrictEqual([
+      "id",
+      "name",
+      "displayName",
+      "agent",
+      "official",
+      "outcome",
+      "connectors",
+      "error",
+    ]);
+    expect(attentionResult?.outcome).toBe("attention");
+    expect(attentionResult?.connectors).toStrictEqual([
+      {
+        slug: "gmail",
+        label: "Gmail",
+        reason: "The workflow reads Gmail messages.",
+        status: "reconnect-required",
+        action: {
+          kind: "reconnect",
+          label: "Reconnect",
+          url: `${API_ORIGIN}/connectors/gmail/connect?agentId=${AGENT_ID}`,
+        },
+      },
+      {
+        slug: "notion",
+        label: "Notion",
+        reason: "The workflow updates Notion pages.",
+        status: "scope-mismatch",
+        action: {
+          kind: "review-permissions",
+          label: "Review permissions",
+          url: `${API_ORIGIN}/connectors/notion/connect?agentId=${AGENT_ID}`,
+        },
+      },
+      {
+        slug: "slack",
+        label: "Slack",
+        reason: "The workflow posts to Slack.",
+        status: "not-connected",
+        action: {
+          kind: "connect",
+          label: "Connect",
+          url: `${API_ORIGIN}/connectors/slack/connect?agentId=${AGENT_ID}`,
+        },
+      },
+      {
+        slug: "github",
+        label: "GitHub",
+        reason: "The workflow reads GitHub issues.",
+        status: "not-enabled-for-agent",
+        action: {
+          kind: "enable-for-agent",
+          label: "Enable for agent",
+          url: `${API_ORIGIN}/connectors/github/authorize?agentId=${AGENT_ID}`,
+        },
+      },
+      {
+        slug: "google-drive",
+        label: "Google Drive",
+        reason: "The workflow reads Drive files.",
+        status: "connected",
+        action: null,
+      },
+    ]);
+
+    const unknownResult = report.workflows.find((item) => {
+      return item.id === UNKNOWN_WORKFLOW_ID;
+    });
+    expect(unknownResult?.outcome).toBe("unknown");
+    expect(unknownResult?.connectors[0]).toMatchObject({
+      slug: "linear",
+      status: "unavailable",
+      action: null,
+    });
+    expect(
+      report.workflows.find((item) => {
+        return item.id === READY_WORKFLOW_ID;
+      })?.outcome,
+    ).toBe("ready");
+    expect(
+      report.workflows.find((item) => {
+        return item.id === EMPTY_WORKFLOW_ID;
+      })?.outcome,
+    ).toBe("no-connectors");
+
+    const officialResult = report.workflows.find((item) => {
+      return item.id === OFFICIAL_WORKFLOW_ID;
+    });
+    expect(officialResult).toMatchObject({
+      outcome: "unknown",
+      official: {
+        definitionName: "official-workflow",
+        installationState: "installed",
+        definitionLifecycle: "active",
+        readOnly: true,
+      },
+      connectors: [],
+      error: {
+        code: "OFFICIAL_WORKFLOW_UNSUPPORTED",
+        message:
+          "Connector readiness is unavailable for this Official Workflow during rollout.",
+        status: 409,
+      },
+    });
+    expect(
+      report.workflows.some((item) => {
+        return item.id === FOREIGN_WORKFLOW_ID;
+      }),
+    ).toBe(false);
+    expect(printed).not.toContain(RAW_SECRET);
+    expect(printed).not.toContain(OWNER_USER_ID);
+    expect(printed).not.toContain(process.env.OKOU_TOKEN);
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it("resolves a workflow name through the normal agent-scoped list", async () => {
+    const selected = workflow(READY_WORKFLOW_ID, "sales-digest", {
+      displayName: "Sales Digest",
+    });
+    let requestedAgentId: string | null = null;
+    server.use(
+      http.get(`${API_ORIGIN}/api/workflows`, ({ request }) => {
+        requestedAgentId = new URL(request.url).searchParams.get("agentId");
+        return HttpResponse.json([selected]);
+      }),
+    );
+    mockWorkflowDetail(selected);
+    server.use(
+      http.post(
+        `${API_ORIGIN}/api/workflows/${selected.id}/connector-readiness`,
+        () => {
+          return HttpResponse.json({ connectors: [] });
+        },
+      ),
+    );
+
+    await run([selected.name, "--agent", AGENT_ID, "--json"]);
+
+    const report = reportFromOutput(output());
+    expect(requestedAgentId).toBe(AGENT_ID);
+    expect(report.summary.checked).toBe(1);
+    expect(report.workflows[0]).toMatchObject({
+      id: selected.id,
+      name: selected.name,
+      displayName: selected.displayName,
+      outcome: "no-connectors",
+    });
+  });
+
+  it("checks a workflow ID without listing other workflows", async () => {
+    const selected = workflow(READY_WORKFLOW_ID, "direct-id");
+    mockWorkflowDetail(selected);
+    server.use(
+      http.post(
+        `${API_ORIGIN}/api/workflows/${selected.id}/connector-readiness`,
+        () => {
+          return HttpResponse.json({ connectors: [] });
+        },
+      ),
+    );
+
+    await run([selected.id, "--json"]);
+
+    expect(reportFromOutput(output()).workflows[0]?.id).toBe(selected.id);
+  });
+
+  it("bounds readiness requests and keeps a partial failure in the report", async () => {
+    const workflows = Array.from({ length: 6 }, (_, index) => {
+      return workflow(
+        `30000000-0000-4000-8000-${String(index + 1).padStart(12, "0")}`,
+        `workflow-${index + 1}`,
+      );
+    });
+    mockWorkflowList(workflows);
+    const requestedWorkflowIds = new Set<string>();
+    let requestCount = 0;
+    let activeRequests = 0;
+    let maxActiveRequests = 0;
+    let releaseRequests: (() => void) | undefined;
+    const requestGate = new Promise<void>((resolve) => {
+      releaseRequests = resolve;
+    });
+    server.use(
+      http.post(
+        `${API_ORIGIN}/api/workflows/:workflowId/connector-readiness`,
+        async ({ params }) => {
+          const workflowId = String(params.workflowId);
+          requestedWorkflowIds.add(workflowId);
+          requestCount += 1;
+          activeRequests += 1;
+          maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+          if (requestCount <= 4) {
+            await requestGate;
+          }
+          activeRequests -= 1;
+          if (workflowId === workflows[4]?.id) {
+            return HttpResponse.json(
+              {
+                error: {
+                  code: "PROVIDER_UNAVAILABLE",
+                  message: `Provider failed with ${RAW_SECRET}`,
+                },
+              },
+              { status: 503 },
+            );
+          }
+          return HttpResponse.json({ connectors: [] });
+        },
+      ),
+    );
+
+    const parsing = run(["--json"]);
+    await expect
+      .poll(() => {
+        return requestCount;
+      })
+      .toBe(4);
+    const firstWaveRequests = requestCount;
+    if (!releaseRequests) {
+      throw new Error(
+        "Expected the connector readiness gate to be initialized",
+      );
+    }
+    releaseRequests();
+    await parsing;
+
+    const printed = output();
+    const report = reportFromOutput(printed);
+    expect(firstWaveRequests).toBe(4);
+    expect(maxActiveRequests).toBe(4);
+    expect(requestedWorkflowIds).toStrictEqual(
+      new Set(
+        workflows.map((item) => {
+          return item.id;
+        }),
+      ),
+    );
+    expect(report.summary).toStrictEqual({
+      checked: 6,
+      attention: 0,
+      unknown: 1,
+      ready: 0,
+      noConnectors: 5,
+    });
+    expect(report.workflows[4]?.error).toStrictEqual({
+      code: "PROVIDER_UNAVAILABLE",
+      message: "The connector readiness provider is unavailable.",
+      status: 503,
+    });
+    expect(printed).not.toContain(RAW_SECRET);
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it("prints actionable and unknown workflows before the compact summary", async () => {
+    const attention = workflow(ATTENTION_WORKFLOW_ID, "needs-connector");
+    const unknown = workflow(UNKNOWN_WORKFLOW_ID, "cannot-check");
+    mockWorkflowList([attention, unknown]);
+    server.use(
+      http.post(
+        `${API_ORIGIN}/api/workflows/:workflowId/connector-readiness`,
+        ({ params }) => {
+          if (String(params.workflowId) === attention.id) {
+            return HttpResponse.json({
+              connectors: [
+                {
+                  connectorSlug: "gmail",
+                  label: "Gmail",
+                  reason: "The workflow reads Gmail messages.",
+                  status: "not-connected",
+                },
+              ] satisfies WorkflowConnectorReadinessEntry[],
+            });
+          }
+          return HttpResponse.json(
+            {
+              error: {
+                code: "PAYLOAD_TOO_LARGE",
+                message: `Workflow input contains ${RAW_SECRET}`,
+              },
+            },
+            { status: 413 },
+          );
+        },
+      ),
+    );
+
+    await run();
+
+    const printed = output();
+    expect(printed).toContain("Needs attention (1)");
+    expect(printed).toContain("Unknown (1)");
+    expect(printed).toContain(
+      `Connect: ${API_ORIGIN}/connectors/gmail/connect?agentId=${AGENT_ID}`,
+    );
+    expect(printed.indexOf("Needs attention")).toBeLessThan(
+      printed.indexOf("Unknown"),
+    );
+    expect(printed.indexOf("Unknown")).toBeLessThan(
+      printed.indexOf("Summary:"),
+    );
+    expect(printed).not.toContain(RAW_SECRET);
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it("prints an all-clear result for ready and connector-free workflows", async () => {
+    const ready = workflow(READY_WORKFLOW_ID, "ready-workflow");
+    const empty = workflow(EMPTY_WORKFLOW_ID, "empty-workflow");
+    mockWorkflowList([ready, empty]);
+    server.use(
+      http.post(
+        `${API_ORIGIN}/api/workflows/:workflowId/connector-readiness`,
+        ({ params }) => {
+          if (String(params.workflowId) === ready.id) {
+            return HttpResponse.json({
+              connectors: [
+                {
+                  connectorSlug: "github",
+                  label: "GitHub",
+                  reason: "The workflow reads GitHub issues.",
+                  status: "connected",
+                },
+              ] satisfies WorkflowConnectorReadinessEntry[],
+            });
+          }
+          return HttpResponse.json({ connectors: [] });
+        },
+      ),
+    );
+
+    await run();
+
+    expect(output()).toContain("✓ All clear: 2 workflows checked");
+    expect(output()).toContain("1 ready · 1 no connectors required");
+  });
+
+  it("prints an empty-owned-workflows result without checking public rows", async () => {
+    mockWorkflowList([
+      workflow(FOREIGN_WORKFLOW_ID, "foreign-workflow", {
+        visibility: "public",
+        ownerUserId: OTHER_USER_ID,
+      }),
+    ]);
+    let readinessRequests = 0;
+    server.use(
+      http.post(
+        `${API_ORIGIN}/api/workflows/:workflowId/connector-readiness`,
+        () => {
+          readinessRequests += 1;
+          return HttpResponse.json({ connectors: [] });
+        },
+      ),
+    );
+
+    await run();
+
+    expect(output()).toContain(
+      "No owned or installed workflows to check for connectors",
+    );
+    expect(readinessRequests).toBe(0);
+  });
+
+  it("fails before listing workflows when OKOU_TOKEN cannot identify the owner", async () => {
+    vi.stubEnv("OKOU_TOKEN", "invalid-token");
+
+    await expect(run()).rejects.toThrow("process.exit called");
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "Authentication failed",
+    );
+  });
+
+  it("fails when --agent is passed without a workflow argument", async () => {
+    await expect(run(["--agent", AGENT_ID])).rejects.toThrow(
+      "process.exit called",
+    );
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "--agent requires a workflow argument",
+    );
+  });
+});

--- a/turbo/apps/cli/src/commands/doctor/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/doctor/__tests__/index.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { doctorCommand } from "../index";
+
+describe("okou doctor command", () => {
+  it("documents the aggregate connector doctor without changing connector check", () => {
+    let help = "";
+    doctorCommand.configureOutput({
+      writeOut: (text: string) => {
+        help += text;
+      },
+    });
+    doctorCommand.outputHelp();
+    const normalizedHelp = help.replace(/\s+/gu, " ");
+
+    expect(normalizedHelp).toContain("connectors [options] [workflow]");
+    expect(normalizedHelp).toContain(
+      "Diagnose stored connector readiness across workflows",
+    );
+    expect(normalizedHelp).toContain(
+      "Use okou connector check for one current-run URL, environment name, firewall decision, or permission failure",
+    );
+  });
+});

--- a/turbo/apps/cli/src/commands/doctor/connectors.ts
+++ b/turbo/apps/cli/src/commands/doctor/connectors.ts
@@ -178,6 +178,9 @@ function apiRequestError(
   error: ApiRequestError,
   workflow: WorkflowSummary,
 ): ConnectorDoctorError {
+  // A commit-addressed CLI can reach an API version from before #30491.
+  // Remove this branch after #30491 is deployed and those API rollback targets
+  // are retired; cleanup is tracked by the parent Connector Doctor EPIC #30469.
   if (workflow.official && error.status === 409) {
     return {
       code: "OFFICIAL_WORKFLOW_UNSUPPORTED",

--- a/turbo/apps/cli/src/commands/doctor/connectors.ts
+++ b/turbo/apps/cli/src/commands/doctor/connectors.ts
@@ -1,0 +1,578 @@
+import type {
+  WorkflowConnectorReadinessEntry,
+  WorkflowConnectorReadinessStatus,
+  WorkflowSummary,
+} from "@okouai/api-contracts/contracts/workflows";
+import chalk from "chalk";
+import { Command } from "commander";
+
+import {
+  getWorkflow,
+  getWorkflowConnectorReadiness,
+  listWorkflows,
+} from "../../lib/api/domains/workflows";
+import { ApiRequestError } from "../../lib/api/core/client-factory";
+import { decodeSandboxTokenPayload } from "../../lib/api/sandbox-token";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { connectorActionUrl } from "../connector/action-url";
+import { resolveWorkflowRef } from "../workflow/resolve-workflow-ref";
+import { getPlatformOrigin } from "./platform-url";
+
+const MAX_CONNECTOR_READINESS_CONCURRENCY = 4;
+
+type ConnectorDoctorOutcome =
+  | "attention"
+  | "unknown"
+  | "ready"
+  | "no-connectors";
+
+type ConnectorDoctorActionKind =
+  | "connect"
+  | "reconnect"
+  | "review-permissions"
+  | "enable-for-agent";
+
+interface ConnectorDoctorAction {
+  readonly kind: ConnectorDoctorActionKind;
+  readonly label: string;
+  readonly url: string;
+}
+
+interface ConnectorDoctorError {
+  readonly code: string;
+  readonly message: string;
+  readonly status: number | null;
+}
+
+interface ConnectorDoctorEntry {
+  readonly slug: string;
+  readonly label: string;
+  readonly reason: string;
+  readonly status: WorkflowConnectorReadinessStatus;
+  readonly action: ConnectorDoctorAction | null;
+}
+
+interface ConnectorDoctorWorkflow {
+  readonly id: string;
+  readonly name: string;
+  readonly displayName: string | null;
+  readonly agent: {
+    readonly id: string;
+    readonly name: string | null;
+    readonly displayName: string | null;
+  };
+  readonly official: {
+    readonly definitionName: string;
+    readonly installationState: "installing" | "installed";
+    readonly definitionLifecycle: "active" | "retired" | "unavailable";
+    readonly readOnly: true;
+  } | null;
+  readonly outcome: ConnectorDoctorOutcome;
+  readonly connectors: readonly ConnectorDoctorEntry[];
+  readonly error: ConnectorDoctorError | null;
+}
+
+interface ConnectorDoctorReport {
+  readonly schemaVersion: 1;
+  readonly summary: {
+    readonly checked: number;
+    readonly attention: number;
+    readonly unknown: number;
+    readonly ready: number;
+    readonly noConnectors: number;
+  };
+  readonly workflows: readonly ConnectorDoctorWorkflow[];
+}
+
+interface ConnectorsOptions {
+  readonly agent?: string;
+  readonly json?: boolean;
+}
+
+function currentRunUserId(): string {
+  const payload = decodeSandboxTokenPayload();
+  if (
+    !payload ||
+    typeof payload.userId !== "string" ||
+    payload.userId.length === 0
+  ) {
+    throw new ApiRequestError("Not authenticated", "UNAUTHORIZED", 401);
+  }
+  return payload.userId;
+}
+
+function connectorAction(
+  entry: WorkflowConnectorReadinessEntry,
+  agentId: string,
+  platformOrigin: string,
+): ConnectorDoctorAction | null {
+  let kind: ConnectorDoctorActionKind;
+  let label: string;
+  let route: "connect" | "authorize";
+  switch (entry.status) {
+    case "reconnect-required": {
+      kind = "reconnect";
+      label = "Reconnect";
+      route = "connect";
+      break;
+    }
+    case "scope-mismatch": {
+      kind = "review-permissions";
+      label = "Review permissions";
+      route = "connect";
+      break;
+    }
+    case "not-connected": {
+      kind = "connect";
+      label = "Connect";
+      route = "connect";
+      break;
+    }
+    case "not-enabled-for-agent": {
+      kind = "enable-for-agent";
+      label = "Enable for agent";
+      route = "authorize";
+      break;
+    }
+    case "connected":
+    case "unavailable": {
+      return null;
+    }
+  }
+
+  return {
+    kind,
+    label,
+    url: connectorActionUrl({
+      origin: platformOrigin,
+      path: `/connectors/${encodeURIComponent(entry.connectorSlug)}/${route}`,
+      agentId,
+    }),
+  };
+}
+
+function workflowIdentity(
+  workflow: WorkflowSummary,
+): Omit<ConnectorDoctorWorkflow, "outcome" | "connectors" | "error"> {
+  return {
+    id: workflow.id,
+    name: workflow.name,
+    displayName: workflow.displayName,
+    agent: {
+      id: workflow.agentId,
+      name: workflow.agentName,
+      displayName: workflow.agentDisplayName,
+    },
+    official: workflow.official
+      ? {
+          definitionName: workflow.official.definitionName,
+          installationState: workflow.official.installationState,
+          definitionLifecycle: workflow.official.definitionLifecycle,
+          readOnly: workflow.official.readOnly,
+        }
+      : null,
+  };
+}
+
+function apiRequestError(
+  error: ApiRequestError,
+  workflow: WorkflowSummary,
+): ConnectorDoctorError {
+  if (workflow.official && error.status === 409) {
+    return {
+      code: "OFFICIAL_WORKFLOW_UNSUPPORTED",
+      message:
+        "Connector readiness is unavailable for this Official Workflow during rollout.",
+      status: 409,
+    };
+  }
+  switch (error.status) {
+    case 400: {
+      return {
+        code: "BAD_REQUEST",
+        message: "The connector readiness request was rejected.",
+        status: error.status,
+      };
+    }
+    case 403: {
+      return {
+        code: "FORBIDDEN",
+        message: "Connector readiness is not available for this workflow.",
+        status: error.status,
+      };
+    }
+    case 404: {
+      return {
+        code: "NOT_FOUND",
+        message: "The workflow was not found during the readiness check.",
+        status: error.status,
+      };
+    }
+    case 409: {
+      return {
+        code: "CONFLICT",
+        message: "The workflow could not be checked in its current state.",
+        status: error.status,
+      };
+    }
+    case 413: {
+      return {
+        code: "PAYLOAD_TOO_LARGE",
+        message: "The workflow exceeds the connector readiness input limit.",
+        status: error.status,
+      };
+    }
+    case 503: {
+      const timedOut = error.code === "CONNECTOR_READINESS_TIMEOUT";
+      return {
+        code: timedOut ? "CONNECTOR_READINESS_TIMEOUT" : "PROVIDER_UNAVAILABLE",
+        message: timedOut
+          ? "The connector readiness check timed out."
+          : "The connector readiness provider is unavailable.",
+        status: error.status,
+      };
+    }
+    default: {
+      return {
+        code: "REQUEST_FAILED",
+        message: "The connector readiness request failed.",
+        status: error.status,
+      };
+    }
+  }
+}
+
+function sanitizedRequestError(
+  error: unknown,
+  workflow: WorkflowSummary,
+): ConnectorDoctorError {
+  if (error instanceof ApiRequestError) {
+    if (error.status === 401 || error.code === "UNAUTHORIZED") {
+      throw error;
+    }
+    return apiRequestError(error, workflow);
+  }
+  if (
+    (error instanceof Error || error instanceof DOMException) &&
+    (error.name === "TimeoutError" || error.name === "AbortError")
+  ) {
+    return {
+      code: "REQUEST_TIMEOUT",
+      message: "The connector readiness request timed out.",
+      status: null,
+    };
+  }
+  return {
+    code: "REQUEST_FAILED",
+    message: "The connector readiness request failed.",
+    status: null,
+  };
+}
+
+function workflowOutcome(
+  connectors: readonly ConnectorDoctorEntry[],
+): ConnectorDoctorOutcome {
+  if (connectors.length === 0) {
+    return "no-connectors";
+  }
+  if (
+    connectors.some((connector) => {
+      return connector.status === "unavailable";
+    })
+  ) {
+    return "unknown";
+  }
+  if (
+    connectors.some((connector) => {
+      return connector.status !== "connected";
+    })
+  ) {
+    return "attention";
+  }
+  return "ready";
+}
+
+async function diagnoseWorkflow(
+  workflow: WorkflowSummary,
+  platformOrigin: string,
+): Promise<ConnectorDoctorWorkflow> {
+  let response;
+  try {
+    response = await getWorkflowConnectorReadiness(workflow.id);
+  } catch (error) {
+    return {
+      ...workflowIdentity(workflow),
+      outcome: "unknown",
+      connectors: [],
+      error: sanitizedRequestError(error, workflow),
+    };
+  }
+  const connectors = response.connectors.map((entry) => {
+    return {
+      slug: entry.connectorSlug,
+      label: entry.label,
+      reason: entry.reason,
+      status: entry.status,
+      action: connectorAction(entry, workflow.agentId, platformOrigin),
+    } satisfies ConnectorDoctorEntry;
+  });
+  return {
+    ...workflowIdentity(workflow),
+    outcome: workflowOutcome(connectors),
+    connectors,
+    error: null,
+  };
+}
+
+async function diagnoseWorkflows(
+  workflows: readonly WorkflowSummary[],
+  platformOrigin: string,
+): Promise<readonly ConnectorDoctorWorkflow[]> {
+  const results: Array<ConnectorDoctorWorkflow | undefined> = Array.from({
+    length: workflows.length,
+  });
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < workflows.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      const workflow = workflows[index];
+      if (!workflow) {
+        throw new Error(`Workflow ${index} is missing from the report input`);
+      }
+      results[index] = await diagnoseWorkflow(workflow, platformOrigin);
+    }
+  }
+
+  await Promise.all(
+    Array.from(
+      {
+        length: Math.min(MAX_CONNECTOR_READINESS_CONCURRENCY, workflows.length),
+      },
+      async () => {
+        await worker();
+      },
+    ),
+  );
+  return results.map((result, index) => {
+    if (!result) {
+      throw new Error(`Workflow ${index} is missing from the report output`);
+    }
+    return result;
+  });
+}
+
+function buildReport(
+  workflows: readonly ConnectorDoctorWorkflow[],
+): ConnectorDoctorReport {
+  let attention = 0;
+  let unknown = 0;
+  let ready = 0;
+  let noConnectors = 0;
+  for (const workflow of workflows) {
+    switch (workflow.outcome) {
+      case "attention": {
+        attention += 1;
+        break;
+      }
+      case "unknown": {
+        unknown += 1;
+        break;
+      }
+      case "ready": {
+        ready += 1;
+        break;
+      }
+      case "no-connectors": {
+        noConnectors += 1;
+        break;
+      }
+    }
+  }
+  return {
+    schemaVersion: 1,
+    summary: {
+      checked: workflows.length,
+      attention,
+      unknown,
+      ready,
+      noConnectors,
+    },
+    workflows,
+  };
+}
+
+function compactText(value: string): string {
+  return value.replace(/\s+/gu, " ").trim();
+}
+
+function workflowLabel(workflow: ConnectorDoctorWorkflow): string {
+  if (!workflow.displayName || workflow.displayName === workflow.name) {
+    return workflow.name;
+  }
+  return `${compactText(workflow.displayName)} (${workflow.name})`;
+}
+
+function agentLabel(workflow: ConnectorDoctorWorkflow): string {
+  return workflow.agent.displayName ?? workflow.agent.name ?? workflow.agent.id;
+}
+
+function readinessStatusLabel(
+  status: WorkflowConnectorReadinessStatus,
+): string {
+  switch (status) {
+    case "connected": {
+      return "connected";
+    }
+    case "not-connected": {
+      return "not connected";
+    }
+    case "scope-mismatch": {
+      return "permission scope mismatch";
+    }
+    case "reconnect-required": {
+      return "reconnect required";
+    }
+    case "not-enabled-for-agent": {
+      return "not enabled for agent";
+    }
+    case "unavailable": {
+      return "unavailable";
+    }
+  }
+}
+
+function printProblemSection(
+  title: string,
+  workflows: readonly ConnectorDoctorWorkflow[],
+): void {
+  if (workflows.length === 0) {
+    return;
+  }
+  console.log(chalk.bold(`${title} (${workflows.length})`));
+  for (const workflow of workflows) {
+    console.log(`  ${workflowLabel(workflow)}`);
+    console.log(chalk.dim(`    Agent: ${compactText(agentLabel(workflow))}`));
+    if (workflow.error) {
+      console.log(
+        `    ${chalk.yellow(workflow.error.code)}: ${workflow.error.message}`,
+      );
+      continue;
+    }
+    for (const connector of workflow.connectors) {
+      if (connector.status === "connected") {
+        continue;
+      }
+      console.log(
+        `    ${compactText(connector.label)}: ${readinessStatusLabel(connector.status)}`,
+      );
+      console.log(chalk.dim(`      ${compactText(connector.reason)}`));
+      if (connector.action) {
+        console.log(
+          chalk.dim(`      ${connector.action.label}: ${connector.action.url}`),
+        );
+      }
+    }
+  }
+}
+
+function printHumanReport(report: ConnectorDoctorReport): void {
+  if (report.summary.checked === 0) {
+    console.log(
+      chalk.green("✓ No owned or installed workflows to check for connectors"),
+    );
+    return;
+  }
+  if (report.summary.attention === 0 && report.summary.unknown === 0) {
+    console.log(
+      chalk.green(
+        `✓ All clear: ${report.summary.checked} workflow${report.summary.checked === 1 ? "" : "s"} checked`,
+      ),
+    );
+    console.log(
+      chalk.dim(
+        `  ${report.summary.ready} ready · ${report.summary.noConnectors} no connectors required`,
+      ),
+    );
+    return;
+  }
+
+  console.log(chalk.bold("Connector diagnostics"));
+  printProblemSection(
+    "Needs attention",
+    report.workflows.filter((workflow) => {
+      return workflow.outcome === "attention";
+    }),
+  );
+  printProblemSection(
+    "Unknown",
+    report.workflows.filter((workflow) => {
+      return workflow.outcome === "unknown";
+    }),
+  );
+  console.log(
+    chalk.dim(
+      `Summary: ${report.summary.checked} checked · ${report.summary.attention} attention · ${report.summary.unknown} unknown · ${report.summary.ready} ready · ${report.summary.noConnectors} no connectors`,
+    ),
+  );
+}
+
+async function selectedWorkflows(
+  workflowRef: string | undefined,
+  options: ConnectorsOptions,
+): Promise<readonly WorkflowSummary[]> {
+  if (workflowRef) {
+    const workflowId = await resolveWorkflowRef(workflowRef, options);
+    return [await getWorkflow(workflowId)];
+  }
+  if (options.agent) {
+    throw new Error("--agent requires a workflow argument");
+  }
+  const userId = currentRunUserId();
+  const workflows = await listWorkflows({});
+  return workflows.filter((workflow) => {
+    return workflow.ownerUserId === userId;
+  });
+}
+
+export const connectorsCommand = new Command()
+  .name("connectors")
+  .description("Diagnose stored connector readiness across workflows")
+  .argument("[workflow]", "Workflow ID or slug name")
+  .option(
+    "--agent <id>",
+    "Agent scope for a workflow slug (defaults to OKOU_AGENT_ID)",
+  )
+  .option("--json", "Print a versioned machine-readable report")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Check owned workflows: okou doctor connectors
+  Check one workflow ID: okou doctor connectors <workflow-id>
+  Check one workflow name: okou doctor connectors <workflow-name> --agent <agent-id>
+  Print JSON: okou doctor connectors --json
+
+Notes:
+  - Without a workflow argument, only workflows owned or installed by the OKOU_TOKEN user are checked
+  - Each workflow is checked through its stored connector-readiness route
+  - Findings and per-workflow unknowns are report data and do not fail the command
+  - Use okou connector check for one current-run URL, firewall decision, or permission failure`,
+  )
+  .action(
+    withErrorHandler(
+      async (workflowRef: string | undefined, options: ConnectorsOptions) => {
+        const workflows = await selectedWorkflows(workflowRef, options);
+        const platformOrigin = await getPlatformOrigin();
+        const report = buildReport(
+          await diagnoseWorkflows(workflows, platformOrigin),
+        );
+        if (options.json) {
+          console.log(JSON.stringify(report, null, 2));
+          return;
+        }
+        printHumanReport(report);
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/doctor/index.ts
+++ b/turbo/apps/cli/src/commands/doctor/index.ts
@@ -1,18 +1,24 @@
 import { Command } from "commander";
+import { connectorsCommand } from "./connectors";
 import { creditCommand } from "./credit";
 
 export const doctorCommand = new Command()
   .name("doctor")
   .description("Diagnose account and runtime issues")
+  .addCommand(connectorsCommand)
   .addCommand(creditCommand)
   .addHelpText(
     "after",
     `
 Examples:
   Check credits? okou doctor credit
+  Check workflow connectors? okou doctor connectors
+  Check one workflow? okou doctor connectors <workflow> --agent <agent-id>
+  Print a structured report? okou doctor connectors --json
 
 Notes:
   - Use okou doctor credit when a run or generation fails because the org has insufficient credits, when a user asks how to recharge, or before trying to buy credits
   - Use okou generate <type> (no --prompt) to see every provider available for a given generation type
-  - Use okou connector check for connector and permission diagnostics`,
+  - Use okou doctor connectors for stored connector readiness across owned or installed workflows
+  - Use okou connector check for one current-run URL, environment name, firewall decision, or permission failure`,
   );

--- a/turbo/apps/cli/src/lib/api/domains/workflows.ts
+++ b/turbo/apps/cli/src/lib/api/domains/workflows.ts
@@ -7,11 +7,14 @@ import {
   workflowsCollectionContract,
   workflowsDetailContract,
   workflowAutomationsContract,
+  type WorkflowConnectorReadinessResponse,
   type WorkflowFileEntry,
   type WorkflowDetailResponse,
   type WorkflowSummary,
 } from "@okouai/api-contracts/contracts/workflows";
 import { getClientConfig, handleError } from "../core/client-factory";
+
+const CONNECTOR_READINESS_REQUEST_TIMEOUT_MS = 35_000;
 
 export type WorkflowAutomationCreateRequest = ServerInferRequest<
   typeof workflowAutomationsContract.create
@@ -63,6 +66,24 @@ export async function getWorkflow(
   const result = await client.get({ params: { workflowId } });
   if (result.status === 200) return result.body;
   handleError(result, `Workflow "${workflowId}" not found`);
+}
+
+export async function getWorkflowConnectorReadiness(
+  workflowId: string,
+): Promise<WorkflowConnectorReadinessResponse> {
+  const config = await getClientConfig();
+  const client = initClient(workflowsDetailContract, config);
+  const result = await client.connectorReadiness({
+    params: { workflowId },
+    fetchOptions: {
+      signal: AbortSignal.timeout(CONNECTOR_READINESS_REQUEST_TIMEOUT_MS),
+    },
+  });
+  if (result.status === 200) return result.body;
+  handleError(
+    result,
+    `Failed to check connector readiness for workflow "${workflowId}"`,
+  );
 }
 
 export async function updateWorkflow(


### PR DESCRIPTION
## Summary

- add `okou doctor connectors [workflow]` with human and versioned JSON output
- filter aggregate checks to workflows owned or installed by the `OKOU_TOKEN` user while preserving normal single-workflow ID/name resolution
- diagnose every selected workflow through the existing readiness route with bounded concurrency, deterministic actions, and sanitized per-workflow unknowns
- document the aggregate command separately from reactive `okou connector check` diagnostics

## Fallbacks

- `turbo/apps/cli/src/commands/doctor/connectors.ts:apiRequestError` — converts an installed Official Workflow's 409 from an API that predates #30491 into an explicit per-workflow unknown. Surface: commit-addressed CLI → old API. Remove after #30491 is deployed and pre-support API rollback targets are retired; cleanup is tracked by parent #30469.

## Testing

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/cli run lint`
- `pnpm --filter @okouai/cli run check-types`
- `pnpm --filter @okouai/cli exec vitest run src/commands/doctor/__tests__/connectors.test.ts`
- `pnpm --filter @okouai/cli exec vitest run src/commands/doctor/__tests__/index.test.ts`
- `git diff --check`

Closes #30490

Parent EPIC: #30469
