### PR TITLE
fix(python): reject malformed platform api urls

### DIFF
--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -201,8 +201,12 @@ def _derive_api_destination(
 ) -> _ApiDestination | None:
     if not api_url:
         return None
-    parsed_api = urllib.parse.urlparse(api_url)
-    if not parsed_api.hostname:
+    try:
+        parsed_api = urllib.parse.urlparse(api_url)
+        api_hostname_raw = parsed_api.hostname
+    except ValueError:
+        return None
+    if not api_hostname_raw:
         return None
     api_scheme = parsed_api.scheme.lower()
     if api_scheme == "http":
@@ -212,10 +216,14 @@ def _derive_api_destination(
     else:
         return None
     try:
-        api_hostname = normalize_hostname(parsed_api.hostname)
+        api_hostname = normalize_hostname(api_hostname_raw)
     except (UnicodeError, ValueError):
         return None
-    api_port = parsed_api.port if parsed_api.port is not None else default_port
+    try:
+        explicit_port = parsed_api.port
+    except ValueError:
+        return None
+    api_port = explicit_port if explicit_port is not None else default_port
     return _ApiDestination(
         scheme=api_scheme,
         host=api_hostname,

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -557,6 +557,19 @@ def fresh_usage_executor():
         yield executor
 
 
+@pytest.fixture(
+    params=[
+        pytest.param("https://[::1", id="unmatched-ipv6-bracket"),
+        pytest.param("https://api.vm0.ai:not-a-port", id="non-numeric-port"),
+        pytest.param("https://api.vm0.ai:65536", id="out-of-range-port"),
+    ]
+)
+def malformed_platform_api_url(request: pytest.FixtureRequest) -> str:
+    value = request.param
+    assert isinstance(value, str)
+    return value
+
+
 @pytest.fixture
 def registry_file(tmp_path):
     """Create a sample proxy registry JSON file and return its path."""

--- a/crates/runner/mitm-addon/tests/test_request_handler_api_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_api_admission.py
@@ -363,6 +363,33 @@ async def test_vm0_api_auto_allow_respects_authority_boundary(
         assert "x-vercel-protection-bypass" not in flow.request.headers
 
 
+async def test_malformed_vm0_api_url_is_cached_as_non_match(
+    registry_file,
+    real_flow,
+    mitm_ctx,
+    monkeypatch,
+    malformed_platform_api_url,
+):
+    flows = [
+        real_flow(with_response=False, host="api.vm0.ai"),
+        real_flow(with_response=False, host="api.vm0.ai"),
+    ]
+    monkeypatch.setattr(platform_api, "VERCEL_BYPASS", "preview-secret")
+
+    with mitm_ctx(
+        registry_path=str(registry_file),
+        api_url=malformed_platform_api_url,
+    ):
+        for flow in flows:
+            await mitm_addon.request(flow)
+
+    for flow in flows:
+        assert flow.response is None
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert "x-vercel-protection-bypass" not in flow.request.headers
+    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+
 async def test_vm0_api_wrong_port_uses_matching_firewall_deny_policy(
     tmp_path,
     real_flow,

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -297,6 +297,26 @@ def test_server_connect_retargets_api_allow_host(registry_file, mitm_ctx, api_ur
     assert binding.kinds == frozenset(("api_allow",))
 
 
+def test_server_connect_does_not_bind_malformed_platform_api_url(
+    registry_file,
+    mitm_ctx,
+    malformed_platform_api_url,
+):
+    data = _data(
+        client_ip="10.200.0.1",
+        sni="api.vm0.ai",
+    )
+
+    with mitm_ctx(
+        registry_path=str(registry_file),
+        api_url=malformed_platform_api_url,
+    ):
+        mitm_addon.server_connect(data)
+
+    assert data.server.address == ("203.0.113.10", 443)
+    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+
 def test_server_connect_treats_api_hostname_on_other_port_as_connector(
     tmp_path,
     mitm_ctx,

--- a/crates/runner/mitm-addon/tests/test_tls_clienthello_hook.py
+++ b/crates/runner/mitm-addon/tests/test_tls_clienthello_hook.py
@@ -89,6 +89,29 @@ class TestTlsClienthello:
         assert binding.kinds == frozenset(("api_allow",))
         assert binding.original_address == ("203.0.113.10", 443)
 
+    def test_registered_sandbox_does_not_bind_malformed_platform_api_url(
+        self,
+        registry_file,
+        make_tls_data,
+        mitm_ctx,
+        malformed_platform_api_url,
+    ):
+        data = make_tls_data(
+            client_ip="10.200.0.1",
+            sni="api.vm0.ai",
+            client_sni="",
+        )
+
+        with mitm_ctx(
+            registry_path=str(registry_file),
+            api_url=malformed_platform_api_url,
+        ):
+            mitm_addon.tls_clienthello(data)
+
+        assert data.ignore_connection is False
+        assert data.context.server.address == ("203.0.113.10", 443)
+        assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
     def test_registered_sandbox_does_not_bind_tls_api_host_for_configured_http_origin(
         self, registry_file, make_tls_data, mitm_ctx
     ):


### PR DESCRIPTION
## Summary

- treat malformed platform API URL syntax and invalid ports as a fail-closed destination non-match
- cache invalid destinations without allowing request, TLS ClientHello, or server connection hooks to create upstream bindings
- cover unmatched IPv6 brackets, non-numeric ports, and out-of-range ports through public hook integration tests

## Exclusions

- no addon configuration lifecycle or logging changes
- no API, runner protocol, queue payload, persisted-state, or migration changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/test_request_handler_api_admission.py tests/test_tls_clienthello_hook.py tests/test_server_connect_hook.py` (72 passed)
- `uv run --no-sync python -m pytest tests/` (7260 passed)

Closes #30663
