### PR TITLE
perf(runner): measure session identity reuse verification

### DIFF
--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -85,6 +85,8 @@ const SESSION_HISTORY_DOWNLOAD_PHASE_TELEMETRY_ERROR: &str =
     "session history download phase failed";
 const SESSION_HISTORY_MATERIALIZATION_WAIT_TELEMETRY_ERROR: &str =
     "session history materialization failed";
+const SESSION_HISTORY_IDENTITY_REUSE_VERIFY_TELEMETRY_ERROR: &str =
+    "session history identity reuse verification failed";
 const WORKSPACE_SESSION_HISTORY_PHASE_TELEMETRY_ERROR: &str =
     "workspace session history phase failed";
 const STORAGE_CACHE_POPULATE_FAILED: &str = "storage-cache-populate-failed";
@@ -1685,7 +1687,18 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     let mut local_session_history_materializer = None;
     let mut session_history_materializer = match session_history_restore_plan {
         SessionHistoryRestorePlan::SkipVerified(identity) => {
-            match verify_restored_session_identity_for_reuse(sandbox, context, identity).await {
+            let verification_started = Instant::now();
+            let verification_result =
+                verify_restored_session_identity_for_reuse(sandbox, context, identity).await;
+            let verification_succeeded = verification_result.is_ok();
+            telemetry.record(
+                "session_history_identity_reuse_verify",
+                verification_started.elapsed(),
+                verification_succeeded,
+                (!verification_succeeded)
+                    .then_some(SESSION_HISTORY_IDENTITY_REUSE_VERIFY_TELEMETRY_ERROR),
+            );
+            match verification_result {
                 Ok(identity) => {
                     telemetry.record(
                         "session_history_identity_reuse_hit",

--- a/crates/runner/src/executor/tests/agent_run_tests/session_history/reuse_identity.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/session_history/reuse_identity.rs
@@ -23,8 +23,8 @@ use super::{
 };
 use crate::executor::agent_run::{RunControls, RunStart, run_in_sandbox};
 use crate::executor::tests::agent_run_tests::support::{
-    assert_no_action, assert_successful_action_once, claude_history_path, claude_history_source,
-    final_identity_runtime_paths,
+    assert_failed_action_error_once, assert_no_action, assert_successful_action_once,
+    claude_history_path, claude_history_source, final_identity_runtime_paths,
 };
 use crate::executor::tests::support::{
     RUN_IN_SANDBOX_TEST_TIMEOUT, create_overridden_sandbox, minimal_context, sandbox_exec_error,
@@ -41,6 +41,9 @@ use crate::types::{
     ResumeSession, ResumeSessionHistory, ResumeSessionHistoryEncoding, ResumeSessionHistoryRef,
     ResumeSessionHistoryRefKind, SandboxReuseResult,
 };
+
+const SESSION_HISTORY_IDENTITY_REUSE_VERIFY_ERROR: &str =
+    "session history identity reuse verification failed";
 
 fn context_with_checkpointed_session_identity(
     session_id: &str,
@@ -149,6 +152,11 @@ async fn assert_checkpointed_final_identity_helper_failure_falls_back(
     history_mock.assert_calls_async(1).await;
     assert_eq!(sandbox.exec_calls().len(), 1);
     let ops = telemetry.pending_ops_snapshot();
+    assert_failed_action_error_once(
+        &ops,
+        "session_history_identity_reuse_verify",
+        SESSION_HISTORY_IDENTITY_REUSE_VERIFY_ERROR,
+    );
     assert_successful_action(&ops, expected_reason_action);
     assert_successful_action(&ops, "session_history_restore_fallback_stale_idle_identity");
     assert!(
@@ -274,6 +282,7 @@ async fn run_in_sandbox_skips_checkpointed_final_session_history_restore() {
     }
     history_mock.assert_calls_async(0).await;
     let ops = telemetry.pending_ops_snapshot();
+    assert_successful_action_once(&ops, "session_history_identity_reuse_verify");
     assert!(
         ops.iter()
             .any(|op| op.0 == "session_history_identity_reuse_hit" && op.1),
@@ -538,6 +547,11 @@ async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_reports
     assert_eq!(writes[0].path, claude_history_path(session_id));
     assert_eq!(writes[0].content, history);
     let ops = telemetry.pending_ops_snapshot();
+    assert_failed_action_error_once(
+        &ops,
+        "session_history_identity_reuse_verify",
+        SESSION_HISTORY_IDENTITY_REUSE_VERIFY_ERROR,
+    );
     assert_successful_action(
         &ops,
         "session_history_identity_verify_helper_history_mismatch",
@@ -623,6 +637,11 @@ async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_exec_er
     history_mock.assert_calls_async(1).await;
     assert_eq!(sandbox.exec_calls().len(), 1);
     let ops = telemetry.pending_ops_snapshot();
+    assert_failed_action_error_once(
+        &ops,
+        "session_history_identity_reuse_verify",
+        SESSION_HISTORY_IDENTITY_REUSE_VERIFY_ERROR,
+    );
     assert_successful_action(&ops, "session_history_identity_verify_helper_exec_error");
     assert_successful_action(&ops, "session_history_restore_fallback_stale_idle_identity");
     assert!(
@@ -740,6 +759,11 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_mismatches_request(
     );
     assert_eq!(writes[0].content, history);
     let ops = telemetry.pending_ops_snapshot();
+    assert_failed_action_error_once(
+        &ops,
+        "session_history_identity_reuse_verify",
+        SESSION_HISTORY_IDENTITY_REUSE_VERIFY_ERROR,
+    );
     assert_successful_action(&ops, "session_history_identity_verify_request_mismatch");
     assert!(
         ops.iter()


### PR DESCRIPTION
## Summary

- add a direct monotonic `session_history_identity_reuse_verify` operation for every verified-reuse verification attempt
- record one bounded parent failure marker while preserving the existing detailed reason, fallback, hit, and skip actions
- extend Runner integration coverage for successful verification, local mismatch, guest helper exits, timeout, history mismatch, and exec errors

## Scope

This is an additive Runner telemetry change. It does not change identity verification behavior, the guest command or protocol, timeout, fallback materialization, storage ordering, real process spawn, API contracts, database state, queues, payloads, or release dependencies.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runner session_history::reuse_identity` (13 passed)
- `cargo clippy -p runner --all-targets --all-features -- -D warnings -D clippy::all`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --no-deps --all-features`
- `cargo test -p runner --all-targets --all-features` (3402 passed, 26 ignored; guest inventory 1 passed)
- pre-commit Cargo format, Clippy, documentation, file-size, and commit-message hooks

Closes #30608

Parent context: #24203
