### PR TITLE
test(e2e): report the observed clerk state on a stalled bootstrap

### DIFF
--- a/e2e/playwright/lib/auth.ts
+++ b/e2e/playwright/lib/auth.ts
@@ -7,6 +7,7 @@ import {
   signInMethodButton,
   submitSignInIdentifier,
 } from "./auth-v2-ui";
+import { waitForClerkReadiness } from "./clerk-readiness";
 
 const CLERK_TEST_EMAIL_CODE = "424242";
 
@@ -29,22 +30,32 @@ export async function signInWithClerkEmailCode(
       url.origin === signInUrl.origin && !url.pathname.startsWith("/sign-in"),
     { timeout: 30_000, waitUntil: "domcontentloaded" },
   );
-  await page.waitForFunction(
-    () => Boolean(window.Clerk?.loaded && window.Clerk.session),
-    undefined,
-    { timeout: 30_000 },
+  await waitForClerkReadiness(
+    page,
+    "the Clerk client to load and expose a session on the page reached after email-code sign-in",
+    () =>
+      page.waitForFunction(
+        () => Boolean(window.Clerk?.loaded && window.Clerk.session),
+        undefined,
+        { timeout: 30_000 },
+      ),
   );
   await activateClerkOrganization(page, options.activeOrganizationId);
-  await page.waitForFunction(
-    (organizationId) => {
-      return Boolean(
-        window.Clerk?.loaded &&
-        window.Clerk.session &&
-        window.Clerk.organization?.id === organizationId,
-      );
-    },
-    options.activeOrganizationId,
-    { timeout: 30_000 },
+  await waitForClerkReadiness(
+    page,
+    `Clerk to activate organization ${options.activeOrganizationId}`,
+    () =>
+      page.waitForFunction(
+        (organizationId) => {
+          return Boolean(
+            window.Clerk?.loaded &&
+              window.Clerk.session &&
+              window.Clerk.organization?.id === organizationId,
+          );
+        },
+        options.activeOrganizationId,
+        { timeout: 30_000 },
+      ),
   );
 
   const token = await refreshClerkSessionToken(page, {
@@ -101,14 +112,24 @@ export async function refreshClerkSessionToken(
   page: Page,
   options: { readonly activeOrganizationId?: string } = {},
 ): Promise<string> {
-  await page.waitForFunction(() => Boolean(window.Clerk?.session), undefined, {
-    timeout: 30_000,
-  });
+  await waitForClerkReadiness(
+    page,
+    "a Clerk session before refreshing its token",
+    () =>
+      page.waitForFunction(() => Boolean(window.Clerk?.session), undefined, {
+        timeout: 30_000,
+      }),
+  );
   if (options.activeOrganizationId) {
-    await page.waitForFunction(
-      (organizationId) => window.Clerk?.organization?.id === organizationId,
-      options.activeOrganizationId,
-      { timeout: 30_000 },
+    await waitForClerkReadiness(
+      page,
+      `Clerk to report organization ${options.activeOrganizationId} before refreshing its token`,
+      () =>
+        page.waitForFunction(
+          (organizationId) => window.Clerk?.organization?.id === organizationId,
+          options.activeOrganizationId,
+          { timeout: 30_000 },
+        ),
     );
   }
   const token = await page.evaluate(async () => {

--- a/e2e/playwright/lib/clerk-readiness.test.ts
+++ b/e2e/playwright/lib/clerk-readiness.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { errors } from "@playwright/test";
+
+import {
+  captureClerkReadiness,
+  describeClerkReadiness,
+  waitForClerkReadiness,
+  type ClerkReadinessPage,
+  type ClerkReadinessState,
+} from "./clerk-readiness";
+
+const BOOTSTRAPPING_APP: ClerkReadinessState = {
+  bootstrapSkeletonPresent: true,
+  client: "absent",
+  organizationId: null,
+  readyState: "complete",
+  route: "https://staging-app.omby.ai/",
+  sessionPresent: false,
+};
+
+const SIGNED_OUT_CLIENT: ClerkReadinessState = {
+  bootstrapSkeletonPresent: false,
+  client: "loaded",
+  organizationId: null,
+  readyState: "complete",
+  route: "https://staging-app.omby.ai/",
+  sessionPresent: false,
+};
+
+function stubPage(state: ClerkReadinessState): ClerkReadinessPage {
+  return {
+    evaluate: () => Promise.resolve(state),
+  };
+}
+
+function failingPage(reason: string): ClerkReadinessPage {
+  return {
+    evaluate: () => Promise.reject(new Error(reason)),
+  };
+}
+
+test("a stalled Clerk bootstrap is described by its observed state", async (context) => {
+  await context.test("an absent client is separated from a loaded one", () => {
+    const stalled = describeClerkReadiness({
+      kind: "observed",
+      state: BOOTSTRAPPING_APP,
+    });
+    assert.match(stalled, /client=absent/u);
+    assert.match(stalled, /bootstrapSkeleton=present/u);
+
+    const signedOut = describeClerkReadiness({
+      kind: "observed",
+      state: SIGNED_OUT_CLIENT,
+    });
+    assert.match(signedOut, /client=loaded/u);
+    assert.match(signedOut, /session=absent/u);
+    assert.match(signedOut, /bootstrapSkeleton=removed/u);
+  });
+
+  await context.test("an unreadable page reports why", () => {
+    const report = describeClerkReadiness({
+      kind: "unavailable",
+      reason: "Target page, context or browser has been closed",
+    });
+    assert.match(report, /unavailable \(Target page/u);
+  });
+});
+
+test("readiness capture never replaces the failure it explains", async (context) => {
+  await context.test(
+    "an evaluate failure becomes an unavailable report",
+    async () => {
+      const report = await captureClerkReadiness(failingPage("page closed"));
+      assert.deepEqual(report, { kind: "unavailable", reason: "page closed" });
+    },
+  );
+
+  await context.test(
+    "a timeout carries the state and the original error",
+    async () => {
+      const timeout = new errors.TimeoutError(
+        "page.waitForFunction: Timeout 30000ms exceeded.",
+      );
+      const failure = await waitForClerkReadiness(
+        stubPage(BOOTSTRAPPING_APP),
+        "the Clerk client to load",
+        () => Promise.reject(timeout),
+      ).then(
+        () => null,
+        (error: unknown) => error,
+      );
+
+      assert.ok(failure instanceof Error);
+      assert.match(failure.message, /Timed out waiting for the Clerk client/u);
+      assert.match(failure.message, /client=absent/u);
+      assert.equal(failure.cause, timeout);
+    },
+  );
+
+  await context.test(
+    "a non-timeout failure is rethrown untouched",
+    async () => {
+      const original = new Error(
+        "Clerk session token unavailable after refresh",
+      );
+      const failure = await waitForClerkReadiness(
+        stubPage(SIGNED_OUT_CLIENT),
+        "a Clerk session",
+        () => Promise.reject(original),
+      ).then(
+        () => null,
+        (error: unknown) => error,
+      );
+
+      assert.equal(failure, original);
+    },
+  );
+});

--- a/e2e/playwright/lib/clerk-readiness.ts
+++ b/e2e/playwright/lib/clerk-readiness.ts
@@ -1,0 +1,94 @@
+import { errors } from "@playwright/test";
+
+/**
+ * `page.waitForFunction` reports only that its predicate never became true, so
+ * a stalled Clerk bootstrap reaches CI as a bare 30s timeout with no way to
+ * tell the failing halves apart. After sign-in the app hard-navigates
+ * (`window.location.href`), so the destination document re-runs the whole
+ * bootstrap: the clerk-js script may never execute, `Clerk.load()` may stall
+ * against FAPI, or the session may never be attached to a loaded client.
+ * Recording the observed state at the timeout keeps those causes separable.
+ */
+export interface ClerkReadinessState {
+  readonly bootstrapSkeletonPresent: boolean;
+  readonly client: "absent" | "loaded" | "loading";
+  readonly organizationId: string | null;
+  readonly readyState: string;
+  /** Origin and pathname only; the query can carry a Clerk handshake token. */
+  readonly route: string;
+  readonly sessionPresent: boolean;
+}
+
+export type ClerkReadinessReport =
+  | { readonly kind: "observed"; readonly state: ClerkReadinessState }
+  | { readonly kind: "unavailable"; readonly reason: string };
+
+export interface ClerkReadinessPage {
+  evaluate(
+    pageFunction: () => ClerkReadinessState,
+  ): Promise<ClerkReadinessState>;
+}
+
+export function describeClerkReadiness(report: ClerkReadinessReport): string {
+  if (report.kind === "unavailable") {
+    return `unavailable (${report.reason})`;
+  }
+  const { state } = report;
+  return [
+    `client=${state.client}`,
+    `session=${state.sessionPresent ? "present" : "absent"}`,
+    `organization=${state.organizationId ?? "none"}`,
+    `bootstrapSkeleton=${state.bootstrapSkeletonPresent ? "present" : "removed"}`,
+    `readyState=${state.readyState}`,
+    `route=${state.route}`,
+  ].join(" ");
+}
+
+export async function captureClerkReadiness(
+  page: ClerkReadinessPage,
+): Promise<ClerkReadinessReport> {
+  try {
+    const state = await page.evaluate((): ClerkReadinessState => {
+      const clerk = window.Clerk;
+      return {
+        bootstrapSkeletonPresent:
+          document.getElementById("app-bootstrap-skeleton") !== null,
+        client: clerk ? (clerk.loaded ? "loaded" : "loading") : "absent",
+        organizationId: clerk?.organization?.id ?? null,
+        readyState: document.readyState,
+        route: `${window.location.origin}${window.location.pathname}`,
+        sessionPresent: Boolean(clerk?.session),
+      };
+    });
+    return { kind: "observed", state };
+  } catch (error: unknown) {
+    return {
+      kind: "unavailable",
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Runs a Clerk wait and, when it times out, replaces the bare Playwright
+ * timeout with the state the page was actually in. The original timeout stays
+ * attached as the cause so its code frame and call log survive.
+ */
+export async function waitForClerkReadiness<T>(
+  page: ClerkReadinessPage,
+  expectation: string,
+  wait: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await wait();
+  } catch (error: unknown) {
+    if (!(error instanceof errors.TimeoutError)) {
+      throw error;
+    }
+    const report = await captureClerkReadiness(page);
+    throw new Error(
+      `Timed out waiting for ${expectation}. Observed Clerk state: ${describeClerkReadiness(report)}`,
+      { cause: error },
+    );
+  }
+}


### PR DESCRIPTION
## Why

`Turbo` run [33402465557](https://github.com/vm0-ai/vm0/actions/runs/33402465557) (push on `main`, SHA `c92fe87`) failed in [`cli-e2e-02-playwright (features)`](https://github.com/vm0-ai/vm0/actions/runs/33402465557/job/99523498687):

```
[setup] › playwright/tests/smoke.spec.ts:7:5 › complete app onboarding to chat page (42.8s)
TimeoutError: page.waitForFunction: Timeout 30000ms exceeded.
   at e2e/playwright/lib/auth.ts:32
```

The `[setup]` project failing is why the report ends with `1 failed, 6 did not run`; those six are cascade, not separate issues.

**Same-SHA contrast.** The `merge_group` run on the identical SHA passed in full: [33401718465](https://github.com/vm0-ai/vm0/actions/runs/33401718465). Note the two runs do not share an environment — `merge_group` resolves `job-ref` to `pr-30606` and targets that preview, while the `main` push resolves it to `staging` (`staging-app.omby.ai` / `staging-api.vm6.ai`).

**Cross-branch correlation.** No other branch's `cli-e2e-02-playwright (features)` job failed in that window, so this was not a fleet-wide Clerk outage. The other concurrent failures were on unrelated jobs.

**Environment checks that came back clean.** The workflow-level `staging` concurrency group held the next `main` push ([33402961171](https://github.com/vm0-ai/vm0/actions/runs/33402961171)) until 14:31:57, after this run ended at 14:31:55, so nothing redeployed staging mid-test. No `Cleanup Clerk Test Resources` run overlapped the 14:30:34–14:31:04 wait either (nearest were 14:16:29–14:17:15 and 14:38:22).

## What the evidence does and does not show

From the blob report, the step timeline is unambiguous: sign-in completed and `Wait for navigation` resolved at 14.0s, then the Clerk wait consumed its full 30s. The captured page snapshot shows the app still on the pre-React `#app-bootstrap-skeleton` from `index.html`:

```yaml
- generic [active]:
  - status "Loading your workspace":
    - paragraph: Loading your workspace...
  - region "Notifications alt+T"
```

After sign-in the app hard-navigates (`window.location.href` in `signals/auth-v2/continuation.ts`), so the destination document re-runs the whole bootstrap: load clerk-js, `clerk.load()` against FAPI, then attach the session. That bootstrap never completed.

What the recorded evidence **cannot** distinguish is which part stalled. `trace` is `on-first-retry` with no retries configured, so there is no trace, no network log and no console log, and `waitForFunction` reports only that its predicate never became true. The three candidates — the clerk-js script never executing, `Clerk.load()` stalling against FAPI, and a loaded client that never attached a session — are exactly the leads that need separating, and today they all look identical in CI. Prior art already records that this boundary can eat the whole budget: #24401 landed with the note "Clerk's testing-token route allows a single FAPI fetch to consume 30s" (that retry was later removed when #29656 moved to email-code sign-in).

So this change does not claim a root cause. It makes the next occurrence attributable.

## What changed

`waitForClerkReadiness` wraps each Clerk wait in `lib/auth.ts`. On a Playwright `TimeoutError` it reads the page's actual state and rethrows with it, keeping the original timeout as `cause` so its code frame and call log survive:

```
Timed out waiting for the Clerk client to load and expose a session on the page
reached after email-code sign-in. Observed Clerk state: client=absent
session=absent organization=none bootstrapSkeleton=present readyState=complete
route=https://staging-app.omby.ai/
```

- `client=absent` → clerk-js never executed
- `client=loading` → `Clerk.load()` stalled against FAPI
- `client=loaded session=absent` → the session was never attached

`bootstrapSkeleton` additionally separates "the app never finished bootstrapping" from "the app rendered but Clerk is missing". `route` is deliberately origin + pathname only, because the query can carry a Clerk handshake token.

The waits, their predicates and their 30s timeouts are unchanged. No retries, sleeps, larger timeouts, skipped tests or weakened assertions. The setup still has to complete onboarding and reach an authenticated chat page.

## Validation

- `cd e2e && pnpm check-types` — clean
- `cd e2e && pnpm test` — 35/35 (28 pre-existing + 7 new)
- `pnpm exec tsx --test playwright/lib/clerk-readiness.test.ts` repeated 5x — 7/7 each run
- `prettier --check` on the touched files — clean; `git diff --check` — clean

New `node:test` coverage asserts the three states stay distinguishable, that a timeout carries both the state and the original error as `cause`, that a non-timeout failure is rethrown untouched, and that a page which can no longer be evaluated degrades to an explained `unavailable` report rather than masking the failure.

**On preview validation:** this change only alters the failure path of waits that succeed in a healthy environment, and the happy path is exercised end-to-end by this PR's own `cli-e2e-02-playwright` job against its preview. Reproducing the timeout would require driving the live Clerk instance from an ad hoc script, which is explicitly out of scope for this repair, so the failure path is covered by the unit tests instead.

## Related but separate

- #30442 (`perf/eager-clerk-onboarding-bootstrap`) touches the product-side Clerk bootstrap and may reduce this stall class; it does not touch `e2e/playwright/lib/auth.ts`, so there is no overlap.
- #30557 improved error reporting for a different provisioning path. This PR does not extend it.
