### PR TITLE
test(e2e): pin the zendesk firewall probe to the public sink

### DIFF
--- a/e2e/tests/03-runner/run-t03-firewall-zendesk.bats
+++ b/e2e/tests/03-runner/run-t03-firewall-zendesk.bats
@@ -39,17 +39,16 @@ set -euo pipefail
 printf 'ZENDESK_API_TOKEN=%s\n' "$ZENDESK_API_TOKEN"
 printf 'ZENDESK_EMAIL=%s\n' "$ZENDESK_EMAIL"
 printf 'ZENDESK_SUBDOMAIN=%s\n' "$ZENDESK_SUBDOMAIN"
-# Raw DNS has dedicated runner coverage. Keep this firewall-auth probe on IPv4
-# so an unavailable AAAA response cannot block an otherwise valid request.
-if curl --ipv4 --silent --show-error --max-time 5 \
+# Raw DNS has dedicated runner coverage. Pin the public sink so this test owns
+# only firewall classification and authentication resolution, never whether a
+# live Zendesk tenant answers. The request host still carries the resolved
+# variable base, which is what the firewall matches on.
+curl_status=0
+curl --silent --show-error --max-time 5 \
+    --resolve '__SUBDOMAIN__.zendesk.com:443:8.8.8.8' \
     --output /dev/null \
-    "https://__SUBDOMAIN__.zendesk.com/api/v2/users/me.json"; then
-    printf 'ZENDESK_REQUEST_SENT\n'
-else
-    curl_status=$?
-    printf 'ZENDESK_REQUEST_FAILED=%s\n' "$curl_status"
-    exit "$curl_status"
-fi
+    "https://__SUBDOMAIN__.zendesk.com/api/v2/users/me.json" || curl_status=$?
+printf 'ZENDESK_REQUEST_SENT=%s\n' "$curl_status"
 EOF
 )
     prompt="${prompt//__SUBDOMAIN__/$subdomain}"
@@ -63,12 +62,11 @@ EOF
     echo "$output"
     assert_success
 
-    # Both outcomes use this prefix so a transport failure surfaces without
-    # waiting for a success marker that can no longer be emitted.
-    run runner_e2e_wait_for_chat_text "$THREAD_ID" "$RUN_ID" ZENDESK_REQUEST_
+    # The marker carries the curl status so a transport anomaly stays visible
+    # without turning sink reachability into the assertion under test.
+    run runner_e2e_wait_for_chat_text "$THREAD_ID" "$RUN_ID" ZENDESK_REQUEST_SENT
     echo "$output"
     assert_success
-    assert_output --partial "ZENDESK_REQUEST_SENT"
     assert_output --partial "ZENDESK_API_TOKEN=zkTkn_CoffeeSafeLocalCoffeeSafeLocalCoffeeSa"
     assert_output --partial "ZENDESK_EMAIL=runner-e2e@vm0.ai"
     assert_output --partial "ZENDESK_SUBDOMAIN=${subdomain}"


### PR DESCRIPTION
## Problem

Turbo run [33404787667](https://github.com/vm0-ai/vm0/actions/runs/33404787667) (`merge_group`, head `329a1df961008ab62804f71af3bc38f2c0c60a7f`, representing #30613) failed in [`cli-e2e-03-runner`](https://github.com/vm0-ai/vm0/actions/runs/33404787667/job/99532533410):

```
not ok 1 runner firewall resolves the Zendesk variable base and header auth # in 11492 ms
  `assert_output --partial "ZENDESK_REQUEST_SENT"' failed
# ZENDESK_API_TOKEN=zkTkn_...        <- resolved
# ZENDESK_EMAIL=runner-e2e@vm0.ai    <- resolved
# ZENDESK_SUBDOMAIN=e2e2089524288    <- resolved
# ZENDESK_REQUEST_FAILED=28
# curl: (28) Operation timed out after 5000 milliseconds with 0 bytes received
```

The identical merge-group head was re-run 12 minutes later as [33405942900](https://github.com/vm0-ai/vm0/actions/runs/33405942900) and the same test passed (`ok 1 ... # in 10223 ms`). Same SHA, same code, opposite outcome, so the failing input was external.

## First causal nondeterminism

The probe generated a fresh random subdomain per run and issued a live request to `https://<random>.zendesk.com/api/v2/users/me.json` with `--max-time 5`. That single budget had to cover DNS for a never-before-queried name, TLS to Zendesk's edge, and Zendesk's unknown-tenant lookup. `#28231` had additionally made the success marker conditional on curl's exit status and `exit`ed with it, so any slow third-party answer failed the test.

The variable-resolution half of the contract had already succeeded before the timeout: all three connector variables were injected and printed. Only the third party's response time was missing.

## Fix

Pin the destination to the public sink that the sibling probes `run-t01-firewall-twilio.bats`, `run-t02-firewall-discord-webhook.bats` and `run-t05-firewall-permission-refresh.bats` already use, and report the curl status next to the marker instead of gating the marker on it.

The product contract is unchanged and still asserted:

- `--resolve` only fixes the connect address. The request host stays `<subdomain>.zendesk.com`, which is what the firewall matches, so variable-base resolution is still exercised end to end.
- `runner_e2e_wait_for_firewall_log "$RUN_ID" zendesk "${subdomain}.zendesk.com" '["ZENDESK_API_TOKEN"]'` is untouched. It is what proves the contract in the test title: the firewall resolved the templated base, classified the flow as `ALLOW` with no `firewall_error`, and injected exactly `ZENDESK_API_TOKEN`.
- `--ipv4` is dropped because `--resolve` removes the name resolution it was hardening. The IPv6 concern `#28231` addressed no longer has a path to occur.
- The removed `assert_output --partial "ZENDESK_REQUEST_SENT"` is not lost coverage: `runner_e2e_wait_for_chat_text` now waits on `ZENDESK_REQUEST_SENT` itself and returns non-zero if the run reaches a terminal status without it.
- `curl` without `--fail` exits 0 on any HTTP status, including a firewall `403`, so its exit status never carried an allow/deny signal. Denial is caught by the firewall-log assertion.

No retry, sleep, skip, weakened business assertion, or timeout increase. `--max-time 5` is unchanged.

## Validation

Local `bats` execution of `tests/03-runner` needs a provisioned runner E2E environment and connector credentials, so it was not run here; the PR pipeline owns it. Validated locally: rendered the substituted probe and confirmed `--resolve` receives the same host as the request URL, `bash -n` syntax, that `curl ... || curl_status=$?` under `set -euo pipefail` always completes and always emits the marker with the real status, and `git diff --check`.

There is no app, API, or browser surface in this change, so no preview validation applies.

## Related, not fixed here

`e2e/tests/03-runner/run-t04-firewall-serpapi.bats` has the identical shape from `#27826` (live `serpapi.com` request inside `--max-time 5`, marker gated on curl's exit status). It has not failed in the window reviewed, so it is left out of this focused change and noted for follow-up.
