### PR TITLE
feat: request connector account switches in chat

### DIFF
--- a/docs/chat-cards.md
+++ b/docs/chat-cards.md
@@ -288,9 +288,11 @@ A connector account switch URL matches:
 Custom connectors use `kind=custom` and `customConnectorId` instead of
 `connectorSlug`. The parser requires exactly one well-formed target, the chat's
 server-derived agent ID, and a callback bound to the current thread. These URL
-values are untrusted claims. The card reads the exact account from the API and
-uses only the live account metadata for presentation; a missing, cross-owner,
-or wrong-target account renders an inert unavailable card.
+values are untrusted claims. Before reading the account, the card resolves the
+current agent's connector authorization and rejects an unauthorized target.
+It then reads the exact account from the API and uses only the live account
+metadata for presentation; a missing, cross-owner, wrong-target, or
+unauthorized account renders an inert unavailable card.
 
 Confirmation writes the exact account selection to the current thread before
 starting the callback round. The selection endpoint resolves the externally
@@ -301,10 +303,11 @@ override used by future runs; it does not mutate the global default or the run
 that produced the card.
 
 Repeated occurrences of the same action share one signals object. The card also
-reads the composer's shared connector-account preference state, so local
-confirmation and thread-detail realtime events update every mounted occurrence.
-The action is gated by `ConnectorAccounts`; older frontends that do not know the
-card continue to render the emitted Markdown link.
+reads the composer's shared connector authorization and connector-account
+preference state, so local confirmation and thread-detail realtime events
+update every mounted occurrence. The action is gated by `ConnectorAccounts`;
+older frontends that do not know the card continue to render the emitted
+Markdown link.
 
 ### Provider-backed resource: Gmail draft
 

--- a/docs/chat-cards.md
+++ b/docs/chat-cards.md
@@ -292,8 +292,10 @@ values are untrusted claims. Before reading the account, the card resolves the
 current agent's connector authorization and rejects an unauthorized target.
 It then reads the exact account from the API and uses only the live account
 metadata plus the current catalog or custom-connector metadata for presentation,
-including the connector's own icon. A missing, cross-owner, wrong-target, or
-unauthorized account renders an inert unavailable card.
+including the connector's own icon. If that presentation metadata cannot load,
+the card keeps the account action available with the standard connector fallback
+icon. A missing, cross-owner, wrong-target, or unauthorized account renders an
+inert unavailable card.
 
 Confirmation writes the exact account selection to the current thread before
 starting the callback round. The selection endpoint resolves the externally

--- a/docs/chat-cards.md
+++ b/docs/chat-cards.md
@@ -49,6 +49,7 @@ Current link-backed card patterns include:
   `/connectors/:connectorSlug/authorize`
 - `/connectors/custom/proposal?p=...`
 - `/agents/:agentId/permissions?...`
+- `/agents/:agentId/connector-accounts/:connectionId/select?...`
 - `/computer-use/authorize/:requestToken`
 - `/?settings=billing&billingView=plans`
 - `/mail/drafts/:vm0DraftId`
@@ -272,6 +273,39 @@ Permission changes can arrive from another card or another product surface. A
 user-level realtime event invalidates the shared grants source, so mounted
 permission cards refresh without replacing their signals identities.
 
+### Confirmed action: connector account switch
+
+A connector account switch URL matches:
+
+```text
+/agents/:agentId/connector-accounts/:connectionId/select
+  ?kind=builtin
+  &connectorSlug=github
+  &threadId=:threadId
+  &callbackPrompt=:prompt
+```
+
+Custom connectors use `kind=custom` and `customConnectorId` instead of
+`connectorSlug`. The parser requires exactly one well-formed target, the chat's
+server-derived agent ID, and a callback bound to the current thread. These URL
+values are untrusted claims. The card reads the exact account from the API and
+uses only the live account metadata for presentation; a missing, cross-owner,
+or wrong-target account renders an inert unavailable card.
+
+Confirmation writes the exact account selection to the current thread before
+starting the callback round. The selection endpoint resolves the externally
+managed account reference again, so an account that was removed, reconnected,
+or otherwise became invalid after the card loaded fails closed. A failed write
+does not run the callback. A successful write updates only the sparse thread
+override used by future runs; it does not mutate the global default or the run
+that produced the card.
+
+Repeated occurrences of the same action share one signals object. The card also
+reads the composer's shared connector-account preference state, so local
+confirmation and thread-detail realtime events update every mounted occurrence.
+The action is gated by `ConnectorAccounts`; older frontends that do not know the
+card continue to render the emitted Markdown link.
+
 ### Provider-backed resource: Gmail draft
 
 A vm0 mail link matches `/mail/drafts/:vm0DraftId`. The vm0 UUID is the stable
@@ -386,6 +420,7 @@ registry.
 - `turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts`
 - `turbo/apps/platform/src/signals/chat-page/artifact-card-signals.ts`
 - `turbo/apps/platform/src/signals/chat-page/connector-action-block.ts`
+- `turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts`
 - `turbo/apps/platform/src/signals/chat-page/permission-action-block.ts`
 - `turbo/apps/platform/src/signals/chat-page/permission-card-signals.ts`
 - `turbo/apps/platform/src/signals/chat-page/mail-draft.ts`
@@ -395,5 +430,6 @@ registry.
 - `turbo/apps/platform/src/signals/chat-page/plan-upgrade-block.ts`
 - `turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx`
 - `turbo/apps/platform/src/views/okou-page/browser-session-card.tsx`
+- `turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx`
 - `turbo/apps/platform/src/views/okou-page/chat-body-cards.tsx`
 - `turbo/apps/platform/src/views/browser-session/browser-session-page.tsx`

--- a/docs/chat-cards.md
+++ b/docs/chat-cards.md
@@ -291,7 +291,8 @@ server-derived agent ID, and a callback bound to the current thread. These URL
 values are untrusted claims. Before reading the account, the card resolves the
 current agent's connector authorization and rejects an unauthorized target.
 It then reads the exact account from the API and uses only the live account
-metadata for presentation; a missing, cross-owner, wrong-target, or
+metadata plus the current catalog or custom-connector metadata for presentation,
+including the connector's own icon. A missing, cross-owner, wrong-target, or
 unauthorized account renders an inert unavailable card.
 
 Confirmation writes the exact account selection to the current thread before

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -14848,6 +14848,9 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
       "only the current thread's override for future runs",
     );
     expect(appendSystemPrompt).toContain(
+      "do not include secrets because it is included in the URL",
+    );
+    expect(appendSystemPrompt).toContain(
       "only after the user confirms and the selection succeeds",
     );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -14804,6 +14804,56 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
     await api.requestCancelRun(actor, gatedOn.runId, [200]);
   });
 
+  it("advertises connector account switching only while the feature is enabled", async () => {
+    const api = createRunsApi(context);
+    const connectors = createConnectorBddApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.ConnectorAccounts]: false,
+    });
+    const gatedOff = await api.createRun(actor, {
+      agentId,
+      prompt: "switch my connector account",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const gatedOffClaim = await api.claimRunnerJob(gatedOff.runId);
+    expect(gatedOffClaim.appendSystemPrompt ?? "").not.toContain(
+      "okou connector account switch-request",
+    );
+    await api.requestCancelRun(actor, gatedOff.runId, [200]);
+
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
+    const gatedOn = await api.createRun(actor, {
+      agentId,
+      prompt: "switch my connector account",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const gatedOnClaim = await api.claimRunnerJob(gatedOn.runId);
+    const appendSystemPrompt = gatedOnClaim.appendSystemPrompt ?? "";
+    expect(appendSystemPrompt).toContain(
+      "okou connector account list <slug> --json",
+    );
+    expect(appendSystemPrompt).toContain(
+      "Use only an exact `connectionId` returned by these commands",
+    );
+    expect(appendSystemPrompt).toContain(
+      "okou connector account switch-request <slug> --connection-id <uuid> --callback-prompt <prompt>",
+    );
+    expect(appendSystemPrompt).toContain(
+      "only the current thread's override for future runs",
+    );
+    expect(appendSystemPrompt).toContain(
+      "only after the user confirms and the selection succeeds",
+    );
+
+    await api.requestCancelRun(actor, gatedOn.runId, [200]);
+  });
+
   it("advertises managed SEO tools by default", async () => {
     const api = createRunsApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();

--- a/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
@@ -470,7 +470,7 @@ function buildAgentToolsPrompt(args: {
     ...(args.connectorAccountsEnabled
       ? [
           "- Connector accounts: inspect the current account with `okou connector status <slug> --json` and list alternatives with `okou connector account list <slug> --json`. Use only an exact `connectionId` returned by these commands; never invent an ID or reuse one from another connector.",
-          "- Request one account switch in the current web chat with `okou connector account switch-request <slug> --connection-id <uuid> --callback-prompt <prompt>`. This changes only the current thread's override for future runs, not the current run or global default. Share the returned link and end the turn; Okou starts the callback round only after the user confirms and the selection succeeds.",
+          "- Request one account switch in the current web chat with `okou connector account switch-request <slug> --connection-id <uuid> --callback-prompt <prompt>`. This changes only the current thread's override for future runs, not the current run or global default. Keep the callback prompt concise and do not include secrets because it is included in the URL. Share the returned link and end the turn; Okou starts the callback round only after the user confirms and the selection succeeds.",
         ]
       : []),
     "- Custom connectors: when the user wants to add their own custom connector, run `okou connector custom -h` first and follow its guidance.",

--- a/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
@@ -417,6 +417,7 @@ function buildAgentToolsPrompt(args: {
   readonly triggerSource: TriggerSource;
   readonly cloudBrowserEnabled: boolean | undefined;
   readonly bankingEnabled: boolean;
+  readonly connectorAccountsEnabled: boolean;
   readonly presentationTemplatesEnabled: boolean;
 }): string {
   const okouCliCommand = `npx --yes --package="\${CLI_PKG_URL}" okou`;
@@ -466,6 +467,12 @@ function buildAgentToolsPrompt(args: {
     "- Current weather, forecasts, and recent history: use `okou weather --help`.",
     "- Static web artifacts can be published with `okou host <dir> --site <slug> [--spa]`; for HTML presentations, include `--artifact-kind presentation-html`; run `okou host --help` for details.",
     "- Third-party services (GitHub, Slack, Notion, 100+ more) are accessed via connectors that expose environment names like `GH_TOKEN`. Find: `okou connector search <keyword>`. List connected: `okou connector list`. Inspect: `okou connector status <slug>`.",
+    ...(args.connectorAccountsEnabled
+      ? [
+          "- Connector accounts: inspect the current account with `okou connector status <slug> --json` and list alternatives with `okou connector account list <slug> --json`. Use only an exact `connectionId` returned by these commands; never invent an ID or reuse one from another connector.",
+          "- Request one account switch in the current web chat with `okou connector account switch-request <slug> --connection-id <uuid> --callback-prompt <prompt>`. This changes only the current thread's override for future runs, not the current run or global default. Share the returned link and end the turn; Okou starts the callback round only after the user confirms and the selection succeeds.",
+        ]
+      : []),
     "- Custom connectors: when the user wants to add their own custom connector, run `okou connector custom -h` first and follow its guidance.",
     "- Model availability and provider routing are workspace model settings, separate from connectors. Use `okou model ls` to list allowed models, `okou model switch` for model-switching guidance, and `okou model-provider ls` to inspect built-in/BYOK routing.",
     "- Credit diagnostics: use `okou doctor credit` when a run or generation fails with insufficient credits, when the user asks how to recharge, or before buying credits. It reports the org balance, tier, purchase eligibility, current user admin status, and org admins. If it says credit purchases are unavailable, do not run `okou credit`.",
@@ -543,6 +550,7 @@ function buildAppendSystemPrompt(args: {
   readonly triggerSource: TriggerSource;
   readonly cloudBrowserEnabled: boolean | undefined;
   readonly bankingEnabled: boolean;
+  readonly connectorAccountsEnabled: boolean;
   readonly presentationTemplatesEnabled: boolean;
 }): string {
   const identity = buildAgentIdentityPrompt(args.agent, args.publicBrand);
@@ -553,6 +561,7 @@ function buildAppendSystemPrompt(args: {
       triggerSource: args.triggerSource,
       cloudBrowserEnabled: args.cloudBrowserEnabled,
       bankingEnabled: args.bankingEnabled,
+      connectorAccountsEnabled: args.connectorAccountsEnabled,
       presentationTemplatesEnabled: args.presentationTemplatesEnabled,
     }),
     buildCurrentUserPrompt(args.userInfo),
@@ -732,6 +741,7 @@ function createRunBody(args: {
   readonly appendSystemPrompt: string | undefined;
   readonly cloudBrowserEnabled: boolean | undefined;
   readonly bankingEnabled: boolean;
+  readonly connectorAccountsEnabled: boolean;
   readonly presentationTemplatesEnabled: boolean;
 }) {
   const triggerSource = args.triggerSource ?? "web";
@@ -742,6 +752,7 @@ function createRunBody(args: {
     triggerSource,
     cloudBrowserEnabled: args.cloudBrowserEnabled,
     bankingEnabled: args.bankingEnabled,
+    connectorAccountsEnabled: args.connectorAccountsEnabled,
     presentationTemplatesEnabled: args.presentationTemplatesEnabled,
   });
   return {
@@ -939,6 +950,10 @@ function buildZeroCreateAgentRunArgs(args: {
       cloudBrowserEnabled: args.cloudBrowserEnabled,
       bankingEnabled: isFeatureEnabled(
         FeatureSwitchKey.Banking,
+        args.featureSwitchContext,
+      ),
+      connectorAccountsEnabled: isFeatureEnabled(
+        FeatureSwitchKey.ConnectorAccounts,
         args.featureSwitchContext,
       ),
       presentationTemplatesEnabled: isFeatureEnabled(

--- a/turbo/apps/cli/src/commands/connector/account/__tests__/switch-request.test.ts
+++ b/turbo/apps/cli/src/commands/connector/account/__tests__/switch-request.test.ts
@@ -244,6 +244,46 @@ describe("okou connector account switch-request command", () => {
     expect(mockConsoleLog).not.toHaveBeenCalled();
   });
 
+  it("requires the current web chat agent", async () => {
+    vi.stubEnv("OKOU_AGENT_ID", "");
+
+    await expect(
+      switchConnectorAccountRequestCommand.parseAsync([
+        "node",
+        "okou",
+        "github",
+        "--connection-id",
+        CONNECTION_ID,
+        "--callback-prompt",
+        "Continue",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "Connector account switches require the current web chat agent",
+    );
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
+  it("rejects a hallucinated connector slug", async () => {
+    await expect(
+      switchConnectorAccountRequestCommand.parseAsync([
+        "node",
+        "okou",
+        "invented-connector",
+        "--connection-id",
+        CONNECTION_ID,
+        "--callback-prompt",
+        "Continue",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "Unknown or unavailable connector: invented-connector",
+    );
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
   it("rejects missing and wrong-target account references", async () => {
     server.use(
       stubInspection({

--- a/turbo/apps/cli/src/commands/connector/account/__tests__/switch-request.test.ts
+++ b/turbo/apps/cli/src/commands/connector/account/__tests__/switch-request.test.ts
@@ -13,13 +13,14 @@ import {
 } from "../../../__tests__/helpers/connector-catalog";
 import {
   customConnector,
+  stubAgentCustomConnectors,
   stubCustomConnectors,
 } from "../../../__tests__/helpers/custom-connectors";
 import { switchConnectorAccountRequestCommand } from "../switch-request";
 
 const CONNECTION_ID = "11111111-1111-4111-8111-111111111111";
 const CUSTOM_CONNECTOR_ID = "22222222-2222-4222-8222-222222222222";
-const AGENT_ID = "agent-account-switch";
+const AGENT_ID = "44444444-4444-4444-8444-444444444444";
 const THREAD_ID = "33333333-3333-4333-8333-333333333333";
 
 function availableInspection(
@@ -50,6 +51,34 @@ function stubCatalog(): ReturnType<typeof http.get> {
       authMethods: [authCodeMethod("oauth")],
     }),
   ]);
+}
+
+function stubAgent(): ReturnType<typeof http.get> {
+  return http.get(`http://localhost:3000/api/agents/${AGENT_ID}`, () => {
+    return HttpResponse.json({
+      agentId: AGENT_ID,
+      ownerId: "owner-1",
+      displayName: "Zero",
+      description: null,
+      sound: null,
+      avatarUrl: null,
+      modelProviderId: null,
+      selectedModel: null,
+      preferPersonalProvider: false,
+      visibility: "private",
+    });
+  });
+}
+
+function stubAgentBuiltinConnectors(
+  enabledConnectorSlugs: readonly string[],
+): ReturnType<typeof http.get> {
+  return http.get(
+    `http://localhost:3000/api/agents/${AGENT_ID}/user-connectors`,
+    () => {
+      return HttpResponse.json({ enabledConnectorSlugs });
+    },
+  );
 }
 
 function stubInspection(
@@ -99,6 +128,9 @@ describe("okou connector account switch-request command", () => {
     server.use(
       stubCatalog(),
       stubCustomConnectors([]),
+      stubAgent(),
+      stubAgentBuiltinConnectors(["github"]),
+      stubAgentCustomConnectors([]),
       stubInspection(availableInspection()),
     );
   });
@@ -164,6 +196,9 @@ describe("okou connector account switch-request command", () => {
           slug: "_acme-search",
           displayName: "Acme Search",
         }),
+      ]),
+      stubAgentCustomConnectors([
+        { customConnectorId: CUSTOM_CONNECTOR_ID, permissionNames: [] },
       ]),
       stubInspection(availableInspection(target)),
     );
@@ -232,6 +267,27 @@ describe("okou connector account switch-request command", () => {
 
     expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
       `Connector account ${CONNECTION_ID} is unavailable for github`,
+    );
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
+  it("rejects a connector target outside the current agent scope", async () => {
+    server.use(stubAgentBuiltinConnectors([]));
+
+    await expect(
+      switchConnectorAccountRequestCommand.parseAsync([
+        "node",
+        "okou",
+        "github",
+        "--connection-id",
+        CONNECTION_ID,
+        "--callback-prompt",
+        "Continue",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "Connector github is not authorized for the current web chat agent",
     );
     expect(mockConsoleLog).not.toHaveBeenCalled();
   });

--- a/turbo/apps/cli/src/commands/connector/account/__tests__/switch-request.test.ts
+++ b/turbo/apps/cli/src/commands/connector/account/__tests__/switch-request.test.ts
@@ -1,0 +1,304 @@
+import type {
+  ConnectorAccountInspectionResult,
+  ConnectorAccountTarget,
+} from "@okouai/api-contracts/contracts/connector-accounts";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { server } from "../../../../mocks/server";
+import {
+  authCodeMethod,
+  catalogStatusItem,
+  stubConnectorCatalogStatus,
+} from "../../../__tests__/helpers/connector-catalog";
+import {
+  customConnector,
+  stubCustomConnectors,
+} from "../../../__tests__/helpers/custom-connectors";
+import { switchConnectorAccountRequestCommand } from "../switch-request";
+
+const CONNECTION_ID = "11111111-1111-4111-8111-111111111111";
+const CUSTOM_CONNECTOR_ID = "22222222-2222-4222-8222-222222222222";
+const AGENT_ID = "agent-account-switch";
+const THREAD_ID = "33333333-3333-4333-8333-333333333333";
+
+function availableInspection(
+  target: ConnectorAccountTarget = {
+    kind: "builtin",
+    connectorSlug: "github",
+  },
+): ConnectorAccountInspectionResult {
+  return {
+    kind: "available",
+    connectionId: CONNECTION_ID,
+    target,
+    authMethod: "oauth",
+    displayName: "Work",
+    externalId: null,
+    externalUsername: "octocat",
+    externalEmail: "work@example.com",
+    connectionStatus: "connected",
+    reconnectReason: null,
+  };
+}
+
+function stubCatalog(): ReturnType<typeof http.get> {
+  return stubConnectorCatalogStatus([
+    catalogStatusItem({
+      connectorSlug: "github",
+      label: "GitHub",
+      authMethods: [authCodeMethod("oauth")],
+    }),
+  ]);
+}
+
+function stubInspection(
+  result: ConnectorAccountInspectionResult,
+  onRequest?: (body: unknown) => void,
+): ReturnType<typeof http.post> {
+  return http.post(
+    "http://localhost:3000/api/connector-accounts/inspect",
+    async ({ request }) => {
+      const body: unknown = await request.json();
+      onRequest?.(body);
+      return HttpResponse.json({ results: [result] });
+    },
+  );
+}
+
+function actionUrlFromOutput(output: string): URL {
+  const href = output.match(/\[Confirm account switch\]\(([^)]+)\)/)?.[1];
+  if (!href) {
+    throw new Error("Expected connector account switch action URL");
+  }
+  return new URL(href);
+}
+
+describe("okou connector account switch-request command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
+    vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
+    switchConnectorAccountRequestCommand.setOptionValue(
+      "connectionId",
+      undefined,
+    );
+    switchConnectorAccountRequestCommand.setOptionValue(
+      "callbackPrompt",
+      undefined,
+    );
+    server.use(
+      stubCatalog(),
+      stubCustomConnectors([]),
+      stubInspection(availableInspection()),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  it("validates and prints an exact built-in account action", async () => {
+    let inspectionBody: unknown;
+    server.use(
+      stubInspection(availableInspection(), (body) => {
+        inspectionBody = body;
+      }),
+    );
+
+    await switchConnectorAccountRequestCommand.parseAsync([
+      "node",
+      "okou",
+      "github",
+      "--connection-id",
+      CONNECTION_ID,
+      "--callback-prompt",
+      "Continue with the selected account & finish",
+    ]);
+
+    expect(inspectionBody).toStrictEqual({
+      selections: [
+        {
+          connectionId: CONNECTION_ID,
+          target: { kind: "builtin", connectorSlug: "github" },
+        },
+      ],
+    });
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("use Work for GitHub in future runs");
+    expect(output).toContain("end the current turn");
+    const url = actionUrlFromOutput(output);
+    expect(url.origin).toBe("http://localhost:3000");
+    expect(url.pathname).toBe(
+      `/agents/${AGENT_ID}/connector-accounts/${CONNECTION_ID}/select`,
+    );
+    expect(Object.fromEntries(url.searchParams)).toStrictEqual({
+      callbackPrompt: "Continue with the selected account & finish",
+      connectorSlug: "github",
+      kind: "builtin",
+      threadId: THREAD_ID,
+    });
+  });
+
+  it("resolves and validates a custom connector target", async () => {
+    const target = {
+      kind: "custom" as const,
+      customConnectorId: CUSTOM_CONNECTOR_ID,
+    };
+    server.use(
+      stubCustomConnectors([
+        customConnector({
+          id: CUSTOM_CONNECTOR_ID,
+          slug: "_acme-search",
+          displayName: "Acme Search",
+        }),
+      ]),
+      stubInspection(availableInspection(target)),
+    );
+
+    await switchConnectorAccountRequestCommand.parseAsync([
+      "node",
+      "okou",
+      "_acme-search",
+      "--connection-id",
+      CONNECTION_ID,
+      "--callback-prompt",
+      "Continue the search",
+    ]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("use Work for Acme Search");
+    expect(
+      Object.fromEntries(actionUrlFromOutput(output).searchParams),
+    ).toStrictEqual({
+      callbackPrompt: "Continue the search",
+      customConnectorId: CUSTOM_CONNECTOR_ID,
+      kind: "custom",
+      threadId: THREAD_ID,
+    });
+  });
+
+  it("rejects malformed connection IDs before account discovery", async () => {
+    await expect(
+      switchConnectorAccountRequestCommand.parseAsync([
+        "node",
+        "okou",
+        "github",
+        "--connection-id",
+        "invented-account",
+        "--callback-prompt",
+        "Continue",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "--connection-id must be a valid UUID",
+    );
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing and wrong-target account references", async () => {
+    server.use(
+      stubInspection({
+        kind: "unavailable",
+        connectionId: CONNECTION_ID,
+        target: { kind: "builtin", connectorSlug: "github" },
+      }),
+    );
+
+    await expect(
+      switchConnectorAccountRequestCommand.parseAsync([
+        "node",
+        "okou",
+        "github",
+        "--connection-id",
+        CONNECTION_ID,
+        "--callback-prompt",
+        "Continue",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      `Connector account ${CONNECTION_ID} is unavailable for github`,
+    );
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
+  it("rejects the request when connector accounts are unavailable", async () => {
+    server.use(
+      http.post("http://localhost:3000/api/connector-accounts/inspect", () => {
+        return HttpResponse.json(
+          { error: { code: "NOT_FOUND", message: "Not found" } },
+          { status: 404 },
+        );
+      }),
+    );
+
+    await expect(
+      switchConnectorAccountRequestCommand.parseAsync([
+        "node",
+        "okou",
+        "github",
+        "--connection-id",
+        CONNECTION_ID,
+        "--callback-prompt",
+        "Continue",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "Connector account switching is unavailable",
+    );
+  });
+
+  it("requires the current web chat callback context", async () => {
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", "");
+
+    await expect(
+      switchConnectorAccountRequestCommand.parseAsync([
+        "node",
+        "okou",
+        "github",
+        "--connection-id",
+        CONNECTION_ID,
+        "--callback-prompt",
+        "Continue",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "--callback-prompt can only target the current web chat thread and agent",
+    );
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty callback prompt", async () => {
+    await expect(
+      switchConnectorAccountRequestCommand.parseAsync([
+        "node",
+        "okou",
+        "github",
+        "--connection-id",
+        CONNECTION_ID,
+        "--callback-prompt",
+        "   ",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "--callback-prompt cannot be empty",
+    );
+  });
+});

--- a/turbo/apps/cli/src/commands/connector/account/index.ts
+++ b/turbo/apps/cli/src/commands/connector/account/index.ts
@@ -1,8 +1,10 @@
 import { Command } from "commander";
 
 import { listConnectorAccountsCommand } from "./list";
+import { switchConnectorAccountRequestCommand } from "./switch-request";
 
 export const connectorAccountCommand = new Command()
   .name("account")
   .description("Inspect connector accounts")
-  .addCommand(listConnectorAccountsCommand);
+  .addCommand(listConnectorAccountsCommand)
+  .addCommand(switchConnectorAccountRequestCommand);

--- a/turbo/apps/cli/src/commands/connector/account/switch-request.ts
+++ b/turbo/apps/cli/src/commands/connector/account/switch-request.ts
@@ -1,0 +1,172 @@
+import {
+  type ConnectorAccountTarget,
+  type ConnectorAccountInspectionResult,
+} from "@okouai/api-contracts/contracts/connector-accounts";
+import { Command, Option } from "commander";
+
+import {
+  inspectConnectorAccounts,
+  listConnectorCatalogStatus,
+  listCustomConnectors,
+} from "../../../lib/api/domains/connectors";
+import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { getOkouAgentId } from "../../../lib/okou-env";
+import { isUuid } from "../../../lib/utils/uuid";
+import { getPlatformOrigin } from "../../doctor/platform-url";
+import { connectorAccountCliLabel } from "../account-label";
+import {
+  addRequestedCallbackSearchParams,
+  printCallbackTurnInstruction,
+} from "../action-url";
+import {
+  connectorDiscoveryItems,
+  type ConnectorDiscoveryItem,
+} from "../discovery";
+
+interface SwitchConnectorAccountRequestOptions {
+  readonly connectionId: string;
+  readonly callbackPrompt: string;
+}
+
+function accountTarget(
+  connector: ConnectorDiscoveryItem,
+): ConnectorAccountTarget {
+  return connector.kind === "catalog"
+    ? { kind: "builtin", connectorSlug: connector.slug }
+    : {
+        kind: "custom",
+        customConnectorId: connector.customConnector.id,
+      };
+}
+
+function addTargetSearchParams(
+  params: URLSearchParams,
+  target: ConnectorAccountTarget,
+): void {
+  params.set("kind", target.kind);
+  if (target.kind === "builtin") {
+    params.set("connectorSlug", target.connectorSlug);
+    return;
+  }
+  params.set("customConnectorId", target.customConnectorId);
+}
+
+function availableInspection(
+  results: readonly ConnectorAccountInspectionResult[] | null,
+  connectorSlug: string,
+  connectionId: string,
+): Extract<ConnectorAccountInspectionResult, { kind: "available" }> {
+  if (results === null) {
+    throw new Error("Connector account switching is unavailable");
+  }
+  const [result] = results;
+  if (result === undefined) {
+    throw new Error("Connector account inspection returned no result");
+  }
+  if (result.kind === "unavailable") {
+    throw new Error(
+      `Connector account ${connectionId} is unavailable for ${connectorSlug}`,
+    );
+  }
+  return result;
+}
+
+export const switchConnectorAccountRequestCommand = new Command()
+  .name("switch-request")
+  .description(
+    "Ask the user to use one exact connector account for future runs in this chat",
+  )
+  .argument("<slug>", "Connector slug")
+  .addOption(
+    new Option(
+      "--connection-id <uuid>",
+      "Exact connection ID returned by connector account list",
+    ).makeOptionMandatory(),
+  )
+  .addOption(
+    new Option(
+      "--callback-prompt <prompt>",
+      "Start the next web chat round with this prompt after confirmation",
+    ).makeOptionMandatory(),
+  )
+  .addHelpText(
+    "after",
+    `
+Example:
+  okou connector account switch-request github --connection-id <uuid> --callback-prompt "Continue the task with the selected GitHub account"
+
+Notes:
+  - First run okou connector account list <slug> --json and use an exact returned connectionId
+  - This changes only future runs in the current web chat thread, not the current run or global default
+  - Callback prompts are included in the URL; keep them concise and do not include secrets
+  - After sharing the generated link, end the current turn`,
+  )
+  .action(
+    withErrorHandler(
+      async (
+        slug: string,
+        options: SwitchConnectorAccountRequestOptions,
+      ): Promise<void> => {
+        const connectionId = options.connectionId.trim();
+        if (!isUuid(connectionId)) {
+          throw new Error("--connection-id must be a valid UUID");
+        }
+        const agentId = getOkouAgentId()?.trim();
+        if (!agentId) {
+          throw new Error(
+            "Connector account switches require the current web chat agent",
+          );
+        }
+        const params = new URLSearchParams();
+        addRequestedCallbackSearchParams(
+          params,
+          options.callbackPrompt,
+          agentId,
+        );
+
+        const [{ connectors }, customConnectors] = await Promise.all([
+          listConnectorCatalogStatus(),
+          listCustomConnectors(),
+        ]);
+        const discoveredConnectors = connectorDiscoveryItems(
+          connectors,
+          customConnectors,
+        );
+        const connector = discoveredConnectors.find((item) => {
+          return item.slug === slug;
+        });
+        if (!connector) {
+          throw new Error(`Unknown or unavailable connector: ${slug}`, {
+            cause: new Error(
+              `Available connectors: ${discoveredConnectors
+                .map((item) => {
+                  return item.slug;
+                })
+                .sort()
+                .join(", ")}`,
+            ),
+          });
+        }
+
+        const target = accountTarget(connector);
+        const inspection = availableInspection(
+          await inspectConnectorAccounts([{ connectionId, target }]),
+          connector.slug,
+          connectionId,
+        );
+        addTargetSearchParams(params, target);
+        const origin = await getPlatformOrigin();
+        const path = `/agents/${encodeURIComponent(agentId)}/connector-accounts/${encodeURIComponent(connectionId)}/select`;
+        const url = `${origin}${path}?${params.toString()}`;
+        const label = connectorAccountCliLabel({
+          ...inspection,
+          connectionId: inspection.connectionId,
+        });
+
+        console.log(
+          `You can use ${label} for ${connector.label} in future runs of this chat: [Confirm account switch](${url})`,
+        );
+        printCallbackTurnInstruction();
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/connector/account/switch-request.ts
+++ b/turbo/apps/cli/src/commands/connector/account/switch-request.ts
@@ -20,8 +20,10 @@ import {
 } from "../action-url";
 import {
   connectorDiscoveryItems,
+  isConnectorDiscoveryAuthorized,
   type ConnectorDiscoveryItem,
 } from "../discovery";
+import { resolveConnectorDiscoveryAgentContext } from "../agent-context";
 
 interface SwitchConnectorAccountRequestOptions {
   readonly connectionId: string;
@@ -124,10 +126,17 @@ Notes:
           agentId,
         );
 
-        const [{ connectors }, customConnectors] = await Promise.all([
-          listConnectorCatalogStatus(),
-          listCustomConnectors(),
-        ]);
+        const [{ connectors }, customConnectors, agentContext] =
+          await Promise.all([
+            listConnectorCatalogStatus(),
+            listCustomConnectors(),
+            resolveConnectorDiscoveryAgentContext(agentId),
+          ]);
+        if (!agentContext) {
+          throw new Error(
+            "Connector account switches require the current web chat agent",
+          );
+        }
         const discoveredConnectors = connectorDiscoveryItems(
           connectors,
           customConnectors,
@@ -146,6 +155,11 @@ Notes:
                 .join(", ")}`,
             ),
           });
+        }
+        if (!isConnectorDiscoveryAuthorized(connector, agentContext)) {
+          throw new Error(
+            `Connector ${slug} is not authorized for the current web chat agent`,
+          );
         }
 
         const target = accountTarget(connector);

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1898,6 +1898,22 @@
       "unsupportedIntelMac": "Erfordert einen Apple Silicon Mac",
       "yourComputer": "Ihr Computer"
     },
+    "connectorAccountSwitch": {
+      "accountFallback": "Connector-Konto",
+      "actionFailed": "Dieses Konto konnte nicht bestätigt oder der Chat nicht fortgesetzt werden. Versuchen Sie es erneut.",
+      "continued": "Fortsetzung angefordert",
+      "continueWithAccount": "Mit diesem Konto fortfahren",
+      "currentRunUnchanged": "Der aktuelle Lauf wird nicht geändert.",
+      "customConnector": "Benutzerdefinierter Connector",
+      "loadFailed": "Dieses Connector-Konto konnte nicht geladen werden.",
+      "reconnectRequired": "Erneute Verbindung erforderlich. Spätere Läufe verwenden möglicherweise den vorhandenen Fallback.",
+      "retry": "Erneut versuchen",
+      "selected": "Bereits für diesen Chat ausgewählt",
+      "title": "{{account}} für zukünftige Läufe verwenden?",
+      "unavailableDescription": "Dieses Konto ist nicht vorhanden oder für diesen Connector nicht verfügbar.",
+      "unavailableTitle": "Konto nicht verfügbar",
+      "useAndContinue": "Konto verwenden und fortfahren"
+    },
     "connectors": {
       "accountForThread": "Konto für diesen Thread",
       "add": "{{connectorName}} hinzufügen",

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1900,19 +1900,17 @@
     },
     "connectorAccountSwitch": {
       "accountFallback": "Connector-Konto",
-      "actionFailed": "Dieses Konto konnte nicht bestätigt oder der Chat nicht fortgesetzt werden. Versuchen Sie es erneut.",
-      "continued": "Fortsetzung angefordert",
-      "continueWithAccount": "Mit diesem Konto fortfahren",
-      "currentRunUnchanged": "Der aktuelle Lauf wird nicht geändert.",
+      "actionFailed": "Kontowechsel fehlgeschlagen. Versuchen Sie es erneut.",
       "customConnector": "Benutzerdefinierter Connector",
       "loadFailed": "Dieses Connector-Konto konnte nicht geladen werden.",
       "reconnectRequired": "Erneute Verbindung erforderlich. Spätere Läufe verwenden möglicherweise den vorhandenen Fallback.",
       "retry": "Erneut versuchen",
-      "selected": "Bereits für diesen Chat ausgewählt",
-      "title": "{{account}} für zukünftige Läufe verwenden?",
+      "selected": "Zu {{account}} gewechselt",
+      "switch": "Wechseln",
+      "switching": "Wechseln...",
+      "title": "Zu {{account}} wechseln?",
       "unavailableDescription": "Dieses Konto ist nicht vorhanden oder für diesen Connector nicht verfügbar.",
-      "unavailableTitle": "Konto nicht verfügbar",
-      "useAndContinue": "Konto verwenden und fortfahren"
+      "unavailableTitle": "Konto nicht verfügbar"
     },
     "connectors": {
       "accountForThread": "Konto für diesen Thread",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1898,6 +1898,22 @@
       "unsupportedIntelMac": "Requires an Apple silicon Mac",
       "yourComputer": "Your computer"
     },
+    "connectorAccountSwitch": {
+      "accountFallback": "Connector account",
+      "actionFailed": "Couldn't confirm this account or continue the chat. Try again.",
+      "continued": "Continuation requested",
+      "continueWithAccount": "Continue with this account",
+      "currentRunUnchanged": "The current run will not change.",
+      "customConnector": "Custom connector",
+      "loadFailed": "Couldn't load this connector account.",
+      "reconnectRequired": "Reconnect required. Later runs may use the existing fallback.",
+      "retry": "Retry",
+      "selected": "Already selected for this chat",
+      "title": "Use {{account}} for future runs?",
+      "unavailableDescription": "This account does not exist or is not available for this connector.",
+      "unavailableTitle": "Account unavailable",
+      "useAndContinue": "Use account and continue"
+    },
     "connectors": {
       "accountForThread": "Account for this chat",
       "add": "Add {{connectorName}}",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1900,19 +1900,17 @@
     },
     "connectorAccountSwitch": {
       "accountFallback": "Connector account",
-      "actionFailed": "Couldn't confirm this account or continue the chat. Try again.",
-      "continued": "Continuation requested",
-      "continueWithAccount": "Continue with this account",
-      "currentRunUnchanged": "The current run will not change.",
+      "actionFailed": "Couldn't switch accounts. Try again.",
       "customConnector": "Custom connector",
       "loadFailed": "Couldn't load this connector account.",
       "reconnectRequired": "Reconnect required. Later runs may use the existing fallback.",
       "retry": "Retry",
-      "selected": "Already selected for this chat",
-      "title": "Use {{account}} for future runs?",
+      "selected": "Switched to {{account}}",
+      "switch": "Switch",
+      "switching": "Switching...",
+      "title": "Switch to {{account}}?",
       "unavailableDescription": "This account does not exist or is not available for this connector.",
-      "unavailableTitle": "Account unavailable",
-      "useAndContinue": "Use account and continue"
+      "unavailableTitle": "Account unavailable"
     },
     "connectors": {
       "accountForThread": "Account for this chat",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1928,6 +1928,22 @@
       "unsupportedIntelMac": "Requiere un Mac Apple Silicon",
       "yourComputer": "Tu ordenador"
     },
+    "connectorAccountSwitch": {
+      "accountFallback": "Cuenta del conector",
+      "actionFailed": "No se pudo confirmar esta cuenta o continuar el chat. Inténtalo de nuevo.",
+      "continued": "Continuación solicitada",
+      "continueWithAccount": "Continuar con esta cuenta",
+      "currentRunUnchanged": "La ejecución actual no cambiará.",
+      "customConnector": "Conector personalizado",
+      "loadFailed": "No se pudo cargar esta cuenta del conector.",
+      "reconnectRequired": "Es necesario volver a conectar. Es posible que las ejecuciones posteriores usen la alternativa existente.",
+      "retry": "Reintentar",
+      "selected": "Ya seleccionada para este chat",
+      "title": "¿Usar {{account}} para futuras ejecuciones?",
+      "unavailableDescription": "Esta cuenta no existe o no está disponible para este conector.",
+      "unavailableTitle": "Cuenta no disponible",
+      "useAndContinue": "Usar cuenta y continuar"
+    },
     "connectors": {
       "accountForThread": "Cuenta para este hilo",
       "add": "Añadir {{connectorName}}",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1930,19 +1930,17 @@
     },
     "connectorAccountSwitch": {
       "accountFallback": "Cuenta del conector",
-      "actionFailed": "No se pudo confirmar esta cuenta o continuar el chat. Inténtalo de nuevo.",
-      "continued": "Continuación solicitada",
-      "continueWithAccount": "Continuar con esta cuenta",
-      "currentRunUnchanged": "La ejecución actual no cambiará.",
+      "actionFailed": "No se pudo cambiar de cuenta. Inténtalo de nuevo.",
       "customConnector": "Conector personalizado",
       "loadFailed": "No se pudo cargar esta cuenta del conector.",
       "reconnectRequired": "Es necesario volver a conectar. Es posible que las ejecuciones posteriores usen la alternativa existente.",
       "retry": "Reintentar",
-      "selected": "Ya seleccionada para este chat",
-      "title": "¿Usar {{account}} para futuras ejecuciones?",
+      "selected": "Se cambió a {{account}}",
+      "switch": "Cambiar",
+      "switching": "Cambiando...",
+      "title": "¿Cambiar a {{account}}?",
       "unavailableDescription": "Esta cuenta no existe o no está disponible para este conector.",
-      "unavailableTitle": "Cuenta no disponible",
-      "useAndContinue": "Usar cuenta y continuar"
+      "unavailableTitle": "Cuenta no disponible"
     },
     "connectors": {
       "accountForThread": "Cuenta para este hilo",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1928,6 +1928,22 @@
       "unsupportedIntelMac": "Nécessite un Mac Apple silicon",
       "yourComputer": "Votre ordinateur"
     },
+    "connectorAccountSwitch": {
+      "accountFallback": "Compte du connecteur",
+      "actionFailed": "Impossible de confirmer ce compte ou de poursuivre le chat. Réessayez.",
+      "continued": "Suite demandée",
+      "continueWithAccount": "Continuer avec ce compte",
+      "currentRunUnchanged": "L’exécution en cours ne changera pas.",
+      "customConnector": "Connecteur personnalisé",
+      "loadFailed": "Impossible de charger ce compte de connecteur.",
+      "reconnectRequired": "Reconnexion requise. Les exécutions ultérieures peuvent utiliser la solution de secours existante.",
+      "retry": "Réessayer",
+      "selected": "Déjà sélectionné pour ce chat",
+      "title": "Utiliser {{account}} pour les prochaines exécutions ?",
+      "unavailableDescription": "Ce compte n’existe pas ou n’est pas disponible pour ce connecteur.",
+      "unavailableTitle": "Compte indisponible",
+      "useAndContinue": "Utiliser le compte et continuer"
+    },
     "connectors": {
       "accountForThread": "Compte pour ce fil",
       "add": "Ajouter {{connectorName}}",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1930,19 +1930,17 @@
     },
     "connectorAccountSwitch": {
       "accountFallback": "Compte du connecteur",
-      "actionFailed": "Impossible de confirmer ce compte ou de poursuivre le chat. Réessayez.",
-      "continued": "Suite demandée",
-      "continueWithAccount": "Continuer avec ce compte",
-      "currentRunUnchanged": "L’exécution en cours ne changera pas.",
+      "actionFailed": "Impossible de changer de compte. Réessayez.",
       "customConnector": "Connecteur personnalisé",
       "loadFailed": "Impossible de charger ce compte de connecteur.",
       "reconnectRequired": "Reconnexion requise. Les exécutions ultérieures peuvent utiliser la solution de secours existante.",
       "retry": "Réessayer",
-      "selected": "Déjà sélectionné pour ce chat",
-      "title": "Utiliser {{account}} pour les prochaines exécutions ?",
+      "selected": "Passé à {{account}}",
+      "switch": "Changer",
+      "switching": "Changement...",
+      "title": "Passer à {{account}} ?",
       "unavailableDescription": "Ce compte n’existe pas ou n’est pas disponible pour ce connecteur.",
-      "unavailableTitle": "Compte indisponible",
-      "useAndContinue": "Utiliser le compte et continuer"
+      "unavailableTitle": "Compte indisponible"
     },
     "connectors": {
       "accountForThread": "Compte pour ce fil",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1900,19 +1900,17 @@
     },
     "connectorAccountSwitch": {
       "accountFallback": "कनेक्टर खाता",
-      "actionFailed": "इस खाते की पुष्टि या चैट को जारी नहीं रखा जा सका। फिर से प्रयास करें।",
-      "continued": "जारी रखने का अनुरोध किया गया",
-      "continueWithAccount": "इस खाते के साथ जारी रखें",
-      "currentRunUnchanged": "वर्तमान रन नहीं बदलेगा।",
+      "actionFailed": "खाता स्विच नहीं किया जा सका। फिर से प्रयास करें।",
       "customConnector": "कस्टम कनेक्टर",
       "loadFailed": "यह कनेक्टर खाता लोड नहीं हो सका।",
       "reconnectRequired": "फिर से कनेक्ट करना आवश्यक है। बाद के रन मौजूदा फ़ॉलबैक का उपयोग कर सकते हैं।",
       "retry": "पुनः प्रयास करें",
-      "selected": "इस चैट के लिए पहले से चयनित",
-      "title": "भविष्य के रन के लिए {{account}} का उपयोग करें?",
+      "selected": "{{account}} पर स्विच किया गया",
+      "switch": "स्विच करें",
+      "switching": "स्विच हो रहा है...",
+      "title": "{{account}} पर स्विच करें?",
       "unavailableDescription": "यह खाता मौजूद नहीं है या इस कनेक्टर के लिए उपलब्ध नहीं है।",
-      "unavailableTitle": "खाता उपलब्ध नहीं है",
-      "useAndContinue": "खाते का उपयोग करें और जारी रखें"
+      "unavailableTitle": "खाता उपलब्ध नहीं है"
     },
     "connectors": {
       "accountForThread": "इस थ्रेड के लिए खाता",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1898,6 +1898,22 @@
       "unsupportedIntelMac": "Apple सिलिकॉन Mac की आवश्यकता है",
       "yourComputer": "आपका कंप्यूटर"
     },
+    "connectorAccountSwitch": {
+      "accountFallback": "कनेक्टर खाता",
+      "actionFailed": "इस खाते की पुष्टि या चैट को जारी नहीं रखा जा सका। फिर से प्रयास करें।",
+      "continued": "जारी रखने का अनुरोध किया गया",
+      "continueWithAccount": "इस खाते के साथ जारी रखें",
+      "currentRunUnchanged": "वर्तमान रन नहीं बदलेगा।",
+      "customConnector": "कस्टम कनेक्टर",
+      "loadFailed": "यह कनेक्टर खाता लोड नहीं हो सका।",
+      "reconnectRequired": "फिर से कनेक्ट करना आवश्यक है। बाद के रन मौजूदा फ़ॉलबैक का उपयोग कर सकते हैं।",
+      "retry": "पुनः प्रयास करें",
+      "selected": "इस चैट के लिए पहले से चयनित",
+      "title": "भविष्य के रन के लिए {{account}} का उपयोग करें?",
+      "unavailableDescription": "यह खाता मौजूद नहीं है या इस कनेक्टर के लिए उपलब्ध नहीं है।",
+      "unavailableTitle": "खाता उपलब्ध नहीं है",
+      "useAndContinue": "खाते का उपयोग करें और जारी रखें"
+    },
     "connectors": {
       "accountForThread": "इस थ्रेड के लिए खाता",
       "add": "{{connectorName}} जोड़ें",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1895,6 +1895,22 @@
       "unsupportedIntelMac": "Memerlukan Mac Apple silicon",
       "yourComputer": "Komputer Anda"
     },
+    "connectorAccountSwitch": {
+      "accountFallback": "Akun konektor",
+      "actionFailed": "Akun ini tidak dapat dikonfirmasi atau chat tidak dapat dilanjutkan. Coba lagi.",
+      "continued": "Kelanjutan diminta",
+      "continueWithAccount": "Lanjutkan dengan akun ini",
+      "currentRunUnchanged": "Proses saat ini tidak akan berubah.",
+      "customConnector": "Konektor khusus",
+      "loadFailed": "Akun konektor ini tidak dapat dimuat.",
+      "reconnectRequired": "Perlu menghubungkan kembali. Proses berikutnya mungkin menggunakan cadangan yang ada.",
+      "retry": "Coba lagi",
+      "selected": "Sudah dipilih untuk chat ini",
+      "title": "Gunakan {{account}} untuk proses berikutnya?",
+      "unavailableDescription": "Akun ini tidak ada atau tidak tersedia untuk konektor ini.",
+      "unavailableTitle": "Akun tidak tersedia",
+      "useAndContinue": "Gunakan akun dan lanjutkan"
+    },
     "connectors": {
       "accountForThread": "Akun untuk utas ini",
       "add": "Tambahkan {{connectorName}}",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1897,19 +1897,17 @@
     },
     "connectorAccountSwitch": {
       "accountFallback": "Akun konektor",
-      "actionFailed": "Akun ini tidak dapat dikonfirmasi atau chat tidak dapat dilanjutkan. Coba lagi.",
-      "continued": "Kelanjutan diminta",
-      "continueWithAccount": "Lanjutkan dengan akun ini",
-      "currentRunUnchanged": "Proses saat ini tidak akan berubah.",
+      "actionFailed": "Tidak dapat beralih akun. Coba lagi.",
       "customConnector": "Konektor khusus",
       "loadFailed": "Akun konektor ini tidak dapat dimuat.",
       "reconnectRequired": "Perlu menghubungkan kembali. Proses berikutnya mungkin menggunakan cadangan yang ada.",
       "retry": "Coba lagi",
-      "selected": "Sudah dipilih untuk chat ini",
-      "title": "Gunakan {{account}} untuk proses berikutnya?",
+      "selected": "Beralih ke {{account}}",
+      "switch": "Beralih",
+      "switching": "Beralih...",
+      "title": "Beralih ke {{account}}?",
       "unavailableDescription": "Akun ini tidak ada atau tidak tersedia untuk konektor ini.",
-      "unavailableTitle": "Akun tidak tersedia",
-      "useAndContinue": "Gunakan akun dan lanjutkan"
+      "unavailableTitle": "Akun tidak tersedia"
     },
     "connectors": {
       "accountForThread": "Akun untuk utas ini",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1928,6 +1928,22 @@
       "unsupportedIntelMac": "Richiede un Mac Apple Silicon",
       "yourComputer": "Il tuo computer"
     },
+    "connectorAccountSwitch": {
+      "accountFallback": "Account del connettore",
+      "actionFailed": "Impossibile confermare questo account o continuare la chat. Riprova.",
+      "continued": "Continuazione richiesta",
+      "continueWithAccount": "Continua con questo account",
+      "currentRunUnchanged": "L'esecuzione corrente non cambierà.",
+      "customConnector": "Connettore personalizzato",
+      "loadFailed": "Impossibile caricare questo account del connettore.",
+      "reconnectRequired": "È necessario riconnettersi. Le esecuzioni successive potrebbero usare l'alternativa esistente.",
+      "retry": "Riprova",
+      "selected": "Già selezionato per questa chat",
+      "title": "Usare {{account}} per le esecuzioni future?",
+      "unavailableDescription": "Questo account non esiste o non è disponibile per questo connettore.",
+      "unavailableTitle": "Account non disponibile",
+      "useAndContinue": "Usa l'account e continua"
+    },
     "connectors": {
       "accountForThread": "Account per questo thread",
       "add": "Aggiungi {{connectorName}}",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1930,19 +1930,17 @@
     },
     "connectorAccountSwitch": {
       "accountFallback": "Account del connettore",
-      "actionFailed": "Impossibile confermare questo account o continuare la chat. Riprova.",
-      "continued": "Continuazione richiesta",
-      "continueWithAccount": "Continua con questo account",
-      "currentRunUnchanged": "L'esecuzione corrente non cambierà.",
+      "actionFailed": "Impossibile cambiare account. Riprova.",
       "customConnector": "Connettore personalizzato",
       "loadFailed": "Impossibile caricare questo account del connettore.",
       "reconnectRequired": "È necessario riconnettersi. Le esecuzioni successive potrebbero usare l'alternativa esistente.",
       "retry": "Riprova",
-      "selected": "Già selezionato per questa chat",
-      "title": "Usare {{account}} per le esecuzioni future?",
+      "selected": "Passaggio a {{account}} completato",
+      "switch": "Cambia",
+      "switching": "Cambio in corso...",
+      "title": "Passare a {{account}}?",
       "unavailableDescription": "Questo account non esiste o non è disponibile per questo connettore.",
-      "unavailableTitle": "Account non disponibile",
-      "useAndContinue": "Usa l'account e continua"
+      "unavailableTitle": "Account non disponibile"
     },
     "connectors": {
       "accountForThread": "Account per questo thread",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1895,6 +1895,22 @@
       "unsupportedIntelMac": "AppleシリコンMacが必要です",
       "yourComputer": "あなたのコンピュータ"
     },
+    "connectorAccountSwitch": {
+      "accountFallback": "コネクターアカウント",
+      "actionFailed": "このアカウントを確認できなかったか、チャットを続行できませんでした。もう一度お試しください。",
+      "continued": "続行をリクエストしました",
+      "continueWithAccount": "このアカウントで続行",
+      "currentRunUnchanged": "現在の実行は変更されません。",
+      "customConnector": "カスタムコネクター",
+      "loadFailed": "このコネクターアカウントを読み込めませんでした。",
+      "reconnectRequired": "再接続が必要です。以降の実行では既存のフォールバックが使用される場合があります。",
+      "retry": "再試行",
+      "selected": "このチャットですでに選択されています",
+      "title": "今後の実行に{{account}}を使用しますか？",
+      "unavailableDescription": "このアカウントは存在しないか、このコネクターでは利用できません。",
+      "unavailableTitle": "アカウントを利用できません",
+      "useAndContinue": "アカウントを使用して続行"
+    },
     "connectors": {
       "accountForThread": "このスレッドのアカウント",
       "add": "{{connectorName}} を追加",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1897,19 +1897,17 @@
     },
     "connectorAccountSwitch": {
       "accountFallback": "コネクターアカウント",
-      "actionFailed": "このアカウントを確認できなかったか、チャットを続行できませんでした。もう一度お試しください。",
-      "continued": "続行をリクエストしました",
-      "continueWithAccount": "このアカウントで続行",
-      "currentRunUnchanged": "現在の実行は変更されません。",
+      "actionFailed": "アカウントを切り替えられませんでした。もう一度お試しください。",
       "customConnector": "カスタムコネクター",
       "loadFailed": "このコネクターアカウントを読み込めませんでした。",
       "reconnectRequired": "再接続が必要です。以降の実行では既存のフォールバックが使用される場合があります。",
       "retry": "再試行",
-      "selected": "このチャットですでに選択されています",
-      "title": "今後の実行に{{account}}を使用しますか？",
+      "selected": "{{account}}に切り替えました",
+      "switch": "切り替える",
+      "switching": "切り替え中...",
+      "title": "{{account}}に切り替えますか？",
       "unavailableDescription": "このアカウントは存在しないか、このコネクターでは利用できません。",
-      "unavailableTitle": "アカウントを利用できません",
-      "useAndContinue": "アカウントを使用して続行"
+      "unavailableTitle": "アカウントを利用できません"
     },
     "connectors": {
       "accountForThread": "このスレッドのアカウント",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1895,6 +1895,22 @@
       "unsupportedIntelMac": "Apple 실리콘 Mac 필요",
       "yourComputer": "내 컴퓨터"
     },
+    "connectorAccountSwitch": {
+      "accountFallback": "커넥터 계정",
+      "actionFailed": "이 계정을 확인하거나 채팅을 계속할 수 없습니다. 다시 시도하세요.",
+      "continued": "계속 요청됨",
+      "continueWithAccount": "이 계정으로 계속",
+      "currentRunUnchanged": "현재 실행은 변경되지 않습니다.",
+      "customConnector": "사용자 지정 커넥터",
+      "loadFailed": "이 커넥터 계정을 불러올 수 없습니다.",
+      "reconnectRequired": "다시 연결해야 합니다. 이후 실행에서는 기존 대체 계정을 사용할 수 있습니다.",
+      "retry": "다시 시도",
+      "selected": "이 채팅에 이미 선택됨",
+      "title": "향후 실행에 {{account}}을(를) 사용하시겠습니까?",
+      "unavailableDescription": "이 계정은 존재하지 않거나 이 커넥터에서 사용할 수 없습니다.",
+      "unavailableTitle": "계정을 사용할 수 없음",
+      "useAndContinue": "계정을 사용하고 계속"
+    },
     "connectors": {
       "accountForThread": "이 스레드의 계정",
       "add": "{{connectorName}} 추가",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1897,19 +1897,17 @@
     },
     "connectorAccountSwitch": {
       "accountFallback": "커넥터 계정",
-      "actionFailed": "이 계정을 확인하거나 채팅을 계속할 수 없습니다. 다시 시도하세요.",
-      "continued": "계속 요청됨",
-      "continueWithAccount": "이 계정으로 계속",
-      "currentRunUnchanged": "현재 실행은 변경되지 않습니다.",
+      "actionFailed": "계정을 전환할 수 없습니다. 다시 시도하세요.",
       "customConnector": "사용자 지정 커넥터",
       "loadFailed": "이 커넥터 계정을 불러올 수 없습니다.",
       "reconnectRequired": "다시 연결해야 합니다. 이후 실행에서는 기존 대체 계정을 사용할 수 있습니다.",
       "retry": "다시 시도",
-      "selected": "이 채팅에 이미 선택됨",
-      "title": "향후 실행에 {{account}}을(를) 사용하시겠습니까?",
+      "selected": "{{account}}(으)로 전환됨",
+      "switch": "전환",
+      "switching": "전환 중...",
+      "title": "{{account}}(으)로 전환하시겠습니까?",
       "unavailableDescription": "이 계정은 존재하지 않거나 이 커넥터에서 사용할 수 없습니다.",
-      "unavailableTitle": "계정을 사용할 수 없음",
-      "useAndContinue": "계정을 사용하고 계속"
+      "unavailableTitle": "계정을 사용할 수 없음"
     },
     "connectors": {
       "accountForThread": "이 스레드의 계정",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1930,19 +1930,17 @@
     },
     "connectorAccountSwitch": {
       "accountFallback": "Conta do conector",
-      "actionFailed": "Não foi possível confirmar esta conta ou continuar o chat. Tente novamente.",
-      "continued": "Continuação solicitada",
-      "continueWithAccount": "Continuar com esta conta",
-      "currentRunUnchanged": "A execução atual não será alterada.",
+      "actionFailed": "Não foi possível mudar de conta. Tente novamente.",
       "customConnector": "Conector personalizado",
       "loadFailed": "Não foi possível carregar esta conta do conector.",
       "reconnectRequired": "É necessário reconectar. Execuções posteriores podem usar a alternativa existente.",
       "retry": "Tentar novamente",
-      "selected": "Já selecionada para este chat",
-      "title": "Usar {{account}} em execuções futuras?",
+      "selected": "Conta alterada para {{account}}",
+      "switch": "Mudar",
+      "switching": "Mudando...",
+      "title": "Mudar para {{account}}?",
       "unavailableDescription": "Esta conta não existe ou não está disponível para este conector.",
-      "unavailableTitle": "Conta indisponível",
-      "useAndContinue": "Usar conta e continuar"
+      "unavailableTitle": "Conta indisponível"
     },
     "connectors": {
       "accountForThread": "Conta para esta conversa",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1928,6 +1928,22 @@
       "unsupportedIntelMac": "O {{assistantName}} Computer Use não é compatível com Macs com processador Intel.",
       "yourComputer": "Seu computador"
     },
+    "connectorAccountSwitch": {
+      "accountFallback": "Conta do conector",
+      "actionFailed": "Não foi possível confirmar esta conta ou continuar o chat. Tente novamente.",
+      "continued": "Continuação solicitada",
+      "continueWithAccount": "Continuar com esta conta",
+      "currentRunUnchanged": "A execução atual não será alterada.",
+      "customConnector": "Conector personalizado",
+      "loadFailed": "Não foi possível carregar esta conta do conector.",
+      "reconnectRequired": "É necessário reconectar. Execuções posteriores podem usar a alternativa existente.",
+      "retry": "Tentar novamente",
+      "selected": "Já selecionada para este chat",
+      "title": "Usar {{account}} em execuções futuras?",
+      "unavailableDescription": "Esta conta não existe ou não está disponível para este conector.",
+      "unavailableTitle": "Conta indisponível",
+      "useAndContinue": "Usar conta e continuar"
+    },
     "connectors": {
       "accountForThread": "Conta para esta conversa",
       "add": "Adicionar {{connectorName}}",

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/parse-body-blocks-cards.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/parse-body-blocks-cards.test.ts
@@ -10,8 +10,10 @@ import { parseBodyBlocks } from "../parse-body-blocks.ts";
  */
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 const THREAD_ID = "e4000000-0000-4000-a000-000000000001";
+const CONNECTION_ID = "a1000000-0000-4000-a000-000000000001";
 const CONNECTOR_URL = `${window.location.origin}/connectors/github/authorize?agentId=${AGENT_ID}`;
 const BANKING_URL = `${window.location.origin}/agents/${AGENT_ID}/banking?reason=Review+recent+expenses&threadId=${THREAD_ID}&callbackPrompt=Continue+the+expense+review`;
+const CONNECTOR_ACCOUNT_URL = `${window.location.origin}/agents/${AGENT_ID}/connector-accounts/${CONNECTION_ID}/select?kind=builtin&connectorSlug=github&threadId=${THREAD_ID}&callbackPrompt=Continue+with+GitHub`;
 
 function shapeOf(content: string): string {
   return parseBodyBlocks(content, {
@@ -73,5 +75,47 @@ describe("card recognition in a message body", () => {
     const url = `${window.location.origin}/agents/${AGENT_ID}/banking?threadId=${THREAD_ID}&callbackPrompt=Continue`;
 
     expect(shapeOf(url)).toBe("unavailable-action");
+  });
+
+  it("recognizes absolute, relative, and Markdown connector account actions", () => {
+    const relative = new URL(CONNECTOR_ACCOUNT_URL);
+    const relativeUrl = `${relative.pathname}${relative.search}`;
+
+    expect(shapeOf(CONNECTOR_ACCOUNT_URL)).toBe("connector-account-action");
+    expect(shapeOf(relativeUrl)).toBe("connector-account-action");
+    expect(shapeOf(`[Switch account](${relativeUrl})`)).toBe(
+      "connector-account-action",
+    );
+  });
+
+  it("makes malformed and ambiguous connector account targets unavailable", () => {
+    const malformedId = CONNECTOR_ACCOUNT_URL.replace(
+      CONNECTION_ID,
+      "invented-account",
+    );
+    const ambiguousTarget = `${CONNECTOR_ACCOUNT_URL}&customConnectorId=${CONNECTION_ID}`;
+
+    expect(shapeOf(malformedId)).toBe("unavailable-action");
+    expect(shapeOf(ambiguousTarget)).toBe("unavailable-action");
+  });
+
+  it("makes copied connector account actions unavailable in another context", () => {
+    const wrongAgent = CONNECTOR_ACCOUNT_URL.replace(
+      `/agents/${AGENT_ID}/`,
+      "/agents/c0000000-0000-4000-a000-000000000099/",
+    );
+    const wrongThread = CONNECTOR_ACCOUNT_URL.replace(
+      THREAD_ID,
+      "e4000000-0000-4000-a000-000000000099",
+    );
+
+    expect(shapeOf(wrongAgent)).toBe("unavailable-action");
+    expect(shapeOf(wrongThread)).toBe("unavailable-action");
+  });
+
+  it("leaves unknown connector account paths as Markdown", () => {
+    const unknown = CONNECTOR_ACCOUNT_URL.replace("/select?", "/rename?");
+
+    expect(shapeOf(unknown)).toBe(`markdown(${JSON.stringify(unknown)})`);
   });
 });

--- a/turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts
@@ -51,7 +51,8 @@ export type ConnectorAccountActionStatus =
 export type ConnectorAccountActionConfirmationState =
   | "idle"
   | "loading"
-  | "continued";
+  | "error"
+  | "switched";
 
 export interface ConnectorAccountActionSignals extends ConnectorAccountActionDescriptor {
   readonly status$: Computed<Promise<ConnectorAccountActionStatus>>;
@@ -227,7 +228,8 @@ function createConnectorAccountActionSignals(
   });
   const confirm$ = command(
     async ({ get, set }, signal: AbortSignal): Promise<void> => {
-      if (get(internalConfirmationState$) !== "idle") {
+      const currentState = get(internalConfirmationState$);
+      if (currentState !== "idle" && currentState !== "error") {
         return;
       }
       set(internalConfirmationState$, "loading");
@@ -243,6 +245,7 @@ function createConnectorAccountActionSignals(
             signal,
           );
           set(refresh$);
+          set(internalConfirmationState$, "switched");
           await set(
             runChatActionCallback$,
             {
@@ -252,11 +255,10 @@ function createConnectorAccountActionSignals(
             },
             signal,
           );
-          set(internalConfirmationState$, "continued");
         })(),
         () => {
           set(internalConfirmationState$, (current) => {
-            return current === "loading" ? "idle" : current;
+            return current === "loading" ? "error" : current;
           });
         },
       );

--- a/turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts
@@ -6,15 +6,18 @@ import {
   type ConnectorAccountSelection,
   type ConnectorAccountTarget,
 } from "@okouai/api-contracts/contracts/connector-accounts";
+import type { PublicConnectorCatalogIcon } from "@okouai/api-contracts/contracts/connector-catalog";
 import { chatThreadConnectorSelectionContract } from "@okouai/api-contracts/contracts/chat-threads";
 import { command, computed, state, type Command, type Computed } from "ccstate";
 
 import { accept } from "../../lib/accept.ts";
 import { apiClient$ } from "../api-client.ts";
+import { connectorCatalogStatusBySlug$ } from "../external/connectors.ts";
 import type {
   ComposerConnectorAuthorizationState,
   ComposerConnectorSignals,
 } from "../okou-page/connectors.ts";
+import { customConnectors$ } from "../okou-page/settings/custom-connectors.ts";
 import { rootSignal$ } from "../root-signal.ts";
 import { withCleanup } from "../utils.ts";
 import {
@@ -40,11 +43,23 @@ export interface ConnectorAccountActionDescriptor {
   readonly threadId: string;
 }
 
+type ConnectorAccountActionConnector =
+  | {
+      readonly kind: "builtin";
+      readonly icon: PublicConnectorCatalogIcon | undefined;
+    }
+  | {
+      readonly kind: "custom";
+      readonly id: string;
+      readonly displayName: string | null;
+    };
+
 export type ConnectorAccountActionStatus =
   | { readonly kind: "unavailable" }
   | {
       readonly kind: "ready";
       readonly account: ConnectorAccountConnection;
+      readonly connector: ConnectorAccountActionConnector;
       readonly selected: boolean;
     };
 
@@ -208,10 +223,32 @@ function createConnectorAccountActionSignals(
       if (result.status === 404) {
         return { kind: "unavailable" };
       }
-      const preference = await get(connector.accounts.preferenceState$);
+      const preferencePromise = get(connector.accounts.preferenceState$);
+      const target = descriptor.selection.target;
+      let presentation: ConnectorAccountActionConnector;
+      if (target.kind === "builtin") {
+        presentation = {
+          kind: "builtin",
+          icon: (await get(connectorCatalogStatusBySlug$)).get(
+            target.connectorSlug,
+          )?.icon,
+        };
+      } else {
+        const customConnectorId = target.customConnectorId;
+        presentation = {
+          kind: "custom",
+          id: customConnectorId,
+          displayName:
+            (await get(customConnectors$)).find((candidate) => {
+              return candidate.id === customConnectorId;
+            })?.displayName ?? null,
+        };
+      }
+      const preference = await preferencePromise;
       return {
         kind: "ready",
         account: result.body,
+        connector: presentation,
         selected: selectionIsCurrent(
           preference.selections,
           descriptor.selection,

--- a/turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts
@@ -92,10 +92,10 @@ function selectionFromUrl(
     kind === "builtin" && connectorSlug && customConnectorId === null
       ? { kind, connectorSlug }
       : kind === "custom" && customConnectorId && connectorSlug === null
-        ? { kind, customConnectorId }
+        ? { kind, customConnectorId: customConnectorId.toLowerCase() }
         : null;
   const parsed = connectorAccountSelectionSchema.safeParse({
-    connectionId,
+    connectionId: connectionId.toLowerCase(),
     target,
   });
   return parsed.success ? parsed.data : null;

--- a/turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts
@@ -32,7 +32,6 @@ export interface ConnectorAccountActionDescriptor {
   readonly agentId: string;
   readonly selection: ConnectorAccountSelection;
   readonly originalUrl: string;
-  readonly search: string;
   readonly callbackPrompt: string;
   readonly threadId: string;
 }
@@ -65,8 +64,17 @@ type ConnectorAccountActionCardSignalsRegistry = CardSignalsRegistry<
 export function connectorAccountActionResourceKey(
   descriptor: ConnectorAccountActionDescriptor,
 ): string {
-  const path = `/agents/${encodeURIComponent(descriptor.agentId)}/connector-accounts/${encodeURIComponent(descriptor.selection.connectionId)}/select`;
-  return `${path}?${descriptor.search}`;
+  const path = `/agents/${encodeURIComponent(descriptor.agentId.toLowerCase())}/connector-accounts/${encodeURIComponent(descriptor.selection.connectionId.toLowerCase())}/select`;
+  const targetKey = connectorAccountTargetKey(descriptor.selection.target);
+  const params = new URLSearchParams({
+    target:
+      descriptor.selection.target.kind === "custom"
+        ? targetKey.toLowerCase()
+        : targetKey,
+    threadId: descriptor.threadId.toLowerCase(),
+    callbackPrompt: descriptor.callbackPrompt,
+  });
+  return `${path}?${params.toString()}`;
 }
 
 function selectionFromUrl(
@@ -123,7 +131,6 @@ export function parseConnectorAccountActionUrl(
       agentId: context.agentId,
       selection,
       originalUrl: value,
-      search: url.searchParams.toString(),
       callbackPrompt: callback.callbackPrompt,
       threadId: callback.threadId,
     },

--- a/turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts
@@ -1,0 +1,225 @@
+import {
+  connectorAccountSelectionSchema,
+  connectorAccountTargetKey,
+  connectorAccountsContract,
+  type ConnectorAccountConnection,
+  type ConnectorAccountSelection,
+} from "@okouai/api-contracts/contracts/connector-accounts";
+import { chatThreadConnectorSelectionContract } from "@okouai/api-contracts/contracts/chat-threads";
+import { command, computed, state, type Command, type Computed } from "ccstate";
+
+import { accept } from "../../lib/accept.ts";
+import { apiClient$ } from "../api-client.ts";
+import type { ComposerConnectorAccountSignals } from "../okou-page/composer-connector-accounts.ts";
+import { rootSignal$ } from "../root-signal.ts";
+import {
+  chatActionCallbackFromUrl,
+  runChatActionCallback$,
+} from "./action-callback.ts";
+import {
+  chatActionIdMatches,
+  type ChatActionContext,
+  type ChatActionParseResult,
+} from "./chat-action-context.ts";
+import {
+  createCardSignalsRegistry,
+  type CardSignalsRegistry,
+} from "./card-signal-map.ts";
+import { parseTrustedPlatformUrl } from "./trusted-platform-url.ts";
+
+export interface ConnectorAccountActionDescriptor {
+  readonly agentId: string;
+  readonly selection: ConnectorAccountSelection;
+  readonly originalUrl: string;
+  readonly search: string;
+  readonly callbackPrompt: string;
+  readonly threadId: string;
+}
+
+export type ConnectorAccountActionStatus =
+  | { readonly kind: "unavailable" }
+  | {
+      readonly kind: "ready";
+      readonly account: ConnectorAccountConnection;
+      readonly selected: boolean;
+    };
+
+export interface ConnectorAccountActionSignals extends ConnectorAccountActionDescriptor {
+  readonly status$: Computed<Promise<ConnectorAccountActionStatus>>;
+  readonly refresh$: Command<void, []>;
+  readonly confirm$: Command<Promise<void>, [AbortSignal]>;
+}
+
+type ConnectorAccountActionCardSignalsRegistry = CardSignalsRegistry<
+  ConnectorAccountActionDescriptor,
+  ConnectorAccountActionSignals
+>;
+
+export function connectorAccountActionResourceKey(
+  descriptor: ConnectorAccountActionDescriptor,
+): string {
+  const path = `/agents/${encodeURIComponent(descriptor.agentId)}/connector-accounts/${encodeURIComponent(descriptor.selection.connectionId)}/select`;
+  return `${path}?${descriptor.search}`;
+}
+
+function selectionFromUrl(
+  url: URL,
+  connectionId: string,
+): ConnectorAccountSelection | null {
+  const kind = url.searchParams.get("kind");
+  const connectorSlug = url.searchParams.get("connectorSlug");
+  const customConnectorId = url.searchParams.get("customConnectorId");
+  const target =
+    kind === "builtin" && connectorSlug && customConnectorId === null
+      ? { kind, connectorSlug }
+      : kind === "custom" && customConnectorId && connectorSlug === null
+        ? { kind, customConnectorId }
+        : null;
+  const parsed = connectorAccountSelectionSchema.safeParse({
+    connectionId,
+    target,
+  });
+  return parsed.success ? parsed.data : null;
+}
+
+export function parseConnectorAccountActionUrl(
+  value: string,
+  context: ChatActionContext | undefined,
+): ChatActionParseResult<ConnectorAccountActionDescriptor> {
+  const url = parseTrustedPlatformUrl(value);
+  if (!url) {
+    return { status: "unrelated" };
+  }
+  const match = url.pathname.match(
+    /^\/agents\/([^/]+)\/connector-accounts\/([^/]+)\/select$/u,
+  );
+  if (!match) {
+    return { status: "unrelated" };
+  }
+  const agentId = match[1] ?? "";
+  const connectionId = match[2] ?? "";
+  const selection = selectionFromUrl(url, connectionId);
+  const callback = context ? chatActionCallbackFromUrl(url, context) : null;
+  if (
+    !context ||
+    !agentId ||
+    !chatActionIdMatches(agentId, context.agentId) ||
+    !selection ||
+    !callback?.callbackPrompt ||
+    !callback.threadId
+  ) {
+    return { status: "invalid", originalUrl: value };
+  }
+  return {
+    status: "valid",
+    descriptor: {
+      agentId: context.agentId,
+      selection,
+      originalUrl: value,
+      search: url.searchParams.toString(),
+      callbackPrompt: callback.callbackPrompt,
+      threadId: callback.threadId,
+    },
+  };
+}
+
+function targetQuery(selection: ConnectorAccountSelection) {
+  return selection.target.kind === "builtin"
+    ? {
+        kind: selection.target.kind,
+        connectorSlug: selection.target.connectorSlug,
+      }
+    : {
+        kind: selection.target.kind,
+        customConnectorId: selection.target.customConnectorId,
+      };
+}
+
+function selectionIsCurrent(
+  current: readonly ConnectorAccountSelection[],
+  requested: ConnectorAccountSelection,
+): boolean {
+  const targetKey = connectorAccountTargetKey(requested.target);
+  return current.some((selection) => {
+    return (
+      connectorAccountTargetKey(selection.target) === targetKey &&
+      selection.connectionId === requested.connectionId
+    );
+  });
+}
+
+function createConnectorAccountActionSignals(
+  descriptor: ConnectorAccountActionDescriptor,
+  accounts: ComposerConnectorAccountSignals,
+): ConnectorAccountActionSignals {
+  const reload$ = state(0);
+  const status$ = computed(
+    async (get): Promise<ConnectorAccountActionStatus> => {
+      get(reload$);
+      if (!get(accounts.enabled$)) {
+        return { kind: "unavailable" };
+      }
+      const result = await accept(
+        get(apiClient$)(connectorAccountsContract).connection({
+          params: { connectionId: descriptor.selection.connectionId },
+          query: targetQuery(descriptor.selection),
+          fetchOptions: { signal: get(rootSignal$) },
+        }),
+        [200, 404],
+      );
+      if (result.status === 404) {
+        return { kind: "unavailable" };
+      }
+      const preference = await get(accounts.preferenceState$);
+      return {
+        kind: "ready",
+        account: result.body,
+        selected: selectionIsCurrent(
+          preference.selections,
+          descriptor.selection,
+        ),
+      };
+    },
+  );
+  const refresh$ = command(({ set }) => {
+    set(reload$, (version) => {
+      return version + 1;
+    });
+    set(accounts.reload$);
+  });
+  const confirm$ = command(
+    async ({ get, set }, signal: AbortSignal): Promise<void> => {
+      await accept(
+        get(apiClient$)(chatThreadConnectorSelectionContract).update({
+          params: { id: descriptor.threadId },
+          body: descriptor.selection,
+          fetchOptions: { signal },
+        }),
+        [200],
+        signal,
+      );
+      set(refresh$);
+      await set(
+        runChatActionCallback$,
+        {
+          threadId: descriptor.threadId,
+          agentId: descriptor.agentId,
+          callbackPrompt: descriptor.callbackPrompt,
+        },
+        signal,
+      );
+    },
+  );
+  return { ...descriptor, status$, refresh$, confirm$ };
+}
+
+export function createConnectorAccountActionCardSignalsRegistry(
+  accounts: ComposerConnectorAccountSignals,
+): ConnectorAccountActionCardSignalsRegistry {
+  return createCardSignalsRegistry(
+    connectorAccountActionResourceKey,
+    (descriptor) => {
+      return createConnectorAccountActionSignals(descriptor, accounts);
+    },
+  );
+}

--- a/turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts
@@ -12,6 +12,7 @@ import { accept } from "../../lib/accept.ts";
 import { apiClient$ } from "../api-client.ts";
 import type { ComposerConnectorAccountSignals } from "../okou-page/composer-connector-accounts.ts";
 import { rootSignal$ } from "../root-signal.ts";
+import { withCleanup } from "../utils.ts";
 import {
   chatActionCallbackFromUrl,
   runChatActionCallback$,
@@ -44,8 +45,14 @@ export type ConnectorAccountActionStatus =
       readonly selected: boolean;
     };
 
+export type ConnectorAccountActionConfirmationState =
+  | "idle"
+  | "loading"
+  | "continued";
+
 export interface ConnectorAccountActionSignals extends ConnectorAccountActionDescriptor {
   readonly status$: Computed<Promise<ConnectorAccountActionStatus>>;
+  readonly confirmationState$: Computed<ConnectorAccountActionConfirmationState>;
   readonly refresh$: Command<void, []>;
   readonly confirm$: Command<Promise<void>, [AbortSignal]>;
 }
@@ -153,6 +160,11 @@ function createConnectorAccountActionSignals(
   accounts: ComposerConnectorAccountSignals,
 ): ConnectorAccountActionSignals {
   const reload$ = state(0);
+  const internalConfirmationState$ =
+    state<ConnectorAccountActionConfirmationState>("idle");
+  const confirmationState$ = computed((get) => {
+    return get(internalConfirmationState$);
+  });
   const status$ = computed(
     async (get): Promise<ConnectorAccountActionStatus> => {
       get(reload$);
@@ -189,28 +201,48 @@ function createConnectorAccountActionSignals(
   });
   const confirm$ = command(
     async ({ get, set }, signal: AbortSignal): Promise<void> => {
-      await accept(
-        get(apiClient$)(chatThreadConnectorSelectionContract).update({
-          params: { id: descriptor.threadId },
-          body: descriptor.selection,
-          fetchOptions: { signal },
-        }),
-        [200],
-        signal,
-      );
-      set(refresh$);
-      await set(
-        runChatActionCallback$,
-        {
-          threadId: descriptor.threadId,
-          agentId: descriptor.agentId,
-          callbackPrompt: descriptor.callbackPrompt,
+      if (get(internalConfirmationState$) !== "idle") {
+        return;
+      }
+      set(internalConfirmationState$, "loading");
+      await withCleanup(
+        (async () => {
+          await accept(
+            get(apiClient$)(chatThreadConnectorSelectionContract).update({
+              params: { id: descriptor.threadId },
+              body: descriptor.selection,
+              fetchOptions: { signal },
+            }),
+            [200],
+            signal,
+          );
+          set(refresh$);
+          await set(
+            runChatActionCallback$,
+            {
+              threadId: descriptor.threadId,
+              agentId: descriptor.agentId,
+              callbackPrompt: descriptor.callbackPrompt,
+            },
+            signal,
+          );
+          set(internalConfirmationState$, "continued");
+        })(),
+        () => {
+          set(internalConfirmationState$, (current) => {
+            return current === "loading" ? "idle" : current;
+          });
         },
-        signal,
       );
     },
   );
-  return { ...descriptor, status$, refresh$, confirm$ };
+  return {
+    ...descriptor,
+    status$,
+    confirmationState$,
+    refresh$,
+    confirm$,
+  };
 }
 
 export function createConnectorAccountActionCardSignalsRegistry(

--- a/turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts
@@ -59,7 +59,6 @@ export type ConnectorAccountActionStatus =
   | {
       readonly kind: "ready";
       readonly account: ConnectorAccountConnection;
-      readonly connector: ConnectorAccountActionConnector;
       readonly selected: boolean;
     };
 
@@ -70,6 +69,7 @@ export type ConnectorAccountActionConfirmationState =
 
 export interface ConnectorAccountActionSignals extends ConnectorAccountActionDescriptor {
   readonly status$: Computed<Promise<ConnectorAccountActionStatus>>;
+  readonly connector$: Computed<Promise<ConnectorAccountActionConnector>>;
   readonly confirmationState$: Computed<ConnectorAccountActionConfirmationState>;
   readonly refresh$: Command<void, []>;
   readonly confirm$: Command<Promise<void>, [AbortSignal]>;
@@ -202,6 +202,28 @@ function createConnectorAccountActionSignals(
   const confirmationState$ = computed((get) => {
     return get(internalConfirmationState$);
   });
+  const connector$ = computed(
+    async (get): Promise<ConnectorAccountActionConnector> => {
+      const target = descriptor.selection.target;
+      if (target.kind === "builtin") {
+        return {
+          kind: "builtin",
+          icon: (await get(connectorCatalogStatusBySlug$)).get(
+            target.connectorSlug,
+          )?.icon,
+        };
+      }
+      const customConnectorId = target.customConnectorId;
+      return {
+        kind: "custom",
+        id: customConnectorId,
+        displayName:
+          (await get(customConnectors$)).find((candidate) => {
+            return candidate.id === customConnectorId;
+          })?.displayName ?? null,
+      };
+    },
+  );
   const status$ = computed(
     async (get): Promise<ConnectorAccountActionStatus> => {
       get(reload$);
@@ -223,32 +245,10 @@ function createConnectorAccountActionSignals(
       if (result.status === 404) {
         return { kind: "unavailable" };
       }
-      const preferencePromise = get(connector.accounts.preferenceState$);
-      const target = descriptor.selection.target;
-      let presentation: ConnectorAccountActionConnector;
-      if (target.kind === "builtin") {
-        presentation = {
-          kind: "builtin",
-          icon: (await get(connectorCatalogStatusBySlug$)).get(
-            target.connectorSlug,
-          )?.icon,
-        };
-      } else {
-        const customConnectorId = target.customConnectorId;
-        presentation = {
-          kind: "custom",
-          id: customConnectorId,
-          displayName:
-            (await get(customConnectors$)).find((candidate) => {
-              return candidate.id === customConnectorId;
-            })?.displayName ?? null,
-        };
-      }
-      const preference = await preferencePromise;
+      const preference = await get(connector.accounts.preferenceState$);
       return {
         kind: "ready",
         account: result.body,
-        connector: presentation,
         selected: selectionIsCurrent(
           preference.selections,
           descriptor.selection,
@@ -308,6 +308,7 @@ function createConnectorAccountActionSignals(
   return {
     ...descriptor,
     status$,
+    connector$,
     confirmationState$,
     refresh$,
     confirm$,

--- a/turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts
@@ -4,13 +4,17 @@ import {
   connectorAccountsContract,
   type ConnectorAccountConnection,
   type ConnectorAccountSelection,
+  type ConnectorAccountTarget,
 } from "@okouai/api-contracts/contracts/connector-accounts";
 import { chatThreadConnectorSelectionContract } from "@okouai/api-contracts/contracts/chat-threads";
 import { command, computed, state, type Command, type Computed } from "ccstate";
 
 import { accept } from "../../lib/accept.ts";
 import { apiClient$ } from "../api-client.ts";
-import type { ComposerConnectorAccountSignals } from "../okou-page/composer-connector-accounts.ts";
+import type {
+  ComposerConnectorAuthorizationState,
+  ComposerConnectorSignals,
+} from "../okou-page/connectors.ts";
 import { rootSignal$ } from "../root-signal.ts";
 import { withCleanup } from "../utils.ts";
 import {
@@ -162,9 +166,20 @@ function selectionIsCurrent(
   });
 }
 
+function targetIsAuthorized(
+  authorization: ComposerConnectorAuthorizationState,
+  target: ConnectorAccountTarget,
+): boolean {
+  return target.kind === "builtin"
+    ? authorization.enabledConnectorSlugs.includes(target.connectorSlug)
+    : authorization.customConnectorGrants.some((grant) => {
+        return grant.customConnectorId === target.customConnectorId;
+      });
+}
+
 function createConnectorAccountActionSignals(
   descriptor: ConnectorAccountActionDescriptor,
-  accounts: ComposerConnectorAccountSignals,
+  connector: ComposerConnectorSignals,
 ): ConnectorAccountActionSignals {
   const reload$ = state(0);
   const internalConfirmationState$ =
@@ -175,7 +190,11 @@ function createConnectorAccountActionSignals(
   const status$ = computed(
     async (get): Promise<ConnectorAccountActionStatus> => {
       get(reload$);
-      if (!get(accounts.enabled$)) {
+      if (!get(connector.accounts.enabled$)) {
+        return { kind: "unavailable" };
+      }
+      const authorization = await get(connector.connectorAuthorization$);
+      if (!targetIsAuthorized(authorization, descriptor.selection.target)) {
         return { kind: "unavailable" };
       }
       const result = await accept(
@@ -189,7 +208,7 @@ function createConnectorAccountActionSignals(
       if (result.status === 404) {
         return { kind: "unavailable" };
       }
-      const preference = await get(accounts.preferenceState$);
+      const preference = await get(connector.accounts.preferenceState$);
       return {
         kind: "ready",
         account: result.body,
@@ -204,7 +223,7 @@ function createConnectorAccountActionSignals(
     set(reload$, (version) => {
       return version + 1;
     });
-    set(accounts.reload$);
+    set(connector.accounts.reload$);
   });
   const confirm$ = command(
     async ({ get, set }, signal: AbortSignal): Promise<void> => {
@@ -253,12 +272,12 @@ function createConnectorAccountActionSignals(
 }
 
 export function createConnectorAccountActionCardSignalsRegistry(
-  accounts: ComposerConnectorAccountSignals,
+  connector: ComposerConnectorSignals,
 ): ConnectorAccountActionCardSignalsRegistry {
   return createCardSignalsRegistry(
     connectorAccountActionResourceKey,
     (descriptor) => {
-      return createConnectorAccountActionSignals(descriptor, accounts);
+      return createConnectorAccountActionSignals(descriptor, connector);
     },
   );
 }

--- a/turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts
@@ -51,8 +51,7 @@ export type ConnectorAccountActionStatus =
 export type ConnectorAccountActionConfirmationState =
   | "idle"
   | "loading"
-  | "error"
-  | "switched";
+  | "error";
 
 export interface ConnectorAccountActionSignals extends ConnectorAccountActionDescriptor {
   readonly status$: Computed<Promise<ConnectorAccountActionStatus>>;
@@ -233,6 +232,7 @@ function createConnectorAccountActionSignals(
         return;
       }
       set(internalConfirmationState$, "loading");
+      let selectionSucceeded = false;
       await withCleanup(
         (async () => {
           await accept(
@@ -244,8 +244,8 @@ function createConnectorAccountActionSignals(
             [200],
             signal,
           );
+          selectionSucceeded = true;
           set(refresh$);
-          set(internalConfirmationState$, "switched");
           await set(
             runChatActionCallback$,
             {
@@ -258,7 +258,11 @@ function createConnectorAccountActionSignals(
         })(),
         () => {
           set(internalConfirmationState$, (current) => {
-            return current === "loading" ? "error" : current;
+            return current === "loading"
+              ? selectionSucceeded
+                ? "idle"
+                : "error"
+              : current;
           });
         },
       );

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -167,6 +167,7 @@ import {
   type AgentReferenceSignalsRegistry,
 } from "./agent-reference-signals.ts";
 import { createConnectorCardSignalsRegistry } from "./connector-action-block.ts";
+import { createConnectorAccountActionCardSignalsRegistry } from "./connector-account-action-block.ts";
 import { createPermissionCardSignalsRegistry } from "./permission-card-signals.ts";
 import { createBankingCardSignalsRegistry } from "./banking-action-block.ts";
 import { createComputerUseAuthorizationCardSignalsRegistry } from "./computer-use-authorization-block.ts";
@@ -240,6 +241,7 @@ import {
 } from "./user-message-files.ts";
 import type { ChatForwardContext } from "./chat-forward.ts";
 import { createComposerConnectorSignals } from "../okou-page/connectors.ts";
+import type { ComposerConnectorAccountSignals } from "../okou-page/composer-connector-accounts.ts";
 
 const L = logger("ChatThread");
 const noOpComposerDraftSave$ = command(
@@ -1779,6 +1781,9 @@ interface EventTreeRegistries {
   readonly connectorCardSignals: ReturnType<
     typeof createConnectorCardSignalsRegistry
   >;
+  readonly connectorAccountActionCardSignals: ReturnType<
+    typeof createConnectorAccountActionCardSignalsRegistry
+  >;
   readonly permissionCardSignals: ReturnType<
     typeof createPermissionCardSignalsRegistry
   >;
@@ -1803,6 +1808,7 @@ function createCardRefRegistrar({
   chatActionContext,
   artifactCardSignals,
   connectorCardSignals,
+  connectorAccountActionCardSignals,
   permissionCardSignals,
   bankingCardSignals,
   computerUseAuthorizationCardSignals,
@@ -1824,6 +1830,15 @@ function createCardRefRegistrar({
           return {
             kind: descriptor.type,
             signals: set(connectorCardSignals.register$, descriptor.descriptor),
+          };
+        }
+        case "connector-account-action": {
+          return {
+            kind: descriptor.type,
+            signals: set(
+              connectorAccountActionCardSignals.register$,
+              descriptor.descriptor,
+            ),
           };
         }
         case "permission-action": {
@@ -2096,10 +2111,21 @@ function createEventTreeSignals(registries: EventTreeRegistries) {
 }
 
 function createPagedEventResources(
-  chatActionContext: ChatActionContext,
-  chatEvents$: Computed<ChatEvent[]>,
-  previewImageUrlsByUrl$: Computed<Promise<ReadonlyMap<string, string>>>,
-  browserLifecycleOptimisticEvents: BrowserLifecycleOptimisticEvents,
+  {
+    chatActionContext,
+    chatEvents$,
+    previewImageUrlsByUrl$,
+    browserLifecycleOptimisticEvents,
+    connectorAccounts,
+  }: {
+    readonly chatActionContext: ChatActionContext;
+    readonly chatEvents$: Computed<ChatEvent[]>;
+    readonly previewImageUrlsByUrl$: Computed<
+      Promise<ReadonlyMap<string, string>>
+    >;
+    readonly browserLifecycleOptimisticEvents: BrowserLifecycleOptimisticEvents;
+    readonly connectorAccounts: ComposerConnectorAccountSignals;
+  },
   ownerSignal: AbortSignal,
 ) {
   const { threadId } = chatActionContext;
@@ -2115,6 +2141,8 @@ function createPagedEventResources(
   );
   const agentReferenceSignals = createAgentReferenceSignalsRegistry();
   const connectorCardSignals = createConnectorCardSignalsRegistry();
+  const connectorAccountActionCardSignals =
+    createConnectorAccountActionCardSignalsRegistry(connectorAccounts);
   const permissionCardSignals = createPermissionCardSignalsRegistry();
   const bankingCardSignals = createBankingCardSignalsRegistry();
   const computerUseAuthorizationCardSignals =
@@ -2148,6 +2176,7 @@ function createPagedEventResources(
     chatActionContext,
     artifactCardSignals,
     connectorCardSignals,
+    connectorAccountActionCardSignals,
     permissionCardSignals,
     bankingCardSignals,
     computerUseAuthorizationCardSignals,
@@ -2473,10 +2502,12 @@ function createChatThreadMessagePipeline(
     chatActionContext,
     chatEvents,
     previewImageUrlsByUrl$,
+    connectorAccounts,
   }: {
     chatActionContext: ChatActionContext;
     chatEvents: ChatEventSignals;
     previewImageUrlsByUrl$: Computed<Promise<ReadonlyMap<string, string>>>;
+    connectorAccounts: ComposerConnectorAccountSignals;
   },
   ownerSignal: AbortSignal,
 ) {
@@ -2486,10 +2517,13 @@ function createChatThreadMessagePipeline(
   // Position is created before scroll writers are wired to the render window.
   const position = createThreadScrollPositionSignals(threadId);
   const resources = createPagedEventResources(
-    chatActionContext,
-    chatEvents.chatEvents$,
-    previewImageUrlsByUrl$,
-    browserLifecycleOptimisticEvents,
+    {
+      chatActionContext,
+      chatEvents$: chatEvents.chatEvents$,
+      previewImageUrlsByUrl$,
+      browserLifecycleOptimisticEvents,
+      connectorAccounts,
+    },
     ownerSignal,
   );
   const projections = createPagedEventProjections({
@@ -4245,6 +4279,7 @@ function createChatPanelSignalsWithDraft(
       previewImageUrlsByUrl$: createArtifactPreviewImageUrls(
         artifact.artifacts$,
       ),
+      connectorAccounts: composer.connector.accounts,
     },
     signal,
   );

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -240,8 +240,10 @@ import {
   userMessageFileAttachments,
 } from "./user-message-files.ts";
 import type { ChatForwardContext } from "./chat-forward.ts";
-import { createComposerConnectorSignals } from "../okou-page/connectors.ts";
-import type { ComposerConnectorAccountSignals } from "../okou-page/composer-connector-accounts.ts";
+import {
+  createComposerConnectorSignals,
+  type ComposerConnectorSignals,
+} from "../okou-page/connectors.ts";
 
 const L = logger("ChatThread");
 const noOpComposerDraftSave$ = command(
@@ -2116,7 +2118,7 @@ function createPagedEventResources(
     chatEvents$,
     previewImageUrlsByUrl$,
     browserLifecycleOptimisticEvents,
-    connectorAccounts,
+    connector,
   }: {
     readonly chatActionContext: ChatActionContext;
     readonly chatEvents$: Computed<ChatEvent[]>;
@@ -2124,7 +2126,7 @@ function createPagedEventResources(
       Promise<ReadonlyMap<string, string>>
     >;
     readonly browserLifecycleOptimisticEvents: BrowserLifecycleOptimisticEvents;
-    readonly connectorAccounts: ComposerConnectorAccountSignals;
+    readonly connector: ComposerConnectorSignals;
   },
   ownerSignal: AbortSignal,
 ) {
@@ -2142,7 +2144,7 @@ function createPagedEventResources(
   const agentReferenceSignals = createAgentReferenceSignalsRegistry();
   const connectorCardSignals = createConnectorCardSignalsRegistry();
   const connectorAccountActionCardSignals =
-    createConnectorAccountActionCardSignalsRegistry(connectorAccounts);
+    createConnectorAccountActionCardSignalsRegistry(connector);
   const permissionCardSignals = createPermissionCardSignalsRegistry();
   const bankingCardSignals = createBankingCardSignalsRegistry();
   const computerUseAuthorizationCardSignals =
@@ -2502,12 +2504,12 @@ function createChatThreadMessagePipeline(
     chatActionContext,
     chatEvents,
     previewImageUrlsByUrl$,
-    connectorAccounts,
+    connector,
   }: {
     chatActionContext: ChatActionContext;
     chatEvents: ChatEventSignals;
     previewImageUrlsByUrl$: Computed<Promise<ReadonlyMap<string, string>>>;
-    connectorAccounts: ComposerConnectorAccountSignals;
+    connector: ComposerConnectorSignals;
   },
   ownerSignal: AbortSignal,
 ) {
@@ -2522,7 +2524,7 @@ function createChatThreadMessagePipeline(
       chatEvents$: chatEvents.chatEvents$,
       previewImageUrlsByUrl$,
       browserLifecycleOptimisticEvents,
-      connectorAccounts,
+      connector,
     },
     ownerSignal,
   );
@@ -4279,7 +4281,7 @@ function createChatPanelSignalsWithDraft(
       previewImageUrlsByUrl$: createArtifactPreviewImageUrls(
         artifact.artifacts$,
       ),
-      connectorAccounts: composer.connector.accounts,
+      connector: composer.connector,
     },
     signal,
   );

--- a/turbo/apps/platform/src/signals/chat-page/markdown-card-ref.ts
+++ b/turbo/apps/platform/src/signals/chat-page/markdown-card-ref.ts
@@ -2,6 +2,7 @@ import type { ArtifactSignals } from "./artifact-card-signals.ts";
 import type { BrowserSessionSignals } from "./browser-session-block.ts";
 import type { BankingSignals } from "./banking-action-block.ts";
 import type { ConnectorSignals } from "./connector-action-block.ts";
+import type { ConnectorAccountActionSignals } from "./connector-account-action-block.ts";
 import type { ComputerUseAuthorizationSignals } from "./computer-use-authorization-block.ts";
 import type { MailDraftSignals } from "./mail-draft.ts";
 import type { PermissionSignals } from "./permission-card-signals.ts";
@@ -20,6 +21,10 @@ export type MarkdownCardRef =
       readonly threadId: string;
     }
   | { readonly kind: "connector-action"; readonly signals: ConnectorSignals }
+  | {
+      readonly kind: "connector-account-action";
+      readonly signals: ConnectorAccountActionSignals;
+    }
   | { readonly kind: "permission-action"; readonly signals: PermissionSignals }
   | { readonly kind: "banking-action"; readonly signals: BankingSignals }
   | { readonly kind: "unavailable-action" }

--- a/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
@@ -2,6 +2,11 @@ import {
   parseConnectorAuthorizeUrl,
   type ConnectorActionDescriptor,
 } from "./connector-action-block.ts";
+import {
+  connectorAccountActionResourceKey,
+  parseConnectorAccountActionUrl,
+  type ConnectorAccountActionDescriptor,
+} from "./connector-account-action-block.ts";
 import type { ChatActionContext } from "./chat-action-context.ts";
 import {
   parsePermissionActionUrl,
@@ -60,6 +65,11 @@ export type ParsedBodyBlock =
       type: "connector-action";
       resourceKey: string;
       descriptor: ConnectorActionDescriptor;
+    }
+  | {
+      type: "connector-account-action";
+      resourceKey: string;
+      descriptor: ConnectorAccountActionDescriptor;
     }
   | {
       type: "permission-action";
@@ -135,7 +145,7 @@ const PLATFORM_FILE_CDN_HOSTS = [
   "cdn.vm7.io",
 ] as const;
 const HOSTED_SITE_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/u;
-const URL_TOKEN_PATTERN = String.raw`(?:https?:\/\/|\/(?:f|artifacts|browsers)\/|\/mail\/drafts\/|\/\?settings=billing&billingView=)[^\s<>"'()（）【】《》「」『』“”‘’，。；：！？、]+`;
+const URL_TOKEN_PATTERN = String.raw`(?:https?:\/\/|\/(?:agents|f|artifacts|browsers)\/|\/mail\/drafts\/|\/\?settings=billing&billingView=)[^\s<>"'()（）【】《》「」『』“”‘’，。；：！？、]+`;
 const URL_TOKEN_OPENING_PREFIX_PATTERN = /^[({<"'“‘（【《「『[]*$/u;
 const MARKDOWN_LINK_TOKEN_PREFIX_PATTERN = /\[[^\]\n]+\]\($/u;
 
@@ -804,6 +814,7 @@ function createActionBlockFromLine(
   {
     type:
       | "connector-action"
+      | "connector-account-action"
       | "permission-action"
       | "banking-action"
       | "unavailable-action"
@@ -831,6 +842,27 @@ function createActionBlockFromLine(
       type: "unavailable-action",
       resourceKey: connectorAction.originalUrl,
       descriptor: { originalUrl: connectorAction.originalUrl },
+    };
+  }
+
+  const connectorAccountAction = parseConnectorAccountActionUrl(
+    url,
+    chatActionContext,
+  );
+  if (connectorAccountAction.status === "valid") {
+    return {
+      type: "connector-account-action",
+      resourceKey: connectorAccountActionResourceKey(
+        connectorAccountAction.descriptor,
+      ),
+      descriptor: connectorAccountAction.descriptor,
+    };
+  }
+  if (connectorAccountAction.status === "invalid") {
+    return {
+      type: "unavailable-action",
+      resourceKey: connectorAccountAction.originalUrl,
+      descriptor: { originalUrl: connectorAccountAction.originalUrl },
     };
   }
 
@@ -1154,6 +1186,9 @@ export function cardSlotUrl(block: CardDescriptorBlock): string {
       return block.descriptor.url;
     }
     case "connector-action": {
+      return block.descriptor.originalUrl;
+    }
+    case "connector-account-action": {
       return block.descriptor.originalUrl;
     }
     case "permission-action": {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
@@ -665,13 +665,14 @@ describe("chat event action cards", () => {
     expect(queryAllByRoleFast("button", card)).toStrictEqual([]);
   });
 
-  it("does not continue when a stale account selection is rejected", async () => {
+  it("retries a rejected selection from another repeated card", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "e4000000-0000-4000-a000-000000000024";
     const account = connectorAccount({
       id: "a1000000-0000-4000-a000-000000000024",
     });
     const sentPrompts: string[] = [];
+    let updateCount = 0;
     context.mocks.api(connectorAccountsContract.connection, ({ respond }) => {
       return respond(200, account);
     });
@@ -683,13 +684,16 @@ describe("chat event action cards", () => {
     );
     context.mocks.api(
       chatThreadConnectorSelectionContract.update,
-      ({ respond }) => {
-        return respond(400, {
-          error: {
-            code: "BAD_REQUEST",
-            message: "Connector account selection is no longer valid",
-          },
-        });
+      ({ body, respond }) => {
+        updateCount += 1;
+        return updateCount === 1
+          ? respond(400, {
+              error: {
+                code: "BAD_REQUEST",
+                message: "Connector account selection is no longer valid",
+              },
+            })
+          : respond(200, body);
       },
     );
     mockChatLifecycle(context, {
@@ -699,7 +703,7 @@ describe("chat event action cards", () => {
         {
           id: `${threadId}-message`,
           role: "assistant",
-          content: connectorAccountActionUrl(threadId, account, "Continue"),
+          content: `${connectorAccountActionUrl(threadId, account, "Continue")}\n\n${connectorAccountActionUrl(threadId, account, "Continue")}`,
           runId: `${threadId}-run`,
           createdAt: "2026-08-31T10:00:00.000Z",
         },
@@ -715,18 +719,37 @@ describe("chat event action cards", () => {
       featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
     });
 
-    const card = await screen.findByTestId(
+    const cards = await screen.findAllByTestId(
       "connector-account-action-card",
       undefined,
       { timeout: 10_000 },
     );
-    await user.click(buttonByText("Use account and continue", card));
+    expect(cards).toHaveLength(2);
+    const firstCard = cards[0];
+    const secondCard = cards[1];
+    if (!firstCard || !secondCard) {
+      throw new Error("Expected repeated connector account action cards");
+    }
+    await user.click(buttonByText("Use account and continue", firstCard));
 
     await waitFor(() => {
-      expect(card).toHaveTextContent(
+      expect(firstCard).toHaveTextContent(
         "Couldn't confirm this account or continue the chat. Try again.",
       );
       expect(sentPrompts).toStrictEqual([]);
+    });
+
+    await user.click(buttonByText("Use account and continue", secondCard));
+
+    await waitFor(() => {
+      expect(updateCount).toBe(2);
+      expect(sentPrompts).toStrictEqual(["Continue"]);
+      for (const card of cards) {
+        expect(card).not.toHaveTextContent(
+          "Couldn't confirm this account or continue the chat. Try again.",
+        );
+        expect(card).toHaveTextContent("Continuation requested");
+      }
     });
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
@@ -63,7 +63,11 @@ import {
   testContext,
   chatEventRowsResponse,
 } from "../../../signals/__tests__/test-helpers.ts";
-import { PLACEHOLDER, mockChatLifecycle } from "./chat-test-helpers.ts";
+import {
+  PLACEHOLDER,
+  mockChatLifecycle,
+  sendMessageInUI,
+} from "./chat-test-helpers.ts";
 import { mockChatEventRows } from "./chat-event-test-helpers.ts";
 
 const context = testContext();
@@ -895,6 +899,76 @@ describe("chat event action cards", () => {
     await waitFor(() => {
       expect(card).toHaveTextContent("Already selected for this chat");
     });
+  });
+
+  it("registers a realtime account card in an optimistic thread", async () => {
+    const user = userEvent.setup({ delay: null });
+    const account = connectorAccount({
+      id: "a1000000-0000-4000-a000-000000000028",
+      displayName: "Realtime account",
+    });
+    let optimisticThreadId: string | undefined;
+    mockConnectorAccountActionAuthorization(account.target);
+    context.mocks.api(
+      connectorAccountsContract.connection,
+      ({ params, respond }) => {
+        expect(params.connectionId).toBe(account.id);
+        return respond(200, account);
+      },
+    );
+    context.mocks.api(
+      chatThreadConnectorSelectionContract.get,
+      ({ params, respond }) => {
+        expect(params.id).toBe(optimisticThreadId);
+        return respond(200, { selections: [], selectedConnections: [] });
+      },
+    );
+    context.mocks.api(browserContract.get, ({ respond }) => {
+      return respond(404, {
+        error: { code: "NOT_FOUND", message: "Browser not found" },
+      });
+    });
+    const lifecycle = mockChatLifecycle(context, {
+      threadTitle: "Optimistic connector account card",
+      onThreadCreate: ({ clientThreadId }) => {
+        optimisticThreadId = clientThreadId;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER);
+    });
+    await sendMessageInUI(user, textarea, "Start with my selected account");
+    await waitFor(() => {
+      expect(optimisticThreadId).toBeDefined();
+      expect(
+        screen.getByText("Start with my selected account"),
+      ).toBeInTheDocument();
+    });
+    if (!optimisticThreadId) {
+      throw new Error("Expected an optimistic thread identifier");
+    }
+
+    lifecycle.completeRun(
+      connectorAccountActionUrl(
+        optimisticThreadId,
+        account,
+        "Continue optimistic task",
+      ),
+    );
+
+    const card = await screen.findByTestId(
+      "connector-account-action-card",
+      undefined,
+      { timeout: 10_000 },
+    );
+    expect(card).toHaveTextContent("Use Realtime account for future runs?");
   });
 
   it("renders an unconnected banking request with the compact action card layout", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
@@ -537,14 +537,16 @@ describe("chat event action cards", () => {
       expect(card).toHaveTextContent("Switch to Work?");
       expect(card).toHaveTextContent("github · work@example.com");
       expect(card).not.toHaveTextContent("The current run will not change.");
-      const icon = card.querySelector("img");
-      if (!(icon instanceof HTMLImageElement)) {
-        throw new Error("GitHub connector icon not found");
-      }
-      expect(icon).toHaveAttribute(
-        "src",
-        "https://icons.example.test/github.svg",
-      );
+      await waitFor(() => {
+        const icon = card.querySelector("img");
+        if (!(icon instanceof HTMLImageElement)) {
+          throw new Error("GitHub connector icon not found");
+        }
+        expect(icon).toHaveAttribute(
+          "src",
+          "https://icons.example.test/github.svg",
+        );
+      });
     }
 
     const firstCard = cards[0];
@@ -661,11 +663,74 @@ describe("chat event action cards", () => {
     expect(card).toHaveTextContent(
       `Custom connector · ${customConnectorId.slice(0, 8)} · work@example.com`,
     );
-    const icon = card.querySelector('[aria-label="Acme Search"]');
-    expect(icon).toHaveTextContent("A");
+    await waitFor(() => {
+      const icon = card.querySelector('[aria-label="Acme Search"]');
+      expect(icon).toHaveTextContent("A");
+    });
     expect(queryAllByRoleFast("button", card)).toStrictEqual([]);
     expect(updateCount).toBe(0);
     expect(sentPrompts).toStrictEqual([]);
+  });
+
+  it("keeps an account switch available when connector icon metadata fails", async () => {
+    const threadId = "e4000000-0000-4000-a000-000000000031";
+    const account = connectorAccount({
+      id: "a1000000-0000-4000-a000-000000000031",
+    });
+    mockConnectorAccountActionAuthorization(account.target);
+    let catalogReadCount = 0;
+    context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
+      catalogReadCount += 1;
+      return respond(500, {
+        error: {
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Connector catalog unavailable",
+        },
+      });
+    });
+    context.mocks.api(connectorAccountsContract.connection, ({ respond }) => {
+      return respond(200, account);
+    });
+    context.mocks.api(
+      chatThreadConnectorSelectionContract.get,
+      ({ respond }) => {
+        return respond(200, { selections: [], selectedConnections: [] });
+      },
+    );
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Connector icon fallback",
+      chatEvents: [
+        {
+          id: `${threadId}-message`,
+          role: "assistant",
+          content: connectorAccountActionUrl(threadId, account, "Continue"),
+          runId: `${threadId}-run`,
+          createdAt: "2026-08-31T10:00:00.000Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    const card = await screen.findByTestId(
+      "connector-account-action-card",
+      undefined,
+      { timeout: 10_000 },
+    );
+    await waitFor(() => {
+      expect(catalogReadCount).toBe(1);
+      expect(buttonByText("Switch", card)).toBeEnabled();
+      expect(
+        within(card).getByRole("img", {
+          name: "Connector icon unavailable",
+        }),
+      ).toBeInTheDocument();
+    });
   });
 
   it("renders a hallucinated or cross-target account as unavailable", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
@@ -522,8 +522,10 @@ describe("chat event action cards", () => {
   it("continues after idempotently writing an already-selected account", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "e4000000-0000-4000-a000-000000000022";
+    const customConnectorId = "a2000000-0000-4000-a000-000000000022";
     const account = connectorAccount({
       id: "a1000000-0000-4000-a000-000000000022",
+      target: { kind: "custom", customConnectorId },
     });
     const selection = {
       connectionId: account.id,
@@ -533,9 +535,13 @@ describe("chat event action cards", () => {
     let updateCount = 0;
     const sentPrompts: string[] = [];
 
-    context.mocks.api(connectorAccountsContract.connection, ({ respond }) => {
-      return respond(200, account);
-    });
+    context.mocks.api(
+      connectorAccountsContract.connection,
+      ({ query, respond }) => {
+        expect(query).toStrictEqual({ kind: "custom", customConnectorId });
+        return respond(200, account);
+      },
+    );
     context.mocks.api(
       chatThreadConnectorSelectionContract.get,
       ({ respond }) => {
@@ -581,6 +587,9 @@ describe("chat event action cards", () => {
       { timeout: 10_000 },
     );
     expect(card).toHaveTextContent("Already selected for this chat");
+    expect(card).toHaveTextContent(
+      `Custom connector · ${customConnectorId.slice(0, 8)} · work@example.com`,
+    );
     await user.click(buttonByText("Continue with this account", card));
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
@@ -255,6 +255,31 @@ function mockAgentConnectorAuthorizations(
   });
 }
 
+function mockConnectorAccountActionAuthorization(
+  target: ConnectorAccountConnection["target"],
+  authorized = true,
+): void {
+  context.mocks.api(userConnectorsContract.get, ({ respond }) => {
+    return respond(200, {
+      enabledConnectorSlugs:
+        authorized && target.kind === "builtin" ? [target.connectorSlug] : [],
+    });
+  });
+  context.mocks.api(agentCustomConnectorsContract.get, ({ respond }) => {
+    return respond(200, {
+      grants:
+        authorized && target.kind === "custom"
+          ? [
+              {
+                customConnectorId: target.customConnectorId,
+                permissionNames: [],
+              },
+            ]
+          : [],
+    });
+  });
+}
+
 function customConnector(
   overrides: Partial<CustomConnectorHttpResponse> = {},
 ): CustomConnectorHttpResponse {
@@ -428,6 +453,7 @@ describe("chat event action cards", () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "e4000000-0000-4000-a000-000000000021";
     const account = connectorAccount();
+    mockConnectorAccountActionAuthorization(account.target);
     const callbackPrompt = "Continue with the selected GitHub account";
     const actionUrl = connectorAccountActionUrl(
       threadId,
@@ -546,6 +572,7 @@ describe("chat event action cards", () => {
       id: "a1000000-0000-4000-a000-000000000022",
       target: { kind: "custom", customConnectorId },
     });
+    mockConnectorAccountActionAuthorization(account.target);
     const selection = {
       connectionId: account.id,
       target: account.target,
@@ -623,6 +650,7 @@ describe("chat event action cards", () => {
     const account = connectorAccount({
       id: "a1000000-0000-4000-a000-000000000023",
     });
+    mockConnectorAccountActionAuthorization(account.target);
     context.mocks.api(connectorAccountsContract.connection, ({ respond }) => {
       return respond(404, {
         error: {
@@ -666,12 +694,68 @@ describe("chat event action cards", () => {
     expect(queryAllByRoleFast("button", card)).toStrictEqual([]);
   });
 
+  it("renders an account outside the current agent scope as unavailable", async () => {
+    const threadId = "e4000000-0000-4000-a000-000000000026";
+    const account = connectorAccount({
+      id: "a1000000-0000-4000-a000-000000000026",
+    });
+    let accountReadCount = 0;
+    let updateCount = 0;
+    const sentPrompts: string[] = [];
+    mockConnectorAccountActionAuthorization(account.target, false);
+    context.mocks.api(connectorAccountsContract.connection, ({ respond }) => {
+      accountReadCount += 1;
+      return respond(200, account);
+    });
+    context.mocks.api(
+      chatThreadConnectorSelectionContract.update,
+      ({ body, respond }) => {
+        updateCount += 1;
+        return respond(200, body);
+      },
+    );
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Unauthorized connector account",
+      chatEvents: [
+        {
+          id: `${threadId}-message`,
+          role: "assistant",
+          content: connectorAccountActionUrl(threadId, account, "Continue"),
+          runId: `${threadId}-run`,
+          createdAt: "2026-08-31T10:00:00.000Z",
+        },
+      ],
+      onSendRequest: ({ prompt }) => {
+        sentPrompts.push(prompt);
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    const card = await screen.findByTestId(
+      "connector-account-action-card-unavailable",
+      undefined,
+      { timeout: 10_000 },
+    );
+    expect(card).toHaveTextContent("Account unavailable");
+    expect(queryAllByRoleFast("button", card)).toStrictEqual([]);
+    expect(accountReadCount).toBe(0);
+    expect(updateCount).toBe(0);
+    expect(sentPrompts).toStrictEqual([]);
+  });
+
   it("retries a rejected selection from another repeated card", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "e4000000-0000-4000-a000-000000000024";
     const account = connectorAccount({
       id: "a1000000-0000-4000-a000-000000000024",
     });
+    mockConnectorAccountActionAuthorization(account.target);
     const sentPrompts: string[] = [];
     let updateCount = 0;
     context.mocks.api(connectorAccountsContract.connection, ({ respond }) => {
@@ -759,6 +843,7 @@ describe("chat event action cards", () => {
     const account = connectorAccount({
       id: "a1000000-0000-4000-a000-000000000025",
     });
+    mockConnectorAccountActionAuthorization(account.target);
     let selections: ConnectorAccountSelection[] = [];
     let selectedConnections: ConnectorAccountConnection[] = [];
     context.mocks.api(connectorAccountsContract.connection, ({ respond }) => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
@@ -438,6 +438,9 @@ describe("chat event action cards", () => {
     let selectedConnections: ConnectorAccountConnection[] = [];
     let updateBody: ConnectorAccountSelection | null = null;
     const actionOrder: string[] = [];
+    let resolveSelectionUpdate = (): void => {
+      throw new Error("Selection update did not start");
+    };
 
     context.mocks.api(
       connectorAccountsContract.connection,
@@ -456,9 +459,14 @@ describe("chat event action cards", () => {
     );
     context.mocks.api(
       chatThreadConnectorSelectionContract.update,
-      ({ params, body, respond }) => {
+      async ({ deferred, params, body, respond }) => {
         expect(params.id).toBe(threadId);
         actionOrder.push("selection");
+        const selectionUpdate = deferred<void>();
+        resolveSelectionUpdate = () => {
+          selectionUpdate.resolve();
+        };
+        await selectionUpdate.promise;
         updateBody = body;
         selections = [body];
         selectedConnections = [account];
@@ -508,6 +516,14 @@ describe("chat event action cards", () => {
     await user.click(buttonByText("Use account and continue", firstCard));
 
     await waitFor(() => {
+      expect(actionOrder).toStrictEqual(["selection"]);
+      for (const card of cards) {
+        expect(buttonByText("Use account and continue", card)).toBeDisabled();
+      }
+    });
+    resolveSelectionUpdate();
+
+    await waitFor(() => {
       expect(updateBody).toStrictEqual({
         connectionId: account.id,
         target: account.target,
@@ -515,6 +531,8 @@ describe("chat event action cards", () => {
       expect(actionOrder).toStrictEqual(["selection", "callback"]);
       for (const card of cards) {
         expect(card).toHaveTextContent("Already selected for this chat");
+        expect(card).toHaveTextContent("Continuation requested");
+        expect(buttonByText("Continuation requested", card)).toBeDisabled();
       }
     });
   });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
@@ -534,9 +534,9 @@ describe("chat event action cards", () => {
     );
     expect(cards).toHaveLength(2);
     for (const card of cards) {
-      expect(card).toHaveTextContent("Use Work for future runs?");
+      expect(card).toHaveTextContent("Switch to Work?");
       expect(card).toHaveTextContent("github · work@example.com");
-      expect(card).toHaveTextContent("The current run will not change.");
+      expect(card).not.toHaveTextContent("The current run will not change.");
     }
 
     const firstCard = cards[0];
@@ -545,14 +545,14 @@ describe("chat event action cards", () => {
       throw new Error("Expected repeated connector account action cards");
     }
     act(() => {
-      buttonByText("Use account and continue", firstCard).click();
-      buttonByText("Use account and continue", secondCard).click();
+      buttonByText("Switch", firstCard).click();
+      buttonByText("Switch", secondCard).click();
     });
 
     await waitFor(() => {
       expect(actionOrder).toStrictEqual(["selection"]);
       for (const card of cards) {
-        expect(buttonByText("Use account and continue", card)).toBeDisabled();
+        expect(buttonByText("Switching...", card)).toBeDisabled();
       }
     });
     resolveSelectionUpdate();
@@ -564,15 +564,13 @@ describe("chat event action cards", () => {
       });
       expect(actionOrder).toStrictEqual(["selection", "callback"]);
       for (const card of cards) {
-        expect(card).toHaveTextContent("Already selected for this chat");
-        expect(card).toHaveTextContent("Continuation requested");
-        expect(buttonByText("Continuation requested", card)).toBeDisabled();
+        expect(card).toHaveTextContent("Switched to Work");
+        expect(queryAllByRoleFast("button", card)).toStrictEqual([]);
       }
     });
   });
 
-  it("continues after idempotently writing an already-selected account", async () => {
-    const user = userEvent.setup({ delay: null });
+  it("renders an already-selected account without another action", async () => {
     const threadId = "e4000000-0000-4000-a000-000000000022";
     const customConnectorId = "a2000000-0000-4000-a000-000000000022";
     const account = connectorAccount({
@@ -640,17 +638,13 @@ describe("chat event action cards", () => {
       undefined,
       { timeout: 10_000 },
     );
-    expect(card).toHaveTextContent("Already selected for this chat");
+    expect(card).toHaveTextContent("Switched to Work");
     expect(card).toHaveTextContent(
       `Custom connector · ${customConnectorId.slice(0, 8)} · work@example.com`,
     );
-    await user.click(buttonByText("Continue with this account", card));
-
-    await waitFor(() => {
-      expect(updateCount).toBe(1);
-      expect(sentPrompts).toStrictEqual([callbackPrompt]);
-      expect(card).toHaveTextContent("Continuation requested");
-    });
+    expect(queryAllByRoleFast("button", card)).toStrictEqual([]);
+    expect(updateCount).toBe(0);
+    expect(sentPrompts).toStrictEqual([]);
   });
 
   it("renders a hallucinated or cross-target account as unavailable", async () => {
@@ -699,6 +693,9 @@ describe("chat event action cards", () => {
       { timeout: 10_000 },
     );
     expect(card).toHaveTextContent("Account unavailable");
+    expect(card).toHaveTextContent(
+      "This account does not exist or is not available for this connector.",
+    );
     expect(queryAllByRoleFast("button", card)).toStrictEqual([]);
   });
 
@@ -883,7 +880,7 @@ describe("chat event action cards", () => {
 
     const card = await screen.findByTestId("connector-account-action-card");
     expect(accountReadCount).toBe(2);
-    expect(card).toHaveTextContent("Use Work for future runs?");
+    expect(card).toHaveTextContent("Switch to Work?");
     expect(card).toHaveTextContent(
       "Reconnect required. Later runs may use the existing fallback.",
     );
@@ -955,25 +952,27 @@ describe("chat event action cards", () => {
     if (!firstCard || !secondCard) {
       throw new Error("Expected repeated connector account action cards");
     }
-    await user.click(buttonByText("Use account and continue", firstCard));
+    await user.click(buttonByText("Switch", firstCard));
 
     await waitFor(() => {
       expect(firstCard).toHaveTextContent(
-        "Couldn't confirm this account or continue the chat. Try again.",
+        "Couldn't switch accounts. Try again.",
       );
+      expect(buttonByText("Retry", firstCard)).toBeEnabled();
       expect(sentPrompts).toStrictEqual([]);
     });
 
-    await user.click(buttonByText("Use account and continue", secondCard));
+    await user.click(buttonByText("Retry", secondCard));
 
     await waitFor(() => {
       expect(updateCount).toBe(2);
       expect(sentPrompts).toStrictEqual(["Continue"]);
       for (const card of cards) {
         expect(card).not.toHaveTextContent(
-          "Couldn't confirm this account or continue the chat. Try again.",
+          "Couldn't switch accounts. Try again.",
         );
-        expect(card).toHaveTextContent("Continuation requested");
+        expect(card).toHaveTextContent("Switched to Work");
+        expect(queryAllByRoleFast("button", card)).toStrictEqual([]);
       }
     });
   });
@@ -1020,7 +1019,7 @@ describe("chat event action cards", () => {
       undefined,
       { timeout: 10_000 },
     );
-    expect(card).not.toHaveTextContent("Already selected for this chat");
+    expect(card).not.toHaveTextContent("Switched to Work");
     await waitFor(() => {
       expect(
         hasSubscription(`chatThreadDetailChanged:${threadId}`),
@@ -1032,7 +1031,8 @@ describe("chat event action cards", () => {
     triggerAblyEvent(`chatThreadDetailChanged:${threadId}`);
 
     await waitFor(() => {
-      expect(card).toHaveTextContent("Already selected for this chat");
+      expect(card).toHaveTextContent("Switched to Work");
+      expect(queryAllByRoleFast("button", card)).toStrictEqual([]);
     });
   });
 
@@ -1103,7 +1103,7 @@ describe("chat event action cards", () => {
       undefined,
       { timeout: 10_000 },
     );
-    expect(card).toHaveTextContent("Use Realtime account for future runs?");
+    expect(card).toHaveTextContent("Switch to Realtime account?");
   });
 
   it("renders an unconnected banking request with the compact action card layout", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
@@ -48,7 +48,7 @@ import {
 } from "@okouai/api-contracts/contracts/user-permission-grants";
 import { UNKNOWN_PERMISSION_GRANT } from "@okouai/connectors/firewall-contracts";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import { screen, waitFor, within } from "@testing-library/react";
+import { act, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse } from "msw";
 import { describe, expect, it, vi } from "vitest";
@@ -454,7 +454,6 @@ function selectMailText(element: HTMLElement): void {
 
 describe("chat event action cards", () => {
   it("switches the thread account before continuing from repeated cards", async () => {
-    const user = userEvent.setup({ delay: null });
     const threadId = "e4000000-0000-4000-a000-000000000021";
     const account = connectorAccount();
     mockConnectorAccountActionAuthorization(account.target);
@@ -541,10 +540,14 @@ describe("chat event action cards", () => {
     }
 
     const firstCard = cards[0];
-    if (!firstCard) {
-      throw new Error("Expected the first connector account action card");
+    const secondCard = cards[1];
+    if (!firstCard || !secondCard) {
+      throw new Error("Expected repeated connector account action cards");
     }
-    await user.click(buttonByText("Use account and continue", firstCard));
+    act(() => {
+      buttonByText("Use account and continue", firstCard).click();
+      buttonByText("Use account and continue", secondCard).click();
+    });
 
     await waitFor(() => {
       expect(actionOrder).toStrictEqual(["selection"]);
@@ -752,6 +755,138 @@ describe("chat event action cards", () => {
     expect(accountReadCount).toBe(0);
     expect(updateCount).toBe(0);
     expect(sentPrompts).toStrictEqual([]);
+  });
+
+  it("renders a feature-disabled account switch as unavailable", async () => {
+    const threadId = "e4000000-0000-4000-a000-000000000029";
+    const account = connectorAccount({
+      id: "a1000000-0000-4000-a000-000000000029",
+    });
+    let accountReadCount = 0;
+    mockConnectorAccountActionAuthorization(account.target);
+    context.mocks.api(connectorAccountsContract.connection, ({ respond }) => {
+      accountReadCount += 1;
+      return respond(200, account);
+    });
+    context.mocks.api(
+      chatThreadConnectorSelectionContract.get,
+      ({ respond }) => {
+        return respond(200, { selections: [], selectedConnections: [] });
+      },
+    );
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Feature-disabled connector account",
+      chatEvents: [
+        {
+          id: `${threadId}-message`,
+          role: "assistant",
+          content: connectorAccountActionUrl(threadId, account, "Continue"),
+          runId: `${threadId}-run`,
+          createdAt: "2026-08-31T10:00:00.000Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: false },
+    });
+
+    const card = await screen.findByTestId(
+      "connector-account-action-card-unavailable",
+      undefined,
+      { timeout: 10_000 },
+    );
+    expect(card).toHaveTextContent("Account unavailable");
+    expect(queryAllByRoleFast("button", card)).toStrictEqual([]);
+    expect(accountReadCount).toBe(0);
+  });
+
+  it("retries a failed account read and shows reconnect status", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "e4000000-0000-4000-a000-000000000030";
+    const account = connectorAccount({
+      id: "a1000000-0000-4000-a000-000000000030",
+      connectionStatus: "reconnect-required",
+      reconnectReason: "authorization_expired_or_revoked",
+    });
+    let accountReadCount = 0;
+    let accountReadStarted = false;
+    let releaseAccountRead = (): void => {
+      throw new Error("Account read did not start");
+    };
+    mockConnectorAccountActionAuthorization(account.target);
+    context.mocks.api(
+      connectorAccountsContract.connection,
+      async ({ deferred, respond }) => {
+        accountReadCount += 1;
+        if (accountReadCount === 1) {
+          const accountRead = deferred<void>();
+          releaseAccountRead = () => {
+            accountRead.resolve();
+          };
+          accountReadStarted = true;
+          await accountRead.promise;
+          return respond(500, {
+            error: {
+              code: "INTERNAL_SERVER_ERROR",
+              message: "Connector account read failed",
+            },
+          });
+        }
+        return respond(200, account);
+      },
+    );
+    context.mocks.api(
+      chatThreadConnectorSelectionContract.get,
+      ({ respond }) => {
+        return respond(200, { selections: [], selectedConnections: [] });
+      },
+    );
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Reconnect connector account",
+      chatEvents: [
+        {
+          id: `${threadId}-message`,
+          role: "assistant",
+          content: connectorAccountActionUrl(threadId, account, "Continue"),
+          runId: `${threadId}-run`,
+          createdAt: "2026-08-31T10:00:00.000Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    await expect(
+      screen.findByTestId("connector-account-action-card-loading"),
+    ).resolves.toBeInTheDocument();
+    await waitFor(() => {
+      expect(accountReadStarted).toBeTruthy();
+    });
+    releaseAccountRead();
+
+    const errorCard = await screen.findByTestId(
+      "connector-account-action-card-error",
+    );
+    expect(errorCard).toHaveTextContent(
+      "Couldn't load this connector account.",
+    );
+    await user.click(buttonByText("Retry", errorCard));
+
+    const card = await screen.findByTestId("connector-account-action-card");
+    expect(accountReadCount).toBe(2);
+    expect(card).toHaveTextContent("Use Work for future runs?");
+    expect(card).toHaveTextContent(
+      "Reconnect required. Later runs may use the existing fallback.",
+    );
   });
 
   it("retries a rejected selection from another repeated card", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
@@ -578,6 +578,7 @@ describe("chat event action cards", () => {
       target: account.target,
     } satisfies ConnectorAccountSelection;
     const callbackPrompt = "Continue the original task";
+    const actionUrl = `${window.location.origin}/agents/${AGENT_ID.toUpperCase()}/connector-accounts/${account.id.toUpperCase()}/select?kind=custom&customConnectorId=${customConnectorId.toUpperCase()}&threadId=${threadId.toUpperCase()}&callbackPrompt=${encodeURIComponent(callbackPrompt)}`;
     let updateCount = 0;
     const sentPrompts: string[] = [];
 
@@ -611,7 +612,7 @@ describe("chat event action cards", () => {
         {
           id: `${threadId}-message`,
           role: "assistant",
-          content: connectorAccountActionUrl(threadId, account, callbackPrompt),
+          content: actionUrl,
           runId: `${threadId}-run`,
           createdAt: "2026-08-31T10:00:00.000Z",
         },

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
@@ -1,11 +1,19 @@
 import type { ConnectorResponse } from "@okouai/api-contracts/contracts/connector-schemas";
 import {
+  connectorAccountsContract,
+  type ConnectorAccountConnection,
+  type ConnectorAccountSelection,
+} from "@okouai/api-contracts/contracts/connector-accounts";
+import {
   bankingUserContract,
   type BankingAccessRequestStatusResponse,
   type BankingAgentGrantRequest,
   type BankingConnectSessionRequest,
 } from "@okouai/api-contracts/contracts/banking";
-import { chatThreadEventsContract } from "@okouai/api-contracts/contracts/chat-threads";
+import {
+  chatThreadConnectorSelectionContract,
+  chatThreadEventsContract,
+} from "@okouai/api-contracts/contracts/chat-threads";
 import {
   connectorManualGrantContract,
   connectorNoAuthGrantContract,
@@ -62,6 +70,46 @@ const context = testContext();
 
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 const THREAD_ID = "e4000000-0000-4000-a000-000000000001";
+
+function connectorAccount(
+  overrides: Partial<ConnectorAccountConnection> = {},
+): ConnectorAccountConnection {
+  return {
+    id: "a1000000-0000-4000-a000-000000000001",
+    target: { kind: "builtin", connectorSlug: "github" },
+    authMethod: "oauth",
+    displayName: "Work",
+    isDefault: false,
+    externalId: null,
+    externalUsername: "octocat",
+    externalEmail: "work@example.com",
+    oauthScopes: ["repo"],
+    connectionStatus: "connected",
+    reconnectReason: null,
+    tokenExpiresAt: null,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-02T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function connectorAccountActionUrl(
+  threadId: string,
+  account: ConnectorAccountConnection,
+  callbackPrompt: string,
+): string {
+  const params = new URLSearchParams({
+    kind: account.target.kind,
+    threadId,
+    callbackPrompt,
+  });
+  if (account.target.kind === "builtin") {
+    params.set("connectorSlug", account.target.connectorSlug);
+  } else {
+    params.set("customConnectorId", account.target.customConnectorId);
+  }
+  return `${window.location.origin}/agents/${AGENT_ID}/connector-accounts/${account.id}/select?${params.toString()}`;
+}
 
 function catalogPermissionDetail(
   overrides: Partial<PublicConnectorCatalogPermissionDetail> &
@@ -376,6 +424,342 @@ function selectMailText(element: HTMLElement): void {
 }
 
 describe("chat event action cards", () => {
+  it("switches the thread account before continuing from repeated cards", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "e4000000-0000-4000-a000-000000000021";
+    const account = connectorAccount();
+    const callbackPrompt = "Continue with the selected GitHub account";
+    const actionUrl = connectorAccountActionUrl(
+      threadId,
+      account,
+      callbackPrompt,
+    );
+    let selections: ConnectorAccountSelection[] = [];
+    let selectedConnections: ConnectorAccountConnection[] = [];
+    let updateBody: ConnectorAccountSelection | null = null;
+    const actionOrder: string[] = [];
+
+    context.mocks.api(
+      connectorAccountsContract.connection,
+      ({ params, query, respond }) => {
+        expect(params.connectionId).toBe(account.id);
+        expect(query).toStrictEqual(account.target);
+        return respond(200, account);
+      },
+    );
+    context.mocks.api(
+      chatThreadConnectorSelectionContract.get,
+      ({ params, respond }) => {
+        expect(params.id).toBe(threadId);
+        return respond(200, { selections, selectedConnections });
+      },
+    );
+    context.mocks.api(
+      chatThreadConnectorSelectionContract.update,
+      ({ params, body, respond }) => {
+        expect(params.id).toBe(threadId);
+        actionOrder.push("selection");
+        updateBody = body;
+        selections = [body];
+        selectedConnections = [account];
+        return respond(200, body);
+      },
+    );
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Connector account switch",
+      chatEvents: [
+        {
+          id: `${threadId}-message`,
+          role: "assistant",
+          content: `${actionUrl}\n\n${actionUrl}`,
+          runId: `${threadId}-run`,
+          createdAt: "2026-08-31T10:00:00.000Z",
+        },
+      ],
+      onSendRequest: ({ prompt }) => {
+        actionOrder.push("callback");
+        expect(prompt).toBe(callbackPrompt);
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    const cards = await screen.findAllByTestId(
+      "connector-account-action-card",
+      undefined,
+      { timeout: 10_000 },
+    );
+    expect(cards).toHaveLength(2);
+    for (const card of cards) {
+      expect(card).toHaveTextContent("Use Work for future runs?");
+      expect(card).toHaveTextContent("github · work@example.com");
+      expect(card).toHaveTextContent("The current run will not change.");
+    }
+
+    const firstCard = cards[0];
+    if (!firstCard) {
+      throw new Error("Expected the first connector account action card");
+    }
+    await user.click(buttonByText("Use account and continue", firstCard));
+
+    await waitFor(() => {
+      expect(updateBody).toStrictEqual({
+        connectionId: account.id,
+        target: account.target,
+      });
+      expect(actionOrder).toStrictEqual(["selection", "callback"]);
+      for (const card of cards) {
+        expect(card).toHaveTextContent("Already selected for this chat");
+      }
+    });
+  });
+
+  it("continues after idempotently writing an already-selected account", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "e4000000-0000-4000-a000-000000000022";
+    const account = connectorAccount({
+      id: "a1000000-0000-4000-a000-000000000022",
+    });
+    const selection = {
+      connectionId: account.id,
+      target: account.target,
+    } satisfies ConnectorAccountSelection;
+    const callbackPrompt = "Continue the original task";
+    let updateCount = 0;
+    const sentPrompts: string[] = [];
+
+    context.mocks.api(connectorAccountsContract.connection, ({ respond }) => {
+      return respond(200, account);
+    });
+    context.mocks.api(
+      chatThreadConnectorSelectionContract.get,
+      ({ respond }) => {
+        return respond(200, {
+          selections: [selection],
+          selectedConnections: [account],
+        });
+      },
+    );
+    context.mocks.api(
+      chatThreadConnectorSelectionContract.update,
+      ({ body, respond }) => {
+        updateCount += 1;
+        return respond(200, body);
+      },
+    );
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Selected connector account",
+      chatEvents: [
+        {
+          id: `${threadId}-message`,
+          role: "assistant",
+          content: connectorAccountActionUrl(threadId, account, callbackPrompt),
+          runId: `${threadId}-run`,
+          createdAt: "2026-08-31T10:00:00.000Z",
+        },
+      ],
+      onSendRequest: ({ prompt }) => {
+        sentPrompts.push(prompt);
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    const card = await screen.findByTestId(
+      "connector-account-action-card",
+      undefined,
+      { timeout: 10_000 },
+    );
+    expect(card).toHaveTextContent("Already selected for this chat");
+    await user.click(buttonByText("Continue with this account", card));
+
+    await waitFor(() => {
+      expect(updateCount).toBe(1);
+      expect(sentPrompts).toStrictEqual([callbackPrompt]);
+      expect(card).toHaveTextContent("Continuation requested");
+    });
+  });
+
+  it("renders a hallucinated or cross-target account as unavailable", async () => {
+    const threadId = "e4000000-0000-4000-a000-000000000023";
+    const account = connectorAccount({
+      id: "a1000000-0000-4000-a000-000000000023",
+    });
+    context.mocks.api(connectorAccountsContract.connection, ({ respond }) => {
+      return respond(404, {
+        error: {
+          code: "NOT_FOUND",
+          message: "Connector account not found",
+        },
+      });
+    });
+    context.mocks.api(
+      chatThreadConnectorSelectionContract.get,
+      ({ respond }) => {
+        return respond(200, { selections: [], selectedConnections: [] });
+      },
+    );
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Unavailable connector account",
+      chatEvents: [
+        {
+          id: `${threadId}-message`,
+          role: "assistant",
+          content: connectorAccountActionUrl(threadId, account, "Continue"),
+          runId: `${threadId}-run`,
+          createdAt: "2026-08-31T10:00:00.000Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    const card = await screen.findByTestId(
+      "connector-account-action-card-unavailable",
+      undefined,
+      { timeout: 10_000 },
+    );
+    expect(card).toHaveTextContent("Account unavailable");
+    expect(queryAllByRoleFast("button", card)).toStrictEqual([]);
+  });
+
+  it("does not continue when a stale account selection is rejected", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "e4000000-0000-4000-a000-000000000024";
+    const account = connectorAccount({
+      id: "a1000000-0000-4000-a000-000000000024",
+    });
+    const sentPrompts: string[] = [];
+    context.mocks.api(connectorAccountsContract.connection, ({ respond }) => {
+      return respond(200, account);
+    });
+    context.mocks.api(
+      chatThreadConnectorSelectionContract.get,
+      ({ respond }) => {
+        return respond(200, { selections: [], selectedConnections: [] });
+      },
+    );
+    context.mocks.api(
+      chatThreadConnectorSelectionContract.update,
+      ({ respond }) => {
+        return respond(400, {
+          error: {
+            code: "BAD_REQUEST",
+            message: "Connector account selection is no longer valid",
+          },
+        });
+      },
+    );
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Stale connector account",
+      chatEvents: [
+        {
+          id: `${threadId}-message`,
+          role: "assistant",
+          content: connectorAccountActionUrl(threadId, account, "Continue"),
+          runId: `${threadId}-run`,
+          createdAt: "2026-08-31T10:00:00.000Z",
+        },
+      ],
+      onSendRequest: ({ prompt }) => {
+        sentPrompts.push(prompt);
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    const card = await screen.findByTestId(
+      "connector-account-action-card",
+      undefined,
+      { timeout: 10_000 },
+    );
+    await user.click(buttonByText("Use account and continue", card));
+
+    await waitFor(() => {
+      expect(card).toHaveTextContent(
+        "Couldn't confirm this account or continue the chat. Try again.",
+      );
+      expect(sentPrompts).toStrictEqual([]);
+    });
+  });
+
+  it("refreshes a mounted account card after a thread-detail change", async () => {
+    const threadId = "e4000000-0000-4000-a000-000000000025";
+    const account = connectorAccount({
+      id: "a1000000-0000-4000-a000-000000000025",
+    });
+    let selections: ConnectorAccountSelection[] = [];
+    let selectedConnections: ConnectorAccountConnection[] = [];
+    context.mocks.api(connectorAccountsContract.connection, ({ respond }) => {
+      return respond(200, account);
+    });
+    context.mocks.api(
+      chatThreadConnectorSelectionContract.get,
+      ({ respond }) => {
+        return respond(200, { selections, selectedConnections });
+      },
+    );
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Realtime connector account",
+      chatEvents: [
+        {
+          id: `${threadId}-message`,
+          role: "assistant",
+          content: connectorAccountActionUrl(threadId, account, "Continue"),
+          runId: `${threadId}-run`,
+          createdAt: "2026-08-31T10:00:00.000Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    const card = await screen.findByTestId(
+      "connector-account-action-card",
+      undefined,
+      { timeout: 10_000 },
+    );
+    expect(card).not.toHaveTextContent("Already selected for this chat");
+    await waitFor(() => {
+      expect(
+        hasSubscription(`chatThreadDetailChanged:${threadId}`),
+      ).toBeTruthy();
+    });
+
+    selections = [{ connectionId: account.id, target: account.target }];
+    selectedConnections = [account];
+    triggerAblyEvent(`chatThreadDetailChanged:${threadId}`);
+
+    await waitFor(() => {
+      expect(card).toHaveTextContent("Already selected for this chat");
+    });
+  });
+
   it("renders an unconnected banking request with the compact action card layout", async () => {
     const threadId = "e4000000-0000-4000-a000-000000000005";
     const reason = "Review recent expenses";

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
@@ -537,6 +537,14 @@ describe("chat event action cards", () => {
       expect(card).toHaveTextContent("Switch to Work?");
       expect(card).toHaveTextContent("github · work@example.com");
       expect(card).not.toHaveTextContent("The current run will not change.");
+      const icon = card.querySelector("img");
+      if (!(icon instanceof HTMLImageElement)) {
+        throw new Error("GitHub connector icon not found");
+      }
+      expect(icon).toHaveAttribute(
+        "src",
+        "https://icons.example.test/github.svg",
+      );
     }
 
     const firstCard = cards[0];
@@ -587,6 +595,17 @@ describe("chat event action cards", () => {
     let updateCount = 0;
     const sentPrompts: string[] = [];
 
+    context.mocks.api(customConnectorsContract.list, ({ respond }) => {
+      return respond(200, {
+        connectors: [
+          customConnector({
+            id: customConnectorId,
+            slug: "_acme-search",
+            displayName: "Acme Search",
+          }),
+        ],
+      });
+    });
     context.mocks.api(
       connectorAccountsContract.connection,
       ({ query, respond }) => {
@@ -642,6 +661,8 @@ describe("chat event action cards", () => {
     expect(card).toHaveTextContent(
       `Custom connector · ${customConnectorId.slice(0, 8)} · work@example.com`,
     );
+    const icon = card.querySelector('[aria-label="Acme Search"]');
+    expect(icon).toHaveTextContent("A");
     expect(queryAllByRoleFast("button", card)).toStrictEqual([]);
     expect(updateCount).toBe(0);
     expect(sentPrompts).toStrictEqual([]);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
@@ -894,6 +894,8 @@ describe("chat event action cards", () => {
     });
     mockConnectorAccountActionAuthorization(account.target);
     const sentPrompts: string[] = [];
+    let selections: ConnectorAccountSelection[] = [];
+    let selectedConnections: ConnectorAccountConnection[] = [];
     let updateCount = 0;
     context.mocks.api(connectorAccountsContract.connection, ({ respond }) => {
       return respond(200, account);
@@ -901,21 +903,24 @@ describe("chat event action cards", () => {
     context.mocks.api(
       chatThreadConnectorSelectionContract.get,
       ({ respond }) => {
-        return respond(200, { selections: [], selectedConnections: [] });
+        return respond(200, { selections, selectedConnections });
       },
     );
     context.mocks.api(
       chatThreadConnectorSelectionContract.update,
       ({ body, respond }) => {
         updateCount += 1;
-        return updateCount === 1
-          ? respond(400, {
-              error: {
-                code: "BAD_REQUEST",
-                message: "Connector account selection is no longer valid",
-              },
-            })
-          : respond(200, body);
+        if (updateCount === 1) {
+          return respond(400, {
+            error: {
+              code: "BAD_REQUEST",
+              message: "Connector account selection is no longer valid",
+            },
+          });
+        }
+        selections = [body];
+        selectedConnections = [account];
+        return respond(200, body);
       },
     );
     mockChatLifecycle(context, {
@@ -1033,6 +1038,15 @@ describe("chat event action cards", () => {
     await waitFor(() => {
       expect(card).toHaveTextContent("Switched to Work");
       expect(queryAllByRoleFast("button", card)).toStrictEqual([]);
+    });
+
+    selections = [];
+    selectedConnections = [];
+    triggerAblyEvent(`chatThreadDetailChanged:${threadId}`);
+
+    await waitFor(() => {
+      expect(card).toHaveTextContent("Switch to Work?");
+      expect(buttonByText("Switch", card)).toBeEnabled();
     });
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
@@ -434,6 +434,7 @@ describe("chat event action cards", () => {
       account,
       callbackPrompt,
     );
+    const equivalentActionUrl = `${window.location.origin}/agents/${AGENT_ID.toUpperCase()}/connector-accounts/${account.id.toUpperCase()}/select?callbackPrompt=${encodeURIComponent(callbackPrompt)}&threadId=${threadId.toUpperCase()}&connectorSlug=github&kind=builtin&presentation=ignored`;
     let selections: ConnectorAccountSelection[] = [];
     let selectedConnections: ConnectorAccountConnection[] = [];
     let updateBody: ConnectorAccountSelection | null = null;
@@ -480,7 +481,7 @@ describe("chat event action cards", () => {
         {
           id: `${threadId}-message`,
           role: "assistant",
-          content: `${actionUrl}\n\n${actionUrl}`,
+          content: `${actionUrl}\n\n${equivalentActionUrl}`,
           runId: `${threadId}-run`,
           createdAt: "2026-08-31T10:00:00.000Z",
         },

--- a/turbo/apps/platform/src/views/okou-page/chat-body-cards.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-body-cards.tsx
@@ -71,6 +71,7 @@ import {
 } from "../../signals/okou-page/attachment-chips.ts";
 import { BrowserSessionCard } from "./browser-session-card.tsx";
 import { BankingActionCard } from "./banking-action-card.tsx";
+import { ConnectorAccountActionCard } from "./connector-account-action-card.tsx";
 import { MailDraftCard } from "./mail-draft-card.tsx";
 
 type ChatImagePreviewLinkProps = {
@@ -285,6 +286,9 @@ export function MarkdownCardView({ card }: { card: MarkdownCardRef }) {
     }
     case "connector-action": {
       return <ConnectorActionCard signals={card.signals} />;
+    }
+    case "connector-account-action": {
+      return <ConnectorAccountActionCard signals={card.signals} />;
     }
     case "permission-action": {
       return <PermissionActionCard signals={card.signals} />;

--- a/turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx
@@ -191,7 +191,8 @@ function ReadyConnectorAccountActionCard({
               })}
             </div>
           ) : null}
-          {confirmLoadable.state === "hasError" ? (
+          {confirmationState === "idle" &&
+          confirmLoadable.state === "hasError" ? (
             <div className="mt-1 text-xs text-destructive">
               {t(($) => {
                 return $.chat.connectorAccountSwitch.actionFailed;

--- a/turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx
@@ -137,7 +137,7 @@ function ReadyConnectorAccountActionCard({
   const pageSignal = useGet(pageSignal$);
   const confirmationState = useGet(signals.confirmationState$);
   const [, confirm] = useLoadableSet(signals.confirm$);
-  const selected = status.selected || confirmationState === "switched";
+  const selected = status.selected;
   const switching = confirmationState === "loading";
   const switchFailed = confirmationState === "error" && !selected;
   const accountLabel = connectorAccountEffectiveLabel(

--- a/turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx
@@ -138,6 +138,7 @@ function ReadyConnectorAccountActionCard({
   const { t } = useTranslation();
   const pageSignal = useGet(pageSignal$);
   const confirmationState = useGet(signals.confirmationState$);
+  const connectorLoadable = useLastLoadable(signals.connector$);
   const [, confirm] = useLoadableSet(signals.confirm$);
   const selected = status.selected;
   const switching = confirmationState === "loading";
@@ -153,13 +154,18 @@ function ReadyConnectorAccountActionCard({
     return $.chat.connectorAccountSwitch.customConnector;
   });
   const target = accountTargetLabel(status.account, customConnectorLabel);
+  const connector =
+    connectorLoadable.state === "hasData" ? connectorLoadable.data : null;
   const connectorIcon =
-    status.connector.kind === "builtin" ? (
-      <ConnectorIcon icon={status.connector.icon} size={22} />
-    ) : (
+    connector?.kind === "custom" ? (
       <CustomConnectorIcon
-        id={status.connector.id}
-        displayName={status.connector.displayName ?? customConnectorLabel}
+        id={connector.id}
+        displayName={connector.displayName ?? customConnectorLabel}
+        size={22}
+      />
+    ) : (
+      <ConnectorIcon
+        icon={connector?.kind === "builtin" ? connector.icon : undefined}
         size={22}
       />
     );

--- a/turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx
@@ -135,9 +135,10 @@ function ReadyConnectorAccountActionCard({
 }) {
   const { t } = useTranslation();
   const pageSignal = useGet(pageSignal$);
+  const confirmationState = useGet(signals.confirmationState$);
   const [confirmLoadable, confirm] = useLoadableSet(signals.confirm$);
-  const loading = confirmLoadable.state === "loading";
-  const continued = confirmLoadable.state === "hasData";
+  const loading = confirmationState === "loading";
+  const continued = confirmationState === "continued";
   const accountLabel = connectorAccountEffectiveLabel(
     status.account,
     t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx
@@ -1,0 +1,224 @@
+import {
+  connectorAccountEffectiveLabel,
+  connectorAccountExternalIdentity,
+  type ConnectorAccountConnection,
+} from "@okouai/api-contracts/contracts/connector-accounts";
+import { Button } from "@okouai/ui";
+import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
+import { AlertCircle, Check, CircleUserRound, Loader2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import type {
+  ConnectorAccountActionSignals,
+  ConnectorAccountActionStatus,
+} from "../../signals/chat-page/connector-account-action-block.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+
+export function ConnectorAccountActionCard({
+  signals,
+}: {
+  readonly signals: ConnectorAccountActionSignals;
+}) {
+  const loadable = useLoadable(signals.status$);
+  const last = useLastLoadable(signals.status$);
+  if (loadable.state === "loading" && last.state !== "hasData") {
+    return <ConnectorAccountActionCardLoading />;
+  }
+  if (loadable.state === "hasError" && last.state !== "hasData") {
+    return <ConnectorAccountActionCardError signals={signals} />;
+  }
+  const status =
+    loadable.state === "hasData"
+      ? loadable.data
+      : last.state === "hasData"
+        ? last.data
+        : null;
+  return status ? (
+    <LoadedConnectorAccountActionCard signals={signals} status={status} />
+  ) : null;
+}
+
+function ConnectorAccountActionCardLoading() {
+  return (
+    <div
+      data-testid="connector-account-action-card-loading"
+      className="flex min-h-[104px] w-full items-center justify-center rounded-lg border border-border/70 bg-background/85 p-3 shadow-sm"
+    >
+      <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+    </div>
+  );
+}
+
+function ConnectorAccountActionCardError({
+  signals,
+}: {
+  readonly signals: ConnectorAccountActionSignals;
+}) {
+  const refresh = useSet(signals.refresh$);
+  const { t } = useTranslation();
+  return (
+    <div
+      data-testid="connector-account-action-card-error"
+      className="flex min-h-[104px] w-full items-center gap-3 rounded-lg border border-border/70 bg-background/85 p-3 shadow-sm"
+    >
+      <AlertCircle className="h-5 w-5 shrink-0 text-destructive" />
+      <div className="min-w-0 flex-1 text-sm text-muted-foreground">
+        {t(($) => {
+          return $.chat.connectorAccountSwitch.loadFailed;
+        })}
+      </div>
+      <Button size="sm" variant="outline" onClick={refresh}>
+        {t(($) => {
+          return $.chat.connectorAccountSwitch.retry;
+        })}
+      </Button>
+    </div>
+  );
+}
+
+function LoadedConnectorAccountActionCard({
+  signals,
+  status,
+}: {
+  readonly signals: ConnectorAccountActionSignals;
+  readonly status: ConnectorAccountActionStatus;
+}) {
+  if (status.kind === "unavailable") {
+    return <UnavailableConnectorAccountActionCard />;
+  }
+  return <ReadyConnectorAccountActionCard signals={signals} status={status} />;
+}
+
+function UnavailableConnectorAccountActionCard() {
+  const { t } = useTranslation();
+  return (
+    <div
+      data-testid="connector-account-action-card-unavailable"
+      className="flex min-h-[104px] w-full items-center gap-3 rounded-lg border border-border/70 bg-background/85 p-3 shadow-sm"
+    >
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40 text-muted-foreground">
+        <AlertCircle size={22} />
+      </div>
+      <div className="min-w-0">
+        <div className="text-[0.9375rem] font-medium text-foreground">
+          {t(($) => {
+            return $.chat.connectorAccountSwitch.unavailableTitle;
+          })}
+        </div>
+        <div className="mt-0.5 text-sm leading-5 text-muted-foreground">
+          {t(($) => {
+            return $.chat.connectorAccountSwitch.unavailableDescription;
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function accountTargetLabel(
+  account: ConnectorAccountConnection,
+  customConnectorLabel: string,
+): string {
+  return account.target.kind === "builtin"
+    ? account.target.connectorSlug
+    : `${customConnectorLabel} · ${account.target.customConnectorId.slice(0, 8)}`;
+}
+
+function ReadyConnectorAccountActionCard({
+  signals,
+  status,
+}: {
+  readonly signals: ConnectorAccountActionSignals;
+  readonly status: Extract<ConnectorAccountActionStatus, { kind: "ready" }>;
+}) {
+  const { t } = useTranslation();
+  const pageSignal = useGet(pageSignal$);
+  const [confirmLoadable, confirm] = useLoadableSet(signals.confirm$);
+  const loading = confirmLoadable.state === "loading";
+  const continued = confirmLoadable.state === "hasData";
+  const accountLabel = connectorAccountEffectiveLabel(
+    status.account,
+    t(($) => {
+      return $.chat.connectorAccountSwitch.accountFallback;
+    }),
+  );
+  const identity = connectorAccountExternalIdentity(status.account);
+  const customConnectorLabel = t(($) => {
+    return $.chat.connectorAccountSwitch.customConnector;
+  });
+  const target = accountTargetLabel(status.account, customConnectorLabel);
+
+  return (
+    <div
+      data-testid="connector-account-action-card"
+      className="w-full rounded-lg border border-border/70 bg-background/85 p-3 text-left shadow-sm"
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40 text-muted-foreground">
+          <CircleUserRound size={22} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-[0.9375rem] font-medium text-foreground">
+            {t(
+              ($) => {
+                return $.chat.connectorAccountSwitch.title;
+              },
+              { account: accountLabel },
+            )}
+          </div>
+          <div className="mt-0.5 truncate text-sm text-muted-foreground">
+            {[target, identity && identity !== accountLabel ? identity : null]
+              .filter(Boolean)
+              .join(" · ")}
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            {status.account.connectionStatus === "reconnect-required"
+              ? t(($) => {
+                  return $.chat.connectorAccountSwitch.reconnectRequired;
+                })
+              : t(($) => {
+                  return $.chat.connectorAccountSwitch.currentRunUnchanged;
+                })}
+          </div>
+          {status.selected ? (
+            <div className="mt-1 flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
+              <Check size={13} />
+              {t(($) => {
+                return $.chat.connectorAccountSwitch.selected;
+              })}
+            </div>
+          ) : null}
+          {confirmLoadable.state === "hasError" ? (
+            <div className="mt-1 text-xs text-destructive">
+              {t(($) => {
+                return $.chat.connectorAccountSwitch.actionFailed;
+              })}
+            </div>
+          ) : null}
+        </div>
+        <Button
+          size="sm"
+          disabled={loading || continued}
+          onClick={() => {
+            detach(confirm(pageSignal), Reason.DomCallback);
+          }}
+        >
+          {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+          {continued
+            ? t(($) => {
+                return $.chat.connectorAccountSwitch.continued;
+              })
+            : status.selected
+              ? t(($) => {
+                  return $.chat.connectorAccountSwitch.continueWithAccount;
+                })
+              : t(($) => {
+                  return $.chat.connectorAccountSwitch.useAndContinue;
+                })}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx
@@ -6,7 +6,7 @@ import {
 import { Button } from "@okouai/ui";
 import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import { AlertCircle, Check, CircleUserRound, Loader2 } from "lucide-react";
+import { AlertCircle, Check, Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import type {
@@ -15,6 +15,8 @@ import type {
 } from "../../signals/chat-page/connector-account-action-block.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
+import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
+import { CustomConnectorIcon } from "./components/settings/custom-connector-icon.tsx";
 
 export function ConnectorAccountActionCard({
   signals,
@@ -151,6 +153,16 @@ function ReadyConnectorAccountActionCard({
     return $.chat.connectorAccountSwitch.customConnector;
   });
   const target = accountTargetLabel(status.account, customConnectorLabel);
+  const connectorIcon =
+    status.connector.kind === "builtin" ? (
+      <ConnectorIcon icon={status.connector.icon} size={22} />
+    ) : (
+      <CustomConnectorIcon
+        id={status.connector.id}
+        displayName={status.connector.displayName ?? customConnectorLabel}
+        size={22}
+      />
+    );
 
   return (
     <div
@@ -159,7 +171,7 @@ function ReadyConnectorAccountActionCard({
     >
       <div className="flex items-start gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40 text-muted-foreground">
-          <CircleUserRound size={22} />
+          {connectorIcon}
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5 truncate text-[0.9375rem] font-medium text-foreground">

--- a/turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx
@@ -136,9 +136,10 @@ function ReadyConnectorAccountActionCard({
   const { t } = useTranslation();
   const pageSignal = useGet(pageSignal$);
   const confirmationState = useGet(signals.confirmationState$);
-  const [confirmLoadable, confirm] = useLoadableSet(signals.confirm$);
-  const loading = confirmationState === "loading";
-  const continued = confirmationState === "continued";
+  const [, confirm] = useLoadableSet(signals.confirm$);
+  const selected = status.selected || confirmationState === "switched";
+  const switching = confirmationState === "loading";
+  const switchFailed = confirmationState === "error" && !selected;
   const accountLabel = connectorAccountEffectiveLabel(
     status.account,
     t(($) => {
@@ -161,38 +162,40 @@ function ReadyConnectorAccountActionCard({
           <CircleUserRound size={22} />
         </div>
         <div className="min-w-0 flex-1">
-          <div className="truncate text-[0.9375rem] font-medium text-foreground">
-            {t(
-              ($) => {
-                return $.chat.connectorAccountSwitch.title;
-              },
-              { account: accountLabel },
-            )}
+          <div className="flex items-center gap-1.5 truncate text-[0.9375rem] font-medium text-foreground">
+            {selected ? (
+              <Check
+                size={15}
+                className="shrink-0 text-emerald-600 dark:text-emerald-400"
+              />
+            ) : null}
+            {selected
+              ? t(
+                  ($) => {
+                    return $.chat.connectorAccountSwitch.selected;
+                  },
+                  { account: accountLabel },
+                )
+              : t(
+                  ($) => {
+                    return $.chat.connectorAccountSwitch.title;
+                  },
+                  { account: accountLabel },
+                )}
           </div>
           <div className="mt-0.5 truncate text-sm text-muted-foreground">
             {[target, identity && identity !== accountLabel ? identity : null]
               .filter(Boolean)
               .join(" · ")}
           </div>
-          <div className="mt-1 text-xs text-muted-foreground">
-            {status.account.connectionStatus === "reconnect-required"
-              ? t(($) => {
-                  return $.chat.connectorAccountSwitch.reconnectRequired;
-                })
-              : t(($) => {
-                  return $.chat.connectorAccountSwitch.currentRunUnchanged;
-                })}
-          </div>
-          {status.selected ? (
-            <div className="mt-1 flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
-              <Check size={13} />
+          {status.account.connectionStatus === "reconnect-required" ? (
+            <div className="mt-1 text-xs text-muted-foreground">
               {t(($) => {
-                return $.chat.connectorAccountSwitch.selected;
+                return $.chat.connectorAccountSwitch.reconnectRequired;
               })}
             </div>
           ) : null}
-          {confirmationState === "idle" &&
-          confirmLoadable.state === "hasError" ? (
+          {switchFailed ? (
             <div className="mt-1 text-xs text-destructive">
               {t(($) => {
                 return $.chat.connectorAccountSwitch.actionFailed;
@@ -200,26 +203,30 @@ function ReadyConnectorAccountActionCard({
             </div>
           ) : null}
         </div>
-        <Button
-          size="sm"
-          disabled={loading || continued}
-          onClick={() => {
-            detach(confirm(pageSignal), Reason.DomCallback);
-          }}
-        >
-          {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-          {continued
-            ? t(($) => {
-                return $.chat.connectorAccountSwitch.continued;
-              })
-            : status.selected
+        {selected ? null : (
+          <Button
+            size="sm"
+            disabled={switching}
+            onClick={() => {
+              detach(confirm(pageSignal), Reason.DomCallback);
+            }}
+          >
+            {switching ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : null}
+            {switching
               ? t(($) => {
-                  return $.chat.connectorAccountSwitch.continueWithAccount;
+                  return $.chat.connectorAccountSwitch.switching;
                 })
-              : t(($) => {
-                  return $.chat.connectorAccountSwitch.useAndContinue;
-                })}
-        </Button>
+              : switchFailed
+                ? t(($) => {
+                    return $.chat.connectorAccountSwitch.retry;
+                  })
+                : t(($) => {
+                    return $.chat.connectorAccountSwitch.switch;
+                  })}
+          </Button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- add `okou connector account switch-request` to validate one exact, agent-authorized account and emit a callback-bound chat action
- render the action as a typed card backed by live account metadata, current agent authorization, shared thread preference state, and the connector's catalog or custom-connector icon
- show `Switch`, `Switching...`, shared retryable failure, or `Switched to <account>` directly from the action and current thread selection state
- write the sparse thread connector-account override before starting the callback round
- gate agent guidance behind `ConnectorAccounts` and document the card trust and deployment model

## Safety and compatibility

- malformed, missing, cross-owner, wrong-target, and agent-unauthorized account references fail closed
- the account and target authorization are resolved before the CLI emits the action, checked again when the card loads, and authoritatively revalidated by the existing selection endpoint at confirmation time
- connector icons come from current authenticated catalog or custom-connector metadata rather than assistant-authored URL claims
- icon presentation metadata loads independently; a failure keeps the switch available and uses the standard connector fallback icon
- nonexistent or unauthorized targets render an unavailable error card without account metadata or an actionable switch control
- a failed selection never starts the callback and exposes a shared retry state across repeated copies of the same action
- a successful selection immediately renders the persisted account as switched and then starts the callback; an already-selected account renders as switched without another action
- mounted cards continue to follow the persisted thread selection, including returning to `Switch` if another account becomes current
- the action changes neither the current run nor the global account default
- no database migration or new API contract is introduced; older frontend bundles keep the message as Markdown until refreshed

## Validation

- `cd turbo && pnpm format`
- `cd turbo && pnpm -F @okouai/cli lint`
- `cd turbo && pnpm -F @okouai/cli check-types`
- `cd turbo && pnpm -F @okouai/cli exec vitest run src/commands/connector/account/__tests__/switch-request.test.ts`
- `cd turbo && pnpm -F @okouai/app lint`
- `cd turbo && pnpm -F @okouai/app check-types`
- `cd turbo && pnpm -F @okouai/app exec vitest run src/signals/chat-page/__tests__/parse-body-blocks-cards.test.ts src/views/okou-page/__tests__/chat-event-action-cards.test.tsx`
- `cd turbo && pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-event-action-cards.test.tsx -t "switches the thread account before continuing from repeated cards|renders an already-selected account without another action|keeps an account switch available when connector icon metadata fails"`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "advertises connector account switching only while the feature is enabled"`
- `cd turbo && pnpm knip`
- `cd turbo && pnpm knip --workspace @okouai/app`
- pre-commit hook: full Turbo `check-types`, Prettier, Knip, staged file-size validation, and commitlint

Closes #30571

Parent context: #22832
