### PR TITLE
test(platform): model no-browser state in keyboard fixture

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-history-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-history-navigation.test.tsx
@@ -2,7 +2,6 @@ import { chatEventRowsResponse } from "../../../signals/__tests__/test-helpers.t
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { browserContract } from "@okouai/api-contracts/contracts/browser";
 import {
   chatEventsContract,
   chatThreadByIdContract,
@@ -50,17 +49,6 @@ import {
 
 const SHARED_DATABASE_REALTIME_CHANNEL = "user-org:test-user-123:org_default";
 type RenameRequest = (threadId: string, title: string) => void;
-
-function mockNoBrowserSession(): void {
-  context.mocks.api(browserContract.get, ({ respond }) => {
-    return respond(404, {
-      error: {
-        code: "BROWSER_NOT_FOUND",
-        message: "Managed browser not found",
-      },
-    });
-  });
-}
 
 function mockNoThreadEvents(): void {
   context.mocks.api(chatThreadEventsContract.rows, ({ query, respond }) => {
@@ -727,7 +715,6 @@ describe("chat lifecycle", () => {
 
   it("moves to the previous chat with a page shortcut from the composer", async () => {
     mockResizeObserver();
-    mockNoBrowserSession();
     mockKeyboardNavigationThreads();
     mockNoThreadEvents();
 
@@ -758,7 +745,6 @@ describe("chat lifecycle", () => {
 
   it("keeps shifted slash editable before opening shortcut help outside the composer", async () => {
     mockResizeObserver();
-    mockNoBrowserSession();
     mockKeyboardNavigationThreads();
     mockNoThreadEvents();
 
@@ -797,7 +783,6 @@ describe("chat lifecycle", () => {
       callback(performance.now());
       return 1;
     });
-    mockNoBrowserSession();
     mockKeyboardNavigationThreads();
     mockNoThreadEvents();
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-lifecycle-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-lifecycle-test-helpers.ts
@@ -1,5 +1,6 @@
 import { screen, waitFor, within } from "@testing-library/react";
 import { expect, vi, type Mock } from "vitest";
+import { browserContract } from "@okouai/api-contracts/contracts/browser";
 import {
   chatThreadByIdContract,
   chatThreadArtifactsContract,
@@ -314,6 +315,14 @@ export function mockKeyboardNavigationThreads({
   currentTitle?: string;
   currentDetailTitle?: string | null;
 } = {}): void {
+  context.mocks.api(browserContract.get, ({ respond }) => {
+    return respond(404, {
+      error: {
+        code: "BROWSER_NOT_FOUND",
+        message: "Managed browser not found",
+      },
+    });
+  });
   const threadFixtures = [
     {
       id: KEYBOARD_PREV_THREAD_ID,


### PR DESCRIPTION
## Summary

- model the shared keyboard-navigation threads with the expected no-active-browser 404
- remove the redundant file-local browser mock from the three shortcut stories
- eliminate browser-session catch-up HTTP 500 work for all 30 current fixture consumers

## Scope

This changes test fixture state only. It does not change production behavior, API contracts, assertions, timeouts, timers, retries, or cleanup.

## Validation

- five fresh one-worker runs of `restores a thread after its old DOM collapses`: 864 ms, 759 ms, 763 ms, 827 ms, 772 ms
- complete scroll-position, history-navigation, and emoji-category files: 58/58 passed
- all 30 shared-fixture consumer stories: 30/30 passed with no browser catch-up HTTP 500 warning
- `pnpm prettier --check --ignore-unknown apps/platform/src/views/okou-page/__tests__/chat-lifecycle-test-helpers.ts apps/platform/src/views/okou-page/__tests__/chat-history-navigation.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- `lefthook run pre-commit`
- `git diff --check`

Closes #30548
