### PR TITLE
perf(api): align chat search ordering with index

### DIFF
--- a/turbo/apps/api/src/signals/services/chat-search.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-search.service.ts
@@ -116,7 +116,9 @@ async function chatSearchIndexedMatches(
           : undefined,
       ),
     )
-    .orderBy(desc(chatEventSearchMessages.createdAt))
+    // Match the existing user/org/created_at index ordering exactly so
+    // PostgreSQL can scan it directly when finding the newest matches.
+    .orderBy(sql`${desc(chatEventSearchMessages.createdAt)} NULLS LAST`)
     .limit(args.limit)
     .as("chat_search_indexed_matches");
 


### PR DESCRIPTION
## Summary

- make the durable chat-search Top-N subquery order by `created_at DESC NULLS LAST`
- align the query order with the existing user/org and agent-scoped `created_at` indexes
- keep the schema and search result semantics unchanged because `created_at` is already non-null

## Diagnostic evidence

On the diagnostic database branch, the explicit null ordering changed the broad-scope search from a bitmap plan touching about 96.7k buffers to an ordered existing-index scan touching about 5.2k buffers while returning the same newest 21 matches.

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/chat-search.service.ts`
- `pnpm -F api lint`
- `pnpm knip`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-search-reader.test.ts` (2 passed)
