### PR TITLE
test(platform): await the cross-thread composer send state

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-lifecycle.test.tsx
@@ -981,7 +981,9 @@ describe("chat lifecycle", () => {
       PLACEHOLDER,
     ) as HTMLTextAreaElement;
     await user.type(otherTextarea, "Fresh draft for other thread");
-    expect(screen.getByLabelText("Send")).toBeEnabled();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Send")).toBeEnabled();
+    });
 
     await user.click(linkByText("Long thread"));
     await waitFor(() => {


### PR DESCRIPTION
## Status: closing without a code change

**This PR is being closed. Its diff does not fix the fingerprint, and no narrow evidence-backed fix is warranted yet.**

The change in this PR wraps the line-984 assertion in `waitFor`. CI proved that insufficient: the fingerprint reproduced with this change already in the tree, in merge-group run [33376215545](https://github.com/vm0-ai/vm0/actions/runs/33376215545) ([job](https://github.com/vm0-ai/vm0/actions/runs/33376215545/job/99438238890)), failing SHA `4d3f419434ee00b27db50d83f279861ba33960fe`. Two independent confirmations: this PR's merge-group head `038ba8ec4108cd6e9d1eda462fb78b16706cc101` is an ancestor of that failing SHA (`GET /compare` reports `status=ahead, ahead_by=2, behind_by=0`), and the failure output quoted the post-fix source including `await waitFor(() => {` with the `waitForWrapper … wait-for.js:163:27` frame.

Per the repair contract, a fingerprint that lacks a narrow evidence-backed fix gets no speculative code change. Closing rather than leaving an open PR whose diff is known not to work, so nothing can accidentally land it.

## Fingerprint

- File: `turbo/apps/platform/src/views/okou-page/__tests__/chat-lifecycle.test.tsx`
- Test: `chat lifecycle > keeps the thread container without carrying resolved history or submission state across threads`
- Anchor: `chat-lifecycle.test.tsx:984`
- Error: `TestingLibraryElementError: Unable to find a label with the text of: Send`
- Job shape: `test-app` shard 3, `Tests 1 failed | 293 passed (294)`

## Occurrence history (15 occurrences, ~2h45m on 2026-08-31)

| # | Run | Failing SHA | Trigger | Duration |
| --- | --- | --- | --- | --- |
| 1 | [33369334642](https://github.com/vm0-ai/vm0/actions/runs/33369334642) | `9dc4e51` | merge_group, queued #30479 | 1934ms |
| 2 | [33372229392](https://github.com/vm0-ai/vm0/actions/runs/33372229392) | `8f335a0` | merge_group, queued #30436 | 1848ms |
| 3 | [33372583091](https://github.com/vm0-ai/vm0/actions/runs/33372583091) | `01e0e5d` | merge_group, queued #30493 | 1910ms |
| 4 | [33373415022](https://github.com/vm0-ai/vm0/actions/runs/33373415022) | `2e4287c` | **push on `main`** | 1951ms |
| 5 | [33373661546](https://github.com/vm0-ai/vm0/actions/runs/33373661546) | `0161da6` | merge_group, queued #30442 | 1551ms |
| 6 | [33374472836](https://github.com/vm0-ai/vm0/actions/runs/33374472836) | `dde56b3` | merge_group, queued #30493 (2nd) | 1944ms |
| 7 | [33374656120](https://github.com/vm0-ai/vm0/actions/runs/33374656120) | `a02f39b` | **push on `main`** | 2179ms |
| 8 | [33375792099](https://github.com/vm0-ai/vm0/actions/runs/33375792099) | `e284bea` | merge_group, queued #30453 | 1574ms |
| 9 | [33376215545](https://github.com/vm0-ai/vm0/actions/runs/33376215545) | `4d3f419` | merge_group, queued #30464 — **post-fix tree** | 2262ms |
| 10 | [33376837807](https://github.com/vm0-ai/vm0/actions/runs/33376837807) | `68a0348` | merge_group, queued #30519 | 1569ms |
| 11 | [33377851040](https://github.com/vm0-ai/vm0/actions/runs/33377851040) | `16add8c` | merge_group, queued #30510 | 2258ms |
| 12 | [33377849591](https://github.com/vm0-ai/vm0/actions/runs/33377849591) | `0681848` | **push on `main`** | 2079ms |
| 13 | [33379179668](https://github.com/vm0-ai/vm0/actions/runs/33379179668) | `45c2123` | merge_group, queued #30453 (2nd) | 1556ms |
| 14 | [33379789838](https://github.com/vm0-ai/vm0/actions/runs/33379789838) | `7966a42` | merge_group, queued #30474 | 1686ms |
| 15 | [33379791016](https://github.com/vm0-ai/vm0/actions/runs/33379791016) | `21c361c` | merge_group, queued #30528 | 1729ms |

No queued change owns it: #30493 touches only `.github/**`, #30510 only `turbo/apps/cli/**`, #30519 only one API test file, and three occurrences are direct `main` pushes. Two SHAs each have a passing and a failing run of identical code (`2e4287c`: passed in 33372940546, failed in 33373415022; `a02f39b`: passed in 33374084133, failed in 33374656120). Durations span 1551-2262ms, so this is not a slow-machine timeout band.

## New findings from this session

All from local instrumentation of the product code and the test (reverted; nothing here is committed).

**1. The failure means the composer resolved to `stop`, so `hasInput$` was false.**
`ComposerSendButton` (`views/okou-page/chat-composer.tsx:9465`) always renders a button: `aria-label="Stop"` when the action is `stop`, otherwise `aria-label="Send"` (disabled when the action is `disabled`). So `getByLabelText("Send")` can only throw when the action is exactly `stop`. In `createComposerPrimaryActionSignal` (`signals/okou-page/composer-signals.ts:757`) `stop` requires `sending && !canSend`, and `canSend = uploadsReady && hasContent`. With no attachments `uploadsReady` is true, so **the typed text never reached `draft.setInput$`** — `internalInput$` was still empty after `user.type` typed 28 characters.

This is a *missed* transition, not a late one, which is the independent reason `waitFor` cannot fix it: there is nothing to wait for.

The only writer during typing is `runtime.update` → `set(draft.setInput$, …)` (`signals/okou-page/tiptap-workflow-composer.ts:2091`), invoked from the TipTap `onUpdate` handler. So the keystrokes reached a ProseMirror view that was not the live one, or reached a runtime that had been reset by `resetMountedWorkflowRuntime`.

**2. The composer's ProseMirror view is destroyed and re-created on the thread switch.**
Instrumenting mount/unmount and tagging element and `Editor` identity shows, at the switch:

```
DIAG-UNMOUNT 1788171682077
DIAG-MOUNT   1788171682081 el=33 ed=35 cid=…902     <- same container element, NEW Editor instance
DIAG-SWITCHED 1788171682163                          <- the test's container-id waitFor resolves
DIAG-CAPTURED 1788171682273                          <- the test captures the composer node
```

The container `<section data-chat-thread-container-id>` is reused (`el=33` unchanged, which is the product contract this test guards), but the per-thread composer signals are replaced, so the ref identity changes, the old `Editor` is unmounted and a new one (`ed=35`) is mounted into the same element. Any keystrokes delivered while the previous view is being torn down are lost, and the new thread's draft stays empty — exactly the observed symptom.

**3. But the test's existing barrier does order that swap, so this alone is not the cause.**
Logging the container-id attribute at mount time shows `cid=…902` (the other thread) already set at the swap-mount. The composer swap and the `data-chat-thread-container-id` update are committed in the **same React commit**, and the test's earlier `waitFor` on that attribute resolves after it. So under the ordering observed locally, the composer is already the new thread's before the element is captured. **My leading hypothesis is falsified**; a second, later teardown would be needed and I did not observe one.

**4. The `ably catch-up failed HTTP 500` warnings are not a CI-only condition.**
The previous investigation recorded zero occurrences locally and treated the CI/local divergence as invalidating local runs. That is not reproducible: a plain single-file run here logs the same `[W][Realtime] ably catch-up failed ApiError: HTTP 500` from `signals/realtime.ts:614`. Single-file local runs do exercise that loop, so they are legitimate evidence.

**5. Running the file with `-t` is not a valid harness.**
`vitest run <file> -t "keeps the thread container…"` fails with `Unable to find an element with the placeholder text of: …`, a different error caused by the first page-rendering test in a worker absorbing a one-time render cost against the short `asyncUtilTimeout`. It must not be cited for this fingerprint.

**6. Not reproduced locally.** Full-file runs pass (30/30). I could not produce the fingerprint, so the first causal nondeterminism remains unproven.

## The strongest remaining lead: temporal onset

The fingerprint has no occurrences before 2026-08-31 and 15 within one morning. The `main` commits immediately preceding the first occurrence:

```
9dc4e51b29 07:35 test(platform): stabilize chat shortcut navigation (#30479)
e9aff31222 07:23 perf(platform): remove server contracts from startup graph (#30444)
e5a37ee36a 07:02 fix(runner): preserve exact-reuse timezone outcomes (#30470)
```

The first failing run is at 07:39 on head `9dc4e51` (07:35). **#30444 "perf(platform): remove server contracts from startup graph" merged 12 minutes before the first occurrence** and is a platform module-graph/startup-ordering change — precisely the class of change that shifts when async bootstrap milestones land relative to each other during a thread switch, without touching any test. Also in range and worth ruling out: #30441 (Mermaid Lite vendor chunk, 06:40) and #30449 (Google Fonts from document head, 05:56).

Separately, `19fe4f529 02:35 fix(platform): derive thinking indicator from chat events (#30357)` changed `deriveRunIndicatorStateFromChatEvents`, which is exactly what `sending$` reads. That is what puts the other thread's composer into the `stop` state at all, i.e. it created the state this assertion now depends on. Before it, an empty composer on that fixture would have resolved to `disabled`, which still renders `aria-label="Send"` and the test would not have been sensitive to this transition.

**Recommended next step: bisect the onset against #30357 and #30444 rather than adjusting the test again.**

## Hypotheses falsified so far

Recorded so they are not retried.

1. Missing synchronization barrier — falsified by CI occurrence 9 on the post-fix tree.
2. Typing lands before the editor mount wires `runtime.update` — not reproduced.
3. The captured textarea is detached or replaced during typing — instrumented, not observed locally.
4. ccstate loses a post-`await` dependency in an async `computed` — probed directly, invalidation works.
5. The composer input is disabled or the placeholder targets the wrong element — the `placeholder` attribute is on the ProseMirror editor node; the sending-dependent placeholder is a separate `aria-hidden` overlay.
6. The composer swap is not ordered by the test's container-id barrier — falsified this session (finding 3): both land in the same React commit.
7. `primaryAction$` never settles because the realtime loop keeps invalidating it — falsified: `hasEvents$` and `sending$` are `Promise.resolve(...)`, so `primaryAction$` always settles within microtasks.

## Excluded remedies

Raising `asyncUtilTimeout` or any timeout, retries, sleeps, skipping or deleting the test, weakening the assertion, or manual detached cleanup.
