### PR TITLE
fix(locator): drop the preview counter and widen the band with its ticks

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
@@ -72,6 +72,13 @@ const TICK_METRICS = {
   assistant: { base: 12, grow: 2.5 },
 } as const;
 
+/**
+ * Resting width of the viewport band. The band grows by exactly as much as the
+ * widest tick it covers, so a magnified bar never spills out of the frame that
+ * is supposed to contain it.
+ */
+export const BAND_BASE_WIDTH_PX = 32;
+
 const GROUP_SELECTOR = '[data-role="user"], [data-role="assistant"]';
 const SCROLL_ANCHOR_SELECTOR = "[data-chat-scroll-anchor-event-id]";
 
@@ -111,9 +118,6 @@ export interface LocatorPreview {
   readonly text: string;
   /** ISO timestamp of the turn, or undefined when it carries none. */
   readonly createdAt: string | undefined;
-  /** 1-based, for the "12/32" counter. */
-  readonly position: number;
-  readonly total: number;
 }
 
 export interface ChatConversationLocatorSignals {
@@ -521,13 +525,28 @@ function tickNodes(rail: HTMLElement): HTMLElement[] {
   return [...rail.querySelectorAll<HTMLElement>("[data-locator-tick]")];
 }
 
-function resetTickWidths(rail: HTMLElement): void {
+/**
+ * The band is the frame around the ticks inside the viewport, so it widens by
+ * whatever its widest tick gained rather than by a growth of its own: one
+ * dimension, one source, and the bars stay enclosed at every magnification.
+ */
+function writeBandWidth(rail: HTMLElement, growth: number): void {
+  const band = rail.querySelector<HTMLElement>(
+    "[data-conversation-locator-band]",
+  );
+  if (band) {
+    band.style.width = `${(BAND_BASE_WIDTH_PX + growth).toFixed(2)}px`;
+  }
+}
+
+function resetRailWidths(rail: HTMLElement): void {
   for (const node of tickNodes(rail)) {
     const role: LocatorRole =
       node.dataset.locatorTick === "user" ? "user" : "assistant";
     node.style.width = `${TICK_METRICS[role].base}px`;
     delete node.dataset.locatorHot;
   }
+  writeBandWidth(rail, 0);
 }
 
 /**
@@ -545,6 +564,8 @@ function applyMagnification(
     MAGNIFY_SIGMA_MIN_PX,
     layout.pitch * MAGNIFY_SIGMA_RATIO,
   );
+  const bandBottom = layout.bandTop + layout.bandHeight;
+  let bandGrowth = 0;
   let nearest = -1;
   let nearestDistance = Number.POSITIVE_INFINITY;
   for (const [index, tick] of layout.ticks.entries()) {
@@ -561,7 +582,11 @@ function applyMagnification(
     const metrics = TICK_METRICS[tick.role];
     const width = metrics.base * (1 + weight * metrics.grow);
     node.style.width = `${width.toFixed(2)}px`;
+    if (tick.y >= layout.bandTop && tick.y <= bandBottom) {
+      bandGrowth = Math.max(bandGrowth, width - metrics.base);
+    }
   }
+  writeBandWidth(rail, bandGrowth);
 
   // Anywhere inside the group the nearest tick is at most half a pitch away,
   // so only overshooting the first or last tick misses.
@@ -707,7 +732,7 @@ function createPaint(
       return;
     }
     if (pointerY === null) {
-      resetTickWidths(rail);
+      resetRailWidths(rail);
       set(store.preview$, null);
       return;
     }
@@ -725,8 +750,7 @@ function createPaint(
       shown?.turnIndex === tick.turnIndex &&
       shown.role === tick.role &&
       shown.text === turn.text &&
-      shown.createdAt === turn.createdAt &&
-      shown.total === layout.turnCount
+      shown.createdAt === turn.createdAt
     ) {
       return;
     }
@@ -735,8 +759,6 @@ function createPaint(
       role: tick.role,
       text: turn.text,
       createdAt: turn.createdAt,
-      position: tick.turnIndex + 1,
-      total: layout.turnCount,
     });
   });
 }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-conversation-locator.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-conversation-locator.test.tsx
@@ -69,7 +69,14 @@ function stubLayout({
   Object.defineProperty(prototype, "scrollTop", {
     configurable: true,
     get(this: HTMLElement): number {
-      return scrollTops.get(this) ?? 0;
+      const stored = scrollTops.get(this) ?? 0;
+      if (!isScroller(this)) {
+        return stored;
+      }
+      // The thread pins itself to the bottom by assigning scrollHeight, so
+      // without a browser's clamp the viewport would read as parked a whole
+      // screen past the last turn.
+      return Math.min(stored, Math.max(0, this.scrollHeight - VIEWPORT_PX));
     },
     set(this: HTMLElement, value: number) {
       scrollTops.set(this, Math.max(0, value));
@@ -576,6 +583,58 @@ describe("chat conversation locator", () => {
     }
   });
 
+  it("widens the viewport band with the ticks it frames", async () => {
+    const { rail } = await renderLongThread();
+
+    const bandElement = await waitFor(() => {
+      const element = rail.querySelector<HTMLElement>(
+        "[data-conversation-locator-band]",
+      );
+      expect(element).not.toBeNull();
+      return element as HTMLElement;
+    });
+    const bandWidth = () => {
+      return Number.parseFloat(bandElement.style.width);
+    };
+    const widestFramedTick = () => {
+      const top = Number.parseFloat(bandElement.style.top);
+      const bottom = top + Number.parseFloat(bandElement.style.height);
+      return Math.max(
+        ...ticksOf(rail)
+          .filter((tick) => {
+            const y = Number.parseFloat(tick.style.top);
+            return y >= top && y <= bottom;
+          })
+          .map((tick) => {
+            return Number.parseFloat(tick.style.width);
+          }),
+      );
+    };
+
+    expect(bandWidth()).toBe(32);
+
+    // A freshly opened thread sits at its tail, so the band frames the last
+    // ticks and the cursor can land on one of them.
+    const ticks = ticksOf(rail);
+    const target = ticks.at(-1) as HTMLElement;
+    pointerAt(rail, 0, "pointerenter");
+    pointerAt(rail, Number.parseFloat(target.style.top), "pointermove");
+    await waitFor(() => {
+      expect(target.dataset.locatorHot).toBe("");
+    });
+
+    // The band grows by exactly what its widest tick gained, so a magnified
+    // bar never spills out of the frame that marks the viewport.
+    expect(widestFramedTick()).toBe(Number.parseFloat(target.style.width));
+    expect(bandWidth()).toBeGreaterThan(32);
+    expect(bandWidth()).toBeCloseTo(32 + widestFramedTick() - 7, 1);
+
+    pointerAt(rail, 200, "pointerleave");
+    await waitFor(() => {
+      expect(bandWidth()).toBe(32);
+    });
+  });
+
   it("pages the window on wheel and hands it back when the pointer leaves", async () => {
     const { rail } = await renderLongThread();
 
@@ -673,9 +732,10 @@ describe("chat conversation locator", () => {
     });
     pointerAt(rail, Number.parseFloat(firstTick.style.top), "pointermove");
 
+    // The first turn is outside the DOM render window, so naming it in the
+    // preview is what proves the rail indexes the whole thread.
     await waitFor(() => {
       expect(locatorPreview()).toHaveTextContent("Virtual question 0");
-      expect(locatorPreview()).toHaveTextContent("1/30");
     });
     rail.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 

--- a/turbo/apps/platform/src/views/okou-page/chat-conversation-locator.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-conversation-locator.tsx
@@ -3,7 +3,10 @@ import { useTranslation } from "react-i18next";
 import { cn } from "@okouai/ui";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import type { ChatPanelSignals } from "../../signals/chat-page/chat-panel-signals.ts";
-import type { LocatorRole } from "../../signals/chat-page/chat-conversation-locator.ts";
+import {
+  BAND_BASE_WIDTH_PX,
+  type LocatorRole,
+} from "../../signals/chat-page/chat-conversation-locator.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { AgentAvatarImg } from "./sidebar-shared.tsx";
 import { formatChatTimestamp } from "../../i18n/format.ts";
@@ -51,9 +54,6 @@ function LocatorPreviewCard({ thread }: { thread: ChatPanelSignals }) {
         <span className="tabular-nums">
           {preview?.createdAt ? formatChatTimestamp(preview.createdAt) : null}
         </span>
-        <span className="ml-auto tabular-nums">
-          {preview ? `${preview.position}/${preview.total}` : null}
-        </span>
       </div>
       <p className="line-clamp-2 text-sm leading-[1.62] text-muted-foreground [overflow-wrap:anywhere]">
         {preview?.text}
@@ -87,8 +87,14 @@ function ConversationLocatorRail({ thread }: { thread: ChatPanelSignals }) {
         {layout.visible && layout.bandHeight > 0 ? (
           <div
             data-conversation-locator-band
-            className="pointer-events-none absolute left-[7px] w-8 rounded-[5px] bg-primary opacity-[0.05]"
-            style={{ top: layout.bandTop, height: layout.bandHeight }}
+            // Width tracks the magnified ticks and is written per pointer
+            // frame by the locator signals, like the ticks themselves.
+            className="pointer-events-none absolute left-[7px] rounded-[5px] bg-primary opacity-[0.05]"
+            style={{
+              top: layout.bandTop,
+              height: layout.bandHeight,
+              width: BAND_BASE_WIDTH_PX,
+            }}
           />
         ) : null}
         {layout.ticks.map((tick) => {


### PR DESCRIPTION
Two fixes to the conversation locator, both reported from screenshots.

## 1. The `n/m` counter is gone

The preview card showed `4/8` / `8/8`. That numbering is not stable: folding and expanding groups changes both the position and the total, so the same turn is numbered differently from one moment to the next. A counter that moves under the reader is worse than no counter, so the card now carries just the role, the avatar and the timestamp. `position` and `total` are dropped from `LocatorPreview` entirely.

## 2. The viewport band widens with the ticks it frames

The orange band marks the turns inside the viewport, but it kept its resting 32px while the ticks it frames magnified on hover — so the hovered bar grew straight out of the frame that is supposed to contain it.

The band now widens by exactly what its widest framed tick gained, written per pointer frame in `applyMagnification` alongside the tick widths. Same source, same frame, so the frame stays locked to the bars instead of trailing them through a CSS transition. One dimension changes, and it returns to 32px on `pointerleave` with the ticks.

## Test harness

The layout stub let `scrollTop` exceed the scrollable range — the thread pins itself to the bottom by assigning `scrollHeight`, so the measured viewport read as parked a whole screen past the last turn and `bandHeight` was `0` for the entire suite. The band was therefore never in the DOM and never testable. The stub now clamps the way a browser does.

## Checks

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-conversation-locator.test.tsx` — 14 passed
- `tsc --noEmit`, `pnpm -F @okouai/app run lint`, `pnpm knip --workspace apps/platform`, `pnpm format` — clean

Behind the `ChatConversationLocator` feature switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)