### PR TITLE
fix: repair stale morning brief chat snapshots

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-event-snapshot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-event-snapshot.test.ts
@@ -1,8 +1,11 @@
-import { randomUUID } from "node:crypto";
-import { gunzipSync } from "node:zlib";
+import { createHash, randomUUID } from "node:crypto";
+import { gunzipSync, gzipSync } from "node:zlib";
 
 import { chatEventFromRow } from "@okouai/api-contracts/contracts/chat-event-row-projection";
-import { chatEventRowSchema } from "@okouai/api-contracts/contracts/chat-event-rows";
+import {
+  chatEventRowSchema,
+  type ChatEventRow,
+} from "@okouai/api-contracts/contracts/chat-event-rows";
 import {
   CHAT_EVENT_SCHEMA_VERSION_HEADER,
   CURRENT_CHAT_EVENT_SCHEMA_VERSION,
@@ -32,7 +35,11 @@ import {
   readFakeChatEventObject,
   writeFakeChatEventObject,
 } from "./helpers/fake-chat-event-r2";
-import { readChatEventSnapshotHead } from "./helpers/runtime-state";
+import {
+  readChatEventRowsAsPreviousApiFixture,
+  readChatEventSnapshotHead,
+  updateChatEventSnapshotHead,
+} from "./helpers/runtime-state";
 import { createFixtureTracker, createRouteMocks } from "./helpers/route-test";
 
 const context = testContext();
@@ -244,6 +251,380 @@ describe("chat event snapshot read endpoints", () => {
     expect(strangerResponse.body).toStrictEqual({
       error: { code: "NOT_FOUND", message: "Chat thread not found" },
     });
+  }, 60_000);
+
+  it("repairs all five retired Morning Brief archive shapes before cold download", async () => {
+    const owner = bdd.user({ orgId: `org_${randomUUID()}` });
+    const agent = await bdd.createAgent(owner, {
+      displayName: "Morning Brief archive repair agent",
+    });
+    const markers = Array.from({ length: 5 }, (_, index) => {
+      return `morning-brief-history-${(index + 1).toString()}-${randomUUID()}`;
+    });
+    let threadId: string | undefined;
+    for (const marker of markers) {
+      threadId = await sendNoCreditMessage(owner, {
+        agentId: agent.agentId,
+        ...(threadId === undefined ? {} : { threadId }),
+        prompt: marker,
+      });
+    }
+    if (threadId === undefined) {
+      throw new Error("Expected a historical Morning Brief thread");
+    }
+
+    await projectChatEventSearch(threadId);
+    await runSnapshotCron([threadId]);
+    const originalHead = await readChatEventSnapshotHead(context, threadId);
+    const originalObject = readFakeChatEventObject(originalHead.object_key);
+    if (originalObject === undefined) {
+      throw new Error("Expected an original Chat Event Snapshot object");
+    }
+    const originalRows = gunzipSync(originalObject)
+      .toString("utf8")
+      .trimEnd()
+      .split("\n")
+      .map((line) => {
+        return chatEventRowSchema.parse(JSON.parse(line));
+      });
+    const promptRows = originalRows.filter((row) => {
+      return row.eventType === "input.prompt";
+    });
+    expect(promptRows).toHaveLength(5);
+
+    const runIds = markers.map(() => {
+      return randomUUID();
+    });
+    const historicalDocuments: readonly UserMessageDocument[] = [
+      {
+        version: 1,
+        parts: [
+          {
+            type: "source",
+            kind: "github",
+            href: "https://github.com/vm0-ai/vm0/issues/30675",
+          },
+          { type: "text", text: "Summarize today's priorities." },
+        ],
+      },
+      {
+        version: 1,
+        parts: [
+          {
+            type: "file",
+            fileId: "historical-file",
+            filenameSnapshot: "priorities.pdf",
+            contentType: "application/pdf",
+          },
+          { type: "text", text: "Include the attached priorities." },
+        ],
+      },
+      {
+        version: 1,
+        parts: [
+          {
+            type: "chat_thread",
+            threadId,
+            titleSnapshot: "Launch planning",
+          },
+          { type: "text", text: "Carry forward the launch decisions." },
+        ],
+      },
+      {
+        version: 1,
+        parts: [
+          {
+            type: "template",
+            titleSnapshot: "Editorial illustration",
+            template: {
+              type: "illustration",
+              selection: { illustrationStyleId: "editorial" },
+            },
+          },
+          {
+            type: "text",
+            text: "Illustrate the highest-priority update.",
+          },
+        ],
+      },
+      {
+        version: 1,
+        parts: [
+          {
+            type: "feedback",
+            quote: "The owner is still unclear.",
+            note: [{ type: "text", text: "Name the owner." }],
+          },
+          { type: "text", text: "Finish the ownership summary." },
+        ],
+      },
+    ];
+    const promptIndexById = new Map(
+      promptRows.map((row, index) => {
+        return [row.id, index] as const;
+      }),
+    );
+    const contextOnlyRow = originalRows.find((row) => {
+      return row.eventType === "input.rejected";
+    });
+    if (contextOnlyRow === undefined) {
+      throw new Error("Expected a context-only historical rejection row");
+    }
+    const expectedRows = originalRows.map((row): ChatEventRow => {
+      const promptIndex = promptIndexById.get(row.id);
+      if (promptIndex === undefined) {
+        return row.id === contextOnlyRow.id
+          ? chatEventRowSchema.parse({
+              ...row,
+              contextType: "web",
+              contextId: null,
+            })
+          : row;
+      }
+      const historicalDocument = historicalDocuments[promptIndex];
+      const runId = runIds[promptIndex];
+      if (historicalDocument === undefined || runId === undefined) {
+        throw new Error("Expected a complete historical shape fixture");
+      }
+      return chatEventRowSchema.parse({
+        ...row,
+        runId,
+        revokesEventId:
+          promptIndex === 1 ? (promptRows[0]?.id ?? null) : row.revokesEventId,
+        contextType: "web",
+        contextId: null,
+        payload: {
+          ...row.payload,
+          userMessage: historicalDocument,
+        },
+      });
+    });
+    for (const row of expectedRows) {
+      chatEventFromRow(row);
+    }
+
+    const staleRows = expectedRows.map((row): ChatEventRow => {
+      const promptIndex = promptIndexById.get(row.id);
+      if (promptIndex !== undefined) {
+        const userMessage = historicalDocuments[promptIndex];
+        if (userMessage === undefined) {
+          throw new Error("Expected a historical document fixture");
+        }
+        return chatEventRowSchema.parse({
+          ...row,
+          contextType: "morning_brief",
+          contextId: row.id,
+          payload: {
+            ...row.payload,
+            userMessage: {
+              ...userMessage,
+              parts: [
+                ...userMessage.parts,
+                {
+                  type: "morning_brief",
+                  briefDate: `2026-08-${(20 + promptIndex).toString()}`,
+                },
+              ],
+            },
+          },
+        });
+      }
+      return row.id === contextOnlyRow.id
+        ? chatEventRowSchema.parse({
+            ...row,
+            contextType: "morning_brief",
+            contextId: row.id,
+          })
+        : row;
+    });
+    const staleBody = gzipSync(
+      Buffer.from(
+        staleRows
+          .map((row) => {
+            return `${JSON.stringify(row)}\n`;
+          })
+          .join(""),
+      ),
+    );
+    const staleObjectKey = `chat-events/${threadId}/${originalHead.last_seq_id.toString()}-${createHash("sha256").update(staleBody).digest("hex")}.ndjson.gz`;
+    writeFakeChatEventObject(staleObjectKey, staleBody);
+    await trackFakeChatEventObject(Promise.resolve(staleObjectKey));
+    await updateChatEventSnapshotHead(context, threadId, staleObjectKey);
+
+    const hotMarker = `hot-after-snapshot-${randomUUID()}`;
+    await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      threadId,
+      prompt: hotMarker,
+    });
+    const canonicalRowsBeforeRepair =
+      await readChatEventRowsAsPreviousApiFixture(context, threadId);
+
+    const download = await accept(
+      eventsClient().snapshot({
+        headers: authenticate(owner),
+        params: { threadId },
+      }),
+      [200],
+    );
+    const repairedHead = await readChatEventSnapshotHead(context, threadId);
+    expect(repairedHead.object_key).toMatch(
+      new RegExp(
+        `^chat-events/${threadId}/${originalHead.last_seq_id.toString()}-r1-[0-9a-f]{64}\\.ndjson\\.gz$`,
+        "u",
+      ),
+    );
+    expect(repairedHead.object_key).not.toBe(staleObjectKey);
+    expect(readFakeChatEventObject(staleObjectKey)).toStrictEqual(staleBody);
+
+    const repairedObject = readFakeChatEventObject(repairedHead.object_key);
+    if (repairedObject === undefined) {
+      throw new Error("Expected a repaired Chat Event Snapshot object");
+    }
+    const repairedRows = gunzipSync(repairedObject)
+      .toString("utf8")
+      .trimEnd()
+      .split("\n")
+      .map((line) => {
+        return chatEventRowSchema.parse(JSON.parse(line));
+      });
+    expect(repairedRows).toStrictEqual(expectedRows);
+    expect(JSON.stringify(repairedRows)).not.toContain("morning_brief");
+    expect(
+      repairedRows.map((row) => {
+        return {
+          id: row.id,
+          seqId: row.seqId,
+          runId: row.runId,
+          revokesEventId: row.revokesEventId,
+        };
+      }),
+    ).toStrictEqual(
+      expectedRows.map((row) => {
+        return {
+          id: row.id,
+          seqId: row.seqId,
+          runId: row.runId,
+          revokesEventId: row.revokesEventId,
+        };
+      }),
+    );
+
+    const projectedSnapshot = repairedRows.map(chatEventFromRow);
+    const projectedPrompts = projectedSnapshot.filter((event) => {
+      return event.eventType === "input.prompt";
+    });
+    expect(
+      projectedPrompts.map((event) => {
+        return event.runId;
+      }),
+    ).toStrictEqual(runIds);
+    expect(
+      projectedPrompts.map((event) => {
+        return event.userMessage;
+      }),
+    ).toStrictEqual(historicalDocuments);
+
+    if (download.body.lastEventId === null) {
+      throw new Error("Expected a non-empty repaired Snapshot cursor");
+    }
+    const hot = await accept(
+      eventsClient().rows({
+        headers: authenticate(owner),
+        params: { threadId },
+        query: {
+          sinceEventId: download.body.lastEventId,
+          sinceSeqId: download.body.lastSeqId,
+        },
+      }),
+      [200],
+    );
+    const projectedColdHistory = [
+      ...projectedSnapshot,
+      ...hot.body.rows.map(chatEventFromRow),
+    ];
+    expect(JSON.stringify(projectedColdHistory)).toContain(hotMarker);
+    await expect(
+      readChatEventRowsAsPreviousApiFixture(context, threadId),
+    ).resolves.toStrictEqual(canonicalRowsBeforeRepair);
+  }, 90_000);
+
+  it("fails closed without moving the pointer for an unexpected retired archive part", async () => {
+    const owner = bdd.user({ orgId: `org_${randomUUID()}` });
+    const agent = await bdd.createAgent(owner, {
+      displayName: "Malformed Morning Brief archive agent",
+    });
+    const threadId = await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      prompt: `malformed-morning-brief-${randomUUID()}`,
+    });
+    await projectChatEventSearch(threadId);
+    await runSnapshotCron([threadId]);
+    const originalHead = await readChatEventSnapshotHead(context, threadId);
+    const originalObject = readFakeChatEventObject(originalHead.object_key);
+    if (originalObject === undefined) {
+      throw new Error("Expected a Snapshot object for the malformed fixture");
+    }
+    const rows = gunzipSync(originalObject)
+      .toString("utf8")
+      .trimEnd()
+      .split("\n")
+      .map((line) => {
+        return chatEventRowSchema.parse(JSON.parse(line));
+      });
+    const prompt = rows.find((row) => {
+      return row.eventType === "input.prompt";
+    });
+    if (prompt === undefined) {
+      throw new Error("Expected a malformed historical prompt fixture");
+    }
+    const staleRows = rows.map((row) => {
+      return row.id === prompt.id
+        ? chatEventRowSchema.parse({
+            ...row,
+            contextType: "morning_brief",
+            contextId: row.id,
+            payload: {
+              ...row.payload,
+              userMessage: {
+                version: 1,
+                parts: [
+                  { type: "text", text: "Preserve this visible prompt." },
+                  {
+                    type: "morning_brief",
+                    briefDate: "2026-08-24",
+                    unexpected: true,
+                  },
+                ],
+              },
+            },
+          })
+        : row;
+    });
+    const staleBody = gzipSync(
+      Buffer.from(
+        staleRows
+          .map((row) => {
+            return `${JSON.stringify(row)}\n`;
+          })
+          .join(""),
+      ),
+    );
+    const staleObjectKey = `chat-events/${threadId}/${originalHead.last_seq_id.toString()}-${createHash("sha256").update(staleBody).digest("hex")}.ndjson.gz`;
+    writeFakeChatEventObject(staleObjectKey, staleBody);
+    await trackFakeChatEventObject(Promise.resolve(staleObjectKey));
+    await updateChatEventSnapshotHead(context, threadId, staleObjectKey);
+    const staleHead = await readChatEventSnapshotHead(context, threadId);
+
+    await expect(
+      eventsClient().snapshot({
+        headers: authenticate(owner),
+        params: { threadId },
+      }),
+    ).rejects.toThrow("Unknown response status 500");
+    await expect(
+      readChatEventSnapshotHead(context, threadId),
+    ).resolves.toStrictEqual(staleHead);
   }, 60_000);
 
   it("applies the same schema-version errors to Snapshot and Raw Event reads", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
@@ -43,7 +43,7 @@ const DUPLICATE_EVENT_ID_WARNING =
 const SNAPSHOT_COMPLETED_MESSAGE = "Completed chat event snapshot";
 const SNAPSHOT_COMPLETED_TYPE = "chat_event_snapshot_completed";
 const OBJECT_KEY_PATTERN =
-  /^chat-events\/([0-9a-f-]{36})\/(\d+)-([0-9a-f]{64})\.ndjson\.gz$/;
+  /^chat-events\/([0-9a-f-]{36})\/(\d+)-r1-([0-9a-f]{64})\.ndjson\.gz$/;
 
 type RecordedPut = RecordedChatEventPut;
 

--- a/turbo/apps/api/src/signals/services/chat-event-snapshot-body.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-snapshot-body.service.ts
@@ -2,12 +2,31 @@ import {
   chatEventRowSchema,
   type ChatEventRow,
 } from "@okouai/api-contracts/contracts/chat-event-rows";
+import { chatEventFromRow } from "@okouai/api-contracts/contracts/chat-event-row-projection";
 
 import { safeJsonParse } from "../utils";
 
-export function decodeChatEventSnapshotBody(
-  body: Buffer,
-): readonly ChatEventRow[] {
+const RETIRED_MORNING_BRIEF_CONTEXT = "morning_brief";
+const RETIRED_MORNING_BRIEF_PART = "morning_brief";
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
+
+interface SnapshotLine {
+  readonly raw: string;
+  readonly row: ChatEventRow;
+}
+
+interface MorningBriefSnapshotRepair {
+  readonly body: Buffer;
+  readonly rows: readonly ChatEventRow[];
+  readonly repairedContextRows: number;
+  readonly removedDocumentParts: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function snapshotLines(body: Buffer): readonly SnapshotLine[] {
   const text = body.toString("utf8");
   if (text.length === 0) {
     return [];
@@ -18,14 +37,155 @@ export function decodeChatEventSnapshotBody(
   return text
     .slice(0, -1)
     .split("\n")
-    .map((line) => {
-      const parsed = safeJsonParse(line);
+    .map((raw) => {
+      const parsed = safeJsonParse(raw);
       if (parsed === undefined) {
         throw new Error("Chat Event snapshot contains invalid JSON");
       }
-      return parsed;
-    })
-    .map((row) => {
-      return chatEventRowSchema.parse(row);
+      return { raw, row: chatEventRowSchema.parse(parsed) };
     });
+}
+
+function retiredMorningBriefPart(part: unknown): boolean {
+  return isRecord(part) && part.type === RETIRED_MORNING_BRIEF_PART;
+}
+
+function assertExactRetiredMorningBriefPart(part: unknown): void {
+  if (
+    !isRecord(part) ||
+    Object.keys(part).length !== 2 ||
+    part.type !== RETIRED_MORNING_BRIEF_PART ||
+    typeof part.briefDate !== "string" ||
+    !ISO_DATE_PATTERN.test(part.briefDate)
+  ) {
+    throw new Error(
+      "Chat Event snapshot has an unexpected retired Morning Brief part",
+    );
+  }
+}
+
+function repairMorningBriefRow(row: ChatEventRow): {
+  readonly row: ChatEventRow;
+  readonly removedDocumentParts: number;
+} {
+  const hasRetiredContext = row.contextType === RETIRED_MORNING_BRIEF_CONTEXT;
+  const userMessage = row.payload?.userMessage;
+  let legacyParts: readonly unknown[] = [];
+  let parts: readonly unknown[] | undefined;
+
+  if (
+    hasRetiredContext &&
+    row.eventType !== "input.prompt" &&
+    row.eventType !== "input.rejected"
+  ) {
+    throw new Error(
+      "Chat Event snapshot has an unexpected retired Morning Brief event",
+    );
+  }
+
+  if (userMessage !== undefined) {
+    if (!isRecord(userMessage) || !Array.isArray(userMessage.parts)) {
+      if (hasRetiredContext) {
+        throw new Error(
+          "Chat Event snapshot has an unexpected retired Morning Brief document",
+        );
+      }
+    } else {
+      parts = userMessage.parts;
+      legacyParts = parts.filter(retiredMorningBriefPart);
+    }
+  }
+
+  if (!hasRetiredContext) {
+    if (legacyParts.length > 0) {
+      throw new Error(
+        "Chat Event snapshot has an unscoped retired Morning Brief part",
+      );
+    }
+    chatEventFromRow(row);
+    return { row, removedDocumentParts: 0 };
+  }
+  if (row.contextId === null) {
+    throw new Error(
+      "Chat Event snapshot has an incomplete retired Morning Brief context",
+    );
+  }
+  if (legacyParts.length > 1) {
+    throw new Error(
+      "Chat Event snapshot has duplicate retired Morning Brief parts",
+    );
+  }
+
+  const removedDocumentParts = legacyParts.length;
+  let payload = row.payload;
+  if (removedDocumentParts === 1) {
+    const retiredPart = legacyParts[0];
+    assertExactRetiredMorningBriefPart(retiredPart);
+    if (!isRecord(userMessage) || userMessage.version !== 1 || !parts) {
+      throw new Error(
+        "Chat Event snapshot has an unexpected retired Morning Brief document",
+      );
+    }
+    const currentParts = parts.filter((part) => {
+      return part !== retiredPart;
+    });
+    if (currentParts.length === 0) {
+      throw new Error(
+        "Chat Event snapshot Morning Brief repair would empty a message",
+      );
+    }
+    payload = {
+      ...row.payload,
+      userMessage: { ...userMessage, parts: currentParts },
+    };
+  }
+
+  const repaired = chatEventRowSchema.parse({
+    ...row,
+    contextType: "web",
+    contextId: null,
+    payload,
+  });
+  chatEventFromRow(repaired);
+  return { row: repaired, removedDocumentParts };
+}
+
+export function decodeChatEventSnapshotBody(
+  body: Buffer,
+): readonly ChatEventRow[] {
+  return snapshotLines(body).map(({ row }) => {
+    return row;
+  });
+}
+
+/**
+ * One-way Phase B archive repair. The retired shape is accepted only inside
+ * snapshot publication, then every output row must project through the current
+ * strict ChatEvent contract before its new immutable object can be published.
+ */
+export function repairMorningBriefPhaseBSnapshot(
+  body: Buffer,
+): MorningBriefSnapshotRepair {
+  let repairedContextRows = 0;
+  let removedDocumentParts = 0;
+  let changed = false;
+  const lines = snapshotLines(body);
+  const rows: ChatEventRow[] = [];
+  const repairedLines = lines.map((line) => {
+    const repaired = repairMorningBriefRow(line.row);
+    rows.push(repaired.row);
+    if (repaired.row === line.row) {
+      return Buffer.from(`${line.raw}\n`);
+    }
+    changed = true;
+    repairedContextRows += 1;
+    removedDocumentParts += repaired.removedDocumentParts;
+    return Buffer.from(`${JSON.stringify(repaired.row)}\n`);
+  });
+  return {
+    body: changed ? Buffer.concat(repairedLines) : body,
+    rows,
+    repairedContextRows,
+    removedDocumentParts,
+  };
 }

--- a/turbo/apps/api/src/signals/services/chat-event-snapshot.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-snapshot.service.ts
@@ -12,7 +12,12 @@ import { chatThreads } from "@okouai/db/schema/chat-thread";
 import { env } from "../../lib/env";
 import { db$, type ReadonlyDb } from "../external/db";
 import { generatePresignedGetUrl } from "../external/s3";
-import { chatEventRowFromDbRow } from "./cron-snapshot-chat-events.service";
+import {
+  chatEventRowFromDbRow,
+  isCurrentChatEventSnapshotObjectKey,
+  isLegacyChatEventSnapshotObjectKey,
+  refreshChatEventSnapshotThread$,
+} from "./cron-snapshot-chat-events.service";
 
 const SNAPSHOT_URL_TTL_SECONDS = 900;
 /** Cursor that reads a thread from its very first event. */
@@ -203,7 +208,7 @@ export function chatThreadEventSnapshot(args: {
 }) {
   return command(
     async (
-      { get },
+      { get, set },
       signal: AbortSignal,
     ): Promise<ChatEventSnapshotDownload> => {
       const db = get(db$);
@@ -217,10 +222,28 @@ export function chatThreadEventSnapshot(args: {
         return { kind: "thread-not-found" } as const;
       }
 
-      const pointer = await currentSnapshotPointer(db, args.threadId);
+      let pointer = await currentSnapshotPointer(db, args.threadId);
       signal.throwIfAborted();
       if (pointer === null) {
         return { kind: "snapshot-not-found" };
+      }
+      if (!isCurrentChatEventSnapshotObjectKey(pointer.objectKey)) {
+        if (!isLegacyChatEventSnapshotObjectKey(pointer.objectKey)) {
+          throw new Error(
+            "Chat Event Snapshot has an unsupported contract revision",
+          );
+        }
+        await set(refreshChatEventSnapshotThread$, args.threadId, signal);
+        pointer = await currentSnapshotPointer(db, args.threadId);
+        signal.throwIfAborted();
+        if (
+          pointer === null ||
+          !isCurrentChatEventSnapshotObjectKey(pointer.objectKey)
+        ) {
+          throw new Error(
+            "Chat Event Snapshot contract repair did not publish",
+          );
+        }
       }
 
       const url = await get(

--- a/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { promisify } from "node:util";
 import { gunzip, gzip } from "node:zlib";
 
+import { chatEventFromRow } from "@okouai/api-contracts/contracts/chat-event-row-projection";
 import {
   chatEventRowSchema,
   type ChatEventRow,
@@ -44,7 +45,10 @@ import {
   prepareChatEventArchiveWithNormalizedIds,
   type DuplicateEventIdNormalizationStats,
 } from "./chat-event-snapshot-duplicate-id-normalization";
-import { decodeChatEventSnapshotBody } from "./chat-event-snapshot-body.service";
+import {
+  decodeChatEventSnapshotBody,
+  repairMorningBriefPhaseBSnapshot,
+} from "./chat-event-snapshot-body.service";
 
 const log = logger("api:cron:snapshot-chat-events");
 
@@ -94,6 +98,12 @@ interface SnapshotCandidate {
  */
 const ARCHIVE_CONTENT_TYPE = "application/x-ndjson";
 const ARCHIVE_CONTENT_ENCODING = "gzip";
+/** V7 wire shape is unchanged; this marks objects validated after Phase B. */
+const ARCHIVE_ROW_CONTRACT_REVISION = 1;
+const ARCHIVE_OBJECT_KEY_PREFIX_PATTERN = "^chat-events/[0-9a-f-]{36}/[0-9]+";
+const ARCHIVE_OBJECT_KEY_SUFFIX_PATTERN = "-[0-9a-f]{64}[.]ndjson[.]gz$";
+const LEGACY_ARCHIVE_OBJECT_KEY_PATTERN = `${ARCHIVE_OBJECT_KEY_PREFIX_PATTERN}${ARCHIVE_OBJECT_KEY_SUFFIX_PATTERN}`;
+const CURRENT_ARCHIVE_OBJECT_KEY_PATTERN = `${ARCHIVE_OBJECT_KEY_PREFIX_PATTERN}-r${ARCHIVE_ROW_CONTRACT_REVISION.toString()}${ARCHIVE_OBJECT_KEY_SUFFIX_PATTERN}`;
 const gzipAsync = promisify(gzip);
 const gunzipAsync = promisify(gunzip);
 /**
@@ -192,7 +202,17 @@ function chatEventSnapshotObjectKey(
   lastSeqId: number,
   contentSha256: string,
 ): string {
-  return `chat-events/${chatThreadId}/${lastSeqId}-${contentSha256}.ndjson.gz`;
+  return `chat-events/${chatThreadId}/${lastSeqId}-r${ARCHIVE_ROW_CONTRACT_REVISION.toString()}-${contentSha256}.ndjson.gz`;
+}
+
+export function isCurrentChatEventSnapshotObjectKey(
+  objectKey: string,
+): boolean {
+  return new RegExp(CURRENT_ARCHIVE_OBJECT_KEY_PATTERN, "u").test(objectKey);
+}
+
+export function isLegacyChatEventSnapshotObjectKey(objectKey: string): boolean {
+  return new RegExp(LEGACY_ARCHIVE_OBJECT_KEY_PATTERN, "u").test(objectKey);
 }
 
 interface CanonicalEventArchive {
@@ -429,14 +449,23 @@ async function decodeSnapshotPrefix(
     );
   }
   const decompressed = await gunzipAsync(compressed);
-  const rows = decodeChatEventSnapshotBody(decompressed);
+  const repaired = repairMorningBriefPhaseBSnapshot(decompressed);
+  const rows = repaired.rows;
   validateSnapshotPrefixRows(rows, args);
   const terminal = rows.at(-1);
   const terminalSeqId = terminal?.seqId ?? 0;
   const terminalEventId = terminal?.id ?? null;
   validateSnapshotPrefixTerminal(args, terminalSeqId, terminalEventId);
+  if (repaired.repairedContextRows > 0) {
+    log.debug("Repaired retired Morning Brief Chat Event Snapshot rows", {
+      type: "chat_event_snapshot_morning_brief_rows_repaired",
+      chatThreadId: args.chatThreadId,
+      repairedContextRows: repaired.repairedContextRows,
+      removedDocumentParts: repaired.removedDocumentParts,
+    });
+  }
   return {
-    body: decompressed,
+    body: repaired.body,
     terminalSeqId,
     terminalEventId,
   };
@@ -665,7 +694,8 @@ function isCurrentSnapshotWithoutTail(
 ): boolean {
   return (
     archiveEventCount === 0 &&
-    source?.schemaVersion === CURRENT_CHAT_EVENT_SCHEMA_VERSION
+    source?.schemaVersion === CURRENT_CHAT_EVENT_SCHEMA_VERSION &&
+    isCurrentChatEventSnapshotObjectKey(source.objectKey)
   );
 }
 
@@ -717,7 +747,11 @@ function prepareSnapshotArchive(
     candidate.chatThreadId,
     prepared.normalization,
   );
-  const preparedTerminal = decodeChatEventSnapshotBody(prepared.body).at(-1);
+  const preparedRows = decodeChatEventSnapshotBody(prepared.body);
+  for (const row of preparedRows) {
+    chatEventFromRow(row);
+  }
+  const preparedTerminal = preparedRows.at(-1);
   const terminalSeqId = preparedTerminal?.seqId ?? 0;
   if (terminalSeqId !== terminal.seqId) {
     throw new Error("Chat Event Snapshot normalization changed event ordering");
@@ -854,6 +888,33 @@ const archiveThread$ = command(async function archiveThread(
     prepared.normalization,
   );
 });
+
+/** Repair or extend one thread without running the global R2 garbage collector. */
+export const refreshChatEventSnapshotThread$ = command(
+  async (
+    { set },
+    chatThreadId: string,
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    const db = set(writeDb$);
+    const [candidate] = await loadSnapshotCandidates(db, [chatThreadId]);
+    signal.throwIfAborted();
+    if (candidate === undefined) {
+      return false;
+    }
+    const archived = await set(
+      archiveThread$,
+      {
+        db,
+        bucket: env("R2_USER_STORAGES_BUCKET_NAME"),
+        candidate,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    return archived.archivedEvents !== null;
+  },
+);
 
 interface R2GcStats {
   readonly scanned: number;
@@ -1067,6 +1128,8 @@ async function loadSnapshotCandidates(
           sql`btrim(${currentSnapshot.objectKey}) = ''`,
           sql`NOT (${currentSnapshot.objectKey}
             ~ '-[0-9a-f]{64}[.]ndjson[.]gz$')`,
+          sql`${currentSnapshot.objectKey}
+            ~ ${LEGACY_ARCHIVE_OBJECT_KEY_PATTERN}`,
         ),
       ),
     )

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-thread-idb.test.tsx
@@ -1,5 +1,6 @@
 import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { chatEventFromRow } from "@okouai/api-contracts/contracts/chat-event-row-projection";
 import type { ChatEventRow } from "@okouai/api-contracts/contracts/chat-event-rows";
 import { CURRENT_CHAT_EVENT_SCHEMA_VERSION } from "@okouai/api-contracts/contracts/chat-event-schema-version";
 import {
@@ -8,6 +9,7 @@ import {
   chatThreadMetadataContract,
   chatThreadMarkReadContract,
   chatThreadsContract,
+  type UserMessageDocument,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { browserContract } from "@okouai/api-contracts/contracts/browser";
 
@@ -664,5 +666,329 @@ describe("okou chat thread IndexedDB fallback", () => {
     expect(emptyThread.wasShown()).toBeFalsy();
     expect(uncoveredLoadingGap).toBeFalsy();
     expect(releaseMarkRead.settled()).toBeFalsy();
+  });
+
+  it("renders repaired Morning Brief history through cold Snapshot, hot rows, and IndexedDB", async () => {
+    prepareDefaultAgent();
+    mockCurrentThreadDetail();
+    mockSidebarThread();
+    const runtimeDb = await primeChatDb();
+    const snapshotUrl =
+      "https://r2.example.com/chat-events/morning-brief-r1.ndjson.gz";
+    const historicalDocuments: readonly UserMessageDocument[] = [
+      {
+        version: 1,
+        parts: [
+          {
+            type: "source",
+            kind: "github",
+            href: "https://github.com/vm0-ai/vm0/issues/30675",
+          },
+          { type: "text", text: "Summarize today's priorities." },
+        ],
+      },
+      {
+        version: 1,
+        parts: [
+          {
+            type: "file",
+            fileId: "historical-file",
+            filenameSnapshot: "priorities.pdf",
+            contentType: "application/pdf",
+          },
+          { type: "text", text: "Include the attached priorities." },
+        ],
+      },
+      {
+        version: 1,
+        parts: [
+          {
+            type: "chat_thread",
+            threadId: OTHER_THREAD_ID,
+            titleSnapshot: "Launch planning",
+          },
+          { type: "text", text: "Carry forward the launch decisions." },
+        ],
+      },
+      {
+        version: 1,
+        parts: [
+          {
+            type: "template",
+            titleSnapshot: "Editorial illustration",
+            template: {
+              type: "illustration",
+              selection: { illustrationStyleId: "editorial" },
+            },
+          },
+          {
+            type: "text",
+            text: "Illustrate the highest-priority update.",
+          },
+        ],
+      },
+      {
+        version: 1,
+        parts: [
+          {
+            type: "feedback",
+            quote: "The owner is still unclear.",
+            note: [{ type: "text", text: "Name the owner." }],
+          },
+          { type: "text", text: "Finish the ownership summary." },
+        ],
+      },
+    ];
+    const snapshotRows: ChatEventRow[] = [];
+    const revokedSourceMarkers: string[] = [];
+    let seqId = 0;
+    const appendRow = (args: {
+      readonly eventType: ChatEventRow["eventType"];
+      readonly payload: ChatEventRow["payload"];
+      readonly runId: string | null;
+      readonly revokesEventId?: string | null;
+      readonly contextType?: string | null;
+    }): ChatEventRow => {
+      seqId += 1;
+      const row = {
+        id: `00000000-0000-4000-8000-${seqId.toString().padStart(12, "0")}`,
+        chatThreadId: THREAD_ID,
+        runId: args.runId,
+        revokesEventId: args.revokesEventId ?? null,
+        eventType: args.eventType,
+        payload: args.payload,
+        contextType: args.contextType ?? null,
+        contextId: null,
+        runEventSequenceNumber: null,
+        runEventId: null,
+        seqId,
+        createdAt: `2026-08-24T07:00:${seqId.toString().padStart(2, "0")}Z`,
+      } satisfies ChatEventRow;
+      snapshotRows.push(row);
+      return row;
+    };
+    const terminalStates = [
+      "completed",
+      "failed",
+      "completed",
+      "cancelled",
+    ] as const;
+    for (const [index, terminalState] of terminalStates.entries()) {
+      const sourceMarker = `Superseded Morning Brief source ${(
+        index + 1
+      ).toString()}`;
+      revokedSourceMarkers.push(sourceMarker);
+      const source = appendRow({
+        eventType: "input.prompt",
+        runId: null,
+        contextType: "web",
+        payload: {
+          userMessage: {
+            version: 1,
+            parts: [{ type: "text", text: sourceMarker }],
+          },
+        },
+      });
+      const runId = `run-morning-brief-history-${(index + 1).toString()}`;
+      appendRow({
+        eventType: "input.prompt",
+        runId,
+        revokesEventId: source.id,
+        contextType: "web",
+        payload: { userMessage: historicalDocuments[index] },
+      });
+      if (terminalState === "completed") {
+        appendRow({
+          eventType: "output.message",
+          runId,
+          payload: {
+            content: `Visible assistant result ${(index + 1).toString()}`,
+          },
+        });
+      } else {
+        appendRow({
+          eventType: "output.error",
+          runId,
+          payload: {
+            error: `Visible ${terminalState} result ${(index + 1).toString()}`,
+          },
+        });
+      }
+      appendRow({
+        eventType: `run.${terminalState}`,
+        runId,
+        payload:
+          terminalState === "completed"
+            ? null
+            : { error: `terminal_${terminalState}` },
+      });
+    }
+    const rejectedSourceMarker = "Superseded Morning Brief source 5";
+    revokedSourceMarkers.push(rejectedSourceMarker);
+    const rejectedSource = appendRow({
+      eventType: "input.prompt",
+      runId: null,
+      contextType: "web",
+      payload: {
+        userMessage: {
+          version: 1,
+          parts: [{ type: "text", text: rejectedSourceMarker }],
+        },
+      },
+    });
+    appendRow({
+      eventType: "input.rejected",
+      runId: null,
+      revokesEventId: rejectedSource.id,
+      contextType: "web",
+      payload: {
+        userMessage: historicalDocuments[4],
+        error: "Historical Morning Brief rejection",
+      },
+    });
+    const terminalSnapshotRow = snapshotRows.at(-1);
+    if (terminalSnapshotRow === undefined) {
+      throw new Error("Expected repaired historical Snapshot rows");
+    }
+
+    const hotRows: ChatEventRow[] = [];
+    const appendHotRow = (args: {
+      readonly eventType: ChatEventRow["eventType"];
+      readonly payload: ChatEventRow["payload"];
+      readonly runId: string | null;
+    }): void => {
+      seqId += 1;
+      hotRows.push({
+        id: `00000000-0000-4000-8000-${seqId.toString().padStart(12, "0")}`,
+        chatThreadId: THREAD_ID,
+        runId: args.runId,
+        revokesEventId: null,
+        eventType: args.eventType,
+        payload: args.payload,
+        contextType: args.eventType === "input.prompt" ? "web" : null,
+        contextId: null,
+        runEventSequenceNumber: null,
+        runEventId: null,
+        seqId,
+        createdAt: `2026-08-24T07:00:${seqId.toString().padStart(2, "0")}Z`,
+      });
+    };
+    const hotRunId = "run-hot-after-repair";
+    appendHotRow({
+      eventType: "input.prompt",
+      runId: hotRunId,
+      payload: {
+        userMessage: {
+          version: 1,
+          parts: [{ type: "text", text: "Current hot Chat message" }],
+        },
+      },
+    });
+    appendHotRow({
+      eventType: "output.message",
+      runId: hotRunId,
+      payload: { content: "Current hot assistant result" },
+    });
+    appendHotRow({
+      eventType: "run.completed",
+      runId: hotRunId,
+      payload: null,
+    });
+    for (const row of [...snapshotRows, ...hotRows]) {
+      chatEventFromRow(row);
+    }
+
+    context.mocks.api(chatThreadEventsContract.snapshot, ({ respond }) => {
+      return respond(200, {
+        url: snapshotUrl,
+        expiresInSeconds: 900,
+        lastEventId: terminalSnapshotRow.id,
+        lastSeqId: terminalSnapshotRow.seqId,
+      });
+    });
+    context.mocks.http.get(snapshotUrl, () => {
+      return new Response(
+        `${snapshotRows
+          .map((row) => {
+            return JSON.stringify(row);
+          })
+          .join("\n")}\n`,
+      );
+    });
+    context.mocks.api(chatThreadEventsContract.rows, ({ query, respond }) => {
+      return respond(200, chatEventRowsResponse(hotRows, query));
+    });
+    context.mocks.api(chatThreadMarkReadContract.markRead, ({ respond }) => {
+      return respond(200, {
+        lastReadAt: hotRows.at(-1)?.createdAt ?? null,
+        unreads: [],
+      });
+    });
+
+    setupChatPage();
+
+    const visibleUserMessages = [
+      "Summarize today's priorities.",
+      "Include the attached priorities.",
+      "Carry forward the launch decisions.",
+      "Illustrate the highest-priority update.",
+      "Finish the ownership summary.",
+      "Current hot Chat message",
+    ];
+    const renderedMessages = await Promise.all(
+      visibleUserMessages.map(async (message) => {
+        return await screen.findByText(message, {}, { timeout: 5000 });
+      }),
+    );
+    await expect(
+      screen.findByText("Visible assistant result 1"),
+    ).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByText("Visible assistant result 3"),
+    ).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByText("Current hot assistant result"),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Open pdf preview for priorities.pdf"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Open chat Launch planning")).toHaveAttribute(
+      "href",
+      `/chats/${OTHER_THREAD_ID}`,
+    );
+    expect(
+      screen.getByTitle("Illustration · Editorial illustration"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("The owner is still unclear.")).toBeInTheDocument();
+    for (const marker of revokedSourceMarkers) {
+      expect(screen.queryByText(marker)).not.toBeInTheDocument();
+    }
+    expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent("Morning Brief");
+    for (let index = 1; index < renderedMessages.length; index++) {
+      expect(
+        renderedMessages[index - 1]?.compareDocumentPosition(
+          renderedMessages[index]!,
+        ) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    }
+
+    await waitFor(async () => {
+      const storedRows = (await runtimeDb.getAll(
+        CHAT_EVENT_ROWS_STORE,
+      )) as ChatEventRow[];
+      expect(storedRows).toHaveLength(snapshotRows.length + hotRows.length);
+      expect(JSON.stringify(storedRows)).not.toContain("morning_brief");
+      expect(
+        storedRows.some((row) => {
+          return row.runId === "run-morning-brief-history-1";
+        }),
+      ).toBeTruthy();
+      expect(
+        storedRows.some((row) => {
+          return row.revokesEventId === snapshotRows[0]?.id;
+        }),
+      ).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- repair exact pre-Phase-B Morning Brief rows while reusing immutable V7 snapshot prefixes, preserving every other row field and byte-identical unchanged line
- publish repaired archives under a content-addressed `r1` row-contract marker with exact-pointer CAS; cold snapshot reads refresh only the historical unversioned key shape and fail closed on malformed or unknown revisions
- validate every final snapshot row through the current strict projection, then cover snapshot download, hot-tail merge, all supported user-message parts, semantic rendering, revocation, Run/result states, ordering, and IndexedDB replay

## Invariants

- The only historical mutations are `morning_brief` context neutralization to ordinary `web` context and removal of one exact retired document part.
- Canonical `chat_events` are not updated, re-enqueued, or made runnable; the old immutable object remains untouched until existing reference-aware GC owns it.
- V7 wire schema is unchanged. This adds archive row-contract marker `r1`; there is no database migration.
- No client fallback or legacy runtime parser is restored.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm --filter api lint` after final key-gate tightening
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app' --log-order grouped`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter ./apps/api exec vitest run src/signals/routes/__tests__/chat-event-snapshot.test.ts src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts` (16 passed)
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-thread-idb.test.tsx` (7 passed)
- `git diff --check`

## Scope

No Official Morning Brief Definition, instruction, Blueprint, generic Automation/result-email behavior, unrelated snapshot format, GitHub Actions, release file, production data, or MaskDB policy is changed.

Closes #30675
