### PR TITLE
test(e2e): retry runner api reads that receive no response

### DIFF
--- a/.github/scripts/tests/runner-api-curl-test.sh
+++ b/.github/scripts/tests/runner-api-curl-test.sh
@@ -11,6 +11,7 @@ trap 'rm -rf "$tmp_dir"' EXIT
 stdout_file="${tmp_dir}/stdout"
 stderr_file="${tmp_dir}/stderr"
 expected_file="${tmp_dir}/expected"
+attempts_file="${tmp_dir}/curl-attempts"
 
 fail() {
     echo "FAIL: $1" >&2
@@ -36,6 +37,29 @@ assert_file_excludes() {
     local sensitive_value="$2"
     if grep -Fq "$sensitive_value" "$actual_file"; then
         fail "sensitive value appeared in ${actual_file}"
+    fi
+}
+
+# The mocked curl runs inside a command substitution, so its attempt counter
+# lives in a file rather than a shell variable.
+reset_curl_attempts() {
+    printf '0' >"$attempts_file"
+}
+
+record_curl_attempt() {
+    local attempts
+    attempts="$(<"$attempts_file")"
+    attempts=$((attempts + 1))
+    printf '%s' "$attempts" >"$attempts_file"
+    printf '%s' "$attempts"
+}
+
+assert_curl_attempts() {
+    local expected="$1"
+    local actual
+    actual="$(<"$attempts_file")"
+    if [[ "$actual" != "$expected" ]]; then
+        fail "expected ${expected} curl attempt(s), got ${actual}"
     fi
 }
 
@@ -96,6 +120,18 @@ curl() {
             echo "curl: (22) The requested URL returned error: 429" >&2
             echo "Vercel logs: $MOCK_CURL_EXPECTED_VERCEL_URL" >&2
             return 22
+            ;;
+        no-response | no-response-then-success)
+            local attempt
+            attempt="$(record_curl_attempt)"
+            if [[ "$MOCK_CURL_MODE" == "no-response-then-success" ]] &&
+                ((attempt > 1)); then
+                printf '{"ok":true}\n'
+                return 0
+            fi
+            echo "curl: (28) Operation timed out after 30002 milliseconds with 0 bytes received" >&2
+            echo "Vercel logs: $MOCK_CURL_EXPECTED_VERCEL_URL" >&2
+            return 28
             ;;
         no-fail-with-body | no-fail-with-body-failure)
             [[ "$saw_no_fail_with_body" == true ]] || {
@@ -185,5 +221,53 @@ assert_file_equals \
 assert_file_excludes "$stderr_file" "$E2E_API_TOKEN"
 assert_file_excludes "$stderr_file" "$VERCEL_AUTOMATION_BYPASS_SECRET"
 assert_file_excludes "$stderr_file" "sensitive-request-payload"
+
+# A stalled request produces no response at all, so a plain GET is sent again.
+# See the merge-group Turbo run 33464652878, where four runner shards gave up
+# on GET /api/runs/:id/context after 30s while the API answered 200 in 30-44s.
+context_vercel_logs_search='https://vercel.com/vm0/vm0-api/logs?search=requestHost%3Apr-27981-api.vm6.ai+requestPath%3A%2Fapi%2Fruns%2Frun-1%2Fcontext'
+MOCK_CURL_EXPECTED_URL="https://pr-27981-api.vm6.ai/api/runs/run-1/context"
+MOCK_CURL_EXPECTED_VERCEL_URL="${context_vercel_logs_search}+status%3A000&timeline=past12Hours"
+MOCK_CURL_EXPECTED_VERCEL_WRITE_OUT='%{onerror}%{stderr}Vercel logs: https://vercel.com/vm0/vm0-api/logs?search=requestHost%%3Apr-27981-api.vm6.ai+requestPath%%3A%%2Fapi%%2Fruns%%2Frun-1%%2Fcontext+status%%3A%{http_code}&timeline=past12Hours\n'
+stall_stderr=$'curl: (28) Operation timed out after 30002 milliseconds with 0 bytes received\nVercel logs: '"$MOCK_CURL_EXPECTED_VERCEL_URL"$'\n'
+retry_stderr=$'runner_api_curl retrying https://pr-27981-api.vm6.ai/api/runs/run-1/context after no response (attempt 1 of 2)\n'
+
+MOCK_CURL_MODE=no-response-then-success
+reset_curl_attempts
+run_request "/api/runs/run-1/context"
+assert_status 0
+assert_curl_attempts 2
+assert_file_equals $'{"ok":true}\n' "$stdout_file"
+assert_file_equals "${stall_stderr}${retry_stderr}" "$stderr_file"
+
+MOCK_CURL_MODE=no-response
+reset_curl_attempts
+run_request "/api/runs/run-1/context"
+assert_status 28
+assert_curl_attempts 2
+assert_file_equals '' "$stdout_file"
+assert_file_equals \
+    "${stall_stderr}${retry_stderr}${stall_stderr}"$'runner_api_curl failed: url=https://pr-27981-api.vm6.ai/api/runs/run-1/context curl_status=28\nrunner_api_curl received no response from https://pr-27981-api.vm6.ai/api/runs/run-1/context within 30s across 2 attempt(s); the API may have answered after the client gave up: '"${context_vercel_logs_search}"$'&timeline=past12Hours\n' \
+    "$stderr_file"
+assert_file_excludes "$stderr_file" "$E2E_API_TOKEN"
+assert_file_excludes "$stderr_file" "$VERCEL_AUTOMATION_BYPASS_SECRET"
+
+# A write may already have been applied by the API, so it is never repeated.
+MOCK_CURL_EXPECTED_URL="https://pr-27981-api.vm6.ai/api/chat/events"
+MOCK_CURL_EXPECTED_VERCEL_URL='https://vercel.com/vm0/vm0-api/logs?search=requestHost%3Apr-27981-api.vm6.ai+requestPath%3A%2Fapi%2Fchat%2Fevents+status%3A000&timeline=past12Hours'
+MOCK_CURL_EXPECTED_VERCEL_WRITE_OUT='%{onerror}%{stderr}Vercel logs: https://vercel.com/vm0/vm0-api/logs?search=requestHost%%3Apr-27981-api.vm6.ai+requestPath%%3A%%2Fapi%%2Fchat%%2Fevents+status%%3A%{http_code}&timeline=past12Hours\n'
+
+MOCK_CURL_MODE=no-response
+reset_curl_attempts
+run_request "/api/chat/events" -X POST -d "$payload"
+assert_status 28
+assert_curl_attempts 1
+assert_file_excludes "$stderr_file" "sensitive-request-payload"
+
+MOCK_CURL_MODE=no-response
+reset_curl_attempts
+run_request "/api/chat/events" -d "$payload"
+assert_status 28
+assert_curl_attempts 1
 
 echo "runner_api_curl tests passed"

--- a/e2e/helpers/runner-chat.bash
+++ b/e2e/helpers/runner-chat.bash
@@ -20,6 +20,8 @@ require_runner_api_credentials() {
     runner_api_token >/dev/null && runner_api_url >/dev/null
 }
 
+# Returns the Vercel log search for one host and path without a status term,
+# so callers decide whether to narrow the search by response status.
 _runner_api_vercel_logs_url_prefix() {
     local base="$1"
     local path="$2"
@@ -33,8 +35,26 @@ _runner_api_vercel_logs_url_prefix() {
     request_path_search="${request_path//%/%25}"
     request_path_search="${request_path_search//\//%2F}"
     request_path_search="${request_path_search//:/%3A}"
-    printf 'https://vercel.com/vm0/vm0-api/logs?search=requestHost%%3A%s+requestPath%%3A%s+status%%3A' \
+    printf 'https://vercel.com/vm0/vm0-api/logs?search=requestHost%%3A%s+requestPath%%3A%s' \
         "$request_host_search" "$request_path_search"
+}
+
+# A request that carries neither a method override nor a body is a plain GET,
+# and only a plain GET may be sent again: the API may already have applied a
+# write whose response never arrived.
+_runner_api_request_is_repeatable() {
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+            -X* | --request | --request=* | \
+                -d* | --data | --data=* | --data-* | \
+                -F* | --form | --form=* | \
+                -T* | --upload-file | --upload-file=*)
+                return 1
+                ;;
+        esac
+    done
+    return 0
 }
 
 runner_api_curl() {
@@ -50,7 +70,7 @@ runner_api_curl() {
     vercel_logs_url_prefix="$(_runner_api_vercel_logs_url_prefix \
         "$base" "$path")"
     vercel_logs_url_prefix_write_out="${vercel_logs_url_prefix//%/%%}"
-    vercel_log_write_out="%{onerror}%{stderr}Vercel logs: ${vercel_logs_url_prefix_write_out}%{http_code}&timeline=past12Hours\n"
+    vercel_log_write_out="%{onerror}%{stderr}Vercel logs: ${vercel_logs_url_prefix_write_out}+status%%3A%{http_code}&timeline=past12Hours\n"
 
     local -a headers=(
         -H "Authorization: Bearer $token"
@@ -62,18 +82,57 @@ runner_api_curl() {
         )
     fi
 
-    local curl_status=0
-    curl --fail-with-body --silent --show-error \
-        --write-out "$vercel_log_write_out" \
-        --connect-timeout "${E2E_CURL_CONNECT_TIMEOUT_SECONDS:-10}" \
-        --max-time "${E2E_CURL_MAX_TIME_SECONDS:-30}" \
-        "${headers[@]}" \
-        "$@" \
-        "$request_url" || curl_status=$?
+    # curl exits `28` when the connect/transfer budget expires before the
+    # deployment answers anything, while `--fail-with-body` reports a served
+    # HTTP error as `22`. Only `28` means the request produced no response, so
+    # only `28` is sent again, and only for a repeatable request. Each attempt
+    # is buffered so a partial body is replaced rather than concatenated.
+    local no_response_status=28
+    local max_attempts=1
+    if _runner_api_request_is_repeatable "$@"; then
+        max_attempts=2
+    fi
+
+    # Command substitution strips trailing newlines, so the exit status is
+    # appended behind a marker and read back from the last occurrence. That
+    # keeps the emitted response byte-for-byte identical to an unbuffered curl.
+    local exit_marker=$'\nRUNNER_API_CURL_EXIT:'
+    local body="" curl_status=0 attempt
+    for ((attempt = 1; attempt <= max_attempts; attempt += 1)); do
+        body="$(
+            curl --fail-with-body --silent --show-error \
+                --write-out "$vercel_log_write_out" \
+                --connect-timeout "${E2E_CURL_CONNECT_TIMEOUT_SECONDS:-10}" \
+                --max-time "${E2E_CURL_MAX_TIME_SECONDS:-30}" \
+                "${headers[@]}" \
+                "$@" \
+                "$request_url"
+            printf '%s%d' "$exit_marker" "$?"
+        )"
+        curl_status="${body##*"$exit_marker"}"
+        body="${body%"$exit_marker"*}"
+
+        if ((curl_status != no_response_status)) ||
+            ((attempt == max_attempts)); then
+            break
+        fi
+        printf 'runner_api_curl retrying %s after no response (attempt %d of %d)\n' \
+            "$diagnostic_url" "$attempt" "$max_attempts" >&2
+    done
+
+    printf '%s' "$body"
 
     if ((curl_status != 0)); then
         printf 'runner_api_curl failed: url=%s curl_status=%d\n' \
             "$diagnostic_url" "$curl_status" >&2
+        if ((curl_status == no_response_status)); then
+            # A stalled request carries no status, so the status-filtered
+            # search above finds nothing even when the API completed the
+            # request late.
+            printf 'runner_api_curl received no response from %s within %ss across %d attempt(s); the API may have answered after the client gave up: %s&timeline=past12Hours\n' \
+                "$diagnostic_url" "${E2E_CURL_MAX_TIME_SECONDS:-30}" \
+                "$attempt" "$vercel_logs_url_prefix" >&2
+        fi
     fi
     return "$curl_status"
 }
@@ -223,7 +282,7 @@ delete_runner_agent_for_stage0_teardown() {
         base="$(runner_api_url)" || return 1
         vercel_logs_url_prefix="$(_runner_api_vercel_logs_url_prefix \
             "$base" "$request_path")"
-        printf 'Vercel logs: %s%s&timeline=past12Hours\n' \
+        printf 'Vercel logs: %s+status%%3A%s&timeline=past12Hours\n' \
             "$vercel_logs_url_prefix" "$http_status" >&2
         return 1
     done


### PR DESCRIPTION
## Problem

Merge-group Turbo run [33464652878](https://github.com/vm0-ai/vm0/actions/runs/33464652878) (queued PR #30591, SHA `0bc551a3`) failed **four** `cli-e2e-03-runner` shards with one identical signature:

| Job | Test | Run ID |
| --- | --- | --- |
| [99722651761](https://github.com/vm0-ai/vm0/actions/runs/33464652878/job/99722651761) | `runner firewall resolves Twilio auth without exposing raw credentials` | `e7cf959f` |
| [99722651791](https://github.com/vm0-ai/vm0/actions/runs/33464652878/job/99722651791) | `vm0 built-in real pi loop returns a successful answer` | `82a6729e` |
| [99722651870](https://github.com/vm0-ai/vm0/actions/runs/33464652878/job/99722651870) | `runner resolves an exact custom connector account on thread continuation` | `adeceb69` |
| [99722651915](https://github.com/vm0-ai/vm0/actions/runs/33464652878/job/99722651915) | `continued runner session refreshes replaced connector credentials` | `3f0f1595` |

All four failed on `GET /api/runs/<id>/context`:

```
curl: (28) Operation timed out after 30002 milliseconds with 0 bytes received
runner_api_curl failed: url=https://pr-30591-api.vm6.ai/api/runs/<runId>/context curl_status=28
```

### The run completed, then the context request hung with zero bytes

In the Twilio shard the agent run reached `status: "completed"` at 03:05:38 and the sandbox printed `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN` and `TWILIO_REQUEST_SENT`. The preview API was creating and completing runs normally. The `/context` read issued moments later returned nothing for 30 seconds.

### The API answered — after the client gave up

The preview request log (`vm0-request-log-dev`, `host == 'pr-30591-api.vm6.ai'`) records exactly what happened:

| `_time` | path | status | duration |
| --- | --- | --- | --- |
| 03:05:39.392 | `GET /api/runs/:id/context` | **200** | **44357 ms** |
| 03:05:40.601 | `GET /api/runs/:id/context` | **200** | **43073 ms** |
| 03:05:44.006 | `GET /api/runs/:id/context` | **200** | **39784 ms** |
| 03:05:54.115 | `GET /api/runs/:id/context` | **200** | **29877 ms** |
| 03:06:19.125 | `GET /api/runs/:id/context` | 200 | 4579 ms |
| 03:06:35.141 | `GET /api/runs/:id/context` | 200 | 687 ms |

No other request on that deployment exceeded 3000 ms in the window, and job 99722651870's third test (`run-t24-built-in-provider-fallback.bats`) passed at 03:06:36 after making two asserted `/context` reads. So this was not a deployment outage: one endpoint's latency spiked past the harness's fixed 30s `--max-time` and recovered within a minute.

`GET /api/runs/:id/context` resolves its snapshot through an Axiom APL query (`runContext` in `turbo/apps/api/src/signals/services/run-detail.service.ts` → `queryAxiom`). Under four concurrent shards that dependency's tail latency reached 30-44s.

**PR #30591 is not implicated.** Its API changes are confined to `email-common.service.ts`, `internal-workflow-automation-result-email-callback.service.ts` and `official-automation-result-email-renderer.ts`, plus platform workflow pages. Nothing in it touches the `/api/runs/:id/context` path, the Axiom client, auth middleware, DB pooling or route registration.

## Change

`runner_api_curl` failed the whole bats test on a single zero-byte 30s stall with no retry, and reported it identically to a served API error.

- **Send the request again only when curl exits `28`** — the deployment produced no response at all. `--fail-with-body` reports a served HTTP error as `22`, so a genuine API error still fails on the first attempt. Blanket retrying on API error responses is not introduced.
- **Only for a repeatable request** — one carrying neither a method override (`-X`/`--request`) nor a body (`-d`/`--data*`/`-F`/`--form`/`-T`/`--upload-file`). A write whose response timed out may already have been applied, so writes are never repeated.
- **Buffer each attempt** so a partial first body is replaced rather than concatenated. The exit status is carried behind a marker because command substitution strips trailing newlines, keeping the emitted response byte-for-byte identical to the previous unbuffered `curl`.
- **Report a stall distinctly**, and point it at a Vercel log search *without* a status filter. A stalled request is recorded as `status:000`, so the existing status-filtered link finds nothing — it actively hid the 200/44357 ms rows above.

Product contracts are untouched: both `/context` responses are still fully asserted, so the runner firewall still has to resolve Twilio auth without exposing raw credentials, and the built-in pi loop still has to return a successful answer. No sleeps, skips, deleted tests, weakened assertions or swallowed failures.

## Validation

- `.github/scripts/tests/runner-api-curl-test.sh` extended with four cases (stall-then-success, stall on both attempts with the exact stderr, `-X POST` not repeated, `-d` without `-X` not repeated) — passes. This suite runs in CI via `Run workflow script tests` in `security.yml`.
- `bash -n` and `shellcheck -s bash -x` clean on both changed files.
- `git diff --check` clean.
- 26 additional throwaway behavioural checks against a stubbed `curl` covering partial-body replacement, header-only GETs, `--data-raw`/`--data-binary`/`--data-urlencode`, `--request PUT` and `-X PATCH`.
- The runner e2e shards themselves validate the invariant on this PR's own CI.

## Follow-up, not in this PR

`queryAxiomDirect` in `turbo/apps/api/src/signals/external/axiom.ts` calls `client.query(apl)` with no abort signal, so `/api/runs/:id/context` has no latency budget of its own; the cursor branch beside it already bounds itself with `AbortSignal.timeout`. A user opening a run's context would have waited 44 seconds here. That is an API-side reliability question and is deliberately left out of this test-harness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
