### PR TITLE
test(python): cover non-positive stream decode chunk limits

### DIFF
--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -240,6 +240,20 @@ class TestStreamDecodeSession:
         assert chunks == [b"hello"]
         assert session.finish_error() is None
 
+    @pytest.mark.parametrize("encoding", ["identity", "gzip", "br"])
+    @pytest.mark.parametrize("max_decoded_chunk", [0, -1])
+    def test_non_positive_max_decoded_chunk_is_rejected(self, headers, encoding, max_decoded_chunk):
+        chunks: list[bytes] = []
+
+        with pytest.raises(ValueError, match=r"^max_decoded_chunk must be positive$"):
+            create_stream_decode_session(
+                headers(("Content-Encoding", encoding)),
+                chunks.append,
+                max_decoded_chunk=max_decoded_chunk,
+            )
+
+        assert chunks == []
+
     def test_identity_document_parser_termination_stops_callbacks(self, headers):
         extractor = JsonSelectiveExtractor(max_work_units=1)
         decoded_callbacks = 0


### PR DESCRIPTION
## Summary

- add a six-case public-helper matrix for zero and negative streaming decode chunk limits
- cover identity, gzip, and Brotli dispatch paths at session construction
- verify invalid limits raise before the decoder callback receives output

## Scope

This is a test-only change. Production decoder behavior, defaults, callers, dependencies, and configuration are unchanged.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_body_decoding.py` (`115 passed`)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`7251 passed`)

Closes #30546
