### PR TITLE
docs(vsock-proto): correct message allocation range

### DIFF
--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -20,10 +20,11 @@
 //!
 //! ## Message Types
 //!
-//! Non-error message types currently occupy the contiguous range `0x00..=0x1C`
-//! in allocation order. Existing values are stable wire assignments: do not
-//! renumber or reuse them. Allocate new non-error messages at the next unused
-//! value below `0xFF`, even when related operations are not adjacent. `0xFF` is
+//! Non-error message types currently occupy the contiguous range `0x00..=0x1D`
+//! in allocation order; `0x1E` is the next available non-error assignment.
+//! Existing values are stable wire assignments: do not renumber or reuse them.
+//! Allocate new non-error messages at the next unused value below `0xFF`, even
+//! when related operations are not adjacent. `0xFF` is
 //! reserved for generic protocol errors. Changing an existing assignment
 //! requires an explicit, versioned host/guest protocol migration.
 //!


### PR DESCRIPTION
## Summary

- Correct the crate-level vsock message allocation range to include the existing `0x1D` assignment.
- Document `0x1E` as the next available non-error message value.

## Scope

This changes only the allocation guidance in `crates/vsock-proto/src/lib.rs`. The message table, exported wire constants, stable-value regression test, serialized protocol values, and runtime behavior are unchanged.

## Validation

- `git diff --check`
- `cargo fmt --all -- --check` (from `crates/`)
- `cargo test --manifest-path crates/Cargo.toml -p vsock-proto` — 159 unit tests, 27 integration tests, and doc-tests passed.

Closes #30664
