### PR TITLE
fix(e2e): report the nested runner credential failure cause

### DIFF
--- a/e2e/playwright/lib/error-report.test.ts
+++ b/e2e/playwright/lib/error-report.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { inspect } from "node:util";
+
+import { expect } from "@playwright/test";
+
+import { formatErrorReport } from "./error-report";
+
+function matcherFailure(): unknown {
+  try {
+    expect("received-value").toBe("expected-value");
+  } catch (error: unknown) {
+    return error;
+  }
+  throw new Error("Expected the matcher to fail");
+}
+
+function runnerCredentialFailure(): AggregateError {
+  const provisioningFailure = new Error(
+    "Failed to provision runner E2E credential for runner-real-claude@vm0-e2e.ai (e2e-api-credentials-runner-real-claude.json)",
+    { cause: matcherFailure() },
+  );
+  return new AggregateError([provisioningFailure], provisioningFailure.message);
+}
+
+test("runner credential failures report the nested matcher cause", async (context) => {
+  const failure = runnerCredentialFailure();
+
+  await context.test("the default inspect depth erases the cause", () => {
+    const truncated = inspect(failure, { depth: 2 });
+    assert.match(truncated, /\[cause\]: \[ExpectError\]/u);
+    assert.doesNotMatch(truncated, /expected-value/u);
+  });
+
+  await context.test("the report keeps the whole cause chain", () => {
+    const report = formatErrorReport(failure);
+    assert.match(report, /Failed to provision runner E2E credential/u);
+    assert.match(report, /expect\(received\)\.toBe\(expected\)/u);
+    assert.match(report, /expected-value/u);
+    assert.match(report, /received-value/u);
+  });
+});

--- a/e2e/playwright/lib/error-report.ts
+++ b/e2e/playwright/lib/error-report.ts
@@ -1,0 +1,13 @@
+import { inspect } from "node:util";
+
+/**
+ * `console.error` renders anything nested deeper than `util.inspect`'s default
+ * depth of 2 as a bare `[ClassName]`. A runner credential failure nests the
+ * real cause three levels below the top-level error
+ * (`AggregateError` -> `[errors]` -> `Error` -> `[cause]`), so the Playwright
+ * matcher failure that actually stopped the job reaches CI logs as
+ * `[ExpectError]` with no message, locator, timeout, or call log.
+ */
+export function formatErrorReport(error: unknown): string {
+  return inspect(error, { depth: null });
+}

--- a/e2e/playwright/runner-token.ts
+++ b/e2e/playwright/runner-token.ts
@@ -12,6 +12,7 @@ import {
 } from "./lib/auth";
 import { issueCliToken } from "./lib/cli-token";
 import { runnerTestAccounts } from "./lib/clerk-api";
+import { formatErrorReport } from "./lib/error-report";
 import {
   ensureRunnerOrganizationReady,
   startVideoOnboardingCheckout,
@@ -268,6 +269,6 @@ function requiredEnvironmentVariable(name: string): string {
 }
 
 void main().catch((error: unknown) => {
-  console.error(error);
+  console.error(formatErrorReport(error));
   process.exitCode = 1;
 });


### PR DESCRIPTION
## Problem

`cli-e2e-03-runner-prepare` fails intermittently while provisioning the four runner E2E credentials, and the log never says why.

`runner-token.ts` wraps a failed target as `AggregateError` → `[errors]` → `Error` → `[cause]`, which puts the real Playwright matcher failure three levels below the top-level error. `console.error` uses `util.inspect`'s default depth of 2, so everything at that level collapses to a bare class name:

```
AggregateError: Failed to provision runner E2E credential for
pr-30436+clerk_test+33378823204-1+runner-real-claude@vm0-e2e.ai
(e2e-api-credentials-runner-real-claude.json)
    at main (e2e/playwright/runner-token.ts:126:15) {
  [errors]: [
    Error: Failed to provision runner E2E credential for ... {
      [cause]: [ExpectError]
    }
  ]
}
```

No message, locator, timeout, call log, or aria snapshot survives, so the failing assertion has to be inferred from wall-clock timing. The job also uploads no page diagnostics for these failures, because `captureStripeCheckoutFailure` only runs around `fillStripeCheckout`.

## Change

Render the whole cause chain with `util.inspect(error, { depth: null })` through a new `lib/error-report.ts` helper, covered by `lib/error-report.test.ts` in the existing `pnpm test` harness.

Diagnostics only. Every runner E2E credential is still genuinely provisioned: no account is skipped or stubbed, no assertion is weakened, and no timeout, retry, sleep, or swallowed rejection is added.

## Evidence

Reproduced against a real Playwright locator timeout wrapped exactly as `main()` wraps it.

Before:

```
[cause]: [ExpectError]
```

After:

```
[cause]: ExpectError: expect(locator).toBeVisible() failed

Expected: visible
Timeout: 2000ms
Error: element(s) not found

Call log:
  - Expect "to.be.visible" with timeout 2000ms

  matcherResult: {
    ...
    ariaSnapshot: '- heading "Some other page" [level=1]'
  }
```

The `ariaSnapshot` is what the next occurrence needs: it shows what the app actually rendered instead of the onboarding heading, which distinguishes a redirect away from `/onboarding` from a page that never finished bootstrapping.

## Triggering run

- Turbo run https://github.com/vm0-ai/vm0/actions/runs/33378823204 (`merge_group`, `gh-readonly-queue/main/pr-30436-…`, SHA `b431a2057fb648a3d0855a0fdcc45a87b4302933`)
- Failing job https://github.com/vm0-ai/vm0/actions/runs/33378823204/job/99446960444, step `cd e2e && pnpm exec tsx playwright/runner-token.ts /tmp`

## Cross-PR recurrence

The same job and the same `[ExpectError]` shape failed six times on 2026-08-31 across two unrelated branches and different base commits:

| Run | Branch | Failing account | Sign-in → throw |
| --- | --- | --- | --- |
| 33378823204 | `gh-readonly-queue/main/pr-30436-…` | `runner-real-claude` | 63.6 s |
| 33377931325 | `feat/shared-worker-indicators` (#30339) | `runner-real-codex` | 61.1 s |
| 33376648477 | `feat/shared-worker-indicators` (#30339) | `runner-real-codex` | 61.1 s |
| 33375899756 | `feat/shared-worker-indicators` (#30339) | `runner-real-codex` | 61.3 s |
| 33373939095 | `feat/shared-worker-indicators` (#30339) | `runner-real-codex` | 61.0 s |
| 33373329895 | `feat/shared-worker-indicators` (#30339) | `runner-real-codex` | 60.6 s |

In all six the interval between `[e2e] Clerk testing helper completed` and the thrown `AggregateError` is 60-64 s, and no Stripe Checkout diagnostics artifact was written. That places the failure on `openOnboarding`'s `expect(heading "What do you want to make first").toBeVisible({ timeout: 60_000 })` and rules out `fillStripeCheckout`. Which nondeterminism keeps that heading from appearing is exactly what the swallowed cause would have told us.

The queued PR #30436 is not implicated: `runner-real-codex` and `runner-mock-claude` completed the identical paid onboarding flow against the same `pr-30436-app.omby.ai` preview seconds earlier in the same job, `cli-e2e-03-runner-prepare` passed on run 33379177692 for #30474 on the same queue base `a616a7c`, and the other five failures predate it on an unrelated branch.

## Validation

- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test` — 55 tests pass
- `pnpm exec tsx --test playwright/lib/error-report.test.ts` repeated 5 times, pass every time
- `prettier --check` on the changed files, `git diff --check` clean

No preview validation applies: the change is confined to how a Node entry script prints a caught error, and it is validated deterministically against a real Playwright matcher failure.
