### PR TITLE
fix(platform): silently handle one tap load failures

### DIFF
--- a/turbo/apps/platform/src/signals/auth-v2/sign-in-external-strategies.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-in-external-strategies.ts
@@ -78,7 +78,7 @@ function supportsGoogleOneTapFedCm(): boolean {
 
 function loadGoogleIdentityApi(
   signal: AbortSignal,
-): Promise<GoogleIdentityApi> {
+): Promise<GoogleIdentityApi | null> {
   signal.throwIfAborted();
   const loadedApi = googleIdentityApi();
   if (loadedApi) {
@@ -95,17 +95,17 @@ function loadGoogleIdentityApi(
     script.src = GOOGLE_IDENTITY_SCRIPT_URL;
   }
 
-  const deferred = createDeferredPromise<GoogleIdentityApi>(signal);
+  const deferred = createDeferredPromise<GoogleIdentityApi | null>(signal);
   const handleLoad = (): void => {
     const api = googleIdentityApi();
     if (api) {
       deferred.resolve(api);
       return;
     }
-    deferred.reject(new Error("Google Identity Services did not initialize"));
+    deferred.resolve(null);
   };
   const handleError = (): void => {
-    deferred.reject(new Error("Google Identity Services could not be loaded"));
+    deferred.resolve(null);
   };
   const cleanup = (): void => {
     script.removeEventListener("load", handleLoad);
@@ -276,6 +276,9 @@ export async function requestGoogleOneTapCredential(
 ): Promise<string | null> {
   const api = await loadGoogleIdentityApi(signal);
   signal.throwIfAborted();
+  if (!api) {
+    return null;
+  }
   const credential = createDeferredPromise<string | null>(signal);
   const finish = (value: string | null): void => {
     if (!credential.settled()) {

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -1037,67 +1037,77 @@ describe("auth v2 sign-in flow", () => {
     expect(mockedClerk.clientSignInCreate).not.toHaveBeenCalled();
   });
 
-  it("silently falls back after a Google One Tap script failure and retries after back navigation", async () => {
-    context.mocks.browser.fedCm();
-    mockAuthV2Capabilities({
-      googleOAuth: true,
-      googleOneTapClientId: "google-client-id",
-    });
-    const failedScript = createStalledGoogleOneTapScript();
-    setupSignInPage({ status: "needs_identifier" });
-
-    // Script loading is a browser resource boundary and cannot be triggered
-    // through a rendered control, so dispatch its terminal event directly.
-    await screen.findByLabelText("Email address");
-    await act(async () => {
-      fireEvent.error(failedScript);
-      await Promise.resolve();
-    });
-
-    expect(failedScript).not.toBeInTheDocument();
-    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-    await expect(
-      screen.findByLabelText("Email address"),
-    ).resolves.toBeEnabled();
-    await expect(
-      waitForRoleElement("button", "Continue with Google"),
-    ).resolves.toBeEnabled();
-
-    navigateToSignUp();
-    await expect(
-      screen.findByRole("region", { name: "Create your account" }),
-    ).resolves.toBeVisible();
-
-    const retryScript = createStalledGoogleOneTapScript();
-    act(() => {
-      window.history.back();
-    });
-    await screen.findByLabelText("Email address");
-    expect(retryScript).not.toBe(failedScript);
-
-    mockGoogleOneTapCredential("retry-google-one-tap-token");
-    mockedClerk.clientSignInCreate.mockImplementation((params) => {
-      if (params.strategy === "google_one_tap") {
-        return Promise.resolve(
-          moveSignInTo({
-            createdSessionId: "session_one_tap_retry",
-            status: "complete",
-          }),
-        );
-      }
-      return Promise.resolve(currentSignInResource());
-    });
-    fireEvent.load(retryScript);
-
-    await waitFor(() => {
-      expect(mockedClerk.clientSignInCreate).toHaveBeenCalledWith({
-        signUpIfMissing: false,
-        strategy: "google_one_tap",
-        token: "retry-google-one-tap-token",
+  it.each([
+    { event: "error" as const, name: "script load failure" },
+    { event: "load" as const, name: "script initialization failure" },
+  ])(
+    "silently falls back after a Google One Tap $name and retries after back navigation",
+    async ({ event }) => {
+      context.mocks.browser.fedCm();
+      mockAuthV2Capabilities({
+        googleOAuth: true,
+        googleOneTapClientId: "google-client-id",
       });
-      expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
-    });
-  });
+      const failedScript = createStalledGoogleOneTapScript();
+      setupSignInPage({ status: "needs_identifier" });
+
+      // Script loading is a browser resource boundary and cannot be triggered
+      // through a rendered control, so dispatch its terminal event directly.
+      await screen.findByLabelText("Email address");
+      await act(async () => {
+        if (event === "error") {
+          fireEvent.error(failedScript);
+        } else {
+          fireEvent.load(failedScript);
+        }
+        await Promise.resolve();
+      });
+
+      expect(failedScript).not.toBeInTheDocument();
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      await expect(
+        screen.findByLabelText("Email address"),
+      ).resolves.toBeEnabled();
+      await expect(
+        waitForRoleElement("button", "Continue with Google"),
+      ).resolves.toBeEnabled();
+
+      navigateToSignUp();
+      await expect(
+        screen.findByRole("region", { name: "Create your account" }),
+      ).resolves.toBeVisible();
+
+      const retryScript = createStalledGoogleOneTapScript();
+      act(() => {
+        window.history.back();
+      });
+      await screen.findByLabelText("Email address");
+      expect(retryScript).not.toBe(failedScript);
+
+      mockGoogleOneTapCredential("retry-google-one-tap-token");
+      mockedClerk.clientSignInCreate.mockImplementation((params) => {
+        if (params.strategy === "google_one_tap") {
+          return Promise.resolve(
+            moveSignInTo({
+              createdSessionId: "session_one_tap_retry",
+              status: "complete",
+            }),
+          );
+        }
+        return Promise.resolve(currentSignInResource());
+      });
+      fireEvent.load(retryScript);
+
+      await waitFor(() => {
+        expect(mockedClerk.clientSignInCreate).toHaveBeenCalledWith({
+          signUpIfMissing: false,
+          strategy: "google_one_tap",
+          token: "retry-google-one-tap-token",
+        });
+        expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
+      });
+    },
+  );
 
   it.each([
     {

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -1037,7 +1037,7 @@ describe("auth v2 sign-in flow", () => {
     expect(mockedClerk.clientSignInCreate).not.toHaveBeenCalled();
   });
 
-  it("retries Google One Tap after a script failure and back navigation", async () => {
+  it("silently falls back after a Google One Tap script failure and retries after back navigation", async () => {
     context.mocks.browser.fedCm();
     mockAuthV2Capabilities({
       googleOAuth: true,
@@ -1049,12 +1049,19 @@ describe("auth v2 sign-in flow", () => {
     // Script loading is a browser resource boundary and cannot be triggered
     // through a rendered control, so dispatch its terminal event directly.
     await screen.findByLabelText("Email address");
-    fireEvent.error(failedScript);
-
-    await waitFor(() => {
-      expect(failedScript).not.toBeInTheDocument();
+    await act(async () => {
+      fireEvent.error(failedScript);
+      await Promise.resolve();
     });
-    await expect(screen.findByRole("alert")).resolves.toBeVisible();
+
+    expect(failedScript).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    await expect(
+      screen.findByLabelText("Email address"),
+    ).resolves.toBeEnabled();
+    await expect(
+      waitForRoleElement("button", "Continue with Google"),
+    ).resolves.toBeEnabled();
 
     navigateToSignUp();
     await expect(


### PR DESCRIPTION
## Context

Google One Tap is an optional sign-in enhancement. When the Google Identity Services script was blocked or loaded without initializing, Auth v2 rejected a tracked promise. That surfaced a generic sign-in alert and produced handled error telemetry even though email and Google OAuth sign-in remained available.

## Summary

- treat Google Identity Services load and initialization failures as One Tap unavailability
- preserve email and Google OAuth sign-in without displaying a generic auth error
- remove the failed script so returning to the sign-in page can retry loading One Tap
- keep Clerk client initialization behavior unchanged

## Testing

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged TypeScript checks for shared packages, Platform, and API
- `pnpm --filter @okouai/app exec vitest run src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx` (62 tests)

## Observability

- Sentry: https://okou.sentry.io/issues/7702165447/
