### PR TITLE
test(platform): gate the first indexed event wait on its poll request

### DIFF
--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-paged-events.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-paged-events.test.tsx
@@ -281,6 +281,7 @@ describe("activity paged events", () => {
   });
 
   it("polls safely while waiting for the first indexed event", async () => {
+    const indexedEventRequestStarted = context.mocks.deferred<void>();
     let requestCount = 0;
     const requestedSequences: (number | undefined)[] = [];
 
@@ -300,6 +301,9 @@ describe("activity paged events", () => {
             lastEventSequence: null,
           } satisfies AgentEventsResponse);
         }
+        if (requestCount === 2) {
+          indexedEventRequestStarted.resolve();
+        }
         return respond(200, {
           events: [makeAssistantEvent(0, "First indexed event")],
           hasMore: false,
@@ -314,6 +318,7 @@ describe("activity paged events", () => {
       path: "/activities/a0000000-0000-4000-a000-000000000099",
     });
 
+    await indexedEventRequestStarted.promise;
     await expect(
       screen.findByText("First indexed event"),
     ).resolves.toBeInTheDocument();


### PR DESCRIPTION
## Problem

`activity paged events > polls safely while waiting for the first indexed event` failed in the merge-queue Turbo run
https://github.com/vm0-ai/vm0/actions/runs/33383496606 (job `test-app (6)`, SHA `1f636ed6d63428c05bfa6e03e12a7da8b05d4f53`):

```
AssertionError: promise rejected "TestingLibraryElementError: Unable to fin…" instead of resolving
 ❯ src/views/activity-page/__tests__/activity-paged-events.test.tsx:319:5
Caused by: TestingLibraryElementError: Unable to find an element with the text: First indexed event
```

The failing test lasted 1034ms, and the printed DOM still contained `data-testid="app-skeleton"` ("Loading your workspace"): the page had not finished bootstrapping when the wait expired.

## Root cause

The test used `detachedSetupPage` (fire-and-forget) and then immediately awaited a single
`screen.findByText("First indexed event")`. The platform test suite does not configure
`asyncUtilTimeout`, so that one wait ran on the Testing Library default of **1000ms**, and it had to absorb:

1. the whole app bootstrap and route render,
2. the `logs.getById` request,
3. the first `runAgentEvents.getAgentEvents` poll (deliberately empty, `status: "running"`),
4. the loop yield in `setLoop`,
5. the second poll that finally returns `First indexed event`,
6. the React render of that event.

That whole sequence normally costs 570-900ms, i.e. 60-90% of the 1000ms budget, so any host slowdown flips
the outcome. The failing shard was running 1.7-2.5x slower than the green `test-app (6)` baseline
(job 99456568448 of run 33382078842) — including tiny pure-CPU files (`diagnostics` 17ms → 43ms), which
indicates host-level CPU contention rather than anything specific to this test. `1034ms ≈ 1000ms + overhead`
confirms the 1000ms async-utility budget expired, not the 5000ms test timeout.

Reproduced locally on a loaded host: the test failed in **3 of 6** unmodified runs with the identical
`TestingLibraryElementError` at line 319, and passing runs sat at 808-979ms.

PR #30474, represented in that merge-queue run, only touches `.github/**` and `e2e/playwright/**`, so it
cannot own this failure.

## Fix

Resolve a `context.mocks.deferred()` when the second (event-bearing) poll request starts, and await it before
`findByText`. Bootstrap and the first poll round then run under the 5000ms test budget, and the 1000ms
async-utility budget only has to cover the response and one React render.

This is exactly the synchronization pattern merged a few hours earlier in #30460 for the sibling test
`polls until the terminal event watermark is visible and then stops` in this same file.

No retry, sleep, raised timeout, skipped test, or weakened assertion. The product contract is unchanged:
the test still asserts that the first indexed event renders and that both polls are issued **without** a
`since` cursor (`requestedSequences` is still `[undefined, undefined]`), which is the "polls safely while
waiting for the first indexed event" invariant.

## Validation

- `vitest run src/views/activity-page/__tests__/activity-paged-events.test.tsx` — 5 runs, target test green
  every time (693ms, 1138ms, 575ms, 861ms, 826ms). The 1138ms run is decisive: before this change that
  duration exceeded the 1000ms budget and failed.
- `prettier --check`, `eslint`, and `pnpm -F @okouai/app check-types` all pass; `git diff --check` is clean.
- No app or API preview validation: this changes a test file only, with no product code touched.

## Related, deliberately not changed here

Under heavy local load, two other tests in this file also fail, both for the same structural reason
(a single 1000ms async-utility budget that has to absorb the full `detachedSetupPage` bootstrap):

- `waits for the complete initial event history before rendering timeline content` — exceeds the 5000ms
  test timeout locally.
- `starts a fresh event poller when navigating between activity runs` — `findByText("Second run final event")`
  expires.

Neither has failed in CI, and this sandbox is measurably slower than the CI runner (it needs >5000ms for a
test that CI completes inside a 4003ms whole-file green run), so those local failures are not yet evidence
of a CI-relevant flake. Flagging them rather than widening this PR's scope.

Triggering run: https://github.com/vm0-ai/vm0/actions/runs/33383496606
