### PR TITLE
fix(api): make timeout an immutable active-input boundary

### DIFF
--- a/docs/active-input-delivery.md
+++ b/docs/active-input-delivery.md
@@ -50,9 +50,12 @@ latency.
 ## Terminal Status and Quiescence
 
 A terminal run status does not by itself prove that the old consumer is gone.
-Cancellation is visible immediately, and heartbeat timeout records an unknown
-consumer state, but neither path releases a reservation. Cooperative Guest
-completion and Runner post-exit completion are the existing quiescence signals.
+Cancellation is visible immediately. Heartbeat timeout still records an unknown
+consumer state, but its transaction now settles any running chat delivery with
+an empty receipt set before committing `timeout`. After commit, the API sends a
+best-effort hard cancellation to the owning Runner group. Pending-run timeout
+does not perform delivery settlement or Runner cancellation because no consumer
+has claimed the run.
 
 ### Post-timeout Webhook Admission
 
@@ -60,12 +63,14 @@ While timeout still represents an uncertain consumer state, runtime mutation
 webhooks stop creating new canonical work for that run. Heartbeat returns `404`,
 event batches retain their existing sequence acknowledgement but are ignored,
 and new checkpoint or checkpoint-history preparation requests return `400`.
-The existing completed Pi checkpoint exact-retry behavior is unchanged.
+Late completion returns the existing `200` failed acknowledgement without
+persisting checkpoint, event watermark, reuse metadata, delivery receipts, or a
+different terminal status. The existing completed Pi checkpoint exact-retry
+behavior is unchanged.
 
 Usage events and telemetry remain accepted after timeout because they report
-work that may already have happened. Storage and firewall admission, together
-with the atomic timeout-versus-completion boundary, are separate rollout stages;
-timeout alone still does not release an active input delivery.
+work that may already have happened. Storage and firewall admission remain
+separate rollout stages.
 
 Codex execution timeout and cancellation first allow an in-flight `turn/steer`
 to settle within the bounded sink window. A successful response still persists
@@ -75,11 +80,11 @@ only then closes the local sink operation and finalizes receipts. The
 unconfirmed delivery ID remains absent from completion, so the existing
 completion transaction releases or expires it only after consumer-stop proof.
 
-An open delivery is therefore a non-expiring thread-ordering barrier. The queue
-scheduler cannot skip its source events or launch later input on the same
-thread, even after cancellation recovery becomes stale. Once completion settles
-the delivery, released prompts return to their original FIFO position and the
-post-commit scheduler may create the successor run.
+Until completion or timeout cleanup settles it, an open delivery is a
+non-expiring thread-ordering barrier. The queue scheduler cannot skip its source
+events or launch later input on the same thread, even after cancellation
+recovery becomes stale. Released prompts return to their original FIFO position
+and the post-commit scheduler may create the successor run.
 
 ## Transaction Boundary
 
@@ -120,22 +125,19 @@ still sends one checkpoint-less completion when checkpoint preparation or the
 combined request is not acknowledged. Local session-history reconciliation
 happens only after the combined request is acknowledged.
 
-The standalone checkpoint route and checkpoint-less completion remain supported
-for outgoing Guests and the unchanged Runner fallback. Runner completion timing
-and payloads are unchanged. The API release that accepts the combined request
-must reach production, and preceding API handlers must drain, before a Guest
-starts sending it. While combined Guests can execute, that API release is the
-rollback floor.
+The standalone checkpoint route rejects `queued`, `pending`, and `running` runs.
+It accepts an exact retry of a completed final checkpoint and retains the
+existing bounded recovery behavior for failed or cancelled runs. Checkpoint-less
+completion remains supported for the unchanged Runner fallback; a clean success
+without a checkpoint still follows the missing-checkpoint failure path.
 
 After the combined Guest/Runner artifact reaches production, record its traffic
 promotion boundary, stop the outgoing Runner target from claiming new work, and
-wait for its existing Guest runs to drain. The later immutable-timeout rollout
-must wait at least 7,200 seconds after that cutover and confirm that no
-pre-cutover `pending` or `running` cohort remains.
-
-This compatibility boundary does not make timeout immutable and does not change
-legacy standalone checkpoint admission. Those changes require the later timeout
-rollout after the old active-run cohort drains.
+wait for its existing Guest runs to drain. This immutable-timeout API release
+must not merge until the recorded cutover is at least 7,200 seconds old and no
+pre-cutover `pending` or `running` cohort remains. That gate ensures no outgoing
+Guest still depends on active standalone checkpoint persistence when the new
+admission rule reaches production.
 
 ## Compatibility
 

--- a/docs/active-input-delivery.md
+++ b/docs/active-input-delivery.md
@@ -88,18 +88,24 @@ and the post-commit scheduler may create the successor run.
 
 ## Transaction Boundary
 
-Reservation, direct receipt, and completion finalization serialize database
-state in this order:
+Reservation serializes database state in this order:
 
 1. chat thread;
 2. agent run;
 3. delivery and delivery items;
 4. source and revoking chat events.
 
-Completion finalizes the delivery and applies or observes the terminal run
-state in one short transaction. Realtime publication, callbacks, usage work,
-and queue drain run only after commit. A first late finalization drains the
-thread without replaying the run's ordinary terminal callbacks or billing work.
+Completion and heartbeat-timeout finalization take the run's checkpoint
+lifecycle advisory lock before the same thread, run, delivery, and event order.
+They finalize the delivery and apply or observe the terminal run state in one
+short transaction. A direct receipt reads the authenticated run/thread scope,
+then serializes on the delivery, its items, and their source/revoking events;
+the delivery lock decides whether receipt or terminal finalization committed
+first.
+
+Realtime publication, callbacks, usage work, and queue drain run only after
+commit. A first late finalization drains the thread without replaying the run's
+ordinary terminal callbacks or billing work.
 
 ### Final Checkpoint Completion
 

--- a/docs/active-input-delivery.md
+++ b/docs/active-input-delivery.md
@@ -88,7 +88,7 @@ and the post-commit scheduler may create the successor run.
 
 ## Transaction Boundary
 
-Reservation serializes database state in this order:
+Reservation and direct receipt serialize database state in this order:
 
 1. chat thread;
 2. agent run;
@@ -98,10 +98,8 @@ Reservation serializes database state in this order:
 Completion and heartbeat-timeout finalization take the run's checkpoint
 lifecycle advisory lock before the same thread, run, delivery, and event order.
 They finalize the delivery and apply or observe the terminal run state in one
-short transaction. A direct receipt reads the authenticated run/thread scope,
-then serializes on the delivery, its items, and their source/revoking events;
-the delivery lock decides whether receipt or terminal finalization committed
-first.
+short transaction. The shared lock order decides whether direct receipt or
+terminal finalization committed first.
 
 Realtime publication, callbacks, usage work, and queue drain run only after
 commit. A first late finalization drains the thread without replaying the run's

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-deletion-interlock.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-deletion-interlock.bdd.test.ts
@@ -88,7 +88,7 @@ function expectRetryConflict(response: {
   });
 }
 
-async function expectCheckpointSucceeds(
+async function expectActiveCheckpointRejected(
   actor: ApiTestUser,
   runId: string,
 ): Promise<void> {
@@ -100,9 +100,12 @@ async function expectCheckpointSucceeds(
       cliAgentSessionHistoryDisposition: "unavailable",
     },
     { authorization: `Bearer ${api.sandboxTokenForRun(actor, runId)}` },
-    [200],
+    [400],
   );
-  expect(response.status).toBe(200);
+  expect(response.status).toBe(400);
+  expect(JSON.stringify(response.body)).toContain(
+    "[CHECKPOINT_RUN_NOT_SETTLED]",
+  );
 }
 
 describe("DELETE /api/agents/:id bounded deletion interlock", () => {
@@ -155,7 +158,7 @@ describe("DELETE /api/agents/:id bounded deletion interlock", () => {
       runId: survivorRun.runId,
       status: "pending",
     });
-    await expectCheckpointSucceeds(actor, survivorRun.runId);
+    await expectActiveCheckpointRejected(actor, survivorRun.runId);
     await expect(readUsageEventRunIdFixture(usageEventId)).resolves.toBeNull();
     await expect(readDatabaseLockTimeoutFixture()).resolves.toBe(
       lockTimeoutBefore,
@@ -278,7 +281,7 @@ describe("DELETE /api/agents/:id bounded deletion interlock", () => {
       runId: survivorRun.runId,
       status: "pending",
     });
-    await expectCheckpointSucceeds(survivorOwner, survivorRun.runId);
+    await expectActiveCheckpointRejected(survivorOwner, survivorRun.runId);
     await expect(
       readUsageEventRunIdFixture(pendingUsageId),
     ).resolves.toBeNull();

--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -142,25 +142,21 @@ async function completeSandboxRun(
       [200],
     );
   }
-  if (exitCode === 0) {
-    // Successful completion requires a checkpoint, like a real sandbox.
-    await webhooks.requestAgentCheckpoint(
-      {
-        runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: agentPhoneCliAgentSessionIdForRun(runId),
-        cliAgentSessionHistoryHash: createHash("sha256")
-          .update(`bdd agentphone history ${runId}`)
-          .digest("hex"),
-      },
-      sandboxHeaders,
-      [200],
-    );
-  }
   await webhooks.requestAgentComplete(
     {
       runId,
       exitCode,
+      ...(exitCode === 0
+        ? {
+            checkpoint: {
+              cliAgentType: "claude-code" as const,
+              cliAgentSessionId: agentPhoneCliAgentSessionIdForRun(runId),
+              cliAgentSessionHistoryHash: createHash("sha256")
+                .update(`bdd agentphone history ${runId}`)
+                .digest("hex"),
+            },
+          }
+        : {}),
       ...(options.error === undefined ? {} : { error: options.error }),
       ...(options.resultText === undefined ? {} : { lastEventSequence: 0 }),
     },

--- a/turbo/apps/api/src/signals/routes/__tests__/artifact-catalog.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifact-catalog.bdd.test.ts
@@ -129,20 +129,15 @@ async function completeChatRunOk(
   const historyHash = createHash("sha256")
     .update(`bdd artifact catalog history ${runId}`)
     .digest("hex");
-  await webhooks.requestAgentCheckpoint(
-    {
-      runId,
-      cliAgentType: "claude-code",
-      cliAgentSessionId: `bdd-cli-${runId}`,
-      cliAgentSessionHistoryHash: historyHash,
-    },
-    sandboxHeaders,
-    [200],
-  );
   await webhooks.requestAgentComplete(
     {
       runId,
       exitCode: 0,
+      checkpoint: {
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `bdd-cli-${runId}`,
+        cliAgentSessionHistoryHash: historyHash,
+      },
       ...(lastEventSequence === undefined ? {} : { lastEventSequence }),
     },
     sandboxHeaders,

--- a/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
@@ -200,18 +200,16 @@ async function completeChatRunOk(
   const historyHash = createHash("sha256")
     .update(`bdd artifacts history ${runId}`)
     .digest("hex");
-  await webhooks.requestAgentCheckpoint(
+  await webhooks.requestAgentComplete(
     {
       runId,
-      cliAgentType: "claude-code",
-      cliAgentSessionId: `bdd-cli-${runId}`,
-      cliAgentSessionHistoryHash: historyHash,
+      exitCode: 0,
+      checkpoint: {
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `bdd-cli-${runId}`,
+        cliAgentSessionHistoryHash: historyHash,
+      },
     },
-    sandboxHeaders,
-    [200],
-  );
-  await webhooks.requestAgentComplete(
-    { runId, exitCode: 0 },
     sandboxHeaders,
     [200],
   );

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -24,7 +24,6 @@ import { setupApp } from "../../../__tests__/test-helpers";
 import { withBuiltInModelRuntimeRouteUnavailableForTest } from "../../../test-fixtures/built-in-model-runtime-route";
 import { readGoalQueueStateFixture } from "../../../test-fixtures/goal-queue";
 import {
-  holdCheckpointReadsFixture,
   holdChatEventInsertTransactionFixture,
   holdGoalThreadLockFixture,
   holdModelPolicyReadsFixture,
@@ -611,29 +610,24 @@ async function goalRunIds(threadId: string): Promise<readonly string[]> {
   return (await readGoalQueueStateFixture(threadId)).runIds;
 }
 
-async function checkpointChatRun(
-  runId: string,
-  sandboxHeaders: { readonly authorization: string },
-): Promise<void> {
+function chatRunCheckpoint(runId: string): {
+  readonly cliAgentType: "claude-code";
+  readonly cliAgentSessionId: string;
+  readonly cliAgentSessionHistoryHash: string;
+} {
   const historyHash = createHash("sha256")
     .update(`bdd chat session history ${runId}`)
     .digest("hex");
-  await webhooks.requestAgentCheckpoint(
-    {
-      runId,
-      cliAgentType: "claude-code",
-      cliAgentSessionId: cliAgentSessionIdForChatRun(runId),
-      cliAgentSessionHistoryHash: historyHash,
-    },
-    sandboxHeaders,
-    [200],
-  );
+  return {
+    cliAgentType: "claude-code",
+    cliAgentSessionId: cliAgentSessionIdForChatRun(runId),
+    cliAgentSessionHistoryHash: historyHash,
+  };
 }
 
 /**
- * Checkpoint + exitCode-0 complete. Completing without a checkpoint routes to
- * the missing-checkpoint handler and FAILS the run, so every successful chat
- * round checkpoints first.
+ * Atomically checkpoint + exitCode-0 complete. Completing without a checkpoint
+ * routes to the missing-checkpoint handler and FAILS the run.
  */
 async function completeChatRunOk(
   runId: string,
@@ -655,11 +649,11 @@ async function completeChatRunOk(
       [200],
     );
   }
-  await checkpointChatRun(runId, sandboxHeaders);
   await webhooks.requestAgentComplete(
     {
       runId,
       exitCode: 0,
+      checkpoint: chatRunCheckpoint(runId),
       ...(lastEventSequence === undefined ? {} : { lastEventSequence }),
     },
     sandboxHeaders,
@@ -3014,7 +3008,7 @@ describe("CHAT-02/RUN-03: cancellation recovery barrier", () => {
     await flushWaitUntilForTest();
   }, 90_000);
 
-  it("records recovery when completion races the cancellation transition", async () => {
+  it("records recovery when checkpointed completion follows cancellation", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     const run = await startChatRun(actor, {
@@ -3022,36 +3016,23 @@ describe("CHAT-02/RUN-03: cancellation recovery barrier", () => {
       prompt: "race completion with cancellation",
     });
     const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
-    await checkpointChatRun(run.runId, sandboxHeaders);
     const queuedEventId = await queueChatEvent(actor, {
       agentId,
       threadId: run.threadId,
       prompt: "continue after the concurrent completion",
     });
     await flushWaitUntilForTest();
-    const checkpointGate = await holdCheckpointReadsFixture({
-      signal: context.signal,
-    });
-    onTestFinished(async () => {
-      checkpointGate.release();
-      await checkpointGate.done;
-    });
-
-    const [completion] = await Promise.all([
-      webhooks.requestAgentComplete(
-        { runId: run.runId, exitCode: 0, lastEventSequence: 0 },
-        sandboxHeaders,
-        [200],
-      ),
-      (async () => {
-        await expect
-          .poll(checkpointGate.blockedWaiterCount)
-          .toBeGreaterThanOrEqual(1);
-        await api.requestCancelRun(actor, run.runId, [200]);
-        checkpointGate.release();
-        await checkpointGate.done;
-      })(),
-    ]);
+    await api.requestCancelRun(actor, run.runId, [200]);
+    const completion = await webhooks.requestAgentComplete(
+      {
+        runId: run.runId,
+        exitCode: 0,
+        lastEventSequence: 0,
+        checkpoint: chatRunCheckpoint(run.runId),
+      },
+      sandboxHeaders,
+      [200],
+    );
     expect(completion.body).toStrictEqual({
       success: true,
       status: "failed",

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -2853,7 +2853,7 @@ describe("CHAT-02: queueing and recalling messages", () => {
     }
     context.mocks.ably.publish.mockClear();
     context.mocks.ably.publish.mockRejectedValueOnce(
-      new Error("timeout cancel unavailable"),
+      new DOMException("timeout cancel unavailable", "AbortError"),
     );
     mockNow(now() + 3 * 60 * 1000);
     onTestFinished(() => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -113,6 +113,7 @@ import { createComputerUseBddApi } from "./helpers/api-bdd-computer-use";
 import { createFirewallApi, secretTemplate } from "./helpers/api-bdd-firewall";
 import { createGithubBddApi } from "./helpers/api-bdd-github";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
+import { cleanupTimedOutRun } from "./helpers/api-bdd-run-timeout";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { readAgentRunState$ } from "./helpers/agent-run-callback";
@@ -922,20 +923,15 @@ async function completeChatRunOk(
   }
   const history = `bdd chat session history ${runId}`;
   const historyHash = createHash("sha256").update(history).digest("hex");
-  await webhooks.requestAgentCheckpoint(
-    {
-      runId,
-      cliAgentType: options.cliAgentType ?? "claude-code",
-      cliAgentSessionId: `bdd-cli-${runId}`,
-      cliAgentSessionHistoryHash: historyHash,
-    },
-    sandboxHeaders,
-    [200],
-  );
   await webhooks.requestAgentComplete(
     {
       runId,
       exitCode: 0,
+      checkpoint: {
+        cliAgentType: options.cliAgentType ?? "claude-code",
+        cliAgentSessionId: `bdd-cli-${runId}`,
+        cliAgentSessionHistoryHash: historyHash,
+      },
       ...(options.activeInputDeliveryIds === undefined
         ? {}
         : { activeInputDeliveryIds: [...options.activeInputDeliveryIds] }),
@@ -2419,37 +2415,6 @@ describe("CHAT-02: queueing and recalling messages", () => {
     }
 
     const history = `bdd chat session history ${active.runId}`;
-    await webhooks.requestAgentCheckpoint(
-      {
-        runId: active.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-cli-${active.runId}`,
-        cliAgentSessionHistoryHash: createHash("sha256")
-          .update(history)
-          .digest("hex"),
-      },
-      claimed.sandboxHeaders,
-      [200],
-    );
-    const checkpointGate = await holdCheckpointReadsFixture({
-      signal: context.signal,
-    });
-    onTestFinished(async () => {
-      checkpointGate.release();
-      await checkpointGate.done;
-    });
-    const completion = webhooks.requestAgentComplete(
-      {
-        runId: active.runId,
-        exitCode: 0,
-        activeInputDeliveryIds: [reserved.deliveryId],
-      },
-      claimed.sandboxHeaders,
-      [200],
-    );
-    await expect
-      .poll(checkpointGate.blockedWaiterCount)
-      .toBeGreaterThanOrEqual(1);
     await expect(
       api.recordRunnerActiveInputDelivery(
         claimed.claim.sandboxToken,
@@ -2457,9 +2422,23 @@ describe("CHAT-02: queueing and recalling messages", () => {
         reserved.deliveryId,
       ),
     ).resolves.toStrictEqual({ outcome: "delivered" });
-    checkpointGate.release();
-    await checkpointGate.done;
-    await expect(completion).resolves.toMatchObject({
+    const completion = await webhooks.requestAgentComplete(
+      {
+        runId: active.runId,
+        exitCode: 0,
+        activeInputDeliveryIds: [reserved.deliveryId],
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-cli-${active.runId}`,
+          cliAgentSessionHistoryHash: createHash("sha256")
+            .update(history)
+            .digest("hex"),
+        },
+      },
+      claimed.sandboxHeaders,
+      [200],
+    );
+    expect(completion).toMatchObject({
       body: { success: true, status: "completed" },
     });
     await flushWaitUntilForTest();
@@ -2842,9 +2821,12 @@ describe("CHAT-02: queueing and recalling messages", () => {
     await cancelChatRun(actor, successor, successorClaim.sandboxHeaders);
   }, 90_000);
 
-  it("keeps timed-out delivery input held until Runner completion", async () => {
+  it("settles timed-out delivery input when stopping the Runner fails", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped chat actor");
+    }
 
     const active = await sendChatRun(actor, {
       agentId,
@@ -2869,31 +2851,25 @@ describe("CHAT-02: queueing and recalling messages", () => {
     if (reserved.outcome !== "reserved") {
       throw new Error("Expected timeout input to be reserved");
     }
-    await timeoutRunWithoutCallbacksFixture({ runId: active.runId });
+    context.mocks.ably.publish.mockClear();
+    context.mocks.ably.publish.mockRejectedValueOnce(
+      new Error("timeout cancel unavailable"),
+    );
+    mockNow(now() + 3 * 60 * 1000);
+    onTestFinished(() => {
+      clearMockNow();
+    });
+    const cleanup = await cleanupTimedOutRun(context, {
+      runId: active.runId,
+      chatThreadId: active.threadId,
+      orgId: actor.orgId,
+    });
+    expect(cleanup.body).toMatchObject({ cleaned: 1, errors: 0 });
     await waitForRunStatus(actor, active.runId, "timeout");
-
-    const laterEventId = randomUUID();
-    const later = await chat.requestSendEvent(
-      actor,
-      {
-        agentId,
-        threadId: active.threadId,
-        prompt: "wait behind the timed-out delivery",
-        clientEventId: laterEventId,
-      },
-      [201],
-    );
-    if (later.status !== 201) {
-      throw new Error("Expected post-timeout input to remain queued");
-    }
-    expect(later.body.runId).toBeNull();
-
-    await failChatRun(
-      active.runId,
-      claimed.sandboxHeaders,
-      "Runner observed timed-out process exit",
-    );
-    await flushWaitUntilForTest();
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith("cancel", {
+      runId: active.runId,
+      mode: "hard",
+    });
     await expect(
       api.recordRunnerActiveInputDelivery(
         claimed.claim.sandboxToken,
@@ -2921,8 +2897,26 @@ describe("CHAT-02: queueing and recalling messages", () => {
     if (!successor) {
       throw new Error("Expected timed-out delivery input to be released");
     }
+
+    const laterEventId = randomUUID();
+    const later = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: active.threadId,
+        prompt: "wait behind the timeout successor",
+        clientEventId: laterEventId,
+      },
+      [201],
+    );
+    if (later.status !== 201) {
+      throw new Error("Expected post-timeout input to remain queued");
+    }
+    expect(later.body.runId).toBeNull();
     expect(
-      userMessages(messages.events).filter((message) => {
+      userMessages(
+        (await chat.listThreadEvents(actor, active.threadId)).events,
+      ).filter((message) => {
         return message.revokesEventId === laterEventId;
       }),
     ).toHaveLength(0);
@@ -5852,7 +5846,7 @@ describe("CHAT-02: model-first provider policies", () => {
     const racedHandoff = await sendChatRun(actor, {
       agentId,
       threadId: run.threadId,
-      prompt: "serialize H2 against an early successful completion",
+      prompt: "reject standalone H2 during an early successful completion",
     });
     const racedManifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${racedHandoff.runId}/manifest.json`;
     await expect
@@ -5893,7 +5887,7 @@ describe("CHAT-02: model-first provider policies", () => {
     });
     const racedCheckpointResponse = await racedCheckpoint;
     expect(JSON.stringify(racedCheckpointResponse.body)).toContain(
-      "[PI_H2_RUN_TERMINAL]",
+      "[CHECKPOINT_RUN_NOT_SETTLED]",
     );
     await waitForRunStatus(actor, racedHandoff.runId, "failed");
     await flushWaitUntilForTest();
@@ -5951,7 +5945,7 @@ describe("CHAT-02: model-first provider policies", () => {
       success: true,
       status: "failed",
     });
-    await waitForRunStatus(actor, retry.runId, "failed");
+    await waitForRunStatus(actor, retry.runId, "timeout");
     await expect(
       readThreadSessionConversation(context, run.threadId),
     ).resolves.toStrictEqual(canonicalConversation);
@@ -8455,21 +8449,16 @@ describe("CHAT-02: run-level model overrides", () => {
       firstClaim.sandboxHeaders,
       [200],
     );
-    await webhooks.requestAgentCheckpoint(
-      {
-        runId: first.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `discarded-cli-${first.runId}`,
-        cliAgentSessionHistoryDisposition: "discarded_oversized",
-      },
-      firstClaim.sandboxHeaders,
-      [200],
-    );
     await webhooks.requestAgentComplete(
       {
         runId: first.runId,
         exitCode: 0,
         lastEventSequence: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `discarded-cli-${first.runId}`,
+          cliAgentSessionHistoryDisposition: "discarded_oversized",
+        },
       },
       firstClaim.sandboxHeaders,
       [200],

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts
@@ -329,20 +329,15 @@ async function completeChatRunOk(
   const historyHash = createHash("sha256")
     .update(`bdd chat session history ${runId}`)
     .digest("hex");
-  await webhooks.requestAgentCheckpoint(
-    {
-      runId,
-      cliAgentType: "claude-code",
-      cliAgentSessionId: `bdd-cli-${runId}`,
-      cliAgentSessionHistoryHash: historyHash,
-    },
-    sandboxHeaders,
-    [200],
-  );
   await webhooks.requestAgentComplete(
     {
       runId,
       exitCode: 0,
+      checkpoint: {
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `bdd-cli-${runId}`,
+        cliAgentSessionHistoryHash: historyHash,
+      },
       ...(options.lastEventSequence === undefined
         ? stagedOutputEvents.length === 0
           ? {}

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -297,20 +297,15 @@ async function completeChatRunOk(
   const historyHash = createHash("sha256")
     .update(`bdd chat thread history ${runId}`)
     .digest("hex");
-  await webhooks.requestAgentCheckpoint(
-    {
-      runId,
-      cliAgentType: "claude-code",
-      cliAgentSessionId: `bdd-cli-${runId}`,
-      cliAgentSessionHistoryHash: historyHash,
-    },
-    sandboxHeaders,
-    [200],
-  );
   await webhooks.requestAgentComplete(
     {
       runId,
       exitCode: 0,
+      checkpoint: {
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `bdd-cli-${runId}`,
+        cliAgentSessionHistoryHash: historyHash,
+      },
       ...(stagedOutputEvents.length === 0
         ? {}
         : {

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
@@ -238,6 +238,7 @@ async function insertRunFixture(args?: {
   readonly triggerSource?: TriggerSource;
   readonly userId?: string;
   readonly orgId?: string;
+  readonly runnerGroup?: string;
 }): Promise<RunFixture> {
   const response = await postCronCleanupState({
     action: "seed-run",
@@ -257,6 +258,7 @@ async function insertRunFixture(args?: {
     trigger_source: args?.triggerSource,
     user_id: args?.userId,
     org_id: args?.orgId,
+    runner_group: args?.runnerGroup,
   });
   return {
     runId: stringField(response, "run_id"),
@@ -1039,9 +1041,14 @@ describe("sandbox cleanup", () => {
 
   it("exposes a pending-run timeout as terminal to connector runtime sync", async () => {
     const fixture = await trackRun(
-      insertRunFixture({ status: "pending", createdAt: minutesAgo(6) }),
+      insertRunFixture({
+        status: "pending",
+        createdAt: minutesAgo(6),
+        runnerGroup: "vm0/test",
+      }),
     );
     await insertRunnerJobEntry(fixture, farFuture());
+    context.mocks.ably.publish.mockClear();
 
     const response = await cleanupRegisteredFixtures();
 
@@ -1060,6 +1067,11 @@ describe("sandbox cleanup", () => {
       error: "Run timed out while pending (never started)",
     });
     await expect(findRunnerJob(fixture.runId)).resolves.toBeNull();
+    expect(
+      context.mocks.ably.publish.mock.calls.filter(([channel]) => {
+        return channel === "cancel";
+      }),
+    ).toHaveLength(0);
 
     const sync = await accept(
       setupApp({ context, routes: runnersRoutes })(
@@ -1128,8 +1140,10 @@ describe("sandbox cleanup", () => {
         status: "running",
         createdAt: minutesAgo(1),
         lastHeartbeatAt: minutesAgo(3),
+        runnerGroup: "vm0/test",
       }),
     );
+    context.mocks.ably.publish.mockClear();
 
     const response = await cleanupRegisteredFixtures();
 
@@ -1147,6 +1161,19 @@ describe("sandbox cleanup", () => {
       status: "timeout",
       error: "Run timed out (no heartbeat)",
     });
+    expect(
+      context.mocks.ably.publish.mock.calls.filter(([channel]) => {
+        return channel === "cancel";
+      }),
+    ).toStrictEqual([["cancel", { runId: fixture.runId, mode: "hard" }]]);
+
+    const duplicate = await cleanupRegisteredFixtures();
+    expect(duplicate.body.results).toHaveLength(0);
+    expect(
+      context.mocks.ably.publish.mock.calls.filter(([channel]) => {
+        return channel === "cancel";
+      }),
+    ).toHaveLength(1);
   });
 
   it("does not cleanup completed runs even when they are old", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -1174,16 +1174,6 @@ describe("Feishu integration", () => {
       headers,
       [200],
     );
-    await webhooksApi.requestAgentCheckpoint(
-      {
-        runId: args.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: args.sessionId,
-        cliAgentSessionHistoryHash: historyHash,
-      },
-      headers,
-      [200],
-    );
     if (args.assistantText !== undefined) {
       const assistantEvent = {
         type: "assistant" as const,
@@ -1210,6 +1200,11 @@ describe("Feishu integration", () => {
       {
         runId: args.runId,
         exitCode: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: args.sessionId,
+          cliAgentSessionHistoryHash: historyHash,
+        },
         ...(args.assistantText === undefined ? {} : { lastEventSequence: 0 }),
       },
       headers,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-run-timeout.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-run-timeout.ts
@@ -31,3 +31,26 @@ export async function transitionRunToTimeout(
 ) {
   return await transitionRunToTerminal(context, runId, "timeout");
 }
+
+export async function cleanupTimedOutRun(
+  context: TestContext,
+  args: {
+    readonly runId: string;
+    readonly chatThreadId: string;
+    readonly orgId: string;
+  },
+) {
+  return await accept(
+    setupApp({ context, routes: testCronCleanupSandboxesStateRoutes })(
+      testCronCleanupSandboxesStateContract,
+    ).cleanup({
+      body: {
+        chatThreadIds: [args.chatThreadId],
+        runIds: [args.runId],
+        orgIds: [args.orgId],
+        exportJobIds: [],
+      },
+    }),
+    [200],
+  );
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-upload-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-upload-complete.test.ts
@@ -109,20 +109,15 @@ async function completeRun(args: {
   const historyHash = createHash("sha256")
     .update(`canonical Slack upload ${args.runId}`)
     .digest("hex");
-  await webhooks.requestAgentCheckpoint(
-    {
-      runId: args.runId,
-      cliAgentType: "claude-code",
-      cliAgentSessionId: `canonical-slack-${args.runId}`,
-      cliAgentSessionHistoryHash: historyHash,
-    },
-    { authorization },
-    [200],
-  );
   await webhooks.requestAgentComplete(
     {
       runId: args.runId,
       exitCode: 0,
+      checkpoint: {
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `canonical-slack-${args.runId}`,
+        cliAgentSessionHistoryHash: historyHash,
+      },
       ...(args.lastEventSequence === undefined
         ? stagedOutputEvents.length === 0
           ? {}

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-post.test.ts
@@ -512,18 +512,16 @@ async function completeCanonicalChatRun(args: {
     headers,
     [200],
   );
-  await webhooksApi.requestAgentCheckpoint(
+  await webhooksApi.requestAgentComplete(
     {
       runId: args.runId,
-      cliAgentType: "claude-code",
-      cliAgentSessionId,
-      cliAgentSessionHistoryHash,
+      exitCode: 0,
+      checkpoint: {
+        cliAgentType: "claude-code",
+        cliAgentSessionId,
+        cliAgentSessionHistoryHash,
+      },
     },
-    headers,
-    [200],
-  );
-  await webhooksApi.requestAgentComplete(
-    { runId: args.runId, exitCode: 0 },
     headers,
     [200],
   );

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -449,18 +449,6 @@ async function completeSlackTriggeredRun(args: {
   const sandboxHeaders = {
     authorization: `Bearer ${args.sandboxToken}`,
   };
-  await webhooks.requestAgentCheckpoint(
-    {
-      runId: args.runId,
-      cliAgentType: args.cliAgentType,
-      cliAgentSessionId: `bdd-slack-cli-${args.runId}`,
-      cliAgentSessionHistoryHash: createHash("sha256")
-        .update(`bdd slack history ${args.runId}`)
-        .digest("hex"),
-    },
-    sandboxHeaders,
-    [200],
-  );
   const assistantEvents =
     args.assistantText === undefined
       ? []
@@ -513,6 +501,13 @@ async function completeSlackTriggeredRun(args: {
     {
       runId: args.runId,
       exitCode: 0,
+      checkpoint: {
+        cliAgentType: args.cliAgentType,
+        cliAgentSessionId: `bdd-slack-cli-${args.runId}`,
+        cliAgentSessionHistoryHash: createHash("sha256")
+          .update(`bdd slack history ${args.runId}`)
+          .digest("hex"),
+      },
       ...(outputEvents.length > 0
         ? { lastEventSequence: outputEvents.length - 1 }
         : {}),

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -585,18 +585,16 @@ async function completeSandboxRun(args: {
       sandboxHeaders,
       [200],
     );
-    await webhooksApi.requestAgentCheckpoint(
+    await webhooksApi.requestAgentComplete(
       {
         runId: args.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId,
-        cliAgentSessionHistoryHash,
+        exitCode: args.exitCode,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId,
+          cliAgentSessionHistoryHash,
+        },
       },
-      sandboxHeaders,
-      [200],
-    );
-    await webhooksApi.requestAgentComplete(
-      { runId: args.runId, exitCode: args.exitCode },
       sandboxHeaders,
       [200],
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/official-automation-result-email.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-automation-result-email.test.ts
@@ -216,22 +216,17 @@ async function completeRun(
   args: { readonly exitCode: number; readonly output?: string },
 ): Promise<void> {
   const reported = await claimAndReportOutput(scenario, runId, args.output);
-  await webhooks.requestAgentCheckpoint(
-    {
-      runId,
-      cliAgentType: "claude-code",
-      cliAgentSessionId: `official-result-email-${runId}`,
-      cliAgentSessionHistoryHash: createHash("sha256")
-        .update(`official result email history ${runId}`)
-        .digest("hex"),
-    },
-    reported.headers,
-    [200],
-  );
   await webhooks.requestAgentComplete(
     {
       runId,
       exitCode: args.exitCode,
+      checkpoint: {
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `official-result-email-${runId}`,
+        cliAgentSessionHistoryHash: createHash("sha256")
+          .update(`official result email history ${runId}`)
+          .digest("hex"),
+      },
       ...(reported.lastEventSequence === undefined
         ? {}
         : { lastEventSequence: reported.lastEventSequence }),

--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -1095,20 +1095,19 @@ async function completeSuccessfulRun(
     headers,
     [200],
   );
-  await webhooks.requestAgentCheckpoint(
+  await webhooks.requestAgentComplete(
     {
       runId,
-      cliAgentType: "claude-code",
-      cliAgentSessionId: `official-result-email-${runId}`,
-      cliAgentSessionHistoryHash: createHash("sha256")
-        .update(`official result email history ${runId}`)
-        .digest("hex"),
+      exitCode: 0,
+      lastEventSequence: 0,
+      checkpoint: {
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `official-result-email-${runId}`,
+        cliAgentSessionHistoryHash: createHash("sha256")
+          .update(`official result email history ${runId}`)
+          .digest("hex"),
+      },
     },
-    headers,
-    [200],
-  );
-  await webhooks.requestAgentComplete(
-    { runId, exitCode: 0, lastEventSequence: 0 },
     headers,
     [200],
   );

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -1496,18 +1496,16 @@ describe("OPS-01: user data export", () => {
     const claim = await runs.claimRunnerJob(run.runId);
     const headers = { authorization: `Bearer ${claim.sandboxToken}` };
 
-    await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: run.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-export-historyless-${run.runId}`,
-        cliAgentSessionHistoryDisposition: "discarded_oversized",
+        exitCode: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-export-historyless-${run.runId}`,
+          cliAgentSessionHistoryDisposition: "discarded_oversized",
+        },
       },
-      headers,
-      [200],
-    );
-    await webhooks.requestAgentComplete(
-      { runId: run.runId, exitCode: 0 },
       headers,
       [200],
     );
@@ -1592,22 +1590,16 @@ describe("OPS-01: user data export", () => {
       existing: false,
       encoding: "gzip",
     });
-    const checkpoint = await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: run.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-export-session-${run.runId}`,
-        cliAgentSessionHistoryHash: historyHash,
+        exitCode: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-export-session-${run.runId}`,
+          cliAgentSessionHistoryHash: historyHash,
+        },
       },
-      headers,
-      [200],
-    );
-    if (checkpoint.status !== 200) {
-      throw new Error("Expected gzip history checkpoint to succeed");
-    }
-    expect(checkpoint.body.conversationId).not.toBe("");
-    await webhooks.requestAgentComplete(
-      { runId: run.runId, exitCode: 0 },
       headers,
       [200],
     );
@@ -1693,22 +1685,16 @@ describe("OPS-01: user data export", () => {
       existing: false,
       encoding: "zstd",
     });
-    const checkpoint = await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: run.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-export-zstd-session-${run.runId}`,
-        cliAgentSessionHistoryHash: historyHash,
+        exitCode: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-export-zstd-session-${run.runId}`,
+          cliAgentSessionHistoryHash: historyHash,
+        },
       },
-      headers,
-      [200],
-    );
-    if (checkpoint.status !== 200) {
-      throw new Error("Expected zstd history checkpoint to succeed");
-    }
-    expect(checkpoint.body.conversationId).not.toBe("");
-    await webhooks.requestAgentComplete(
-      { runId: run.runId, exitCode: 0 },
       headers,
       [200],
     );
@@ -1785,21 +1771,16 @@ describe("OPS-01: user data export", () => {
       headers,
       [200],
     );
-    const checkpoint = await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: run.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-export-corrupt-session-${run.runId}`,
-        cliAgentSessionHistoryHash: historyHash,
+        exitCode: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-export-corrupt-session-${run.runId}`,
+          cliAgentSessionHistoryHash: historyHash,
+        },
       },
-      headers,
-      [200],
-    );
-    if (checkpoint.status !== 200) {
-      throw new Error("Expected gzip history checkpoint to succeed");
-    }
-    await webhooks.requestAgentComplete(
-      { runId: run.runId, exitCode: 0 },
       headers,
       [200],
     );
@@ -1867,21 +1848,16 @@ describe("OPS-01: user data export", () => {
       headers,
       [200],
     );
-    const checkpoint = await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: run.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-export-corrupt-zstd-session-${run.runId}`,
-        cliAgentSessionHistoryHash: historyHash,
+        exitCode: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-export-corrupt-zstd-session-${run.runId}`,
+          cliAgentSessionHistoryHash: historyHash,
+        },
       },
-      headers,
-      [200],
-    );
-    if (checkpoint.status !== 200) {
-      throw new Error("Expected zstd history checkpoint to succeed");
-    }
-    await webhooks.requestAgentComplete(
-      { runId: run.runId, exitCode: 0 },
       headers,
       [200],
     );
@@ -1946,21 +1922,16 @@ describe("OPS-01: user data export", () => {
       headers,
       [200],
     );
-    const checkpoint = await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: run.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-export-oversized-session-${run.runId}`,
-        cliAgentSessionHistoryHash: historyHash,
+        exitCode: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-export-oversized-session-${run.runId}`,
+          cliAgentSessionHistoryHash: historyHash,
+        },
       },
-      headers,
-      [200],
-    );
-    if (checkpoint.status !== 200) {
-      throw new Error("Expected gzip history checkpoint to succeed");
-    }
-    await webhooks.requestAgentComplete(
-      { runId: run.runId, exitCode: 0 },
       headers,
       [200],
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -85,7 +85,10 @@ import {
   setRunModelProviderFixture,
   setRunModelRuntimeRouteFixture,
 } from "../../../test-fixtures/agent-runs";
-import { timeoutRunWithoutCallbacksFixture } from "../../../test-fixtures/chat-events";
+import {
+  holdCheckpointReadsFixture,
+  timeoutRunWithoutCallbacksFixture,
+} from "../../../test-fixtures/chat-events";
 import {
   createBddApi,
   expectApiError,
@@ -103,6 +106,7 @@ import {
 } from "./helpers/api-bdd-connectors";
 import { createFirewallApi, secretTemplate } from "./helpers/api-bdd-firewall";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
+import { cleanupTimedOutRun } from "./helpers/api-bdd-run-timeout";
 import {
   createRunsApi,
   expectCanonicalStorageManifest,
@@ -1520,18 +1524,17 @@ async function setupSameThreadReuseScenario(sourceRunnerIdentity?: {
   const history = `bdd reuse history ${first.runId}`;
   const historyHash = createHash("sha256").update(history).digest("hex");
   mockSessionHistoryBlob(historyHash, history);
-  await webhooks.requestAgentCheckpoint(
+  await webhooks.requestAgentComplete(
     {
       runId: first.runId,
-      cliAgentType: "claude-code",
-      cliAgentSessionId,
-      cliAgentSessionHistoryHash: historyHash,
+      exitCode: 0,
+      lastEventSequence: 0,
+      checkpoint: {
+        cliAgentType: "claude-code",
+        cliAgentSessionId,
+        cliAgentSessionHistoryHash: historyHash,
+      },
     },
-    { authorization: `Bearer ${firstClaim.sandboxToken}` },
-    [200],
-  );
-  await webhooks.requestAgentComplete(
-    { runId: first.runId, exitCode: 0, lastEventSequence: 0 },
     { authorization: `Bearer ${firstClaim.sandboxToken}` },
     [200],
   );
@@ -4111,59 +4114,59 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       versionId: preparedMemory.versionId,
       files: [memoryFile],
     });
-    const checkpoint = await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: initialRun.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-storage-cli-${initialRun.runId}`,
-        cliAgentSessionHistoryDisposition: "discarded_oversized",
-        artifactSnapshots: [
-          {
-            name: initialMemory.name,
-            version: preparedMemory.versionId,
-            mountPath: initialMemory.mountPath,
-            ...(initialMemory.missingRootPolicy === undefined
-              ? {}
-              : { missingRootPolicy: initialMemory.missingRootPolicy }),
-          },
-          {
-            name: initialCustomArtifact.name,
-            version: initialCustomArtifact.versionId,
-            mountPath: initialCustomArtifact.mountPath,
-            ...(initialCustomArtifact.missingRootPolicy === undefined
-              ? {}
-              : {
-                  missingRootPolicy: initialCustomArtifact.missingRootPolicy,
-                }),
-          },
-          {
-            name: initialPinnedArtifact.name,
-            version: initialPinnedArtifact.versionId,
-            mountPath: initialPinnedArtifact.mountPath,
-            ...(initialPinnedArtifact.missingRootPolicy === undefined
-              ? {}
-              : {
-                  missingRootPolicy: initialPinnedArtifact.missingRootPolicy,
-                }),
-          },
-        ],
+        exitCode: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-storage-cli-${initialRun.runId}`,
+          cliAgentSessionHistoryDisposition: "discarded_oversized",
+          artifactSnapshots: [
+            {
+              name: initialMemory.name,
+              version: preparedMemory.versionId,
+              mountPath: initialMemory.mountPath,
+              ...(initialMemory.missingRootPolicy === undefined
+                ? {}
+                : { missingRootPolicy: initialMemory.missingRootPolicy }),
+            },
+            {
+              name: initialCustomArtifact.name,
+              version: initialCustomArtifact.versionId,
+              mountPath: initialCustomArtifact.mountPath,
+              ...(initialCustomArtifact.missingRootPolicy === undefined
+                ? {}
+                : {
+                    missingRootPolicy: initialCustomArtifact.missingRootPolicy,
+                  }),
+            },
+            {
+              name: initialPinnedArtifact.name,
+              version: initialPinnedArtifact.versionId,
+              mountPath: initialPinnedArtifact.mountPath,
+              ...(initialPinnedArtifact.missingRootPolicy === undefined
+                ? {}
+                : {
+                    missingRootPolicy: initialPinnedArtifact.missingRootPolicy,
+                  }),
+            },
+          ],
+        },
       },
       { authorization: `Bearer ${initialClaim.sandboxToken}` },
       [200],
     );
-    if (checkpoint.status !== 200) {
-      throw new Error("Expected the canonical checkpoint to succeed");
+    const completedInitialRun = await api.readRun(actor, initialRun.runId);
+    const checkpointId = completedInitialRun.result?.checkpointId;
+    if (!checkpointId) {
+      throw new Error("Expected the canonical checkpoint to persist");
     }
-    await webhooks.requestAgentComplete(
-      { runId: initialRun.runId, exitCode: 0 },
-      { authorization: `Bearer ${initialClaim.sandboxToken}` },
-      [200],
-    );
     await expect(
       readStoragePersistenceState(context, {
         runId: initialRun.runId,
         sessionId: initialRun.sessionId,
-        checkpointId: checkpoint.body.checkpointId,
+        checkpointId,
       }),
     ).resolves.toStrictEqual({
       run_canonical: true,
@@ -4293,14 +4296,17 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     );
     await removeRunCanonicalStorageState(context, invalidPersistenceRun.runId);
 
-    const rejectedCheckpoint = await webhooks.requestAgentCheckpoint(
+    const rejectedCheckpoint = await webhooks.requestAgentComplete(
       {
         runId: invalidPersistenceRun.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-canonical-required-${invalidPersistenceRun.runId}`,
-        cliAgentSessionHistoryHash: createHash("sha256")
-          .update(`canonical required ${invalidPersistenceRun.runId}`)
-          .digest("hex"),
+        exitCode: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-canonical-required-${invalidPersistenceRun.runId}`,
+          cliAgentSessionHistoryHash: createHash("sha256")
+            .update(`canonical required ${invalidPersistenceRun.runId}`)
+            .digest("hex"),
+        },
       },
       { authorization: `Bearer ${canonicalClaim.sandboxToken}` },
       [500],
@@ -4583,18 +4589,17 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const historyHash = createHash("sha256").update(history).digest("hex");
     mockSessionHistoryBlob(historyHash, history);
 
-    await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: first.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-timing-cli-${first.runId}`,
-        cliAgentSessionHistoryHash: historyHash,
+        exitCode: 0,
+        lastEventSequence: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-timing-cli-${first.runId}`,
+          cliAgentSessionHistoryHash: historyHash,
+        },
       },
-      { authorization: `Bearer ${claim.sandboxToken}` },
-      [200],
-    );
-    await webhooks.requestAgentComplete(
-      { runId: first.runId, exitCode: 0, lastEventSequence: 0 },
       { authorization: `Bearer ${claim.sandboxToken}` },
       [200],
     );
@@ -4738,19 +4743,17 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const historyHash = createHash("sha256")
       .update(`bdd session history ${created.runId}`)
       .digest("hex");
-    await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: created.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-cli-${created.runId}`,
-        cliAgentSessionHistoryHash: historyHash,
+        exitCode: 0,
+        lastEventSequence: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-cli-${created.runId}`,
+          cliAgentSessionHistoryHash: historyHash,
+        },
       },
-      sandboxHeaders,
-      [200],
-    );
-
-    await webhooks.requestAgentComplete(
-      { runId: created.runId, exitCode: 0, lastEventSequence: 0 },
       sandboxHeaders,
       [200],
     );
@@ -5370,18 +5373,17 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const history = `bdd no-thread history ${first.runId}`;
     const historyHash = createHash("sha256").update(history).digest("hex");
     mockSessionHistoryBlob(historyHash, history);
-    await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: first.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId,
-        cliAgentSessionHistoryHash: historyHash,
+        exitCode: 0,
+        lastEventSequence: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId,
+          cliAgentSessionHistoryHash: historyHash,
+        },
       },
-      { authorization: `Bearer ${firstClaim.sandboxToken}` },
-      [200],
-    );
-    await webhooks.requestAgentComplete(
-      { runId: first.runId, exitCode: 0, lastEventSequence: 0 },
       { authorization: `Bearer ${firstClaim.sandboxToken}` },
       [200],
     );
@@ -5438,18 +5440,17 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       .update(resumedHistory)
       .digest("hex");
     mockSessionHistoryBlob(resumedHistoryHash, resumedHistory);
-    await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: resumed.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId,
-        cliAgentSessionHistoryHash: resumedHistoryHash,
+        exitCode: 0,
+        lastEventSequence: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId,
+          cliAgentSessionHistoryHash: resumedHistoryHash,
+        },
       },
-      { authorization: `Bearer ${resumedClaim.sandboxToken}` },
-      [200],
-    );
-    await webhooks.requestAgentComplete(
-      { runId: resumed.runId, exitCode: 0, lastEventSequence: 0 },
       { authorization: `Bearer ${resumedClaim.sandboxToken}` },
       [200],
     );
@@ -5482,18 +5483,17 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       .update(firstHistory)
       .digest("hex");
     mockSessionHistoryBlob(firstHistoryHash, firstHistory);
-    await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: first.runId,
-        cliAgentType: firstClaim.cliAgentType,
-        cliAgentSessionId,
-        cliAgentSessionHistoryHash: firstHistoryHash,
+        exitCode: 0,
+        lastEventSequence: 0,
+        checkpoint: {
+          cliAgentType: firstClaim.cliAgentType,
+          cliAgentSessionId,
+          cliAgentSessionHistoryHash: firstHistoryHash,
+        },
       },
-      { authorization: `Bearer ${firstClaim.sandboxToken}` },
-      [200],
-    );
-    await webhooks.requestAgentComplete(
-      { runId: first.runId, exitCode: 0, lastEventSequence: 0 },
       { authorization: `Bearer ${firstClaim.sandboxToken}` },
       [200],
     );
@@ -5535,18 +5535,17 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       .update(resumedHistory)
       .digest("hex");
     mockSessionHistoryBlob(resumedHistoryHash, resumedHistory);
-    await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: resumed.runId,
-        cliAgentType: resumedClaim.cliAgentType,
-        cliAgentSessionId,
-        cliAgentSessionHistoryHash: resumedHistoryHash,
+        exitCode: 0,
+        lastEventSequence: 0,
+        checkpoint: {
+          cliAgentType: resumedClaim.cliAgentType,
+          cliAgentSessionId,
+          cliAgentSessionHistoryHash: resumedHistoryHash,
+        },
       },
-      { authorization: `Bearer ${resumedClaim.sandboxToken}` },
-      [200],
-    );
-    await webhooks.requestAgentComplete(
-      { runId: resumed.runId, exitCode: 0, lastEventSequence: 0 },
       { authorization: `Bearer ${resumedClaim.sandboxToken}` },
       [200],
     );
@@ -6592,18 +6591,17 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const history = `bdd heartbeat order history ${first.runId}`;
     const historyHash = createHash("sha256").update(history).digest("hex");
     mockSessionHistoryBlob(historyHash, history);
-    await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: first.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId,
-        cliAgentSessionHistoryHash: historyHash,
+        exitCode: 0,
+        lastEventSequence: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId,
+          cliAgentSessionHistoryHash: historyHash,
+        },
       },
-      { authorization: `Bearer ${firstClaim.sandboxToken}` },
-      [200],
-    );
-    await webhooks.requestAgentComplete(
-      { runId: first.runId, exitCode: 0, lastEventSequence: 0 },
       { authorization: `Bearer ${firstClaim.sandboxToken}` },
       [200],
     );
@@ -6761,18 +6759,17 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const history = `bdd reusable priority history ${first.runId}`;
     const historyHash = createHash("sha256").update(history).digest("hex");
     mockSessionHistoryBlob(historyHash, history);
-    await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: first.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId,
-        cliAgentSessionHistoryHash: historyHash,
+        exitCode: 0,
+        lastEventSequence: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId,
+          cliAgentSessionHistoryHash: historyHash,
+        },
       },
-      { authorization: `Bearer ${firstClaim.sandboxToken}` },
-      [200],
-    );
-    await webhooks.requestAgentComplete(
-      { runId: first.runId, exitCode: 0, lastEventSequence: 0 },
       { authorization: `Bearer ${firstClaim.sandboxToken}` },
       [200],
     );
@@ -6924,18 +6921,17 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const history = `bdd workspace priority history ${first.runId}`;
     const historyHash = createHash("sha256").update(history).digest("hex");
     mockSessionHistoryBlob(historyHash, history);
-    await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: first.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId,
-        cliAgentSessionHistoryHash: historyHash,
+        exitCode: 0,
+        lastEventSequence: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId,
+          cliAgentSessionHistoryHash: historyHash,
+        },
       },
-      { authorization: `Bearer ${firstClaim.sandboxToken}` },
-      [200],
-    );
-    await webhooks.requestAgentComplete(
-      { runId: first.runId, exitCode: 0, lastEventSequence: 0 },
       { authorization: `Bearer ${firstClaim.sandboxToken}` },
       [200],
     );
@@ -11180,18 +11176,17 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const history = `bounded MCP awareness history ${claudeRun.runId}`;
     const historyHash = createHash("sha256").update(history).digest("hex");
     mockSessionHistoryBlob(historyHash, history);
-    await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: claudeRun.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-mcp-awareness-${claudeRun.runId}`,
-        cliAgentSessionHistoryHash: historyHash,
+        exitCode: 0,
+        lastEventSequence: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-mcp-awareness-${claudeRun.runId}`,
+          cliAgentSessionHistoryHash: historyHash,
+        },
       },
-      { authorization: `Bearer ${claudeClaim.sandboxToken}` },
-      [200],
-    );
-    await webhooks.requestAgentComplete(
-      { runId: claudeRun.runId, exitCode: 0, lastEventSequence: 0 },
       { authorization: `Bearer ${claudeClaim.sandboxToken}` },
       [200],
     );
@@ -13891,18 +13886,17 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const sandboxHeaders = {
       authorization: `Bearer ${claim.sandboxToken}`,
     };
-    await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: run.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `terminal-refresh-${run.runId}`,
-        cliAgentSessionHistoryHash: historyHash,
+        exitCode: 0,
+        lastEventSequence: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `terminal-refresh-${run.runId}`,
+          cliAgentSessionHistoryHash: historyHash,
+        },
       },
-      sandboxHeaders,
-      [200],
-    );
-    await webhooks.requestAgentComplete(
-      { runId: run.runId, exitCode: 0, lastEventSequence: 0 },
       sandboxHeaders,
       [200],
     );
@@ -14027,18 +14021,17 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const history = `bdd combined claim history ${first.runId}`;
     const historyHash = createHash("sha256").update(history).digest("hex");
     mockSessionHistoryBlob(historyHash, history);
-    await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: first.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-combined-cli-${first.runId}`,
-        cliAgentSessionHistoryHash: historyHash,
+        exitCode: 0,
+        lastEventSequence: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-combined-cli-${first.runId}`,
+          cliAgentSessionHistoryHash: historyHash,
+        },
       },
-      { authorization: `Bearer ${firstClaim.sandboxToken}` },
-      [200],
-    );
-    await webhooks.requestAgentComplete(
-      { runId: first.runId, exitCode: 0, lastEventSequence: 0 },
       { authorization: `Bearer ${firstClaim.sandboxToken}` },
       [200],
     );
@@ -15222,18 +15215,17 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     const historyHash = createHash("sha256")
       .update(`missing claim history ${source.runId}`)
       .digest("hex");
-    await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: source.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-failed-claim-${source.runId}`,
-        cliAgentSessionHistoryHash: historyHash,
+        exitCode: 0,
+        lastEventSequence: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-failed-claim-${source.runId}`,
+          cliAgentSessionHistoryHash: historyHash,
+        },
       },
-      { authorization: `Bearer ${sourceClaim.sandboxToken}` },
-      [200],
-    );
-    await webhooks.requestAgentComplete(
-      { runId: source.runId, exitCode: 0, lastEventSequence: 0 },
       { authorization: `Bearer ${sourceClaim.sandboxToken}` },
       [200],
     );
@@ -16502,18 +16494,17 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
     const historyHash = createHash("sha256")
       .update(`bdd cleanup-first session history ${runId}`)
       .digest("hex");
-    await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-cleanup-first-${runId}`,
-        cliAgentSessionHistoryHash: historyHash,
+        exitCode: 0,
+        lastEventSequence: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-cleanup-first-${runId}`,
+          cliAgentSessionHistoryHash: historyHash,
+        },
       },
-      sandboxHeaders,
-      [200],
-    );
-    await webhooks.requestAgentComplete(
-      { runId, exitCode: 0, lastEventSequence: 0 },
       sandboxHeaders,
       [200],
     );
@@ -18365,7 +18356,7 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
     await api.requestCancelRun(actor, continued.runId, [200]);
   });
 
-  it("rejects a combined checkpoint after timeout without partial persistence", async () => {
+  it("acknowledges completion after timeout without partial persistence", async () => {
     const api = createRunsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId } = await entitledRunActor();
@@ -18375,16 +18366,20 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
       modelProvider: "anthropic-api-key",
     });
     const claim = await api.claimRunnerJob(run.runId);
-    const history = `bdd timed out combined history ${run.runId}`;
-    const historyHash = createHash("sha256").update(history).digest("hex");
-    mockSessionHistoryBlob(historyHash, history);
+    const historyHash = createHash("sha256")
+      .update(`bdd timed out combined history ${run.runId}`)
+      .digest("hex");
     const sandboxHeaders = { authorization: `Bearer ${claim.sandboxToken}` };
     await timeoutRunWithoutCallbacksFixture({ runId: run.runId });
+    const timedOut = await api.readRun(actor, run.runId);
+    const runnerMetadata = await api.requestRunRunner(actor, run.runId, [200]);
 
-    const rejected = await webhooks.requestAgentComplete(
+    const completion = await webhooks.requestAgentComplete(
       {
         runId: run.runId,
         exitCode: 0,
+        sandboxReuseResult: "poolMiss",
+        workspaceReuseResult: "diskPressure",
         checkpoint: {
           cliAgentType: "claude-code",
           cliAgentSessionId: `bdd-timeout-combined-${run.runId}`,
@@ -18392,13 +18387,15 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
         },
       },
       sandboxHeaders,
-      [400],
+      [200],
     );
-    expectApiError(rejected.body);
-    expect(rejected.body.error.message).toContain("run status is timeout");
-    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
-      status: "timeout",
-    });
+    expect(completion.body).toStrictEqual({ success: true, status: "failed" });
+    await expect(api.readRun(actor, run.runId)).resolves.toStrictEqual(
+      timedOut,
+    );
+    await expect(
+      api.requestRunRunner(actor, run.runId, [200]),
+    ).resolves.toStrictEqual(runnerMetadata);
 
     const fallback = await webhooks.requestAgentComplete(
       { runId: run.runId, exitCode: 0 },
@@ -18406,8 +18403,72 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
       [200],
     );
     expect(fallback.body).toStrictEqual({ success: true, status: "failed" });
-    const failed = await api.readRun(actor, run.runId);
-    expect(failed.error).toBe("Checkpoint for run not found");
+    await expect(api.readRun(actor, run.runId)).resolves.toStrictEqual(
+      timedOut,
+    );
+  });
+
+  it("serializes timeout cleanup behind checkpointed completion", async () => {
+    const api = createRunsApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped actor");
+    }
+    const startedAt = now();
+    mockNow(startedAt);
+    onTestFinished(() => {
+      clearMockNow();
+    });
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "complete while timeout cleanup waits",
+      modelProvider: "anthropic-api-key",
+    });
+    const claim = await api.claimRunnerJob(run.runId);
+    const checkpointGate = await holdCheckpointReadsFixture({
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      checkpointGate.release();
+      await checkpointGate.done;
+    });
+    const completion = webhooks.requestAgentComplete(
+      {
+        runId: run.runId,
+        exitCode: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-timeout-race-${run.runId}`,
+          cliAgentSessionHistoryDisposition: "unavailable",
+        },
+      },
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      [200],
+    );
+    await expect
+      .poll(checkpointGate.blockedWaiterCount)
+      .toBeGreaterThanOrEqual(1);
+
+    mockNow(startedAt + 3 * 60 * 1000);
+    const cleanup = cleanupTimedOutRun(context, {
+      runId: run.runId,
+      chatThreadId: randomUUID(),
+      orgId: actor.orgId,
+    });
+    checkpointGate.release();
+    await checkpointGate.done;
+
+    await expect(completion).resolves.toMatchObject({
+      body: { success: true, status: "completed" },
+    });
+    await expect(cleanup).resolves.toMatchObject({
+      body: { cleaned: 0, errors: 0, results: [] },
+    });
+    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+      status: "completed",
+      result: { checkpointId: expect.any(String) },
+    });
   });
 
   it("keeps claim auth valid through timeout completion and final telemetry", async () => {
@@ -18653,20 +18714,19 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
     const historyHash = createHash("sha256")
       .update(`bdd cancelled checkpoint ${run.runId}`)
       .digest("hex");
-    await webhooks.requestAgentCheckpoint(
-      {
-        runId: run.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-cancelled-cli-${run.runId}`,
-        cliAgentSessionHistoryHash: historyHash,
-      },
-      sandboxHeaders,
-      [200],
-    );
     await api.requestCancelRun(actor, run.runId, [200]);
 
     const late = await webhooks.requestAgentComplete(
-      { runId: run.runId, exitCode: 0, lastEventSequence: 0 },
+      {
+        runId: run.runId,
+        exitCode: 0,
+        lastEventSequence: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-cancelled-cli-${run.runId}`,
+          cliAgentSessionHistoryHash: historyHash,
+        },
+      },
       sandboxHeaders,
       [200],
     );
@@ -18714,7 +18774,7 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
     const historyHash = createHash("sha256")
       .update(`bdd null vars checkpoint ${run.runId}`)
       .digest("hex");
-    const checkpoint = await webhooks.requestAgentCheckpoint(
+    const rejectedCheckpoint = await webhooks.requestAgentCheckpoint(
       {
         runId: run.runId,
         cliAgentType: "claude-code",
@@ -18722,16 +18782,24 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
         cliAgentSessionHistoryHash: historyHash,
       },
       sandboxHeaders,
-      [200],
+      [400],
     );
-    if (checkpoint.status !== 200) {
-      throw new Error("Expected the null-vars checkpoint to succeed");
-    }
-    expect(checkpoint.body.artifacts).toBeUndefined();
-    expect(checkpoint.body.volumes).toBeUndefined();
+    expectApiError(rejectedCheckpoint.body);
+    expect(rejectedCheckpoint.body.error.message).toContain(
+      "Standalone checkpoint cannot persist while the run status is pending",
+    );
 
     await webhooks.requestAgentComplete(
-      { runId: run.runId, exitCode: 0, lastEventSequence: 0 },
+      {
+        runId: run.runId,
+        exitCode: 0,
+        lastEventSequence: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-null-vars-cli-${run.runId}`,
+          cliAgentSessionHistoryHash: historyHash,
+        },
+      },
       sandboxHeaders,
       [200],
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -149,7 +149,7 @@ function s3BytesBody(bytes: Buffer): AsyncIterable<Buffer> {
 
 /**
  * Marks a claimed run completed through the sandbox webhooks. Successful
- * completion requires a checkpoint, so one is always posted first.
+ * completion requires a checkpoint, so one is included atomically.
  */
 async function completeRun(
   runId: string,
@@ -157,22 +157,17 @@ async function completeRun(
   options: { readonly lastEventSequence?: number } = {},
 ): Promise<void> {
   const headers = sandboxHeaders(sandboxToken);
-  await webhooks.requestAgentCheckpoint(
-    {
-      runId,
-      cliAgentType: "claude-code",
-      cliAgentSessionId: `bdd-cli-${runId}`,
-      cliAgentSessionHistoryHash: createHash("sha256")
-        .update(`bdd run reads history ${runId}`)
-        .digest("hex"),
-    },
-    headers,
-    [200],
-  );
   await webhooks.requestAgentComplete(
     {
       runId,
       exitCode: 0,
+      checkpoint: {
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `bdd-cli-${runId}`,
+        cliAgentSessionHistoryHash: createHash("sha256")
+          .update(`bdd run reads history ${runId}`)
+          .digest("hex"),
+      },
       ...(options.lastEventSequence === undefined
         ? {}
         : { lastEventSequence: options.lastEventSequence }),
@@ -963,19 +958,16 @@ describe("RUN-01/RUN-02: session continuation, memory policies, and volume pinni
       existing: true,
       encoding: "gzip",
     });
-    const checkpointed = await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: run.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-cli-${run.runId}`,
-        cliAgentSessionHistoryHash: historyHash,
+        exitCode: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-cli-${run.runId}`,
+          cliAgentSessionHistoryHash: historyHash,
+        },
       },
-      headers,
-      [200],
-    );
-    mustOk(checkpointed, "compressed resume checkpoint");
-    await webhooks.requestAgentComplete(
-      { runId: run.runId, exitCode: 0 },
       headers,
       [200],
     );
@@ -1072,19 +1064,16 @@ describe("RUN-01/RUN-02: session continuation, memory policies, and volume pinni
       existing: true,
       encoding: "zstd",
     });
-    const checkpointed = await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: run.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-cli-${run.runId}`,
-        cliAgentSessionHistoryHash: historyHash,
+        exitCode: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-cli-${run.runId}`,
+          cliAgentSessionHistoryHash: historyHash,
+        },
       },
-      headers,
-      [200],
-    );
-    mustOk(checkpointed, "zstd compressed resume checkpoint");
-    await webhooks.requestAgentComplete(
-      { runId: run.runId, exitCode: 0 },
       headers,
       [200],
     );
@@ -1418,29 +1407,24 @@ describe("RUN-01/RUN-02: session continuation, memory policies, and volume pinni
 
     const cliAgentSessionId = `bdd-cli-${r1.runId}`;
     const headers1 = sandboxHeaders(claim1.sandboxToken);
-    const checkpointed = await webhooks.requestAgentCheckpoint(
+    await webhooks.requestAgentComplete(
       {
         runId: r1.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId,
-        cliAgentSessionHistoryHash: historyHash,
-        artifactSnapshots: [
-          {
-            name: "memory",
-            version: memory1.versionId,
-            mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
-          },
-        ],
-        volumeVersionsSnapshot: { versions: { data: volumeVersion } },
+        exitCode: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId,
+          cliAgentSessionHistoryHash: historyHash,
+          artifactSnapshots: [
+            {
+              name: "memory",
+              version: memory1.versionId,
+              mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+            },
+          ],
+          volumeVersionsSnapshot: { versions: { data: volumeVersion } },
+        },
       },
-      headers1,
-      [200],
-    );
-    if (checkpointed.status !== 200) {
-      throw new Error("Expected the resume checkpoint webhook to succeed");
-    }
-    await webhooks.requestAgentComplete(
-      { runId: r1.runId, exitCode: 0 },
       headers1,
       [200],
     );
@@ -2491,23 +2475,17 @@ describe("RUN-04: agent run telemetry families", () => {
       const claim = await api.claimRunnerJob(run.runId);
       const headers = sandboxHeaders(claim.sandboxToken);
 
-      await webhooks.requestAgentCheckpoint(
-        {
-          runId: run.runId,
-          cliAgentType: "claude-code",
-          cliAgentSessionId: `bdd-cli-${run.runId}`,
-          cliAgentSessionHistoryHash: createHash("sha256")
-            .update(`bdd sandbox reuse ${run.runId}`)
-            .digest("hex"),
-        },
-        headers,
-        [200],
-      );
-
       const completion = await webhooks.requestAgentComplete(
         {
           runId: run.runId,
           exitCode: 0,
+          checkpoint: {
+            cliAgentType: "claude-code",
+            cliAgentSessionId: `bdd-cli-${run.runId}`,
+            cliAgentSessionHistoryHash: createHash("sha256")
+              .update(`bdd sandbox reuse ${run.runId}`)
+              .digest("hex"),
+          },
           sandboxReuseResult: scenario.sandboxResult,
           workspaceReuseResult: scenario.workspaceResult,
         },
@@ -2612,22 +2590,17 @@ describe("RUN-04: agent run telemetry families", () => {
     });
     const claim = await api.claimRunnerJob(agentRun.runId);
     const headers = sandboxHeaders(claim.sandboxToken);
-    await webhooks.requestAgentCheckpoint(
-      {
-        runId: agentRun.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-cli-${agentRun.runId}`,
-        cliAgentSessionHistoryHash: createHash("sha256")
-          .update(`bdd zero detail ${agentRun.runId}`)
-          .digest("hex"),
-      },
-      headers,
-      [200],
-    );
     await webhooks.requestAgentComplete(
       {
         runId: agentRun.runId,
         exitCode: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-cli-${agentRun.runId}`,
+          cliAgentSessionHistoryHash: createHash("sha256")
+            .update(`bdd zero detail ${agentRun.runId}`)
+            .digest("hex"),
+        },
         sandboxReuseResult: "reused",
         workspaceReuseResult: "sandboxReused",
       },

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
@@ -99,20 +99,18 @@ async function completeClaimedRunOk(
 ): Promise<void> {
   const sandboxHeaders = { authorization: `Bearer ${sandboxToken}` };
   const history = `GitHub workflow BDD history ${runId}`;
-  await webhooksApi.requestAgentCheckpoint(
+  await webhooksApi.requestAgentComplete(
     {
       runId,
-      cliAgentType: "claude-code",
-      cliAgentSessionId: `github-workflow-bdd-${runId}`,
-      cliAgentSessionHistoryHash: createHash("sha256")
-        .update(history)
-        .digest("hex"),
+      exitCode: 0,
+      checkpoint: {
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `github-workflow-bdd-${runId}`,
+        cliAgentSessionHistoryHash: createHash("sha256")
+          .update(history)
+          .digest("hex"),
+      },
     },
-    sandboxHeaders,
-    [200],
-  );
-  await webhooksApi.requestAgentComplete(
-    { runId, exitCode: 0 },
     sandboxHeaders,
     [200],
   );

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
@@ -626,20 +626,18 @@ async function completeRunThroughSandbox(
   await runsApi.heartbeatRunner(runnerGroup);
   const claim = await runsApi.claimRunnerJob(runId);
   const sandboxHeaders = { authorization: `Bearer ${claim.sandboxToken}` };
-  await webhooksApi.requestAgentCheckpoint(
+  await webhooksApi.requestAgentComplete(
     {
       runId,
-      cliAgentType: "claude-code",
-      cliAgentSessionId: `gmail-workflow-cli-${runId}`,
-      cliAgentSessionHistoryHash: createHash("sha256")
-        .update(`gmail workflow history ${runId}`)
-        .digest("hex"),
+      exitCode: 0,
+      checkpoint: {
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `gmail-workflow-cli-${runId}`,
+        cliAgentSessionHistoryHash: createHash("sha256")
+          .update(`gmail workflow history ${runId}`)
+          .digest("hex"),
+      },
     },
-    sandboxHeaders,
-    [200],
-  );
-  await webhooksApi.requestAgentComplete(
-    { runId, exitCode: 0 },
     sandboxHeaders,
     [200],
   );

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
@@ -43,20 +43,18 @@ async function completeRunThroughSandbox(
   runId: string,
 ): Promise<void> {
   const sandboxHeaders = { authorization: `Bearer ${sandboxToken}` };
-  await webhooksApi.requestAgentCheckpoint(
+  await webhooksApi.requestAgentComplete(
     {
       runId,
-      cliAgentType: "claude-code",
-      cliAgentSessionId: `calendar-webhook-cli-${runId}`,
-      cliAgentSessionHistoryHash: createHash("sha256")
-        .update(`calendar webhook history ${runId}`)
-        .digest("hex"),
+      exitCode: 0,
+      checkpoint: {
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `calendar-webhook-cli-${runId}`,
+        cliAgentSessionHistoryHash: createHash("sha256")
+          .update(`calendar webhook history ${runId}`)
+          .digest("hex"),
+      },
     },
-    sandboxHeaders,
-    [200],
-  );
-  await webhooksApi.requestAgentComplete(
-    { runId, exitCode: 0 },
     sandboxHeaders,
     [200],
   );

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-automation-scheduler.test.ts
@@ -243,20 +243,18 @@ async function completeRunThroughSandbox(
   await runsApi.heartbeatRunner(scenario.runnerGroup);
   const claim = await runsApi.claimRunnerJob(runId);
   const sandboxHeaders = { authorization: `Bearer ${claim.sandboxToken}` };
-  await webhooksApi.requestAgentCheckpoint(
+  await webhooksApi.requestAgentComplete(
     {
       runId,
-      cliAgentType: "claude-code",
-      cliAgentSessionId: `workflow-automation-cli-${runId}`,
-      cliAgentSessionHistoryHash: createHash("sha256")
-        .update(`workflow automation history ${runId}`)
-        .digest("hex"),
+      exitCode,
+      checkpoint: {
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `workflow-automation-cli-${runId}`,
+        cliAgentSessionHistoryHash: createHash("sha256")
+          .update(`workflow automation history ${runId}`)
+          .digest("hex"),
+      },
     },
-    sandboxHeaders,
-    [200],
-  );
-  await webhooksApi.requestAgentComplete(
-    { runId, exitCode },
     sandboxHeaders,
     [200],
   );

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
@@ -390,22 +390,17 @@ async function requestRunCompletionThroughSandbox(
       [200],
     );
   }
-  await webhooksApi.requestAgentCheckpoint(
-    {
-      runId,
-      cliAgentType: "claude-code",
-      cliAgentSessionId: `workflow-queue-cli-${runId}`,
-      cliAgentSessionHistoryHash: createHash("sha256")
-        .update(`workflow automation history ${runId}`)
-        .digest("hex"),
-    },
-    sandboxHeaders,
-    [200],
-  );
   await webhooksApi.requestAgentComplete(
     {
       runId,
       exitCode: 0,
+      checkpoint: {
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `workflow-queue-cli-${runId}`,
+        cliAgentSessionHistoryHash: createHash("sha256")
+          .update(`workflow automation history ${runId}`)
+          .digest("hex"),
+      },
       ...(stagedOutputEvents.length === 0
         ? {}
         : {
@@ -1128,19 +1123,6 @@ describe("workflow queue", () => {
     const sandboxHeaders = {
       authorization: `Bearer ${firstClaim.sandboxToken}`,
     };
-    await webhooksApi.requestAgentCheckpoint(
-      {
-        runId: firstRunId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `workflow-queue-cli-${firstRunId}`,
-        cliAgentSessionHistoryHash: createHash("sha256")
-          .update(`workflow automation history ${firstRunId}`)
-          .digest("hex"),
-      },
-      sandboxHeaders,
-      [200],
-    );
-
     mockEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
     const admissionLock = await holdOrgAdmissionLockFixture({
       orgId: scenario.orgId,
@@ -1152,7 +1134,17 @@ describe("workflow queue", () => {
     });
     const routeSignal = new AbortController();
     const completion = webhooksApi.requestAgentComplete(
-      { runId: firstRunId, exitCode: 0 },
+      {
+        runId: firstRunId,
+        exitCode: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `workflow-queue-cli-${firstRunId}`,
+          cliAgentSessionHistoryHash: createHash("sha256")
+            .update(`workflow automation history ${firstRunId}`)
+            .digest("hex"),
+        },
+      },
       sandboxHeaders,
       [200],
       routeSignal.signal,

--- a/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
@@ -185,6 +185,7 @@ async function seedRunForAction(
       createdAt: readDate(body, "created_at") ?? undefined,
       completedAt: readNullableDate(body, "completed_at"),
       lastHeartbeatAt: readNullableDate(body, "last_heartbeat_at"),
+      runnerGroup: readOptionalString(body, "runner_group"),
       cancellationRecoveryCompleted: readOptionalBoolean(
         body,
         "cancellation_recovery_completed",

--- a/turbo/apps/api/src/signals/services/active-input-delivery.service.ts
+++ b/turbo/apps/api/src/signals/services/active-input-delivery.service.ts
@@ -860,7 +860,7 @@ async function recordActiveInputDeliveryReceiptTransition(
   };
 }
 
-export async function finalizeActiveInputDeliveryForCompletion(
+export async function finalizeActiveInputDelivery(
   tx: ActiveInputDeliveryTransaction,
   args: ActiveInputDeliveryIdentity & {
     readonly deliveredDeliveryIds: ReadonlySet<string>;

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -85,6 +85,11 @@ type AgentCheckpointPreparation =
       readonly response: AgentCheckpointErrorResponse;
     };
 
+type AgentCheckpointPersistenceSource =
+  | "standalone-webhook"
+  | "combined-completion"
+  | "pi-api-first-turn";
+
 interface CheckpointRunContext {
   readonly agentSessionConversationId: string | null;
   readonly chatThreadId: string | null;
@@ -739,6 +744,10 @@ function checkpointRunStateError(status: RunStatus): string {
   return `[CHECKPOINT_RUN_TERMINAL] Checkpoint cannot become canonical while the run status is ${status}`;
 }
 
+function standaloneCheckpointRunStateError(status: RunStatus): string {
+  return `[CHECKPOINT_RUN_NOT_SETTLED] Standalone checkpoint cannot persist while the run status is ${status}`;
+}
+
 interface ExistingCheckpoint {
   readonly checkpointId: string;
   readonly conversationId: string;
@@ -984,14 +993,47 @@ async function exactCheckpointRetryResponse(
   );
 }
 
+function isUnsettledCheckpointStatus(status: RunStatus): boolean {
+  return status === "queued" || status === "pending" || status === "running";
+}
+
+async function standaloneCheckpointAdmissionResponse(
+  tx: Tx,
+  run: CheckpointRunContext,
+  body: AgentCheckpointBody,
+  storageMounts: readonly PersistedStorageMount[],
+  signal: AbortSignal,
+): Promise<AgentCheckpointResponse | undefined> {
+  if (isUnsettledCheckpointStatus(run.status)) {
+    return badRequestMessage(standaloneCheckpointRunStateError(run.status));
+  }
+  if (isPiCheckpointRun(run) || run.status !== "completed") {
+    return undefined;
+  }
+
+  const exactRetry = await exactCheckpointRetryResponse(
+    tx,
+    run,
+    body,
+    storageMounts,
+    signal,
+  );
+  return (
+    exactRetry ??
+    badRequestMessage(
+      "[CHECKPOINT_ALREADY_COMMITTED] Final checkpoint does not exactly match the completed run",
+    )
+  );
+}
+
 export async function persistAgentCheckpointInTransaction(
   tx: Tx,
   input: AgentCheckpointInput,
   prepared: PreparedAgentCheckpoint,
   signal: AbortSignal,
   options: {
-    readonly combinedCompletion?: true;
-  } = {},
+    readonly source: AgentCheckpointPersistenceSource;
+  },
 ): Promise<AgentCheckpointResponse> {
   const run = await lockCheckpointRunContext(tx, input);
   signal.throwIfAborted();
@@ -1011,8 +1053,20 @@ export async function persistAgentCheckpointInTransaction(
   if (!piRun && run.status === "timeout") {
     return badRequestMessage(checkpointRunStateError(run.status));
   }
+  if (options.source === "standalone-webhook") {
+    const response = await standaloneCheckpointAdmissionResponse(
+      tx,
+      run,
+      input.body,
+      storageMounts,
+      signal,
+    );
+    if (response) {
+      return response;
+    }
+  }
   if (
-    options.combinedCompletion &&
+    options.source === "combined-completion" &&
     (run.status === "completed" ||
       run.status === "failed" ||
       run.status === "cancelled")
@@ -1074,6 +1128,9 @@ export const prepareAgentCheckpointPersistence$ = command(
   async (
     { set },
     input: AgentCheckpointInput,
+    options: {
+      readonly source: AgentCheckpointPersistenceSource;
+    },
     signal: AbortSignal,
   ): Promise<AgentCheckpointPreparation> => {
     const db = set(writeDb$);
@@ -1087,6 +1144,17 @@ export const prepareAgentCheckpointPersistence$ = command(
     const typeError = piCheckpointTypeError(run, input.body);
     if (typeError) {
       return { ok: false, response: badRequestMessage(typeError) };
+    }
+    if (
+      options.source === "standalone-webhook" &&
+      isUnsettledCheckpointStatus(run.status)
+    ) {
+      return {
+        ok: false,
+        response: badRequestMessage(
+          standaloneCheckpointRunStateError(run.status),
+        ),
+      };
     }
     const piNeedsValidation =
       isPiCheckpointRun(run) && isActivePiCheckpointStatus(run.status);
@@ -1116,6 +1184,7 @@ async function commitAgentCheckpoint(
   input: AgentCheckpointInput,
   prepared: PreparedAgentCheckpoint,
   signal: AbortSignal,
+  source: AgentCheckpointPersistenceSource,
 ): Promise<AgentCheckpointResponse> {
   return await db.transaction(async (tx) => {
     await lockAgentRunCheckpointLifecycle(tx, input.body.runId);
@@ -1125,6 +1194,7 @@ async function commitAgentCheckpoint(
       input,
       prepared,
       signal,
+      { source },
     );
   });
 }
@@ -1135,12 +1205,42 @@ export const createAgentCheckpoint$ = command(
     const preparation = await set(
       prepareAgentCheckpointPersistence$,
       input,
+      { source: "standalone-webhook" },
       signal,
     );
     if (!preparation.ok) {
       return preparation.response;
     }
 
-    return await commitAgentCheckpoint(db, input, preparation.prepared, signal);
+    return await commitAgentCheckpoint(
+      db,
+      input,
+      preparation.prepared,
+      signal,
+      "standalone-webhook",
+    );
+  },
+);
+
+export const createPiApiFirstTurnCheckpoint$ = command(
+  async ({ set }, input: AgentCheckpointInput, signal: AbortSignal) => {
+    const db = set(writeDb$);
+    const preparation = await set(
+      prepareAgentCheckpointPersistence$,
+      input,
+      { source: "pi-api-first-turn" },
+      signal,
+    );
+    if (!preparation.ok) {
+      return preparation.response;
+    }
+
+    return await commitAgentCheckpoint(
+      db,
+      input,
+      preparation.prepared,
+      signal,
+      "pi-api-first-turn",
+    );
   },
 );

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -30,7 +30,7 @@ import {
 } from "./agent-run-callback.service";
 import { drainChatThreadQueueForRun$ } from "./chat-thread-queue-drain.service";
 import {
-  finalizeActiveInputDeliveryForCompletion,
+  finalizeActiveInputDelivery,
   type FinalizeActiveInputDeliveryResult,
 } from "./active-input-delivery.service";
 import { lockChatQueueThread } from "./chat-event-queue.service";
@@ -63,6 +63,11 @@ export interface TerminalSideEffectsInput {
   readonly orgId: string;
   readonly status: TerminalStatus;
   readonly error?: string;
+  readonly deliveryNotification?: {
+    readonly userId: string;
+    readonly chatThreadId: string;
+    readonly chatEventsAppended: boolean;
+  };
 }
 
 export interface CancellationRecoverySideEffectsInput {
@@ -376,7 +381,7 @@ async function applyTerminalCompletion(
       and(
         eq(agentRuns.id, input.body.runId),
         eq(agentRuns.userId, input.auth.userId),
-        inArray(agentRuns.status, ["pending", "running", "timeout"]),
+        inArray(agentRuns.status, ["pending", "running"]),
       ),
     )
     .returning({ id: agentRuns.id });
@@ -396,7 +401,6 @@ interface CompletionTransitionContext {
   readonly checkpointInput: AgentCheckpointInput | null;
   readonly checkpointPreparation: PreparedAgentCheckpoint | null;
   readonly expectedChatThreadId: string | null;
-  readonly legacyPrepared: PreparedCompletion | null;
 }
 
 async function completeAgentRunTransition(
@@ -405,12 +409,8 @@ async function completeAgentRunTransition(
   context: CompletionTransitionContext,
   signal: AbortSignal,
 ): Promise<CompletionTransactionResult> {
-  const {
-    checkpointInput,
-    checkpointPreparation,
-    expectedChatThreadId,
-    legacyPrepared,
-  } = context;
+  const { checkpointInput, checkpointPreparation, expectedChatThreadId } =
+    context;
   const threadLocked =
     expectedChatThreadId === null
       ? false
@@ -425,6 +425,17 @@ async function completeAgentRunTransition(
   if (expectedChatThreadId !== null && !threadLocked) {
     throw new Error("Agent run retained a missing chat thread");
   }
+  if (run.status === "timeout") {
+    return {
+      kind: "committed",
+      commit: {
+        run,
+        transitioned: false,
+        responseStatus: "failed",
+        finalization: noActiveInputFinalization(),
+      },
+    };
+  }
   if (checkpointInput) {
     if (!checkpointPreparation) {
       throw new Error("Included agent checkpoint was not prepared");
@@ -434,20 +445,16 @@ async function completeAgentRunTransition(
       checkpointInput,
       checkpointPreparation,
       signal,
-      { combinedCompletion: true },
+      { source: "combined-completion" },
     );
     if (checkpointResult.status !== 200) {
       return { kind: "response", response: checkpointResult };
     }
   }
-  const canTransition =
-    run.status === "pending" ||
-    run.status === "running" ||
-    run.status === "timeout";
-  const prepared =
-    checkpointInput && canTransition
-      ? await prepareCompletion(tx, input, run.sessionId, signal)
-      : legacyPrepared;
+  const canTransition = run.status === "pending" || run.status === "running";
+  const prepared = canTransition
+    ? await prepareCompletion(tx, input, run.sessionId, signal)
+    : null;
   signal.throwIfAborted();
   if (input.body.lastEventSequence !== undefined) {
     await persistLastEventSequence(
@@ -460,7 +467,7 @@ async function completeAgentRunTransition(
   const finalization =
     run.chatThreadId === null
       ? noActiveInputFinalization()
-      : await finalizeActiveInputDeliveryForCompletion(tx, {
+      : await finalizeActiveInputDelivery(tx, {
           runId: input.body.runId,
           chatThreadId: run.chatThreadId,
           deliveredDeliveryIds: new Set(
@@ -516,6 +523,15 @@ function completionResponse(
       ...(commit.transitionError !== undefined
         ? { error: commit.transitionError }
         : {}),
+      ...(commit.run.chatThreadId !== null
+        ? {
+            deliveryNotification: {
+              userId: commit.run.userId,
+              chatThreadId: commit.run.chatThreadId,
+              chatEventsAppended: commit.finalization.chatEventsAppended,
+            },
+          }
+        : {}),
       ...piCleanup,
     };
   } else if (
@@ -553,7 +569,7 @@ function completionResponse(
   };
 }
 
-function deletedRunCompletionResponse(run: RunRecord): CompletionResponse {
+function settledRunCompletionResponse(run: RunRecord): CompletionResponse {
   return {
     status: 200,
     body: {
@@ -570,6 +586,14 @@ const dispatchTerminalCompleteSideEffects$ = command(
     signal: AbortSignal,
   ): Promise<void> => {
     const db = set(writeDb$);
+    if (input.deliveryNotification?.chatEventsAppended) {
+      await publishChatThreadMessageCreatedSafely({
+        userId: input.deliveryNotification.userId,
+        orgId: input.orgId,
+        threadId: input.deliveryNotification.chatThreadId,
+      });
+      signal.throwIfAborted();
+    }
     const callbackStatus =
       input.status === "completed" ? "completed" : "failed";
     const chatCallbackId = await chatCallbackIdForRun(db, input.runId);
@@ -728,12 +752,16 @@ export const completeAgentRun$ = command(
     if (!initialRun) {
       return notFound("Agent run not found");
     }
+    if (initialRun.status === "timeout") {
+      return settledRunCompletionResponse(initialRun);
+    }
     const checkpointInput = checkpointInputForCompletion(input);
     let checkpointPreparation: PreparedAgentCheckpoint | null = null;
     if (checkpointInput) {
       const preparation = await set(
         prepareAgentCheckpointPersistence$,
         checkpointInput,
+        { source: "combined-completion" },
         signal,
       );
       if (!preparation.ok) {
@@ -741,20 +769,11 @@ export const completeAgentRun$ = command(
       }
       checkpointPreparation = preparation.prepared;
     }
-    const shouldPrepareLegacyCompletion =
-      !checkpointInput &&
-      (initialRun.status === "pending" ||
-        initialRun.status === "running" ||
-        initialRun.status === "timeout");
     let expectedChatThreadId = initialRun.chatThreadId;
     let commit: CompletionCommit;
     while (true) {
       const result = await db.transaction(async (tx) => {
         await lockAgentRunCheckpointLifecycle(tx, input.body.runId);
-        signal.throwIfAborted();
-        const legacyPrepared = shouldPrepareLegacyCompletion
-          ? await prepareCompletion(tx, input, initialRun.sessionId, signal)
-          : null;
         signal.throwIfAborted();
         return await completeAgentRunTransition(
           tx,
@@ -763,7 +782,6 @@ export const completeAgentRun$ = command(
             checkpointInput,
             checkpointPreparation,
             expectedChatThreadId,
-            legacyPrepared,
           },
           signal,
         );
@@ -774,7 +792,7 @@ export const completeAgentRun$ = command(
         continue;
       }
       if (result.kind === "not-found") {
-        return deletedRunCompletionResponse(initialRun);
+        return settledRunCompletionResponse(initialRun);
       }
       if (result.kind === "response") {
         return result.response;

--- a/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
@@ -8,8 +8,10 @@ import { and, eq, inArray, isNotNull, lt, lte, sql } from "drizzle-orm";
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
+import type { Tx } from "../../lib/db-types";
 import { writeDb$, type Db } from "../external/db";
 import {
+  publishCancelToRunnerGroup,
   publishChatThreadMessageCreatedSafely,
   publishThreadListChanged,
 } from "../external/realtime";
@@ -35,6 +37,12 @@ import {
   type ThreadlessRunCleanupResult,
 } from "./threadless-run-cleanup.service";
 import { cleanupExpiredPiApiFirstTurnData$ } from "./pi-api-first-turn-cleanup.service";
+import { lockAgentRunCheckpointLifecycle } from "./agent-run-checkpoint-lifecycle-lock.service";
+import { lockChatQueueThread } from "./chat-event-queue.service";
+import {
+  finalizeActiveInputDelivery,
+  type FinalizeActiveInputDeliveryResult,
+} from "./active-input-delivery.service";
 
 const L = logger("CronCleanupSandboxes");
 
@@ -74,8 +82,11 @@ type CleanupSandboxesScope =
 interface StaleRun {
   readonly id: string;
   readonly orgId: string;
+  readonly userId: string;
   readonly status: string;
   readonly sandboxId: string | null;
+  readonly runnerGroup: string | null;
+  readonly chatThreadId: string | null;
   readonly lastHeartbeatAt: Date | null;
   readonly createdAt: Date;
   readonly composeName: string | null;
@@ -92,7 +103,38 @@ interface MaintenanceTerminalSideEffectsInput {
   readonly orgId: string;
   readonly error: string;
   readonly queueMarkerNotification: QueueMarkerRevokeNotification | null;
+  readonly deliveryNotification?: {
+    readonly userId: string;
+    readonly chatThreadId: string;
+    readonly chatEventsAppended: boolean;
+  };
 }
+
+interface LockedTimeoutRun {
+  readonly status: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly sandboxId: string | null;
+  readonly runnerGroup: string | null;
+  readonly chatThreadId: string | null;
+  readonly lastHeartbeatAt: Date | null;
+  readonly createdAt: Date;
+}
+
+interface CommittedTimeout {
+  readonly previousStatus: "pending" | "running";
+  readonly orgId: string;
+  readonly userId: string;
+  readonly sandboxId: string | null;
+  readonly runnerGroup: string | null;
+  readonly chatThreadId: string | null;
+  readonly finalization: FinalizeActiveInputDeliveryResult;
+}
+
+type TimeoutTransactionResult =
+  | { readonly kind: "retry"; readonly chatThreadId: string | null }
+  | { readonly kind: "skipped" }
+  | { readonly kind: "committed"; readonly timeout: CommittedTimeout };
 
 function staleRunCutoff(run: StaleRun, cutoffs: CleanupCutoffs): Date {
   if (run.status === "pending") {
@@ -118,6 +160,28 @@ async function publishQueueMarkerNotificationSafely(
     threadId: notification.chatThreadId,
   });
   await publishThreadListChanged({ userId: notification.userId, orgId });
+}
+
+async function lockTimeoutRun(
+  tx: Tx,
+  runId: string,
+): Promise<LockedTimeoutRun | null> {
+  const [run] = await tx
+    .select({
+      status: agentRuns.status,
+      orgId: agentRuns.orgId,
+      userId: agentRuns.userId,
+      sandboxId: agentRuns.sandboxId,
+      runnerGroup: agentRuns.runnerGroup,
+      chatThreadId: agentRuns.chatThreadId,
+      lastHeartbeatAt: agentRuns.lastHeartbeatAt,
+      createdAt: agentRuns.createdAt,
+    })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .for("update", { of: agentRuns })
+    .limit(1);
+  return run ?? null;
 }
 
 const cleanupExportJobs$ = command(
@@ -238,12 +302,110 @@ const dispatchMaintenanceTerminalSideEffects$ = command(
         orgId: input.orgId,
         status: "failed",
         error: input.error,
+        ...(input.deliveryNotification
+          ? { deliveryNotification: input.deliveryNotification }
+          : {}),
       },
       signal,
     );
     signal.throwIfAborted();
   },
 );
+
+async function commitStaleRunTimeout(
+  db: Db,
+  run: StaleRun,
+  cutoff: Date,
+  timeoutReason: string,
+  signal: AbortSignal,
+): Promise<CommittedTimeout | undefined> {
+  let expectedChatThreadId = run.chatThreadId;
+  while (true) {
+    const result = await db.transaction(
+      async (tx): Promise<TimeoutTransactionResult> => {
+        await lockAgentRunCheckpointLifecycle(tx, run.id);
+        signal.throwIfAborted();
+        const threadLocked =
+          expectedChatThreadId === null
+            ? false
+            : await lockChatQueueThread(tx, expectedChatThreadId);
+        signal.throwIfAborted();
+        const lockedRun = await lockTimeoutRun(tx, run.id);
+        signal.throwIfAborted();
+        if (!lockedRun) {
+          return { kind: "skipped" };
+        }
+        if (lockedRun.chatThreadId !== expectedChatThreadId) {
+          return { kind: "retry", chatThreadId: lockedRun.chatThreadId };
+        }
+        if (expectedChatThreadId !== null && !threadLocked) {
+          throw new Error("Agent run retained a missing chat thread");
+        }
+        if (
+          lockedRun.status !== run.status ||
+          (lockedRun.status !== "pending" && lockedRun.status !== "running")
+        ) {
+          return { kind: "skipped" };
+        }
+        const referenceTime = lockedRun.lastHeartbeatAt ?? lockedRun.createdAt;
+        if (referenceTime >= cutoff) {
+          return { kind: "skipped" };
+        }
+
+        const finalization =
+          lockedRun.status === "running" && lockedRun.chatThreadId !== null
+            ? await finalizeActiveInputDelivery(tx, {
+                runId: run.id,
+                chatThreadId: lockedRun.chatThreadId,
+                deliveredDeliveryIds: new Set<string>(),
+              })
+            : { finalized: false, chatEventsAppended: false };
+        signal.throwIfAborted();
+
+        const [updatedRun] = await tx
+          .update(agentRuns)
+          .set({
+            status: "timeout",
+            completedAt: nowDate(),
+            error: timeoutReason,
+          })
+          .where(
+            and(
+              eq(agentRuns.id, run.id),
+              eq(agentRuns.status, lockedRun.status),
+            ),
+          )
+          .returning({ id: agentRuns.id });
+        signal.throwIfAborted();
+        if (!updatedRun) {
+          throw new Error("Locked stale run lost its timeout transition");
+        }
+
+        await tx.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, run.id));
+        signal.throwIfAborted();
+
+        return {
+          kind: "committed",
+          timeout: {
+            previousStatus: lockedRun.status,
+            orgId: lockedRun.orgId,
+            userId: lockedRun.userId,
+            sandboxId: lockedRun.sandboxId,
+            runnerGroup: lockedRun.runnerGroup,
+            chatThreadId: lockedRun.chatThreadId,
+            finalization,
+          },
+        };
+      },
+    );
+    signal.throwIfAborted();
+    if (result.kind === "retry") {
+      expectedChatThreadId = result.chatThreadId;
+      continue;
+    }
+    return result.kind === "committed" ? result.timeout : undefined;
+  }
+}
 
 const cleanupSingleRun$ = command(
   async (
@@ -258,51 +420,50 @@ const cleanupSingleRun$ = command(
         ? "Run timed out while pending (never started)"
         : "Run timed out (no heartbeat)";
     const cutoff = staleRunCutoff(run, cutoffs);
-
-    const updated = await db.transaction(async (tx) => {
-      const [updatedRun] = await tx
-        .update(agentRuns)
-        .set({
-          status: "timeout",
-          completedAt: nowDate(),
-          error: timeoutReason,
-        })
-        .where(
-          and(
-            eq(agentRuns.id, run.id),
-            eq(agentRuns.status, run.status),
-            lt(
-              sql`COALESCE(${agentRuns.lastHeartbeatAt}, ${agentRuns.createdAt})`,
-              sql.param(cutoff, agentRuns.createdAt),
-            ),
-          ),
-        )
-        .returning({ id: agentRuns.id });
-      signal.throwIfAborted();
-
-      if (!updatedRun) {
-        return undefined;
-      }
-
-      await tx.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, run.id));
-      signal.throwIfAborted();
-
-      return updatedRun;
-    });
+    const committed = await commitStaleRunTimeout(
+      db,
+      run,
+      cutoff,
+      timeoutReason,
+      signal,
+    );
     signal.throwIfAborted();
 
-    if (!updated) {
+    if (!committed) {
       L.debug("Run already transitioned, skipping timeout", { runId: run.id });
       return undefined;
+    }
+
+    if (committed.previousStatus === "running" && committed.runnerGroup) {
+      await tapError(
+        publishCancelToRunnerGroup(committed.runnerGroup, run.id, "hard"),
+        (error) => {
+          L.error("Failed to publish timeout cancel to runner group", {
+            runId: run.id,
+            runnerGroup: committed.runnerGroup,
+            error,
+          });
+        },
+      );
+      signal.throwIfAborted();
     }
 
     await set(
       dispatchMaintenanceTerminalSideEffects$,
       {
         runId: run.id,
-        orgId: run.orgId,
+        orgId: committed.orgId,
         error: timeoutReason,
         queueMarkerNotification: null,
+        ...(committed.chatThreadId !== null
+          ? {
+              deliveryNotification: {
+                userId: committed.userId,
+                chatThreadId: committed.chatThreadId,
+                chatEventsAppended: committed.finalization.chatEventsAppended,
+              },
+            }
+          : {}),
       },
       signal,
     );
@@ -313,7 +474,7 @@ const cleanupSingleRun$ = command(
     L.debug("Cleaned up expired run", {
       runId: run.id,
       status: run.status,
-      sandboxId: run.sandboxId,
+      sandboxId: committed.sandboxId,
       composeName: run.composeName,
       isDebug,
       referenceTime: referenceTime.toISOString(),
@@ -321,7 +482,7 @@ const cleanupSingleRun$ = command(
 
     return {
       runId: run.id,
-      sandboxId: run.sandboxId,
+      sandboxId: committed.sandboxId,
       status: "cleaned",
       reason: timeoutReason,
     };
@@ -529,8 +690,11 @@ export const cleanupSandboxes$ = command(
       .select({
         id: agentRuns.id,
         orgId: agentRuns.orgId,
+        userId: agentRuns.userId,
         status: agentRuns.status,
         sandboxId: agentRuns.sandboxId,
+        runnerGroup: agentRuns.runnerGroup,
+        chatThreadId: agentRuns.chatThreadId,
         lastHeartbeatAt: agentRuns.lastHeartbeatAt,
         createdAt: agentRuns.createdAt,
         composeName: agents.name,

--- a/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
@@ -16,7 +16,7 @@ import {
   publishThreadListChanged,
 } from "../external/realtime";
 import { deleteS3Objects } from "../external/s3";
-import { settle, tapError } from "../utils";
+import { settle, settleIncludingAbort, tapError } from "../utils";
 import {
   dispatchCompleteSideEffects$,
   drainStaleQueues$,
@@ -435,17 +435,17 @@ const cleanupSingleRun$ = command(
     }
 
     if (committed.previousStatus === "running" && committed.runnerGroup) {
-      await tapError(
+      const cancellation = await settleIncludingAbort(
         publishCancelToRunnerGroup(committed.runnerGroup, run.id, "hard"),
-        (error) => {
-          L.error("Failed to publish timeout cancel to runner group", {
-            runId: run.id,
-            runnerGroup: committed.runnerGroup,
-            error,
-          });
-        },
       );
       signal.throwIfAborted();
+      if (!cancellation.ok) {
+        L.error("Failed to publish timeout cancel to runner group", {
+          runId: run.id,
+          runnerGroup: committed.runnerGroup,
+          error: cancellation.error,
+        });
+      }
     }
 
     await set(

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
@@ -39,7 +39,7 @@ import {
   type CompleteSideEffectsInput,
   type DispatchCompleteSideEffectsInput,
 } from "./agent-webhook-complete.service";
-import { createAgentCheckpoint$ } from "./agent-webhook-checkpoints.service";
+import { createPiApiFirstTurnCheckpoint$ } from "./agent-webhook-checkpoints.service";
 import { resolveModelProviderRuntimeSecretForApi } from "./agent-webhook-firewall-auth.service";
 import {
   dispatchOptionalAgentEventConsumers$,
@@ -921,7 +921,7 @@ const persistCompleteTurnCheckpoint$ = command(
       signal,
     );
     const checkpoint = await set(
-      createAgentCheckpoint$,
+      createPiApiFirstTurnCheckpoint$,
       {
         auth: prepared.auth,
         body: {


### PR DESCRIPTION
## Summary

- serialize stale-run timeout with the checkpoint lifecycle, chat thread, run, and active-input delivery locks
- settle unconfirmed running chat input atomically with `timeout`, then publish one best-effort hard Runner cancellation after commit
- make late Guest and Runner completion a zero-mutation HTTP 200 acknowledgement once timeout owns the run
- reject standalone checkpoint persistence for unsettled runs while preserving combined completion, Pi API-first persistence, terminal recovery, and exact retries
- migrate affected integration fixtures to atomic checkpointed completion and document the activated timeout contract

## Compatibility

- checkpoint-less Runner fallback remains supported
- active Pi API-first checkpoint persistence remains an explicit internal path
- no schema, run status, request, response, or Runner protocol field is added

## Validation

- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts src/signals/routes/__tests__/chat-callbacks.bdd.test.ts --maxWorkers=1 --silent=passed-only` (284 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts --maxWorkers=1 --silent=passed-only` (131 passed)
- all 24 affected API test files passed with one worker; two unrelated shared-state/time-limit failures in the combined run passed on isolated rerun (824 tests covered)
- current-head self-review regression selection: four timeout/completion/cancellation tests passed
- `pnpm exec prettier --check ../docs/active-input-delivery.md`
- pre-commit hooks: Prettier, full-repository Knip, full-repository TypeScript checks, file-size validation, and commitlint

## Rollout status

The rollout gate in #30347 was rechecked after the outgoing Runner/Guest cohort drained and the API compatibility floor was confirmed. This PR is now ready for review. No merge is authorized by this submission or self-review.

Closes #30347

Parent: #30250

Delivery parent: #30246
