### PR TITLE
feat(pi): fall back before provider ownership

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -36,6 +36,7 @@ import {
   ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES,
   CANCELLATION_RECOVERY_STALE_AFTER_MS,
   DEFAULT_PROFILE,
+  piApiFirstTurnManifestV3Schema,
 } from "@okouai/api-contracts/contracts/runners";
 import { mailContract } from "@okouai/api-contracts/contracts/mail";
 import {
@@ -120,6 +121,7 @@ import { readAgentRunState$ } from "./helpers/agent-run-callback";
 import { chatEventDisplayText } from "./helpers/chat-event";
 import {
   clearThreadSessionBinding,
+  enableQueuedPiOwnershipTransferFixture,
   readRunAutonomyBudgetFixture,
   readRunLaunchSnapshotFixture,
   readThreadSessionBinding,
@@ -847,6 +849,7 @@ async function waitForRunStatus(
     | "completed"
     | "failed"
     | "pending"
+    | "queued"
     | "running"
     | "timeout",
   timeout = 1000,
@@ -5570,7 +5573,7 @@ describe("CHAT-02: model-first provider policies", () => {
   it.each([
     {
       failure: "resource download",
-      expectedCode: "PI_API_RESOURCE_INVALID",
+      expectedCode: "PI_API_RESOURCE_PREPARATION_FAILED",
       failResource: true,
       expectedModelCalls: 0,
     },
@@ -5627,6 +5630,251 @@ describe("CHAT-02: model-first provider policies", () => {
     },
     90_000,
   );
+
+  it("hands a proven pre-provider failure to Sandbox without replaying a later provider failure", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    if (!actor.orgId) {
+      throw new Error("Expected entitled chat actor to have an org");
+    }
+    mockEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
+    await api.heartbeatRunner(runnerGroup);
+    const anchor = await sendChatRun(actor, {
+      agentId,
+      prompt: "hold the thread while the future Pi launch is queued",
+      model: "claude-sonnet-5",
+    });
+    await flushWaitUntilForTest();
+    const anchorState = await api.readRun(actor, anchor.runId);
+    if (anchorState.status !== "pending") {
+      throw new Error(
+        `Expected pending anchor before claim: ${JSON.stringify(anchorState)}`,
+      );
+    }
+    const anchorClaim = await claimChatRun(runnerGroup, anchor.runId);
+    expect(anchorClaim.claim.cliAgentType).toBe("claude-code");
+
+    await configureBuiltInPiModel(actor, "deepseek-v4-flash");
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId: actor.orgId },
+      { [FeatureSwitchKey.PiLoop]: true },
+    );
+    mockPiResourceArchiveDownloads(true);
+    let modelCalls = 0;
+    server.use(
+      http.post("https://api.deepseek.com/responses", () => {
+        modelCalls += 1;
+        return HttpResponse.json(
+          { error: "provider unavailable" },
+          { status: 503 },
+        );
+      }),
+    );
+    const checkpointObjects = mockPiCheckpointObjectStore();
+    const fallbackPrompt = "execute this fallback prompt exactly once";
+    const fallback = await sendChatRun(actor, {
+      agentId,
+      prompt: fallbackPrompt,
+      model: "deepseek-v4-flash",
+    });
+    await waitForRunStatus(actor, fallback.runId, "queued");
+    await enableQueuedPiOwnershipTransferFixture(context, fallback.runId);
+
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
+    const fallbackManifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${fallback.runId}/manifest.json`;
+    await expect
+      .poll(
+        () => {
+          return checkpointObjects.get(fallbackManifestKey);
+        },
+        { timeout: 5000 },
+      )
+      .toBeInstanceOf(Buffer);
+    expect(modelCalls).toBe(0);
+
+    const fallbackManifest = piApiFirstTurnManifestV3Schema.parse(
+      JSON.parse(
+        checkpointObjects.get(fallbackManifestKey)?.toString("utf8") ?? "{}",
+      ),
+    );
+    expect(fallbackManifest).toMatchObject({
+      schemaVersion: 3,
+      outcome: "ownership-transfer",
+      mode: "sandbox-first",
+      baseSession: { sessionId: fallback.threadId, sha256: null },
+      session: {
+        sessionId: fallback.threadId,
+        sha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
+        rawSize: expect.any(Number),
+      },
+      sandboxEventSequenceStart: 1,
+    });
+    const fallbackSessionKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${fallback.runId}/session.jsonl`;
+    const fallbackH0 =
+      checkpointObjects.get(fallbackSessionKey)?.toString("utf8") ?? "";
+    expect(Buffer.byteLength(fallbackH0)).toBe(
+      fallbackManifest.session.rawSize,
+    );
+    expect(createHash("sha256").update(fallbackH0).digest("hex")).toBe(
+      fallbackManifest.session.sha256,
+    );
+    const sandboxSession = MemoryPiSession.fromJsonl(fallbackH0);
+    expect(sandboxSession.getSessionId()).toBe(fallback.threadId);
+    expect(sandboxSession.buildSessionContext().messages).toHaveLength(0);
+
+    const fallbackClaim = await claimChatRun(runnerGroup, fallback.runId);
+    expect(fallbackClaim.claim).toMatchObject({
+      cliAgentType: "pi",
+      piSessionId: fallback.threadId,
+      prompt: fallbackPrompt,
+      piLaunchConfig: {
+        apiFirstTurn: {
+          ownershipTransfer: { schemaVersion: 1 },
+          sandboxEventSequenceStart: 1,
+        },
+      },
+    });
+    const postProviderPrompt = "must fail after one provider request";
+    const postProvider = await sendChatRun(actor, {
+      agentId,
+      prompt: postProviderPrompt,
+      model: "deepseek-v4-flash",
+    });
+    await waitForRunStatus(actor, postProvider.runId, "queued");
+    await enableQueuedPiOwnershipTransferFixture(context, postProvider.runId);
+
+    mockPiResourceArchiveDownloads();
+    sandboxSession.appendMessage({
+      role: "user",
+      content: fallbackPrompt,
+      timestamp: 1,
+    });
+    const fallbackAnswer = "Sandbox completed the fallback exactly once";
+    sandboxSession.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: fallbackAnswer }],
+      api: "openai-responses",
+      provider: "deepseek",
+      model: "deepseek-v4-flash",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+      stopReason: "stop",
+      timestamp: 2,
+    });
+    const fallbackH2 = sandboxSession.toJsonl();
+    expect(occurrences(fallbackH2, fallbackPrompt)).toBe(1);
+    expect(
+      MemoryPiSession.fromJsonl(fallbackH2).isSettledCheckpoint(),
+    ).toBeTruthy();
+    const fallbackH2Hash = createHash("sha256")
+      .update(fallbackH2)
+      .digest("hex");
+    const preparedH2 = await webhooks.requestAgentCheckpointPrepareHistory(
+      {
+        runId: fallback.runId,
+        hash: fallbackH2Hash,
+        rawSize: Buffer.byteLength(fallbackH2),
+        encodedSize: Buffer.byteLength(fallbackH2),
+        encoding: "identity",
+      },
+      fallbackClaim.sandboxHeaders,
+      [200],
+    );
+    expect(preparedH2.body).toMatchObject({
+      existing: false,
+      encoding: "identity",
+    });
+    checkpointObjects.set(
+      `${env("R2_USER_STORAGES_BUCKET_NAME")}/blobs/${fallbackH2Hash}.blob`,
+      Buffer.from(fallbackH2, "utf8"),
+    );
+    await webhooks.requestAgentEvents(
+      {
+        runId: fallback.runId,
+        events: [
+          {
+            type: "assistant",
+            sequenceNumber: 1,
+            message: {
+              content: [{ type: "text", text: fallbackAnswer }],
+            },
+          },
+          {
+            type: "result",
+            sequenceNumber: 2,
+            result: fallbackAnswer,
+          },
+        ],
+      },
+      fallbackClaim.sandboxHeaders,
+      [200],
+    );
+    const completedFallback = await webhooks.requestAgentComplete(
+      {
+        runId: fallback.runId,
+        exitCode: 0,
+        lastEventSequence: 2,
+        checkpoint: {
+          cliAgentType: "pi",
+          cliAgentSessionId: fallback.threadId,
+          cliAgentSessionHistoryHash: fallbackH2Hash,
+        },
+      },
+      fallbackClaim.sandboxHeaders,
+      [200],
+    );
+    expect(completedFallback.body).toStrictEqual({
+      success: true,
+      status: "completed",
+    });
+    await waitForRunStatus(actor, fallback.runId, "completed", 5000);
+    await waitForRunStatus(actor, postProvider.runId, "failed", 5000);
+    await flushWaitUntilForTest();
+
+    expect(modelCalls).toBe(1);
+    expect((await api.readRun(actor, postProvider.runId)).error).toContain(
+      "[PI_API_MODEL_FAILED]",
+    );
+    const postProviderManifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${postProvider.runId}/manifest.json`;
+    expect(checkpointObjects.has(postProviderManifestKey)).toBeFalsy();
+    const postProviderClaim = await api.requestClaimRunnerJob(
+      true,
+      postProvider.runId,
+      [404],
+    );
+    expect(postProviderClaim.status).toBe(404);
+    const finalThread = await waitForThreadMessages(
+      actor,
+      fallback.threadId,
+      (messages) => {
+        return eventBackedContents(messages, fallback.runId).some((message) => {
+          return message.content === fallbackAnswer;
+        });
+      },
+    );
+    expect(
+      eventBackedContents(finalThread.events, fallback.runId).filter(
+        (message) => {
+          return message.content === fallbackAnswer;
+        },
+      ),
+    ).toHaveLength(1);
+    await expect(
+      readThreadSessionConversation(context, fallback.threadId),
+    ).resolves.toMatchObject({ conversation_run_id: fallback.runId });
+  }, 90_000);
 
   it("fails a corrupt Pi H0 before a second model call and preserves H0", async () => {
     const { actor, agentId } = await entitledChatActor();

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -600,6 +600,16 @@ export async function mutateRunnerJobSecretValueEnvironmentKeys(
   });
 }
 
+export async function enableQueuedPiOwnershipTransferFixture(
+  context: TestContext,
+  runId: string,
+): Promise<void> {
+  await postAction(context, {
+    action: "enable-queued-pi-ownership-transfer",
+    run_id: runId,
+  });
+}
+
 export async function mutateRunnerJobConnectorPermissionBaseline(
   context: TestContext,
   runId: string,

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -10,7 +10,10 @@ import {
 } from "@okouai/api-contracts/contracts/test-runtime-state";
 import { chatEventRowSchema } from "@okouai/api-contracts/contracts/chat-event-rows";
 import { CURRENT_CHAT_EVENT_SCHEMA_VERSION } from "@okouai/api-contracts/contracts/chat-event-schema-version";
-import { compatibleStoredExecutionContextSchema } from "@okouai/api-contracts/contracts/runners";
+import {
+  compatibleStoredExecutionContextSchema,
+  storedExecutionContextSchema,
+} from "@okouai/api-contracts/contracts/runners";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { agentRunCallbacks } from "@okouai/db/schema/agent-run-callback";
 import { agentRunQueue } from "@okouai/db/schema/agent-run-queue";
@@ -61,6 +64,10 @@ import { usagePackPurchaseSerializationSchemaAvailable } from "../services/usage
 import { encryptPersistentSecretValue } from "../services/crypto.utils";
 import { writeRunMetadata } from "../services/agent-run-metadata-write.service";
 import { saveRunSummary } from "../services/run-summary.service";
+import {
+  decryptQueuedRunnerJobPayload,
+  encryptQueuedRunnerJobPayload,
+} from "../services/agent-run-queue-payload.service";
 import { reconcileSocialKitDownloads$ } from "../services/socialkit-download.service";
 import { steerRunNearTimeBudgetForTest } from "../services/cron-steer-run-time-budget.service";
 import {
@@ -1786,6 +1793,59 @@ async function setRunnerJobContextProfileAsPreviousApi(
   return { status: 200 as const, body: { ok: true as const } };
 }
 
+async function enableQueuedPiOwnershipTransfer(
+  db: Db,
+  runId: string,
+  signal: AbortSignal,
+): Promise<void> {
+  // Production intentionally leaves this capability absent until a future
+  // route selects a proven-compatible Sandbox. This test-only mutation lets
+  // BDD exercise that deployment boundary without adding a production writer.
+  const [row] = await db
+    .select({ encryptedParams: agentRunQueue.encryptedParams })
+    .from(agentRunQueue)
+    .where(eq(agentRunQueue.runId, runId))
+    .limit(1);
+  signal.throwIfAborted();
+  const payload = await decryptQueuedRunnerJobPayload(
+    row?.encryptedParams ?? null,
+  );
+  signal.throwIfAborted();
+  const piLaunchConfig = payload?.executionContext.piLaunchConfig;
+  if (!payload || !piLaunchConfig) {
+    throw new Error("Expected a queued Pi runner payload");
+  }
+  const executionContext = storedExecutionContextSchema.parse({
+    ...payload.executionContext,
+    piLaunchConfig: {
+      ...piLaunchConfig,
+      apiFirstTurn: {
+        ...piLaunchConfig.apiFirstTurn,
+        ownershipTransfer: { schemaVersion: 1 },
+      },
+    },
+  });
+  const encryptedParams = await encryptQueuedRunnerJobPayload({
+    version: payload.version,
+    runnerGroup: payload.runnerGroup,
+    profile: payload.profile,
+    cliAgentSessionId: payload.cliAgentSessionId,
+    reuseKey: payload.reuseKey,
+    historyGenerationRunId: payload.historyGenerationRunId,
+    executionContext,
+  });
+  signal.throwIfAborted();
+  const [updated] = await db
+    .update(agentRunQueue)
+    .set({ encryptedParams })
+    .where(eq(agentRunQueue.runId, runId))
+    .returning({ runId: agentRunQueue.runId });
+  signal.throwIfAborted();
+  if (!updated) {
+    throw new Error("Expected a queued Pi runner payload to update");
+  }
+}
+
 type CompatibilityFixtureAction =
   | AutonomyBudgetFixtureAction
   | LegacyArtifactCatalogFileAction
@@ -2519,6 +2579,10 @@ const postRuntimeStateAction$ = command(
           body.mode,
           signal,
         );
+        return { status: 200 as const, body: { ok: true as const } };
+      }
+      case "enable-queued-pi-ownership-transfer": {
+        await enableQueuedPiOwnershipTransfer(db, body.run_id, signal);
         return { status: 200 as const, body: { ok: true as const } };
       }
       case "set-runner-job-connector-runtime-targets": {

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
@@ -13,8 +13,11 @@ import { activeInputDeliveries } from "@okouai/db/schema/active-input-delivery";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { blobs } from "@okouai/db/schema/blob";
 import {
+  createPiApiFirstTurnOwnership,
+  createPiSessionJsonl,
   inspectPiSessionJsonl,
   runPiApiFirstTurn,
+  type PiApiFirstTurnOwnership,
   type PiApiFirstTurnResult,
   UnsupportedPiResourceSnapshotError,
   UnsupportedPiSessionVersionError,
@@ -64,6 +67,7 @@ import {
   type PiApiFirstTurnActivation,
 } from "./pi-api-first-turn-config";
 import {
+  PiResourceSnapshotPreparationError,
   preparePiResourceSnapshot,
   UnsupportedPiResourceError,
 } from "./pi-resource-snapshot.service";
@@ -80,8 +84,11 @@ type PiApiFirstTurnErrorCode =
   | "PI_API_MODEL_FAILED"
   | "PI_API_MODEL_CREDENTIAL_INVALID"
   | "PI_API_PROMPT_UNSUPPORTED"
+  | "PI_API_PREHEAT_FAILED"
   | "PI_API_RESOURCE_INVALID"
+  | "PI_API_RESOURCE_PREPARATION_FAILED"
   | "PI_API_RESOURCE_UNSUPPORTED"
+  | "PI_API_SANDBOX_FALLBACK_FAILED"
   | "PI_H0_DECOMPRESSION_FAILED"
   | "PI_H0_DOWNLOAD_FAILED"
   | "PI_H0_ENCODING_UNSUPPORTED"
@@ -638,6 +645,13 @@ const loadApiFirstTurnResource$ = command(
           prepared.error,
         );
       }
+      if (prepared.error instanceof PiResourceSnapshotPreparationError) {
+        throw piApiFirstTurnError(
+          "PI_API_RESOURCE_PREPARATION_FAILED",
+          prepared.error.message,
+          prepared.error,
+        );
+      }
       throw piApiFirstTurnError(
         "PI_API_RESOURCE_INVALID",
         "Pi resource snapshot could not be loaded strictly",
@@ -723,9 +737,10 @@ async function executeApiModelTurn(
     readonly apiKey: string;
     readonly executionContext: ApiFirstTurnExecutionContext;
     readonly launchConfig: ApiFirstTurnLaunchConfig;
-    readonly loadedSession: LoadedResumeSession;
     readonly resourceSnapshot: PiResourceSnapshot;
+    readonly sessionJsonl: string;
     readonly sessionId: string;
+    readonly ownership: PiApiFirstTurnOwnership;
   },
   signal: AbortSignal,
 ): Promise<{
@@ -750,11 +765,12 @@ async function executeApiModelTurn(
         cwd: CANONICAL_WORKING_DIR,
         agentDir: PI_AGENT_DIR,
         sessionId: args.sessionId,
-        sessionJsonl: args.loadedSession.jsonl,
+        sessionJsonl: args.sessionJsonl,
         prompt: args.activation.prompt,
         appendSystemPrompt: args.activation.appendSystemPrompt,
         model: { ...args.executionContext.piModelConfig, apiKey: args.apiKey },
         resourceSnapshot: args.resourceSnapshot,
+        ownership: args.ownership,
       },
       modelSignal,
     ),
@@ -762,7 +778,7 @@ async function executeApiModelTurn(
   if (!executed.ok) {
     if (executed.error instanceof UnsupportedPiResourceSnapshotError) {
       throw piApiFirstTurnError(
-        "PI_API_RESOURCE_UNSUPPORTED",
+        "PI_API_PREHEAT_FAILED",
         executed.error.message,
         executed.error,
       );
@@ -869,9 +885,182 @@ function ownershipTransferManifest(args: {
   };
 }
 
+type PiSandboxFallbackReason =
+  | "PI_API_PREHEAT_FAILED"
+  | "PI_API_RESOURCE_PREPARATION_FAILED";
+
+function eligibleSandboxFallbackReason(
+  args: {
+    readonly failure: PiApiFirstTurnError;
+    readonly ownership: PiApiFirstTurnOwnership;
+    readonly launchConfig: ApiFirstTurnLaunchConfig;
+  },
+  signal: AbortSignal,
+): PiSandboxFallbackReason | null {
+  if (
+    signal.aborted ||
+    args.ownership.stage !== "pre-provider" ||
+    args.launchConfig.ownershipTransfer?.schemaVersion !== 1
+  ) {
+    return null;
+  }
+  switch (args.failure.code) {
+    case "PI_API_PREHEAT_FAILED":
+    case "PI_API_RESOURCE_PREPARATION_FAILED": {
+      return args.failure.code;
+    }
+    default: {
+      return null;
+    }
+  }
+}
+
+function validateSandboxFallbackSession(
+  sessionJsonl: string,
+  sessionId: string,
+): { readonly bytes: Buffer; readonly hash: string } {
+  const bytes = Buffer.from(sessionJsonl, "utf8");
+  if (
+    bytes.length === 0 ||
+    bytes.length > PI_API_FIRST_TURN_SESSION_MAX_BYTES
+  ) {
+    throw piApiFirstTurnError(
+      "PI_H0_TOO_LARGE",
+      "Pi sandbox fallback H0 is empty or exceeds the API first-turn limit",
+    );
+  }
+  const inspected = safeSync(() => {
+    return inspectPiSessionJsonl(sessionJsonl);
+  });
+  if ("error" in inspected) {
+    throw piApiFirstTurnError(
+      "PI_H0_JSONL_INVALID",
+      "Pi sandbox fallback H0 is not a valid native Pi session",
+      inspected.error,
+    );
+  }
+  if (inspected.ok.sessionId !== sessionId) {
+    throw piApiFirstTurnError(
+      "PI_H0_SESSION_MISMATCH",
+      "Pi sandbox fallback H0 session id does not match the launch session",
+    );
+  }
+  return { bytes, hash: sha256(bytes) };
+}
+
+function materializeApiFirstTurnH0(args: {
+  readonly apiStartTime: number;
+  readonly loadedSession: LoadedResumeSession;
+  readonly sessionId: string;
+}): string {
+  return (
+    args.loadedSession.jsonl ??
+    createPiSessionJsonl({
+      cwd: CANONICAL_WORKING_DIR,
+      sessionId: args.sessionId,
+      timestamp: new Date(args.apiStartTime).toISOString(),
+    })
+  );
+}
+
+/**
+ * Intentional runtime ownership fallback for a real preparation failure. This
+ * is not old-Sandbox tolerance: the immutable launch capability proves the V3
+ * reader. Keep it while API preparation happens after durable activation;
+ * parent issue #30564 owns that lifecycle boundary.
+ */
+const publishSandboxFallback$ = command(async function publishSandboxFallback(
+  { get, set },
+  args: ApiFirstTurnContext,
+  signal: AbortSignal,
+): Promise<void> {
+  const { executionContext, launchConfig, sessionId } =
+    validateApiFirstTurnLaunch(args);
+  if (launchConfig.ownershipTransfer?.schemaVersion !== 1) {
+    throw piApiFirstTurnError(
+      "PI_LAUNCH_CONFIG_INVALID",
+      "Pi sandbox fallback requires ownership-transfer capability proof",
+    );
+  }
+  await assertApiTurnCommittable(
+    args,
+    launchConfig.deadlineAt,
+    "Pi sandbox fallback is no longer eligible to commit",
+  );
+  signal.throwIfAborted();
+  const loadedSession = await set(
+    loadResumeSessionJsonl$,
+    {
+      db: args.db,
+      resumeSession: executionContext.resumeSession,
+    },
+    signal,
+  );
+  validateResumeSession({
+    loaded: loadedSession,
+    expectedBaseSession: launchConfig.baseSession,
+    sessionId,
+  });
+  const sessionJsonl = materializeApiFirstTurnH0({
+    apiStartTime: executionContext.apiStartTime,
+    loadedSession,
+    sessionId,
+  });
+  const session = validateSandboxFallbackSession(sessionJsonl, sessionId);
+  const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+  const sessionKey = piApiFirstTurnObjectKey(args.activation.runId, "session");
+  await get(
+    putS3Object(
+      bucket,
+      sessionKey,
+      session.bytes,
+      "application/x-ndjson",
+      signal,
+    ),
+  );
+  signal.throwIfAborted();
+  const uploaded = await get(
+    downloadS3BufferWithMaxBytes(
+      bucket,
+      sessionKey,
+      session.bytes.length,
+      signal,
+    ),
+  );
+  signal.throwIfAborted();
+  if (
+    uploaded.length !== session.bytes.length ||
+    sha256(uploaded) !== session.hash
+  ) {
+    throw piApiFirstTurnError(
+      "PI_API_SANDBOX_FALLBACK_FAILED",
+      "Pi sandbox fallback H0 failed read-after-write validation",
+    );
+  }
+  await assertApiTurnCommittable(
+    args,
+    launchConfig.deadlineAt,
+    "Pi sandbox fallback lost commit eligibility before publication",
+  );
+  signal.throwIfAborted();
+  const manifest = ownershipTransferManifest({
+    capability: launchConfig.ownershipTransfer,
+    mode: "sandbox-first",
+    baseSession: launchConfig.baseSession,
+    session: {
+      sessionId,
+      sha256: session.hash,
+      rawSize: session.bytes.length,
+    },
+    sandboxEventSequenceStart: launchConfig.sandboxEventSequenceStart,
+  });
+  await set(writeManifest$, { runId: args.activation.runId, manifest }, signal);
+});
+
 const prepareApiFirstTurn$ = command(async function prepareApiFirstTurn(
   { set },
   args: ApiFirstTurnContext,
+  ownership: PiApiFirstTurnOwnership,
   signal: AbortSignal,
 ): Promise<PreparedApiFirstTurn> {
   const { executionContext, launchConfig, sessionId } =
@@ -905,15 +1094,21 @@ const prepareApiFirstTurn$ = command(async function prepareApiFirstTurn(
     expectedBaseSession: launchConfig.baseSession,
     sessionId,
   });
+  const sessionJsonl = materializeApiFirstTurnH0({
+    apiStartTime: executionContext.apiStartTime,
+    loadedSession,
+    sessionId,
+  });
   const { startedAt, turn } = await executeApiModelTurn(
     {
       activation: args.activation,
       apiKey,
       executionContext,
       launchConfig,
-      loadedSession,
       resourceSnapshot,
+      sessionJsonl,
       sessionId,
+      ownership,
     },
     signal,
   );
@@ -1093,9 +1288,10 @@ const commitApiFirstTurn$ = command(async function commitApiFirstTurn(
 const executeApiFirstTurn$ = command(async function executeApiFirstTurn(
   { set },
   args: ApiFirstTurnContext,
+  ownership: PiApiFirstTurnOwnership,
   signal: AbortSignal,
 ): Promise<CompleteSideEffectsInput | undefined> {
-  const prepared = await set(prepareApiFirstTurn$, args, signal);
+  const prepared = await set(prepareApiFirstTurn$, args, ownership, signal);
   const committed = await settle(
     set(commitApiFirstTurn$, args, prepared, signal),
     signal,
@@ -1127,6 +1323,24 @@ function normalizedApiFirstTurnFailure(
     signal.aborted
       ? "Pi API first-turn deadline elapsed"
       : "Pi API first turn failed",
+    error,
+  );
+}
+
+function normalizedSandboxFallbackFailure(
+  error: unknown,
+  signal: AbortSignal,
+): PiApiFirstTurnError {
+  if (error instanceof PiApiFirstTurnError) {
+    return error;
+  }
+  return piApiFirstTurnError(
+    signal.aborted
+      ? "PI_API_FIRST_TURN_DEADLINE_EXCEEDED"
+      : "PI_API_SANDBOX_FALLBACK_FAILED",
+    signal.aborted
+      ? "Pi API first-turn deadline elapsed during sandbox fallback"
+      : "Pi sandbox fallback publication failed",
     error,
   );
 }
@@ -1187,8 +1401,9 @@ export const runPiApiFirstTurn$ = command(
     signal: AbortSignal,
   ): Promise<DispatchCompleteSideEffectsInput | undefined> => {
     const context: ApiFirstTurnContext = { db: set(writeDb$), activation };
+    const ownership = createPiApiFirstTurnOwnership();
     const executed = await settleApiFirstTurnExecution(
-      set(executeApiFirstTurn$, context, signal),
+      set(executeApiFirstTurn$, context, ownership, signal),
       signal,
     );
     if (executed.ok) {
@@ -1199,11 +1414,37 @@ export const runPiApiFirstTurn$ = command(
           }
         : undefined;
     }
-    const failure = normalizedApiFirstTurnFailure(executed.error, signal);
-    L.warn("Pi API first-turn failed", {
+    let failure = normalizedApiFirstTurnFailure(executed.error, signal);
+    const fallbackReason = eligibleSandboxFallbackReason(
+      {
+        failure,
+        ownership,
+        launchConfig: activation.executionContext.piLaunchConfig.apiFirstTurn,
+      },
+      signal,
+    );
+    if (fallbackReason) {
+      const fallback = await settleApiFirstTurnExecution(
+        set(publishSandboxFallback$, context, signal),
+        signal,
+      );
+      if (fallback.ok) {
+        L.debug("Pi API first-turn outcome", {
+          runId: activation.runId,
+          outcome: "sandbox_fallback",
+          reason: fallbackReason,
+          ownershipStage: ownership.stage,
+        });
+        return undefined;
+      }
+      failure = normalizedSandboxFallbackFailure(fallback.error, signal);
+    }
+    L.warn("Pi API first-turn outcome", {
       runId: activation.runId,
-      code: failure.code,
-      error: failure,
+      outcome: "terminal_failure",
+      reason: failure.code,
+      ownershipStage: ownership.stage,
+      ...(fallbackReason ? { fallbackReason } : {}),
     });
     return set(failApiFirstTurn$, context, failure);
   },

--- a/turbo/apps/api/src/signals/services/pi-resource-snapshot.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-resource-snapshot.service.ts
@@ -17,7 +17,7 @@ import ignore, { type Ignore } from "ignore";
 
 import { extractBinaryFilesFromTarGz } from "../../lib/tar";
 import type { Db } from "../external/db";
-import { startUntrackedBestEffortCleanup } from "../utils";
+import { safeSync, settle, startUntrackedBestEffortCleanup } from "../utils";
 
 const RESOURCE_ARCHIVE_MAX_BYTES = 32 * 1024 * 1024;
 const RESOURCE_ARCHIVE_MAX_OUTPUT_BYTES = 64 * 1024 * 1024;
@@ -43,6 +43,15 @@ function decodePiDiscoveryText(content: Buffer): string {
 }
 
 export class UnsupportedPiResourceError extends Error {}
+
+export class PiResourceSnapshotPreparationError extends Error {}
+
+function resourcePreparationError(cause: unknown): Error {
+  return new PiResourceSnapshotPreparationError(
+    "Pi resource snapshot archive could not be prepared",
+    { cause },
+  );
+}
 
 function snapshotIdentity(mounts: readonly StoredStorageMountEntry[]): string {
   return JSON.stringify({
@@ -114,16 +123,39 @@ async function downloadArchive(
   if (!mount.archiveUrl) {
     return null;
   }
-  const expectedSize = expectedArchiveSize(mount);
-  const response = await fetch(mount.archiveUrl, {
-    cache: "no-store",
-    signal,
+  const expectedSize = safeSync(() => {
+    return expectedArchiveSize(mount);
   });
-  if (!response.ok) {
-    throw new Error(`Pi resource snapshot archive returned ${response.status}`);
+  if ("error" in expectedSize) {
+    throw resourcePreparationError(expectedSize.error);
   }
-  validateArchiveContentLength(response, expectedSize);
-  return await readArchiveBody(response, expectedSize);
+  const fetched = await settle(
+    fetch(mount.archiveUrl, {
+      cache: "no-store",
+      signal,
+    }),
+    signal,
+  );
+  if (!fetched.ok) {
+    throw resourcePreparationError(fetched.error);
+  }
+  const response = fetched.value;
+  if (!response.ok) {
+    throw resourcePreparationError(
+      new Error(`Pi resource snapshot archive returned ${response.status}`),
+    );
+  }
+  const validated = safeSync(() => {
+    validateArchiveContentLength(response, expectedSize.ok);
+  });
+  if ("error" in validated) {
+    throw resourcePreparationError(validated.error);
+  }
+  const body = await settle(readArchiveBody(response, expectedSize.ok), signal);
+  if (!body.ok) {
+    throw resourcePreparationError(body.error);
+  }
+  return body.value;
 }
 
 function expectedArchiveSize(mount: StoredStorageMountEntry): number {

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -103,6 +103,10 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     mode: z.enum(["remove", "invalid"]),
   }),
   z.object({
+    action: z.literal("enable-queued-pi-ownership-transfer"),
+    run_id: z.uuid(),
+  }),
+  z.object({
     action: z.literal("mutate-runner-job-connector-permission-baseline"),
     run_id: z.uuid(),
     mode: z.enum([

--- a/turbo/packages/pi-agent-runtime/src/api-turn.ts
+++ b/turbo/packages/pi-agent-runtime/src/api-turn.ts
@@ -104,6 +104,7 @@ export async function runPiApiFirstTurn(
         apiKey: args.model.apiKey,
         signal,
       },
+      ownership: args.ownership,
     });
     return {
       assistantMessage: projectPiApiAssistantMessage(turn.assistantMessage),

--- a/turbo/packages/pi-agent-runtime/src/api-types.ts
+++ b/turbo/packages/pi-agent-runtime/src/api-types.ts
@@ -1,4 +1,5 @@
 import type { PiAgentModelConfig } from "./types";
+import type { PiApiFirstTurnOwnership } from "./provider-ownership";
 
 export interface PiPreheatedAgentsFile {
   readonly path: string;
@@ -68,6 +69,7 @@ export interface PiApiFirstTurnArgs {
   readonly appendSystemPrompt: string | null;
   readonly model: PiAgentModelConfig;
   readonly resourceSnapshot: PiPreheatedResourceSnapshot;
+  readonly ownership: PiApiFirstTurnOwnership;
 }
 
 export interface PiApiFirstTurnResult {

--- a/turbo/packages/pi-agent-runtime/src/api.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/api.test.ts
@@ -5,6 +5,8 @@ import { CURRENT_SESSION_VERSION } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 
 import {
+  createPiApiFirstTurnOwnership,
+  createPiSessionJsonl,
   inspectPiSessionJsonl,
   runPiApiFirstTurn,
   UnsupportedPiSessionVersionError,
@@ -13,6 +15,7 @@ import { projectPiApiAssistantMessage } from "./api-turn";
 import { MemoryPiSession } from "./session-memory";
 
 const SESSION_ID = "00000000-0000-4000-8000-000000000123";
+const SESSION_TIMESTAMP = "2026-08-31T12:34:56.000Z";
 
 function responsesTextSse(response: ServerResponse, text: string): void {
   const responseId = "resp_terra_api_first";
@@ -86,6 +89,35 @@ function responsesTextSse(response: ServerResponse, text: string): void {
 }
 
 describe("Pi API facade", () => {
+  it("keeps provider request ownership monotonic", () => {
+    const ownership = createPiApiFirstTurnOwnership();
+
+    expect(ownership.stage).toBe("pre-provider");
+    ownership.markProviderRequestMayHaveStarted();
+    expect(ownership.stage).toBe("provider-may-have-started");
+    ownership.markProviderRequestMayHaveStarted();
+    expect(ownership.stage).toBe("provider-may-have-started");
+  });
+
+  it("creates one canonical empty native Pi history", () => {
+    const jsonl = createPiSessionJsonl({
+      cwd: "/home/user/workspace",
+      sessionId: SESSION_ID,
+      timestamp: SESSION_TIMESTAMP,
+    });
+
+    expect(inspectPiSessionJsonl(jsonl)).toStrictEqual({
+      sessionId: SESSION_ID,
+      messageCount: 0,
+      hasPendingToolCalls: false,
+      isSettledCheckpoint: false,
+    });
+    expect(JSON.parse(jsonl.split("\n")[0] ?? "{}")).toMatchObject({
+      id: SESSION_ID,
+      timestamp: SESSION_TIMESTAMP,
+    });
+  });
+
   it("uses Terra Responses with low thinking for an API-first turn", async () => {
     let providerRequest:
       | { readonly url: string | undefined; readonly body: unknown }
@@ -135,6 +167,7 @@ describe("Pi API facade", () => {
           thinkingLevel: "low",
         },
         resourceSnapshot: { schemaVersion: 1, agentsFiles: [], skills: [] },
+        ownership: createPiApiFirstTurnOwnership(),
       });
 
       expect(providerRequest).toMatchObject({

--- a/turbo/packages/pi-agent-runtime/src/api.ts
+++ b/turbo/packages/pi-agent-runtime/src/api.ts
@@ -18,7 +18,13 @@ import {
   UnsupportedPiResourceSnapshotError,
   UnsupportedPiSessionVersionError,
 } from "./errors";
+import { createPiApiFirstTurnOwnership } from "./provider-ownership";
+import type {
+  PiApiFirstTurnOwnership,
+  PiApiFirstTurnOwnershipStage,
+} from "./provider-ownership";
 export { UnsupportedPiResourceSnapshotError, UnsupportedPiSessionVersionError };
+export { createPiApiFirstTurnOwnership };
 export type {
   PiApiAssistantContent,
   PiApiAssistantMessage,
@@ -31,10 +37,25 @@ export type {
   PiPreheatedResourceSnapshot,
   PiPreheatedSkill,
   PiSessionInspection,
+  PiApiFirstTurnOwnership,
+  PiApiFirstTurnOwnershipStage,
 };
 
 /** Run one provider turn without exposing Pi's native declaration surface. */
 export const runPiApiFirstTurn: RunPiApiFirstTurn = runPiApiFirstTurnImpl;
+
+/** Create the canonical empty native Pi history for a new API-first launch. */
+export function createPiSessionJsonl(args: {
+  readonly cwd: string;
+  readonly sessionId: string;
+  readonly timestamp: string;
+}): string {
+  return MemoryPiSession.create({
+    cwd: args.cwd,
+    id: args.sessionId,
+    timestamp: args.timestamp,
+  }).toJsonl();
+}
 
 /** Inspect one native Pi JSONL session through a stable structural result. */
 export function inspectPiSessionJsonl(jsonl: string): PiSessionInspection {

--- a/turbo/packages/pi-agent-runtime/src/node.ts
+++ b/turbo/packages/pi-agent-runtime/src/node.ts
@@ -1,6 +1,10 @@
 export { resumePiApiFirstTurn, runPiOfficialRpcMode } from "./rpc";
 export type { PiSandboxOwnershipTransferMode } from "./rpc";
-export { runPiApiFirstTurn } from "./api";
+export {
+  createPiApiFirstTurnOwnership,
+  createPiSessionJsonl,
+  runPiApiFirstTurn,
+} from "./api";
 export { MemoryPiSession } from "./session-memory";
 export {
   UnsupportedPiResourceSnapshotError,
@@ -12,4 +16,8 @@ export type {
   PiPreheatedResourceSnapshot,
   PiPreheatedSkill,
 } from "./api-types";
+export type {
+  PiApiFirstTurnOwnership,
+  PiApiFirstTurnOwnershipStage,
+} from "./provider-ownership";
 export * from "./index";

--- a/turbo/packages/pi-agent-runtime/src/provider-ownership.ts
+++ b/turbo/packages/pi-agent-runtime/src/provider-ownership.ts
@@ -1,0 +1,21 @@
+export type PiApiFirstTurnOwnershipStage =
+  | "pre-provider"
+  | "provider-may-have-started";
+
+export interface PiApiFirstTurnOwnership {
+  readonly stage: PiApiFirstTurnOwnershipStage;
+  markProviderRequestMayHaveStarted(): void;
+}
+
+/** Track the irreversible provider-request ownership boundary for one turn. */
+export function createPiApiFirstTurnOwnership(): PiApiFirstTurnOwnership {
+  let stage: PiApiFirstTurnOwnershipStage = "pre-provider";
+  return {
+    get stage() {
+      return stage;
+    },
+    markProviderRequestMayHaveStarted() {
+      stage = "provider-may-have-started";
+    },
+  };
+}

--- a/turbo/packages/pi-agent-runtime/src/session-memory.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-memory.test.ts
@@ -18,6 +18,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { MemoryPiSession, runPiFirstModelTurn } from "./session-memory";
 import { UnsupportedPiSessionVersionError } from "./errors";
+import { createPiApiFirstTurnOwnership } from "./provider-ownership";
 
 const SESSION_ID = "00000000-0000-4000-8000-000000000123";
 const temporaryDirectories: string[] = [];
@@ -67,8 +68,10 @@ describe("MemoryPiSession", () => {
       api: "memory-test",
       provider: "memory-test",
     });
+    const ownership = createPiApiFirstTurnOwnership();
     faux.setResponses([
       (context, options) => {
+        expect(ownership.stage).toBe("provider-may-have-started");
         modelContext = context;
         expect(options?.sessionId).toBe(SESSION_ID);
         return fauxAssistantMessage(
@@ -91,9 +94,11 @@ describe("MemoryPiSession", () => {
           parameters: Type.Object({ path: Type.String() }),
         },
       ],
+      ownership,
     });
 
     expect(turn.handoffRequired).toBe(true);
+    expect(ownership.stage).toBe("provider-may-have-started");
     expect(faux.state.callCount).toBe(1);
     expect(modelContext?.systemPrompt).toBe("preheated Pi system prompt");
     expect(
@@ -140,8 +145,10 @@ describe("MemoryPiSession", () => {
       },
     };
     let requestedReasoning: string | undefined;
+    const ownership = createPiApiFirstTurnOwnership();
     faux.setResponses([
       (_context, options) => {
+        expect(ownership.stage).toBe("provider-may-have-started");
         requestedReasoning = options?.reasoning;
         return fauxAssistantMessage(
           fauxToolCall("read", { path: "/etc/os-release" }),
@@ -164,6 +171,7 @@ describe("MemoryPiSession", () => {
           parameters: Type.Object({ path: Type.String() }),
         },
       ],
+      ownership,
     });
 
     expect(requestedReasoning).toBe("high");
@@ -235,6 +243,7 @@ describe("MemoryPiSession", () => {
       thinkingLevel: "low",
       timestamp: 1,
       tools: [],
+      ownership: createPiApiFirstTurnOwnership(),
     });
     await runPiFirstModelTurn({
       model: faux.getModel(),
@@ -245,6 +254,7 @@ describe("MemoryPiSession", () => {
       thinkingLevel: "high",
       timestamp: 3,
       tools: [],
+      ownership: createPiApiFirstTurnOwnership(),
     });
 
     expect(requestedReasoning).toStrictEqual(["low", "low"]);
@@ -302,6 +312,34 @@ describe("MemoryPiSession", () => {
           return entry.type === "thinking_level_change";
         }),
     ).toHaveLength(1);
+  });
+
+  it("moves ownership before a synchronous provider transport failure", async () => {
+    const memory = MemoryPiSession.create({
+      cwd: "/home/user/workspace",
+      id: SESSION_ID,
+    });
+    const faux = createFauxCore({
+      api: "memory-failure-test",
+      provider: "memory-failure-test",
+    });
+    const ownership = createPiApiFirstTurnOwnership();
+
+    await expect(
+      runPiFirstModelTurn({
+        model: faux.getModel(),
+        session: memory,
+        stream: () => {
+          expect(ownership.stage).toBe("provider-may-have-started");
+          throw new Error("provider transport failed");
+        },
+        systemPrompt: "system",
+        prompt: "must not be replayed",
+        tools: [],
+        ownership,
+      }),
+    ).rejects.toThrow("provider transport failed");
+    expect(ownership.stage).toBe("provider-may-have-started");
   });
 
   it("uses Pi migrations and compacted-context projection", async () => {

--- a/turbo/packages/pi-agent-runtime/src/session-memory.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-memory.ts
@@ -26,11 +26,13 @@ import {
 } from "@earendil-works/pi-coding-agent";
 
 import { UnsupportedPiSessionVersionError } from "./errors";
+import type { PiApiFirstTurnOwnership } from "./provider-ownership";
 
 interface CreateMemoryPiSessionOptions {
   readonly cwd: string;
   readonly id: string;
   readonly parentSession?: string;
+  readonly timestamp?: string;
 }
 
 interface RunPiFirstModelTurnOptions<TApi extends Api = Api> {
@@ -43,6 +45,7 @@ interface RunPiFirstModelTurnOptions<TApi extends Api = Api> {
   readonly thinkingLevel?: ModelThinkingLevel;
   readonly timestamp?: number;
   readonly streamOptions?: Omit<SimpleStreamOptions, "sessionId">;
+  readonly ownership: PiApiFirstTurnOwnership;
 }
 
 interface PiModelTurnResult {
@@ -123,7 +126,7 @@ export class MemoryPiSession {
       type: "session",
       version: CURRENT_SESSION_VERSION,
       id: options.id,
-      timestamp: new Date().toISOString(),
+      timestamp: options.timestamp ?? new Date().toISOString(),
       cwd: options.cwd,
       parentSession: options.parentSession,
     };
@@ -308,6 +311,7 @@ export async function runPiFirstModelTurn<TApi extends Api>(
     messages: convertToLlm(sessionContext.messages),
     tools: [...options.tools],
   };
+  options.ownership.markProviderRequestMayHaveStarted();
   const responseStream = options.stream(options.model, context, {
     ...options.streamOptions,
     reasoning:


### PR DESCRIPTION
## Summary

- add a monotonic pre-provider to provider-may-have-started ownership boundary around the Pi provider transport
- publish validated canonical H0 as V3 sandbox-first only for bounded pre-provider resource or preheat failures and an immutable ownership-transfer V1 capability
- preserve capability-absent V1/V2 behavior and prove both successful Sandbox takeover and the post-provider duplicate-request trap

## Compatibility and rollback

- Capability-absent launches remain terminal for resource failures and retain existing V1/V2 pending-tool continuation behavior.
- Production still does not advertise ownership-transfer support; the BDD enables it only through a test-only queued-payload fixture, so an older or unproven Sandbox never receives V3.
- API, CLI, Guest, and Runner skew remains fail-closed through the existing schema gates. Rollback is a code revert with no database migration or persisted-schema contraction.

## Fallbacks

- turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts:publishSandboxFallback$ — transfers one bounded resource-download or Pi preheat failure to an already-prepared, capability-proven Sandbox before provider ownership. Surface: API to selected Sandbox; window: one activated run. Remove when API preparation moves before durable Sandbox activation under Parent #30564.

## Verification

- Pi runtime: 15 tests passed
- API fallback BDD: 1 passed, 133 skipped
- API legacy failure BDD: 2 passed, 132 skipped
- Pi resource snapshot: 5 tests passed
- API contracts runner suite: 106 tests passed
- CLI handoff and AgentSession suites: 37 tests passed
- Guest Pi boundary: 3 focused Rust tests passed
- Prettier checks passed
- pi-agent-runtime and api-contracts type/lint checks passed
- full API check-types and lint passed
- Runner focused Rust build was attempted locally but its cold binary compilation was killed by the runtime memory limit; no Rust source changed, and PR CI remains authoritative

Parent: #30564
Closes #30614