### PR TITLE
feat(desktop): deliver finished recordings back to okou

### DIFF
--- a/turbo/apps/desktop/src/desktop-auth-session.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.ts
@@ -129,9 +129,18 @@ export class DesktopAuthSession {
     return await this.refresh();
   }
 
-  async fetchWithSessionAuth(requestUrl: URL): Promise<Response> {
+  /**
+   * `init` carries the method and body for non-GET calls. Its `headers` are
+   * merged under the session headers, which always win, so a caller cannot
+   * accidentally drop the cookie or bearer token.
+   */
+  async fetchWithSessionAuth(
+    requestUrl: URL,
+    init?: RequestInit,
+  ): Promise<Response> {
     const response = await fetch(requestUrl, {
-      headers: await this.headersFor(requestUrl),
+      ...init,
+      headers: await this.headersFor(requestUrl, init?.headers),
     });
     if (response.status !== 401 || !this.token) {
       return response;
@@ -139,7 +148,8 @@ export class DesktopAuthSession {
 
     this.token = null;
     return await fetch(requestUrl, {
-      headers: await this.headersFor(requestUrl),
+      ...init,
+      headers: await this.headersFor(requestUrl, init?.headers),
     });
   }
 
@@ -298,11 +308,15 @@ export class DesktopAuthSession {
     this.onChange();
   }
 
-  private async headersFor(requestUrl: URL): Promise<Headers> {
-    const headers = await headersWithSessionCookies(this.cookieSource, [
-      ...this.cookieUrls,
-      requestUrl,
-    ]);
+  private async headersFor(
+    requestUrl: URL,
+    extraHeaders?: HeadersInit,
+  ): Promise<Headers> {
+    const headers = await headersWithSessionCookies(
+      this.cookieSource,
+      [...this.cookieUrls, requestUrl],
+      extraHeaders,
+    );
     if (this.token) {
       headers.set("authorization", `Bearer ${this.token}`);
     }

--- a/turbo/apps/desktop/src/desktop-recorder-controller.test.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-controller.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { DesktopRecorderController } from "./desktop-recorder-controller";
+import type { DeliveredRecording } from "./desktop-recorder-delivery";
 import type {
   DesktopRecorderNativeStatus,
   DesktopRecorderRecording,
@@ -47,19 +48,44 @@ function createBackendFake(
   };
 }
 
+const DELIVERED: DeliveredRecording = {
+  videoUploadId: "upload-video",
+  clickTrackUploadId: "upload-clicks",
+  reviewUrl: "https://app.okou.ai/?intro-video-recording=upload-video",
+};
+
 function createController(
   backend: RecorderNativeBackend = createBackendFake(),
+  overrides: {
+    readonly canDeliver?: () => Promise<boolean>;
+    readonly deliver?: () => Promise<DeliveredRecording>;
+  } = {},
 ) {
   const onChange = vi.fn();
   const logError = vi.fn();
   const createBackend = vi.fn(() => backend);
+  const openReview = vi.fn();
+  const canDeliver = vi.fn(overrides.canDeliver ?? (async () => true));
+  const deliver = vi.fn(overrides.deliver ?? (async () => DELIVERED));
   const controller = new DesktopRecorderController({
     createBackend,
     createOutputPath: () => "/tmp/recording.mp4",
+    canDeliver,
+    deliver,
+    openReview,
     onChange,
     logError,
   });
-  return { controller, backend, createBackend, onChange, logError };
+  return {
+    controller,
+    backend,
+    createBackend,
+    onChange,
+    logError,
+    openReview,
+    canDeliver,
+    deliver,
+  };
 }
 
 async function enableAndPrepare(controller: DesktopRecorderController) {
@@ -154,6 +180,90 @@ describe("DesktopRecorderController", () => {
     );
     expect(backend.prepare).not.toHaveBeenCalled();
     expect(controller.getState().status).toBe("idle");
+  });
+
+  it("uploads the finished recording and opens it for review", async () => {
+    const { controller, deliver, openReview } = createController();
+    await enableAndPrepare(controller);
+    await controller.start();
+
+    await controller.stop();
+
+    expect(deliver).toHaveBeenCalledWith(RECORDING);
+    expect(openReview).toHaveBeenCalledWith(DELIVERED.reviewUrl);
+    expect(controller.getState()).toMatchObject({
+      status: "idle",
+      error: null,
+    });
+  });
+
+  it("refuses to record while signed out, before anything is captured", async () => {
+    const { controller, backend } = createController(createBackendFake(), {
+      canDeliver: async () => false,
+    });
+    controller.setFeatureEnabled(true);
+
+    await expect(controller.startMainDisplayRecording()).rejects.toThrow(
+      "Cannot record while signed out of Okou",
+    );
+    expect(backend.prepare).not.toHaveBeenCalled();
+    expect(controller.getState()).toMatchObject({
+      status: "idle",
+      error: { code: "signed_out" },
+    });
+  });
+
+  it("keeps the recording and stays retryable when delivery fails", async () => {
+    const { controller, openReview } = createController(createBackendFake(), {
+      deliver: async () => {
+        throw new Error("Uploading recording.mp4 failed with 503");
+      },
+    });
+    await enableAndPrepare(controller);
+    await controller.start();
+
+    await expect(controller.stop()).resolves.toEqual(RECORDING);
+
+    expect(openReview).not.toHaveBeenCalled();
+    expect(controller.getState()).toMatchObject({
+      status: "idle",
+      lastRecording: RECORDING,
+      error: {
+        code: "delivery_failed",
+        message: "Uploading recording.mp4 failed with 503",
+      },
+    });
+  });
+
+  it("delivers the same recording again on retry", async () => {
+    let attempts = 0;
+    const { controller, openReview } = createController(createBackendFake(), {
+      deliver: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new Error("network down");
+        }
+        return DELIVERED;
+      },
+    });
+    await enableAndPrepare(controller);
+    await controller.start();
+    await controller.stop();
+
+    await controller.retryDelivery();
+
+    expect(attempts).toBe(2);
+    expect(openReview).toHaveBeenCalledWith(DELIVERED.reviewUrl);
+    expect(controller.getState().error).toBeNull();
+  });
+
+  it("has nothing to retry before a recording exists", async () => {
+    const { controller } = createController();
+    controller.setFeatureEnabled(true);
+
+    await expect(controller.retryDelivery()).rejects.toThrow(
+      "There is no recording to deliver",
+    );
   });
 
   it("rejects starting before a session is prepared", async () => {

--- a/turbo/apps/desktop/src/desktop-recorder-controller.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-controller.ts
@@ -1,3 +1,4 @@
+import type { DeliveredRecording } from "./desktop-recorder-delivery";
 import {
   UNAVAILABLE_RECORDER_STATE,
   type DesktopRecorderError,
@@ -14,6 +15,18 @@ interface DesktopRecorderControllerOptions {
   readonly createBackend: () => RecorderNativeBackend;
   /** Absolute path the next recording is written to. */
   readonly createOutputPath: () => string;
+  /**
+   * Whether delivery back to Okou is currently possible. Checked before the
+   * capture starts rather than after, so a signed-out user is told before
+   * spending minutes recording something that cannot be handed over.
+   */
+  readonly canDeliver: () => Promise<boolean>;
+  /** Uploads the finished recording and returns the review link to open. */
+  readonly deliver: (
+    recording: DesktopRecorderRecording,
+  ) => Promise<DeliveredRecording>;
+  /** Opens the review link in the user's browser. */
+  readonly openReview: (reviewUrl: string) => void;
   /** Zero-arg "something changed" signal; defaults to a no-op. */
   readonly onChange?: () => void;
   /** Called for failures on paths that cannot propagate to a caller. */
@@ -33,6 +46,11 @@ interface DesktopRecorderControllerOptions {
 export class DesktopRecorderController {
   private readonly createBackend: () => RecorderNativeBackend;
   private readonly createOutputPath: () => string;
+  private readonly canDeliver: () => Promise<boolean>;
+  private readonly deliver: (
+    recording: DesktopRecorderRecording,
+  ) => Promise<DeliveredRecording>;
+  private readonly openReview: (reviewUrl: string) => void;
   private readonly onChange: () => void;
   private readonly logError: (error: unknown) => void;
 
@@ -47,6 +65,9 @@ export class DesktopRecorderController {
   constructor(options: DesktopRecorderControllerOptions) {
     this.createBackend = options.createBackend;
     this.createOutputPath = options.createOutputPath;
+    this.canDeliver = options.canDeliver;
+    this.deliver = options.deliver;
+    this.openReview = options.openReview;
     this.onChange = options.onChange ?? (() => {});
     this.logError = options.logError ?? (() => {});
   }
@@ -114,6 +135,15 @@ export class DesktopRecorderController {
   async prepare(request: DesktopRecorderPrepareRequest): Promise<void> {
     const backend = this.requireBackend();
     this.requireStatus("idle");
+    if (!(await this.canDeliver())) {
+      this.error = {
+        code: "signed_out",
+        message:
+          "Sign in to Okou before recording so the result can be delivered",
+      };
+      this.onChange();
+      throw new Error("Cannot record while signed out of Okou");
+    }
     this.setStatus("preparing");
     const prepared = await backend.prepare(request);
     if (!this.featureEnabled) {
@@ -142,12 +172,51 @@ export class DesktopRecorderController {
     this.requireStatus("recording");
     this.setStatus("finalizing");
     const recording = await backend.stop(sessionId);
-    if (this.featureEnabled) {
-      this.lastRecording = recording;
-      this.sessionId = null;
+    if (!this.featureEnabled) {
+      return recording;
+    }
+    this.lastRecording = recording;
+    this.sessionId = null;
+    await this.runDelivery(recording);
+    return recording;
+  }
+
+  /**
+   * Uploads the last recording again after a failed delivery.
+   *
+   * The capture itself already succeeded and the files are still on disk, so a
+   * network failure must not cost the user the recording.
+   */
+  async retryDelivery(): Promise<void> {
+    const recording = this.lastRecording;
+    if (!recording) {
+      throw new Error("There is no recording to deliver");
+    }
+    this.requireStatus("idle");
+    await this.runDelivery(recording);
+  }
+
+  /**
+   * Delivery failures are captured into state rather than propagated: the
+   * recording on disk is intact and retryable, so losing the upload is not a
+   * reason to fail the stop the user just asked for.
+   */
+  private async runDelivery(
+    recording: DesktopRecorderRecording,
+  ): Promise<void> {
+    this.setStatus("delivering");
+    try {
+      const delivered = await this.deliver(recording);
+      this.error = null;
+      this.setStatus("idle");
+      this.openReview(delivered.reviewUrl);
+    } catch (error) {
+      this.error = {
+        code: "delivery_failed",
+        message: error instanceof Error ? error.message : String(error),
+      };
       this.setStatus("idle");
     }
-    return recording;
   }
 
   /**

--- a/turbo/apps/desktop/src/desktop-recorder-delivery.test.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-delivery.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+import { deliverRecording } from "./desktop-recorder-delivery";
+import type { RecorderDeliveryDependencies } from "./desktop-recorder-delivery";
+import type { DesktopRecorderRecording } from "./desktop-recorder-types";
+
+const RECORDING: DesktopRecorderRecording = {
+  videoPath: "/recordings/screen-recording-1.mp4",
+  clickTrackPath: "/recordings/screen-recording-1.clicks.json",
+  durationMs: 42_130,
+  sizeBytes: 8_912_345,
+  width: 1920,
+  height: 1200,
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function createDependencies(
+  overrides: Partial<RecorderDeliveryDependencies> = {},
+): RecorderDeliveryDependencies {
+  let prepared = 0;
+  return {
+    apiBaseUrl: "https://api.vm0.ai",
+    appUrl: "https://app.okou.ai",
+    userId: "user_1",
+    readFile: vi.fn(async () => new Blob([new Uint8Array([1, 2, 3, 4])])),
+    fetchWithSessionAuth: vi.fn(async (url: URL) => {
+      if (url.pathname === "/api/uploads/prepare") {
+        prepared += 1;
+        return jsonResponse({
+          id: `upload-${prepared.toString()}`,
+          uploadUrl: `https://r2.example/put/${prepared.toString()}`,
+          uploadHeaders: { "content-type": "application/octet-stream" },
+        });
+      }
+      return jsonResponse({ id: `upload-${prepared.toString()}` });
+    }),
+    fetchUpload: vi.fn(async () => new Response(null, { status: 200 })),
+    ...overrides,
+  };
+}
+
+describe("deliverRecording", () => {
+  it("uploads the video and the click track as separate attachments", async () => {
+    const deps = createDependencies();
+
+    const delivered = await deliverRecording(RECORDING, deps);
+
+    expect(delivered.videoUploadId).toBe("upload-1");
+    expect(delivered.clickTrackUploadId).toBe("upload-2");
+    expect(deps.readFile).toHaveBeenCalledWith(RECORDING.videoPath);
+    expect(deps.readFile).toHaveBeenCalledWith(RECORDING.clickTrackPath);
+  });
+
+  it("declares each file with its own name, type, and byte length", async () => {
+    const deps = createDependencies();
+
+    await deliverRecording(RECORDING, deps);
+
+    const prepareCalls = vi
+      .mocked(deps.fetchWithSessionAuth)
+      .mock.calls.filter(([url]) => {
+        return url.pathname === "/api/uploads/prepare";
+      });
+    expect(JSON.parse(String(prepareCalls[0]?.[1]?.body))).toEqual({
+      filename: "screen-recording-1.mp4",
+      contentType: "video/mp4",
+      size: 4,
+    });
+    expect(JSON.parse(String(prepareCalls[1]?.[1]?.body))).toEqual({
+      filename: "screen-recording-1.clicks.json",
+      contentType: "application/json",
+      size: 4,
+    });
+  });
+
+  it("sends the file body to the presigned URL without session credentials", async () => {
+    const deps = createDependencies();
+
+    await deliverRecording(RECORDING, deps);
+
+    expect(deps.fetchUpload).toHaveBeenCalledWith(
+      "https://r2.example/put/1",
+      expect.objectContaining({
+        method: "PUT",
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+  });
+
+  it("builds a review link carrying both uploads and the signed-in user", async () => {
+    const deps = createDependencies();
+
+    const delivered = await deliverRecording(RECORDING, deps);
+    const url = new URL(delivered.reviewUrl);
+
+    expect(url.origin).toBe("https://app.okou.ai");
+    expect(url.searchParams.get("intro-video-recording")).toBe("upload-1");
+    expect(url.searchParams.get("intro-video-clicks")).toBe("upload-2");
+    // Uploads are owned by the account that created them, so the browser needs
+    // to know which account the desktop was signed in as.
+    expect(url.searchParams.get("intro-video-user")).toBe("user_1");
+  });
+
+  it("reports which step failed and its status", async () => {
+    const deps = createDependencies({
+      fetchUpload: vi.fn(
+        async () => new Response("slow down", { status: 503 }),
+      ),
+    });
+
+    await expect(deliverRecording(RECORDING, deps)).rejects.toThrow(
+      "Uploading screen-recording-1.mp4 failed with 503: slow down",
+    );
+  });
+
+  it("stops before uploading when the session is rejected", async () => {
+    const deps = createDependencies({
+      fetchWithSessionAuth: vi.fn(async () =>
+        jsonResponse({ error: "unauthorized" }, 401),
+      ),
+    });
+
+    await expect(deliverRecording(RECORDING, deps)).rejects.toThrow(
+      "Preparing the upload of screen-recording-1.mp4 failed with 401",
+    );
+    expect(deps.fetchUpload).not.toHaveBeenCalled();
+  });
+
+  it("refuses a multipart response it did not ask for", async () => {
+    const deps = createDependencies({
+      fetchWithSessionAuth: vi.fn(async () =>
+        jsonResponse({
+          id: "upload-1",
+          multipart: { uploadId: "m1", partSize: 1024, parts: [] },
+        }),
+      ),
+    });
+
+    await expect(deliverRecording(RECORDING, deps)).rejects.toThrow(
+      "returned no direct upload URL",
+    );
+  });
+});

--- a/turbo/apps/desktop/src/desktop-recorder-delivery.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-delivery.ts
@@ -1,0 +1,191 @@
+import path from "node:path";
+import type { DesktopRecorderRecording } from "./desktop-recorder-types";
+
+const VIDEO_CONTENT_TYPE = "video/mp4";
+const CLICK_TRACK_CONTENT_TYPE = "application/json";
+
+class DesktopRecorderDeliveryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DesktopRecorderDeliveryError";
+  }
+}
+
+export interface RecorderDeliveryDependencies {
+  readonly apiBaseUrl: string;
+  /** Origin the review link opens on, e.g. `https://app.okou.ai`. */
+  readonly appUrl: string;
+  /** Session-authenticated fetch against the Okou API. */
+  readonly fetchWithSessionAuth: (
+    url: URL,
+    init?: RequestInit,
+  ) => Promise<Response>;
+  /**
+   * Unauthenticated fetch for the presigned R2 PUT. Deliberately separate: the
+   * upload URL already carries its own signature, and sending Okou session
+   * cookies to storage would leak them outside the API.
+   */
+  readonly fetchUpload: (url: string, init: RequestInit) => Promise<Response>;
+  /**
+   * Reads a file as a `Blob` so the bytes are a valid `BodyInit` regardless of
+   * which ArrayBuffer flavour the platform read produced.
+   */
+  readonly readFile: (filePath: string) => Promise<Blob>;
+  /** User the desktop is signed in as, carried so the browser can compare. */
+  readonly userId: string;
+}
+
+export interface DeliveredRecording {
+  readonly videoUploadId: string;
+  readonly clickTrackUploadId: string;
+  readonly reviewUrl: string;
+}
+
+interface PreparedUpload {
+  readonly id: string;
+  readonly uploadUrl: string;
+  readonly uploadHeaders: Record<string, string>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function failureMessage(
+  response: Response,
+  action: string,
+): Promise<string> {
+  const body = await response.text().catch(() => "");
+  const detail = body.slice(0, 200);
+  return `${action} failed with ${response.status.toString()}${detail ? `: ${detail}` : ""}`;
+}
+
+async function prepareUpload(
+  deps: RecorderDeliveryDependencies,
+  file: {
+    readonly name: string;
+    readonly contentType: string;
+    readonly size: number;
+  },
+): Promise<PreparedUpload> {
+  const response = await deps.fetchWithSessionAuth(
+    new URL("/api/uploads/prepare", deps.apiBaseUrl),
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        filename: file.name,
+        contentType: file.contentType,
+        size: file.size,
+      }),
+    },
+  );
+  if (!response.ok) {
+    throw new DesktopRecorderDeliveryError(
+      await failureMessage(response, `Preparing the upload of ${file.name}`),
+    );
+  }
+
+  const body: unknown = await response.json();
+  if (!isRecord(body) || typeof body.id !== "string") {
+    throw new DesktopRecorderDeliveryError(
+      `Preparing the upload of ${file.name} returned no upload id`,
+    );
+  }
+  if (typeof body.uploadUrl !== "string") {
+    // The API only returns multipart parts when the request asks for them, and
+    // a single PUT from the main process has no body-size limit to work around.
+    throw new DesktopRecorderDeliveryError(
+      `Preparing the upload of ${file.name} returned no direct upload URL`,
+    );
+  }
+
+  const uploadHeaders = isRecord(body.uploadHeaders) ? body.uploadHeaders : {};
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(uploadHeaders)) {
+    if (typeof value === "string") {
+      headers[key] = value;
+    }
+  }
+  return { id: body.id, uploadUrl: body.uploadUrl, uploadHeaders: headers };
+}
+
+async function uploadFile(
+  deps: RecorderDeliveryDependencies,
+  filePath: string,
+  contentType: string,
+): Promise<string> {
+  const name = path.basename(filePath);
+  const body = await deps.readFile(filePath);
+  const prepared = await prepareUpload(deps, {
+    name,
+    contentType,
+    size: body.size,
+  });
+
+  const putResponse = await deps.fetchUpload(prepared.uploadUrl, {
+    method: "PUT",
+    headers: prepared.uploadHeaders,
+    body,
+  });
+  if (!putResponse.ok) {
+    throw new DesktopRecorderDeliveryError(
+      await failureMessage(putResponse, `Uploading ${name}`),
+    );
+  }
+
+  const completeResponse = await deps.fetchWithSessionAuth(
+    new URL("/api/uploads/complete", deps.apiBaseUrl),
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: prepared.id, contentType }),
+    },
+  );
+  if (!completeResponse.ok) {
+    throw new DesktopRecorderDeliveryError(
+      await failureMessage(
+        completeResponse,
+        `Completing the upload of ${name}`,
+      ),
+    );
+  }
+  return prepared.id;
+}
+
+/**
+ * Uploads a finished recording and returns the link that opens it for review.
+ *
+ * The video and its click track are uploaded as two separate attachments so the
+ * editor can consume the interaction data without parsing the video container.
+ *
+ * The review link carries the signed-in user id. Uploaded objects are owned by
+ * the account that created them, so a browser signed in as somebody else would
+ * otherwise fail to load the attachment with nothing explaining why.
+ */
+export async function deliverRecording(
+  recording: DesktopRecorderRecording,
+  deps: RecorderDeliveryDependencies,
+): Promise<DeliveredRecording> {
+  const videoUploadId = await uploadFile(
+    deps,
+    recording.videoPath,
+    VIDEO_CONTENT_TYPE,
+  );
+  const clickTrackUploadId = await uploadFile(
+    deps,
+    recording.clickTrackPath,
+    CLICK_TRACK_CONTENT_TYPE,
+  );
+
+  const reviewUrl = new URL("/", deps.appUrl);
+  reviewUrl.searchParams.set("intro-video-recording", videoUploadId);
+  reviewUrl.searchParams.set("intro-video-clicks", clickTrackUploadId);
+  reviewUrl.searchParams.set("intro-video-user", deps.userId);
+
+  return {
+    videoUploadId,
+    clickTrackUploadId,
+    reviewUrl: reviewUrl.toString(),
+  };
+}

--- a/turbo/apps/desktop/src/desktop-recorder-types.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-types.ts
@@ -6,6 +6,7 @@
  */
 
 export type DesktopRecorderStatus =
+  | "delivering"
   | "finalizing"
   | "idle"
   | "preparing"
@@ -15,8 +16,10 @@ export type DesktopRecorderStatus =
 
 export type DesktopRecorderErrorCode =
   | "capture_failed"
+  | "delivery_failed"
   | "helper_unavailable"
   | "permission_denied"
+  | "signed_out"
   | "source_lost";
 
 export interface DesktopRecorderError {

--- a/turbo/apps/desktop/src/desktop-tray-menu.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.test.ts
@@ -118,6 +118,7 @@ function trayActions(
     setKeepAwakeEnabled: vi.fn(),
     startScreenRecording: vi.fn(),
     stopScreenRecording: vi.fn(),
+    retryScreenRecordingDelivery: vi.fn(),
     quit: vi.fn(),
     ...overrides,
   };

--- a/turbo/apps/desktop/src/desktop-tray-menu.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.ts
@@ -54,6 +54,7 @@ export interface DesktopTrayMenuActions {
   readonly setKeepAwakeEnabled: (enabled: boolean) => void;
   readonly startScreenRecording: () => void;
   readonly stopScreenRecording: () => void;
+  readonly retryScreenRecordingDelivery: () => void;
   readonly quit: () => void;
 }
 
@@ -393,6 +394,8 @@ function screenRecordingStatusLabel(recorder: DesktopRecorderState): string {
       return "Starting...";
     case "finalizing":
       return "Saving...";
+    case "delivering":
+      return "Uploading...";
     case "ready":
       return "Ready";
     default:
@@ -425,6 +428,14 @@ function buildScreenRecordingSubmenu(
       separator(),
       disabledLabel(truncateMenuLabel(recorder.error.message)),
     );
+    // The capture succeeded and both files are still on disk, so a failed
+    // upload is worth retrying rather than re-recording.
+    if (recorder.error.code === "delivery_failed" && recorder.lastRecording) {
+      items.push({
+        label: "Retry Delivery",
+        click: actions.retryScreenRecordingDelivery,
+      });
+    }
   }
   if (recorder.lastRecording) {
     items.push(

--- a/turbo/apps/desktop/src/desktop-tray.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray.test.ts
@@ -169,6 +169,7 @@ function installController(getState: () => DesktopComputerUseState) {
     getRecorderState: () => UNAVAILABLE_RECORDER_STATE,
     startScreenRecording: vi.fn(async () => {}),
     stopScreenRecording: vi.fn(async () => {}),
+    retryScreenRecordingDelivery: vi.fn(async () => {}),
     quit: vi.fn(),
   });
   controller.install();

--- a/turbo/apps/desktop/src/desktop-tray.ts
+++ b/turbo/apps/desktop/src/desktop-tray.ts
@@ -38,6 +38,7 @@ interface DesktopTrayControllerOptions {
   readonly getRecorderState: () => DesktopRecorderState;
   readonly startScreenRecording: () => Promise<void>;
   readonly stopScreenRecording: () => Promise<void>;
+  readonly retryScreenRecordingDelivery: () => Promise<void>;
   readonly quit: () => void;
 }
 
@@ -388,6 +389,12 @@ export class DesktopTrayController {
       stopScreenRecording: this.runAction("stop screen recording", () => {
         return this.options.stopScreenRecording();
       }),
+      retryScreenRecordingDelivery: this.runAction(
+        "retry screen recording delivery",
+        () => {
+          return this.options.retryScreenRecordingDelivery();
+        },
+      ),
       quit: () => {
         this.options.quit();
       },

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -1,5 +1,5 @@
 import { captureDesktopNativeHelperError } from "./sentry-main";
-import { writeSync } from "node:fs";
+import { openAsBlob, writeSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -49,6 +49,7 @@ import { ComputerUseRuntimeController } from "./computer-use-runtime-controller"
 import { DeveloperToolsController } from "./desktop-developer-tools-controller";
 import { DesktopRecorderController } from "./desktop-recorder-controller";
 import { createRecorderNativeBackend } from "./desktop-recorder-native";
+import { deliverRecording } from "./desktop-recorder-delivery";
 import { STOP_SCREEN_RECORDING_ACCELERATOR } from "./desktop-recorder-types";
 import {
   getComputerUsePermissionState,
@@ -217,6 +218,29 @@ const screenRecorder = new DesktopRecorderController({
       "recordings",
       `screen-recording-${Date.now().toString()}.mp4`,
     ),
+  canDeliver: async () => {
+    const auth = await getAuthSession().getAuthState();
+    return auth.status === "signed_in" && auth.organization !== null;
+  },
+  deliver: async (recording) => {
+    const auth = await getAuthSession().getAuthState();
+    if (auth.status !== "signed_in") {
+      throw new Error("Sign in to Okou to upload the recording");
+    }
+    return await deliverRecording(recording, {
+      apiBaseUrl: desktopApiBaseUrl,
+      appUrl: config.platformUrl.toString(),
+      userId: auth.user.userId,
+      fetchWithSessionAuth: (url, init) =>
+        getAuthSession().fetchWithSessionAuth(url, init),
+      fetchUpload: (url, init) => fetch(url, init),
+      // Streams from disk rather than buffering a whole video in memory.
+      readFile: (filePath) => openAsBlob(filePath),
+    });
+  },
+  openReview: (reviewUrl) => {
+    openExternal(reviewUrl);
+  },
   onChange: notifyScreenRecorderChanged,
   logError: (error) => {
     console.warn("Desktop screen recording teardown failed", error);
@@ -834,6 +858,9 @@ function installTray(): void {
     },
     stopScreenRecording: async () => {
       await screenRecorder.stop();
+    },
+    retryScreenRecordingDelivery: async () => {
+      await screenRecorder.retryDelivery();
     },
     quit: () => {
       requestDesktopQuit();


### PR DESCRIPTION
Stacked on #30518 → #30506 → #30504. Review those first.

Closes the loop: stop a recording in the menu bar, and it uploads and opens in
the browser for review.

## Flow

`stop` → upload MP4 → upload `clicks.json` → open
`app.okou.ai/?intro-video-recording=…&intro-video-clicks=…&intro-video-user=…`

## Decisions worth reviewing

- **Two attachments, not one.** The click track is uploaded separately so the
  editor can read the interaction data without parsing the video container.
- **The presigned PUT uses a separate unauthenticated fetch.** That URL already
  carries its own signature; sending Okou session cookies to storage would leak
  them outside the API. The two fetches are distinct dependencies so this cannot
  be wired wrong by accident.
- **Files stream from disk** via `openAsBlob` rather than being read into memory.
  A long recording is easily hundreds of megabytes.
- **Sign-in is checked before the capture starts.** Checking after would mean
  telling someone their five-minute recording cannot be delivered once it is too
  late to do anything about it.
- **A failed upload does not lose the recording.** Delivery errors are captured
  into state instead of propagating out of `stop`, the files stay on disk, and
  the tray offers `Retry Delivery`. This is one of the few places a catch earns
  its keep — there is a real recovery.
- **The review link carries the signed-in user id.** Uploaded objects are owned
  by the account that created them, so a browser signed in as a different
  account fails to load the attachment. Without this the browser cannot tell
  that mismatch apart from a generic failure. Acting on it is the browser's job
  in the next slice.
- **No multipart.** The API only returns multipart parts when asked, and a
  single PUT from the main process has no body-size limit to work around. An
  unexpected multipart response is rejected explicitly rather than silently
  producing a broken upload.
- `fetchWithSessionAuth` gains an optional `init` so it can issue POSTs. Session
  headers are merged last, so a caller cannot drop the cookie or bearer token.

## Not in this PR

The browser side. Nothing consumes those query parameters yet, so the link
currently opens a normal Okou page. Seeding the intro video wizard from an
already-uploaded attachment is a change in `apps/platform` against a
1,000-line signals file and the existing `Source → Avatar → Voice → Review`
wizard — different app, different reviewers, and large enough that folding it in
here would make neither half reviewable. It is the next slice.

## Verification

`check-types`, `lint`, `knip`, desktop vitest (439 passed) locally. Twelve new
tests: seven on delivery itself (per-file name/type/size, credentials kept off
the storage PUT, the review link, which step failed and its status, stopping
before upload on a rejected session, refusing an unrequested multipart response)
and five on the controller (upload-then-open, refusing to record while signed
out before anything is captured, keeping the recording when delivery fails,
retrying the same recording, and having nothing to retry).

All TypeScript, so the checks genuinely exercise it. **Unverified on hardware**:
a real upload against the live API, and whether the browser lands where intended
once the next slice consumes the parameters.

The two `src/bootstrap-degraded.test.ts` failures are pre-existing in this
sandbox and pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)