### PR TITLE
test(platform): stabilize chat shortcut navigation timing

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-history-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-history-navigation.test.tsx
@@ -2,6 +2,7 @@ import { chatEventRowsResponse } from "../../../signals/__tests__/test-helpers.t
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import { browserContract } from "@okouai/api-contracts/contracts/browser";
 import {
   chatEventsContract,
   chatThreadByIdContract,
@@ -12,7 +13,6 @@ import {
   type ChatThreadEvent,
   type ChatEvent,
 } from "@okouai/api-contracts/contracts/chat-threads";
-import { browserContract } from "@okouai/api-contracts/contracts/browser";
 import { CHAT_THREAD_VIRTUAL_ROW_HEIGHT } from "../../../signals/okou-page/sidebar-state.ts";
 import { pathname$ } from "../../../signals/route.ts";
 import { click, fill } from "../../../__tests__/page-helper.ts";
@@ -46,6 +46,23 @@ import {
 
 const SHARED_DATABASE_REALTIME_CHANNEL = "user-org:test-user-123:org_default";
 type RenameRequest = (threadId: string, title: string) => void;
+
+function mockNoBrowserSession(): void {
+  context.mocks.api(browserContract.get, ({ respond }) => {
+    return respond(404, {
+      error: {
+        code: "BROWSER_NOT_FOUND",
+        message: "Managed browser not found",
+      },
+    });
+  });
+}
+
+function mockNoThreadEvents(): void {
+  context.mocks.api(chatThreadEventsContract.rows, ({ query, respond }) => {
+    return respond(200, chatEventRowsResponse([], query));
+  });
+}
 
 describe("chat lifecycle", () => {
   it("renders new messages after a payload-less created event", async () => {
@@ -721,22 +738,16 @@ describe("chat lifecycle", () => {
 
   it("moves to the previous chat with a page shortcut from the composer", async () => {
     mockResizeObserver();
+    mockNoBrowserSession();
     mockKeyboardNavigationThreads();
+    mockNoThreadEvents();
 
     detachedSetupPage({
       context,
       path: "/chats/b0000000-0000-4000-a000-000000000708",
     });
 
-    const chatList = await screen.findByTestId("chat-list-column");
-    await waitFor(() => {
-      expect(
-        screen.getByText("Current thread launch note"),
-      ).toBeInTheDocument();
-      expect(
-        within(chatList).getByText("Previous keyboard thread"),
-      ).toBeInTheDocument();
-    });
+    await screen.findByPlaceholderText(PLACEHOLDER);
 
     const composer = chatComposerTextarea();
     composer.focus();
@@ -747,9 +758,9 @@ describe("chat lifecycle", () => {
     });
 
     await waitFor(() => {
-      expect(
-        screen.getByText("Previous thread launch note"),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("chat-thread-header-title")).toHaveTextContent(
+        "Previous keyboard thread",
+      );
     });
     expect(context.store.get(pathname$)).toBe(
       `/chats/${KEYBOARD_PREV_THREAD_ID}`,
@@ -758,18 +769,17 @@ describe("chat lifecycle", () => {
 
   it("keeps shifted slash editable before opening shortcut help outside the composer", async () => {
     mockResizeObserver();
+    mockNoBrowserSession();
     mockKeyboardNavigationThreads();
+    mockNoThreadEvents();
 
     detachedSetupPage({
       context,
       path: "/chats/b0000000-0000-4000-a000-000000000708",
     });
 
-    await waitFor(() => {
-      expect(
-        screen.getByText("Current thread launch note"),
-      ).toBeInTheDocument();
-    });
+    await screen.findByLabelText("Chat thread");
+    await screen.findByPlaceholderText(PLACEHOLDER);
 
     const composer = chatComposerTextarea();
     composer.focus();
@@ -798,15 +808,9 @@ describe("chat lifecycle", () => {
       callback(performance.now());
       return 1;
     });
+    mockNoBrowserSession();
     mockKeyboardNavigationThreads();
-    context.mocks.api(browserContract.get, ({ respond }) => {
-      return respond(404, {
-        error: { code: "BROWSER_NOT_FOUND", message: "Browser not found" },
-      });
-    });
-    context.mocks.api(chatThreadEventsContract.rows, ({ query, respond }) => {
-      return respond(200, chatEventRowsResponse([], query));
-    });
+    mockNoThreadEvents();
 
     detachedSetupPage({
       context,
@@ -849,6 +853,9 @@ describe("chat lifecycle", () => {
     });
 
     await waitFor(() => {
+      expect(screen.getByTestId("chat-thread-header-title")).toHaveTextContent(
+        "Next keyboard thread",
+      );
       expect(context.store.get(pathname$)).toBe(
         `/chats/${KEYBOARD_NEXT_THREAD_ID}`,
       );


### PR DESCRIPTION
## Summary

- Model the expected no-browser and no-thread-events states locally in the three chat shortcut stories, removing unrelated background requests without changing shared fixtures.
- Start previous navigation from the rendered composer and let the production shortcut handler await its thread-list signal.
- Assert previous and next destinations through the visible main-thread header while retaining pathname, shortcut-help, and exact sidebar-alignment coverage.

## Scope

This is a one-file integration-test stabilization. It does not change production code, shared test helpers, page setup, cleanup, test timeouts, APIs, or UX.

## Validation

- Five fresh sequential focused Vitest runs with one worker: all 15 target executions passed under the default timeout; slowest target was 3.221 seconds.
- Post-rebase focused Vitest run with one worker: 3/3 target tests passed in 2.84 seconds.
- Complete `chat-history-navigation.test.tsx`: 30/30 passed.
- `pnpm exec prettier --check apps/platform/src/views/okou-page/__tests__/chat-history-navigation.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- `git diff --check`
- Pre-commit hooks: Prettier, full-repository Knip, full-repository TypeScript checks, file-size validation, and commitlint.

Follow-up to #30479.

Closes #30509
