### PR TITLE
test(codex): distinguish replay usage baselines

### DIFF
--- a/crates/guest-mock-codex/src/app_server/messages.rs
+++ b/crates/guest-mock-codex/src/app_server/messages.rs
@@ -49,6 +49,14 @@ const HISTORICAL_USAGE: MockTokenUsage = MockTokenUsage {
     reasoning_output_tokens: 10,
     total_tokens: 150,
 };
+const HISTORICAL_LAST_USAGE: MockTokenUsage = MockTokenUsage {
+    input_tokens: 6,
+    cached_input_tokens: 1,
+    cache_write_input_tokens: 1,
+    output_tokens: 12,
+    reasoning_output_tokens: 2,
+    total_tokens: 18,
+};
 const FIRST_RESPONSE_USAGE: MockTokenUsage = MockTokenUsage {
     input_tokens: 7,
     cached_input_tokens: 2,
@@ -627,7 +635,7 @@ pub(super) fn historical_token_usage_notification(thread_id: &str) -> Value {
         thread_id,
         HISTORICAL_TURN_ID,
         HISTORICAL_USAGE,
-        HISTORICAL_USAGE,
+        HISTORICAL_LAST_USAGE,
     )
 }
 


### PR DESCRIPTION
## Summary

- give replayed Codex usage distinct cumulative and latest-response fixture values
- keep the existing repeated current snapshot and exact per-turn usage assertion as the regression boundary
- make the resume integration path fail if replay baseline selection changes from `tokenUsage.total` to `tokenUsage.last`

## Scope

- test fixture values only
- no production behavior, API, persistence, deployment protocol, UI, or user-flow changes
- no direct tracker unit test; coverage remains at the guest-agent backend integration boundary

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_app_server_backend_resume`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_app_server_backend --test codex_app_server_backend_resume_usage_no_replay --test codex_app_server_backend_secondary_thread`
- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-codex`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-mock-codex -p guest-agent --all-targets -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p guest-mock-codex -p guest-agent --no-deps`
- pre-commit hooks: cargo format, documentation, Clippy, file-size, and commit-message checks

Closes #30669
