### PR TITLE
fix(pi): keep one eligibility snapshot

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -151,6 +151,7 @@ import { verifyOkouToken } from "../../auth/tokens";
 import {
   createUnassociatedThreadBoundAgentRunFixture,
   createUnassociatedThreadBoundAgentRunsServiceFixture,
+  holdAgentRunPiExecutionSnapshotFixture,
 } from "../../../test-fixtures/thread-bound-run-admission";
 import {
   acquireBddVm0ApiKey,
@@ -5071,6 +5072,185 @@ describe("CHAT-02: model-first provider policies", () => {
         await api.requestCancelRun(actor, vm0Body.runId, [200]);
       }
     }
+  }, 90_000);
+
+  it("keeps captured Pi admission after PiLoop turns off", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    const orgId = requireOrgId(actor);
+    await configureBuiltInPiModel(actor, "gpt-5.6-terra");
+    mockPiResourceArchiveDownloads(true);
+    mockPiCheckpointObjectStore();
+    await api.heartbeatRunner(runnerGroup);
+
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId },
+      { [FeatureSwitchKey.PiLoop]: false },
+    );
+    const baseline = await sendChatRun(actor, {
+      agentId,
+      prompt: "establish the captured Codex session family",
+      model: "gpt-5.6-terra",
+    });
+    await flushWaitUntilForTest();
+    await expect(api.readRun(actor, baseline.runId)).resolves.toMatchObject({
+      status: "pending",
+    });
+    await expect(
+      readRunLaunchSnapshotFixture(context, baseline.runId),
+    ).resolves.toMatchObject({
+      launch_snapshot: { framework: "codex" },
+    });
+    const baselineClaim = await claimChatRun(runnerGroup, baseline.runId);
+    expect(baselineClaim.claim.cliAgentType).toBe("codex");
+    expect(baselineClaim.claim.piLaunchConfig).toBeUndefined();
+    const baselineBinding = await readThreadSessionBinding(
+      context,
+      baseline.threadId,
+    );
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(baseline.runId, baselineClaim.sandboxHeaders, {
+      cliAgentType: "codex",
+    });
+    await flushWaitUntilForTest();
+
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId },
+      { [FeatureSwitchKey.PiLoop]: true },
+    );
+    const enabledGate = holdAgentRunPiExecutionSnapshotFixture({
+      userId: actor.userId,
+      orgId,
+      signal: context.signal,
+    });
+    onTestFinished(enabledGate.release);
+    const enabledSend = sendChatRun(actor, {
+      agentId,
+      threadId: baseline.threadId,
+      prompt: "keep Pi after the switch turns off",
+      model: "gpt-5.6-terra",
+    });
+    const enabledSnapshot = await enabledGate.arrival;
+    expect(enabledSnapshot).toMatchObject({
+      chatThreadId: baseline.threadId,
+      piExecution: true,
+      threadSessionCliAgentType: "pi",
+    });
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId },
+      { [FeatureSwitchKey.PiLoop]: false },
+    );
+    enabledGate.release();
+    const enabled = await enabledSend;
+    await flushWaitUntilForTest();
+    const enabledClaim = await claimChatRun(runnerGroup, enabled.runId);
+    expect(enabledClaim.claim.cliAgentType).toBe("pi");
+    expect(enabledClaim.claim.piLaunchConfig).toBeDefined();
+    await expect(
+      readRunLaunchSnapshotFixture(context, enabled.runId),
+    ).resolves.toMatchObject({
+      launch_snapshot: { framework: "pi" },
+    });
+    const enabledBinding = await readThreadSessionBinding(
+      context,
+      enabled.threadId,
+    );
+    expect(enabledBinding.agent_session_id).not.toBe(
+      baselineBinding.agent_session_id,
+    );
+    await cancelChatRun(actor, enabled.runId, enabledClaim.sandboxHeaders);
+  }, 90_000);
+
+  it("keeps captured Codex admission after PiLoop turns on", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    const orgId = requireOrgId(actor);
+    const usagePricingResolution = await createTerraUsagePricingResolution();
+    await configureBuiltInPiModel(actor, "gpt-5.6-terra");
+    mockPiResourceArchiveDownloads();
+    mockPiCheckpointObjectStore();
+    server.use(
+      http.post("https://api.openai.com/v1/responses", () => {
+        return new HttpResponse(piResponsesTextSse("baseline Pi answer", 0), {
+          headers: { "content-type": "text/event-stream" },
+        });
+      }),
+    );
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId },
+      { [FeatureSwitchKey.PiLoop]: true },
+    );
+    const baseline = await sendChatRun(
+      actor,
+      {
+        agentId,
+        prompt: "establish the captured Pi session family",
+        model: "gpt-5.6-terra",
+      },
+      "vm0",
+      usagePricingResolution,
+    );
+    await waitForRunStatus(actor, baseline.runId, "completed", 10_000);
+    await flushWaitUntilForTest();
+    await expect(
+      readRunLaunchSnapshotFixture(context, baseline.runId),
+    ).resolves.toMatchObject({
+      launch_snapshot: { framework: "pi" },
+    });
+    const baselineBinding = await readThreadSessionBinding(
+      context,
+      baseline.threadId,
+    );
+
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId },
+      { [FeatureSwitchKey.PiLoop]: false },
+    );
+    const disabledGate = holdAgentRunPiExecutionSnapshotFixture({
+      userId: actor.userId,
+      orgId,
+      signal: context.signal,
+    });
+    onTestFinished(disabledGate.release);
+    const disabledSend = sendChatRun(actor, {
+      agentId,
+      threadId: baseline.threadId,
+      prompt: "keep Codex after the switch turns on",
+      model: "gpt-5.6-terra",
+    });
+    const disabledSnapshot = await disabledGate.arrival;
+    expect(disabledSnapshot).toMatchObject({
+      chatThreadId: baseline.threadId,
+      piExecution: false,
+      threadSessionCliAgentType: "codex",
+    });
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId },
+      { [FeatureSwitchKey.PiLoop]: true },
+    );
+    disabledGate.release();
+    const disabled = await disabledSend;
+    await flushWaitUntilForTest();
+    const disabledClaim = await claimChatRun(runnerGroup, disabled.runId);
+    expect(disabledClaim.claim.cliAgentType).toBe("codex");
+    expect(disabledClaim.claim.piLaunchConfig).toBeUndefined();
+    await expect(
+      readRunLaunchSnapshotFixture(context, disabled.runId),
+    ).resolves.toMatchObject({
+      launch_snapshot: { framework: "codex" },
+    });
+    const disabledBinding = await readThreadSessionBinding(
+      context,
+      disabled.threadId,
+    );
+    expect(disabledBinding.agent_session_id).not.toBe(
+      baselineBinding.agent_session_id,
+    );
+    await cancelChatRun(actor, disabled.runId, disabledClaim.sandboxHeaders);
   }, 90_000);
 
   it.each(["deepseek-v4-flash", "deepseek-v4-pro", "gpt-5.6-terra"] as const)(

--- a/turbo/apps/api/src/signals/routes/test-run-fixture.ts
+++ b/turbo/apps/api/src/signals/routes/test-run-fixture.ts
@@ -64,6 +64,7 @@ const createAgentRunFixture$ = command(
           body: body.data,
           apiStartTime,
           publicBrand: get(publicBrand$),
+          piExecution: false,
           timing,
         };
       },

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -238,10 +238,7 @@ import {
 } from "./agent-run-queue-payload.service";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import {
-  resolvePiSandboxModelConfig,
-  shouldUsePiExecution,
-} from "./pi-sandbox-config";
+import { resolvePiSandboxModelConfig } from "./pi-sandbox-config";
 import {
   piResourceDiscoveryMounts,
   piResourceSnapshotDigest,
@@ -1000,6 +997,8 @@ export interface CreateAgentRunArgs {
   readonly dispatchFailedCallbacks?: DispatchFailedRunCallbacks;
   readonly queueFirstAssociation?: QueueFirstRunAssociation;
   readonly agentRunModelPin?: AgentRunModelPin;
+  /** Immutable Pi eligibility captured by the caller's admission snapshot. */
+  readonly piExecution: boolean;
   readonly timing?: ApiDispatchTimingCollector;
   readonly timingDimensions?: ApiDispatchTimingDimensions;
 }
@@ -8238,26 +8237,11 @@ interface FinalizedPreparedRunContext extends PreparedRunContext {
   readonly launchSnapshot: AgentRunLaunchSnapshot;
 }
 
-function isPiSandboxEnabledForRun(
-  createArgs: CreateAgentRunArgs,
-  featureSwitchContext: FeatureSwitchContext,
-): boolean {
-  return shouldUsePiExecution({
-    chatThreadId: createArgs.chatThreadId,
-    modelProviderType: createArgs.agentRunModelPin?.modelProvider,
-    selectedModel: createArgs.agentRunModelPin?.selectedModel,
-    codexServiceTier: createArgs.codexServiceTier,
-    triggerSource: createArgs.body.triggerSource,
-    featureSwitchContext,
-  });
-}
-
 function resolvePreparedPiModelConfig(args: {
   readonly createArgs: CreateAgentRunArgs;
-  readonly featureSwitchContext: FeatureSwitchContext;
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
 }): PiModelConfig | undefined {
-  if (!isPiSandboxEnabledForRun(args.createArgs, args.featureSwitchContext)) {
+  if (!args.createArgs.piExecution) {
     return undefined;
   }
   const config = resolvePiSandboxModelConfig(args.modelProvider);
@@ -9426,7 +9410,6 @@ function prepareRunContext(
       });
       const piSandbox = resolvePreparedPiModelConfig({
         createArgs: args,
-        featureSwitchContext: bodyContext.featureSwitchContext,
         modelProvider: runtimeContext.modelProvider,
       });
 

--- a/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
@@ -188,6 +188,8 @@ interface CreateAgentRunCommandArgs {
   readonly requiredOfficialWorkflowIds?: readonly string[];
   readonly dispatchFailedCallbacks?: DispatchFailedRunCallbacks;
   readonly agentRunModelPin?: AgentRunModelPin;
+  /** Immutable Pi eligibility captured by the caller's admission snapshot. */
+  readonly piExecution: boolean;
   readonly timing?: ApiDispatchTimingCollector;
   readonly agentRunPreCreateSource?: AgentRunPreCreateSource;
 }
@@ -229,6 +231,34 @@ export function setOfficialWorkflowBootstrapRequirementHookForTest(
 
 export function clearOfficialWorkflowBootstrapRequirementHookForTest(): void {
   officialWorkflowBootstrapRequirementHook.clear();
+}
+
+export interface AgentRunPiExecutionSnapshot {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly chatThreadId: string | undefined;
+  readonly piExecution: boolean;
+  readonly threadSessionCliAgentType: string | null | undefined;
+}
+
+type AgentRunPiExecutionSnapshotHook = (
+  snapshot: AgentRunPiExecutionSnapshot,
+) => Promise<void>;
+
+const agentRunPiExecutionSnapshotHook = testOverride<
+  AgentRunPiExecutionSnapshotHook | undefined
+>(() => {
+  return undefined;
+});
+
+export function setAgentRunPiExecutionSnapshotHookForTest(
+  hook: AgentRunPiExecutionSnapshotHook,
+): void {
+  agentRunPiExecutionSnapshotHook.set(hook);
+}
+
+export function clearAgentRunPiExecutionSnapshotHookForTest(): void {
+  agentRunPiExecutionSnapshotHook.clear();
 }
 
 function assertThreadBoundAgentRunHasQueueAssociation(
@@ -965,6 +995,7 @@ function buildZeroCreateAgentRunArgs(args: {
     ...(command.agentRunModelPin
       ? { agentRunModelPin: command.agentRunModelPin }
       : {}),
+    piExecution: command.piExecution,
     ...("queueFirstAssociation" in command
       ? { queueFirstAssociation: command.queueFirstAssociation }
       : {}),
@@ -1179,6 +1210,15 @@ const createAgentRunInternal$ = command(
       });
       signal.throwIfAborted();
     }
+
+    await agentRunPiExecutionSnapshotHook.get()?.({
+      userId: args.auth.userId,
+      orgId: args.auth.orgId,
+      chatThreadId: args.chatThreadId,
+      piExecution: args.piExecution,
+      threadSessionCliAgentType: args.threadSessionRoute?.cliAgentType,
+    });
+    signal.throwIfAborted();
 
     const {
       userInfo,

--- a/turbo/apps/api/src/signals/services/chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/chat-events.command.ts
@@ -3389,6 +3389,7 @@ function buildCreateAgentRunArgs(params: {
       modelProviderCredentialScope: modelPin.modelProviderCredentialScope,
       selectedModel: modelPin.selectedModel,
     },
+    piExecution: prepared.piExecution,
     threadSessionRoute: {
       selectedModel: modelPin.selectedModel,
       modelProvider: providerAdmission.effectiveModelProvider ?? null,

--- a/turbo/apps/api/src/signals/services/goal-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/goal-queue-drain.service.ts
@@ -226,6 +226,7 @@ function buildQueueFirstGoalRunInput(args: {
       modelProviderCredentialScope: modelPin.modelProviderCredentialScope,
       selectedModel: modelPin.selectedModel,
     },
+    piExecution: false,
     dispatchFailedCallbacks: args.dispatchFailedCallbacks,
     timing: args.timing,
   };

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -161,6 +161,7 @@ import {
   scheduleChatThreadTitleGeneration,
 } from "./chat-title.service";
 import { createQueueFirstAgentRun$ } from "./agent-runs-create.service";
+import { shouldUsePiExecution } from "./pi-sandbox-config";
 import { loadActiveGoalForThread } from "./goal.service";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { formatIntegrationRunError$ } from "./integration-run-errors.service";
@@ -684,6 +685,7 @@ interface CreateQueuedChatRunInput {
   readonly effectiveModelProvider: string | null | undefined;
   readonly builtInModelRuntimeRoute: BuiltInModelRuntimeRoute | undefined;
   readonly cliAgentType: string | null;
+  readonly piExecution: boolean;
   readonly codexServiceTier: "fast" | undefined;
   readonly computerUseHostGrant: {
     readonly hostId: string;
@@ -957,6 +959,7 @@ function buildQueuedCreateAgentRunArgs(
       modelProviderCredentialScope: input.modelPin.modelProviderCredentialScope,
       selectedModel: input.modelPin.selectedModel,
     },
+    piExecution: input.piExecution,
     agentRunMetadata: { autonomyBudget: input.autonomyBudget },
     ...(input.requiredOfficialWorkflowIds === undefined
       ? {}
@@ -2601,6 +2604,34 @@ interface QueuedMessageModelRoute {
   readonly codexServiceTier: "fast" | undefined;
 }
 
+function routeQueuedMessagePiExecution(args: {
+  readonly input: CreateQueuedChatRunInputArgs;
+  readonly modelRoute: QueuedMessageModelRoute;
+  readonly featureSwitchContext: FeatureSwitchContext;
+}) {
+  const triggerSource = queuedUserMessageTriggerSource(
+    args.input.queuedMessage.contextType,
+  );
+  const piExecution = shouldUsePiExecution({
+    chatThreadId: args.input.threadId,
+    modelProviderType: args.modelRoute.effectiveModelProvider,
+    selectedModel: args.modelRoute.modelPin.selectedModel,
+    codexServiceTier: args.modelRoute.codexServiceTier,
+    triggerSource,
+    featureSwitchContext: args.featureSwitchContext,
+  });
+  return {
+    piExecution,
+    triggerSource,
+    routedModel: {
+      ...args.modelRoute,
+      cliAgentType: piExecution
+        ? ("pi" as const)
+        : args.modelRoute.cliAgentType,
+    },
+  };
+}
+
 interface QueuedMessageModelRouteError {
   readonly code: string;
   readonly message: string;
@@ -3219,9 +3250,16 @@ async function buildCreateQueuedChatRunInput(
     );
   }
   const modelRoute = modelRouteResolution.route;
+  // Keep session routing and launch on the same queued-message admission.
+  const { piExecution, routedModel, triggerSource } =
+    routeQueuedMessagePiExecution({
+      input: args,
+      modelRoute,
+      featureSwitchContext,
+    });
 
   const [startNewSession, loadedIncompleteContext] =
-    await loadQueuedMessageSessionState(args, modelRoute);
+    await loadQueuedMessageSessionState(args, routedModel);
   const incompleteContext = startNewSession ? "" : loadedIncompleteContext;
   const priorContext = await measureChatCallbackPreCreateTiming(
     args.timing,
@@ -3254,10 +3292,6 @@ async function buildCreateQueuedChatRunInput(
   const prompt = queuedMessagePrompt({
     launchMaterial,
   });
-  const triggerSource = queuedUserMessageTriggerSource(
-    args.queuedMessage.contextType,
-  );
-
   return {
     orgId: args.agent.orgId,
     userId: args.userId,
@@ -3283,11 +3317,12 @@ async function buildCreateQueuedChatRunInput(
           requiredOfficialWorkflowIds:
             args.queuedMessage.requiredOfficialWorkflowIds,
         }),
-    modelPin: modelRoute.modelPin,
-    effectiveModelProvider: modelRoute.effectiveModelProvider,
-    builtInModelRuntimeRoute: modelRoute.builtInModelRuntimeRoute,
-    cliAgentType: modelRoute.cliAgentType,
-    codexServiceTier: modelRoute.codexServiceTier,
+    modelPin: routedModel.modelPin,
+    effectiveModelProvider: routedModel.effectiveModelProvider,
+    builtInModelRuntimeRoute: routedModel.builtInModelRuntimeRoute,
+    cliAgentType: routedModel.cliAgentType,
+    piExecution,
+    codexServiceTier: routedModel.codexServiceTier,
     computerUseHostGrant,
     triggerSource,
     realAgentInPreview: isFeatureEnabled(

--- a/turbo/apps/api/src/signals/services/workflow-automation-launch.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation-launch.service.ts
@@ -595,6 +595,18 @@ async function checkQueuedWorkflowLaunchReadiness(
   );
 }
 
+function workflowAutomationAgentRunAuth(automation: {
+  readonly orgId: string;
+  readonly ownerUserId: string;
+}) {
+  return {
+    orgId: automation.orgId,
+    orgRole: "member" as const,
+    userId: automation.ownerUserId,
+    tokenType: "session" as const,
+  };
+}
+
 export const launchQueuedWorkflowAutomation$ = command(
   async (
     { set },
@@ -655,12 +667,7 @@ export const launchQueuedWorkflowAutomation$ = command(
     const result = await set(
       createQueueFirstAgentRun$,
       {
-        auth: {
-          orgId: automation.orgId,
-          orgRole: "member",
-          userId: automation.ownerUserId,
-          tokenType: "session",
-        },
+        auth: workflowAutomationAgentRunAuth(automation),
         body: {
           prompt: runInput.prompt,
           agentId,
@@ -700,6 +707,7 @@ export const launchQueuedWorkflowAutomation$ = command(
           modelProviderCredentialScope: modelPin.modelProviderCredentialScope,
           selectedModel: modelPin.selectedModel,
         },
+        piExecution: false,
         dispatchFailedCallbacks: args.dispatchFailedCallbacks,
         timing,
       },

--- a/turbo/apps/api/src/test-fixtures/agent-runs.ts
+++ b/turbo/apps/api/src/test-fixtures/agent-runs.ts
@@ -413,6 +413,7 @@ export async function createDirectRunFixture(args: {
       orgId: args.orgId,
       apiStartTime: now(),
       modelProviderType: body.modelProviderType,
+      piExecution: false,
       testOnlyResolveDirectRun: resolveDirectRun,
       connectorScope: connectorScope ?? {
         allowedConnectorSlugs: [],

--- a/turbo/apps/api/src/test-fixtures/thread-bound-run-admission.ts
+++ b/turbo/apps/api/src/test-fixtures/thread-bound-run-admission.ts
@@ -4,11 +4,47 @@ import { createStore } from "ccstate";
 
 import { now } from "../lib/time";
 import { createAgentRun$ } from "../signals/services/agent-run-create.service";
-import { createTestFixtureAgentRun$ } from "../signals/services/agent-runs-create.service";
+import {
+  clearAgentRunPiExecutionSnapshotHookForTest,
+  createTestFixtureAgentRun$,
+  setAgentRunPiExecutionSnapshotHookForTest,
+  type AgentRunPiExecutionSnapshot,
+} from "../signals/services/agent-runs-create.service";
 import { buildAgentExecutionConfig } from "../signals/services/agent-execution-config";
+import { createDeferredPromise } from "../signals/utils";
 
 const USER_ID = "thread-run-invariant-user";
 const ORG_ID = "thread-run-invariant-org";
+
+export function holdAgentRunPiExecutionSnapshotFixture(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly signal: AbortSignal;
+}): {
+  readonly arrival: Promise<AgentRunPiExecutionSnapshot>;
+  readonly release: () => void;
+} {
+  const arrival = createDeferredPromise<AgentRunPiExecutionSnapshot>(
+    args.signal,
+  );
+  const released = createDeferredPromise<void>(args.signal);
+  setAgentRunPiExecutionSnapshotHookForTest(async (snapshot) => {
+    if (snapshot.userId !== args.userId || snapshot.orgId !== args.orgId) {
+      return;
+    }
+    arrival.resolve(snapshot);
+    await released.promise;
+  });
+  return {
+    arrival: arrival.promise,
+    release: () => {
+      clearAgentRunPiExecutionSnapshotHookForTest();
+      if (!released.settled()) {
+        released.resolve(undefined);
+      }
+    },
+  };
+}
 
 /**
  * Exercise the agent-runs-create service boundary that public contracts cannot
@@ -31,6 +67,7 @@ export async function createUnassociatedThreadBoundAgentRunsServiceFixture(
         prompt: "must be rejected before Zero run preparation",
       },
       apiStartTime: now(),
+      piExecution: false,
       chatThreadId,
     },
     new AbortController().signal,
@@ -57,6 +94,7 @@ export async function createUnassociatedThreadBoundAgentRunFixture(
       productAgentExecutionPlan: {
         content: buildAgentExecutionConfig("thread-run-invariant-agent"),
       },
+      piExecution: false,
       chatThreadId,
       connectorScope: {
         allowedConnectorSlugs: [],


### PR DESCRIPTION
Parent: #30564
Closes #30656

## Summary

- capture Pi eligibility once at normal Web/agent message admission and carry it through thread-session routing and launch
- preserve the logical `agentRunModelPin` eligibility contract while keeping runtime Pi provider compatibility as an independent fail-closed check
- make deferred queued-message admission use the same immutable decision and keep non-Web workflow/goal/direct-run paths explicitly on their existing harnesses
- add deterministic persisted `PiLoop` on-to-off and off-to-on race regressions that assert the session family, launch snapshot, and runner harness stay aligned

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api run check-types:tests`
- `pnpm --filter api exec vitest run src/signals/services/__tests__/pi-sandbox-config.test.ts --silent=passed-only` (12 passed)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t 'keeps captured' --silent=passed-only` (2 passed)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t 'queues, retries, and recalls messages behind an active run' --silent=passed-only` (1 passed)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t 'routes model policy providers into the runner claim|runs the Pi API first turn once|preserves generations across standard Terra, fast Terra, and standard Terra|hands a Terra resource failure to Sandbox' --silent=passed-only` (6 passed)
- `git diff --check`

Repository-wide validation is left to the protected PR pipeline as required.
