### PR TITLE
feat(api): support official workflow connector readiness

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -113,6 +113,10 @@ function authHeaders(actor: ApiTestUser) {
   return { authorization: "Bearer clerk-session" };
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 async function selectBuiltInDefaultModel(actor: ApiTestUser): Promise<void> {
   await seedVm0BuiltInModelKey(context, "claude-sonnet-5");
   await runs.updateOrgModelPolicies(actor, [
@@ -1668,6 +1672,137 @@ describe.sequential("Official Workflow installations", () => {
     ).toBeTruthy();
   });
 
+  it("uses accepted Official content and installation dependencies for connector readiness", async () => {
+    installCatalogStorageFixture();
+    const suffix = randomUUID().replaceAll("-", "").slice(0, 10);
+    const definitionName = `api-test-readiness-${suffix}`;
+    const instruction = "Read the accepted Official Gmail inbox.";
+    const sourceCatalog = catalog([
+      activeDefinition(definitionName, [gmailBlueprint()], instruction),
+    ]);
+    await syncCatalog(sourceCatalog);
+
+    const { actor } = await workflowBdd.setupWorkflowOrg();
+    const { agentId } = await workflowBdd.createAgent(actor);
+    onTestFinished(async () => {
+      installCatalogStorageFixture();
+      await bdd.deleteAgent(actor, agentId);
+      await cleanupCatalog();
+    });
+
+    mockGmailConnectorOAuth({
+      email: `official-readiness-${suffix}@example.test`,
+    });
+    await workflowBdd.connectConnector(actor, "gmail");
+    await runs.enableAgentConnectors(actor, agentId, ["gmail"]);
+    mockOptionalEnv("GMAIL_PUBSUB_TOPIC_NAME", GMAIL_TOPIC_NAME);
+    server.use(
+      http.post("https://gmail.googleapis.com/gmail/v1/users/me/watch", () => {
+        return HttpResponse.json({
+          historyId: "100",
+          expiration: "4102444800000",
+        });
+      }),
+      http.post("https://gmail.googleapis.com/gmail/v1/users/me/stop", () => {
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+    await setOfficialWorkflowsEnabled(actor, true);
+    if (!actor.orgId) {
+      throw new Error("Expected organization-scoped readiness actor");
+    }
+    await updateFeatureSwitchesForUser(
+      context,
+      { orgId: actor.orgId, userId: actor.userId },
+      { [FeatureSwitchKey.WorkflowConnectorReadiness]: true },
+    );
+    const headers = authHeaders(actor);
+    const installed = await accept(
+      officialClient().install({
+        headers,
+        params: { definitionName },
+        body: {
+          agentId,
+          blueprints: [{ blueprintKey: "gmail-trigger", bindings: [] }],
+        },
+      }),
+      [201],
+    );
+
+    const modelRequests: unknown[] = [];
+    mockOptionalEnv("OPENROUTER_API_KEY", "official-readiness-test-key");
+    server.use(
+      http.post(
+        "https://openrouter.ai/api/v1/chat/completions",
+        async ({ request }) => {
+          modelRequests.push(await request.json());
+          return HttpResponse.json({
+            choices: [
+              {
+                finish_reason: "stop",
+                message: {
+                  content: JSON.stringify({ connectors: [] }),
+                },
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    const readiness = await accept(
+      workflowClient().connectorReadiness({
+        headers,
+        params: { workflowId: installed.body.workflow.id },
+      }),
+      [200],
+    );
+
+    expect(readiness.body.connectors).toMatchObject([
+      {
+        connectorSlug: "gmail",
+        reason: "This workflow has a Gmail event automation.",
+        status: "connected",
+      },
+    ]);
+    expect(modelRequests).toHaveLength(1);
+    const modelRequest = modelRequests[0];
+    if (!isRecord(modelRequest) || !Array.isArray(modelRequest.messages)) {
+      throw new Error("Expected OpenRouter request messages");
+    }
+    const userMessage = modelRequest.messages.find((message) => {
+      return isRecord(message) && message.role === "user";
+    });
+    if (!isRecord(userMessage) || typeof userMessage.content !== "string") {
+      throw new Error("Expected OpenRouter user message");
+    }
+    const modelPayload: unknown = JSON.parse(userMessage.content);
+    expect(modelPayload).toMatchObject({
+      workflow: {
+        name: definitionName,
+        description: `Description for ${definitionName}`,
+        instruction,
+      },
+    });
+
+    await cleanupCatalog();
+    const unavailable = await accept(
+      workflowClient().connectorReadiness({
+        headers,
+        params: { workflowId: installed.body.workflow.id },
+      }),
+      [503],
+    );
+    expect(unavailable.body).toStrictEqual({
+      error: {
+        code: "PROVIDER_UNAVAILABLE",
+        message:
+          "Official Workflow content is temporarily unavailable. Please retry.",
+      },
+    });
+    expect(modelRequests).toHaveLength(1);
+  });
+
   it("projects installed state, guards mutations, and preserves reconfiguration identity", async () => {
     const {
       actor,
@@ -1892,13 +2027,6 @@ describe.sequential("Official Workflow installations", () => {
     );
     await accept(
       workflowClient().chatThread({
-        headers,
-        params: { workflowId: firstWorkflowId },
-      }),
-      [409],
-    );
-    await accept(
-      workflowClient().connectorReadiness({
         headers,
         params: { workflowId: firstWorkflowId },
       }),

--- a/turbo/apps/api/src/signals/routes/workflows.ts
+++ b/turbo/apps/api/src/signals/routes/workflows.ts
@@ -551,8 +551,31 @@ const connectorReadinessInner$ = command(
     if (!visible) {
       return workflowNotFound(params.workflowId);
     }
-    if (visible.workflow.officialDefinitionName !== null) {
-      return conflict(OFFICIAL_WORKFLOW_READ_ONLY_MESSAGE);
+
+    const officialDefinition = visible.workflow.officialDefinitionName
+      ? await readAcceptedOfficialWorkflowDefinition(
+          get(db$),
+          visible.workflow.officialDefinitionName,
+          signal,
+        )
+      : null;
+    const officialRevision = officialDefinition
+      ? await readAcceptedOfficialWorkflowRevision(
+          get(db$),
+          {
+            name: officialDefinition.name,
+            revision: officialDefinition.revision,
+          },
+          signal,
+        )
+      : null;
+    if (
+      visible.workflow.officialDefinitionName !== null &&
+      officialRevision === null
+    ) {
+      return providerUnavailable(
+        "Official Workflow content is temporarily unavailable. Please retry.",
+      );
     }
 
     const detected = await settle(
@@ -563,11 +586,17 @@ const connectorReadinessInner$ = command(
           userId: auth.userId,
           agentId: visible.workflow.agentId,
           workflowId: visible.workflow.id,
-          workflow: {
-            name: visible.workflow.name,
-            description: visible.workflow.description,
-            instruction: visible.workflow.instruction,
-          },
+          workflow: officialRevision
+            ? {
+                name: officialRevision.definition.name,
+                description: officialRevision.definition.workflow.description,
+                instruction: officialRevision.definition.workflow.instruction,
+              }
+            : {
+                name: visible.workflow.name,
+                description: visible.workflow.description,
+                instruction: visible.workflow.instruction,
+              },
           featureStates: getAllFeatureStates(featureContext),
           publicBrand: get(publicBrand$),
         },


### PR DESCRIPTION
## Summary

- allow the existing connector-readiness route to inspect installed Official Workflows
- resolve Official workflow name, description, and instruction from the accepted authoritative Definition revision
- preserve the installation workflow ID for Automation dependencies and installation Agent ID for connector authorization
- return an explicit provider-unavailable response when authoritative Official content is missing instead of falling back to the installation row

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/workflows.test.ts`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/official-workflows.test.ts`
- `git diff --check`

Closes #30491

Parent EPIC: #30469
