### PR TITLE
test(api): bound chat search projection test to its own thread

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-project-chat-event-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-project-chat-event-search.test.ts
@@ -27,19 +27,12 @@ const bdd = createBddApi(context);
 const chat = createChatFilesBddApi(context);
 const CRON_SECRET = "durable-chat-search-projection-secret";
 
-async function projectChatEventSearch() {
+function cronClient() {
   mockEnv("CRON_SECRET", CRON_SECRET);
-  const client = setupApp({
+  return setupApp({
     context,
     routes: cronProjectChatEventSearchRoutes,
   })(cronProjectChatEventSearchContract);
-  const response = await accept(
-    client.project({
-      headers: { authorization: `Bearer ${CRON_SECRET}` },
-    }),
-    [200],
-  );
-  return response.body;
 }
 
 async function projectOwnedChatEventSearch(chatThreadIds: readonly string[]) {
@@ -104,18 +97,12 @@ describe("GET /api/cron/project-chat-event-search", () => {
     expect(projection.indexedSeqId).toBe(projection.lastChatEventSeqId);
   });
 
-  it("authorizes the cron route and bounds its tick to the thread batch", async () => {
-    // The cron route projects every lagging thread in the database, so this
-    // shared-database test must cap the batch instead of scaling with the
-    // threads that unrelated test files leave behind.
-    mockOptionalEnv("CHAT_EVENT_SEARCH_PROJECTION_BATCH_SIZE", "1");
-    const tick = await projectChatEventSearch();
+  it("requires the cron secret", async () => {
+    const response = await accept(cronClient().project({ headers: {} }), [401]);
 
-    expect(tick.success).toBeTruthy();
-    expect(tick.threads).toBeLessThanOrEqual(1);
-    expect(tick.convergence.eligibleThreads).toBeGreaterThanOrEqual(
-      tick.convergence.durableCaughtUpThreads,
-    );
+    expect(response.body).toStrictEqual({
+      error: { code: "UNAUTHORIZED", message: "Invalid cron secret" },
+    });
   });
 
   it("keeps overlapping projection ticks idempotent", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-project-chat-event-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-project-chat-event-search.test.ts
@@ -79,14 +79,12 @@ describe("GET /api/cron/project-chat-event-search", () => {
       terminalText,
     });
 
-    const tick = await projectChatEventSearch();
+    const tick = await projectOwnedChatEventSearch([chatThreadId]);
     expect(tick.success).toBeTruthy();
-    expect(tick.threads).toBeGreaterThanOrEqual(1);
-    expect(tick.indexedEvents).toBeGreaterThanOrEqual(2);
-    expect(tick.convergence.eligibleThreads).toBeGreaterThanOrEqual(
-      tick.convergence.durableCaughtUpThreads,
-    );
-    expect(tick.convergence.durableCaughtUpThreads).toBeGreaterThanOrEqual(1);
+    expect(tick.threads).toBe(1);
+    expect(tick.indexedEvents).toBe(2);
+    expect(tick.convergence.eligibleThreads).toBe(1);
+    expect(tick.convergence.durableCaughtUpThreads).toBe(1);
 
     const projection = await readChatEventSearchProjectionFixture(chatThreadId);
     expect(projection.messages).toStrictEqual([
@@ -104,6 +102,20 @@ describe("GET /api/cron/project-chat-event-search", () => {
       },
     ]);
     expect(projection.indexedSeqId).toBe(projection.lastChatEventSeqId);
+  });
+
+  it("authorizes the cron route and bounds its tick to the thread batch", async () => {
+    // The cron route projects every lagging thread in the database, so this
+    // shared-database test must cap the batch instead of scaling with the
+    // threads that unrelated test files leave behind.
+    mockOptionalEnv("CHAT_EVENT_SEARCH_PROJECTION_BATCH_SIZE", "1");
+    const tick = await projectChatEventSearch();
+
+    expect(tick.success).toBeTruthy();
+    expect(tick.threads).toBeLessThanOrEqual(1);
+    expect(tick.convergence.eligibleThreads).toBeGreaterThanOrEqual(
+      tick.convergence.durableCaughtUpThreads,
+    );
   });
 
   it("keeps overlapping projection ticks idempotent", async () => {


### PR DESCRIPTION
## Summary

Fixes the flaky `GET /api/cron/project-chat-event-search > projects only non-empty visible user and assistant messages` timeout in `test-api` shard 8.

The test drove the **unscoped** production cron route (`projectChatEventSearch()`). That route's work is `O(lagging chat threads in the entire shared test database)`: `loadCandidateThreads` selects up to `DEFAULT_THREAD_BATCH_SIZE = 500` threads ordered by `chat_threads.id`, and `projectChatEventSearch` then runs **one serial transaction per thread**, each taking `FOR KEY SHARE` and several round trips.

API tests share one Postgres and `testContext()` does not roll back persisted rows, so the test's cost scaled with whatever threads the other 26 test files in the shard happened to have left unprojected. Every other test in the file uses the thread-scoped `projectOwnedChatEventSearch(...)` route and is O(1) — which is exactly why they all passed while this one timed out.

This is the case `docs/testing/api-testing.md` describes directly: *"When a production cron scans a global table, keep production behavior global but drive correctness through a test-only route whose request names the owned IDs."*

## Evidence

- Failing run: https://github.com/vm0-ai/vm0/actions/runs/33371026274 (job https://github.com/vm0-ai/vm0/actions/runs/33371026274/job/99422037596), `Error: Test timed out in 5000ms.` at `cron-project-chat-event-search.test.ts:68`, observed 5010ms, file total 13187ms.
- **Same-SHA comparison**: the merge-group run for the identical SHA `c8023c8dcd85a347b5a8df282e16e6d957b5af15` passed in full (https://github.com/vm0-ai/vm0/actions/runs/33370593456, job https://github.com/vm0-ai/vm0/actions/runs/33370593456/job/99420643473). There the same test took **527ms** and the file took 1222ms. Same code, same shard, no rerun attempt. The merged commit came from #29355, unrelated to chat-search projection.
- 527ms was already 43% of that file's total — by far its most expensive test, consistent with it being the only unbounded one.

Local reproduction against Postgres 18, seeding the shared database with unrelated lagging threads to imitate sibling-file residue:

| lagging threads in DB | failing test | five sibling tests |
| --- | --- | --- |
| 1 (empty DB) | 126ms | 53-114ms |
| 301 | 795ms | 53-108ms (unchanged) |
| 701 | 1152ms | 55-113ms (unchanged) |

Only this test scales; the siblings are flat. In CI the whole file additionally ran about 10x slower under shard contention, which pushed the already-unbounded test past the 5000ms budget.

## Change

- Project the fixture through the existing thread-scoped test route, so the tick touches only the thread this test created.
- Tighten the assertions from `toBeGreaterThanOrEqual` lower bounds to exact counts. Those lower bounds only existed to tolerate unrelated global state, which `docs/testing/api-testing.md` calls out as residue-tolerant assertions.
- Replace the file's only remaining use of the production-global cron route with the fixed missing-secret rejection that `cron-monitor-chat-event-queue`, `cron-retain-chat-events`, `cron-snapshot-chat-events`, `cron-compact-usage-events`, and `cron-connector-catalog` already use. That is the one form the testing guide sanctions for a production-global route, it keeps route wiring and `CRON_SECRET` authorization covered, and it does no database work at all because the handler returns `cronUnauthorized()` before invoking the projection.

The product contract is preserved and strengthened: `projection.messages` is still asserted with `toStrictEqual` to contain exactly the non-empty visible user and assistant messages, still excluding the error and terminal events, and the watermark equality check is unchanged.

No retries, sleeps, raised timeouts, skips, or weakened business assertions.

## Coordination

Checked against in-flight work before editing. #30453 (`fix/chat-search-eventual-consistency`) also touches this file and the projection service, but only the thread-deletion test at lines ~175+ and the service; it does not touch this test and does not remove the unscoped scan, so it does not fix this flake. This change is confined to the top of the test file and touches no product code, so the two do not overlap. No other open PR or merge-queue entry addresses this fingerprint.

Follow-up worth tracking separately: `chat-threads.bdd.test.ts` calls the same unscoped cron route nine times and carries the same latent unboundedness. It is left alone here because #30453 is actively rewriting that file.

## Testing

- Target file run 5/5 times with ~700 lagging residue threads seeded in the shared database: all 7 pass, the previously failing test flat at 134-178ms (previously 1152ms under the same load) and the auth case at 5ms.
- Related regression files `chat-search-reader.test.ts`, `cron-project-chat-event-search.test.ts`, `vercel-crons.test.ts`: 12 passed.
- `prettier`, `pnpm lint` (exit 0, no findings on this file), `pnpm check-types` (14/14 tasks), `git diff --check`, and the full lefthook pre-commit hook.

Preview/browser validation is not applicable: this is an API test-only change with no user-facing or deployed surface.
