### PR TITLE
refactor(api): unify the teams oauth callback and delete the legacy zero path map

### DIFF
--- a/turbo/apps/api/src/__tests__/api-namespace-compatibility.test.ts
+++ b/turbo/apps/api/src/__tests__/api-namespace-compatibility.test.ts
@@ -14,10 +14,12 @@ import {
 const CANONICAL_PREFIX = "/api/okou";
 const LEGACY_PREFIX = "/api/zero";
 
-// The six legacy `/api/zero/**` paths this service still owes a caller after
-// #28701, keyed by the canonical `/api/okou/**` path. Restated here rather than
-// imported from `route-entry.ts`, so narrowing the production table fails this
-// file instead of quietly agreeing with itself.
+// The six legacy `/api/zero/**` paths this service still owes a caller, keyed
+// by the canonical `/api/okou/**` path the same handler answers. #30667 deleted
+// `LEGACY_ZERO_PATHS`, so none of them is derived any more: each is named
+// directly by a `MIGRATED_BRANDED_PATHS` row. Restated here rather than
+// imported from `route-entry.ts`, so narrowing that table fails this file
+// instead of quietly agreeing with itself.
 //
 // Every row is held by a Slack or Teams app configuration: a provider console
 // holds the URL, so no deploy and no client release drains it. `slack/commands`
@@ -25,7 +27,7 @@ const LEGACY_PREFIX = "/api/zero";
 // `vm0-request-log-prod` retained when #28701 read it, and stay because they
 // live in the same Slack app configuration as the Event Subscriptions URL that
 // demonstrably still points at the legacy path.
-const LEGACY_ZERO_PATHS: Readonly<Record<string, string>> = {
+const SERVED_LEGACY_PATHS: Readonly<Record<string, string>> = {
   "/api/okou/slack/events": "/api/zero/slack/events",
   "/api/okou/slack/oauth/install": "/api/zero/slack/oauth/install",
   "/api/okou/slack/oauth/callback": "/api/zero/slack/oauth/callback",
@@ -34,12 +36,12 @@ const LEGACY_ZERO_PATHS: Readonly<Record<string, string>> = {
   "/api/okou/teams/oauth/callback": "/api/zero/teams/oauth/callback",
 };
 
-// A row #28701 removed from the compatibility table whose path did not retire
-// with it: `MIGRATED_BRANDED_PATHS` names both branded forms of the neutral
-// `/api/org` contract, so the table row recorded that the path was owed rather
-// than being what served it. Pinned here because it is the difference between
-// the two tables, and the reason removing twenty-five rows changed nothing a
-// caller can observe.
+// A row #28701 removed from `LEGACY_ZERO_PATHS` whose path did not retire with
+// it: `MIGRATED_BRANDED_PATHS` names both branded forms of the neutral
+// `/api/org` contract, so the removed row recorded that the path was owed
+// rather than being what served it. Pinned here because it is why removing
+// twenty-five rows changed nothing a caller can observe, and why #30667 could
+// remove the remaining six the same way.
 const MIGRATED_BRANDED_SUBJECT = {
   neutral: "/api/org",
   canonical: "/api/okou/org",
@@ -60,7 +62,7 @@ function canonicalPath(path: string): string {
 // Both branded forms of every compatibility path, taken from the literal list
 // above rather than from `apiNamespaceAliasPaths` or the production table.
 function compatibilityPaths(): readonly string[] {
-  return Object.entries(LEGACY_ZERO_PATHS).flat();
+  return Object.entries(SERVED_LEGACY_PATHS).flat();
 }
 
 // Composed the way production registers routes, so a slice that moves a listed
@@ -82,26 +84,22 @@ function missingCompatibilityPaths(
     .sort();
 }
 
-// A route entry declaring a branded path, for the two guards below that pin how
-// the expansion treats one. #28946 moved the last contract off `/api/okou/**`,
-// so `ROUTES` no longer holds such an entry and it has to be composed. The
-// expansion still has to handle a branded declaration — `apiNamespaceAliasPaths`
-// and `servesNamespaceAliasPath` both branch on one — and these are the only
-// tests left that reach that branch.
+// A route entry declaring a branded path, for the three guards below that pin
+// how the expansion treats one. #28946 moved the last contract off
+// `/api/okou/**`, so `ROUTES` no longer holds such an entry and it has to be
+// composed. The expansion still has to handle a branded declaration —
+// `apiNamespaceAliasPaths` and `servesNamespaceAliasPath` both branch on one —
+// and these are the only tests left that reach that branch.
 //
-// Composed from a real neutral route so everything but the path is ordinary,
-// and from one whose canonical form `LEGACY_ZERO_PATHS` does not name, so the
-// expansion's own rule decides whether the legacy form registers rather than a
-// table row deciding for it.
+// Composed from a real neutral route so everything but the path is ordinary.
+// Which route no longer matters: since #30667 the expansion consults no table,
+// so its own rule is the only thing deciding whether the legacy form registers.
 function brandedRouteSource(): RouteEntry {
   const entry = ROUTES.find(({ route }) => {
-    if (brandedApiNamespace(route.path) !== undefined) {
-      return false;
-    }
-    if (!route.path.startsWith("/api/")) {
-      return false;
-    }
-    return LEGACY_ZERO_PATHS[brandedPath(route.path)] === undefined;
+    return (
+      brandedApiNamespace(route.path) === undefined &&
+      route.path.startsWith("/api/")
+    );
   });
   if (!entry) {
     throw new Error("Expected a neutral /api/ route to compose a branded path");
@@ -118,9 +116,8 @@ function brandedPath(neutralPath: string): string {
 
 // Per-endpoint behaviour is covered through the endpoints themselves. This
 // file asserts the properties no single endpoint can express: over the whole
-// route table, which paths are registered, which of them the compatibility
-// table owes on purpose, and which the expansion is no longer allowed to
-// derive.
+// route table, which paths are registered, which legacy paths are still served
+// on purpose, and that the expansion derives none of them.
 describe("API namespace compatibility", () => {
   const registeredRoutes = withApiNamespaceAliases(ROUTES);
   // Composed the way production registers routes. The expansion above is the
@@ -176,22 +173,31 @@ describe("API namespace compatibility", () => {
     }).not.toThrow();
   });
 
-  // What #28701 replaced the fallback with. Before it, the expansion derived
-  // the legacy form of every branded contract path and only marked the ones the
-  // table did not list; a `/api/zero/**` path now exists because the table names
-  // it, not because something derived it.
-  it("derives no legacy path the compatibility table does not name", () => {
-    const owed = new Set(Object.values(LEGACY_ZERO_PATHS));
-    const derived = registeredRoutes
-      .map(({ route }) => {
-        return route.path;
-      })
-      .filter((path) => {
-        return brandedApiNamespace(path) === "zero" && !owed.has(path);
-      })
-      .sort();
+  // What #28701 replaced the fallback with and #30667 finished. The expansion
+  // used to derive the legacy form of every branded contract path and keep the
+  // ones `LEGACY_ZERO_PATHS` named; with that table gone it derives none, and a
+  // `/api/zero/**` path exists only where a `MIGRATED_BRANDED_PATHS` row names
+  // it. The composed branded declaration is what carries this assertion —
+  // `ROUTES` declares no branded path any more, so the sweep over it would pass
+  // whatever the expansion did.
+  it("derives no legacy path from a branded declaration", () => {
+    const declared = brandedRouteSource();
 
-    expect(derived).toStrictEqual([]);
+    expect(
+      withApiNamespaceAliases([declared]).map(({ route }) => {
+        return route.path;
+      }),
+    ).toStrictEqual([declared.route.path]);
+    expect(
+      registeredRoutes
+        .map(({ route }) => {
+          return route.path;
+        })
+        .filter((path) => {
+          return brandedApiNamespace(path) === "zero";
+        })
+        .sort(),
+    ).toStrictEqual([]);
   });
 
   // The issue that narrowed the table proposed `/api/zero/org` as the retired
@@ -251,7 +257,7 @@ describe("API namespace compatibility", () => {
   });
 
   it("serves every listed legacy path with the handler that serves its canonical path", () => {
-    for (const [canonical, legacy] of Object.entries(LEGACY_ZERO_PATHS)) {
+    for (const [canonical, legacy] of Object.entries(SERVED_LEGACY_PATHS)) {
       const sources = registrationsFor(canonical);
       expect(
         sources.length,
@@ -295,8 +301,8 @@ describe("API namespace compatibility", () => {
     const declared = "/api/webhooks/slack/events";
     const neutral = "/api/slack/events";
     expect(
-      LEGACY_ZERO_PATHS[canonical],
-      `${canonical} must stay in the compatibility list for this guard to mean anything`,
+      SERVED_LEGACY_PATHS[canonical],
+      `${canonical} must stay in the served-legacy list for this guard to mean anything`,
     ).toBe(legacy);
     expect(
       ROUTES.filter((entry) => {
@@ -346,7 +352,7 @@ describe("API namespace compatibility", () => {
     );
 
     expect(
-      Object.keys(LEGACY_ZERO_PATHS).filter((path) => {
+      Object.keys(SERVED_LEGACY_PATHS).filter((path) => {
         return !servedCanonicalPaths.has(path);
       }),
     ).toStrictEqual([]);

--- a/turbo/apps/api/src/__tests__/api-namespace-legacy-paths.test.ts
+++ b/turbo/apps/api/src/__tests__/api-namespace-legacy-paths.test.ts
@@ -9,14 +9,15 @@ import { testContext } from "./test-context";
 const c = initContract();
 const REQUEST_ORIGIN = "http://api.test";
 
-// `/api/okou/slack/events` is one of the six paths the compatibility table in
-// `route-entry.ts` still lists, so its `/api/zero/**` form is served. The
-// `__test` paths deliberately are not listed, so they stand in for the branded
-// contract paths #28701 stopped deriving a legacy form for.
+// `/api/webhooks/slack/events` is a `MIGRATED_BRANDED_PATHS` key in
+// `route-entry.ts`, so a contract declaring it is registered on both branded
+// forms as well. The `__test` paths are named by no table, so they stand in for
+// the branded contract paths #28701 stopped deriving a legacy form for and
+// #30667 made unconditional.
 const namespaceContract = c.router({
-  listed: {
+  migrated: {
     method: "GET",
-    path: "/api/okou/slack/events",
+    path: "/api/webhooks/slack/events",
     responses: {
       200: z.object({ served: z.literal(true) }),
     },
@@ -43,7 +44,7 @@ const served$ = computed(() => {
 });
 
 const TEST_ROUTES: readonly RouteEntry[] = [
-  { route: namespaceContract.listed, handler: served$ },
+  { route: namespaceContract.migrated, handler: served$ },
   { route: namespaceContract.unlisted, handler: served$ },
   { route: namespaceContract.unlistedById, handler: served$ },
 ];
@@ -59,21 +60,27 @@ describe("legacy API namespace paths", () => {
     return createAppWithRoutes({ signal: context.signal, routes: TEST_ROUTES });
   }
 
-  it("serves a listed legacy path and its canonical path", async () => {
+  it("serves a migrated route's declared path and both branded paths", async () => {
     const app = createTestApp();
 
     const legacy = await app.request(`${REQUEST_ORIGIN}/api/zero/slack/events`);
     const canonical = await app.request(
       `${REQUEST_ORIGIN}/api/okou/slack/events`,
     );
+    const declared = await app.request(
+      `${REQUEST_ORIGIN}/api/webhooks/slack/events`,
+    );
 
-    expect([legacy.status, canonical.status]).toStrictEqual([200, 200]);
+    expect([legacy.status, canonical.status, declared.status]).toStrictEqual([
+      200, 200, 200,
+    ]);
     await expect(legacy.json()).resolves.toStrictEqual({ served: true });
   });
 
   // Before #28701 this path was served by the blanket expansion and reported
-  // once per app instance. The table is exhaustive now, so it is a 404.
-  it("returns 404 for an unlisted legacy path while its canonical path is served", async () => {
+  // once per app instance. #28701 narrowed it to a table of six, and #30667
+  // deleted that table: a derived legacy form is now always a 404.
+  it("returns 404 for a derived legacy path while its canonical path is served", async () => {
     const app = createTestApp();
 
     const legacy = await app.request(
@@ -89,7 +96,7 @@ describe("legacy API namespace paths", () => {
     await expect(canonical.json()).resolves.toStrictEqual({ served: true });
   });
 
-  it("returns 404 for an unlisted legacy path template with parameters", async () => {
+  it("returns 404 for a derived legacy path template with parameters", async () => {
     const app = createTestApp();
 
     const legacy = await app.request(

--- a/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
+++ b/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
@@ -330,9 +330,10 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   // now that the Microsoft consoles hold the final URL. #28917 removed the
   // slice's other row, the Teams bot ingress, whose branded forms nothing holds
   // once the Azure Bot messaging endpoint moved. `/api/zero/teams/oauth/callback`
-  // is still emitted on purpose by the VM0 brand, so it is a producer target
-  // rather than drain-window compatibility; `route-entry.ts` records why on the
-  // row, and it is why #28917 kept this row against its own inventory.
+  // was emitted on purpose by the VM0 brand, which made it a producer target
+  // rather than drain-window compatibility and is why #28917 kept the row
+  // against its own inventory; #30667 unified that producer onto the canonical
+  // path, and `route-entry.ts` records what the row holds open now.
   "/api/integrations/teams/oauth/callback": [
     "/api/okou/teams/oauth/callback",
     "/api/zero/teams/oauth/callback",
@@ -791,9 +792,9 @@ describe("branded paths for migrated neutral routes", () => {
   // The #28545 twin, and the one slice where the branded forms are held by a
   // provider console rather than by a released client: the Microsoft app
   // registration still lists both callback URLs, so a dropped row 404s
-  // Microsoft itself with no drain window to wait out. The `zero` form is also
-  // what `callbackRedirectUri` emits for the VM0 brand, so this row has a live
-  // producer as well as a console holder. #28917 removed the slice's bot row —
+  // Microsoft itself with no drain window to wait out. The `zero` form was also
+  // what `callbackRedirectUri` emitted for the VM0 brand until #30667 unified
+  // it onto the canonical path. #28917 removed the slice's bot row —
   // the Azure Bot messaging endpoint had already been repointed at the neutral
   // path — which is why only the callback is exercised here now. Requests carry
   // no credentials, so the status is whatever the handler returns before it has

--- a/turbo/apps/api/src/signals/route-entry.ts
+++ b/turbo/apps/api/src/signals/route-entry.ts
@@ -40,113 +40,38 @@ function routeEntryWithPath(entry: RouteEntry, path: string): RouteEntry {
 }
 
 /**
- * The legacy `/api/zero/**` paths this service owes callers, keyed by the
- * canonical `/api/okou/**` path of the contract that serves them. This table
- * is the source of truth for Phase A compatibility from #26487: an entry here
- * is compatibility kept deliberately, rather than a derivation nobody can
- * audit.
- *
- * The table is exhaustive. #28701 removed the blanket expansion that used to
- * keep every other `/api/zero/**` path resolving behind it, so a `/api/zero/**`
- * path is served only when this table or `MIGRATED_BRANDED_PATHS` names it, and
- * removing a row now retires the path rather than downgrading it to a reported
- * one.
- *
- * Keyed by path alone rather than by `METHOD path`: the evidence below is a
- * path template with no method attached, so restricting an entry to the single
- * method that happened to appear inside the retained window would 404 a
- * caller's other methods on the same path.
- *
- * Every remaining row belongs to a provider console — a Slack or Teams app
- * configuration holds the URL, not a client we control — so no deploy and no
- * client release drains it. #28701 narrowed the table to these six against the
- * 6.3 days `vm0-request-log-prod` retains, 2026-08-17 to 2026-08-23:
- *
- * - `slack/events`, `slack/oauth/install`, and `slack/oauth/callback` were
- *   still taking requests on the last day of the window, from 33 and 17
- *   distinct source addresses inside Slack's own infrastructure. That is what
- *   proves the Slack app configuration still points at the legacy paths.
- * - `slack/commands` and `slack/interactive` saw no traffic in the window and
- *   stay anyway: they live in the same Slack app configuration as the Event
- *   Subscriptions URL that is demonstrably still legacy, so their silence says
- *   nobody used a slash command that week, not that the configuration moved.
- * - `slack/oauth/callback` and `teams/oauth/callback` are also produced inside
- *   this repository, as `redirect_uri` values in `routes/slack-oauth.ts` and
- *   `routes/teams-oauth.ts`. The Teams row is held deliberately so that
- *   `api.vm0.ai` and `/api/zero/**` retire together, as recorded on #26701.
- *
- * The rows #28701 removed are still served, by `MIGRATED_BRANDED_PATHS`: each
- * of those contracts moved to a neutral path in a #28278 slice, and a row there
- * names both branded forms. A row here records that a path is owed rather than
- * which table serves it, which is why removing these twenty-five changed
- * nothing a caller can observe.
- */
-const LEGACY_ZERO_PATHS: Readonly<Record<string, string>> = {
-  "/api/okou/slack/events": "/api/zero/slack/events",
-  "/api/okou/slack/oauth/install": "/api/zero/slack/oauth/install",
-  "/api/okou/slack/oauth/callback": "/api/zero/slack/oauth/callback",
-  "/api/okou/slack/commands": "/api/zero/slack/commands",
-  "/api/okou/slack/interactive": "/api/zero/slack/interactive",
-  "/api/okou/teams/oauth/callback": "/api/zero/teams/oauth/callback",
-};
-
-interface BrandedPathForms {
-  readonly canonical: string;
-  readonly legacy: string;
-}
-
-/**
- * Splits a branded path into its canonical and legacy forms, so the table can
- * be keyed on the canonical path no matter which namespace the contract
- * happens to declare today.
- */
-function brandedPathForms(path: string): BrandedPathForms | undefined {
-  const aliases = apiNamespaceAliasPaths(path);
-  const canonical = aliases.find((alias) => {
-    return brandedApiNamespace(alias) === "okou";
-  });
-  const legacy = aliases.find((alias) => {
-    return brandedApiNamespace(alias) === "zero";
-  });
-  if (canonical === undefined || legacy === undefined) {
-    return undefined;
-  }
-  return { canonical, legacy };
-}
-
-/**
  * True when the expansion may register `aliasPath` for a contract declaring
  * `declaredPath`. The declared path and the canonical `/api/okou/**` form
- * always register; a derived `/api/zero/**` path registers only when
- * `LEGACY_ZERO_PATHS` names it.
+ * register; a derived `/api/zero/**` form never does.
  */
 function servesNamespaceAliasPath(
   declaredPath: string,
   aliasPath: string,
 ): boolean {
-  if (aliasPath === declaredPath) {
-    return true;
-  }
-  const forms = brandedPathForms(declaredPath);
-  if (!forms || aliasPath !== forms.legacy) {
-    return true;
-  }
-  return LEGACY_ZERO_PATHS[forms.canonical] === aliasPath;
+  return (
+    aliasPath === declaredPath || brandedApiNamespace(aliasPath) !== "zero"
+  );
 }
 
 /**
- * Registers the canonical `/api/okou/**` form of every branded contract path,
- * and the legacy `/api/zero/**` form only where `LEGACY_ZERO_PATHS` names it.
+ * Registers the canonical `/api/okou/**` form of every branded contract path.
+ * The legacy `/api/zero/**` form is never derived.
  *
  * Until #28701 this expansion derived the legacy form unconditionally and
- * marked the registrations the table did not list, so `createAppWithRoutes`
- * could report the first request that reached one. That fallback existed
- * because the request log retained about three days, which cannot tell a
- * drained caller apart from a weekly one, and narrowing on that evidence would
- * have silently 404ed a real client. The log retains 6.3 days now and #28701
- * measured the whole window, so the table names every legacy path still owed
- * and the derivation behind it is gone — the reporting was retired because it
- * had nothing left to find, not because it was unwanted.
+ * marked the registrations `LEGACY_ZERO_PATHS` did not list, so
+ * `createAppWithRoutes` could report the first request that reached one. That
+ * fallback existed because the request log retained about three days, which
+ * cannot tell a drained caller apart from a weekly one. #28701 measured the
+ * whole 6.3-day window instead, narrowed that table to the six paths a Slack or
+ * Teams app configuration still held, and dropped both the derivation and the
+ * reporting behind it.
+ *
+ * #30667 then removed the table itself. Each of its six paths is named directly
+ * by a `MIGRATED_BRANDED_PATHS` row below, so none of them lost a registration,
+ * and nothing in this repository produces a `/api/zero/**` URL any more — the
+ * last producer was `callbackRedirectUri` in `routes/teams-oauth.ts`, unified
+ * onto the canonical path in the same commit. A `/api/zero/**` path is now
+ * served only where that table names it.
  */
 export function withApiNamespaceAliases(
   routes: readonly RouteEntry[],
@@ -166,16 +91,15 @@ export function withApiNamespaceAliases(
  * The branded paths a migrated route still answers on, keyed by the neutral
  * canonical path its contract now declares.
  *
- * `LEGACY_ZERO_PATHS` cannot express this, which is why this is a second table
- * rather than more rows in that one. That table names the `/api/zero/**` form
- * the expansion above may derive for a contract that still declares a branded
- * path; this one names branded registrations for a contract that declares a
- * neutral one, including the `/api/okou/**` form the expansion cannot derive
- * either. `apiNamespaceAliasPaths` returns a neutral path unchanged, so once
- * #28278 moves a contract off `/api/okou/**` the expansion produces no branded
- * path for it and neither branded path is registered any more — published CLI
- * builds still calling the branded path would get a 404 with nothing in either
- * table able to say otherwise.
+ * This is the only table left that registers a branded path, and since #30667
+ * the only thing that registers a `/api/zero/**` path at all. It names branded
+ * registrations for a contract that declares a neutral path, including the
+ * `/api/okou/**` form the expansion above cannot derive.
+ * `apiNamespaceAliasPaths` returns a neutral path unchanged, so once #28278
+ * moves a contract off `/api/okou/**` the expansion produces no branded path
+ * for it and neither branded path is registered any more — published CLI builds
+ * still calling the branded path would get a 404 with nothing able to say
+ * otherwise.
  *
  * A migrated route generally owes both branded forms, so a value is a list
  * rather than a single path.
@@ -183,8 +107,8 @@ export function withApiNamespaceAliases(
  * Each #28278 slice adds the rows for the paths it moves, so a move and the
  * compatibility it owes land in one commit.
  *
- * Every row is compatibility debt under the same removal gate as
- * `LEGACY_ZERO_PATHS`: a row is removed only under #26701's evidence rules.
+ * Every row is compatibility debt under #26701's removal gate: a row is removed
+ * only under its evidence rules.
  * `vm0-request-log-prod` retained 6.3 days when #28701 read it, which is long
  * enough to name a caller that is still there and not long enough to prove a
  * silent row has no caller that returns.
@@ -252,9 +176,10 @@ export function withApiNamespaceAliases(
  * a zero-count reading fails:
  *
  * - `integrations/teams/oauth/callback`. `callbackRedirectUri` in
- *   `routes/teams-oauth.ts` still emits its `zero` form for the VM0 brand, so
- *   the row is an active producer target. No window can drain it and no count
- *   can retire it; see the comment on the row itself.
+ *   `routes/teams-oauth.ts` still emitted its `zero` form for the VM0 brand
+ *   then, so the row was an active producer target that no window could drain
+ *   and no count could retire. #30667 unified that producer onto the canonical
+ *   path; see the comment on the row itself.
  * - `computer-use/hosts/start` and `computer-use/host/stop`. Both are
  *   hardcoded in every Desktop build up to 0.38.53, and those builds were
  *   still sending branded `heartbeat` and `host/commands/next` inside this
@@ -454,8 +379,8 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   // desktop, or platform build emits a branded literal for any of them, and
   // every caller derives its URL from a contract that has declared the neutral
   // path since #28457. `/api/zero/billing/concurrency-checkout/preview` was
-  // among the nine: it carried measured traffic when #28701 dropped its
-  // `LEGACY_ZERO_PATHS` row and these rows are what served it afterwards, but
+  // among the nine: it carried measured traffic when #28701 dropped its row
+  // from the legacy-path table, and these rows are what served it after, but
   // the retained window recorded no request on either branded form.
   //
   // #28916 then removed the six that were not silent — plan checkout, invoices,
@@ -498,11 +423,12 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   // heartbeat but can no longer open or close a session.
   //
   // Four of these paths — `host/commands/next`, `audit-events`, `heartbeat`,
-  // and `hosts/start` — were served by `LEGACY_ZERO_PATHS` before this move and
-  // are served by these rows after it: the contract no longer declares a
-  // branded path for the expansion to derive. #28701 dropped their rows from
-  // that table once it was clear these rows are what serve them. Removal of
-  // these follows #26701's evidence rules like every other row here.
+  // and `hosts/start` — were served by the legacy-path table #30667 deleted
+  // before this move and are served by these rows after it: the contract no
+  // longer declares a branded path for the expansion to derive. #28701 dropped
+  // their rows from that table once it was clear these rows are what serve
+  // them. Removal of these follows #26701's evidence rules like every other row
+  // here.
   //
   // #28916 listed `audit-events` and `host/commands/:commandId/complete` for
   // removal and both were kept, for the mirror image of #28917's reason. All of
@@ -643,9 +569,9 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   // The OAuth-start paths have a second holder that no client version bounds: a
   // connect or install link the API handed out earlier lives in a Slack message
   // a user can still click, and `/api/okou/slack/oauth/install` is measured
-  // traffic listed in `LEGACY_ZERO_PATHS` above, which after this move only
-  // these rows can serve. Removal follows the #26701 evidence gate like every
-  // other row, not either clock.
+  // traffic that the legacy-path table #30667 deleted also listed, which after
+  // this move only these rows can serve. Removal follows the #26701 evidence
+  // gate like every other row, not either clock.
   "/api/slack/channels": [
     "/api/okou/slack/channels",
     "/api/zero/slack/channels",
@@ -785,29 +711,27 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   // What holds the branded forms open is not a released client but the
   // Microsoft consoles themselves, which have no drain window: they keep
   // sending to whatever URL is registered until an operator changes it.
-  // Removal follows #26701's evidence rules, and for the `zero` callback the
-  // ordering constraint recorded there.
+  // Removal follows #26701's evidence rules.
   //
   // #28917 removed the slice's `webhooks/teams/bot` row. #28545 records that an
   // operator had already repointed the Azure Bot messaging endpoint at the
   // neutral path before that slice landed, so nothing on the Microsoft side
   // still holds either branded bot URL, and the retained window measured both
   // silent. The OAuth callback row below stays for the reason its own comment
-  // gives, which is not a drain window and is not measurable in the log at all.
+  // gives.
   "/api/integrations/teams/oauth/callback": [
     "/api/okou/teams/oauth/callback",
-    // Not drain-window compatibility. `callbackRedirectUri` in
-    // `routes/teams-oauth.ts` is brand-conditional and still emits this exact
-    // path for the VM0 brand on purpose: it is registered in the Microsoft app
-    // registration, and #26701 records that it retires together with the
-    // `api.vm0.ai` brand host. So this row is an active producer target, not a
-    // leftover — do not prune it merely for being an `/api/zero/` path, or
-    // live VM0-brand connects lose the callback they were sent to.
+    // `callbackRedirectUri` in `routes/teams-oauth.ts` was brand-conditional
+    // and emitted this exact path for the VM0 brand, which made the row an
+    // active producer target no traffic sweep could retire: a quiet window
+    // meant nobody connected Teams under the VM0 brand that week, and the next
+    // person who did was sent here regardless. #28917 listed the row for
+    // removal on that silence and it was held back for exactly that reason.
     //
-    // A traffic sweep cannot retire this row: a quiet window means nobody
-    // connected Teams under the VM0 brand that week, and the next person who
-    // does is sent here regardless. #28917 listed this row for removal on that
-    // silence and it was held back for exactly this reason.
+    // #30667 unified the producer onto the canonical path, so what this row
+    // now holds open is an authorization that started before that deploy and
+    // carries the legacy `redirect_uri` in its state. Removal follows #26701's
+    // evidence rules like every other row.
     "/api/zero/teams/oauth/callback",
   ],
   // #28463: avatar video generation, the per-token browser authorization

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
@@ -24,7 +24,7 @@ const context = testContext();
 const mocks = createRouteMocks(context);
 const store = createStore();
 const API_ORIGIN = "https://api.vm0.ai";
-const CALLBACK_REDIRECT_URI = `${API_ORIGIN}/api/zero/teams/oauth/callback`;
+const CALLBACK_REDIRECT_URI = `${API_ORIGIN}/api/integrations/teams/oauth/callback`;
 const OKOU_API_ORIGIN = "https://api.okou.ai";
 const OKOU_APP_ORIGIN = "https://app.okou.ai";
 const WEB_ORIGIN = "https://www.vm0.ai";
@@ -69,7 +69,7 @@ function callbackPath(args: {
     params.set("code", args.code);
   }
   params.set("state", JSON.stringify(args.state));
-  return `/api/zero/teams/oauth/callback?${params.toString()}`;
+  return `/api/integrations/teams/oauth/callback?${params.toString()}`;
 }
 
 function teamsInstallUrl(tenantId: string): string {
@@ -94,7 +94,7 @@ function mockMicrosoftOAuth(args: {
       expect(body.get("client_secret")).toBe("test-microsoft-client-secret");
       expect(body.get("redirect_uri")).toBe(
         args.expectedRedirectUri ??
-          `${API_ORIGIN}/api/zero/teams/oauth/callback`,
+          `${API_ORIGIN}/api/integrations/teams/oauth/callback`,
       );
       expect(body.get("grant_type")).toBe("authorization_code");
       return HttpResponse.json({
@@ -171,7 +171,7 @@ describe("Teams OAuth API routes", () => {
       "test-microsoft-client-id",
     );
     expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
-      `${API_ORIGIN}/api/zero/teams/oauth/callback`,
+      `${API_ORIGIN}/api/integrations/teams/oauth/callback`,
     );
     expect(redirectUrl.searchParams.get("scope")).toBe(
       "openid profile email User.Read",
@@ -185,7 +185,7 @@ describe("Teams OAuth API routes", () => {
     expect(state).toStrictEqual({
       orgId: "org_1",
       publicBrand: "vm0",
-      redirectUri: `${API_ORIGIN}/api/zero/teams/oauth/callback`,
+      redirectUri: `${API_ORIGIN}/api/integrations/teams/oauth/callback`,
       userId: "user_1",
     });
   });
@@ -202,7 +202,7 @@ describe("Teams OAuth API routes", () => {
       "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
     );
     expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
-      `${API_ORIGIN}/api/zero/teams/oauth/callback`,
+      `${API_ORIGIN}/api/integrations/teams/oauth/callback`,
     );
   });
 
@@ -227,10 +227,10 @@ describe("Teams OAuth API routes", () => {
     });
   });
 
-  // api.vm0.ai and /api/zero/** retire together, so the VM0 brand never moves
-  // to the canonical namespace. Pin the exact registered value as a literal:
-  // a refactor that moves it off this string breaks Microsoft's allowlist.
-  it("leaves the VM0 brand authorization URI on the registered legacy value", async () => {
+  // The VM0 brand keeps its own API host and sends the same canonical path the
+  // Okou brand does. Pin the exact registered value as a literal: a refactor
+  // that moves it off this string breaks Microsoft's allowlist.
+  it("sends the VM0 brand authorization URI on the VM0 API host", async () => {
     const response = await appRequest(
       "/api/teams/oauth/connect?orgId=org_1&userId=user_1",
       { origin: API_ORIGIN },
@@ -243,11 +243,11 @@ describe("Teams OAuth API routes", () => {
       readonly redirectUri: string;
     };
     expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
-      "https://api.vm0.ai/api/zero/teams/oauth/callback",
+      "https://api.vm0.ai/api/integrations/teams/oauth/callback",
     );
     expect(state).toMatchObject({
       publicBrand: "vm0",
-      redirectUri: "https://api.vm0.ai/api/zero/teams/oauth/callback",
+      redirectUri: "https://api.vm0.ai/api/integrations/teams/oauth/callback",
     });
   });
 
@@ -286,7 +286,7 @@ describe("Teams OAuth API routes", () => {
       mockEnv("APP_URL", "https://app.vm0.ai");
 
       const response = await appRequest(
-        `/api/zero/teams/oauth/callback?code=valid-code${stateQuery}`,
+        `/api/integrations/teams/oauth/callback?code=valid-code${stateQuery}`,
         { origin: OKOU_API_ORIGIN },
       );
 
@@ -302,7 +302,7 @@ describe("Teams OAuth API routes", () => {
     mockEnv("APP_URL", "https://app.vm0.ai");
 
     const response = await appRequest(
-      `/api/zero/teams/oauth/callback?error=access_denied&state=${encodeURIComponent("not-json")}`,
+      `/api/integrations/teams/oauth/callback?error=access_denied&state=${encodeURIComponent("not-json")}`,
       { origin: OKOU_API_ORIGIN },
     );
 
@@ -368,7 +368,7 @@ describe("Teams OAuth API routes", () => {
     await seedMembership(fixture.orgId, fixture.userId, "admin");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
     const recordedRedirectUri =
-      "https://pr-1-api.vm7.ai/api/zero/teams/oauth/callback";
+      "https://pr-1-api.vm7.ai/api/integrations/teams/oauth/callback";
     mockMicrosoftOAuth({
       tenantId: fixture.teamsTenantId,
       aadObjectId: fixture.teamsAadObjectId,

--- a/turbo/apps/api/src/signals/routes/teams-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/teams-oauth.ts
@@ -166,19 +166,18 @@ function parseOAuthState(state: string | undefined): OAuthState | null {
 }
 
 /**
- * `api.vm0.ai` and `/api/zero/**` retire together, so the VM0 brand keeps the
- * legacy path. Only the Okou brand moves to the canonical namespace. Both
- * values are already registered in the Microsoft app registration, so this
- * ships with no provider-console change.
+ * Both brands send Microsoft the canonical path; the brand decides the host
+ * only. The VM0 brand used to keep `/api/zero/teams/oauth/callback` so that
+ * `api.vm0.ai` and `/api/zero/**` would retire together, and #30667 unpicked
+ * that coupling: the Microsoft app registration already holds the canonical
+ * path on both brand hosts, so unifying it needs no provider-console change.
  *
  * Project here rather than in `getOAuthApiOrigin`, whose other caller builds
  * the built-in connector callback that is already registered with every
  * provider.
  */
 function callbackRedirectUri(origin: string, publicBrand: PublicBrand): string {
-  return publicBrand === "okou"
-    ? `${apiUrlForPublicBrand(origin, "okou")}/api/integrations/teams/oauth/callback`
-    : `${apiUrlForPublicBrand(origin, "vm0")}/api/zero/teams/oauth/callback`;
+  return `${apiUrlForPublicBrand(origin, publicBrand)}/api/integrations/teams/oauth/callback`;
 }
 
 function microsoftCredentials(): {


### PR DESCRIPTION
Closes #30667. Part of #26701.

## What changed

**1. The Teams OAuth callback is unified across brands.** `callbackRedirectUri` in `turbo/apps/api/src/signals/routes/teams-oauth.ts` was brand-conditional: the Okou brand sent Microsoft `/api/integrations/teams/oauth/callback` while the VM0 brand still sent `/api/zero/teams/oauth/callback`, held there so `api.vm0.ai` and `/api/zero/**` would retire together. Both arms collapse onto the canonical path; `apiUrlForPublicBrand(origin, publicBrand)` still chooses the host, so the brand decides the host only. The comment is rewritten rather than deleted — the note about projecting here instead of in `getOAuthApiOrigin` still holds.

**2. `LEGACY_ZERO_PATHS` and all six rows are deleted**, in the same commit and after the producer change. Removing the row while the code still emitted the old URI would have made Microsoft reject the token exchange for any VM0-brand Teams install — the failure mode `slack-oauth.ts` documented before #30551. `servesNamespaceAliasPath` no longer consults a table and reduces to "the declared path and the canonical `/api/okou/**` form register; the legacy form never does"; `brandedPathForms` and `BrandedPathForms` went with the table that needed them.

## No registration is lost

`LEGACY_ZERO_PATHS` only gated the alias expansion for a contract declaring a branded path, and #28946 moved the last such contract off `/api/okou/**` — so the table had already stopped being what serves its six paths. Each of them is named directly by a `MIGRATED_BRANDED_PATHS` row, a different mechanism that registers branded paths for a contract declaring a neutral one. Those six rows are out of scope here and are removed separately, so a failure stays attributable.

## Tests

Reworked to assert the new behaviour rather than deleted, and no case asserts that a removed path 404s (`docs/fallback.md` section 1).

- `api-namespace-compatibility.test.ts` — keeps its own restatement of the six paths, renamed `SERVED_LEGACY_PATHS` for what now serves them. The derivation case becomes "derives no legacy path from a branded declaration", carried by a composed `/api/okou/**` contract that must register itself only; `ROUTES` declares no branded path, so a sweep over it alone would pass whatever the expansion did.
- `api-namespace-legacy-paths.test.ts` — drives the same rule through the production app factory. Its served subject moves from a contract declaring `/api/okou/slack/events` (which the deleted table used to expand) to the neutral `/api/webhooks/slack/events`, whose branded forms a `MIGRATED_BRANDED_PATHS` row registers. The two `__test` 404 cases are unchanged and now cover an unconditional rule.
- `teams-oauth.test.ts` — the VM0-brand `redirect_uri` and connect state now pin `https://api.vm0.ai/api/integrations/teams/oauth/callback`.
- `migrated-branded-paths.test.ts` — comment-only, for the two places that said the VM0 brand still emits the `zero` form.

## Evidence

After the 2026-08-31 15:01 UTC production deploy of #30551, every `/api/zero/**` and `/api/okou/**` path is at zero requests across the retained window — not a subset. The Slack console was repointed before 09:00 that day and the branded paths stopped the same hour:

```
/api/zero/slack/events           79   last 08-31 08:54
/api/zero/slack/commands          1   last 08-31 08:41
/api/zero/slack/interactive       0
/api/zero/slack/oauth/callback    0
/api/zero/teams/oauth/callback    0
/api/zero/slack/oauth/install     25  last 08-31 13:04 (migration probe traffic, not a client)
```

## Verification

Local, against the api workspace: `check-types`, `lint` (exit 0), `knip --workspace apps/api` clean, and `vitest run src/__tests__` (99 passed) plus `teams-oauth`, `slack-oauth` and `provider-console-paths` (78 passed).

After deploy: every `/api/zero/**` path that no `MIGRATED_BRANDED_PATHS` row names must 404, `/api/integrations/teams/oauth/callback` must still answer, and a Teams install from either brand must complete its token exchange.

## Note for the reviewer

The unblocking fact this change rests on is the existing comment's "Both values are already registered in the Microsoft app registration". Read strictly, those two values were the Okou host on the canonical path and the VM0 host on the legacy path; the value this PR newly emits — `https://api.vm0.ai/api/integrations/teams/oauth/callback` — is a third one. #30667 states the Microsoft side is ready and no console change is needed, and this ships on that basis. If the VM0 host is not registered on the canonical path, a VM0-brand Teams connect fails at the Microsoft authorize step; worth confirming in the Azure app registration before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
