### PR TITLE
feat(pi): preserve api-first input and cancellation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -153,6 +153,7 @@ import {
   holdChatEventQueueItemFixture,
   holdChatThreadRowLockFixture,
   holdOrgAdmissionLockFixture,
+  holdPiApiFirstTurnLifecycleLockFixture,
   holdThreadSessionBindingClearFixture,
   holdThreadSessionConversationChangesFixture,
   holdThreadSessionConversationClearFixture,
@@ -4655,6 +4656,50 @@ function mockPiResourceArchiveDownloads(unavailable = false): void {
   );
 }
 
+async function queueCapabilityProvenPiRun(args: {
+  readonly actor: ApiTestUser;
+  readonly agentId: string;
+  readonly runnerGroup: string;
+  readonly prompt: string;
+}): Promise<{
+  readonly anchor: { readonly runId: string; readonly threadId: string };
+  readonly anchorClaim: Awaited<ReturnType<typeof claimChatRun>>;
+  readonly run: { readonly runId: string; readonly threadId: string };
+}> {
+  if (!args.actor.orgId) {
+    throw new Error("Expected entitled chat actor to have an org");
+  }
+  mockEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
+  await api.heartbeatRunner(args.runnerGroup);
+  const anchor = await sendChatRun(args.actor, {
+    agentId: args.agentId,
+    prompt: "hold capacity for a capability-proven Pi launch",
+    model: "claude-sonnet-5",
+  });
+  await flushWaitUntilForTest();
+  const anchorState = await api.readRun(args.actor, anchor.runId);
+  if (anchorState.status !== "pending") {
+    throw new Error(
+      `Expected pending capability anchor: ${JSON.stringify(anchorState)}`,
+    );
+  }
+  const anchorClaim = await claimChatRun(args.runnerGroup, anchor.runId);
+  await configureBuiltInPiModel(args.actor, "deepseek-v4-flash");
+  await updateFeatureSwitchesForUser(
+    context,
+    { ...args.actor, orgId: args.actor.orgId },
+    { [FeatureSwitchKey.PiLoop]: true },
+  );
+  const run = await sendChatRun(args.actor, {
+    agentId: args.agentId,
+    prompt: args.prompt,
+    model: "deepseek-v4-flash",
+  });
+  await waitForRunStatus(args.actor, run.runId, "queued");
+  await enableQueuedPiOwnershipTransferFixture(context, run.runId);
+  return { anchor, anchorClaim, run };
+}
+
 function occurrences(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1;
 }
@@ -5568,6 +5613,719 @@ describe("CHAT-02: model-first provider policies", () => {
       { content: "gamma", sequenceNumber: 2, runEventId: "event:2" },
       { content: "delta", sequenceNumber: 3, runEventId: "event:3" },
     ]);
+  }, 90_000);
+
+  it("transfers pre-provider active input through one stable sandbox-first delivery", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    const resourceEntered = createDeferredPromise<void>(context.signal);
+    const releaseResource = createDeferredPromise<void>(context.signal);
+    server.use(
+      http.get(PI_RESOURCE_ARCHIVE_DOWNLOAD_URL, async ({ request }) => {
+        if (!resourceEntered.settled()) {
+          resourceEntered.resolve(undefined);
+        }
+        await releaseResource.promise;
+        const objectKey = new URL(request.url).searchParams.get("object");
+        if (!objectKey) {
+          throw new Error("Expected Pi resource archive object identity");
+        }
+        return new HttpResponse(piS3Object(objectKey), {
+          headers: { "content-type": "application/gzip" },
+        });
+      }),
+    );
+    let modelCalls = 0;
+    server.use(
+      http.post("https://api.deepseek.com/responses", () => {
+        modelCalls += 1;
+        return new HttpResponse(piResponsesTextSse("unexpected", modelCalls), {
+          headers: { "content-type": "text/event-stream" },
+        });
+      }),
+    );
+    const checkpointObjects = mockPiCheckpointObjectStore();
+    const prompt = "execute the original prompt once in Sandbox";
+    const { anchor, anchorClaim, run } = await queueCapabilityProvenPiRun({
+      actor,
+      agentId,
+      runnerGroup,
+      prompt,
+    });
+
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
+    await resourceEntered.promise;
+    const claimed = await claimChatRun(runnerGroup, run.runId);
+    await waitForRunStatus(actor, run.runId, "running", 5000);
+    const activeInput = "apply this accepted steer once";
+    const activeInputEventId = randomUUID();
+    await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: run.threadId,
+        prompt: activeInput,
+        clientEventId: activeInputEventId,
+      },
+      [201],
+    );
+    const sandboxToken = claimed.claim.sandboxToken;
+    const reserved = await api.reserveRunnerActiveInputs(
+      sandboxToken,
+      run.runId,
+    );
+    if (reserved.outcome !== "reserved") {
+      throw new Error("Expected pre-provider active input to be reserved");
+    }
+    await expect(
+      api.reserveRunnerActiveInputs(sandboxToken, run.runId),
+    ).resolves.toStrictEqual(reserved);
+
+    releaseResource.resolve(undefined);
+    const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`;
+    await expect
+      .poll(() => {
+        return checkpointObjects.get(manifestKey);
+      })
+      .toBeInstanceOf(Buffer);
+    expect(modelCalls).toBe(0);
+    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+      status: "running",
+    });
+    const manifest = piApiFirstTurnManifestV3Schema.parse(
+      JSON.parse(checkpointObjects.get(manifestKey)?.toString("utf8") ?? "{}"),
+    );
+    expect(manifest).toMatchObject({
+      schemaVersion: 3,
+      outcome: "ownership-transfer",
+      mode: "sandbox-first",
+      baseSession: { sessionId: run.threadId, sha256: null },
+      sandboxEventSequenceStart: 1,
+    });
+    const h0 =
+      checkpointObjects
+        .get(
+          `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/session.jsonl`,
+        )
+        ?.toString("utf8") ?? "";
+    expect(
+      MemoryPiSession.fromJsonl(h0).buildSessionContext().messages,
+    ).toHaveLength(0);
+    expect(claimed.claim.prompt).toBe(prompt);
+    const receipts = await Promise.all([
+      api.recordRunnerActiveInputDelivery(
+        claimed.claim.sandboxToken,
+        run.runId,
+        reserved.deliveryId,
+      ),
+      api.recordRunnerActiveInputDelivery(
+        claimed.claim.sandboxToken,
+        run.runId,
+        reserved.deliveryId,
+      ),
+    ]);
+    expect(receipts).toStrictEqual([
+      { outcome: "delivered" },
+      { outcome: "delivered" },
+    ]);
+    await expect(
+      api.recordRunnerActiveInputDelivery(
+        claimed.claim.sandboxToken,
+        run.runId,
+        reserved.deliveryId,
+      ),
+    ).resolves.toStrictEqual({ outcome: "delivered" });
+    const events = await chat.listThreadEvents(actor, run.threadId);
+    expect(
+      events.events.filter((event) => {
+        return (
+          event.runId === run.runId &&
+          event.revokesEventId === activeInputEventId
+        );
+      }),
+    ).toHaveLength(1);
+    await cancelChatRun(actor, run.runId, claimed.sandboxHeaders);
+  }, 90_000);
+
+  it("publishes text H1 once and continues one in-flight active input as a new prompt", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    mockPiResourceArchiveDownloads();
+    const providerEntered = createDeferredPromise<void>(context.signal);
+    const releaseProvider = createDeferredPromise<void>(context.signal);
+    let modelCalls = 0;
+    const apiAnswer = "API H1 settled before the accepted input";
+    server.use(
+      http.post("https://api.deepseek.com/responses", async () => {
+        modelCalls += 1;
+        if (!providerEntered.settled()) {
+          providerEntered.resolve(undefined);
+        }
+        await releaseProvider.promise;
+        return new HttpResponse(piResponsesTextSse(apiAnswer, modelCalls), {
+          headers: { "content-type": "text/event-stream" },
+        });
+      }),
+    );
+    const checkpointObjects = mockPiCheckpointObjectStore();
+    const originalPrompt = "settle this original API prompt once";
+    const { anchor, anchorClaim, run } = await queueCapabilityProvenPiRun({
+      actor,
+      agentId,
+      runnerGroup,
+      prompt: originalPrompt,
+    });
+
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
+    await providerEntered.promise;
+    const claimed = await claimChatRun(runnerGroup, run.runId);
+    const activeInput = "continue H1 with exactly one new prompt";
+    await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: run.threadId,
+        prompt: activeInput,
+        clientEventId: randomUUID(),
+      },
+      [201],
+    );
+    const sandboxToken = claimed.claim.sandboxToken;
+    const reserved = await api.reserveRunnerActiveInputs(
+      sandboxToken,
+      run.runId,
+    );
+    if (reserved.outcome !== "reserved") {
+      throw new Error("Expected in-flight active input to be reserved");
+    }
+    releaseProvider.resolve(undefined);
+
+    const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`;
+    await expect
+      .poll(() => {
+        return checkpointObjects.get(manifestKey);
+      })
+      .toBeInstanceOf(Buffer);
+    expect(modelCalls).toBe(1);
+    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+      status: "running",
+    });
+    const manifest = piApiFirstTurnManifestV3Schema.parse(
+      JSON.parse(checkpointObjects.get(manifestKey)?.toString("utf8") ?? "{}"),
+    );
+    expect(manifest).toMatchObject({
+      schemaVersion: 3,
+      outcome: "ownership-transfer",
+      mode: "settled-session-continuation",
+      sandboxEventSequenceStart: 1,
+    });
+    const apiMessages = eventBackedContents(
+      (await chat.listThreadEvents(actor, run.threadId)).events,
+      run.runId,
+    );
+    expect(
+      apiMessages.filter((message) => {
+        return message.content === apiAnswer;
+      }),
+    ).toHaveLength(1);
+
+    const h1 =
+      checkpointObjects
+        .get(
+          `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/session.jsonl`,
+        )
+        ?.toString("utf8") ?? "";
+    expect(occurrences(h1, originalPrompt)).toBe(1);
+    expect(occurrences(h1, apiAnswer)).toBe(1);
+    expect(occurrences(h1, activeInput)).toBe(0);
+    const h2Session = MemoryPiSession.fromJsonl(h1);
+    h2Session.appendMessage({
+      role: "user",
+      content: activeInput,
+      timestamp: 3,
+    });
+    const sandboxAnswer = "Sandbox answered the accepted prompt once";
+    h2Session.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: sandboxAnswer }],
+      api: "openai-responses",
+      provider: "deepseek",
+      model: "deepseek-v4-flash",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: 4,
+    });
+    const h2 = h2Session.toJsonl();
+    expect(occurrences(h2, originalPrompt)).toBe(1);
+    expect(occurrences(h2, activeInput)).toBe(1);
+    const h2Hash = createHash("sha256").update(h2).digest("hex");
+    await webhooks.requestAgentCheckpointPrepareHistory(
+      {
+        runId: run.runId,
+        hash: h2Hash,
+        rawSize: Buffer.byteLength(h2),
+        encodedSize: Buffer.byteLength(h2),
+        encoding: "identity",
+      },
+      claimed.sandboxHeaders,
+      [200],
+    );
+    checkpointObjects.set(
+      `${env("R2_USER_STORAGES_BUCKET_NAME")}/blobs/${h2Hash}.blob`,
+      Buffer.from(h2, "utf8"),
+    );
+    await expect(
+      api.recordRunnerActiveInputDelivery(
+        claimed.claim.sandboxToken,
+        run.runId,
+        reserved.deliveryId,
+      ),
+    ).resolves.toStrictEqual({ outcome: "delivered" });
+    await webhooks.requestAgentEvents(
+      {
+        runId: run.runId,
+        events: [
+          {
+            type: "assistant",
+            sequenceNumber: 1,
+            message: { content: [{ type: "text", text: sandboxAnswer }] },
+          },
+          {
+            type: "result",
+            sequenceNumber: 2,
+            result: sandboxAnswer,
+          },
+        ],
+      },
+      claimed.sandboxHeaders,
+      [200],
+    );
+    const completion = await webhooks.requestAgentComplete(
+      {
+        runId: run.runId,
+        exitCode: 0,
+        lastEventSequence: 2,
+        activeInputDeliveryIds: [reserved.deliveryId],
+        checkpoint: {
+          cliAgentType: "pi",
+          cliAgentSessionId: run.threadId,
+          cliAgentSessionHistoryHash: h2Hash,
+        },
+      },
+      claimed.sandboxHeaders,
+      [200],
+    );
+    expect(completion.body).toStrictEqual({
+      success: true,
+      status: "completed",
+    });
+    await waitForRunStatus(actor, run.runId, "completed", 5000);
+    expect(modelCalls).toBe(1);
+  }, 90_000);
+
+  it("retains pending-tool continuation while one accepted input remains a steer", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    mockPiResourceArchiveDownloads();
+    const providerEntered = createDeferredPromise<void>(context.signal);
+    const releaseProvider = createDeferredPromise<void>(context.signal);
+    let modelCalls = 0;
+    server.use(
+      http.post("https://api.deepseek.com/responses", async () => {
+        modelCalls += 1;
+        if (!providerEntered.settled()) {
+          providerEntered.resolve(undefined);
+        }
+        await releaseProvider.promise;
+        return new HttpResponse(
+          piResponsesToolSse({
+            callId: "call_active_input_tool",
+            name: "read",
+            arguments: { path: "/home/user/workspace/***/pending.txt" },
+            sequence: modelCalls,
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+    const checkpointObjects = mockPiCheckpointObjectStore();
+    const originalPrompt = "start one provider request with a pending tool";
+    const { anchor, anchorClaim, run } = await queueCapabilityProvenPiRun({
+      actor,
+      agentId,
+      runnerGroup,
+      prompt: originalPrompt,
+    });
+
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
+    await providerEntered.promise;
+    const claimed = await claimChatRun(runnerGroup, run.runId);
+    const activeInput = "steer once after the pending tool boundary";
+    await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: run.threadId,
+        prompt: activeInput,
+        clientEventId: randomUUID(),
+      },
+      [201],
+    );
+    const sandboxToken = claimed.claim.sandboxToken;
+    const reserved = await api.reserveRunnerActiveInputs(
+      sandboxToken,
+      run.runId,
+    );
+    if (reserved.outcome !== "reserved") {
+      throw new Error("Expected pending-tool active input to be reserved");
+    }
+    releaseProvider.resolve(undefined);
+
+    const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`;
+    await expect
+      .poll(() => {
+        return checkpointObjects.get(manifestKey);
+      })
+      .toBeInstanceOf(Buffer);
+    const manifest = piApiFirstTurnManifestV3Schema.parse(
+      JSON.parse(checkpointObjects.get(manifestKey)?.toString("utf8") ?? "{}"),
+    );
+    expect(manifest).toMatchObject({
+      schemaVersion: 3,
+      outcome: "ownership-transfer",
+      mode: "pending-tool-continuation",
+      sandboxEventSequenceStart: 1,
+    });
+    expect(modelCalls).toBe(1);
+    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+      status: "running",
+    });
+    const h1 =
+      checkpointObjects
+        .get(
+          `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/session.jsonl`,
+        )
+        ?.toString("utf8") ?? "";
+    const h2Session = MemoryPiSession.fromJsonl(h1);
+    expect(h2Session.hasPendingToolCalls()).toBeTruthy();
+    expect(occurrences(h1, originalPrompt)).toBe(1);
+    expect(occurrences(h1, activeInput)).toBe(0);
+    const pendingTool = [...h2Session.buildSessionContext().messages]
+      .reverse()
+      .find((message) => {
+        return message.role === "assistant";
+      });
+    const toolCall =
+      pendingTool?.role === "assistant"
+        ? pendingTool.content.find((content) => {
+            return content.type === "toolCall";
+          })
+        : undefined;
+    if (toolCall?.type !== "toolCall") {
+      throw new Error("Expected one pending Pi tool call");
+    }
+    h2Session.appendMessage({
+      role: "toolResult",
+      toolCallId: toolCall.id,
+      toolName: toolCall.name,
+      content: [{ type: "text", text: "Sandbox resumed the pending tool" }],
+      details: {},
+      isError: false,
+      timestamp: 3,
+    });
+    h2Session.appendMessage({
+      role: "user",
+      content: activeInput,
+      timestamp: 4,
+    });
+    h2Session.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "Sandbox applied the steer once" }],
+      api: "openai-responses",
+      provider: "deepseek",
+      model: "deepseek-v4-flash",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: 5,
+    });
+    const h2 = h2Session.toJsonl();
+    expect(occurrences(h2, originalPrompt)).toBe(1);
+    expect(occurrences(h2, activeInput)).toBe(1);
+    expect(MemoryPiSession.fromJsonl(h2).hasPendingToolCalls()).toBeFalsy();
+    await expect(
+      api.recordRunnerActiveInputDelivery(
+        claimed.claim.sandboxToken,
+        run.runId,
+        reserved.deliveryId,
+      ),
+    ).resolves.toStrictEqual({ outcome: "delivered" });
+    await cancelChatRun(actor, run.runId, claimed.sandboxHeaders);
+    expect(modelCalls).toBe(1);
+  }, 90_000);
+
+  it("lets canonical cancellation win before provider ownership without API artifacts", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    const resourceEntered = createDeferredPromise<void>(context.signal);
+    const releaseResource = createDeferredPromise<void>(context.signal);
+    server.use(
+      http.get(PI_RESOURCE_ARCHIVE_DOWNLOAD_URL, async ({ request }) => {
+        if (!resourceEntered.settled()) {
+          resourceEntered.resolve(undefined);
+        }
+        await releaseResource.promise;
+        const objectKey = new URL(request.url).searchParams.get("object");
+        if (!objectKey) {
+          throw new Error("Expected Pi resource archive object identity");
+        }
+        return new HttpResponse(piS3Object(objectKey), {
+          headers: { "content-type": "application/gzip" },
+        });
+      }),
+    );
+    let modelCalls = 0;
+    server.use(
+      http.post("https://api.deepseek.com/responses", () => {
+        modelCalls += 1;
+        return new HttpResponse(piResponsesTextSse("late", modelCalls), {
+          headers: { "content-type": "text/event-stream" },
+        });
+      }),
+    );
+    const checkpointObjects = mockPiCheckpointObjectStore();
+    const { anchor, anchorClaim, run } = await queueCapabilityProvenPiRun({
+      actor,
+      agentId,
+      runnerGroup,
+      prompt: "cancel before the provider boundary",
+    });
+
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
+    await resourceEntered.promise;
+    await cancelChatRun(actor, run.runId);
+    releaseResource.resolve(undefined);
+    await flushWaitUntilForTest();
+
+    expect(modelCalls).toBe(0);
+    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+      status: "cancelled",
+    });
+    expect(
+      checkpointObjects.has(
+        `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`,
+      ),
+    ).toBeFalsy();
+    expect(
+      checkpointObjects.has(
+        `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/session.jsonl`,
+      ),
+    ).toBeFalsy();
+    expect(
+      eventBackedContents(
+        (await chat.listThreadEvents(actor, run.threadId)).events,
+        run.runId,
+      ),
+    ).toHaveLength(0);
+    const claim = await api.requestClaimRunnerJob(true, run.runId, [404]);
+    expect(claim.status).toBe(404);
+  }, 90_000);
+
+  it("aborts or disregards one in-flight provider result after canonical cancellation", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    mockPiResourceArchiveDownloads();
+    const providerEntered = createDeferredPromise<void>(context.signal);
+    const releaseProvider = createDeferredPromise<void>(context.signal);
+    let modelCalls = 0;
+    server.use(
+      http.post("https://api.deepseek.com/responses", async () => {
+        modelCalls += 1;
+        if (!providerEntered.settled()) {
+          providerEntered.resolve(undefined);
+        }
+        await releaseProvider.promise;
+        return new HttpResponse(
+          piResponsesTextSse("discard this late provider result", modelCalls),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+    const checkpointObjects = mockPiCheckpointObjectStore();
+    const { anchor, anchorClaim, run } = await queueCapabilityProvenPiRun({
+      actor,
+      agentId,
+      runnerGroup,
+      prompt: "cancel one in-flight API-first request",
+    });
+
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
+    await providerEntered.promise;
+    await cancelChatRun(actor, run.runId);
+    expect(modelCalls).toBe(1);
+    releaseProvider.resolve(undefined);
+    await flushWaitUntilForTest();
+
+    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+      status: "cancelled",
+    });
+    expect(modelCalls).toBe(1);
+    expect(
+      checkpointObjects.has(
+        `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`,
+      ),
+    ).toBeFalsy();
+    expect(
+      checkpointObjects.has(
+        `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/session.jsonl`,
+      ),
+    ).toBeFalsy();
+    expect(
+      eventBackedContents(
+        (await chat.listThreadEvents(actor, run.threadId)).events,
+        run.runId,
+      ),
+    ).toHaveLength(0);
+    const claim = await api.requestClaimRunnerJob(true, run.runId, [404]);
+    expect(claim.status).toBe(404);
+  }, 90_000);
+
+  it("makes post-provider cancellation the durable winner before publication", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    mockPiResourceArchiveDownloads();
+    const providerEntered = createDeferredPromise<void>(context.signal);
+    const releaseProvider = createDeferredPromise<void>(context.signal);
+    let modelCalls = 0;
+    server.use(
+      http.post("https://api.deepseek.com/responses", async () => {
+        modelCalls += 1;
+        if (!providerEntered.settled()) {
+          providerEntered.resolve(undefined);
+        }
+        await releaseProvider.promise;
+        return new HttpResponse(
+          piResponsesTextSse("result blocked before publication", modelCalls),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+    const checkpointObjects = mockPiCheckpointObjectStore();
+    const { anchor, anchorClaim, run } = await queueCapabilityProvenPiRun({
+      actor,
+      agentId,
+      runnerGroup,
+      prompt: "let cancellation commit before API publication",
+    });
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
+    await providerEntered.promise;
+    const lifecycleLock = await holdPiApiFirstTurnLifecycleLockFixture({
+      runId: run.runId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      lifecycleLock.release();
+      await lifecycleLock.done;
+    });
+
+    const cancellation = api.requestCancelRun(actor, run.runId, [200]);
+    await expect.poll(lifecycleLock.waiterCount).toBe(1);
+    releaseProvider.resolve(undefined);
+    await expect.poll(lifecycleLock.waiterCount).toBe(2);
+    lifecycleLock.release();
+    await lifecycleLock.done;
+    await cancellation;
+    await flushWaitUntilForTest();
+
+    expect(modelCalls).toBe(1);
+    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+      status: "cancelled",
+    });
+    expect(
+      checkpointObjects.has(
+        `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`,
+      ),
+    ).toBeFalsy();
+    expect(
+      checkpointObjects.has(
+        `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/session.jsonl`,
+      ),
+    ).toBeFalsy();
+    expect(
+      eventBackedContents(
+        (await chat.listThreadEvents(actor, run.threadId)).events,
+        run.runId,
+      ),
+    ).toHaveLength(0);
+  }, 90_000);
+
+  it("keeps API completion terminal when it wins the lifecycle lock before cancellation", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    mockPiResourceArchiveDownloads();
+    const providerEntered = createDeferredPromise<void>(context.signal);
+    const releaseProvider = createDeferredPromise<void>(context.signal);
+    let modelCalls = 0;
+    const answer = "completion committed before cancellation";
+    server.use(
+      http.post("https://api.deepseek.com/responses", async () => {
+        modelCalls += 1;
+        if (!providerEntered.settled()) {
+          providerEntered.resolve(undefined);
+        }
+        await releaseProvider.promise;
+        return new HttpResponse(piResponsesTextSse(answer, modelCalls), {
+          headers: { "content-type": "text/event-stream" },
+        });
+      }),
+    );
+    mockPiCheckpointObjectStore();
+    const { anchor, anchorClaim, run } = await queueCapabilityProvenPiRun({
+      actor,
+      agentId,
+      runnerGroup,
+      prompt: "let API completion commit first",
+    });
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
+    await providerEntered.promise;
+    const lifecycleLock = await holdPiApiFirstTurnLifecycleLockFixture({
+      runId: run.runId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      lifecycleLock.release();
+      await lifecycleLock.done;
+    });
+
+    releaseProvider.resolve(undefined);
+    await expect.poll(lifecycleLock.waiterCount).toBe(1);
+    const cancellation = api.requestCancelRun(actor, run.runId, [400]);
+    await expect.poll(lifecycleLock.waiterCount).toBe(2);
+    lifecycleLock.release();
+    await lifecycleLock.done;
+    const cancelResponse = await cancellation;
+    expectApiError(cancelResponse.body);
+    expect(cancelResponse.body.error.message).toContain(
+      "Run cannot be cancelled",
+    );
+    await waitForRunStatus(actor, run.runId, "completed", 5000);
+    await flushWaitUntilForTest();
+
+    expect(modelCalls).toBe(1);
+    expect(
+      eventBackedContents(
+        (await chat.listThreadEvents(actor, run.threadId)).events,
+        run.runId,
+      ).filter((message) => {
+        return message.content === answer;
+      }),
+    ).toHaveLength(1);
   }, 90_000);
 
   it.each([

--- a/turbo/apps/api/src/signals/services/active-input-delivery.service.ts
+++ b/turbo/apps/api/src/signals/services/active-input-delivery.service.ts
@@ -27,6 +27,7 @@ import { logTemplateUsage } from "../../lib/template-usage-log";
 import type { GenerationTemplateIdentity } from "@okouai/core/generation-template-identity";
 import { lockChatQueueThread } from "./chat-event-queue.service";
 import { replaceLoadedChatEvent } from "./chat-event.service";
+import { lockPiApiFirstTurnLifecycle } from "./pi-api-first-turn-lifecycle.service";
 
 interface ActiveInputDeliveryScope {
   readonly runId: string;
@@ -258,6 +259,7 @@ async function transitionReservation(
   scope: ActiveInputDeliveryScope,
   prepared: PreparedReservation,
 ): Promise<ReserveTransitionResult> {
+  await lockPiApiFirstTurnLifecycle(tx, scope.runId);
   if (!(await lockChatQueueThread(tx, scope.chatThreadId))) {
     return { outcome: "forbidden" };
   }

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn-lifecycle.service.ts
@@ -1,0 +1,61 @@
+import { sql } from "drizzle-orm";
+
+import type { Tx } from "../../lib/db-types";
+import { singleton } from "../../lib/singleton";
+
+const activeCancellationControllers = singleton(() => {
+  return new Map<string, Set<AbortController>>();
+});
+
+/** Serialize active-input reservation, API-first publication, and cancellation. */
+export async function lockPiApiFirstTurnLifecycle(
+  tx: Pick<Tx, "execute">,
+  runId: string,
+): Promise<void> {
+  await tx.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtextextended(${`pi_api_first_turn:${runId}`}, 0))`,
+  );
+}
+
+/**
+ * Bind one API-first execution to canonical Run cancellation in this API
+ * process. The database lifecycle lock and status revalidation remain the
+ * cross-process authority; this controller only shortens provider shutdown.
+ */
+export function registerPiApiFirstTurnCancellation(
+  runId: string,
+  parentSignal: AbortSignal,
+): {
+  readonly signal: AbortSignal;
+  readonly release: () => void;
+} {
+  const controller = new AbortController();
+  const controllers =
+    activeCancellationControllers().get(runId) ?? new Set<AbortController>();
+  controllers.add(controller);
+  activeCancellationControllers().set(runId, controllers);
+
+  let released = false;
+  return {
+    signal: AbortSignal.any([parentSignal, controller.signal]),
+    release: () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      controllers.delete(controller);
+      if (controllers.size === 0) {
+        activeCancellationControllers().delete(runId);
+      }
+    },
+  };
+}
+
+/** Abort every local API-first execution after canonical cancellation commits. */
+export function abortPiApiFirstTurnAfterCanonicalCancellation(
+  runId: string,
+): void {
+  for (const controller of activeCancellationControllers().get(runId) ?? []) {
+    controller.abort();
+  }
+}

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn-registration.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn-registration.service.ts
@@ -4,6 +4,7 @@ import type { PiApiFirstTurnActivation } from "./pi-api-first-turn-config";
 import { runPiApiFirstTurn$ } from "./pi-api-first-turn.service";
 import { dispatchCompleteSideEffects$ } from "./agent-run-lifecycle.service";
 import { configurePiApiFirstTurnCommand } from "./pi-api-first-turn-dispatch.service";
+import { registerPiApiFirstTurnCancellation } from "./pi-api-first-turn-lifecycle.service";
 
 const COMPLETE_SIDE_EFFECT_TIMEOUT_MS = 10_000;
 
@@ -13,14 +14,28 @@ const configuredPiApiFirstTurn$ = command(
     activation: PiApiFirstTurnActivation,
     signal: AbortSignal,
   ): Promise<void> => {
-    const sideEffects = await set(runPiApiFirstTurn$, activation, signal);
-    if (sideEffects) {
-      await set(
-        dispatchCompleteSideEffects$,
-        sideEffects,
-        AbortSignal.timeout(COMPLETE_SIDE_EFFECT_TIMEOUT_MS),
+    const cancellation = registerPiApiFirstTurnCancellation(
+      activation.runId,
+      signal,
+    );
+    const operation = (async () => {
+      const sideEffects = await set(
+        runPiApiFirstTurn$,
+        activation,
+        cancellation.signal,
       );
-    }
+      cancellation.signal.throwIfAborted();
+      if (sideEffects) {
+        await set(
+          dispatchCompleteSideEffects$,
+          sideEffects,
+          AbortSignal.timeout(COMPLETE_SIDE_EFFECT_TIMEOUT_MS),
+        );
+      }
+    })();
+    await operation.finally(() => {
+      cancellation.release();
+    });
   },
 );
 

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
@@ -26,6 +26,7 @@ import { command } from "ccstate";
 import { and, eq } from "drizzle-orm";
 
 import { env } from "../../lib/env";
+import type { Tx } from "../../lib/db-types";
 import type { AgentEvent } from "../../lib/event-consumer/verify";
 import { logger } from "../../lib/log";
 import { now } from "../../lib/time";
@@ -71,7 +72,14 @@ import {
   preparePiResourceSnapshot,
   UnsupportedPiResourceError,
 } from "./pi-resource-snapshot.service";
-import { safeSync, settle, settleIncludingAbort, tapError } from "../utils";
+import { lockPiApiFirstTurnLifecycle } from "./pi-api-first-turn-lifecycle.service";
+import {
+  awaitWithSignal,
+  safeSync,
+  settle,
+  settleIncludingAbort,
+  tapError,
+} from "../utils";
 
 const MODEL_COMMIT_BUDGET_MS = 2000;
 const FAILURE_COMMIT_TIMEOUT_MS = 10_000;
@@ -113,6 +121,20 @@ class PiApiFirstTurnError extends Error {
     super(`[${code}] ${message}`, options);
     this.name = "PiApiFirstTurnError";
     this.code = code;
+  }
+}
+
+class PiApiFirstTurnActiveInputBeforeProviderError extends Error {
+  constructor() {
+    super("Active input committed before Pi provider ownership");
+    this.name = "PiApiFirstTurnActiveInputBeforeProviderError";
+  }
+}
+
+class PiApiFirstTurnCanonicalCancellationError extends Error {
+  constructor() {
+    super("Canonical Run cancellation owns the Pi API first turn");
+    this.name = "PiApiFirstTurnCanonicalCancellationError";
   }
 }
 
@@ -350,21 +372,30 @@ function validateResumeSession(args: {
   }
 }
 
-async function canCommitApiTurn(
-  db: Db,
+interface ApiFirstTurnLifecycleState {
+  readonly activeDeliveryId: string | null;
+  readonly chatThreadId: string | null;
+  readonly orgId: string;
+  readonly status: string;
+  readonly userId: string;
+}
+
+async function readApiFirstTurnLifecycleState(
+  tx: Tx,
   runId: string,
-  deadlineAt: number,
-): Promise<boolean> {
-  if (now() + MODEL_COMMIT_BUDGET_MS >= deadlineAt) {
-    return false;
-  }
+): Promise<ApiFirstTurnLifecycleState | null> {
   const [[run], [activeInput]] = await Promise.all([
-    db
-      .select({ status: agentRuns.status })
+    tx
+      .select({
+        status: agentRuns.status,
+        userId: agentRuns.userId,
+        orgId: agentRuns.orgId,
+        chatThreadId: agentRuns.chatThreadId,
+      })
       .from(agentRuns)
       .where(eq(agentRuns.id, runId))
       .limit(1),
-    db
+    tx
       .select({ id: activeInputDeliveries.id })
       .from(activeInputDeliveries)
       .where(
@@ -375,9 +406,12 @@ async function canCommitApiTurn(
       )
       .limit(1),
   ]);
-  return (
-    (run?.status === "pending" || run?.status === "running") && !activeInput
-  );
+  return run
+    ? {
+        ...run,
+        activeDeliveryId: activeInput?.id ?? null,
+      }
+    : null;
 }
 
 function projectedAssistantBlocks(
@@ -565,6 +599,7 @@ interface PreparedApiFirstTurn {
   readonly apiStartTime: number;
   readonly auth: SandboxAuth;
   readonly baseSession: PiApiFirstTurnManifest["baseSession"];
+  readonly commitIdentity: ApiFirstTurnCommitIdentity;
   readonly sessionBytes: Buffer;
   readonly sessionHash: string;
   readonly sessionId: string;
@@ -577,6 +612,58 @@ type ApiFirstTurnExecutionContext =
   PiApiFirstTurnActivation["executionContext"];
 type ApiFirstTurnLaunchConfig =
   ApiFirstTurnExecutionContext["piLaunchConfig"]["apiFirstTurn"];
+
+interface ApiFirstTurnCommitIdentity {
+  readonly baseSessionId: string;
+  readonly baseSessionSha256: string | null;
+  readonly deadlineAt: number;
+  readonly ownershipTransferSchemaVersion: 1 | null;
+  readonly resourceSnapshotDigest: string;
+  readonly sandboxEventSequenceStart: number;
+  readonly sessionId: string;
+}
+
+function apiFirstTurnCommitIdentity(
+  args: ApiFirstTurnContext,
+): ApiFirstTurnCommitIdentity {
+  const { launchConfig, sessionId } = validateApiFirstTurnLaunch(args);
+  return {
+    baseSessionId: launchConfig.baseSession.sessionId,
+    baseSessionSha256: launchConfig.baseSession.sha256,
+    deadlineAt: launchConfig.deadlineAt,
+    ownershipTransferSchemaVersion:
+      launchConfig.ownershipTransfer?.schemaVersion ?? null,
+    resourceSnapshotDigest: launchConfig.resourceSnapshotDigest,
+    sandboxEventSequenceStart: launchConfig.sandboxEventSequenceStart,
+    sessionId,
+  };
+}
+
+function sameApiFirstTurnCommitIdentity(
+  left: ApiFirstTurnCommitIdentity,
+  right: ApiFirstTurnCommitIdentity,
+): boolean {
+  return (
+    left.baseSessionId === right.baseSessionId &&
+    left.baseSessionSha256 === right.baseSessionSha256 &&
+    left.deadlineAt === right.deadlineAt &&
+    left.ownershipTransferSchemaVersion ===
+      right.ownershipTransferSchemaVersion &&
+    left.resourceSnapshotDigest === right.resourceSnapshotDigest &&
+    left.sandboxEventSequenceStart === right.sandboxEventSequenceStart &&
+    left.sessionId === right.sessionId
+  );
+}
+
+async function withApiFirstTurnLifecycle<T>(
+  args: ApiFirstTurnContext,
+  operation: (tx: Tx) => Promise<T>,
+): Promise<T> {
+  return await args.db.transaction(async (tx) => {
+    await lockPiApiFirstTurnLifecycle(tx, args.activation.runId);
+    return await operation(tx);
+  });
+}
 
 function validateApiFirstTurnLaunch(args: ApiFirstTurnContext): {
   readonly executionContext: ApiFirstTurnExecutionContext;
@@ -607,14 +694,38 @@ function validateApiFirstTurnLaunch(args: ApiFirstTurnContext): {
   return { executionContext, launchConfig, sessionId };
 }
 
-async function assertApiTurnCommittable(
+function validateApiFirstTurnLifecycleCommit(
   args: ApiFirstTurnContext,
-  deadlineAt: number,
+  state: ApiFirstTurnLifecycleState | null,
+  expectedIdentity: ApiFirstTurnCommitIdentity,
   message: string,
-): Promise<void> {
-  if (!(await canCommitApiTurn(args.db, args.activation.runId, deadlineAt))) {
+): ApiFirstTurnLifecycleState {
+  if (state?.status === "cancelled") {
+    throw new PiApiFirstTurnCanonicalCancellationError();
+  }
+  if (
+    !state ||
+    (state.status !== "pending" && state.status !== "running") ||
+    state.userId !== args.activation.userId ||
+    state.orgId !== args.activation.orgId ||
+    state.chatThreadId !== expectedIdentity.sessionId
+  ) {
     throw piApiFirstTurnError("PI_API_FIRST_TURN_NOT_COMMITTABLE", message);
   }
+  const currentIdentity = apiFirstTurnCommitIdentity(args);
+  if (!sameApiFirstTurnCommitIdentity(currentIdentity, expectedIdentity)) {
+    throw piApiFirstTurnError(
+      "PI_LAUNCH_CONFIG_INVALID",
+      "Pi API first-turn immutable launch identity changed before commit",
+    );
+  }
+  if (now() + MODEL_COMMIT_BUDGET_MS >= expectedIdentity.deadlineAt) {
+    throw piApiFirstTurnError(
+      "PI_API_FIRST_TURN_DEADLINE_EXCEEDED",
+      "Pi API first turn has no remaining commit budget",
+    );
+  }
+  return state;
 }
 
 const loadApiFirstTurnResource$ = command(
@@ -731,10 +842,28 @@ async function resolveApiFirstTurnKey(
   return apiKey;
 }
 
+async function observeDiscardedProviderResult(
+  operation: Promise<PiApiFirstTurnResult>,
+  runId: string,
+  ownership: PiApiFirstTurnOwnership,
+): Promise<void> {
+  const late = await settleIncludingAbort(operation);
+  if (late.ok) {
+    L.warn("Pi API first-turn outcome", {
+      runId,
+      outcome: "discarded_late_provider_result",
+      reason: "aborted_execution",
+      ownershipStage: ownership.stage,
+    });
+  }
+}
+
 async function executeApiModelTurn(
   args: {
     readonly activation: PiApiFirstTurnActivation;
     readonly apiKey: string;
+    readonly context: ApiFirstTurnContext;
+    readonly commitIdentity: ApiFirstTurnCommitIdentity;
     readonly executionContext: ApiFirstTurnExecutionContext;
     readonly launchConfig: ApiFirstTurnLaunchConfig;
     readonly resourceSnapshot: PiResourceSnapshot;
@@ -759,23 +888,62 @@ async function executeApiModelTurn(
     signal,
     AbortSignal.timeout(Math.max(1, modelDeadline - now())),
   ]);
-  const executed = await settleIncludingAbort(
-    runPiApiFirstTurn(
-      {
-        cwd: CANONICAL_WORKING_DIR,
-        agentDir: PI_AGENT_DIR,
-        sessionId: args.sessionId,
-        sessionJsonl: args.sessionJsonl,
-        prompt: args.activation.prompt,
-        appendSystemPrompt: args.activation.appendSystemPrompt,
-        model: { ...args.executionContext.piModelConfig, apiKey: args.apiKey },
-        resourceSnapshot: args.resourceSnapshot,
-        ownership: args.ownership,
+  const operation = runPiApiFirstTurn(
+    {
+      cwd: CANONICAL_WORKING_DIR,
+      agentDir: PI_AGENT_DIR,
+      sessionId: args.sessionId,
+      sessionJsonl: args.sessionJsonl,
+      prompt: args.activation.prompt,
+      appendSystemPrompt: args.activation.appendSystemPrompt,
+      model: { ...args.executionContext.piModelConfig, apiKey: args.apiKey },
+      resourceSnapshot: args.resourceSnapshot,
+      ownership: args.ownership,
+      providerRequestBoundary: async (markProviderRequestMayHaveStarted) => {
+        await withApiFirstTurnLifecycle(args.context, async (tx) => {
+          modelSignal.throwIfAborted();
+          const state = validateApiFirstTurnLifecycleCommit(
+            args.context,
+            await readApiFirstTurnLifecycleState(tx, args.activation.runId),
+            args.commitIdentity,
+            "Pi API first turn lost eligibility before provider ownership",
+          );
+          if (state.activeDeliveryId) {
+            if (args.commitIdentity.ownershipTransferSchemaVersion === 1) {
+              throw new PiApiFirstTurnActiveInputBeforeProviderError();
+            }
+            throw piApiFirstTurnError(
+              "PI_API_FIRST_TURN_NOT_COMMITTABLE",
+              "Pi API first turn cannot claim provider ownership with active input",
+            );
+          }
+          modelSignal.throwIfAborted();
+          markProviderRequestMayHaveStarted();
+        });
       },
-      modelSignal,
-    ),
+    },
+    modelSignal,
+  );
+  const executed = await settleIncludingAbort(
+    awaitWithSignal(operation, modelSignal),
   );
   if (!executed.ok) {
+    if (modelSignal.aborted) {
+      waitUntil(
+        observeDiscardedProviderResult(
+          operation,
+          args.activation.runId,
+          args.ownership,
+        ),
+      );
+    }
+    if (
+      executed.error instanceof PiApiFirstTurnError ||
+      executed.error instanceof PiApiFirstTurnActiveInputBeforeProviderError ||
+      executed.error instanceof PiApiFirstTurnCanonicalCancellationError
+    ) {
+      throw executed.error;
+    }
     if (executed.error instanceof UnsupportedPiResourceSnapshotError) {
       throw piApiFirstTurnError(
         "PI_API_PREHEAT_FAILED",
@@ -889,6 +1057,8 @@ type PiSandboxFallbackReason =
   | "PI_API_PREHEAT_FAILED"
   | "PI_API_RESOURCE_PREPARATION_FAILED";
 
+type PiSandboxFirstReason = PiSandboxFallbackReason | "active_input";
+
 function eligibleSandboxFallbackReason(
   args: {
     readonly failure: PiApiFirstTurnError;
@@ -972,21 +1142,18 @@ function materializeApiFirstTurnH0(args: {
 const publishSandboxFallback$ = command(async function publishSandboxFallback(
   { get, set },
   args: ApiFirstTurnContext,
+  reason: PiSandboxFirstReason,
   signal: AbortSignal,
 ): Promise<void> {
   const { executionContext, launchConfig, sessionId } =
     validateApiFirstTurnLaunch(args);
+  const commitIdentity = apiFirstTurnCommitIdentity(args);
   if (launchConfig.ownershipTransfer?.schemaVersion !== 1) {
     throw piApiFirstTurnError(
       "PI_LAUNCH_CONFIG_INVALID",
       "Pi sandbox fallback requires ownership-transfer capability proof",
     );
   }
-  await assertApiTurnCommittable(
-    args,
-    launchConfig.deadlineAt,
-    "Pi sandbox fallback is no longer eligible to commit",
-  );
   signal.throwIfAborted();
   const loadedSession = await set(
     loadResumeSessionJsonl$,
@@ -1007,54 +1174,70 @@ const publishSandboxFallback$ = command(async function publishSandboxFallback(
     sessionId,
   });
   const session = validateSandboxFallbackSession(sessionJsonl, sessionId);
-  const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
-  const sessionKey = piApiFirstTurnObjectKey(args.activation.runId, "session");
-  await get(
-    putS3Object(
-      bucket,
-      sessionKey,
-      session.bytes,
-      "application/x-ndjson",
-      signal,
-    ),
-  );
-  signal.throwIfAborted();
-  const uploaded = await get(
-    downloadS3BufferWithMaxBytes(
-      bucket,
-      sessionKey,
-      session.bytes.length,
-      signal,
-    ),
-  );
-  signal.throwIfAborted();
-  if (
-    uploaded.length !== session.bytes.length ||
-    sha256(uploaded) !== session.hash
-  ) {
-    throw piApiFirstTurnError(
-      "PI_API_SANDBOX_FALLBACK_FAILED",
-      "Pi sandbox fallback H0 failed read-after-write validation",
+  await withApiFirstTurnLifecycle(args, async (tx) => {
+    signal.throwIfAborted();
+    const state = validateApiFirstTurnLifecycleCommit(
+      args,
+      await readApiFirstTurnLifecycleState(tx, args.activation.runId),
+      commitIdentity,
+      "Pi sandbox-first transfer lost commit eligibility",
     );
-  }
-  await assertApiTurnCommittable(
-    args,
-    launchConfig.deadlineAt,
-    "Pi sandbox fallback lost commit eligibility before publication",
-  );
-  signal.throwIfAborted();
-  const manifest = ownershipTransferManifest({
-    capability: launchConfig.ownershipTransfer,
-    mode: "sandbox-first",
-    baseSession: launchConfig.baseSession,
-    session: {
-      sessionId,
-      sha256: session.hash,
-      rawSize: session.bytes.length,
-    },
-    sandboxEventSequenceStart: launchConfig.sandboxEventSequenceStart,
+    if (reason === "active_input" && !state.activeDeliveryId) {
+      throw piApiFirstTurnError(
+        "PI_API_FIRST_TURN_NOT_COMMITTABLE",
+        "Pi active-input sandbox-first transfer lost its durable delivery",
+      );
+    }
+    const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+    const sessionKey = piApiFirstTurnObjectKey(
+      args.activation.runId,
+      "session",
+    );
+    await get(
+      putS3Object(
+        bucket,
+        sessionKey,
+        session.bytes,
+        "application/x-ndjson",
+        signal,
+      ),
+    );
+    signal.throwIfAborted();
+    const uploaded = await get(
+      downloadS3BufferWithMaxBytes(
+        bucket,
+        sessionKey,
+        session.bytes.length,
+        signal,
+      ),
+    );
+    signal.throwIfAborted();
+    if (
+      uploaded.length !== session.bytes.length ||
+      sha256(uploaded) !== session.hash
+    ) {
+      throw piApiFirstTurnError(
+        "PI_API_SANDBOX_FALLBACK_FAILED",
+        "Pi sandbox fallback H0 failed read-after-write validation",
+      );
+    }
+    const manifest = ownershipTransferManifest({
+      capability: launchConfig.ownershipTransfer,
+      mode: "sandbox-first",
+      baseSession: launchConfig.baseSession,
+      session: {
+        sessionId,
+        sha256: session.hash,
+        rawSize: session.bytes.length,
+      },
+      sandboxEventSequenceStart: launchConfig.sandboxEventSequenceStart,
+    });
+    await set(
+      writeManifest$,
+      { runId: args.activation.runId, manifest },
+      signal,
+    );
   });
-  await set(writeManifest$, { runId: args.activation.runId, manifest }, signal);
 });
 
 const prepareApiFirstTurn$ = command(async function prepareApiFirstTurn(
@@ -1065,11 +1248,7 @@ const prepareApiFirstTurn$ = command(async function prepareApiFirstTurn(
 ): Promise<PreparedApiFirstTurn> {
   const { executionContext, launchConfig, sessionId } =
     validateApiFirstTurnLaunch(args);
-  await assertApiTurnCommittable(
-    args,
-    launchConfig.deadlineAt,
-    "Pi API first turn is no longer eligible to commit",
-  );
+  const commitIdentity = apiFirstTurnCommitIdentity(args);
   signal.throwIfAborted();
   const resourceSnapshot = await set(
     loadApiFirstTurnResource$,
@@ -1103,6 +1282,8 @@ const prepareApiFirstTurn$ = command(async function prepareApiFirstTurn(
     {
       activation: args.activation,
       apiKey,
+      context: args,
+      commitIdentity,
       executionContext,
       launchConfig,
       resourceSnapshot,
@@ -1114,11 +1295,6 @@ const prepareApiFirstTurn$ = command(async function prepareApiFirstTurn(
   );
   signal.throwIfAborted();
   const { sessionBytes, sessionHash } = validateApiFirstTurnH1(turn, sessionId);
-  await assertApiTurnCommittable(
-    args,
-    launchConfig.deadlineAt,
-    "Pi API first turn lost commit eligibility after the model request",
-  );
   signal.throwIfAborted();
   const auth: SandboxAuth = {
     userId: args.activation.userId,
@@ -1129,6 +1305,7 @@ const prepareApiFirstTurn$ = command(async function prepareApiFirstTurn(
     apiStartTime: executionContext.apiStartTime,
     auth,
     baseSession: launchConfig.baseSession,
+    commitIdentity,
     sessionBytes,
     sessionHash,
     sessionId,
@@ -1226,63 +1403,109 @@ const commitApiFirstTurn$ = command(async function commitApiFirstTurn(
   prepared: PreparedApiFirstTurn,
   signal: AbortSignal,
 ): Promise<CompleteSideEffectsInput | undefined> {
-  await get(
-    putS3Object(
-      env("R2_USER_STORAGES_BUCKET_NAME"),
-      piApiFirstTurnObjectKey(args.activation.runId, "session"),
-      prepared.sessionBytes,
-      "application/x-ndjson",
-      signal,
-    ),
-  );
-  signal.throwIfAborted();
+  return await withApiFirstTurnLifecycle(args, async (tx) => {
+    signal.throwIfAborted();
+    const state = validateApiFirstTurnLifecycleCommit(
+      args,
+      await readApiFirstTurnLifecycleState(tx, args.activation.runId),
+      prepared.commitIdentity,
+      "Pi API first turn lost commit eligibility after the provider request",
+    );
+    const hasActiveInput = state.activeDeliveryId !== null;
+    if (
+      hasActiveInput &&
+      prepared.commitIdentity.ownershipTransferSchemaVersion !== 1
+    ) {
+      throw piApiFirstTurnError(
+        "PI_API_FIRST_TURN_NOT_COMMITTABLE",
+        "Pi API first turn cannot preserve active input without ownership-transfer capability",
+      );
+    }
+    const transferMode: PiApiFirstTurnOwnershipTransferMode | null = prepared
+      .turn.handoffRequired
+      ? "pending-tool-continuation"
+      : hasActiveInput
+        ? "settled-session-continuation"
+        : null;
 
-  const blockEvents = assistantEvents(
-    args.activation.runId,
-    prepared.turn.assistantMessage,
-  );
-  const nextSequenceNumber = blockEvents.length;
-  const events = prepared.turn.handoffRequired
-    ? blockEvents
-    : [
-        ...blockEvents,
-        resultEvent(
-          prepared.turn.assistantMessage,
-          prepared.startedAt,
-          nextSequenceNumber,
-        ),
-      ];
-  await set(publishEvents$, { auth: prepared.auth, events }, signal);
-  if (prepared.turn.handoffRequired) {
-    const manifest = ownershipTransferManifest({
-      capability: prepared.ownershipTransferCapability,
-      mode: "pending-tool-continuation",
-      baseSession: prepared.baseSession,
-      session: {
-        sessionId: prepared.sessionId,
-        sha256: prepared.sessionHash,
-        rawSize: prepared.sessionBytes.length,
-      },
-      sandboxEventSequenceStart: nextSequenceNumber,
-    });
-    await set(
-      writeManifest$,
-      { runId: args.activation.runId, manifest },
+    await get(
+      putS3Object(
+        env("R2_USER_STORAGES_BUCKET_NAME"),
+        piApiFirstTurnObjectKey(args.activation.runId, "session"),
+        prepared.sessionBytes,
+        "application/x-ndjson",
+        signal,
+      ),
+    );
+    signal.throwIfAborted();
+
+    const blockEvents = assistantEvents(
+      args.activation.runId,
+      prepared.turn.assistantMessage,
+    );
+    const nextSequenceNumber = blockEvents.length;
+    if (
+      transferMode &&
+      nextSequenceNumber < prepared.commitIdentity.sandboxEventSequenceStart
+    ) {
+      throw piApiFirstTurnError(
+        "PI_LAUNCH_CONFIG_INVALID",
+        "Pi API first-turn event boundary precedes the immutable Sandbox boundary",
+      );
+    }
+    const events = transferMode
+      ? blockEvents
+      : [
+          ...blockEvents,
+          resultEvent(
+            prepared.turn.assistantMessage,
+            prepared.startedAt,
+            nextSequenceNumber,
+          ),
+        ];
+    await set(publishEvents$, { auth: prepared.auth, events }, signal);
+    if (transferMode) {
+      const manifest = ownershipTransferManifest({
+        capability: prepared.ownershipTransferCapability,
+        mode: transferMode,
+        baseSession: prepared.baseSession,
+        session: {
+          sessionId: prepared.sessionId,
+          sha256: prepared.sessionHash,
+          rawSize: prepared.sessionBytes.length,
+        },
+        sandboxEventSequenceStart: nextSequenceNumber,
+      });
+      await set(
+        writeManifest$,
+        { runId: args.activation.runId, manifest },
+        signal,
+      );
+      if (hasActiveInput) {
+        L.debug("Pi API first-turn outcome", {
+          runId: args.activation.runId,
+          outcome: "ownership_transfer",
+          reason:
+            transferMode === "settled-session-continuation"
+              ? "active_input_settled_session"
+              : "active_input_pending_tool",
+          ownershipStage: "provider-may-have-started",
+        });
+      }
+      return undefined;
+    }
+
+    await set(persistCompleteTurnCheckpoint$, args, prepared, signal);
+    const sideEffects = await set(
+      finalizeCompleteTurn$,
+      args,
+      prepared,
+      nextSequenceNumber,
       signal,
     );
-    return undefined;
-  }
-
-  await set(persistCompleteTurnCheckpoint$, args, prepared, signal);
-  const sideEffects = await set(
-    finalizeCompleteTurn$,
-    args,
-    prepared,
-    nextSequenceNumber,
-    signal,
-  );
-  stopPreparedSandbox(args.activation, "completed");
-  return sideEffects;
+    stopPreparedSandbox(args.activation, "completed");
+    return sideEffects;
+  });
 });
 
 const executeApiFirstTurn$ = command(async function executeApiFirstTurn(
@@ -1297,7 +1520,10 @@ const executeApiFirstTurn$ = command(async function executeApiFirstTurn(
     signal,
   );
   if (!committed.ok) {
-    if (committed.error instanceof PiApiFirstTurnError) {
+    if (
+      committed.error instanceof PiApiFirstTurnError ||
+      committed.error instanceof PiApiFirstTurnCanonicalCancellationError
+    ) {
       throw committed.error;
     }
     throw piApiFirstTurnError(
@@ -1359,39 +1585,80 @@ async function settleApiFirstTurnExecution<T>(
   };
 }
 
+async function canonicalApiFirstTurnCancellationWon(
+  args: ApiFirstTurnContext,
+): Promise<boolean> {
+  return await withApiFirstTurnLifecycle(args, async (tx) => {
+    const state = await readApiFirstTurnLifecycleState(
+      tx,
+      args.activation.runId,
+    );
+    return state?.status === "cancelled";
+  });
+}
+
+function logCanonicalApiFirstTurnCancellation(
+  runId: string,
+  ownership: PiApiFirstTurnOwnership,
+): void {
+  L.debug("Pi API first-turn outcome", {
+    runId,
+    outcome: "canonical_cancellation",
+    reason:
+      ownership.stage === "pre-provider"
+        ? "canonical_cancellation_before_provider_ownership"
+        : "canonical_cancellation_after_provider_ownership",
+    ownershipStage: ownership.stage,
+  });
+}
+
 const failApiFirstTurn$ = command(async function failApiFirstTurn(
   { set },
   args: ApiFirstTurnContext,
   failure: PiApiFirstTurnError,
+  ownership: PiApiFirstTurnOwnership,
 ): Promise<DispatchCompleteSideEffectsInput | undefined> {
   const failureSignal = AbortSignal.timeout(FAILURE_COMMIT_TIMEOUT_MS);
-  const completion = await set(
-    completeAgentRun$,
-    {
-      auth: {
-        userId: args.activation.userId,
-        orgId: args.activation.orgId,
-        runId: args.activation.runId,
+  return await withApiFirstTurnLifecycle(args, async (tx) => {
+    const state = await readApiFirstTurnLifecycleState(
+      tx,
+      args.activation.runId,
+    );
+    if (state?.status === "cancelled") {
+      logCanonicalApiFirstTurnCancellation(args.activation.runId, ownership);
+      return undefined;
+    }
+    if (!state || (state.status !== "pending" && state.status !== "running")) {
+      return undefined;
+    }
+    const completion = await set(
+      completeAgentRun$,
+      {
+        auth: {
+          userId: args.activation.userId,
+          orgId: args.activation.orgId,
+          runId: args.activation.runId,
+        },
+        body: {
+          runId: args.activation.runId,
+          exitCode: 1,
+          error: failure.message,
+        },
       },
-      body: {
-        runId: args.activation.runId,
-        exitCode: 1,
-        error: failure.message,
-      },
-    },
-    failureSignal,
-  );
-  failureSignal.throwIfAborted();
-  if (completion.status !== 200) {
-    throw new Error("Pi API first-turn failure transition was rejected");
-  }
-  stopPreparedSandbox(args.activation, "failed");
-  return completion.sideEffects
-    ? {
-        ...completion.sideEffects,
-        apiStartTime: args.activation.executionContext.apiStartTime,
-      }
-    : undefined;
+      failureSignal,
+    );
+    failureSignal.throwIfAborted();
+    if (completion.status !== 200) {
+      throw new Error("Pi API first-turn failure transition was rejected");
+    }
+    stopPreparedSandbox(args.activation, "failed");
+    return completion.sideEffects
+      ? {
+          ...completion.sideEffects,
+          apiStartTime: args.activation.executionContext.apiStartTime,
+        }
+      : undefined;
+  });
 });
 
 export const runPiApiFirstTurn$ = command(
@@ -1414,38 +1681,68 @@ export const runPiApiFirstTurn$ = command(
           }
         : undefined;
     }
+    const activeInputBeforeProvider =
+      executed.error instanceof PiApiFirstTurnActiveInputBeforeProviderError;
     let failure = normalizedApiFirstTurnFailure(executed.error, signal);
-    const fallbackReason = eligibleSandboxFallbackReason(
-      {
-        failure,
-        ownership,
-        launchConfig: activation.executionContext.piLaunchConfig.apiFirstTurn,
-      },
-      signal,
-    );
-    if (fallbackReason) {
+    const resourceFallbackReason = activeInputBeforeProvider
+      ? null
+      : eligibleSandboxFallbackReason(
+          {
+            failure,
+            ownership,
+            launchConfig:
+              activation.executionContext.piLaunchConfig.apiFirstTurn,
+          },
+          signal,
+        );
+    const sandboxFirstReason: PiSandboxFirstReason | null =
+      activeInputBeforeProvider ? "active_input" : resourceFallbackReason;
+    if (sandboxFirstReason) {
       const fallback = await settleApiFirstTurnExecution(
-        set(publishSandboxFallback$, context, signal),
+        set(publishSandboxFallback$, context, sandboxFirstReason, signal),
         signal,
       );
       if (fallback.ok) {
         L.debug("Pi API first-turn outcome", {
           runId: activation.runId,
-          outcome: "sandbox_fallback",
-          reason: fallbackReason,
+          outcome:
+            sandboxFirstReason === "active_input"
+              ? "ownership_transfer"
+              : "sandbox_fallback",
+          reason:
+            sandboxFirstReason === "active_input"
+              ? "active_input_sandbox_first"
+              : sandboxFirstReason,
           ownershipStage: ownership.stage,
         });
         return undefined;
       }
       failure = normalizedSandboxFallbackFailure(fallback.error, signal);
     }
+    if (await canonicalApiFirstTurnCancellationWon(context)) {
+      if (
+        executed.error instanceof PiApiFirstTurnCanonicalCancellationError &&
+        ownership.stage === "provider-may-have-started"
+      ) {
+        L.warn("Pi API first-turn outcome", {
+          runId: activation.runId,
+          outcome: "discarded_late_provider_result",
+          reason: "canonical_cancellation",
+          ownershipStage: ownership.stage,
+        });
+      }
+      logCanonicalApiFirstTurnCancellation(activation.runId, ownership);
+      return undefined;
+    }
     L.warn("Pi API first-turn outcome", {
       runId: activation.runId,
       outcome: "terminal_failure",
       reason: failure.code,
       ownershipStage: ownership.stage,
-      ...(fallbackReason ? { fallbackReason } : {}),
+      ...(resourceFallbackReason
+        ? { fallbackReason: resourceFallbackReason }
+        : {}),
     });
-    return set(failApiFirstTurn$, context, failure);
+    return set(failApiFirstTurn$, context, failure, ownership);
   },
 );

--- a/turbo/apps/api/src/signals/services/run-cancel.service.ts
+++ b/turbo/apps/api/src/signals/services/run-cancel.service.ts
@@ -23,6 +23,10 @@ import {
 import { drainChatThreadQueueForRun$ } from "./chat-thread-queue-drain.service";
 import { processOrgUsageEvents$ } from "./credit-usage.service";
 import { drainOrgQueue$ } from "./agent-run-lifecycle.service";
+import {
+  abortPiApiFirstTurnAfterCanonicalCancellation,
+  lockPiApiFirstTurnLifecycle,
+} from "./pi-api-first-turn-lifecycle.service";
 
 const L = logger("RunCancel");
 
@@ -42,6 +46,22 @@ export interface CancelRunResult {
 
 type NotFoundResponse = ReturnType<typeof notFound>;
 type RunNotCancellableResponse = ReturnType<typeof runNotCancellable>;
+
+async function abortAfterCanonicalCancellation<T>(
+  transition: Promise<T>,
+): Promise<T> {
+  const result = await transition;
+  if (
+    typeof result === "object" &&
+    result !== null &&
+    "alreadyCancelled" in result &&
+    "runId" in result &&
+    typeof result.runId === "string"
+  ) {
+    abortPiApiFirstTurnAfterCanonicalCancellation(result.runId);
+  }
+  return result;
+}
 
 const ACTIVE_STATUSES = ["queued", "pending", "running"] as const;
 type ActiveStatus = (typeof ACTIVE_STATUSES)[number];
@@ -79,7 +99,8 @@ export const cancelRun$ = command(
     const apiStartTime = args.apiStartTime ?? now();
     const writeDb = set(writeDb$);
 
-    const result = await writeDb.transaction(async (tx) => {
+    const transition = writeDb.transaction(async (tx) => {
+      await lockPiApiFirstTurnLifecycle(tx, args.runId);
       const [run] = await tx
         .select({
           id: agentRuns.id,
@@ -160,6 +181,7 @@ export const cancelRun$ = command(
         alreadyCancelled: false,
       };
     });
+    const result = await abortAfterCanonicalCancellation(transition);
     signal.throwIfAborted();
 
     return result;

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -1974,6 +1974,71 @@ export async function holdOrgAdmissionLockFixture(args: {
 }
 
 /**
+ * Holds the production Pi API-first lifecycle key so BDDs can deterministically
+ * order publication and canonical cancellation without timing sleeps.
+ */
+export async function holdPiApiFirstTurnLifecycleLockFixture(args: {
+  readonly runId: string;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly release: () => void;
+  readonly done: Promise<void>;
+  readonly waiterCount: () => Promise<number>;
+}> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const done = db().transaction(async (tx) => {
+    const rows = await executeRawRows(
+      tx,
+      sql`
+        SELECT
+          pg_backend_pid() AS "pid",
+          pg_advisory_xact_lock(
+            hashtextextended(${`pi_api_first_turn:${args.runId}`}, 0)
+          )
+      `,
+      databasePidRowSchema,
+    );
+    const holderPid = rows[0]?.pid;
+    if (!holderPid) {
+      throw new Error("Expected the Pi lifecycle lock holder pid");
+    }
+    started.resolve(holderPid);
+    await released.promise;
+  });
+  const holderPid = await started.promise;
+
+  return {
+    release: () => {
+      if (!released.settled()) {
+        released.resolve(undefined);
+      }
+    },
+    done,
+    waiterCount: async () => {
+      const rows = await executeRawRows(
+        db(),
+        sql`
+          SELECT ${count()}::int AS "waiterCount"
+          FROM pg_locks AS waiting
+          WHERE waiting.locktype = 'advisory'
+            AND NOT waiting.granted
+            AND (waiting.classid, waiting.objid, waiting.objsubid) IN (
+              SELECT held.classid, held.objid, held.objsubid
+              FROM pg_locks AS held
+              WHERE held.locktype = 'advisory'
+                AND held.pid = ${holderPid}
+                AND held.granted
+            )
+        `,
+        waiterCountRowSchema,
+      );
+      return rows[0]?.waiterCount ?? 0;
+    },
+  };
+}
+
+/**
  * Holds the workflow queue admission key so tests can observe concurrent
  * requests waiting on the per-thread lock.
  */

--- a/turbo/packages/pi-agent-runtime/src/api-turn.ts
+++ b/turbo/packages/pi-agent-runtime/src/api-turn.ts
@@ -105,6 +105,7 @@ export async function runPiApiFirstTurn(
         signal,
       },
       ownership: args.ownership,
+      providerRequestBoundary: args.providerRequestBoundary,
     });
     return {
       assistantMessage: projectPiApiAssistantMessage(turn.assistantMessage),

--- a/turbo/packages/pi-agent-runtime/src/api-types.ts
+++ b/turbo/packages/pi-agent-runtime/src/api-types.ts
@@ -70,6 +70,13 @@ export interface PiApiFirstTurnArgs {
   readonly model: PiAgentModelConfig;
   readonly resourceSnapshot: PiPreheatedResourceSnapshot;
   readonly ownership: PiApiFirstTurnOwnership;
+  /**
+   * Optional durable gate run immediately before the provider transport.
+   * The gate must invoke the marker while it owns its commit boundary.
+   */
+  readonly providerRequestBoundary?: (
+    markProviderRequestMayHaveStarted: () => void,
+  ) => Promise<void>;
 }
 
 export interface PiApiFirstTurnResult {

--- a/turbo/packages/pi-agent-runtime/src/session-memory.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-memory.test.ts
@@ -23,6 +23,22 @@ import { createPiApiFirstTurnOwnership } from "./provider-ownership";
 const SESSION_ID = "00000000-0000-4000-8000-000000000123";
 const temporaryDirectories: string[] = [];
 
+function promiseWithResolvers<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+  readonly reject: (reason?: unknown) => void;
+} {
+  return (
+    Promise as PromiseConstructor & {
+      withResolvers<TValue>(): {
+        readonly promise: Promise<TValue>;
+        readonly resolve: (value: TValue) => void;
+        readonly reject: (reason?: unknown) => void;
+      };
+    }
+  ).withResolvers<T>();
+}
+
 async function temporaryDirectory(): Promise<string> {
   const directory = await mkdtemp(join(tmpdir(), "pi-memory-session-"));
   temporaryDirectories.push(directory);
@@ -38,6 +54,50 @@ afterEach(async () => {
 });
 
 describe("MemoryPiSession", () => {
+  it("commits the durable provider boundary before invoking transport", async () => {
+    const memory = MemoryPiSession.create({
+      cwd: "/home/user/workspace",
+      id: SESSION_ID,
+    });
+    const faux = createFauxCore({
+      api: "provider-boundary-test",
+      provider: "provider-boundary-test",
+    });
+    const ownership = createPiApiFirstTurnOwnership();
+    const boundaryEntered = promiseWithResolvers<void>();
+    const releaseBoundary = promiseWithResolvers<void>();
+    faux.setResponses([
+      () => {
+        expect(ownership.stage).toBe("provider-may-have-started");
+        return fauxAssistantMessage("boundary committed");
+      },
+    ]);
+
+    const turn = runPiFirstModelTurn({
+      model: faux.getModel(),
+      session: memory,
+      stream: faux.streamSimple,
+      systemPrompt: "system",
+      prompt: "cross the durable provider boundary",
+      tools: [],
+      ownership,
+      providerRequestBoundary: async (markProviderRequestMayHaveStarted) => {
+        expect(ownership.stage).toBe("pre-provider");
+        boundaryEntered.resolve();
+        await releaseBoundary.promise;
+        markProviderRequestMayHaveStarted();
+      },
+    });
+
+    await boundaryEntered.promise;
+    expect(faux.state.callCount).toBe(0);
+    expect(ownership.stage).toBe("pre-provider");
+    releaseBoundary.resolve();
+    await expect(turn).resolves.toMatchObject({ handoffRequired: false });
+    expect(faux.state.callCount).toBe(1);
+    expect(ownership.stage).toBe("provider-may-have-started");
+  });
+
   it("round-trips native Pi JSONL and appends one API model turn", async () => {
     const directory = await temporaryDirectory();
     const nativeSession = SessionManager.create(

--- a/turbo/packages/pi-agent-runtime/src/session-memory.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-memory.ts
@@ -46,6 +46,9 @@ interface RunPiFirstModelTurnOptions<TApi extends Api = Api> {
   readonly timestamp?: number;
   readonly streamOptions?: Omit<SimpleStreamOptions, "sessionId">;
   readonly ownership: PiApiFirstTurnOwnership;
+  readonly providerRequestBoundary?: (
+    markProviderRequestMayHaveStarted: () => void,
+  ) => Promise<void>;
 }
 
 interface PiModelTurnResult {
@@ -311,7 +314,18 @@ export async function runPiFirstModelTurn<TApi extends Api>(
     messages: convertToLlm(sessionContext.messages),
     tools: [...options.tools],
   };
-  options.ownership.markProviderRequestMayHaveStarted();
+  if (options.providerRequestBoundary) {
+    await options.providerRequestBoundary(() => {
+      options.ownership.markProviderRequestMayHaveStarted();
+    });
+    if (options.ownership.stage !== "provider-may-have-started") {
+      throw new Error(
+        "Pi provider request boundary returned without claiming ownership",
+      );
+    }
+  } else {
+    options.ownership.markProviderRequestMayHaveStarted();
+  }
   const responseStream = options.stream(options.model, context, {
     ...options.streamOptions,
     reasoning:


### PR DESCRIPTION
Parent: #30564
Closes #30629

## Summary

- serialize API-first provider ownership, active-input delivery reservation, and canonical cancellation with a per-run durable lifecycle lock
- preserve the existing stable delivery ID and ack-gated receipt protocol while routing capability-proven pre-provider input through sandbox-first H0 with zero provider calls
- publish text H1 once without completing the run, then continue through settled-session continuation; retain pending-tool continuation for tool-bearing H1
- abort or disregard provider work after canonical cancellation and suppress all late events, manifests, checkpoints, completion, and failure transitions
- add deterministic race coverage for pre-provider input, in-flight text H1, pending tools, receipt retry/idempotency, and all cancellation winner boundaries

## Focused verification

- `pnpm --filter @okouai/pi-agent-runtime check-types`
- `pnpm --filter @okouai/pi-agent-runtime build`
- `pnpm --filter @okouai/pi-agent-runtime lint`
- `pnpm --filter @okouai/pi-agent-runtime test`
- `pnpm --filter @vm0/api check-types:gateways`
- `pnpm --filter @vm0/api check-types:core`
- `pnpm --filter @vm0/api check-types:tests`
- targeted Oxlint and ESLint over every changed API file
- targeted chat-events BDDs: 7 new orchestration/cancellation cases passed
- targeted existing Pi API-first compatibility BDDs: 6 passed
- `cargo test -p guest-agent --test pi_cli_handoff_boundary --test active_input_receipts` (9 passed)
- `git diff --check origin/main...HEAD`

## Compatibility and rollout

This remains capability-gated and preserves the monotonic provider boundary introduced by #30614. Capability-absent runs keep the existing fail-closed behavior, the durable active-input queue/receipt contract is unchanged, and production ownership-transfer capability advertisement remains absent. This PR does not activate a Terra route or service tier and introduces no schema or data migration.

## Rollback

Revert this PR. Because production capability advertisement remains absent and there is no migration, rollback restores the prior API-first fail-closed/deadline behavior without data repair.