### PR TITLE
fix(desktop): treat a user-ended screen share as a finished recording

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/StreamStopReason.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/StreamStopReason.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ScreenCaptureKit
 
 /// Why a capture stream ended without the app asking it to.
 public enum StreamStopReason: Equatable, Sendable {
@@ -11,14 +12,16 @@ public enum StreamStopReason: Equatable, Sendable {
 }
 
 public enum StreamStopClassifier {
-    /// `SCStreamErrorUserStopped`. macOS reports the user ending the share
-    /// through its own indicator as an `SCStreamError`, so the only thing
-    /// separating "finished" from "broken" is this code.
-    public static let userStoppedErrorCode = -3817
+    /// macOS reports the user ending the share through its own indicator as an
+    /// `SCStreamError`, so the only thing separating "finished" from "broken"
+    /// is this code. Taken from the SDK rather than written out, because a
+    /// mistyped literal would classify every user stop as a fault and silently
+    /// restore the bug this classifier exists to fix.
+    public static let userStoppedErrorCode = SCStreamError.Code.userStopped.rawValue
 
     /// `SCStreamError` values live in this domain; codes from anywhere else
     /// carry no such guarantee and are treated as faults.
-    public static let streamErrorDomain = "com.apple.ScreenCaptureKit.SCStreamErrorDomain"
+    public static let streamErrorDomain = SCStreamError.errorDomain
 
     public static func classify(domain: String, code: Int) -> StreamStopReason {
         guard domain == streamErrorDomain, code == userStoppedErrorCode else {

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/StreamStopReason.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/StreamStopReason.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Why a capture stream ended without the app asking it to.
+public enum StreamStopReason: Equatable, Sendable {
+    /// The person recording ended the share themselves, from the system's own
+    /// screen-sharing indicator. This is an ordinary finish, not a fault.
+    case userStopped
+    /// The capture broke: the window closed, the display was unplugged, or the
+    /// stream was revoked.
+    case failed
+}
+
+public enum StreamStopClassifier {
+    /// `SCStreamErrorUserStopped`. macOS reports the user ending the share
+    /// through its own indicator as an `SCStreamError`, so the only thing
+    /// separating "finished" from "broken" is this code.
+    public static let userStoppedErrorCode = -3817
+
+    /// `SCStreamError` values live in this domain; codes from anywhere else
+    /// carry no such guarantee and are treated as faults.
+    public static let streamErrorDomain = "com.apple.ScreenCaptureKit.SCStreamErrorDomain"
+
+    public static func classify(domain: String, code: Int) -> StreamStopReason {
+        guard domain == streamErrorDomain, code == userStoppedErrorCode else {
+            return .failed
+        }
+        return .userStopped
+    }
+}

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
@@ -168,6 +168,10 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
 
     private var state: RecorderSessionState = .ready
     private var failure: HelperFailure?
+    /// Set when the stream ended without `stop` being called. The session stays
+    /// finalizable so the partial recording and its click track are still
+    /// written; only the reported status changes.
+    private var externalStop: (reason: StreamStopReason, message: String)?
     private var stream: SCStream?
     private var writer: AVAssetWriter?
     private var videoInput: AVAssetWriterInput?
@@ -449,7 +453,7 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         lock.lock()
         defer { lock.unlock() }
         var described: [String: Any] = [
-            "status": state.rawValue,
+            "status": reportedStatusLocked(),
             "elapsedMs": Int(elapsedSecondsLocked() * 1000),
         ]
         if let failure {
@@ -457,8 +461,23 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
                 "code": failure.code,
                 "message": failure.message,
             ]
+        } else if let externalStop, externalStop.reason == .failed {
+            described["error"] = [
+                "code": "source_lost",
+                "message": externalStop.message,
+            ]
         }
         return described
+    }
+
+    /// The status the caller sees. An externally ended stream is reported as
+    /// finished or failed straight away, while `state` stays `.recording` so
+    /// the caller can still run `stop` to finalize the file it already has.
+    private func reportedStatusLocked() -> String {
+        guard let externalStop, state == .recording else {
+            return state.rawValue
+        }
+        return externalStop.reason == .userStopped ? "stopped" : "failed"
     }
 
     var isTerminal: Bool {
@@ -485,23 +504,39 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         return max(0, CMTimeGetSeconds(CMTimeSubtract(latest, start)))
     }
 
-    private func markFailed(code: String, message: String) {
+    /// Records that the stream ended on its own.
+    ///
+    /// Deliberately does not move to a terminal state: the writer still holds
+    /// frames that were captured before the stream ended, and discarding them
+    /// would throw away the recording the user just made. `stop` finalizes as
+    /// usual, and the reported status tells the caller to run it.
+    private func noteExternalStop(reason: StreamStopReason, message: String) {
         lock.lock()
-        state = .failed
-        failure = HelperFailure(code: code, message: message)
+        if externalStop == nil {
+            externalStop = (reason, message)
+        }
         let captureStream = stream
         stream = nil
         lock.unlock()
         captureStream?.stopCapture { _ in }
-        // The tap outlives the stream unless it is torn down here: a failed
-        // session is never stopped by the caller.
+        // The tap outlives the stream unless it is torn down here.
         clickTracker.stop()
     }
 
     // MARK: SCStreamDelegate
 
     func stream(_ stream: SCStream, didStopWithError error: Error) {
-        markFailed(code: "source_lost", message: error.localizedDescription)
+        // Ending the share from the system indicator arrives here as an error
+        // like any other, so the code decides whether this is a finish or a
+        // fault. Reporting a deliberate stop as a failure was wrong.
+        let nsError = error as NSError
+        noteExternalStop(
+            reason: StreamStopClassifier.classify(
+                domain: nsError.domain,
+                code: nsError.code
+            ),
+            message: error.localizedDescription
+        )
     }
 
     // MARK: SCStreamOutput

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
@@ -167,7 +167,6 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
     private var timebase = mach_timebase_info_data_t()
 
     private var state: RecorderSessionState = .ready
-    private var failure: HelperFailure?
     /// Set when the stream ended without `stop` being called. The session stays
     /// finalizable so the partial recording and its click track are still
     /// written; only the reported status changes.
@@ -456,12 +455,7 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
             "status": reportedStatusLocked(),
             "elapsedMs": Int(elapsedSecondsLocked() * 1000),
         ]
-        if let failure {
-            described["error"] = [
-                "code": failure.code,
-                "message": failure.message,
-            ]
-        } else if let externalStop, externalStop.reason == .failed {
+        if let externalStop, externalStop.reason == .failed {
             described["error"] = [
                 "code": "source_lost",
                 "message": externalStop.message,
@@ -722,21 +716,25 @@ private func handleStart(_ request: [String: Any]) throws -> [String: Any] {
 private func handleStop(_ request: [String: Any]) throws -> [String: Any] {
     let sessionId = try requiredString(request, "sessionId")
     let session = try sessionStore.session(sessionId)
-    let result = try session.stop()
-    sessionStore.remove(sessionId)
-    return result
+    // `stop` reaches its terminal state before any of the work that can throw,
+    // so a finalize that fails partway leaves a session that can never be
+    // stopped again. Releasing on the way out either way is what keeps the
+    // store bounded; the caller gives up on a rejected stop and never retries.
+    defer {
+        if session.isTerminal {
+            sessionStore.remove(sessionId)
+        }
+    }
+    return try session.stop()
 }
 
 private func handleState(_ request: [String: Any]) throws -> [String: Any] {
     let sessionId = try requiredString(request, "sessionId")
     let session = try sessionStore.session(sessionId)
-    let described = session.describedState()
-    if session.isTerminal {
-        // A session that failed on the delegate queue is never stopped by the
-        // caller, so releasing it here is what keeps the store bounded.
-        sessionStore.remove(sessionId)
-    }
-    return described
+    // A stream that ended on its own is reported here but deliberately left in
+    // the store: it still holds the frames the user captured, and only `stop`
+    // can finalize them. `handleStop` is what releases it.
+    return session.describedState()
 }
 
 private func handle(_ request: [String: Any]) throws -> [String: Any] {

--- a/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/StreamStopReasonTests.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/StreamStopReasonTests.swift
@@ -17,7 +17,7 @@ struct StreamStopReasonTests {
 
     @Test
     func treatsEveryOtherStreamErrorAsAFault() {
-        // A closed window or an unplugged display arrives in the same domain
+        // A revoked, declined, or broken capture arrives in the same domain
         // with a different code, and must not be reported as a clean finish.
         #expect(StreamStopClassifier.classify(domain: domain, code: -3801) == .failed)
         #expect(StreamStopClassifier.classify(domain: domain, code: 0) == .failed)

--- a/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/StreamStopReasonTests.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/StreamStopReasonTests.swift
@@ -1,0 +1,38 @@
+import Testing
+
+@testable import ScreenRecorderCore
+
+struct StreamStopReasonTests {
+    private let domain = StreamStopClassifier.streamErrorDomain
+
+    @Test
+    func treatsTheUserEndingTheShareAsAnOrdinaryFinish() {
+        #expect(
+            StreamStopClassifier.classify(
+                domain: domain,
+                code: StreamStopClassifier.userStoppedErrorCode
+            ) == .userStopped
+        )
+    }
+
+    @Test
+    func treatsEveryOtherStreamErrorAsAFault() {
+        // A closed window or an unplugged display arrives in the same domain
+        // with a different code, and must not be reported as a clean finish.
+        #expect(StreamStopClassifier.classify(domain: domain, code: -3801) == .failed)
+        #expect(StreamStopClassifier.classify(domain: domain, code: 0) == .failed)
+    }
+
+    @Test
+    func doesNotTrustTheCodeFromAnotherErrorDomain() {
+        // -3817 means something else entirely outside ScreenCaptureKit, so the
+        // domain has to match before the code is believed.
+        #expect(
+            StreamStopClassifier.classify(
+                domain: "NSOSStatusErrorDomain",
+                code: StreamStopClassifier.userStoppedErrorCode
+            ) == .failed
+        )
+        #expect(StreamStopClassifier.classify(domain: "", code: -3817) == .failed)
+    }
+}

--- a/turbo/apps/desktop/src/desktop-recorder-controller.test.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-controller.test.ts
@@ -441,29 +441,6 @@ describe("DesktopRecorderController", () => {
     });
   });
 
-  it("ends the session when the capture source disappears", async () => {
-    const backend = createBackendFake({
-      getStatus: vi.fn(
-        async (): Promise<DesktopRecorderNativeStatus> => ({
-          status: "failed",
-          elapsedMs: 2000,
-          error: { code: "source_lost", message: "Display disconnected" },
-        }),
-      ),
-    });
-    const { controller } = createController(backend);
-    await enableAndPrepare(controller);
-    await controller.start();
-
-    await controller.refreshRecordingStatus();
-
-    expect(controller.getState()).toMatchObject({
-      status: "idle",
-      sessionId: null,
-      error: { code: "source_lost", message: "Display disconnected" },
-    });
-  });
-
   it("finalizes the file and releases the helper when the switch is withdrawn", async () => {
     const { controller, backend } = createController();
     await enableAndPrepare(controller);

--- a/turbo/apps/desktop/src/desktop-recorder-controller.test.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-controller.test.ts
@@ -337,6 +337,110 @@ describe("DesktopRecorderController", () => {
     expect(onChange).toHaveBeenCalledOnce();
   });
 
+  it("finishes and delivers when the user ends the share from the system indicator", async () => {
+    const backend = createBackendFake({
+      getStatus: vi.fn(
+        async (): Promise<DesktopRecorderNativeStatus> => ({
+          status: "stopped",
+          elapsedMs: 4200,
+        }),
+      ),
+    });
+    const { controller, deliver, openReview } = createController(backend);
+    await enableAndPrepare(controller);
+    await controller.start();
+
+    await controller.refreshRecordingStatus();
+
+    // The capture is finalized through the same path an explicit stop uses, so
+    // the click track is written and the recording is handed over.
+    expect(backend.stop).toHaveBeenCalledWith("session-1");
+    expect(deliver).toHaveBeenCalledWith(RECORDING);
+    expect(openReview).toHaveBeenCalledWith(DELIVERED.reviewUrl);
+    expect(controller.getState()).toMatchObject({
+      status: "idle",
+      sessionId: null,
+      error: null,
+      lastRecording: RECORDING,
+    });
+  });
+
+  it("keeps the partial recording when the capture breaks", async () => {
+    const backend = createBackendFake({
+      getStatus: vi.fn(
+        async (): Promise<DesktopRecorderNativeStatus> => ({
+          status: "failed",
+          elapsedMs: 2000,
+          error: { code: "source_lost", message: "Display disconnected" },
+        }),
+      ),
+    });
+    const { controller, deliver } = createController(backend);
+    await enableAndPrepare(controller);
+    await controller.start();
+
+    await controller.refreshRecordingStatus();
+
+    // Finalized so the frames already captured and their click track survive,
+    // but not shipped on its own: a broken capture is the user's call.
+    expect(backend.stop).toHaveBeenCalledWith("session-1");
+    expect(deliver).not.toHaveBeenCalled();
+    expect(controller.getState()).toMatchObject({
+      status: "idle",
+      sessionId: null,
+      lastRecording: RECORDING,
+      error: { code: "source_lost", message: "Display disconnected" },
+    });
+  });
+
+  it("can deliver a salvaged recording on request", async () => {
+    const backend = createBackendFake({
+      getStatus: vi.fn(
+        async (): Promise<DesktopRecorderNativeStatus> => ({
+          status: "failed",
+          elapsedMs: 2000,
+          error: { code: "source_lost", message: "Display disconnected" },
+        }),
+      ),
+    });
+    const { controller, openReview } = createController(backend);
+    await enableAndPrepare(controller);
+    await controller.start();
+    await controller.refreshRecordingStatus();
+
+    await controller.retryDelivery();
+
+    expect(openReview).toHaveBeenCalledWith(DELIVERED.reviewUrl);
+  });
+
+  it("reports the capture reason when the salvage itself fails", async () => {
+    const backend = createBackendFake({
+      getStatus: vi.fn(
+        async (): Promise<DesktopRecorderNativeStatus> => ({
+          status: "failed",
+          elapsedMs: 2000,
+          error: { code: "source_lost", message: "Display disconnected" },
+        }),
+      ),
+      stop: vi.fn(async () => {
+        throw new Error("helper is gone");
+      }),
+    });
+    const { controller, logError } = createController(backend);
+    await enableAndPrepare(controller);
+    await controller.start();
+
+    await controller.refreshRecordingStatus();
+
+    expect(logError).toHaveBeenCalledOnce();
+    expect(controller.getState()).toMatchObject({
+      status: "idle",
+      sessionId: null,
+      lastRecording: null,
+      error: { code: "source_lost" },
+    });
+  });
+
   it("ends the session when the capture source disappears", async () => {
     const backend = createBackendFake({
       getStatus: vi.fn(

--- a/turbo/apps/desktop/src/desktop-recorder-controller.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-controller.ts
@@ -247,8 +247,15 @@ export class DesktopRecorderController {
     if (this.status !== "recording" || this.sessionId !== sessionId) {
       return;
     }
+    if (native.status === "stopped") {
+      // Ending the share from the system indicator is an ordinary finish, so it
+      // takes the same path an explicit stop would: finalize, then deliver.
+      await this.collectAfterExternalStop(sessionId, null);
+      return;
+    }
     if (native.status === "failed") {
-      this.failSession(
+      await this.collectAfterExternalStop(
+        sessionId,
         native.error ?? {
           code: "capture_failed",
           message: "Screen recording stopped unexpectedly",
@@ -260,6 +267,48 @@ export class DesktopRecorderController {
       this.elapsedMs = native.elapsedMs;
       this.onChange();
     }
+  }
+
+  /**
+   * Finalizes a capture that ended without `stop` being called.
+   *
+   * The frames already written are the recording the user made, so the file and
+   * its click track are collected either way. A capture that ended cleanly is
+   * then delivered; one that broke is kept with its reason so the tray can offer
+   * a retry, rather than silently shipping a recording that failed.
+   */
+  private async collectAfterExternalStop(
+    sessionId: string,
+    failure: DesktopRecorderError | null,
+  ): Promise<void> {
+    const backend = this.backend;
+    if (!backend) {
+      return;
+    }
+    this.setStatus("finalizing");
+
+    let recording: DesktopRecorderRecording;
+    try {
+      recording = await backend.stop(sessionId);
+    } catch (error) {
+      this.logError(error);
+      this.failSession(
+        failure ?? {
+          code: "capture_failed",
+          message: "Screen recording could not be finalized",
+        },
+      );
+      return;
+    }
+
+    this.lastRecording = recording;
+    this.sessionId = null;
+    this.elapsedMs = 0;
+    if (failure) {
+      this.failSession(failure);
+      return;
+    }
+    await this.runDelivery(recording);
   }
 
   /**

--- a/turbo/apps/desktop/src/desktop-tray-menu.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.test.ts
@@ -748,6 +748,34 @@ describe("desktop tray screen recording section", () => {
     expect(actions.retryScreenRecordingDelivery).toHaveBeenCalledOnce();
   });
 
+  it("does not offer to redeliver an earlier recording when signing in is what failed", () => {
+    const menu = menuFor(
+      recorderState({
+        error: {
+          code: "signed_out",
+          message:
+            "Sign in to Okou before recording so the result can be delivered",
+        },
+        // Left over from a recording that was already delivered, so retrying
+        // would hand the same capture over a second time.
+        lastRecording: {
+          videoPath: "/recordings/screen-recording-1.mp4",
+          clickTrackPath: "/recordings/screen-recording-1.clicks.json",
+          durationMs: 12_000,
+          sizeBytes: 2_600_000,
+          width: 1920,
+          height: 1200,
+        },
+      }),
+    );
+
+    const section = findItem(menu, "Screen Recording: Failed");
+    const labels = submenu(section).map((item) => {
+      return item.label;
+    });
+    expect(labels).not.toContain("Retry Delivery");
+  });
+
   it("shows where the finished recording was written", () => {
     const menu = menuFor(
       recorderState({

--- a/turbo/apps/desktop/src/desktop-tray-menu.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.test.ts
@@ -725,6 +725,29 @@ describe("desktop tray screen recording section", () => {
     expect(actions.startScreenRecording).toHaveBeenCalledOnce();
   });
 
+  it("offers to deliver a recording that was salvaged from a broken capture", () => {
+    const actions = trayActions();
+    const menu = menuFor(
+      recorderState({
+        error: { code: "source_lost", message: "Display disconnected" },
+        lastRecording: {
+          videoPath: "/recordings/screen-recording-1.mp4",
+          clickTrackPath: "/recordings/screen-recording-1.clicks.json",
+          durationMs: 12_000,
+          sizeBytes: 2_600_000,
+          width: 1920,
+          height: 1200,
+        },
+      }),
+      actions,
+    );
+
+    const section = findItem(menu, "Screen Recording: Failed");
+    click(findItem(submenu(section), "Retry Delivery"));
+
+    expect(actions.retryScreenRecordingDelivery).toHaveBeenCalledOnce();
+  });
+
   it("shows where the finished recording was written", () => {
     const menu = menuFor(
       recorderState({

--- a/turbo/apps/desktop/src/desktop-tray-menu.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.ts
@@ -428,9 +428,10 @@ function buildScreenRecordingSubmenu(
       separator(),
       disabledLabel(truncateMenuLabel(recorder.error.message)),
     );
-    // The capture succeeded and both files are still on disk, so a failed
-    // upload is worth retrying rather than re-recording.
-    if (recorder.error.code === "delivery_failed" && recorder.lastRecording) {
+    // Whatever went wrong, the capture already produced files on disk, so
+    // delivering them is worth another try rather than re-recording. This
+    // covers a capture that broke partway as well as a failed upload.
+    if (recorder.lastRecording) {
       items.push({
         label: "Retry Delivery",
         click: actions.retryScreenRecordingDelivery,

--- a/turbo/apps/desktop/src/desktop-tray-menu.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.ts
@@ -1,6 +1,7 @@
 import type { DesktopAuthState } from "./desktop-bridge";
 import {
   STOP_SCREEN_RECORDING_ACCELERATOR_LABEL,
+  type DesktopRecorderErrorCode,
   type DesktopRecorderState,
 } from "./desktop-recorder-types";
 import {
@@ -28,6 +29,20 @@ const COMMAND_STATUS_LABELS = {
 } as const satisfies Record<ComputerUseLocalCommandLogEntry["status"], string>;
 
 const MAX_RECENT_COMMANDS = 5;
+
+/**
+ * Errors that leave an undelivered capture on disk, so offering it again is
+ * worth more than re-recording.
+ *
+ * The set matters because `lastRecording` outlives a successful delivery.
+ * `signed_out` is raised by `prepare` before anything is captured, so retrying
+ * on it would re-upload an unrelated recording that was already handed over.
+ */
+const UNDELIVERED_RECORDING_ERROR_CODES = new Set<DesktopRecorderErrorCode>([
+  "capture_failed",
+  "delivery_failed",
+  "source_lost",
+]);
 const MAX_COMMAND_LABEL_LENGTH = 90;
 
 export interface DesktopTrayMenuItem {
@@ -428,10 +443,13 @@ function buildScreenRecordingSubmenu(
       separator(),
       disabledLabel(truncateMenuLabel(recorder.error.message)),
     );
-    // Whatever went wrong, the capture already produced files on disk, so
-    // delivering them is worth another try rather than re-recording. This
-    // covers a capture that broke partway as well as a failed upload.
-    if (recorder.lastRecording) {
+    // The capture already produced files on disk, so delivering them is worth
+    // another try rather than re-recording. This covers a capture that broke
+    // partway as well as a failed upload.
+    if (
+      UNDELIVERED_RECORDING_ERROR_CODES.has(recorder.error.code) &&
+      recorder.lastRecording
+    ) {
       items.push({
         label: "Retry Delivery",
         click: actions.retryScreenRecordingDelivery,


### PR DESCRIPTION
Found by dogfooding on real hardware: stopping a recording from the macOS
screen-sharing indicator showed `Screen Recording: Failed` — "用户已停止流播放" —
and no `.clicks.json` was ever written.

## Two defects, one path

Both live on the path where the stream ends without `stop` being called.

**1. A deliberate finish was reported as a fault.** macOS delivers the user
ending the share as an `SCStreamError` through `didStopWithError`, the same way
it delivers a real breakage. The old code mapped every such error to
`source_lost`. Ending the share is how you stop a recording, so this was the
normal path being labelled a failure.

**2. Nothing was finalized.** The click track is written by `stop`, so an
externally ended capture lost it every time. The video only survived at all
because the writer runs with `movieFragmentInterval` — the fragments on disk
were the whole reason two playable `.mp4` files existed with no `.clicks.json`
beside them.

## The fix

`StreamStopClassifier` (pure, in `ScreenRecorderCore`) separates
`SCStreamErrorUserStopped` from a genuine fault. It checks the **error domain
before believing the code**, because -3817 means something unrelated outside
ScreenCaptureKit.

An externally ended stream no longer moves the session to a terminal state. The
writer still holds frames the user captured, and throwing those away would
discard the recording they just made — so the session stays finalizable, and
only the *reported* status changes. `stop` then finalizes exactly as it always
did, which is also why the click track now gets written on this path.

The controller reacts to the two reported statuses differently:

- **stopped** — finalize, then deliver, identical to an explicit stop.
- **failed** — finalize so the partial video and click track survive, keep the
  reason, and do **not** auto-deliver. Shipping a recording that broke partway
  without being asked is the wrong default; the tray offers `Retry Delivery`
  instead.

The tray's retry item was previously limited to `delivery_failed`; a salvaged
capture is equally worth delivering, so it now appears whenever files exist.

## Verification

`check-types`, `lint`, `knip`, desktop vitest (444 passed) locally. Four new
controller tests (clean finish delivers; broken capture is kept but not shipped;
a salvaged recording can be delivered on request; a salvage that itself fails
reports the capture reason), one new tray test, and three new Swift tests on the
classifier including the wrong-domain case.

**Unverified on hardware**: that -3817 in that domain is what macOS actually
sends for this. The pure classifier is tested, but the value it is fed comes
from a real `SCStreamError` I cannot produce in CI. Worth confirming on the next
dogfood run that the same action now reads as a normal finish and leaves a
`.clicks.json` behind.

The two `src/bootstrap-degraded.test.ts` failures are pre-existing in this
sandbox and pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)