### PR TITLE
fix(email): link official workflow result footer to automation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/official-automation-result-email.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-automation-result-email.test.ts
@@ -470,7 +470,19 @@ describe.sequential("Official Automation result email callbacks", () => {
       props: {
         resultText: expect.stringContaining("[Result truncated]"),
         runUrl: `https://app.okou.ai/activities/${runId}`,
+        manageUrl: `https://app.okou.ai/workflows/${scenario.workflowId}/automations?automationId=${scenario.automationId}`,
       },
+    });
+    const automationUrl = `https://app.okou.ai/workflows/${scenario.workflowId}/automations?automationId=${scenario.automationId}`;
+    const accountUnsubscribeUrl = `https://app.okou.ai/email/unsubscribe?token=${unsubscribeToken(
+      scenario.actor.userId,
+    )}`;
+    expect(automationUrl).not.toContain("token=");
+    expect(item.headers).toStrictEqual({
+      "List-Unsubscribe": `<https://api.okou.ai/api/email/unsubscribe?token=${unsubscribeToken(
+        scenario.actor.userId,
+      )}>`,
+      "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
     });
 
     await expect(outbox.drainItems([item.id])).resolves.toBe(1);
@@ -531,7 +543,15 @@ describe.sequential("Official Automation result email callbacks", () => {
     }
     expect(html).toContain("[Result truncated]");
     expect(html).toContain(`https://app.okou.ai/activities/${runId}`);
-    expect(html).toContain("https://app.okou.ai/email/unsubscribe");
+    expect(html).toContain(
+      "This result was sent by an Official Workflow automation.<br>",
+    );
+    expect(html).toContain(`href="${automationUrl}"`);
+    expect(html).toContain(
+      `>Manage this automation</a> &middot; <a href="${accountUnsubscribeUrl}"`,
+    );
+    expect(html).toContain(">Unsubscribe</a>");
+    expect(automationUrl).not.toBe(accountUnsubscribeUrl);
     expect(Buffer.byteLength(html, "utf8")).toBeLessThanOrEqual(96 * 1024);
 
     const text =
@@ -548,7 +568,9 @@ describe.sequential("Official Automation result email callbacks", () => {
     expect(text).toContain(longPlainText);
     expect(text).toContain("[Result truncated]");
     expect(text).toContain(`https://app.okou.ai/activities/${runId}`);
-    expect(text).toContain("https://app.okou.ai/email/unsubscribe");
+    expect(text).toContain(
+      `This result was sent by an Official Workflow automation.\nManage this automation [${automationUrl}] · Unsubscribe [${accountUnsubscribeUrl}]`,
+    );
   });
 
   it("falls back after pathological Markdown expansion and sends one bounded multipart email", async () => {
@@ -616,6 +638,35 @@ describe.sequential("Official Automation result email callbacks", () => {
       status: "sent",
       attempts: 1,
     });
+  });
+
+  it("keeps the existing automation switch separate from account-level unsubscribe", async () => {
+    const scenario = await setupScenario();
+    await clearResultEmailUserStateFixture(scenario.actor.userId);
+    await expect(
+      readResultEmailPreferenceFixture(scenario.actor.userId),
+    ).resolves.toBeNull();
+
+    const disabled = await accept(
+      automationsClient().disable({
+        headers: authHeaders(),
+        params: { id: scenario.automationId },
+      }),
+      [200],
+    );
+
+    expect(disabled.body.enabled).toBeFalsy();
+    await expect(
+      readResultEmailPreferenceFixture(scenario.actor.userId),
+    ).resolves.toBeNull();
+
+    await misc.requestEmailUnsubscribe(
+      unsubscribeToken(scenario.actor.userId),
+      [200],
+    );
+    await expect(
+      readResultEmailPreferenceFixture(scenario.actor.userId),
+    ).resolves.toBeTruthy();
   });
 
   it("keeps suppression at send and leaves a successful Run unchanged", async () => {

--- a/turbo/apps/api/src/signals/services/email-common.service.ts
+++ b/turbo/apps/api/src/signals/services/email-common.service.ts
@@ -170,6 +170,41 @@ function appUrl(publicBrand: PublicBrand): string {
   return appUrlForPublicBrand(env("APP_URL"), publicBrand);
 }
 
+function officialAutomationResultUnsubscribeUrl(
+  headers: Readonly<Record<string, string>> | undefined,
+  publicBrand: PublicBrand,
+): string {
+  const listUnsubscribe = headers?.["List-Unsubscribe"];
+  if (
+    !listUnsubscribe ||
+    !listUnsubscribe.startsWith("<") ||
+    !listUnsubscribe.endsWith(">")
+  ) {
+    throw new Error(
+      "Official Automation result email is missing its List-Unsubscribe URL",
+    );
+  }
+  const oneClickUrl = new URL(listUnsubscribe.slice(1, -1));
+  if (
+    oneClickUrl.protocol !== "https:" ||
+    !oneClickUrl.pathname.endsWith("/api/email/unsubscribe")
+  ) {
+    throw new Error(
+      "Official Automation result email has an invalid List-Unsubscribe URL",
+    );
+  }
+  const token = oneClickUrl.searchParams.get("token");
+  if (!token) {
+    throw new Error(
+      "Official Automation result email is missing its unsubscribe token",
+    );
+  }
+
+  const unsubscribeUrl = new URL(`${appUrl(publicBrand)}/email/unsubscribe`);
+  unsubscribeUrl.searchParams.set("token", token);
+  return unsubscribeUrl.toString();
+}
+
 function getFromDomain(publicBrand: PublicBrand): string {
   const domain = env("RESEND_FROM_DOMAIN");
   if (!domain) {
@@ -262,6 +297,7 @@ interface RenderedEmailTemplate {
 function renderTemplate(
   template: EmailTemplate,
   publicBrand: PublicBrand,
+  headers: Readonly<Record<string, string>> | undefined,
 ): RenderedEmailTemplate {
   switch (template.template) {
     case "data-export-ready": {
@@ -304,6 +340,7 @@ function renderTemplate(
       const rendered = renderOfficialAutomationResultEmail(
         template.props,
         publicBrand,
+        officialAutomationResultUnsubscribeUrl(headers, publicBrand),
       );
       if (rendered.fallback) {
         log.warn("Official Automation result email used fallback renderer", {
@@ -331,7 +368,11 @@ async function sendEmailDirect(options: {
   | { readonly ok: false; readonly error: string }
 > {
   const resend = getResendClient();
-  const rendered = renderTemplate(options.template, options.publicBrand);
+  const rendered = renderTemplate(
+    options.template,
+    options.publicBrand,
+    options.headers,
+  );
   const { data, error } = await resend.emails.send({
     from: options.from,
     to: typeof options.to === "string" ? options.to : [...options.to],

--- a/turbo/apps/api/src/signals/services/internal-workflow-automation-result-email-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-workflow-automation-result-email-callback.service.ts
@@ -4,8 +4,9 @@ import { agentRuns } from "@okouai/db/schema/agent-run";
 import { emailOutbox } from "@okouai/db/schema/email-outbox";
 import { officialAutomationResultEmailClaims } from "@okouai/db/schema/official-automation-result-email-claim";
 import { users } from "@okouai/db/schema/user";
+import { workflowAutomations } from "@okouai/db/schema/workflow";
 import { command, createStore } from "ccstate";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { env } from "../../lib/env";
@@ -16,7 +17,6 @@ import {
   buildFromAddress,
   buildOneClickUnsubscribeUrl,
   buildUnsubscribeHeaders,
-  buildUnsubscribeUrl,
   getUserEmail,
   OFFICIAL_AUTOMATION_RESULT_EMAIL_SUBJECT_MAX_CHARACTERS,
   OFFICIAL_AUTOMATION_RESULT_EMAIL_TEXT_MAX_CHARACTERS,
@@ -94,6 +94,35 @@ function boundedResultText(output: string | undefined): string {
   );
 }
 
+interface WorkflowAutomationManageUrlArgs {
+  readonly automationId: string;
+  readonly userId: string;
+  readonly productUrl: string;
+}
+
+async function workflowAutomationManageUrl(
+  db: Db,
+  args: WorkflowAutomationManageUrlArgs,
+  signal: AbortSignal,
+): Promise<string> {
+  const [automation] = await db
+    .select({ workflowId: workflowAutomations.workflowId })
+    .from(workflowAutomations)
+    .where(
+      and(
+        eq(workflowAutomations.id, args.automationId),
+        eq(workflowAutomations.ownerUserId, args.userId),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+  return automation
+    ? `${args.productUrl}/workflows/${encodeURIComponent(
+        automation.workflowId,
+      )}/automations?automationId=${encodeURIComponent(args.automationId)}`
+    : `${args.productUrl}/workflows`;
+}
+
 export async function handleWorkflowAutomationResultEmailInternalCallback(
   db: Db,
   envelope: InternalRunCallbackEnvelope,
@@ -139,7 +168,15 @@ export async function handleWorkflowAutomationResultEmailInternalCallback(
   const output = await getRunOutputText(db, envelope.runId, signal);
   const publicBrand = payload.data.publicBrand;
   const productUrl = appUrlForPublicBrand(env("APP_URL"), publicBrand);
-  const manageUrl = buildUnsubscribeUrl(run.userId, publicBrand);
+  const manageUrl = await workflowAutomationManageUrl(
+    db,
+    {
+      automationId: payload.data.automationId,
+      userId: run.userId,
+      productUrl,
+    },
+    signal,
+  );
   const enqueued = await db.transaction(async (tx) => {
     // Linearize the final preference decision with enqueue. Both explicit
     // unsubscribe and complaint handling upsert this same row, so their write
@@ -199,6 +236,9 @@ export async function handleWorkflowAutomationResultEmailInternalCallback(
           title: resultEmailTitle(payload.data.workflowName),
           resultText: boundedResultText(output),
           runUrl: `${productUrl}/activities/${encodeURIComponent(envelope.runId)}`,
+          // Keep the persisted props shape rollout-compatible while changing
+          // manageUrl from the legacy account unsubscribe destination to the
+          // originating automation deep link.
           manageUrl,
         },
       },

--- a/turbo/apps/api/src/signals/services/official-automation-result-email-renderer.ts
+++ b/turbo/apps/api/src/signals/services/official-automation-result-email-renderer.ts
@@ -213,9 +213,27 @@ function officialAutomationResultEmailHtml(
   props: OfficialAutomationResultEmailRenderProps,
   publicBrand: PublicBrand,
   resultBodyHtml: string,
+  unsubscribeUrl: string,
 ): string {
   const presentation = publicBrandPresentation(publicBrand);
   const assistantMark = publicBrand === "okou" ? "O" : "0";
+  // During the API rollout and rollback window, persisted outbox rows from
+  // the previous callback still carry the account-level confirmation URL in
+  // manageUrl. Remove after those API targets and rows drain; tracked by
+  // #30592. Until then, preserve their old footer instead of mislabelling a
+  // global unsubscribe as automation management.
+  const legacyManageUrl = new URL(props.manageUrl).pathname.endsWith(
+    "/email/unsubscribe",
+  );
+  const footer = legacyManageUrl
+    ? `This result was sent by an Official Automation. <a href="${escapeHtml(
+        props.manageUrl,
+      )}" style="${LINK_STYLE}">Manage email preferences</a>.`
+    : `This result was sent by an Official Workflow automation.<br><a href="${escapeHtml(
+        props.manageUrl,
+      )}" style="${LINK_STYLE}">Manage this automation</a> &middot; <a href="${escapeHtml(
+        unsubscribeUrl,
+      )}" style="${LINK_STYLE}">Unsubscribe</a>`;
 
   return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="color-scheme" content="light"><meta name="supported-color-schemes" content="light"></head><body style="margin:0;padding:0;background-color:#ffffff;color:#202124;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:1.55;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%"><table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#ffffff" style="width:100%;border-collapse:collapse;background-color:#ffffff"><tr><td align="left" style="padding:24px 20px 40px"><table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%;max-width:680px;border-collapse:collapse;text-align:left"><tr><td><table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;margin:0 0 24px"><tr><td width="40" height="40" align="center" valign="middle" bgcolor="#ed4e01" style="width:40px;height:40px;border-radius:10px;color:#ffffff;font-size:17px;font-weight:700;line-height:40px;mso-line-height-rule:exactly">${assistantMark}</td><td valign="middle" style="padding-left:12px;line-height:1.4"><strong>${escapeHtml(
     presentation.assistantName,
@@ -225,9 +243,7 @@ function officialAutomationResultEmailHtml(
     props.runUrl,
   )}" style="${LINK_STYLE};font-weight:600">View run in ${escapeHtml(
     presentation.assistantName,
-  )} &rarr;</a></p><hr style="height:1px;margin:0 0 20px;border:0;background-color:#e4e6e8"><p style="margin:0;color:#737373;font-size:12px;line-height:1.45">This result was sent by an Official Automation. <a href="${escapeHtml(
-    props.manageUrl,
-  )}" style="${LINK_STYLE}">Manage email preferences</a>.</p></td></tr></table></td></tr></table></body></html>`;
+  )} &rarr;</a></p><hr style="height:1px;margin:0 0 20px;border:0;background-color:#e4e6e8"><p style="margin:0;color:#737373;font-size:12px;line-height:1.45">${footer}</p></td></tr></table></td></tr></table></body></html>`;
 }
 
 function plainTextFromHtml(html: string): string {
@@ -237,6 +253,7 @@ function plainTextFromHtml(html: string): string {
 export function renderOfficialAutomationResultEmail(
   props: OfficialAutomationResultEmailRenderProps,
   publicBrand: PublicBrand,
+  unsubscribeUrl: string,
 ): RenderedOfficialAutomationResultEmail {
   let attemptedHtmlBytes: number | null = null;
   let fallbackReason: OfficialAutomationResultEmailFallback["reason"] =
@@ -247,6 +264,7 @@ export function renderOfficialAutomationResultEmail(
       props,
       publicBrand,
       markdownRenderer.render(props.resultText),
+      unsubscribeUrl,
     );
     const htmlBytes = Buffer.byteLength(html, "utf8");
     if (htmlBytes <= OFFICIAL_AUTOMATION_RESULT_EMAIL_HTML_MAX_BYTES) {
@@ -277,6 +295,7 @@ export function renderOfficialAutomationResultEmail(
     `<pre style="margin:0;font-family:inherit;font-size:14px;line-height:1.55;white-space:pre-wrap;overflow-wrap:anywhere;word-break:break-word">${escapeHtml(
       props.resultText,
     )}</pre>`,
+    unsubscribeUrl,
   );
   const fallbackHtmlBytes = Buffer.byteLength(fallbackHtml, "utf8");
   if (fallbackHtmlBytes > OFFICIAL_AUTOMATION_RESULT_EMAIL_HTML_MAX_BYTES) {

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -57,6 +57,7 @@ import {
   workflowReloadVersion$,
 } from "./workflow-reload.ts";
 import type { PlatformWorkflowConnectorReadinessResponse } from "../connector-domain.ts";
+import { onRef } from "../utils.ts";
 
 type WorkflowDetailActionDialog = "copy" | "delete" | null;
 export type WorkflowDetailTab = "automations" | "instructions" | "info";
@@ -131,6 +132,7 @@ type WorkflowWebhookAutomationSummary = Extract<
 >;
 export type WorkflowAutomationEntry = WorkflowAutomationsListEntry;
 const WORKFLOW_DETAIL_FILE_PARAM = "file";
+const WORKFLOW_AUTOMATION_TARGET_PARAM = "automationId";
 
 function workflowDetailTabFromRoute(route: RouteKey | null): WorkflowDetailTab {
   switch (route) {
@@ -694,6 +696,17 @@ export const selectedWorkflowFilePath$ = computed((get) => {
     get(internalSelectedFilePath$)
   );
 });
+
+export const targetedWorkflowAutomationId$ = computed((get) => {
+  return get(searchParams$).get(WORKFLOW_AUTOMATION_TARGET_PARAM);
+});
+
+export const scrollTargetedWorkflowAutomationIntoViewRef$ = onRef(
+  command((_context, element: HTMLElement, signal: AbortSignal) => {
+    signal.throwIfAborted();
+    element.scrollIntoView({ block: "center" });
+  }),
+);
 
 export const setSelectedWorkflowFilePath$ = command(
   ({ get, set }, path: string | null) => {

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -28,7 +28,7 @@ import {
 import { integrationsGithubContract } from "@okouai/api-contracts/contracts/integrations-github";
 import { strapiIntegrationsContract } from "@okouai/api-contracts/contracts/strapi-integrations";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, type Mock } from "vitest";
 
 import {
   click,
@@ -98,6 +98,15 @@ function detachedSetupWorkflowDetailPage(
       ...featureSwitches,
     },
   });
+}
+
+function installScrollIntoViewMock(): Mock<HTMLElement["scrollIntoView"]> {
+  const scrollIntoView = vi.fn<HTMLElement["scrollIntoView"]>();
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+    configurable: true,
+    value: scrollIntoView,
+  });
+  return scrollIntoView;
 }
 
 function billingStatus(
@@ -2057,6 +2066,80 @@ describe("workflow detail page", () => {
     );
     expect(pathname()).toBe(`/workflows/${SALES_WORKFLOW_ID}/instructions`);
     expect(search()).toBe("?file=config%2Fsettings.json");
+  });
+
+  it("locates the deep-linked automation and keeps its existing switch scoped to that row", async () => {
+    context.mocks.data.userPreferences({ timezone: "UTC" });
+    const workflow = {
+      ...salesResearch(),
+      automations: [weekdayWorkflowAutomation(), gmailWorkflowAutomation()],
+    };
+    const scrollIntoView = installScrollIntoViewMock();
+    mockWorkflowApis([workflow]);
+
+    detachedSetupWorkflowDetailPage(
+      `${workflowDetailPath("automations")}?automationId=${GMAIL_AUTOMATION_ID}`,
+    );
+
+    const gmailSwitch = await screen.findByRole("switch", {
+      name: "Disable Gmail new message",
+    });
+    const gmailRow = document.querySelector(
+      `[data-automation-id="${GMAIL_AUTOMATION_ID}"]`,
+    );
+    const weekdayRow = document.querySelector(
+      '[data-automation-id="workflow-automation-weekday-brief"]',
+    );
+    expect(gmailRow).toHaveAttribute("aria-current", "true");
+    expect(weekdayRow).not.toHaveAttribute("aria-current");
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "center" });
+    expect(search()).toBe(`?automationId=${GMAIL_AUTOMATION_ID}`);
+
+    click(gmailSwitch);
+
+    await screen.findByRole("switch", { name: "Enable Gmail new message" });
+    expect(
+      screen.getByRole("switch", {
+        name: "Disable Every weekday at 9:00 AM",
+      }),
+    ).toBeChecked();
+    expect(workflow.automations[0]?.enabled).toBeTruthy();
+    expect(workflow.automations[1]?.enabled).toBeFalsy();
+  });
+
+  it("leaves the Automations page usable when the targeted automation is stale", async () => {
+    context.mocks.data.userPreferences({ timezone: "UTC" });
+    const scrollIntoView = installScrollIntoViewMock();
+    mockWorkflowApis([salesResearch()]);
+
+    detachedSetupWorkflowDetailPage(
+      `${workflowDetailPath("automations")}?automationId=deleted-automation`,
+    );
+
+    await expect(
+      screen.findByRole("switch", {
+        name: "Disable Every weekday at 9:00 AM",
+      }),
+    ).resolves.toBeInTheDocument();
+    expect(document.querySelector('[aria-current="true"]')).toBeNull();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("fails gracefully when a deep-linked workflow is no longer readable", async () => {
+    const scrollIntoView = installScrollIntoViewMock();
+    mockWorkflowApis([]);
+
+    detachedSetupWorkflowDetailPage(
+      `${workflowDetailPath("automations")}?automationId=${GMAIL_AUTOMATION_ID}`,
+    );
+
+    await expect(
+      screen.findByText("Workflow not found."),
+    ).resolves.toBeInTheDocument();
+    expect(pathname()).toBe(`/workflows/${SALES_WORKFLOW_ID}/automations`);
+    expect(search()).toBe(`?automationId=${GMAIL_AUTOMATION_ID}`);
+    expect(document.querySelector('[aria-current="true"]')).toBeNull();
+    expect(scrollIntoView).not.toHaveBeenCalled();
   });
 
   it("checks connector readiness only on request and shows every status", async () => {

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -168,6 +168,7 @@ import {
   setWorkflowCopyForm$,
   setWorkflowAutomationCreateDialog$,
   setWorkflowAutomationEnabled$,
+  scrollTargetedWorkflowAutomationIntoViewRef$,
   updateWorkflowGithubWebhookAutomation$,
   updateWorkflowGithubWorkflowRunCompletedAutomation$,
   updateWorkflowGmailNewMessageAutomation$,
@@ -201,6 +202,7 @@ import {
   type GmailTextOperator,
   workflowMetadataPatch$,
   workflowConnectorReadiness$,
+  targetedWorkflowAutomationId$,
 } from "../../signals/workflows-page/workflows-signals.ts";
 import {
   currentOfficialWorkflowInstallation$,
@@ -10039,22 +10041,27 @@ function officialIntendedStateLabel(enabled: boolean): string {
       });
 }
 
+interface AutomationRowProps {
+  readonly automation: WorkflowAutomationSummary;
+  readonly canOperate: boolean;
+  readonly canEditStructure: boolean;
+  readonly displayTimezone: string;
+  readonly showDivider: boolean;
+}
+
 function AutomationRow({
   automation,
   canOperate,
   canEditStructure,
   displayTimezone,
   showDivider,
-}: {
-  readonly automation: WorkflowAutomationSummary;
-  readonly canOperate: boolean;
-  readonly canEditStructure: boolean;
-  readonly displayTimezone: string;
-  readonly showDivider: boolean;
-}) {
+}: AutomationRowProps) {
+  const targetedAutomationId = useGet(targetedWorkflowAutomationId$);
+  const scrollRef = useSet(scrollTargetedWorkflowAutomationIntoViewRef$);
   const editingAutomationId = useGet(editingWorkflowAutomationId$);
   const setEditingAutomationId = useSet(setEditingWorkflowAutomationId$);
   const editing = editingAutomationId === automation.id;
+  const targeted = targetedAutomationId === automation.id;
   const title = workflowScheduleTitle(automation, displayTimezone);
   const subtitle = workflowAutomationSubtitle(automation);
   const stripeAutomation =
@@ -10066,8 +10073,12 @@ function AutomationRow({
   return (
     <>
       <div
+        ref={targeted ? scrollRef : undefined}
+        data-automation-id={automation.id}
+        aria-current={targeted ? "true" : undefined}
         className={cn(
           "group grid min-w-0 grid-cols-1 gap-3 px-5 py-4 transition-colors first:rounded-t-2xl last:rounded-b-2xl hover:bg-state-hover sm:grid-cols-[minmax(0,1.2fr)_minmax(9rem,0.9fr)_minmax(13.5rem,1.1fr)_auto_7.75rem] sm:items-center sm:gap-4",
+          targeted && "bg-state-selected ring-2 ring-inset ring-ring",
           !automation.enabled && "opacity-75",
         )}
       >


### PR DESCRIPTION
## Summary

- render the approved Official Workflow result footer with separate automation-management and account-unsubscribe links
- persist a brand-correct deep link to the originating workflow automation and highlight/scroll the matching row on the existing Automations page
- preserve one-click unsubscribe headers, existing switch semantics, Markdown safety, plain text, and size bounds
- cover multiple automations plus stale and unreadable deep-link destinations

## Fallbacks

- `official-automation-result-email-renderer.ts:officialAutomationResultEmailHtml` preserves the legacy footer for persisted outbox rows written by the previous API callback, whose `manageUrl` is still the account-level unsubscribe confirmation URL. Surface: persisted backend outbox across the API rollout and rollback window (up to about 102 minutes). Remove after the previous API artifact is no longer serving, draining, or retained for rollback and all pending or retryable pre-release rows have drained or expired; follow-up #30592.

## Verification

- `pnpm format`
- `pnpm lint`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter="!api" --filter="!@okouai/app"`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/services/__tests__/official-automation-result-email-renderer.test.ts` (25 passed)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/official-automation-result-email.test.ts` (11 passed)
- `pnpm --filter @okouai/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx` (78 passed)

Closes #30569