### PR TITLE
test(platform): gate thinking indicator frames on page readiness

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-thinking-indicator.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-thinking-indicator.test.tsx
@@ -1,6 +1,7 @@
 import { waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { context, detachedSetupPage } from "./chat-lifecycle-test-helpers.ts";
+import { setupPageAndWaitForContent } from "../../../__tests__/page-helper.ts";
+import { context } from "./chat-lifecycle-test-helpers.ts";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
 
 const THREAD_ID = "b0000000-0000-4000-a000-000000000210";
@@ -105,7 +106,7 @@ function recordRenderedLabelText(): string[] {
   return rendered;
 }
 
-function setupThinkingRun(): string[] {
+async function setupThinkingRun(): Promise<string[]> {
   stubLabelTextMeasurement();
   mockChatLifecycle(context, {
     threadId: THREAD_ID,
@@ -137,17 +138,22 @@ function setupThinkingRun(): string[] {
   });
 
   const rendered = recordRenderedLabelText();
-  detachedSetupPage({
+  // Page bootstrap costs far more than the animation itself, so it gets its own
+  // barrier instead of eating into the `waitFor` budget the frames need.
+  await setupPageAndWaitForContent({
     context,
     path: `/chats/${THREAD_ID}`,
   });
   return rendered;
 }
 
-async function waitForBothLines(rendered: readonly string[]): Promise<void> {
-  await waitFor(() => {
-    expect(rendered).toContain(FIRST_OVERFLOW_FRAME);
-  });
+/**
+ * The typewriter stops on the last explicit line, so that frame is the stable
+ * end of the animation. Waiting for it means every earlier frame is already
+ * recorded and can be asserted synchronously, without sampling for a frame that
+ * only exists mid-animation.
+ */
+async function waitForTypedLines(rendered: readonly string[]): Promise<void> {
   await waitFor(() => {
     expect(rendered).toContain(SECOND_LINE);
   });
@@ -155,8 +161,8 @@ async function waitForBothLines(rendered: readonly string[]): Promise<void> {
 
 describe("chat thinking indicator", () => {
   it("discards an overflowing line remainder before showing the next explicit line", async () => {
-    const rendered = setupThinkingRun();
-    await waitForBothLines(rendered);
+    const rendered = await setupThinkingRun();
+    await waitForTypedLines(rendered);
 
     expect(rendered).toContain(FIRST_OVERFLOW_FRAME);
     expect(rendered).toContain(SECOND_LINE);
@@ -174,8 +180,8 @@ describe("chat thinking indicator", () => {
   });
 
   it("never turns an overflowing remainder into another displayed line", async () => {
-    const rendered = setupThinkingRun();
-    await waitForBothLines(rendered);
+    const rendered = await setupThinkingRun();
+    await waitForTypedLines(rendered);
 
     for (const frame of rendered) {
       expect(


### PR DESCRIPTION
## Problem

`chat-thinking-indicator.test.tsx > chat thinking indicator > discards an overflowing line remainder before showing the next explicit line` fails intermittently on `test-app` shard 2.

Two occurrences, different SHAs, byte-for-byte identical signature:

- [Run 33465042196](https://github.com/vm0-ai/vm0/actions/runs/33465042196) (merge_group, `ae5d5f5b2f02ff3d4fd18a1b4b8b169328a5e473`, queued PR #30673)
- [Run 33465762538](https://github.com/vm0-ai/vm0/actions/runs/33465762538) (merge_group, `912a52f530828b67eed3a44cc14883f0c019e528`, queued PR #30688)

```
AssertionError: expected [ '整理这' ] to include '整理这些文…'
 ❯ src/views/okou-page/__tests__/chat-thinking-indicator.test.tsx:149:22
```

The recorded frame log held exactly one frame, `'整理这'`, both times.

## Root cause

Missing test synchronization boundary. `turbo/apps/platform` sets no testing-library `configure()`, so `waitFor` uses the default 1000ms `asyncUtilTimeout`. `detachedSetupPage` is fire-and-forget, so the `waitFor` placed straight after it had to cover the entire chat page bootstrap *and* the typewriter animation inside that single budget.

Reproduced locally on a 2-core box by running the file with 3 `node` busy-loop processes, and instrumented `setThinkingIndicatorTextRef$` / `setLoop` to timestamp every step:

| | idle | under contention |
|---|---|---|
| page bootstrap, up to the label ref being attached | 276ms | 1136ms |
| first frame `整理这` | 280ms | 1148ms |
| animation complete at `生成结果。` | 390ms | never reached inside the budget |

The animation itself is healthy and deterministic — `整理这` → `整理这些文…` → `生成结` → `生成结果。`, about 110ms end to end. It is the bootstrap in front of it that scales with shard load and eats the budget. That is why both CI runs captured the identical single frame rather than a random partial one: `'整理这'` is deterministically the first frame, recorded just before the wait expired.

`FIRST_OVERFLOW_FRAME` is correct and is still emitted; the step size and the constant match. The `test-app (7)` cancellations, `ci-gate-turbo`, and the trailing codecov `No coverage reports found` lines are downstream noise, not causes.

## Fix

- Absorb page bootstrap with `setupPageAndWaitForContent`, the existing helper used by `chat-thread-metadata-readiness`, `sidebar`, `sidebar-account-menu`, and `agents-page-tabs`. It gates on the app skeleton clearing via its own `MutationObserver`, so bootstrap no longer competes with the frames for the 1000ms `asyncUtilTimeout`.
- Wait for the last explicit line instead of a mid-animation frame. The typewriter stops there, so that frame is the stable end of the animation and every earlier frame is already in the recorded log.

No timeout was raised, no sleep, retry, or manual detached cleanup was added, and no product code changed.

The contract is unchanged and still enforced synchronously on the full recorded sequence: the overflow frame `整理这些文…` must be present, the frame immediately before the first second-line frame must be exactly that overflow frame, no frame may contain the discarded remainder `隐藏后缀`, and every frame must be a prefix of one of the two explicit lines. A leaked remainder still fails the test.

## Validation

Targeted, `@okouai/app`, 2-core box:

- 5/5 pass normally, ~1.8s of test time, unchanged from before the fix.
- Under 3 busy-loop processes, the reproduction condition: **before** 5/5 failed with the exact CI assertion; **after** 5/5 pass.
- `chat-thinking-indicator-event-sequences.test.tsx` (same feature, sibling file): 8/8 pass.
- `prettier --check`, `eslint`, `tsc -p tsconfig.tests.json --noEmit`, `git diff --check`: clean.

Preview validation is not applicable — this is a test-only change with no product or UI behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
