### PR TITLE
fix(app): open billing plans from upgrade card

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/plan-upgrade-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/plan-upgrade-block.ts
@@ -2,13 +2,16 @@ import {
   createCardSignalsRegistry,
   type CardSignalsRegistry,
 } from "./card-signal-map.ts";
+import { openSettingsBillingPlansDialog$ } from "../okou-page/settings/settings-dialog.ts";
 import { parseTrustedPlatformActionUrl } from "./platform-action-url.ts";
 
 export interface PlanUpgradeDescriptor {
   readonly href: string;
 }
 
-export type PlanUpgradeSignals = PlanUpgradeDescriptor;
+export interface PlanUpgradeSignals extends PlanUpgradeDescriptor {
+  readonly open$: typeof openSettingsBillingPlansDialog$;
+}
 
 type PlanUpgradeCardSignalsRegistry = CardSignalsRegistry<
   PlanUpgradeDescriptor,
@@ -39,7 +42,10 @@ export function createPlanUpgradeCardSignalsRegistry(): PlanUpgradeCardSignalsRe
       return descriptor.href;
     },
     (descriptor) => {
-      return descriptor;
+      return {
+        ...descriptor,
+        open$: openSettingsBillingPlansDialog$,
+      };
     },
   );
 }

--- a/turbo/apps/platform/src/signals/okou-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/settings-dialog.ts
@@ -247,6 +247,13 @@ export const setSettingsDialogOpen$ = command(
   },
 );
 
+export const openSettingsBillingPlansDialog$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    set(openSettingsBillingPlans$);
+    await set(setSettingsDialogOpen$, true, signal);
+  },
+);
+
 /**
  * Open the dialog directly on a target section. Used by entry-point components
  * (account dropdown, org switcher) to deep-link into a specific area.

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
@@ -3810,7 +3810,7 @@ describe("chat event action cards", () => {
       });
 
       const card = await screen.findByTestId("plan-upgrade-card");
-      expect(buttonByText("Compare plans", card)).toHaveClass("bg-primary");
+      expect(buttonByText("Compare plans", card)).toBeInTheDocument();
     },
   );
 
@@ -3886,7 +3886,7 @@ describe("chat event action cards", () => {
       ),
     ).toBeInTheDocument();
     for (const card of cards) {
-      expect(buttonByText("Compare plans", card)).toHaveClass("bg-primary");
+      expect(buttonByText("Compare plans", card)).toBeInTheDocument();
     }
     expect(linkByText("Untrusted plan", document)).toHaveAttribute(
       "href",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
@@ -3810,14 +3810,12 @@ describe("chat event action cards", () => {
       });
 
       const card = await screen.findByTestId("plan-upgrade-card");
-      expect(linkByText("Compare plans", card)).toHaveAttribute(
-        "href",
-        "/?settings=billing&billingView=plans",
-      );
+      expect(buttonByText("Compare plans", card)).toHaveClass("bg-primary");
     },
   );
 
-  it("renders trusted plan links as upgrade cards", async () => {
+  it("opens billing plans from trusted plan upgrade cards", async () => {
+    const user = userEvent.setup({ delay: null });
     const absoluteUrl =
       "https://app.vm0.ai/?settings=billing&billingView=plans";
     const relativeUrl = "/?settings=billing&billingView=plans";
@@ -3888,8 +3886,7 @@ describe("chat event action cards", () => {
       ),
     ).toBeInTheDocument();
     for (const card of cards) {
-      const comparePlansLink = linkByText("Compare plans", card);
-      expect(comparePlansLink).toHaveAttribute("href", relativeUrl);
+      expect(buttonByText("Compare plans", card)).toHaveClass("bg-primary");
     }
     expect(linkByText("Untrusted plan", document)).toHaveAttribute(
       "href",
@@ -3911,6 +3908,10 @@ describe("chat event action cards", () => {
       "href",
       creditUrl,
     );
+    await user.click(buttonByText("Compare plans", cards[0]!));
+    await expect(
+      screen.findByRole("dialog", { name: "Choose a plan" }),
+    ).resolves.toBeInTheDocument();
   });
 
   it("does not cancel stale permission loading when a confirmed grant reloads cards", async () => {

--- a/turbo/apps/platform/src/views/okou-page/chat-body-cards.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-body-cards.tsx
@@ -11,12 +11,15 @@ import type {
 } from "../../signals/chat-page/connector-action-block.ts";
 import { contentTypeForBodyPreviewKind } from "../../signals/chat-page/parse-body-blocks.ts";
 import type { PermissionSignals } from "../../signals/chat-page/permission-card-signals.ts";
-import type { PlanUpgradeSignals } from "../../signals/chat-page/plan-upgrade-block.ts";
 import type {
   PlatformConnectorPermissionMetadata,
   PlatformUserPermissionGrant,
 } from "../../signals/connector-domain.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
+import {
+  openSettingsBillingPlans$,
+  setSettingsDialogOpen$,
+} from "../../signals/okou-page/settings/settings-dialog.ts";
 import {
   applyUserPermissionGrant$,
   findPermissionInMetadata,
@@ -44,7 +47,7 @@ import {
   type FirewallPolicyValue,
 } from "@okouai/connectors/firewall-contracts";
 import { r2ImageTransformUrl } from "@okouai/core/r2-image-transform";
-import { Skeleton, cn } from "@okouai/ui";
+import { Button, Skeleton, cn } from "@okouai/ui";
 import {
   useGet,
   useLastLoadable,
@@ -299,7 +302,7 @@ export function MarkdownCardView({ card }: { card: MarkdownCardRef }) {
       return <ComputerUseAuthorizationCard signals={card.signals} />;
     }
     case "plan-upgrade": {
-      return <PlanUpgradeCard signals={card.signals} />;
+      return <PlanUpgradeCard />;
     }
     case "mail-draft": {
       return <MailDraftCard signals={card.signals} />;
@@ -587,8 +590,17 @@ function ComputerUseAuthorizationCard({
   );
 }
 
-function PlanUpgradeCard({ signals }: { signals: PlanUpgradeSignals }) {
+function PlanUpgradeCard() {
   const { t } = useTranslation();
+  const pageSignal = useGet(pageSignal$);
+  const openBillingPlans = useSet(openSettingsBillingPlans$);
+  const openSettings = useSet(setSettingsDialogOpen$);
+
+  const handleClick = () => {
+    openBillingPlans();
+    detach(openSettings(true, pageSignal), Reason.DomCallback);
+  };
+
   return (
     <div
       data-testid="plan-upgrade-card"
@@ -611,17 +623,15 @@ function PlanUpgradeCard({ signals }: { signals: PlanUpgradeSignals }) {
           </div>
         </div>
       </div>
-      <a
-        href={signals.href}
-        target="_blank"
-        rel="noreferrer"
-        className="inline-flex h-9 w-full shrink-0 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-[0.9375rem] font-medium text-foreground transition-colors hover:bg-state-hover sm:w-auto"
+      <Button
+        type="button"
+        onClick={handleClick}
+        className="w-full shrink-0 sm:w-auto"
       >
         {t(($) => {
           return $.chat.billing.comparePlans;
         })}
-        <ArrowUpRight size={15} />
-      </a>
+      </Button>
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/chat-body-cards.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-body-cards.tsx
@@ -11,15 +11,12 @@ import type {
 } from "../../signals/chat-page/connector-action-block.ts";
 import { contentTypeForBodyPreviewKind } from "../../signals/chat-page/parse-body-blocks.ts";
 import type { PermissionSignals } from "../../signals/chat-page/permission-card-signals.ts";
+import type { PlanUpgradeSignals } from "../../signals/chat-page/plan-upgrade-block.ts";
 import type {
   PlatformConnectorPermissionMetadata,
   PlatformUserPermissionGrant,
 } from "../../signals/connector-domain.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import {
-  openSettingsBillingPlans$,
-  setSettingsDialogOpen$,
-} from "../../signals/okou-page/settings/settings-dialog.ts";
 import {
   applyUserPermissionGrant$,
   findPermissionInMetadata,
@@ -302,7 +299,7 @@ export function MarkdownCardView({ card }: { card: MarkdownCardRef }) {
       return <ComputerUseAuthorizationCard signals={card.signals} />;
     }
     case "plan-upgrade": {
-      return <PlanUpgradeCard />;
+      return <PlanUpgradeCard signals={card.signals} />;
     }
     case "mail-draft": {
       return <MailDraftCard signals={card.signals} />;
@@ -590,15 +587,13 @@ function ComputerUseAuthorizationCard({
   );
 }
 
-function PlanUpgradeCard() {
+function PlanUpgradeCard({ signals }: { signals: PlanUpgradeSignals }) {
   const { t } = useTranslation();
   const pageSignal = useGet(pageSignal$);
-  const openBillingPlans = useSet(openSettingsBillingPlans$);
-  const openSettings = useSet(setSettingsDialogOpen$);
+  const open = useSet(signals.open$);
 
   const handleClick = () => {
-    openBillingPlans();
-    detach(openSettings(true, pageSignal), Reason.DomCallback);
+    detach(open(pageSignal), Reason.DomCallback);
   };
 
   return (


### PR DESCRIPTION
## Summary
- render the plan-upgrade chat action with the shared primary Button
- open the in-app billing plans dialog instead of a new tab
- cover the primary styling and dialog interaction in the page-level card test

## Verification
- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- pnpm turbo run check-types --concurrency=1 --filter=!api --filter=!@okouai/app
- pnpm --filter @okouai/app run check-types
- pnpm --filter api run check-types
- pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-event-action-cards.test.tsx -t localizes-a-persisted-or-opens-billing-plans-from-trusted --maxWorkers=1 --testTimeout=30000