### PR TITLE
ci: drop redundant app preview runtime probe

### DIFF
--- a/.github/scripts/tests/deploy-okou-pages-workflow-test.sh
+++ b/.github/scripts/tests/deploy-okou-pages-workflow-test.sh
@@ -63,6 +63,7 @@ preview_readiness_step = find_step(
     turbo_job, "Wait for Cloudflare Pages deployment readiness"
 )
 preview_gateway_step = find_step(turbo_job, "Smoke test app preview gateway")
+app_preview_url_step = find_step(turbo_job, "Resolve app preview gateway URL")
 prepare_release_step = find_step(
     release_job, "Prepare Cloudflare Pages production deployment"
 )
@@ -158,35 +159,43 @@ if not (
 if "publish-okou-app-assets.sh" in str(release_job):
     raise RuntimeError("production promotion must not publish immutable app assets")
 
-require_fragments(
+readiness_source = require_fragments(
     preview_readiness_step,
     [
         'id="app-bootstrap-skeleton"',
         "Cloudflare Pages shell is ready",
-        "bash .github/scripts/verify-okou-app-runtime.sh",
-        '"https://static.okou.io/okou-app/assets"',
-        '"$CANONICAL_ASSETS"',
     ],
 )
 if "PAGES_DIST" in preview_readiness_step.get("env", {}):
     raise RuntimeError("Pages shell readiness must not inspect removed app assets")
-if preview_readiness_step.get("env", {}).get("CANONICAL_ASSETS") != (
-    "${{ steps.pages-preview.outputs.canonical-dist }}/assets"
-):
-    raise RuntimeError("Pages readiness must verify the canonical App bundles")
-require_fragments(
+# A Pages alias can serve the shell and then 404 again while the edge converges.
+# Readiness only waits for that propagation; point sampling the runtime contract
+# here fails the job on flapping the very next second.
+if "verify-okou-app-runtime.sh" in readiness_source:
+    raise RuntimeError("Pages readiness must not point sample the runtime contract")
+gateway_source = require_fragments(
     preview_gateway_step,
     [
         "bash .github/scripts/verify-okou-app-runtime.sh",
         '"$APP_PREVIEW_URL"',
         '"https://static.okou.io/okou-app/assets"',
         '"$CANONICAL_ASSETS"',
+        "{1..12}",
     ],
 )
 if preview_gateway_step.get("env", {}).get("CANONICAL_ASSETS") != (
     "${{ steps.pages-preview.outputs.canonical-dist }}/assets"
 ):
     raise RuntimeError("SharedWorker smoke test must use canonical app assets")
+if turbo_source.count("bash .github/scripts/verify-okou-app-runtime.sh") != 1:
+    raise RuntimeError(
+        "the app preview runtime contract must be verified exactly once, with retries"
+    )
+if "if" in app_preview_url_step:
+    raise RuntimeError(
+        "the app preview gateway URL must always resolve, "
+        "or runtime verification silently skips"
+    )
 release_step_source = require_fragments(
     release_step,
     [

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1534,9 +1534,12 @@ jobs:
 
           echo "url=$deployment_url" >> "$GITHUB_OUTPUT"
 
+      # A Pages deployment alias can serve the shell and then 404 again while
+      # the edge is still converging, so this step only waits for propagation.
+      # The runtime contract is verified once, by the gateway smoke test below,
+      # which retries to convergence instead of point sampling.
       - name: Wait for Cloudflare Pages deployment readiness
         env:
-          CANONICAL_ASSETS: ${{ steps.pages-preview.outputs.canonical-dist }}/assets
           PAGES_URL: ${{ steps.pages-deploy.outputs.url }}
         run: |
           set -euo pipefail
@@ -1563,10 +1566,6 @@ jobs:
 
             if (( ready_passes >= 2 )); then
               echo "Cloudflare Pages shell is ready"
-              bash .github/scripts/verify-okou-app-runtime.sh \
-                "$PAGES_URL" \
-                "https://static.okou.io/okou-app/assets" \
-                "$CANONICAL_ASSETS"
               exit 0
             fi
             sleep 2


### PR DESCRIPTION
## Problem

Turbo run [33416483779](https://github.com/vm0-ai/vm0/actions/runs/33416483779) (`push` on `main`, SHA `634e4cd`) failed in [`deploy-app`](https://github.com/vm0-ai/vm0/actions/runs/33416483779/job/99568240458) at **Wait for Cloudflare Pages deployment readiness**. The Pages deployment alias served the app shell, and then returned 404 for the same URL thirteen seconds later:

```
16:53:40  curl: (22) The requested URL returned error: 404
16:53:40  ::warning:: Cloudflare Pages shell is not ready (attempt 1/60)
16:53:45  curl: (22) The requested URL returned error: 404
16:53:45  ::warning:: Cloudflare Pages shell is not ready (attempt 3/60)
16:53:49  Cloudflare Pages shell is ready
16:54:02  App runtime document did not converge for https://d37712aa.okou-app.pages.dev
          after probe 1/1 (13s); final probe evidence:
16:54:02  Transport probe failed for https://d37712aa.okou-app.pages.dev/sign-up (curl exit 22)
16:54:02  curl: (22) The requested URL returned error: 404   (x7)
##[error]Process completed with exit code 1
```

The readiness poll loop is deliberately tolerant of this: 60 attempts, two-second sleeps, two consecutive passes required. But once it passed, it called `verify-okou-app-runtime.sh` inline, and that script defaults `OKOU_APP_RUNTIME_MAX_ATTEMPTS` to `1`. So the step absorbed the propagation flapping in its own loop and then failed the job on the same flapping one line later. The seven identical 404 lines are curl's own `--retry 6 --retry-all-errors` budget: total tolerance was thirteen seconds.

Recurring, across branches. Three `deploy-app` jobs hit the identical signature within 2.5 hours on 2026-08-31:

| Job | Branch | Evidence |
| --- | --- | --- |
| 99568240458 | `main` (push) | `did not converge for https://d37712aa.okou-app.pages.dev after probe 1/1 (13s)` |
| 99552634053 | `fix/30593-gmail-trigger-account-selection` | `did not converge for https://f8fca087.okou-app.pages.dev after probe 1/1 (12s)` |
| 99528527133 | `feat/issue-30571-connector-account-switch-card` | `did not converge for https://2927b04a.okou-app.pages.dev after probe 1/1 (13s)` |

Job 99528527133 saw no readiness warnings at all: the alias answered on the first two probes and 404'd thirteen seconds later.

## Why the probe is redundant, not just impatient

`deploy-app` verifies the app runtime contract **twice**:

1. **Wait for Cloudflare Pages deployment readiness** — calls `verify-okou-app-runtime.sh` against the immutable deployment alias, once, with no retry.
2. **Smoke test app preview gateway** — calls the *same script* against the branch alias, inside `for attempt in {1..12}` with a five-second backoff.

Both check the same invariants: build metadata (`okou-app-git-commit-sha`, `okou-app-version`) against the canonical document, the deferred CDN app entry, the after-first-paint entry, the runtime/vendor modulepreloads, the absence of static module scripts, the four asset URLs on the CDN, and the SharedWorker same-origin proxy returning 206.

The second one always runs: `Resolve app preview gateway URL` has no `if:` and unconditionally writes `https://${PAGES_BRANCH}.${CF_PAGES_PREVIEW_DOMAIN}`, so `steps.app-preview.outputs.url != ''` is always true, on `push`, `pull_request` and `merge_group` alike.

So the first call was a second, retry-free sample of an invariant that gets verified to convergence one step later. Removing it costs no coverage; it removes the only place in the preview path where Pages propagation flapping is fatal.

## Change

- Delete the `verify-okou-app-runtime.sh` call (and its now-unused `CANONICAL_ASSETS` env) from the readiness step. That step goes back to doing exactly one job: waiting for the alias to propagate.
- Lock the remaining verification in place with three assertions in `deploy-okou-pages-workflow-test.sh`:
  - readiness must not call the runtime verifier again;
  - `verify-okou-app-runtime.sh` must appear exactly once in `turbo.yml`, and the gateway step must keep its `{1..12}` retry loop;
  - `Resolve app preview gateway URL` must stay unconditional, so the surviving check can never silently skip.

`verify-okou-app-runtime.sh` itself is unchanged, and the production promotion path in `release-please.yml` (which sets 60 probes) is untouched.

## Validation

Run locally against this branch:

- `.github/scripts/tests/deploy-okou-pages-workflow-test.sh` — pass
- `.github/scripts/tests/verify-okou-app-runtime-test.sh` — pass (script unchanged)
- `deploy-okou-pages-test.sh`, `verify-okou-app-assets-test.sh`, `app-preview-ingress-workflow-test.sh`, and every other test that parses `turbo.yml` — pass
- `bash -n` over all `.github/scripts` and `.github/scripts/tests`, `shellcheck`, `check-workflow-shell-compatibility.sh`, `git diff --check` — clean

All three new assertions were mutation-tested and fail on the corresponding regression: re-adding the readiness probe, shrinking the gateway retry loop, and making the gateway URL conditional.

The invariant is validated by this PR's own `deploy-app` job, which runs the modified workflow against a real Cloudflare Pages preview deployment.

## Trade-off

The immutable deployment alias (`<hash>.okou-app.pages.dev`) is no longer runtime-verified; only the branch alias the preview gateway serves is. Under concurrent deploys to the same Pages branch the branch alias can point at a newer deployment — but that was already true of the smoke test, and the build metadata assertion still fails closed if the served document is not the one this run built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
