### PR TITLE
feat(platform): add chat event deep links

### DIFF
--- a/turbo/apps/platform/src/__tests__/page-helper.ts
+++ b/turbo/apps/platform/src/__tests__/page-helper.ts
@@ -18,6 +18,7 @@ import {
   mockPushState,
   mockReplaceState,
   pushState,
+  setHash,
   setPathname,
   setSearch,
 } from "../signals/location";
@@ -257,6 +258,7 @@ function createPushStateMock(signal: AbortSignal) {
   const updateLocation = (entry: HistoryEntry) => {
     setPathname(entry.url.pathname, signal);
     setSearch(entry.url.search, signal);
+    setHash(entry.url.hash, signal);
   };
 
   const fn = vi.fn<typeof window.history.pushState>(

--- a/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
@@ -20,7 +20,7 @@ import {
 } from "ccstate";
 import { animationFrame, timeout } from "signal-timers";
 import { logger } from "../log.ts";
-import { onRef, resetSignal } from "../utils.ts";
+import { onDomEventFn, onRef, resetSignal } from "../utils.ts";
 
 const L = logger("ConversationLocator");
 
@@ -37,8 +37,6 @@ const SHOW_MIN_TURNS = 8;
 const SHOW_MIN_SCREENS = 3;
 /** Fraction of the viewport that decides which turn counts as "current". */
 const CURRENT_TURN_VIEWPORT_RATIO = 0.38;
-/** Where a jump parks its target inside the viewport. */
-const JUMP_VIEWPORT_RATIO = 0.28;
 /** Wheel travel that advances the window by one tick. */
 const WHEEL_STEP_PX = 26;
 /** Follow coefficient for the preview card; below 1 it trails the cursor. */
@@ -60,6 +58,7 @@ const TICK_METRICS = {
 } as const;
 
 const GROUP_SELECTOR = '[data-role="user"], [data-role="assistant"]';
+const SCROLL_ANCHOR_SELECTOR = "[data-chat-scroll-anchor-event-id]";
 
 export type LocatorRole = keyof typeof TICK_METRICS;
 
@@ -105,7 +104,7 @@ export interface ChatConversationLocatorSignals {
   readonly preview$: Computed<LocatorPreview | null>;
   /** True while the pointer is over the rail. */
   readonly engaged$: Computed<boolean>;
-  readonly jumpToTurn$: Command<void, [number]>;
+  readonly jumpToTurn$: Command<Promise<void>, [number, AbortSignal]>;
 }
 
 function emptyLayout(): LocatorLayout {
@@ -121,6 +120,7 @@ function emptyLayout(): LocatorLayout {
 
 interface DomTurn {
   readonly element: HTMLElement;
+  readonly eventId: string;
   readonly role: LocatorRole;
   /** ISO timestamp stamped on the turn wrapper, absent on optimistic rows. */
   readonly createdAt: string | undefined;
@@ -188,8 +188,16 @@ function readTurns(container: HTMLElement): DomTurn[] {
     if (rect.height === 0) {
       continue;
     }
+    const anchor = element.matches(SCROLL_ANCHOR_SELECTOR)
+      ? element
+      : element.querySelector<HTMLElement>(SCROLL_ANCHOR_SELECTOR);
+    const eventId = anchor?.dataset.chatScrollAnchorEventId;
+    if (!eventId) {
+      continue;
+    }
     turns.push({
       element,
+      eventId,
       role: roleOf(element),
       createdAt: element.dataset.turnCreatedAt,
       top: rect.top - containerTop + scrollTop,
@@ -508,37 +516,34 @@ function createPaint(store: LocatorStore) {
 function createJump(
   store: LocatorStore,
   threadId: string,
-  scrollContainer$: Computed<HTMLElement | null>,
-  signal: AbortSignal,
+  scrollToEvent$: Command<Promise<void>, [string, AbortSignal]>,
 ) {
   const resetLandedSignal$ = resetSignal();
 
-  return command(({ get, set }, turnIndex: number) => {
-    const container = get(scrollContainer$);
-    const turn = store.turns[turnIndex];
-    if (!container || !turn) {
-      return;
-    }
-    L.debug("jump to turn", { threadId, turnIndex });
-    container.scrollTo({
-      top: Math.max(0, turn.top - container.clientHeight * JUMP_VIEWPORT_RATIO),
-      behavior: "smooth",
-    });
-    const landedSignal = set(resetLandedSignal$, signal);
-    turn.element.dataset.locatorLanded = "";
-    const clearLanded = () => {
-      delete turn.element.dataset.locatorLanded;
-    };
-    landedSignal.addEventListener("abort", clearLanded, { once: true });
-    timeout(
-      () => {
-        landedSignal.removeEventListener("abort", clearLanded);
-        clearLanded();
-      },
-      LANDED_MARK_MS,
-      { signal: landedSignal },
-    );
-  });
+  return command(
+    async ({ set }, turnIndex: number, signal: AbortSignal): Promise<void> => {
+      const turn = store.turns[turnIndex];
+      if (!turn) {
+        return;
+      }
+      L.debug("jump to turn", { threadId, turnIndex, eventId: turn.eventId });
+      const landedSignal = set(resetLandedSignal$, signal);
+      turn.element.dataset.locatorLanded = "";
+      const clearLanded = () => {
+        delete turn.element.dataset.locatorLanded;
+      };
+      landedSignal.addEventListener("abort", clearLanded, { once: true });
+      timeout(
+        () => {
+          landedSignal.removeEventListener("abort", clearLanded);
+          clearLanded();
+        },
+        LANDED_MARK_MS,
+        { signal: landedSignal },
+      );
+      await set(scrollToEvent$, turn.eventId, signal);
+    },
+  );
 }
 
 /**
@@ -607,12 +612,12 @@ function createLeaveRail(
 
 function createClickJump(
   store: LocatorStore,
-  jumpToTurn$: Command<void, [number]>,
+  jumpToTurn$: Command<Promise<void>, [number, AbortSignal]>,
 ) {
-  return command(({ get, set }) => {
+  return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
     const preview = get(store.preview$);
     if (preview) {
-      set(jumpToTurn$, preview.turnIndex);
+      await set(jumpToTurn$, preview.turnIndex, signal);
     }
   });
 }
@@ -639,11 +644,15 @@ function createPageWindow(
   });
 }
 
-/** True while the rail owns the wheel instead of the page. */
-function createOwnsWheel(store: LocatorStore) {
-  return command(({ get }) => {
+/** True when the rail can move in this wheel event's direction. */
+function createCanPageWindow(store: LocatorStore) {
+  return command(({ get }, deltaY: number) => {
     const layout = get(store.layout$);
-    return layout.visible && layout.turnCount > MAX_TICKS;
+    if (!layout.visible || layout.turnCount <= MAX_TICKS || deltaY === 0) {
+      return false;
+    }
+    const start = get(store.windowStart$);
+    return deltaY < 0 ? start > 0 : start < layout.turnCount - MAX_TICKS;
   });
 }
 
@@ -651,7 +660,7 @@ interface RailHandlers {
   readonly pointerEnter: () => void;
   readonly pointerMove: (event: PointerEvent) => void;
   readonly pointerLeave: () => void;
-  readonly click: () => void;
+  readonly click: (event: MouseEvent) => void;
   readonly wheel: (event: WheelEvent) => void;
   readonly scroll: () => void;
   readonly contentResize: () => void;
@@ -732,9 +741,9 @@ interface RailCommands {
   readonly paint$: Command<void, [number | null]>;
   readonly followStep$: Command<void, [HTMLElement, RailRuntime]>;
   readonly leaveRail$: Command<void, []>;
-  readonly clickJump$: Command<void, []>;
+  readonly clickJump$: Command<Promise<void>, [AbortSignal]>;
   readonly pageWindow$: Command<boolean, [number]>;
-  readonly ownsWheel$: Command<boolean, []>;
+  readonly canPageWindow$: Command<boolean, [number]>;
 }
 
 function createRailOnRef(
@@ -811,11 +820,12 @@ function createRailOnRef(
           runtime.wheelTravel = 0;
           set(commands.leaveRail$);
         },
-        click: () => {
-          set(commands.clickJump$);
-        },
+        click: onDomEventFn<MouseEvent>(async () => {
+          await set(commands.clickJump$, signal);
+        }),
         wheel: (event) => {
-          if (!set(commands.ownsWheel$)) {
+          if (!set(commands.canPageWindow$, event.deltaY)) {
+            runtime.wheelTravel = 0;
             return;
           }
           event.preventDefault();
@@ -880,20 +890,19 @@ function createPreviewOnRef(store: LocatorStore) {
   );
 }
 
-export function createChatConversationLocatorSignals(
-  {
-    threadId,
-    scrollContainer$,
-  }: {
-    threadId: string;
-    scrollContainer$: Computed<HTMLElement | null>;
-  },
-  signal: AbortSignal,
-): ChatConversationLocatorSignals {
+export function createChatConversationLocatorSignals({
+  threadId,
+  scrollContainer$,
+  scrollToEvent$,
+}: {
+  threadId: string;
+  scrollContainer$: Computed<HTMLElement | null>;
+  scrollToEvent$: Command<Promise<void>, [string, AbortSignal]>;
+}): ChatConversationLocatorSignals {
   const store = createStore();
   const recompute$ = createRecompute(store, scrollContainer$);
   const paint$ = createPaint(store);
-  const jumpToTurn$ = createJump(store, threadId, scrollContainer$, signal);
+  const jumpToTurn$ = createJump(store, threadId, scrollToEvent$);
   const railOnRef$ = createRailOnRef(store, threadId, scrollContainer$, {
     recompute$,
     paint$,
@@ -901,7 +910,7 @@ export function createChatConversationLocatorSignals(
     leaveRail$: createLeaveRail(store, recompute$, paint$),
     clickJump$: createClickJump(store, jumpToTurn$),
     pageWindow$: createPageWindow(store, recompute$),
-    ownsWheel$: createOwnsWheel(store),
+    canPageWindow$: createCanPageWindow(store),
   });
 
   return {

--- a/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
@@ -1,13 +1,13 @@
 /**
  * Conversation locator
  *
- * A tick rail beside a long chat thread. One tick per rendered turn, evenly
+ * A tick rail beside a long chat thread. One tick per visible turn, evenly
  * spaced; hovering magnifies neighbouring ticks, names the turn under the
  * cursor in a floating preview, and clicking jumps to it.
  *
- * Turn geometry is read from the DOM rather than the group signals, the same
- * way `chat-thread-scroll.ts` reads its anchors: only rendered turns can be
- * pointed at, and the paged renderer decides what is rendered.
+ * The turn sequence comes from the complete, non-virtual chat projection.
+ * The DOM contributes geometry only for the currently rendered window; a jump
+ * asks the thread scroll signals to reveal an off-window event before landing.
  */
 
 import {
@@ -19,8 +19,20 @@ import {
   type State,
 } from "ccstate";
 import { animationFrame, timeout } from "signal-timers";
+import {
+  chatEventCompatibilityRole,
+  isChatEventContentTextType,
+} from "@okouai/api-contracts/contracts/chat-events";
 import { logger } from "../log.ts";
+import { messageDocumentToDisplayText } from "../okou-page/user-message-document-codec.ts";
 import { onDomEventFn, onRef, resetSignal } from "../utils.ts";
+import { hasChatEventBodyContent } from "./chat-event-body-blocks.ts";
+import type { ChatEventGroup, EnrichedChatEvent } from "./chat-event.ts";
+import {
+  buildRunGroupFolding,
+  runGroupExpansionOverrides$,
+} from "./run-group-folding.ts";
+import type { ThreadScrollPosition } from "./chat-thread-scroll.ts";
 
 const L = logger("ConversationLocator");
 
@@ -61,6 +73,13 @@ const GROUP_SELECTOR = '[data-role="user"], [data-role="assistant"]';
 const SCROLL_ANCHOR_SELECTOR = "[data-chat-scroll-anchor-event-id]";
 
 export type LocatorRole = keyof typeof TICK_METRICS;
+
+export interface LocatorTurn {
+  readonly eventId: string;
+  readonly role: LocatorRole;
+  readonly text: string;
+  readonly createdAt: string | undefined;
+}
 
 interface LocatorTick {
   readonly turnIndex: number;
@@ -104,6 +123,8 @@ export interface ChatConversationLocatorSignals {
   readonly preview$: Computed<LocatorPreview | null>;
   /** True while the pointer is over the rail. */
   readonly engaged$: Computed<boolean>;
+  /** Complete folded turn sequence, independent of the DOM render window. */
+  readonly visibleTurns$: Computed<readonly LocatorTurn[]>;
   readonly jumpToTurn$: Command<Promise<void>, [number, AbortSignal]>;
 }
 
@@ -121,24 +142,36 @@ function emptyLayout(): LocatorLayout {
 interface DomTurn {
   readonly element: HTMLElement;
   readonly eventId: string;
-  readonly role: LocatorRole;
-  /** ISO timestamp stamped on the turn wrapper, absent on optimistic rows. */
-  readonly createdAt: string | undefined;
   /** Offset inside the scroll content, not the offsetParent chain. */
   readonly top: number;
   readonly height: number;
 }
 
+interface IndexedDomTurn extends DomTurn {
+  readonly turnIndex: number;
+}
+
+interface LocatorMeasurement {
+  readonly renderedTurns: readonly DomTurn[];
+  readonly scrollTop: number;
+  readonly clientHeight: number;
+  readonly scrollHeight: number;
+  readonly railHeight: number;
+}
+
+interface ResolvedLocatorLayout {
+  readonly layout: LocatorLayout;
+  readonly windowStart: number;
+}
+
 interface LocatorStore {
   readonly rail$: State<HTMLElement | null>;
   readonly previewElement$: State<HTMLElement | null>;
-  readonly layout$: State<LocatorLayout>;
+  readonly measurement$: State<LocatorMeasurement>;
   readonly preview$: State<LocatorPreview | null>;
   readonly engaged$: State<boolean>;
   readonly windowStart$: State<number>;
   readonly pagedByReader$: State<boolean>;
-  /** Last measurement, reused while only the scroll offset changes. */
-  turns: DomTurn[];
 }
 
 /** Per-binding pointer and scheduling bookkeeping. */
@@ -157,10 +190,6 @@ interface RailRuntime {
 
 function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
-}
-
-function roleOf(element: HTMLElement): LocatorRole {
-  return element.dataset.role === "user" ? "user" : "assistant";
 }
 
 /**
@@ -198,8 +227,6 @@ function readTurns(container: HTMLElement): DomTurn[] {
     turns.push({
       element,
       eventId,
-      role: roleOf(element),
-      createdAt: element.dataset.turnCreatedAt,
       top: rect.top - containerTop + scrollTop,
       height: rect.height,
     });
@@ -207,27 +234,161 @@ function readTurns(container: HTMLElement): DomTurn[] {
   return turns;
 }
 
-/** The message body alone — tool chrome and action labels are not a preview. */
-function previewTextFor(element: HTMLElement): string {
-  const bubble = element.querySelector<HTMLElement>(
-    ".zero-chat-bubble-user, .zero-chat-bubble-assistant",
+function normalizePreviewText(value: string | null | undefined): string {
+  return value?.replace(/\s+/gu, " ").trim() ?? "";
+}
+
+function userMessageForLocator(event: EnrichedChatEvent) {
+  return "userMessage" in event ? event.userMessage : undefined;
+}
+
+function userMessageAnnotationForLocator(event: EnrichedChatEvent) {
+  return userMessageForLocator(event)?.parts.find((part) => {
+    return part.type === "automation" || part.type === "goal";
+  });
+}
+
+function rejectedGoalForLocator(event: EnrichedChatEvent): boolean {
+  return (
+    event.eventType === "input.rejected" &&
+    userMessageAnnotationForLocator(event)?.type === "goal"
   );
-  return (bubble ?? element).textContent?.replace(/\s+/gu, " ").trim() ?? "";
+}
+
+function userPreviewText(event: EnrichedChatEvent): string {
+  const messageText = normalizePreviewText(
+    messageDocumentToDisplayText(userMessageForLocator(event)),
+  );
+  if (messageText) {
+    return messageText;
+  }
+  const annotation = userMessageAnnotationForLocator(event);
+  if (annotation?.type === "goal") {
+    return normalizePreviewText(annotation.goalBrief);
+  }
+  if (annotation?.type === "automation") {
+    const brief = normalizePreviewText(annotation.automationBrief);
+    return brief || normalizePreviewText(annotation.workflowName);
+  }
+  return normalizePreviewText(event.content);
+}
+
+function assistantErrorForLocator(
+  event: EnrichedChatEvent,
+): string | undefined {
+  if (
+    event.eventType === "output.error" ||
+    event.eventType === "run.failed" ||
+    event.eventType === "run.cancelled"
+  ) {
+    return event.error;
+  }
+  return undefined;
+}
+
+function rendersAssistantTurn(event: EnrichedChatEvent): boolean {
+  return (
+    chatEventCompatibilityRole(event.eventType) === "assistant" &&
+    ((isChatEventContentTextType(event.eventType) && Boolean(event.content)) ||
+      Boolean(assistantErrorForLocator(event)) ||
+      hasChatEventBodyContent(event))
+  );
+}
+
+function assistantPreviewText(event: EnrichedChatEvent): string {
+  return normalizePreviewText(assistantErrorForLocator(event) ?? event.content);
+}
+
+function activeGroupsForLocator(
+  groups: readonly ChatEventGroup[],
+): ChatEventGroup[] {
+  return groups.flatMap((group) => {
+    if (group.role === "assistant") {
+      return [group];
+    }
+    const activeEvents = group.events.filter((event) => {
+      return !event.isQueued;
+    });
+    const beginEventId = activeEvents[0]?.id;
+    return beginEventId === undefined
+      ? []
+      : [{ ...group, beginEventId, events: activeEvents }];
+  });
+}
+
+function turnsFromGroups(groups: readonly ChatEventGroup[]): LocatorTurn[] {
+  return groups.flatMap((group): LocatorTurn[] => {
+    if (group.role === "user") {
+      return group.events.flatMap((event) => {
+        return rejectedGoalForLocator(event)
+          ? []
+          : [
+              {
+                eventId: event.id,
+                role: "user" as const,
+                text: userPreviewText(event),
+                createdAt: event.createdAt,
+              },
+            ];
+      });
+    }
+    const event = group.events.find(rendersAssistantTurn);
+    return event === undefined
+      ? []
+      : [
+          {
+            eventId: event.id,
+            role: "assistant" as const,
+            text: assistantPreviewText(event),
+            createdAt: group.events[0]?.createdAt,
+          },
+        ];
+  });
+}
+
+function createVisibleTurns(
+  allChatGroups$: Computed<readonly ChatEventGroup[]>,
+  threadScrollPosition$: Computed<ThreadScrollPosition | null>,
+): Computed<readonly LocatorTurn[]> {
+  return computed((get): readonly LocatorTurn[] => {
+    const activeGroups = activeGroupsForLocator(get(allChatGroups$));
+    const folding = buildRunGroupFolding(
+      activeGroups,
+      get(runGroupExpansionOverrides$),
+      get(threadScrollPosition$)?.targetEventId ?? null,
+    );
+    return turnsFromGroups(folding?.visibleGroups ?? activeGroups);
+  });
+}
+
+function indexedDomTurns(
+  turns: readonly LocatorTurn[],
+  renderedTurns: readonly DomTurn[],
+): IndexedDomTurn[] {
+  const indexByEventId = new Map(
+    turns.map((turn, turnIndex) => {
+      return [turn.eventId, turnIndex] as const;
+    }),
+  );
+  return renderedTurns.flatMap((turn) => {
+    const turnIndex = indexByEventId.get(turn.eventId);
+    return turnIndex === undefined ? [] : [{ ...turn, turnIndex }];
+  });
 }
 
 function currentTurnIndex(
-  turns: readonly DomTurn[],
+  turns: readonly IndexedDomTurn[],
   scrollTop: number,
   clientHeight: number,
 ): number {
   const focus = scrollTop + clientHeight * CURRENT_TURN_VIEWPORT_RATIO;
-  let best = 0;
+  let best = turns[0]?.turnIndex ?? 0;
   let bestDistance = Number.POSITIVE_INFINITY;
-  for (const [index, turn] of turns.entries()) {
+  for (const turn of turns) {
     const distance = Math.abs(turn.top + turn.height / 2 - focus);
     if (distance < bestDistance) {
       bestDistance = distance;
-      best = index;
+      best = turn.turnIndex;
     }
   }
   return best;
@@ -291,7 +452,7 @@ function windowGeometry(
 }
 
 function buildTicks(
-  turns: readonly DomTurn[],
+  turns: readonly LocatorTurn[],
   geometry: WindowGeometry,
   current: number,
 ): LocatorTick[] {
@@ -317,17 +478,22 @@ function buildTicks(
 }
 
 function buildBand(
-  turns: readonly DomTurn[],
+  turns: readonly IndexedDomTurn[],
   geometry: WindowGeometry,
   scrollTop: number,
   clientHeight: number,
 ): { bandTop: number; bandHeight: number } {
   const { windowStart, windowCount, pitch, origin } = geometry;
   const viewportBottom = scrollTop + clientHeight;
+  const turnByIndex = new Map(
+    turns.map((turn) => {
+      return [turn.turnIndex, turn] as const;
+    }),
+  );
   let first = -1;
   let last = -1;
   for (let offset = 0; offset < windowCount; offset += 1) {
-    const turn = turns[windowStart + offset];
+    const turn = turnByIndex.get(windowStart + offset);
     if (!turn) {
       continue;
     }
@@ -413,13 +579,76 @@ function createStore(): LocatorStore {
   return {
     rail$: state<HTMLElement | null>(null),
     previewElement$: state<HTMLElement | null>(null),
-    layout$: state<LocatorLayout>(emptyLayout()),
+    measurement$: state<LocatorMeasurement>({
+      renderedTurns: [],
+      scrollTop: 0,
+      clientHeight: 0,
+      scrollHeight: 0,
+      railHeight: 0,
+    }),
     preview$: state<LocatorPreview | null>(null),
     engaged$: state(false),
     windowStart$: state(0),
     pagedByReader$: state(false),
-    turns: [],
   };
+}
+
+function createResolvedLayout(
+  store: LocatorStore,
+  visibleTurns$: Computed<readonly LocatorTurn[]>,
+): Computed<ResolvedLocatorLayout> {
+  return computed((get): ResolvedLocatorLayout => {
+    const turns = get(visibleTurns$);
+    const measurement = get(store.measurement$);
+    const renderedTurnCount = measurement.renderedTurns.length;
+    // A virtual window's scrollHeight covers only its DOM slice. Scale that
+    // measured slice to the complete turn count before applying the physical
+    // screen-length floor.
+    const estimatedScrollHeight =
+      renderedTurnCount === 0
+        ? measurement.scrollHeight
+        : Math.max(
+            measurement.scrollHeight,
+            (measurement.scrollHeight * turns.length) / renderedTurnCount,
+          );
+    const enoughScroll =
+      measurement.clientHeight > 0 &&
+      estimatedScrollHeight >= measurement.clientHeight * SHOW_MIN_SCREENS;
+    if (turns.length < SHOW_MIN_TURNS || !enoughScroll) {
+      return {
+        layout: { ...emptyLayout(), turnCount: turns.length },
+        windowStart: 0,
+      };
+    }
+
+    const renderedTurns = indexedDomTurns(turns, measurement.renderedTurns);
+    const current = currentTurnIndex(
+      renderedTurns,
+      measurement.scrollTop,
+      measurement.clientHeight,
+    );
+    const geometry = windowGeometry(
+      turns.length,
+      measurement.railHeight,
+      current,
+      get(store.pagedByReader$) ? get(store.windowStart$) : null,
+    );
+    return {
+      layout: {
+        visible: true,
+        ticks: buildTicks(turns, geometry, current),
+        pitch: geometry.pitch,
+        ...buildBand(
+          renderedTurns,
+          geometry,
+          measurement.scrollTop,
+          measurement.clientHeight,
+        ),
+        turnCount: turns.length,
+      },
+      windowStart: geometry.windowStart,
+    };
+  });
 }
 
 /**
@@ -436,51 +665,43 @@ function createRecompute(
     if (!container || !rail) {
       return;
     }
-    if (remeasure) {
-      store.turns = readTurns(container);
-    }
-    const turns = store.turns;
-    const enoughScroll =
-      container.clientHeight > 0 &&
-      container.scrollHeight >= container.clientHeight * SHOW_MIN_SCREENS;
-    if (turns.length < SHOW_MIN_TURNS || !enoughScroll) {
-      set(store.layout$, { ...emptyLayout(), turnCount: turns.length });
+    const previous = get(store.measurement$);
+    const next: LocatorMeasurement = {
+      renderedTurns: remeasure ? readTurns(container) : previous.renderedTurns,
+      scrollTop: container.scrollTop,
+      clientHeight: container.clientHeight,
+      scrollHeight: container.scrollHeight,
+      railHeight: rail.clientHeight,
+    };
+    if (
+      next.renderedTurns === previous.renderedTurns &&
+      next.scrollTop === previous.scrollTop &&
+      next.clientHeight === previous.clientHeight &&
+      next.scrollHeight === previous.scrollHeight &&
+      next.railHeight === previous.railHeight
+    ) {
       return;
     }
-
-    const current = currentTurnIndex(
-      turns,
-      container.scrollTop,
-      container.clientHeight,
-    );
-    const geometry = windowGeometry(
-      turns.length,
-      rail.clientHeight,
-      current,
-      get(store.pagedByReader$) ? get(store.windowStart$) : null,
-    );
-    if (geometry.windowStart !== get(store.windowStart$)) {
-      set(store.windowStart$, geometry.windowStart);
-    }
-    set(store.layout$, {
-      visible: true,
-      ticks: buildTicks(turns, geometry, current),
-      pitch: geometry.pitch,
-      ...buildBand(
-        turns,
-        geometry,
-        container.scrollTop,
-        container.clientHeight,
-      ),
-      turnCount: turns.length,
-    });
+    set(store.measurement$, next);
   });
 }
 
-function createPaint(store: LocatorStore) {
+function createLayout(
+  resolvedLayout$: Computed<ResolvedLocatorLayout>,
+): Computed<LocatorLayout> {
+  return computed((get): LocatorLayout => {
+    return get(resolvedLayout$).layout;
+  });
+}
+
+function createPaint(
+  store: LocatorStore,
+  visibleTurns$: Computed<readonly LocatorTurn[]>,
+  layout$: Computed<LocatorLayout>,
+) {
   return command(({ get, set }, pointerY: number | null) => {
     const rail = get(store.rail$);
-    const layout = get(store.layout$);
+    const layout = get(layout$);
     if (!rail || !layout.visible) {
       return;
     }
@@ -491,7 +712,7 @@ function createPaint(store: LocatorStore) {
     }
     const nearest = applyMagnification(rail, layout, pointerY);
     const tick = nearest === null ? undefined : layout.ticks[nearest];
-    const turn = tick ? store.turns[tick.turnIndex] : undefined;
+    const turn = tick ? get(visibleTurns$)[tick.turnIndex] : undefined;
     const shown = get(store.preview$);
     if (!tick || !turn) {
       if (shown) {
@@ -499,13 +720,19 @@ function createPaint(store: LocatorStore) {
       }
       return;
     }
-    if (shown?.turnIndex === tick.turnIndex) {
+    if (
+      shown?.turnIndex === tick.turnIndex &&
+      shown.role === tick.role &&
+      shown.text === turn.text &&
+      shown.createdAt === turn.createdAt &&
+      shown.total === layout.turnCount
+    ) {
       return;
     }
     set(store.preview$, {
       turnIndex: tick.turnIndex,
       role: tick.role,
-      text: previewTextFor(turn.element),
+      text: turn.text,
       createdAt: turn.createdAt,
       position: tick.turnIndex + 1,
       total: layout.turnCount,
@@ -514,23 +741,39 @@ function createPaint(store: LocatorStore) {
 }
 
 function createJump(
-  store: LocatorStore,
   threadId: string,
+  visibleTurns$: Computed<readonly LocatorTurn[]>,
+  scrollContainer$: Computed<HTMLElement | null>,
   scrollToEvent$: Command<Promise<void>, [string, AbortSignal]>,
 ) {
   const resetLandedSignal$ = resetSignal();
 
   return command(
-    async ({ set }, turnIndex: number, signal: AbortSignal): Promise<void> => {
-      const turn = store.turns[turnIndex];
+    async (
+      { get, set },
+      turnIndex: number,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      const turn = get(visibleTurns$)[turnIndex];
       if (!turn) {
         return;
       }
       L.debug("jump to turn", { threadId, turnIndex, eventId: turn.eventId });
+      await set(scrollToEvent$, turn.eventId, signal);
+      signal.throwIfAborted();
+      const container = get(scrollContainer$);
+      const element = container
+        ? readTurns(container).find((candidate) => {
+            return candidate.eventId === turn.eventId;
+          })?.element
+        : undefined;
+      if (!element) {
+        return;
+      }
       const landedSignal = set(resetLandedSignal$, signal);
-      turn.element.dataset.locatorLanded = "";
+      element.dataset.locatorLanded = "";
       const clearLanded = () => {
-        delete turn.element.dataset.locatorLanded;
+        delete element.dataset.locatorLanded;
       };
       landedSignal.addEventListener("abort", clearLanded, { once: true });
       timeout(
@@ -541,7 +784,6 @@ function createJump(
         LANDED_MARK_MS,
         { signal: landedSignal },
       );
-      await set(scrollToEvent$, turn.eventId, signal);
     },
   );
 }
@@ -595,7 +837,6 @@ function createFollowStep(store: LocatorStore) {
 
 function createLeaveRail(
   store: LocatorStore,
-  recompute$: Command<void, [boolean]>,
   paint$: Command<void, [number | null]>,
 ) {
   return command(({ get, set }) => {
@@ -605,7 +846,6 @@ function createLeaveRail(
     // rail; leaving hands it back to the reading position.
     if (get(store.pagedByReader$)) {
       set(store.pagedByReader$, false);
-      set(recompute$, false);
     }
   });
 }
@@ -625,34 +865,33 @@ function createClickJump(
 /** Returns true when the rail took the wheel, so the caller can repaint. */
 function createPageWindow(
   store: LocatorStore,
-  recompute$: Command<void, [boolean]>,
+  resolvedLayout$: Computed<ResolvedLocatorLayout>,
 ) {
   return command(({ get, set }, steps: number) => {
-    const layout = get(store.layout$);
+    const { layout, windowStart } = get(resolvedLayout$);
     if (!layout.visible || layout.turnCount <= MAX_TICKS) {
       return false;
     }
-    const start = get(store.windowStart$);
-    const next = clamp(start + steps, 0, layout.turnCount - MAX_TICKS);
-    if (next === start) {
+    const next = clamp(windowStart + steps, 0, layout.turnCount - MAX_TICKS);
+    if (next === windowStart) {
       return false;
     }
     set(store.pagedByReader$, true);
     set(store.windowStart$, next);
-    set(recompute$, false);
     return true;
   });
 }
 
 /** True when the rail can move in this wheel event's direction. */
-function createCanPageWindow(store: LocatorStore) {
+function createCanPageWindow(resolvedLayout$: Computed<ResolvedLocatorLayout>) {
   return command(({ get }, deltaY: number) => {
-    const layout = get(store.layout$);
+    const { layout, windowStart } = get(resolvedLayout$);
     if (!layout.visible || layout.turnCount <= MAX_TICKS || deltaY === 0) {
       return false;
     }
-    const start = get(store.windowStart$);
-    return deltaY < 0 ? start > 0 : start < layout.turnCount - MAX_TICKS;
+    return deltaY < 0
+      ? windowStart > 0
+      : windowStart < layout.turnCount - MAX_TICKS;
   });
 }
 
@@ -864,7 +1103,13 @@ function createRailOnRef(
           runtime.followRunning = false;
           detachListeners?.();
           set(store.rail$, null);
-          set(store.layout$, emptyLayout());
+          set(store.measurement$, {
+            renderedTurns: [],
+            scrollTop: 0,
+            clientHeight: 0,
+            scrollHeight: 0,
+            railHeight: 0,
+          });
           set(store.preview$, null);
           set(store.engaged$, false);
           L.debug("rail unbound", { threadId });
@@ -894,37 +1139,51 @@ export function createChatConversationLocatorSignals({
   threadId,
   scrollContainer$,
   scrollToEvent$,
+  allChatGroups$,
+  threadScrollPosition$,
 }: {
   threadId: string;
   scrollContainer$: Computed<HTMLElement | null>;
   scrollToEvent$: Command<Promise<void>, [string, AbortSignal]>;
+  allChatGroups$: Computed<readonly ChatEventGroup[]>;
+  threadScrollPosition$: Computed<ThreadScrollPosition | null>;
 }): ChatConversationLocatorSignals {
   const store = createStore();
+  const visibleTurns$ = createVisibleTurns(
+    allChatGroups$,
+    threadScrollPosition$,
+  );
+  const resolvedLayout$ = createResolvedLayout(store, visibleTurns$);
+  const layout$ = createLayout(resolvedLayout$);
   const recompute$ = createRecompute(store, scrollContainer$);
-  const paint$ = createPaint(store);
-  const jumpToTurn$ = createJump(store, threadId, scrollToEvent$);
+  const paint$ = createPaint(store, visibleTurns$, layout$);
+  const jumpToTurn$ = createJump(
+    threadId,
+    visibleTurns$,
+    scrollContainer$,
+    scrollToEvent$,
+  );
   const railOnRef$ = createRailOnRef(store, threadId, scrollContainer$, {
     recompute$,
     paint$,
     followStep$: createFollowStep(store),
-    leaveRail$: createLeaveRail(store, recompute$, paint$),
+    leaveRail$: createLeaveRail(store, paint$),
     clickJump$: createClickJump(store, jumpToTurn$),
-    pageWindow$: createPageWindow(store, recompute$),
-    canPageWindow$: createCanPageWindow(store),
+    pageWindow$: createPageWindow(store, resolvedLayout$),
+    canPageWindow$: createCanPageWindow(resolvedLayout$),
   });
 
   return {
     railOnRef$,
     previewOnRef$: createPreviewOnRef(store),
-    layout$: computed((get) => {
-      return get(store.layout$);
-    }),
+    layout$,
     preview$: computed((get) => {
       return get(store.preview$);
     }),
     engaged$: computed((get) => {
       return get(store.engaged$);
     }),
+    visibleTurns$,
     jumpToTurn$,
   };
 }

--- a/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
@@ -20,13 +20,16 @@ import {
 } from "ccstate";
 import { animationFrame, timeout } from "signal-timers";
 import {
-  chatEventCompatibilityRole,
-  isChatEventContentTextType,
-} from "@okouai/api-contracts/contracts/chat-events";
+  applyCompletedWorkExpansion,
+  buildCompletedWorkFolding,
+  chatEventDisplayError,
+  completedWorkExpandedKeys$,
+  completedWorkExpandedKeysForScrollTarget,
+  isRenderableAssistantEvent,
+} from "./completed-work-folding.ts";
 import { logger } from "../log.ts";
 import { messageDocumentToDisplayText } from "../okou-page/user-message-document-codec.ts";
 import { onDomEventFn, onRef, resetSignal } from "../utils.ts";
-import { hasChatEventBodyContent } from "./chat-event-body-blocks.ts";
 import type { ChatEventGroup, EnrichedChatEvent } from "./chat-event.ts";
 import {
   buildRunGroupFolding,
@@ -273,30 +276,8 @@ function userPreviewText(event: EnrichedChatEvent): string {
   return normalizePreviewText(event.content);
 }
 
-function assistantErrorForLocator(
-  event: EnrichedChatEvent,
-): string | undefined {
-  if (
-    event.eventType === "output.error" ||
-    event.eventType === "run.failed" ||
-    event.eventType === "run.cancelled"
-  ) {
-    return event.error;
-  }
-  return undefined;
-}
-
-function rendersAssistantTurn(event: EnrichedChatEvent): boolean {
-  return (
-    chatEventCompatibilityRole(event.eventType) === "assistant" &&
-    ((isChatEventContentTextType(event.eventType) && Boolean(event.content)) ||
-      Boolean(assistantErrorForLocator(event)) ||
-      hasChatEventBodyContent(event))
-  );
-}
-
 function assistantPreviewText(event: EnrichedChatEvent): string {
-  return normalizePreviewText(assistantErrorForLocator(event) ?? event.content);
+  return normalizePreviewText(chatEventDisplayError(event) ?? event.content);
 }
 
 function activeGroupsForLocator(
@@ -332,7 +313,7 @@ function turnsFromGroups(groups: readonly ChatEventGroup[]): LocatorTurn[] {
             ];
       });
     }
-    const event = group.events.find(rendersAssistantTurn);
+    const event = group.events.find(isRenderableAssistantEvent);
     return event === undefined
       ? []
       : [
@@ -340,7 +321,10 @@ function turnsFromGroups(groups: readonly ChatEventGroup[]): LocatorTurn[] {
             eventId: event.id,
             role: "assistant" as const,
             text: assistantPreviewText(event),
-            createdAt: group.events[0]?.createdAt,
+            createdAt:
+              group.events.find((candidate) => {
+                return candidate.id === group.beginEventId;
+              })?.createdAt ?? group.events[0]?.createdAt,
           },
         ];
   });
@@ -352,12 +336,29 @@ function createVisibleTurns(
 ): Computed<readonly LocatorTurn[]> {
   return computed((get): readonly LocatorTurn[] => {
     const activeGroups = activeGroupsForLocator(get(allChatGroups$));
-    const folding = buildRunGroupFolding(
+    const targetEventId = get(threadScrollPosition$)?.targetEventId ?? null;
+    const runGroupFolding = buildRunGroupFolding(
       activeGroups,
       get(runGroupExpansionOverrides$),
-      get(threadScrollPosition$)?.targetEventId ?? null,
+      targetEventId,
     );
-    return turnsFromGroups(folding?.visibleGroups ?? activeGroups);
+    const runGroupVisibleGroups =
+      runGroupFolding?.visibleGroups ?? activeGroups;
+    const completedWorkFolding = buildCompletedWorkFolding(
+      runGroupVisibleGroups,
+    );
+    const completedWorkExpandedKeys = completedWorkExpandedKeysForScrollTarget(
+      completedWorkFolding,
+      get(completedWorkExpandedKeys$),
+      targetEventId,
+    );
+    return turnsFromGroups(
+      applyCompletedWorkExpansion(
+        runGroupVisibleGroups,
+        completedWorkFolding,
+        completedWorkExpandedKeys,
+      ),
+    );
   });
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -1,10 +1,12 @@
 import { command } from "ccstate";
 import { createElement } from "react";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { ChatThreadPage } from "../../views/okou-page/chat-thread-page.tsx";
 import { updatePage$ } from "../react-router.ts";
 import { currentChatThreadId$ } from "../agent-chat.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
 import { onboardGuard$ } from "../okou-page/onboard-guard.ts";
-import { searchParams$ } from "../route.ts";
+import { hash$, searchParams$ } from "../route.ts";
 import {
   SIDEBAR_PARAM,
   setupLeftThread$,
@@ -20,8 +22,23 @@ import {
   recordBootstrapThreadMetadataTiming$,
 } from "../../lib/posthog.ts";
 
+const CHAT_EVENT_HASH_PREFIX = "#event-";
+
+function chatEventIdFromHash(hash: string): string | null {
+  if (!hash.startsWith(CHAT_EVENT_HASH_PREFIX)) {
+    return null;
+  }
+  const encodedEventId = hash.slice(CHAT_EVENT_HASH_PREFIX.length);
+  return encodedEventId.length > 0 ? decodeURIComponent(encodedEventId) : null;
+}
+
 const setupResolvedLeftThread$ = command(
-  async ({ set }, threadId: string, signal: AbortSignal): Promise<void> => {
+  async (
+    { set },
+    threadId: string,
+    initialEventId: string | null,
+    signal: AbortSignal,
+  ): Promise<void> => {
     const resolution = await set(resolveThreadMeta$, threadId, signal);
     signal.throwIfAborted();
     set(recordBootstrapThreadMetadataTiming$, {
@@ -31,7 +48,7 @@ const setupResolvedLeftThread$ = command(
     });
     const { meta } = resolution;
     if (meta) {
-      await set(setupLeftThread$, meta, signal);
+      await set(setupLeftThread$, meta, initialEventId, signal);
       return;
     }
     await set(setupLeftThreadNotFound$, threadId, signal);
@@ -63,11 +80,16 @@ const internalSetupChatPage$ = command(
     set(captureNavigationTiming$);
 
     const sidebarThreadId = get(searchParams$).get(SIDEBAR_PARAM);
+    const initialEventId = get(featureSwitch$)[
+      FeatureSwitchKey.ChatConversationLocator
+    ]
+      ? chatEventIdFromHash(get(hash$))
+      : null;
     const rightThreadId =
       sidebarThreadId && sidebarThreadId !== threadId ? sidebarThreadId : null;
 
     await Promise.all([
-      set(setupResolvedLeftThread$, threadId, signal),
+      set(setupResolvedLeftThread$, threadId, initialEventId, signal),
       rightThreadId
         ? set(setupResolvedRightThread$, rightThreadId, signal)
         : set(unloadRightThread$),

--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -29,7 +29,12 @@ function chatEventIdFromHash(hash: string): string | null {
     return null;
   }
   const encodedEventId = hash.slice(CHAT_EVENT_HASH_PREFIX.length);
-  return encodedEventId.length > 0 ? decodeURIComponent(encodedEventId) : null;
+  if (encodedEventId.length === 0) {
+    return null;
+  }
+  return new URLSearchParams(
+    `event=${encodedEventId.replaceAll("+", "%2B")}`,
+  ).get("event");
 }
 
 const setupResolvedLeftThread$ = command(

--- a/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
@@ -161,6 +161,7 @@ export interface ChatPanelSignals {
   /** The mounted scroll viewport, for readers that measure it themselves. */
   readonly scrollContainer$: Computed<HTMLElement | null>;
   readonly threadScrollPosition$: Computed<ThreadScrollPosition | null>;
+  readonly scrollToEvent$: Command<Promise<void>, [string, AbortSignal]>;
   readonly scrollTo$: Command<void, [ThreadScrollPosition]>;
   readonly scrollToBottom$: Command<Promise<void>, [AbortSignal]>;
   readonly scrollToTop$: Command<Promise<void>, [AbortSignal]>;

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -183,13 +183,12 @@ const resolvePaneThread$ = command(
     L.debug("resolvePaneThread$ Promise.all start", {
       threadId: thread.threadId,
     });
-    if (initialEventId) {
-      await set(thread.scrollToEvent$, initialEventId, signal);
-      signal.throwIfAborted();
-    }
     await Promise.all([
       set(loadDraft$, thread, isNew, signal),
       set(thread.subscribeChatThread$, signal),
+      initialEventId
+        ? set(thread.scrollToEvent$, initialEventId, signal)
+        : Promise.resolve(),
     ]);
     signal.throwIfAborted();
     L.debug("resolvePaneThread$ Promise.all done", {

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -174,14 +174,19 @@ const resolvePaneThread$ = command(
     args: {
       thread: ChatPanelSignals;
       isNew: boolean;
+      initialEventId: string | null;
     },
     signal: AbortSignal,
   ): Promise<void> => {
-    const { thread, isNew } = args;
+    const { thread, isNew, initialEventId } = args;
 
     L.debug("resolvePaneThread$ Promise.all start", {
       threadId: thread.threadId,
     });
+    if (initialEventId) {
+      await set(thread.scrollToEvent$, initialEventId, signal);
+      signal.throwIfAborted();
+    }
     await Promise.all([
       set(loadDraft$, thread, isNew, signal),
       set(thread.subscribeChatThread$, signal),
@@ -217,6 +222,7 @@ const setupPaneThread$ = command(
     { set },
     spec: PaneSpec,
     meta: ThreadMeta,
+    initialEventId: string | null,
     parentSignal: AbortSignal,
   ): Promise<void> => {
     const signal = set(beginPaneSetup$, spec, parentSignal);
@@ -237,6 +243,7 @@ const setupPaneThread$ = command(
       {
         thread,
         isNew,
+        initialEventId,
       },
       signal,
     );
@@ -262,6 +269,7 @@ export const setupLeftThread$ = command(
   async (
     { set },
     meta: ThreadMeta,
+    initialEventId: string | null,
     parentSignal: AbortSignal,
   ): Promise<void> => {
     await Promise.all([
@@ -273,6 +281,7 @@ export const setupLeftThread$ = command(
           resetSetupSignal$: resetLeftSetupSignal$,
         },
         meta,
+        initialEventId,
         parentSignal,
       ),
     ]);
@@ -312,6 +321,7 @@ export const setupRightThread$ = command(
         resetSetupSignal$: resetRightSetupSignal$,
       },
       meta,
+      null,
       parentSignal,
     );
   },

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
@@ -1,7 +1,8 @@
 import { command, computed, state, type Command, type Computed } from "ccstate";
 import { animationFrame } from "signal-timers";
 import { logger } from "../log.ts";
-import { onDomEventFn, onRef } from "../utils.ts";
+import { onDomEventFn, onRef, setLoop } from "../utils.ts";
+import type { ChatEvent } from "./chat-event-types.ts";
 
 const L = logger("AutoScroll");
 const AT_BOTTOM_THRESHOLD_PX = 10;
@@ -98,12 +99,10 @@ function scrollAnchorForEvent(
   container: HTMLElement,
   eventId: string,
 ): HTMLElement | null {
-  // Selected by attribute rather than scanned out of `scrollAnchors`: a reader
-  // holding an anchor restores on every frame the thread grows, and collecting
-  // every anchor in the thread first would walk the whole history before each
-  // paint.
-  return container.querySelector<HTMLElement>(
-    `[${SCROLL_ANCHOR_ATTRIBUTE}="${eventId}"]`,
+  return (
+    scrollAnchors(container).find((anchor) => {
+      return anchor.getAttribute(SCROLL_ANCHOR_ATTRIBUTE) === eventId;
+    }) ?? null
   );
 }
 
@@ -688,6 +687,8 @@ export function createChatThreadScrollSignals(
   threadId: string,
   position: ThreadScrollPositionSignals,
   afterThreadScrollPositionChanged$: Command<Promise<void>, [AbortSignal]>,
+  chatEvents$: Computed<readonly ChatEvent[]>,
+  initialEventsReady$: Computed<boolean>,
 ): ChatThreadScrollSignals {
   const runtime: ScrollRuntime = {
     initialized: false,
@@ -715,7 +716,27 @@ export function createChatThreadScrollSignals(
   );
   const scrollContentOnRef$ = createScrollContentOnRef(threadId, navigation);
   const scrollToEvent$ = command(
-    async ({ set }, eventId: string, signal: AbortSignal): Promise<void> => {
+    async (
+      { get, set },
+      eventId: string,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      await setLoop(
+        () => {
+          return get(initialEventsReady$);
+        },
+        16,
+        signal,
+        { retryTransientErrors: false },
+      );
+      signal.throwIfAborted();
+      const eventExists = get(chatEvents$).some((event) => {
+        return event.id === eventId;
+      });
+      if (!eventExists) {
+        L.debug("scroll target event not found", { threadId, eventId });
+        return;
+      }
       const position: ThreadScrollPosition = {
         targetEventId: eventId,
         viewportOffsetTop: 0,

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
@@ -50,6 +50,7 @@ export interface ChatThreadScrollSignals {
     Promise<void>,
     [ThreadScrollPosition | null, AbortSignal]
   >;
+  readonly scrollToEvent$: Command<Promise<void>, [string, AbortSignal]>;
   readonly scrollTo$: Command<void, [ThreadScrollPosition]>;
   readonly scrollToTop$: Command<Promise<void>, [AbortSignal]>;
   readonly scrollToBottom$: Command<Promise<void>, [AbortSignal]>;
@@ -313,6 +314,7 @@ function createInternalScrollSignals(
     awayFromBottom$,
     readRenderedThreadScrollPosition$,
     syncThreadScrollPosition$,
+    setThreadScrollPosition$,
     clearThreadScrollPosition$,
     bindScrollContainer$,
     clearScrollContainer$,
@@ -712,6 +714,17 @@ export function createChatThreadScrollSignals(
     runtime,
   );
   const scrollContentOnRef$ = createScrollContentOnRef(threadId, navigation);
+  const scrollToEvent$ = command(
+    async ({ set }, eventId: string, signal: AbortSignal): Promise<void> => {
+      const position: ThreadScrollPosition = {
+        targetEventId: eventId,
+        viewportOffsetTop: 0,
+      };
+      await set(scroll.setThreadScrollPosition$, position, signal);
+      signal.throwIfAborted();
+      await set(render.autoScroll$, position, signal);
+    },
+  );
 
   return {
     scrollContainerOnRef$,
@@ -723,6 +736,7 @@ export function createChatThreadScrollSignals(
     awayFromBottom$: scroll.awayFromBottom$,
     readRenderedThreadScrollPosition$: scroll.readRenderedThreadScrollPosition$,
     autoScroll$: render.autoScroll$,
+    scrollToEvent$,
     scrollTo$: navigation.scrollTo$,
     scrollToTop$: navigation.scrollToTop$,
     scrollToBottom$: navigation.scrollToBottom$,

--- a/turbo/apps/platform/src/signals/chat-page/completed-work-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/completed-work-folding.ts
@@ -1,4 +1,15 @@
 import { command, computed, state } from "ccstate";
+import type { ChatEventUsagePayload } from "@okouai/api-contracts/contracts/chat-threads";
+import {
+  chatEventCompatibilityRole,
+  foldLatestChatUsageByRunId,
+  isChatEventContentTextType,
+  terminatedChatRunIds,
+} from "@okouai/api-contracts/contracts/chat-events";
+import { hasChatEventBodyContent } from "./chat-event-body-blocks.ts";
+import type { ChatEventGroup, EnrichedChatEvent } from "./chat-event.ts";
+import type { ChatEvent } from "./chat-event-types.ts";
+import { isCancelledRunEvent } from "./chat-run-lifecycle.ts";
 
 const internalCompletedWorkExpandedKeys$ = state<Set<string>>(new Set());
 
@@ -17,3 +28,406 @@ export const toggleCompletedWorkExpanded$ = command(({ set }, key: string) => {
     return next;
   });
 });
+
+export interface CompletedWorkFold {
+  readonly key: string;
+  readonly finalEventId: string;
+  readonly hiddenGroups: ChatEventGroup[];
+  readonly labelGroups: ChatEventGroup[];
+}
+
+export interface CompletedWorkFolding {
+  readonly visibleGroups: ChatEventGroup[];
+  readonly foldsByFinalEventId: Map<string, CompletedWorkFold>;
+}
+
+export function chatEventDisplayError(event: ChatEvent): string | undefined {
+  if (
+    event.eventType === "input.rejected" ||
+    event.eventType === "output.error" ||
+    event.eventType === "run.failed" ||
+    event.eventType === "run.cancelled"
+  ) {
+    return event.error;
+  }
+  return undefined;
+}
+
+function chatEventHasAttachments(event: EnrichedChatEvent): boolean {
+  return (
+    "userMessage" in event &&
+    (event.userMessage?.parts.some((part) => {
+      return part.type === "file";
+    }) ??
+      false)
+  );
+}
+
+export function isRenderableAssistantEvent(event: EnrichedChatEvent): boolean {
+  return (
+    chatEventCompatibilityRole(event.eventType) === "assistant" &&
+    ((isChatEventContentTextType(event.eventType) && Boolean(event.content)) ||
+      Boolean(chatEventDisplayError(event)) ||
+      hasChatEventBodyContent(event) ||
+      chatEventHasAttachments(event))
+  );
+}
+
+export function completedWorkFoldForGroup(
+  completedWorkFolding: CompletedWorkFolding | null,
+  group: ChatEventGroup,
+): CompletedWorkFold | null {
+  if (completedWorkFolding === null) {
+    return null;
+  }
+  return (
+    group.events
+      .map((event) => {
+        return completedWorkFolding.foldsByFinalEventId.get(event.id);
+      })
+      .find((fold) => {
+        return fold !== undefined;
+      }) ?? null
+  );
+}
+
+export function completedWorkExpandedKeysForScrollTarget(
+  folding: CompletedWorkFolding | null,
+  expandedKeys: ReadonlySet<string>,
+  targetEventId: string | null,
+): ReadonlySet<string> {
+  if (folding === null || targetEventId === null) {
+    return expandedKeys;
+  }
+  const targetFold = Array.from(folding.foldsByFinalEventId.values()).find(
+    (fold) => {
+      return fold.hiddenGroups.some((group) => {
+        return group.events.some((event) => {
+          return event.id === targetEventId;
+        });
+      });
+    },
+  );
+  if (!targetFold || expandedKeys.has(targetFold.key)) {
+    return expandedKeys;
+  }
+  const next = new Set(expandedKeys);
+  next.add(targetFold.key);
+  return next;
+}
+
+function groupEventsByRole(
+  events: readonly EnrichedChatEvent[],
+): ChatEventGroup[] {
+  const groups: ChatEventGroup[] = [];
+  for (const event of events) {
+    const role = chatEventCompatibilityRole(event.eventType);
+    const last = groups[groups.length - 1];
+    if (last && last.role === role) {
+      last.events.push(event);
+      continue;
+    }
+    groups.push({
+      beginEventId: event.id,
+      role,
+      events: [event],
+    });
+  }
+  return groups;
+}
+
+function groupEventsForCompletedWorkDisplay(
+  events: readonly EnrichedChatEvent[],
+  foldFinalEventIds: ReadonlySet<string>,
+): ChatEventGroup[] {
+  const groups: ChatEventGroup[] = [];
+  for (const event of events) {
+    const role = chatEventCompatibilityRole(event.eventType);
+    const forceStandalone = foldFinalEventIds.has(event.id);
+    const last = groups[groups.length - 1];
+    const lastHasFoldFinal =
+      last?.events.some((candidate) => {
+        return foldFinalEventIds.has(candidate.id);
+      }) ?? false;
+    const lastFoldFinal = last?.events.find((candidate) => {
+      return foldFinalEventIds.has(candidate.id);
+    });
+    const continuesFoldFinalRun =
+      lastFoldFinal?.runId !== undefined && lastFoldFinal.runId === event.runId;
+
+    if (
+      !forceStandalone &&
+      last &&
+      last.role === role &&
+      (!lastHasFoldFinal || continuesFoldFinalRun)
+    ) {
+      last.events.push(event);
+      continue;
+    }
+
+    groups.push({
+      beginEventId: event.id,
+      role,
+      events: [event],
+    });
+  }
+  return groups;
+}
+
+function firstRunIdForEvents(
+  events: readonly EnrichedChatEvent[],
+): string | undefined {
+  return events.find((event) => {
+    return event.runId !== undefined;
+  })?.runId;
+}
+
+function usageByRunIdFromGroups(
+  groups: readonly ChatEventGroup[],
+): Map<string, ChatEventUsagePayload> {
+  return foldLatestChatUsageByRunId(
+    groups.flatMap((group) => {
+      const runId = firstRunIdForEvents(group.events);
+      return group.role === "assistant" &&
+        group.usage !== undefined &&
+        runId !== undefined
+        ? [
+            {
+              eventType: "usage.recorded" as const,
+              runId,
+              usage: group.usage,
+            },
+          ]
+        : [];
+    }),
+  );
+}
+
+function attachUsageToCompletedWorkGroups(
+  groups: readonly ChatEventGroup[],
+  usageByRunId: ReadonlyMap<string, ChatEventUsagePayload>,
+): ChatEventGroup[] {
+  const lastAssistantGroupIndexByRunId = new Map<string, number>();
+  for (const [index, group] of groups.entries()) {
+    if (
+      group.role !== "assistant" ||
+      !group.events.some(isRenderableAssistantEvent)
+    ) {
+      continue;
+    }
+    const runId = firstRunIdForEvents(group.events);
+    if (runId !== undefined) {
+      lastAssistantGroupIndexByRunId.set(runId, index);
+    }
+  }
+  return groups.map((group, index) => {
+    if (group.role !== "assistant") {
+      return group;
+    }
+    const runId = firstRunIdForEvents(group.events);
+    if (
+      runId === undefined ||
+      lastAssistantGroupIndexByRunId.get(runId) !== index
+    ) {
+      return group;
+    }
+    const usage = usageByRunId.get(runId);
+    return usage === undefined ? group : { ...group, usage };
+  });
+}
+
+function isThinkingOnlyAssistantEvent(event: EnrichedChatEvent): boolean {
+  return (
+    event.eventType === "output.thinking" && event.thinking.trim().length > 0
+  );
+}
+
+function splitCompletedWorkEventsAtUsers(
+  events: readonly EnrichedChatEvent[],
+): EnrichedChatEvent[][] {
+  const phases: EnrichedChatEvent[][] = [];
+  let phase: EnrichedChatEvent[] = [];
+  for (const event of events) {
+    if (
+      phase.length > 0 &&
+      chatEventCompatibilityRole(event.eventType) === "user"
+    ) {
+      phases.push(phase);
+      phase = [];
+    }
+    phase.push(event);
+  }
+  if (phase.length > 0) {
+    phases.push(phase);
+  }
+  return phases;
+}
+
+function lastCompletedWorkEventIndex(
+  events: readonly EnrichedChatEvent[],
+  predicate: (event: EnrichedChatEvent) => boolean,
+): number {
+  for (let index = events.length - 1; index >= 0; index--) {
+    if (predicate(events[index]!)) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function completedWorkFinalEventIndex(
+  events: readonly EnrichedChatEvent[],
+): number {
+  return lastCompletedWorkEventIndex(events, isRenderableAssistantEvent);
+}
+
+function canFoldCompletedWorkTrailingEvent(event: EnrichedChatEvent): boolean {
+  const role = chatEventCompatibilityRole(event.eventType);
+  return (
+    role === "user" ||
+    (role === "assistant" && !isRenderableAssistantEvent(event))
+  );
+}
+
+interface CompletedWorkPhaseFolding {
+  readonly visibleEvents: readonly EnrichedChatEvent[];
+  readonly fold: CompletedWorkFold | null;
+}
+
+function foldCompletedWorkPhase(
+  runId: string,
+  events: readonly EnrichedChatEvent[],
+): CompletedWorkPhaseFolding {
+  const finalEventIndex = completedWorkFinalEventIndex(events);
+  const finalEvent =
+    finalEventIndex >= 0 ? events[finalEventIndex]! : undefined;
+  const precedingEvents =
+    finalEventIndex > 0 ? events.slice(0, finalEventIndex) : [];
+  const hiddenEvents = precedingEvents.filter((event) => {
+    return (
+      chatEventCompatibilityRole(event.eventType) !== "user" &&
+      !isThinkingOnlyAssistantEvent(event)
+    );
+  });
+  const userEvents = events.filter((event) => {
+    return chatEventCompatibilityRole(event.eventType) === "user";
+  });
+  const trailingEvents =
+    finalEventIndex >= 0 ? events.slice(finalEventIndex + 1) : [];
+  const trailingEventsCanFold = trailingEvents.every((event) => {
+    return canFoldCompletedWorkTrailingEvent(event);
+  });
+  if (
+    finalEvent === undefined ||
+    hiddenEvents.length === 0 ||
+    !trailingEventsCanFold
+  ) {
+    return { visibleEvents: events, fold: null };
+  }
+  return {
+    visibleEvents: [
+      ...userEvents,
+      finalEvent,
+      ...trailingEvents.filter(isRenderableAssistantEvent),
+    ],
+    fold: {
+      key: `${runId}:${finalEvent.id}`,
+      finalEventId: finalEvent.id,
+      hiddenGroups: groupEventsByRole(hiddenEvents),
+      labelGroups: groupEventsByRole(events),
+    },
+  };
+}
+
+export function buildCompletedWorkFolding(
+  groups: readonly ChatEventGroup[],
+): CompletedWorkFolding | null {
+  const usageByRunId = usageByRunIdFromGroups(groups);
+  const events = groups.flatMap((group) => {
+    return group.events;
+  });
+  const terminatedRunIds = terminatedChatRunIds(events);
+  const visibleEvents: EnrichedChatEvent[] = [];
+  const folds: CompletedWorkFold[] = [];
+  let hasCompletedWorkPhaseBoundary = false;
+
+  for (let index = 0; index < events.length; ) {
+    const runId = events[index]!.runId;
+    if (runId === undefined) {
+      visibleEvents.push(events[index]!);
+      index++;
+      continue;
+    }
+
+    let endIndex = index + 1;
+    while (endIndex < events.length && events[endIndex]!.runId === runId) {
+      endIndex++;
+    }
+
+    const runEvents = events.slice(index, endIndex);
+    if (!terminatedRunIds.has(runId) || runEvents.some(isCancelledRunEvent)) {
+      visibleEvents.push(...runEvents);
+      index = endIndex;
+      continue;
+    }
+
+    const completedWorkEventGroups = splitCompletedWorkEventsAtUsers(runEvents);
+    if (completedWorkEventGroups.length > 1) {
+      hasCompletedWorkPhaseBoundary = true;
+    }
+    for (const completedWorkEvents of completedWorkEventGroups) {
+      const phaseFolding = foldCompletedWorkPhase(runId, completedWorkEvents);
+      visibleEvents.push(...phaseFolding.visibleEvents);
+      if (phaseFolding.fold !== null) {
+        folds.push(phaseFolding.fold);
+      }
+    }
+
+    index = endIndex;
+  }
+
+  if (folds.length === 0 && !hasCompletedWorkPhaseBoundary) {
+    return null;
+  }
+
+  const foldFinalEventIds = new Set(
+    folds.map((fold) => {
+      return fold.finalEventId;
+    }),
+  );
+  return {
+    visibleGroups: attachUsageToCompletedWorkGroups(
+      groupEventsForCompletedWorkDisplay(visibleEvents, foldFinalEventIds),
+      usageByRunId,
+    ),
+    foldsByFinalEventId: new Map(
+      folds.map((fold) => {
+        return [fold.finalEventId, fold];
+      }),
+    ),
+  };
+}
+
+/** Match the event ordering inside each outer page row after fold expansion. */
+export function applyCompletedWorkExpansion(
+  groups: readonly ChatEventGroup[],
+  folding: CompletedWorkFolding | null,
+  expandedKeys: ReadonlySet<string>,
+): ChatEventGroup[] {
+  const visibleGroups = folding?.visibleGroups ?? groups;
+  return visibleGroups.map((group) => {
+    const fold = completedWorkFoldForGroup(folding, group);
+    if (fold === null || !expandedKeys.has(fold.key)) {
+      return group;
+    }
+    return {
+      ...group,
+      events: [
+        ...fold.hiddenGroups.flatMap((hiddenGroup) => {
+          return hiddenGroup.events;
+        }),
+        ...group.events,
+      ],
+    };
+  });
+}

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -2502,6 +2502,9 @@ function createChatThreadMessagePipeline(
     eventTreeErrors$: resources.eventTreeErrors$,
   });
   const initialEventsReady$ = state(false);
+  const initialEventsReadyView$ = computed((get): boolean => {
+    return get(initialEventsReady$);
+  });
   const renderWindow = createChatRenderWindow({
     threadId,
     allRenderedChatGroups$: projections.allRenderedChatGroups$,
@@ -2532,6 +2535,8 @@ function createChatThreadMessagePipeline(
     threadId,
     position,
     ensureVisibleEventTreesAfterScroll$,
+    chatEvents.chatEvents$,
+    initialEventsReadyView$,
   );
   const effects = createEventChangeEffects(
     {
@@ -2543,9 +2548,6 @@ function createChatThreadMessagePipeline(
     },
     ownerSignal,
   );
-  const initialEventsReadyView$ = computed((get): boolean => {
-    return get(initialEventsReady$);
-  });
   const lifecycle = createChatEventPresentationLifecycle({
     chatEvents,
     afterEventsChange$: effects.afterEventsChange$,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1119,14 +1119,15 @@ function groupEventsForDisplay(events: EnrichedChatEvent[]): ChatEventGroup[] {
 function createRenderedChatGroups(
   semanticEvents$: Computed<SemanticChatEvent[]>,
 ) {
-  const transcriptEvents$ = createTranscriptEventsComputed(semanticEvents$);
+  const allChatGroups$ = computed((get): ChatEventGroup[] => {
+    return groupEventsForDisplay(
+      enrichedChatEventsFromSemantic(get(semanticEvents$)),
+    );
+  });
 
-  const allRenderedChatGroups$ = computed(
-    async (get): Promise<ChatEventGroup[]> => {
-      const events = await get(transcriptEvents$);
-      return groupEventsForDisplay(events);
-    },
-  );
+  const allRenderedChatGroups$ = computed((get): Promise<ChatEventGroup[]> => {
+    return Promise.resolve(get(allChatGroups$));
+  });
   const eventImageGroups$ = computed(
     async (get): Promise<EventImageGroupProjection[]> => {
       return (await get(allRenderedChatGroups$)).map((group) => {
@@ -1146,6 +1147,7 @@ function createRenderedChatGroups(
   );
 
   return {
+    allChatGroups$,
     allRenderedChatGroups$,
     eventImageGroups$,
   };
@@ -1356,22 +1358,18 @@ function createRawEventsComputed(
   });
 }
 
-function createTranscriptEventsComputed(
-  semanticEvents$: Computed<SemanticChatEvent[]>,
-): Computed<Promise<EnrichedChatEvent[]>> {
-  return computed((get): Promise<EnrichedChatEvent[]> => {
-    return Promise.resolve(
-      get(semanticEvents$).map((entry) => {
-        const { event, isQueued, userMessageRenderDocument } = entry;
-        return {
-          ...event,
-          tree: entry.tree,
-          richContentError: entry.richContentError,
-          isQueued,
-          userMessageRenderDocument,
-        };
-      }),
-    );
+function enrichedChatEventsFromSemantic(
+  entries: readonly SemanticChatEvent[],
+): EnrichedChatEvent[] {
+  return entries.map((entry) => {
+    const { event, isQueued, userMessageRenderDocument } = entry;
+    return {
+      ...event,
+      tree: entry.tree,
+      richContentError: entry.richContentError,
+      isQueued,
+      userMessageRenderDocument,
+    };
   });
 }
 
@@ -4241,17 +4239,18 @@ function createChatPanelSignalsWithDraft(
     draft,
   );
   const feedback = createChatThreadFeedbackSignals(threadId, composer.feedback);
+  const messagePipeline = createChatThreadMessagePipeline(
+    {
+      chatActionContext: { threadId, agentId },
+      chatEvents,
+      previewImageUrlsByUrl$: createArtifactPreviewImageUrls(
+        artifact.artifacts$,
+      ),
+    },
+    signal,
+  );
   const messages: MessageListSignals = {
-    ...createChatThreadMessagePipeline(
-      {
-        chatActionContext: { threadId, agentId },
-        chatEvents,
-        previewImageUrlsByUrl$: createArtifactPreviewImageUrls(
-          artifact.artifacts$,
-        ),
-      },
-      signal,
-    ),
+    ...messagePipeline,
     ...artifact,
   };
   const sharing = createChatThreadSharingSignals(threadId, messages.scroll);
@@ -4259,6 +4258,8 @@ function createChatPanelSignalsWithDraft(
     threadId,
     scrollContainer$: messages.scroll.scrollContainer$,
     scrollToEvent$: messages.scroll.scrollToEvent$,
+    allChatGroups$: messagePipeline.allChatGroups$,
+    threadScrollPosition$: messages.scroll.threadScrollPosition$,
   });
   const runTracking = createRunTracking({
     threadId,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -4255,13 +4255,11 @@ function createChatPanelSignalsWithDraft(
     ...artifact,
   };
   const sharing = createChatThreadSharingSignals(threadId, messages.scroll);
-  const locator = createChatConversationLocatorSignals(
-    {
-      threadId,
-      scrollContainer$: messages.scroll.scrollContainer$,
-    },
-    signal,
-  );
+  const locator = createChatConversationLocatorSignals({
+    threadId,
+    scrollContainer$: messages.scroll.scrollContainer$,
+    scrollToEvent$: messages.scroll.scrollToEvent$,
+  });
   const runTracking = createRunTracking({
     threadId,
     setupChatEvents$: messages.setup$,
@@ -4287,6 +4285,7 @@ function createChatPanelSignalsWithDraft(
     scrollContainer$: messages.scroll.scrollContainer$,
     threadScrollPosition$: messages.scroll.threadScrollPosition$,
     awayFromBottom$: messages.scroll.awayFromBottom$,
+    scrollToEvent$: messages.scroll.scrollToEvent$,
     scrollTo$: messages.scroll.scrollTo$,
     scrollToTop$: messages.scroll.scrollToTop$,
     scrollToBottom$: messages.scroll.scrollToBottom$,

--- a/turbo/apps/platform/src/signals/location.ts
+++ b/turbo/apps/platform/src/signals/location.ts
@@ -2,6 +2,7 @@ class LocationOverrides {
   ownerSignal: AbortSignal | undefined = undefined;
   pathname: string | undefined = undefined;
   search: string | undefined = undefined;
+  hash: string | undefined = undefined;
   pushState: typeof window.history.pushState | undefined = undefined;
   replaceState: typeof window.history.replaceState | undefined = undefined;
 }
@@ -11,6 +12,7 @@ const overrides = new LocationOverrides();
 function clearOverrideValues(): void {
   overrides.pathname = undefined;
   overrides.search = undefined;
+  overrides.hash = undefined;
   overrides.pushState = undefined;
   overrides.replaceState = undefined;
 }
@@ -45,12 +47,21 @@ export const setSearch = (search: string, signal: AbortSignal) => {
   overrides.search = search;
 };
 
+export const setHash = (hash: string, signal: AbortSignal) => {
+  ownOverrides(signal);
+  overrides.hash = hash;
+};
+
 export const pathname = () => {
   return overrides.pathname ?? location.pathname;
 };
 
 export const search = () => {
   return overrides.search ?? location.search;
+};
+
+export const hash = () => {
+  return overrides.hash ?? location.hash;
 };
 
 export const pushState = (

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -2,7 +2,7 @@ import { command, computed, state, type Command } from "ccstate";
 import { match } from "path-to-regexp";
 import type { RoutePath } from "./route-paths";
 import { clerk$, needsOrgSelection$, resolveAppAuthUrl } from "./auth.ts";
-import { pathname, pushState, replaceState, search } from "./location.ts";
+import { hash, pathname, pushState, replaceState, search } from "./location.ts";
 import { setPageSignal$ } from "./page-signal.ts";
 import { clearPage$ } from "./react-router.ts";
 import { rootSignal$ } from "./root-signal.ts";
@@ -37,6 +37,11 @@ export const pathname$ = computed((get) => {
 export const searchParams$ = computed((get) => {
   get(reloadPathname$);
   return new URLSearchParams(search());
+});
+
+export const hash$ = computed((get) => {
+  get(reloadPathname$);
+  return hash();
 });
 
 export const historyState$ = computed((get) => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-conversation-locator.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-conversation-locator.test.tsx
@@ -414,6 +414,36 @@ describe("chat conversation locator", () => {
     });
   });
 
+  it("hands the wheel back at the beginning of the locator window", async () => {
+    const { rail } = await renderLongThread();
+
+    const firstIndex = () => {
+      const tick = ticksOf(rail)[0];
+      return Number.parseFloat(tick?.dataset.turnIndex ?? "-1");
+    };
+    pointerAt(rail, 0, "pointerenter");
+
+    rail.dispatchEvent(
+      new WheelEvent("wheel", {
+        bubbles: true,
+        cancelable: true,
+        deltaY: -3000,
+      }),
+    );
+    await waitFor(() => {
+      expect(firstIndex()).toBe(0);
+    });
+
+    const boundaryWheel = new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaY: -300,
+    });
+    rail.dispatchEvent(boundaryWheel);
+
+    expect(boundaryWheel.defaultPrevented).toBeFalsy();
+  });
+
   it("marks the turn a click lands on", async () => {
     const { rail } = await renderLongThread();
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-conversation-locator.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-conversation-locator.test.tsx
@@ -13,6 +13,7 @@ const THREAD_ID = "b0000000-0000-4000-a000-000000000806";
 const GEOMETRY_THREAD_ID = "b0000000-0000-4000-a000-000000000807";
 const VIRTUAL_THREAD_ID = "b0000000-0000-4000-a000-000000000808";
 const GOAL_THREAD_ID = "b0000000-0000-4000-a000-000000000809";
+const COMPLETED_WORK_THREAD_ID = "b0000000-0000-4000-a000-000000000810";
 
 const VIEWPORT_PX = 600;
 const RAIL_PX = 600;
@@ -257,6 +258,60 @@ function goalConversation(): MockChatEventInput[] {
       runGroupId,
       runLifecycleEvent: "completed",
       createdAt: "2026-06-09T13:12:30Z",
+    },
+  ];
+}
+
+function completedWorkConversation(): MockChatEventInput[] {
+  const prefix = Array.from({ length: 5 }, (_unused, index) => {
+    const minute = String(index).padStart(2, "0");
+    const runId = `run-locator-work-prefix-${index}`;
+    return [
+      {
+        id: `locator-work-prefix-user-${index}`,
+        eventType: "input.prompt" as const,
+        role: "user" as const,
+        content: `Work prefix question ${index}`,
+        runId,
+        createdAt: `2026-06-09T14:${minute}:00Z`,
+      },
+      {
+        id: `locator-work-prefix-assistant-${index}`,
+        eventType: "output.message" as const,
+        role: "assistant" as const,
+        content: `Work prefix answer ${index}`,
+        runId,
+        createdAt: `2026-06-09T14:${minute}:30Z`,
+      },
+    ];
+  }).flat();
+  const runId = "run-locator-completed-work";
+  return [
+    ...prefix,
+    {
+      id: "locator-work-user",
+      eventType: "input.prompt",
+      role: "user",
+      content: "Summarize completed work",
+      runId,
+      createdAt: "2026-06-09T14:10:00Z",
+    },
+    {
+      id: "locator-work-hidden-assistant",
+      eventType: "output.message",
+      role: "assistant",
+      content: "Checking completed work in the locator",
+      runId,
+      createdAt: "2026-06-09T14:10:30Z",
+    },
+    {
+      id: "locator-work-final-assistant",
+      eventType: "output.message",
+      role: "assistant",
+      content: "Completed work is summarized in the locator",
+      runId,
+      runLifecycleEvent: "completed",
+      createdAt: "2026-06-09T14:11:00Z",
     },
   ];
 }
@@ -676,6 +731,68 @@ describe("chat conversation locator", () => {
       const landed = anchor?.closest<HTMLElement>('[data-role="assistant"]');
       expect(landed).not.toBeNull();
       expect(landed).toHaveAttribute("data-locator-landed");
+    });
+  });
+
+  it("tracks the visible assistant event in folded completed work", async () => {
+    const { rail, resize } = await renderMeasuredThread({
+      threadId: COMPLETED_WORK_THREAD_ID,
+      threadTitle: "Completed work locator turns",
+      chatEvents: completedWorkConversation(),
+      renderedText: "Completed work is summarized in the locator",
+    });
+
+    expect(
+      screen.queryByText("Checking completed work in the locator"),
+    ).toBeNull();
+    expect(ticksOf(rail)).toHaveLength(12);
+
+    pointerAt(rail, 0, "pointerenter");
+    let assistantTick = ticksOf(rail).find((tick) => {
+      return tick.dataset.turnIndex === "11";
+    });
+    expect(assistantTick).toBeDefined();
+    pointerAt(rail, Number.parseFloat(assistantTick!.style.top), "pointermove");
+    await waitFor(() => {
+      expect(locatorPreview()).toHaveTextContent(
+        "Completed work is summarized in the locator",
+      );
+    });
+    rail.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await waitFor(() => {
+      const anchor = document.querySelector<HTMLElement>(
+        '[data-chat-scroll-anchor-event-id="locator-work-final-assistant"]',
+      );
+      expect(anchor?.closest('[data-role="assistant"]')).toHaveAttribute(
+        "data-locator-landed",
+      );
+    });
+
+    fireEvent.click(screen.getByLabelText("Expand work history"));
+    await screen.findByText("Checking completed work in the locator");
+    resize.automationAll();
+    await waitFor(() => {
+      expect(ticksOf(rail)).toHaveLength(12);
+    });
+
+    assistantTick = ticksOf(rail).find((tick) => {
+      return tick.dataset.turnIndex === "11";
+    });
+    expect(assistantTick).toBeDefined();
+    pointerAt(rail, Number.parseFloat(assistantTick!.style.top), "pointermove");
+    await waitFor(() => {
+      expect(locatorPreview()).toHaveTextContent(
+        "Checking completed work in the locator",
+      );
+    });
+    rail.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await waitFor(() => {
+      const anchor = document.querySelector<HTMLElement>(
+        '[data-chat-scroll-anchor-event-id="locator-work-hidden-assistant"]',
+      );
+      expect(anchor?.closest('[data-role="assistant"]')).toHaveAttribute(
+        "data-locator-landed",
+      );
     });
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-conversation-locator.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-conversation-locator.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
@@ -11,6 +11,8 @@ import {
 
 const THREAD_ID = "b0000000-0000-4000-a000-000000000806";
 const GEOMETRY_THREAD_ID = "b0000000-0000-4000-a000-000000000807";
+const VIRTUAL_THREAD_ID = "b0000000-0000-4000-a000-000000000808";
+const GOAL_THREAD_ID = "b0000000-0000-4000-a000-000000000809";
 
 const VIEWPORT_PX = 600;
 const RAIL_PX = 600;
@@ -24,7 +26,13 @@ const TURN_SELECTOR = '[data-role="user"], [data-role="assistant"]';
  * as zero-sized and never open. This models the one layout it cares about: a
  * fixed-height viewport scrolling over turns of equal height.
  */
-function stubLayout(): void {
+function stubLayout({
+  minimumScrollTurns = 0,
+  turnHeight = TURN_PX,
+}: {
+  minimumScrollTurns?: number;
+  turnHeight?: number;
+} = {}): void {
   const prototype = globalThis.HTMLElement.prototype;
   const rectDescriptor = Object.getOwnPropertyDescriptor(
     prototype,
@@ -81,7 +89,12 @@ function stubLayout(): void {
       if (!isScroller(this)) {
         return 0;
       }
-      return this.querySelectorAll(TURN_SELECTOR).length * TURN_PX;
+      return (
+        Math.max(
+          minimumScrollTurns,
+          this.querySelectorAll(TURN_SELECTOR).length,
+        ) * turnHeight
+      );
     },
   });
   Object.defineProperty(prototype, "getBoundingClientRect", {
@@ -113,7 +126,7 @@ function stubLayout(): void {
         return originalRect.call(this);
       }
       const scroller = this.closest<HTMLElement>("[data-scroll-container]");
-      return rect(index * TURN_PX - (scroller?.scrollTop ?? 0), TURN_PX);
+      return rect(index * turnHeight - (scroller?.scrollTop ?? 0), turnHeight);
     },
   });
 
@@ -152,6 +165,102 @@ function longConversation(): MockChatEventInput[] {
   });
 }
 
+function virtualConversation(): MockChatEventInput[] {
+  return Array.from({ length: 15 }, (_unused, index) => {
+    const minute = String(index).padStart(2, "0");
+    const runId = `run-locator-virtual-${index}`;
+    return [
+      {
+        id: `locator-virtual-user-${index}`,
+        eventType: "input.prompt" as const,
+        role: "user" as const,
+        content: `Virtual question ${index}`,
+        runId,
+        createdAt: `2026-06-09T12:${minute}:00Z`,
+      },
+      {
+        id: `locator-virtual-assistant-${index}`,
+        eventType: "output.message" as const,
+        role: "assistant" as const,
+        content: `Virtual answer ${index}`,
+        runId,
+        createdAt: `2026-06-09T12:${minute}:30Z`,
+      },
+    ];
+  }).flat();
+}
+
+function goalConversation(): MockChatEventInput[] {
+  const prefix = Array.from({ length: 5 }, (_unused, index) => {
+    const minute = String(index).padStart(2, "0");
+    const runId = `run-locator-goal-prefix-${index}`;
+    return [
+      {
+        id: `locator-goal-prefix-user-${index}`,
+        eventType: "input.prompt" as const,
+        role: "user" as const,
+        content: `Goal prefix question ${index}`,
+        runId,
+        createdAt: `2026-06-09T13:${minute}:00Z`,
+      },
+      {
+        id: `locator-goal-prefix-assistant-${index}`,
+        eventType: "output.message" as const,
+        role: "assistant" as const,
+        content: `Goal prefix answer ${index}`,
+        runId,
+        createdAt: `2026-06-09T13:${minute}:30Z`,
+      },
+    ];
+  }).flat();
+  const runGroupId = "run-group-locator-goal";
+  const goalBrief = "Keep the locator goal moving";
+  return [
+    ...prefix,
+    {
+      id: "locator-goal-hidden-user",
+      role: "user",
+      content: goalBrief,
+      userMessage: {
+        version: 1,
+        parts: [{ type: "goal", goalBrief }],
+      },
+      runId: "run-locator-goal-hidden",
+      runGroupId,
+      createdAt: "2026-06-09T13:10:00Z",
+    },
+    {
+      id: "locator-goal-hidden-assistant",
+      role: "assistant",
+      content: "First goal result in the locator",
+      runId: "run-locator-goal-hidden",
+      runGroupId,
+      createdAt: "2026-06-09T13:10:30Z",
+    },
+    {
+      id: "locator-goal-latest-user",
+      role: "user",
+      content: goalBrief,
+      userMessage: {
+        version: 1,
+        parts: [{ type: "goal", goalBrief }],
+      },
+      runId: "run-locator-goal-latest",
+      runGroupId,
+      createdAt: "2026-06-09T13:12:00Z",
+    },
+    {
+      id: "locator-goal-latest-assistant",
+      role: "assistant",
+      content: "Latest goal result in the locator",
+      runId: "run-locator-goal-latest",
+      runGroupId,
+      runLifecycleEvent: "completed",
+      createdAt: "2026-06-09T13:12:30Z",
+    },
+  ];
+}
+
 function pointerAt(rail: HTMLElement, y: number, type: string): void {
   rail.dispatchEvent(
     new MouseEvent(type, { bubbles: true, clientX: 20, clientY: y }),
@@ -162,26 +271,48 @@ function ticksOf(rail: HTMLElement): HTMLElement[] {
   return [...rail.querySelectorAll<HTMLElement>("[data-locator-tick]")];
 }
 
-async function renderLongThread(): Promise<{
+function locatorPreview(): HTMLElement {
+  const preview = document.querySelector<HTMLElement>(
+    "[data-conversation-locator-preview]",
+  );
+  expect(preview).not.toBeNull();
+  return preview as HTMLElement;
+}
+
+async function renderMeasuredThread({
+  threadId,
+  threadTitle,
+  chatEvents,
+  renderedText,
+  minimumScrollTurns = 0,
+  turnHeight = TURN_PX,
+}: {
+  threadId: string;
+  threadTitle: string;
+  chatEvents: MockChatEventInput[];
+  renderedText: string;
+  minimumScrollTurns?: number;
+  turnHeight?: number;
+}): Promise<{
   rail: HTMLElement;
   resize: { automationAll: () => void };
 }> {
-  stubLayout();
+  stubLayout({ minimumScrollTurns, turnHeight });
   const resize = mockResizeObserver();
   mockChatLifecycle(context, {
-    threadId: GEOMETRY_THREAD_ID,
-    threadTitle: "Locator geometry",
-    chatEvents: longConversation(),
+    threadId,
+    threadTitle,
+    chatEvents,
   });
   detachedSetupPage({
     context,
-    path: `/chats/${GEOMETRY_THREAD_ID}`,
+    path: `/chats/${threadId}`,
     featureSwitches: {
       [FeatureSwitchKey.ChatConversationLocator]: true,
     },
   });
 
-  await screen.findByText(`Prompt ${LONG_TURN_COUNT - 1}`);
+  await screen.findByText(renderedText);
   const rail = await waitFor(() => {
     const element = document.querySelector<HTMLElement>(
       "[data-conversation-locator]",
@@ -196,6 +327,18 @@ async function renderLongThread(): Promise<{
     expect(ticksOf(rail).length).toBeGreaterThan(0);
   });
   return { rail, resize };
+}
+
+function renderLongThread(): Promise<{
+  rail: HTMLElement;
+  resize: { automationAll: () => void };
+}> {
+  return renderMeasuredThread({
+    threadId: GEOMETRY_THREAD_ID,
+    threadTitle: "Locator geometry",
+    chatEvents: longConversation(),
+    renderedText: `Prompt ${LONG_TURN_COUNT - 1}`,
+  });
 }
 
 /** Ten alternating turns: past the locator's turn floor on its own. */
@@ -442,6 +585,98 @@ describe("chat conversation locator", () => {
     rail.dispatchEvent(boundaryWheel);
 
     expect(boundaryWheel.defaultPrevented).toBeFalsy();
+  });
+
+  it("lists and jumps to a turn outside the virtual render window", async () => {
+    const { rail } = await renderMeasuredThread({
+      threadId: VIRTUAL_THREAD_ID,
+      threadTitle: "Virtual locator turns",
+      chatEvents: virtualConversation(),
+      renderedText: "Virtual answer 14",
+      turnHeight: 60,
+    });
+
+    expect(
+      document.querySelector(
+        '[data-chat-scroll-anchor-event-id="locator-virtual-user-0"]',
+      ),
+    ).toBeNull();
+    expect(ticksOf(rail)).toHaveLength(24);
+
+    pointerAt(rail, 0, "pointerenter");
+    rail.dispatchEvent(
+      new WheelEvent("wheel", {
+        bubbles: true,
+        cancelable: true,
+        deltaY: -3000,
+      }),
+    );
+    const firstTick = await waitFor(() => {
+      const tick = ticksOf(rail)[0];
+      expect(tick?.dataset.turnIndex).toBe("0");
+      return tick as HTMLElement;
+    });
+    pointerAt(rail, Number.parseFloat(firstTick.style.top), "pointermove");
+
+    await waitFor(() => {
+      expect(locatorPreview()).toHaveTextContent("Virtual question 0");
+      expect(locatorPreview()).toHaveTextContent("1/30");
+    });
+    rail.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    await screen.findByText("Virtual question 0");
+    await waitFor(() => {
+      const target = document.querySelector<HTMLElement>(
+        '[data-chat-scroll-anchor-event-id="locator-virtual-user-0"]',
+      );
+      expect(target).not.toBeNull();
+      expect(target).toHaveAttribute("data-locator-landed");
+    });
+  });
+
+  it("keeps merged goal turns out of the locator until the group expands", async () => {
+    const { rail, resize } = await renderMeasuredThread({
+      threadId: GOAL_THREAD_ID,
+      threadTitle: "Goal locator turns",
+      chatEvents: goalConversation(),
+      renderedText: "Latest goal result in the locator",
+    });
+
+    expect(screen.queryByText("First goal result in the locator")).toBeNull();
+    expect(ticksOf(rail)).toHaveLength(12);
+
+    fireEvent.click(screen.getByLabelText("Expand grouped run history"));
+    await screen.findByText("First goal result in the locator");
+    resize.automationAll();
+    await waitFor(() => {
+      expect(ticksOf(rail)).toHaveLength(14);
+    });
+
+    const hiddenAssistantTick = ticksOf(rail).find((tick) => {
+      return tick.dataset.turnIndex === "11";
+    });
+    expect(hiddenAssistantTick).toBeDefined();
+    pointerAt(rail, 0, "pointerenter");
+    pointerAt(
+      rail,
+      Number.parseFloat(hiddenAssistantTick!.style.top),
+      "pointermove",
+    );
+    await waitFor(() => {
+      expect(locatorPreview()).toHaveTextContent(
+        "First goal result in the locator",
+      );
+    });
+    rail.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    await waitFor(() => {
+      const anchor = document.querySelector<HTMLElement>(
+        '[data-chat-scroll-anchor-event-id="locator-goal-hidden-assistant"]',
+      );
+      const landed = anchor?.closest<HTMLElement>('[data-role="assistant"]');
+      expect(landed).not.toBeNull();
+      expect(landed).toHaveAttribute("data-locator-landed");
+    });
   });
 
   it("marks the turn a click lands on", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-scroll-position.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-scroll-position.test.tsx
@@ -683,6 +683,51 @@ describe("chat scroll position", () => {
     expect(chatScrollContainer().scrollTop).toBe(0);
   });
 
+  it("opens an event hash instead of following the thread tail", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000817";
+    const events = simpleUserEvents(threadId, "deep-link", 20);
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Event deep link",
+      chatEvents: events,
+    });
+    installChatLayout(
+      new Map([
+        [
+          threadId,
+          {
+            clientHeight: () => {
+              return 300;
+            },
+            scrollHeight: () => {
+              return 2000;
+            },
+            eventRect: (eventId) => {
+              const index = Number(eventId.split("-").at(-1));
+              return Number.isFinite(index)
+                ? { top: index * 100, height: 80 }
+                : undefined;
+            },
+          },
+        ],
+      ]),
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}#event-deep-link-2`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatConversationLocator]: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("deep-link message 2")).toBeInTheDocument();
+      expect(chatScrollContainer().scrollTop).toBe(200);
+      expect(viewportOffsetTop("deep-link-2")).toBe(0);
+    });
+  });
+
   it("follows the tail when a new message arrives while at the bottom", async () => {
     const threadId = "b0000000-0000-4000-a000-000000000801";
     const initialEvents = simpleUserEvents(threadId, "tail-follow", 8);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-scroll-position.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-scroll-position.test.tsx
@@ -358,9 +358,13 @@ function installResizeObserver(): ResizeObserverController {
 }
 
 function eventAnchor(eventId: string): HTMLElement {
-  const anchor = document.querySelector(
-    `[data-chat-scroll-anchor-event-id="${eventId}"]`,
-  );
+  const anchor = Array.from(
+    document.querySelectorAll<HTMLElement>(
+      "[data-chat-scroll-anchor-event-id]",
+    ),
+  ).find((candidate) => {
+    return candidate.dataset.chatScrollAnchorEventId === eventId;
+  });
   if (!(anchor instanceof HTMLElement)) {
     throw new Error(`Chat scroll anchor not found: ${eventId}`);
   }
@@ -725,6 +729,112 @@ describe("chat scroll position", () => {
       expect(screen.getByText("deep-link message 2")).toBeInTheDocument();
       expect(chatScrollContainer().scrollTop).toBe(200);
       expect(viewportOffsetTop("deep-link-2")).toBe(0);
+    });
+  });
+
+  it.each([
+    {
+      hash: "#event-%",
+      label: "malformed",
+      threadId: "b0000000-0000-4000-a000-000000000818",
+    },
+    {
+      hash: `#event-${encodeURIComponent('missing-"]')}`,
+      label: "unknown",
+      threadId: "b0000000-0000-4000-a000-000000000819",
+    },
+  ])(
+    "ignores a $label event hash and follows the thread tail",
+    async ({ hash, threadId }) => {
+      const events = simpleUserEvents(threadId, "invalid-deep-link", 20);
+      mockChatLifecycle(context, {
+        threadId,
+        threadTitle: "Invalid event deep link",
+        chatEvents: events,
+      });
+      installChatLayout(
+        new Map([
+          [
+            threadId,
+            {
+              clientHeight: () => {
+                return 300;
+              },
+              scrollHeight: () => {
+                return 2000;
+              },
+              eventRect: (eventId) => {
+                const index = Number(eventId.split("-").at(-1));
+                return Number.isFinite(index)
+                  ? { top: index * 100, height: 80 }
+                  : undefined;
+              },
+            },
+          ],
+        ]),
+      );
+
+      detachedSetupPage({
+        context,
+        path: `/chats/${threadId}${hash}`,
+        featureSwitches: {
+          [FeatureSwitchKey.ChatConversationLocator]: true,
+        },
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("invalid-deep-link message 19"),
+        ).toBeInTheDocument();
+        expect(chatScrollContainer().scrollTop).toBe(1700);
+      });
+    },
+  );
+
+  it("opens an encoded selector-sensitive event hash", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000820";
+    const prefix = 'quoted-"event';
+    const events = simpleUserEvents(threadId, prefix, 20);
+    const targetEventId = `${prefix}-2`;
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Encoded event deep link",
+      chatEvents: events,
+    });
+    installChatLayout(
+      new Map([
+        [
+          threadId,
+          {
+            clientHeight: () => {
+              return 300;
+            },
+            scrollHeight: () => {
+              return 2000;
+            },
+            eventRect: (eventId) => {
+              const index = Number(eventId.split("-").at(-1));
+              return Number.isFinite(index)
+                ? { top: index * 100, height: 80 }
+                : undefined;
+            },
+          },
+        ],
+      ]),
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}#event-${encodeURIComponent(targetEventId)}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatConversationLocator]: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(`${prefix} message 2`)).toBeInTheDocument();
+      expect(chatScrollContainer().scrollTop).toBe(200);
+      expect(viewportOffsetTop(targetEventId)).toBe(0);
     });
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -8,6 +8,7 @@ import {
   VIDEO_TEMPLATE_ITEMS,
   WEBSITE_TEMPLATE_ITEMS,
 } from "@okouai/core";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { goalsContract } from "@okouai/api-contracts/contracts/goals";
 import type {
   ChatThreadWorkflowAutomation,
@@ -1133,6 +1134,79 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
       expect(screen.queryByText(goalPrompt)).not.toBeInTheDocument();
       expect(screen.getAllByText("Worked for 30s").length).toBeGreaterThan(0);
     });
+  });
+
+  it("expands archived goal history for an event hash", async () => {
+    const threadId = "e9000000-0000-4000-a000-000000000016";
+    const runGroupId = "f0000001-0000-4000-a000-00000000092b";
+    const goalBrief = "Open the archived goal event";
+    const goalPrompt = `${goalBrief}\n\nFull autonomous goal prompt`;
+
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Goal event deep link",
+      chatEvents: [
+        {
+          id: "msg-goal-deep-link-user-1",
+          role: "user",
+          content: goalPrompt,
+          userMessage: {
+            version: 1,
+            parts: [{ type: "goal", goalBrief }],
+          },
+          runId: "f0000001-0000-4000-a000-00000000092c",
+          runGroupId,
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-goal-deep-link-assistant-1",
+          role: "assistant",
+          content: "Archived goal result",
+          runId: "f0000001-0000-4000-a000-00000000092c",
+          runGroupId,
+          createdAt: "2026-06-09T10:00:30Z",
+        },
+        {
+          id: "msg-goal-deep-link-user-2",
+          role: "user",
+          content: goalPrompt,
+          userMessage: {
+            version: 1,
+            parts: [{ type: "goal", goalBrief }],
+          },
+          runId: "f0000001-0000-4000-a000-00000000092d",
+          runGroupId,
+          createdAt: "2026-06-09T10:02:00Z",
+        },
+        {
+          id: "msg-goal-deep-link-assistant-2",
+          role: "assistant",
+          content: "Latest goal result",
+          runId: "f0000001-0000-4000-a000-00000000092d",
+          runGroupId,
+          runLifecycleEvent: "completed",
+          createdAt: "2026-06-09T10:02:30Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}#event-msg-goal-deep-link-assistant-1`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatConversationLocator]: true,
+      },
+    });
+
+    await expect(
+      screen.findByText("Archived goal result"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByText("Latest goal result")).toBeInTheDocument();
+    expect(
+      document.querySelector(
+        '[data-chat-scroll-anchor-event-id="msg-goal-deep-link-assistant-1"]',
+      ),
+    ).not.toBeNull();
   });
 
   it("keeps archived goal history below a running goal without assistant text", async () => {

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -97,12 +97,7 @@ import type {
   UserMessageDocument,
   UserMessagePart,
 } from "@okouai/api-contracts/contracts/chat-threads";
-import {
-  chatEventCompatibilityRole,
-  foldLatestChatUsageByRunId,
-  isChatEventContentTextType,
-  terminatedChatRunIds,
-} from "@okouai/api-contracts/contracts/chat-events";
+import { isChatEventContentTextType } from "@okouai/api-contracts/contracts/chat-events";
 import {
   messageDocumentToDisplayText,
   messageDocumentToPrompt,
@@ -152,10 +147,16 @@ import {
   closeChatConnectorActionConnectDialog$,
 } from "../../signals/chat-page/connector-action-block.ts";
 import {
+  buildCompletedWorkFolding,
+  chatEventDisplayError,
   completedWorkExpandedKeys$,
+  completedWorkExpandedKeysForScrollTarget,
+  completedWorkFoldForGroup,
+  isRenderableAssistantEvent,
   toggleCompletedWorkExpanded$,
+  type CompletedWorkFold,
+  type CompletedWorkFolding,
 } from "../../signals/chat-page/completed-work-folding.ts";
-import { isCancelledRunEvent } from "../../signals/chat-page/chat-run-lifecycle.ts";
 import {
   buildRunGroupFolding,
   runGroupExpansionOverrides$,
@@ -489,24 +490,6 @@ function eventNonContentPart(
   return userMessageNonContentPart(
     isInputChatEvent(event) ? event.userMessage : undefined,
   );
-}
-
-function chatEventAttachments(event: ChatEvent) {
-  return isInputChatEvent(event)
-    ? userMessageFileAttachments(event.userMessage)
-    : undefined;
-}
-
-function chatEventError(event: ChatEvent): string | undefined {
-  if (
-    event.eventType === "input.rejected" ||
-    event.eventType === "output.error" ||
-    event.eventType === "run.failed" ||
-    event.eventType === "run.cancelled"
-  ) {
-    return event.error;
-  }
-  return undefined;
 }
 
 function ArtifactsButton({ thread }: { thread: ChatPanelSignals }) {
@@ -3482,367 +3465,12 @@ function assistantGroupIdForCollapsedRunGroupFold(
   return undefined;
 }
 
-function completedWorkFoldForGroup(
-  completedWorkFolding: CompletedWorkFolding | null,
-  group: ChatEventGroup,
-): CompletedWorkFold | null {
-  if (completedWorkFolding === null) {
-    return null;
-  }
-  return (
-    group.events
-      .map((event) => {
-        return completedWorkFolding.foldsByFinalEventId.get(event.id);
-      })
-      .find((fold) => {
-        return fold !== undefined;
-      }) ?? null
-  );
-}
-
-function groupEventsByRole(
-  events: readonly EnrichedChatEvent[],
-): ChatEventGroup[] {
-  const groups: ChatEventGroup[] = [];
-  for (const event of events) {
-    const role = chatEventCompatibilityRole(event.eventType);
-    const last = groups[groups.length - 1];
-    if (last && last.role === role) {
-      last.events.push(event);
-      continue;
-    }
-    groups.push({
-      beginEventId: event.id,
-      role,
-      events: [event],
-    });
-  }
-  return groups;
-}
-
-interface CompletedWorkFold {
-  key: string;
-  finalEventId: string;
-  hiddenGroups: ChatEventGroup[];
-  labelGroups: ChatEventGroup[];
-}
-
-interface CompletedWorkFolding {
-  visibleGroups: ChatEventGroup[];
-  foldsByFinalEventId: Map<string, CompletedWorkFold>;
-}
-
-function completedWorkExpandedKeysForScrollTarget(
-  folding: CompletedWorkFolding | null,
-  expandedKeys: ReadonlySet<string>,
-  targetEventId: string | null,
-): ReadonlySet<string> {
-  if (folding === null || targetEventId === null) {
-    return expandedKeys;
-  }
-  const targetFold = Array.from(folding.foldsByFinalEventId.values()).find(
-    (fold) => {
-      return fold.hiddenGroups.some((group) => {
-        return group.events.some((event) => {
-          return event.id === targetEventId;
-        });
-      });
-    },
-  );
-  if (!targetFold || expandedKeys.has(targetFold.key)) {
-    return expandedKeys;
-  }
-  const next = new Set(expandedKeys);
-  next.add(targetFold.key);
-  return next;
-}
-
-function groupEventsForCompletedWorkDisplay(
-  events: readonly EnrichedChatEvent[],
-  foldFinalEventIds: ReadonlySet<string>,
-): ChatEventGroup[] {
-  const groups: ChatEventGroup[] = [];
-  for (const event of events) {
-    const role = chatEventCompatibilityRole(event.eventType);
-    const forceStandalone = foldFinalEventIds.has(event.id);
-    const last = groups[groups.length - 1];
-    const lastHasFoldFinal =
-      last?.events.some((candidate) => {
-        return foldFinalEventIds.has(candidate.id);
-      }) ?? false;
-    const lastFoldFinal = last?.events.find((candidate) => {
-      return foldFinalEventIds.has(candidate.id);
-    });
-    const continuesFoldFinalRun =
-      lastFoldFinal?.runId !== undefined && lastFoldFinal.runId === event.runId;
-
-    if (
-      !forceStandalone &&
-      last &&
-      last.role === role &&
-      (!lastHasFoldFinal || continuesFoldFinalRun)
-    ) {
-      last.events.push(event);
-      continue;
-    }
-
-    groups.push({
-      beginEventId: event.id,
-      role,
-      events: [event],
-    });
-  }
-  return groups;
-}
-
 function firstRunIdForEvents(
   events: readonly EnrichedChatEvent[],
 ): string | undefined {
   return events.find((event) => {
     return event.runId !== undefined;
   })?.runId;
-}
-
-function usageByRunIdFromGroups(
-  groups: readonly ChatEventGroup[],
-): Map<string, ChatEventUsagePayload> {
-  return foldLatestChatUsageByRunId(
-    groups.flatMap((group) => {
-      const runId = firstRunIdForEvents(group.events);
-      return group.role === "assistant" &&
-        group.usage !== undefined &&
-        runId !== undefined
-        ? [
-            {
-              eventType: "usage.recorded" as const,
-              runId,
-              usage: group.usage,
-            },
-          ]
-        : [];
-    }),
-  );
-}
-
-function attachUsageToCompletedWorkGroups(
-  groups: readonly ChatEventGroup[],
-  usageByRunId: ReadonlyMap<string, ChatEventUsagePayload>,
-): ChatEventGroup[] {
-  const lastAssistantGroupIndexByRunId = new Map<string, number>();
-  for (const [index, group] of groups.entries()) {
-    if (
-      group.role !== "assistant" ||
-      !group.events.some(isRenderableAssistantEvent)
-    ) {
-      continue;
-    }
-    const runId = firstRunIdForEvents(group.events);
-    if (runId !== undefined) {
-      lastAssistantGroupIndexByRunId.set(runId, index);
-    }
-  }
-  return groups.map((group, index) => {
-    if (group.role !== "assistant") {
-      return group;
-    }
-    const runId = firstRunIdForEvents(group.events);
-    if (
-      runId === undefined ||
-      lastAssistantGroupIndexByRunId.get(runId) !== index
-    ) {
-      return group;
-    }
-    const usage = usageByRunId.get(runId);
-    return usage === undefined ? group : { ...group, usage };
-  });
-}
-
-function isRenderableAssistantEvent(event: EnrichedChatEvent): boolean {
-  return (
-    chatEventCompatibilityRole(event.eventType) === "assistant" &&
-    ((isChatEventContentTextType(event.eventType) && Boolean(event.content)) ||
-      Boolean(chatEventError(event)) ||
-      hasChatEventBodyContent(event) ||
-      Boolean(chatEventAttachments(event)?.length))
-  );
-}
-
-function isThinkingOnlyAssistantEvent(event: EnrichedChatEvent): boolean {
-  return (
-    event.eventType === "output.thinking" && event.thinking.trim().length > 0
-  );
-}
-
-function terminatedRunIdsForCompletedWork(
-  events: readonly EnrichedChatEvent[],
-): Set<string> {
-  return terminatedChatRunIds(events);
-}
-
-function splitCompletedWorkEventsAtUsers(
-  events: readonly EnrichedChatEvent[],
-): EnrichedChatEvent[][] {
-  const phases: EnrichedChatEvent[][] = [];
-  let phase: EnrichedChatEvent[] = [];
-  for (const event of events) {
-    if (
-      phase.length > 0 &&
-      chatEventCompatibilityRole(event.eventType) === "user"
-    ) {
-      phases.push(phase);
-      phase = [];
-    }
-    phase.push(event);
-  }
-  if (phase.length > 0) {
-    phases.push(phase);
-  }
-  return phases;
-}
-
-function lastCompletedWorkEventIndex(
-  events: readonly EnrichedChatEvent[],
-  predicate: (event: EnrichedChatEvent) => boolean,
-): number {
-  for (let index = events.length - 1; index >= 0; index--) {
-    if (predicate(events[index]!)) {
-      return index;
-    }
-  }
-  return -1;
-}
-
-function completedWorkFinalEventIndex(
-  events: readonly EnrichedChatEvent[],
-): number {
-  return lastCompletedWorkEventIndex(events, isRenderableAssistantEvent);
-}
-
-function canFoldCompletedWorkTrailingEvent(event: EnrichedChatEvent): boolean {
-  const role = chatEventCompatibilityRole(event.eventType);
-  return (
-    role === "user" ||
-    (role === "assistant" && !isRenderableAssistantEvent(event))
-  );
-}
-
-interface CompletedWorkPhaseFolding {
-  visibleEvents: readonly EnrichedChatEvent[];
-  fold: CompletedWorkFold | null;
-}
-
-function foldCompletedWorkPhase(
-  runId: string,
-  events: readonly EnrichedChatEvent[],
-): CompletedWorkPhaseFolding {
-  const finalEventIndex = completedWorkFinalEventIndex(events);
-  const finalEvent =
-    finalEventIndex >= 0 ? events[finalEventIndex]! : undefined;
-  const precedingEvents =
-    finalEventIndex > 0 ? events.slice(0, finalEventIndex) : [];
-  const hiddenEvents = precedingEvents.filter((event) => {
-    return (
-      chatEventCompatibilityRole(event.eventType) !== "user" &&
-      !isThinkingOnlyAssistantEvent(event)
-    );
-  });
-  const userEvents = events.filter((event) => {
-    return chatEventCompatibilityRole(event.eventType) === "user";
-  });
-  const trailingEvents =
-    finalEventIndex >= 0 ? events.slice(finalEventIndex + 1) : [];
-  const trailingEventsCanFold = trailingEvents.every((event) => {
-    return canFoldCompletedWorkTrailingEvent(event);
-  });
-  if (
-    finalEvent === undefined ||
-    hiddenEvents.length === 0 ||
-    !trailingEventsCanFold
-  ) {
-    return { visibleEvents: events, fold: null };
-  }
-  return {
-    visibleEvents: [
-      ...userEvents,
-      finalEvent,
-      ...trailingEvents.filter(isRenderableAssistantEvent),
-    ],
-    fold: {
-      key: `${runId}:${finalEvent.id}`,
-      finalEventId: finalEvent.id,
-      hiddenGroups: groupEventsByRole(hiddenEvents),
-      labelGroups: groupEventsByRole(events),
-    },
-  };
-}
-
-function buildCompletedWorkFolding(
-  groups: readonly ChatEventGroup[],
-): CompletedWorkFolding | null {
-  const usageByRunId = usageByRunIdFromGroups(groups);
-  const events = groups.flatMap((group) => {
-    return group.events;
-  });
-  const terminatedRunIds = terminatedRunIdsForCompletedWork(events);
-  const visibleEvents: EnrichedChatEvent[] = [];
-  const folds: CompletedWorkFold[] = [];
-  let hasCompletedWorkPhaseBoundary = false;
-
-  for (let index = 0; index < events.length; ) {
-    const runId = events[index]!.runId;
-    if (runId === undefined) {
-      visibleEvents.push(events[index]!);
-      index++;
-      continue;
-    }
-
-    let endIndex = index + 1;
-    while (endIndex < events.length && events[endIndex]!.runId === runId) {
-      endIndex++;
-    }
-
-    const runEvents = events.slice(index, endIndex);
-    if (!terminatedRunIds.has(runId) || runEvents.some(isCancelledRunEvent)) {
-      visibleEvents.push(...runEvents);
-      index = endIndex;
-      continue;
-    }
-
-    const completedWorkEventGroups = splitCompletedWorkEventsAtUsers(runEvents);
-    if (completedWorkEventGroups.length > 1) {
-      hasCompletedWorkPhaseBoundary = true;
-    }
-    for (const completedWorkEvents of completedWorkEventGroups) {
-      const phaseFolding = foldCompletedWorkPhase(runId, completedWorkEvents);
-      visibleEvents.push(...phaseFolding.visibleEvents);
-      if (phaseFolding.fold !== null) {
-        folds.push(phaseFolding.fold);
-      }
-    }
-
-    index = endIndex;
-  }
-
-  if (folds.length === 0 && !hasCompletedWorkPhaseBoundary) {
-    return null;
-  }
-
-  const foldFinalEventIds = new Set(
-    folds.map((fold) => {
-      return fold.finalEventId;
-    }),
-  );
-  return {
-    visibleGroups: attachUsageToCompletedWorkGroups(
-      groupEventsForCompletedWorkDisplay(visibleEvents, foldFinalEventIds),
-      usageByRunId,
-    ),
-    foldsByFinalEventId: new Map(
-      folds.map((fold) => {
-        return [fold.finalEventId, fold];
-      }),
-    ),
-  };
 }
 
 function parseEventTime(value: string): number | null {
@@ -7553,7 +7181,7 @@ function PagedAssistantEventItem({
 }) {
   const retryRichEventTree = useSet(thread.retryRichEventTree$);
   const pageSignal = useGet(pageSignal$);
-  const error = chatEventError(event);
+  const error = chatEventDisplayError(event);
   if (error) {
     return (
       <ChatAssistantMessageBody


### PR DESCRIPTION
## Summary

- add `#event-<eventId>` chat deep links behind `ChatConversationLocator`, with the event target taking precedence over the existing initial tail/anchor behavior
- expose `scrollToEvent$` on thread signals so virtualized groups and folded goal history are revealed before the existing render-commit scroll runs
- derive locator turns from the complete non-virtual folded chat projection while using the DOM only for current-window measurements and final landing
- route locator clicks through the event scroll command and let boundary wheel events fall through to the chat viewport

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- platform production and test type checks
- `pnpm vitest run --project=@okouai/app apps/platform/src/views/okou-page/__tests__/chat-conversation-locator.test.tsx --silent=passed-only` (12 tests)
- `pnpm vitest run --project=@okouai/app apps/platform/src/views/okou-page/__tests__/chat-scroll-position.test.tsx --silent=passed-only` (22 tests)
- `pnpm vitest run --project=@okouai/app apps/platform/src/views/okou-page/__tests__/chat-workflows-and-goals.test.tsx --silent=passed-only` (33 tests)
- PR Preview browser QA for folded/expanded goal runs, a virtual-window-outside locator jump, and an `#event-<eventId>` deep link
