### PR TITLE
test(python): cover leading sigv4 dot segments

### DIFF
--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -358,6 +358,55 @@ def test_sign_request_reuses_matching_inspection_without_changing_output() -> No
 
 
 @pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("/../x", id="leading-parent"),
+        pytest.param("/../../x", id="multiple-leading-parents"),
+        pytest.param("/a/../../x", id="over-traversal"),
+    ],
+)
+def test_header_auth_leading_dot_segments_use_normalized_canonical_path(path: str) -> None:
+    url = f"https://{STS_HOST}{path}"
+
+    signed_url, signed_headers = sign_request(
+        method="GET",
+        url=url,
+        headers=_header_auth_headers(),
+        body=None,
+        credentials=_credentials(),
+    )
+
+    authorization = {name.lower(): value for name, value in signed_headers}["authorization"]
+    assert signed_url == url
+    assert authorization == (
+        "AWS4-HMAC-SHA256 "
+        "Credential=AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request, "
+        "SignedHeaders=host;x-amz-date, "
+        "Signature=df6768fccf76887a9d31a01e2d0d48ae57ecdce506e745b20b6ad1960411066b"
+    )
+
+
+def test_header_auth_s3_keeps_dot_segments_in_canonical_path() -> None:
+    authorizations: list[str] = []
+    for path in ("/../x", "/x"):
+        url = f"https://{_AWS_S3_EXAMPLE_HOST}{path}"
+        signed_url, signed_headers = sign_request(
+            method="GET",
+            url=url,
+            headers=_aws_s3_header_auth_headers(_AWS_S3_EMPTY_PAYLOAD_HASH),
+            body=None,
+            credentials=_aws_s3_example_credentials(),
+        )
+
+        assert signed_url == url
+        authorizations.append(
+            {name.lower(): value for name, value in signed_headers}["authorization"]
+        )
+
+    assert authorizations[0] != authorizations[1]
+
+
+@pytest.mark.parametrize(
     ("changed_url", "changed_headers"),
     [
         pytest.param(

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -125,6 +125,59 @@ async def test_re_signs_header_sigv4_request_to_reference_signature(
     assert "x-amz-security-token" not in flow.request.headers
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("/../x", id="leading-parent"),
+        pytest.param("/../../x", id="multiple-leading-parents"),
+        pytest.param("/a/../../x", id="over-traversal"),
+    ],
+)
+async def test_re_signs_header_sigv4_request_with_leading_dot_segments(
+    path: str,
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    auth_response = aws_auth_response(include_session_token=False)
+    api_entry = aws_api_entry(base="https://iam.amazonaws.com", include_session_token=False)
+    flow = real_flow(
+        with_response=False,
+        host="iam.amazonaws.com",
+        path=path,
+        method="GET",
+        request_headers=headers(
+            ("Host", "iam.amazonaws.com"),
+            ("X-Amz-Date", "20150830T123600Z"),
+            (
+                "Authorization",
+                aws_sigv4_authorization(
+                    date="20150830",
+                    service="iam",
+                ),
+            ),
+        ),
+    )
+
+    result = await handle_firewall_request_with_auth_endpoint(
+        flow,
+        tmp_path,
+        mitm_ctx,
+        auth_response=auth_response,
+        allow=aws_allow(
+            api_entry,
+            permission="leading-dot-segments",
+            rule="GET /{path+}",
+            rel_path=path,
+        ),
+    )
+
+    assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+    assert flow.response is None
+    assert flow.request.url == f"https://iam.amazonaws.com{path}"
+
+
 async def test_re_signs_header_sigv4_request_with_encoded_path(
     real_flow,
     headers,

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -176,6 +176,10 @@ async def test_re_signs_header_sigv4_request_with_leading_dot_segments(
     assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
     assert flow.response is None
     assert flow.request.url == f"https://iam.amazonaws.com{path}"
+    authorization = flow.request.headers["authorization"]
+    assert authorization.startswith("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/")
+    assert "PLACEHOLDER" not in authorization
+    assert "Signature=placeholder" not in authorization
 
 
 async def test_re_signs_header_sigv4_request_with_encoded_path(


### PR DESCRIPTION
## Summary

- cover leading and over-traversing dot segments through the public AWS SigV4 signer boundary
- verify the same path matrix completes through the real firewall-auth flow without rewriting request URLs
- lock S3's intentionally distinct raw-path signing behavior

## Scope

This is a test-only change. It does not modify production signing or auth behavior.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`7258 passed`)
- focused mutation check: replacing the guarded empty-stack pop with an unconditional pop made all six new non-S3 signer and auth cases fail with `IndexError`; restoring the guard made all seven focused cases pass
- pre-commit Ruff, file-size, and commitlint hooks

Closes #30670
