### PR TITLE
refactor(runtime): require canonical platform environment

### DIFF
--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -525,16 +525,9 @@ pub fn is_guest_agent_tuning_env_key(key: &str) -> bool {
 /// or integration contracts. Runner and local-submit code use this predicate to
 /// scrub or reject user-provided env keys before the guest-agent starts.
 pub fn is_runner_owned_env_key(key: &str) -> bool {
-    key.starts_with("OKOU_") || is_pre_platform_environment_runner_owned_env_key(key)
-}
-
-/// Returns whether `key` was runner-owned before `platformEnvironment` claims.
-///
-/// New runners use this only for old API claims or legitimately stored pre-field
-/// contexts. Remove it after previous API rollback targets, supported pre-field
-/// contexts, and old runners/sandboxes pass the #28914 drain gates.
-pub fn is_pre_platform_environment_runner_owned_env_key(key: &str) -> bool {
-    key.starts_with("VM0_") || EXPLICIT_RUNNER_OWNED_ENV_KEYS.contains(&key)
+    key.starts_with("OKOU_")
+        || key.starts_with("VM0_")
+        || EXPLICIT_RUNNER_OWNED_ENV_KEYS.contains(&key)
 }
 
 /// Escapes and bounds a user-controlled env key for diagnostics.
@@ -832,23 +825,6 @@ mod tests {
         assert!(is_runner_owned_env_key("OKOU_TOKEN"));
         assert!(is_runner_owned_env_key("OKOU_UNRELATED"));
         assert!(!is_runner_owned_env_key("CUSTOM_ENV"));
-    }
-
-    #[test]
-    fn pre_platform_environment_detection_preserves_previous_ownership() {
-        assert!(is_pre_platform_environment_runner_owned_env_key(RUN_ID_ENV));
-        assert!(is_pre_platform_environment_runner_owned_env_key(
-            "VM0_FUTURE_RUNNER_KEY"
-        ));
-        assert!(!is_pre_platform_environment_runner_owned_env_key(
-            "OKOU_TOKEN"
-        ));
-        assert!(!is_pre_platform_environment_runner_owned_env_key(
-            "OKOU_UNRELATED"
-        ));
-        assert!(!is_pre_platform_environment_runner_owned_env_key(
-            "CUSTOM_ENV"
-        ));
     }
 
     #[test]

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -383,18 +383,9 @@ fn for_each_guest_user_env_entry<'a>(
     context: &'a ExecutionContext,
     mut visit: impl FnMut(&'a str, &'a str),
 ) {
-    let is_untrusted_runner_owned: fn(&str) -> bool = if context.platform_environment.is_some() {
-        is_runner_owned_env_key
-    } else {
-        // Old API/stored context -> new runner: preserve the exact
-        // pre-platformEnvironment filter until prior API rollback targets,
-        // supported pre-field contexts, and old runners/sandboxes pass the
-        // #28914 drain gates.
-        guest_contracts::env::is_pre_platform_environment_runner_owned_env_key
-    };
     for_each_filtered_environment_entry(
         context.environment.as_ref(),
-        is_untrusted_runner_owned,
+        is_runner_owned_env_key,
         &mut visit,
     );
 
@@ -408,10 +399,8 @@ fn for_each_guest_user_env_entry<'a>(
         }
     }
 
-    if let Some(platform_environment) = &context.platform_environment {
-        for (key, value) in platform_environment {
-            visit(key, value);
-        }
+    for (key, value) in &context.platform_environment {
+        visit(key, value);
     }
 }
 

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -686,7 +686,7 @@ fn platform_environment_claim_filters_untrusted_namespaces_and_applies_trusted_l
             "untrusted-bypass".into(),
         ),
     ]));
-    ctx.platform_environment = Some(HashMap::from([
+    ctx.platform_environment = HashMap::from([
         ("DUPLICATE".into(), "trusted".into()),
         ("OKOU_TOKEN".into(), "trusted-token".into()),
         ("OKOU_PLATFORM_ONLY".into(), "trusted-platform".into()),
@@ -695,7 +695,7 @@ fn platform_environment_claim_filters_untrusted_namespaces_and_applies_trusted_l
             guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV.into(),
             "trusted-bypass".into(),
         ),
-    ]));
+    ]);
 
     assert_eq!(
         build_user_env_json(&ctx),
@@ -711,153 +711,6 @@ fn platform_environment_claim_filters_untrusted_namespaces_and_applies_trusted_l
             ),
         ])
     );
-}
-
-#[test]
-fn platform_environment_overlays_legacy_environment() {
-    let mut ctx = minimal_context();
-    ctx.environment = Some(HashMap::from([
-        ("DUPLICATE".into(), "legacy".into()),
-        ("LEGACY_ONLY".into(), "legacy-only".into()),
-    ]));
-    ctx.platform_environment = Some(HashMap::from([
-        ("DUPLICATE".into(), "trusted".into()),
-        ("PLATFORM_ONLY".into(), "platform-only".into()),
-    ]));
-
-    let environment = build_user_env_json(&ctx);
-
-    assert_eq!(environment["DUPLICATE"], "trusted");
-    assert_eq!(environment["LEGACY_ONLY"], "legacy-only");
-    assert_eq!(environment["PLATFORM_ONLY"], "platform-only");
-}
-
-#[test]
-fn fieldless_context_preserves_pre_platform_environment_filtering() {
-    let mut ctx = minimal_context();
-    ctx.cli_agent_type = "codex".into();
-    ctx.environment = Some(HashMap::from([
-        ("CUSTOM_ENV".into(), "kept".into()),
-        ("OKOU_TOKEN".into(), "legitimate-okou-token".into()),
-        ("OKOU_UNRELATED".into(), "legacy-okou-value".into()),
-        (
-            guest_contracts::env::RUN_ID_ENV.into(),
-            "user-controlled-run-id".into(),
-        ),
-        (
-            guest_contracts::env::PI_SESSION_ID_ENV.into(),
-            "user-controlled-pi-session".into(),
-        ),
-        (
-            guest_contracts::env::PI_LAUNCH_CONFIG_ENV.into(),
-            "user-controlled-pi-prompt".into(),
-        ),
-        (
-            guest_contracts::env::PI_MODEL_CONFIG_ENV.into(),
-            "user-controlled-pi-model".into(),
-        ),
-        (
-            guest_contracts::env::PROMPT_ENV.into(),
-            "user prompt".into(),
-        ),
-        ("VM0_API_TOKEN".into(), "stolen".into()),
-        (
-            guest_contracts::env::WORKING_DIR_ENV.into(),
-            "/legacy".into(),
-        ),
-        (
-            "VM0_GUEST_RUNTIME_DIR".into(),
-            "/user/controlled/runtime".into(),
-        ),
-        (
-            guest_contracts::env::FEATURE_FLAGS_ENV.into(),
-            r#"{"bad":true}"#.into(),
-        ),
-        ("VM0_FUTURE_RUNNER_KEY".into(), "future".into()),
-        (
-            guest_contracts::env::CLI_AGENT_TYPE_ENV.into(),
-            "claude-code".into(),
-        ),
-        (
-            guest_contracts::env::USE_MOCK_CLAUDE_ENV.into(),
-            "true".into(),
-        ),
-        (guest_contracts::env::USE_MOCK_CODEX_ENV.into(), "1".into()),
-        (
-            guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV.into(),
-            "user-bypass".into(),
-        ),
-        (
-            guest_contracts::env::DISALLOWED_TOOLS_ENV.into(),
-            "CronCreate".into(),
-        ),
-        (guest_contracts::env::TOOLS_ENV.into(), "Bash".into()),
-        (
-            guest_contracts::env::SETTINGS_ENV.into(),
-            r#"{"hooks":{}}"#.into(),
-        ),
-        ("VM0_MOCK_CLAUDE_PATH".into(), "/tmp/mock-claude".into()),
-        ("VM0_MOCK_CODEX_PATH".into(), "/tmp/mock-codex".into()),
-        ("VM0_USER_ENV_FILE".into(), "/tmp/user-env".into()),
-        ("VM0_RUN_PAYLOAD_FILE".into(), "/tmp/run-payload".into()),
-    ]));
-
-    let bootstrap_env = build_env_for_test(&ctx, "http://localhost");
-    let user_env = build_user_env_json(&ctx);
-
-    assert!(!bootstrap_env.contains_key("CUSTOM_ENV"));
-    assert!(!bootstrap_env.contains_key("VM0_PROMPT"));
-    assert_eq!(
-        build_run_payload_for_run(&ctx).unwrap().prompt,
-        "test prompt"
-    );
-    assert_eq!(
-        bootstrap_env
-            .get(guest_contracts::env::CANONICAL_API_TOKEN_ENV)
-            .unwrap(),
-        "tok"
-    );
-    assert!(!bootstrap_env.contains_key("VM0_API_TOKEN"));
-    assert_eq!(
-        bootstrap_env.get(guest_contracts::env::RUN_ID_ENV).unwrap(),
-        &ctx.run_id.to_string()
-    );
-    assert_eq!(
-        bootstrap_env
-            .get(guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV)
-            .unwrap(),
-        &guest_runtime_dir(ctx.run_id).unwrap()
-    );
-    assert!(!bootstrap_env.contains_key("VM0_GUEST_RUNTIME_DIR"));
-    assert_eq!(bootstrap_env.get("CLI_AGENT_TYPE").unwrap(), "codex");
-    assert_eq!(user_env.get("CUSTOM_ENV").unwrap(), "kept");
-    assert_eq!(user_env.get("OKOU_TOKEN").unwrap(), "legitimate-okou-token");
-    assert_eq!(user_env.get("OKOU_UNRELATED").unwrap(), "legacy-okou-value");
-    for key in [
-        guest_contracts::env::RUN_ID_ENV,
-        guest_contracts::env::PI_SESSION_ID_ENV,
-        guest_contracts::env::PI_LAUNCH_CONFIG_ENV,
-        guest_contracts::env::PI_MODEL_CONFIG_ENV,
-        guest_contracts::env::PROMPT_ENV,
-        "VM0_API_TOKEN",
-        guest_contracts::env::WORKING_DIR_ENV,
-        "VM0_GUEST_RUNTIME_DIR",
-        guest_contracts::env::FEATURE_FLAGS_ENV,
-        "VM0_FUTURE_RUNNER_KEY",
-        guest_contracts::env::CLI_AGENT_TYPE_ENV,
-        guest_contracts::env::USE_MOCK_CLAUDE_ENV,
-        guest_contracts::env::USE_MOCK_CODEX_ENV,
-        guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV,
-        guest_contracts::env::DISALLOWED_TOOLS_ENV,
-        guest_contracts::env::TOOLS_ENV,
-        guest_contracts::env::SETTINGS_ENV,
-        "VM0_MOCK_CLAUDE_PATH",
-        "VM0_MOCK_CODEX_PATH",
-        "VM0_USER_ENV_FILE",
-        "VM0_RUN_PAYLOAD_FILE",
-    ] {
-        assert!(!user_env.contains_key(key), "{key} should be scrubbed");
-    }
 }
 
 #[test]
@@ -1817,6 +1670,7 @@ fn execution_context_deserializes_with_firewalls() {
         "sandboxToken": "tok",
         "cliAgentType": "claude-code",
         "billableFirewalls": [],
+        "platformEnvironment": {},
         "connectorRuntimeTargets": [],
         "firewalls": [{
             "kind": "inline",
@@ -1866,6 +1720,7 @@ fn execution_context_deserializes_without_firewalls() {
         "sandboxToken": "tok",
         "cliAgentType": "claude-code",
         "billableFirewalls": [],
+        "platformEnvironment": {},
         "connectorRuntimeTargets": []
     });
     let ctx: ExecutionContext = serde_json::from_value(json).unwrap();

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -1118,6 +1118,16 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
             "/tmp/evil-connector-account-context.json".into(),
         ),
     ]));
+    ctx.platform_environment = HashMap::from([
+        (
+            "OKOU_APP_URL".into(),
+            "https://app.runner-env.example.test/path".into(),
+        ),
+        (
+            "ZERO_APP_URL".into(),
+            "https://app.runner-env.example.test/path".into(),
+        ),
+    ]);
     ctx.connector_runtime_targets = vec![
         ConnectorRuntimeTargetRegistration::Builtin {
             connector_slug: "github".into(),

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -3512,6 +3512,7 @@ mod tests {
                         "name": "github"
                     }],
                     "billableFirewalls": [],
+                    "platformEnvironment": {},
                     "connectorRuntimeTargets": []
                 }));
             })
@@ -3562,6 +3563,7 @@ mod tests {
                         "name": "github"
                     }],
                     "billableFirewalls": [],
+                    "platformEnvironment": {},
                     "connectorRuntimeTargets": []
                 }));
             })
@@ -3612,6 +3614,7 @@ mod tests {
                         "apis": []
                     }],
                     "billableFirewalls": [],
+                    "platformEnvironment": {},
                     "connectorRuntimeTargets": []
                 }));
             })
@@ -3672,6 +3675,7 @@ mod tests {
                         }
                     },
                     "billableFirewalls": [],
+                    "platformEnvironment": {},
                     "connectorRuntimeTargets": []
                 }));
             })
@@ -3721,6 +3725,7 @@ mod tests {
                         "OPENAI_API_KEY": 123
                     },
                     "billableFirewalls": [],
+                    "platformEnvironment": {},
                     "connectorRuntimeTargets": []
                 }));
             })
@@ -3765,6 +3770,7 @@ mod tests {
                 "prompt": "hello",
                 "sandboxToken": "claim-sandbox-token",
                 "cliAgentType": "claude_code",
+                "platformEnvironment": {},
                 "connectorRuntimeTargets": [],
                 "codexRuntimeConfig": {
                     "providerId": 123,
@@ -3796,6 +3802,7 @@ mod tests {
                 "prompt": "hello",
                 "sandboxToken": "claim-sandbox-token",
                 "cliAgentType": "claude_code",
+                "platformEnvironment": {},
                 "connectorRuntimeTargets": [],
                 "networkPolicyRefreshes": {
                     "secret-connector-name": {
@@ -3826,6 +3833,7 @@ mod tests {
                 "prompt": "hello",
                 "sandboxToken": "claim-sandbox-token",
                 "cliAgentType": "claude_code",
+                "platformEnvironment": {},
                 "connectorRuntimeTargets": [],
                 "environment": {"prompt": 123}
             }),
@@ -3852,6 +3860,7 @@ mod tests {
                 "prompt": "hello",
                 "sandboxToken": "claim-sandbox-token",
                 "cliAgentType": "claude_code",
+                "platformEnvironment": {},
                 "connectorRuntimeTargets": [],
                 "codexRuntimeConfig": {
                     "providerId": "provider",
@@ -4106,7 +4115,7 @@ mod tests {
             "fixture-model"
         );
         assert_eq!(
-            context.platform_environment.as_ref().unwrap()["OKOU_AGENT_ID"],
+            context.platform_environment["OKOU_AGENT_ID"],
             "fixture-agent-id"
         );
         assert_eq!(
@@ -4227,6 +4236,7 @@ mod tests {
                     "prompt": "minimal response",
                     "sandboxToken": "minimal-sandbox-token",
                     "cliAgentType": "claude_code",
+                    "platformEnvironment": {},
                     "connectorRuntimeTargets": []
                 }));
             })
@@ -4268,6 +4278,7 @@ mod tests {
                     "prompt": "response with additive field",
                     "sandboxToken": "additive-sandbox-token",
                     "cliAgentType": "claude_code",
+                    "platformEnvironment": {},
                     "connectorRuntimeTargets": [],
                     "futureClaimMetadata": {"version": 2}
                 }));
@@ -4304,6 +4315,7 @@ mod tests {
                     "prompt": "attempt local secret trust",
                     "sandboxToken": "local-secret-sandbox-token",
                     "cliAgentType": "claude_code",
+                    "platformEnvironment": {},
                     "connectorRuntimeTargets": [],
                     "localSecretEnvKeys": ["ANTHROPIC_API_KEY"]
                 }));
@@ -4342,6 +4354,7 @@ mod tests {
                     "sandboxToken": "claim-sandbox-token",
                     "cliAgentType": "claude_code",
                     "billableFirewalls": [],
+                    "platformEnvironment": {},
                     "connectorRuntimeTargets": []
                 }));
             })
@@ -4380,6 +4393,7 @@ mod tests {
                     "sandboxToken": "claim-sandbox-token",
                     "cliAgentType": "claude_code",
                     "billableFirewalls": [],
+                    "platformEnvironment": {},
                     "connectorRuntimeTargets": []
                 }));
             })
@@ -4435,6 +4449,7 @@ mod tests {
                     "sandboxToken": "sandbox-token-a",
                     "cliAgentType": "claude_code",
                     "billableFirewalls": [],
+                    "platformEnvironment": {},
                     "connectorRuntimeTargets": []
                 }));
             })
@@ -4448,6 +4463,7 @@ mod tests {
                     "sandboxToken": "sandbox-token-b",
                     "cliAgentType": "claude_code",
                     "billableFirewalls": [],
+                    "platformEnvironment": {},
                     "connectorRuntimeTargets": []
                 }));
             })

--- a/crates/runner/src/provider/local/mod.rs
+++ b/crates/runner/src/provider/local/mod.rs
@@ -269,7 +269,7 @@ impl JobProvider for LocalProvider {
             sandbox_token: String::new(),
             storage_manifest: None,
             environment: environment_merge.environment,
-            platform_environment: None,
+            platform_environment: HashMap::new(),
             resume_session: req
                 .session_id
                 .as_ref()

--- a/crates/runner/src/provider/local/tests/claim.rs
+++ b/crates/runner/src/provider/local/tests/claim.rs
@@ -46,6 +46,7 @@ async fn claim_maps_secret_environment_into_context_and_masking() {
     let secret_values = ctx.secret_values.as_ref().unwrap();
     let local_secret_env_keys = ctx.local_secret_env_keys.as_ref().unwrap();
 
+    assert!(ctx.platform_environment.is_empty());
     assert_eq!(
         environment.get("ANTHROPIC_MODEL").map(String::as_str),
         Some("claude-haiku-4-5")

--- a/crates/runner/src/test_fixtures/execution_context.rs
+++ b/crates/runner/src/test_fixtures/execution_context.rs
@@ -1,5 +1,6 @@
 use crate::ids::RunId;
 use crate::types::ExecutionContext;
+use std::collections::HashMap;
 
 pub(crate) fn execution_context_for_test(run_id: RunId) -> ExecutionContext {
     ExecutionContext {
@@ -11,7 +12,7 @@ pub(crate) fn execution_context_for_test(run_id: RunId) -> ExecutionContext {
         sandbox_token: "tok".into(),
         storage_manifest: None,
         environment: None,
-        platform_environment: None,
+        platform_environment: HashMap::new(),
         resume_session: None,
         secret_values: None,
         local_secret_env_keys: None,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -86,11 +86,8 @@ pub struct ExecutionContext {
     pub(crate) storage_manifest: Option<StorageManifest>,
     #[serde(default)]
     pub environment: Option<HashMap<String, String>>,
-    /// Trusted API-authored agent environment. Old API/stored claims omit it;
-    /// keep the default until prior API rollback targets and supported pre-field
-    /// contexts are gone. #28914 tracks that gate.
-    #[serde(default)]
-    pub platform_environment: Option<HashMap<String, String>>,
+    /// Trusted API-authored agent environment.
+    pub platform_environment: HashMap<String, String>,
     #[serde(default)]
     pub resume_session: Option<ResumeSession>,
     // Plain secret values used only for redaction. These are values, not names.
@@ -1819,31 +1816,6 @@ mod tests {
     }
 
     #[test]
-    fn execution_context_accepts_optional_platform_environment() {
-        let previous_api_response = json!({
-            "runId": "11111111-1111-4111-8111-111111111111",
-            "prompt": "hello",
-            "sandboxToken": "tok",
-            "cliAgentType": "claude-code",
-            "connectorRuntimeTargets": []
-        });
-        let previous_context: ExecutionContext =
-            serde_json::from_value(previous_api_response.clone()).unwrap();
-        assert!(previous_context.platform_environment.is_none());
-
-        let mut current_api_response = previous_api_response;
-        current_api_response["platformEnvironment"] = json!({
-            "OKOU_AGENT_ID": "trusted-agent-id"
-        });
-        let current_context: ExecutionContext =
-            serde_json::from_value(current_api_response).unwrap();
-        assert_eq!(
-            current_context.platform_environment.as_ref().unwrap()["OKOU_AGENT_ID"],
-            "trusted-agent-id"
-        );
-    }
-
-    #[test]
     fn execution_context_deserializes_pi_sandbox_resources() {
         let json = serde_json::json!({
             "runId": "11111111-1111-4111-8111-111111111111",
@@ -1873,6 +1845,7 @@ mod tests {
                 "apiKeyEnv": "OPENAI_API_KEY",
                 "credentialSecretName": "DEEPSEEK_API_KEY"
             },
+            "platformEnvironment": {},
             "connectorRuntimeTargets": []
         });
 
@@ -1905,6 +1878,7 @@ mod tests {
             "prompt": "hello",
             "sandboxToken": "tok",
             "cliAgentType": "claude-code",
+            "platformEnvironment": {},
             "connectorRuntimeTargets": [],
             "firewalls": [{
                 "name": "github",
@@ -1930,6 +1904,7 @@ mod tests {
             "prompt": "hello",
             "sandboxToken": "tok",
             "cliAgentType": "claude-code",
+            "platformEnvironment": {},
             "connectorRuntimeTargets": [],
             "firewalls": [{
                 "kind": "unknown",
@@ -2272,6 +2247,7 @@ mod tests {
             "sandboxToken": "tok",
             "cliAgentType": "claude_code",
             "billableFirewalls": [],
+            "platformEnvironment": {},
             "connectorRuntimeTargets": []
         });
         let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
@@ -2287,6 +2263,7 @@ mod tests {
                 "sandboxToken": "tok",
                 "cliAgentType": "claude_code",
                 "billableFirewalls": [],
+                "platformEnvironment": {},
                 "connectorRuntimeTargets": [target]
             })
         };
@@ -2343,6 +2320,7 @@ mod tests {
                 "sessionHistory": "{}"
             },
             "billableFirewalls": [],
+            "platformEnvironment": {},
             "connectorRuntimeTargets": []
         });
         let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
@@ -2376,6 +2354,7 @@ mod tests {
                 }
             },
             "billableFirewalls": [],
+            "platformEnvironment": {},
             "connectorRuntimeTargets": []
         });
         let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
@@ -2409,6 +2388,7 @@ mod tests {
                 }
             },
             "billableFirewalls": [],
+            "platformEnvironment": {},
             "connectorRuntimeTargets": []
         });
         let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
@@ -2446,6 +2426,7 @@ mod tests {
                 }
             },
             "billableFirewalls": [],
+            "platformEnvironment": {},
             "connectorRuntimeTargets": []
         });
         let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
@@ -2477,6 +2458,7 @@ mod tests {
                 }
             },
             "billableFirewalls": [],
+            "platformEnvironment": {},
             "connectorRuntimeTargets": []
         });
         let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
@@ -2500,6 +2482,7 @@ mod tests {
             "storageManifest": storage_manifest,
             "cliAgentType": "claude_code",
             "billableFirewalls": [],
+            "platformEnvironment": {},
             "connectorRuntimeTargets": []
         })
     }

--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -107,7 +107,7 @@ async function claimDispatchedRun(runnerGroup: string): Promise<{
     sandboxToken: claim.sandboxToken,
     prompt: claim.prompt,
     appendSystemPrompt: claim.appendSystemPrompt ?? "",
-    okouToken: claim.environment?.OKOU_TOKEN,
+    okouToken: claim.platformEnvironment.OKOU_TOKEN,
   };
 }
 
@@ -1286,7 +1286,7 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     });
     await runs.heartbeatRunner(runnerGroup);
     const claim = await runs.claimRunnerJob(run.runId);
-    const okouToken = claim.environment?.OKOU_TOKEN;
+    const okouToken = claim.platformEnvironment.OKOU_TOKEN;
     if (!okouToken) {
       throw new Error("Expected the claimed run to expose OKOU_TOKEN");
     }

--- a/turbo/apps/api/src/signals/routes/__tests__/artifact-catalog.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifact-catalog.bdd.test.ts
@@ -114,9 +114,11 @@ async function claimChatRun(
 }
 
 function okouTokenFromClaim(claim: RunnerClaim): string {
-  const token = claim.environment?.OKOU_TOKEN;
+  const token = claim.platformEnvironment.OKOU_TOKEN;
   if (!token || !token.startsWith("vm0_sandbox_")) {
-    throw new Error("Expected the claim environment to carry an OKOU_TOKEN");
+    throw new Error(
+      "Expected the claim platform environment to carry an OKOU_TOKEN",
+    );
   }
   return token;
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
@@ -164,9 +164,11 @@ async function claimChatRun(
 }
 
 function okouTokenFromClaim(claim: RunnerClaim): string {
-  const token = claim.environment?.OKOU_TOKEN;
+  const token = claim.platformEnvironment.OKOU_TOKEN;
   if (!token || !token.startsWith("vm0_sandbox_")) {
-    throw new Error("Expected the claim environment to carry an OKOU_TOKEN");
+    throw new Error(
+      "Expected the claim platform environment to carry an OKOU_TOKEN",
+    );
   }
   return token;
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
@@ -208,7 +208,7 @@ async function claimChatRun(
 ) {
   await flushWaitUntilForTest();
   const claim = await runs.claimRunnerJob(runId);
-  const okouToken = claim.environment?.OKOU_TOKEN;
+  const okouToken = claim.platformEnvironment.OKOU_TOKEN;
   if (!okouToken) {
     throw new Error("Expected the runner claim to include OKOU_TOKEN");
   }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -741,8 +741,8 @@ async function expectRunPublicBrandTransport(args: {
   if (!args.actor.orgId) {
     throw new Error("Expected an organization-scoped chat actor");
   }
-  expect(args.claim.environment?.OKOU_APP_URL).toBe(args.appUrl);
-  const token = args.claim.environment?.OKOU_TOKEN;
+  expect(args.claim.platformEnvironment.OKOU_APP_URL).toBe(args.appUrl);
+  const token = args.claim.platformEnvironment.OKOU_TOKEN;
   if (!token) {
     throw new Error("Expected the run context to contain an Okou token");
   }
@@ -777,10 +777,10 @@ async function steerOwnedRunAtElapsedTime(
 }
 
 function claimEnvironment(claim: RunnerClaim): Record<string, string> {
-  if (!claim.environment) {
-    throw new Error("Expected the runner claim to carry an environment");
-  }
-  return claim.environment;
+  return {
+    ...claim.environment,
+    ...claim.platformEnvironment,
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -937,11 +937,13 @@ function expectPiLaunchResourceTiming(
   );
 }
 
-/** Sandbox-scoped Okou token issued to the run, exposed via the claim env. */
+/** Sandbox-scoped Okou token issued through the trusted claim environment. */
 function okouTokenFromClaim(claim: RunnerClaim): string {
   const token = claimEnvironment(claim).OKOU_TOKEN;
   if (!token || !token.startsWith("vm0_sandbox_")) {
-    throw new Error("Expected the claim environment to carry an OKOU_TOKEN");
+    throw new Error(
+      "Expected the claim platform environment to carry an OKOU_TOKEN",
+    );
   }
   return token;
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -221,9 +221,11 @@ async function claimChatRun(
 
 /** Sandbox-scoped Okou token issued to the run, exposed via the claim env. */
 function okouTokenFromClaim(claim: RunnerClaim): string {
-  const token = claim.environment?.OKOU_TOKEN;
+  const token = claim.platformEnvironment.OKOU_TOKEN;
   if (!token || !token.startsWith("vm0_sandbox_")) {
-    throw new Error("Expected the claim environment to carry an OKOU_TOKEN");
+    throw new Error(
+      "Expected the claim platform environment to carry an OKOU_TOKEN",
+    );
   }
   return token;
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -4378,7 +4378,7 @@ describe("Feishu integration", () => {
     await runsApi.heartbeatRunner(runnerGroup);
     const claim = await runsApi.claimRunnerJob(run.id);
     expect(claim.prompt).toBe("do the Feishu task");
-    expect(claim.environment?.OKOU_AGENT_ID).toBe(alternateAgentId);
+    expect(claim.platformEnvironment.OKOU_AGENT_ID).toBe(alternateAgentId);
     expect(claim.environment ?? {}).not.toHaveProperty("ZERO_AGENT_ID");
     expect(claim.appendSystemPrompt).toContain(
       "You are currently running inside: Feishu",
@@ -4638,7 +4638,7 @@ describe("Feishu integration", () => {
     const switchedAgentClaim = await runsApi.claimRunnerJob(
       switchedAgentRun.id,
     );
-    expect(switchedAgentClaim.environment?.OKOU_AGENT_ID).toBe(
+    expect(switchedAgentClaim.platformEnvironment.OKOU_AGENT_ID).toBe(
       alternateAgentId,
     );
     expect(switchedAgentClaim.environment ?? {}).not.toHaveProperty(

--- a/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
@@ -21,7 +21,7 @@ legacy zero-host.test.ts and zero-maps.test.ts route tests:
   and complete response bodies; maps org-credit row asserts are
   replaced by billing-status deltas.
 - The run-artifact chain uses the run's real Okou token from the runner claim
-  (`claim.environment.OKOU_TOKEN`) instead of seeding runs and rewriting
+  (`claim.platformEnvironment.OKOU_TOKEN`) instead of seeding runs and rewriting
   deployment rows.
 - Maps gates (NOT_CONFIGURED / 402 / invalid location) stay owned by
   billing-usage-media.bdd.test.ts BILL-02; the slug-suffix reuse and
@@ -953,10 +953,10 @@ describe("CHAIN-BILLING-MEDIA/FILE-01: run-scoped agent-token attribution", () =
 
     // The default agent compose maps OKOU_TOKEN from the run secrets, so the
     // claimed execution context exposes the real run-scoped Okou token.
-    const okouToken = claim.environment?.OKOU_TOKEN;
+    const okouToken = claim.platformEnvironment.OKOU_TOKEN;
     if (!okouToken) {
       throw new Error(
-        "Expected claim.environment.OKOU_TOKEN to carry the run-scoped Okou token",
+        "Expected claim.platformEnvironment.OKOU_TOKEN to carry the run-scoped Okou token",
       );
     }
     expect(okouToken).toMatch(/^vm0_sandbox_/);

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -4368,9 +4368,9 @@ describe("INT-01: Slack app deep webhook flows", () => {
     const fastRunId = await pollSlackRun(runnerGroup);
     const fastClaim = await runs.claimRunnerJob(fastRunId);
     expect(fastClaim.cliAgentType).toBe("codex");
-    expect(fastClaim.environment?.OKOU_CODEX_SERVICE_TIER).toBe("fast");
+    expect(fastClaim.platformEnvironment.OKOU_CODEX_SERVICE_TIER).toBe("fast");
     expect(fastClaim.environment?.VM0_CODEX_SERVICE_TIER).toBeUndefined();
-    const fastOkouToken = fastClaim.environment?.OKOU_TOKEN;
+    const fastOkouToken = fastClaim.platformEnvironment.OKOU_TOKEN;
     if (!fastOkouToken) {
       throw new Error("Expected the Slack Fast run to expose OKOU_TOKEN");
     }
@@ -5488,9 +5488,9 @@ describe("INT-02: Telegram integration", () => {
     );
     const claim = await runs.claimRunnerJob(runId);
     expect(claim.cliAgentType).toBe("codex");
-    expect(claim.environment?.OKOU_CODEX_SERVICE_TIER).toBe("fast");
+    expect(claim.platformEnvironment.OKOU_CODEX_SERVICE_TIER).toBe("fast");
     expect(claim.environment?.VM0_CODEX_SERVICE_TIER).toBeUndefined();
-    const okouToken = claim.environment?.OKOU_TOKEN;
+    const okouToken = claim.platformEnvironment.OKOU_TOKEN;
     if (!okouToken) {
       throw new Error("Expected the Telegram Fast run to expose OKOU_TOKEN");
     }

--- a/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
@@ -1064,10 +1064,10 @@ describe("AUTH-02/ORG-01: run-scoped agent tokens on org routes", () => {
     const poll = await runs.pollRunner(runnerGroup);
     expect(poll.body.job?.runId).toBe(created.runId);
     const claim = await runs.claimRunnerJob(created.runId);
-    const okouToken = claim.environment?.OKOU_TOKEN;
+    const okouToken = claim.platformEnvironment.OKOU_TOKEN;
     if (!okouToken) {
       throw new Error(
-        "Expected claim.environment.OKOU_TOKEN to carry the run-scoped Okou token",
+        "Expected claim.platformEnvironment.OKOU_TOKEN to carry the run-scoped Okou token",
       );
     }
     expect(okouToken).toMatch(/^vm0_sandbox_/);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -858,6 +858,7 @@ function sandboxTokenPayload(token: string): Record<string, unknown> {
 
 function expectCanonicalOkouRunEnvironment(args: {
   readonly environment: Readonly<Record<string, string>> | null | undefined;
+  readonly platformEnvironment: Readonly<Record<string, string>>;
   readonly secretValues: readonly string[] | null | undefined;
   readonly appUrl: string;
   readonly agentId: string;
@@ -867,17 +868,19 @@ function expectCanonicalOkouRunEnvironment(args: {
   readonly publicBrand?: PublicBrand;
   readonly chatThreadId?: string;
 }): void {
-  expect(args.environment?.OKOU_APP_URL).toBe(args.appUrl);
-  expect(args.environment?.OKOU_AGENT_ID).toBe(args.agentId);
+  expect(args.platformEnvironment.OKOU_APP_URL).toBe(args.appUrl);
+  expect(args.platformEnvironment.OKOU_AGENT_ID).toBe(args.agentId);
   if (args.chatThreadId) {
-    expect(args.environment?.OKOU_CHAT_THREAD_ID).toBe(args.chatThreadId);
+    expect(args.platformEnvironment.OKOU_CHAT_THREAD_ID).toBe(
+      args.chatThreadId,
+    );
   }
   expect(
     Object.keys(args.environment ?? {}).filter((key) => {
       return key.startsWith("ZERO_");
     }),
   ).toStrictEqual([]);
-  const okouToken = args.environment?.OKOU_TOKEN;
+  const okouToken = args.platformEnvironment.OKOU_TOKEN;
   if (!okouToken) {
     throw new Error(
       "Expected the claim to expose the canonical Okou run token",
@@ -1512,7 +1515,9 @@ async function setupSameThreadReuseScenario(sourceRunnerIdentity?: {
     first.runId,
     sourceRunnerIdentity ? { runnerIdentity: sourceRunnerIdentity } : {},
   );
-  expect(firstClaim.environment?.OKOU_CHAT_THREAD_ID).toBe(first.threadId);
+  expect(firstClaim.platformEnvironment.OKOU_CHAT_THREAD_ID).toBe(
+    first.threadId,
+  );
   expect(
     Object.keys(firstClaim.environment ?? {}).filter((key) => {
       return key.startsWith("ZERO_");
@@ -7320,7 +7325,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     await api.heartbeatRunner(runnerGroup);
     const thirdClaim = await api.claimRunnerJob(third.runId);
     expect(thirdClaim.prompt).toBe("queued run three");
-    const okouToken = thirdClaim.environment?.OKOU_TOKEN;
+    const okouToken = thirdClaim.platformEnvironment.OKOU_TOKEN;
     if (!okouToken) {
       throw new Error("Expected the promoted claim to expose the Okou token");
     }
@@ -8256,7 +8261,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     }
 
     const unsupported = await claimModel(unsupportedModel);
-    const unsupportedToken = unsupported.claim.environment?.OKOU_TOKEN;
+    const unsupportedToken = unsupported.claim.platformEnvironment.OKOU_TOKEN;
     if (!unsupportedToken) {
       throw new Error(
         "Expected the unsupported-model run to expose OKOU_TOKEN",
@@ -8271,7 +8276,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     await api.requestCancelRun(actor, unsupported.runId, [200]);
 
     const supported = await claimModel(supportedModel);
-    const supportedToken = supported.claim.environment?.OKOU_TOKEN;
+    const supportedToken = supported.claim.platformEnvironment.OKOU_TOKEN;
     if (!supportedToken) {
       throw new Error("Expected the supported-model run to expose OKOU_TOKEN");
     }
@@ -8284,7 +8289,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     await api.requestCancelRun(actor, supported.runId, [200]);
 
     const unknown = await claimModel(unknownModel);
-    const unknownToken = unknown.claim.environment?.OKOU_TOKEN;
+    const unknownToken = unknown.claim.platformEnvironment.OKOU_TOKEN;
     if (!unknownToken) {
       throw new Error("Expected the unknown-model run to expose OKOU_TOKEN");
     }
@@ -14264,7 +14269,7 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
       expect(r2Claim.appendSystemPrompt ?? "").toContain(
         `Run commands with: \`npx --yes --package="\${CLI_PKG_URL}" okou <command>\``,
       );
-      expect(r2Claim.environment?.CLI_PKG_URL).toBe(
+      expect(r2Claim.platformEnvironment.CLI_PKG_URL).toBe(
         `https://${staticDomain}/okou-cli/test-commit/package.tgz`,
       );
       await api.requestCancelRun(actor, r2Run.runId, [200]);
@@ -14328,6 +14333,7 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
     const currentClaim = await api.claimRunnerJob(current.runId);
     expectCanonicalOkouRunEnvironment({
       environment: currentClaim.environment,
+      platformEnvironment: currentClaim.platformEnvironment,
       secretValues: currentClaim.secretValues,
       appUrl,
       agentId,
@@ -14596,6 +14602,7 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
     expect(claim.disallowedTools).not.toContain("WebFetch");
     expectCanonicalOkouRunEnvironment({
       environment: claim.environment,
+      platformEnvironment: claim.platformEnvironment,
       secretValues: claim.secretValues,
       appUrl,
       agentId: agent.agentId,
@@ -14606,13 +14613,11 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
     expect(claim.platformEnvironment).toMatchObject({
       OKOU_APP_URL: appUrl,
       OKOU_AGENT_ID: agent.agentId,
-      OKOU_TOKEN: claim.environment?.OKOU_TOKEN,
+      OKOU_TOKEN: claim.platformEnvironment.OKOU_TOKEN,
       CLI_PKG_URL: "https://static.vm0.io/okou-cli/test-commit/package.tgz",
     });
-    for (const [key, value] of Object.entries(
-      claim.platformEnvironment ?? {},
-    )) {
-      expect(claim.environment?.[key]).toBe(value);
+    for (const key of Object.keys(claim.platformEnvironment)) {
+      expect(claim.environment).not.toHaveProperty(key);
     }
     const runContextSnapshot = runContextSnapshotForRun(run.runId);
     expect(runContextSnapshot.secretNames).toContain("OKOU_TOKEN");
@@ -14621,9 +14626,6 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
       name: "OKOU_TOKEN",
       value: "***",
     });
-    expect(claim.environment?.CLI_PKG_URL).toBe(
-      "https://static.vm0.io/okou-cli/test-commit/package.tgz",
-    );
     expect(claim.environment?.VM0_APP_URL).toBeUndefined();
     expect(claim.environment?.APP_URL).toBeUndefined();
     expect(claim.environment ?? {}).not.toHaveProperty(
@@ -15002,7 +15004,7 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
 
     // A run-scoped Okou token issued without a host binding cannot reach
     // computer-use write routes.
-    const okouToken = claim.environment?.OKOU_TOKEN;
+    const okouToken = claim.platformEnvironment.OKOU_TOKEN;
     if (!okouToken) {
       throw new Error("Expected the promoted claim to expose the Okou token");
     }
@@ -15194,9 +15196,12 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         throw new Error("Expected preview run creation to succeed");
       }
       const claim = await api.claimRunnerJob(created.body.runId);
-      expect(claim.environment).toMatchObject({
+      expect(claim.platformEnvironment).toMatchObject({
         VERCEL_AUTOMATION_BYPASS_SECRET: previewBypass,
       });
+      expect(claim.environment).not.toHaveProperty(
+        "VERCEL_AUTOMATION_BYPASS_SECRET",
+      );
       await api.requestCancelRun(actor, created.body.runId, [200]);
     }
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -3414,7 +3414,7 @@ describe("RUN-04/OPS-01: agent run logs", () => {
       modelProvider: "anthropic-api-key",
     });
     const tokenClaim = await api.claimRunnerJob(tokenRun.runId);
-    const okouToken = tokenClaim.environment?.OKOU_TOKEN;
+    const okouToken = tokenClaim.platformEnvironment.OKOU_TOKEN;
     if (!okouToken) {
       throw new Error("Expected the claimed run to expose an OKOU_TOKEN");
     }

--- a/turbo/apps/api/src/signals/routes/__tests__/runner-environment-ownership.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runner-environment-ownership.test.ts
@@ -28,7 +28,7 @@ function runContextSnapshotForRun(runId: string): Record<string, unknown> {
 }
 
 describe("runner environment ownership", () => {
-  it("removes untrusted OKOU entries before dual-carrying platform environment", async () => {
+  it("separates trusted platform environment from untrusted entries", async () => {
     const bdd = createBddApi(context);
     const runs = createRunsApi(context);
     const actor = bdd.user();
@@ -71,10 +71,8 @@ describe("runner environment ownership", () => {
     expect(claim.platformEnvironment).toMatchObject({
       CLI_PKG_URL: expect.any(String),
     });
-    for (const [key, value] of Object.entries(
-      claim.platformEnvironment ?? {},
-    )) {
-      expect(claim.environment?.[key]).toBe(value);
+    for (const key of Object.keys(claim.platformEnvironment)) {
+      expect(claim.environment).not.toHaveProperty(key);
     }
 
     const snapshot = runContextSnapshotForRun(run.runId);

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
@@ -3220,7 +3220,7 @@ describe("POST /api/webhooks/teams/bot", () => {
     const firstRunId = await runIdForPrompt(actor, "authorize the browser");
     await runsApi.heartbeatRunner(runnerGroup);
     const firstClaim = await runsApi.claimRunnerJob(firstRunId);
-    const firstOkouToken = firstClaim.environment?.OKOU_TOKEN;
+    const firstOkouToken = firstClaim.platformEnvironment.OKOU_TOKEN;
     if (!firstOkouToken) {
       throw new Error("Claimed Teams runner job did not include OKOU_TOKEN");
     }
@@ -3252,7 +3252,7 @@ describe("POST /api/webhooks/teams/bot", () => {
     const secondRunId = await runIdForPrompt(actor, "use the browser");
     await runsApi.heartbeatRunner(runnerGroup);
     const secondClaim = await runsApi.claimRunnerJob(secondRunId);
-    const secondOkouToken = secondClaim.environment?.OKOU_TOKEN;
+    const secondOkouToken = secondClaim.platformEnvironment.OKOU_TOKEN;
     if (!secondOkouToken) {
       throw new Error("Claimed Teams runner job did not include OKOU_TOKEN");
     }

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
@@ -645,7 +645,7 @@ describe("POST /api/webhooks/github for workflow automations", () => {
         throw new Error(`Expected a ${testCase.name} automation run`);
       }
       const claim = await runsApi.claimRunnerJob(runId);
-      const okouToken = claim.environment?.OKOU_TOKEN;
+      const okouToken = claim.platformEnvironment.OKOU_TOKEN;
       if (!okouToken) {
         throw new Error("Expected the webhook run to expose OKOU_TOKEN");
       }
@@ -730,7 +730,7 @@ describe("POST /api/webhooks/github for workflow automations", () => {
       throw new Error("Expected the queued Okou automation run to drain");
     }
     const promotedClaim = await runsApi.claimRunnerJob(promotedRunId);
-    const okouToken = promotedClaim.environment?.OKOU_TOKEN;
+    const okouToken = promotedClaim.platformEnvironment.OKOU_TOKEN;
     if (!okouToken) {
       throw new Error("Expected the drained run to expose OKOU_TOKEN");
     }
@@ -860,7 +860,7 @@ describe("POST /api/webhooks/github for workflow automations", () => {
       expect(promotedClaim.appendSystemPrompt).not.toContain(
         `Bot username: ${testCase.excludedBotUsername}`,
       );
-      const okouToken = promotedClaim.environment?.OKOU_TOKEN;
+      const okouToken = promotedClaim.platformEnvironment.OKOU_TOKEN;
       if (!okouToken) {
         throw new Error("Expected the GitHub chat run to expose OKOU_TOKEN");
       }
@@ -1292,7 +1292,7 @@ describe("POST /api/webhooks/github for workflow automations", () => {
     });
     expect(chatEventDisplayText(claimedEvent)).toBe(displayMessage);
     const claim = await runsApi.claimRunnerJob(runId);
-    const okouToken = claim.environment?.OKOU_TOKEN;
+    const okouToken = claim.platformEnvironment.OKOU_TOKEN;
     if (!okouToken) {
       throw new Error("Expected the automation event run to expose OKOU_TOKEN");
     }

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-automation-scheduler.test.ts
@@ -89,9 +89,11 @@ function expectOk(response: Response, operation: string): void {
 function okouTokenFromClaim(
   claim: Awaited<ReturnType<typeof runsApi.claimRunnerJob>>,
 ): string {
-  const token = claim.environment?.OKOU_TOKEN;
+  const token = claim.platformEnvironment.OKOU_TOKEN;
   if (!token || !token.startsWith("vm0_sandbox_")) {
-    throw new Error("Expected the claim environment to carry an OKOU_TOKEN");
+    throw new Error(
+      "Expected the claim platform environment to carry an OKOU_TOKEN",
+    );
   }
   return token;
 }

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -1304,15 +1304,16 @@ function preparedSecretValuesForRunner(
     return { status: "resolved", secretValues: null };
   }
 
+  const environment = {
+    ...storedContext.environment,
+    ...storedContext.platformEnvironment,
+  };
   const secretValues: string[] = [];
   for (const key of keys) {
-    if (
-      !storedContext.environment ||
-      !Object.hasOwn(storedContext.environment, key)
-    ) {
+    if (!Object.hasOwn(environment, key)) {
       return { status: "invalid-keys" };
     }
-    const value = storedContext.environment[key];
+    const value = environment[key];
     if (typeof value !== "string") {
       return { status: "invalid-keys" };
     }
@@ -1339,9 +1340,12 @@ async function secretValuesForRunner(
       return null;
     }
 
-    const envValues = storedContext.environment
-      ? new Set(Object.values(storedContext.environment))
-      : new Set<string>();
+    const envValues = new Set(
+      Object.values({
+        ...storedContext.environment,
+        ...storedContext.platformEnvironment,
+      }),
+    );
     return Object.values(secretsMap).filter((value) => {
       return envValues.has(value);
     });

--- a/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
@@ -605,6 +605,7 @@ async function seedRunnerJobForAction(
     executionContext: {
       storageMounts: [],
       environment: null,
+      platformEnvironment: {},
       resumeSession: null,
       encryptedSecrets: null,
       cliAgentType: "claude-code",
@@ -650,6 +651,7 @@ async function seedQueueEntryForAction(
         executionContext: {
           storageMounts: [],
           environment: null,
+          platformEnvironment: {},
           secretValueEnvironmentKeys: null,
           resumeSession: null,
           encryptedSecrets: null,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -6374,6 +6374,18 @@ function buildStoredPlatformEnvironment(args: {
     : platformEnvironment;
 }
 
+function buildStoredUntrustedEnvironment(args: {
+  readonly expandedEnvironment: Record<string, string> | null;
+  readonly canonicalOkouRuntime: boolean;
+}): Record<string, string> | null {
+  if (!args.canonicalOkouRuntime) {
+    return args.expandedEnvironment;
+  }
+  return (
+    withoutLegacyZeroEntries(args.expandedEnvironment ?? undefined) ?? null
+  );
+}
+
 async function buildStoredExecutionContextDraft(args: {
   readonly runId: string;
   readonly userId: string;
@@ -6431,17 +6443,16 @@ async function buildStoredExecutionContextDraft(args: {
     okouTokenPublicBrand: args.okouTokenPublicBrand,
     canonicalOkouRuntime: args.includeOkouTokenSecret === true,
   });
-  // New API -> old runner: keep trusted entries in legacy environment until
-  // prior API rollback targets retire and old runners/sandboxes finish their
-  // up-to-two-hour drain. #28914 tracks removal after both gates are proven.
-  const environment = {
-    ...(args.includeOkouTokenSecret
-      ? withoutLegacyZeroEntries(expandedEnvironment ?? undefined)
-      : expandedEnvironment),
+  const environment = buildStoredUntrustedEnvironment({
+    expandedEnvironment,
+    canonicalOkouRuntime: args.includeOkouTokenSecret === true,
+  });
+  const effectiveEnvironment = {
+    ...environment,
     ...platformEnvironment,
   };
   const environmentKeyByValue = new Map<string, string>();
-  for (const [key, value] of Object.entries(environment)) {
+  for (const [key, value] of Object.entries(effectiveEnvironment)) {
     if (!environmentKeyByValue.has(value)) {
       environmentKeyByValue.set(value, key);
     }
@@ -6535,7 +6546,10 @@ function buildRunContextSnapshot(args: {
 }): RunContextAxiomSnapshot {
   const storedContext = args.builtContext.context;
   const sanitizedEnvironment = sanitizeEnvironment(
-    storedContext.environment,
+    {
+      ...storedContext.environment,
+      ...storedContext.platformEnvironment,
+    },
     args.builtContext.secretValues,
   );
   const cliAgentSessionId =

--- a/turbo/packages/api-contracts/src/contracts/__tests__/fixtures/runner-claim-response.json
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/fixtures/runner-claim-response.json
@@ -28,8 +28,7 @@
   },
   "environment": {
     "FIXTURE_API_KEY": "fixture-placeholder-not-a-secret",
-    "FIXTURE_MODEL": "fixture-model",
-    "OKOU_AGENT_ID": "fixture-agent-id"
+    "FIXTURE_MODEL": "fixture-model"
   },
   "platformEnvironment": {
     "OKOU_AGENT_ID": "fixture-agent-id"

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -270,6 +270,7 @@ describe("runner claim response contract", () => {
       modelUsageProvider: "fixture-model",
       platformEnvironment: { OKOU_AGENT_ID: "fixture-agent-id" },
     });
+    expect(context.environment).not.toHaveProperty("OKOU_AGENT_ID");
     expect(context).not.toHaveProperty("experimentalProfile");
   });
 
@@ -285,30 +286,11 @@ describe("runner claim response contract", () => {
     expect(context).not.toHaveProperty("connectorPermissionBaseline");
   });
 
-  it("keeps old API and old runner claim shapes compatible", () => {
-    const current = executionContextSchema.parse(
-      loadRunnerClaimResponseFixture(),
-    );
-    const previousApiResponse: Record<string, unknown> = { ...current };
-    Reflect.deleteProperty(previousApiResponse, "platformEnvironment");
-    expect(
-      executionContextSchema.parse(previousApiResponse),
-    ).not.toHaveProperty("platformEnvironment");
-
-    const previousRunnerSchema = z
-      .object(executionContextSchema.shape)
-      .omit({ platformEnvironment: true });
-    expect(previousRunnerSchema.parse(current)).not.toHaveProperty(
-      "platformEnvironment",
-    );
-  });
-
-  it("round-trips the optional trusted environment through stored contexts", () => {
+  it("round-trips canonical trusted environments through stored contexts", () => {
     const storedContext = storedExecutionContextSchema.parse({
       storageMounts: [],
       connectorRuntimeTargets: [],
       environment: {
-        OKOU_AGENT_ID: "stored-agent-id",
         USER_VALUE: "user-value",
       },
       platformEnvironment: { OKOU_AGENT_ID: "stored-agent-id" },
@@ -324,16 +306,15 @@ describe("runner claim response contract", () => {
     expect(roundTripped.platformEnvironment).toStrictEqual({
       OKOU_AGENT_ID: "stored-agent-id",
     });
-    expect(roundTripped.environment).toMatchObject({
-      OKOU_AGENT_ID: "stored-agent-id",
+    expect(roundTripped.environment).toStrictEqual({
+      USER_VALUE: "user-value",
     });
 
-    const previousStoredContextSchema = z
-      .object(storedExecutionContextSchema.shape)
-      .omit({ platformEnvironment: true });
-    expect(previousStoredContextSchema.parse(storedContext)).not.toHaveProperty(
-      "platformEnvironment",
-    );
+    const emptyTrustedContext = compatibleStoredExecutionContextSchema.parse({
+      ...storedContext,
+      platformEnvironment: {},
+    });
+    expect(emptyTrustedContext.platformEnvironment).toStrictEqual({});
   });
 });
 
@@ -343,6 +324,7 @@ describe("Pi sandbox execution contract", () => {
     storageMounts: [],
     connectorRuntimeTargets: [],
     environment: null,
+    platformEnvironment: {},
     secretValueEnvironmentKeys: null,
     resumeSession: null,
     encryptedSecrets: null,
@@ -926,6 +908,7 @@ describe("stored connector permission baseline contract", () => {
     storageMounts: [],
     connectorRuntimeTargets: [],
     environment: null,
+    platformEnvironment: {},
     secretValueEnvironmentKeys: null,
     resumeSession: null,
     encryptedSecrets: null,
@@ -1071,6 +1054,7 @@ describe("runner storage manifest contract", () => {
     storageMounts: [],
     connectorRuntimeTargets: [],
     environment: null,
+    platformEnvironment: {},
     secretValueEnvironmentKeys: null,
     resumeSession: null,
     encryptedSecrets: null,

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -1005,12 +1005,9 @@ const storedExecutionContextObjectSchema = z.object({
     .array(storedStorageMountEntrySchema)
     .superRefine(uniqueStorageMountPaths),
   environment: z.record(z.string(), z.string()).nullable(),
-  // Old API/stored payload -> new API: previous contexts omit this field. Keep
-  // it optional until prior API rollback targets retire and no supported
-  // resumable context predates it; #28914 tracks that gate.
-  platformEnvironment: z.record(z.string(), z.string()).optional(),
+  platformEnvironment: z.record(z.string(), z.string()),
   // API-only references used to reconstruct runner masking values from the
-  // stored environment. Null means no persistent secret map, and array
+  // effective stored agent environment. Null means no persistent secret map, and array
   // order/repetition follows secret-map values.
   // This field must not be included in the runner-facing ExecutionContext.
   secretValueEnvironmentKeys: z.array(z.string()).nullable(),
@@ -1111,10 +1108,7 @@ const executionContextObjectSchema = z.object({
   sandboxToken: z.string(),
   storageManifest: storageManifestSchema.nullable(),
   environment: z.record(z.string(), z.string()).nullable(),
-  // Old API -> new runner: previous claims omit this field. Keep it optional
-  // until prior API rollback targets and supported pre-field claims are gone;
-  // #28914 tracks that gate. Old runners ignore it and use legacy environment.
-  platformEnvironment: z.record(z.string(), z.string()).optional(),
+  platformEnvironment: z.record(z.string(), z.string()),
   resumeSession: resumeSessionSchema.nullable(),
   // Plain secret values used by the runner for redaction. These are values, not
   // names, and are base64-encoded only when exported through VM0_SECRET_VALUES.


### PR DESCRIPTION
## Summary

- stop copying trusted `platformEnvironment` values into legacy untrusted `environment`
- require the canonical trusted record across stored/claim contracts, Rust API projection, local construction, and fixtures
- remove field-less/pre-ownership filtering compatibility while preserving the full `OKOU_*` / `VM0_*` / explicit-key guard and trusted-last precedence
- keep secret reconstruction and run-context redaction based on the effective trusted-last environment

## Verification

- `cargo fmt --all -- --check`
- strict `cargo check` and `cargo clippy` for `guest-contracts` and `runner`, all targets/features, with warnings denied
- focused Guest ownership test: 1 passed
- API lint and type checks
- API-contract lint and type checks
- focused API-contract Runner suite: 105 passed
- PostgreSQL-backed API ownership runtime test: 1 passed
- canonical Rust and Python binding generators: no drift
- Prettier and `git diff --check`

The focused monolithic Runner test was attempted once on the 3.8 GiB/no-swap host and reached its final link before exit 137. Kernel evidence identified the rustc process as the cgroup OOM victim at 3,716,056 KiB anonymous RSS; protected CI is the remaining runtime evidence for that binary.

No Actions, workflow, deployment, release, Ansible, production configuration, or external configuration files are changed.

Closes #30694
Parent: #28914