### PR TITLE
fix(e2e): retry a create whose connection was never established

### DIFF
--- a/e2e/playwright/lib/clerk-api.test.ts
+++ b/e2e/playwright/lib/clerk-api.test.ts
@@ -298,6 +298,44 @@ test("does not replay non-idempotent user creation", async () => {
   );
 });
 
+test("does not replay a create whose response is lost after it was sent", async () => {
+  await withClerkServer(
+    (request, response) => {
+      if (request.method === "POST" && request.url === "/v1/users") {
+        requestSocketFailure(response);
+        return;
+      }
+      sendJson(response, 404, { errors: [] });
+    },
+    async (requests) => {
+      const error = await captureError(async () => {
+        await createUser("lost-response@example.com");
+      });
+
+      assert.match(
+        error.message,
+        /^create Clerk user request failed after 1 attempt: /,
+      );
+      assert.match(error.message, /UND_ERR_SOCKET/);
+      assert.equal(countRequests(requests, "POST", "/v1/users"), 1);
+    },
+  );
+});
+
+test("reissues a create whose connection was never established", async () => {
+  await withUnreachableClerkServer(async () => {
+    const error = await captureError(async () => {
+      await createUser("unreachable@example.com");
+    });
+
+    assert.match(
+      error.message,
+      /^create Clerk user request failed after 4 attempts: /,
+    );
+    assert.match(error.message, /ECONNREFUSED/);
+  });
+});
+
 test("collects all pages before generation cleanup and isolates roles", async () => {
   const currentPlaywrightEmail =
     "test-job+clerk_test+4000-2+playwright-deadbeef@vm0-e2e.ai";
@@ -911,6 +949,41 @@ async function withClerkServer(
         await closeServer(server);
       }
     },
+  );
+}
+
+/**
+ * Binds and releases a loopback port so the Clerk base URL points at a port
+ * nothing listens on. Every connection is then refused before a request byte
+ * can be written, which is the failure the create path is allowed to reissue.
+ */
+async function withUnreachableClerkServer(
+  run: () => Promise<void>,
+): Promise<void> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  await closeServer(server);
+  if (!address || typeof address === "string") {
+    throw new Error("Expected Clerk test server to listen on a TCP port");
+  }
+
+  await withEnvironmentAsync(
+    {
+      CLERK_API_TEST_BASE_URL: `http://127.0.0.1:${address.port}/v1`,
+      CLERK_SECRET_KEY: "sk_test_fixture",
+      JOB_REF: "test-job",
+      GITHUB_RUN_ID: "4000",
+      GITHUB_RUN_ATTEMPT: "2",
+    },
+    run,
   );
 }
 

--- a/e2e/playwright/lib/clerk-api.ts
+++ b/e2e/playwright/lib/clerk-api.ts
@@ -4,6 +4,24 @@ const DEFAULT_CLERK_API_BASE = "https://api.clerk.com/v1";
 const CLERK_PAGE_LIMIT = 500;
 const CLERK_RETRY_DELAYS_MS = [500, 1_500, 3_500] as const;
 const CLERK_MAX_RETRY_AFTER_MS = 30_000;
+/**
+ * Syscall and undici codes that can only be raised while the connection is
+ * still being established, so no request byte reached Clerk and replaying a
+ * non-idempotent create cannot duplicate a resource. `ECONNRESET`,
+ * `UND_ERR_SOCKET` and the header/body timeouts are deliberately absent: they
+ * can surface after the request was written and the response was lost.
+ */
+const CLERK_CONNECT_FAILURE_CODES = new Set([
+  "EADDRNOTAVAIL",
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "EHOSTDOWN",
+  "EHOSTUNREACH",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "UND_ERR_CONNECT_TIMEOUT",
+]);
 const CLERK_BULK_REQUEST_PACE_MS = 110;
 const CLERK_TEST_DOMAIN = "vm0-e2e.ai";
 const CLERK_TEST_MARKER = "clerk_test";
@@ -97,6 +115,10 @@ interface ClerkCleanupResources {
 
 interface RetryableClerkRequestInit extends RequestInit {
   readonly method: "GET" | "DELETE" | "PATCH";
+}
+
+interface CreateClerkRequestInit extends RequestInit {
+  readonly method: "POST";
 }
 
 type ClerkCleanupSelection =
@@ -250,7 +272,7 @@ export function parseClerkTestOrganizationMetadata(
 }
 
 export async function createUser(email: string): Promise<string> {
-  const response = await requestClerk("create Clerk user", "/users", {
+  const response = await requestClerkCreate("create Clerk user", "/users", {
     method: "POST",
     headers: getClerkHeaders(),
     body: JSON.stringify({
@@ -274,7 +296,7 @@ export async function createOrganization(
   role: ClerkTestRole,
 ): Promise<string> {
   const owner = currentClerkTestOwner(role);
-  const response = await requestClerk(
+  const response = await requestClerkCreate(
     "create Clerk organization",
     "/organizations",
     {
@@ -763,16 +785,31 @@ async function paceClerkBulkRequest(
   await wait(CLERK_BULK_REQUEST_PACE_MS);
 }
 
-async function requestClerk(
+/**
+ * Creates are not idempotent, so a lost response must never be replayed. A
+ * failure raised while the connection was still being established is the one
+ * exception: Clerk never saw the request, so the create can be reissued. Every
+ * other transport failure, and every HTTP error response, is surfaced as-is.
+ */
+async function requestClerkCreate(
   operation: string,
   path: string,
-  init: RequestInit,
+  init: CreateClerkRequestInit,
 ): Promise<Response> {
   const url = `${getClerkApiBase()}${path}`;
-  try {
-    return await fetch(url, init);
-  } catch (cause) {
-    throw new Error(`${operation} request failed`, { cause });
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await fetch(url, init);
+    } catch (cause) {
+      const delayMs = CLERK_RETRY_DELAYS_MS[attempt];
+      if (delayMs === undefined || !isClerkConnectFailure(cause)) {
+        throw new Error(
+          `${operation} request failed after ${formatAttemptCount(attempt + 1)}: ${describeClerkTransportCause(cause)}`,
+          { cause },
+        );
+      }
+      await waitBeforeClerkRetry(delayMs);
+    }
   }
 }
 
@@ -789,9 +826,12 @@ async function requestClerkWithRetry(
     } catch (cause) {
       const fallbackDelayMs = CLERK_RETRY_DELAYS_MS[attempt];
       if (fallbackDelayMs === undefined) {
-        throw new Error(`${operation} request failed`, { cause });
+        throw new Error(
+          `${operation} request failed after ${formatAttemptCount(attempt + 1)}: ${describeClerkTransportCause(cause)}`,
+          { cause },
+        );
       }
-      await wait(fallbackDelayMs);
+      await waitBeforeClerkRetry(fallbackDelayMs);
       continue;
     }
 
@@ -808,9 +848,84 @@ async function requestClerkWithRetry(
       return response;
     }
     await response.body?.cancel();
-    await wait(delayMs);
+    await waitBeforeClerkRetry(delayMs);
   }
   throw new Error(`${operation} exhausted its retry budget`);
+}
+
+/**
+ * `TypeError: fetch failed` never names the syscall that failed, and the
+ * per-address `AggregateError` undici nests underneath it prints as an empty
+ * line in CI, so a DNS failure, a refused connection and a TLS failure are
+ * indistinguishable in the log. Flatten the chain into the thrown message for
+ * the same reason `formatErrorReport` rescues a nested runner credential cause.
+ */
+function describeClerkTransportCause(cause: unknown): string {
+  if (!(cause instanceof Error)) {
+    return String(cause);
+  }
+
+  const head = `${clerkTransportCode(cause) ?? cause.name}${cause.message ? `: ${cause.message}` : ""}`;
+  const nested = clerkTransportCauses(cause).map(describeClerkTransportCause);
+  return nested.length === 0 ? head : `${head} [${nested.join("; ")}]`;
+}
+
+/**
+ * `fetch` reports every transport failure as an uncoded `TypeError`, and undici
+ * reports a lost address race as an `AggregateError` holding one error per
+ * address, so the decision has to walk the whole chain. Every leaf must be a
+ * connection-establishment failure before a create may be reissued.
+ */
+function isClerkConnectFailure(cause: unknown): boolean {
+  if (!(cause instanceof Error)) {
+    return false;
+  }
+
+  const code = clerkTransportCode(cause);
+  if (code !== undefined) {
+    return CLERK_CONNECT_FAILURE_CODES.has(code);
+  }
+
+  const nested = clerkTransportCauses(cause);
+  return (
+    nested.length > 0 &&
+    nested.every((nestedCause) => isClerkConnectFailure(nestedCause))
+  );
+}
+
+function clerkTransportCauses(error: Error): readonly unknown[] {
+  const nested: unknown[] = [];
+  const aggregated: unknown = isRecord(error) ? error.errors : undefined;
+  if (Array.isArray(aggregated)) {
+    for (const aggregatedError of aggregated) {
+      nested.push(aggregatedError);
+    }
+  }
+  if (error.cause !== undefined) {
+    nested.push(error.cause);
+  }
+  return nested;
+}
+
+function clerkTransportCode(error: Error): string | undefined {
+  const code: unknown = isRecord(error) ? error.code : undefined;
+  return typeof code === "string" ? code : undefined;
+}
+
+function formatAttemptCount(attempts: number): string {
+  return `${attempts} attempt${attempts === 1 ? "" : "s"}`;
+}
+
+/**
+ * The local Clerk fixture server refuses or answers a connection immediately,
+ * so tests assert the attempt sequence without paying the production backoff.
+ * `paceClerkBulkRequest` skips its pacing under the same fixture switch.
+ */
+async function waitBeforeClerkRetry(delayMs: number): Promise<void> {
+  if (process.env.CLERK_API_TEST_BASE_URL) {
+    return;
+  }
+  await wait(delayMs);
 }
 
 function isTransientClerkStatus(status: number): boolean {

--- a/e2e/playwright/lib/clerk-api.ts
+++ b/e2e/playwright/lib/clerk-api.ts
@@ -871,14 +871,22 @@ function describeClerkTransportCause(cause: unknown): string {
 }
 
 /**
- * `fetch` reports every transport failure as an uncoded `TypeError`, and undici
- * reports a lost address race as an `AggregateError` holding one error per
- * address, so the decision has to walk the whole chain. Every leaf must be a
+ * `fetch` reports every transport failure as an uncoded `TypeError`, so the
+ * decision has to walk the whole chain. Every leaf must be a
  * connection-establishment failure before a create may be reissued.
  */
 function isClerkConnectFailure(cause: unknown): boolean {
   if (!(cause instanceof Error)) {
     return false;
+  }
+
+  // undici aggregates errors only while racing the addresses of one host, so
+  // the aggregation itself proves the failure happened before a request byte
+  // was written. Node stamps the shared per-address code onto the aggregate,
+  // and an all-addresses `ETIMEDOUT` race carries a code this set withholds
+  // from single errors because it can also fire on an established socket.
+  if (cause instanceof AggregateError) {
+    return true;
   }
 
   const code = clerkTransportCode(cause);


### PR DESCRIPTION
## Problem

Turbo run [33456769289](https://github.com/vm0-ai/vm0/actions/runs/33456769289) (push to `main`, SHA `81b4bb3`) failed in [`cli-e2e-02-playwright (paid-onboarding)`](https://github.com/vm0-ai/vm0/actions/runs/33456769289/job/99698917964) on the first step of its only test:

```
Error: create Clerk user request failed
    at requestClerk (e2e/playwright/lib/clerk-api.ts:775:11)
    at createUser (e2e/playwright/lib/clerk-api.ts:253:20)
    at e2e/playwright/tests/paid-onboarding.spec.ts:28:20
  [cause]: TypeError: fetch failed
  [cause]: AggregateError:
```

`TypeError: fetch failed` wrapping an `AggregateError` is undici's signature for a connection-level failure. No Clerk status code was ever returned, and no application behaviour had run yet.

The failure was not a Clerk outage or instance-wide throttling:

- The same job process had just completed several Clerk Backend API calls: `[globalSetup] Clerk resources ready` at `01:00:08.68`, ~2.6s before the failed connect.
- Three sibling jobs in the same run reached the same Clerk instance in the same window and passed: `cli-e2e-02-playwright (features)`, `cli-e2e-02-playwright (auth-v2)` (both `00:59:43` → `01:00:3x`) and `cli-e2e-02-browser` (`00:59:20` → `01:00:11`).
- Across the last 100 Turbo runs the `paid-onboarding` lane executed 64 times and failed exactly once — this run.

What is repo-owned is the amplifier. `requestClerk` wrapped a single `fetch` in a try/catch and rethrew, so one connection blip failed the whole job, while `requestClerkWithRetry` already retried the idempotent verbs (`GET`/`DELETE`/`PATCH`) with backoff on both transport failures and `429`/`5xx`.

## Change

`requestClerkCreate` replaces `requestClerk` for the two `POST` creates (`createUser`, `createOrganization`). It reuses the existing `CLERK_RETRY_DELAYS_MS` backoff, but reissues a create **only** when the failure was raised while the connection was still being established, so Clerk cannot have seen the request and a replay cannot duplicate a resource:

- Retried: any `AggregateError`, because undici aggregates only while racing the addresses of one host, which proves the failure preceded the first request byte; plus the single-error codes `ECONNREFUSED`, `ENOTFOUND`, `EAI_AGAIN`, `EHOSTUNREACH`, `ENETUNREACH`, `ENETDOWN`, `EHOSTDOWN`, `EADDRNOTAVAIL` and `UND_ERR_CONNECT_TIMEOUT`.
- `ETIMEDOUT` is withheld from the single-error set because it can also fire on an established socket. Node stamps the shared per-address code onto the aggregate, so an all-addresses `ETIMEDOUT` race — the most likely shape of the observed ~7s failure — is covered by the `AggregateError` rule rather than by the code set (commit `e34df24`).
- Not retried: `UND_ERR_SOCKET`, `ECONNRESET`, header/body timeouts — the request may already have been delivered — and every HTTP error response. The existing `does not replay non-idempotent user creation` test (one `POST` on `503`) is unchanged and still passes.

The run's own evidence gap is closed too: the nested `AggregateError` printed as an empty line, so DNS vs connect vs TLS was unknowable. Both transport throw sites now flatten the whole cause chain and the attempt count into the message, e.g. `create Clerk user request failed after 4 attempts: TypeError: fetch failed [ECONNREFUSED: connect ECONNREFUSED ...]`.

`waitBeforeClerkRetry` skips the production backoff under the loopback fixture switch, exactly as `paceClerkBulkRequest` already does, so the new tests assert the attempt sequence without paying wall-clock delay.

No sleeps, no skipped or deleted tests, no weakened assertions, no Playwright-level retries; the test still creates a real Clerk user and drives paid onboarding through the video template deep link.

## Validation

- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test` — 37 pass, 0 fail; repeated 5×, stable. Suite time went from 6.7s to 5.5s.
- `prettier --check` on both changed files, `git diff --check` clean.
- Mutation-checked both new tests: forcing `isClerkConnectFailure` to `false` fails `reissues a create whose connection was never established`; forcing it to `true` fails `does not replay a create whose response is lost after it was sent`.
- This PR touches `e2e/`, so `cli-e2e-02-playwright (paid-onboarding)` runs on it — that job passing is the end-to-end evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

