### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/turbo/apps/platform/src/lib/posthog.ts
+++ b/turbo/apps/platform/src/lib/posthog.ts
@@ -385,7 +385,6 @@ export function captureTaskCompletedSuccessfully(): void {
 
 export type ChatThreadMetadataShortcutOutcome =
   | "hit"
-  | "older-payload"
   | "not-found"
   | "transport-failure";
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
@@ -421,16 +421,7 @@ export function threadMeta(threadId: string) {
   });
 }
 
-function remoteThreadMeta(metadata: ChatThreadMetadata): ThreadMeta | null {
-  if (
-    metadata.pinnedAt === undefined ||
-    metadata.computerUseHostId === undefined ||
-    metadata.cloudBrowserEnabled === undefined ||
-    metadata.selectedVideoModel === undefined ||
-    metadata.selectedImageModel === undefined
-  ) {
-    return null;
-  }
+function remoteThreadMeta(metadata: ChatThreadMetadata): ThreadMeta {
   return {
     id: metadata.id,
     agentId: metadata.agentId,
@@ -464,10 +455,7 @@ const fetchRemoteThreadMeta$ = command(
     if (result.status === 404) {
       return { meta: null, outcome: "not-found" };
     }
-    const meta = remoteThreadMeta(result.body);
-    return meta?.id === threadId
-      ? { meta, outcome: "hit" }
-      : { meta: null, outcome: "older-payload" };
+    return { meta: remoteThreadMeta(result.body), outcome: "hit" };
   },
 );
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-thread-idb.test.tsx
@@ -183,60 +183,6 @@ function trackActiveAgentError(): () => boolean {
 }
 
 describe("okou chat thread IndexedDB fallback", () => {
-  it("falls back to canonical sync when narrow metadata is incomplete", async () => {
-    prepareDefaultAgent();
-    mockCurrentThreadDetail();
-    context.mocks.api(chatThreadMetadataContract.get, ({ respond }) => {
-      return respond(200, {
-        id: THREAD_ID,
-        agentId: AGENT_ID,
-        title: "Older API payload",
-        selectedModel: null,
-        serviceTier: null,
-      });
-    });
-    context.mocks.api(browserContract.get, ({ respond }) => {
-      return respond(404, {
-        error: {
-          code: "BROWSER_NOT_FOUND",
-          message: "Managed browser not found",
-        },
-      });
-    });
-    await primeChatDb();
-    const snapshotRequested = context.mocks.deferred<void>();
-    const releaseSnapshot = context.mocks.deferred<void>();
-    const activeAgentErrorLogged = trackActiveAgentError();
-    context.mocks.api(chatThreadsContract.snapshot, async ({ respond }) => {
-      if (!snapshotRequested.settled()) {
-        snapshotRequested.resolve();
-      }
-      await releaseSnapshot.promise;
-      return respond(200, currentThreadSnapshot());
-    });
-    context.mocks.api(chatThreadsContract.events, ({ respond }) => {
-      return respond(200, { events: [], hasMore: false });
-    });
-
-    setupChatPage();
-    await snapshotRequested.promise;
-
-    const appSkeleton = await screen.findByTestId("app-skeleton");
-    expect(appSkeleton).not.toHaveAttribute("aria-hidden");
-    expect(screen.queryByPlaceholderText(PLACEHOLDER)).not.toBeInTheDocument();
-    expect(activeAgentErrorLogged()).toBeFalsy();
-
-    releaseSnapshot.resolve();
-
-    await expect(
-      screen.findByPlaceholderText(PLACEHOLDER),
-    ).resolves.toBeInTheDocument();
-    await waitFor(() => {
-      expect(appSkeleton).toHaveAttribute("aria-hidden", "true");
-    });
-    expect(activeAgentErrorLogged()).toBeFalsy();
-  });
-
   it("shows chat thread not found after remote metadata sync confirms a miss", async () => {
     await primeChatDb();
     const snapshotRequested = context.mocks.deferred<void>();

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -975,18 +975,11 @@ const chatThreadMetadataSchema = z.object({
   title: z.string().nullable(),
   selectedModel: z.string().nullable(),
   serviceTier: chatThreadServiceTierSchema.nullable(),
-  /**
-   * Rolling new app -> old API compatibility for the metadata shortcut. Keep
-   * these fields optional while the older API is serving or remains a rollback
-   * target; remove the optionality only after that rollback window closes. The
-   * app falls back to the event-sourced projection until then. Follow-up:
-   * #29576.
-   */
-  pinnedAt: z.string().nullable().optional(),
-  computerUseHostId: z.string().uuid().nullable().optional(),
-  cloudBrowserEnabled: z.boolean().optional(),
-  selectedVideoModel: z.string().nullable().optional(),
-  selectedImageModel: z.string().nullable().optional(),
+  pinnedAt: z.string().nullable(),
+  computerUseHostId: z.string().uuid().nullable(),
+  cloudBrowserEnabled: z.boolean(),
+  selectedVideoModel: z.string().nullable(),
+  selectedImageModel: z.string().nullable(),
 });
 
 const chatThreadDraftSchema = z


### PR DESCRIPTION
Removes the new-App-to-old-API fallback on the chat thread metadata shortcut added by #29598.

## Cohort — chat thread metadata shortcut fields

**Old boundary:** #29598 extended `GET` chat thread metadata with five fields so the App could skip the event-sourced projection on first paint. During rollout a newly promoted App could still reach an API that omitted them, so the contract kept all five optional, `remoteThreadMeta` returned `null` when any was `undefined`, and the App fell back to canonical sync and reported a `older-payload` shortcut outcome.

**New boundary:** all five fields are required. `remoteThreadMeta` returns a `ThreadMeta` unconditionally and the shortcut always resolves.

Removed:
- `.optional()` and the rollout comment on `pinnedAt`, `computerUseHostId`, `cloudBrowserEnabled`, `selectedVideoModel`, and `selectedImageModel` in `chatThreadMetadataSchema`
- the five-way `=== undefined` guard in `remoteThreadMeta`, and its `| null` return type
- the `meta?.id === threadId` branch in `fetchRemoteThreadMeta$`, which could only produce `older-payload` once the guard was gone
- the `"older-payload"` member of `ChatThreadMetadataShortcutOutcome`
- the `falls back to canonical sync when narrow metadata is incomplete` regression, whose fixture responded with a literal `"Older API payload"` body missing all five fields

**Window:** the consumer is a new App calling an older API, so the governing gate is the old API leaving service — canonical window 1 — plus the comment's requirement that it no longer be a rollback target.

**Rollout evidence (observed):**
- #29598 merged `2026-08-26T12:44:42Z` (`b4f7387f421`).
- First `api/production` deployment containing it: `45865d362f`, `2026-08-26T13:04:25Z`, confirmed with `git merge-base --is-ancestor` walking the deployment list forward from oldest.
- **53 further `api/production` deployments** have been promoted since.
- Elapsed: **5 days 8 hours**, the longest-expired candidate in the current backlog.

**Source evidence that the current API always sets all five:** `getInner$` in `turbo/apps/api/src/signals/routes/chat-threads-get.ts` selects `pinnedAt`, `computerUseHostId`, `cloudBrowserEnabled`, `selectedVideoModel`, and `selectedImageModel` from `chat_threads` and returns each one on its single success path; the only other exit is a `404`. No branch omits a field.

**Analytics change, called out for review:** this drops the `"older-payload"` value from the `chat_thread_metadata_shortcut` PostHog event's `outcome` property. It exists solely to count old-API shortcut misses and becomes unreachable once the guard is gone, so leaving it would keep a misnamed dead branch. If a dashboard filters on that value it will simply stop matching; `hit`, `not-found`, and `transport-failure` are unchanged. Flagging it explicitly because it is the one externally observable effect of this PR.

**Axiom:** no route-level signal applies. The discriminator is the presence of five response-body keys, and `vm0-request-log-prod` records `path_template`, `method`, `status`, and client headers but not response bodies. Recorded as a deliberate non-use rather than a zero-count claim.

**MaskDB:** not applicable. No schema, column, or persisted payload changes; the five `chat_threads` columns are untouched.

## Explicitly deferred

- **Connector Doctor 409 branch (`turbo/apps/cli/src/commands/doctor/connectors.ts`).** #30513 closed #30491 only at `2026-08-31T09:33:48Z`, about 11.5 hours before this run. The pre-#30491 API is still a realistic rollback target.
- **#29991 remaining Official Workflow fallbacks** (`definition`, and the P1 `workflow.official` / `automation.official` optionals). A dedicated one-shot workflow is scheduled to re-evaluate these on 2026-09-02.
- **#28914 OKOU environment aliases.** Open PR #30615 is already retiring the runner operator aliases.
- **#30468 chat-search rollout compatibility.** Its producer #30453 is days old at most and the tracking issue is open.
- **AgentPhone brandless connect.** Yesterday's client-version census showed App builds below the pre-rollout `0.788.0` still issuing requests; that path validates a request signature from exactly those clients.
- **Queued-launch-context brand reads** for Telegram, AgentPhone, and Feishu. MaskDB's projection still does not expose `public_brand` on the context tables, and `feishu_chat_ingress` is still absent.
- **#28571, #29908, #26519, #27786, #28275** — unchanged product or evidence gates.

## Checks (run once against the combined diff)

- `pnpm format`
- `pnpm -F @okouai/app lint`, `pnpm -F @okouai/api-contracts lint` (no new warnings)
- `pnpm -F @okouai/api-contracts check-types`, `pnpm -F @okouai/app check-types`, `pnpm -F api check-types`
- `pnpm knip` (no new unused files, exports, or dependencies)
- `pnpm -F @okouai/api-contracts exec vitest run` — 657 passing across 35 files
- `pnpm -F @okouai/app exec vitest run` on `chat-thread-idb` + `chat-thread-metadata-readiness` — 15 passing
- `pnpm -F api exec vitest run` on `chat-threads-get` (2), and `chat-threads.bdd` + `chat-threads-image-model` + `chat-threads-video-model` (48) — against a local Postgres with `timezone=UTC`

Full coverage is left to the PR pipeline; no full local Vitest run and no local dev server.
