### PR TITLE
feat(runner): attribute claim response headers

### DIFF
--- a/crates/runner/src/executor/telemetry.rs
+++ b/crates/runner/src/executor/telemetry.rs
@@ -309,6 +309,12 @@ impl RunnerPreSpawnTiming {
                 None,
             );
             telemetry.record(
+                "runner_claim_request_to_response_headers",
+                timing.request_to_response_headers_elapsed(),
+                true,
+                None,
+            );
+            telemetry.record(
                 "runner_claim_response_body_read",
                 timing.response_body_read_elapsed(),
                 true,

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -261,6 +261,7 @@ fn assert_action_once_with_duration(telemetry: &JobTelemetry, action: &str, dura
 fn assert_lacks_api_claim_timing(telemetry: &JobTelemetry) {
     for action in [
         "runner_claim_http_request",
+        "runner_claim_request_to_response_headers",
         "runner_claim_response_body_read",
         "runner_claim_response_decode",
     ] {
@@ -663,6 +664,7 @@ fn pre_spawn_timing_with_phases_and_concurrency(
         Instant::now(),
         Some(ApiClaimTiming::new(
             Duration::from_millis(42),
+            Duration::from_millis(11),
             Duration::from_millis(7),
             Duration::from_millis(3),
         )),
@@ -1106,6 +1108,7 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
 
     for action in [
         "runner_claim_http_request",
+        "runner_claim_request_to_response_headers",
         "runner_claim_response_body_read",
         "runner_claim_response_decode",
         "runner_claim_to_executor_start",
@@ -1137,6 +1140,7 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
         assert_has_action(&telemetry, action);
     }
     assert_action_once_with_duration(&telemetry, "runner_claim_http_request", 42);
+    assert_action_once_with_duration(&telemetry, "runner_claim_request_to_response_headers", 11);
     assert_action_once_with_duration(&telemetry, "runner_claim_response_body_read", 7);
     assert_action_once_with_duration(&telemetry, "runner_claim_response_decode", 3);
     assert_action_duration(&telemetry, "workspace_drive_mount_guest_exec", 23);
@@ -1572,6 +1576,7 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
 
     for action in [
         "runner_claim_http_request",
+        "runner_claim_request_to_response_headers",
         "runner_claim_response_body_read",
         "runner_claim_response_decode",
         "runner_claim_to_executor_start",
@@ -1596,6 +1601,7 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
         assert_has_action(&telemetry, action);
     }
     assert_action_once_with_duration(&telemetry, "runner_claim_http_request", 42);
+    assert_action_once_with_duration(&telemetry, "runner_claim_request_to_response_headers", 11);
     assert_action_once_with_duration(&telemetry, "runner_claim_response_body_read", 7);
     assert_action_once_with_duration(&telemetry, "runner_claim_response_decode", 3);
     assert_pre_spawn_phase_actions_succeeded(&telemetry);

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -141,6 +141,7 @@ enum ClaimApiError {
 #[cfg_attr(test, derive(Debug))]
 struct SuccessfulClaimResponse {
     context: ExecutionContext,
+    request_to_response_headers_elapsed: Duration,
     response_body_read_elapsed: Duration,
     response_decode_elapsed: Duration,
 }
@@ -658,11 +659,13 @@ impl JobProvider for ApiProvider {
         match claim_result {
             Ok(Some(SuccessfulClaimResponse {
                 context: ctx,
+                request_to_response_headers_elapsed,
                 response_body_read_elapsed,
                 response_decode_elapsed,
             })) => {
                 let api_claim_timing = ApiClaimTiming::new(
                     claim_request_elapsed,
+                    request_to_response_headers_elapsed,
                     response_body_read_elapsed,
                     response_decode_elapsed,
                 );
@@ -1070,20 +1073,20 @@ impl ApiClient {
         let run_id = candidate.run_id();
         let body = claim_request_body(candidate, runner_identity, runner_hostname);
         let run_id = run_id.to_string();
-        let resp = send_api(
-            self.http
-                .request_resolved_route(
-                    routes::runners::jobs::by_id::claim::route(
-                        routes::runners::jobs::by_id::claim::Params {
-                            id: run_id.as_str(),
-                        },
-                    ),
-                    &self.token,
-                )
-                .json(&body),
-            "claim",
-        )
-        .await?;
+        let request = self
+            .http
+            .request_resolved_route(
+                routes::runners::jobs::by_id::claim::route(
+                    routes::runners::jobs::by_id::claim::Params {
+                        id: run_id.as_str(),
+                    },
+                ),
+                &self.token,
+            )
+            .json(&body);
+        let request_to_response_headers_started_at = Instant::now();
+        let resp = send_api(request, "claim").await?;
+        let request_to_response_headers_elapsed = request_to_response_headers_started_at.elapsed();
 
         if resp.status() == StatusCode::NOT_FOUND {
             return Ok(None);
@@ -1102,6 +1105,7 @@ impl ApiClient {
 
         Ok(Some(SuccessfulClaimResponse {
             context,
+            request_to_response_headers_elapsed,
             response_body_read_elapsed,
             response_decode_elapsed,
         }))
@@ -4075,7 +4079,8 @@ mod tests {
             .expect("successful API claim should retain timing");
         assert!(
             claim_timing.request_elapsed()
-                >= claim_timing.response_body_read_elapsed()
+                >= claim_timing.request_to_response_headers_elapsed()
+                    + claim_timing.response_body_read_elapsed()
                     + claim_timing.response_decode_elapsed()
         );
         let context = claimed.context();

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -522,6 +522,7 @@ pub struct ClaimedJob {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct ApiClaimTiming {
     request_elapsed: Duration,
+    request_to_response_headers_elapsed: Duration,
     response_body_read_elapsed: Duration,
     response_decode_elapsed: Duration,
 }
@@ -529,11 +530,13 @@ pub(crate) struct ApiClaimTiming {
 impl ApiClaimTiming {
     pub(crate) const fn new(
         request_elapsed: Duration,
+        request_to_response_headers_elapsed: Duration,
         response_body_read_elapsed: Duration,
         response_decode_elapsed: Duration,
     ) -> Self {
         Self {
             request_elapsed,
+            request_to_response_headers_elapsed,
             response_body_read_elapsed,
             response_decode_elapsed,
         }
@@ -541,6 +544,10 @@ impl ApiClaimTiming {
 
     pub(crate) const fn request_elapsed(self) -> Duration {
         self.request_elapsed
+    }
+
+    pub(crate) const fn request_to_response_headers_elapsed(self) -> Duration {
+        self.request_to_response_headers_elapsed
     }
 
     pub(crate) const fn response_body_read_elapsed(self) -> Duration {
@@ -821,6 +828,7 @@ mod tests {
     fn api_claim_timing() -> ApiClaimTiming {
         ApiClaimTiming::new(
             Duration::from_millis(10),
+            Duration::from_millis(4),
             Duration::from_millis(2),
             Duration::from_millis(3),
         )


### PR DESCRIPTION
## Summary

- measure the Runner claim request interval from immediately before request execution through receipt of response headers
- carry the duration only on a valid successful API-backed claim and emit the fixed `runner_claim_request_to_response_headers` operation
- cover provider ownership plus fresh and reuse startup telemetry with real HTTP boundaries and exact constructed durations

## Behavior and compatibility

This is additive Runner telemetry. It does not change claim requests or responses, API routes, status classification, retries, cooldown, cancellation, reuse, spawn boundaries, queues, persistence, or database state. Local providers and unsuccessful API claims do not emit the successful operation. Old Runner releases simply omit the new fixed action.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner` (3,389 passed, 26 ignored; guest inventory integration passed)
- staged Lefthook Rust formatting, workspace Clippy, workspace documentation, file-size, and commit-message checks

Closes #30494

Parent context: #27735
