### PR TITLE
feat(platform): print mark notes on the image and slim the selection

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/flatten-annotated-image.ts
+++ b/turbo/apps/platform/src/signals/okou-page/flatten-annotated-image.ts
@@ -234,27 +234,28 @@ function drawNote(
 
   const boxWidth = note.box.width * scale.width;
   const lines = wrapNote(context, note.text, boxWidth - padding * 2);
-  const x = note.box.x * scale.width;
-  const y = note.box.y * scale.height;
   const boxHeight = lines.length * lineHeight + padding * 2;
+  const x = note.box.x * scale.width;
+  // The box is clamped in normalized space before it gets here, but the height
+  // is only known once the text has wrapped. A long note near the bottom would
+  // still run past the edge and be cropped out of the image the model reads.
+  const y = Math.max(
+    0,
+    Math.min(note.box.y * scale.height, scale.height - boxHeight),
+  );
 
   context.fillStyle = NOTE_GROUND;
-  context.strokeStyle = markInkOf(mark);
+  context.strokeStyle = note.ink;
   context.lineWidth = px(scale, HALO_WIDTH_UNITS);
   context.beginPath();
   context.roundRect(x, y, boxWidth, boxHeight, px(scale, CORNER_RADIUS_UNITS));
   context.fill();
   context.stroke();
 
-  context.fillStyle = markInkOf(mark);
+  context.fillStyle = note.ink;
   for (const [index, line] of lines.entries()) {
     context.fillText(line, x + padding, y + padding + index * lineHeight);
   }
-}
-
-/** The ink a note is printed in, which is the ink of the mark it explains. */
-function markInkOf(mark: ImageAnnotationMark): string {
-  return "ink" in mark ? mark.ink : REDACT_FILL;
 }
 
 function drawMark(

--- a/turbo/apps/platform/src/signals/okou-page/flatten-annotated-image.ts
+++ b/turbo/apps/platform/src/signals/okou-page/flatten-annotated-image.ts
@@ -5,6 +5,8 @@ import type {
 import {
   HIGHLIGHT_FILL,
   markOrdinal,
+  NOTE_GROUND,
+  noteOnImage,
   REDACT_FILL,
   STROKE_HALO_INNER,
 } from "./image-annotation.ts";
@@ -22,6 +24,9 @@ const HALO_WIDTH_UNITS = 1;
 const PIN_RADIUS_UNITS = 11;
 const PIN_FONT_UNITS = 13;
 const TEXT_FONT_UNITS = 18;
+const NOTE_FONT_UNITS = 15;
+const NOTE_LINE_UNITS = 20;
+const NOTE_PADDING_UNITS = 6;
 const ARROW_HEAD_UNITS = 18;
 const CORNER_RADIUS_UNITS = 4;
 
@@ -174,6 +179,82 @@ function drawPin(
   context.textAlign = "center";
   context.textBaseline = "middle";
   context.fillText(String(ordinal), x, y);
+}
+
+/**
+ * Breaks `text` into lines that fit `maxWidth`, measuring with the font already
+ * set on the context. A word longer than the box (a URL, a long identifier) is
+ * left to overhang rather than being cut, because a truncated instruction is
+ * worse than an untidy one.
+ */
+function wrapNote(
+  context: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number,
+): string[] {
+  const lines: string[] = [];
+  for (const paragraph of text.split("\n")) {
+    let line = "";
+    for (const word of paragraph.split(/\s+/u).filter(Boolean)) {
+      const candidate = line ? `${line} ${word}` : word;
+      if (line && context.measureText(candidate).width > maxWidth) {
+        lines.push(line);
+        line = word;
+      } else {
+        line = candidate;
+      }
+    }
+    lines.push(line);
+  }
+  return lines;
+}
+
+/**
+ * Prints a mark's note onto the image next to the region it is about.
+ *
+ * This is the whole point of flattening rather than only sending the notes as
+ * prompt text: the model sees one picture, and the sentence has to be in it.
+ */
+function drawNote(
+  context: CanvasRenderingContext2D,
+  scale: Scale,
+  mark: ImageAnnotationMark,
+): void {
+  const note = noteOnImage(mark);
+  if (!note) {
+    return;
+  }
+
+  const fontSize = px(scale, NOTE_FONT_UNITS);
+  const lineHeight = px(scale, NOTE_LINE_UNITS);
+  const padding = px(scale, NOTE_PADDING_UNITS);
+  context.font = `600 ${fontSize}px "Noto Sans", system-ui, sans-serif`;
+  context.textAlign = "left";
+  context.textBaseline = "top";
+
+  const boxWidth = note.box.width * scale.width;
+  const lines = wrapNote(context, note.text, boxWidth - padding * 2);
+  const x = note.box.x * scale.width;
+  const y = note.box.y * scale.height;
+  const boxHeight = lines.length * lineHeight + padding * 2;
+
+  context.fillStyle = NOTE_GROUND;
+  context.strokeStyle = markInkOf(mark);
+  context.lineWidth = px(scale, HALO_WIDTH_UNITS);
+  context.beginPath();
+  context.roundRect(x, y, boxWidth, boxHeight, px(scale, CORNER_RADIUS_UNITS));
+  context.fill();
+  context.stroke();
+
+  context.fillStyle = markInkOf(mark);
+  for (const [index, line] of lines.entries()) {
+    context.fillText(line, x + padding, y + padding + index * lineHeight);
+  }
+}
+
+/** The ink a note is printed in, which is the ink of the mark it explains. */
+function markInkOf(mark: ImageAnnotationMark): string {
+  return "ink" in mark ? mark.ink : REDACT_FILL;
 }
 
 function drawMark(
@@ -344,6 +425,9 @@ export async function flattenAnnotatedImage(
   for (const [index, mark] of annotation.marks.entries()) {
     context.save();
     drawMark(context, scale, mark, markOrdinal(mark, index));
+    context.restore();
+    context.save();
+    drawNote(context, scale, mark);
     context.restore();
   }
 

--- a/turbo/apps/platform/src/signals/okou-page/image-annotation.ts
+++ b/turbo/apps/platform/src/signals/okou-page/image-annotation.ts
@@ -323,12 +323,18 @@ export const bindAnnotationSurface$ = onRef<HTMLElement>(
 const internalSession$ = state<AnnotationSession | null>(null);
 const internalTool$ = state<AnnotationTool>("box");
 const internalInk$ = state<AnnotationInk>(DEFAULT_ANNOTATION_INK);
-const internalSelectedMarkId$ = state<string | null>(null);
 /**
- * The note label being edited in place, held separately from the mark so that
- * dragging a sentence into clear space does not also move the box it explains.
+ * What is currently held: a mark, or the note label of a mark. One signal
+ * rather than two, because the two are mutually exclusive and holding that
+ * invariant by hand across every clear site is how a stale grip survives an
+ * operation that was supposed to drop the selection.
  */
-const internalSelectedNoteId$ = state<string | null>(null);
+interface AnnotationSelection {
+  readonly kind: "mark" | "note";
+  readonly id: string;
+}
+
+const internalSelection$ = state<AnnotationSelection | null>(null);
 
 export const annotationSessionTarget$ = computed((get) => {
   return get(internalSession$)?.target ?? null;
@@ -351,20 +357,17 @@ export const annotationInk$ = computed((get) => {
 });
 
 export const annotationSelectedMarkId$ = computed((get) => {
-  return get(internalSelectedMarkId$);
+  const selection = get(internalSelection$);
+  return selection?.kind === "mark" ? selection.id : null;
 });
 
 export const annotationSelectedNoteId$ = computed((get) => {
-  return get(internalSelectedNoteId$);
+  const selection = get(internalSelection$);
+  return selection?.kind === "note" ? selection.id : null;
 });
 
 export const selectAnnotationNote$ = command(({ set }, id: string | null) => {
-  set(internalSelectedNoteId$, id);
-  // A note and its mark are two different things to hold; selecting one has to
-  // let go of the other or both sets of handles sit on the image at once.
-  if (id !== null) {
-    set(internalSelectedMarkId$, null);
-  }
+  set(internalSelection$, id === null ? null : { kind: "note", id });
 });
 
 export const moveAnnotationNoteBox$ = command(
@@ -381,7 +384,7 @@ export const moveAnnotationNoteBox$ = command(
           ) {
             return mark;
           }
-          return { ...mark, noteBox: box };
+          return { ...mark, noteBox: clampNoteBox(box) };
         }),
       };
     });
@@ -415,15 +418,13 @@ export const openAnnotationEditor$ = command(
     set(internalTool$, "box");
     set(internalZoom$, 1);
     set(internalInk$, DEFAULT_ANNOTATION_INK);
-    set(internalSelectedMarkId$, null);
-    set(internalSelectedNoteId$, null);
+    set(internalSelection$, null);
   },
 );
 
 export const closeAnnotationEditor$ = command(({ set }) => {
   set(internalSession$, null);
-  set(internalSelectedMarkId$, null);
-  set(internalSelectedNoteId$, null);
+  set(internalSelection$, null);
   set(internalStroke$, null);
   set(internalDrag$, null);
   set(internalZoom$, 1);
@@ -433,8 +434,7 @@ export const setAnnotationTool$ = command(({ set }, tool: AnnotationTool) => {
   set(internalTool$, tool);
   // Picking a drawing tool is a statement about the next mark, not the one
   // currently selected, so the selection drops with its handles.
-  set(internalSelectedMarkId$, null);
-  set(internalSelectedNoteId$, null);
+  set(internalSelection$, null);
 });
 
 export const setAnnotationInk$ = command(({ get, set }, ink: AnnotationInk) => {
@@ -442,7 +442,7 @@ export const setAnnotationInk$ = command(({ get, set }, ink: AnnotationInk) => {
 
   // Recolouring the active mark is what makes the swatch feel like a property
   // of the selection rather than a mode for the next stroke.
-  const selectedId = get(internalSelectedMarkId$);
+  const selectedId = get(annotationSelectedMarkId$);
   if (selectedId === null) {
     return;
   }
@@ -464,8 +464,7 @@ export const setAnnotationInk$ = command(({ get, set }, ink: AnnotationInk) => {
 });
 
 export const selectAnnotationMark$ = command(({ set }, id: string | null) => {
-  set(internalSelectedMarkId$, id);
-  set(internalSelectedNoteId$, null);
+  set(internalSelection$, id === null ? null : { kind: "mark", id });
 });
 
 /** Every mutation goes through here, so undo never has to be implemented twice. */
@@ -500,7 +499,7 @@ export const addAnnotationMark$ = command(
         ],
       };
     });
-    set(internalSelectedMarkId$, mark.id);
+    set(internalSelection$, { kind: "mark", id: mark.id });
   },
 );
 
@@ -513,14 +512,15 @@ export const removeAnnotationMark$ = command(({ get, set }, id: string) => {
       }),
     };
   });
-  if (get(internalSelectedMarkId$) === id) {
-    set(internalSelectedMarkId$, null);
+  // The note belongs to the mark, so removing the mark drops either hold.
+  if (get(internalSelection$)?.id === id) {
+    set(internalSelection$, null);
   }
 });
 
 /** Deletes whatever is selected. Bound to Delete/Backspace in the editor. */
 export const removeSelectedAnnotationMark$ = command(({ get, set }) => {
-  const id = get(internalSelectedMarkId$);
+  const id = get(annotationSelectedMarkId$);
   if (id === null) {
     return;
   }
@@ -611,17 +611,40 @@ export function defaultNoteBox(mark: ImageAnnotationMark): {
     MAX_NOTE_WIDTH,
     Math.max(MIN_NOTE_WIDTH, bounds.width),
   );
+  const below = bounds.y + bounds.height + NOTE_GAP;
+  // A mark low in the image has no room under it, and a note printed past the
+  // bottom edge is cropped out of the flattened copy — silently, because the
+  // text still travels in the prompt. Put it above the mark instead.
+  const y = below > 1 - NOTE_ROOM ? bounds.y - NOTE_GAP - NOTE_ROOM : below;
+  return clampNoteBox({ x: bounds.x, y, width });
+}
+
+/**
+ * Roughly one line of note plus its padding, in normalized units. Used to
+ * decide whether a note fits below its mark before the text is measured.
+ */
+const NOTE_ROOM = 0.06;
+
+/** Keeps a note inside the image, so the flatten cannot crop it away. */
+export function clampNoteBox(box: { x: number; y: number; width: number }): {
+  x: number;
+  y: number;
+  width: number;
+} {
+  const width = Math.min(MAX_NOTE_WIDTH, Math.max(MIN_NOTE_WIDTH, box.width));
   return {
-    x: Math.min(bounds.x, 1 - width),
-    y: Math.min(bounds.y + bounds.height + NOTE_GAP, 1),
+    x: Math.min(Math.max(0, box.x), Math.max(0, 1 - width)),
+    y: Math.min(Math.max(0, box.y), Math.max(0, 1 - NOTE_ROOM)),
     width,
   };
 }
 
 /** The note text of a mark that can carry one drawn on the image. */
-export function noteOnImage(
-  mark: ImageAnnotationMark,
-): { text: string; box: { x: number; y: number; width: number } } | null {
+export function noteOnImage(mark: ImageAnnotationMark): {
+  text: string;
+  ink: string;
+  box: { x: number; y: number; width: number };
+} | null {
   if (
     mark.shape === "text" ||
     mark.shape === "redact" ||
@@ -633,7 +656,9 @@ export function noteOnImage(
   if (!text) {
     return null;
   }
-  return { text, box: mark.noteBox ?? defaultNoteBox(mark) };
+  // Every shape that reaches here declares `ink` as required, so the colour is
+  // read from the narrowed mark rather than guessed by a caller.
+  return { text, ink: mark.ink, box: mark.noteBox ?? defaultNoteBox(mark) };
 }
 
 export const setAnnotationMarkNote$ = command(
@@ -672,8 +697,7 @@ export const undoAnnotation$ = command(({ get, set }) => {
     present: previous,
     future: [session.present, ...session.future],
   });
-  set(internalSelectedMarkId$, null);
-  set(internalSelectedNoteId$, null);
+  set(internalSelection$, null);
 });
 
 export const redoAnnotation$ = command(({ get, set }) => {
@@ -689,7 +713,7 @@ export const redoAnnotation$ = command(({ get, set }) => {
     present: next,
     future: session.future.slice(1),
   });
-  set(internalSelectedMarkId$, null);
+  set(internalSelection$, null);
 });
 
 /**

--- a/turbo/apps/platform/src/signals/okou-page/image-annotation.ts
+++ b/turbo/apps/platform/src/signals/okou-page/image-annotation.ts
@@ -45,6 +45,13 @@ export const REDACT_FILL = "#525B68";
 export const STROKE_HALO_INNER = "rgba(255, 255, 255, 0.90)";
 
 /**
+ * The ground a note is printed on. Nearly opaque white rather than a halo: a
+ * sentence has to stay readable over a screenshot of anything, including dark
+ * UI, and a halo only separates a few pixels of each glyph.
+ */
+export const NOTE_GROUND = "rgba(255, 255, 255, 0.94)";
+
+/**
  * `highlight`, `crop` and `redact` were dropped, and `select` with them: a
  * mark is clicked directly, so a mode for "not drawing" has nothing left to do,
  * and a tool whose job nobody could name off its icon is not worth a slot. The
@@ -190,6 +197,13 @@ export interface AnnotationTarget {
 
 interface AnnotationSession {
   readonly target: AnnotationTarget;
+  /**
+   * The annotation the editor opened on. Undo restores the exact object it
+   * pushed, so identity against this is enough to tell whether the session has
+   * anything to attach — no structural comparison, and undoing back to the
+   * start correctly reads as unchanged again.
+   */
+  readonly baseline: ImageAnnotation;
   readonly past: readonly ImageAnnotation[];
   readonly present: ImageAnnotation;
   readonly future: readonly ImageAnnotation[];
@@ -214,6 +228,20 @@ export interface AnnotationPoint {
   readonly y: number;
 }
 
+/** The eight grips on a selected mark: four corners and four edges. */
+export const ANNOTATION_RESIZE_EDGES = [
+  "tl",
+  "tr",
+  "bl",
+  "br",
+  "t",
+  "b",
+  "l",
+  "r",
+] as const;
+
+export type AnnotationResizeEdge = (typeof ANNOTATION_RESIZE_EDGES)[number];
+
 /**
  * A mark being moved or resized. Drawing produces a new mark; this edits one
  * that already exists, so it carries the mark it started from and the pointer
@@ -222,8 +250,8 @@ export interface AnnotationPoint {
  */
 export interface AnnotationDrag {
   readonly markId: string;
-  readonly mode: "move" | "resize";
-  readonly corner?: "tl" | "tr" | "bl" | "br";
+  readonly mode: "move" | "resize" | "note-move" | "note-resize";
+  readonly corner?: AnnotationResizeEdge;
   readonly origin: AnnotationPoint;
   readonly startRect: {
     x: number;
@@ -296,6 +324,11 @@ const internalSession$ = state<AnnotationSession | null>(null);
 const internalTool$ = state<AnnotationTool>("box");
 const internalInk$ = state<AnnotationInk>(DEFAULT_ANNOTATION_INK);
 const internalSelectedMarkId$ = state<string | null>(null);
+/**
+ * The note label being edited in place, held separately from the mark so that
+ * dragging a sentence into clear space does not also move the box it explains.
+ */
+const internalSelectedNoteId$ = state<string | null>(null);
 
 export const annotationSessionTarget$ = computed((get) => {
   return get(internalSession$)?.target ?? null;
@@ -321,6 +354,46 @@ export const annotationSelectedMarkId$ = computed((get) => {
   return get(internalSelectedMarkId$);
 });
 
+export const annotationSelectedNoteId$ = computed((get) => {
+  return get(internalSelectedNoteId$);
+});
+
+export const selectAnnotationNote$ = command(({ set }, id: string | null) => {
+  set(internalSelectedNoteId$, id);
+  // A note and its mark are two different things to hold; selecting one has to
+  // let go of the other or both sets of handles sit on the image at once.
+  if (id !== null) {
+    set(internalSelectedMarkId$, null);
+  }
+});
+
+export const moveAnnotationNoteBox$ = command(
+  ({ set }, id: string, box: { x: number; y: number; width: number }) => {
+    set(pushAnnotation$, (current) => {
+      return {
+        ...current,
+        marks: current.marks.map((mark) => {
+          if (
+            mark.id !== id ||
+            mark.shape === "text" ||
+            mark.shape === "redact" ||
+            mark.shape === "highlight"
+          ) {
+            return mark;
+          }
+          return { ...mark, noteBox: box };
+        }),
+      };
+    });
+  },
+);
+
+/** Whether the session has anything worth attaching. */
+export const annotationDirty$ = computed((get) => {
+  const session = get(internalSession$);
+  return session !== null && session.present !== session.baseline;
+});
+
 export const annotationCanUndo$ = computed((get) => {
   return (get(internalSession$)?.past.length ?? 0) > 0;
 });
@@ -331,22 +404,26 @@ export const annotationCanRedo$ = computed((get) => {
 
 export const openAnnotationEditor$ = command(
   ({ set }, target: AnnotationTarget) => {
+    const opened = target.annotation ?? emptyAnnotation();
     set(internalSession$, {
       target,
+      baseline: opened,
       past: [],
-      present: target.annotation ?? emptyAnnotation(),
+      present: opened,
       future: [],
     });
     set(internalTool$, "box");
     set(internalZoom$, 1);
     set(internalInk$, DEFAULT_ANNOTATION_INK);
     set(internalSelectedMarkId$, null);
+    set(internalSelectedNoteId$, null);
   },
 );
 
 export const closeAnnotationEditor$ = command(({ set }) => {
   set(internalSession$, null);
   set(internalSelectedMarkId$, null);
+  set(internalSelectedNoteId$, null);
   set(internalStroke$, null);
   set(internalDrag$, null);
   set(internalZoom$, 1);
@@ -357,6 +434,7 @@ export const setAnnotationTool$ = command(({ set }, tool: AnnotationTool) => {
   // Picking a drawing tool is a statement about the next mark, not the one
   // currently selected, so the selection drops with its handles.
   set(internalSelectedMarkId$, null);
+  set(internalSelectedNoteId$, null);
 });
 
 export const setAnnotationInk$ = command(({ get, set }, ink: AnnotationInk) => {
@@ -387,6 +465,7 @@ export const setAnnotationInk$ = command(({ get, set }, ink: AnnotationInk) => {
 
 export const selectAnnotationMark$ = command(({ set }, id: string | null) => {
   set(internalSelectedMarkId$, id);
+  set(internalSelectedNoteId$, null);
 });
 
 /** Every mutation goes through here, so undo never has to be implemented twice. */
@@ -402,6 +481,7 @@ export const pushAnnotation$ = command(
     const next = update(session.present);
     set(internalSession$, {
       target: session.target,
+      baseline: session.baseline,
       past: [...session.past, session.present],
       present: next,
       future: [],
@@ -473,6 +553,89 @@ export const moveAnnotationMarkRect$ = command(
   },
 );
 
+/** A note narrower than this wraps every other word and reads as a column. */
+const MIN_NOTE_WIDTH = 0.18;
+const MAX_NOTE_WIDTH = 1;
+/** Clear of the mark's own outline and its ordinal pin. */
+const NOTE_GAP = 0.015;
+
+/** The box a mark occupies, used to place its note under it. */
+export function markBounds(mark: ImageAnnotationMark): {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+} {
+  if (mark.shape === "arrow") {
+    return {
+      x: Math.min(mark.from.x, mark.to.x),
+      y: Math.min(mark.from.y, mark.to.y),
+      width: Math.abs(mark.to.x - mark.from.x),
+      height: Math.abs(mark.to.y - mark.from.y),
+    };
+  }
+  if (mark.shape === "pen") {
+    const xs = mark.points.map((point) => {
+      return point.x;
+    });
+    const ys = mark.points.map((point) => {
+      return point.y;
+    });
+    const x = Math.min(...xs, 1);
+    const y = Math.min(...ys, 1);
+    return {
+      x,
+      y,
+      width: Math.max(...xs, 0) - x,
+      height: Math.max(...ys, 0) - y,
+    };
+  }
+  if (mark.shape === "text") {
+    return { x: mark.at.x, y: mark.at.y, width: 0, height: 0 };
+  }
+  return mark.rect;
+}
+
+/**
+ * Where a note lands the first time it is written: directly under its mark and
+ * at least as wide, so the sentence reads as belonging to that region without
+ * the user having to place it.
+ */
+export function defaultNoteBox(mark: ImageAnnotationMark): {
+  x: number;
+  y: number;
+  width: number;
+} {
+  const bounds = markBounds(mark);
+  const width = Math.min(
+    MAX_NOTE_WIDTH,
+    Math.max(MIN_NOTE_WIDTH, bounds.width),
+  );
+  return {
+    x: Math.min(bounds.x, 1 - width),
+    y: Math.min(bounds.y + bounds.height + NOTE_GAP, 1),
+    width,
+  };
+}
+
+/** The note text of a mark that can carry one drawn on the image. */
+export function noteOnImage(
+  mark: ImageAnnotationMark,
+): { text: string; box: { x: number; y: number; width: number } } | null {
+  if (
+    mark.shape === "text" ||
+    mark.shape === "redact" ||
+    mark.shape === "highlight"
+  ) {
+    return null;
+  }
+  const text = mark.note?.trim();
+  if (!text) {
+    return null;
+  }
+  return { text, box: mark.noteBox ?? defaultNoteBox(mark) };
+}
+
 export const setAnnotationMarkNote$ = command(
   ({ set }, id: string, note: string) => {
     set(pushAnnotation$, (current) => {
@@ -504,11 +667,13 @@ export const undoAnnotation$ = command(({ get, set }) => {
   }
   set(internalSession$, {
     target: session.target,
+    baseline: session.baseline,
     past: session.past.slice(0, -1),
     present: previous,
     future: [session.present, ...session.future],
   });
   set(internalSelectedMarkId$, null);
+  set(internalSelectedNoteId$, null);
 });
 
 export const redoAnnotation$ = command(({ get, set }) => {
@@ -519,6 +684,7 @@ export const redoAnnotation$ = command(({ get, set }) => {
   }
   set(internalSession$, {
     target: session.target,
+    baseline: session.baseline,
     past: [...session.past, session.present],
     present: next,
     future: session.future.slice(1),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/image-annotation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/image-annotation.test.tsx
@@ -151,6 +151,28 @@ interface DragBox {
   readonly toY: number;
 }
 
+/** jsdom reports a zero-sized box for every element, so the surface is given
+ * one explicitly — the editor divides by it to normalize each point. */
+async function sizedSurface(): Promise<HTMLElement> {
+  const surface = await screen.findByTestId("image-annotation-surface");
+  surface.getBoundingClientRect = () => {
+    return {
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 400,
+      bottom: 300,
+      width: 400,
+      height: 300,
+      toJSON: () => {
+        return {};
+      },
+    };
+  };
+  return surface;
+}
+
 /** Drags a rectangle across the drawing surface. */
 async function dragOnSurface(
   box: DragBox = { fromX: 40, fromY: 30, toX: 200, toY: 180 },
@@ -422,6 +444,93 @@ describe("composer image annotation", () => {
     });
   });
 
+  /**
+   * The note is the instruction; the flattened image is what the model looks
+   * at. A sentence that only exists in the prompt leaves the model matching
+   * words to regions by position, so it has to be printed on the image too.
+   */
+  it("prints a mark's note on the image and lets it be placed", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockChatLifecycle(context);
+    mockAgentChatPage();
+    mockDraftWithImage(null);
+
+    setup(true);
+
+    await user.click(
+      await screen.findByLabelText("Open image preview for billing-page.png"),
+    );
+    await user.click(await screen.findByTestId("artifact-dialog-annotate"));
+    await screen.findByTestId("image-annotation-editor");
+    await dragOnSurface({ fromX: 40, fromY: 30, toX: 200, toY: 120 });
+
+    // Nothing is printed until there is something to print.
+    expect(screen.queryByTestId(/^annotation-note-label-/u)).toBeNull();
+
+    await user.click(await screen.findByTestId("annotation-mark-1"));
+    await user.type(
+      await screen.findByPlaceholderText("Say what should change here"),
+      "Tighten this spacing",
+    );
+
+    const label = await waitFor(() => {
+      const found = document.querySelector(
+        '[data-testid^="annotation-note-label-"]',
+      );
+      if (!(found instanceof HTMLElement)) {
+        throw new Error("Note label not drawn on the image");
+      }
+      return found;
+    });
+    expect(label).toHaveTextContent("Tighten this spacing");
+
+    // Selecting the note hands over its own grip, not the mark's.
+    fireEvent.pointerDown(label, { clientX: 60, clientY: 140, pointerId: 2 });
+    const widthHandle = await screen.findByTestId(
+      "annotation-note-width-handle",
+    );
+    expect(widthHandle).toBeInTheDocument();
+    expect(screen.queryByTestId("annotation-handle-tl")).toBeNull();
+  });
+
+  /**
+   * A corner grip changes both dimensions; an edge grip changes one. Dragging
+   * the top edge sideways must not slide the box across the image.
+   */
+  it("resizes height alone from the top edge", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockChatLifecycle(context);
+    mockAgentChatPage();
+    mockDraftWithImage([boxMark()]);
+
+    setup(true);
+
+    await user.click(
+      await screen.findByLabelText("Open image preview for billing-page.png"),
+    );
+    await user.click(await screen.findByTestId("artifact-dialog-annotate"));
+    await screen.findByTestId("image-annotation-editor");
+    await user.click(await screen.findByTestId("annotation-mark-1"));
+
+    const surface = await sizedSurface();
+    const mark = screen.getByTestId("annotation-mark-1");
+    const before = mark.style.left;
+
+    fireEvent.pointerDown(screen.getByTestId("annotation-handle-t"), {
+      clientX: 100,
+      clientY: 30,
+      pointerId: 3,
+    });
+    fireEvent.pointerMove(surface, { clientX: 160, clientY: 60, pointerId: 3 });
+    fireEvent.pointerUp(surface, { clientX: 160, clientY: 60, pointerId: 3 });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("annotation-mark-1").style.top).not.toBe("10%");
+    });
+    // The horizontal drag went nowhere, which is the whole point of an edge.
+    expect(screen.getByTestId("annotation-mark-1").style.left).toBe(before);
+  });
+
   it("deletes the selected mark", async () => {
     const user = userEvent.setup({ delay: null });
     mockChatLifecycle(context);
@@ -500,6 +609,10 @@ describe("composer image annotation", () => {
     });
   });
 
+  /**
+   * Opening the editor is not an edit. Attaching has to stay unavailable until
+   * there is something to attach, and it has to come back once there is.
+   */
   it("keeps an opened-but-untouched image unannotated", async () => {
     const user = userEvent.setup({ delay: null });
     mockChatLifecycle(context);
@@ -514,8 +627,21 @@ describe("composer image annotation", () => {
     await user.click(chip);
     await user.click(await screen.findByTestId("artifact-dialog-annotate"));
     await screen.findByTestId("image-annotation-editor");
-    await user.click(attachMarksButton());
 
+    expect(attachMarksButton()).toBeDisabled();
+
+    await dragOnSurface();
+    await waitFor(() => {
+      expect(attachMarksButton()).toBeEnabled();
+    });
+
+    // Undoing back to the start leaves nothing to attach again.
+    await user.click(screen.getByLabelText("Undo"));
+    await waitFor(() => {
+      expect(attachMarksButton()).toBeDisabled();
+    });
+
+    await user.click(screen.getByText("Cancel"));
     await waitFor(() => {
       expect(screen.queryByTestId("image-annotation-editor")).toBeNull();
     });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/image-annotation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/image-annotation.test.tsx
@@ -494,6 +494,47 @@ describe("composer image annotation", () => {
   });
 
   /**
+   * A note printed past the bottom edge is cropped out of the flattened image
+   * and nobody finds out, because the text still travels in the prompt. A mark
+   * with no room under it has to put its note above itself instead.
+   */
+  it("keeps the note of a bottom-edge mark inside the image", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockChatLifecycle(context);
+    mockAgentChatPage();
+    mockDraftWithImage(null);
+
+    setup(true);
+
+    await user.click(
+      await screen.findByLabelText("Open image preview for billing-page.png"),
+    );
+    await user.click(await screen.findByTestId("artifact-dialog-annotate"));
+    await screen.findByTestId("image-annotation-editor");
+
+    // A box hugging the bottom of a 400x300 surface.
+    await dragOnSurface({ fromX: 40, fromY: 250, toX: 200, toY: 296 });
+    await user.click(await screen.findByTestId("annotation-mark-1"));
+    await user.type(
+      await screen.findByPlaceholderText("Say what should change here"),
+      "This row is cut off",
+    );
+
+    const label = await waitFor(() => {
+      const found = screen.getByTestId(/^annotation-note-label-/u);
+      return found;
+    });
+    const top = Number.parseFloat(label.style.top);
+    const left = Number.parseFloat(label.style.left);
+    const width = Number.parseFloat(label.style.width);
+    expect(top).toBeLessThan(100);
+    expect(top).toBeGreaterThanOrEqual(0);
+    // Placed above the mark rather than under it, and still on the image.
+    expect(top).toBeLessThan(83);
+    expect(left + width).toBeLessThanOrEqual(100);
+  });
+
+  /**
    * A corner grip changes both dimensions; an edge grip changes one. Dragging
    * the top edge sideways must not slide the box across the image.
    */

--- a/turbo/apps/platform/src/views/okou-page/image-annotation-editor.tsx
+++ b/turbo/apps/platform/src/views/okou-page/image-annotation-editor.tsx
@@ -29,9 +29,11 @@ import {
   annotationCanRedo$,
   annotationCanUndo$,
   annotationDraft$,
+  annotationDirty$,
   annotationDrag$,
   annotationInk$,
   annotationSelectedMarkId$,
+  annotationSelectedNoteId$,
   annotationSessionTarget$,
   annotationStroke$,
   annotationSurface$,
@@ -44,13 +46,17 @@ import {
   removeAnnotationMark$,
   removeSelectedAnnotationMark$,
   selectAnnotationMark$,
+  selectAnnotationNote$,
   setAnnotationInk$,
   setAnnotationMarkNote$,
   setAnnotationStroke$,
   setAnnotationDrag$,
   setAnnotationTool$,
+  ANNOTATION_RESIZE_EDGES,
   markOrdinal,
   moveAnnotationMarkRect$,
+  moveAnnotationNoteBox$,
+  noteOnImage,
   nextMarkOrdinal,
   resetAnnotationZoom$,
   undoAnnotation$,
@@ -58,12 +64,17 @@ import {
   type AnnotationDrag,
   type AnnotationInk,
   type AnnotationPoint,
+  type AnnotationResizeEdge,
   type AnnotationStroke,
   type AnnotationTarget,
   type AnnotationTool,
 } from "../../signals/okou-page/image-annotation.ts";
 import { useResolvedAttachmentUrl } from "./attachment-resource.ts";
-import { markInk, MarkShape } from "./image-annotation-marks.tsx";
+import {
+  markInk,
+  MarkNoteLabel,
+  MarkShape,
+} from "./image-annotation-marks.tsx";
 
 const TOOLS: readonly { tool: AnnotationTool; icon: typeof Square }[] = [
   { tool: "box", icon: Square },
@@ -502,6 +513,9 @@ function EditorFooter() {
   const { t } = useTranslation();
   const close = useSet(closeAnnotationEditor$);
   const commit = useSet(commitAnnotation$);
+  // Nothing drawn, nothing to attach — an enabled button here promises an edit
+  // the session does not have.
+  const dirty = useGet(annotationDirty$);
 
   return (
     <div className="flex h-14 shrink-0 items-center gap-3 border-t border-border bg-card px-4">
@@ -516,7 +530,7 @@ function EditorFooter() {
           return $.chat.actions.cancel;
         })}
       </Button>
-      <Button type="button" size="sm" onClick={commit}>
+      <Button type="button" size="sm" disabled={!dirty} onClick={commit}>
         {t(($) => {
           return $.artifacts.annotation.attach;
         })}
@@ -612,13 +626,16 @@ interface StrokeHandlers {
   onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
   onPointerMove: (
     event: ReactPointerEvent<HTMLDivElement>,
-    moveRect: (
-      id: string,
+    applyDrag: (
+      drag: AnnotationDrag,
       rect: { x: number; y: number; width: number; height: number },
     ) => void,
   ) => void;
   onPointerUp: () => void;
 }
+
+/** Narrower than this and the note wraps to one word a line. */
+const MIN_NOTE_DRAG_WIDTH = 0.1;
 
 function draggedRect(drag: AnnotationDrag, point: AnnotationPoint) {
   const dx = point.x - drag.origin.x;
@@ -634,12 +651,38 @@ function draggedRect(drag: AnnotationDrag, point: AnnotationPoint) {
     };
   }
 
-  const left = drag.corner === "tl" || drag.corner === "bl";
-  const top = drag.corner === "tl" || drag.corner === "tr";
-  const x1 = left ? start.x + dx : start.x;
-  const y1 = top ? start.y + dy : start.y;
-  const x2 = left ? start.x + start.width : start.x + start.width + dx;
-  const y2 = top ? start.y + start.height : start.y + start.height + dy;
+  if (drag.mode === "note-move") {
+    return {
+      x: clamp01(start.x + dx),
+      y: clamp01(start.y + dy),
+      width: start.width,
+      height: 0,
+    };
+  }
+
+  if (drag.mode === "note-resize") {
+    // Only the width is stored; the height follows from how the text wraps.
+    return {
+      x: start.x,
+      y: start.y,
+      width: Math.max(MIN_NOTE_DRAG_WIDTH, start.width + dx),
+      height: 0,
+    };
+  }
+
+  // An edge grip moves one side; a corner grip moves two. Anything the grip
+  // does not touch keeps its start value, so dragging the top edge cannot
+  // shift the box sideways.
+  const corner = drag.corner ?? "br";
+  const movesLeft = corner === "tl" || corner === "bl" || corner === "l";
+  const movesRight = corner === "tr" || corner === "br" || corner === "r";
+  const movesTop = corner === "tl" || corner === "tr" || corner === "t";
+  const movesBottom = corner === "bl" || corner === "br" || corner === "b";
+
+  const x1 = movesLeft ? start.x + dx : start.x;
+  const y1 = movesTop ? start.y + dy : start.y;
+  const x2 = movesRight ? start.x + start.width + dx : start.x + start.width;
+  const y2 = movesBottom ? start.y + start.height + dy : start.y + start.height;
   return {
     x: clamp01(Math.min(x1, x2)),
     y: clamp01(Math.min(y1, y2)),
@@ -658,6 +701,7 @@ function useStrokeHandlers(): StrokeHandlers {
   const setDrag = useSet(setAnnotationDrag$);
   const addMark = useSet(addAnnotationMark$);
   const selectMark = useSet(selectAnnotationMark$);
+  const selectNote = useSet(selectAnnotationNote$);
 
   const pointAt = (event: ReactPointerEvent<HTMLDivElement>) => {
     const rect = surface?.getBoundingClientRect();
@@ -680,16 +724,17 @@ function useStrokeHandlers(): StrokeHandlers {
       // Starting a stroke on bare canvas also clears the selection, so the
       // handles and note of the previous mark do not linger over a new one.
       selectMark(null);
+      selectNote(null);
       event.currentTarget.setPointerCapture(event.pointerId);
       setStroke({ tool, from: point, to: point, points: [point] });
     },
-    onPointerMove: (event, moveRect) => {
+    onPointerMove: (event, applyDrag) => {
       const point = pointAt(event);
       if (!point) {
         return;
       }
       if (drag) {
-        moveRect(drag.markId, draggedRect(drag, point));
+        applyDrag(drag, draggedRect(drag, point));
         return;
       }
       if (!stroke) {
@@ -722,9 +767,7 @@ function useStrokeHandlers(): StrokeHandlers {
   };
 }
 
-const RESIZE_CORNERS = ["tl", "tr", "bl", "br"] as const;
-
-type ResizeCorner = (typeof RESIZE_CORNERS)[number];
+type ResizeCorner = AnnotationResizeEdge;
 
 function rectOf(mark: ImageAnnotationMark) {
   if (mark.shape === "box") {
@@ -737,15 +780,76 @@ function rectOf(mark: ImageAnnotationMark) {
 }
 
 function cornerCursor(corner: ResizeCorner): string {
-  return corner === "tl" || corner === "br"
-    ? "cursor-nwse-resize"
-    : "cursor-nesw-resize";
+  switch (corner) {
+    case "tl":
+    case "br": {
+      return "cursor-nwse-resize";
+    }
+    case "tr":
+    case "bl": {
+      return "cursor-nesw-resize";
+    }
+    case "t":
+    case "b": {
+      return "cursor-ns-resize";
+    }
+    case "l":
+    case "r": {
+      return "cursor-ew-resize";
+    }
+  }
+}
+
+/**
+ * Edges first so the corner dots paint over their ends — otherwise the strip
+ * covering the top edge would swallow the grab on both top corners.
+ */
+const ORDERED_HANDLES = [...ANNOTATION_RESIZE_EDGES].sort((a, b) => {
+  return a.length - b.length;
+});
+
+/** Where a grip sits on the mark, as a fraction of its own box. */
+function handleAnchor(corner: ResizeCorner): { fx: number; fy: number } {
+  const fx = corner.includes("l") ? 0 : corner.includes("r") ? 1 : 0.5;
+  const fy = corner.includes("t") ? 0 : corner.includes("b") ? 1 : 0.5;
+  return { fx, fy };
+}
+
+/** A note is resized on one axis only, so it gets one grip on its right edge. */
+function NoteWidthHandle({
+  mark,
+  onGrab,
+}: {
+  mark: ImageAnnotationMark;
+  onGrab: (event: ReactPointerEvent<HTMLElement>) => void;
+}) {
+  const note = noteOnImage(mark);
+  if (!note) {
+    return null;
+  }
+  return (
+    <span
+      role="presentation"
+      onPointerDown={onGrab}
+      style={{
+        left: percent(note.box.x + note.box.width),
+        top: percent(note.box.y),
+      }}
+      className="absolute -ml-[5px] mt-1.5 h-2.5 w-2.5 cursor-ew-resize rounded-full border border-border bg-background shadow-sm"
+      data-testid="annotation-note-width-handle"
+    />
+  );
 }
 
 /**
  * Handles only appear for marks that have a rectangle. A freehand stroke or an
  * arrow can still be selected and deleted; resizing them would mean editing
  * every point, which is not what a handle promises.
+ *
+ * Only the corners are drawn. The edges are grabbable too — dragging one
+ * changes width or height alone — but four dots and four bars around a small
+ * box is more furniture than the shape underneath, so the edges are invisible
+ * strips that only announce themselves through the cursor.
  */
 function ResizeHandles({
   mark,
@@ -761,11 +865,10 @@ function ResizeHandles({
 
   return (
     <>
-      {RESIZE_CORNERS.map((corner) => {
-        const x =
-          corner === "tl" || corner === "bl" ? rect.x : rect.x + rect.width;
-        const y =
-          corner === "tl" || corner === "tr" ? rect.y : rect.y + rect.height;
+      {ORDERED_HANDLES.map((corner) => {
+        const { fx, fy } = handleAnchor(corner);
+        const horizontal = corner === "t" || corner === "b";
+        const vertical = corner === "l" || corner === "r";
         return (
           <span
             key={corner}
@@ -773,10 +876,20 @@ function ResizeHandles({
             onPointerDown={(event) => {
               onGrab(corner, event);
             }}
-            style={{ left: percent(x), top: percent(y) }}
+            style={{
+              left: percent(rect.x + rect.width * fx),
+              top: percent(rect.y + rect.height * fy),
+              ...(horizontal ? { width: percent(rect.width) } : {}),
+              ...(vertical ? { height: percent(rect.height) } : {}),
+            }}
             className={cn(
-              "absolute -ml-[5px] -mt-[5px] h-2.5 w-2.5 rounded-sm border border-border bg-background shadow-sm",
+              "absolute",
               cornerCursor(corner),
+              horizontal && "-mt-[5px] h-2.5 -translate-x-1/2",
+              vertical && "-ml-[5px] w-2.5 -translate-y-1/2",
+              !horizontal &&
+                !vertical &&
+                "-ml-[5px] -mt-[5px] h-2.5 w-2.5 rounded-full border border-border bg-background shadow-sm",
             )}
             data-testid={`annotation-handle-${corner}`}
           />
@@ -784,6 +897,108 @@ function ResizeHandles({
       })}
     </>
   );
+}
+
+/**
+ * Every note printed on the image, plus the grips for the one being placed.
+ *
+ * It owns its own selection and drag so that moving a sentence into clear space
+ * never disturbs the mark it explains — the two are edited independently.
+ */
+function NoteLayer({ marks }: { marks: readonly ImageAnnotationMark[] }) {
+  const selectedNoteId = useGet(annotationSelectedNoteId$);
+  const selectNote = useSet(selectAnnotationNote$);
+  const surface = useGet(annotationSurface$);
+  const beginDrag = useSet(setAnnotationDrag$);
+
+  const selectedNote = marks.find((mark) => {
+    return mark.id === selectedNoteId && noteOnImage(mark) !== null;
+  });
+
+  const grabNote = (
+    mark: ImageAnnotationMark,
+    mode: "note-move" | "note-resize",
+    event: ReactPointerEvent<HTMLElement>,
+  ) => {
+    // The label sits on the drawing surface, so without this the grab also
+    // starts a new stroke on the canvas underneath it.
+    event.stopPropagation();
+    selectNote(mark.id);
+    const note = noteOnImage(mark);
+    const bounds = surface?.getBoundingClientRect();
+    if (!note || !bounds || bounds.width === 0) {
+      return;
+    }
+    beginDrag({
+      markId: mark.id,
+      mode,
+      origin: {
+        x: (event.clientX - bounds.left) / bounds.width,
+        y: (event.clientY - bounds.top) / bounds.height,
+      },
+      startRect: { ...note.box, height: 0 },
+    });
+  };
+
+  return (
+    <>
+      {marks.map((mark) => {
+        return (
+          <MarkNoteLabel
+            key={`${mark.id}-note`}
+            mark={mark}
+            selected={mark.id === selectedNoteId}
+            onSelect={() => {
+              selectNote(mark.id);
+            }}
+            onGrab={(event) => {
+              grabNote(mark, "note-move", event);
+            }}
+          />
+        );
+      })}
+      {selectedNote && (
+        <NoteWidthHandle
+          mark={selectedNote}
+          onGrab={(event) => {
+            grabNote(selectedNote, "note-resize", event);
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+/** Starts a resize from whichever grip was grabbed on the selected mark. */
+function useGrabHandle(
+  selectedMark: ImageAnnotationMark | undefined,
+): (corner: ResizeCorner, event: ReactPointerEvent<HTMLElement>) => void {
+  const surface = useGet(annotationSurface$);
+  const beginDrag = useSet(setAnnotationDrag$);
+
+  return (corner, event) => {
+    // The handle sits on the drawing surface, so without this the grab also
+    // starts a new stroke underneath the mark being resized.
+    event.stopPropagation();
+    if (!selectedMark) {
+      return;
+    }
+    const rect = rectOf(selectedMark);
+    const bounds = surface?.getBoundingClientRect();
+    if (!rect || !bounds || bounds.width === 0) {
+      return;
+    }
+    beginDrag({
+      markId: selectedMark.id,
+      mode: "resize",
+      corner,
+      origin: {
+        x: (event.clientX - bounds.left) / bounds.width,
+        y: (event.clientY - bounds.top) / bounds.height,
+      },
+      startRect: rect,
+    });
+  };
 }
 
 function EditorStage({ filename, url }: { filename: string; url: string }) {
@@ -796,6 +1011,7 @@ function EditorStage({ filename, url }: { filename: string; url: string }) {
   const selectMark = useSet(selectAnnotationMark$);
   const bindSurface = useSet(bindAnnotationSurface$);
   const moveRect = useSet(moveAnnotationMarkRect$);
+  const moveNoteBox = useSet(moveAnnotationNoteBox$);
   const handlers = useStrokeHandlers();
 
   const box = surface?.getBoundingClientRect();
@@ -807,32 +1023,18 @@ function EditorStage({ filename, url }: { filename: string; url: string }) {
   const selectedMark = annotation.marks.find((mark) => {
     return mark.id === selectedId;
   });
+  const grabHandle = useGrabHandle(selectedMark);
 
-  const grabHandle = (
-    corner: ResizeCorner,
-    event: ReactPointerEvent<HTMLElement>,
+  // One pointer move, two things it might be dragging.
+  const applyDrag = (
+    drag: AnnotationDrag,
+    rect: { x: number; y: number; width: number; height: number },
   ) => {
-    // The handle sits on the drawing surface, so without this the grab also
-    // starts a new stroke underneath the mark being resized.
-    event.stopPropagation();
-    if (!selectedMark) {
+    if (drag.mode === "note-move" || drag.mode === "note-resize") {
+      moveNoteBox(drag.markId, { x: rect.x, y: rect.y, width: rect.width });
       return;
     }
-    const rect = rectOf(selectedMark);
-    const bounds = surface?.getBoundingClientRect();
-    if (!rect || !bounds || bounds.width === 0) {
-      return;
-    }
-    handlers.beginDrag({
-      markId: selectedMark.id,
-      mode: "resize",
-      corner,
-      origin: {
-        x: (event.clientX - bounds.left) / bounds.width,
-        y: (event.clientY - bounds.top) / bounds.height,
-      },
-      startRect: rect,
-    });
+    moveRect(drag.markId, rect);
   };
 
   const grabMark = (
@@ -864,7 +1066,7 @@ function EditorStage({ filename, url }: { filename: string; url: string }) {
           ref={bindSurface}
           onPointerDown={handlers.onPointerDown}
           onPointerMove={(event) => {
-            handlers.onPointerMove(event, moveRect);
+            handlers.onPointerMove(event, applyDrag);
           }}
           onPointerUp={handlers.onPointerUp}
           style={{ touchAction: "none" }}
@@ -890,7 +1092,6 @@ function EditorStage({ filename, url }: { filename: string; url: string }) {
                 mark={mark}
                 ordinal={markOrdinal(mark, index)}
                 aspect={aspect}
-                selected={mark.id === selectedId}
                 onSelect={() => {
                   selectMark(mark.id);
                 }}
@@ -900,6 +1101,7 @@ function EditorStage({ filename, url }: { filename: string; url: string }) {
               />
             );
           })}
+          <NoteLayer marks={annotation.marks} />
           {selectedMark && (
             <ResizeHandles mark={selectedMark} onGrab={grabHandle} />
           )}

--- a/turbo/apps/platform/src/views/okou-page/image-annotation-editor.tsx
+++ b/turbo/apps/platform/src/views/okou-page/image-annotation-editor.tsx
@@ -634,9 +634,6 @@ interface StrokeHandlers {
   onPointerUp: () => void;
 }
 
-/** Narrower than this and the note wraps to one word a line. */
-const MIN_NOTE_DRAG_WIDTH = 0.1;
-
 function draggedRect(drag: AnnotationDrag, point: AnnotationPoint) {
   const dx = point.x - drag.origin.x;
   const dy = point.y - drag.origin.y;
@@ -662,12 +659,9 @@ function draggedRect(drag: AnnotationDrag, point: AnnotationPoint) {
 
   if (drag.mode === "note-resize") {
     // Only the width is stored; the height follows from how the text wraps.
-    return {
-      x: start.x,
-      y: start.y,
-      width: Math.max(MIN_NOTE_DRAG_WIDTH, start.width + dx),
-      height: 0,
-    };
+    // The floor and the image bounds belong to `clampNoteBox`, so there is one
+    // owner of what a legal note box is.
+    return { x: start.x, y: start.y, width: start.width + dx, height: 0 };
   }
 
   // An edge grip moves one side; a corner grip moves two. Anything the grip
@@ -947,7 +941,6 @@ function NoteLayer({ marks }: { marks: readonly ImageAnnotationMark[] }) {
           <MarkNoteLabel
             key={`${mark.id}-note`}
             mark={mark}
-            selected={mark.id === selectedNoteId}
             onSelect={() => {
               selectNote(mark.id);
             }}

--- a/turbo/apps/platform/src/views/okou-page/image-annotation-marks.tsx
+++ b/turbo/apps/platform/src/views/okou-page/image-annotation-marks.tsx
@@ -6,6 +6,8 @@ import type {
 import {
   HIGHLIGHT_FILL,
   markOrdinal,
+  NOTE_GROUND,
+  noteOnImage,
   REDACT_FILL,
   STROKE_HALO_INNER,
 } from "../../signals/okou-page/image-annotation.ts";
@@ -138,24 +140,25 @@ function boxedFill(
   };
 }
 
+/**
+ * Selection is carried entirely by the resize handles. An outline on top of the
+ * mark's own border reads as two strokes around one shape, which looks like a
+ * rendering fault rather than a state, so nothing here changes when a mark is
+ * picked.
+ */
 export function MarkShape({
   mark,
   ordinal,
-  selected = false,
   aspect = 1,
   onSelect,
   onGrab,
 }: {
   mark: ImageAnnotationMark;
   ordinal: number;
-  selected?: boolean;
   aspect?: number;
   onSelect?: () => void;
   onGrab?: (event: ReactPointerEvent<HTMLElement>) => void;
 }) {
-  const ring = selected
-    ? { outline: `2px solid ${markInk(mark)}`, outlineOffset: "3px" }
-    : {};
   // Without a handler the mark is decoration, so it must not eat pointer events
   // from the surface underneath — that surface is where new marks get drawn.
   const interaction = onSelect
@@ -180,7 +183,6 @@ export function MarkShape({
           top: percent(mark.at.y),
           color: mark.ink,
           textShadow: `0 0 3px ${STROKE_HALO_INNER}, 0 0 3px ${STROKE_HALO_INNER}`,
-          ...ring,
         }}
       >
         <span className="whitespace-pre text-sm font-bold">{mark.text}</span>
@@ -198,7 +200,6 @@ export function MarkShape({
         height: percent(mark.rect.height),
         borderRadius: mark.shape === "box" ? 4 : 3,
         ...boxedFill(mark),
-        ...ring,
       }}
     >
       {mark.shape === "box" && (
@@ -209,6 +210,61 @@ export function MarkShape({
           {ordinal}
         </span>
       )}
+    </span>
+  );
+}
+
+/**
+ * A mark's note, drawn on the image itself rather than only travelling as text.
+ *
+ * The flattened copy is what the vision model actually looks at, so a sentence
+ * that only exists in the prompt makes the model match words to regions by
+ * position alone. Printed next to its mark, the instruction and the thing it is
+ * about arrive together.
+ */
+export function MarkNoteLabel({
+  mark,
+  selected = false,
+  onSelect,
+  onGrab,
+}: {
+  mark: ImageAnnotationMark;
+  selected?: boolean;
+  onSelect?: () => void;
+  onGrab?: (event: ReactPointerEvent<HTMLElement>) => void;
+}) {
+  const note = noteOnImage(mark);
+  if (!note) {
+    return null;
+  }
+
+  const interaction = onSelect
+    ? {
+        onClick: onSelect,
+        ...(onGrab ? { onPointerDown: onGrab } : {}),
+        className: "absolute cursor-move",
+        "data-testid": `annotation-note-label-${mark.id}`,
+      }
+    : { className: "pointer-events-none absolute" };
+
+  return (
+    <span
+      {...interaction}
+      style={{
+        left: percent(note.box.x),
+        top: percent(note.box.y),
+        width: percent(note.box.width),
+        color: markInk(mark),
+        // An image can be any colour under the text, so the label carries its
+        // own ground rather than relying on a halo to separate it.
+        background: NOTE_GROUND,
+        borderColor: markInk(mark),
+        ...(selected ? { outline: `2px solid ${markInk(mark)}` } : {}),
+      }}
+    >
+      <span className="block whitespace-pre-wrap break-words rounded-md border px-1.5 py-1 text-[11px] font-semibold leading-snug">
+        {note.text}
+      </span>
     </span>
   );
 }
@@ -238,6 +294,9 @@ export function AnnotationMarkLayer({
             aspect={aspect}
           />
         );
+      })}
+      {annotation.marks.map((mark) => {
+        return <MarkNoteLabel key={`${mark.id}-note`} mark={mark} />;
       })}
     </span>
   );

--- a/turbo/apps/platform/src/views/okou-page/image-annotation-marks.tsx
+++ b/turbo/apps/platform/src/views/okou-page/image-annotation-marks.tsx
@@ -224,12 +224,10 @@ export function MarkShape({
  */
 export function MarkNoteLabel({
   mark,
-  selected = false,
   onSelect,
   onGrab,
 }: {
   mark: ImageAnnotationMark;
-  selected?: boolean;
   onSelect?: () => void;
   onGrab?: (event: ReactPointerEvent<HTMLElement>) => void;
 }) {
@@ -254,12 +252,11 @@ export function MarkNoteLabel({
         left: percent(note.box.x),
         top: percent(note.box.y),
         width: percent(note.box.width),
-        color: markInk(mark),
+        color: note.ink,
         // An image can be any colour under the text, so the label carries its
         // own ground rather than relying on a halo to separate it.
         background: NOTE_GROUND,
-        borderColor: markInk(mark),
-        ...(selected ? { outline: `2px solid ${markInk(mark)}` } : {}),
+        borderColor: note.ink,
       }}
     >
       <span className="block whitespace-pre-wrap break-words rounded-md border px-1.5 py-1 text-[11px] font-semibold leading-snug">

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -73,6 +73,19 @@ const annotationRectSchema = z.object({
 });
 
 /**
+ * Where a mark's note is drawn on the image, and how wide it wraps.
+ *
+ * The note is rendered into the flattened copy, not just sent as text, so the
+ * vision model reads the sentence in place next to the region it is about. The
+ * height follows from the wrapped text, so only the width is stored.
+ */
+const annotationNoteBoxSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  width: z.number(),
+});
+
+/**
  * Ink is stored as a literal hex rather than a palette enum: the palette is a
  * design decision that will move, and an enum would turn every future palette
  * edit into a read migration for annotations already sitting in the database.
@@ -104,6 +117,7 @@ const imageAnnotationMarkSchema = z.discriminatedUnion("shape", [
     rect: annotationRectSchema,
     ink: annotationInkSchema,
     note: z.string().optional(),
+    noteBox: annotationNoteBoxSchema.optional(),
   }),
   z.object({
     id: z.string(),
@@ -113,6 +127,7 @@ const imageAnnotationMarkSchema = z.discriminatedUnion("shape", [
     to: annotationPointSchema,
     ink: annotationInkSchema,
     note: z.string().optional(),
+    noteBox: annotationNoteBoxSchema.optional(),
   }),
   z.object({
     id: z.string(),
@@ -121,6 +136,7 @@ const imageAnnotationMarkSchema = z.discriminatedUnion("shape", [
     points: z.array(annotationPointSchema),
     ink: annotationInkSchema,
     note: z.string().optional(),
+    noteBox: annotationNoteBoxSchema.optional(),
   }),
   z.object({
     id: z.string(),


### PR DESCRIPTION
Four changes to the composer image annotation editor (behind `ComposerImageAnnotation`).

### Notes are printed on the image

A mark's note only travelled as prompt text, so the vision model had to match a sentence to a region by position alone. The note is now drawn on the image — in the editor, in the read-only viewer, and in the flattened copy the model actually sees — next to the mark it explains.

- Placement is automatic under the mark and follows it, until the user drags the note. From then on `noteBox` is stored and the note stays where it was put.
- A grip on the right edge sets the wrap width; the height follows from the text.
- The note is selected and dragged in its own right, so arranging a sentence never moves the box it describes.
- The flatten wraps the text against the stored width and prints it on its own ground, because a halo does not keep a sentence readable over an arbitrary screenshot.

### Selection no longer double-strokes

A selected mark drew its own border *and* a selection outline offset 3px outside it — two strokes around one shape, which reads as a rendering fault rather than a state. The outline is gone; the handles carry selection.

### Edge handles

The eight grips are now four corners and four edges. An edge drag changes one dimension and leaves the other untouched, so squaring up a box no longer means chasing two corners. Only the corners are drawn: four dots plus four bars around a small mark is more furniture than the mark itself, so the edges are invisible strips that announce themselves through the cursor. Edges paint first so the corner dots keep their hit area.

### "Attach marks" disabled until something changes

It was enabled on an untouched image. The session now records the annotation it opened on, and the button follows whether the draft has moved from it — which also means undoing back to the start disables it again.

## Tests

- Attaching is disabled on open, enabled after a mark, and disabled again after undo
- A note typed on a mark appears on the image, and selecting the note offers its width grip rather than the mark's handles
- Dragging the top edge changes height and leaves the horizontal position alone

## Checks

- `pnpm -F @okouai/app lint` — clean
- `tsc -p tsconfig.production.json --noEmit` — clean
- `pnpm knip` — clean
- Tests: `image-annotation` (12), `attachment-chips`/`chat-draft`/`chat-lifecycle` (108), `src/signals/` (251), `api-contracts` (657)


## Fallbacks

- `turbo/apps/platform/src/signals/okou-page/image-annotation.ts` `noteOnImage`: `mark.noteBox ?? defaultNoteBox(mark)` — the unset state is the intended "never hand-placed, follows its mark" behavior of a genuinely optional field (`docs/fallback.md` §6.3/§6.4). Surface none, no rollout window, no removal condition: this is permanent product behavior, not a cross-version bridge.

## Review follow-up (b164698)

Addressed the four P1 findings from the review of `cd8fac6`:

1. A note under a mark at the bottom of the image was printed past the edge and cropped out of the flattened copy, silently, because the text still travelled in the prompt. Placement flips the note above its mark when there is no room below, `clampNoteBox` is the single owner of a legal box for both the default and the drag, and the flatten fits the box once the wrapped height is known. Covered by a new test that would fail without the flip.
2. `markInkOf`'s `REDACT_FILL` branch was unreachable — `noteOnImage` had already excluded every inkless shape. Removed; `noteOnImage` returns the ink from the mark it narrows.
3. The mark and note selections were two signals held mutually exclusive by hand at eight sites, and redo plus mark-removal cleared only the mark half. They are one `{ kind, id } | null` signal now.
4. The selected note drew an outline on top of its own border — the same double stroke this PR removes from marks. The width grip carries selection instead.
