### PR TITLE
feat(pi): activate built-in terra routing

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
@@ -141,13 +141,7 @@ async function sendChatRun(
   },
   publicBrand: PublicBrand = "vm0",
 ): Promise<{ readonly runId: string; readonly threadId: string }> {
-  const sent = await chat.requestSendEvent(
-    actor,
-    body,
-    [201],
-    undefined,
-    publicBrand,
-  );
+  const sent = await chat.requestSendEvent(actor, body, [201], { publicBrand });
   if (sent.status !== 201 || sent.body.runId === null) {
     throw new Error("Expected chat send to create a run");
   }

--- a/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
@@ -284,8 +284,7 @@ async function createClaimedChatRun(
       cloudBrowserEnabled: true,
     },
     [201],
-    undefined,
-    publicBrand,
+    { publicBrand },
   );
   if (sent.status !== 201 || sent.body.runId === null) {
     throw new Error("Expected a chat run");

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -297,13 +297,7 @@ async function startChatRun(
       : { revokesEventId: body.revokesEventId }),
     ...(selectedModel === undefined ? {} : { model: selectedModel }),
   };
-  const sent = await chat.requestSendEvent(
-    actor,
-    requestBody,
-    [201],
-    undefined,
-    options?.publicBrand,
-  );
+  const sent = await chat.requestSendEvent(actor, requestBody, [201], options);
   if (sent.status !== 201) {
     throw new Error("Expected the entitled chat send to create a run");
   }
@@ -4259,8 +4253,7 @@ describe("CHAT-02: drain-time admission failure", () => {
           clientEventId: queuedEventId,
         },
         [201],
-        undefined,
-        publicBrand,
+        { publicBrand },
       );
       if ("error" in queued.body) {
         throw new Error(queued.body.error.message);
@@ -4358,8 +4351,7 @@ describe("CHAT-02: drain-time admission failure", () => {
           clientEventId: queuedEventId,
         },
         [201],
-        undefined,
-        publicBrand,
+        { publicBrand },
       );
       if ("error" in retried.body) {
         throw new Error(retried.body.error.message);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -75,6 +75,10 @@ import {
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { upsertOrgPlanEntitlementFixture } from "../../../test-fixtures/org-plan-entitlement";
 import { setOrgModelPolicyProviderTypeFixture } from "../../../test-fixtures/org-model-policies";
+import {
+  createUsagePricingFixture,
+  type UsagePricingFixture,
+} from "../../../test-fixtures/usage-pricing";
 import { setChatThreadVideoModelFixture } from "../../../test-fixtures/chat-thread-events";
 import { seededSystemSkillArchive } from "../../../test-fixtures/seeded-system-skill-archive";
 import {
@@ -212,6 +216,24 @@ const runStateStore = createStore();
 const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
 const CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET = "okou web upload-file -f <path>";
 const RUN_TIME_BUDGET_STEER_AT_MS = 115 * 60 * 1000;
+const TERRA_STANDARD_USAGE_PRICING = [
+  "tokens.input",
+  "tokens.output",
+  "tokens.cache_read",
+  "tokens.cache_creation",
+  "tokens.input.long_context",
+  "tokens.output.long_context",
+  "tokens.cache_read.long_context",
+  "tokens.cache_creation.long_context",
+].map((category) => {
+  return {
+    kind: "model",
+    provider: "gpt-5.6-terra",
+    category,
+    unitPrice: 1,
+    unitSize: 1_000_000,
+  };
+});
 const RUN_TIME_BUDGET_MESSAGE = `This runner has a hard maximum runtime of 2 hours. The current run has been active for 115 minutes, leaving approximately 5 minutes before it is terminated.
 
 An active goal allows unfinished work to continue in a later run. An existing goal already provides that continuity and remains unchanged. If no goal exists, the unfinished outcome needs to be captured in a new goal before this run ends.
@@ -551,20 +573,36 @@ async function expectTerraApiFirstTurnUsage(
 }
 
 async function expectTerraApiFollowUpUsage(runId: string): Promise<void> {
-  await expect(readRunUsageEventsFixture(runId)).resolves.toStrictEqual([
+  const usageRows = await readRunUsageEventsFixture(runId);
+  expect(usageRows).toStrictEqual([
     expect.objectContaining({
       provider: "gpt-5.6-terra",
       category: "tokens.input",
       quantity: 5,
       status: "processed",
+      billingError: null,
+      creditsCharged: expect.any(Number),
     }),
     expect.objectContaining({
       provider: "gpt-5.6-terra",
       category: "tokens.output",
       quantity: 3,
       status: "processed",
+      billingError: null,
+      creditsCharged: expect.any(Number),
     }),
   ]);
+  expect(totalChargedCredits(usageRows)).toBeGreaterThan(0);
+}
+
+async function createTerraUsagePricingResolution(): Promise<
+  UsagePricingFixture["resolution"]
+> {
+  const pricing = await createUsagePricingFixture({
+    configured: TERRA_STANDARD_USAGE_PRICING,
+  });
+  onTestFinished(pricing.cleanup);
+  return pricing.resolution;
 }
 
 async function seedVm0BuiltInModelKey(selectedModel: string): Promise<string> {
@@ -592,6 +630,7 @@ async function sendChatRun(
   actor: ApiTestUser,
   body: ChatRunSendBody,
   publicBrand: PublicBrand = "vm0",
+  usagePricingResolution?: UsagePricingFixture["resolution"],
 ): Promise<{ readonly runId: string; readonly threadId: string }> {
   const { template, ...canonicalBody } = body;
   const requestBody = {
@@ -607,6 +646,7 @@ async function sendChatRun(
     [201],
     undefined,
     publicBrand,
+    usagePricingResolution,
   );
   if (sent.status !== 201) {
     throw new Error("Expected the entitled chat send to create a run");
@@ -4777,6 +4817,7 @@ async function queueCapabilityProvenPiRun(args: {
   readonly anchor: { readonly runId: string; readonly threadId: string };
   readonly anchorClaim: Awaited<ReturnType<typeof claimChatRun>>;
   readonly run: { readonly runId: string; readonly threadId: string };
+  readonly usagePricingResolution: UsagePricingFixture["resolution"];
 }> {
   if (!args.actor.orgId) {
     throw new Error("Expected entitled chat actor to have an org");
@@ -4802,13 +4843,19 @@ async function queueCapabilityProvenPiRun(args: {
     { ...args.actor, orgId: args.actor.orgId },
     { [FeatureSwitchKey.PiLoop]: true },
   );
-  const run = await sendChatRun(args.actor, {
-    agentId: args.agentId,
-    prompt: args.prompt,
-    model: "gpt-5.6-terra",
-  });
+  const usagePricingResolution = await createTerraUsagePricingResolution();
+  const run = await sendChatRun(
+    args.actor,
+    {
+      agentId: args.agentId,
+      prompt: args.prompt,
+      model: "gpt-5.6-terra",
+    },
+    "vm0",
+    usagePricingResolution,
+  );
   await waitForRunStatus(args.actor, run.runId, "queued");
-  return { anchor, anchorClaim, run };
+  return { anchor, anchorClaim, run, usagePricingResolution };
 }
 
 function occurrences(haystack: string, needle: string): number {
@@ -5039,6 +5086,7 @@ describe("CHAT-02: model-first provider policies", () => {
     "runs the Pi API first turn once for %s and resumes canonical JSONL",
     async (selectedModel) => {
       const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const usagePricingResolution = await createTerraUsagePricingResolution();
       const orgId = actor.orgId;
       if (!orgId) {
         throw new Error("Expected entitled chat actor to have an org");
@@ -5100,11 +5148,16 @@ describe("CHAT-02: model-first provider policies", () => {
         }),
       );
       const firstPrompt = "persist this turn in the native Pi session";
-      const first = await sendChatRun(actor, {
-        agentId,
-        prompt: firstPrompt,
-        model: selectedModel,
-      });
+      const first = await sendChatRun(
+        actor,
+        {
+          agentId,
+          prompt: firstPrompt,
+          model: selectedModel,
+        },
+        "vm0",
+        usagePricingResolution,
+      );
       await waitForRunStatus(actor, first.runId, "completed");
       await flushWaitUntilForTest();
       await expect(
@@ -5169,11 +5222,16 @@ describe("CHAT-02: model-first provider policies", () => {
       ]);
 
       const secondPrompt = "continue the same Pi session";
-      const second = await sendChatRun(actor, {
-        agentId,
-        threadId: first.threadId,
-        prompt: secondPrompt,
-      });
+      const second = await sendChatRun(
+        actor,
+        {
+          agentId,
+          threadId: first.threadId,
+          prompt: secondPrompt,
+        },
+        "vm0",
+        usagePricingResolution,
+      );
       await waitForRunStatus(actor, second.runId, "completed");
       await flushWaitUntilForTest();
       expect(modelRequests).toHaveLength(2);
@@ -6285,7 +6343,7 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(claim.status).toBe(404);
   }, 90_000);
 
-  it("aborts or disregards one in-flight provider result after canonical cancellation", async () => {
+  it("does not fabricate usage when cancellation aborts an in-flight provider response", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     mockPiResourceArchiveDownloads();
     const providerEntered = createDeferredPromise<void>(context.signal);
@@ -6318,33 +6376,14 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(modelCalls).toBe(1);
     releaseProvider.resolve(undefined);
     await flushWaitUntilForTest();
-    if (!actor.orgId) {
-      throw new Error("Expected cancellation actor to have an org");
-    }
-    await api.reconcileBillingOrganizations([actor.orgId]);
 
     await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
       status: "cancelled",
     });
     expect(modelCalls).toBe(1);
-    const cancelledUsage = await readRunUsageEventsFixture(run.runId);
-    expect(cancelledUsage).toStrictEqual([
-      expect.objectContaining({
-        provider: "gpt-5.6-terra",
-        category: "tokens.input",
-        quantity: 5,
-        status: "processed",
-        billingError: null,
-      }),
-      expect.objectContaining({
-        provider: "gpt-5.6-terra",
-        category: "tokens.output",
-        quantity: 3,
-        status: "processed",
-        billingError: null,
-      }),
-    ]);
-    expect(totalChargedCredits(cancelledUsage)).toBeGreaterThan(0);
+    await expect(readRunUsageEventsFixture(run.runId)).resolves.toStrictEqual(
+      [],
+    );
     expect(
       checkpointObjects.has(
         `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`,
@@ -6385,12 +6424,13 @@ describe("CHAT-02: model-first provider policies", () => {
       }),
     );
     const checkpointObjects = mockPiCheckpointObjectStore();
-    const { anchor, anchorClaim, run } = await queueCapabilityProvenPiRun({
-      actor,
-      agentId,
-      runnerGroup,
-      prompt: "let cancellation commit before API publication",
-    });
+    const { anchor, anchorClaim, run, usagePricingResolution } =
+      await queueCapabilityProvenPiRun({
+        actor,
+        agentId,
+        runnerGroup,
+        prompt: "let cancellation commit before API publication",
+      });
     await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
     await providerEntered.promise;
     const lifecycleLock = await holdPiApiFirstTurnLifecycleLockFixture({
@@ -6410,8 +6450,13 @@ describe("CHAT-02: model-first provider policies", () => {
     await lifecycleLock.done;
     await cancellation;
     await flushWaitUntilForTest();
+    await api.reconcileBillingOrganizations(
+      [requireOrgId(actor)],
+      usagePricingResolution,
+    );
 
     expect(modelCalls).toBe(1);
+    await expectTerraApiFollowUpUsage(run.runId);
     await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
       status: "cancelled",
     });
@@ -6540,7 +6585,7 @@ describe("CHAT-02: model-first provider policies", () => {
         model: "deepseek-v4-flash",
       });
 
-      await waitForRunStatus(actor, run.runId, "failed");
+      await waitForRunStatus(actor, run.runId, "failed", 5000);
       await flushWaitUntilForTest();
       const failed = await api.readRun(actor, run.runId);
       expect(failed.error).toContain(`[${expectedCode}]`);
@@ -6804,6 +6849,7 @@ describe("CHAT-02: model-first provider policies", () => {
     if (!actor.orgId) {
       throw new Error("Expected entitled chat actor to have an org");
     }
+    const usagePricingResolution = await createTerraUsagePricingResolution();
     mockEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
     const runnerIdentity = {
       runnerId: randomUUID(),
@@ -6855,11 +6901,16 @@ describe("CHAT-02: model-first provider policies", () => {
       }),
     );
     const checkpointObjects = mockPiCheckpointObjectStore();
-    const first = await sendChatRun(actor, {
-      agentId,
-      prompt: "create a settled Pi checkpoint",
-      model: "gpt-5.6-terra",
-    });
+    const first = await sendChatRun(
+      actor,
+      {
+        agentId,
+        prompt: "create a settled Pi checkpoint",
+        model: "gpt-5.6-terra",
+      },
+      "vm0",
+      usagePricingResolution,
+    );
     await waitForRunStatus(actor, first.runId, "completed");
     await flushWaitUntilForTest();
     expect(modelCalls).toBe(1);
@@ -6891,12 +6942,17 @@ describe("CHAT-02: model-first provider policies", () => {
 
     mockEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
     const prompt = "preserve this original prompt for official compaction";
-    const second = await sendChatRun(actor, {
-      agentId,
-      threadId: first.threadId,
-      prompt,
-      model: "gpt-5.6-terra",
-    });
+    const second = await sendChatRun(
+      actor,
+      {
+        agentId,
+        threadId: first.threadId,
+        prompt,
+        model: "gpt-5.6-terra",
+      },
+      "vm0",
+      usagePricingResolution,
+    );
     await waitForRunStatus(actor, second.runId, "queued");
     context.mocks.axiomLogging.debug.mockClear();
     await completeChatRunOk(anchor.runId, anchorSandboxHeaders);
@@ -7041,6 +7097,7 @@ describe("CHAT-02: model-first provider policies", () => {
   it("publishes ordered mixed blocks and hands explicit Sandbox tool turns to H2", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     const orgId = requireOrgId(actor);
+    const usagePricingResolution = await createTerraUsagePricingResolution();
     await configureBuiltInPiModel(actor, "gpt-5.6-terra");
     await updateFeatureSwitchesForUser(
       context,
@@ -7098,11 +7155,16 @@ describe("CHAT-02: model-first provider policies", () => {
     );
     const checkpointObjects = mockPiCheckpointObjectStore();
     const prompt = "use the Okou CLI through the Sandbox handoff";
-    const run = await sendChatRun(actor, {
-      agentId,
-      prompt,
-      model: "gpt-5.6-terra",
-    });
+    const run = await sendChatRun(
+      actor,
+      {
+        agentId,
+        prompt,
+        model: "gpt-5.6-terra",
+      },
+      "vm0",
+      usagePricingResolution,
+    );
     const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`;
     await expect
       .poll(() => {
@@ -7209,11 +7271,13 @@ describe("CHAT-02: model-first provider policies", () => {
         { runId: run.runId, events: [sandboxUsageEvent] },
         claimed.sandboxHeaders,
         [200],
+        usagePricingResolution,
       ),
       webhooks.requestAgentUsageEvent(
         { runId: run.runId, events: [sandboxUsageEvent] },
         claimed.sandboxHeaders,
         [200],
+        usagePricingResolution,
       ),
     ]);
     expect(
@@ -7425,6 +7489,8 @@ describe("CHAT-02: model-first provider policies", () => {
       },
       claimed.sandboxHeaders,
       [200],
+      undefined,
+      usagePricingResolution,
     );
     expect(combinedH2.body).toStrictEqual({
       success: true,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -478,6 +478,95 @@ function requireOrgId(actor: ApiTestUser): string {
   return actor.orgId;
 }
 
+function totalChargedCredits(
+  rows: readonly { readonly creditsCharged: number | null }[],
+): number {
+  return rows.reduce((total, row) => {
+    if (row.creditsCharged === null) {
+      throw new Error("Expected processed usage to have charged credits");
+    }
+    return total + row.creditsCharged;
+  }, 0);
+}
+
+async function expectTerraApiFirstTurnUsage(
+  runId: string,
+  sessionBytes: Buffer,
+): Promise<void> {
+  const firstSession = MemoryPiSession.fromJsonl(sessionBytes.toString("utf8"));
+  const firstAssistant = [...firstSession.buildSessionContext().messages]
+    .reverse()
+    .find((message) => {
+      return message.role === "assistant";
+    });
+  expect(
+    firstAssistant?.role === "assistant" ? firstAssistant.usage : null,
+  ).toMatchObject({
+    input: 5,
+    output: 3,
+    cacheRead: 3,
+    cacheWrite: 2,
+  });
+  const usageRows = await readRunUsageEventsFixture(runId);
+  expect(usageRows).toStrictEqual([
+    expect.objectContaining({
+      provider: "gpt-5.6-terra",
+      category: "tokens.cache_creation",
+      quantity: 2,
+      status: "processed",
+      billingError: null,
+      creditsCharged: expect.any(Number),
+    }),
+    expect.objectContaining({
+      provider: "gpt-5.6-terra",
+      category: "tokens.cache_read",
+      quantity: 3,
+      status: "processed",
+      billingError: null,
+      creditsCharged: expect.any(Number),
+    }),
+    expect.objectContaining({
+      provider: "gpt-5.6-terra",
+      category: "tokens.input",
+      quantity: 5,
+      status: "processed",
+      billingError: null,
+      creditsCharged: expect.any(Number),
+    }),
+    expect.objectContaining({
+      provider: "gpt-5.6-terra",
+      category: "tokens.output",
+      quantity: 3,
+      status: "processed",
+      billingError: null,
+      creditsCharged: expect.any(Number),
+    }),
+  ]);
+  expect(totalChargedCredits(usageRows)).toBeGreaterThan(0);
+  expect(
+    usageRows.some((row) => {
+      return row.category.endsWith(".fast");
+    }),
+  ).toBeFalsy();
+}
+
+async function expectTerraApiFollowUpUsage(runId: string): Promise<void> {
+  await expect(readRunUsageEventsFixture(runId)).resolves.toStrictEqual([
+    expect.objectContaining({
+      provider: "gpt-5.6-terra",
+      category: "tokens.input",
+      quantity: 5,
+      status: "processed",
+    }),
+    expect.objectContaining({
+      provider: "gpt-5.6-terra",
+      category: "tokens.output",
+      quantity: 3,
+      status: "processed",
+    }),
+  ]);
+}
+
 async function seedVm0BuiltInModelKey(selectedModel: string): Promise<string> {
   const fixture = await seedVm0BuiltInModelKeyState(context, selectedModel);
   return fixture.selectedModel;
@@ -5048,74 +5137,16 @@ describe("CHAT-02: model-first provider policies", () => {
       const firstSessionBytes = firstSessionEntry?.[1];
       expect(checkpointObjects.has(firstManifestKey)).toBeFalsy();
       expect(checkpointObjects.has(firstSessionKey)).toBeFalsy();
-      expect(firstSessionBytes).toBeDefined();
+      if (!firstSessionBytes) {
+        throw new Error("Expected the first Pi run to persist native H1");
+      }
       if (selectedModel === "gpt-5.6-terra") {
-        const firstSession = MemoryPiSession.fromJsonl(
-          firstSessionBytes?.toString("utf8") ?? "",
-        );
-        const firstAssistant = [...firstSession.buildSessionContext().messages]
-          .reverse()
-          .find((message) => {
-            return message.role === "assistant";
-          });
-        expect(
-          firstAssistant?.role === "assistant" ? firstAssistant.usage : null,
-        ).toMatchObject({
-          input: 5,
-          output: 3,
-          cacheRead: 3,
-          cacheWrite: 2,
-        });
-        const usageRows = await readRunUsageEventsFixture(first.runId);
-        expect(usageRows).toStrictEqual([
-          expect.objectContaining({
-            provider: "gpt-5.6-terra",
-            category: "tokens.cache_creation",
-            quantity: 2,
-            status: "processed",
-            billingError: null,
-            creditsCharged: expect.any(Number),
-          }),
-          expect.objectContaining({
-            provider: "gpt-5.6-terra",
-            category: "tokens.cache_read",
-            quantity: 3,
-            status: "processed",
-            billingError: null,
-            creditsCharged: expect.any(Number),
-          }),
-          expect.objectContaining({
-            provider: "gpt-5.6-terra",
-            category: "tokens.input",
-            quantity: 5,
-            status: "processed",
-            billingError: null,
-            creditsCharged: expect.any(Number),
-          }),
-          expect.objectContaining({
-            provider: "gpt-5.6-terra",
-            category: "tokens.output",
-            quantity: 3,
-            status: "processed",
-            billingError: null,
-            creditsCharged: expect.any(Number),
-          }),
-        ]);
-        expect(
-          usageRows.reduce((total, row) => {
-            return total + (row.creditsCharged ?? 0);
-          }, 0),
-        ).toBeGreaterThan(0);
-        expect(
-          usageRows.some((row) => {
-            return row.category.endsWith(".fast");
-          }),
-        ).toBeFalsy();
+        await expectTerraApiFirstTurnUsage(first.runId, firstSessionBytes);
       }
       const firstSessionHash = createHash("sha256")
-        .update(firstSessionBytes ?? Buffer.alloc(0))
+        .update(firstSessionBytes)
         .digest("hex");
-      expect(firstSessionBytes?.toString("utf8")).toContain(first.threadId);
+      expect(firstSessionBytes.toString("utf8")).toContain(first.threadId);
       expect(context.mocks.ably.channelGet).toHaveBeenCalledWith(
         `runner-group:${runnerGroup}`,
       );
@@ -5147,22 +5178,7 @@ describe("CHAT-02: model-first provider policies", () => {
       await flushWaitUntilForTest();
       expect(modelRequests).toHaveLength(2);
       if (selectedModel === "gpt-5.6-terra") {
-        await expect(
-          readRunUsageEventsFixture(second.runId),
-        ).resolves.toStrictEqual([
-          expect.objectContaining({
-            provider: "gpt-5.6-terra",
-            category: "tokens.input",
-            quantity: 5,
-            status: "processed",
-          }),
-          expect.objectContaining({
-            provider: "gpt-5.6-terra",
-            category: "tokens.output",
-            quantity: 3,
-            status: "processed",
-          }),
-        ]);
+        await expectTerraApiFollowUpUsage(second.runId);
       }
       expect(modelRequests[1]?.authorization).toMatch(
         /^Bearer vm0-key-runtime-fixture-/u,
@@ -6328,11 +6344,7 @@ describe("CHAT-02: model-first provider policies", () => {
         billingError: null,
       }),
     ]);
-    expect(
-      cancelledUsage.reduce((total, row) => {
-        return total + (row.creditsCharged ?? 0);
-      }, 0),
-    ).toBeGreaterThan(0);
+    expect(totalChargedCredits(cancelledUsage)).toBeGreaterThan(0);
     expect(
       checkpointObjects.has(
         `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`,
@@ -6899,8 +6911,12 @@ describe("CHAT-02: model-first provider policies", () => {
     await expect(
       readRunUsageEventsFixture(second.runId),
     ).resolves.toStrictEqual([]);
+    const manifestBytes = checkpointObjects.get(manifestKey);
+    if (!manifestBytes) {
+      throw new Error("Expected compaction ownership-transfer manifest");
+    }
     const manifest = piApiFirstTurnManifestV3Schema.parse(
-      JSON.parse(checkpointObjects.get(manifestKey)?.toString("utf8") ?? "{}"),
+      JSON.parse(manifestBytes.toString("utf8")),
     );
     expect(manifest).toMatchObject({
       schemaVersion: 3,
@@ -6914,12 +6930,13 @@ describe("CHAT-02: model-first provider policies", () => {
       },
       sandboxEventSequenceStart: 1,
     });
-    const transferredH0 =
-      checkpointObjects
-        .get(
-          `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${second.runId}/session.jsonl`,
-        )
-        ?.toString("utf8") ?? "";
+    const transferredH0Bytes = checkpointObjects.get(
+      `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${second.runId}/session.jsonl`,
+    );
+    if (!transferredH0Bytes) {
+      throw new Error("Expected compaction ownership-transfer session");
+    }
+    const transferredH0 = transferredH0Bytes.toString("utf8");
     expect(transferredH0).toBe(compactionH0);
     const claim = await api.claimRunnerJob(second.runId, { runnerIdentity });
     const sandboxHeaders = {
@@ -7105,8 +7122,12 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(terraTools).toStrictEqual(
       expect.arrayContaining(["read", "write", "edit", "bash"]),
     );
+    const manifestBytes = checkpointObjects.get(manifestKey);
+    if (!manifestBytes) {
+      throw new Error("Expected pending-tool ownership-transfer manifest");
+    }
     const manifest = piApiFirstTurnManifestV3Schema.parse(
-      JSON.parse(checkpointObjects.get(manifestKey)?.toString("utf8") ?? "{}"),
+      JSON.parse(manifestBytes.toString("utf8")),
     );
     expect(manifest).toMatchObject({
       schemaVersion: 3,
@@ -7153,15 +7174,22 @@ describe("CHAT-02: model-first provider policies", () => {
     const terraEnvironment = claimEnvironment(claimed.claim);
     expect(terraEnvironment.OKOU_TOKEN).toBeTruthy();
     expect(terraEnvironment.CLI_PKG_URL).toBeTruthy();
-    const terraInstructions = claimed.claim.appendSystemPrompt ?? "";
+    const terraInstructions = claimed.claim.appendSystemPrompt;
+    if (!terraInstructions) {
+      throw new Error("Expected Terra Web instructions");
+    }
     expect(terraInstructions).toContain(
       "You are currently running inside: Web",
     );
     expect(terraInstructions).toContain("okou web download-file -h");
     expect(terraInstructions).not.toMatch(/auto.?memory/iu);
-    const terraMounts =
-      expectCanonicalStorageManifest(claimed.claim.storageManifest)
-        ?.storageMounts ?? [];
+    const terraStorageManifest = expectCanonicalStorageManifest(
+      claimed.claim.storageManifest,
+    );
+    if (!terraStorageManifest) {
+      throw new Error("Expected Terra storage manifest");
+    }
+    const terraMounts = terraStorageManifest.storageMounts;
     expect(terraMounts).not.toContainEqual(
       expect.objectContaining({ name: "memory" }),
     );
@@ -7193,12 +7221,13 @@ describe("CHAT-02: model-first provider policies", () => {
         return receipt.body;
       }),
     ).toStrictEqual([{ success: true }, { success: true }]);
-    const h1 =
-      checkpointObjects
-        .get(
-          `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/session.jsonl`,
-        )
-        ?.toString("utf8") ?? "";
+    const h1Bytes = checkpointObjects.get(
+      `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/session.jsonl`,
+    );
+    if (!h1Bytes) {
+      throw new Error("Expected pending-tool ownership-transfer session");
+    }
+    const h1 = h1Bytes.toString("utf8");
     expect(h1).toContain('"type":"thinking_level_change"');
     expect(h1).toContain('"thinkingLevel":"low"');
     const h2Session = MemoryPiSession.fromJsonl(h1);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -640,14 +640,10 @@ async function sendChatRun(
       : { userMessage: userMessageWithTemplate(body.prompt, template) }),
     clientEventId: body.clientEventId ?? randomUUID(),
   };
-  const sent = await chat.requestSendEvent(
-    actor,
-    requestBody,
-    [201],
-    undefined,
+  const sent = await chat.requestSendEvent(actor, requestBody, [201], {
     publicBrand,
     usagePricingResolution,
-  );
+  });
   if (sent.status !== 201) {
     throw new Error("Expected the entitled chat send to create a run");
   }
@@ -4126,13 +4122,9 @@ describe("CHAT-02: admission without spendable credits", () => {
       model: "claude-sonnet-5",
       clientEventId,
     };
-    const sent = await chat.requestSendEvent(
-      actor,
-      sendBody,
-      [201],
-      undefined,
-      "okou",
-    );
+    const sent = await chat.requestSendEvent(actor, sendBody, [201], {
+      publicBrand: "okou",
+    });
     if (sent.status !== 201) {
       throw new Error("Expected the blocked send to return 201 without a run");
     }
@@ -4205,8 +4197,7 @@ describe("CHAT-02: admission without spendable credits", () => {
       actor,
       { ...sendBody, threadId: sent.body.threadId },
       [201],
-      undefined,
-      "okou",
+      { publicBrand: "okou" },
     );
     expect(retry.body).toStrictEqual(sent.body);
     const afterRetry = await chat.listThreadEvents(actor, sent.body.threadId);
@@ -6442,7 +6433,12 @@ describe("CHAT-02: model-first provider policies", () => {
       await lifecycleLock.done;
     });
 
-    const cancellation = api.requestCancelRun(actor, run.runId, [200]);
+    const cancellation = api.requestCancelRun(
+      actor,
+      run.runId,
+      [200],
+      usagePricingResolution,
+    );
     await expect.poll(lifecycleLock.waiterCount).toBe(1);
     releaseProvider.resolve(undefined);
     await expect.poll(lifecycleLock.waiterCount).toBe(2);
@@ -6450,10 +6446,6 @@ describe("CHAT-02: model-first provider policies", () => {
     await lifecycleLock.done;
     await cancellation;
     await flushWaitUntilForTest();
-    await api.reconcileBillingOrganizations(
-      [requireOrgId(actor)],
-      usagePricingResolution,
-    );
 
     expect(modelCalls).toBe(1);
     await expectTerraApiFollowUpUsage(run.runId);
@@ -6540,68 +6532,51 @@ describe("CHAT-02: model-first provider policies", () => {
     ).toHaveLength(1);
   }, 90_000);
 
-  it.each([
-    {
-      failure: "resource download",
-      expectedCode: "PI_API_RESOURCE_PREPARATION_FAILED",
-      failResource: true,
-      expectedModelCalls: 0,
-    },
-    {
-      failure: "model request",
-      expectedCode: "PI_API_MODEL_FAILED",
-      failResource: false,
-      expectedModelCalls: 1,
-    },
-  ] as const)(
-    "fails Pi on $failure without claiming Sandbox or replaying the model",
-    async ({ expectedCode, failResource, expectedModelCalls }) => {
-      const { actor, agentId } = await entitledChatActor();
-      if (!actor.orgId) {
-        throw new Error("Expected entitled chat actor to have an org");
-      }
-      await configureBuiltInPiModel(actor, "deepseek-v4-flash");
-      await updateFeatureSwitchesForUser(
-        context,
-        { ...actor, orgId: actor.orgId },
-        { [FeatureSwitchKey.PiLoop]: true },
-      );
-      mockPiResourceArchiveDownloads(failResource);
-      let modelCalls = 0;
-      server.use(
-        http.post("https://api.deepseek.com/responses", () => {
-          modelCalls += 1;
-          return HttpResponse.json(
-            { error: "provider unavailable" },
-            { status: 503 },
-          );
-        }),
-      );
-      const checkpointObjects = mockPiCheckpointObjectStore();
-      const prompt = `strict ${expectedCode} prompt`;
-      const run = await sendChatRun(actor, {
-        agentId,
-        prompt,
-        model: "deepseek-v4-flash",
-      });
+  it("fails Pi after one model request without claiming Sandbox or replaying the model", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    if (!actor.orgId) {
+      throw new Error("Expected entitled chat actor to have an org");
+    }
+    await configureBuiltInPiModel(actor, "deepseek-v4-flash");
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId: actor.orgId },
+      { [FeatureSwitchKey.PiLoop]: true },
+    );
+    mockPiResourceArchiveDownloads();
+    let modelCalls = 0;
+    server.use(
+      http.post("https://api.deepseek.com/responses", () => {
+        modelCalls += 1;
+        return HttpResponse.json(
+          { error: "provider unavailable" },
+          { status: 503 },
+        );
+      }),
+    );
+    const checkpointObjects = mockPiCheckpointObjectStore();
+    const prompt = "strict PI_API_MODEL_FAILED prompt";
+    const run = await sendChatRun(actor, {
+      agentId,
+      prompt,
+      model: "deepseek-v4-flash",
+    });
 
-      await waitForRunStatus(actor, run.runId, "failed", 5000);
-      await flushWaitUntilForTest();
-      const failed = await api.readRun(actor, run.runId);
-      expect(failed.error).toContain(`[${expectedCode}]`);
-      expect(modelCalls).toBe(expectedModelCalls);
-      expect(
-        checkpointObjects.has(
-          `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`,
-        ),
-      ).toBeFalsy();
-      const claim = await api.requestClaimRunnerJob(true, run.runId, [404]);
-      expect(claim.status).toBe(404);
-    },
-    90_000,
-  );
+    await waitForRunStatus(actor, run.runId, "failed");
+    await flushWaitUntilForTest();
+    const failed = await api.readRun(actor, run.runId);
+    expect(failed.error).toContain("[PI_API_MODEL_FAILED]");
+    expect(modelCalls).toBe(1);
+    expect(
+      checkpointObjects.has(
+        `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`,
+      ),
+    ).toBeFalsy();
+    const claim = await api.requestClaimRunnerJob(true, run.runId, [404]);
+    expect(claim.status).toBe(404);
+  }, 90_000);
 
-  it("hands a proven pre-provider failure to Sandbox without replaying a later provider failure", async () => {
+  it("hands a Terra resource failure to Sandbox without replaying a later provider failure", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     if (!actor.orgId) {
       throw new Error("Expected entitled chat actor to have an org");
@@ -6623,7 +6598,7 @@ describe("CHAT-02: model-first provider policies", () => {
     const anchorClaim = await claimChatRun(runnerGroup, anchor.runId);
     expect(anchorClaim.claim.cliAgentType).toBe("claude-code");
 
-    await configureBuiltInPiModel(actor, "deepseek-v4-flash");
+    await configureBuiltInPiModel(actor, "gpt-5.6-terra");
     await updateFeatureSwitchesForUser(
       context,
       { ...actor, orgId: actor.orgId },
@@ -6632,7 +6607,7 @@ describe("CHAT-02: model-first provider policies", () => {
     mockPiResourceArchiveDownloads(true);
     let modelCalls = 0;
     server.use(
-      http.post("https://api.deepseek.com/responses", () => {
+      http.post("https://api.openai.com/v1/responses", () => {
         modelCalls += 1;
         return HttpResponse.json(
           { error: "provider unavailable" },
@@ -6645,20 +6620,14 @@ describe("CHAT-02: model-first provider policies", () => {
     const fallback = await sendChatRun(actor, {
       agentId,
       prompt: fallbackPrompt,
-      model: "deepseek-v4-flash",
+      model: "gpt-5.6-terra",
     });
     await waitForRunStatus(actor, fallback.runId, "queued");
 
     await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
+    await flushWaitUntilForTest();
     const fallbackManifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${fallback.runId}/manifest.json`;
-    await expect
-      .poll(
-        () => {
-          return checkpointObjects.get(fallbackManifestKey);
-        },
-        { timeout: 5000 },
-      )
-      .toBeInstanceOf(Buffer);
+    expect(checkpointObjects.get(fallbackManifestKey)).toBeInstanceOf(Buffer);
     expect(modelCalls).toBe(0);
 
     const fallbackManifest = piApiFirstTurnManifestV3Schema.parse(
@@ -6707,7 +6676,7 @@ describe("CHAT-02: model-first provider policies", () => {
     const postProvider = await sendChatRun(actor, {
       agentId,
       prompt: postProviderPrompt,
-      model: "deepseek-v4-flash",
+      model: "gpt-5.6-terra",
     });
     await waitForRunStatus(actor, postProvider.runId, "queued");
 
@@ -6722,8 +6691,8 @@ describe("CHAT-02: model-first provider policies", () => {
       role: "assistant",
       content: [{ type: "text", text: fallbackAnswer }],
       api: "openai-responses",
-      provider: "deepseek",
-      model: "deepseek-v4-flash",
+      provider: "openai",
+      model: "gpt-5.6-terra",
       usage: {
         input: 0,
         output: 0,
@@ -13713,8 +13682,7 @@ describe("CHAT-02: public-brand default assistant identity", () => {
           clientEventId: queuedEventId,
         },
         [201],
-        undefined,
-        queuedBrand,
+        { publicBrand: queuedBrand },
       );
       if (queued.status !== 201) {
         throw new Error(

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -36,6 +36,7 @@ import {
   ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES,
   CANCELLATION_RECOVERY_STALE_AFTER_MS,
   DEFAULT_PROFILE,
+  PI_MEMORY_ROOT,
   piApiFirstTurnManifestV3Schema,
 } from "@okouai/api-contracts/contracts/runners";
 import { mailContract } from "@okouai/api-contracts/contracts/mail";
@@ -115,13 +116,15 @@ import { createFirewallApi, secretTemplate } from "./helpers/api-bdd-firewall";
 import { createGithubBddApi } from "./helpers/api-bdd-github";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { cleanupTimedOutRun } from "./helpers/api-bdd-run-timeout";
-import { createRunsApi } from "./helpers/api-bdd-runs";
+import {
+  createRunsApi,
+  expectCanonicalStorageManifest,
+} from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { readAgentRunState$ } from "./helpers/agent-run-callback";
 import { chatEventDisplayText } from "./helpers/chat-event";
 import {
   clearThreadSessionBinding,
-  enableQueuedPiOwnershipTransferFixture,
   readRunAutonomyBudgetFixture,
   readRunLaunchSnapshotFixture,
   readThreadSessionBinding,
@@ -158,6 +161,7 @@ import {
   holdThreadSessionConversationChangesFixture,
   holdThreadSessionConversationClearFixture,
   readCanonicalChatEventStorageFixture,
+  readRunUsageEventsFixture,
   releaseBddVm0ApiKey,
   removeChatCallbackPublicBrandFixture,
   replayPendingChatInputQueueEventFixture,
@@ -467,6 +471,13 @@ async function entitledChatActor(
   return { actor, agentId: agent.agentId, runnerGroup, providerId };
 }
 
+function requireOrgId(actor: ApiTestUser): string {
+  if (!actor.orgId) {
+    throw new Error("Expected entitled chat actor to have an org");
+  }
+  return actor.orgId;
+}
+
 async function seedVm0BuiltInModelKey(selectedModel: string): Promise<string> {
   const fixture = await seedVm0BuiltInModelKeyState(context, selectedModel);
   return fixture.selectedModel;
@@ -474,7 +485,7 @@ async function seedVm0BuiltInModelKey(selectedModel: string): Promise<string> {
 
 async function configureBuiltInPiModel(
   actor: ApiTestUser,
-  selectedModel: "deepseek-v4-flash" | "deepseek-v4-pro",
+  selectedModel: "deepseek-v4-flash" | "deepseek-v4-pro" | "gpt-5.6-terra",
 ): Promise<void> {
   await seedVm0BuiltInModelKey(selectedModel);
   await api.updateOrgModelPolicies(actor, [
@@ -4227,6 +4238,10 @@ function piResponsesTextSse(
     readonly input_tokens: number;
     readonly output_tokens: number;
     readonly total_tokens: number;
+    readonly input_tokens_details?: {
+      readonly cached_tokens?: number;
+      readonly cache_write_tokens?: number;
+    };
   } = { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
 ): string {
   const responseId = `resp_pi_api_${sequence.toString()}`;
@@ -4692,7 +4707,7 @@ async function queueCapabilityProvenPiRun(args: {
     );
   }
   const anchorClaim = await claimChatRun(args.runnerGroup, anchor.runId);
-  await configureBuiltInPiModel(args.actor, "deepseek-v4-flash");
+  await configureBuiltInPiModel(args.actor, "gpt-5.6-terra");
   await updateFeatureSwitchesForUser(
     context,
     { ...args.actor, orgId: args.actor.orgId },
@@ -4701,10 +4716,9 @@ async function queueCapabilityProvenPiRun(args: {
   const run = await sendChatRun(args.actor, {
     agentId: args.agentId,
     prompt: args.prompt,
-    model: "deepseek-v4-flash",
+    model: "gpt-5.6-terra",
   });
   await waitForRunStatus(args.actor, run.runId, "queued");
-  await enableQueuedPiOwnershipTransferFixture(context, run.runId);
   return { anchor, anchorClaim, run };
 }
 
@@ -4932,7 +4946,7 @@ describe("CHAT-02: model-first provider policies", () => {
     }
   }, 90_000);
 
-  it.each(["deepseek-v4-flash", "deepseek-v4-pro"] as const)(
+  it.each(["deepseek-v4-flash", "deepseek-v4-pro", "gpt-5.6-terra"] as const)(
     "runs the Pi API first turn once for %s and resumes canonical JSONL",
     async (selectedModel) => {
       const { actor, agentId, runnerGroup } = await entitledChatActor();
@@ -4956,8 +4970,12 @@ describe("CHAT-02: model-first provider policies", () => {
         `first API answer for ${selectedModel}`,
         `second API answer for ${selectedModel}`,
       ];
+      const providerUrl =
+        selectedModel === "gpt-5.6-terra"
+          ? "https://api.openai.com/v1/responses"
+          : "https://api.deepseek.com/responses";
       server.use(
-        http.post("https://api.deepseek.com/responses", async ({ request }) => {
+        http.post(providerUrl, async ({ request }) => {
           const sequence = modelRequests.length;
           modelRequests.push({
             authorization: request.headers.get("authorization"),
@@ -4970,9 +4988,26 @@ describe("CHAT-02: model-first provider policies", () => {
               { status: 500 },
             );
           }
-          return new HttpResponse(piResponsesTextSse(answer, sequence), {
-            headers: { "content-type": "text/event-stream" },
-          });
+          const usage =
+            selectedModel === "gpt-5.6-terra" && sequence === 0
+              ? {
+                  input_tokens: 10,
+                  output_tokens: 3,
+                  total_tokens: 13,
+                  input_tokens_details: {
+                    cached_tokens: 3,
+                    cache_write_tokens: 2,
+                  },
+                }
+              : undefined;
+          return new HttpResponse(
+            usage
+              ? piResponsesTextSse(answer, sequence, usage)
+              : piResponsesTextSse(answer, sequence),
+            {
+              headers: { "content-type": "text/event-stream" },
+            },
+          );
         }),
       );
       const firstPrompt = "persist this turn in the native Pi session";
@@ -5014,6 +5049,69 @@ describe("CHAT-02: model-first provider policies", () => {
       expect(checkpointObjects.has(firstManifestKey)).toBeFalsy();
       expect(checkpointObjects.has(firstSessionKey)).toBeFalsy();
       expect(firstSessionBytes).toBeDefined();
+      if (selectedModel === "gpt-5.6-terra") {
+        const firstSession = MemoryPiSession.fromJsonl(
+          firstSessionBytes?.toString("utf8") ?? "",
+        );
+        const firstAssistant = [...firstSession.buildSessionContext().messages]
+          .reverse()
+          .find((message) => {
+            return message.role === "assistant";
+          });
+        expect(
+          firstAssistant?.role === "assistant" ? firstAssistant.usage : null,
+        ).toMatchObject({
+          input: 5,
+          output: 3,
+          cacheRead: 3,
+          cacheWrite: 2,
+        });
+        const usageRows = await readRunUsageEventsFixture(first.runId);
+        expect(usageRows).toStrictEqual([
+          expect.objectContaining({
+            provider: "gpt-5.6-terra",
+            category: "tokens.cache_creation",
+            quantity: 2,
+            status: "processed",
+            billingError: null,
+            creditsCharged: expect.any(Number),
+          }),
+          expect.objectContaining({
+            provider: "gpt-5.6-terra",
+            category: "tokens.cache_read",
+            quantity: 3,
+            status: "processed",
+            billingError: null,
+            creditsCharged: expect.any(Number),
+          }),
+          expect.objectContaining({
+            provider: "gpt-5.6-terra",
+            category: "tokens.input",
+            quantity: 5,
+            status: "processed",
+            billingError: null,
+            creditsCharged: expect.any(Number),
+          }),
+          expect.objectContaining({
+            provider: "gpt-5.6-terra",
+            category: "tokens.output",
+            quantity: 3,
+            status: "processed",
+            billingError: null,
+            creditsCharged: expect.any(Number),
+          }),
+        ]);
+        expect(
+          usageRows.reduce((total, row) => {
+            return total + (row.creditsCharged ?? 0);
+          }, 0),
+        ).toBeGreaterThan(0);
+        expect(
+          usageRows.some((row) => {
+            return row.category.endsWith(".fast");
+          }),
+        ).toBeFalsy();
+      }
       const firstSessionHash = createHash("sha256")
         .update(firstSessionBytes ?? Buffer.alloc(0))
         .digest("hex");
@@ -5048,6 +5146,24 @@ describe("CHAT-02: model-first provider policies", () => {
       await waitForRunStatus(actor, second.runId, "completed");
       await flushWaitUntilForTest();
       expect(modelRequests).toHaveLength(2);
+      if (selectedModel === "gpt-5.6-terra") {
+        await expect(
+          readRunUsageEventsFixture(second.runId),
+        ).resolves.toStrictEqual([
+          expect.objectContaining({
+            provider: "gpt-5.6-terra",
+            category: "tokens.input",
+            quantity: 5,
+            status: "processed",
+          }),
+          expect.objectContaining({
+            provider: "gpt-5.6-terra",
+            category: "tokens.output",
+            quantity: 3,
+            status: "processed",
+          }),
+        ]);
+      }
       expect(modelRequests[1]?.authorization).toMatch(
         /^Bearer vm0-key-runtime-fixture-/u,
       );
@@ -5082,24 +5198,14 @@ describe("CHAT-02: model-first provider policies", () => {
     90_000,
   );
 
-  it("bounds Pi resume history to each cross-harness generation", async () => {
+  it("preserves generations across standard Terra, fast Terra, and standard Terra", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     const orgId = actor.orgId;
     if (!orgId) {
       throw new Error("Expected entitled chat actor to have an org");
     }
-    const piModel = "deepseek-v4-flash";
-    const codexModel = "gpt-5.6-luna";
+    const piModel = "gpt-5.6-terra";
     await seedVm0BuiltInModelKey(piModel);
-    await misc.upsertPersonalModelProvider(
-      actor,
-      {
-        type: "codex-oauth-token",
-        authMethod: "auth_json",
-        secrets: { CODEX_AUTH_JSON: codexAuthJson() },
-      },
-      [200, 201],
-    );
     await api.updateOrgModelPolicies(actor, [
       {
         model: piModel,
@@ -5108,18 +5214,14 @@ describe("CHAT-02: model-first provider policies", () => {
         credentialScope: "org",
         modelProviderId: null,
       },
-      {
-        model: codexModel,
-        isDefault: false,
-        defaultProviderType: "codex-oauth-token",
-        credentialScope: "member",
-        modelProviderId: null,
-      },
     ]);
     await updateFeatureSwitchesForUser(
       context,
       { ...actor, orgId },
-      { [FeatureSwitchKey.PiLoop]: true },
+      {
+        [FeatureSwitchKey.PiLoop]: true,
+        [FeatureSwitchKey.CodexFastMode]: true,
+      },
     );
     mockPiResourceArchiveDownloads();
     const checkpointObjects = mockPiCheckpointObjectStore();
@@ -5129,7 +5231,7 @@ describe("CHAT-02: model-first provider policies", () => {
     const repeatedPiAnswer = "repeated Pi generation answer";
     const modelRequests: unknown[] = [];
     server.use(
-      http.post("https://api.deepseek.com/responses", async ({ request }) => {
+      http.post("https://api.openai.com/v1/responses", async ({ request }) => {
         const requestIndex = modelRequests.length;
         modelRequests.push(await request.json());
         const body =
@@ -5184,7 +5286,8 @@ describe("CHAT-02: model-first provider policies", () => {
       agentId,
       threadId: firstPi.threadId,
       prompt: firstCodexPrompt,
-      model: codexModel,
+      model: piModel,
+      runOptions: { codexServiceTier: "fast" },
     });
     const firstCodexBinding = await readThreadSessionBinding(
       context,
@@ -5201,6 +5304,10 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(firstCodexRun.appendSystemPrompt).toContain(firstPiAnswer);
     const firstCodexClaim = await claimChatRun(runnerGroup, firstCodex.runId);
     expect(firstCodexClaim.claim.cliAgentType).toBe("codex");
+    expect(
+      claimEnvironment(firstCodexClaim.claim).OKOU_CODEX_SERVICE_TIER,
+    ).toBe("fast");
+    expect(firstCodexClaim.claim.piLaunchConfig).toBeUndefined();
     expect(firstCodexClaim.claim.resumeSession).toBeNull();
     chatCallbacks.mockChatOutputEvents([assistantEvent(0, firstCodexAnswer)]);
     await completeChatRunOk(firstCodex.runId, firstCodexClaim.sandboxHeaders, {
@@ -5210,6 +5317,9 @@ describe("CHAT-02: model-first provider policies", () => {
     await flushWaitUntilForTest();
 
     const returnedPiPrompt = "return to Pi with every visible prior turn";
+    await chat.updateThreadModelSelection(actor, firstPi.threadId, piModel, {
+      codexServiceTier: null,
+    });
     const returnedPi = await sendChatRun(actor, {
       agentId,
       threadId: firstPi.threadId,
@@ -5340,7 +5450,8 @@ describe("CHAT-02: model-first provider policies", () => {
       agentId,
       threadId: firstPi.threadId,
       prompt: repeatedCodexPrompt,
-      model: codexModel,
+      model: piModel,
+      runOptions: { codexServiceTier: "fast" },
     });
     const repeatedCodexBinding = await readThreadSessionBinding(
       context,
@@ -5354,6 +5465,10 @@ describe("CHAT-02: model-first provider policies", () => {
       repeatedCodex.runId,
     );
     expect(repeatedCodexClaim.claim.cliAgentType).toBe("codex");
+    expect(
+      claimEnvironment(repeatedCodexClaim.claim).OKOU_CODEX_SERVICE_TIER,
+    ).toBe("fast");
+    expect(repeatedCodexClaim.claim.piLaunchConfig).toBeUndefined();
     expect(repeatedCodexClaim.claim.resumeSession).toBeNull();
     const repeatedCodexRun = await api.readRun(actor, repeatedCodex.runId);
     expect(repeatedCodexRun.appendSystemPrompt).toContain(piFollowUpPrompt);
@@ -5372,6 +5487,9 @@ describe("CHAT-02: model-first provider policies", () => {
     await flushWaitUntilForTest();
 
     const repeatedPiPrompt = "return to a third Pi generation";
+    await chat.updateThreadModelSelection(actor, firstPi.threadId, piModel, {
+      codexServiceTier: null,
+    });
     const repeatedPi = await sendChatRun(actor, {
       agentId,
       threadId: firstPi.threadId,
@@ -5528,7 +5646,7 @@ describe("CHAT-02: model-first provider policies", () => {
     if (!actor.orgId) {
       throw new Error("Expected entitled chat actor to have an org");
     }
-    await configureBuiltInPiModel(actor, "deepseek-v4-flash");
+    await configureBuiltInPiModel(actor, "gpt-5.6-terra");
     await updateFeatureSwitchesForUser(
       context,
       { ...actor, orgId: actor.orgId },
@@ -5560,7 +5678,7 @@ describe("CHAT-02: model-first provider policies", () => {
           });
         },
       ),
-      http.post("https://api.deepseek.com/responses", () => {
+      http.post("https://api.openai.com/v1/responses", () => {
         return new HttpResponse(
           piResponsesContentSse({
             blocks: [
@@ -5580,7 +5698,7 @@ describe("CHAT-02: model-first provider policies", () => {
     const run = await sendChatRun(actor, {
       agentId,
       prompt: "preserve each complete API-first text block",
-      model: "deepseek-v4-flash",
+      model: "gpt-5.6-terra",
     });
     await waitForRunStatus(actor, run.runId, "completed");
     await flushWaitUntilForTest();
@@ -5644,7 +5762,7 @@ describe("CHAT-02: model-first provider policies", () => {
     );
     let modelCalls = 0;
     server.use(
-      http.post("https://api.deepseek.com/responses", () => {
+      http.post("https://api.openai.com/v1/responses", () => {
         modelCalls += 1;
         return new HttpResponse(piResponsesTextSse("unexpected", modelCalls), {
           headers: { "content-type": "text/event-stream" },
@@ -5762,7 +5880,7 @@ describe("CHAT-02: model-first provider policies", () => {
     let modelCalls = 0;
     const apiAnswer = "API H1 settled before the accepted input";
     server.use(
-      http.post("https://api.deepseek.com/responses", async () => {
+      http.post("https://api.openai.com/v1/responses", async () => {
         modelCalls += 1;
         if (!providerEntered.settled()) {
           providerEntered.resolve(undefined);
@@ -5855,8 +5973,8 @@ describe("CHAT-02: model-first provider policies", () => {
       role: "assistant",
       content: [{ type: "text", text: sandboxAnswer }],
       api: "openai-responses",
-      provider: "deepseek",
-      model: "deepseek-v4-flash",
+      provider: "openai",
+      model: "gpt-5.6-terra",
       usage: {
         input: 0,
         output: 0,
@@ -5943,7 +6061,7 @@ describe("CHAT-02: model-first provider policies", () => {
     const releaseProvider = createDeferredPromise<void>(context.signal);
     let modelCalls = 0;
     server.use(
-      http.post("https://api.deepseek.com/responses", async () => {
+      http.post("https://api.openai.com/v1/responses", async () => {
         modelCalls += 1;
         if (!providerEntered.settled()) {
           providerEntered.resolve(undefined);
@@ -6054,8 +6172,8 @@ describe("CHAT-02: model-first provider policies", () => {
       role: "assistant",
       content: [{ type: "text", text: "Sandbox applied the steer once" }],
       api: "openai-responses",
-      provider: "deepseek",
-      model: "deepseek-v4-flash",
+      provider: "openai",
+      model: "gpt-5.6-terra",
       usage: {
         input: 0,
         output: 0,
@@ -6103,7 +6221,7 @@ describe("CHAT-02: model-first provider policies", () => {
     );
     let modelCalls = 0;
     server.use(
-      http.post("https://api.deepseek.com/responses", () => {
+      http.post("https://api.openai.com/v1/responses", () => {
         modelCalls += 1;
         return new HttpResponse(piResponsesTextSse("late", modelCalls), {
           headers: { "content-type": "text/event-stream" },
@@ -6125,6 +6243,9 @@ describe("CHAT-02: model-first provider policies", () => {
     await flushWaitUntilForTest();
 
     expect(modelCalls).toBe(0);
+    await expect(readRunUsageEventsFixture(run.runId)).resolves.toStrictEqual(
+      [],
+    );
     await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
       status: "cancelled",
     });
@@ -6155,7 +6276,7 @@ describe("CHAT-02: model-first provider policies", () => {
     const releaseProvider = createDeferredPromise<void>(context.signal);
     let modelCalls = 0;
     server.use(
-      http.post("https://api.deepseek.com/responses", async () => {
+      http.post("https://api.openai.com/v1/responses", async () => {
         modelCalls += 1;
         if (!providerEntered.settled()) {
           providerEntered.resolve(undefined);
@@ -6181,11 +6302,37 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(modelCalls).toBe(1);
     releaseProvider.resolve(undefined);
     await flushWaitUntilForTest();
+    if (!actor.orgId) {
+      throw new Error("Expected cancellation actor to have an org");
+    }
+    await api.reconcileBillingOrganizations([actor.orgId]);
 
     await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
       status: "cancelled",
     });
     expect(modelCalls).toBe(1);
+    const cancelledUsage = await readRunUsageEventsFixture(run.runId);
+    expect(cancelledUsage).toStrictEqual([
+      expect.objectContaining({
+        provider: "gpt-5.6-terra",
+        category: "tokens.input",
+        quantity: 5,
+        status: "processed",
+        billingError: null,
+      }),
+      expect.objectContaining({
+        provider: "gpt-5.6-terra",
+        category: "tokens.output",
+        quantity: 3,
+        status: "processed",
+        billingError: null,
+      }),
+    ]);
+    expect(
+      cancelledUsage.reduce((total, row) => {
+        return total + (row.creditsCharged ?? 0);
+      }, 0),
+    ).toBeGreaterThan(0);
     expect(
       checkpointObjects.has(
         `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`,
@@ -6213,7 +6360,7 @@ describe("CHAT-02: model-first provider policies", () => {
     const releaseProvider = createDeferredPromise<void>(context.signal);
     let modelCalls = 0;
     server.use(
-      http.post("https://api.deepseek.com/responses", async () => {
+      http.post("https://api.openai.com/v1/responses", async () => {
         modelCalls += 1;
         if (!providerEntered.settled()) {
           providerEntered.resolve(undefined);
@@ -6282,7 +6429,7 @@ describe("CHAT-02: model-first provider policies", () => {
     let modelCalls = 0;
     const answer = "completion committed before cancellation";
     server.use(
-      http.post("https://api.deepseek.com/responses", async () => {
+      http.post("https://api.openai.com/v1/responses", async () => {
         modelCalls += 1;
         if (!providerEntered.settled()) {
           providerEntered.resolve(undefined);
@@ -6444,7 +6591,6 @@ describe("CHAT-02: model-first provider policies", () => {
       model: "deepseek-v4-flash",
     });
     await waitForRunStatus(actor, fallback.runId, "queued");
-    await enableQueuedPiOwnershipTransferFixture(context, fallback.runId);
 
     await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
     const fallbackManifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${fallback.runId}/manifest.json`;
@@ -6507,7 +6653,6 @@ describe("CHAT-02: model-first provider policies", () => {
       model: "deepseek-v4-flash",
     });
     await waitForRunStatus(actor, postProvider.runId, "queued");
-    await enableQueuedPiOwnershipTransferFixture(context, postProvider.runId);
 
     mockPiResourceArchiveDownloads();
     sandboxSession.appendMessage({
@@ -6676,7 +6821,7 @@ describe("CHAT-02: model-first provider policies", () => {
     };
     mockEnv("CONCURRENT_RUN_LIMIT_CAP", "2");
 
-    await configureBuiltInPiModel(actor, "deepseek-v4-flash");
+    await configureBuiltInPiModel(actor, "gpt-5.6-terra");
     await updateFeatureSwitchesForUser(
       context,
       { ...actor, orgId: actor.orgId },
@@ -6685,7 +6830,7 @@ describe("CHAT-02: model-first provider policies", () => {
     mockPiResourceArchiveDownloads();
     let modelCalls = 0;
     server.use(
-      http.post("https://api.deepseek.com/responses", () => {
+      http.post("https://api.openai.com/v1/responses", () => {
         modelCalls += 1;
         return new HttpResponse(
           piResponsesTextSse("seed the compaction checkpoint", modelCalls, {
@@ -6701,11 +6846,23 @@ describe("CHAT-02: model-first provider policies", () => {
     const first = await sendChatRun(actor, {
       agentId,
       prompt: "create a settled Pi checkpoint",
-      model: "deepseek-v4-flash",
+      model: "gpt-5.6-terra",
     });
     await waitForRunStatus(actor, first.runId, "completed");
     await flushWaitUntilForTest();
     expect(modelCalls).toBe(1);
+    await expect(readRunUsageEventsFixture(first.runId)).resolves.toStrictEqual(
+      [
+        expect.objectContaining({
+          provider: "gpt-5.6-terra",
+          category: "tokens.input.long_context",
+          quantity: 983_617,
+          status: "processed",
+          billingError: null,
+          creditsCharged: expect.any(Number),
+        }),
+      ],
+    );
 
     const blobPrefix = `${env("R2_USER_STORAGES_BUCKET_NAME")}/blobs/`;
     const persistedBlobs = [...checkpointObjects.entries()].filter(([key]) => {
@@ -6726,10 +6883,9 @@ describe("CHAT-02: model-first provider policies", () => {
       agentId,
       threadId: first.threadId,
       prompt,
-      model: "deepseek-v4-flash",
+      model: "gpt-5.6-terra",
     });
     await waitForRunStatus(actor, second.runId, "queued");
-    await enableQueuedPiOwnershipTransferFixture(context, second.runId);
     context.mocks.axiomLogging.debug.mockClear();
     await completeChatRunOk(anchor.runId, anchorSandboxHeaders);
 
@@ -6740,6 +6896,9 @@ describe("CHAT-02: model-first provider policies", () => {
       })
       .toBeInstanceOf(Buffer);
     expect(modelCalls).toBe(1);
+    await expect(
+      readRunUsageEventsFixture(second.runId),
+    ).resolves.toStrictEqual([]);
     const manifest = piApiFirstTurnManifestV3Schema.parse(
       JSON.parse(checkpointObjects.get(manifestKey)?.toString("utf8") ?? "{}"),
     );
@@ -6864,22 +7023,23 @@ describe("CHAT-02: model-first provider policies", () => {
 
   it("publishes ordered mixed blocks and hands explicit Sandbox tool turns to H2", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
-    if (!actor.orgId) {
-      throw new Error("Expected entitled chat actor to have an org");
-    }
-    await configureBuiltInPiModel(actor, "deepseek-v4-flash");
+    const orgId = requireOrgId(actor);
+    await configureBuiltInPiModel(actor, "gpt-5.6-terra");
     await updateFeatureSwitchesForUser(
       context,
-      { ...actor, orgId: actor.orgId },
+      { ...actor, orgId },
       {
         [FeatureSwitchKey.PiLoop]: true,
       },
     );
     mockPiResourceArchiveDownloads();
+    const okouCliCommand = `npx --yes --package="\${CLI_PKG_URL}" okou --help`;
     let modelCalls = 0;
+    const terraModelRequests: unknown[] = [];
     server.use(
-      http.post("https://api.deepseek.com/responses", () => {
+      http.post("https://api.openai.com/v1/responses", async ({ request }) => {
         modelCalls += 1;
+        terraModelRequests.push(await request.json());
         return new HttpResponse(
           modelCalls === 1
             ? piResponsesContentSse({
@@ -6888,9 +7048,9 @@ describe("CHAT-02: model-first provider policies", () => {
                   {
                     type: "toolCall",
                     callId: "call_pi_read",
-                    name: "read",
+                    name: "bash",
                     arguments: {
-                      path: "/home/user/workspace/***/handoff.txt",
+                      command: okouCliCommand,
                     },
                   },
                   {
@@ -6909,8 +7069,10 @@ describe("CHAT-02: model-first provider policies", () => {
               })
             : piResponsesToolSse({
                 callId: "call_pi_read",
-                name: "read",
-                arguments: { path: "/home/user/workspace/***/handoff.txt" },
+                name: "bash",
+                arguments: {
+                  command: okouCliCommand,
+                },
                 sequence: modelCalls,
               }),
           { headers: { "content-type": "text/event-stream" } },
@@ -6918,11 +7080,11 @@ describe("CHAT-02: model-first provider policies", () => {
       }),
     );
     const checkpointObjects = mockPiCheckpointObjectStore();
-    const prompt = "read the Sandbox handoff fixture";
+    const prompt = "use the Okou CLI through the Sandbox handoff";
     const run = await sendChatRun(actor, {
       agentId,
       prompt,
-      model: "deepseek-v4-flash",
+      model: "gpt-5.6-terra",
     });
     const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`;
     await expect
@@ -6931,22 +7093,25 @@ describe("CHAT-02: model-first provider policies", () => {
       })
       .toBe(true);
     expect(modelCalls).toBe(1);
-    const manifest = JSON.parse(
-      checkpointObjects.get(manifestKey)?.toString("utf8") ?? "{}",
-    ) as {
-      readonly schemaVersion?: unknown;
-      readonly outcome?: unknown;
-      readonly baseSession?: unknown;
-      readonly session?: {
-        readonly sessionId?: unknown;
-        readonly sha256?: unknown;
-        readonly rawSize?: unknown;
-      };
-      readonly sandboxEventSequenceStart?: unknown;
-    };
+    const terraTools = z
+      .object({
+        tools: z.array(z.object({ name: z.string() }).passthrough()),
+      })
+      .passthrough()
+      .parse(terraModelRequests[0])
+      .tools.map((tool) => {
+        return tool.name;
+      });
+    expect(terraTools).toStrictEqual(
+      expect.arrayContaining(["read", "write", "edit", "bash"]),
+    );
+    const manifest = piApiFirstTurnManifestV3Schema.parse(
+      JSON.parse(checkpointObjects.get(manifestKey)?.toString("utf8") ?? "{}"),
+    );
     expect(manifest).toMatchObject({
-      schemaVersion: 2,
-      outcome: "handoff",
+      schemaVersion: 3,
+      outcome: "ownership-transfer",
+      mode: "pending-tool-continuation",
       baseSession: { sessionId: run.threadId, sha256: null },
       session: {
         sessionId: run.threadId,
@@ -6980,14 +7145,54 @@ describe("CHAT-02: model-first provider policies", () => {
       schemaVersion: 2,
       apiFirstTurn: {
         schemaVersion: 1,
+        ownershipTransfer: { schemaVersion: 1 },
         baseSession: { sessionId: run.threadId, sha256: null },
         sandboxEventSequenceStart: 1,
       },
     });
-    expect(claimed.claim.piLaunchConfig?.apiFirstTurn).not.toHaveProperty(
-      "ownershipTransfer",
+    const terraEnvironment = claimEnvironment(claimed.claim);
+    expect(terraEnvironment.OKOU_TOKEN).toBeTruthy();
+    expect(terraEnvironment.CLI_PKG_URL).toBeTruthy();
+    const terraInstructions = claimed.claim.appendSystemPrompt ?? "";
+    expect(terraInstructions).toContain(
+      "You are currently running inside: Web",
+    );
+    expect(terraInstructions).toContain("okou web download-file -h");
+    expect(terraInstructions).not.toMatch(/auto.?memory/iu);
+    const terraMounts =
+      expectCanonicalStorageManifest(claimed.claim.storageManifest)
+        ?.storageMounts ?? [];
+    expect(terraMounts).not.toContainEqual(
+      expect.objectContaining({ name: "memory" }),
+    );
+    expect(terraMounts).not.toContainEqual(
+      expect.objectContaining({ mountPath: PI_MEMORY_ROOT }),
     );
     expect(claimed.claim.prompt).toBe(prompt);
+    const sandboxUsageEvent = {
+      idempotencyKey: randomUUID(),
+      kind: "model" as const,
+      provider: "gpt-5.6-terra",
+      category: "tokens.output",
+      quantity: 2,
+    };
+    const sandboxUsageReceipts = await Promise.all([
+      webhooks.requestAgentUsageEvent(
+        { runId: run.runId, events: [sandboxUsageEvent] },
+        claimed.sandboxHeaders,
+        [200],
+      ),
+      webhooks.requestAgentUsageEvent(
+        { runId: run.runId, events: [sandboxUsageEvent] },
+        claimed.sandboxHeaders,
+        [200],
+      ),
+    ]);
+    expect(
+      sandboxUsageReceipts.map((receipt) => {
+        return receipt.body;
+      }),
+    ).toStrictEqual([{ success: true }, { success: true }]);
     const h1 =
       checkpointObjects
         .get(
@@ -6995,7 +7200,7 @@ describe("CHAT-02: model-first provider policies", () => {
         )
         ?.toString("utf8") ?? "";
     expect(h1).toContain('"type":"thinking_level_change"');
-    expect(h1).toContain('"thinkingLevel":"high"');
+    expect(h1).toContain('"thinkingLevel":"low"');
     const h2Session = MemoryPiSession.fromJsonl(h1);
     const h1Assistant = [...h2Session.buildSessionContext().messages]
       .reverse()
@@ -7043,7 +7248,7 @@ describe("CHAT-02: model-first provider policies", () => {
       {
         type: "toolCall",
         id: "call_pi_read|fc_pi_content_1_1",
-        name: "read",
+        name: "bash",
       },
       {
         type: "toolCall",
@@ -7071,8 +7276,10 @@ describe("CHAT-02: model-first provider policies", () => {
                 {
                   type: "tool_use",
                   id: "call_pi_read|fc_pi_content_1_1",
-                  name: "read",
-                  input: { path: "/home/user/workspace/***/handoff.txt" },
+                  name: "bash",
+                  input: {
+                    command: okouCliCommand,
+                  },
                 },
               ],
             },
@@ -7124,8 +7331,8 @@ describe("CHAT-02: model-first provider policies", () => {
     h2Session.appendMessage({
       role: "toolResult",
       toolCallId: "call_pi_read|fc_pi_content_1_1",
-      toolName: "read",
-      content: [{ type: "text", text: "Sandbox tool output" }],
+      toolName: "bash",
+      content: [{ type: "text", text: "Okou CLI help output" }],
       details: {},
       isError: false,
       timestamp: 2,
@@ -7143,8 +7350,8 @@ describe("CHAT-02: model-first provider policies", () => {
       role: "assistant",
       content: [{ type: "text", text: "Sandbox H2 complete" }],
       api: "openai-responses",
-      provider: "deepseek",
-      model: "deepseek-v4-flash",
+      provider: "openai",
+      model: "gpt-5.6-terra",
       usage: {
         input: 5,
         output: 3,
@@ -7196,6 +7403,33 @@ describe("CHAT-02: model-first provider policies", () => {
     });
     await waitForRunStatus(actor, run.runId, "completed");
     await flushWaitUntilForTest();
+    const combinedUsage = await readRunUsageEventsFixture(run.runId);
+    expect(
+      combinedUsage.filter((row) => {
+        return row.category === "tokens.input" && row.quantity === 5;
+      }),
+    ).toHaveLength(1);
+    expect(
+      combinedUsage.filter((row) => {
+        return row.category === "tokens.output" && row.quantity === 3;
+      }),
+    ).toHaveLength(1);
+    expect(
+      combinedUsage.filter((row) => {
+        return row.category === "tokens.output" && row.quantity === 2;
+      }),
+    ).toHaveLength(1);
+    expect(combinedUsage).toHaveLength(3);
+    expect(
+      combinedUsage.every((row) => {
+        return (
+          row.provider === "gpt-5.6-terra" &&
+          row.status === "processed" &&
+          row.billingError === null &&
+          !row.category.endsWith(".fast")
+        );
+      }),
+    ).toBeTruthy();
     const committedH2 = await webhooks.requestAgentCheckpoint(
       {
         runId: run.runId,
@@ -7246,8 +7480,8 @@ describe("CHAT-02: model-first provider policies", () => {
       role: "assistant",
       content: [{ type: "text", text: "late replacement H2" }],
       api: "openai-responses",
-      provider: "deepseek",
-      model: "deepseek-v4-flash",
+      provider: "openai",
+      model: "gpt-5.6-terra",
       usage: {
         input: 0,
         output: 0,
@@ -7709,50 +7943,66 @@ describe("CHAT-02: model-first provider policies", () => {
     await cancelChatRun(actor, followUp.runId);
   });
 
-  it("keeps direct DeepSeek BYOK out of Pi execution", async () => {
-    const { actor, agentId } = await entitledChatActor();
-    chatCallbacks.failIfChatCallbackRouteIsFetched();
-    if (!actor.orgId) {
-      throw new Error("Expected entitled chat actor to have an org");
-    }
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId: actor.orgId },
-      { [FeatureSwitchKey.PiLoop]: true },
-    );
-    const { providerId } = await upsertOrgModelProvider(actor, {
-      type: "deepseek",
-      secret: "selected-deepseek-pi-disabled-key",
-    });
-    await api.updateOrgModelPolicies(actor, [
-      {
-        model: "deepseek-v4-flash",
-        isDefault: true,
-        defaultProviderType: "deepseek",
-        credentialScope: "org",
-        modelProviderId: providerId,
-      },
-    ]);
-
-    const run = await sendChatRun(actor, {
-      agentId,
-      prompt: "keep direct DeepSeek on the standard runtime",
+  it.each([
+    {
+      name: "DeepSeek",
       model: "deepseek-v4-flash",
-    });
-    await flushWaitUntilForTest();
-    await expect
-      .poll(() => {
-        return apiDispatchTimingEventsForRun(run.runId).some((event) => {
-          return event.op_type === "api_dispatch_build_runner_job_payload";
-        });
-      })
-      .toBe(true);
-    expectPiLaunchResourceTiming(
-      apiDispatchTimingEventsForRun(run.runId),
-      "not_required",
-    );
-    await cancelChatRun(actor, run.runId);
-  }, 30_000);
+      providerType: "deepseek",
+    },
+    {
+      name: "Terra",
+      model: "gpt-5.6-terra",
+      providerType: "openai-api-key",
+    },
+  ] as const)(
+    "keeps direct $name BYOK out of Pi execution",
+    async ({ model, providerType }) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      chatCallbacks.failIfChatCallbackRouteIsFetched();
+      const orgId = requireOrgId(actor);
+      await updateFeatureSwitchesForUser(
+        context,
+        { ...actor, orgId },
+        { [FeatureSwitchKey.PiLoop]: true },
+      );
+      const { providerId } = await upsertOrgModelProvider(actor, {
+        type: providerType,
+        secret: `selected-${model}-pi-disabled-key`,
+      });
+      await api.updateOrgModelPolicies(actor, [
+        {
+          model,
+          isDefault: true,
+          defaultProviderType: providerType,
+          credentialScope: "org",
+          modelProviderId: providerId,
+        },
+      ]);
+
+      const run = await sendChatRun(actor, {
+        agentId,
+        prompt: `keep direct ${model} on the standard runtime`,
+        model,
+      });
+      await flushWaitUntilForTest();
+      await expect
+        .poll(() => {
+          return apiDispatchTimingEventsForRun(run.runId).some((event) => {
+            return event.op_type === "api_dispatch_build_runner_job_payload";
+          });
+        })
+        .toBe(true);
+      expectPiLaunchResourceTiming(
+        apiDispatchTimingEventsForRun(run.runId),
+        "not_required",
+      );
+      const claimed = await claimChatRun(runnerGroup, run.runId);
+      expect(claimed.claim.cliAgentType).toBe("codex");
+      expect(claimed.claim.piLaunchConfig).toBeUndefined();
+      await cancelChatRun(actor, run.runId, claimed.sandboxHeaders);
+    },
+    30_000,
+  );
 
   it("reuses a Codex session across DeepSeek V4 model switches", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -141,6 +141,11 @@ type BddSendEventBody =
       readonly clientEventId?: string;
     };
 
+interface RequestSendEventOptions {
+  readonly publicBrand?: PublicBrand;
+  readonly usagePricingResolution?: UsagePricingResolution;
+}
+
 function authHeaders(actor: ApiTestUser | null): AuthHeaders {
   return actor
     ? {
@@ -356,10 +361,6 @@ export function createChatFilesBddApi(context: TestContext) {
 
   function threadComputerUseHostClient() {
     return chatFilesApp(context)(chatThreadComputerUseHostContract);
-  }
-
-  function chatEventsClient() {
-    return chatFilesApp(context)(chatEventsContract);
   }
 
   function chatSearchClient() {
@@ -1317,17 +1318,17 @@ export function createChatFilesBddApi(context: TestContext) {
         | 429
         | 503
       )[],
+      options: RequestSendEventOptions = {},
       signal?: AbortSignal,
-      publicBrand: PublicBrand = "vm0",
-      usagePricingResolution?: UsagePricingResolution,
     ) {
+      const publicBrand = options.publicBrand ?? "vm0";
       const client = setupAppWithRoutes({
         context,
         routes: chatFilesRoutes,
         ...(signal === undefined ? {} : { signal }),
-        ...(usagePricingResolution === undefined
+        ...(options.usagePricingResolution === undefined
           ? {}
-          : { usagePricingResolution }),
+          : { usagePricingResolution: options.usagePricingResolution }),
       })(chatEventsContract);
       const defaultModel =
         "prompt" in body &&

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -72,6 +72,7 @@ import {
 } from "@okouai/api-contracts/contracts/uploads";
 import { setupAppWithRoutes } from "../../../../__tests__/test-app";
 import { accept, type TestContext } from "../../../../__tests__/test-context";
+import type { UsagePricingResolution } from "../../../context/usage-pricing-resolution";
 import {
   buildArtifactKey,
   sanitizeArtifactFilename,
@@ -1318,12 +1319,16 @@ export function createChatFilesBddApi(context: TestContext) {
       )[],
       signal?: AbortSignal,
       publicBrand: PublicBrand = "vm0",
+      usagePricingResolution?: UsagePricingResolution,
     ) {
-      const client = signal
-        ? setupAppWithRoutes({ context, routes: chatFilesRoutes, signal })(
-            chatEventsContract,
-          )
-        : chatEventsClient();
+      const client = setupAppWithRoutes({
+        context,
+        routes: chatFilesRoutes,
+        ...(signal === undefined ? {} : { signal }),
+        ...(usagePricingResolution === undefined
+          ? {}
+          : { usagePricingResolution }),
+      })(chatEventsContract);
       const defaultModel =
         "prompt" in body &&
         body.threadId === undefined &&

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -171,8 +171,15 @@ const runRoutes = [
   ...userPermissionGrantsRoutes,
 ] as const;
 
-function runApp(context: TestContext) {
-  return setupAppWithRoutes({ context, routes: runRoutes });
+function runApp(
+  context: TestContext,
+  usagePricingResolution?: UsagePricingResolution,
+) {
+  return setupAppWithRoutes({
+    context,
+    routes: runRoutes,
+    ...(usagePricingResolution === undefined ? {} : { usagePricingResolution }),
+  });
 }
 
 function clerkUserProfile(actor: ApiTestUser): ClerkUserProfile {
@@ -1167,9 +1174,13 @@ export function createRunsApi(context: TestContext) {
       actor: ApiTestUser | null,
       runId: string,
       statuses: readonly (200 | 400 | 401 | 403 | 404)[],
+      usagePricingResolution?: UsagePricingResolution,
     ) {
       return await accept(
-        runApp(context)(runsCancelContract).cancel({
+        runApp(
+          context,
+          usagePricingResolution,
+        )(runsCancelContract).cancel({
           headers: authenticate(context, actor),
           params: { id: runId },
         }),
@@ -1379,16 +1390,10 @@ export function createRunsApi(context: TestContext) {
       };
     },
 
-    async reconcileBillingOrganizations(
-      orgIds: readonly string[],
-      usagePricingResolution?: UsagePricingResolution,
-    ) {
+    async reconcileBillingOrganizations(orgIds: readonly string[]) {
       const client = setupAppWithRoutes({
         context,
         routes: testBillingReconciliationStateRoutes,
-        ...(usagePricingResolution === undefined
-          ? {}
-          : { usagePricingResolution }),
       })(testBillingReconciliationStateContract);
       return await accept(
         client.reconcile({

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -56,6 +56,7 @@ import { apiTestS3PresignedUrl } from "../../../../__tests__/mocks";
 import { mockEnv, mockOptionalEnv } from "../../../../lib/env";
 import { now, withNowScopeForTest } from "../../../../lib/time";
 import { createDeferredPromise } from "../../../utils";
+import type { UsagePricingResolution } from "../../../context/usage-pricing-resolution";
 import {
   createDirectAgentExecutionFixture,
   createDirectRunFixture,
@@ -1378,10 +1379,16 @@ export function createRunsApi(context: TestContext) {
       };
     },
 
-    async reconcileBillingOrganizations(orgIds: readonly string[]) {
+    async reconcileBillingOrganizations(
+      orgIds: readonly string[],
+      usagePricingResolution?: UsagePricingResolution,
+    ) {
       const client = setupAppWithRoutes({
         context,
         routes: testBillingReconciliationStateRoutes,
+        ...(usagePricingResolution === undefined
+          ? {}
+          : { usagePricingResolution }),
       })(testBillingReconciliationStateContract);
       return await accept(
         client.reconcile({

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
@@ -26,6 +26,7 @@ import { env, mockEnv, mockOptionalEnv } from "../../../../lib/env";
 import { now } from "../../../../lib/time";
 import { server } from "../../../../mocks/server";
 import { generateSandboxToken } from "../../../auth/tokens";
+import type { UsagePricingResolution } from "../../../context/usage-pricing-resolution";
 import { mockStripeClient } from "../../../external/stripe-client";
 import { accept, type TestContext } from "../../../../__tests__/test-context";
 import { setupApp } from "../../../../__tests__/test-helpers";
@@ -568,6 +569,7 @@ export function createWebhookCallbackApi(context: TestContext) {
       headers: SandboxWebhookHeaders,
       statuses: readonly (200 | 400 | 401 | 404 | 500)[],
       signal?: AbortSignal,
+      usagePricingResolution?: UsagePricingResolution,
     ) {
       const historyHash = body.checkpoint?.cliAgentSessionHistoryHash;
       if (historyHash !== undefined) {
@@ -594,15 +596,14 @@ export function createWebhookCallbackApi(context: TestContext) {
           );
         }
       }
-      const client = signal
-        ? setupAppWithRoutes({
-            context,
-            routes: webhooksAgentCompleteRoutes,
-            signal,
-          })(webhookCompleteContract)
-        : setupApp({ context, routes: webhooksAgentCompleteRoutes })(
-            webhookCompleteContract,
-          );
+      const client = setupAppWithRoutes({
+        context,
+        routes: webhooksAgentCompleteRoutes,
+        ...(signal === undefined ? {} : { signal }),
+        ...(usagePricingResolution === undefined
+          ? {}
+          : { usagePricingResolution }),
+      })(webhookCompleteContract);
       return await accept(
         client.complete({
           headers,
@@ -785,14 +786,16 @@ export function createWebhookCallbackApi(context: TestContext) {
       body: AgentUsageEventBody,
       headers: SandboxWebhookHeaders,
       statuses: readonly (200 | 400 | 401 | 404 | 500)[],
+      usagePricingResolution?: UsagePricingResolution,
     ) {
       return await accept(
-        setupApp({ context, routes: webhooksAgentHealthUsageTelemetryRoutes })(
-          webhookUsageEventContract,
-        ).send({
-          headers,
-          body,
-        }),
+        setupApp({
+          context,
+          routes: webhooksAgentHealthUsageTelemetryRoutes,
+          ...(usagePricingResolution === undefined
+            ? {}
+            : { usagePricingResolution }),
+        })(webhookUsageEventContract).send({ headers, body }),
         statuses,
       );
     },

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -600,16 +600,6 @@ export async function mutateRunnerJobSecretValueEnvironmentKeys(
   });
 }
 
-export async function enableQueuedPiOwnershipTransferFixture(
-  context: TestContext,
-  runId: string,
-): Promise<void> {
-  await postAction(context, {
-    action: "enable-queued-pi-ownership-transfer",
-    run_id: runId,
-  });
-}
-
 export async function mutateRunnerJobConnectorPermissionBaseline(
   context: TestContext,
   runId: string,

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -10,10 +10,7 @@ import {
 } from "@okouai/api-contracts/contracts/test-runtime-state";
 import { chatEventRowSchema } from "@okouai/api-contracts/contracts/chat-event-rows";
 import { CURRENT_CHAT_EVENT_SCHEMA_VERSION } from "@okouai/api-contracts/contracts/chat-event-schema-version";
-import {
-  compatibleStoredExecutionContextSchema,
-  storedExecutionContextSchema,
-} from "@okouai/api-contracts/contracts/runners";
+import { compatibleStoredExecutionContextSchema } from "@okouai/api-contracts/contracts/runners";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { agentRunCallbacks } from "@okouai/db/schema/agent-run-callback";
 import { agentRunQueue } from "@okouai/db/schema/agent-run-queue";
@@ -64,10 +61,6 @@ import { usagePackPurchaseSerializationSchemaAvailable } from "../services/usage
 import { encryptPersistentSecretValue } from "../services/crypto.utils";
 import { writeRunMetadata } from "../services/agent-run-metadata-write.service";
 import { saveRunSummary } from "../services/run-summary.service";
-import {
-  decryptQueuedRunnerJobPayload,
-  encryptQueuedRunnerJobPayload,
-} from "../services/agent-run-queue-payload.service";
 import { reconcileSocialKitDownloads$ } from "../services/socialkit-download.service";
 import { steerRunNearTimeBudgetForTest } from "../services/cron-steer-run-time-budget.service";
 import {
@@ -1793,59 +1786,6 @@ async function setRunnerJobContextProfileAsPreviousApi(
   return { status: 200 as const, body: { ok: true as const } };
 }
 
-async function enableQueuedPiOwnershipTransfer(
-  db: Db,
-  runId: string,
-  signal: AbortSignal,
-): Promise<void> {
-  // Production intentionally leaves this capability absent until a future
-  // route selects a proven-compatible Sandbox. This test-only mutation lets
-  // BDD exercise that deployment boundary without adding a production writer.
-  const [row] = await db
-    .select({ encryptedParams: agentRunQueue.encryptedParams })
-    .from(agentRunQueue)
-    .where(eq(agentRunQueue.runId, runId))
-    .limit(1);
-  signal.throwIfAborted();
-  const payload = await decryptQueuedRunnerJobPayload(
-    row?.encryptedParams ?? null,
-  );
-  signal.throwIfAborted();
-  const piLaunchConfig = payload?.executionContext.piLaunchConfig;
-  if (!payload || !piLaunchConfig) {
-    throw new Error("Expected a queued Pi runner payload");
-  }
-  const executionContext = storedExecutionContextSchema.parse({
-    ...payload.executionContext,
-    piLaunchConfig: {
-      ...piLaunchConfig,
-      apiFirstTurn: {
-        ...piLaunchConfig.apiFirstTurn,
-        ownershipTransfer: { schemaVersion: 1 },
-      },
-    },
-  });
-  const encryptedParams = await encryptQueuedRunnerJobPayload({
-    version: payload.version,
-    runnerGroup: payload.runnerGroup,
-    profile: payload.profile,
-    cliAgentSessionId: payload.cliAgentSessionId,
-    reuseKey: payload.reuseKey,
-    historyGenerationRunId: payload.historyGenerationRunId,
-    executionContext,
-  });
-  signal.throwIfAborted();
-  const [updated] = await db
-    .update(agentRunQueue)
-    .set({ encryptedParams })
-    .where(eq(agentRunQueue.runId, runId))
-    .returning({ runId: agentRunQueue.runId });
-  signal.throwIfAborted();
-  if (!updated) {
-    throw new Error("Expected a queued Pi runner payload to update");
-  }
-}
-
 type CompatibilityFixtureAction =
   | AutonomyBudgetFixtureAction
   | LegacyArtifactCatalogFileAction
@@ -2579,10 +2519,6 @@ const postRuntimeStateAction$ = command(
           body.mode,
           signal,
         );
-        return { status: 200 as const, body: { ok: true as const } };
-      }
-      case "enable-queued-pi-ownership-transfer": {
-        await enableQueuedPiOwnershipTransfer(db, body.run_id, signal);
         return { status: 200 as const, body: { ok: true as const } };
       }
       case "set-runner-job-connector-runtime-targets": {

--- a/turbo/apps/api/src/signals/services/__tests__/pi-sandbox-config.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-sandbox-config.test.ts
@@ -62,17 +62,106 @@ describe("Pi sandbox model configuration", () => {
     ).toBeNull();
   });
 
-  it("does not make Terra eligible for Pi execution", () => {
+  it.each(["web", "agent"] as const)(
+    "makes standard built-in Terra eligible for %s chat",
+    (triggerSource) => {
+      expect(
+        shouldUsePiExecution({
+          chatThreadId: "thread-id",
+          modelProviderType: "built-in",
+          selectedModel: "gpt-5.6-terra",
+          codexServiceTier: undefined,
+          triggerSource,
+          featureSwitchContext: {
+            overrides: { [FeatureSwitchKey.PiLoop]: true },
+          },
+        }),
+      ).toBeTruthy();
+    },
+  );
+
+  it.each([
+    {
+      name: "feature switch off",
+      modelProviderType: "built-in",
+      selectedModel: "gpt-5.6-terra",
+      codexServiceTier: undefined,
+      triggerSource: "web" as const,
+      chatThreadId: "thread-id",
+      enabled: false,
+    },
+    {
+      name: "fast Terra",
+      modelProviderType: "built-in",
+      selectedModel: "gpt-5.6-terra",
+      codexServiceTier: "fast" as const,
+      triggerSource: "web" as const,
+      chatThreadId: "thread-id",
+      enabled: true,
+    },
+    {
+      name: "Terra BYOK",
+      modelProviderType: "openai-api-key",
+      selectedModel: "gpt-5.6-terra",
+      codexServiceTier: undefined,
+      triggerSource: "web" as const,
+      chatThreadId: "thread-id",
+      enabled: true,
+    },
+    {
+      name: "non-Web trigger",
+      modelProviderType: "built-in",
+      selectedModel: "gpt-5.6-terra",
+      codexServiceTier: undefined,
+      triggerSource: "slack" as const,
+      chatThreadId: "thread-id",
+      enabled: true,
+    },
+    {
+      name: "unbound chat thread",
+      modelProviderType: "built-in",
+      selectedModel: "gpt-5.6-terra",
+      codexServiceTier: undefined,
+      triggerSource: "web" as const,
+      chatThreadId: undefined,
+      enabled: true,
+    },
+    {
+      name: "unrelated model",
+      modelProviderType: "built-in",
+      selectedModel: "gpt-5.6-sol",
+      codexServiceTier: undefined,
+      triggerSource: "web" as const,
+      chatThreadId: "thread-id",
+      enabled: true,
+    },
+  ])("keeps $name on Codex", (testCase) => {
+    expect(
+      shouldUsePiExecution({
+        chatThreadId: testCase.chatThreadId,
+        modelProviderType: testCase.modelProviderType,
+        selectedModel: testCase.selectedModel,
+        codexServiceTier: testCase.codexServiceTier,
+        triggerSource: testCase.triggerSource,
+        featureSwitchContext: {
+          overrides: { [FeatureSwitchKey.PiLoop]: testCase.enabled },
+        },
+      }),
+    ).toBeFalsy();
+  });
+
+  it("preserves existing built-in DeepSeek Pi routing", () => {
     expect(
       shouldUsePiExecution({
         chatThreadId: "thread-id",
         modelProviderType: "built-in",
-        selectedModel: "gpt-5.6-terra",
+        selectedModel: "deepseek-v4-flash",
+        codexServiceTier: "fast",
         triggerSource: "web",
         featureSwitchContext: {
           overrides: { [FeatureSwitchKey.PiLoop]: true },
         },
       }),
-    ).toBeFalsy();
+    ).toBeTruthy();
   });
 });

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -1510,36 +1510,26 @@ function frameworkApiKeyEnv(framework: SupportedFramework): string {
   return framework === "codex" ? "OPENAI_API_KEY" : "ANTHROPIC_API_KEY";
 }
 
-function autoMemoryMountPath(
-  framework: SupportedFramework,
-  usePiMemoryPath: boolean,
-): string {
-  if (usePiMemoryPath) {
-    return PI_MEMORY_ROOT;
-  }
+function autoMemoryMountPath(framework: SupportedFramework): string {
   return framework === "codex"
     ? CANONICAL_CODEX_MEMORY_MOUNT_PATH
     : CANONICAL_CLAUDE_MEMORY_MOUNT_PATH;
 }
 
-function autoMemoryArtifact(
-  framework: SupportedFramework,
-  usePiMemoryPath: boolean,
-): ContextArtifact {
+function autoMemoryArtifact(framework: SupportedFramework): ContextArtifact {
   return withAutoMemoryMissingRootPolicy({
     name: AUTO_MEMORY_ARTIFACT_NAME,
-    mountPath: autoMemoryMountPath(framework, usePiMemoryPath),
+    mountPath: autoMemoryMountPath(framework),
   });
 }
 
 function isCanonicalAutoMemoryArtifact(
   artifact: ContextArtifact,
   framework: SupportedFramework,
-  usePiMemoryPath: boolean,
 ): boolean {
   return (
     artifact.name === AUTO_MEMORY_ARTIFACT_NAME &&
-    artifact.mountPath === autoMemoryMountPath(framework, usePiMemoryPath)
+    artifact.mountPath === autoMemoryMountPath(framework)
   );
 }
 
@@ -1555,10 +1545,9 @@ function withAutoMemoryMissingRootPolicy(
 function withCanonicalAutoMemoryMissingRootPolicy(
   artifacts: readonly ContextArtifact[],
   framework: SupportedFramework,
-  usePiMemoryPath: boolean,
 ): readonly ContextArtifact[] {
   return artifacts.map((artifact) => {
-    return isCanonicalAutoMemoryArtifact(artifact, framework, usePiMemoryPath)
+    return isCanonicalAutoMemoryArtifact(artifact, framework)
       ? withAutoMemoryMissingRootPolicy(artifact)
       : artifact;
   });
@@ -1567,24 +1556,22 @@ function withCanonicalAutoMemoryMissingRootPolicy(
 function claimsAutoMemorySlot(
   artifact: ContextArtifact,
   framework: SupportedFramework,
-  usePiMemoryPath: boolean,
 ): boolean {
   return (
     artifact.name === AUTO_MEMORY_ARTIFACT_NAME ||
-    artifact.mountPath === autoMemoryMountPath(framework, usePiMemoryPath)
+    artifact.mountPath === autoMemoryMountPath(framework)
   );
 }
 
 function withoutSupersededAutoMemoryArtifacts(
   artifacts: readonly ContextArtifact[],
   framework: SupportedFramework,
-  usePiMemoryPath: boolean,
   slotOwnerIndex: number,
 ): readonly ContextArtifact[] {
   return artifacts.filter((artifact, index) => {
     return (
       index >= slotOwnerIndex ||
-      !isCanonicalAutoMemoryArtifact(artifact, framework, usePiMemoryPath)
+      !isCanonicalAutoMemoryArtifact(artifact, framework)
     );
   });
 }
@@ -1610,7 +1597,7 @@ function composeArtifacts(
 function artifactsForRun(args: {
   readonly resolved: ResolvedAgentExecution;
   readonly framework: SupportedFramework;
-  readonly usePiMemoryPath: boolean;
+  readonly includeAutoMemory: boolean;
   readonly bodyArtifacts: readonly ContextArtifact[] | undefined;
 }): RunArtifacts {
   const isContinuation = Boolean(args.resolved.agentSessionId);
@@ -1622,40 +1609,37 @@ function artifactsForRun(args: {
     : [...composeContextArtifacts, ...args.resolved.artifacts];
   const bodyArtifacts = args.bodyArtifacts ?? [];
   const artifacts = [...baseArtifacts, ...bodyArtifacts];
+  if (!args.includeAutoMemory) {
+    return {
+      artifacts: artifacts.filter((artifact) => {
+        return (
+          artifact.name !== AUTO_MEMORY_ARTIFACT_NAME &&
+          artifact.mountPath !== PI_MEMORY_ROOT
+        );
+      }),
+    };
+  }
 
   let autoMemorySlotArtifactIndex: number | undefined;
   for (let index = artifacts.length - 1; index >= 0; index -= 1) {
     const artifact = artifacts[index];
-    if (
-      artifact &&
-      claimsAutoMemorySlot(artifact, args.framework, args.usePiMemoryPath)
-    ) {
+    if (artifact && claimsAutoMemorySlot(artifact, args.framework)) {
       autoMemorySlotArtifactIndex = index;
       break;
     }
   }
   if (autoMemorySlotArtifactIndex === undefined) {
     return {
-      artifacts: [
-        ...artifacts,
-        autoMemoryArtifact(args.framework, args.usePiMemoryPath),
-      ],
+      artifacts: [...artifacts, autoMemoryArtifact(args.framework)],
     };
   }
 
   const slotOwner = artifacts[autoMemorySlotArtifactIndex]!;
-  if (
-    !isCanonicalAutoMemoryArtifact(
-      slotOwner,
-      args.framework,
-      args.usePiMemoryPath,
-    )
-  ) {
+  if (!isCanonicalAutoMemoryArtifact(slotOwner, args.framework)) {
     return {
       artifacts: withoutSupersededAutoMemoryArtifacts(
         artifacts,
         args.framework,
-        args.usePiMemoryPath,
         autoMemorySlotArtifactIndex,
       ),
     };
@@ -1665,7 +1649,6 @@ function artifactsForRun(args: {
     artifacts: withCanonicalAutoMemoryMissingRootPolicy(
       artifacts,
       args.framework,
-      args.usePiMemoryPath,
     ),
   };
 }
@@ -7012,6 +6995,7 @@ function preparePiLaunchResources(args: {
             schemaVersion: 2,
             apiFirstTurn: {
               schemaVersion: 1,
+              ownershipTransfer: { schemaVersion: 1 },
               resourceSnapshotDigest: piResourceSnapshotDigest(
                 piResourceDiscoveryMounts(args.storageMounts),
               ),
@@ -7020,9 +7004,6 @@ function preparePiLaunchResources(args: {
               deadlineAt: args.apiStartTime + PI_API_FIRST_TURN_TIMEOUT_MS,
               baseSession: piBaseSession(resumeSession, chatThreadId),
               sandboxEventSequenceStart: 1,
-              // Consumer-first rollout: keep V3 ownership transfer disabled
-              // until the compatible CLI and Guest release is proven live on
-              // every Pi-eligible Sandbox path.
             },
           },
           resumeSession,
@@ -8260,12 +8241,16 @@ interface FinalizedPreparedRunContext extends PreparedRunContext {
 function isPiSandboxEnabledForRun(
   createArgs: CreateAgentRunArgs,
   featureSwitchContext: FeatureSwitchContext,
-  modelProvider: ResolvedModelProviderEnvironment | null,
 ): boolean {
   return shouldUsePiExecution({
     chatThreadId: createArgs.chatThreadId,
-    modelProviderType: modelProvider?.type,
-    selectedModel: createArgs.selectedModelOverride,
+    modelProviderType:
+      createArgs.agentRunModelPin?.modelProvider ??
+      createArgs.modelProviderType,
+    selectedModel:
+      createArgs.agentRunModelPin?.selectedModel ??
+      createArgs.selectedModelOverride,
+    codexServiceTier: createArgs.codexServiceTier,
     triggerSource: createArgs.body.triggerSource,
     featureSwitchContext,
   });
@@ -8276,13 +8261,7 @@ function resolvePreparedPiModelConfig(args: {
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
 }): PiModelConfig | undefined {
-  if (
-    !isPiSandboxEnabledForRun(
-      args.createArgs,
-      args.featureSwitchContext,
-      args.modelProvider,
-    )
-  ) {
+  if (!isPiSandboxEnabledForRun(args.createArgs, args.featureSwitchContext)) {
     return undefined;
   }
   const config = resolvePiSandboxModelConfig(args.modelProvider);
@@ -9260,7 +9239,7 @@ function prepareRunOutputMetadata(args: {
   const artifacts = artifactsForRun({
     resolved: args.resolved,
     framework: args.framework,
-    usePiMemoryPath: args.piSandbox !== undefined,
+    includeAutoMemory: args.piSandbox === undefined,
     bodyArtifacts: args.body.artifacts,
   }).artifacts;
   return {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -8244,12 +8244,8 @@ function isPiSandboxEnabledForRun(
 ): boolean {
   return shouldUsePiExecution({
     chatThreadId: createArgs.chatThreadId,
-    modelProviderType:
-      createArgs.agentRunModelPin?.modelProvider ??
-      createArgs.modelProviderType,
-    selectedModel:
-      createArgs.agentRunModelPin?.selectedModel ??
-      createArgs.selectedModelOverride,
+    modelProviderType: createArgs.agentRunModelPin?.modelProvider,
+    selectedModel: createArgs.agentRunModelPin?.selectedModel,
     codexServiceTier: createArgs.codexServiceTier,
     triggerSource: createArgs.body.triggerSource,
     featureSwitchContext,

--- a/turbo/apps/api/src/signals/services/chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/chat-events.command.ts
@@ -2686,6 +2686,7 @@ function usesPi(
     modelProviderType:
       runConfiguration.providerAdmission.effectiveModelProvider,
     selectedModel: runConfiguration.modelPin.selectedModel ?? undefined,
+    codexServiceTier: runConfiguration.codexServiceTier,
     triggerSource: normalSendTriggerSource(args.auth),
     featureSwitchContext: featureSwitches.featureSwitchContext,
   });

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn-config.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn-config.ts
@@ -15,6 +15,7 @@ export interface PiApiFirstTurnActivation {
     StoredExecutionContext,
     | "encryptedSecrets"
     | "environment"
+    | "modelUsageProvider"
     | "resumeSession"
     | "secretConnectorMap"
     | "secretConnectorMetadataMap"
@@ -36,6 +37,7 @@ export function requirePiApiFirstTurnExecutionContext(
     | "apiStartTime"
     | "encryptedSecrets"
     | "environment"
+    | "modelUsageProvider"
     | "piLaunchConfig"
     | "piModelConfig"
     | "piSessionId"
@@ -57,6 +59,7 @@ export function requirePiApiFirstTurnExecutionContext(
     apiStartTime: context.apiStartTime,
     encryptedSecrets: context.encryptedSecrets,
     environment: context.environment,
+    modelUsageProvider: context.modelUsageProvider,
     piLaunchConfig: context.piLaunchConfig,
     piModelConfig: context.piModelConfig,
     piSessionId: context.piSessionId,

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn-usage.service.ts
@@ -15,6 +15,17 @@ const PI_API_FIRST_TURN_OBSERVATION_NAMESPACE =
   "670e6ebc-79c3-4f44-b322-e26d1be7cf2e";
 const TERRA_MODEL = "gpt-5.6-terra";
 
+function terraLongContextMinimumInputTokens(): number {
+  const minimum = MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS[TERRA_MODEL];
+  if (minimum === undefined) {
+    throw new Error("Terra long-context pricing threshold is missing");
+  }
+  return minimum;
+}
+
+const TERRA_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS =
+  terraLongContextMinimumInputTokens();
+
 type PiUsageCategoryBase =
   | "tokens.input"
   | "tokens.output"
@@ -65,8 +76,7 @@ function piApiFirstTurnUsageEntries(
   const cacheCreation = usageQuantity(usage.cacheWrite, "cache-creation");
   const longContext =
     input + cacheRead + cacheCreation >=
-    (MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS[TERRA_MODEL] ??
-      Number.POSITIVE_INFINITY);
+    TERRA_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS;
   const suffix = longContext ? ".long_context" : "";
   return (
     [

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn-usage.service.ts
@@ -1,0 +1,224 @@
+import { createHash } from "node:crypto";
+
+import { MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS } from "@okouai/api-contracts/contracts/model-price-tiers";
+import { modelUsageObservation } from "@okouai/db/schema/model-usage-observation";
+import { usageEvent } from "@okouai/db/schema/usage-event";
+import type { PiApiFirstTurnResult } from "@okouai/pi-agent-runtime/api";
+import { and, eq, inArray } from "drizzle-orm";
+import { v5 as uuidv5 } from "uuid";
+
+import type { Db } from "../external/db";
+
+const PI_API_FIRST_TURN_USAGE_NAMESPACE =
+  "26e1c547-485d-4438-bf6d-4b77959da0cb";
+const PI_API_FIRST_TURN_OBSERVATION_NAMESPACE =
+  "670e6ebc-79c3-4f44-b322-e26d1be7cf2e";
+const TERRA_MODEL = "gpt-5.6-terra";
+
+type PiUsageCategoryBase =
+  | "tokens.input"
+  | "tokens.output"
+  | "tokens.cache_read"
+  | "tokens.cache_creation";
+type PiUsageCategory =
+  | PiUsageCategoryBase
+  | `${PiUsageCategoryBase}.long_context`;
+
+interface PiApiFirstTurnUsageEntry {
+  readonly category: PiUsageCategory;
+  readonly quantity: number;
+}
+
+interface RecordPiApiFirstTurnUsageArgs {
+  readonly runId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly modelUsageProvider: string | undefined;
+  readonly turn: PiApiFirstTurnResult;
+}
+
+function usageQuantity(value: number, field: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`Pi API first-turn ${field} usage is invalid`);
+  }
+  return value;
+}
+
+function sourceId(turn: PiApiFirstTurnResult): string {
+  return (
+    turn.assistantMessage.responseId ??
+    createHash("sha256").update(turn.sessionJsonl).digest("hex")
+  );
+}
+
+function idempotencyKey(namespace: string, parts: readonly string[]): string {
+  return uuidv5(JSON.stringify(parts), namespace);
+}
+
+function piApiFirstTurnUsageEntries(
+  turn: PiApiFirstTurnResult,
+): readonly PiApiFirstTurnUsageEntry[] {
+  const usage = turn.assistantMessage.usage;
+  const input = usageQuantity(usage.input, "input");
+  const output = usageQuantity(usage.output, "output");
+  const cacheRead = usageQuantity(usage.cacheRead, "cache-read");
+  const cacheCreation = usageQuantity(usage.cacheWrite, "cache-creation");
+  const longContext =
+    input + cacheRead + cacheCreation >=
+    (MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS[TERRA_MODEL] ??
+      Number.POSITIVE_INFINITY);
+  const suffix = longContext ? ".long_context" : "";
+  return (
+    [
+      { category: `tokens.input${suffix}`, quantity: input },
+      { category: `tokens.output${suffix}`, quantity: output },
+      { category: `tokens.cache_read${suffix}`, quantity: cacheRead },
+      {
+        category: `tokens.cache_creation${suffix}`,
+        quantity: cacheCreation,
+      },
+    ] satisfies readonly {
+      readonly category: PiUsageCategory;
+      readonly quantity: number;
+    }[]
+  ).filter((entry) => {
+    return entry.quantity > 0;
+  });
+}
+
+function sameObservation(
+  row: typeof modelUsageObservation.$inferSelect,
+  expected: typeof modelUsageObservation.$inferInsert,
+): boolean {
+  return (
+    row.model === expected.model &&
+    row.inputTokens === expected.inputTokens &&
+    row.outputTokens === expected.outputTokens &&
+    row.cacheReadInputTokens === expected.cacheReadInputTokens &&
+    row.cacheCreationInputTokens === expected.cacheCreationInputTokens
+  );
+}
+
+/**
+ * Persist API-owned Terra usage before any lifecycle commit. The response
+ * identity owns both billing and public model observation rows, so retries and
+ * late cancellation observers converge on the same immutable records. Sandbox
+ * provider calls keep their independent MITM-owned delivery identities.
+ */
+export async function recordPiApiFirstTurnUsage(
+  db: Db,
+  args: RecordPiApiFirstTurnUsageArgs,
+): Promise<void> {
+  if (args.modelUsageProvider !== TERRA_MODEL) {
+    return;
+  }
+  const responseSourceId = sourceId(args.turn);
+  const entries = piApiFirstTurnUsageEntries(args.turn);
+  const usageRows = entries.map((entry) => {
+    return {
+      runId: args.runId,
+      idempotencyKey: idempotencyKey(PI_API_FIRST_TURN_USAGE_NAMESPACE, [
+        args.runId,
+        responseSourceId,
+        entry.category,
+      ]),
+      orgId: args.orgId,
+      userId: args.userId,
+      kind: "model",
+      provider: TERRA_MODEL,
+      category: entry.category,
+      quantity: entry.quantity,
+    } as const;
+  });
+  const usage = args.turn.assistantMessage.usage;
+  const observationRow = {
+    idempotencyKey: idempotencyKey(PI_API_FIRST_TURN_OBSERVATION_NAMESPACE, [
+      args.runId,
+      responseSourceId,
+    ]),
+    model: TERRA_MODEL,
+    inputTokens: usageQuantity(usage.input, "input"),
+    outputTokens: usageQuantity(usage.output, "output"),
+    cacheReadInputTokens: usageQuantity(usage.cacheRead, "cache-read"),
+    cacheCreationInputTokens: usageQuantity(usage.cacheWrite, "cache-creation"),
+  } as const;
+
+  await db.transaction(async (tx) => {
+    if (usageRows.length > 0) {
+      await tx
+        .insert(usageEvent)
+        .values(usageRows)
+        .onConflictDoNothing({ target: [usageEvent.idempotencyKey] });
+      const storedUsageRows = await tx
+        .select({
+          idempotencyKey: usageEvent.idempotencyKey,
+          runId: usageEvent.runId,
+          orgId: usageEvent.orgId,
+          userId: usageEvent.userId,
+          kind: usageEvent.kind,
+          provider: usageEvent.provider,
+          category: usageEvent.category,
+          quantity: usageEvent.quantity,
+        })
+        .from(usageEvent)
+        .where(
+          inArray(
+            usageEvent.idempotencyKey,
+            usageRows.map((row) => {
+              return row.idempotencyKey;
+            }),
+          ),
+        );
+      const expectedByKey = new Map(
+        usageRows.map((row) => {
+          return [row.idempotencyKey, row] as const;
+        }),
+      );
+      for (const row of storedUsageRows) {
+        const expected = expectedByKey.get(row.idempotencyKey);
+        if (
+          !expected ||
+          row.runId !== expected.runId ||
+          row.orgId !== expected.orgId ||
+          row.userId !== expected.userId ||
+          row.kind !== expected.kind ||
+          row.provider !== expected.provider ||
+          row.category !== expected.category ||
+          row.quantity !== expected.quantity
+        ) {
+          throw new Error("Pi API first-turn usage identity collision");
+        }
+        expectedByKey.delete(row.idempotencyKey);
+      }
+      if (expectedByKey.size > 0) {
+        throw new Error("Pi API first-turn usage persistence is incomplete");
+      }
+    }
+
+    await tx
+      .insert(modelUsageObservation)
+      .values(observationRow)
+      .onConflictDoNothing({
+        target: [modelUsageObservation.idempotencyKey],
+      });
+    const [storedObservation] = await tx
+      .select()
+      .from(modelUsageObservation)
+      .where(
+        and(
+          eq(
+            modelUsageObservation.idempotencyKey,
+            observationRow.idempotencyKey,
+          ),
+          eq(modelUsageObservation.model, TERRA_MODEL),
+        ),
+      )
+      .limit(1);
+    if (
+      !storedObservation ||
+      !sameObservation(storedObservation, observationRow)
+    ) {
+      throw new Error("Pi API first-turn observation identity collision");
+    }
+  });
+}

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
@@ -68,6 +68,7 @@ import {
   piApiFirstTurnObjectKey,
   type PiApiFirstTurnActivation,
 } from "./pi-api-first-turn-config";
+import { recordPiApiFirstTurnUsage } from "./pi-api-first-turn-usage.service";
 import {
   PiResourceSnapshotPreparationError,
   preparePiResourceSnapshot,
@@ -846,13 +847,20 @@ async function resolveApiFirstTurnKey(
 
 async function observeDiscardedProviderResult(
   operation: Promise<PiApiFirstTurnResult>,
-  runId: string,
+  args: ApiFirstTurnContext,
   ownership: PiApiFirstTurnOwnership,
 ): Promise<void> {
   const late = await settleIncludingAbort(operation);
   if (late.ok) {
+    await recordPiApiFirstTurnUsage(args.db, {
+      runId: args.activation.runId,
+      orgId: args.activation.orgId,
+      userId: args.activation.userId,
+      modelUsageProvider: args.activation.executionContext.modelUsageProvider,
+      turn: late.value,
+    });
     L.warn("Pi API first-turn outcome", {
-      runId,
+      runId: args.activation.runId,
       outcome: "discarded_late_provider_result",
       reason: "aborted_execution",
       ownershipStage: ownership.stage,
@@ -932,11 +940,7 @@ async function executeApiModelTurn(
   if (!executed.ok) {
     if (modelSignal.aborted) {
       waitUntil(
-        observeDiscardedProviderResult(
-          operation,
-          args.activation.runId,
-          args.ownership,
-        ),
+        observeDiscardedProviderResult(operation, args.context, args.ownership),
       );
     }
     if (
@@ -971,6 +975,13 @@ async function executeApiModelTurn(
     );
   }
   const turn = executed.value;
+  await recordPiApiFirstTurnUsage(args.context.db, {
+    runId: args.activation.runId,
+    orgId: args.activation.orgId,
+    userId: args.activation.userId,
+    modelUsageProvider: args.executionContext.modelUsageProvider,
+    turn,
+  });
   if (
     turn.assistantMessage.stopReason === "error" ||
     turn.assistantMessage.stopReason === "aborted"

--- a/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
+++ b/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
@@ -82,17 +82,21 @@ export function shouldUsePiExecution(args: {
   readonly chatThreadId: string | undefined;
   readonly modelProviderType: string | null | undefined;
   readonly selectedModel: string | undefined;
+  readonly codexServiceTier: "fast" | undefined;
   readonly triggerSource: TriggerSource;
   readonly featureSwitchContext: FeatureSwitchContext;
 }): boolean {
-  const isPiModel =
+  const isExistingPiModel =
     args.selectedModel === "deepseek-v4-flash" ||
     args.selectedModel === "deepseek-v4-pro";
+  const isStandardTerra =
+    args.selectedModel === "gpt-5.6-terra" &&
+    args.codexServiceTier === undefined;
   return (
     args.chatThreadId !== undefined &&
     isWebChatTriggerSource(args.triggerSource) &&
     isBuiltInModelProviderType(args.modelProviderType) &&
-    isPiModel &&
+    (isExistingPiModel || isStandardTerra) &&
     isFeatureEnabled(FeatureSwitchKey.PiLoop, args.featureSwitchContext)
   );
 }

--- a/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
+++ b/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
@@ -81,7 +81,7 @@ function piCredentialSecretName(
 export function shouldUsePiExecution(args: {
   readonly chatThreadId: string | undefined;
   readonly modelProviderType: string | null | undefined;
-  readonly selectedModel: string | undefined;
+  readonly selectedModel: string | null | undefined;
   readonly codexServiceTier: "fast" | undefined;
   readonly triggerSource: TriggerSource;
   readonly featureSwitchContext: FeatureSwitchContext;

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -2992,6 +2992,11 @@ export async function isVisibleChatEventFixture(
   return event !== undefined;
 }
 
+/**
+ * Usage-ledger rows have no production read endpoint. This test-only fixture is
+ * the narrow external-behavior exception needed to prove exactly-once billing
+ * without exposing internal billing records through a new product API.
+ */
 export async function readRunUsageEventsFixture(runId: string): Promise<
   readonly {
     readonly provider: string;

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -33,6 +33,7 @@ import { githubInstallations } from "@okouai/db/schema/github-installation";
 import { orgModelPolicies } from "@okouai/db/schema/org-model-policy";
 import { runOutputMaterializations } from "@okouai/db/schema/run-output-materialization";
 import { threadGoals } from "@okouai/db/schema/thread-goal";
+import { usageEvent } from "@okouai/db/schema/usage-event";
 import {
   and,
   asc,
@@ -2989,6 +2990,30 @@ export async function isVisibleChatEventFixture(
     .where(and(eq(chatEvents.id, eventId), visibleChatEventCondition(database)))
     .limit(1);
   return event !== undefined;
+}
+
+export async function readRunUsageEventsFixture(runId: string): Promise<
+  readonly {
+    readonly provider: string;
+    readonly category: string;
+    readonly quantity: number;
+    readonly status: string;
+    readonly creditsCharged: number | null;
+    readonly billingError: string | null;
+  }[]
+> {
+  return await db()
+    .select({
+      provider: usageEvent.provider,
+      category: usageEvent.category,
+      quantity: usageEvent.quantity,
+      status: usageEvent.status,
+      creditsCharged: usageEvent.creditsCharged,
+      billingError: usageEvent.billingError,
+    })
+    .from(usageEvent)
+    .where(eq(usageEvent.runId, runId))
+    .orderBy(usageEvent.category);
 }
 
 /**

--- a/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
@@ -394,6 +394,29 @@ function prepareDeepSeekModel(session: MemoryPiSession, baseUrl: string): void {
   });
 }
 
+function prepareTerraModel(session: MemoryPiSession, baseUrl: string): void {
+  session.prepareModelTurn(
+    {
+      id: "gpt-5.6-terra",
+      name: "GPT 5.6 Terra",
+      api: "openai-responses",
+      provider: "openai",
+      baseUrl,
+      reasoning: true,
+      input: ["text", "image"],
+      cost: {
+        input: 2,
+        output: 12,
+        cacheRead: 0.2,
+        cacheWrite: 2.5,
+      },
+      contextWindow: 272_000,
+      maxTokens: 128_000,
+    },
+    "low",
+  );
+}
+
 async function startOwnershipTransferHost(args: {
   readonly root: string;
   readonly jsonl: string;
@@ -403,6 +426,7 @@ async function startOwnershipTransferHost(args: {
     | "settled-session-continuation";
   readonly baseSessionSha256: string | null;
   readonly providerBaseUrl: string;
+  readonly model?: "deepseek" | "terra";
 }): Promise<{
   readonly host: RpcHost;
   readonly handoffServer: Server;
@@ -479,17 +503,21 @@ async function startOwnershipTransferHost(args: {
     }),
     { mode: 0o600 },
   );
+  const terra = args.model === "terra";
   const env = {
     ...process.env,
     OKOU_RUN_ID: RUN_ID,
     OKOU_PI_SESSION_ID: SESSION_ID,
     OKOU_PI_LAUNCH_PAYLOAD_FILE: payloadFile,
     OKOU_PI_MODEL_CONFIG: JSON.stringify({
-      provider: "deepseek",
+      provider: terra ? "openai" : "deepseek",
       baseUrl: args.providerBaseUrl,
-      model: "deepseek-v4-flash",
+      model: terra ? "gpt-5.6-terra" : "deepseek-v4-flash",
+      ...(terra
+        ? { api: "openai-responses" as const, thinkingLevel: "low" as const }
+        : {}),
       apiKeyEnv: "OPENAI_API_KEY",
-      credentialSecretName: "DEEPSEEK_API_KEY",
+      credentialSecretName: terra ? "OPENAI_API_KEY" : "DEEPSEEK_API_KEY",
     }),
     OPENAI_API_KEY: "pi-ownership-transfer-test-key",
   };
@@ -586,29 +614,27 @@ describe("sandbox Pi agent loop", () => {
     }
   });
 
-  it("restores API H1, executes its pending tool, and continues without replaying the prompt", async () => {
-    const root = await mkdtemp(join(tmpdir(), "vm0-pi-handoff-rpc-"));
-    const agentDir = join(root, ".pi", "agent");
-    const sessionDir = join(agentDir, "sessions", "--test--");
-    const sourceFile = join(root, "handoff-source.txt");
-    const prompt = "read the handoff source exactly once";
+  it("restores Terra H1, executes its pending tool, and checkpoints H2", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vm0-pi-terra-handoff-rpc-"));
+    const sourceFile = join(root, "terra-handoff-source.txt");
+    const prompt = "read the Terra handoff source exactly once";
     const provider = await ProviderHarness.start();
     const memory = MemoryPiSession.create({ cwd: root, id: SESSION_ID });
-    prepareDeepSeekModel(memory, provider.baseUrl);
+    prepareTerraModel(memory, provider.baseUrl);
     memory.appendMessage({ role: "user", content: prompt, timestamp: 1 });
     memory.appendMessage({
       role: "assistant",
       content: [
         {
           type: "thinking",
-          thinking: "API-first reasoning preserved for the tool handoff",
+          thinking: "Terra reasoning preserved for the Okou handoff",
           thinkingSignature: JSON.stringify({
             type: "reasoning",
-            id: "rs_api_handoff",
+            id: "rs_terra_okou_handoff",
             content: [
               {
                 type: "reasoning_text",
-                text: "API-first reasoning preserved for the tool handoff",
+                text: "Terra reasoning preserved for the Okou handoff",
               },
             ],
             summary: [],
@@ -616,14 +642,14 @@ describe("sandbox Pi agent loop", () => {
         },
         {
           type: "toolCall",
-          id: "api-read-call",
+          id: "api-terra-read-call",
           name: "read",
           arguments: { path: sourceFile },
         },
       ],
       api: "openai-responses",
-      provider: "deepseek",
-      model: "deepseek-v4-flash",
+      provider: "openai",
+      model: "gpt-5.6-terra",
       usage: {
         input: 5,
         output: 3,
@@ -636,110 +662,44 @@ describe("sandbox Pi agent loop", () => {
       timestamp: 2,
     });
     const h1 = memory.toJsonl();
-    const manifest = {
-      schemaVersion: 2,
-      outcome: "handoff",
-      baseSession: { sessionId: SESSION_ID, sha256: null },
-      session: {
-        sessionId: SESSION_ID,
-        sha256: createHash("sha256").update(h1).digest("hex"),
-        rawSize: Buffer.byteLength(h1),
-      },
-      sandboxEventSequenceStart: 4,
-    };
-    const handoffServer = createServer((request, response) => {
-      if (request.url === "/manifest.json") {
-        response.writeHead(200, { "content-type": "application/json" });
-        response.end(JSON.stringify(manifest));
-        return;
-      }
-      if (request.url === "/session.jsonl") {
-        response.writeHead(200, {
-          "content-type": "application/x-ndjson",
-          "content-length": String(Buffer.byteLength(h1)),
-        });
-        response.end(h1);
-        return;
-      }
-      response.writeHead(404);
-      response.end();
-    });
     let host: RpcHost | undefined;
+    let handoffServer: Server | undefined;
 
     try {
-      await mkdir(agentDir, { recursive: true });
-      await writeFile(sourceFile, "tool output from the sandbox filesystem");
-      await new Promise<void>((resolve, reject) => {
-        handoffServer.once("error", reject);
-        handoffServer.listen(0, "127.0.0.1", () => {
-          handoffServer.off("error", reject);
-          resolve();
-        });
-      });
-      const address = handoffServer.address();
-      if (address === null || typeof address === "string") {
-        throw new Error("Pi handoff test server has no TCP address");
-      }
-      const handoffBaseUrl = `http://127.0.0.1:${address.port}`;
-      const payloadFile = join(root, "launch-payload.json");
       await writeFile(
-        payloadFile,
-        JSON.stringify({
-          schemaVersion: 1,
-          appendSystemPrompt: null,
-          launchConfig: {
-            schemaVersion: 2,
-            apiFirstTurn: {
-              schemaVersion: 1,
-              resourceSnapshotDigest: "a".repeat(64),
-              manifestUrl: `${handoffBaseUrl}/manifest.json`,
-              sessionUrl: `${handoffBaseUrl}/session.jsonl`,
-              deadlineAt: Date.now() + 10_000,
-              baseSession: { sessionId: SESSION_ID, sha256: null },
-              sandboxEventSequenceStart: 1,
-            },
-          },
-        }),
-        { mode: 0o600 },
+        sourceFile,
+        "Terra tool output from the sandbox filesystem",
       );
-      const env = {
-        ...process.env,
-        OKOU_RUN_ID: RUN_ID,
-        OKOU_PI_SESSION_ID: SESSION_ID,
-        OKOU_PI_LAUNCH_PAYLOAD_FILE: payloadFile,
-        OKOU_PI_MODEL_CONFIG: JSON.stringify({
-          provider: "deepseek",
-          baseUrl: provider.baseUrl,
-          model: "deepseek-v4-flash",
-          apiKeyEnv: "OPENAI_API_KEY",
-          credentialSecretName: "DEEPSEEK_API_KEY",
-        }),
-        OPENAI_API_KEY: "pi-handoff-test-key",
-      };
+      const started = await startOwnershipTransferHost({
+        root,
+        jsonl: h1,
+        mode: "pending-tool-continuation",
+        baseSessionSha256: null,
+        providerBaseUrl: provider.baseUrl,
+        model: "terra",
+      });
+      host = started.host;
+      handoffServer = started.handoffServer;
 
-      host = new RpcHost({ cwd: root, agentDir, sessionDir, env });
-      const state = await host.state("handoff-state");
+      const state = await host.state("terra-handoff-state");
       expect(host.records[0]).toStrictEqual({
         type: "vm0_pi_api_first_turn_boundary",
-        schemaVersion: 1,
+        schemaVersion: 2,
         sandboxEventSequenceStart: 4,
+        ownershipTransferMode: "pending-tool-continuation",
       });
-      expect(state).toMatchObject({
-        sessionId: SESSION_ID,
-        messageCount: 2,
-      });
+      expect(state).toMatchObject({ sessionId: SESSION_ID, messageCount: 2 });
       expect(String(state.sessionFile)).toContain("api-first-turn-");
 
-      host.send({ id: "handoff", type: "prompt", message: prompt });
+      host.send({ id: "terra-handoff", type: "prompt", message: prompt });
       const continuationRequest = await provider.nextRequest();
       const continuationBody = JSON.stringify(continuationRequest.body);
       expect(continuationBody).toContain(
-        "tool output from the sandbox filesystem",
+        "Terra tool output from the sandbox filesystem",
       );
-      expect(continuationBody).toContain("rs_api_handoff");
-      expect(continuationBody).toContain("reasoning_text");
+      expect(continuationBody).toContain("rs_terra_okou_handoff");
       expect(occurrences(continuationBody, prompt)).toBe(1);
-      continuationRequest.respond("handoff continuation complete");
+      continuationRequest.respond("Terra Okou handoff complete");
       await host.waitFor((record) => {
         return record.type === "agent_settled";
       });
@@ -749,23 +709,23 @@ describe("sandbox Pi agent loop", () => {
       expect(provider.requests).toHaveLength(1);
       const persisted = await readFile(String(state.sessionFile), "utf8");
       expect(occurrences(persisted, prompt)).toBe(1);
-      expect(persisted).toContain("api-read-call");
-      expect(persisted).toContain("handoff continuation complete");
+      expect(persisted).toContain("api-terra-read-call");
+      expect(persisted).toContain(
+        "Terra tool output from the sandbox filesystem",
+      );
+      expect(persisted).toContain("Terra Okou handoff complete");
+      expect(MemoryPiSession.fromJsonl(persisted).isSettledCheckpoint()).toBe(
+        true,
+      );
     } finally {
       await host?.terminate();
+      if (handoffServer) {
+        await closeServer(handoffServer);
+      }
       await provider.close();
-      await new Promise<void>((resolve, reject) => {
-        handoffServer.close((error) => {
-          if (error) {
-            reject(error);
-          } else {
-            resolve();
-          }
-        });
-      });
       await rm(root, { recursive: true, force: true });
     }
-  }, 20_000);
+  }, 30_000);
 
   it("runs the sandbox-first prompt exactly once through AgentSession", async () => {
     const root = await mkdtemp(join(tmpdir(), "vm0-pi-sandbox-first-rpc-"));

--- a/turbo/packages/pi-agent-runtime/src/rpc.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/rpc.test.ts
@@ -135,4 +135,95 @@ describe("Pi API first-turn sandbox resume", () => {
       "sandbox continuation complete",
     );
   });
+
+  it("executes the representative Okou CLI handoff through sandbox bash", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pi-okou-resume-"));
+    temporaryDirectories.push(directory);
+    const sessionFile = join(directory, "handoff.jsonl");
+    const command = 'npx --yes --package="${CLI_PKG_URL}" okou --help';
+    const memory = MemoryPiSession.create({
+      cwd: "/home/user/workspace",
+      id: SESSION_ID,
+    });
+    memory.appendMessage({
+      role: "user",
+      content: "inspect Okou once",
+      timestamp: 1,
+    });
+    memory.appendMessage(
+      fauxAssistantMessage(
+        fauxToolCall("bash", { command }, { id: TOOL_CALL_ID }),
+        { stopReason: "toolUse", timestamp: 2 },
+      ),
+    );
+    await writeFile(sessionFile, memory.toJsonl());
+
+    const execute = vi.fn(async (_id: string, args: { command: string }) => {
+      return {
+        content: [{ type: "text" as const, text: "Okou CLI fixture help" }],
+        details: { command: args.command },
+      };
+    });
+    const faux = createFauxCore({
+      api: "terra-okou-resume-test",
+      provider: "openai",
+    });
+    faux.setResponses([
+      (context) => {
+        expect(context.messages.at(-1)).toMatchObject({
+          role: "toolResult",
+          toolCallId: TOOL_CALL_ID,
+          content: [{ type: "text", text: "Okou CLI fixture help" }],
+        });
+        return fauxAssistantMessage("Okou handoff complete", {
+          timestamp: 3,
+        });
+      },
+    ]);
+    const modelRuntime = await ModelRuntime.create({
+      allowModelNetwork: false,
+      modelsPath: null,
+      refreshOnCreate: false,
+    });
+    modelRuntime.registerProvider(faux.provider, {
+      name: faux.provider,
+      api: faux.api,
+      baseUrl: faux.getModel().baseUrl,
+      apiKey: "test-api-key",
+      streamSimple: faux.streamSimple,
+      models: faux.models,
+    });
+    const { session } = await createAgentSession({
+      cwd: "/home/user/workspace",
+      agentDir: join(directory, "agent"),
+      model: faux.getModel(),
+      modelRuntime,
+      sessionManager: SessionManager.open(sessionFile),
+      tools: ["bash"],
+      customTools: [
+        {
+          name: "bash",
+          label: "bash",
+          description: "Execute a sandboxed command",
+          parameters: Type.Object({ command: Type.String() }),
+          execute,
+        },
+      ],
+    });
+
+    await resumePiApiFirstTurn(session);
+
+    expect(execute).toHaveBeenCalledExactlyOnceWith(
+      TOOL_CALL_ID,
+      { command },
+      undefined,
+      undefined,
+      expect.anything(),
+    );
+    expect(faux.state.callCount).toBe(1);
+    session.dispose();
+    const persisted = await readFile(sessionFile, "utf8");
+    expect(persisted).toContain("Okou CLI fixture help");
+    expect(persisted).toContain("Okou handoff complete");
+  });
 });


### PR DESCRIPTION
Parent: #30564
Closes #30647

## Summary

- route standard built-in GPT-5.6 Terra Web and agent chat through the canonical Pi eligibility contract while retaining Codex fallbacks and existing DeepSeek behavior
- advertise the production V3 ownership-transfer capability, remove the test-only payload mutation, and keep Pi V1 free of auto-memory artifacts
- persist idempotent API-owned Terra usage through the canonical usage ledger, including cache and long-context categories, while keeping sandbox usage independently owned
- cover Terra text resume, Pi -> Codex -> Pi generation boundaries, Okou CLI tool handoff/H2, BYOK and fast fallbacks, and production lifecycle cross-sections

## Fallbacks

- `pi-api-first-turn-usage.service.ts:sourceId` — when optional provider response metadata omits `responseId`, derive the stable response identity from the SHA-256 of canonical session JSONL. Surface: genuinely optional provider data; no rollout window. This remains required while `PiApiAssistantMessage.responseId` is optional and can be removed if that runtime contract becomes required; no rollout follow-up applies.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged workspace, Platform, and API type-check commands from commit-check
- 10 CLI Pi loop tests
- 23 Pi runtime API/model/compaction/session/RPC tests
- `git diff origin/main...HEAD --check`

Database-backed API BDDs require PostgreSQL, which is unavailable in this runner; protected PR CI is the authoritative execution for those focused route and billing cases.