### PR TITLE
perf(vsock-proto): encode storage results directly

### DIFF
--- a/crates/vsock-proto/src/payloads/exec_operation.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation.rs
@@ -18,6 +18,7 @@ pub use output::{
     DecodedExecOutput, ExecOutputStream, decode_exec_output, encode_exec_output,
     encode_exec_output_frame_into,
 };
+pub(crate) use result::encode_exec_result_frame_into_with_type;
 pub use result::{
     DecodedExecResult, ExecCapturedOutput, decode_exec_result, encode_exec_result,
     encode_exec_result_frame_into,

--- a/crates/vsock-proto/src/payloads/exec_operation/result.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/result.rs
@@ -169,9 +169,29 @@ pub fn encode_exec_result_frame_into(
     diagnostic: &str,
 ) -> Result<(), ProtocolError> {
     frame.clear();
+    encode_exec_result_frame_into_with_type::<MSG_EXEC_RESULT>(
+        frame,
+        seq,
+        termination,
+        duration_ms,
+        stdout,
+        stderr,
+        diagnostic,
+    )
+}
+
+pub(crate) fn encode_exec_result_frame_into_with_type<const MSG_TYPE: u8>(
+    frame: &mut Vec<u8>,
+    seq: u32,
+    termination: ExecTermination,
+    duration_ms: u32,
+    stdout: ExecCapturedOutput<'_>,
+    stderr: ExecCapturedOutput<'_>,
+    diagnostic: &str,
+) -> Result<(), ProtocolError> {
     let (diagnostic_len, payload_len) =
         validate_exec_result_payload(termination, stdout, stderr, diagnostic)?;
-    encode_into(frame, MSG_EXEC_RESULT, seq, payload_len, |frame| {
+    encode_into(frame, MSG_TYPE, seq, payload_len, |frame| {
         append_exec_result_payload(
             frame,
             termination,

--- a/crates/vsock-proto/src/payloads/guest_storage_manifest.rs
+++ b/crates/vsock-proto/src/payloads/guest_storage_manifest.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use crate::ProtocolError;
 use crate::frame::encode_into;
+use crate::payloads::exec_operation::encode_exec_result_frame_into_with_type;
 use crate::read::{
     checked_payload_len_add, ensure_payload_fits_message, ensure_u16_len, ensure_u32_len,
     expect_consumed, read_slice, read_str, read_u16, read_u32,
@@ -177,6 +178,16 @@ pub fn encode_guest_storage_manifest_result(
 }
 
 /// Encode a full fixed guest storage-manifest terminal result frame.
+///
+/// # Errors
+///
+/// Returns [`ProtocolError`] if stdout or stderr was discarded or exceeds
+/// [`GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES`] bytes; if `diagnostic` cannot
+/// fit its wire length field; or if the encoded payload exceeds the maximum
+/// message size.
+///
+/// Validation runs before the shared frame encoder clears `frame`, so a
+/// validation error leaves the destination unchanged.
 pub fn encode_guest_storage_manifest_result_frame_into(
     frame: &mut Vec<u8>,
     seq: u32,
@@ -186,14 +197,16 @@ pub fn encode_guest_storage_manifest_result_frame_into(
     stderr: ExecCapturedOutput<'_>,
     diagnostic: &str,
 ) -> Result<(), ProtocolError> {
-    let payload =
-        encode_guest_storage_manifest_result(termination, duration_ms, stdout, stderr, diagnostic)?;
-    encode_into(
+    validate_result_output(stdout, "stdout")?;
+    validate_result_output(stderr, "stderr")?;
+    encode_exec_result_frame_into_with_type::<MSG_GUEST_STORAGE_MANIFEST_RESULT>(
         frame,
-        MSG_GUEST_STORAGE_MANIFEST_RESULT,
         seq,
-        payload.len(),
-        |frame| frame.extend_from_slice(&payload),
+        termination,
+        duration_ms,
+        stdout,
+        stderr,
+        diagnostic,
     )
 }
 

--- a/crates/vsock-proto/tests/guest_storage_manifest_properties.rs
+++ b/crates/vsock-proto/tests/guest_storage_manifest_properties.rs
@@ -544,6 +544,19 @@ fn result_enforces_capture_contract_for_each_stream() {
         let decoded = decode_guest_storage_manifest_result(&payload).unwrap();
         assert_eq!(decoded.stdout, stdout);
         assert_eq!(decoded.stderr, stderr);
+        let expected_frame = encode(MSG_GUEST_STORAGE_MANIFEST_RESULT, 42, &payload).unwrap();
+        let mut frame = b"stale frame bytes".to_vec();
+        encode_guest_storage_manifest_result_frame_into(
+            &mut frame,
+            42,
+            ExecTermination::Exited { exit_code: 7 },
+            u32::MAX,
+            stdout,
+            stderr,
+            "boundary",
+        )
+        .unwrap();
+        assert_eq!(frame, expected_frame);
 
         let oversized_output = vec![0xA5; GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES + 1];
         let selected = ExecCapturedOutput::Captured {
@@ -565,6 +578,24 @@ fn result_enforces_capture_contract_for_each_stream() {
                 if field == stream.name()
                     && size == GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES + 1
         ));
+        let mut frame = b"stale frame bytes".to_vec();
+        let frame_error = encode_guest_storage_manifest_result_frame_into(
+            &mut frame,
+            42,
+            ExecTermination::WaitFailed,
+            0,
+            stdout,
+            stderr,
+            "",
+        )
+        .unwrap_err();
+        assert!(matches!(
+            frame_error,
+            ProtocolError::PayloadTooLarge(field, size)
+                if field == stream.name()
+                    && size == GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES + 1
+        ));
+        assert_eq!(frame, b"stale frame bytes");
         let generic_payload =
             encode_exec_result(ExecTermination::WaitFailed, 0, stdout, stderr, "").unwrap();
         let decode_error = decode_guest_storage_manifest_result(&generic_payload).unwrap_err();
@@ -582,6 +613,22 @@ fn result_enforces_capture_contract_for_each_stream() {
                 "guest_storage_manifest_result output must be captured"
             ))
         ));
+        let mut frame = b"stale frame bytes".to_vec();
+        assert!(matches!(
+            encode_guest_storage_manifest_result_frame_into(
+                &mut frame,
+                42,
+                ExecTermination::Cancelled,
+                0,
+                stdout,
+                stderr,
+                "",
+            ),
+            Err(ProtocolError::InvalidPayload(
+                "guest_storage_manifest_result output must be captured"
+            ))
+        ));
+        assert_eq!(frame, b"stale frame bytes");
         let generic_payload =
             encode_exec_result(ExecTermination::Cancelled, 0, stdout, stderr, "").unwrap();
         assert!(matches!(
@@ -591,4 +638,57 @@ fn result_enforces_capture_contract_for_each_stream() {
             ))
         ));
     }
+}
+
+#[test]
+fn result_frame_enforces_diagnostic_boundary() {
+    let stdout = ExecCapturedOutput::Captured {
+        bytes: b"stdout",
+        truncated: true,
+    };
+    let stderr = ExecCapturedOutput::Captured {
+        bytes: b"stderr",
+        truncated: false,
+    };
+    let max_diagnostic = "x".repeat(u16::MAX as usize);
+    let payload = encode_guest_storage_manifest_result(
+        ExecTermination::TimedOut,
+        u32::MAX,
+        stdout,
+        stderr,
+        &max_diagnostic,
+    )
+    .unwrap();
+    let expected_frame = encode(MSG_GUEST_STORAGE_MANIFEST_RESULT, 42, &payload).unwrap();
+    let mut frame = b"stale frame bytes".to_vec();
+    encode_guest_storage_manifest_result_frame_into(
+        &mut frame,
+        42,
+        ExecTermination::TimedOut,
+        u32::MAX,
+        stdout,
+        stderr,
+        &max_diagnostic,
+    )
+    .unwrap();
+    assert_eq!(frame, expected_frame);
+
+    let oversized_diagnostic = format!("{max_diagnostic}x");
+    let mut frame = b"stale frame bytes".to_vec();
+    let error = encode_guest_storage_manifest_result_frame_into(
+        &mut frame,
+        42,
+        ExecTermination::TimedOut,
+        u32::MAX,
+        stdout,
+        stderr,
+        &oversized_diagnostic,
+    )
+    .unwrap_err();
+    assert!(matches!(
+        error,
+        ProtocolError::PayloadTooLarge("diagnostic", size)
+            if size == oversized_diagnostic.len()
+    ));
+    assert_eq!(frame, b"stale frame bytes");
 }


### PR DESCRIPTION
## Summary

- reuse the shared exec-result validator and appender through a crate-private, message-type-specific direct frame helper
- encode guest storage-manifest results into the final frame without an intermediate payload allocation or full payload copy
- preserve the owned payload API, wire bytes, and destination-frame behavior on validation errors
- cover stream and diagnostic boundaries through the public storage frame encoder

## Scope

- no protocol message type, payload schema, public function signature, or validation limit changes
- no changes to guest writer-lock ordering, cancellation, or operation completion

## Validation

- `cargo fmt --all -- --check`
- `cargo xtask check-rust-path-attributes`
- `cargo clippy --all-targets --all-features`
- `cargo clippy -p vsock-guest --release --no-default-features --all-targets`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p vsock-proto`
- `cargo test -p vsock-guest --all-features`

Closes #30538
