### PR TITLE
test(platform): gate event-sourced rename on rendered readiness

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-history-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-history-navigation.test.tsx
@@ -1090,7 +1090,10 @@ describe("chat lifecycle", () => {
       },
     );
 
-    await setupPageAndWaitForContent({
+    // Thread detail never responds in this scenario, so page bootstrap has no
+    // settled completion to await. Readiness comes from the rendered thread
+    // instead, per the `detachedSetupPage` contract.
+    detachedSetupPage({
       context,
       path: `/chats/${EVENT_SOURCED_RENAME_THREAD_ID}`,
       sharedWorkerTestTransport: "message-port",
@@ -1124,6 +1127,15 @@ describe("chat lifecycle", () => {
     });
 
     expect(document.title).toBe(`${originalTitle} | VM0`);
+    // A publish on an unsubscribed channel is dropped silently, so wait for the
+    // shared database subscription before triggering the thread list refresh.
+    await waitFor(() => {
+      expect(
+        context.mocks.ably.hasChannelSubscriptionOnChannel(
+          SHARED_DATABASE_REALTIME_CHANNEL,
+        ),
+      ).toBeTruthy();
+    });
     context.mocks.ably.triggerOnChannel(
       SHARED_DATABASE_REALTIME_CHANNEL,
       "threadListChanged",


### PR DESCRIPTION
## Problem

`chat lifecycle > renames the event-sourced current chat while thread detail is pending` intermittently fails with a bare `Error: Test timed out in 5000ms.` and no assertion detail.

- Triggering run (main, push): https://github.com/vm0-ai/vm0/actions/runs/33402961171 — job https://github.com/vm0-ai/vm0/actions/runs/33402961171/job/99524310146, SHA `a982b33938dd7c44a1471006d8e0afadc3f8dd27`, `test-app` shard 5, observed duration 5042 ms.
- Same-SHA contrast: the merge-group run on the identical SHA (https://github.com/vm0-ai/vm0/actions/runs/33401983863) reported success, but `test-app` was **skipped** there, so it is not a code-equivalent contrast. The real contrast is same-day green runs of the same shard where this test took 741 ms / 903 ms / 934 ms / 1317 ms / 1416 ms.
- Two further occurrences today, on unrelated branches: https://github.com/vm0-ai/vm0/actions/runs/33387371323 (11:34) and https://github.com/vm0-ai/vm0/actions/runs/33395211384 (13:10). All three occurrences are on trees that already contained #30339; no occurrence was found on trees without it.

## First causal nondeterminism

Every remaining wait in this test is a `waitFor` / `findBy*`, bounded by Testing Library's default 1000 ms `asyncUtilTimeout` (the repo sets no override), and each fails with a descriptive message. A bare 5000 ms Vitest budget exhaustion can therefore only come from an **unbounded** await.

The test had exactly one: `await setupPageAndWaitForContent(...)`, introduced into this test by #30339. It awaits `waitForPageContent`, a MutationObserver promise with no timeout that resolves only once the app skeleton is hidden — which now depends on the SharedWorker handshake and `initialEventsReady$`. This scenario deliberately makes `chatThreadByIdContract.get` return `never()`, so page bootstrap has no settled completion at all; `detachedSetupPage`'s own docstring covers precisely this case. Under load the wait was reproduced still pending past 2.5 s with the skeleton visible while the chat was already rendered.

#30339 also deleted this test's `waitFor(hasChannelSubscriptionOnChannel(...))` gate before `context.mocks.ably.triggerOnChannel(...)`. `triggerAblyChannelEvent` resolves the channel with `realtime.getExistingChannel(channelName)?.trigger(...)`, so a publish before the shared database channel is subscribed is dropped silently and the final title assertion can never satisfy.

## Excluded

- The 68 `[W][Realtime] ably catch-up failed ApiError: HTTP 500` warnings in the failing job are incidental: they come from `fetchBrowserSession` in `browser-session-block.ts` for tests that do not mock `browserContract.get`, they appear in passing tests throughout this file, and that catch-up runs in its own realtime payload loop.
- Budget headroom is not the cause: this test normally uses 15–28% of its 5000 ms budget, and the failing shard's file total (55.2 s) is in line with green runs (49.6 s / 53.2 s).
- `test-app` shards 2, 3, 6, 7, 8 were fail-fast cancellations and `ci-gate-turbo` is the aggregate gate; neither is a repair target.

## Fix

Test-only, scoped to this one scenario:

1. Use `detachedSetupPage` instead of `await setupPageAndWaitForContent`, keeping `sharedWorkerTestTransport: "message-port"`. Readiness is asserted through the already-present rendered-thread waits.
2. Restore the explicit shared database channel subscription gate before publishing `threadListChanged`.

No retries, sleeps, raised timeouts, skipped or deleted tests, weakened assertions, manual detached cleanup, or swallowed rejections. The product contract — an event-sourced current chat can be renamed while its thread detail is still pending — and every assertion are preserved.

## Validation

- `npx vitest run src/views/okou-page/__tests__/chat-history-navigation.test.tsx` — 5 consecutive runs, 30/30 passing each time.
- Prettier, ESLint (`--max-warnings 0`), oxlint on the changed file, and `git diff --check` all clean.
- Deployed-preview validation is not applicable: the change touches only a Vitest file and no app, API, or runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
