### PR TITLE
refactor(runner): bridge legacy and canonical rootfs locks

### DIFF
--- a/crates/runner/src/cmd/build/mod.rs
+++ b/crates/runner/src/cmd/build/mod.rs
@@ -1,8 +1,6 @@
-use std::fs::File;
 use std::path::{Path, PathBuf};
 
 use clap::Args;
-use nix::fcntl::Flock;
 use sandbox::SnapshotProvider;
 use sandbox_fc::DNS_PROBE_RESOLVER_IPV4;
 
@@ -13,6 +11,7 @@ use crate::lock;
 use crate::paths::{HomePaths, RootfsPaths, touch_mtime};
 use crate::profile;
 use crate::r2_cache::R2ImageCache;
+use crate::rootfs_lock::{self, RootfsLockGuard};
 
 mod guest;
 mod hashes;
@@ -259,8 +258,8 @@ struct RootfsBuildInput<'a> {
 }
 
 enum RootfsImageLock {
-    Shared { _guard: Flock<File> },
-    Exclusive { _guard: Flock<File> },
+    Shared { _guard: RootfsLockGuard },
+    Exclusive { _guard: RootfsLockGuard },
 }
 
 impl RootfsImageLock {
@@ -288,16 +287,11 @@ async fn acquire_rootfs_lock_for_image_build_inner(
     rootfs_paths: &RootfsPaths,
     mut before_shared_lock: impl FnMut(),
 ) -> RunnerResult<RootfsImageLock> {
-    let rootfs_lock_path = paths.rootfs_lock(rootfs_hash);
-
     loop {
         if is_rootfs_present(rootfs_paths).await? {
             before_shared_lock();
-            tracing::info!(
-                "acquiring shared rootfs lock for image build: {}",
-                rootfs_lock_path.display()
-            );
-            let guard = lock::acquire_shared(rootfs_lock_path.clone()).await?;
+            tracing::info!("acquiring shared rootfs lock pair for image build: {rootfs_hash}");
+            let guard = rootfs_lock::acquire_shared(paths, rootfs_hash).await?;
             if is_rootfs_present(rootfs_paths).await? {
                 return Ok(RootfsImageLock::Shared { _guard: guard });
             }
@@ -308,11 +302,8 @@ async fn acquire_rootfs_lock_for_image_build_inner(
             continue;
         }
 
-        tracing::info!(
-            "acquiring exclusive rootfs lock for image build: {}",
-            rootfs_lock_path.display()
-        );
-        let guard = lock::acquire(rootfs_lock_path.clone()).await?;
+        tracing::info!("acquiring exclusive rootfs lock pair for image build: {rootfs_hash}");
+        let guard = rootfs_lock::acquire(paths, rootfs_hash).await?;
         if is_rootfs_present(rootfs_paths).await? {
             drop(guard);
             tracing::info!(
@@ -452,7 +443,7 @@ pub async fn run_build(mut args: BuildArgs, provider: &dyn SnapshotProvider) -> 
     ) && is_rootfs_present(rootfs_paths).await?
         && provider.is_complete(snapshot_dir).await.unwrap_or(false)
     {
-        let _rootfs_lock = lock::acquire_shared(paths.rootfs_lock(rootfs_hash)).await?;
+        let _rootfs_lock = rootfs_lock::acquire_shared(&paths, rootfs_hash).await?;
         let rootfs_still_present = is_rootfs_present(rootfs_paths).await?;
         let _snapshot_lock = lock::acquire_shared(paths.snapshot_lock(snapshot_hash)).await?;
         if rootfs_still_present && provider.is_complete(snapshot_dir).await.unwrap_or(false) {

--- a/crates/runner/src/cmd/build/tests/rootfs_lock.rs
+++ b/crates/runner/src/cmd/build/tests/rootfs_lock.rs
@@ -1,6 +1,16 @@
 use super::fixtures::*;
 use super::*;
 
+async fn assert_rootfs_pair_held(home: &HomePaths, hash: &str) {
+    for path in [home.legacy_rootfs_lock(hash), home.rootfs_lock(hash)] {
+        let error = lock::try_acquire(path).await.unwrap_err();
+        assert!(
+            error.to_string().contains("lock is already held"),
+            "unexpected rootfs lock error: {error}"
+        );
+    }
+}
+
 #[tokio::test]
 async fn existing_rootfs_best_effort_allows_missing_r2_cache() {
     let dir = tempfile::tempdir().unwrap();
@@ -105,6 +115,7 @@ async fn rootfs_image_lock_uses_shared_for_existing_rootfs_in_use() {
     .unwrap();
 
     assert!(image_lock.is_shared());
+    assert_rootfs_pair_held(&home, rootfs_hash).await;
 }
 
 #[tokio::test]
@@ -119,6 +130,7 @@ async fn rootfs_image_lock_uses_exclusive_for_missing_rootfs() {
         .unwrap();
 
     assert!(image_lock.is_exclusive());
+    assert_rootfs_pair_held(&home, rootfs_hash).await;
 }
 
 #[tokio::test]

--- a/crates/runner/src/cmd/gc/images.rs
+++ b/crates/runner/src/cmd/gc/images.rs
@@ -7,6 +7,7 @@ use tracing::{info, warn};
 use crate::byte_size::human_bytes;
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
+use crate::rootfs_lock::{self, RootfsLockGuard, TryRootfsLock};
 
 use super::GC_MIN_AGE;
 use super::filesystem::{
@@ -44,6 +45,20 @@ struct RootfsState {
 struct SnapshotDeletion {
     path: PathBuf,
     hash: String,
+}
+
+enum RootfsLockProbe {
+    Free(RootfsLockGuard),
+    Held,
+    Error(String),
+}
+
+fn probe_rootfs_lock(home: &HomePaths, hash: &str) -> RootfsLockProbe {
+    match rootfs_lock::try_acquire_or_busy_blocking(home, hash) {
+        Ok(TryRootfsLock::Acquired(lock)) => RootfsLockProbe::Free(lock),
+        Ok(TryRootfsLock::Busy) => RootfsLockProbe::Held,
+        Err(error) => RootfsLockProbe::Error(error.to_string()),
+    }
 }
 
 /// Try to delete an orphaned rootfs directory (no surviving snapshots).
@@ -159,16 +174,15 @@ async fn gc_rootfs_action(
     dry_run: bool,
     snapshot_entry_reader: &mut GcDirEntryReader,
 ) -> GcReport {
-    let rootfs_lock_path = home.rootfs_lock(&state.hash);
-    let _rootfs_lock = match probe_lock(&rootfs_lock_path) {
-        LockProbe::Free(lock) => lock,
-        LockProbe::Held => {
+    let _rootfs_lock = match probe_rootfs_lock(home, &state.hash) {
+        RootfsLockProbe::Free(lock) => lock,
+        RootfsLockProbe::Held => {
             if dry_run {
                 info!("images/{}: rootfs in use, skipping", state.hash);
             }
             return GcReport::default();
         }
-        LockProbe::Error(e) => {
+        RootfsLockProbe::Error(e) => {
             warn!("images/{}: lock probe failed ({e}), skipping", state.hash);
             return GcReport::default();
         }
@@ -463,16 +477,15 @@ async fn gc_nested_images_with_protected_refs_and_readers(
         // `runner start` acquires shared rootfs before shared snapshot; cleaning
         // snapshots while only the rootfs lock is held can race that acquisition
         // window and delete a snapshot the runner is about to lock.
-        let rootfs_lock_path = home.rootfs_lock(&rootfs_hash);
-        let rootfs_lock = match probe_lock(&rootfs_lock_path) {
-            LockProbe::Free(lock) => lock,
-            LockProbe::Held => {
+        let rootfs_lock = match probe_rootfs_lock(home, &rootfs_hash) {
+            RootfsLockProbe::Free(lock) => lock,
+            RootfsLockProbe::Held => {
                 if dry_run {
                     info!("images/{rootfs_hash}: rootfs in use, skipping");
                 }
                 continue;
             }
-            LockProbe::Error(e) => {
+            RootfsLockProbe::Error(e) => {
                 warn!("images/{rootfs_hash}: lock probe failed ({e}), skipping");
                 continue;
             }

--- a/crates/runner/src/cmd/gc/images/tests.rs
+++ b/crates/runner/src/cmd/gc/images/tests.rs
@@ -890,8 +890,7 @@ async fn gc_nested_images_recent_snapshot_protected() {
 /// When the rootfs lock is held, GC skips the whole rootfs. This avoids
 /// racing `runner start`, which acquires shared rootfs before shared
 /// snapshot and may be between those two locks.
-#[tokio::test]
-async fn gc_nested_images_locked_rootfs_keeps_all_snapshots() {
+async fn assert_locked_rootfs_keeps_all_snapshots(use_legacy_identity: bool) {
     use std::fs::FileTimes;
 
     let dir = tempfile::tempdir().unwrap();
@@ -917,7 +916,12 @@ async fn gc_nested_images_locked_rootfs_keeps_all_snapshots() {
         .unwrap();
 
     // Simulate `runner start` holding shared locks on rootfs + snap_used.
-    let rootfs_lock_file = lock::open_lock_file(&home.rootfs_lock("can_delete_rootfs")).unwrap();
+    let rootfs_lock_path = if use_legacy_identity {
+        home.legacy_rootfs_lock("can_delete_rootfs")
+    } else {
+        home.rootfs_lock("can_delete_rootfs")
+    };
+    let rootfs_lock_file = lock::open_lock_file(&rootfs_lock_path).unwrap();
     let _rootfs_held = Flock::lock(rootfs_lock_file, FlockArg::LockShared).unwrap();
     let snap_lock_file = lock::open_lock_file(&home.snapshot_lock("snap_used")).unwrap();
     let _snap_held = Flock::lock(snap_lock_file, FlockArg::LockShared).unwrap();
@@ -930,6 +934,16 @@ async fn gc_nested_images_locked_rootfs_keeps_all_snapshots() {
     assert!(snap_used.exists(), "locked snapshot must survive");
     assert!(rootfs_dir.exists(), "rootfs must survive (lock held)");
     assert_eq!(freed, 0);
+}
+
+#[tokio::test]
+async fn gc_nested_images_historical_rootfs_lock_keeps_all_snapshots() {
+    assert_locked_rootfs_keeps_all_snapshots(true).await;
+}
+
+#[tokio::test]
+async fn gc_nested_images_canonical_rootfs_lock_keeps_all_snapshots() {
+    assert_locked_rootfs_keeps_all_snapshots(false).await;
 }
 
 /// A locked snapshot must survive even with keep_latest=0 and old mtime.
@@ -994,6 +1008,51 @@ async fn gc_rootfs_action_keeps_candidate_locked_after_inventory() {
         "a candidate locked after inventory must survive action"
     );
     assert!(rootfs_dir.exists(), "the candidate's rootfs must survive");
+}
+
+async fn assert_rootfs_action_keeps_candidate_for_rootfs_lock(use_legacy_identity: bool) {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    std::fs::create_dir_all(home.locks_dir()).unwrap();
+
+    let rootfs_hash = "rootfs_action_rootfs_lock";
+    let snapshot_hash = "snapshot_action_rootfs_lock";
+    let rootfs_dir = home.images_dir().join(rootfs_hash);
+    let snapshot_dir = rootfs_dir.join("snapshots").join(snapshot_hash);
+    std::fs::create_dir_all(&snapshot_dir).unwrap();
+    std::fs::write(snapshot_dir.join("snapshot.bin"), b"snapshot").unwrap();
+    std::fs::write(rootfs_dir.join("rootfs.ext4"), b"rootfs").unwrap();
+    set_mtime(&snapshot_dir, old_gc_time());
+    set_mtime(&rootfs_dir, old_gc_time());
+
+    let state = rootfs_state_with_deletion(rootfs_dir.clone(), rootfs_hash, snapshot_hash);
+    let rootfs_lock_path = if use_legacy_identity {
+        home.legacy_rootfs_lock(rootfs_hash)
+    } else {
+        home.rootfs_lock(rootfs_hash)
+    };
+    let rootfs_lock_file = lock::open_lock_file(&rootfs_lock_path).unwrap();
+    let _rootfs_lock = Flock::lock(rootfs_lock_file, FlockArg::LockShared).unwrap();
+    let mut action_entry_reader = GcDirEntryReader::new();
+
+    let report = gc_rootfs_action(&home, &state, false, &mut action_entry_reader).await;
+
+    assert_eq!(report, GcReport::default());
+    assert!(
+        snapshot_dir.exists(),
+        "a candidate protected by either rootfs identity must survive action"
+    );
+    assert!(rootfs_dir.exists(), "the candidate's rootfs must survive");
+}
+
+#[tokio::test]
+async fn gc_rootfs_action_keeps_candidate_with_historical_rootfs_lock() {
+    assert_rootfs_action_keeps_candidate_for_rootfs_lock(true).await;
+}
+
+#[tokio::test]
+async fn gc_rootfs_action_keeps_candidate_with_canonical_rootfs_lock() {
+    assert_rootfs_action_keeps_candidate_for_rootfs_lock(false).await;
 }
 
 #[tokio::test]

--- a/crates/runner/src/cmd/gc/orphaned_locks.rs
+++ b/crates/runner/src/cmd/gc/orphaned_locks.rs
@@ -67,6 +67,24 @@ mod tests {
     use crate::lock;
 
     #[tokio::test]
+    async fn gc_orphaned_locks_removes_free_rootfs_bridge_locks() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let historical = home.legacy_rootfs_lock("test-rootfs");
+        let canonical = home.rootfs_lock("test-rootfs");
+        std::fs::create_dir_all(home.locks_dir()).unwrap();
+        std::fs::write(&historical, "").unwrap();
+        std::fs::write(&canonical, "").unwrap();
+
+        let report = gc_orphaned_locks(&home, false).await.unwrap();
+
+        assert_eq!(report.activity_count, 2);
+        assert_eq!(report.freed_bytes, 0);
+        assert!(!historical.exists());
+        assert!(!canonical.exists());
+    }
+
+    #[tokio::test]
     async fn gc_orphaned_locks_preserves_only_current_service_locks() {
         let dir = tempfile::tempdir().unwrap();
         let home = test_home(dir.path());

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -1209,13 +1209,16 @@ profiles:
     }
 
     async fn assert_artifact_locks_held(home: &HomePaths) {
-        let rootfs_err = crate::lock::try_acquire(home.rootfs_lock(TEST_ROOTFS_HASH))
-            .await
-            .unwrap_err();
-        assert!(
-            rootfs_err.to_string().contains("lock is already held"),
-            "unexpected rootfs lock error: {rootfs_err}"
-        );
+        for path in [
+            home.legacy_rootfs_lock(TEST_ROOTFS_HASH),
+            home.rootfs_lock(TEST_ROOTFS_HASH),
+        ] {
+            let error = crate::lock::try_acquire(path).await.unwrap_err();
+            assert!(
+                error.to_string().contains("lock is already held"),
+                "unexpected rootfs lock error: {error}"
+            );
+        }
 
         let snapshot_err = crate::lock::try_acquire(home.snapshot_lock(TEST_SNAPSHOT_HASH))
             .await
@@ -1227,10 +1230,12 @@ profiles:
     }
 
     async fn assert_artifact_locks_released(home: &HomePaths) {
-        let rootfs_lock = crate::lock::try_acquire(home.rootfs_lock(TEST_ROOTFS_HASH))
-            .await
-            .unwrap();
-        drop(rootfs_lock);
+        for path in [
+            home.legacy_rootfs_lock(TEST_ROOTFS_HASH),
+            home.rootfs_lock(TEST_ROOTFS_HASH),
+        ] {
+            drop(crate::lock::try_acquire(path).await.unwrap());
+        }
 
         let snapshot_lock = crate::lock::try_acquire(home.snapshot_lock(TEST_SNAPSHOT_HASH))
             .await

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -55,6 +55,7 @@ use guest_contracts::process_containment::{
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::{HomePaths, RootfsPaths, SnapshotPaths};
 use crate::profile;
+use crate::rootfs_lock::{self, RootfsLockGuard};
 
 /// 0 means auto-detect from host CPU and memory at startup.
 pub(crate) const DEFAULT_MAX_CONCURRENT: usize = 0;
@@ -428,7 +429,7 @@ async fn validate_profile_snapshot_artifacts(
 }
 
 pub(crate) struct LockedProfileImageArtifacts {
-    _rootfs_locks: Vec<Flock<File>>,
+    _rootfs_locks: Vec<RootfsLockGuard>,
     _snapshot_locks: Vec<Flock<File>>,
     snapshot_paths: SnapshotPaths,
 }
@@ -455,7 +456,7 @@ impl LockedProfileImageArtifactPaths {
 }
 
 pub(crate) struct LockedRunnerImageArtifacts {
-    _rootfs_locks: Vec<Flock<File>>,
+    _rootfs_locks: Vec<RootfsLockGuard>,
     _snapshot_locks: Vec<Flock<File>>,
     profile_paths: BTreeMap<String, LockedProfileImageArtifactPaths>,
 }
@@ -514,7 +515,7 @@ pub(crate) async fn lock_and_validate_runner_image_artifacts(
 
     let mut rootfs_locks = Vec::with_capacity(rootfs_hashes.len());
     for hash in rootfs_hashes {
-        rootfs_locks.push(crate::lock::acquire_shared(home.rootfs_lock(hash)).await?);
+        rootfs_locks.push(rootfs_lock::acquire_shared(home, hash).await?);
     }
 
     let mut rootfs_paths = BTreeMap::new();

--- a/crates/runner/src/config/tests.rs
+++ b/crates/runner/src/config/tests.rs
@@ -7,6 +7,22 @@ const OTHER_ROOTFS_HASH: &str = "11111111111111111111111111111111111111111111111
 const OTHER_SNAPSHOT_HASH: &str =
     "2222222222222222222222222222222222222222222222222222222222222222";
 
+async fn assert_rootfs_pair_held(home: &HomePaths, hash: &str) {
+    for path in [home.legacy_rootfs_lock(hash), home.rootfs_lock(hash)] {
+        let error = crate::lock::try_acquire(path).await.unwrap_err();
+        assert!(
+            error.to_string().contains("lock is already held"),
+            "unexpected rootfs lock error: {error}"
+        );
+    }
+}
+
+async fn assert_rootfs_pair_released(home: &HomePaths, hash: &str) {
+    for path in [home.legacy_rootfs_lock(hash), home.rootfs_lock(hash)] {
+        drop(crate::lock::try_acquire(path).await.unwrap());
+    }
+}
+
 struct ConfigFixture {
     dir: tempfile::TempDir,
     firecracker: std::path::PathBuf,
@@ -961,13 +977,7 @@ async fn lock_and_validate_profile_image_artifacts_holds_resource_locks() {
         .await
         .unwrap();
 
-    let rootfs_err = crate::lock::try_acquire(home.rootfs_lock(TEST_ROOTFS_HASH))
-        .await
-        .unwrap_err();
-    assert!(
-        rootfs_err.to_string().contains("lock is already held"),
-        "got: {rootfs_err}"
-    );
+    assert_rootfs_pair_held(&home, TEST_ROOTFS_HASH).await;
 
     let snapshot_err = crate::lock::try_acquire(home.snapshot_lock(TEST_SNAPSHOT_HASH))
         .await
@@ -978,10 +988,7 @@ async fn lock_and_validate_profile_image_artifacts_holds_resource_locks() {
     );
 
     drop(guard);
-    let released_lock = crate::lock::try_acquire(home.rootfs_lock(TEST_ROOTFS_HASH))
-        .await
-        .unwrap();
-    drop(released_lock);
+    assert_rootfs_pair_released(&home, TEST_ROOTFS_HASH).await;
     let released_lock = crate::lock::try_acquire(home.snapshot_lock(TEST_SNAPSHOT_HASH))
         .await
         .unwrap();
@@ -1006,10 +1013,7 @@ async fn lock_and_validate_runner_image_artifacts_releases_locks_on_validation_e
         "expected missing cow bitmap error, got: {err}"
     );
 
-    let rootfs_lock = crate::lock::try_acquire(home.rootfs_lock(TEST_ROOTFS_HASH))
-        .await
-        .unwrap();
-    drop(rootfs_lock);
+    assert_rootfs_pair_released(&home, TEST_ROOTFS_HASH).await;
     let snapshot_lock = crate::lock::try_acquire(home.snapshot_lock(TEST_SNAPSHOT_HASH))
         .await
         .unwrap();
@@ -1059,13 +1063,7 @@ async fn lock_and_validate_runner_image_artifacts_holds_all_resource_locks() {
         (TEST_ROOTFS_HASH, TEST_SNAPSHOT_HASH),
         (OTHER_ROOTFS_HASH, OTHER_SNAPSHOT_HASH),
     ] {
-        let rootfs_err = crate::lock::try_acquire(home.rootfs_lock(rootfs_hash))
-            .await
-            .unwrap_err();
-        assert!(
-            rootfs_err.to_string().contains("lock is already held"),
-            "got: {rootfs_err}"
-        );
+        assert_rootfs_pair_held(&home, rootfs_hash).await;
         let snapshot_err = crate::lock::try_acquire(home.snapshot_lock(snapshot_hash))
             .await
             .unwrap_err();
@@ -1080,10 +1078,7 @@ async fn lock_and_validate_runner_image_artifacts_holds_all_resource_locks() {
         (TEST_ROOTFS_HASH, TEST_SNAPSHOT_HASH),
         (OTHER_ROOTFS_HASH, OTHER_SNAPSHOT_HASH),
     ] {
-        let released_lock = crate::lock::try_acquire(home.rootfs_lock(rootfs_hash))
-            .await
-            .unwrap();
-        drop(released_lock);
+        assert_rootfs_pair_released(&home, rootfs_hash).await;
         let released_lock = crate::lock::try_acquire(home.snapshot_lock(snapshot_hash))
             .await
             .unwrap();

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -51,6 +51,7 @@ mod r2_cache;
 mod resource_budget;
 mod restored_session_identity;
 mod retry;
+mod rootfs_lock;
 mod run_cancellation;
 mod run_resolution;
 mod runner_dirname;

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -271,11 +271,15 @@ impl HomePaths {
         self.locks_dir().join(base_dir_lock_name(base_dir))
     }
 
-    /// Lock file for a rootfs hash.
-    ///
-    /// Keeps the `image-` prefix for backward compatibility: during rolling
-    /// deploys, old runner binaries still hold locks under this name.
     pub fn rootfs_lock(&self, hash: &str) -> PathBuf {
+        self.locks_dir().join(format!("rootfs-{hash}.lock"))
+    }
+
+    /// Compatibility lock for rootfs users from before the canonical rename.
+    ///
+    /// Bridge releases acquire this before [`Self::rootfs_lock`]. Remove it
+    /// only after the rollout gate in vm0-ai/vm0#30478 is complete.
+    pub fn legacy_rootfs_lock(&self, hash: &str) -> PathBuf {
         self.locks_dir().join(format!("image-{hash}.lock"))
     }
 
@@ -553,8 +557,11 @@ mod tests {
     fn lock_paths() {
         let home = HomePaths::with_root(PathBuf::from("/test"));
         let rootfs_lock = home.rootfs_lock("abc123");
-        assert!(rootfs_lock.starts_with("/test/locks/"));
-        assert!(rootfs_lock.to_string_lossy().contains("image-abc123"));
+        assert_eq!(rootfs_lock, PathBuf::from("/test/locks/rootfs-abc123.lock"));
+        assert_eq!(
+            home.legacy_rootfs_lock("abc123"),
+            PathBuf::from("/test/locks/image-abc123.lock")
+        );
         let template_lock = home.template_lock("def456");
         assert!(template_lock.starts_with("/test/locks/"));
         assert!(template_lock.to_string_lossy().contains("template-def456"));

--- a/crates/runner/src/rootfs_lock.rs
+++ b/crates/runner/src/rootfs_lock.rs
@@ -1,0 +1,174 @@
+//! Rootfs lock identity bridge for rolling Runner deployments.
+//!
+//! Pre-bridge releases use only `image-{hash}.lock`. Bridge releases acquire
+//! that historical identity before the canonical `rootfs-{hash}.lock`, so
+//! they coordinate with both pre-bridge and future canonical-only releases.
+//! Every caller must acquire rootfs pairs before snapshot locks. Remove the
+//! historical guard only after the rollout gate in vm0-ai/vm0#30478.
+
+use std::fs::File;
+
+use nix::fcntl::Flock;
+
+use crate::error::RunnerResult;
+use crate::lock::{self, TryLock};
+use crate::paths::HomePaths;
+
+pub(crate) struct RootfsLockGuard {
+    // Struct fields drop in declaration order. Release the canonical identity
+    // first so the historical bridge remains held until the pair is gone.
+    _canonical: Flock<File>,
+    _legacy: Flock<File>,
+}
+
+pub(crate) enum TryRootfsLock {
+    Acquired(RootfsLockGuard),
+    Busy,
+}
+
+pub(crate) async fn acquire(home: &HomePaths, hash: &str) -> RunnerResult<RootfsLockGuard> {
+    let legacy = lock::acquire(home.legacy_rootfs_lock(hash)).await?;
+    let canonical = lock::acquire(home.rootfs_lock(hash)).await?;
+    Ok(RootfsLockGuard {
+        _canonical: canonical,
+        _legacy: legacy,
+    })
+}
+
+pub(crate) async fn acquire_shared(home: &HomePaths, hash: &str) -> RunnerResult<RootfsLockGuard> {
+    let legacy = lock::acquire_shared(home.legacy_rootfs_lock(hash)).await?;
+    let canonical = lock::acquire_shared(home.rootfs_lock(hash)).await?;
+    Ok(RootfsLockGuard {
+        _canonical: canonical,
+        _legacy: legacy,
+    })
+}
+
+pub(crate) fn try_acquire_or_busy_blocking(
+    home: &HomePaths,
+    hash: &str,
+) -> RunnerResult<TryRootfsLock> {
+    let legacy = match lock::try_acquire_or_busy_blocking(&home.legacy_rootfs_lock(hash))? {
+        TryLock::Acquired(legacy) => legacy,
+        TryLock::Busy => return Ok(TryRootfsLock::Busy),
+    };
+    let canonical = match lock::try_acquire_or_busy_blocking(&home.rootfs_lock(hash))? {
+        TryLock::Acquired(canonical) => canonical,
+        TryLock::Busy => return Ok(TryRootfsLock::Busy),
+    };
+    Ok(TryRootfsLock::Acquired(RootfsLockGuard {
+        _canonical: canonical,
+        _legacy: legacy,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_home(dir: &tempfile::TempDir) -> HomePaths {
+        HomePaths::with_root(dir.path().join("runner"))
+    }
+
+    async fn assert_exclusive_busy(path: std::path::PathBuf) {
+        let result = lock::try_acquire_or_busy(path).await.unwrap();
+        assert!(matches!(result, TryLock::Busy));
+    }
+
+    #[tokio::test]
+    async fn shared_pair_holds_and_releases_both_identities() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(&dir);
+        let hash = "shared";
+
+        let guard = acquire_shared(&home, hash).await.unwrap();
+        assert_exclusive_busy(home.legacy_rootfs_lock(hash)).await;
+        assert_exclusive_busy(home.rootfs_lock(hash)).await;
+
+        drop(guard);
+        drop(
+            lock::try_acquire(home.legacy_rootfs_lock(hash))
+                .await
+                .unwrap(),
+        );
+        drop(lock::try_acquire(home.rootfs_lock(hash)).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn exclusive_pair_holds_both_identities() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(&dir);
+        let hash = "exclusive";
+
+        let _guard = acquire(&home, hash).await.unwrap();
+        assert_exclusive_busy(home.legacy_rootfs_lock(hash)).await;
+        assert_exclusive_busy(home.rootfs_lock(hash)).await;
+    }
+
+    #[tokio::test]
+    async fn nonblocking_pair_is_busy_for_historical_only_holder() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(&dir);
+        let hash = "historical-busy";
+        let _holder = lock::acquire_shared(home.legacy_rootfs_lock(hash))
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            try_acquire_or_busy_blocking(&home, hash).unwrap(),
+            TryRootfsLock::Busy
+        ));
+    }
+
+    #[tokio::test]
+    async fn nonblocking_pair_is_busy_for_canonical_only_holder() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(&dir);
+        let hash = "canonical-busy";
+        let _holder = lock::acquire_shared(home.rootfs_lock(hash)).await.unwrap();
+
+        assert!(matches!(
+            try_acquire_or_busy_blocking(&home, hash).unwrap(),
+            TryRootfsLock::Busy
+        ));
+        drop(
+            lock::try_acquire(home.legacy_rootfs_lock(hash))
+                .await
+                .unwrap(),
+        );
+    }
+
+    #[tokio::test]
+    async fn nonblocking_pair_holds_both_identities() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(&dir);
+        let hash = "nonblocking";
+
+        let guard = match try_acquire_or_busy_blocking(&home, hash).unwrap() {
+            TryRootfsLock::Acquired(guard) => guard,
+            TryRootfsLock::Busy => panic!("unheld pair must be acquired"),
+        };
+        assert_exclusive_busy(home.legacy_rootfs_lock(hash)).await;
+        assert_exclusive_busy(home.rootfs_lock(hash)).await;
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn canonical_path_error_releases_historical_guard() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(&dir);
+        let hash = "canonical-error";
+        std::fs::create_dir_all(home.rootfs_lock(hash)).unwrap();
+
+        let error = match acquire_shared(&home, hash).await {
+            Ok(_) => panic!("directory lock path must fail"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("rootfs-canonical-error.lock"));
+        drop(
+            lock::try_acquire(home.legacy_rootfs_lock(hash))
+                .await
+                .unwrap(),
+        );
+    }
+}

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -150,6 +150,24 @@ The backend must support old runner requests until old runners have fully
 drained. Runner changes that require backend support must be staged so a new
 runner can also survive briefly talking to an old backend.
 
+Rootfs locks have a host-local cross-version transition of their own. Releases
+before the canonical rename coordinate through `image-{hash}.lock`; bridge
+releases acquire that historical identity and then `rootfs-{hash}.lock`; a
+future cleanup release will use only the canonical identity. This ordering lets
+pre-bridge and bridge processes coordinate through the historical lock, while
+bridge and post-cleanup processes coordinate through the canonical lock.
+Pre-bridge and post-cleanup releases must not overlap directly or remain
+simultaneously supported for rollback.
+
+During the bridge, every caller acquires the historical rootfs identity before
+the canonical identity, releases them in reverse order, and acquires all rootfs
+identities before any snapshot identity. Bridge processes legitimately keep
+historical locks held. Remove the historical acquisition only after exact
+production and rollback artifacts are bridge-capable and the rollout gate in
+vm0-ai/vm0#30478 proves that no pre-bridge process remains. Verify zero held
+historical rootfs locks after the canonical-only rollout drains bridge
+processes.
+
 Runner and guest binaries are deployed as one runner artifact. Compatibility is
 not required between a runner binary and a guest binary from a different version.
 


### PR DESCRIPTION
## Summary

- Introduce a rootfs-specific lock bridge that acquires the historical `image-{hash}.lock` identity before the canonical `rootfs-{hash}.lock` identity.
- Route runner build, startup validation/service activation, and image GC rootfs locking through the bridge while preserving rootfs-before-snapshot ordering.
- Cover both identities, lock contention, guard release, GC inventory/action behavior, and orphan-lock cleanup with real filesystem lock tests.
- Document the pre-bridge, bridge, and post-cleanup deployment compatibility contract and rollout gate.

## Scope

This PR implements only the bridge phase. It intentionally retains the historical lock acquisition; removing it is a later child issue after the rollout and rollback gate in #30478 passes.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets -- -D warnings`
- `cargo doc -p runner --no-deps`
- `cargo test -p runner` (3402 passed, 0 failed, 26 existing ignored; guest inventory 1 passed)
- Repository pre-commit and commit-message hooks

Closes #30498

Parent: #30478
