### PR TITLE
fix(runner): treat systemd daemon-reload notice as advisory

### DIFF
--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -9,6 +9,7 @@ use crate::bounded_command::{
 use crate::error::{RunnerError, RunnerResult};
 use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
+use tracing::warn;
 
 use super::diagnostic::status_field_preview;
 use super::target::RunnerServiceUnit;
@@ -899,17 +900,66 @@ fn service_restart_policy_from_systemctl_show(
     Ok(restart)
 }
 
+/// Strip the leading ANSI escape sequences systemd writes when it colorizes a
+/// log line, so advisory detection does not depend on `SYSTEMD_COLORS`.
+fn strip_leading_ansi(line: &str) -> &str {
+    let mut rest = line;
+    while let Some(after_escape) = rest.strip_prefix('\u{1b}') {
+        let Some(after_bracket) = after_escape.strip_prefix('[') else {
+            break;
+        };
+        let mut chars = after_bracket.char_indices();
+        let Some((idx, terminator)) = chars.find(|(_, c)| !matches!(c, '0'..='9' | ';')) else {
+            break;
+        };
+        rest = &after_bracket[idx + terminator.len_utf8()..];
+    }
+    rest
+}
+
+/// Classify one `systemctl cat` stderr line as systemd's advisory notice.
+///
+/// `systemctl cat` prints this notice with `fprintf(stderr, …)` when the unit
+/// reports `NeedDaemonReload`, and systemd itself documents the block as
+/// informational: the exit status stays 0 and the selected unit content is
+/// still written to stdout. `NeedDaemonReload` is derived from mtime
+/// comparisons over the unit's fragment and drop-in set, so it is routinely
+/// raised without this unit's own content having changed, and a
+/// `daemon-reload` does not reliably clear it — see systemd issues 10974,
+/// 17730 and 35710. Failing a read on it therefore rejects healthy output for
+/// a condition the caller neither owns nor can repair.
+///
+/// systemd only uses the `#` comment form for that notice; real `cat`
+/// diagnostics are plain sentences, so they still fail the read.
+fn is_systemctl_cat_advisory_line(line: &str) -> bool {
+    strip_leading_ansi(line.trim_start())
+        .trim_start()
+        .starts_with('#')
+}
+
 fn unit_content_from_systemctl_cat(svc: &str, output: &Output) -> RunnerResult<String> {
     let stderr = String::from_utf8_lossy(&output.stderr);
     let stderr = stderr.trim();
     if !output.status.success() {
         return Err(systemctl_cat_status_error(svc, &output.status, stderr));
     }
-    if !stderr.is_empty() {
+    let unexpected = stderr
+        .lines()
+        .filter(|line| !line.trim().is_empty() && !is_systemctl_cat_advisory_line(line))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if !unexpected.is_empty() {
         return Err(RunnerError::Internal(format!(
             "systemctl cat {svc} emitted stderr: {:?}",
-            status_field_preview(stderr)
+            status_field_preview(&unexpected)
         )));
+    }
+    if !stderr.is_empty() {
+        warn!(
+            unit = svc,
+            advisory = %status_field_preview(stderr),
+            "systemctl cat reported a pending systemd daemon-reload"
+        );
     }
 
     let stdout = std::str::from_utf8(&output.stdout).map_err(|e| {
@@ -1090,6 +1140,83 @@ mod tests {
         assert!(message.contains("emitted stderr"));
         assert!(message.contains("[truncated]"));
         assert!(message.len() < stderr.len());
+    }
+
+    /// systemd emits this block on stderr while `systemctl cat` still exits 0.
+    /// Reproduced from the `deploy-runner-start` failure in Turbo run
+    /// 33409335059, where the runner had already reported ready.
+    const DAEMON_RELOAD_ADVISORY: &str = concat!(
+        "# Warning: vm0-runner-test.service changed on disk, the version systemd has loaded is outdated.\n",
+        "# This output shows the current version of the unit's original fragment and drop-in files.\n",
+        "# If fragments or drop-ins were added or removed, they are not properly reflected in this output.\n",
+        "# Run 'systemctl daemon-reload' to reload units.",
+    );
+
+    #[test]
+    fn systemctl_cat_accepts_daemon_reload_advisory_stderr() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let output = systemctl_show_output(
+            ExitStatus::from_raw(0),
+            b"[Service]\nExecStart=/usr/bin/runner start --config /data/runner.yaml\n",
+            DAEMON_RELOAD_ADVISORY.as_bytes(),
+        );
+
+        assert_eq!(
+            unit_content_from_systemctl_cat("vm0-runner-test.service", &output).unwrap(),
+            "[Service]\nExecStart=/usr/bin/runner start --config /data/runner.yaml\n"
+        );
+    }
+
+    #[test]
+    fn systemctl_cat_accepts_colorized_daemon_reload_advisory_stderr() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let colorized = DAEMON_RELOAD_ADVISORY
+            .lines()
+            .map(|line| format!("\u{1b}[0;1;31m{line}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let output = systemctl_show_output(
+            ExitStatus::from_raw(0),
+            b"[Service]\n",
+            format!("{colorized}\u{1b}[0m").as_bytes(),
+        );
+
+        assert_eq!(
+            unit_content_from_systemctl_cat("vm0-runner-test.service", &output).unwrap(),
+            "[Service]\n"
+        );
+    }
+
+    #[test]
+    fn systemctl_cat_rejects_failed_exit_with_advisory_only_stderr() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let output = systemctl_show_output(
+            ExitStatus::from_raw(0x100),
+            b"",
+            DAEMON_RELOAD_ADVISORY.as_bytes(),
+        );
+
+        assert!(unit_content_from_systemctl_cat("vm0-runner-test.service", &output).is_err());
+    }
+
+    #[test]
+    fn systemctl_cat_rejects_real_diagnostic_alongside_advisory_stderr() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let stderr =
+            format!("{DAEMON_RELOAD_ADVISORY}\nFailed to get unit file path: No such file");
+        let output =
+            systemctl_show_output(ExitStatus::from_raw(0), b"[Service]\n", stderr.as_bytes());
+        let message = unit_content_from_systemctl_cat("vm0-runner-test.service", &output)
+            .unwrap_err()
+            .to_string();
+
+        assert!(message.contains("emitted stderr"));
+        assert!(message.contains("Failed to get unit file path"));
+        assert!(!message.contains("# Warning:"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Turbo run [33409335059](https://github.com/vm0-ai/vm0/actions/runs/33409335059) (merge_group, `pr-30618`, SHA `3ba6746e3eef82093f1f790b86d62fe97bf8cd4b`) failed in [`deploy-runner-start`](https://github.com/vm0-ai/vm0/actions/runs/33409335059/job/99545498447) with `Runner start failed on dev-1.aws.vm3.ai`.

The ordering in the host transcript is the whole story — the runner had **already started successfully** before the job went red:

```
15:38:28.062  INFO runner::cmd::service: transient service started unit=vm0-runner-pr-30618-1
              Runner ready on dev-1.aws.vm3.ai: max_concurrent=47
15:38:34.833  error: internal error: systemctl cat vm0-runner-pr-30618-1.service emitted stderr:
              "# Warning: vm0-runner-pr-30618-1.service changed on disk, the version systemd has
               loaded is outdated.\n# This output shows the cu...[truncated]"
```

`runner service start` succeeded, `runner service wait-running` reported ready, and the *next* step — `runner doctor --name pr-30618-1` in `.github/scripts/reconcile-and-start-runner-groups.sh` — failed. The second host completed the identical sequence cleanly (`Runner ready on dev-11.gcp.vm3.ai`, `Runners (1 running, 0 stopped)`, `0 warning(s) found`), so this is not a host outage and not the known `mode=starting` saturation pattern.

## Root cause

`unit_content_from_systemctl_cat` rejected **any** non-empty stderr from a *successful* `systemctl cat`:

```rust
if !output.status.success() { return Err(...); }
if !stderr.is_empty() { return Err(RunnerError::Internal(...)); }  // ← fired here
```

The error text proves the exit status was 0: the message came from the `!stderr.is_empty()` branch, which is only reachable after `status.success()`.

The stderr systemd wrote is its `NeedDaemonReload` notice. systemd emits it with `fprintf(stderr, ...)` and its own source comments it as informational output ([systemd#10974](https://github.com/systemd/systemd/issues/10974)); the exit status is unchanged and the selected unit content is still written to stdout, which is all `read_unit_config_path` consumes.

`NeedDaemonReload` is derived from mtime comparisons across a unit's fragment and drop-in set, so it is routinely raised on a shared host without this unit's own content changing, and it is not reliably clearable by running `daemon-reload`: see [systemd#17730](https://github.com/systemd/systemd/issues/17730) (relative drop-in mtime ordering keeps the flag set across reloads) and [systemd#35710](https://github.com/systemd/systemd/issues/35710) (units created by `systemd-run`, exactly how `runner service start` creates this transient unit, report `NeedDaemonReload=yes` since v230). The advisory is therefore a condition this job neither owns nor can repair, which is why it appears on one dev host and not the other for the same code at the same moment.

The same job already demonstrates the intended tolerance elsewhere: `systemctl stop` / `reset-failed` against a not-yet-existing unit produced `exit status: 5` and were correctly downgraded to `WARN ... during cleanup`. `systemctl is-enabled` likewise never fails on stderr. Only `systemctl cat` was intolerant.

## Fix

Reject only the stderr lines that are **not** part of systemd's comment block, and log the advisory rather than failing on it.

Deliberately **not** chosen: forcing a `systemctl daemon-reload` before `cat`. It would mutate manager-wide state on a shared multi-tenant dev host from a read-only diagnostic, contradicts the anti-storm design added in #24109, still races, and per systemd#17730 / #35710 would not even clear the condition for a transient unit.

Verification is not weakened:

- a non-zero exit status still fails, with or without the advisory;
- a real diagnostic (`Failed to get unit file path: ...`) still fails, including when mixed into the advisory block, and only the real line is reported;
- `runner service wait-running` remains the readiness gate and is untouched;
- ANSI-colorized advisories (`SYSTEMD_COLORS`) are handled so the same flake cannot return through a formatting variant.

## Validation

- `cargo fmt -p runner -- --check` — pass
- `cargo clippy -j 1 -p runner --all-targets` — pass (compiles the new `#[cfg(test)]` code under the workspace `warnings = "deny"` lint)
- `git diff --check` — clean
- The `runner` test binary could not be linked in the repair sandbox (rustc was OOM-killed at 3.58 GiB RSS in a 3.9 GiB cgroup), so the five new/existing `systemctl cat` cases were executed by extracting the changed functions verbatim into a standalone harness: 7 tests, 5 consecutive runs, all green. The crate's own `cargo test` runs here in `crates`.
- The `deploy-runner-start` job on this PR exercises the original invariant end to end.
