### PR TITLE
test(platform): stop happy-dom fetching index.html font stylesheet

### DIFF
--- a/turbo/apps/platform/vitest.config.ts
+++ b/turbo/apps/platform/vitest.config.ts
@@ -60,6 +60,18 @@ export default defineConfig({
           // NotSupportedError instead of initiating a network request. The
           // error is suppressed in setup.ts.
           disableIframePageLoading: true,
+          // Prevent happy-dom from making real TCP connections for
+          // `<link rel="stylesheet">` hrefs. Tests that parse index.html into a
+          // live document connect its Google Fonts stylesheet link, and
+          // happy-dom starts a fetch that no test owns or awaits. Vitest only
+          // aborts it when it tears the window down after the whole file, and
+          // destroying the socket mid-TLS-write surfaces as an uncaught
+          // `write ECANCELED Canceled because of SSL destruction`.
+          disableCSSFileLoading: true,
+          // Report the skipped stylesheet load as a `load` event instead of a
+          // console error plus `error` event, so disabling the fetch does not
+          // trade a leaked socket for teardown noise.
+          handleDisabledFileLoadingAsSuccess: true,
         },
       },
     },


### PR DESCRIPTION
## Problem

`test-app` shard 8 fails with every test passing:

```
⎯⎯⎯⎯⎯ Uncaught Exception ⎯⎯⎯⎯⎯
Error: write ECANCELED Canceled because of SSL destruction
 ❯ WriteWrap.onWriteComplete [as oncomplete] node:internal/stream_base_commons:87:19
 ❯ TCP.done node:internal/tls/wrap:741:11
Serialized Error: { errno: -125, code: 'ECANCELED', syscall: 'write' }
This error originated in "apps/platform/src/signals/__tests__/bootstrap-locale.test.ts" test file.

 Test Files  20 passed (20)
      Tests  249 passed (249)
     Errors  1 error
```

Observed twice within nine minutes, on two SHAs and two trigger events:

- push on `main`: [run 33463492688](https://github.com/vm0-ai/vm0/actions/runs/33463492688) at `3e19b65f258ea31fcf143e84fdb81c67726f190c`
- merge group: [run 33464047088](https://github.com/vm0-ai/vm0/actions/runs/33464047088) at `6245121faa85af5bb50e28cfb7bbbc00410f613c`

## Root cause

`bootstrap-locale.test.ts` ends with a test that parses the raw entrypoint into a live document:

```ts
const parsedDocument = new DOMParser().parseFromString(indexHtml, "text/html");
```

`index.html` contains an external Google Fonts stylesheet:

```html
<link
  rel="stylesheet"
  href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
/>
```

happy-dom connects that `<link rel="stylesheet">` and immediately starts a real `fetch()` for it. Nothing in the test owns or awaits that request, so it outlives the test and is only cancelled when Vitest tears the window down after the whole file, via `DetachedWindowAPI.abort()` → `AsyncTaskManager.abortAll()` → `ClientRequest.destroy()`.

Destroying the request destroys the socket. When a TLS write happens to be in flight at that instant, Node reports the cancelled write asynchronously, after the file's lifetime, and Vitest can only surface it as an unhandled uncaught exception. That timing window is why the job passes 249 tests and still exits non-zero, and why it is intermittent rather than constant.

The same leak was latent in `src/__tests__/clerk-entrypoint.test.ts`, which parses `index.html` the same way in a different shard.

### Reproduction, before the fix

Running the file alone reproduces the leaked request and its teardown abort deterministically:

```
 Test Files  1 passed (1)
      Tests  10 passed (10)

DOMException [AbortError]: The operation was aborted.
    at Fetch.onAsyncTaskManagerAbort (.../happy-dom/lib/fetch/Fetch.js:546:23)
    at AsyncTaskManager.abortAll (.../happy-dom/lib/async-task-manager/AsyncTaskManager.js:292:30)
    at DetachedWindowAPI.abort (.../happy-dom/lib/window/DetachedWindowAPI.js:51:35)
    at teardownWindow (.../vitest/dist/chunks/index.DC7d2Pf8.js:331:22)
DOMException [NetworkError]: Failed to execute "fetch()" on "Window" with URL
  "https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap":
  The operation was aborted.
    at MockHttpSocket.destroy (.../@mswjs/interceptors/lib/node/ClientRequest-Ca8Qykuv.mjs:414:19)
    at ClientRequest.destroy (node:_http_client:695:16)
    at Fetch.onAsyncTaskManagerAbort (.../happy-dom/lib/fetch/Fetch.js:557:30)
```

Narrowing with `-t` pins the owner exactly: `-t "keeps metadata English"` emits the `fonts.googleapis.com` request, while `-t "starts in English regardless"` emits none. So the attribution to `bootstrap-locale.test.ts` is not coincidental shard neighbouring; that file's last test is the owner.

## Fix

Turn the stylesheet fetch off at the environment boundary, next to the existing `disableIframePageLoading` setting that already exists for the same reason:

```ts
disableCSSFileLoading: true,
handleDisabledFileLoadingAsSuccess: true,
```

With `disableCSSFileLoading`, happy-dom's `HTMLLinkElement` returns before constructing the `ResourceFetch`, so no socket is ever opened and there is nothing left to abort at teardown. `handleDisabledFileLoadingAsSuccess` makes the skipped load dispatch a `load` event instead of logging a `NotSupportedError` and dispatching `error`, so removing the leaked socket does not trade it for teardown noise.

This removes the unowned client rather than hiding its symptom. No unhandled error is swallowed, no uncaught-exception handler is added, and Vitest is not configured to ignore unhandled errors. No sleeps, retries, skips, deletions, or weakened assertions.

No app test depends on an external stylesheet actually being fetched — such a test would be network-dependent by construction, and a search for `cssRules` / `.sheet` assertions in the app suite returns nothing.

## Validation

- `src/signals/__tests__/bootstrap-locale.test.ts` run 5 times: 10/10 passing each time, and the `fonts.googleapis.com` request and its teardown `AbortError` are gone from every run.
- The full shard 8 file set (all 20 files enumerated from the failing job log) plus `src/__tests__/clerk-entrypoint.test.ts`, run once in one process: **21 files passed, 270 tests passed, exit 0, zero unhandled errors, no `fonts.googleapis.com` request**.
- `prettier --check`, `eslint`, `pnpm -F @okouai/app check-types`, and `git diff --check` all clean.
- The full repository Vitest suite was not run, per the repair constraints.

No app, API, runner, or dev server was started; this is a Node-level test-environment fix, so preview browser validation does not apply.
