### PR TITLE
perf(api): consolidate goal queue selection reads

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
@@ -20,6 +20,7 @@ import {
   drainChatThreadQueueFixture,
   pauseGoalQueueTargetFixture,
   readGoalQueueStateFixture,
+  setGoalQueueEventCreatedAtFixture,
 } from "../../../test-fixtures/goal-queue";
 import {
   admitWorkflowAutomationEventFixture,
@@ -684,6 +685,63 @@ describe("workflow queue", () => {
       throw new Error("Expected the goal continuation to create a run");
     }
     await runsApi.requestCancelRun(scenario.actor, goalRunId, [200]);
+  });
+
+  it("ignores a fresh automation outside the cutoff while selecting a stale goal", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const admissionLock = await holdOrgAdmissionLockFixture({
+      orgId: scenario.orgId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      admissionLock.release();
+      await admissionLock.done;
+    });
+
+    const goal = await createActiveGoalQueueEventFixture({
+      threadId: automation.threadId,
+      orgId: scenario.orgId,
+      userId: scenario.userId,
+      agentId: scenario.agentId,
+      objective: "continue during the stale sweep",
+      objectiveBrief: "Continue during the stale sweep",
+    });
+    await setGoalQueueEventCreatedAtFixture({
+      eventId: goal.eventId,
+      createdAt: new Date("2019-12-31T23:54:00.000Z"),
+    });
+    const freshAutomationEventId = await admitWorkflowAutomationEventFixture({
+      automationId: automation.automationId,
+      chatThreadId: automation.threadId,
+      triggerBrief: "Fresh automation outside the stale sweep",
+    });
+    await setWorkflowQueueEventCreatedAtFixture({
+      eventId: freshAutomationEventId,
+      createdAt: new Date("2020-01-01T00:01:00.000Z"),
+    });
+
+    const goalDrain = drainChatThreadQueueFixture({
+      threadId: automation.threadId,
+      signal: context.signal,
+      queueItemCreatedBefore: new Date("2020-01-01T00:00:00.000Z"),
+    });
+
+    // Reaching the organization lock proves the stale goal passed selection;
+    // the unchanged final queue claim still rejects it while fresh work exists.
+    await expect.poll(admissionLock.waiterCount).toBeGreaterThanOrEqual(1);
+    admissionLock.release();
+    await goalDrain;
+    await admissionLock.done;
+
+    await expect(
+      readGoalQueueStateFixture(automation.threadId),
+    ).resolves.toMatchObject({ runIds: [], eventIds: [goal.eventId] });
+    expect(
+      (await pendingAutomationEvents(automation.threadId)).map((event) => {
+        return event.id;
+      }),
+    ).toContain(freshAutomationEventId);
   });
 
   it("keeps an automation event ahead of a goal continuation during final queue claim", async () => {

--- a/turbo/apps/api/src/signals/services/chat-active-run.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-active-run.service.ts
@@ -13,6 +13,7 @@ import {
   isNotNull,
   lte,
   ne,
+  not,
   notExists,
   or,
   sql,
@@ -24,6 +25,12 @@ import { pendingChatQueueEventCondition } from "./chat-event-queue.service";
 import { chatEventTypeIn } from "./chat-event-type.service";
 
 const ACTIVE_CHAT_RUN_STATUSES = ["queued", "pending", "running"] as const;
+
+interface ChatThreadAdmissionConditionArgs {
+  readonly threadId: string;
+  readonly excludeRunId?: string;
+  readonly apiStartTime?: number;
+}
 
 function activeChatRunCondition(db: Pick<Db, "select">) {
   return and(
@@ -119,13 +126,59 @@ export async function cancellationRecoveryPendingForThread(
   return run !== undefined;
 }
 
+function chatThreadRunAdmissionBlockerExists(
+  db: Pick<Db, "select">,
+  args: ChatThreadAdmissionConditionArgs,
+): SQL {
+  return exists(
+    db
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.chatThreadId, args.threadId),
+          args.excludeRunId === undefined
+            ? undefined
+            : ne(agentRuns.id, args.excludeRunId),
+          or(
+            activeChatRunCondition(db),
+            freshUnresolvedCancellationRecoveryCondition(db, args.apiStartTime),
+          ),
+        ),
+      ),
+  );
+}
+
+function chatThreadOpenDeliveryExists(
+  db: Pick<Db, "select">,
+  threadId: string,
+): SQL {
+  return exists(
+    db
+      .select({ id: activeInputDeliveries.id })
+      .from(activeInputDeliveries)
+      .where(
+        and(
+          eq(activeInputDeliveries.chatThreadId, threadId),
+          eq(activeInputDeliveries.status, "open"),
+        ),
+      ),
+  );
+}
+
+export function chatThreadAdmissionAllowedCondition(
+  db: Pick<Db, "select">,
+  args: ChatThreadAdmissionConditionArgs,
+): SQL | undefined {
+  return and(
+    not(chatThreadRunAdmissionBlockerExists(db, args)),
+    not(chatThreadOpenDeliveryExists(db, args.threadId)),
+  );
+}
+
 async function chatThreadAdmissionBlockerExists(
   db: Pick<Db, "select">,
-  args: {
-    readonly threadId: string;
-    readonly excludeRunId?: string;
-    readonly apiStartTime?: number;
-  },
+  args: ChatThreadAdmissionConditionArgs,
 ): Promise<boolean> {
   const [thread] = await db
     .select({ id: chatThreads.id })
@@ -134,37 +187,8 @@ async function chatThreadAdmissionBlockerExists(
       and(
         eq(chatThreads.id, args.threadId),
         or(
-          exists(
-            db
-              .select({ id: agentRuns.id })
-              .from(agentRuns)
-              .where(
-                and(
-                  eq(agentRuns.chatThreadId, args.threadId),
-                  args.excludeRunId === undefined
-                    ? undefined
-                    : ne(agentRuns.id, args.excludeRunId),
-                  or(
-                    activeChatRunCondition(db),
-                    freshUnresolvedCancellationRecoveryCondition(
-                      db,
-                      args.apiStartTime,
-                    ),
-                  ),
-                ),
-              ),
-          ),
-          exists(
-            db
-              .select({ id: activeInputDeliveries.id })
-              .from(activeInputDeliveries)
-              .where(
-                and(
-                  eq(activeInputDeliveries.chatThreadId, args.threadId),
-                  eq(activeInputDeliveries.status, "open"),
-                ),
-              ),
-          ),
+          chatThreadRunAdmissionBlockerExists(db, args),
+          chatThreadOpenDeliveryExists(db, args.threadId),
         ),
       ),
     )

--- a/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
@@ -2,23 +2,23 @@ import { chatEvents } from "@okouai/db/schema/chat-event";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
 import { threadGoals } from "@okouai/db/schema/thread-goal";
 import { agents } from "@okouai/db/schema/agent";
-import { and, eq, isNull, notExists, sql } from "drizzle-orm";
+import { and, asc, eq, isNull, lt, notExists, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
 import { pgTextDecoder } from "../../lib/db-structured-result";
 import { nowDate } from "../../lib/time";
 import type { Db } from "../external/db";
 import {
-  listPendingChatQueueEvents,
   loadPendingChatQueueEvent,
   lockChatQueueThread,
+  pendingChatQueueEventCondition,
 } from "./chat-event-queue.service";
 import {
   insertChatEvent,
   revokeChatEvent,
   replaceChatEvent,
 } from "./chat-event.service";
-import { chatThreadAdmissionBlocked } from "./chat-active-run.service";
+import { chatThreadAdmissionAllowedCondition } from "./chat-active-run.service";
 import { chatEventTypeIn } from "./chat-event-type.service";
 import { appendGoalCloseMarker } from "./chat-goal-marker.service";
 import { createUserMessageDocument } from "./chat-user-message.service";
@@ -133,18 +133,6 @@ export async function loadNextGoalQueueEvent(
     if (!(await lockChatQueueThread(tx, chatThreadId))) {
       return null;
     }
-    if (await chatThreadAdmissionBlocked(tx, { threadId: chatThreadId })) {
-      return null;
-    }
-    const pending = await listPendingChatQueueEvents(
-      tx,
-      chatThreadId,
-      queueItemCreatedBefore,
-    );
-    const head = pending[0];
-    if (!head || head.eventType !== "input.goal") {
-      return null;
-    }
 
     const [event] = await tx
       .select({
@@ -158,7 +146,35 @@ export async function loadNextGoalQueueEvent(
       .from(chatEvents)
       .innerJoin(chatThreads, eq(chatThreads.id, chatEvents.chatThreadId))
       .innerJoin(agents, eq(agents.id, chatThreads.agentId))
-      .where(eq(chatEvents.id, head.id))
+      .where(
+        and(
+          eq(chatEvents.chatThreadId, chatThreadId),
+          pendingChatQueueEventCondition(tx),
+          chatEventTypeIn(["input.goal"]),
+          queueItemCreatedBefore
+            ? lt(chatEvents.createdAt, queueItemCreatedBefore)
+            : undefined,
+          notExists(
+            tx
+              .select({ id: chatEvents.id })
+              .from(chatEvents)
+              .where(
+                and(
+                  eq(chatEvents.chatThreadId, chatThreadId),
+                  pendingChatQueueEventCondition(tx),
+                  chatEventTypeIn(["input.prompt", "input.automation"]),
+                  queueItemCreatedBefore
+                    ? lt(chatEvents.createdAt, queueItemCreatedBefore)
+                    : undefined,
+                ),
+              ),
+          ),
+          chatThreadAdmissionAllowedCondition(tx, {
+            threadId: chatThreadId,
+          }),
+        ),
+      )
+      .orderBy(asc(chatEvents.createdAt), asc(chatEvents.id))
       .limit(1);
     if (!event) {
       return null;

--- a/turbo/apps/api/src/test-fixtures/goal-queue.ts
+++ b/turbo/apps/api/src/test-fixtures/goal-queue.ts
@@ -2,7 +2,7 @@ import { chatEvents } from "@okouai/db/schema/chat-event";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { threadGoals } from "@okouai/db/schema/thread-goal";
 import { createStore } from "ccstate";
-import { and, eq, isNotNull } from "drizzle-orm";
+import { and, eq, isNotNull, sql } from "drizzle-orm";
 
 import { db } from "../lib/db";
 import { dispatchFailedRunCallbacks } from "../signals/services/agent-run-callback.service";
@@ -81,15 +81,40 @@ export async function readGoalQueueStateFixture(threadId: string): Promise<{
 export async function drainChatThreadQueueFixture(args: {
   readonly threadId: string;
   readonly signal: AbortSignal;
+  readonly queueItemCreatedBefore?: Date;
 }): Promise<void> {
   await createStore().set(
     drainChatThreadQueueForThread$,
     {
       chatThreadId: args.threadId,
       dispatchFailedCallbacks: dispatchFailedRunCallbacks,
+      queueItemCreatedBefore: args.queueItemCreatedBefore,
     },
     args.signal,
   );
+}
+
+/** Move one goal trigger before a stale-sweep cutoff. */
+export async function setGoalQueueEventCreatedAtFixture(args: {
+  readonly eventId: string;
+  readonly createdAt: Date;
+}): Promise<void> {
+  const updated = await db().transaction(async (tx) => {
+    await tx.execute(sql`SET LOCAL session_replication_role = replica`);
+    return await tx
+      .update(chatEvents)
+      .set({ createdAt: args.createdAt })
+      .where(
+        and(
+          eq(chatEvents.id, args.eventId),
+          eq(chatEvents.eventType, "input.goal"),
+        ),
+      )
+      .returning({ id: chatEvents.id });
+  });
+  if (updated.length !== 1) {
+    throw new Error("Expected one goal queue event to become historical");
+  }
 }
 
 /** Invalidate a goal without triggering a separate queue drain. */


### PR DESCRIPTION
## Summary

- replace the goal queue's three post-lock reads with one bounded structured selection
- share the existing active-run, cancellation-recovery, and open-delivery admission predicates instead of copying them
- preserve strict sweep cutoffs and add a real-database regression for fresh higher-priority work outside the cutoff

## Problem

`loadNextGoalQueueEvent()` locked the thread, queried admission blockers, loaded and sorted the complete pending queue, and then loaded the selected goal's details. The last three serial statements delayed the common successful goal-continuation path and materialized rows the scheduler did not consume.

## Solution

The thread `FOR UPDATE` remains the first statement. One post-lock query now:

- selects at most one pending goal in PostgreSQL FIFO order;
- rejects pending prompt or automation work from the identical cutoff universe;
- requires the existing run/recovery and open-delivery blockers to be absent; and
- joins the thread, Agent, and canonical goal fields required for preparation.

The higher-priority exclusion is intentionally emitted before admission predicates. Actual generated-query plans make it the first one-time check, so user/automation heads skip admission, goal-candidate, and detail work. `loadGoalQueueTarget()` and the final queue-first verification and claim/CAS are unchanged.

## Query-plan evidence

The exact Drizzle-generated statement and ordered parameters were captured and explained against rolled-back PostgreSQL fixtures:

| Queue shape | Shared hits | Planning | Execution |
| --- | ---: | ---: | ---: |
| Empty | 13 | 0.827 ms | 0.111 ms |
| User head plus goal | 6 | 0.591 ms | 0.038 ms |
| Automation head plus goal | 6 | 0.549 ms | 0.034 ms |
| Goal head | 22 | 0.646 ms | 0.077 ms |

These local values validate bounded shape and index use; they are not production latency predictions. No schema or index change is required.

## Correctness and compatibility

- the pending-event definition, strict cutoff, class priority, PostgreSQL timestamp precision, and ID tie-break remain database-owned
- the existing thread lock and final global queue-head claim remain authoritative for concurrent inserts
- active runs, fresh cancellation recovery, and open active-input deliveries use the same shared predicate leaves as existing callers
- no public API, schema, persisted state, queue payload, Runner protocol, or cross-version contract changes
- organization-concurrency queue wait remains outside `api_to_spawn`; the post-promotion durable Runner queue remains inside it

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/workflow-queue.test.ts src/signals/routes/__tests__/chat-callbacks.bdd.test.ts --maxWorkers=4 --silent=passed-only` (88 passed)
- `pnpm knip --workspace api`
- lefthook full Turbo Knip and type checks (14/14 type-check tasks passed)

Closes #30533

Parent: #24203
