### PR TITLE
test(connectors): remove retired api url tombstone

### DIFF
--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/test-oauth.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/test-oauth.test.ts
@@ -104,33 +104,6 @@ describe("test-oauth provider URLs", () => {
     expect(authorizationUrl.origin).toBe("https://pr-12962-api.vm6.ai");
   });
 
-  it("ignores the retired API URL input with or without canonical config", () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "https://legacy-api.example.test");
-
-    const fallbackAuthorizationUrl = new URL(
-      buildTestOAuthAuthorizationUrl(
-        authCodeGrant(),
-        "test-client",
-        "https://app.vm0.ai/callback",
-        "state-123",
-      ),
-    );
-    expect(fallbackAuthorizationUrl.origin).toBe("http://localhost:3000");
-
-    vi.stubEnv("OKOU_API_BACKEND_URL", "https://canonical-api.example.test");
-    const canonicalAuthorizationUrl = new URL(
-      buildTestOAuthAuthorizationUrl(
-        authCodeGrant(),
-        "test-client",
-        "https://app.vm0.ai/callback",
-        "state-123",
-      ),
-    );
-    expect(canonicalAuthorizationUrl.origin).toBe(
-      "https://canonical-api.example.test",
-    );
-  });
-
   it("uses the canonical Web URL before the APP_URL fallback", () => {
     vi.stubEnv("OKOU_WEB_URL", "https://pr-12962-www.vm6.ai/");
     vi.stubEnv("APP_URL", "https://app-fallback.example.test");


### PR DESCRIPTION
## Summary

- remove the complete `ignores the retired API URL input with or without canonical config` tombstone test
- preserve production code and all positive canonical test-oauth coverage

## Just-in-time audit

- reviewed base: `7ee0f4570327b8e73fdc4af0cb65f303aafc455d`
- `VM0_API_BACKEND_URL` appeared exactly once under `turbo/packages/connectors/**` before the change, in the deleted test only
- fully paginated 22 open PRs and matched all 583/583 GitHub-declared changed files; no target-file or caller-surface overlap

## Verification

- `pnpm exec prettier --write packages/connectors/src/auth-providers/connectors/__tests__/test-oauth.test.ts` (Prettier 3.8.1)
- `pnpm --filter @okouai/connectors run lint`
- `pnpm --filter @okouai/connectors run check-types`
- `pnpm --filter @okouai/connectors exec vitest run src/auth-providers/connectors/__tests__/test-oauth.test.ts` (9 tests passed)
- exact `VM0_API_BACKEND_URL` inventory under `turbo/packages/connectors/**` (0 matches)
- `git diff --check`

Parent: #28914

Closes #30589
