### PR TITLE
fix(api): bound pi resume to harness generations

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -849,12 +849,16 @@ async function waitForRunStatus(
     | "pending"
     | "running"
     | "timeout",
+  timeout = 1000,
 ): Promise<void> {
   await expect
-    .poll(async () => {
-      const run = await api.readRun(actor, runId);
-      return run.status;
-    })
+    .poll(
+      async () => {
+        const run = await api.readRun(actor, runId);
+        return run.status;
+      },
+      { timeout },
+    )
     .toBe(status);
 }
 
@@ -5021,6 +5025,447 @@ describe("CHAT-02: model-first provider policies", () => {
     },
     90_000,
   );
+
+  it("bounds Pi resume history to each cross-harness generation", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    const orgId = actor.orgId;
+    if (!orgId) {
+      throw new Error("Expected entitled chat actor to have an org");
+    }
+    const piModel = "deepseek-v4-flash";
+    const codexModel = "gpt-5.6-luna";
+    await seedVm0BuiltInModelKey(piModel);
+    await misc.upsertPersonalModelProvider(
+      actor,
+      {
+        type: "codex-oauth-token",
+        authMethod: "auth_json",
+        secrets: { CODEX_AUTH_JSON: codexAuthJson() },
+      },
+      [200, 201],
+    );
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: piModel,
+        isDefault: true,
+        defaultProviderType: "built-in",
+        credentialScope: "org",
+        modelProviderId: null,
+      },
+      {
+        model: codexModel,
+        isDefault: false,
+        defaultProviderType: "codex-oauth-token",
+        credentialScope: "member",
+        modelProviderId: null,
+      },
+    ]);
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId },
+      { [FeatureSwitchKey.PiLoop]: true },
+    );
+    mockPiResourceArchiveDownloads();
+    const checkpointObjects = mockPiCheckpointObjectStore();
+    const firstPiAnswer = "first Pi generation answer";
+    const returnedPiAnswer = "returned Pi generation answer";
+    const interruptedPiAnswer = "Pi follow-up before Sandbox handoff";
+    const repeatedPiAnswer = "repeated Pi generation answer";
+    const modelRequests: unknown[] = [];
+    server.use(
+      http.post("https://api.deepseek.com/responses", async ({ request }) => {
+        const requestIndex = modelRequests.length;
+        modelRequests.push(await request.json());
+        const body =
+          requestIndex === 2
+            ? piResponsesContentSse({
+                blocks: [
+                  { type: "text", text: interruptedPiAnswer },
+                  {
+                    type: "toolCall",
+                    callId: "call_generation_boundary",
+                    name: "read",
+                    arguments: { path: "/home/user/workspace/AGENTS.md" },
+                  },
+                ],
+                sequence: requestIndex,
+              })
+            : piResponsesTextSse(
+                [firstPiAnswer, returnedPiAnswer, undefined, repeatedPiAnswer][
+                  requestIndex
+                ] ?? "unexpected duplicate Pi model request",
+                requestIndex,
+              );
+        return new HttpResponse(body, {
+          headers: { "content-type": "text/event-stream" },
+        });
+      }),
+    );
+
+    const firstPiPrompt = "start the first Pi generation";
+    const firstPi = await sendChatRun(actor, {
+      agentId,
+      prompt: firstPiPrompt,
+      model: piModel,
+    });
+    await waitForRunStatus(actor, firstPi.runId, "completed", 10_000);
+    await flushWaitUntilForTest();
+    expect(modelRequests).toHaveLength(1);
+    const firstPiBinding = await readThreadSessionBinding(
+      context,
+      firstPi.threadId,
+    );
+    if (!firstPiBinding.agent_session_id) {
+      throw new Error("Expected the first Pi run to bind a canonical session");
+    }
+    await expect(
+      readThreadSessionConversation(context, firstPi.threadId),
+    ).resolves.toMatchObject({ conversation_run_id: firstPi.runId });
+
+    const firstCodexPrompt = "continue through Codex between Pi generations";
+    const firstCodexAnswer = "Codex answer between Pi generations";
+    const firstCodex = await sendChatRun(actor, {
+      agentId,
+      threadId: firstPi.threadId,
+      prompt: firstCodexPrompt,
+      model: codexModel,
+    });
+    const firstCodexBinding = await readThreadSessionBinding(
+      context,
+      firstPi.threadId,
+    );
+    expect(firstCodexBinding.agent_session_id).not.toBe(
+      firstPiBinding.agent_session_id,
+    );
+    const firstCodexRun = await api.readRun(actor, firstCodex.runId);
+    expect(firstCodexRun.appendSystemPrompt).toContain(
+      "# Web Chat Run Context",
+    );
+    expect(firstCodexRun.appendSystemPrompt).toContain(firstPiPrompt);
+    expect(firstCodexRun.appendSystemPrompt).toContain(firstPiAnswer);
+    const firstCodexClaim = await claimChatRun(runnerGroup, firstCodex.runId);
+    expect(firstCodexClaim.claim.cliAgentType).toBe("codex");
+    expect(firstCodexClaim.claim.resumeSession).toBeNull();
+    chatCallbacks.mockChatOutputEvents([assistantEvent(0, firstCodexAnswer)]);
+    await completeChatRunOk(firstCodex.runId, firstCodexClaim.sandboxHeaders, {
+      cliAgentType: "codex",
+      lastEventSequence: 0,
+    });
+    await flushWaitUntilForTest();
+
+    const returnedPiPrompt = "return to Pi with every visible prior turn";
+    const returnedPi = await sendChatRun(actor, {
+      agentId,
+      threadId: firstPi.threadId,
+      prompt: returnedPiPrompt,
+      model: piModel,
+    });
+    await waitForRunStatus(actor, returnedPi.runId, "completed", 10_000);
+    await flushWaitUntilForTest();
+    expect(modelRequests).toHaveLength(2);
+    const returnedPiBinding = await readThreadSessionBinding(
+      context,
+      firstPi.threadId,
+    );
+    if (!returnedPiBinding.agent_session_id) {
+      throw new Error("Expected the returned Pi run to bind a new session");
+    }
+    expect(returnedPiBinding.agent_session_id).not.toBe(
+      firstCodexBinding.agent_session_id,
+    );
+    expect(returnedPiBinding.agent_session_id).not.toBe(
+      firstPiBinding.agent_session_id,
+    );
+    const returnedPiRun = await api.readRun(actor, returnedPi.runId);
+    const returnedPiAppend = returnedPiRun.appendSystemPrompt ?? "";
+    expect(returnedPiAppend).toContain("# Web Chat Run Context");
+    for (const prior of [
+      firstPiPrompt,
+      firstPiAnswer,
+      firstCodexPrompt,
+      firstCodexAnswer,
+    ]) {
+      expect(occurrences(returnedPiAppend, prior)).toBe(1);
+    }
+    const returnedPiInput = JSON.stringify(modelRequests[1]);
+    for (const turn of [
+      firstPiPrompt,
+      firstPiAnswer,
+      firstCodexPrompt,
+      firstCodexAnswer,
+      returnedPiPrompt,
+    ]) {
+      expect(occurrences(returnedPiInput, turn)).toBe(1);
+    }
+    await expect(
+      readThreadSessionConversation(context, firstPi.threadId),
+    ).resolves.toMatchObject({
+      agent_session_id: returnedPiBinding.agent_session_id,
+      conversation_run_id: returnedPi.runId,
+    });
+
+    const piFollowUpPrompt = "resume the returned Pi generation once";
+    const piFollowUp = await sendChatRun(actor, {
+      agentId,
+      threadId: firstPi.threadId,
+      prompt: piFollowUpPrompt,
+      model: piModel,
+    });
+    const piFollowUpManifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${piFollowUp.runId}/manifest.json`;
+    await expect
+      .poll(() => {
+        return checkpointObjects.has(piFollowUpManifestKey);
+      })
+      .toBe(true);
+    expect(modelRequests).toHaveLength(3);
+    const piFollowUpRun = await api.readRun(actor, piFollowUp.runId);
+    const piFollowUpAppend = piFollowUpRun.appendSystemPrompt ?? "";
+    expect(piFollowUpAppend).not.toContain("# Web Chat Run Context");
+    expect(piFollowUpAppend).not.toContain(firstPiPrompt);
+    expect(piFollowUpAppend).not.toContain(firstCodexPrompt);
+    const piFollowUpInput = JSON.stringify(modelRequests[2]);
+    expect(occurrences(piFollowUpInput, returnedPiPrompt)).toBe(1);
+    expect(occurrences(piFollowUpInput, returnedPiAnswer)).toBe(1);
+    expect(occurrences(piFollowUpInput, piFollowUpPrompt)).toBe(1);
+    expect(piFollowUpInput).not.toContain(firstPiPrompt);
+    expect(piFollowUpInput).not.toContain(firstCodexPrompt);
+    const piFollowUpBinding = await readThreadSessionBinding(
+      context,
+      firstPi.threadId,
+    );
+    expect(piFollowUpBinding.agent_session_id).toBe(
+      returnedPiBinding.agent_session_id,
+    );
+    const piFollowUpClaim = await claimChatRun(runnerGroup, piFollowUp.runId);
+    const resumedPiSession = piFollowUpClaim.claim.resumeSession;
+    if (!resumedPiSession || !("historyRef" in resumedPiSession)) {
+      throw new Error("Expected the Pi follow-up to resume a blob checkpoint");
+    }
+    expect(resumedPiSession).toMatchObject({
+      sessionId: firstPi.threadId,
+      historyRef: {
+        kind: "blob",
+        hash: expect.stringMatching(/^[a-f0-9]{64}$/u),
+      },
+    });
+    expect(piFollowUpClaim.claim.piSessionId).toBe(firstPi.threadId);
+    expect(piFollowUpClaim.claim.piLaunchConfig).toMatchObject({
+      apiFirstTurn: {
+        baseSession: {
+          sessionId: firstPi.threadId,
+          sha256: resumedPiSession.historyRef.hash,
+        },
+      },
+    });
+    const piFollowUpManifest = JSON.parse(
+      checkpointObjects.get(piFollowUpManifestKey)?.toString("utf8") ?? "{}",
+    ) as {
+      readonly baseSession?: {
+        readonly sessionId?: unknown;
+        readonly sha256?: unknown;
+      };
+    };
+    expect(piFollowUpManifest.baseSession).toStrictEqual({
+      sessionId: firstPi.threadId,
+      sha256: resumedPiSession.historyRef.hash,
+    });
+    await cancelChatRun(
+      actor,
+      piFollowUp.runId,
+      piFollowUpClaim.sandboxHeaders,
+    );
+    await expect(
+      readThreadSessionConversation(context, firstPi.threadId),
+    ).resolves.toMatchObject({ conversation_run_id: returnedPi.runId });
+
+    const repeatedCodexPrompt = "cross Codex before returning to Pi again";
+    const repeatedCodexAnswer = "second intervening Codex answer";
+    const repeatedCodex = await sendChatRun(actor, {
+      agentId,
+      threadId: firstPi.threadId,
+      prompt: repeatedCodexPrompt,
+      model: codexModel,
+    });
+    const repeatedCodexBinding = await readThreadSessionBinding(
+      context,
+      firstPi.threadId,
+    );
+    expect(repeatedCodexBinding.agent_session_id).not.toBe(
+      returnedPiBinding.agent_session_id,
+    );
+    const repeatedCodexClaim = await claimChatRun(
+      runnerGroup,
+      repeatedCodex.runId,
+    );
+    expect(repeatedCodexClaim.claim.cliAgentType).toBe("codex");
+    expect(repeatedCodexClaim.claim.resumeSession).toBeNull();
+    const repeatedCodexRun = await api.readRun(actor, repeatedCodex.runId);
+    expect(repeatedCodexRun.appendSystemPrompt).toContain(piFollowUpPrompt);
+    expect(repeatedCodexRun.appendSystemPrompt).toContain("Run cancelled");
+    expect(repeatedCodexRun.appendSystemPrompt).not.toContain(
+      interruptedPiAnswer,
+    );
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(0, repeatedCodexAnswer),
+    ]);
+    await completeChatRunOk(
+      repeatedCodex.runId,
+      repeatedCodexClaim.sandboxHeaders,
+      { cliAgentType: "codex", lastEventSequence: 0 },
+    );
+    await flushWaitUntilForTest();
+
+    const repeatedPiPrompt = "return to a third Pi generation";
+    const repeatedPi = await sendChatRun(actor, {
+      agentId,
+      threadId: firstPi.threadId,
+      prompt: repeatedPiPrompt,
+      model: piModel,
+    });
+    await waitForRunStatus(actor, repeatedPi.runId, "completed", 10_000);
+    await flushWaitUntilForTest();
+    expect(modelRequests).toHaveLength(4);
+    const repeatedPiBinding = await readThreadSessionBinding(
+      context,
+      firstPi.threadId,
+    );
+    expect(repeatedPiBinding.agent_session_id).not.toBe(
+      repeatedCodexBinding.agent_session_id,
+    );
+    expect(repeatedPiBinding.agent_session_id).not.toBe(
+      returnedPiBinding.agent_session_id,
+    );
+    const repeatedPiRun = await api.readRun(actor, repeatedPi.runId);
+    const repeatedPiAppend = repeatedPiRun.appendSystemPrompt ?? "";
+    expect(repeatedPiAppend).toContain("# Web Chat Run Context");
+    for (const prior of [
+      firstPiPrompt,
+      firstPiAnswer,
+      firstCodexPrompt,
+      firstCodexAnswer,
+      returnedPiPrompt,
+      returnedPiAnswer,
+      piFollowUpPrompt,
+      "Run cancelled",
+      repeatedCodexPrompt,
+      repeatedCodexAnswer,
+    ]) {
+      expect(occurrences(repeatedPiAppend, prior)).toBe(1);
+    }
+    expect(repeatedPiAppend).not.toContain(interruptedPiAnswer);
+    const repeatedPiInput = JSON.stringify(modelRequests[3]);
+    for (const turn of [
+      firstPiPrompt,
+      firstPiAnswer,
+      firstCodexPrompt,
+      firstCodexAnswer,
+      returnedPiPrompt,
+      returnedPiAnswer,
+      piFollowUpPrompt,
+      "Run cancelled",
+      repeatedCodexPrompt,
+      repeatedCodexAnswer,
+      repeatedPiPrompt,
+    ]) {
+      expect(occurrences(repeatedPiInput, turn)).toBe(1);
+    }
+    expect(repeatedPiInput).not.toContain(interruptedPiAnswer);
+    await expect(
+      readThreadSessionConversation(context, firstPi.threadId),
+    ).resolves.toMatchObject({
+      agent_session_id: repeatedPiBinding.agent_session_id,
+      conversation_run_id: repeatedPi.runId,
+    });
+
+    const visibleTurns = [
+      { runId: firstPi.runId, prompt: firstPiPrompt, answer: firstPiAnswer },
+      {
+        runId: firstCodex.runId,
+        prompt: firstCodexPrompt,
+        answer: firstCodexAnswer,
+      },
+      {
+        runId: returnedPi.runId,
+        prompt: returnedPiPrompt,
+        answer: returnedPiAnswer,
+      },
+      {
+        runId: piFollowUp.runId,
+        prompt: piFollowUpPrompt,
+        answer: interruptedPiAnswer,
+      },
+      {
+        runId: repeatedCodex.runId,
+        prompt: repeatedCodexPrompt,
+        answer: repeatedCodexAnswer,
+      },
+      {
+        runId: repeatedPi.runId,
+        prompt: repeatedPiPrompt,
+        answer: repeatedPiAnswer,
+      },
+    ];
+    const finalEvents = await waitForThreadMessages(
+      actor,
+      firstPi.threadId,
+      (events) => {
+        return eventBackedContents(events, repeatedPi.runId).some((event) => {
+          return event.content === repeatedPiAnswer;
+        });
+      },
+    );
+    const allRunIds = new Set(
+      visibleTurns.map((turn) => {
+        return turn.runId;
+      }),
+    );
+    expect(
+      finalEvents.events
+        .filter((event) => {
+          return (
+            event.runId !== undefined &&
+            event.runId !== null &&
+            allRunIds.has(event.runId) &&
+            (event.eventType === "input.prompt" ||
+              event.eventType === "output.message")
+          );
+        })
+        .map((event) => {
+          return {
+            runId: event.runId,
+            eventType: event.eventType,
+            content: chatEventDisplayText(event),
+          };
+        }),
+    ).toStrictEqual(
+      visibleTurns.flatMap((turn) => {
+        return [
+          {
+            runId: turn.runId,
+            eventType: "input.prompt",
+            content: turn.prompt,
+          },
+          {
+            runId: turn.runId,
+            eventType: "output.message",
+            content: turn.answer,
+          },
+        ];
+      }),
+    );
+    await expect(api.readRun(actor, firstPi.runId)).resolves.toMatchObject({
+      status: "completed",
+    });
+    await expect(api.readRun(actor, firstCodex.runId)).resolves.toMatchObject({
+      status: "completed",
+    });
+    await expect(api.readRun(actor, returnedPi.runId)).resolves.toMatchObject({
+      status: "completed",
+    });
+    await expect(api.readRun(actor, piFollowUp.runId)).resolves.toMatchObject({
+      status: "cancelled",
+    });
+  }, 90_000);
 
   it("projects complete API-first text blocks in source order and completes at N", async () => {
     const { actor, agentId } = await entitledChatActor();

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -5784,6 +5784,7 @@ function resumeSessionFromSnapshot(
 async function resolveLatestPiResumeSession(
   db: Db,
   chatThreadId: string,
+  agentSessionId: string,
 ): Promise<StoredExecutionContext["resumeSession"] | undefined> {
   const [snapshot] = await db
     .select({
@@ -5799,6 +5800,10 @@ async function resolveLatestPiResumeSession(
     .where(
       and(
         eq(agentRuns.chatThreadId, chatThreadId),
+        // Canonical chat-session rotation owns the Pi history generation.
+        // Restrict before ordering so a pre-rotation Pi checkpoint cannot
+        // cross an intervening harness boundary.
+        eq(agentRuns.sessionId, agentSessionId),
         eq(agentRuns.status, "completed"),
         isNotNull(agentRuns.triggerSource),
         eq(conversations.cliAgentType, "pi"),
@@ -6947,6 +6952,7 @@ function storedExecutionContextWithPiResources(
 function preparePiLaunchResources(args: {
   readonly db: Db;
   readonly runId: string;
+  readonly agentSessionId: string;
   readonly apiStartTime: number;
   readonly storageMounts: StoredExecutionContext["storageMounts"];
   readonly piSandbox: PiModelConfig | undefined;
@@ -6972,7 +6978,11 @@ function preparePiLaunchResources(args: {
           "api_dispatch_prepare_pi_launch_resume_session",
           "nested",
           async () => {
-            return await resolveLatestPiResumeSession(args.db, chatThreadId);
+            return await resolveLatestPiResumeSession(
+              args.db,
+              chatThreadId,
+              args.agentSessionId,
+            );
           },
         );
         const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
@@ -7121,6 +7131,7 @@ function buildRunnerJobPayload(
       preparePiLaunchResources({
         db,
         runId: args.run.id,
+        agentSessionId: args.run.sessionId,
         apiStartTime: args.apiStartTime,
         storageMounts: builtContext.context.storageMounts,
         piSandbox: args.piSandbox,


### PR DESCRIPTION
## Summary

- scope Pi resume checkpoint selection to the current canonical agent session generation
- prevent a Pi return after Codex from restoring stale pre-rotation JSONL while preserving exactly-once visible-context replay
- cover repeated Pi and Codex crossings, same-generation Pi resume, incomplete-round replay semantics, and visible event ordering

## Verification

- Prettier check for the two touched files
- API lint
- API layered type-check
- chat-events BDD transition matrix: bounds Pi resume history to each cross-harness generation
- existing DeepSeek V4 flash and pro Pi API-first canonical JSONL resume cases

Closes #30574
Parent: #30564