### PR TITLE
test(api): scope telegram cleanup batch test to owned rows

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-delete-cleanups.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-delete-cleanups.test.ts
@@ -1,14 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { cronTelegramCleanupContract } from "@okouai/api-contracts/contracts/cron";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  onTestFinished,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { stubTestTimezone } from "../../../__tests__/env-stub";
 import { accept, testContext } from "../../../__tests__/test-context";
@@ -27,7 +20,9 @@ import { cronTelegramCleanupRoutes } from "../cron-telegram-cleanup";
 const context = testContext();
 const CRON_SECRET = "test-delete-cleanups-secret";
 const CONNECTOR_EXPIRED_COUNT = 11;
-const TELEGRAM_EXPIRED_COUNT = 10_001;
+// One more than the test delete batch size, so the cleanup loop runs a full
+// batch followed by a short batch exactly as the production batch size does.
+const TELEGRAM_EXPIRED_COUNT = 3;
 const CUTOFF_MS = Date.parse("1950-01-31T00:00:00.000Z");
 const TELEGRAM_CUTOFF_MS = Date.parse("1950-04-20T00:00:00.000Z");
 const TELEGRAM_NOW_MS = Date.parse("1950-05-20T00:00:00.000Z");
@@ -46,15 +41,6 @@ async function requestFixture(
     [200],
   );
   return response.body;
-}
-
-function registerFixtureCleanup(
-  action: "delete-telegram",
-  marker: string,
-): void {
-  onTestFinished(async () => {
-    await requestFixture({ action, marker });
-  });
 }
 
 async function seedConnectorFixture(expiredCount: number) {
@@ -85,16 +71,32 @@ async function seedConnectorFixture(expiredCount: number) {
   };
 }
 
-async function seedTelegramFixture(expiredCount: number): Promise<string> {
+async function seedTelegramFixture(expiredCount: number) {
   const marker = `telegram-cleanup-${randomUUID()}`;
-  registerFixtureCleanup("delete-telegram", marker);
-  await requestFixture({
-    action: "seed-telegram",
-    marker,
-    cutoff: new Date(TELEGRAM_CUTOFF_MS).toISOString(),
-    expiredCount,
+  const owner = createFixtureOperationOwner(async () => {
+    await requestFixture({ action: "delete-telegram", marker });
   });
-  return marker;
+  await owner.run(async () => {
+    await requestFixture({
+      action: "seed-telegram",
+      marker,
+      cutoff: new Date(TELEGRAM_CUTOFF_MS).toISOString(),
+      expiredCount,
+    });
+  });
+  return {
+    marker,
+    cleanup: async () => {
+      return await owner.run(async () => {
+        return await requestFixture({ action: "cleanup-telegram", marker });
+      });
+    },
+    read: async () => {
+      return await owner.run(async () => {
+        return await requestFixture({ action: "read-telegram", marker });
+      });
+    },
+  };
 }
 
 function cronHeaders() {
@@ -161,31 +163,27 @@ describe("complete delete cleanup crons", () => {
   it("runs full and short telegram batches across a non-UTC daylight-saving boundary", async () => {
     stubTestTimezone("America/New_York");
     mockNow(TELEGRAM_NOW_MS);
-    const marker = await seedTelegramFixture(TELEGRAM_EXPIRED_COUNT);
+    const fixture = await seedTelegramFixture(TELEGRAM_EXPIRED_COUNT);
 
-    const cleanup = await cleanupTelegramMessages();
-    expect(cleanup.body.deleted).toBe(TELEGRAM_EXPIRED_COUNT);
-    await expect(
-      requestFixture({ action: "read-telegram", marker }),
-    ).resolves.toStrictEqual({
+    const cleanup = await fixture.cleanup();
+    expect(cleanup.deleted).toBe(TELEGRAM_EXPIRED_COUNT);
+    await expect(fixture.read()).resolves.toStrictEqual({
       ok: true,
       remaining: ["equal", "future"],
     });
 
-    const empty = await cleanupTelegramMessages();
-    expect(empty.body.deleted).toBe(0);
+    const empty = await fixture.cleanup();
+    expect(empty.deleted).toBe(0);
   });
 
   it("preserves the strict telegram cutoff in UTC", async () => {
     stubTestTimezone("UTC");
     mockNow(TELEGRAM_NOW_MS);
-    const marker = await seedTelegramFixture(1);
+    const fixture = await seedTelegramFixture(1);
 
     const cleanup = await cleanupTelegramMessages();
     expect(cleanup.body.deleted).toBe(1);
-    await expect(
-      requestFixture({ action: "read-telegram", marker }),
-    ).resolves.toStrictEqual({
+    await expect(fixture.read()).resolves.toStrictEqual({
       ok: true,
       remaining: ["equal", "future"],
     });

--- a/turbo/apps/api/src/signals/routes/test-cron-delete-cleanups-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-delete-cleanups-state.ts
@@ -10,13 +10,13 @@ import { bodyResultOf } from "../context/request";
 import { type Db, writeDb$ } from "../external/db";
 import type { RouteEntry } from "../route-entry";
 import { cleanupConnectorOauthStatesForTest$ } from "../services/cron-connector-oauth-state-cleanup.service";
+import { cleanupTelegramMessagesForTest$ } from "../services/cron-telegram-cleanup.service";
 import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
 } from "./test-endpoint-helpers";
 
-const FIXTURE_INSERT_BATCH_SIZE = 5000;
-const MAX_EXPIRED_COUNT = 10_001;
+const MAX_EXPIRED_COUNT = 100;
 
 const markerSchema = z.string().min(1);
 const actionBodySchema = z.discriminatedUnion("action", [
@@ -50,6 +50,10 @@ const actionBodySchema = z.discriminatedUnion("action", [
   }),
   z.object({
     action: z.literal("delete-telegram"),
+    marker: markerSchema,
+  }),
+  z.object({
+    action: z.literal("cleanup-telegram"),
     marker: markerSchema,
   }),
 ]);
@@ -121,14 +125,8 @@ async function seedConnectorStates(
       };
     },
   );
-  for (
-    let offset = 0;
-    offset < expiredStates.length;
-    offset += FIXTURE_INSERT_BATCH_SIZE
-  ) {
-    await db
-      .insert(connectorOauthStates)
-      .values(expiredStates.slice(offset, offset + FIXTURE_INSERT_BATCH_SIZE));
+  if (expiredStates.length > 0) {
+    await db.insert(connectorOauthStates).values(expiredStates);
     signal.throwIfAborted();
   }
   await db.insert(connectorOauthStates).values([
@@ -214,16 +212,8 @@ async function seedTelegramMessages(
       };
     },
   );
-  for (
-    let offset = 0;
-    offset < expiredMessages.length;
-    offset += FIXTURE_INSERT_BATCH_SIZE
-  ) {
-    await db
-      .insert(telegramMessages)
-      .values(
-        expiredMessages.slice(offset, offset + FIXTURE_INSERT_BATCH_SIZE),
-      );
+  if (expiredMessages.length > 0) {
+    await db.insert(telegramMessages).values(expiredMessages);
     signal.throwIfAborted();
   }
   await db.insert(telegramMessages).values([
@@ -326,6 +316,11 @@ const mutateTestCronDeleteCleanupsState$ = command(
       case "delete-telegram": {
         await deleteTelegramMessages(db, body.marker, signal);
         return actionOk();
+      }
+      case "cleanup-telegram": {
+        return cleanupActionOk(
+          await set(cleanupTelegramMessagesForTest$, body.marker, signal),
+        );
       }
     }
   },

--- a/turbo/apps/api/src/signals/services/cron-telegram-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-telegram-cleanup.service.ts
@@ -1,41 +1,80 @@
 import { command } from "ccstate";
 import { telegramMessages } from "@okouai/db/schema/telegram-message";
-import { inArray, lt, sql } from "drizzle-orm";
+import { and, eq, inArray, lt, sql } from "drizzle-orm";
 
 import { pgTextDecoder } from "../../lib/db-structured-result";
 import { nowDate } from "../../lib/time";
-import { writeDb$ } from "../external/db";
+import { type Db, writeDb$ } from "../external/db";
 
 const TELEGRAM_MESSAGE_RETENTION_DAYS = 30;
 const TELEGRAM_MESSAGE_DELETE_BATCH_SIZE = 10_000;
+const TEST_TELEGRAM_MESSAGE_DELETE_BATCH_SIZE = 2;
 const telegramMessageCtid = sql`ctid`.mapWith(pgTextDecoder);
+
+function retentionCutoff(): Date {
+  const cutoffDate = nowDate();
+  cutoffDate.setUTCDate(
+    cutoffDate.getUTCDate() - TELEGRAM_MESSAGE_RETENTION_DAYS,
+  );
+  return cutoffDate;
+}
+
+async function cleanupTelegramMessages(
+  db: Db,
+  cutoff: Date,
+  officialOrgId: string | undefined,
+  batchSize: number,
+  signal: AbortSignal,
+): Promise<number> {
+  const expiredWhere =
+    officialOrgId === undefined
+      ? lt(telegramMessages.createdAt, cutoff)
+      : and(
+          lt(telegramMessages.createdAt, cutoff),
+          eq(telegramMessages.officialOrgId, officialOrgId),
+        );
+
+  let totalDeleted = 0;
+  let batchDeleted: number;
+
+  do {
+    const expiredMessages = db
+      .select({ ctid: telegramMessageCtid })
+      .from(telegramMessages)
+      .where(expiredWhere)
+      .limit(batchSize);
+    const { rowCount } = await db
+      .delete(telegramMessages)
+      .where(inArray(telegramMessageCtid, expiredMessages));
+    signal.throwIfAborted();
+
+    batchDeleted = rowCount ?? 0;
+    totalDeleted += batchDeleted;
+  } while (batchDeleted === batchSize);
+
+  return totalDeleted;
+}
 
 export const cleanupTelegramMessages$ = command(
   async ({ set }, signal: AbortSignal): Promise<number> => {
-    const db = set(writeDb$);
-    const cutoffDate = nowDate();
-    cutoffDate.setUTCDate(
-      cutoffDate.getUTCDate() - TELEGRAM_MESSAGE_RETENTION_DAYS,
+    return await cleanupTelegramMessages(
+      set(writeDb$),
+      retentionCutoff(),
+      undefined,
+      TELEGRAM_MESSAGE_DELETE_BATCH_SIZE,
+      signal,
     );
+  },
+);
 
-    let totalDeleted = 0;
-    let batchDeleted: number;
-
-    do {
-      const expiredMessages = db
-        .select({ ctid: telegramMessageCtid })
-        .from(telegramMessages)
-        .where(lt(telegramMessages.createdAt, cutoffDate))
-        .limit(TELEGRAM_MESSAGE_DELETE_BATCH_SIZE);
-      const { rowCount } = await db
-        .delete(telegramMessages)
-        .where(inArray(telegramMessageCtid, expiredMessages));
-      signal.throwIfAborted();
-
-      batchDeleted = rowCount ?? 0;
-      totalDeleted += batchDeleted;
-    } while (batchDeleted === TELEGRAM_MESSAGE_DELETE_BATCH_SIZE);
-
-    return totalDeleted;
+export const cleanupTelegramMessagesForTest$ = command(
+  async ({ set }, marker: string, signal: AbortSignal): Promise<number> => {
+    return await cleanupTelegramMessages(
+      set(writeDb$),
+      retentionCutoff(),
+      marker,
+      TEST_TELEGRAM_MESSAGE_DELETE_BATCH_SIZE,
+      signal,
+    );
   },
 );


### PR DESCRIPTION
## Problem

Turbo run [33379177692](https://github.com/vm0-ai/vm0/actions/runs/33379177692) (`merge_group`, SHA `7f666a0a`) failed in [`test-api (4)`](https://github.com/vm0-ai/vm0/actions/runs/33379177692/job/99447437443):

```
FAIL  api  src/signals/routes/__tests__/cron-delete-cleanups.test.ts
  > complete delete cleanup crons
  > runs full and short telegram batches across a non-UTC daylight-saving boundary
Error: Test timed out in 5000ms.
 ❯ src/signals/routes/__tests__/cron-delete-cleanups.test.ts:161:3
```

The test consumed 5022ms of the 5000ms per-test budget while the other 459 tests in the shard passed.

## First causal nondeterminism

The test is not racy — it is oversized, and the shard was slow.

`TELEGRAM_EXPIRED_COUNT` was `10_001`: the test seeded 10,001 telegram rows and deleted them again, purely so the production loop in `cleanupTelegramMessages$` (`TELEGRAM_MESSAGE_DELETE_BATCH_SIZE = 10_000`) would run one full batch followed by one short batch. That single test therefore owned almost the entire file's cost.

Baseline durations for the same test on healthy shards:

| Run | Shard `tests` total | This test |
| --- | --- | --- |
| [33379430099](https://github.com/vm0-ai/vm0/actions/runs/33379430099) (success) | 76.09s | 1624ms |
| [33378618555](https://github.com/vm0-ai/vm0/actions/runs/33378618555) (success) | 65.61s | 1980ms |
| [33379177692](https://github.com/vm0-ai/vm0/actions/runs/33379177692) (failure) | 111.33s | 5022ms (timeout) |

The failing shard's aggregate test time was ~1.5-1.7x the healthy baseline — three `merge_group` Turbo runs started within four minutes of each other, so the runner host and its Postgres were saturated. At ~1.8s baseline this test had under 3x headroom against the 5000ms budget, and the saturation consumed it. Every other test in the shard had enough headroom to survive the same slowdown, which is why only this one failed.

The other two tests in the file (353ms and 17ms) were never at risk, so the fix targets the oversized one.

## Fix

Give telegram cleanup the shape `cron-connector-oauth-state-cleanup.service.ts` already uses (added in #26623):

- one shared batch loop parameterised by batch size and optional owner;
- `cleanupTelegramMessages$` — unchanged production behavior: global sweep, batch size 10,000;
- `cleanupTelegramMessagesForTest$` — scoped to one `officialOrgId` marker, batch size 2;
- a `cleanup-telegram` action on the existing test-only fixture route.

The batch test now seeds 3 expired rows, so the loop still runs a full batch (2) followed by a short batch (1) and stops, through the identical code path. `MAX_EXPIRED_COUNT` on the fixture route drops from `10_001` to `100` so the volume cannot come back, which makes the 5000-row insert chunking dead code and it is removed.

This also aligns the test with `docs/testing/api-testing.md`: *"When a production cron scans a global table, keep production behavior global but drive correctness through a test-only route whose request names the owned IDs."* The batch test no longer asserts an exact count from a production-global sweep against the shared database.

The telegram fixture also moves to `createFixtureOperationOwner` (the helper #30088 added for the connector fixture), so a timed-out request can no longer race its own teardown and leave 1950-dated rows behind.

## Product contract preserved

- The timezone dimension is untouched: still `America/New_York`, still `TELEGRAM_NOW_MS` 1950-05-20 (EDT) with a 30-day cutoff at 1950-04-20 (EST), crossing the 1950 US DST boundary.
- The cutoff is still computed by the same `setUTCDate` logic, now shared by both commands.
- Full-batch-then-short-batch is still exercised; only the batch size constant differs.
- `preserves the strict telegram cutoff in UTC` still drives the real `cronTelegramCleanupRoutes` cron route end to end, and `run-cron.bdd.test.ts` still covers its missing-auth contract.
- No retries, sleeps, raised timeouts, skips, or weakened assertions.

## Validation

Local Postgres (UTC session timezone), `pnpm -F api exec vitest run`:

- `cron-delete-cleanups.test.ts` — 5/5 runs pass. The target test drops from **1102ms** (this branch's parent, same machine) to **19-26ms**; the whole file's `tests` time drops from ~1.2s to ~0.19s.
- Regression: `cron-connector-oauth-state-cleanup.test.ts`, `global-sweep-contracts.test.ts`, `vercel-crons.test.ts`, `run-cron.bdd.test.ts` — 25/25 pass.
- `pnpm -F api lint` (no errors, no new warnings), `pnpm -F api check-types`, `pnpm knip --workspace apps/api`, `prettier --check`, `git diff --check` — all clean.

Preview validation is not applicable: this changes an API service, a test-only fixture route, and a test file, with no user-facing surface to exercise in a browser.

Refs https://github.com/vm0-ai/vm0/actions/runs/33379177692

🤖 Generated with [Claude Code](https://claude.com/claude-code)
