### PR TITLE
fix(ci): upload app source maps to okou sentry

### DIFF
--- a/.github/scripts/tests/deploy-okou-pages-workflow-test.sh
+++ b/.github/scripts/tests/deploy-okou-pages-workflow-test.sh
@@ -78,6 +78,7 @@ release_api_verification_step = find_step(
     release_api_job, "Verify production App and API domains"
 )
 rollback_step = find_step(rollback_job, "Deploy App to Cloudflare Pages production")
+rollback_sentry_step = find_step(rollback_job, "Upload App source maps to Sentry")
 rollback_verification_step = find_step(
     rollback_verification_job, "Verify production App and API domains"
 )
@@ -157,6 +158,18 @@ if not (
     raise RuntimeError("CDN assets must be verified before production Pages deployment")
 if "publish-okou-app-assets.sh" in str(release_job):
     raise RuntimeError("production promotion must not publish immutable app assets")
+
+for step in (release_sentry_step, rollback_sentry_step):
+    if step.get("env", {}).get("SENTRY_ORG") != "okou":
+        raise RuntimeError(
+            f"App source maps must upload to the Okou Sentry org: {step['name']}"
+        )
+    if step.get("env", {}).get("SENTRY_PROJECT") != (
+        "${{ vars.SENTRY_PROJECT_APP }}"
+    ):
+        raise RuntimeError(
+            f"App source maps must upload to the App Sentry project: {step['name']}"
+        )
 
 require_fragments(
     preview_readiness_step,

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1601,7 +1601,7 @@ jobs:
         env:
           CANONICAL_DIST: ${{ steps.pages-production.outputs.canonical-dist }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_ORG: okou
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT_APP }}
         working-directory: turbo
         run: |

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -185,7 +185,7 @@ jobs:
         env:
           CANONICAL_DIST: ${{ steps.app.outputs.canonical_dist }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_ORG: okou
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT_APP }}
         working-directory: turbo
         run: pnpm --filter @okouai/app exec sentry-cli sourcemaps upload "$CANONICAL_DIST"


### PR DESCRIPTION
## Summary

- upload App source maps to the `okou/platform` Sentry project during production promotion
- keep production rollback source-map uploads on the same Sentry target
- add workflow regression coverage for the App Sentry organization and project

## Verification

- `pnpm dlx prettier@3.8.1 --check .github/workflows/release-please.yml .github/workflows/rollback-production.yml`
- `bash -n .github/scripts/tests/deploy-okou-pages-workflow-test.sh`
- `bash .github/scripts/tests/deploy-okou-pages-workflow-test.sh`
- `actionlint v1.7.12 .github/workflows/release-please.yml .github/workflows/rollback-production.yml`
