### PR TITLE
fix(platform): stop connector account pagination at the last page

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/connector-accounts.ts
+++ b/turbo/apps/platform/src/signals/okou-page/connector-accounts.ts
@@ -83,7 +83,10 @@ function mergeConnectorAccountPages(
         return page.connections;
       }),
     ],
-    nextCursor: pages.at(-1)?.nextCursor ?? firstPage.nextCursor,
+    // The newest loaded page owns the cursor, including when it ends the list
+    // with a null cursor. Falling back to the first page's cursor there would
+    // keep "Load more" alive and re-request the page after the first one.
+    nextCursor: (pages.at(-1) ?? firstPage).nextCursor,
     available: firstPage.available,
   };
 }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -1773,12 +1773,28 @@ describe("connectors page", () => {
   });
 
   it("paginates a feature-on account manager", async () => {
-    const accounts = mockGitHubConnectorAccounts(101);
+    const accounts = mockGitHubConnectorAccounts(8);
+    // The server projects rows away before slicing, so a page can hold fewer
+    // connections than the requested limit and still report a next cursor.
+    // Serving short pages walks the same three-page cursor chain the client
+    // follows for a full connector, without rendering hundreds of rows.
+    const serverPageSize = 3;
+    const accountQueries: {
+      readonly limit: number;
+      readonly cursor: string | null;
+    }[] = [];
     context.mocks.api(
       connectorAccountsContract.connections,
       ({ query, respond }) => {
+        accountQueries.push({
+          limit: query.limit,
+          cursor: query.cursor ?? null,
+        });
         const start = query.cursor ? Number(query.cursor) : 0;
-        const page = accounts.slice(start, start + query.limit);
+        const page = accounts.slice(
+          start,
+          start + Math.min(query.limit, serverPageSize),
+        );
         const next = start + page.length;
         return respond(200, {
           connections: page,
@@ -1794,17 +1810,39 @@ describe("connectors page", () => {
 
     click(await waitForButtonByAriaLabel("Manage GitHub accounts"));
     const dialog = await screen.findByRole("dialog", { name: "GitHub" });
-    expect(within(dialog).queryByText("Work 50")).toBeNull();
+    expect(within(dialog).getByText("Work 7")).toBeInTheDocument();
+    expect(within(dialog).queryByText("Work 4")).toBeNull();
     click(buttonByText("Load more", dialog));
     await waitFor(() => {
-      expect(within(dialog).getByText("Work 50")).toBeInTheDocument();
+      expect(within(dialog).getByText("Work 4")).toBeInTheDocument();
     });
+    expect(within(dialog).getByText("Work 7")).toBeInTheDocument();
     click(buttonByText("Load more", dialog));
+    // The last page carries an account of its own, so waiting for that account
+    // pins the assertions below to the render that consumed it. Waiting on the
+    // "Load more" label instead would pass mid-request, while the button still
+    // reads "Loading more".
     await waitFor(() => {
-      expect(queryButtonByText("Load more", dialog)).toBeNull();
       expect(within(dialog).getByText("Work 1")).toBeInTheDocument();
-      expect(within(dialog).getAllByText("Account #00000000")).toHaveLength(1);
     });
+    expect(queryButtonByText("Load more", dialog)).toBeNull();
+    expect(within(dialog).getByText("Work 7")).toBeInTheDocument();
+    expect(within(dialog).getByText("Work 4")).toBeInTheDocument();
+    expect(within(dialog).getAllByText("Account #00000000")).toHaveLength(1);
+    const requestedLimits = new Set(
+      accountQueries.map((query) => {
+        return query.limit;
+      }),
+    );
+    expect(
+      accountQueries.map((query) => {
+        return query.cursor;
+      }),
+    ).toStrictEqual([null, "3", "6"]);
+    // One bounded limit per request, wider than the whole fixture: every extra
+    // page came from following the server cursor, not from a client-side slice.
+    expect([...requestedLimits]).toHaveLength(1);
+    expect([...requestedLimits][0]).toBeGreaterThan(accounts.length);
   });
 
   it("debounces feature-on account manager searches", async () => {


### PR DESCRIPTION
## Trigger

Turbo run [33380291749](https://github.com/vm0-ai/vm0/actions/runs/33380291749) (`merge_group`, SHA `0269de5`) failed in `test-app` shard 7:

```
FAIL src/views/okou-page/__tests__/connectors-page.test.tsx > connectors page > paginates a feature-on account manager
Error: Test timed out in 5000ms.   (5075ms)
```

The other 342 tests in the shard passed. The queued PR #30464 touches only `e2e/playwright/**` and workflow files, so it cannot own a `turbo/apps/platform` failure.

## Root cause

Two independent causes, both in this one test.

**1. Budget headroom (why it timed out).** No `waitFor` in the test ever exceeded its own 1000ms async-utility timeout, so nothing raced. The test simply spent the whole 5000ms per-test budget. On a quiet host it was the slowest test in a 120-test file by a wide margin:

| test | duration |
| --- | --- |
| **paginates a feature-on account manager** | **2325ms** |
| names the exact account after a feature-on manual account addition | 1620ms |
| renames and deletes an exact account after bounded impact | 1251ms |
| debounces feature-on account manager searches | 1169ms |

Instrumenting the phases showed where it went: bootstrap plus the dialog with the first 50 rows 1331ms, first `Load more` to 100 rows 642ms, second `Load more` to 101 rows 654ms. The cost is rendering the fixture, and `mockGitHubConnectorAccounts(101)` existed only to cross two 50-row page boundaries. The failing shard ran 410.08s of cumulative test time in 188.51s of wall clock, i.e. about 2.2x parallel oversubscription; 2325ms x 2.2 is 5075ms, the exact observed duration.

**2. A real product bug the test was hiding.** `mergeConnectorAccountPages` computed the merged cursor as `pages.at(-1)?.nextCursor ?? firstPage.nextCursor`. `??` treats the last page's terminal `null` as "absent" and falls back to the first page's cursor, so **`Load more` never disappeared and re-requested the page after the first one forever.**

Probed on `main` with the request log:

```
after last page:  queries=[cursor:null, cursor:"3", cursor:"6"]  loadMoreVisible=true
after one more click: queries=[cursor:null, cursor:"3", cursor:"6", cursor:"3"]
```

The test never caught it because its terminal assertion matched the button by the literal text `Load more` inside a `waitFor`. While the last request is in flight the button reads `Loading more`, so `queryButtonByText("Load more", dialog)` returned `null` and the whole `waitFor` block passed mid-request, before the last page was ever applied.

## Change

`turbo/apps/platform/src/signals/okou-page/connector-accounts.ts` — the newest loaded page owns the cursor, including a terminal `null`:

```ts
nextCursor: (pages.at(-1) ?? firstPage).nextCursor,
```

`connectors-page.test.tsx` — same product contract, deterministic and cheap:

- Wait for `Work 1`, an account only the last page carries, then assert the terminal state synchronously. This pins the assertions to the render that consumed the last page instead of to a transient label.
- Assert the recorded cursor chain `[null, "3", "6"]`, which asserts directly what the old test only implied, and assert one bounded request limit wider than the whole fixture, so the extra pages provably come from following the server cursor rather than a client-side slice.
- Keep appending explicit: `Work 7` and `Work 4` are still present at the end.
- Fixture drops from 101 accounts to 8, served 3 per page. A page shorter than the requested limit with a non-null cursor is real server behaviour, because `listConnectorAccounts` projects rows away before slicing.

No retries, sleeps, larger timeouts, skips, deletions, or weakened assertions.

## Validation

Mutation-tested against `main`'s product code to confirm the smaller fixture still guards the contract:

| mutation | caught |
| --- | --- |
| `nextCursor: firstPage.nextCursor` (no chaining from the latest page) | yes, `expected [null, '3', '3'] to strictly equal [null, '3', '6']` |
| `loadMore` replaces `pages` instead of appending | yes, `Work 4` missing at the end |

Full-file runs on a healthy host:

- Before: `120 passed`, target test 2325ms, slowest in the file.
- After: `120 passed`, target test **699ms**, 14% of the 5000ms budget and mid-pack.

Related regression files, both green: `chat-composer-connector-connect.test.tsx` and `personal-usage-tab.test.tsx` (34 tests). `pnpm prettier --check`, `oxlint --deny-warnings`, `eslint --max-warnings 0`, `tsc -p tsconfig.tests.json`, `tsc -p tsconfig.production.json`, and `git diff --check` all pass.

Three further full-file runs happened while the sandbox host was memory-starved (267MB available, file wall clock 2-3.7x baseline). The target test passed in all of them at 950-1539ms, while 3-7 unrelated tests in the same file hit the same 5000ms timeout, which is the same budget-headroom mechanism this PR removes for this test. Repeated timing validation on a healthy host beyond the runs above was not possible locally; CI covers it.

No app, API, or browser environment is needed to validate this change, so no preview validation applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
