### PR TITLE
test(platform): wait for chat thread readiness

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-localization.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-localization.test.tsx
@@ -129,6 +129,9 @@ describe("chat localization", () => {
     await expect(
       screen.findByText("Ask me to automate workflows, manage tasks..."),
     ).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByText("Send a message to start the conversation"),
+    ).resolves.toBeInTheDocument();
     const editor = await findComposerEditor();
     await user.click(editor);
     await user.keyboard(authoredDraft);


### PR DESCRIPTION
## Summary

- wait for the rendered empty-thread state before typing the locale-switch draft
- synchronize the test with initial chat event readiness instead of CI timing
- preserve the existing sendability, editor identity, draft, thread, route, and locale assertions

## Scope

Test-only change. No production behavior, timeout, retry, skip, API, database, or dependency changes.

## Validation

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-localization.test.tsx --maxWorkers=1` (9 passed)
- `pnpm vitest run --project=@okouai/app --shard=4/8 --coverage.enabled --coverage.reporter=json` (252 passed)
- `pnpm exec prettier --check apps/platform/src/views/okou-page/__tests__/chat-localization.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace apps/platform`
- pre-commit hooks: repository Knip, repository TypeScript checks, file-size check, and commitlint

Closes #30630
