### PR TITLE
chore(api): refresh post-merge preview qa marker

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createProductionApp } from "./production-bootstrap";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed for #27599 rollback rotation on 2026-08-18)
+// (no-op API release marker refreshed for #30442 post-merge QA on 2026-09-01)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
## Purpose

Behavior-neutral API release marker refresh for #30442.

The PR changes only the date and context in the repository existing no-op API release marker. Runtime behavior is unchanged.

## CI remediation

- rebased onto the current stable main branch so the validation run includes the latest Pi API-first, cancellation, runner, and E2E fixes
- retained the one-line behavior-neutral marker diff

## Local checks

- git diff --check
- Prettier check for turbo/apps/api/src/index.ts
