### PR TITLE
test(api): synchronize cancellation chat callback delivery

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -15816,21 +15816,20 @@ describe("HOOK-01/RUN-03: terminal run callbacks dispatch on cancellation", () =
       prompt: "first cancellable chat run",
     });
     await api.requestCancelRun(actor, first.runId, [200]);
+    // Cancellation delivers its chat callback from the route's `waitUntil`
+    // work, so drain that work instead of polling for the appended event.
+    await flushWaitUntilForTest();
 
     const firstCancelled = await api.readRun(actor, first.runId);
     expect(firstCancelled.status).toBe("cancelled");
-    await expect
-      .poll(async () => {
-        const messages = await chat.listThreadEvents(actor, first.threadId);
-        return messages.events.some((message) => {
-          return (
-            message.eventType === "run.cancelled" &&
-            message.runId === first.runId &&
-            message.runLifecycleEvent === "cancelled"
-          );
-        });
-      })
-      .toBe(true);
+    const firstEvents = await chat.listThreadEvents(actor, first.threadId);
+    expect(firstEvents.events).toContainEqual(
+      expect.objectContaining({
+        eventType: "run.cancelled",
+        runId: first.runId,
+        runLifecycleEvent: "cancelled",
+      }),
+    );
     expect(routeRequests).toBe(0);
 
     const second = await sendChatRunMessage(actor, {
@@ -15839,21 +15838,18 @@ describe("HOOK-01/RUN-03: terminal run callbacks dispatch on cancellation", () =
       prompt: "second cancellable chat run",
     });
     await api.requestCancelRun(actor, second.runId, [200]);
+    await flushWaitUntilForTest();
 
     const secondCancelled = await api.readRun(actor, second.runId);
     expect(secondCancelled.status).toBe("cancelled");
-    await expect
-      .poll(async () => {
-        const messages = await chat.listThreadEvents(actor, first.threadId);
-        return messages.events.some((message) => {
-          return (
-            message.eventType === "run.cancelled" &&
-            message.runId === second.runId &&
-            message.runLifecycleEvent === "cancelled"
-          );
-        });
-      })
-      .toBe(true);
+    const secondEvents = await chat.listThreadEvents(actor, first.threadId);
+    expect(secondEvents.events).toContainEqual(
+      expect.objectContaining({
+        eventType: "run.cancelled",
+        runId: second.runId,
+        runLifecycleEvent: "cancelled",
+      }),
+    );
     expect(routeRequests).toBe(0);
 
     const third = await sendChatRunMessage(actor, {
@@ -15862,25 +15858,17 @@ describe("HOOK-01/RUN-03: terminal run callbacks dispatch on cancellation", () =
       prompt: "third cancellable chat run",
     });
     await api.requestCancelRun(actor, third.runId, [200]);
+    await flushWaitUntilForTest();
 
     const thirdCancelled = await api.readRun(actor, third.runId);
     expect(thirdCancelled.status).toBe("cancelled");
 
-    let cancelNote:
-      | Awaited<ReturnType<typeof chat.listThreadEvents>>["events"][number]
-      | undefined;
-    await expect
-      .poll(async () => {
-        const messages = await chat.listThreadEvents(actor, first.threadId);
-        cancelNote = messages.events.find((message) => {
-          return (
-            message.eventType === "run.cancelled" &&
-            message.runId === third.runId
-          );
-        });
-        return cancelNote?.eventType;
-      })
-      .toBe("run.cancelled");
+    const thirdEvents = await chat.listThreadEvents(actor, first.threadId);
+    const cancelNote = thirdEvents.events.find((message) => {
+      return (
+        message.eventType === "run.cancelled" && message.runId === third.runId
+      );
+    });
     if (!cancelNote || cancelNote.eventType !== "run.cancelled") {
       throw new Error(
         "Expected the delivered chat callback to append a cancellation event",


### PR DESCRIPTION
## Summary

- Drain the cancel route's tracked `waitUntil` work with `flushWaitUntilForTest()` before asserting the delivered chat callback, instead of polling for its effect.
- Replace the three `expect.poll(...)` blocks with direct `toContainEqual` / `find` assertions on the thread events.
- Preserve both halves of the product contract: the `run.cancelled` chat event with `runLifecycleEvent: "cancelled"` is still required for every cancellation, and `routeRequests` must still be `0` (no HTTP self-dispatch).

## Failure evidence

- Trigger: [Turbo run 33465886041](https://github.com/vm0-ai/vm0/actions/runs/33465886041), `push` on `main`, SHA `3ecf775e6c353b9aa8f8dcb0c35b0909a1520a26`, [test-api shard 7](https://github.com/vm0-ai/vm0/actions/runs/33465886041/job/99725987111)
- Failing test: `HOOK-01/RUN-03: terminal run callbacks dispatch on cancellation > delivers chat run callbacks through cancellation side effects without HTTP self-dispatch`
- Causal chain:

  ```
  AssertionError: expected false to be true // Object.is equality
   ❯ src/signals/routes/__tests__/run-lifecycle.bdd.test.ts:15833:8

  Caused by: Error: Matcher did not succeed in time.
   ❯ src/signals/routes/__tests__/run-lifecycle.bdd.test.ts:15822:5
  ```

  `expected false to be true` is the surface; `Matcher did not succeed in time` is the cause. The polling block never converged, so the following `expect(routeRequests).toBe(0)` was never reached.
- Shard summary: `Test Files 1 failed | 26 passed (27)`, `Tests 1 failed | 426 passed (427)`.

## Root cause

`runsCancelRoutes` returns its `200` as soon as `cancelRun$` commits and schedules the callback delivery in the background:

```ts
// turbo/apps/api/src/signals/routes/runs-cancel.ts
if (shouldDispatchCancelSideEffects(result)) {
  const backgroundSignal = new AbortController().signal;
  waitUntil(tapError(set(dispatchCancelSideEffects$, result, backgroundSignal), ...));
}
```

The `run.cancelled` chat event is written much later in that background chain, inside a transaction in `insertAssistantErrorEvent` (`internal-chat-run-callback.service.ts`), reached through `dispatchCancelSideEffects$ -> dispatchRunCallbacks$ -> dispatchSingleInternalCallback$`.

The test had no barrier for that work and instead polled for the event with `expect.poll`, which has no explicit options here. Vitest 4 defaults to `interval = 50`, `timeout = 1000`, and neither `apps/api/vitest.config.ts` nor `turbo/vitest.config.ts` configures `expect.poll`. So the assertion had a hard 1000 ms budget for a background Postgres write chain, while CI runs eight `test-api` shard files in parallel against one shared Postgres container. The job log shows `run-lifecycle.bdd.test.ts`, `chat-threads.bdd.test.ts` and `test-runtime-state.test.ts` interleaved in the same window.

Classification: missing test synchronization (first category in the flaky-test skill). This is not a product race: every observed interleaving is valid behaviour, and the delivery is already fully awaited inside the `waitUntil` promise, so `flushWaitUntilForTest()` is an exact completion boundary rather than a longer wait.

The `DrizzleQueryError` on `agent_run_queue` with `cause: Error: Cannot use a pool after calling end on the pool` at 03:25:04 belongs to `test-runtime-state.test.ts`, a different file with its own module registry, and is not causal. The `run-context ingest failed`, `sandbox telemetry ingest failed`, `enqueue telemetry failed`, `OpenRouter completion finished with unknown` and `google-drive token refresh failed: 503` lines are deliberate negative-path fixtures.

## Why this shape of fix

`flushWaitUntilForTest()` is the sanctioned barrier for API `waitUntil()` work and is already used 48 times in this same file, including by the sibling cancellation test at `run-lifecycle.bdd.test.ts:15121` which does exactly `requestCancelRun` then `flushWaitUntilForTest` then a hard assertion. No retries, sleeps, larger budgets, skips or weakened assertions are involved; the assertions are now unconditional, and a missing delivery fails immediately with the actual event list instead of `expected false to be true`.

## Validation

- Target test, 5 consecutive isolated runs: 5/5 passed (713-774 ms each).
- Full `run-lifecycle.bdd.test.ts`: 186/186 passed.
- Negative control: removing the first `flushWaitUntilForTest()` makes the test fail immediately with `expected [ ... ] to deep equally contain ObjectContaining{...}`, confirming the event really is produced by background work and that the new assertion still detects a missed delivery.
- Instrumented measurement on the pre-fix code: the first poll converged in 71 ms idle and 59 ms under two-worker local contention, against the 1000 ms budget. The local machine has 2 CPUs, so the CI shard's eight-way saturation could not be reproduced here; the fix removes the budget rather than widening it.
- `pnpm format`, `pnpm -F api run lint` (exit 0, only pre-existing warnings), `tsc -p tsconfig.gateways.json`, `tsconfig.core.json`, `tsconfig.bootstrap.json`, `tsc -p tsconfig.tests.json --noEmit` all pass. `git diff --check` clean.

## Limitations

The full repository Vitest suite was not run, per repository guidance; the PR pipeline covers it. No app, API, runner or dev server was started, and no secret manager was used.
