### PR TITLE
refactor(slack): point the install callback at the neutral path and drop the zero alias

### DIFF
--- a/turbo/apps/api/src/lib/slack-connect-blocks.ts
+++ b/turbo/apps/api/src/lib/slack-connect-blocks.ts
@@ -7,7 +7,6 @@ import type {
   SlackView,
 } from "../signals/external/slack-block-kit";
 import {
-  OFFICIAL_SLACK_LEGACY_COMMAND,
   OFFICIAL_SLACK_PRIMARY_COMMAND,
   officialSlackBotMention,
 } from "./slack-official-app";
@@ -164,7 +163,7 @@ function appHomeHelpBlocks(options: AppHomeViewOptions): SlackAnyBlock[] {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*Commands*\n\u2022 \`${OFFICIAL_SLACK_PRIMARY_COMMAND} connect\` - Connect to ${assistantName}\n\u2022 \`${OFFICIAL_SLACK_PRIMARY_COMMAND} disconnect\` - Disconnect from ${assistantName}\n\u2022 \`${OFFICIAL_SLACK_LEGACY_COMMAND}\` - Legacy alias`,
+        text: `*Commands*\n\u2022 \`${OFFICIAL_SLACK_PRIMARY_COMMAND} connect\` - Connect to ${assistantName}\n\u2022 \`${OFFICIAL_SLACK_PRIMARY_COMMAND} disconnect\` - Disconnect from ${assistantName}`,
       },
     },
     {

--- a/turbo/apps/api/src/lib/slack-official-app.ts
+++ b/turbo/apps/api/src/lib/slack-official-app.ts
@@ -3,7 +3,6 @@ import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 export const OFFICIAL_SLACK_PUBLIC_BRAND = "okou" satisfies PublicBrand;
 export const OFFICIAL_SLACK_APP_NAME = "Okou";
 export const OFFICIAL_SLACK_PRIMARY_COMMAND = "/okou";
-export const OFFICIAL_SLACK_LEGACY_COMMAND = "/zero";
 
 export function officialSlackBotMention(botUserId: string): string {
   return `<@${botUserId}>`;

--- a/turbo/apps/api/src/lib/slack-webhook-blocks.ts
+++ b/turbo/apps/api/src/lib/slack-webhook-blocks.ts
@@ -12,7 +12,6 @@ import type {
 import { env } from "./env";
 import {
   OFFICIAL_SLACK_APP_NAME,
-  OFFICIAL_SLACK_LEGACY_COMMAND,
   OFFICIAL_SLACK_PRIMARY_COMMAND,
   officialSlackBotMention,
 } from "./slack-official-app";
@@ -216,7 +215,7 @@ function buildAppHomeUsageBlocks(options: AppHomeOptions): SlackBlocks {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*Commands*\n\u2022 \`${OFFICIAL_SLACK_PRIMARY_COMMAND} connect\` - Connect to ${assistantName}\n\u2022 \`${OFFICIAL_SLACK_PRIMARY_COMMAND} disconnect\` - Disconnect from ${assistantName}\n\u2022 \`${OFFICIAL_SLACK_LEGACY_COMMAND}\` - Legacy alias`,
+        text: `*Commands*\n\u2022 \`${OFFICIAL_SLACK_PRIMARY_COMMAND} connect\` - Connect to ${assistantName}\n\u2022 \`${OFFICIAL_SLACK_PRIMARY_COMMAND} disconnect\` - Disconnect from ${assistantName}`,
       },
     },
     {
@@ -358,7 +357,7 @@ export function buildHelpMessage(
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*Commands*\n\u2022 \`${OFFICIAL_SLACK_PRIMARY_COMMAND} connect\` - Connect to ${assistantName}${switchLine}${modelLine}\n\u2022 \`${OFFICIAL_SLACK_PRIMARY_COMMAND} disconnect\` - Disconnect from ${assistantName}\n\u2022 \`${OFFICIAL_SLACK_LEGACY_COMMAND}\` - Legacy alias`,
+        text: `*Commands*\n\u2022 \`${OFFICIAL_SLACK_PRIMARY_COMMAND} connect\` - Connect to ${assistantName}${switchLine}${modelLine}\n\u2022 \`${OFFICIAL_SLACK_PRIMARY_COMMAND} disconnect\` - Disconnect from ${assistantName}`,
       },
     },
     {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -252,7 +252,6 @@ interface SlackCommandRequest {
   readonly teamId: string;
   readonly userId: string;
   readonly text: string;
-  readonly command?: "/okou" | "/zero";
   readonly channelId?: string;
   readonly triggerId?: string;
   readonly publicBrand?: PublicBrand;
@@ -287,7 +286,7 @@ function slackCommandRequestBody(args: SlackCommandRequest): string {
     channel_name: "general",
     user_id: args.userId,
     user_name: "bdduser",
-    command: args.command ?? "/okou",
+    command: "/okou",
     text: args.text,
     response_url: "https://hooks.slack.com/commands/bdd/response",
     trigger_id: args.triggerId ?? "trigger-bdd",

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -3530,7 +3530,6 @@ describe("INT-01: Slack app deep webhook flows", () => {
       expect(helpJson).toContain(`<@${botUserId}> Slack Bot Help`);
       expect(helpJson).toContain("/okou switch");
       expect(helpJson).toContain("/okou model");
-      expect(helpJson).toContain("/zero");
       expect(helpJson).toContain(`<@${botUserId}>`);
     }
 
@@ -3545,17 +3544,6 @@ describe("INT-01: Slack app deep webhook flows", () => {
     expect(vm0HostHelpJson).toContain(`<@${botUserId}> Slack Bot Help`);
     expect(vm0HostHelpJson).toContain("Connect to Zero");
     expect(vm0HostHelpJson).toContain(`<@${botUserId}>`);
-
-    const legacyHelp = await integrations.postSlackCommand({
-      teamId,
-      userId: slackUserId,
-      channelId: "C_BDD_CMD",
-      command: "/zero",
-      text: "help",
-    });
-    expect(JSON.stringify(legacyHelp)).toContain(
-      `<@${botUserId}> Slack Bot Help`,
-    );
 
     const alreadyConnected = await integrations.postSlackCommand({
       teamId,
@@ -3676,7 +3664,6 @@ describe("INT-01: Slack app deep webhook flows", () => {
     expect(helpJson).toContain("/okou connect");
     expect(helpJson).not.toContain("/okou switch");
     expect(helpJson).not.toContain("/okou model");
-    expect(helpJson).toContain("/zero");
   });
 
   it("prompts for login when switching agents without a Slack connection", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/slack-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/slack-oauth.test.ts
@@ -130,7 +130,7 @@ describe("Slack OAuth API routes", () => {
         "test-slack-client-id",
       );
       expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
-        `${WEB_ORIGIN}/api/zero/slack/oauth/callback`,
+        `${WEB_ORIGIN}/api/integrations/slack/oauth/callback`,
       );
       const scopes = redirectUrl.searchParams.get("scope")?.split(",") ?? [];
       expect(scopes).toContain("app_mentions:read");
@@ -252,7 +252,7 @@ describe("Slack OAuth API routes", () => {
       expect(response.status).toBe(307);
       const redirectUrl = new URL(response.headers.get("location")!);
       expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
-        `${WEB_ORIGIN}/api/zero/slack/oauth/callback`,
+        `${WEB_ORIGIN}/api/integrations/slack/oauth/callback`,
       );
     });
 
@@ -266,7 +266,7 @@ describe("Slack OAuth API routes", () => {
       const redirectUrl = new URL(response.headers.get("location")!);
       expect(redirectUrl.origin).toBe("https://slack.com");
       expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
-        `${WEB_ORIGIN}/api/zero/slack/oauth/callback`,
+        `${WEB_ORIGIN}/api/integrations/slack/oauth/callback`,
       );
     });
 
@@ -304,7 +304,7 @@ describe("Slack OAuth API routes", () => {
       const redirectUrl = new URL(response.headers.get("location")!);
       expect(redirectUrl.origin).toBe("https://slack.com");
       expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
-        `${WEB_ORIGIN}/api/zero/slack/oauth/callback`,
+        `${WEB_ORIGIN}/api/integrations/slack/oauth/callback`,
       );
     });
 
@@ -345,7 +345,7 @@ describe("Slack OAuth API routes", () => {
       expect(response.status).toBe(307);
       const redirectUrl = new URL(response.headers.get("location")!);
       expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
-        `${WEB_ORIGIN}/api/zero/slack/oauth/callback`,
+        `${WEB_ORIGIN}/api/integrations/slack/oauth/callback`,
       );
       expect(redirectUrl.searchParams.get("user_scope")).toBe("identity.basic");
       expect(redirectUrl.searchParams.get("team")).toBe(
@@ -398,7 +398,7 @@ describe("Slack OAuth API routes", () => {
       expect(response.status).toBe(307);
       const redirectUrl = new URL(response.headers.get("location")!);
       expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
-        `${WEB_ORIGIN}/api/zero/slack/oauth/callback`,
+        `${WEB_ORIGIN}/api/integrations/slack/oauth/callback`,
       );
     });
 
@@ -578,7 +578,7 @@ describe("Slack OAuth API routes", () => {
       });
       expect(context.mocks.slack.oauth.v2.access).toHaveBeenCalledWith(
         expect.objectContaining({
-          redirect_uri: `${WEB_ORIGIN}/api/zero/slack/oauth/callback`,
+          redirect_uri: `${WEB_ORIGIN}/api/integrations/slack/oauth/callback`,
         }),
       );
 
@@ -672,7 +672,7 @@ describe("Slack OAuth API routes", () => {
       expect(response.status).toBe(307);
       expect(context.mocks.slack.oauth.v2.access).toHaveBeenCalledWith(
         expect.objectContaining({
-          redirect_uri: `${WEB_ORIGIN}/api/zero/slack/oauth/callback`,
+          redirect_uri: `${WEB_ORIGIN}/api/integrations/slack/oauth/callback`,
         }),
       );
     });
@@ -742,7 +742,7 @@ describe("Slack OAuth API routes", () => {
       const authorizationUrl = new URL(start.headers.get("location")!);
       expect(authorizationUrl.origin).toBe("https://slack.com");
       expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
-        `${previewApiOrigin}/api/zero/slack/oauth/callback`,
+        `${previewApiOrigin}/api/integrations/slack/oauth/callback`,
       );
       const state = authorizationUrl.searchParams.get("state");
       if (!state) {
@@ -764,7 +764,7 @@ describe("Slack OAuth API routes", () => {
       expect(callbackLocation.pathname).toBe("/slack/failed");
       expect(context.mocks.slack.oauth.v2.access).toHaveBeenCalledWith(
         expect.objectContaining({
-          redirect_uri: `${previewApiOrigin}/api/zero/slack/oauth/callback`,
+          redirect_uri: `${previewApiOrigin}/api/integrations/slack/oauth/callback`,
         }),
       );
     });

--- a/turbo/apps/api/src/signals/routes/slack-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/slack-oauth.ts
@@ -127,13 +127,8 @@ function parseOAuthState(state: string | undefined): OAuthState | null {
   };
 }
 
-// Deliberately still the branded form after #28600 moved the callback contract
-// to `/api/integrations/slack/oauth/callback`. Slack rejects a token exchange
-// whose `redirect_uri` is not registered in the app configuration, and that
-// configuration has not been repointed, so this value moves only once it has.
-// Its `MIGRATED_BRANDED_PATHS` row keeps the path served in the meantime.
 function callbackRedirectUri(origin: string): string {
-  return `${origin}/api/zero/slack/oauth/callback`;
+  return `${origin}/api/integrations/slack/oauth/callback`;
 }
 
 function slackCredentials(): {


### PR DESCRIPTION
Closes #30549. Part of #26720.

## What changed

**`apps/api/src/signals/routes/slack-oauth.ts`** — `callbackRedirectUri` now returns `${origin}/api/integrations/slack/oauth/callback`. The five-line comment above it explained why the value was pinned to the branded form; the condition it described ("that configuration has not been repointed") no longer holds, so the comment is removed with it.

On 2026-08-31 the Okou Slack app (`A0AD6KS3D32`) console gained three Redirect URLs with nothing removed, so both the old and the new callback are on the allow list during the transition.

**`apps/api/src/lib/slack-official-app.ts`** — `OFFICIAL_SLACK_LEGACY_COMMAND = "/zero"` is deleted. Slack's Slash Commands list only ever contained `/okou`; `/zero` was never registered, so the constant only produced help text advertising a command that does not exist.

Its three render sites lose the `` `/zero` - Legacy alias `` bullet:

- `slack-webhook-blocks.ts:219` — app home usage blocks
- `slack-webhook-blocks.ts:361` — bot help message
- `slack-connect-blocks.ts:167` — connect app home help blocks

**`apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts`** — the two `expect(helpJson).toContain("/zero")` assertions on the rendered Slack help are removed, along with the `legacyHelp` request that posted a `command: "/zero"` slash-command payload. Slack only ever registered `/okou`, so that payload is not a shape Slack can deliver. `helpers/api-bdd-integrations.ts` loses the now-callerless `command` option and always sends `/okou`.

**`apps/api/src/signals/routes/__tests__/slack-oauth.test.ts`** — the ten assertions that pin the emitted `redirect_uri` (six on the authorize URL, four on the `oauth.v2.access` token exchange, including the preview-origin case) move to the neutral path. Assertions that *request* `/api/zero/slack/oauth/callback` are unchanged, because that path must keep serving.

## Not changed

- The Slack `MIGRATED_BRANDED_PATHS` row and the five `LEGACY_ZERO_PATHS` Slack entries. `/api/zero/slack/oauth/callback` keeps answering until the old redirect URI drains from in-flight OAuth flows; those rows retire on their own traffic evidence in a later issue.
- `app-oauth-callback.ts` and the built-in `slack` connector callback. That is a separate OAuth flow tracked by #28381 and dispatched separately.
- `parseTeamsBotCommand` in `teams-dispatch.service.ts:261`. Slack has no equivalent `zero`/`okou` command-prefix branch — `handleSlackCommands$` reads the slash-command payload text directly, so there was nothing to drop on the Slack side. The Teams branch belongs to a different integration and is out of scope here.

## Deploy note

`callbackRedirectUri` builds on `getOAuthWebOrigin`, which resolves to `OKOU_WEB_URL`. The console entry added for the neutral path is `https://api.okou.ai/api/integrations/slack/oauth/callback`. If production `OKOU_WEB_URL` is still `https://www.vm0.ai`, the emitted `redirect_uri` will be `https://www.vm0.ai/api/integrations/slack/oauth/callback`, which is not on the allow list, and Slack will hard-reject the token exchange. Adding that one entry to the console is non-destructive and removes the risk.

## Verify after deploy

A fresh Slack install must complete: the authorize URL carries `redirect_uri=.../api/integrations/slack/oauth/callback` and the token exchange succeeds. In Axiom, `/api/integrations/slack/oauth/callback` should start receiving callbacks and `/api/zero/slack/oauth/callback` should stop receiving new ones.
