### PR TITLE
refactor(connectors): enable the direct okou oauth callback for the slack connector

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts
@@ -356,8 +356,8 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
       expect(response.status).toBe(200);
       const authorizationUrl = await authorizationUrlFromResponse(response);
       expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
-        connectorSlug === "slack"
-          ? `${WEB_ORIGIN}/api/connectors/slack/callback`
+        connectorSlug === "github"
+          ? "https://app.vm0.ai/connectors/github/callback"
           : `https://app.${publicBrand === "okou" ? "okou" : "vm0"}.ai/connectors/google-maps/callback`,
       );
       const state = authorizationUrl.searchParams.get("state") ?? "";
@@ -387,9 +387,9 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
     expect(okou.location.origin).toBe("https://app.okou.ai");
     expect(okou.location.pathname).toBe("/connector/error");
 
-    const legacyCallback = await callbackLocation("okou", "slack");
-    expect(legacyCallback.state).toMatch(/^okou\.[0-9a-f]{64}$/u);
-    expect(legacyCallback.location.origin).toBe("https://app.okou.ai");
+    const notDirectReady = await callbackLocation("okou", "github");
+    expect(notDirectReady.state).toMatch(/^okou\.[0-9a-f]{64}$/u);
+    expect(notDirectReady.location.origin).toBe("https://app.okou.ai");
 
     const vm0 = await callbackLocation("vm0");
     expect(vm0.state).toMatch(/^[0-9a-f]{64}$/u);
@@ -1039,7 +1039,7 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
     await rejectProviderAuthorization(authorizationUrl);
   });
 
-  it("keeps denylisted callbacks on the legacy path", async () => {
+  it("uses the direct Okou App callback for Slack", async () => {
     mockEnv("APP_URL", "https://app.vm0.ai");
     mockAuthenticatedSession();
 
@@ -1052,9 +1052,28 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
     expect(response.status).toBe(200);
     const authorizationUrl = await authorizationUrlFromResponse(response);
     expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
-      `${WEB_ORIGIN}/api/connectors/slack/callback`,
+      "https://app.okou.ai/connectors/slack/callback",
     );
     expectOkouOauthState(authorizationUrl);
+    await rejectProviderAuthorization(authorizationUrl);
+  });
+
+  it("keeps the VM0 App callback for Slack", async () => {
+    mockEnv("APP_URL", "https://app.vm0.ai");
+    mockAuthenticatedSession();
+
+    const response = await requestOauthStart("slack", {
+      headers: authHeaders(),
+      origin: API_ORIGIN,
+      callbackTarget: "app",
+    });
+
+    expect(response.status).toBe(200);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+      "https://app.vm0.ai/connectors/slack/callback",
+    );
+    expectOauthState(authorizationUrl);
     await rejectProviderAuthorization(authorizationUrl);
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -3234,6 +3234,7 @@ describe("connectors page", () => {
     ["outlook-mail", "Outlook Mail"],
     ["sentry", "Sentry"],
     ["server-authored-oauth", "Server-authored OAuth"],
+    ["slack", "Slack"],
     ["strava", "Strava"],
     ["todoist", "Todoist"],
     ["vercel", "Vercel"],
@@ -3283,49 +3284,6 @@ describe("connectors page", () => {
       });
     },
   );
-
-  it("keeps denylisted OAuth connectors on their legacy callback", async () => {
-    mockConnectors([]);
-    mockPublicConnectorStatus([
-      publicStatusItem({
-        connectorSlug: "slack",
-        label: "Slack",
-        authMethods: [
-          {
-            id: "oauth",
-            label: "OAuth",
-            description: null,
-            grantKind: "auth-code",
-            manualFields: [],
-            startOptions: [],
-          },
-        ],
-        singleAuthCodeAuthMethodId: "oauth",
-      }),
-    ]);
-    const authWindow = createMockAuthWindow();
-    context.mocks.browser.open(authWindow);
-    context.mocks.api(
-      connectorOauthStartContract.start,
-      ({ body, params, respond }) => {
-        expect(params.connectorSlug).toBe("slack");
-        expect(body.callbackTarget).toBeUndefined();
-        return respond(200, {
-          authorizationUrl: "https://oauth.test/slack/authorize",
-        });
-      },
-    );
-
-    detachedSetupPage({ context, path: "/connectors" });
-
-    click(await screen.findByLabelText("Connect Slack"));
-
-    await waitFor(() => {
-      expect(authWindow.location.href).toBe(
-        "https://oauth.test/slack/authorize",
-      );
-    });
-  });
 
   it("routes a feature-on OpenID account addition from catalog metadata", async () => {
     const connectorSlug = "server-authored-steam";

--- a/turbo/packages/connectors/src/__tests__/app-oauth-callback.test.ts
+++ b/turbo/packages/connectors/src/__tests__/app-oauth-callback.test.ts
@@ -25,6 +25,7 @@ const DIRECT_OKOU_READY_CONNECTORS = [
   "notion",
   "outlook-calendar",
   "outlook-mail",
+  "slack",
   "tiktok-ads",
   "youtube",
 ] as const;
@@ -56,7 +57,7 @@ describe("direct Okou OAuth callback readiness", () => {
     },
   );
 
-  it.each(["github", "slack", "test-oauth"])(
+  it.each(["github", "test-oauth"])(
     "keeps %s on its existing callback",
     (connectorSlug) => {
       expect(isConnectorDirectOkouOauthCallbackReady(connectorSlug)).toBe(

--- a/turbo/packages/connectors/src/app-oauth-callback.ts
+++ b/turbo/packages/connectors/src/app-oauth-callback.ts
@@ -1,8 +1,11 @@
-// Keep a connector here until its OAuth app accepts the App callback URL.
 export const CONNECTOR_APP_OAUTH_CALLBACK_METADATA_STORAGE_KEY =
   "vm0.connector.appOauthCallbackMetadata";
 
-const LEGACY_CALLBACK_CONNECTOR_SLUGS: ReadonlySet<string> = new Set(["slack"]);
+// Keep a connector here until its OAuth app accepts the App callback URL.
+// Intentionally empty: every connector now has the App callback registered with
+// its provider. A connector added before its provider console is updated must be
+// listed here, otherwise it emits a redirect_uri the provider rejects.
+const LEGACY_CALLBACK_CONNECTOR_SLUGS: ReadonlySet<string> = new Set<string>();
 
 // Provider allowlists roll out independently of the API. Until #28381 confirms
 // every provider is ready, unlisted connectors must keep their VM0 App callback.
@@ -29,6 +32,7 @@ const DIRECT_OKOU_OAUTH_CALLBACK_READY_CONNECTOR_SLUGS: ReadonlySet<string> =
     "notion",
     "outlook-calendar",
     "outlook-mail",
+    "slack",
     "tiktok-ads",
     "youtube",
   ]);


### PR DESCRIPTION
Closes #30550. Part of #28381.

Removes the connector-level legacy App callback exception so the built-in `slack` connector uses the direct Okou App OAuth callback, which is the remaining-work item the EPIC lists for itself.

## Change

`turbo/packages/connectors/src/app-oauth-callback.ts`:

- `"slack"` removed from `LEGACY_CALLBACK_CONNECTOR_SLUGS`.
- `"slack"` added to `DIRECT_OKOU_OAUTH_CALLBACK_READY_CONNECTOR_SLUGS`, in the existing alphabetical position between `outlook-mail` and `tiktok-ads`.

### Empty set kept, not collapsed to `return true`

The issue asked for an explicit decision. `LEGACY_CALLBACK_CONNECTOR_SLUGS` stays as an empty set with an expanded comment stating that it is intentionally empty and what it is for.

- The set is a live rollout kill-switch, not a leftover abstraction. New OAuth connectors are added regularly, and each one emits the App callback by default from the moment it lands. A connector whose provider console has not been updated yet must be listed here or its `redirect_uri` is rejected by the provider. Deleting the set would delete the only mechanism for that, and the next connector in that position would have to reintroduce it.
- `return true` would leave a predicate that ignores its `connectorSlug` parameter. Making that honest means deleting `isConnectorAppOauthCallbackEnabled` and its four call sites in `apps/api/src/signals/routes/connector-oauth-origin.ts`, `apps/platform/src/signals/okou-page/settings/connectors.ts`, and `apps/platform/src/views/okou-page/artifact-actions.tsx` — an unrelated frontend refactor inside a provider cutover PR.

The pre-existing comment was detached from the set (it sat above the storage-key export), so it is moved onto the declaration it documents.

## Provider allowlist evidence

Verified in the Okou Slack app console (`A0AD6KS3D32`) on 2026-08-31. Three entries added, none removed; five redirect URLs now registered:

```
https://www.vm0.ai/api/connectors/slack/callback            connector legacy web form (retained)
https://www.vm0.ai/api/zero/slack/oauth/callback            first-party install, legacy (retained)
https://api.okou.ai/api/integrations/slack/oauth/callback   first-party install, new (added)
https://app.okou.ai/connectors/slack/callback               connector App callback, okou brand (added)
https://app.vm0.ai/connectors/slack/callback                connector App callback, vm0 brand (added)
```

Both brands are registered deliberately. `getConnectorOAuthCallbackUrlForMethod` resolves the App URL through `appUrlForPublicBrand(env("APP_URL"), brand)` and production `APP_URL` is `https://app.vm0.ai`, so an `okou`-brand flow emits `app.okou.ai` and a `vm0`-brand flow emits `app.vm0.ai`. Registering only one would make the other a hard rejection by Slack at token exchange, not a soft fallback. The old URLs are retained, so this change is safe in both rollout directions.

## Tests

Three existing suites asserted the old denylist behavior and are updated to the new behavior rather than left as tombstones:

- `packages/connectors/src/__tests__/app-oauth-callback.test.ts` — `slack` moves from the "keeps its existing callback" list into `DIRECT_OKOU_READY_CONNECTORS`.
- `apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts` — `keeps denylisted callbacks on the legacy path` becomes `uses the direct Okou App callback for Slack` (okou origin → `https://app.okou.ai/connectors/slack/callback`), and a companion `keeps the VM0 App callback for Slack` covers the vm0 origin → `https://app.vm0.ai/connectors/slack/callback`. That pair is the both-brands guarantee the issue asks for.
- The same file's `uses persisted brand context for App callback redirects` used `slack` for its non-direct sub-case. With the denylist empty no connector reaches that branch, so it now uses `github`, which is still a non-direct-ready connector, and asserts an okou-brand start still lands `https://app.vm0.ai/connectors/github/callback` while state and the error redirect stay okou-branded. This keeps coverage of the readiness false-path under the okou brand, which nothing else covered.
- `apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx` — `slack` joins the `starts %s OAuth with the app callback` table, and the now-unreachable `keeps denylisted OAuth connectors on their legacy callback` test is removed.

Verified locally: `@okouai/connectors` (1081 tests), `connectors-oauth-start.test.ts` (39), `connectors.bdd.test.ts` (76), `connectors-page.test.tsx` (120), plus `pnpm format`, `pnpm check-types`, and lint on the three affected workspaces.

## Out of scope

`slack-oauth.ts`, `MIGRATED_BRANDED_PATHS`, and `LEGACY_ZERO_PATHS` are untouched. Those belong to the first-party Slack installation flow tracked in #30549, which #28381 line 137 explicitly warns against conflating with the built-in connector callback matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
