### PR TITLE
test(platform): model no-browser lifecycle fixtures

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-history-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-history-navigation.test.tsx
@@ -19,11 +19,7 @@ import {
   fill,
   setupPageAndWaitForContent,
 } from "../../../__tests__/page-helper.ts";
-import {
-  mockChatLifecycle,
-  PLACEHOLDER,
-  sendMessageInUI,
-} from "./chat-test-helpers.ts";
+import { PLACEHOLDER, sendMessageInUI } from "./chat-test-helpers.ts";
 import { mockChatEventRows } from "./chat-event-test-helpers.ts";
 import {
   context,
@@ -36,6 +32,7 @@ import {
   AGENT_CHAT_PATH,
   makeRunGroupMessages,
   makeEvent,
+  mockChatLifecycleWithoutBrowserSession,
   mockKeyboardNavigationThreads,
   buttonByText,
   buttonByLabel,
@@ -77,7 +74,7 @@ describe("chat lifecycle", () => {
     } satisfies ChatEvent;
     let exposeNewMessage = false;
 
-    mockChatLifecycle(context, {
+    mockChatLifecycleWithoutBrowserSession({
       threadId,
       threadTitle: "Live message regression",
     });
@@ -151,7 +148,7 @@ describe("chat lifecycle", () => {
     let persistedMessage: ChatEvent | null = null;
     let exposePersistedMessage = false;
 
-    mockChatLifecycle(context, {
+    mockChatLifecycleWithoutBrowserSession({
       threadId,
       threadTitle: "Optimistic realtime reconciliation",
     });
@@ -289,7 +286,7 @@ describe("chat lifecycle", () => {
     } satisfies ChatEvent;
     let exposeReplacement = false;
 
-    mockChatLifecycle(context, {
+    mockChatLifecycleWithoutBrowserSession({
       threadId,
       threadTitle: "Durable steer projection",
       activeRunIds: [runId],
@@ -437,7 +434,7 @@ describe("chat lifecycle", () => {
   it("keeps chat scroll controls responsive to buttons and keyboard", async () => {
     mockResizeObserver();
     const threadId = "b0000000-0000-4000-a000-000000000722";
-    mockChatLifecycle(context, {
+    mockChatLifecycleWithoutBrowserSession({
       threadId,
       threadTitle: "Scroll history",
       chatEvents: Array.from({ length: 8 }, (_, index) => {
@@ -537,7 +534,7 @@ describe("chat lifecycle", () => {
       };
     });
 
-    mockChatLifecycle(context, {
+    mockChatLifecycleWithoutBrowserSession({
       threadId,
       threadTitle: "Render window",
       chatEvents,
@@ -587,7 +584,7 @@ describe("chat lifecycle", () => {
 
   it("counts a folded tail run group as one item in the initial chat window", async () => {
     const threadId = "e5000000-0000-4000-a000-000000000002";
-    mockChatLifecycle(context, {
+    mockChatLifecycleWithoutBrowserSession({
       threadId,
       threadTitle: "Tail run group window",
       chatEvents: [
@@ -647,7 +644,7 @@ describe("chat lifecycle", () => {
           }
         : message;
     });
-    mockChatLifecycle(context, {
+    mockChatLifecycleWithoutBrowserSession({
       threadId,
       threadTitle: "Structured run group label",
       chatEvents: messages,
@@ -672,7 +669,7 @@ describe("chat lifecycle", () => {
 
   it("keeps the item before a folded middle run group in the initial chat window", async () => {
     const threadId = "e5000000-0000-4000-a000-000000000004";
-    mockChatLifecycle(context, {
+    mockChatLifecycleWithoutBrowserSession({
       threadId,
       threadTitle: "Middle run group window",
       chatEvents: [
@@ -1014,7 +1011,7 @@ describe("chat lifecycle", () => {
       updatedAt: "2026-06-01T00:00:00.000Z",
       pinnedAt: null,
     };
-    const lifecycle = mockChatLifecycle(context, {
+    const lifecycle = mockChatLifecycleWithoutBrowserSession({
       threadId: EVENT_SOURCED_RENAME_THREAD_ID,
       threadTitle: "Thread detail should stay pending",
     });
@@ -1133,7 +1130,7 @@ describe("chat lifecycle", () => {
   it("keeps F2 rename available after creating a chat from the agent composer", async () => {
     const user = userEvent.setup({ delay: null });
     mockResizeObserver();
-    mockChatLifecycle(context);
+    mockChatLifecycleWithoutBrowserSession();
 
     detachedSetupPage({ context, path: AGENT_CHAT_PATH });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-lifecycle-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-lifecycle-test-helpers.ts
@@ -308,13 +308,7 @@ export function makeEvent(
   };
 }
 
-export function mockKeyboardNavigationThreads({
-  currentTitle = "Current keyboard thread",
-  currentDetailTitle = currentTitle,
-}: {
-  currentTitle?: string;
-  currentDetailTitle?: string | null;
-} = {}): void {
+export function mockNoBrowserSession(): void {
   context.mocks.api(browserContract.get, ({ respond }) => {
     return respond(404, {
       error: {
@@ -323,6 +317,23 @@ export function mockKeyboardNavigationThreads({
       },
     });
   });
+}
+
+export function mockChatLifecycleWithoutBrowserSession(
+  options?: Parameters<typeof mockChatLifecycle>[1],
+): ReturnType<typeof mockChatLifecycle> {
+  mockNoBrowserSession();
+  return mockChatLifecycle(context, options);
+}
+
+export function mockKeyboardNavigationThreads({
+  currentTitle = "Current keyboard thread",
+  currentDetailTitle = currentTitle,
+}: {
+  currentTitle?: string;
+  currentDetailTitle?: string | null;
+} = {}): void {
+  mockNoBrowserSession();
   const threadFixtures = [
     {
       id: KEYBOARD_PREV_THREAD_ID,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-lifecycle-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-lifecycle-test-helpers.ts
@@ -308,7 +308,7 @@ export function makeEvent(
   };
 }
 
-export function mockNoBrowserSession(): void {
+function mockNoBrowserSession(): void {
   context.mocks.api(browserContract.get, ({ respond }) => {
     return respond(404, {
       error: {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-scroll-position.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-scroll-position.test.tsx
@@ -690,7 +690,7 @@ describe("chat scroll position", () => {
   it("opens an event hash instead of following the thread tail", async () => {
     const threadId = "b0000000-0000-4000-a000-000000000817";
     const events = simpleUserEvents(threadId, "deep-link", 20);
-    mockChatLifecycle(context, {
+    mockChatLifecycleWithoutBrowserSession({
       threadId,
       threadTitle: "Event deep link",
       chatEvents: events,
@@ -747,7 +747,7 @@ describe("chat scroll position", () => {
     "ignores a $label event hash and follows the thread tail",
     async ({ hash, threadId }) => {
       const events = simpleUserEvents(threadId, "invalid-deep-link", 20);
-      mockChatLifecycle(context, {
+      mockChatLifecycleWithoutBrowserSession({
         threadId,
         threadTitle: "Invalid event deep link",
         chatEvents: events,
@@ -796,7 +796,7 @@ describe("chat scroll position", () => {
     const prefix = 'quoted-"event';
     const events = simpleUserEvents(threadId, prefix, 20);
     const targetEventId = `${prefix}-2`;
-    mockChatLifecycle(context, {
+    mockChatLifecycleWithoutBrowserSession({
       threadId,
       threadTitle: "Encoded event deep link",
       chatEvents: events,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-scroll-position.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-scroll-position.test.tsx
@@ -10,7 +10,7 @@ import {
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { click, queryAllByRoleFast } from "../../../__tests__/page-helper.ts";
 import { createChatEvent } from "../../../mocks/mock-helpers.ts";
-import { mockChatLifecycle, sendMessageInUI } from "./chat-test-helpers.ts";
+import { sendMessageInUI } from "./chat-test-helpers.ts";
 import {
   mockChatEventRows,
   normalizeMockChatEvents,
@@ -23,6 +23,7 @@ import {
   KEYBOARD_PREV_THREAD_ID,
   chatScrollContainer,
   linkByText,
+  mockChatLifecycleWithoutBrowserSession,
   mockKeyboardNavigationThreads,
 } from "./chat-lifecycle-test-helpers.ts";
 
@@ -443,7 +444,7 @@ function mockLiveThread({
   ).length;
   let appendedEventsPublished = false;
 
-  mockChatLifecycle(context, {
+  mockChatLifecycleWithoutBrowserSession({
     threadId,
     threadTitle: `Scroll position ${threadId}`,
     chatEvents: [...initialEvents],
@@ -653,7 +654,7 @@ function mockKeyboardThreadScrollLayout({
 describe("chat scroll position", () => {
   it("does not scroll an empty thread", async () => {
     const threadId = "b0000000-0000-4000-a000-000000000800";
-    mockChatLifecycle(context, {
+    mockChatLifecycleWithoutBrowserSession({
       threadId,
       threadTitle: "Empty scroll thread",
       chatEvents: [],
@@ -1143,7 +1144,7 @@ describe("chat scroll position", () => {
     const initialEvents = simpleUserEvents(threadId, "local-send-tail", 8);
     const sendGate = context.mocks.deferred<void>();
     let sent = false;
-    mockChatLifecycle(context, {
+    mockChatLifecycleWithoutBrowserSession({
       threadId,
       chatEvents: initialEvents,
       sendGate: sendGate.promise,
@@ -1401,7 +1402,7 @@ describe("chat scroll position", () => {
         seqId: index + 1,
       };
     });
-    mockChatLifecycle(context, {
+    mockChatLifecycleWithoutBrowserSession({
       threadId,
       threadTitle: "Prepend anchor",
       chatEvents,
@@ -1819,7 +1820,7 @@ describe("chat scroll position", () => {
     let scrollHeight = 1000;
     let targetTop = 400;
     const resizeObserver = installResizeObserver();
-    mockChatLifecycle(context, {
+    mockChatLifecycleWithoutBrowserSession({
       threadId,
       threadTitle: "Resize preserve",
       chatEvents: events,
@@ -1886,7 +1887,7 @@ describe("chat scroll position", () => {
     const events = simpleUserEvents(threadId, "resize-follow", 8);
     let clientHeight = 300;
     const resizeObserver = installResizeObserver();
-    mockChatLifecycle(context, {
+    mockChatLifecycleWithoutBrowserSession({
       threadId,
       threadTitle: "Resize follow",
       chatEvents: events,
@@ -1938,7 +1939,7 @@ describe("chat scroll position", () => {
         document.querySelector("[data-chat-share-selectable-group]") !== null
       );
     };
-    mockChatLifecycle(context, {
+    mockChatLifecycleWithoutBrowserSession({
       threadId,
       threadTitle: "Sharing transition",
       chatEvents: events,


### PR DESCRIPTION
## Summary

- centralize the canonical no-active-browser response in the shared chat lifecycle test fixture
- opt the remaining history-navigation and scroll-position lifecycle families into an explicit no-browser composition
- preserve keyboard fixture behavior while removing 29 failed realtime catch-up requests from 28 stories

## Scope

This changes test fixtures only. It does not change production code, UI, user flows, API contracts, assertions, timers, timeouts, retries, fake timers, skips, or cleanup.

## Validation

- complete scroll-position, history-navigation, and emoji-category files: 58/58 passed in one unsilenced, one-worker Vitest process with no browser catch-up HTTP 500 warning
- `pnpm prettier --check --ignore-unknown apps/platform/src/views/okou-page/__tests__/chat-lifecycle-test-helpers.ts apps/platform/src/views/okou-page/__tests__/chat-history-navigation.test.tsx apps/platform/src/views/okou-page/__tests__/chat-scroll-position.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- `lefthook run pre-commit`
- `git diff --check`

Closes #30635
