### PR TITLE
feat(api): publish connector doctor official workflow

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
@@ -246,6 +246,13 @@ function s3BodyBuffer(body: unknown): Buffer {
   throw new Error("Expected an S3 object body");
 }
 
+function requireValue<T>(value: T | null | undefined, message: string): T {
+  if (value === null || value === undefined) {
+    throw new Error(message);
+  }
+  return value;
+}
+
 function missingS3Object(key: string): Error {
   return Object.assign(new Error(`Missing S3 object ${key}`), {
     name: "NotFound",
@@ -378,7 +385,7 @@ describe.sequential("Official Workflow catalog release boundary", () => {
     });
   });
 
-  it("releases the deployed Morning Brief catalog with stable executable identity", async () => {
+  it("releases the deployed catalog with stable unique executable identities", async () => {
     const s3 = installVolumeS3Fixture();
     const first = await syncDeployedCatalog();
     expect(first.body).toMatchObject({
@@ -386,10 +393,29 @@ describe.sequential("Official Workflow catalog release boundary", () => {
       diagnostics: [],
     });
 
-    const firstState = await readState("morning-brief");
-    const definition = firstState.body.definition;
-    expect(firstState.body.catalog?.payload.definitions).toHaveLength(1);
-    expect(definition).toMatchObject({
+    const morningBriefState = await readState("morning-brief");
+    const connectorDoctorState = await readState("connector-doctor");
+    const deployedCatalog = requireValue(
+      morningBriefState.body.catalog,
+      "Expected the deployed catalog release",
+    );
+    const morningBriefDefinition = requireValue(
+      morningBriefState.body.definition,
+      "Expected the Morning Brief Definition",
+    );
+    const connectorDoctorDefinition = requireValue(
+      connectorDoctorState.body.definition,
+      "Expected the Connector Doctor Definition",
+    );
+    expect(
+      deployedCatalog.payload.definitions.map(({ name, lifecycle }) => {
+        return { name, lifecycle };
+      }),
+    ).toStrictEqual([
+      { name: "connector-doctor", lifecycle: "active" },
+      { name: "morning-brief", lifecycle: "active" },
+    ]);
+    expect(morningBriefDefinition).toMatchObject({
       name: "morning-brief",
       lifecycle: "active",
       blueprints: [
@@ -416,48 +442,170 @@ describe.sequential("Official Workflow catalog release boundary", () => {
         },
       ],
     });
-    expect(firstState.body.storage).toMatchObject({
+    expect(connectorDoctorDefinition).toMatchObject({
+      name: "connector-doctor",
+      lifecycle: "active",
+      blueprints: [
+        {
+          key: "weekly-check",
+          parameters: [
+            {
+              key: "timezone",
+              type: "string",
+              format: "timezone",
+              required: true,
+              derivation: { kind: "user-timezone" },
+            },
+          ],
+          desiredState: {
+            kind: "schedule",
+            schedule: {
+              type: "cron",
+              cronExpression: "0 9 * * 1",
+              timezone: { parameter: "timezone" },
+            },
+          },
+          runtime: { resultEmail: false },
+        },
+      ],
+    });
+    expect(morningBriefState.body.storage).toMatchObject({
       storageName: "official-workflow@morning-brief",
       orgId: SYSTEM_ORG_ID,
       userId: VOLUME_ORG_USER_ID,
-      headVersionId: definition?.artifact.storageVersion,
+      headVersionId: morningBriefDefinition.artifact.storageVersion,
       versionCount: 1,
     });
-    expect(firstState.body.counts).toStrictEqual({
-      releases: 1,
-      revisions: 1,
-      storages: 1,
-      storageVersions: 1,
+    expect(connectorDoctorState.body.storage).toMatchObject({
+      storageName: "official-workflow@connector-doctor",
+      orgId: SYSTEM_ORG_ID,
+      userId: VOLUME_ORG_USER_ID,
+      headVersionId: connectorDoctorDefinition.artifact.storageVersion,
+      versionCount: 1,
     });
-    expect(s3.objects.size).toBe(2);
+    expect(morningBriefState.body.counts).toStrictEqual({
+      releases: 1,
+      revisions: 2,
+      storages: 2,
+      storageVersions: 2,
+    });
+    expect(s3.objects.size).toBe(4);
 
-    const revision = definition?.revision;
-    expect(revision).toBeDefined();
-    if (!revision) {
-      throw new Error("Expected the Morning Brief Definition revision");
-    }
-    const exact = await readState("morning-brief", revision);
-    const instruction = exact.body.revision?.definition.workflow.instruction;
-    expect(exact.body.revision?.definition.workflow).toMatchObject({
+    const morningBriefRevision = morningBriefDefinition.revision;
+    const connectorDoctorRevision = connectorDoctorDefinition.revision;
+    const exactMorningBrief = await readState(
+      "morning-brief",
+      morningBriefRevision,
+    );
+    const exactMorningBriefRevision = requireValue(
+      exactMorningBrief.body.revision,
+      "Expected the exact Morning Brief revision",
+    );
+    const morningBriefInstruction =
+      exactMorningBriefRevision.definition.workflow.instruction;
+    expect(exactMorningBriefRevision.definition.workflow).toMatchObject({
       displayName: "Morning Brief",
       description:
         "Summarize today's email, GitHub, calendar, and unread Chat priorities.",
       files: [],
     });
-    expect(instruction).toContain("Gmail connector skill");
-    expect(instruction).toContain("GitHub connector skill");
-    expect(instruction).toContain("Google Calendar connector skill");
-    expect(instruction).toContain("okou chat list --unread --all-agents");
-    expect(instruction).toContain("Never invent, infer, or claim source data");
-    expect(instruction).toContain("Do not send email");
-    expect(instruction).not.toMatch(
+    expect(morningBriefInstruction).toContain("Gmail connector skill");
+    expect(morningBriefInstruction).toContain("GitHub connector skill");
+    expect(morningBriefInstruction).toContain(
+      "Google Calendar connector skill",
+    );
+    expect(morningBriefInstruction).toContain(
+      "okou chat list --unread --all-agents",
+    );
+    expect(morningBriefInstruction).toContain(
+      "Never invent, infer, or claim source data",
+    );
+    expect(morningBriefInstruction).toContain("Do not send email");
+    expect(morningBriefInstruction).not.toMatch(
       /morning-brief-(?:collect|run)|morning_brief|chat_morning_brief_context/,
     );
 
-    const firstIdentity = {
-      revision: definition?.revision,
-      blueprintFingerprint: definition?.blueprints[0]?.fingerprint,
-      artifact: definition?.artifact,
+    const exactConnectorDoctor = await readState(
+      "connector-doctor",
+      connectorDoctorRevision,
+    );
+    const exactConnectorDoctorRevision = requireValue(
+      exactConnectorDoctor.body.revision,
+      "Expected the exact Connector Doctor revision",
+    );
+    const connectorDoctorInstruction =
+      exactConnectorDoctorRevision.definition.workflow.instruction;
+    expect(exactConnectorDoctorRevision.definition.workflow).toMatchObject({
+      displayName: "Connector Doctor",
+      description:
+        "Diagnose connector readiness across your workflows and group exact repair actions.",
+      files: [],
+    });
+    expect(
+      connectorDoctorInstruction.match(/okou doctor connectors --json/gu),
+    ).toHaveLength(1);
+    expect(connectorDoctorInstruction).toContain(
+      "sole source of diagnostic facts",
+    );
+    expect(connectorDoctorInstruction).toContain("schemaVersion` is `1");
+    expect(connectorDoctorInstruction).toContain(
+      "identical `action.kind` and exact `action.url`",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "list every affected workflow with the connector's returned readiness status and reason",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "Never merge entries whose exact URLs differ",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "every connector whose status is `unavailable` and every workflow with a non-null `error`",
+    );
+    expect(connectorDoctorInstruction).toContain("Unknown is never healthy");
+    expect(connectorDoctorInstruction).toContain("summary.checked === 0");
+    expect(connectorDoctorInstruction).toContain(
+      "not an all-clear over diagnosed workflows",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "summary.attention === 0`, and `summary.unknown === 0",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "command fails, its output is not valid JSON, or its schema version is unsupported",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "Do not invoke connector or provider skills, third-party provider APIs",
+    );
+    expect(connectorDoctorInstruction).toContain("okou connector list");
+    expect(connectorDoctorInstruction).toContain("okou connector status");
+    expect(connectorDoctorInstruction).toContain("okou connector check");
+    expect(connectorDoctorInstruction).toContain(
+      "Do not write to or mutate application or provider state",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "Do not connect, reconnect, authorize, start OAuth flows, request permissions, create callbacks, mutate connectors",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "Do not send email or directly send any chat or other message",
+    );
+
+    expect(morningBriefRevision).not.toBe(connectorDoctorRevision);
+    expect(morningBriefDefinition.blueprints[0]?.fingerprint).not.toBe(
+      connectorDoctorDefinition.blueprints[0]?.fingerprint,
+    );
+    expect(morningBriefDefinition.artifact.storageVersion).not.toBe(
+      connectorDoctorDefinition.artifact.storageVersion,
+    );
+    const firstIdentities = {
+      morningBrief: {
+        revision: morningBriefDefinition.revision,
+        blueprintFingerprint: morningBriefDefinition.blueprints[0]?.fingerprint,
+        artifact: morningBriefDefinition.artifact,
+      },
+      connectorDoctor: {
+        revision: connectorDoctorDefinition.revision,
+        blueprintFingerprint:
+          connectorDoctorDefinition.blueprints[0]?.fingerprint,
+        artifact: connectorDoctorDefinition.artifact,
+      },
     };
     s3.clearWrites();
     const second = await syncDeployedCatalog();
@@ -466,12 +614,26 @@ describe.sequential("Official Workflow catalog release boundary", () => {
       releaseId: first.body.releaseId,
       diagnostics: [],
     });
-    const secondDefinition = (await readState("morning-brief")).body.definition;
+    const secondMorningBrief = requireValue(
+      (await readState("morning-brief")).body.definition,
+      "Expected the unchanged Morning Brief Definition",
+    );
+    const secondConnectorDoctor = requireValue(
+      (await readState("connector-doctor")).body.definition,
+      "Expected the unchanged Connector Doctor Definition",
+    );
     expect({
-      revision: secondDefinition?.revision,
-      blueprintFingerprint: secondDefinition?.blueprints[0]?.fingerprint,
-      artifact: secondDefinition?.artifact,
-    }).toStrictEqual(firstIdentity);
+      morningBrief: {
+        revision: secondMorningBrief.revision,
+        blueprintFingerprint: secondMorningBrief.blueprints[0]?.fingerprint,
+        artifact: secondMorningBrief.artifact,
+      },
+      connectorDoctor: {
+        revision: secondConnectorDoctor.revision,
+        blueprintFingerprint: secondConnectorDoctor.blueprints[0]?.fingerprint,
+        artifact: secondConnectorDoctor.artifact,
+      },
+    }).toStrictEqual(firstIdentities);
     expect(s3.writes).toStrictEqual([]);
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -1277,7 +1277,7 @@ beforeEach(async () => {
 });
 
 describe.sequential("Official Workflow installations", () => {
-  it("materializes the deployed Morning Brief through generic installation state", async () => {
+  it("materializes the deployed Official Workflows through generic installation state", async () => {
     installCatalogStorageFixture();
     const synced = await syncDeployedCatalog();
     expect(synced.body).toMatchObject({ outcome: "accepted", diagnostics: [] });
@@ -1298,14 +1298,22 @@ describe.sequential("Official Workflow installations", () => {
     await setOfficialWorkflowsEnabled(actor, true);
 
     const discovered = await accept(officialClient().list({ headers }), [200]);
-    expect(discovered.body).toMatchObject([
+    expect(
+      discovered.body.map(({ name, displayName }) => {
+        return { name, displayName };
+      }),
+    ).toStrictEqual([
+      {
+        name: "connector-doctor",
+        displayName: "Connector Doctor",
+      },
       {
         name: "morning-brief",
         displayName: "Morning Brief",
       },
     ]);
 
-    const installed = await accept(
+    const installedMorningBrief = await accept(
       officialClient().install({
         headers,
         params: { definitionName: "morning-brief" },
@@ -1316,12 +1324,12 @@ describe.sequential("Official Workflow installations", () => {
       }),
       [201],
     );
-    expect(installed.body.definition).toMatchObject({
+    expect(installedMorningBrief.body.definition).toMatchObject({
       name: "morning-brief",
       lifecycle: "active",
       blueprints: [{ key: "daily-delivery" }],
     });
-    expect(installed.body.workflow).toMatchObject({
+    expect(installedMorningBrief.body.workflow).toMatchObject({
       name: "morning-brief",
       displayName: "Morning Brief",
       agentId,
@@ -1332,11 +1340,13 @@ describe.sequential("Official Workflow installations", () => {
         readOnly: true,
       },
     });
-    expect(installed.body.workflow.automations).toHaveLength(1);
-    const automation = installed.body.workflow.automations[0];
-    expect(automation).toMatchObject({
+    expect(installedMorningBrief.body.workflow.automations).toHaveLength(1);
+    const morningBriefAutomation =
+      installedMorningBrief.body.workflow.automations[0];
+    expect(morningBriefAutomation).toMatchObject({
       kind: "schedule",
       enabled: true,
+      chatThreadId: expect.any(String),
       schedule: {
         type: "cron",
         cronExpression: "0 7 * * *",
@@ -1349,16 +1359,94 @@ describe.sequential("Official Workflow installations", () => {
         parameterBindings: [{ key: "timezone", value: "Asia/Shanghai" }],
       },
     });
-    if (!automation) {
+    if (!morningBriefAutomation) {
       throw new Error("Expected the Morning Brief Automation");
     }
     await expect(
-      readWorkflowAutomationAutonomyFixture(context, automation.id),
+      readWorkflowAutomationAutonomyFixture(context, morningBriefAutomation.id),
     ).resolves.toMatchObject({
       autonomyBudget: 10,
       enabled: true,
       officialBlueprintKey: "daily-delivery",
       officialResultEmailEnabled: true,
+    });
+
+    const installedConnectorDoctor = await accept(
+      officialClient().install({
+        headers,
+        params: { definitionName: "connector-doctor" },
+        body: {
+          agentId,
+          blueprints: [{ blueprintKey: "weekly-check", bindings: [] }],
+        },
+      }),
+      [201],
+    );
+    expect(installedConnectorDoctor.body.definition).toMatchObject({
+      name: "connector-doctor",
+      lifecycle: "active",
+      blueprints: [{ key: "weekly-check" }],
+    });
+    expect(installedConnectorDoctor.body.workflow).toMatchObject({
+      name: "connector-doctor",
+      displayName: "Connector Doctor",
+      agentId,
+      official: {
+        definitionName: "connector-doctor",
+        installationState: "installed",
+        definitionLifecycle: "active",
+        readOnly: true,
+      },
+    });
+    expect(installedConnectorDoctor.body.workflow.automations).toHaveLength(1);
+    const connectorDoctorAutomation =
+      installedConnectorDoctor.body.workflow.automations[0];
+    expect(connectorDoctorAutomation).toMatchObject({
+      kind: "schedule",
+      enabled: true,
+      chatThreadId: expect.any(String),
+      schedule: {
+        type: "cron",
+        cronExpression: "0 9 * * 1",
+        timezone: "Asia/Shanghai",
+      },
+      official: {
+        blueprintKey: "weekly-check",
+        reconciliationStatus: "current",
+        intendedEnabled: true,
+        parameterBindings: [{ key: "timezone", value: "Asia/Shanghai" }],
+      },
+    });
+    if (!connectorDoctorAutomation?.chatThreadId) {
+      throw new Error("Expected the Connector Doctor shared automation thread");
+    }
+    expect(connectorDoctorAutomation.chatThreadId).not.toBe(
+      morningBriefAutomation.chatThreadId,
+    );
+    const persistedConnectorDoctor = await accept(
+      installationClient().get({
+        headers,
+        params: { workflowId: installedConnectorDoctor.body.workflow.id },
+      }),
+      [200],
+    );
+    expect(persistedConnectorDoctor.body.workflow.automations).toHaveLength(1);
+    expect(persistedConnectorDoctor.body.workflow.automations).toMatchObject([
+      {
+        id: connectorDoctorAutomation.id,
+        chatThreadId: connectorDoctorAutomation.chatThreadId,
+      },
+    ]);
+    await expect(
+      readWorkflowAutomationAutonomyFixture(
+        context,
+        connectorDoctorAutomation.id,
+      ),
+    ).resolves.toMatchObject({
+      autonomyBudget: 10,
+      enabled: true,
+      officialBlueprintKey: "weekly-check",
+      officialResultEmailEnabled: false,
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/test-official-workflow-catalog-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-official-workflow-catalog-state.ts
@@ -23,7 +23,7 @@ import {
 } from "@okouai/db/schema/workflow";
 import { storages, storageVersions } from "@okouai/db/schema/storage";
 import { command } from "ccstate";
-import { and, asc, count, eq, like, or } from "drizzle-orm";
+import { and, asc, count, eq, inArray, like, or } from "drizzle-orm";
 
 import { nowDate } from "../../lib/time";
 import { testOverride } from "../../lib/singleton";
@@ -53,8 +53,10 @@ const actionBody$ = bodyResultOf(
   testOfficialWorkflowCatalogStateContract.action,
 );
 const TEST_STORAGE_NAME_PATTERN = "official-workflow@api-test-%";
-const DEPLOYED_TEST_STORAGE_NAME =
-  getOfficialWorkflowDefinitionStorageName("morning-brief");
+const DEPLOYED_TEST_STORAGE_NAMES = [
+  getOfficialWorkflowDefinitionStorageName("connector-doctor"),
+  getOfficialWorkflowDefinitionStorageName("morning-brief"),
+] as const;
 
 interface DormantMaterializationPause {
   readonly reached: ReturnType<typeof createDeferredPromise<void>>;
@@ -164,7 +166,7 @@ async function cleanupTestState(db: Db, signal: AbortSignal): Promise<void> {
         eq(storages.userId, VOLUME_ORG_USER_ID),
         or(
           like(storages.name, TEST_STORAGE_NAME_PATTERN),
-          eq(storages.name, DEPLOYED_TEST_STORAGE_NAME),
+          inArray(storages.name, DEPLOYED_TEST_STORAGE_NAMES),
         ),
       ),
     );
@@ -185,7 +187,7 @@ async function catalogCounts(db: Db, signal: AbortSignal) {
             eq(storages.userId, VOLUME_ORG_USER_ID),
             or(
               like(storages.name, TEST_STORAGE_NAME_PATTERN),
-              eq(storages.name, DEPLOYED_TEST_STORAGE_NAME),
+              inArray(storages.name, DEPLOYED_TEST_STORAGE_NAMES),
             ),
           ),
         ),
@@ -199,7 +201,7 @@ async function catalogCounts(db: Db, signal: AbortSignal) {
             eq(storages.userId, VOLUME_ORG_USER_ID),
             or(
               like(storages.name, TEST_STORAGE_NAME_PATTERN),
-              eq(storages.name, DEPLOYED_TEST_STORAGE_NAME),
+              inArray(storages.name, DEPLOYED_TEST_STORAGE_NAMES),
             ),
           ),
         ),

--- a/turbo/apps/api/src/signals/services/official-workflow-catalog-source.ts
+++ b/turbo/apps/api/src/signals/services/official-workflow-catalog-source.ts
@@ -24,6 +24,30 @@ Return only the briefing as concise Markdown. Choose short headings and bullets 
 
 Do not read application database tables or use internal application APIs, signed input or output URLs, or callback endpoints. Do not send email, drafts, chat messages, or provider-side updates. The platform owns any result-email delivery after the run succeeds.`;
 
+const CONNECTOR_DOCTOR_INSTRUCTION = `# Connector Doctor
+
+Produce a concise Markdown connector-readiness report in this Official Workflow's shared automation thread.
+
+## Diagnose once
+
+Run \`okou doctor connectors --json\` exactly once per scheduled or manual run. Parse its standard output as JSON and accept it only when \`schemaVersion\` is \`1\`. Treat that one report as the sole source of diagnostic facts. Do not supplement, verify, or reinterpret it from any other source.
+
+If the command fails, its output is not valid JSON, or its schema version is unsupported, return a diagnosis-unavailable report under an **Unknown** heading. State the observed failure without claiming that any connector or workflow is healthy.
+
+## Report valid results
+
+- If \`summary.checked === 0\`, report that no owned or installed workflows were available to check. Treat this as a distinct no-workflows result, not an all-clear over diagnosed workflows.
+- Group every connector entry with a non-null action by identical \`action.kind\` and exact \`action.url\`. Include the repair link once for each group, then list every affected workflow with the connector's returned readiness status and reason. Never merge entries whose exact URLs differ, even when their action kinds or connector labels match, because the URL identifies the target Agent.
+- Under **Unknown**, list every connector whose status is \`unavailable\` and every workflow with a non-null \`error\`. Include the returned workflow identity and reason or error message. Unknown is never healthy.
+- Emit a short all-clear only when \`summary.checked > 0\`, \`summary.attention === 0\`, and \`summary.unknown === 0\`.
+- Keep the report concise and include only facts, counts, statuses, reasons, and repair links present in the returned JSON.
+
+## Safety boundaries
+
+Do not invoke connector or provider skills, third-party provider APIs, \`okou connector list\`, \`okou connector status\`, \`okou connector check\`, application-internal APIs, or application database tables. Do not write to or mutate application or provider state. Do not connect, reconnect, authorize, start OAuth flows, request permissions, create callbacks, mutate connectors, or follow repair links. Do not select or recommend models, and do not recommend workflow or Automation cleanup.
+
+Return only the Markdown report. The platform delivers it to the shared automation thread. Do not send email or directly send any chat or other message.`;
+
 /**
  * The sole deployed source candidate. Every Definition uses the same validated
  * release boundary and immutable shared-artifact publication path.
@@ -63,6 +87,41 @@ export const OFFICIAL_WORKFLOW_SOURCE_CATALOG: OfficialWorkflowSourceCatalog =
               },
             },
             runtime: { resultEmail: true },
+          },
+        ],
+        presentation: { category: "productivity" },
+      },
+      {
+        name: "connector-doctor",
+        lifecycle: "active",
+        workflow: {
+          displayName: "Connector Doctor",
+          description:
+            "Diagnose connector readiness across your workflows and group exact repair actions.",
+          instruction: CONNECTOR_DOCTOR_INSTRUCTION,
+          files: [],
+        },
+        blueprints: [
+          {
+            key: "weekly-check",
+            parameters: [
+              {
+                key: "timezone",
+                type: "string",
+                format: "timezone",
+                required: true,
+                derivation: { kind: "user-timezone" },
+              },
+            ],
+            desiredState: {
+              kind: "schedule",
+              schedule: {
+                type: "cron",
+                cronExpression: "0 9 * * 1",
+                timezone: { parameter: "timezone" },
+              },
+            },
+            runtime: { resultEmail: false },
           },
         ],
         presentation: { category: "productivity" },


### PR DESCRIPTION
## Summary

- publish the weekly Connector Doctor Official Workflow with Monday 09:00 user-timezone scheduling and result email disabled
- make the versioned Doctor JSON the sole diagnostic source, with exact action grouping and fail-closed Unknown handling
- preserve Morning Brief behavior while expanding deployed-catalog identity and generic public installation coverage

## Testing

- pnpm exec prettier --check on the four changed API files
- pnpm --filter api run lint
- pnpm --filter api run check-types
- pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
- pnpm --filter api exec vitest run src/signals/routes/__tests__/official-workflows.test.ts -t materializes the deployed Official Workflows through generic installation state
- pnpm knip
- git diff --check

Closes #30581

Parent EPIC: #30469