### PR TITLE
test(api): stabilize lifecycle race fixtures

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -157,7 +157,7 @@ import {
   acquireBddVm0ApiKey,
   completeRunWithoutCallbacksFixture,
   deleteAgentRunFixture,
-  holdCheckpointReadsFixture,
+  holdAgentRunRowLockFixture,
   holdChatEventQueueItemFixture,
   holdChatThreadRowLockFixture,
   holdOrgAdmissionLockFixture,
@@ -7928,21 +7928,22 @@ describe("CHAT-02: model-first provider policies", () => {
       })
       .toBe(true);
     const racedClaim = await claimChatRun(runnerGroup, racedHandoff.runId);
-    const checkpointGate = await holdCheckpointReadsFixture({
+    const lifecycleGate = await holdAgentRunRowLockFixture({
+      runId: racedHandoff.runId,
       signal: context.signal,
     });
+    const ownedRequests: Promise<unknown>[] = [];
     onTestFinished(async () => {
-      checkpointGate.release();
-      await checkpointGate.done;
+      lifecycleGate.release();
+      await Promise.all([lifecycleGate.done, ...ownedRequests]);
     });
     const racedCompletion = webhooks.requestAgentComplete(
       { runId: racedHandoff.runId, exitCode: 0 },
       racedClaim.sandboxHeaders,
       [200],
     );
-    await expect
-      .poll(checkpointGate.blockedWaiterCount)
-      .toBeGreaterThanOrEqual(1);
+    ownedRequests.push(Promise.allSettled([racedCompletion]));
+    await expect.poll(lifecycleGate.waiterCount).toBe(1);
     const racedCheckpoint = webhooks.requestAgentCheckpoint(
       {
         runId: racedHandoff.runId,
@@ -7953,15 +7954,19 @@ describe("CHAT-02: model-first provider policies", () => {
       racedClaim.sandboxHeaders,
       [400],
     );
-    checkpointGate.release();
-    await checkpointGate.done;
-    await expect(racedCompletion).resolves.toMatchObject({
-      body: { success: true, status: "failed" },
-    });
-    const racedCheckpointResponse = await racedCheckpoint;
-    expect(JSON.stringify(racedCheckpointResponse.body)).toContain(
+    ownedRequests.push(Promise.allSettled([racedCheckpoint]));
+    const racedCheckpointResult = await racedCheckpoint;
+    expect(JSON.stringify(racedCheckpointResult.body)).toContain(
       "[CHECKPOINT_RUN_NOT_SETTLED]",
     );
+    lifecycleGate.release();
+    const [, racedCompletionResult] = await Promise.all([
+      lifecycleGate.done,
+      racedCompletion,
+    ] as const);
+    expect(racedCompletionResult).toMatchObject({
+      body: { success: true, status: "failed" },
+    });
     await waitForRunStatus(actor, racedHandoff.runId, "failed");
     await flushWaitUntilForTest();
     await expect(

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -7935,7 +7935,8 @@ describe("CHAT-02: model-first provider policies", () => {
     const ownedRequests: Promise<unknown>[] = [];
     onTestFinished(async () => {
       lifecycleGate.release();
-      await Promise.all([lifecycleGate.done, ...ownedRequests]);
+      await Promise.all(ownedRequests);
+      await lifecycleGate.done;
     });
     const racedCompletion = webhooks.requestAgentComplete(
       { runId: racedHandoff.runId, exitCode: 0 },

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -18381,7 +18381,8 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
     const ownedRequests: Promise<unknown>[] = [];
     onTestFinished(async () => {
       lifecycleGate.release();
-      await Promise.all([lifecycleGate.done, ...ownedRequests]);
+      await Promise.all(ownedRequests);
+      await lifecycleGate.done;
     });
     const completion = webhooks.requestAgentComplete(
       {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -86,7 +86,7 @@ import {
   setRunModelRuntimeRouteFixture,
 } from "../../../test-fixtures/agent-runs";
 import {
-  holdCheckpointReadsFixture,
+  holdAgentRunRowLockFixture,
   timeoutRunWithoutCallbacksFixture,
 } from "../../../test-fixtures/chat-events";
 import {
@@ -18374,12 +18374,14 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
       modelProvider: "anthropic-api-key",
     });
     const claim = await api.claimRunnerJob(run.runId);
-    const checkpointGate = await holdCheckpointReadsFixture({
+    const lifecycleGate = await holdAgentRunRowLockFixture({
+      runId: run.runId,
       signal: context.signal,
     });
+    const ownedRequests: Promise<unknown>[] = [];
     onTestFinished(async () => {
-      checkpointGate.release();
-      await checkpointGate.done;
+      lifecycleGate.release();
+      await Promise.all([lifecycleGate.done, ...ownedRequests]);
     });
     const completion = webhooks.requestAgentComplete(
       {
@@ -18394,9 +18396,8 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
       { authorization: `Bearer ${claim.sandboxToken}` },
       [200],
     );
-    await expect
-      .poll(checkpointGate.blockedWaiterCount)
-      .toBeGreaterThanOrEqual(1);
+    ownedRequests.push(Promise.allSettled([completion]));
+    await expect.poll(lifecycleGate.waiterCount).toBe(1);
 
     mockNow(startedAt + 3 * 60 * 1000);
     const cleanup = cleanupTimedOutRun(context, {
@@ -18404,13 +18405,19 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
       chatThreadId: randomUUID(),
       orgId: actor.orgId,
     });
-    checkpointGate.release();
-    await checkpointGate.done;
+    ownedRequests.push(Promise.allSettled([cleanup]));
+    await expect.poll(lifecycleGate.waiterCount).toBe(2);
+    const requests = Promise.all([completion, cleanup] as const);
+    lifecycleGate.release();
+    const [, [completionResult, cleanupResult]] = await Promise.all([
+      lifecycleGate.done,
+      requests,
+    ] as const);
 
-    await expect(completion).resolves.toMatchObject({
+    expect(completionResult).toMatchObject({
       body: { success: true, status: "completed" },
     });
-    await expect(cleanup).resolves.toMatchObject({
+    expect(cleanupResult).toMatchObject({
       body: { cleaned: 0, errors: 0, results: [] },
     });
     await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -26,7 +26,6 @@ import { chatEvents } from "@okouai/db/schema/chat-event";
 import { chatEventSearchMessageWatermarks } from "@okouai/db/schema/chat-event-search";
 import { feishuChatIngress } from "@okouai/db/schema/feishu-chat-ingress";
 import { feishuOrgEvents } from "@okouai/db/schema/feishu-org-event";
-import { checkpoints } from "@okouai/db/schema/checkpoint";
 import { conversations } from "@okouai/db/schema/conversation";
 import { githubChatThreadRoutes } from "@okouai/db/schema/github-chat-thread-route";
 import { githubInstallations } from "@okouai/db/schema/github-installation";
@@ -997,20 +996,27 @@ export async function timeoutRunWithoutCallbacksFixture(args: {
   }
 }
 
-/**
- * Holds checkpoint reads after `/complete` has loaded its run but before its
- * terminal compare-and-set. Product APIs cannot pause at this race boundary.
- */
-export async function holdCheckpointReadsFixture(args: {
+/** Holds one unique run row so route tests can order lifecycle competitors. */
+export async function holdAgentRunRowLockFixture(args: {
+  readonly runId: string;
   readonly signal: AbortSignal;
 }): Promise<{
   readonly release: () => void;
   readonly done: Promise<void>;
-  readonly blockedWaiterCount: () => Promise<number>;
+  readonly waiterCount: () => Promise<number>;
 }> {
   const started = createDeferredPromise<number>(args.signal);
   const released = createDeferredPromise<void>(args.signal);
   const done = db().transaction(async (tx) => {
+    const [run] = await tx
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, args.runId))
+      .for("update")
+      .limit(1);
+    if (!run) {
+      throw new Error("Expected the agent run row to lock");
+    }
     const pidRows = await executeRawRows(
       tx,
       sql`
@@ -1020,9 +1026,8 @@ export async function holdCheckpointReadsFixture(args: {
     );
     const holderPid = pidRows[0]?.pid;
     if (!holderPid) {
-      throw new Error("Expected the checkpoint lock holder pid");
+      throw new Error("Expected the agent run row lock holder pid");
     }
-    await tx.execute(sql`LOCK TABLE ${checkpoints} IN ACCESS EXCLUSIVE MODE`);
     started.resolve(holderPid);
     await released.promise;
   });
@@ -1035,8 +1040,8 @@ export async function holdCheckpointReadsFixture(args: {
       }
     },
     done,
-    blockedWaiterCount: async () => {
-      return await directBlockedWaiterCount(holderPid);
+    waiterCount: () => {
+      return transitiveBlockedWaiterCount(holderPid);
     },
   };
 }


### PR DESCRIPTION
## Summary

- replace the table-wide checkpoint read fixture with a row lock scoped to the test-owned agent run
- order timeout cleanup behind a completion that already owns lifecycle serialization and explicitly settle every concurrent request during teardown
- keep the Pi H2 unsettled-checkpoint rejection deterministic while completion remains in flight

## Scope

This is a test-only stabilization. It does not change production lifecycle behavior, API contracts, persistence, timeouts, retries, worker configuration, or user flows.

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (five consecutive runs, 186/186 each)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts` (42/42)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t 'publishes ordered mixed blocks and hands explicit Sandbox tool turns to H2'`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- staged pre-commit checks: Prettier, full Knip, full Turbo type checks, and file-size validation

Closes #30710
