### PR TITLE
feat(api): add secure mcp oauth foundations

### DIFF
--- a/turbo/apps/api/package.json
+++ b/turbo/apps/api/package.json
@@ -30,6 +30,7 @@
     "@clerk/backend": "^3.13.1",
     "@hono/node-server": "^2.0.10",
     "@hono/otel": "^1.1.2",
+    "@modelcontextprotocol/client": "^2.0.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.215.0",
     "@opentelemetry/semantic-conventions": "^1.43.0",

--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import type StripeSDK from "stripe";
 import type { LookupFunction } from "node:net";
 import { computed } from "ccstate";
@@ -53,8 +54,10 @@ type BrowserUseCdpCommandMock = Mock<
 interface RequestOptionsLike {
   readonly family?: number;
   readonly headers?: RequestInit["headers"];
+  readonly maxHeaderSize?: number;
   readonly method?: string;
   readonly lookup?: LookupFunction;
+  readonly signal?: AbortSignal;
 }
 
 type PinnedRequestCallback = (
@@ -778,9 +781,9 @@ async function mockPinnedRequestModule<TModule extends object>(
     }
     const [url, options, callback] = args;
     const req = new EventEmitter() as InstanceType<typeof EventEmitter> & {
-      end: (body?: string) => void;
+      end: (body?: string | Uint8Array) => void;
     };
-    req.end = (requestBody?: string) => {
+    req.end = (requestBody?: string | Uint8Array) => {
       queueMicrotask(() => {
         void (async () => {
           if (options.family === 4 || options.family === 6) {
@@ -826,10 +829,23 @@ async function mockPinnedRequestModule<TModule extends object>(
                 ? undefined
                 : requestBody,
             redirect: "manual",
+            signal: options.signal,
           });
           const headers: Record<string, string> = {};
           for (const [key, value] of fetched.headers) {
             headers[key] = value;
+          }
+          const responseHeaderBytes = Object.entries(headers).reduce(
+            (bytes, [name, value]) => {
+              return bytes + Buffer.byteLength(`${name}: ${value}\r\n`);
+            },
+            2,
+          );
+          if (
+            options.maxHeaderSize !== undefined &&
+            responseHeaderBytes > options.maxHeaderSize
+          ) {
+            throw new Error("Parse Error: Header overflow");
           }
           const body = fetched.body
             ? Readable.from([new Uint8Array(await fetched.arrayBuffer())])

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -101,6 +101,7 @@ import { logsRoutes } from "./routes/logs";
 import { mailRoutes } from "./routes/mail";
 import { mapsRoutes } from "./routes/maps";
 import { mcpConnectorsRoutes } from "./routes/mcp-connectors";
+import { mcpOAuthClientMetadataRoutes } from "./routes/mcp-oauth-client-metadata";
 import { weatherRoutes } from "./routes/weather";
 import { modelPoliciesRoutes } from "./routes/model-policies";
 import { modelProviderGatewayRoutes } from "./routes/model-provider-gateways";
@@ -296,6 +297,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...mailRoutes,
   ...mapsRoutes,
   ...mcpConnectorsRoutes,
+  ...mcpOAuthClientMetadataRoutes,
   ...weatherRoutes,
   ...scrapeRoutes,
   ...peopleSearchRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/mcp-oauth-foundations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mcp-oauth-foundations.test.ts
@@ -1,0 +1,389 @@
+import { mcpOAuthContract } from "@okouai/api-contracts/contracts/mcp-oauth";
+import {
+  testMcpOAuthFetchContract,
+  type TestMcpOAuthFetchRequest,
+} from "@okouai/api-contracts/contracts/test-mcp-oauth-fetch";
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp, setupRawAppRequest } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { server } from "../../../mocks/server";
+import { mcpOAuthClientMetadataRoutes } from "../mcp-oauth-client-metadata";
+import { testMcpOAuthFetchRoutes } from "../test-mcp-oauth-fetch";
+
+const context = testContext();
+
+function metadataClient(baseUrl = "http://api.test") {
+  return setupApp({
+    baseUrl,
+    context,
+    routes: mcpOAuthClientMetadataRoutes,
+  })(mcpOAuthContract);
+}
+
+function probeClient() {
+  return setupApp({ context, routes: testMcpOAuthFetchRoutes })(
+    testMcpOAuthFetchContract,
+  );
+}
+
+function allowPublicHost(hostname: string, address = "8.8.8.8"): void {
+  context.mocks.dns.lookupOverrides.set(hostname, [{ address, family: 4 }]);
+}
+
+async function requestProbeSuccess(body: TestMcpOAuthFetchRequest) {
+  return await accept(probeClient().request({ body }), [200]);
+}
+
+async function requestProbeFailure(body: TestMcpOAuthFetchRequest) {
+  return await accept(probeClient().request({ body }), [502]);
+}
+
+describe("MCP OAuth foundations", () => {
+  it("publishes exact public Okou client metadata from configured origins", async () => {
+    mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+    mockEnv("OKOU_WEB_URL", "https://www.vm0.ai");
+    mockEnv("APP_URL", "https://app.vm0.ai");
+
+    const response = await accept(metadataClient().okouClientMetadata(), [200]);
+
+    expect(response.body).toStrictEqual({
+      client_id: "https://api.okou.ai/api/oauth/mcp/client-metadata/okou.json",
+      client_name: "Okou",
+      client_uri: "https://app.okou.ai/",
+      redirect_uris: ["https://app.okou.ai/connectors/custom/callback"],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      application_type: "web",
+      token_endpoint_auth_method: "none",
+    });
+  });
+
+  it("does not let the request host change the Okou client identity", async () => {
+    mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+    mockEnv("OKOU_WEB_URL", "https://www.vm0.ai");
+    mockEnv("APP_URL", "https://app.vm0.ai");
+
+    const response = await accept(
+      metadataClient("https://attacker.example.com").okouClientMetadata(),
+      [200],
+    );
+
+    expect(response.body.client_id).toBe(
+      "https://api.okou.ai/api/oauth/mcp/client-metadata/okou.json",
+    );
+    expect(response.body.client_uri).toBe("https://app.okou.ai/");
+    expect(response.body.redirect_uris).toStrictEqual([
+      "https://app.okou.ai/connectors/custom/callback",
+    ]);
+  });
+
+  it("does not register a VM0 client metadata route", async () => {
+    const request = setupRawAppRequest({
+      context,
+      routes: mcpOAuthClientMetadataRoutes,
+    });
+
+    const response = await request("/api/oauth/mcp/client-metadata/vm0.json", {
+      method: "GET",
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("supports OAuth metadata and SDK request body shapes with DNS pinning", async () => {
+    allowPublicHost("oauth.example.com");
+    server.use(
+      http.get("https://oauth.example.com/metadata", ({ request }) => {
+        return HttpResponse.json({ method: request.method });
+      }),
+      http.head("https://oauth.example.com/metadata", () => {
+        return new HttpResponse(null, {
+          status: 200,
+          headers: { "x-oauth-metadata": "present" },
+        });
+      }),
+      http.post("https://oauth.example.com/token", async ({ request }) => {
+        return HttpResponse.json({
+          contentType: request.headers.get("content-type"),
+          body: await request.text(),
+        });
+      }),
+    );
+
+    const metadata = await requestProbeSuccess({
+      url: "https://oauth.example.com/metadata",
+      method: "GET",
+    });
+    const head = await requestProbeSuccess({
+      url: "https://oauth.example.com/metadata",
+      method: "HEAD",
+    });
+    const form = await requestProbeSuccess({
+      url: "https://oauth.example.com/token",
+      method: "POST",
+      bodyKind: "form",
+      body: "grant_type=authorization_code&code=code_test",
+    });
+    const json = await requestProbeSuccess({
+      url: "https://oauth.example.com/token",
+      method: "POST",
+      bodyKind: "json",
+      body: '{"redirect_uris":["https://app.okou.ai/callback"]}',
+    });
+
+    expect(metadata).toMatchObject({ status: 200 });
+    expect(metadata.body).toMatchObject({ status: 200 });
+    expect(JSON.parse(metadata.body.body)).toStrictEqual({ method: "GET" });
+    expect(head.body).toMatchObject({
+      status: 200,
+      body: "",
+      headers: expect.objectContaining({ "x-oauth-metadata": "present" }),
+    });
+    expect(JSON.parse(form.body.body)).toStrictEqual({
+      contentType: "application/x-www-form-urlencoded;charset=UTF-8",
+      body: "grant_type=authorization_code&code=code_test",
+    });
+    expect(JSON.parse(json.body.body)).toStrictEqual({
+      contentType: "application/json",
+      body: '{"redirect_uris":["https://app.okou.ai/callback"]}',
+    });
+    expect(context.mocks.nodeRequest.pinnedAddresses).toStrictEqual([
+      "8.8.8.8",
+      "8.8.8.8",
+      "8.8.8.8",
+      "8.8.8.8",
+    ]);
+  });
+
+  it.each([
+    "http://oauth.example.com/metadata",
+    "https://user:password@oauth.example.com/metadata",
+    "https://oauth.example.com/metadata#fragment",
+    "https://localhost/metadata",
+    "https://internal/metadata",
+  ])("rejects unsafe OAuth URL %s", async (url) => {
+    allowPublicHost("oauth.example.com");
+
+    const response = await requestProbeFailure({ url, method: "GET" });
+
+    expect(response.status).toBe(502);
+    expect(context.mocks.nodeRequest.pinnedAddresses).toStrictEqual([]);
+  });
+
+  it("rejects the whole DNS answer set when one address is private", async () => {
+    context.mocks.dns.lookupOverrides.set("mixed.example.com", [
+      { address: "8.8.8.8", family: 4 },
+      { address: "10.0.0.1", family: 4 },
+    ]);
+
+    const response = await requestProbeFailure({
+      url: "https://mixed.example.com/metadata",
+      method: "GET",
+    });
+
+    expect(response.status).toBe(502);
+    expect(context.mocks.nodeRequest.pinnedAddresses).toStrictEqual([]);
+  });
+
+  it("follows three metadata redirects and pins every hop", async () => {
+    allowPublicHost("oauth.example.com");
+    server.use(
+      http.get("https://oauth.example.com/redirect/:step", ({ params }) => {
+        const step = Number(params.step);
+        return step < 3
+          ? new HttpResponse(null, {
+              status: 302,
+              headers: { location: `/redirect/${step + 1}` },
+            })
+          : HttpResponse.json({ issuer: "https://oauth.example.com" });
+      }),
+    );
+
+    const response = await requestProbeSuccess({
+      url: "https://oauth.example.com/redirect/0",
+      method: "GET",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe(200);
+    expect(context.mocks.nodeRequest.pinnedAddresses).toStrictEqual([
+      "8.8.8.8",
+      "8.8.8.8",
+      "8.8.8.8",
+      "8.8.8.8",
+    ]);
+  });
+
+  it("rejects a fourth metadata redirect", async () => {
+    allowPublicHost("oauth.example.com");
+    server.use(
+      http.get("https://oauth.example.com/redirect/:step", ({ params }) => {
+        const step = Number(params.step);
+        return new HttpResponse(null, {
+          status: 302,
+          headers: { location: `/redirect/${step + 1}` },
+        });
+      }),
+    );
+
+    const response = await requestProbeFailure({
+      url: "https://oauth.example.com/redirect/0",
+      method: "GET",
+    });
+
+    expect(response.status).toBe(502);
+    expect(response.body).toStrictEqual({
+      error: "MCP OAuth response has too many redirects",
+    });
+    expect(context.mocks.nodeRequest.pinnedAddresses).toHaveLength(4);
+  });
+
+  it("revalidates a metadata redirect target before fetching it", async () => {
+    allowPublicHost("oauth.example.com");
+    context.mocks.dns.lookupOverrides.set("private.example.com", [
+      { address: "10.0.0.1", family: 4 },
+    ]);
+    server.use(
+      http.get("https://oauth.example.com/redirect", () => {
+        return new HttpResponse(null, {
+          status: 302,
+          headers: { location: "https://private.example.com/metadata" },
+        });
+      }),
+    );
+
+    const response = await requestProbeFailure({
+      url: "https://oauth.example.com/redirect",
+      method: "GET",
+    });
+
+    expect(response.status).toBe(502);
+    expect(context.mocks.nodeRequest.pinnedAddresses).toStrictEqual([
+      "8.8.8.8",
+    ]);
+  });
+
+  it("removes authorization before a metadata redirect", async () => {
+    allowPublicHost("oauth.example.com");
+    allowPublicHost("metadata.example.com", "1.1.1.1");
+    server.use(
+      http.get("https://oauth.example.com/redirect", ({ request }) => {
+        return request.headers.get("authorization") === "Bearer secret"
+          ? new HttpResponse(null, {
+              status: 302,
+              headers: {
+                location: "https://metadata.example.com/document",
+              },
+            })
+          : new HttpResponse(null, { status: 400 });
+      }),
+      http.get("https://metadata.example.com/document", ({ request }) => {
+        return HttpResponse.json({
+          authorization: request.headers.get("authorization"),
+        });
+      }),
+    );
+
+    const response = await requestProbeSuccess({
+      url: "https://oauth.example.com/redirect",
+      method: "GET",
+      authorization: "Bearer secret",
+    });
+
+    expect(response.status).toBe(200);
+    expect(JSON.parse(response.body.body)).toStrictEqual({
+      authorization: null,
+    });
+    expect(context.mocks.nodeRequest.pinnedAddresses).toStrictEqual([
+      "8.8.8.8",
+      "1.1.1.1",
+    ]);
+  });
+
+  it("rejects token and DCR POST redirects without replay", async () => {
+    allowPublicHost("oauth.example.com");
+    server.use(
+      http.post("https://oauth.example.com/token", () => {
+        return new HttpResponse(null, {
+          status: 307,
+          headers: { location: "/redirected-token" },
+        });
+      }),
+    );
+
+    const response = await requestProbeFailure({
+      url: "https://oauth.example.com/token",
+      method: "POST",
+      bodyKind: "form",
+      body: "grant_type=refresh_token&refresh_token=secret",
+      authorization: "Basic secret",
+    });
+
+    expect(response.status).toBe(502);
+    expect(response.body).toStrictEqual({
+      error: "MCP OAuth POST redirects are not allowed",
+    });
+    expect(context.mocks.nodeRequest.pinnedAddresses).toStrictEqual([
+      "8.8.8.8",
+    ]);
+  });
+
+  it("enforces header and response body size limits", async () => {
+    allowPublicHost("oauth.example.com");
+    server.use(
+      http.get("https://oauth.example.com/large-header", () => {
+        return HttpResponse.json(
+          { ok: true },
+          { headers: { "x-large": "x".repeat(17 * 1024) } },
+        );
+      }),
+      http.get("https://oauth.example.com/large-body", () => {
+        return HttpResponse.text("x".repeat(64 * 1024 + 1));
+      }),
+    );
+
+    const header = await requestProbeFailure({
+      url: "https://oauth.example.com/large-header",
+      method: "GET",
+    });
+    const body = await requestProbeFailure({
+      url: "https://oauth.example.com/large-body",
+      method: "GET",
+    });
+
+    expect(header.status).toBe(502);
+    expect(header.body).toStrictEqual({
+      error: "Parse Error: Header overflow",
+    });
+    expect(body.status).toBe(502);
+    expect(body.body).toStrictEqual({
+      error: "MCP OAuth response is too large",
+    });
+  });
+
+  it("honors caller cancellation and the transport deadline", async () => {
+    allowPublicHost("oauth.example.com");
+
+    const cancelled = await requestProbeFailure({
+      url: "https://oauth.example.com/metadata",
+      method: "GET",
+      cancel: true,
+    });
+
+    expect(cancelled.status).toBe(502);
+
+    context.mocks.abortSignal.timeout.mockImplementation((milliseconds) => {
+      return milliseconds === 10_000 ? AbortSignal.abort() : undefined;
+    });
+    const timedOut = await requestProbeFailure({
+      url: "https://oauth.example.com/metadata",
+      method: "GET",
+    });
+
+    expect(timedOut.status).toBe(502);
+    expect(context.mocks.nodeRequest.pinnedAddresses).toStrictEqual([]);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/mcp-oauth-client-metadata.ts
+++ b/turbo/apps/api/src/signals/routes/mcp-oauth-client-metadata.ts
@@ -1,0 +1,20 @@
+import { mcpOAuthContract } from "@okouai/api-contracts/contracts/mcp-oauth";
+import { computed } from "ccstate";
+
+import { request$ } from "../context/hono";
+import type { RouteEntry } from "../route-entry";
+import { okouMcpOAuthClientMetadata } from "../services/mcp-oauth-client-metadata.service";
+
+const okouClientMetadata$ = computed((get) => {
+  return {
+    status: 200 as const,
+    body: okouMcpOAuthClientMetadata(get(request$).raw),
+  };
+});
+
+export const mcpOAuthClientMetadataRoutes: readonly RouteEntry[] = [
+  {
+    route: mcpOAuthContract.okouClientMetadata,
+    handler: okouClientMetadata$,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/test-mcp-oauth-fetch.ts
+++ b/turbo/apps/api/src/signals/routes/test-mcp-oauth-fetch.ts
@@ -1,0 +1,88 @@
+import {
+  testMcpOAuthFetchContract,
+  type TestMcpOAuthFetchRequest,
+} from "@okouai/api-contracts/contracts/test-mcp-oauth-fetch";
+import { command } from "ccstate";
+
+import { request$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route-entry";
+import { mcpOAuthSafeFetch } from "../services/mcp-oauth-safe-fetch.service";
+import { settleIncludingAbort } from "../utils";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-endpoint-helpers";
+
+function probeBody(
+  input: TestMcpOAuthFetchRequest,
+): string | URLSearchParams | undefined {
+  if (input.bodyKind === "form") {
+    return new URLSearchParams(input.body ?? "");
+  }
+  if (input.bodyKind === "json") {
+    return input.body ?? "";
+  }
+  return undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Unknown MCP OAuth error";
+}
+
+const probeRequestBody$ = bodyResultOf(testMcpOAuthFetchContract.request);
+const probeRequest$ = command(async ({ get }, signal: AbortSignal) => {
+  if (!isTestEndpointAllowed(get(request$))) {
+    return testEndpointNotFoundResponse();
+  }
+  const bodyResult = await get(probeRequestBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const caller = new AbortController();
+  if (bodyResult.data.cancel) {
+    caller.abort();
+  }
+  const requestSignal = AbortSignal.any([signal, caller.signal]);
+  const result = await settleIncludingAbort(
+    mcpOAuthSafeFetch(bodyResult.data.url, {
+      method: bodyResult.data.method,
+      headers: {
+        ...(bodyResult.data.authorization
+          ? { authorization: bodyResult.data.authorization }
+          : {}),
+        ...(bodyResult.data.bodyKind === "json"
+          ? { "content-type": "application/json" }
+          : {}),
+      },
+      body: probeBody(bodyResult.data),
+      signal: requestSignal,
+    }),
+  );
+  signal.throwIfAborted();
+  if (!result.ok) {
+    return {
+      status: 502 as const,
+      body: { error: errorMessage(result.error) },
+    };
+  }
+  const responseBody = await result.value.text();
+  signal.throwIfAborted();
+  return {
+    status: 200 as const,
+    body: {
+      status: result.value.status,
+      headers: Object.fromEntries(result.value.headers),
+      body: responseBody,
+    },
+  };
+});
+
+export const testMcpOAuthFetchRoutes: readonly RouteEntry[] = [
+  {
+    route: testMcpOAuthFetchContract.request,
+    handler: probeRequest$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -1,7 +1,5 @@
 import { Buffer } from "node:buffer";
 import { createHash, randomBytes } from "node:crypto";
-import { isIP } from "node:net";
-import { request as httpsRequest } from "node:https";
 
 import { command } from "ccstate";
 import { and, eq, exists } from "drizzle-orm";
@@ -23,18 +21,13 @@ import { orgCustomConnectorOauthConfigs } from "@okouai/db/schema/org-custom-con
 import { orgCustomConnectors } from "@okouai/db/schema/org-custom-connector";
 import { secrets } from "@okouai/db/schema/secret";
 
-import {
-  fetchHostHasBlockedAddress,
-  resolveFetchHostAddresses,
-  type ResolvedFetchAddress,
-} from "../../lib/blocked-fetch-host";
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
 import { nowDate } from "../../lib/time";
 import {
   connectorOAuthStateExpiresAt,
   generateConnectorOAuthState,
 } from "../../lib/connector-oauth-state";
-import { createDeferredPromise, safeJsonParse, settle } from "../utils";
+import { safeJsonParse, settle } from "../utils";
 import { writeDb$, type Db } from "../external/db";
 import {
   exchangeFeishuOAuthCode,
@@ -70,8 +63,8 @@ import {
 } from "./connector-connection-write.service";
 import { connectorAccountSiblingWritesEnabled } from "./connector-account-mutation.service";
 import { userFeatureSwitchContext } from "./feature-switches.service";
+import { mcpOAuthSafeFetch } from "./mcp-oauth-safe-fetch.service";
 
-const MAX_TOKEN_RESPONSE_BYTES = 64 * 1024;
 const TOKEN_REFRESH_LEEWAY_MS = 60 * 1000;
 
 const customConnectorOAuthStateContextSchema = z.object({
@@ -122,115 +115,6 @@ interface PublicHttpsResponse {
   readonly status: number;
   readonly contentType: string;
   readonly body: string;
-}
-
-function internalHostname(hostname: string): boolean {
-  const normalized = hostname.toLowerCase().replace(/\.$/u, "");
-  return (
-    normalized.length === 0 ||
-    normalized === "localhost" ||
-    normalized === "localhost.localdomain" ||
-    normalized.endsWith(".localhost") ||
-    normalized.endsWith(".local") ||
-    (isIP(normalized) === 0 && !normalized.includes("."))
-  );
-}
-
-function ipLiteralAddress(hostname: string): ResolvedFetchAddress | null {
-  const address =
-    hostname.startsWith("[") && hostname.endsWith("]")
-      ? hostname.slice(1, -1)
-      : hostname;
-  const family = isIP(address);
-  if (family === 0) {
-    return null;
-  }
-  return { address, family: family === 6 ? 6 : 4 };
-}
-
-async function resolvePublicHttpsAddress(
-  url: URL,
-): Promise<ResolvedFetchAddress> {
-  if (
-    url.protocol !== "https:" ||
-    url.username ||
-    url.password ||
-    internalHostname(url.hostname)
-  ) {
-    throw new Error("OAuth token URL is not allowed");
-  }
-  const literal = ipLiteralAddress(url.hostname);
-  const addresses = literal
-    ? [literal]
-    : await resolveFetchHostAddresses(url.hostname);
-  const address = addresses[0];
-  if (!address || fetchHostHasBlockedAddress(addresses)) {
-    throw new Error("OAuth token URL is not allowed");
-  }
-  return address;
-}
-
-async function postPublicHttpsForm(
-  url: URL,
-  form: URLSearchParams,
-  authorization: string | undefined,
-  signal: AbortSignal,
-): Promise<PublicHttpsResponse> {
-  const address = await resolvePublicHttpsAddress(url);
-  signal.throwIfAborted();
-  const body = form.toString();
-  const deferred = createDeferredPromise<PublicHttpsResponse>(signal);
-  const request = httpsRequest(
-    url,
-    {
-      family: address.family,
-      method: "POST",
-      headers: {
-        accept: "application/json",
-        "content-type": "application/x-www-form-urlencoded",
-        "content-length": Buffer.byteLength(body).toString(),
-        ...(authorization ? { authorization } : {}),
-      },
-      lookup: (_hostname, _options, callback) => {
-        callback(null, address.address, address.family);
-      },
-      signal,
-    },
-    (response) => {
-      response.setEncoding("utf8");
-      let responseBody = "";
-      let responseBytes = 0;
-      response.on("data", (chunk: string) => {
-        responseBody += chunk;
-        responseBytes += Buffer.byteLength(chunk);
-        if (responseBytes > MAX_TOKEN_RESPONSE_BYTES && !deferred.settled()) {
-          deferred.reject(new Error("OAuth token response is too large"));
-          response.destroy();
-        }
-      });
-      response.on("error", (error) => {
-        if (!deferred.settled()) {
-          deferred.reject(error);
-        }
-      });
-      response.on("end", () => {
-        if (!deferred.settled()) {
-          deferred.resolve({
-            status: response.statusCode ?? 502,
-            contentType: response.headers["content-type"] ?? "",
-            body: responseBody,
-          });
-        }
-      });
-    },
-  );
-  request.on("error", (error) => {
-    if (!deferred.settled()) {
-      deferred.reject(error);
-    }
-  });
-  request.end(body);
-  return await deferred.promise;
 }
 
 function tokenResponseData(response: PublicHttpsResponse): unknown {
@@ -352,12 +236,21 @@ async function requestToken(
   signal: AbortSignal,
 ): Promise<OAuthTokenResult> {
   const authorization = tokenRequestAuthentication(args);
-  const response = await postPublicHttpsForm(
-    new URL(args.config.tokenUrl),
-    args.form,
-    authorization,
+  const fetched = await mcpOAuthSafeFetch(args.config.tokenUrl, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/x-www-form-urlencoded",
+      ...(authorization ? { authorization } : {}),
+    },
+    body: args.form,
     signal,
-  );
+  });
+  const response: PublicHttpsResponse = {
+    status: fetched.status,
+    contentType: fetched.headers.get("content-type") ?? "",
+    body: await fetched.text(),
+  };
   signal.throwIfAborted();
   return tokenResult(response);
 }

--- a/turbo/apps/api/src/signals/services/mcp-oauth-client-metadata.service.ts
+++ b/turbo/apps/api/src/signals/services/mcp-oauth-client-metadata.service.ts
@@ -1,0 +1,36 @@
+import type { OAuthClientMetadata } from "@modelcontextprotocol/client";
+import type { OkouMcpOAuthClientMetadata } from "@okouai/api-contracts/contracts/mcp-oauth";
+import {
+  apiUrlForPublicBrand,
+  appUrlForPublicBrand,
+} from "@okouai/core/public-brand";
+
+import { env } from "../../lib/env";
+import { getOAuthApiOrigin } from "../../lib/oauth-origin";
+
+const OKOU_MCP_OAUTH_CLIENT_METADATA_PATH =
+  "/api/oauth/mcp/client-metadata/okou.json";
+const CUSTOM_CONNECTOR_OAUTH_CALLBACK_PATH = "/connectors/custom/callback";
+
+export function okouMcpOAuthClientMetadata(
+  request: Request,
+): OkouMcpOAuthClientMetadata & OAuthClientMetadata {
+  const apiOrigin = apiUrlForPublicBrand(getOAuthApiOrigin(request), "okou");
+  const appOrigin = appUrlForPublicBrand(env("APP_URL"), "okou");
+  const metadata: OkouMcpOAuthClientMetadata & OAuthClientMetadata = {
+    client_id: new URL(
+      OKOU_MCP_OAUTH_CLIENT_METADATA_PATH,
+      apiOrigin,
+    ).toString(),
+    client_name: "Okou",
+    client_uri: new URL("/", appOrigin).toString(),
+    redirect_uris: [
+      new URL(CUSTOM_CONNECTOR_OAUTH_CALLBACK_PATH, appOrigin).toString(),
+    ],
+    grant_types: ["authorization_code", "refresh_token"],
+    response_types: ["code"],
+    application_type: "web",
+    token_endpoint_auth_method: "none",
+  };
+  return metadata;
+}

--- a/turbo/apps/api/src/signals/services/mcp-oauth-safe-fetch.service.ts
+++ b/turbo/apps/api/src/signals/services/mcp-oauth-safe-fetch.service.ts
@@ -1,0 +1,324 @@
+import { Buffer } from "node:buffer";
+import { request as httpsRequest } from "node:https";
+import { isIP } from "node:net";
+
+import type { FetchLike } from "@modelcontextprotocol/client";
+
+import {
+  fetchHostHasBlockedAddress,
+  resolveFetchHostAddresses,
+  type ResolvedFetchAddress,
+} from "../../lib/blocked-fetch-host";
+import { awaitWithSignal, createDeferredPromise } from "../utils";
+
+const MCP_OAUTH_FETCH_TIMEOUT_MS = 10_000;
+const MCP_OAUTH_MAX_HEADER_BYTES = 16 * 1024;
+const MCP_OAUTH_MAX_RESPONSE_BYTES = 64 * 1024;
+const MCP_OAUTH_MAX_REDIRECTS = 3;
+
+const ALLOWED_METHODS = Object.freeze(["GET", "HEAD", "POST"]);
+const REDIRECT_STATUSES = Object.freeze([301, 302, 303, 307, 308]);
+const FORBIDDEN_REQUEST_HEADERS = Object.freeze([
+  "connection",
+  "cookie",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "set-cookie",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+const REDIRECT_SENSITIVE_HEADERS = [
+  "authorization",
+  "cookie",
+  "proxy-authorization",
+] as const;
+
+interface SerializedRequest {
+  readonly method: "GET" | "HEAD" | "POST";
+  readonly headers: Headers;
+  readonly body: Buffer | undefined;
+}
+
+type PinnedRequestOutcome =
+  | { readonly ok: true; readonly response: Response }
+  | { readonly ok: false; readonly error: unknown };
+
+function internalHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/\.$/u, "");
+  return (
+    normalized.length === 0 ||
+    normalized === "localhost" ||
+    normalized === "localhost.localdomain" ||
+    normalized.endsWith(".localhost") ||
+    normalized.endsWith(".local") ||
+    (isIP(normalized) === 0 && !normalized.includes("."))
+  );
+}
+
+function ipLiteralAddress(hostname: string): ResolvedFetchAddress | null {
+  const address =
+    hostname.startsWith("[") && hostname.endsWith("]")
+      ? hostname.slice(1, -1)
+      : hostname;
+  const family = isIP(address);
+  if (family === 0) {
+    return null;
+  }
+  return { address, family: family === 6 ? 6 : 4 };
+}
+
+function allowedUrl(input: string | URL): URL {
+  const url = new URL(input);
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.hash ||
+    internalHostname(url.hostname)
+  ) {
+    throw new Error("MCP OAuth URL is not allowed");
+  }
+  return url;
+}
+
+async function resolvePublicAddress(
+  url: URL,
+  signal: AbortSignal,
+): Promise<ResolvedFetchAddress> {
+  const literal = ipLiteralAddress(url.hostname);
+  const addresses = literal
+    ? [literal]
+    : await awaitWithSignal(resolveFetchHostAddresses(url.hostname), signal);
+  signal.throwIfAborted();
+  const address = addresses[0];
+  if (!address || fetchHostHasBlockedAddress(addresses)) {
+    throw new Error("MCP OAuth URL is not allowed");
+  }
+  return address;
+}
+
+function requestMethod(
+  method: string | undefined,
+): SerializedRequest["method"] {
+  const normalized = (method ?? "GET").toUpperCase();
+  if (
+    !ALLOWED_METHODS.some((allowedMethod) => {
+      return allowedMethod === normalized;
+    })
+  ) {
+    throw new Error(`MCP OAuth request method is not allowed: ${normalized}`);
+  }
+  if (normalized === "GET" || normalized === "HEAD") {
+    return normalized;
+  }
+  return "POST";
+}
+
+function validateRequestHeaders(headers: Headers): void {
+  for (const name of FORBIDDEN_REQUEST_HEADERS) {
+    if (headers.has(name)) {
+      throw new Error(`MCP OAuth request header is not allowed: ${name}`);
+    }
+  }
+}
+
+function serializeRequestBody(
+  body: RequestInit["body"],
+  headers: Headers,
+): Buffer | undefined {
+  if (body === undefined || body === null) {
+    headers.delete("content-length");
+    return undefined;
+  }
+
+  let serialized: Buffer;
+  if (typeof body === "string") {
+    serialized = Buffer.from(body);
+  } else if (body instanceof URLSearchParams) {
+    if (!headers.has("content-type")) {
+      headers.set(
+        "content-type",
+        "application/x-www-form-urlencoded;charset=UTF-8",
+      );
+    }
+    serialized = Buffer.from(body.toString());
+  } else if (body instanceof ArrayBuffer) {
+    serialized = Buffer.from(body);
+  } else if (ArrayBuffer.isView(body)) {
+    serialized = Buffer.from(body.buffer, body.byteOffset, body.byteLength);
+  } else {
+    throw new Error("MCP OAuth request body type is not supported");
+  }
+
+  headers.set("content-length", String(serialized.byteLength));
+  return serialized;
+}
+
+function serializedRequest(init: RequestInit | undefined): SerializedRequest {
+  const method = requestMethod(init?.method);
+  const headers = new Headers(init?.headers);
+  validateRequestHeaders(headers);
+  const body = serializeRequestBody(init?.body, headers);
+  if ((method === "GET" || method === "HEAD") && body) {
+    throw new Error(`MCP OAuth ${method} requests cannot have a body`);
+  }
+  return { method, headers, body };
+}
+
+function responseHeaders(
+  rawHeaders: Readonly<Record<string, string | string[] | undefined>>,
+): Headers {
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(rawHeaders)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        headers.append(name, item);
+      }
+    } else if (value !== undefined) {
+      headers.set(name, value);
+    }
+  }
+  return headers;
+}
+
+function responseCanHaveBody(method: string, status: number): boolean {
+  return (
+    method !== "HEAD" && status !== 204 && status !== 205 && status !== 304
+  );
+}
+
+function outgoingRequestHeaders(headers: Headers): Record<string, string> {
+  return Object.fromEntries(headers);
+}
+
+async function pinnedRequest(
+  url: URL,
+  requestData: SerializedRequest,
+  signal: AbortSignal,
+): Promise<Response> {
+  const address = await resolvePublicAddress(url, signal);
+  signal.throwIfAborted();
+  const deferred = createDeferredPromise<PinnedRequestOutcome>(signal);
+  const request = httpsRequest(
+    url,
+    {
+      agent: false,
+      family: address.family,
+      method: requestData.method,
+      headers: outgoingRequestHeaders(requestData.headers),
+      lookup: (_hostname, _options, callback) => {
+        callback(null, address.address, address.family);
+      },
+      maxHeaderSize: MCP_OAUTH_MAX_HEADER_BYTES,
+      signal,
+    },
+    (response) => {
+      const chunks: Buffer[] = [];
+      let responseBytes = 0;
+      response.on("data", (chunk: Buffer) => {
+        if (deferred.settled()) {
+          return;
+        }
+        responseBytes += chunk.byteLength;
+        if (responseBytes > MCP_OAUTH_MAX_RESPONSE_BYTES) {
+          const error = new Error("MCP OAuth response is too large");
+          deferred.resolve({ ok: false, error });
+          response.destroy(error);
+          return;
+        }
+        chunks.push(Buffer.from(chunk));
+      });
+      response.on("error", (error) => {
+        if (!deferred.settled()) {
+          deferred.resolve({ ok: false, error });
+        }
+      });
+      response.on("aborted", () => {
+        if (!deferred.settled()) {
+          deferred.resolve({
+            ok: false,
+            error: new Error("MCP OAuth response was aborted"),
+          });
+        }
+      });
+      response.on("end", () => {
+        if (deferred.settled()) {
+          return;
+        }
+        const status = response.statusCode ?? 502;
+        if (status < 200 || status > 599) {
+          deferred.resolve({
+            ok: false,
+            error: new Error("MCP OAuth response status is invalid"),
+          });
+          return;
+        }
+        const body = Buffer.concat(chunks);
+        deferred.resolve({
+          ok: true,
+          response: new Response(
+            responseCanHaveBody(requestData.method, status) ? body : null,
+            {
+              status,
+              statusText: response.statusMessage,
+              headers: responseHeaders(response.headers),
+            },
+          ),
+        });
+      });
+    },
+  );
+  request.on("error", (error) => {
+    if (!deferred.settled()) {
+      deferred.resolve({ ok: false, error });
+    }
+  });
+  request.end(requestData.body);
+  const outcome = await deferred.promise;
+  if (!outcome.ok) {
+    throw outcome.error;
+  }
+  return outcome.response;
+}
+
+function redirectLocation(response: Response): string | null {
+  return REDIRECT_STATUSES.some((status) => {
+    return status === response.status;
+  })
+    ? response.headers.get("location")
+    : null;
+}
+
+export const mcpOAuthSafeFetch: FetchLike = async (input, init) => {
+  const timeoutSignal = AbortSignal.timeout(MCP_OAUTH_FETCH_TIMEOUT_MS);
+  const signal = AbortSignal.any([
+    new Request(input, init).signal,
+    timeoutSignal,
+  ]);
+  const requestData = serializedRequest(init);
+  let url = allowedUrl(input);
+  let redirectCount = 0;
+
+  while (true) {
+    const response = await pinnedRequest(url, requestData, signal);
+    const location = redirectLocation(response);
+    if (location === null) {
+      return response;
+    }
+    if (requestData.method === "POST") {
+      throw new Error("MCP OAuth POST redirects are not allowed");
+    }
+    if (redirectCount === MCP_OAUTH_MAX_REDIRECTS) {
+      throw new Error("MCP OAuth response has too many redirects");
+    }
+    for (const name of REDIRECT_SENSITIVE_HEADERS) {
+      requestData.headers.delete(name);
+    }
+    url = allowedUrl(new URL(location, url));
+    redirectCount += 1;
+  }
+};

--- a/turbo/packages/api-contracts/src/contracts/mcp-oauth.ts
+++ b/turbo/packages/api-contracts/src/contracts/mcp-oauth.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const okouMcpOAuthClientMetadataSchema = z.object({
+  client_id: z.url(),
+  client_name: z.literal("Okou"),
+  client_uri: z.url(),
+  redirect_uris: z.array(z.url()).length(1),
+  grant_types: z.tuple([
+    z.literal("authorization_code"),
+    z.literal("refresh_token"),
+  ]),
+  response_types: z.tuple([z.literal("code")]),
+  application_type: z.literal("web"),
+  token_endpoint_auth_method: z.literal("none"),
+});
+export type OkouMcpOAuthClientMetadata = z.infer<
+  typeof okouMcpOAuthClientMetadataSchema
+>;
+
+export const mcpOAuthContract = c.router({
+  okouClientMetadata: {
+    method: "GET",
+    path: "/api/oauth/mcp/client-metadata/okou.json",
+    responses: {
+      200: okouMcpOAuthClientMetadataSchema,
+    },
+    summary: "Get the Okou MCP OAuth client metadata document",
+  },
+});
+export type McpOAuthContract = typeof mcpOAuthContract;

--- a/turbo/packages/api-contracts/src/contracts/test-mcp-oauth-fetch.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-mcp-oauth-fetch.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const testMcpOAuthFetchRequestSchema = z.object({
+  url: z.url(),
+  method: z.enum(["GET", "HEAD", "POST"]),
+  bodyKind: z.enum(["form", "json"]).optional(),
+  body: z.string().optional(),
+  authorization: z.string().optional(),
+  cancel: z.boolean().optional(),
+});
+export type TestMcpOAuthFetchRequest = z.infer<
+  typeof testMcpOAuthFetchRequestSchema
+>;
+
+export const testMcpOAuthFetchContract = c.router({
+  request: {
+    method: "POST",
+    path: "/api/test/mcp-oauth-fetch",
+    body: testMcpOAuthFetchRequestSchema,
+    responses: {
+      200: z.object({
+        status: z.number().int(),
+        headers: z.record(z.string(), z.string()),
+        body: z.string(),
+      }),
+      404: z.string(),
+      502: z.object({ error: z.string() }),
+    },
+    summary: "Probe the MCP OAuth fetch policy in API tests",
+  },
+});

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       '@hono/otel':
         specifier: ^1.1.2
         version: 1.1.2(hono@4.13.0)
+      '@modelcontextprotocol/client':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@okouai/api-contracts':
         specifier: workspace:*
         version: link:../../packages/api-contracts


### PR DESCRIPTION
## Summary

- add an API-owned MCP SDK-compatible OAuth fetch adapter with HTTPS-only destination validation, all-address SSRF checks, DNS pinning, per-hop redirect policy, cancellation, and response limits
- migrate existing standard Custom OAuth token exchange and refresh requests to the shared adapter while preserving JSON/form responses and client authentication modes
- publish the exact public Okou client metadata document from configured canonical origins, with route-level security and compatibility coverage

## Security boundary

- metadata GET/HEAD requests follow at most three redirects and revalidate and pin every destination
- token and DCR POST redirects are rejected without credential replay
- connections do not reuse pooled sockets, so each request uses the address selected by the current validated DNS result
- no credential-bearing response bodies are logged

## Out of scope

- accepting `oauthSetup: automatic`
- MCP authorization discovery or CIMD/DCR orchestration
- persistence, callback issuer validation, frontend, CLI, or runner behavior changes

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F api check-types`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm knip --workspace api`
- `pnpm knip --workspace @okouai/api-contracts`
- `pnpm -F @okouai/api-contracts test` (645 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/mcp-oauth-foundations.test.ts` (17 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts -t 'stores an OAuth app config and lets members authorize'`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t 'serializes reconnect-marked custom OAuth recovery'`
- pre-commit repository-wide Knip and Turbo type checks

Closes #30486

Parent delivery issue: #30466
