### PR TITLE
perf(platform): cache repeated eslint runs

### DIFF
--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -11,19 +11,28 @@ const eslintCacheInputPaths = globSync(
   [
     "eslint.config.js",
     "package.json",
-    "../../packages/eslint-config/*.js",
-    "../../packages/eslint-config/package.json",
-    "../../packages/eslint-rules/package.json",
-    "../../packages/eslint-rules/src/ccstate/index.ts",
-    "../../packages/eslint-rules/src/ccstate/utils.ts",
-    "../../packages/eslint-rules/src/ccstate/rules/*.ts",
+    "../../package.json",
     "../../pnpm-lock.yaml",
+    "../../pnpm-workspace.yaml",
     "../../turbo.json",
+    "../../{apps,packages}/*/turbo.{json,jsonc}",
+    "../../packages/eslint-config/**/*.{js,cjs,mjs,json}",
+    "../../packages/eslint-rules/package.json",
+    "../../packages/eslint-rules/src/ccstate/**/*.ts",
   ],
-  { cwd: import.meta.dirname },
+  {
+    cwd: import.meta.dirname,
+    exclude: [
+      "../../packages/eslint-config/**/*.node.js",
+      "../../packages/eslint-rules/src/ccstate/__tests__/**",
+    ],
+  },
 ).sort();
 const eslintCacheHash = createHash("sha256");
 
+// Cached results must only depend on the linted file, its calculated config,
+// and the inputs above. Add new external inputs here before enabling a rule
+// that reads them; type-aware or other cross-file rules need broader invalidation.
 for (const inputPath of eslintCacheInputPaths) {
   eslintCacheHash.update(inputPath).update("\0");
   eslintCacheHash

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -1,14 +1,47 @@
+import { createHash } from "node:crypto";
+import { globSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { config as baseConfig, oxlint } from "@okouai/eslint-config/base";
 import ccstatePlugin from "@okouai/eslint-rules/ccstate";
 import pluginReactHooks from "eslint-plugin-react-hooks";
 import pluginReact from "eslint-plugin-react";
+
+const eslintCacheInputPaths = globSync(
+  [
+    "eslint.config.js",
+    "package.json",
+    "../../packages/eslint-config/*.js",
+    "../../packages/eslint-config/package.json",
+    "../../packages/eslint-rules/package.json",
+    "../../packages/eslint-rules/src/ccstate/index.ts",
+    "../../packages/eslint-rules/src/ccstate/utils.ts",
+    "../../packages/eslint-rules/src/ccstate/rules/*.ts",
+    "../../pnpm-lock.yaml",
+    "../../turbo.json",
+  ],
+  { cwd: import.meta.dirname },
+).sort();
+const eslintCacheHash = createHash("sha256");
+
+for (const inputPath of eslintCacheInputPaths) {
+  eslintCacheHash.update(inputPath).update("\0");
+  eslintCacheHash
+    .update(readFileSync(resolve(import.meta.dirname, inputPath)))
+    .update("\0");
+}
+
+const eslintCacheFingerprint = eslintCacheHash.digest("hex");
 
 /** @type {import("eslint").Linter.Config[]} */
 export default [
   ...baseConfig,
   {
     ...pluginReact.configs.flat.recommended,
-    settings: { react: { version: "detect" } },
+    settings: {
+      react: { version: "detect" },
+      "vm0/eslint-cache-fingerprint": eslintCacheFingerprint,
+    },
   },
   {
     plugins: {

--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -16,7 +16,7 @@
     "lint:build-config": "tsx --test scripts/check-build-config.node.ts",
     "lint:localized-ui": "node --test scripts/check-localized-ui.node.mjs && node scripts/check-localized-ui.mjs",
     "lint:static-assets": "node scripts/check-static-assets.mjs",
-    "lint": "pnpm lint:static-assets && pnpm lint:emoji-data && pnpm lint:localized-ui && pnpm lint:build-config && pnpm i18n:check && oxlint --deny-warnings && oxlint --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings && eslint . --max-warnings 0",
+    "lint": "pnpm lint:static-assets && pnpm lint:emoji-data && pnpm lint:localized-ui && pnpm lint:build-config && pnpm i18n:check && oxlint --deny-warnings && oxlint --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings && eslint . --max-warnings 0 --cache --cache-strategy content --cache-location .eslintcache",
     "check-types": "tsc -p tsconfig.production.json --noEmit && tsc -p tsconfig.tests.json --noEmit && tsc -p tsconfig.build-config.json --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- enable ESLint's persistent content cache for direct platform lint runs
- fingerprint platform configuration, recursively discovered lint rule sources, dependency state, workspace discovery inputs, and Turbo configuration into the calculated ESLint config
- keep one ignored `.eslintcache` artifact without changing rules, warning policy, or linted files

## Cache correctness

The platform uses a namespaced calculated-config setting derived from sorted input paths and contents. This makes changes to repository-owned rule functions and dynamic lint inputs invalidate cached results even though JavaScript function implementations are not serialized by ESLint's native config hash.

The fingerprint covers:

- platform ESLint config and package metadata
- root package and pnpm workspace metadata
- shared ESLint config runtime sources and package metadata, discovered recursively
- production ccstate plugin runtime sources, discovered recursively while excluding rule tests
- `pnpm-lock.yaml` for dependency-provided parser and plugin implementations
- root and future workspace `turbo.json` or `turbo.jsonc` files for `turbo/no-undeclared-env-vars`

The cache remains intentionally limited to per-file rules. A future type-aware, cross-file, or externally configured rule must add its external inputs or use broader invalidation before being enabled.

No production runtime code, lint rule, ignore pattern, warning threshold, Turbo task output, or file category changes.

## Validation

- direct ESLint cold content cache: passed in 158.41s
- direct ESLint warm content cache: passed in 31.76s (about 80% lower wall time)
- `pnpm -F @okouai/app lint` with an empty platform cache: passed in 549.86s
- `pnpm -F @okouai/app lint` with the resulting warm cache: passed in 187.13s
- `pnpm -F @okouai/app lint` after recursive invalidation hardening: passed
- direct ESLint warm-cache follow-up after hardening: passed in 8.53s
- `pnpm -F @okouai/app check-types`: passed
- `pnpm knip --workspace @okouai/app`: passed
- `pnpm exec prettier --write apps/platform/eslint.config.js`: passed without changes
- `git diff --check`: passed
- full pre-commit Knip, formatting, file-size, and commitlint hooks: passed

Invalidation probes used the real ESLint CLI and were restored before commit:

- a linted source edit invalidated only that source file's cached result
- platform config, shared config, ccstate rule source, lockfile, and Turbo config probes each changed the calculated fingerprint
- a newly added nested ccstate helper changed the fingerprint, and removing it restored the baseline fingerprint
- a shared-config fingerprint change rejected all 877 existing cached lint results

Absolute timings varied under shared-host contention; cold and warm comparisons above were run sequentially in the same prepared environment.

Closes #30678

Parent context: #30676
