### PR TITLE
test(platform): synchronize workflow reload completion

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
@@ -700,6 +700,103 @@ describe("chat composer models", () => {
     });
   });
 
+  it("reloads workflow suggestions and highlights without remounting the composer", async () => {
+    const user = userEvent.setup({ delay: null });
+    const reloadWorkflowsRequested = context.mocks.deferred<void>();
+    const releaseReloadWorkflows = context.mocks.deferred<void>();
+    const reloadedWorkflow = workflowSummary({
+      name: "new-chat-workflow",
+      displayName: "New Chat Workflow",
+      description: "Created by the current chat run",
+      agentId: AGENT_ID,
+    });
+    let workflowPhase: "initial" | "reloaded" = "initial";
+    mockOrgModelRoutes("claude-fable-5");
+    mockAgent();
+    mockThread();
+    context.mocks.api(chatThreadDraftContract.get, ({ respond }) => {
+      return respond(200, {
+        draftUserMessage: {
+          version: 1,
+          parts: [{ type: "text", text: "/new-chat-workflow" }],
+        },
+        draftAttachments: null,
+      });
+    });
+    context.mocks.api(workflowsCollectionContract.list, async ({ respond }) => {
+      if (workflowPhase === "initial") {
+        return respond(200, []);
+      }
+      if (!reloadWorkflowsRequested.settled()) {
+        reloadWorkflowsRequested.resolve();
+      }
+      await releaseReloadWorkflows.promise;
+      return respond(200, [reloadedWorkflow]);
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        context.mocks.ably.hasSubscription(
+          `chatThreadWorkflowsChanged:${THREAD_ID}`,
+        ),
+      ).toBeTruthy();
+      expect(screen.getByTestId("app-skeleton")).toHaveAttribute(
+        "aria-hidden",
+        "true",
+      );
+    });
+    const thread = await screen.findByLabelText("Chat thread");
+    const initialEditor = await within(thread).findByRole("textbox", {
+      name: "Message",
+    });
+    await waitFor(() => {
+      expect(initialEditor).toHaveTextContent("/new-chat-workflow");
+      expect(
+        initialEditor.querySelector("span.text-primary"),
+      ).not.toBeInTheDocument();
+    });
+
+    workflowPhase = "reloaded";
+    act(() => {
+      context.mocks.ably.trigger(
+        `chatThreadWorkflowsChanged:${THREAD_ID}`,
+        null,
+      );
+    });
+    await reloadWorkflowsRequested.promise;
+    releaseReloadWorkflows.resolve();
+
+    await waitFor(() => {
+      expect(within(initialEditor).getByText("/new-chat-workflow")).toHaveClass(
+        "text-primary",
+      );
+    });
+    await expect(findComposerEditor()).resolves.toBe(initialEditor);
+    await user.click(initialEditor);
+    await user.keyboard("{Control>}a{/Control}{Backspace}/");
+    await expect(
+      screen.findByText("new-chat-workflow"),
+    ).resolves.toBeInTheDocument();
+    await expect(findComposerEditor()).resolves.toBe(initialEditor);
+
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(mountedComposerText()).toContain("/new-chat-workflow");
+    });
+    const highlightedWorkflow = screen
+      .getAllByText("/new-chat-workflow")
+      .find((element) => {
+        return element.tagName.toLowerCase() === "span";
+      });
+    expect(highlightedWorkflow).toHaveClass("text-primary");
+  });
+
   it("keeps the latest workflow highlights when split-pane reloads resolve out of order", async () => {
     const user = userEvent.setup({ delay: null });
     const staleRequestsStarted = context.mocks.deferred<void>();


### PR DESCRIPTION
## Summary

- restore an unmatched workflow token into the real mounted chat composer before the reload
- wait for that token to become highlighted as the observable completion boundary for the workflow refresh
- preserve the same-editor, suggestion insertion, and final highlight assertions without changing production behavior

## Validation

- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-editor-and-suggestions.test.tsx --maxWorkers=1 --silent=passed-only` (22 passed)
- pre-commit: Prettier, Knip, repository TypeScript checks, file-size check, and commitlint

## Notes

- No production code or user-facing behavior changes.
- A local full Platform test attempt passed the target test but hit 23 unrelated failures across 15 files under severe host load, mostly the default 5-second timeout plus TLS teardown cancellation errors. The same-file unrelated failure passed in isolation.

Closes #30524
