### PR TITLE
feat(auth): prepare okou primary-domain cutover

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -221,7 +221,6 @@
         var PREVIEW_API_HOSTNAME_PATTERN =
           /^(?:staging|pr-[0-9]+)-api\.vm6\.ai$/;
         var PREVIEW_API_ROOT_DOMAIN = "vm6.ai";
-        var PRODUCTION_SATELLITE_DOMAIN = "app.okou.ai";
         var PROTECTION_BYPASS_NAME = "x-vercel-protection-bypass";
         var hostname = location.hostname.toLowerCase();
         var production =
@@ -229,12 +228,31 @@
           hostname.endsWith(".vm0.ai") ||
           hostname === "okou.ai" ||
           hostname.endsWith(".okou.ai");
-        var satellite =
-          hostname === "app.okou.ai" || hostname.endsWith(".app.okou.ai");
         var publishableKey = production
           ? "%VITE_CLERK_PUBLISHABLE_KEY_PROD%"
           : "%VITE_CLERK_PUBLISHABLE_KEY_PREVIEW%";
-        var authOrigin = satellite ? "https://app.vm0.ai" : location.origin;
+        var primaryClerkFrontendApi = clerkFrontendApi(publishableKey);
+        var okouPrimary = primaryClerkFrontendApi === "clerk.app.okou.ai";
+        var satelliteDomain = null;
+        if (
+          production &&
+          okouPrimary &&
+          isDomainOrSubdomain(hostname, "vm0.ai")
+        ) {
+          satelliteDomain = "vm0.ai";
+        } else if (
+          production &&
+          !okouPrimary &&
+          isDomainOrSubdomain(hostname, "app.okou.ai")
+        ) {
+          satelliteDomain = "app.okou.ai";
+        }
+        var satellite = satelliteDomain !== null;
+        var authOrigin = satellite
+          ? okouPrimary
+            ? "https://app.okou.ai"
+            : "https://app.vm0.ai"
+          : location.origin;
         var loadOptions = {
           afterSignOutUrl: new URL("/sign-in", authOrigin).toString(),
           signInUrl: new URL("/sign-in", authOrigin).toString(),
@@ -255,7 +273,7 @@
             onboardingController.abort();
           },
           clientSessionId: clientSessionId,
-          domain: satellite ? PRODUCTION_SATELLITE_DOMAIN : undefined,
+          domain: satelliteDomain || undefined,
           loadOptions: loadOptions,
           publishableKey: publishableKey,
         };
@@ -263,6 +281,17 @@
 
         function isDomainOrSubdomain(value, domain) {
           return value === domain || value.endsWith("." + domain);
+        }
+
+        function clerkFrontendApi(key) {
+          var encoded = key.split("_")[2];
+          if (!encoded) return "";
+          try {
+            var decoded = atob(encoded);
+            return decoded.endsWith("$") ? decoded.slice(0, -1) : "";
+          } catch (_error) {
+            return "";
+          }
         }
 
         function rewriteServiceHostname(value, target) {
@@ -594,7 +623,7 @@
         script.dataset.clerkJsScript = "";
         script.dataset.clerkPublishableKey = publishableKey;
         if (satellite) {
-          script.dataset.clerkDomain = PRODUCTION_SATELLITE_DOMAIN;
+          script.dataset.clerkDomain = satelliteDomain;
         }
         script.onerror = function () {
           script.remove();

--- a/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
@@ -21,6 +21,7 @@ vi.unmock("@clerk/shared/loadClerkJsScript");
 
 const PREVIEW_FRONTEND_API_HOST = "informed-calf-6.clerk.accounts.dev";
 const PRODUCTION_FRONTEND_API_HOST = "clerk.vm0.ai";
+const OKOU_PRODUCTION_FRONTEND_API_HOST = "clerk.app.okou.ai";
 const PRODUCTION_SATELLITE_DOMAIN = "app.okou.ai";
 const CLERK_BOOTSTRAP_SELECTOR = "script[data-vm0-clerk-bootstrap]";
 const CLERK_CORE_SCRIPT_ID = "vm0-clerk-core-script";
@@ -68,6 +69,7 @@ interface ClerkPageOptions {
   readonly apiOriginMarker?: string | null;
   readonly cookie?: string;
   readonly path?: string;
+  readonly productionPublishableKey?: string;
   readonly url?: string;
 }
 
@@ -85,6 +87,10 @@ const PRODUCTION_PUBLISHABLE_KEY = publishableKey(
   "live",
   PRODUCTION_FRONTEND_API_HOST,
 );
+const OKOU_PRODUCTION_PUBLISHABLE_KEY = publishableKey(
+  "live",
+  OKOU_PRODUCTION_FRONTEND_API_HOST,
+);
 
 function expectedClerkScriptUrl(): string {
   return `https://cdn.jsdelivr.net/npm/@clerk/clerk-js@${CLERK_JS_VERSION}/dist/clerk.browser.js`;
@@ -94,12 +100,17 @@ function expectedFallbackClerkScriptUrl(host: string): string {
   return `https://${host}/npm/@clerk/clerk-js@${CLERK_JS_VERSION}/dist/clerk.browser.js`;
 }
 
-function stubClerkBuildEnvironment(): void {
+function stubClerkBuildEnvironment(
+  productionPublishableKey = PRODUCTION_PUBLISHABLE_KEY,
+): void {
   vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PREVIEW", PREVIEW_PUBLISHABLE_KEY);
-  vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PROD", PRODUCTION_PUBLISHABLE_KEY);
+  vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PROD", productionPublishableKey);
 }
 
-function builtIndexHtml(appVersion = TEST_APP_VERSION): string {
+function builtIndexHtml(
+  appVersion = TEST_APP_VERSION,
+  productionPublishableKey = PRODUCTION_PUBLISHABLE_KEY,
+): string {
   return transformClerkCoreScriptUrls(
     indexHtml
       .replaceAll(
@@ -108,7 +119,7 @@ function builtIndexHtml(appVersion = TEST_APP_VERSION): string {
       )
       .replaceAll(
         "%VITE_CLERK_PUBLISHABLE_KEY_PROD%",
-        PRODUCTION_PUBLISHABLE_KEY,
+        productionPublishableKey,
       ),
     {
       appVersion,
@@ -150,9 +161,12 @@ function executeClerkBootstrap(html: string): void {
 
 function captureClerkBootstrapScript(
   url: string,
-  options: Pick<ClerkPageOptions, "apiOriginMarker" | "cookie"> = {},
+  options: Pick<
+    ClerkPageOptions,
+    "apiOriginMarker" | "cookie" | "productionPublishableKey"
+  > = {},
 ): HTMLScriptElement {
-  stubClerkBuildEnvironment();
+  stubClerkBuildEnvironment(options.productionPublishableKey);
   context.mocks.browser.url(url, {
     apiOriginMarker: options.apiOriginMarker,
   });
@@ -170,7 +184,10 @@ function captureClerkBootstrapScript(
     },
     { once: true },
   );
-  const html = builtIndexHtml();
+  const html = builtIndexHtml(
+    TEST_APP_VERSION,
+    options.productionPublishableKey,
+  );
   const clerkScript = createClerkCoreScript(html);
   const scriptUrl = clerkScript.src;
   clerkScript.removeAttribute("src");
@@ -184,7 +201,7 @@ function captureClerkBootstrapScript(
 function startClerkPage(
   options: ClerkPageOptions = {},
 ): ClerkEntrypointHarness {
-  stubClerkBuildEnvironment();
+  stubClerkBuildEnvironment(options.productionPublishableKey);
   const requests: ClerkScriptRequest[] = [];
   const clerkLoaderWatchingEarlyScript = context.mocks.deferred<void>();
   const retryStarted = context.mocks.deferred<void>();
@@ -234,7 +251,10 @@ function startClerkPage(
           return observeScript(appendToBody, node);
         });
 
-      const html = builtIndexHtml();
+      const html = builtIndexHtml(
+        TEST_APP_VERSION,
+        options.productionPublishableKey,
+      );
       const staticClerkScript = createClerkCoreScript(html);
       document.head.appendChild(staticClerkScript);
       earlyScript = staticClerkScript;
@@ -417,6 +437,7 @@ describe("platform Clerk entrypoint", () => {
     {
       authOrigin: "https://pr-30199-app.omby.ai",
       domain: null,
+      productionPublishableKey: PRODUCTION_PUBLISHABLE_KEY,
       publishableKey: PREVIEW_PUBLISHABLE_KEY,
       scriptUrl: expectedClerkScriptUrl(),
       url: "https://pr-30199-app.omby.ai/",
@@ -424,6 +445,7 @@ describe("platform Clerk entrypoint", () => {
     {
       authOrigin: "https://app.vm0.ai",
       domain: null,
+      productionPublishableKey: PRODUCTION_PUBLISHABLE_KEY,
       publishableKey: PRODUCTION_PUBLISHABLE_KEY,
       scriptUrl: expectedClerkScriptUrl(),
       url: "https://app.vm0.ai/",
@@ -431,21 +453,48 @@ describe("platform Clerk entrypoint", () => {
     {
       authOrigin: "https://app.vm0.ai",
       domain: PRODUCTION_SATELLITE_DOMAIN,
+      productionPublishableKey: PRODUCTION_PUBLISHABLE_KEY,
       publishableKey: PRODUCTION_PUBLISHABLE_KEY,
       scriptUrl: expectedClerkScriptUrl(),
       url: "https://app.okou.ai/",
     },
     {
+      authOrigin: "https://app.okou.ai",
+      domain: null,
+      productionPublishableKey: OKOU_PRODUCTION_PUBLISHABLE_KEY,
+      publishableKey: OKOU_PRODUCTION_PUBLISHABLE_KEY,
+      scriptUrl: expectedClerkScriptUrl(),
+      url: "https://app.okou.ai/",
+    },
+    {
+      authOrigin: "https://app.okou.ai",
+      domain: "vm0.ai",
+      productionPublishableKey: OKOU_PRODUCTION_PUBLISHABLE_KEY,
+      publishableKey: OKOU_PRODUCTION_PUBLISHABLE_KEY,
+      scriptUrl: expectedClerkScriptUrl(),
+      url: "https://app.vm0.ai/",
+    },
+    {
       authOrigin: "https://okou.ai.evil.example",
       domain: null,
+      productionPublishableKey: PRODUCTION_PUBLISHABLE_KEY,
       publishableKey: PREVIEW_PUBLISHABLE_KEY,
       scriptUrl: expectedClerkScriptUrl(),
       url: "https://okou.ai.evil.example/",
     },
   ])(
     "selects the Clerk core configuration on $url",
-    ({ authOrigin, domain, publishableKey, scriptUrl, url }) => {
-      const script = captureClerkBootstrapScript(url);
+    ({
+      authOrigin,
+      domain,
+      productionPublishableKey,
+      publishableKey,
+      scriptUrl,
+      url,
+    }) => {
+      const script = captureClerkBootstrapScript(url, {
+        productionPublishableKey,
+      });
       const bootstrap = window.__vm0ClerkBootstrap;
       if (!bootstrap) {
         throw new Error("Clerk bootstrap did not expose its shared state");

--- a/turbo/apps/platform/src/lib/__tests__/clerk-production-topology.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/clerk-production-topology.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveClerkProductionSatelliteDomain,
+  resolveClerkProductionTopology,
+} from "../clerk-production-topology.ts";
+
+const VM0_PRIMARY_PUBLISHABLE_KEY = "pk_live_Y2xlcmsudm0wLmFpJA";
+const OKOU_PRIMARY_PUBLISHABLE_KEY = "pk_live_Y2xlcmsuYXBwLm9rb3UuYWkk";
+
+describe("clerk production topology", () => {
+  it("keeps the deployed VM0 primary topology for the legacy key", () => {
+    expect(
+      resolveClerkProductionTopology(VM0_PRIMARY_PUBLISHABLE_KEY),
+    ).toStrictEqual({
+      primaryAppOrigin: "https://app.vm0.ai",
+      primaryBrand: "vm0",
+      primaryUserProfileUrl: "https://accounts.vm0.ai/user",
+    });
+    expect(
+      resolveClerkProductionSatelliteDomain(
+        "app.okou.ai",
+        VM0_PRIMARY_PUBLISHABLE_KEY,
+      ),
+    ).toBe("app.okou.ai");
+    expect(
+      resolveClerkProductionSatelliteDomain(
+        "app.vm0.ai",
+        VM0_PRIMARY_PUBLISHABLE_KEY,
+      ),
+    ).toBeNull();
+  });
+
+  it("switches VM0 hosts to the root satellite when Okou is primary", () => {
+    expect(
+      resolveClerkProductionTopology(OKOU_PRIMARY_PUBLISHABLE_KEY),
+    ).toStrictEqual({
+      primaryAppOrigin: "https://app.okou.ai",
+      primaryBrand: "okou",
+      primaryUserProfileUrl: "https://accounts.app.okou.ai/user",
+    });
+    expect(
+      resolveClerkProductionSatelliteDomain(
+        "app.okou.ai",
+        OKOU_PRIMARY_PUBLISHABLE_KEY,
+      ),
+    ).toBeNull();
+    expect(
+      resolveClerkProductionSatelliteDomain(
+        "app.vm0.ai",
+        OKOU_PRIMARY_PUBLISHABLE_KEY,
+      ),
+    ).toBe("vm0.ai");
+    expect(
+      resolveClerkProductionSatelliteDomain(
+        "www.vm0.ai",
+        OKOU_PRIMARY_PUBLISHABLE_KEY,
+      ),
+    ).toBe("vm0.ai");
+    expect(
+      resolveClerkProductionSatelliteDomain(
+        "vm0.ai.evil.example",
+        OKOU_PRIMARY_PUBLISHABLE_KEY,
+      ),
+    ).toBeNull();
+  });
+
+  it("falls back to the rollback-safe VM0 topology for an unknown key", () => {
+    expect(resolveClerkProductionTopology("invalid-key")).toMatchObject({
+      primaryAppOrigin: "https://app.vm0.ai",
+      primaryBrand: "vm0",
+    });
+  });
+});

--- a/turbo/apps/platform/src/lib/clerk-production-topology.ts
+++ b/turbo/apps/platform/src/lib/clerk-production-topology.ts
@@ -1,0 +1,62 @@
+import { parsePublishableKey } from "@clerk/shared/keys";
+
+export const OKOU_CLERK_PRIMARY_APP_ORIGIN = "https://app.okou.ai";
+export const VM0_CLERK_PRIMARY_APP_ORIGIN = "https://app.vm0.ai";
+
+const OKOU_CLERK_FRONTEND_API = "clerk.app.okou.ai";
+const OKOU_CLERK_PRIMARY_USER_PROFILE_URL = "https://accounts.app.okou.ai/user";
+const VM0_CLERK_PRIMARY_USER_PROFILE_URL = "https://accounts.vm0.ai/user";
+
+export type ClerkProductionDomain = "app.okou.ai" | "vm0.ai";
+
+interface ClerkProductionTopology {
+  readonly primaryAppOrigin:
+    | typeof OKOU_CLERK_PRIMARY_APP_ORIGIN
+    | typeof VM0_CLERK_PRIMARY_APP_ORIGIN;
+  readonly primaryUserProfileUrl:
+    | typeof OKOU_CLERK_PRIMARY_USER_PROFILE_URL
+    | typeof VM0_CLERK_PRIMARY_USER_PROFILE_URL;
+  readonly primaryBrand: "okou" | "vm0";
+}
+
+function isDomainOrSubdomain(hostname: string, domain: string): boolean {
+  return hostname === domain || hostname.endsWith(`.${domain}`);
+}
+
+// The production domain change generates a new publishable key whose decoded
+// Frontend API hostname identifies the active primary. Keeping the legacy VM0
+// fallback makes the same artifact safe before the cutover and during rollback.
+export function resolveClerkProductionTopology(
+  publishableKey: string,
+): ClerkProductionTopology {
+  const frontendApi = parsePublishableKey(publishableKey)?.frontendApi;
+  if (frontendApi === OKOU_CLERK_FRONTEND_API) {
+    return {
+      primaryAppOrigin: OKOU_CLERK_PRIMARY_APP_ORIGIN,
+      primaryBrand: "okou",
+      primaryUserProfileUrl: OKOU_CLERK_PRIMARY_USER_PROFILE_URL,
+    };
+  }
+
+  return {
+    primaryAppOrigin: VM0_CLERK_PRIMARY_APP_ORIGIN,
+    primaryBrand: "vm0",
+    primaryUserProfileUrl: VM0_CLERK_PRIMARY_USER_PROFILE_URL,
+  };
+}
+
+export function resolveClerkProductionSatelliteDomain(
+  hostname: string,
+  publishableKey: string,
+): ClerkProductionDomain | null {
+  const normalizedHostname = hostname.toLowerCase();
+  const topology = resolveClerkProductionTopology(publishableKey);
+
+  if (topology.primaryBrand === "okou") {
+    return isDomainOrSubdomain(normalizedHostname, "vm0.ai") ? "vm0.ai" : null;
+  }
+
+  return isDomainOrSubdomain(normalizedHostname, "app.okou.ai")
+    ? "app.okou.ai"
+    : null;
+}

--- a/turbo/apps/platform/src/lib/platform-host.ts
+++ b/turbo/apps/platform/src/lib/platform-host.ts
@@ -35,7 +35,6 @@ const OKOU_ROOT_DOMAINS = [
 const PREVIEW_API_DOMAIN = "vm6.ai";
 const PRODUCTION_HOSTED_SITE_DOMAINS = ["sites.vm0.io", "okou.app"] as const;
 const PREVIEW_HOSTED_SITE_DOMAINS = ["sites.vm7.io"] as const;
-export const PRODUCTION_SATELLITE_HOSTNAME = "app.okou.ai";
 const PLATFORM_SERVICE_LABELS = ["platform", "app", "www", "api"] as const;
 
 function browserHostname(): string | null {
@@ -68,14 +67,6 @@ function resolvePlatformPublicBrand(
 export function isOkouProductionHostname(hostname: string): boolean {
   const normalizedHostname = hostname.toLowerCase();
   return isDomainOrSubdomain(normalizedHostname, OKOU_PRODUCTION_DOMAIN);
-}
-
-export function isProductionSatelliteHostname(hostname: string): boolean {
-  const normalizedHostname = hostname.toLowerCase();
-  return (
-    normalizedHostname === PRODUCTION_SATELLITE_HOSTNAME ||
-    normalizedHostname.endsWith(`.${PRODUCTION_SATELLITE_HOSTNAME}`)
-  );
 }
 
 function isProductionHostname(hostname: string): boolean {

--- a/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
@@ -1,5 +1,5 @@
 import { waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { detachedSetupPage, setupPage } from "../../__tests__/page-helper.ts";
 import {
@@ -151,6 +151,29 @@ describe("platform auth URLs", () => {
       isSatellite: true,
       satelliteAutoSync: true,
     });
+  });
+
+  it("uses Okou auth and the VM0 root satellite after the cutover", () => {
+    vi.stubEnv(
+      "VITE_CLERK_PUBLISHABLE_KEY_PROD",
+      "pk_live_Y2xlcmsuYXBwLm9rb3UuYWkk",
+    );
+    try {
+      setBrowserUrl("https://app.okou.ai/agents");
+      expect(resolveAppAuthUrl("/sign-in")).toBe("https://app.okou.ai/sign-in");
+      expect(resolveWebOrigin()).toBe("https://www.okou.ai");
+      expect(resolveClerkSatelliteConfig()).toBeNull();
+
+      setBrowserUrl("https://app.vm0.ai/agents");
+      expect(resolveAppAuthUrl("/sign-in")).toBe("https://app.okou.ai/sign-in");
+      expect(resolveClerkSatelliteConfig()).toStrictEqual({
+        domain: "vm0.ai",
+        isSatellite: true,
+        satelliteAutoSync: true,
+      });
+    } finally {
+      vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PROD", "test_production_key");
+    }
   });
 
   it("does not enable satellite mode on an unregistered okou.ai sibling", () => {

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -14,12 +14,17 @@ import {
 import { appendCapturedPreviewBypassToUrl } from "../lib/preview-bypass-cookie.ts";
 import {
   derivePlatformServiceOrigin,
-  isProductionSatelliteHostname,
-  PRODUCTION_SATELLITE_HOSTNAME,
+  isOkouProductionHostname,
   type PlatformService,
   resolvePlatformEnvironment,
   resolvePlatformRuntimeConfig,
 } from "../lib/platform-host.ts";
+import {
+  resolveClerkProductionSatelliteDomain,
+  resolveClerkProductionTopology,
+  type ClerkProductionDomain,
+  VM0_CLERK_PRIMARY_APP_ORIGIN,
+} from "../lib/clerk-production-topology.ts";
 import { resolveBrandNameForHostname, type BrandName } from "./branding.ts";
 import { bestEffort, onDomEventFn } from "./utils.ts";
 import { createAuthRecovery, setupForegroundCatchUp$ } from "./auth-retry.ts";
@@ -33,14 +38,17 @@ const clerkVersion$ = state(0);
 const ATTRIBUTION_SOURCE_PARAM = "vm0_source";
 const HOMEPAGE_ATTRIBUTION_VALUE = "homepage";
 const VM0_ONBOARDING_PATH = "/onboarding";
-const CLERK_PRIMARY_APP_ORIGIN = "https://app.vm0.ai";
 const CLERK_SATELLITE_REDIRECT_ORIGIN_PATTERN =
   /^https:\/\/(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*okou\.ai(?::\d+)?$/i;
+const PRODUCTION_VM0_AUTH_REDIRECT_ORIGINS = [
+  VM0_CLERK_PRIMARY_APP_ORIGIN,
+  "https://www.vm0.ai",
+] as const;
 
 type AllowedAuthRedirectOrigin = string | RegExp;
 
 interface ClerkSatelliteConfig {
-  readonly domain: typeof PRODUCTION_SATELLITE_HOSTNAME;
+  readonly domain: ClerkProductionDomain;
   readonly isSatellite: true;
   readonly satelliteAutoSync: true;
 }
@@ -89,7 +97,16 @@ const MAX_URL_PORT = 65_535;
 export function deriveServiceOrigin(
   currentOrigin: string,
   service: Extract<PlatformService, "www" | "app" | "api">,
+  publishableKey = resolvePlatformRuntimeConfig().clerkPublishableKey,
 ): string {
+  const currentUrl = new URL(currentOrigin);
+  if (
+    isOkouProductionHostname(currentUrl.hostname) &&
+    resolveClerkProductionTopology(publishableKey).primaryBrand === "okou"
+  ) {
+    currentUrl.hostname = `${service}.okou.ai`;
+    return currentUrl.origin;
+  }
   return derivePlatformServiceOrigin(currentOrigin, service);
 }
 
@@ -108,24 +125,40 @@ function resolveAppOrigin(): string {
 }
 
 export function resolveClerkSatelliteConfig(): ClerkSatelliteConfig | null {
-  if (
-    typeof location === "undefined" ||
-    !isProductionSatelliteHostname(location.hostname)
-  ) {
+  if (typeof location === "undefined") {
+    return null;
+  }
+
+  const publishableKey = resolvePlatformRuntimeConfig().clerkPublishableKey;
+  const domain = resolveClerkProductionSatelliteDomain(
+    location.hostname,
+    publishableKey,
+  );
+  if (!domain) {
     return null;
   }
 
   return {
-    domain: PRODUCTION_SATELLITE_HOSTNAME,
+    domain,
     isSatellite: true,
     satelliteAutoSync: true,
   };
 }
 
 function resolveAuthOrigin(): string {
-  return resolveClerkSatelliteConfig()
-    ? CLERK_PRIMARY_APP_ORIGIN
+  const publishableKey = resolvePlatformRuntimeConfig().clerkPublishableKey;
+  return resolveClerkProductionSatelliteDomain(
+    location.hostname,
+    publishableKey,
+  )
+    ? resolveClerkProductionTopology(publishableKey).primaryAppOrigin
     : resolveAppOrigin();
+}
+
+export function resolvePrimaryClerkUserProfileUrl(): string {
+  return resolveClerkProductionTopology(
+    resolvePlatformRuntimeConfig().clerkPublishableKey,
+  ).primaryUserProfileUrl;
 }
 
 function parseUrl(value: string): URL | null {
@@ -198,7 +231,10 @@ export function getAllowedAuthRedirectOrigins(): AllowedAuthRedirectOrigin[] {
   }
   const productionOrigins =
     resolvePlatformEnvironment() === "production"
-      ? [CLERK_PRIMARY_APP_ORIGIN, CLERK_SATELLITE_REDIRECT_ORIGIN_PATTERN]
+      ? [
+          ...PRODUCTION_VM0_AUTH_REDIRECT_ORIGINS,
+          CLERK_SATELLITE_REDIRECT_ORIGIN_PATTERN,
+        ]
       : [];
   return [
     ...new Set([

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
@@ -1297,6 +1297,38 @@ describe("zero sidebar account menu", () => {
     );
   });
 
+  it("links the VM0 satellite to the Okou hosted user profile after cutover", async () => {
+    vi.stubEnv(
+      "VITE_CLERK_PUBLISHABLE_KEY_PROD",
+      "pk_live_Y2xlcmsuYXBwLm9rb3UuYWkk",
+    );
+    try {
+      context.mocks.browser.url("https://app.vm0.ai/");
+      prepareDefaultAgent();
+
+      detachedSetupPage({
+        context,
+        path: `/agents/${AGENT_ID}/chat`,
+        user: {
+          id: "test-user-123",
+          fullName: "Alex Rivera",
+          email: "alex.rivera@example.test",
+        },
+      });
+
+      const menu = await openAccountMenu();
+      click(within(menu).getByText("Settings"));
+
+      await screen.findByRole("dialog", { name: "Settings" });
+      expect(linkByText("Manage")).toHaveAttribute(
+        "href",
+        "https://accounts.app.okou.ai/user",
+      );
+    } finally {
+      vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PROD", "test_production_key");
+    }
+  });
+
   it("hides debug settings when OkouDebug is disabled", async () => {
     prepareDefaultAgent();
 

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/account-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/account-section.tsx
@@ -5,12 +5,10 @@ import { Button } from "@okouai/ui/components/ui/button";
 import {
   clerk$,
   currentUserInfo$,
+  resolvePrimaryClerkUserProfileUrl,
   resolveClerkSatelliteConfig,
 } from "../../../../../signals/auth.ts";
 import { UserAvatar } from "../../../../components/avatar.tsx";
-
-// Clerk satellite domains do not receive their own hosted Account Portal.
-const CLERK_PRIMARY_USER_PROFILE_URL = "https://accounts.vm0.ai/user";
 
 export function AccountSection() {
   const { t } = useTranslation();
@@ -20,7 +18,7 @@ export function AccountSection() {
   const userLoadable = useLoadable(currentUserInfo$);
   const user = userLoadable.state === "hasData" ? userLoadable.data : undefined;
   const userProfileUrl = resolveClerkSatelliteConfig()
-    ? CLERK_PRIMARY_USER_PROFILE_URL
+    ? resolvePrimaryClerkUserProfileUrl()
     : clerk?.buildUrlWithAuth(clerk.buildUserProfileUrl());
 
   const displayName = user?.fullName ?? user?.firstName ?? "";


### PR DESCRIPTION
## Summary

- derive the active Clerk production primary from the publishable key in both the early HTML bootstrap and application runtime
- make `app.okou.ai` primary and the `vm0.ai` root a satellite when the new `clerk.app.okou.ai` key is deployed
- preserve the current VM0-primary behavior under the existing key for staged deployment and rollback
- route auth URLs, allowed redirect origins, Okou web links, and the hosted Account Portal through the active primary

## Deployment dependency

Companion: vm0-ai/vm0-marketing#520.

Both PRs may merge independently, but both compatible builds must be deployed with the current `clerk.vm0.ai` key before any Clerk production mutation. Then:

1. allow the new Google OAuth origin and Clerk callback
2. pre-provision Clerk primary DNS for secondary application `app.okou.ai`
3. change the Clerk primary, ensure `vm0.ai` is registered as a root satellite, and wait for DNS/certificates
4. update both production publishable-key variables to the generated `clerk.app.okou.ai` key and redeploy
5. verify Okou sign-up/sign-in/callback/redirect plus VM0 compatibility

The Clerk domain change invalidates existing sessions. The shared instance preserves users and organizations, but the 15 accounts currently holding passkeys must use another factor and enroll a new Okou-domain passkey. Keep `clerk.vm0.ai` as the VM0 satellite and for existing invitation/email links through the rollback window.

Rollback changes the Clerk primary back to `vm0.ai`, ensures the Okou satellites are restored, updates both repositories to the newly generated matching VM0 key, and redeploys. No code revert is required.

Do not close #27750 until production verification succeeds.

## Verification

- `pnpm exec vitest run src/lib/__tests__/clerk-production-topology.test.ts src/signals/__tests__/auth-url.test.ts src/__tests__/clerk-entrypoint.test.ts src/__tests__/platform-runtime-environment.test.ts src/views/okou-page/__tests__/sidebar-account-menu.test.tsx` — 85 passed on the rebased head
- `pnpm check-types`
- `pnpm lint`
- full monorepo `pnpm lint` also passed during pre-commit verification

Refs #27750