### PR TITLE
fix(cli): diagnose effective visible workflows

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
@@ -563,10 +563,19 @@ describe.sequential("Official Workflow catalog release boundary", () => {
     expect(connectorDoctorInstruction).toContain("Unknown is never healthy");
     expect(connectorDoctorInstruction).toContain("summary.checked === 0");
     expect(connectorDoctorInstruction).toContain(
+      "no effective visible workflows were available to check",
+    );
+    expect(connectorDoctorInstruction).toContain(
       "not an all-clear over diagnosed workflows",
     );
     expect(connectorDoctorInstruction).toContain(
       "summary.attention === 0`, and `summary.unknown === 0",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "aggregate covered effective visible workflows",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "compact inventory of every checked entry in `workflows`, grouped by its returned Agent identity",
     );
     expect(connectorDoctorInstruction).toContain(
       "command fails, its output is not valid JSON, or its schema version is unsupported",

--- a/turbo/apps/api/src/signals/services/official-workflow-catalog-source.ts
+++ b/turbo/apps/api/src/signals/services/official-workflow-catalog-source.ts
@@ -36,10 +36,10 @@ If the command fails, its output is not valid JSON, or its schema version is uns
 
 ## Report valid results
 
-- If \`summary.checked === 0\`, report that no owned or installed workflows were available to check. Treat this as a distinct no-workflows result, not an all-clear over diagnosed workflows.
+- If \`summary.checked === 0\`, report that no effective visible workflows were available to check. Treat this as a distinct no-workflows result, not an all-clear over diagnosed workflows.
 - Group every connector entry with a non-null action by identical \`action.kind\` and exact \`action.url\`. Include the repair link once for each group, then list every affected workflow with the connector's returned readiness status and reason. Never merge entries whose exact URLs differ, even when their action kinds or connector labels match, because the URL identifies the target Agent.
 - Under **Unknown**, list every connector whose status is \`unavailable\` and every workflow with a non-null \`error\`. Include the returned workflow identity and reason or error message. Unknown is never healthy.
-- Emit a short all-clear only when \`summary.checked > 0\`, \`summary.attention === 0\`, and \`summary.unknown === 0\`.
+- Emit a short all-clear only when \`summary.checked > 0\`, \`summary.attention === 0\`, and \`summary.unknown === 0\`. State that the aggregate covered effective visible workflows and include a compact inventory of every checked entry in \`workflows\`, grouped by its returned Agent identity. Use only workflow and Agent names or IDs present in the JSON.
 - Keep the report concise and include only facts, counts, statuses, reasons, and repair links present in the returned JSON.
 
 ## Safety boundaries

--- a/turbo/apps/cli/src/commands/doctor/__tests__/connectors.test.ts
+++ b/turbo/apps/cli/src/commands/doctor/__tests__/connectors.test.ts
@@ -14,12 +14,15 @@ const API_ORIGIN = "http://localhost:3000";
 const OWNER_USER_ID = "user-owner";
 const OTHER_USER_ID = "user-other";
 const AGENT_ID = "11111111-1111-1111-1111-111111111111";
+const SECOND_AGENT_ID = "11111111-1111-1111-1111-111111111112";
 const ATTENTION_WORKFLOW_ID = "20000000-0000-4000-8000-000000000001";
 const UNKNOWN_WORKFLOW_ID = "20000000-0000-4000-8000-000000000002";
 const READY_WORKFLOW_ID = "20000000-0000-4000-8000-000000000003";
 const EMPTY_WORKFLOW_ID = "20000000-0000-4000-8000-000000000004";
 const OFFICIAL_WORKFLOW_ID = "20000000-0000-4000-8000-000000000005";
 const FOREIGN_WORKFLOW_ID = "20000000-0000-4000-8000-000000000006";
+const SHADOWED_WORKFLOW_ID = "20000000-0000-4000-8000-000000000007";
+const PRIVATE_WINNER_WORKFLOW_ID = "20000000-0000-4000-8000-000000000008";
 const RAW_SECRET = "raw-secret-must-not-appear";
 
 interface JsonConnector {
@@ -176,7 +179,7 @@ describe("okou doctor connectors command", () => {
     await connectorsCommand.parseAsync(["node", "cli", ...args]);
   }
 
-  it("reports only owned workflows with stable outcomes and action links", async () => {
+  it("reports effective visible workflows with stable outcomes and action links", async () => {
     const attention = workflow(ATTENTION_WORKFLOW_ID, "attention-workflow", {
       displayName: "Attention Workflow",
       description: `Connector configuration ${RAW_SECRET}`,
@@ -193,6 +196,9 @@ describe("okou doctor connectors command", () => {
       },
     });
     const foreign = workflow(FOREIGN_WORKFLOW_ID, "foreign-workflow", {
+      agentId: SECOND_AGENT_ID,
+      agentName: "public-agent",
+      agentDisplayName: "Public Agent",
       visibility: "public",
       ownerUserId: OTHER_USER_ID,
     });
@@ -285,6 +291,18 @@ describe("okou doctor connectors command", () => {
               { status: 409 },
             );
           }
+          if (workflowId === FOREIGN_WORKFLOW_ID) {
+            return HttpResponse.json({
+              connectors: [
+                {
+                  connectorSlug: "github",
+                  label: "GitHub",
+                  reason: "The public workflow reads GitHub issues.",
+                  status: "connected",
+                },
+              ] satisfies WorkflowConnectorReadinessEntry[],
+            });
+          }
           throw new Error(`Unexpected readiness request for ${workflowId}`);
         },
       ),
@@ -301,10 +319,10 @@ describe("okou doctor connectors command", () => {
     ]);
     expect(report.schemaVersion).toBe(1);
     expect(report.summary).toStrictEqual({
-      checked: 5,
+      checked: 6,
       attention: 1,
       unknown: 2,
-      ready: 1,
+      ready: 2,
       noConnectors: 1,
     });
     expect(checkedWorkflowIds).toStrictEqual(
@@ -314,6 +332,7 @@ describe("okou doctor connectors command", () => {
         READY_WORKFLOW_ID,
         EMPTY_WORKFLOW_ID,
         OFFICIAL_WORKFLOW_ID,
+        FOREIGN_WORKFLOW_ID,
       ]),
     );
 
@@ -425,14 +444,64 @@ describe("okou doctor connectors command", () => {
       },
     });
     expect(
-      report.workflows.some((item) => {
+      report.workflows.find((item) => {
         return item.id === FOREIGN_WORKFLOW_ID;
       }),
-    ).toBe(false);
+    ).toMatchObject({
+      agent: { id: SECOND_AGENT_ID },
+      outcome: "ready",
+    });
     expect(printed).not.toContain(RAW_SECRET);
     expect(printed).not.toContain(OWNER_USER_ID);
     expect(printed).not.toContain(process.env.OKOU_TOKEN);
     expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it("checks only the private runtime winner when it shadows a public workflow", async () => {
+    const privateWinner = workflow(
+      PRIVATE_WINNER_WORKFLOW_ID,
+      "shared-workflow",
+      { displayName: "Private Winner" },
+    );
+    const shadowedPublic = workflow(SHADOWED_WORKFLOW_ID, "shared-workflow", {
+      displayName: "Public Workflow",
+      visibility: "public",
+      ownerUserId: OTHER_USER_ID,
+      shadowedBy: {
+        id: privateWinner.id,
+        name: privateWinner.name,
+        displayName: privateWinner.displayName,
+      },
+    });
+    const publicWinner = workflow(FOREIGN_WORKFLOW_ID, "public-winner", {
+      visibility: "public",
+      ownerUserId: OTHER_USER_ID,
+    });
+    mockWorkflowList([shadowedPublic, privateWinner, publicWinner]);
+
+    const checkedWorkflowIds = new Set<string>();
+    server.use(
+      http.post(
+        `${API_ORIGIN}/api/workflows/:workflowId/connector-readiness`,
+        ({ params }) => {
+          checkedWorkflowIds.add(String(params.workflowId));
+          return HttpResponse.json({ connectors: [] });
+        },
+      ),
+    );
+
+    await run(["--json"]);
+
+    const report = reportFromOutput(output());
+    expect(report.summary.checked).toBe(2);
+    expect(checkedWorkflowIds).toStrictEqual(
+      new Set([PRIVATE_WINNER_WORKFLOW_ID, FOREIGN_WORKFLOW_ID]),
+    );
+    expect(
+      report.workflows.map((item) => {
+        return item.id;
+      }),
+    ).toStrictEqual([PRIVATE_WINNER_WORKFLOW_ID, FOREIGN_WORKFLOW_ID]);
   });
 
   it("resolves a workflow name through the normal agent-scoped list", async () => {
@@ -470,7 +539,15 @@ describe("okou doctor connectors command", () => {
   });
 
   it("checks a workflow ID without listing other workflows", async () => {
-    const selected = workflow(READY_WORKFLOW_ID, "direct-id");
+    const selected = workflow(READY_WORKFLOW_ID, "direct-id", {
+      visibility: "public",
+      ownerUserId: OTHER_USER_ID,
+      shadowedBy: {
+        id: PRIVATE_WINNER_WORKFLOW_ID,
+        name: "direct-id",
+        displayName: "Private Direct ID",
+      },
+    });
     mockWorkflowDetail(selected);
     server.use(
       http.post(
@@ -484,6 +561,25 @@ describe("okou doctor connectors command", () => {
     await run([selected.id, "--json"]);
 
     expect(reportFromOutput(output()).workflows[0]?.id).toBe(selected.id);
+  });
+
+  it("preserves the single-workflow all-clear copy", async () => {
+    const selected = workflow(READY_WORKFLOW_ID, "direct-id");
+    mockWorkflowDetail(selected);
+    server.use(
+      http.post(
+        `${API_ORIGIN}/api/workflows/${selected.id}/connector-readiness`,
+        () => {
+          return HttpResponse.json({ connectors: [] });
+        },
+      ),
+    );
+
+    await run([selected.id]);
+
+    expect(output()).toContain("✓ All clear: 1 workflow checked");
+    expect(output()).toContain("0 ready · 1 no connectors required");
+    expect(output()).not.toContain("Checked workflows by Agent:");
   });
 
   it("bounds readiness requests and keeps a partial failure in the report", async () => {
@@ -624,10 +720,22 @@ describe("okou doctor connectors command", () => {
     expect(mockExit).not.toHaveBeenCalled();
   });
 
-  it("prints an all-clear result for ready and connector-free workflows", async () => {
+  it("prints effective visible all-clear coverage across every Agent", async () => {
     const ready = workflow(READY_WORKFLOW_ID, "ready-workflow");
-    const empty = workflow(EMPTY_WORKFLOW_ID, "empty-workflow");
-    mockWorkflowList([ready, empty]);
+    const empty = workflow(EMPTY_WORKFLOW_ID, "empty-workflow", {
+      agentId: SECOND_AGENT_ID,
+      agentName: "operations-agent",
+      agentDisplayName: "Operations Agent",
+      displayName: "Empty Workflow",
+    });
+    vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
+    let requestedAgentId: string | null = AGENT_ID;
+    server.use(
+      http.get(`${API_ORIGIN}/api/workflows`, ({ request }) => {
+        requestedAgentId = new URL(request.url).searchParams.get("agentId");
+        return HttpResponse.json([ready, empty]);
+      }),
+    );
     server.use(
       http.post(
         `${API_ORIGIN}/api/workflows/:workflowId/connector-readiness`,
@@ -651,17 +759,19 @@ describe("okou doctor connectors command", () => {
 
     await run();
 
-    expect(output()).toContain("✓ All clear: 2 workflows checked");
-    expect(output()).toContain("1 ready · 1 no connectors required");
+    const printed = output();
+    expect(requestedAgentId).toBeNull();
+    expect(printed).toContain("✓ All clear across effective visible workflows");
+    expect(printed).toContain("2 checked · 1 ready · 1 no connectors required");
+    expect(printed).toContain("Checked workflows by Agent:");
+    expect(printed).toContain("Doctor Agent: ready-workflow");
+    expect(printed).toContain(
+      "Operations Agent: Empty Workflow (empty-workflow)",
+    );
   });
 
-  it("prints an empty-owned-workflows result without checking public rows", async () => {
-    mockWorkflowList([
-      workflow(FOREIGN_WORKFLOW_ID, "foreign-workflow", {
-        visibility: "public",
-        ownerUserId: OTHER_USER_ID,
-      }),
-    ]);
+  it("prints an empty effective-visible result without readiness requests", async () => {
+    mockWorkflowList([]);
     let readinessRequests = 0;
     server.use(
       http.post(
@@ -676,13 +786,21 @@ describe("okou doctor connectors command", () => {
     await run();
 
     expect(output()).toContain(
-      "No owned or installed workflows to check for connectors",
+      "No effective visible workflows to check for connectors",
     );
     expect(readinessRequests).toBe(0);
   });
 
-  it("fails before listing workflows when OKOU_TOKEN cannot identify the owner", async () => {
+  it("fails when the aggregate workflow list rejects authentication", async () => {
     vi.stubEnv("OKOU_TOKEN", "invalid-token");
+    server.use(
+      http.get(`${API_ORIGIN}/api/workflows`, () => {
+        return HttpResponse.json(
+          { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+          { status: 401 },
+        );
+      }),
+    );
 
     await expect(run()).rejects.toThrow("process.exit called");
 
@@ -700,6 +818,24 @@ describe("okou doctor connectors command", () => {
     expect(mockExit).toHaveBeenCalledWith(1);
     expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
       "--agent requires a workflow argument",
+    );
+  });
+
+  it("documents the effective visible aggregate scope", () => {
+    let help = "";
+    connectorsCommand.configureOutput({
+      writeOut: (text: string) => {
+        help += text;
+      },
+    });
+    connectorsCommand.outputHelp();
+    help = help.replace(/\s+/gu, " ");
+
+    expect(help).toContain(
+      "every effective visible workflow across all visible Agents is checked; shadowed workflows are skipped",
+    );
+    expect(help).toContain(
+      "Aggregate mode is not limited by OKOU_AGENT_ID; each workflow's Agent is used for connector authorization",
     );
   });
 });

--- a/turbo/apps/cli/src/commands/doctor/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/doctor/__tests__/index.test.ts
@@ -18,6 +18,9 @@ describe("okou doctor command", () => {
       "Diagnose stored connector readiness across workflows",
     );
     expect(normalizedHelp).toContain(
+      "stored connector readiness across effective visible workflows on every visible Agent",
+    );
+    expect(normalizedHelp).toContain(
       "Use okou connector check for one current-run URL, environment name, firewall decision, or permission failure",
     );
   });

--- a/turbo/apps/cli/src/commands/doctor/connectors.ts
+++ b/turbo/apps/cli/src/commands/doctor/connectors.ts
@@ -12,7 +12,6 @@ import {
   listWorkflows,
 } from "../../lib/api/domains/workflows";
 import { ApiRequestError } from "../../lib/api/core/client-factory";
-import { decodeSandboxTokenPayload } from "../../lib/api/sandbox-token";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { connectorActionUrl } from "../connector/action-url";
 import { resolveWorkflowRef } from "../workflow/resolve-workflow-ref";
@@ -87,18 +86,6 @@ interface ConnectorDoctorReport {
 interface ConnectorsOptions {
   readonly agent?: string;
   readonly json?: boolean;
-}
-
-function currentRunUserId(): string {
-  const payload = decodeSandboxTokenPayload();
-  if (
-    !payload ||
-    typeof payload.userId !== "string" ||
-    payload.userId.length === 0
-  ) {
-    throw new ApiRequestError("Not authenticated", "UNAUTHORIZED", 401);
-  }
-  return payload.userId;
 }
 
 function connectorAction(
@@ -480,24 +467,57 @@ function printProblemSection(
   }
 }
 
-function printHumanReport(report: ConnectorDoctorReport): void {
+function printWorkflowInventory(
+  workflows: readonly ConnectorDoctorWorkflow[],
+): void {
+  const workflowsByAgent = new Map<
+    string,
+    { readonly label: string; readonly workflows: string[] }
+  >();
+  for (const workflow of workflows) {
+    const group = workflowsByAgent.get(workflow.agent.id);
+    if (group) {
+      group.workflows.push(workflowLabel(workflow));
+      continue;
+    }
+    workflowsByAgent.set(workflow.agent.id, {
+      label: compactText(agentLabel(workflow)),
+      workflows: [workflowLabel(workflow)],
+    });
+  }
+
+  console.log(chalk.dim("  Checked workflows by Agent:"));
+  for (const group of workflowsByAgent.values()) {
+    console.log(chalk.dim(`    ${group.label}: ${group.workflows.join(", ")}`));
+  }
+}
+
+function printHumanReport(
+  report: ConnectorDoctorReport,
+  aggregateMode: boolean,
+): void {
   if (report.summary.checked === 0) {
     console.log(
-      chalk.green("✓ No owned or installed workflows to check for connectors"),
+      chalk.green("✓ No effective visible workflows to check for connectors"),
     );
     return;
   }
   if (report.summary.attention === 0 && report.summary.unknown === 0) {
     console.log(
       chalk.green(
-        `✓ All clear: ${report.summary.checked} workflow${report.summary.checked === 1 ? "" : "s"} checked`,
+        aggregateMode
+          ? "✓ All clear across effective visible workflows"
+          : `✓ All clear: ${report.summary.checked} workflow${report.summary.checked === 1 ? "" : "s"} checked`,
       ),
     );
     console.log(
       chalk.dim(
-        `  ${report.summary.ready} ready · ${report.summary.noConnectors} no connectors required`,
+        `  ${aggregateMode ? `${report.summary.checked} checked · ` : ""}${report.summary.ready} ready · ${report.summary.noConnectors} no connectors required`,
       ),
     );
+    if (aggregateMode) {
+      printWorkflowInventory(report.workflows);
+    }
     return;
   }
 
@@ -532,10 +552,9 @@ async function selectedWorkflows(
   if (options.agent) {
     throw new Error("--agent requires a workflow argument");
   }
-  const userId = currentRunUserId();
   const workflows = await listWorkflows({});
   return workflows.filter((workflow) => {
-    return workflow.ownerUserId === userId;
+    return workflow.shadowedBy == null;
   });
 }
 
@@ -552,13 +571,14 @@ export const connectorsCommand = new Command()
     "after",
     `
 Examples:
-  Check owned workflows: okou doctor connectors
+  Check effective visible workflows: okou doctor connectors
   Check one workflow ID: okou doctor connectors <workflow-id>
   Check one workflow name: okou doctor connectors <workflow-name> --agent <agent-id>
   Print JSON: okou doctor connectors --json
 
 Notes:
-  - Without a workflow argument, only workflows owned or installed by the OKOU_TOKEN user are checked
+  - Without a workflow argument, every effective visible workflow across all visible Agents is checked; shadowed workflows are skipped
+  - Aggregate mode is not limited by OKOU_AGENT_ID; each workflow's Agent is used for connector authorization
   - Each workflow is checked through its stored connector-readiness route
   - Findings and per-workflow unknowns are report data and do not fail the command
   - Use okou connector check for one current-run URL, firewall decision, or permission failure`,
@@ -575,7 +595,7 @@ Notes:
           console.log(JSON.stringify(report, null, 2));
           return;
         }
-        printHumanReport(report);
+        printHumanReport(report, workflowRef === undefined);
       },
     ),
   );

--- a/turbo/apps/cli/src/commands/doctor/index.ts
+++ b/turbo/apps/cli/src/commands/doctor/index.ts
@@ -19,6 +19,6 @@ Examples:
 Notes:
   - Use okou doctor credit when a run or generation fails because the org has insufficient credits, when a user asks how to recharge, or before trying to buy credits
   - Use okou generate <type> (no --prompt) to see every provider available for a given generation type
-  - Use okou doctor connectors for stored connector readiness across owned or installed workflows
+  - Use okou doctor connectors for stored connector readiness across effective visible workflows on every visible Agent
   - Use okou connector check for one current-run URL, environment name, firewall decision, or permission failure`,
   );


### PR DESCRIPTION
## Summary

- make aggregate `okou doctor connectors` diagnose every effective visible workflow returned by the existing list API, filtering to runtime winners with `shadowedBy == null`
- preserve explicit workflow ID/name resolution, per-workflow readiness behavior, failure isolation, and the four-worker bounded concurrency drain
- explain the effective-visible scope in CLI help, empty/all-clear output, and the installed Official Workflow instruction, including a compact checked-workflow inventory
- cover public and cross-Agent inclusion, shadow exclusion, private and Official preservation, explicit single-workflow behavior, worker draining, and transparent all-clear coverage

## Testing

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter @okouai/cli run check-types`
- `pnpm --filter api run check-types`
- `pnpm knip`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter @okouai/cli exec vitest run src/commands/doctor/__tests__/connectors.test.ts --reporter=dot` (12 passed)
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter @okouai/cli exec vitest run src/commands/doctor/__tests__/index.test.ts --reporter=dot` (1 passed)
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts --reporter=dot` (13 passed)
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/workflows.test.ts -t 'lets any public workflow viewer detect connector readiness' --reporter=dot` (1 passed, 25 skipped)
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/official-workflows.test.ts -t 'materializes the deployed Official Workflows through generic installation state' --reporter=dot` (1 passed, 34 skipped)
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/official-workflows.test.ts -t 'uses accepted Official content and installation dependencies for connector readiness' --reporter=dot` (1 passed, 34 skipped)
- `git diff --check origin/main...HEAD`

Closes #30672
