### PR TITLE
test(platform): stabilize chat emoji picker timing

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-history-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-history-navigation.test.tsx
@@ -1227,6 +1227,7 @@ describe("chat lifecycle", () => {
     const renameRequest = vi.fn<RenameRequest>();
     mockResizeObserver();
     mockKeyboardNavigationThreads({ currentDetailTitle: null });
+    mockNoThreadEvents();
     context.mocks.api(
       chatThreadRenameContract.rename,
       ({ body, params, respond }) => {
@@ -1240,10 +1241,8 @@ describe("chat lifecycle", () => {
       path: "/chats/b0000000-0000-4000-a000-000000000708",
     });
 
+    await screen.findByPlaceholderText(PLACEHOLDER);
     await waitFor(() => {
-      expect(
-        screen.getByText("Current thread launch note"),
-      ).toBeInTheDocument();
       expect(
         screen.getAllByText("Current keyboard thread").length,
       ).toBeGreaterThan(0);
@@ -1467,6 +1466,7 @@ describe("chat lifecycle", () => {
     mockKeyboardNavigationThreads({
       currentTitle: "🔥 Current keyboard thread",
     });
+    mockNoThreadEvents();
 
     detachedSetupPage({
       context,
@@ -1474,9 +1474,6 @@ describe("chat lifecycle", () => {
     });
 
     await waitFor(() => {
-      expect(
-        screen.getByText("Current thread launch note"),
-      ).toBeInTheDocument();
       expect(screen.getByLabelText("Change icon")).toHaveTextContent("🔥");
     });
 
@@ -1521,6 +1518,7 @@ describe("chat lifecycle", () => {
     mockKeyboardNavigationThreads({
       currentTitle: "🔥   Current keyboard thread",
     });
+    mockNoThreadEvents();
     context.mocks.api(
       chatThreadRenameContract.rename,
       ({ body, params, respond }) => {
@@ -1535,9 +1533,6 @@ describe("chat lifecycle", () => {
     });
 
     await waitFor(() => {
-      expect(
-        screen.getByText("Current thread launch note"),
-      ).toBeInTheDocument();
       expect(document.title).toBe("🔥   Current keyboard thread | VM0");
       expect(screen.getByLabelText("Change icon")).toHaveTextContent("🔥");
       expect(screen.getByText("Current keyboard thread")).toBeInTheDocument();
@@ -1564,6 +1559,7 @@ describe("chat lifecycle", () => {
     mockKeyboardNavigationThreads({
       currentTitle: "🔥 Current keyboard thread",
     });
+    mockNoThreadEvents();
     context.mocks.api(
       chatThreadRenameContract.rename,
       ({ body, params, respond }) => {
@@ -1600,6 +1596,7 @@ describe("chat lifecycle", () => {
     const renameRequest = vi.fn<RenameRequest>();
     mockResizeObserver();
     mockKeyboardNavigationThreads({ currentTitle: "🔥" });
+    mockNoThreadEvents();
     context.mocks.api(
       chatThreadRenameContract.rename,
       ({ body, params, respond }) => {


### PR DESCRIPTION
## Summary

- isolate all five chat emoji picker stories from unrelated browser-session catch-up and thread-event rendering
- retain rendered composer, icon, title, picker interaction, and rename assertions under the unchanged five-second timeout
- keep production behavior, shared fixtures, real timers, and the full emoji catalog unchanged

## Validation

- five fresh sequential one-worker runs of the five picker-opening stories (25/25 passed; slowest story 824 ms)
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-history-navigation.test.tsx --maxWorkers=1` (30/30 passed)
- `pnpm exec prettier --check apps/platform/src/views/okou-page/__tests__/chat-history-navigation.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- `git diff --check`
- lefthook pre-commit checks (full Knip, full TypeScript checks, formatting, file size, and commitlint)

Closes #30547
