### PR TITLE
fix(db): remove migration 1037 marker scan

### DIFF
--- a/turbo/packages/db/src/migrations/1037_morning_brief_phase_b_cleanup.sql
+++ b/turbo/packages/db/src/migrations/1037_morning_brief_phase_b_cleanup.sql
@@ -178,21 +178,6 @@ BEGIN
     RAISE EXCEPTION 'Morning Brief event document has an unexpected historical shape';
   END IF;
 
-  IF EXISTS (
-    SELECT 1
-    FROM "chat_events" AS "event"
-    WHERE "event"."context_type" IS DISTINCT FROM 'morning_brief'
-      AND jsonb_typeof("event"."payload" -> 'userMessage' -> 'parts') = 'array'
-      AND EXISTS (
-        SELECT 1
-        FROM jsonb_array_elements(
-          "event"."payload" -> 'userMessage' -> 'parts'
-        ) AS "part"
-        WHERE "part" ->> 'type' = 'morning_brief'
-      )
-  ) THEN
-    RAISE EXCEPTION 'Morning Brief document marker exists outside its legacy context';
-  END IF;
 END;
 $$;
 --> statement-breakpoint


### PR DESCRIPTION
## Summary

- Remove only the final full-table JSON marker check from migration `1037_morning_brief_phase_b_cleanup.sql`.
- This check scans `chat_events` outside the legacy context and exceeds the migration runner's fixed 10-second `statement_timeout` at production scale (approximately 1.4 million rows).
- The marker invariant is already covered by the preceding Phase A historical-shape validation, and the dev-branch verification returned `marker_exists = false`.
- Preserve the surrounding `DO` block syntax and all other migration logic. This PR does not change the migration runner or any GitHub Actions variables.

## Verification

- `DATABASE_URL='postgresql://postgres@127.0.0.1:55432/postgres' npx --yes pnpm@10.33.4 --filter @okouai/db test:morning-brief-phase-b-cleanup` — passed against an isolated local PostgreSQL instance.
- `git diff --check` — passed.
