### PR TITLE
perf(platform): start shared worker before auth handshake

### DIFF
--- a/turbo/apps/platform/src/mocks/ably.ts
+++ b/turbo/apps/platform/src/mocks/ably.ts
@@ -560,8 +560,7 @@ export function triggerAblyReconnect(): void {
   }
 }
 
-/** Reconnect only the Realtime client that owns SharedWorker database events. */
-export function triggerSharedWorkerAblyReconnect(): void {
+function requireSharedWorkerRealtime(): Realtime {
   for (const realtime of realtimeInstances) {
     if (realtime.connection.state === "closed") {
       continue;
@@ -575,13 +574,45 @@ export function triggerSharedWorkerAblyReconnect(): void {
       },
     );
     if (ownsSharedDatabaseEvents) {
-      realtime.reconnect();
-      return;
+      return realtime;
     }
   }
   throw new Error(
-    "SharedWorker Ably reconnect triggered before its database subscription",
+    "SharedWorker Ably action triggered before its database subscription",
   );
+}
+
+/** Reconnect only the Realtime client that owns SharedWorker database events. */
+export function triggerSharedWorkerAblyReconnect(): void {
+  requireSharedWorkerRealtime().reconnect();
+}
+
+/** Transition only the Realtime client that owns SharedWorker database events. */
+export function triggerSharedWorkerAblyConnectionState(
+  state: "connected" | "disconnected" | "suspended",
+  options: {
+    readonly code?: number;
+    readonly message?: string;
+    readonly retryIn?: number;
+    readonly statusCode?: number;
+  } = {},
+): void {
+  requireSharedWorkerRealtime().transitionTo(
+    state,
+    {
+      code: options.code,
+      message: options.message,
+      statusCode: options.statusCode,
+    },
+    options.retryIn,
+  );
+}
+
+/** Fail only the Realtime client that owns SharedWorker database events. */
+export function triggerSharedWorkerAblyFailure(
+  message = "connection failed",
+): void {
+  requireSharedWorkerRealtime().fail(message);
 }
 
 /** Forward mock realtime recovery to a direct worker test host. */

--- a/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
@@ -24,10 +24,9 @@ import type {
 } from "../data-key.ts";
 import { MessagePortSharedDatabaseBridge } from "../message-port-client.ts";
 import { SharedDatabaseMessagePortServer } from "../message-port-server.ts";
-import {
-  SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME,
-  type SharedDatabaseClientMessage,
-  type SharedDatabaseConnectionStatus,
+import type {
+  SharedDatabaseClientMessage,
+  SharedDatabaseConnectionStatus,
 } from "../protocol.ts";
 import { SingleConnectionSharedDatabaseBridge } from "../single-connection-client.ts";
 import { SharedDatabaseWorkerContext } from "../worker-host-context.ts";
@@ -199,7 +198,7 @@ async function installProtocolBridge(): Promise<{
 }
 
 describe("shared database MessagePort protocol", () => {
-  it("waits for the credential realtime subscription before completing the initial heartbeat", async () => {
+  it("completes the initial heartbeat before the credential realtime subscription", async () => {
     installHeartbeatAuthentication();
     const initialAttachment = context.mocks.ably.deferNextSubscribe();
     const workerContext = new SharedDatabaseWorkerContext(
@@ -215,7 +214,6 @@ describe("shared database MessagePort protocol", () => {
     })();
 
     await initialAttachment.started;
-    expect(heartbeatCompleted).toBeFalsy();
     await expect(
       bridge.query(
         {
@@ -225,17 +223,15 @@ describe("shared database MessagePort protocol", () => {
         },
         owner.signal,
       ),
-    ).rejects.toMatchObject({
-      name: SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME,
-    });
-    initialAttachment.attach();
+    ).resolves.toStrictEqual([]);
     await completion;
 
     expect(heartbeatCompleted).toBeTruthy();
+    initialAttachment.attach();
     owner.abort();
   });
 
-  it("rejects the initial heartbeat when the credential realtime subscription fails", async () => {
+  it("keeps the initial heartbeat successful when the credential realtime subscription fails", async () => {
     installHeartbeatAuthentication();
     context.mocks.ably.rejectNextSubscribe("credential attach failed");
     const workerContext = new SharedDatabaseWorkerContext(
@@ -245,9 +241,9 @@ describe("shared database MessagePort protocol", () => {
     const bridge = connectProtocolTransport(workerContext, bridgeEvents());
     const owner = createChildAbortController(context.signal);
 
-    await expect(bridge.heartbeat(heartbeat(), owner.signal)).rejects.toThrow(
-      "credential attach failed",
-    );
+    await expect(
+      bridge.heartbeat(heartbeat(), owner.signal),
+    ).resolves.toStrictEqual({ clientReconnected: false });
 
     owner.abort(new DOMException("App unloaded", "AbortError"));
     await vi.waitFor(() => {

--- a/turbo/apps/platform/src/shared-database/__tests__/platform-direct-bridge.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/platform-direct-bridge.test.ts
@@ -228,7 +228,7 @@ describe("shared database direct Platform bridge", () => {
     expect(context.store.get(okouDebugRealtimeIndicator$)).toBe("disconnected");
   });
 
-  it("starts app realtime while the initial worker heartbeat handshake is pending", async () => {
+  it("starts app realtime after the initial worker heartbeat handshake completes", async () => {
     const heartbeatGates: {
       readonly promise: Promise<void>;
       readonly resolve: (value: void) => void;
@@ -256,16 +256,19 @@ describe("shared database direct Platform bridge", () => {
 
     await vi.waitFor(() => {
       expect(heartbeatGates).toHaveLength(1);
-      expect(context.mocks.ably.getAuthTokenHistory()).toHaveLength(2);
+      expect(context.mocks.ably.getAuthTokenHistory()).toHaveLength(1);
     });
     expect(
       context.mocks.ably.hasSubscription("connectorPermissionUpdated"),
-    ).toBeTruthy();
+    ).toBeFalsy();
     heartbeatGates[0]?.resolve(undefined);
     await bootstrap;
-    expect(
-      context.mocks.ably.hasSubscription("connectorPermissionUpdated"),
-    ).toBeTruthy();
+    await vi.waitFor(() => {
+      expect(
+        context.mocks.ably.hasSubscription("connectorPermissionUpdated"),
+      ).toBeTruthy();
+      expect(context.mocks.ably.getAuthTokenHistory()).toHaveLength(2);
+    });
     expect(heartbeatGates).toHaveLength(1);
     expect(context.store).not.toBe(context.workerStore);
   });

--- a/turbo/apps/platform/src/shared-database/__tests__/single-connection-client.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/single-connection-client.test.ts
@@ -119,6 +119,32 @@ function query() {
 }
 
 describe("single-connection shared database bridge", () => {
+  it("prepares one transport before the initial heartbeat", async () => {
+    const bridges: FakeBridge[] = [];
+    const statuses: SharedDatabaseConnectionStatus[] = [];
+    const bridge = new SingleConnectionSharedDatabaseBridge({
+      createBridge: () => {
+        const created = new FakeBridge();
+        bridges.push(created);
+        return created;
+      },
+      events: createEvents(statuses),
+    });
+    const owner = createChildAbortController(context.signal);
+
+    await bridge.prepare(owner.signal);
+
+    expect(bridges).toHaveLength(1);
+    expect(bridges[0]!.heartbeatCalls).toBe(0);
+    expect(statuses).toStrictEqual(["connecting"]);
+
+    await bridge.heartbeat(heartbeat(), owner.signal);
+
+    expect(bridges).toHaveLength(1);
+    expect(bridges[0]!.heartbeatCalls).toBe(1);
+    owner.abort();
+  });
+
   it("requests a reload when transport construction fails synchronously", async () => {
     const statuses: SharedDatabaseConnectionStatus[] = [];
     const events = createEvents(statuses);

--- a/turbo/apps/platform/src/shared-database/__tests__/worker-runtime.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/worker-runtime.test.ts
@@ -658,12 +658,9 @@ describe("shared database worker runtime", () => {
       { identity: identity(), apiBaseUrl: location.origin },
       firstSignal,
     );
-    const credentialStoreReady = store.set(
-      startCredentialStoreDaemons$,
-      (daemon) => {
-        context.track(daemon);
-      },
-    );
+    store.set(startCredentialStoreDaemons$, (daemon) => {
+      context.track(daemon);
+    });
     await initialAttachment.started;
     for (const port of [firstPort, secondPort]) {
       expect(
@@ -673,7 +670,6 @@ describe("shared database worker runtime", () => {
       ).toBeFalsy();
     }
     initialAttachment.attach();
-    await credentialStoreReady;
     await vi.waitFor(() => {
       expect(
         context.mocks.ably.hasChannelSubscriptionOnChannel(realtimeChannel()),

--- a/turbo/apps/platform/src/shared-database/message-port-server.ts
+++ b/turbo/apps/platform/src/shared-database/message-port-server.ts
@@ -258,7 +258,7 @@ export class SharedDatabaseMessagePortServer {
       if (currentBinding.credentialId !== credentialId) {
         return this.reloadAfterCredentialChange();
       }
-      return await this.heartbeatBoundConnection(
+      return this.heartbeatBoundConnection(
         currentBinding,
         message,
         identity,
@@ -275,15 +275,10 @@ export class SharedDatabaseMessagePortServer {
     });
     const { binding, signal: credentialConnectionSignal } = update;
     this.setCredentialBinding(binding, credentialConnectionSignal);
-    return await this.heartbeatBoundConnection(
-      binding,
-      message,
-      identity,
-      signal,
-    );
+    return this.heartbeatBoundConnection(binding, message, identity, signal);
   }
 
-  private async heartbeatBoundConnection(
+  private heartbeatBoundConnection(
     binding: SharedDatabaseConnectionBinding,
     message: Extract<
       SharedDatabaseClientMessage,
@@ -291,7 +286,7 @@ export class SharedDatabaseMessagePortServer {
     >,
     identity: SharedDatabaseIdentity,
     signal: AbortSignal,
-  ): Promise<SharedDatabaseHeartbeatResult> {
+  ): SharedDatabaseHeartbeatResult {
     const credentialConnectionSignal = this.credentialConnectionSignal;
     if (!credentialConnectionSignal || binding !== this.binding) {
       throw new SharedDatabaseClientNotConnectedError();
@@ -303,7 +298,7 @@ export class SharedDatabaseMessagePortServer {
       identity,
       credentialConnectionSignal,
     );
-    await this.context.startCredentialStoreDaemons(binding.credentialId);
+    this.context.startCredentialStoreDaemons(binding.credentialId);
     signal.throwIfAborted();
     credentialConnectionSignal.throwIfAborted();
     this.credentialReady = true;

--- a/turbo/apps/platform/src/shared-database/single-connection-client.ts
+++ b/turbo/apps/platform/src/shared-database/single-connection-client.ts
@@ -71,6 +71,7 @@ export class SingleConnectionSharedDatabaseBridge implements SharedDatabaseBridg
   private bridge: SharedDatabaseBridge | null = null;
   private connectionController: AbortController | null = null;
   private ownerSignal: AbortSignal | null = null;
+  private preparation: Promise<void> | null = null;
   private reloadRequested = false;
 
   constructor(
@@ -86,12 +87,28 @@ export class SingleConnectionSharedDatabaseBridge implements SharedDatabaseBridg
     };
   }
 
+  prepare(signal: AbortSignal): Promise<void> {
+    this.bindOwner(signal);
+    if (this.bridge) {
+      return Promise.resolve();
+    }
+    if (this.preparation) {
+      return this.preparation;
+    }
+    if (this.reloadRequested) {
+      return this.waitForReload(signal);
+    }
+    const preparation = this.prepareTransport(signal);
+    this.preparation = preparation;
+    return preparation;
+  }
+
   async heartbeat(
     heartbeat: SharedDatabaseHeartbeat,
     signal: AbortSignal,
   ): Promise<SharedDatabaseHeartbeatResult> {
-    this.bindOwner(signal);
-    const bridge = await this.createBridgeOrReload(signal);
+    await this.prepare(signal);
+    const bridge = this.requireBridge();
     return await this.runWithReload(() => {
       return bridge.heartbeat(
         heartbeat,
@@ -132,15 +149,7 @@ export class SingleConnectionSharedDatabaseBridge implements SharedDatabaseBridg
     this.ownerSignal = signal;
   }
 
-  private async createBridgeOrReload(
-    signal: AbortSignal,
-  ): Promise<SharedDatabaseBridge> {
-    if (this.bridge) {
-      return this.bridge;
-    }
-    if (this.reloadRequested) {
-      return await this.waitForReload(signal);
-    }
+  private async prepareTransport(signal: AbortSignal): Promise<void> {
     signal.throwIfAborted();
     const controller = createChildAbortController(this.requireOwnerSignal());
     this.options.events.statusChanged("connecting");
@@ -152,10 +161,8 @@ export class SingleConnectionSharedDatabaseBridge implements SharedDatabaseBridg
       controller.abort(created.error);
       return await this.requestReload(signal);
     }
-    const bridge = created.value;
     this.connectionController = controller;
-    this.bridge = bridge;
-    return bridge;
+    this.bridge = created.value;
   }
 
   private async constructBridge(

--- a/turbo/apps/platform/src/shared-database/test-bridge.ts
+++ b/turbo/apps/platform/src/shared-database/test-bridge.ts
@@ -71,7 +71,7 @@ interface DirectWorkerState {
 }
 
 interface DirectSharedDatabaseBridgeOptions {
-  readonly identity: Pick<SharedDatabaseIdentity, "orgId" | "userId">;
+  readonly identity: Pick<SharedDatabaseIdentity, "orgId" | "userId"> | null;
   readonly apiBaseUrl: string;
 }
 
@@ -176,6 +176,9 @@ class DirectSharedDatabaseBridge implements SharedDatabaseBridge {
     heartbeat: SharedDatabaseHeartbeat,
     signal: AbortSignal,
   ): Promise<SharedDatabaseHeartbeatResult> {
+    if (!this.options.identity) {
+      throw new Error("Authenticated test identity is required");
+    }
     const identity = { ...this.options.identity, token: heartbeat.token };
     if (!this.state.credentialController) {
       const credentialController = createChildAbortController(
@@ -340,9 +343,6 @@ export const setupSharedWorkerTestBootstrap$ = command(
             events,
           );
         } else {
-          if (!directIdentity) {
-            throw new Error("Authenticated test identity is required");
-          }
           if (!directRealtimeForwardingInstalled) {
             subscribeChatDatabaseEvents((message) => {
               directBridge?.handleRealtimeMessage(message);

--- a/turbo/apps/platform/src/shared-database/worker-host-context.ts
+++ b/turbo/apps/platform/src/shared-database/worker-host-context.ts
@@ -93,12 +93,12 @@ export class SharedDatabaseWorkerContext {
     return { binding, signal };
   }
 
-  startCredentialStoreDaemons(credentialId: string): Promise<void> {
+  startCredentialStoreDaemons(credentialId: string): void {
     const store = this.credentialStores.get(credentialId);
     if (!store) {
       throw new Error("Shared database credential Store was not found");
     }
-    return store.set(startCredentialStoreDaemons$, (daemon) => {
+    store.set(startCredentialStoreDaemons$, (daemon) => {
       this.ownCredentialDaemon(daemon);
     });
   }

--- a/turbo/apps/platform/src/shared-database/worker-signals.ts
+++ b/turbo/apps/platform/src/shared-database/worker-signals.ts
@@ -20,11 +20,7 @@ import {
   type RealtimeConnectionState,
 } from "../signals/realtime.ts";
 import { rootSignal$, setRootSignal$ } from "../signals/root-signal.ts";
-import {
-  createChildAbortController,
-  createDeferredPromise,
-  settle,
-} from "../signals/utils.ts";
+import { createChildAbortController, settle } from "../signals/utils.ts";
 import { chatThreadIndicators$ } from "../signals/chat-page/chat-thread-indicators.ts";
 import type {
   ChatThreadIndicators,
@@ -57,7 +53,7 @@ const STALE_CONNECTION_AFTER_MS = 3 * 60 * 1000;
 
 const credentialControllerState$ = state<AbortController | null>(null);
 const workerRuntimeState$ = state<SharedDatabaseWorkerRuntime | null>(null);
-const credentialStoreDaemonsReadyState$ = state<Promise<void> | null>(null);
+const credentialStoreDaemonsStartedState$ = state(false);
 const sharedDatabaseClientFactory$ = computed((get) => {
   return createSharedDatabaseContractClientFactory(get(appVersion$));
 });
@@ -264,11 +260,7 @@ export const recoverCredentialStoreAfterRealtimeReconnect$ = command(
 );
 
 const runCredentialStoreDaemons$ = command(
-  async (
-    { set },
-    ready: ReturnType<typeof createDeferredPromise<void>>,
-    signal: AbortSignal,
-  ): Promise<void> => {
+  async ({ set }, signal: AbortSignal): Promise<void> => {
     set(
       subscribeRealtimeConnectionState$,
       ({ state, reconnected }) => {
@@ -281,12 +273,10 @@ const runCredentialStoreDaemons$ = command(
     );
     const setup = await settle(set(setupRealtime$, signal), signal);
     if (!setup.ok) {
-      if (!ready.settled()) {
-        ready.reject(setup.error);
-      }
       set(updateSharedDatabaseRealtimeStatus$, "failed");
       return;
     }
+    let initiallySubscribed = false;
     const subscriptions = await settle(
       Promise.all([
         set(
@@ -298,8 +288,8 @@ const runCredentialStoreDaemons$ = command(
             includeMessage: true,
             options: {
               onSubscribed: () => {
-                if (!ready.settled()) {
-                  ready.resolve();
+                if (!initiallySubscribed) {
+                  initiallySubscribed = true;
                   return;
                 }
                 set(broadcastSharedDatabaseReconnect$);
@@ -315,25 +305,19 @@ const runCredentialStoreDaemons$ = command(
     );
     signal.throwIfAborted();
     if (!subscriptions.ok) {
-      if (!ready.settled()) {
-        ready.reject(subscriptions.error);
-      }
       set(updateSharedDatabaseRealtimeStatus$, "failed");
     }
   },
 );
 
 export const startCredentialStoreDaemons$ = command(
-  ({ get, set }, ownDaemon: CredentialStoreDaemonOwner): Promise<void> => {
-    const existing = get(credentialStoreDaemonsReadyState$);
-    if (existing) {
-      return existing;
+  ({ get, set }, ownDaemon: CredentialStoreDaemonOwner): void => {
+    if (get(credentialStoreDaemonsStartedState$)) {
+      return;
     }
     const signal = get(rootSignal$);
-    const ready = createDeferredPromise<void>(signal);
-    set(credentialStoreDaemonsReadyState$, ready.promise);
-    ownDaemon(set(runCredentialStoreDaemons$, ready, signal));
-    return ready.promise;
+    set(credentialStoreDaemonsStartedState$, true);
+    ownDaemon(set(runCredentialStoreDaemons$, signal));
   },
 );
 

--- a/turbo/apps/platform/src/signals/__tests__/shared-database-browser.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/shared-database-browser.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { SharedDatabasePortLike } from "../../shared-database/bridge.ts";
 import type { AuthRecovery } from "../auth-retry.ts";
-import { setupSharedDatabaseBridge$ } from "../shared-database-browser.ts";
+import {
+  prepareSharedDatabaseBridge$,
+  setupSharedDatabaseBridge$,
+} from "../shared-database-browser.ts";
 import { testContext } from "./test-helpers.ts";
 
 const context = testContext();
@@ -166,6 +169,15 @@ async function setupBridge(recovery = authRecovery()): Promise<void> {
 }
 
 describe("shared database browser bridge", () => {
+  it("starts the shared worker before the authentication handshake", async () => {
+    const { constructorCalls, workers } = installSharedWorkerMock();
+
+    await context.store.set(prepareSharedDatabaseBridge$, context.signal);
+
+    expect(constructorCalls).toHaveLength(1);
+    expect(workers[0]!.port.heartbeatTokens).toStrictEqual([]);
+  });
+
   it("forces an auth refresh when the worker rejects its credential", async () => {
     const { workers } = installSharedWorkerMock();
     await setupBridge();

--- a/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
+++ b/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
@@ -17,6 +17,8 @@ import {
   triggerAblyFailure,
   triggerAblyReauth,
   triggerAblyReconnect,
+  triggerSharedWorkerAblyConnectionState,
+  triggerSharedWorkerAblyFailure,
   triggerSharedWorkerAblyReconnect,
 } from "../../mocks/ably.ts";
 import { setMockAgents } from "../../mocks/handlers/api-agents.ts";
@@ -470,6 +472,9 @@ export function createTestMocks(getSignal: () => AbortSignal) {
       triggerConnectionState: triggerAblyConnectionState,
       triggerFailure: triggerAblyFailure,
       triggerReconnect: triggerAblyReconnect,
+      triggerSharedWorkerConnectionState:
+        triggerSharedWorkerAblyConnectionState,
+      triggerSharedWorkerFailure: triggerSharedWorkerAblyFailure,
       triggerSharedWorkerReconnect: triggerSharedWorkerAblyReconnect,
       triggerReauth: triggerAblyReauth,
       triggerConnectionClosed: triggerAblyConnectionClosed,

--- a/turbo/apps/platform/src/signals/authenticated-daemons.ts
+++ b/turbo/apps/platform/src/signals/authenticated-daemons.ts
@@ -66,10 +66,10 @@ export const setupAuthenticatedDaemons$ = command(
 
     const authRecovery = await get(authRecovery$);
     signal.throwIfAborted();
-    const appRealtimeDaemons = set(runAppRealtimeDaemons$, signal);
-    ownDaemon(appRealtimeDaemons);
     await set(setupSharedDatabaseBridge$, authRecovery, signal);
     signal.throwIfAborted();
+    const appRealtimeDaemons = set(runAppRealtimeDaemons$, signal);
+    ownDaemon(appRealtimeDaemons);
     set(authenticatedServicesInstalled$, true);
   },
 );

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -18,6 +18,7 @@ import { initLocale$, syncLocalePreference$ } from "./locale.ts";
 import { setRootSignal$ } from "./root-signal.ts";
 import { setApiClientRuntime$ } from "./api-client-runtime.ts";
 import { setAuthenticatedServicesReady$ } from "./auth-context.ts";
+import { prepareSharedDatabaseBridge$ } from "./shared-database-browser.ts";
 import { resolveApiBaseForTarget, resolveOAuthApiBase } from "./api-base.ts";
 import { getCapturedPreviewBypassForTarget } from "../lib/preview-bypass-cookie.ts";
 import {
@@ -545,6 +546,7 @@ export const bootstrap$ = command(
       oauthApiBaseUrl: resolveOAuthApiBase(),
       ...(vercelProtectionBypass ? { vercelProtectionBypass } : {}),
     });
+    ownDaemon(set(prepareSharedDatabaseBridge$, signal));
     set(initClerkRuntime$, signal);
     set(initAuthRecovery$, signal);
     set(initBootstrapSkeleton$);

--- a/turbo/apps/platform/src/signals/shared-database-browser.ts
+++ b/turbo/apps/platform/src/signals/shared-database-browser.ts
@@ -160,6 +160,15 @@ const sharedDatabaseBridgeHostState$ = state<SharedDatabaseBridgeHost>({
   createBridge: createBrowserSharedDatabaseBridge,
 });
 
+interface PreparedSharedDatabaseBridge {
+  readonly apiBaseUrl: string;
+  readonly authenticationRequiredTarget: EventTarget;
+  readonly bridge: SingleConnectionSharedDatabaseBridge;
+}
+
+const preparedSharedDatabaseBridgeState$ =
+  state<PreparedSharedDatabaseBridge | null>(null);
+
 const syncSharedDatabaseInvalidation$ = command(
   async (
     { set },
@@ -189,25 +198,18 @@ export const setSharedDatabaseBridgeHostForTest$ = command(
   },
 );
 
-export const setupSharedDatabaseBridge$ = command(
-  async (
-    { get, set },
-    authRecovery: AuthRecovery,
-    signal: AbortSignal,
-  ): Promise<void> => {
+export const prepareSharedDatabaseBridge$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
     signal.throwIfAborted();
-    if (get(sharedDatabaseBridgeInstalled$)) {
+    const existing = get(preparedSharedDatabaseBridgeState$);
+    if (existing) {
+      await existing.bridge.prepare(signal);
       return;
-    }
-    const token = await authRecovery.getToken(signal);
-    signal.throwIfAborted();
-    if (!token) {
-      throw new Error("Clerk token is required for the shared database");
     }
     const apiBaseUrl = resolveApiBaseForTarget("api");
     const bridgeHost = get(sharedDatabaseBridgeHostState$);
     const authenticationRequiredTarget = new EventTarget();
-    const singleConnectionBridge = new SingleConnectionSharedDatabaseBridge({
+    const bridge = new SingleConnectionSharedDatabaseBridge({
       createBridge: (events, connectionSignal) => {
         return bridgeHost.createBridge(apiBaseUrl, events, connectionSignal);
       },
@@ -234,22 +236,52 @@ export const setupSharedDatabaseBridge$ = command(
         },
       },
     });
+    set(preparedSharedDatabaseBridgeState$, {
+      apiBaseUrl,
+      authenticationRequiredTarget,
+      bridge,
+    });
+    await bridge.prepare(signal);
+  },
+);
+
+export const setupSharedDatabaseBridge$ = command(
+  async (
+    { get, set },
+    authRecovery: AuthRecovery,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    signal.throwIfAborted();
+    if (get(sharedDatabaseBridgeInstalled$)) {
+      return;
+    }
+    await set(prepareSharedDatabaseBridge$, signal);
+    const prepared = get(preparedSharedDatabaseBridgeState$);
+    if (!prepared) {
+      throw new Error("Shared database bridge was not prepared");
+    }
+    const token = await authRecovery.getToken(signal);
+    signal.throwIfAborted();
+    if (!token) {
+      throw new Error("Clerk token is required for the shared database");
+    }
     const bridge = new AuthRecoveringSharedDatabaseBridge(
-      singleConnectionBridge,
+      prepared.bridge,
       async (recoverySignal) => {
         return await authRecovery.forceRefreshToken(recoverySignal);
       },
       signal,
     );
-    authenticationRequiredTarget.addEventListener(
+    prepared.authenticationRequiredTarget.addEventListener(
       AUTHENTICATION_REQUIRED_EVENT,
       onDomEventFn(async () => {
         await bridge.authenticationRequired();
       }),
       { signal },
     );
-    const vercelProtectionBypass =
-      getCapturedPreviewBypassForTarget(apiBaseUrl);
+    const vercelProtectionBypass = getCapturedPreviewBypassForTarget(
+      prepared.apiBaseUrl,
+    );
     await set(
       installSharedDatabaseBridge$,
       bridge,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
@@ -391,10 +391,15 @@ describe("zero sidebar account menu", () => {
     }
     await waitFor(() => {
       expect(within(accountButton).queryByRole("status")).toBeNull();
+      expect(
+        context.mocks.ably.hasChannelSubscriptionOnChannel(
+          "user-org:test-user-123:org_default",
+        ),
+      ).toBeTruthy();
     });
 
     act(() => {
-      context.mocks.ably.triggerConnectionState("disconnected", {
+      context.mocks.ably.triggerSharedWorkerConnectionState("disconnected", {
         retryIn: 5000,
       });
     });
@@ -407,14 +412,16 @@ describe("zero sidebar account menu", () => {
     });
 
     act(() => {
-      context.mocks.ably.triggerConnectionState("connected");
+      context.mocks.ably.triggerSharedWorkerConnectionState("connected");
     });
     await waitFor(() => {
       expect(within(accountButton).queryByRole("status")).toBeNull();
     });
 
     act(() => {
-      context.mocks.ably.triggerFailure("terminal connection failure");
+      context.mocks.ably.triggerSharedWorkerFailure(
+        "terminal connection failure",
+      );
     });
     await waitFor(() => {
       expect(


### PR DESCRIPTION
## Summary

- start the shared-database SharedWorker during app bootstrap, before Clerk finishes loading
- send the first heartbeat immediately after authenticated Clerk setup, before starting App realtime
- complete the worker handshake after `/api/auth/me` succeeds and run credential Ably setup as a background daemon
- cover pre-auth worker startup, handshake/realtime ordering, and Ably attach failure with regression tests

This removes the worker Ably connection and channel attachment from the authenticated bootstrap critical path.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged workspace, App, and API TypeScript checks
- `pnpm --filter @okouai/app exec vitest run src/shared-database/__tests__/single-connection-client.test.ts`
- `pnpm --filter @okouai/app exec vitest run src/signals/__tests__/shared-database-browser.test.ts`
- `pnpm --filter @okouai/app exec vitest run src/shared-database/__tests__/message-port.test.ts`
- `pnpm --filter @okouai/app exec vitest run src/views/auth/__tests__/auth-page.test.tsx`
- `pnpm --filter @okouai/app exec vitest run src/shared-database/__tests__/platform-direct-bridge.test.ts`
- `pnpm --filter @okouai/app exec vitest run src/shared-database/__tests__/worker-runtime.test.ts`
