### PR TITLE
fix(auth): drive clerk cutover from primary app domain

### DIFF
--- a/.github/scripts/prepare-okou-pages-dist.sh
+++ b/.github/scripts/prepare-okou-pages-dist.sh
@@ -9,8 +9,17 @@ fi
 canonical_dist="$1"
 pages_dist="$2"
 preview_api_origin="${3:-}"
+production_satellite_domain="${CLERK_PRODUCTION_SATELLITE_DOMAIN:-app.okou.ai}"
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 pages_config_dir="${script_dir}/../pages/okou-app"
+
+case "$production_satellite_domain" in
+  app.okou.ai | vm0.ai) ;;
+  *)
+    echo "invalid Clerk production satellite domain: ${production_satellite_domain}" >&2
+    exit 1
+    ;;
+esac
 
 if [[ ! -f "${canonical_dist}/index.html" ]]; then
   echo "canonical app artifact must contain index.html" >&2
@@ -23,6 +32,13 @@ if [[ ! -d "$pages_dist" ]] || [[ -n "$(find "$pages_dist" -mindepth 1 -print -q
 fi
 
 cp -a "${canonical_dist}/." "$pages_dist/"
+
+clerk_satellite_domain_marker="__VM0_CLERK_PRODUCTION_SATELLITE_DOMAIN__"
+if grep -Fq "$clerk_satellite_domain_marker" "${pages_dist}/index.html"; then
+  sed -i \
+    "s|${clerk_satellite_domain_marker}|${production_satellite_domain}|g" \
+    "${pages_dist}/index.html"
+fi
 
 if [[ -n "$preview_api_origin" ]]; then
   if [[ ! "$preview_api_origin" =~ ^https://(staging|pr-[0-9]+)-api\.vm6\.ai$ ]]; then

--- a/.github/scripts/prepare-okou-pages-dist.sh
+++ b/.github/scripts/prepare-okou-pages-dist.sh
@@ -9,14 +9,14 @@ fi
 canonical_dist="$1"
 pages_dist="$2"
 preview_api_origin="${3:-}"
-production_satellite_domain="${CLERK_PRODUCTION_SATELLITE_DOMAIN:-app.okou.ai}"
+production_primary_app_domain="${CLERK_PRODUCTION_PRIMARY_APP_DOMAIN:-app.vm0.ai}"
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 pages_config_dir="${script_dir}/../pages/okou-app"
 
-case "$production_satellite_domain" in
-  app.okou.ai | vm0.ai) ;;
+case "$production_primary_app_domain" in
+  app.vm0.ai | app.okou.ai) ;;
   *)
-    echo "invalid Clerk production satellite domain: ${production_satellite_domain}" >&2
+    echo "invalid Clerk production primary app domain: ${production_primary_app_domain}" >&2
     exit 1
     ;;
 esac
@@ -33,10 +33,10 @@ fi
 
 cp -a "${canonical_dist}/." "$pages_dist/"
 
-clerk_satellite_domain_marker="__VM0_CLERK_PRODUCTION_SATELLITE_DOMAIN__"
-if grep -Fq "$clerk_satellite_domain_marker" "${pages_dist}/index.html"; then
+clerk_primary_app_domain_marker="__VM0_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN__"
+if grep -Fq "$clerk_primary_app_domain_marker" "${pages_dist}/index.html"; then
   sed -i \
-    "s|${clerk_satellite_domain_marker}|${production_satellite_domain}|g" \
+    "s|${clerk_primary_app_domain_marker}|${production_primary_app_domain}|g" \
     "${pages_dist}/index.html"
 fi
 

--- a/.github/scripts/tests/deploy-okou-pages-workflow-test.sh
+++ b/.github/scripts/tests/deploy-okou-pages-workflow-test.sh
@@ -79,11 +79,20 @@ release_api_verification_step = find_step(
     release_api_job, "Verify production App and API domains"
 )
 rollback_step = find_step(rollback_job, "Deploy App to Cloudflare Pages production")
+rollback_prepare_step = find_step(rollback_job, "Prepare App production deployment")
 rollback_verification_step = find_step(
     rollback_verification_job, "Verify production App and API domains"
 )
 
 shared_script = "bash .github/scripts/deploy-okou-pages.sh"
+satellite_domain_expression = (
+    "${{ vars.CLERK_PRODUCTION_SATELLITE_DOMAIN || 'app.okou.ai' }}"
+)
+for step in (prepare_preview_step, prepare_release_step, rollback_prepare_step):
+    if step.get("env", {}).get("CLERK_PRODUCTION_SATELLITE_DOMAIN") != satellite_domain_expression:
+        raise RuntimeError(
+            f"step {step.get('name')} must inject the Clerk production satellite domain"
+        )
 require_fragments(
     build_step,
     ["build:verify-hashes", "--sourcemap", "sentry-cli sourcemaps inject dist"],

--- a/.github/scripts/tests/deploy-okou-pages-workflow-test.sh
+++ b/.github/scripts/tests/deploy-okou-pages-workflow-test.sh
@@ -85,13 +85,13 @@ rollback_verification_step = find_step(
 )
 
 shared_script = "bash .github/scripts/deploy-okou-pages.sh"
-satellite_domain_expression = (
-    "${{ vars.CLERK_PRODUCTION_SATELLITE_DOMAIN || 'app.okou.ai' }}"
+primary_app_domain_expression = (
+    "${{ vars.CLERK_PRODUCTION_PRIMARY_APP_DOMAIN || 'app.vm0.ai' }}"
 )
 for step in (prepare_preview_step, prepare_release_step, rollback_prepare_step):
-    if step.get("env", {}).get("CLERK_PRODUCTION_SATELLITE_DOMAIN") != satellite_domain_expression:
+    if step.get("env", {}).get("CLERK_PRODUCTION_PRIMARY_APP_DOMAIN") != primary_app_domain_expression:
         raise RuntimeError(
-            f"step {step.get('name')} must inject the Clerk production satellite domain"
+            f"step {step.get('name')} must inject the Clerk production primary app domain"
         )
 require_fragments(
     build_step,

--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -183,6 +183,7 @@ const builtIndexTemplate = indexTemplate
     "%VITE_CLERK_PUBLISHABLE_KEY_PROD%",
     productionClerkPublishableKey,
   )
+  .replaceAll("__VM0_CLERK_PRODUCTION_SATELLITE_DOMAIN__", "app.okou.ai")
   .replaceAll("__VM0_CLERK_BROWSER_SCRIPT_URL__", clerkBrowserScriptUrl);
 const expectedClerkCoreScript = clerkCoreScript(builtIndexTemplate);
 const expectedClerkBootstrap = clerkBootstrap(builtIndexTemplate);

--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -183,7 +183,7 @@ const builtIndexTemplate = indexTemplate
     "%VITE_CLERK_PUBLISHABLE_KEY_PROD%",
     productionClerkPublishableKey,
   )
-  .replaceAll("__VM0_CLERK_PRODUCTION_SATELLITE_DOMAIN__", "app.okou.ai")
+  .replaceAll("__VM0_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN__", "app.vm0.ai")
   .replaceAll("__VM0_CLERK_BROWSER_SCRIPT_URL__", clerkBrowserScriptUrl);
 const expectedClerkCoreScript = clerkCoreScript(builtIndexTemplate);
 const expectedClerkBootstrap = clerkBootstrap(builtIndexTemplate);

--- a/.github/scripts/tests/prepare-okou-pages-dist-test.sh
+++ b/.github/scripts/tests/prepare-okou-pages-dist-test.sh
@@ -17,6 +17,7 @@ printf '%s\n' \
   '  <meta name="okou-app-git-commit-sha" content="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">' \
   '  <meta name="okou-app-version" content="0.812.5">' \
   '</head>' \
+  '<script>window.testSatellite="__VM0_CLERK_PRODUCTION_SATELLITE_DOMAIN__";</script>' \
   '<script type="module" src="https://static.okou.io/okou-app/assets/app-123.js"></script>' \
   > "${canonical_dist}/index.html"
 cp "${repo_root}/turbo/apps/platform/public/robots.txt" \
@@ -57,6 +58,7 @@ grep -Fq \
   "${pages_dist}/index.html"
 grep -Fq '<meta name="okou-app-version" content="0.812.5">' \
   "${pages_dist}/index.html"
+grep -Fq 'window.testSatellite="app.okou.ai"' "${pages_dist}/index.html"
 grep -Fxq 'Allow: /' "${pages_dist}/robots.txt"
 ! grep -Fq 'Disallow:' "${pages_dist}/robots.txt"
 
@@ -87,6 +89,22 @@ grep -Fq \
   "${preview_pages_dist}/index.html"
 grep -Fq '<meta name="okou-app-version" content="0.812.5">' \
   "${preview_pages_dist}/index.html"
+
+cutover_pages_dist="${tmp_dir}/cutover-pages"
+mkdir -p "$cutover_pages_dist"
+CLERK_PRODUCTION_SATELLITE_DOMAIN=vm0.ai \
+  bash "$script" "$canonical_dist" "$cutover_pages_dist"
+grep -Fq 'window.testSatellite="vm0.ai"' \
+  "${cutover_pages_dist}/index.html"
+
+invalid_satellite_dist="${tmp_dir}/invalid-satellite"
+mkdir -p "$invalid_satellite_dist"
+if CLERK_PRODUCTION_SATELLITE_DOMAIN=evil.example \
+  bash "$script" "$canonical_dist" "$invalid_satellite_dist" \
+  >/dev/null 2>&1; then
+  echo "expected an invalid Clerk satellite domain to be rejected" >&2
+  exit 1
+fi
 
 invalid_origin_dist="${tmp_dir}/invalid-origin"
 mkdir -p "$invalid_origin_dist"

--- a/.github/scripts/tests/prepare-okou-pages-dist-test.sh
+++ b/.github/scripts/tests/prepare-okou-pages-dist-test.sh
@@ -17,7 +17,7 @@ printf '%s\n' \
   '  <meta name="okou-app-git-commit-sha" content="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">' \
   '  <meta name="okou-app-version" content="0.812.5">' \
   '</head>' \
-  '<script>window.testSatellite="__VM0_CLERK_PRODUCTION_SATELLITE_DOMAIN__";</script>' \
+  '<script>window.testPrimary="__VM0_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN__";</script>' \
   '<script type="module" src="https://static.okou.io/okou-app/assets/app-123.js"></script>' \
   > "${canonical_dist}/index.html"
 cp "${repo_root}/turbo/apps/platform/public/robots.txt" \
@@ -58,7 +58,7 @@ grep -Fq \
   "${pages_dist}/index.html"
 grep -Fq '<meta name="okou-app-version" content="0.812.5">' \
   "${pages_dist}/index.html"
-grep -Fq 'window.testSatellite="app.okou.ai"' "${pages_dist}/index.html"
+grep -Fq 'window.testPrimary="app.vm0.ai"' "${pages_dist}/index.html"
 grep -Fxq 'Allow: /' "${pages_dist}/robots.txt"
 ! grep -Fq 'Disallow:' "${pages_dist}/robots.txt"
 
@@ -92,17 +92,17 @@ grep -Fq '<meta name="okou-app-version" content="0.812.5">' \
 
 cutover_pages_dist="${tmp_dir}/cutover-pages"
 mkdir -p "$cutover_pages_dist"
-CLERK_PRODUCTION_SATELLITE_DOMAIN=vm0.ai \
+CLERK_PRODUCTION_PRIMARY_APP_DOMAIN=app.okou.ai \
   bash "$script" "$canonical_dist" "$cutover_pages_dist"
-grep -Fq 'window.testSatellite="vm0.ai"' \
+grep -Fq 'window.testPrimary="app.okou.ai"' \
   "${cutover_pages_dist}/index.html"
 
 invalid_satellite_dist="${tmp_dir}/invalid-satellite"
 mkdir -p "$invalid_satellite_dist"
-if CLERK_PRODUCTION_SATELLITE_DOMAIN=evil.example \
+if CLERK_PRODUCTION_PRIMARY_APP_DOMAIN=evil.example \
   bash "$script" "$canonical_dist" "$invalid_satellite_dist" \
   >/dev/null 2>&1; then
-  echo "expected an invalid Clerk satellite domain to be rejected" >&2
+  echo "expected an invalid Clerk primary app domain to be rejected" >&2
   exit 1
 fi
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1528,7 +1528,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_STATIC_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_STATIC_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
-          CLERK_PRODUCTION_SATELLITE_DOMAIN: ${{ vars.CLERK_PRODUCTION_SATELLITE_DOMAIN || 'app.okou.ai' }}
+          CLERK_PRODUCTION_PRIMARY_APP_DOMAIN: ${{ vars.CLERK_PRODUCTION_PRIMARY_APP_DOMAIN || 'app.vm0.ai' }}
           R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
           R2_BUCKET_NAME: ${{ vars.R2_STATIC_BUCKET_NAME }}
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1528,6 +1528,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_STATIC_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_STATIC_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
+          CLERK_PRODUCTION_SATELLITE_DOMAIN: ${{ vars.CLERK_PRODUCTION_SATELLITE_DOMAIN || 'app.okou.ai' }}
           R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
           R2_BUCKET_NAME: ${{ vars.R2_STATIC_BUCKET_NAME }}
         run: |

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -156,7 +156,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_STATIC_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_STATIC_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
-          CLERK_PRODUCTION_SATELLITE_DOMAIN: ${{ vars.CLERK_PRODUCTION_SATELLITE_DOMAIN || 'app.okou.ai' }}
+          CLERK_PRODUCTION_PRIMARY_APP_DOMAIN: ${{ vars.CLERK_PRODUCTION_PRIMARY_APP_DOMAIN || 'app.vm0.ai' }}
           R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
           R2_BUCKET_NAME: ${{ vars.R2_STATIC_BUCKET_NAME }}
           TARGET_COMMIT: ${{ needs.resolve-target.outputs.target_commit }}

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -156,6 +156,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_STATIC_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_STATIC_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
+          CLERK_PRODUCTION_SATELLITE_DOMAIN: ${{ vars.CLERK_PRODUCTION_SATELLITE_DOMAIN || 'app.okou.ai' }}
           R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
           R2_BUCKET_NAME: ${{ vars.R2_STATIC_BUCKET_NAME }}
           TARGET_COMMIT: ${{ needs.resolve-target.outputs.target_commit }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1430,6 +1430,7 @@ jobs:
       - name: Prepare Cloudflare Pages preview
         id: pages-preview
         env:
+          CLERK_PRODUCTION_SATELLITE_DOMAIN: ${{ vars.CLERK_PRODUCTION_SATELLITE_DOMAIN || 'app.okou.ai' }}
           ARTIFACT_EXISTS: ${{ steps.existing.outputs.exists }}
           ARTIFACT_PREFIX: ${{ steps.artifact.outputs.prefix }}
           PAGES_BRANCH: ${{ steps.pages-branch.outputs.branch }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1430,7 +1430,7 @@ jobs:
       - name: Prepare Cloudflare Pages preview
         id: pages-preview
         env:
-          CLERK_PRODUCTION_SATELLITE_DOMAIN: ${{ vars.CLERK_PRODUCTION_SATELLITE_DOMAIN || 'app.okou.ai' }}
+          CLERK_PRODUCTION_PRIMARY_APP_DOMAIN: ${{ vars.CLERK_PRODUCTION_PRIMARY_APP_DOMAIN || 'app.vm0.ai' }}
           ARTIFACT_EXISTS: ${{ steps.existing.outputs.exists }}
           ARTIFACT_PREFIX: ${{ steps.artifact.outputs.prefix }}
           PAGES_BRANCH: ${{ steps.pages-branch.outputs.branch }}

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -225,23 +225,28 @@
         var publishableKey = production
           ? "%VITE_CLERK_PUBLISHABLE_KEY_PROD%"
           : "%VITE_CLERK_PUBLISHABLE_KEY_PREVIEW%";
-        var productionSatelliteDomain =
-          "__VM0_CLERK_PRODUCTION_SATELLITE_DOMAIN__" === "vm0.ai"
-            ? "vm0.ai"
-            : "app.okou.ai";
-        var okouPrimary = productionSatelliteDomain === "vm0.ai";
+        var productionPrimaryAppDomain =
+          "__VM0_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN__" === "app.okou.ai"
+            ? "app.okou.ai"
+            : "app.vm0.ai";
+        var okouPrimary = productionPrimaryAppDomain === "app.okou.ai";
         var satelliteDomain = null;
         if (
           production &&
-          isDomainOrSubdomain(hostname, productionSatelliteDomain)
+          okouPrimary &&
+          isDomainOrSubdomain(hostname, "vm0.ai")
         ) {
-          satelliteDomain = productionSatelliteDomain;
+          satelliteDomain = "vm0.ai";
+        } else if (
+          production &&
+          !okouPrimary &&
+          isDomainOrSubdomain(hostname, "app.okou.ai")
+        ) {
+          satelliteDomain = "app.okou.ai";
         }
         var satellite = satelliteDomain !== null;
         var authOrigin = satellite
-          ? okouPrimary
-            ? "https://app.okou.ai"
-            : "https://app.vm0.ai"
+          ? "https://" + productionPrimaryAppDomain
           : location.origin;
         var loadOptions = {
           afterSignOutUrl: new URL("/sign-in", authOrigin).toString(),
@@ -265,7 +270,7 @@
           clientSessionId: clientSessionId,
           domain: satelliteDomain || undefined,
           loadOptions: loadOptions,
-          productionSatelliteDomain: productionSatelliteDomain,
+          productionPrimaryAppDomain: productionPrimaryAppDomain,
           publishableKey: publishableKey,
         };
         window.__vm0ClerkBootstrap = bootstrap;

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -225,21 +225,17 @@
         var publishableKey = production
           ? "%VITE_CLERK_PUBLISHABLE_KEY_PROD%"
           : "%VITE_CLERK_PUBLISHABLE_KEY_PREVIEW%";
-        var primaryClerkFrontendApi = clerkFrontendApi(publishableKey);
-        var okouPrimary = primaryClerkFrontendApi === "clerk.app.okou.ai";
+        var productionSatelliteDomain =
+          "__VM0_CLERK_PRODUCTION_SATELLITE_DOMAIN__" === "vm0.ai"
+            ? "vm0.ai"
+            : "app.okou.ai";
+        var okouPrimary = productionSatelliteDomain === "vm0.ai";
         var satelliteDomain = null;
         if (
           production &&
-          okouPrimary &&
-          isDomainOrSubdomain(hostname, "vm0.ai")
+          isDomainOrSubdomain(hostname, productionSatelliteDomain)
         ) {
-          satelliteDomain = "vm0.ai";
-        } else if (
-          production &&
-          !okouPrimary &&
-          isDomainOrSubdomain(hostname, "app.okou.ai")
-        ) {
-          satelliteDomain = "app.okou.ai";
+          satelliteDomain = productionSatelliteDomain;
         }
         var satellite = satelliteDomain !== null;
         var authOrigin = satellite
@@ -269,23 +265,13 @@
           clientSessionId: clientSessionId,
           domain: satelliteDomain || undefined,
           loadOptions: loadOptions,
+          productionSatelliteDomain: productionSatelliteDomain,
           publishableKey: publishableKey,
         };
         window.__vm0ClerkBootstrap = bootstrap;
 
         function isDomainOrSubdomain(value, domain) {
           return value === domain || value.endsWith("." + domain);
-        }
-
-        function clerkFrontendApi(key) {
-          var encoded = key.split("_")[2];
-          if (!encoded) return "";
-          try {
-            var decoded = atob(encoded);
-            return decoded.endsWith("$") ? decoded.slice(0, -1) : "";
-          } catch (_error) {
-            return "";
-          }
         }
 
         function rewriteServiceHostname(value, target) {

--- a/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
@@ -21,8 +21,8 @@ vi.unmock("@clerk/shared/loadClerkJsScript");
 
 const PREVIEW_FRONTEND_API_HOST = "informed-calf-6.clerk.accounts.dev";
 const PRODUCTION_FRONTEND_API_HOST = "clerk.vm0.ai";
-const PRODUCTION_SATELLITE_DOMAIN = "app.okou.ai";
-const CUTOVER_SATELLITE_DOMAIN = "vm0.ai";
+const CURRENT_PRIMARY_APP_DOMAIN = "app.vm0.ai";
+const CUTOVER_PRIMARY_APP_DOMAIN = "app.okou.ai";
 const CLERK_BOOTSTRAP_SELECTOR = "script[data-vm0-clerk-bootstrap]";
 const CLERK_CORE_SCRIPT_ID = "vm0-clerk-core-script";
 const CLERK_SCRIPT_SELECTOR = "script[data-clerk-js-script]";
@@ -70,9 +70,9 @@ interface ClerkPageOptions {
   readonly cookie?: string;
   readonly path?: string;
   readonly productionPublishableKey?: string;
-  readonly productionSatelliteDomain?:
-    | typeof CUTOVER_SATELLITE_DOMAIN
-    | typeof PRODUCTION_SATELLITE_DOMAIN;
+  readonly productionPrimaryAppDomain?:
+    | typeof CURRENT_PRIMARY_APP_DOMAIN
+    | typeof CUTOVER_PRIMARY_APP_DOMAIN;
   readonly url?: string;
 }
 
@@ -108,7 +108,7 @@ function stubClerkBuildEnvironment(
 function builtIndexHtml(
   appVersion = TEST_APP_VERSION,
   productionPublishableKey = PRODUCTION_PUBLISHABLE_KEY,
-  productionSatelliteDomain = PRODUCTION_SATELLITE_DOMAIN,
+  productionPrimaryAppDomain = CURRENT_PRIMARY_APP_DOMAIN,
 ): string {
   return transformClerkCoreScriptUrls(
     indexHtml
@@ -118,8 +118,8 @@ function builtIndexHtml(
       )
       .replaceAll("%VITE_CLERK_PUBLISHABLE_KEY_PROD%", productionPublishableKey)
       .replaceAll(
-        "__VM0_CLERK_PRODUCTION_SATELLITE_DOMAIN__",
-        productionSatelliteDomain,
+        "__VM0_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN__",
+        productionPrimaryAppDomain,
       ),
     {
       appVersion,
@@ -166,7 +166,7 @@ function captureClerkBootstrapScript(
     | "apiOriginMarker"
     | "cookie"
     | "productionPublishableKey"
-    | "productionSatelliteDomain"
+    | "productionPrimaryAppDomain"
   > = {},
 ): HTMLScriptElement {
   stubClerkBuildEnvironment(options.productionPublishableKey);
@@ -190,7 +190,7 @@ function captureClerkBootstrapScript(
   const html = builtIndexHtml(
     TEST_APP_VERSION,
     options.productionPublishableKey,
-    options.productionSatelliteDomain,
+    options.productionPrimaryAppDomain,
   );
   const clerkScript = createClerkCoreScript(html);
   const scriptUrl = clerkScript.src;
@@ -258,7 +258,7 @@ function startClerkPage(
       const html = builtIndexHtml(
         TEST_APP_VERSION,
         options.productionPublishableKey,
-        options.productionSatelliteDomain,
+        options.productionPrimaryAppDomain,
       );
       const staticClerkScript = createClerkCoreScript(html);
       document.head.appendChild(staticClerkScript);
@@ -443,7 +443,7 @@ describe("platform Clerk entrypoint", () => {
     },
     {
       authOrigin: "https://app.vm0.ai",
-      domain: PRODUCTION_SATELLITE_DOMAIN,
+      domain: "app.okou.ai",
       publishableKey: PRODUCTION_PUBLISHABLE_KEY,
       scriptUrl: expectedClerkScriptUrl(),
       url: "https://app.okou.ai/",
@@ -451,7 +451,7 @@ describe("platform Clerk entrypoint", () => {
     {
       authOrigin: "https://app.okou.ai",
       domain: null,
-      productionSatelliteDomain: CUTOVER_SATELLITE_DOMAIN,
+      productionPrimaryAppDomain: CUTOVER_PRIMARY_APP_DOMAIN,
       publishableKey: PRODUCTION_PUBLISHABLE_KEY,
       scriptUrl: expectedClerkScriptUrl(),
       url: "https://app.okou.ai/",
@@ -459,7 +459,7 @@ describe("platform Clerk entrypoint", () => {
     {
       authOrigin: "https://app.okou.ai",
       domain: "vm0.ai",
-      productionSatelliteDomain: CUTOVER_SATELLITE_DOMAIN,
+      productionPrimaryAppDomain: CUTOVER_PRIMARY_APP_DOMAIN,
       publishableKey: PRODUCTION_PUBLISHABLE_KEY,
       scriptUrl: expectedClerkScriptUrl(),
       url: "https://app.vm0.ai/",
@@ -476,14 +476,14 @@ describe("platform Clerk entrypoint", () => {
     ({
       authOrigin,
       domain,
-      productionSatelliteDomain,
+      productionPrimaryAppDomain,
       publishableKey,
       scriptUrl,
       url,
     }) => {
       const script = captureClerkBootstrapScript(url, {
-        productionSatelliteDomain:
-          productionSatelliteDomain as ClerkPageOptions["productionSatelliteDomain"],
+        productionPrimaryAppDomain:
+          productionPrimaryAppDomain as ClerkPageOptions["productionPrimaryAppDomain"],
       });
       const bootstrap = window.__vm0ClerkBootstrap;
       if (!bootstrap) {
@@ -506,8 +506,8 @@ describe("platform Clerk entrypoint", () => {
       expect(script.onload).toStrictEqual(expect.any(Function));
       expect(script.type).toBe("text/javascript");
       expect(bootstrap.publishableKey).toBe(publishableKey);
-      expect(bootstrap.productionSatelliteDomain).toBe(
-        productionSatelliteDomain ?? PRODUCTION_SATELLITE_DOMAIN,
+      expect(bootstrap.productionPrimaryAppDomain).toBe(
+        productionPrimaryAppDomain ?? CURRENT_PRIMARY_APP_DOMAIN,
       );
       expect(bootstrap.domain ?? null).toBe(domain);
       expect(bootstrap.loadOptions).toStrictEqual({
@@ -629,7 +629,7 @@ describe("platform Clerk entrypoint", () => {
       authOrigin: "https://app.vm0.ai",
       bypass: null,
       cookie: undefined,
-      domain: PRODUCTION_SATELLITE_DOMAIN,
+      domain: "app.okou.ai",
       expectedRequestUrl: "https://api.okou.ai/api/onboarding/status",
       expectedScriptUrl: expectedClerkScriptUrl(),
       url: "https://app.okou.ai/",

--- a/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
@@ -21,8 +21,8 @@ vi.unmock("@clerk/shared/loadClerkJsScript");
 
 const PREVIEW_FRONTEND_API_HOST = "informed-calf-6.clerk.accounts.dev";
 const PRODUCTION_FRONTEND_API_HOST = "clerk.vm0.ai";
-const OKOU_PRODUCTION_FRONTEND_API_HOST = "clerk.app.okou.ai";
 const PRODUCTION_SATELLITE_DOMAIN = "app.okou.ai";
+const CUTOVER_SATELLITE_DOMAIN = "vm0.ai";
 const CLERK_BOOTSTRAP_SELECTOR = "script[data-vm0-clerk-bootstrap]";
 const CLERK_CORE_SCRIPT_ID = "vm0-clerk-core-script";
 const CLERK_SCRIPT_SELECTOR = "script[data-clerk-js-script]";
@@ -70,6 +70,9 @@ interface ClerkPageOptions {
   readonly cookie?: string;
   readonly path?: string;
   readonly productionPublishableKey?: string;
+  readonly productionSatelliteDomain?:
+    | typeof CUTOVER_SATELLITE_DOMAIN
+    | typeof PRODUCTION_SATELLITE_DOMAIN;
   readonly url?: string;
 }
 
@@ -87,11 +90,6 @@ const PRODUCTION_PUBLISHABLE_KEY = publishableKey(
   "live",
   PRODUCTION_FRONTEND_API_HOST,
 );
-const OKOU_PRODUCTION_PUBLISHABLE_KEY = publishableKey(
-  "live",
-  OKOU_PRODUCTION_FRONTEND_API_HOST,
-);
-
 function expectedClerkScriptUrl(): string {
   return `https://cdn.jsdelivr.net/npm/@clerk/clerk-js@${CLERK_JS_VERSION}/dist/clerk.browser.js`;
 }
@@ -110,6 +108,7 @@ function stubClerkBuildEnvironment(
 function builtIndexHtml(
   appVersion = TEST_APP_VERSION,
   productionPublishableKey = PRODUCTION_PUBLISHABLE_KEY,
+  productionSatelliteDomain = PRODUCTION_SATELLITE_DOMAIN,
 ): string {
   return transformClerkCoreScriptUrls(
     indexHtml
@@ -117,9 +116,10 @@ function builtIndexHtml(
         "%VITE_CLERK_PUBLISHABLE_KEY_PREVIEW%",
         PREVIEW_PUBLISHABLE_KEY,
       )
+      .replaceAll("%VITE_CLERK_PUBLISHABLE_KEY_PROD%", productionPublishableKey)
       .replaceAll(
-        "%VITE_CLERK_PUBLISHABLE_KEY_PROD%",
-        productionPublishableKey,
+        "__VM0_CLERK_PRODUCTION_SATELLITE_DOMAIN__",
+        productionSatelliteDomain,
       ),
     {
       appVersion,
@@ -163,7 +163,10 @@ function captureClerkBootstrapScript(
   url: string,
   options: Pick<
     ClerkPageOptions,
-    "apiOriginMarker" | "cookie" | "productionPublishableKey"
+    | "apiOriginMarker"
+    | "cookie"
+    | "productionPublishableKey"
+    | "productionSatelliteDomain"
   > = {},
 ): HTMLScriptElement {
   stubClerkBuildEnvironment(options.productionPublishableKey);
@@ -187,6 +190,7 @@ function captureClerkBootstrapScript(
   const html = builtIndexHtml(
     TEST_APP_VERSION,
     options.productionPublishableKey,
+    options.productionSatelliteDomain,
   );
   const clerkScript = createClerkCoreScript(html);
   const scriptUrl = clerkScript.src;
@@ -254,6 +258,7 @@ function startClerkPage(
       const html = builtIndexHtml(
         TEST_APP_VERSION,
         options.productionPublishableKey,
+        options.productionSatelliteDomain,
       );
       const staticClerkScript = createClerkCoreScript(html);
       document.head.appendChild(staticClerkScript);
@@ -425,7 +430,6 @@ describe("platform Clerk entrypoint", () => {
     {
       authOrigin: "https://pr-30199-app.omby.ai",
       domain: null,
-      productionPublishableKey: PRODUCTION_PUBLISHABLE_KEY,
       publishableKey: PREVIEW_PUBLISHABLE_KEY,
       scriptUrl: expectedClerkScriptUrl(),
       url: "https://pr-30199-app.omby.ai/",
@@ -433,7 +437,6 @@ describe("platform Clerk entrypoint", () => {
     {
       authOrigin: "https://app.vm0.ai",
       domain: null,
-      productionPublishableKey: PRODUCTION_PUBLISHABLE_KEY,
       publishableKey: PRODUCTION_PUBLISHABLE_KEY,
       scriptUrl: expectedClerkScriptUrl(),
       url: "https://app.vm0.ai/",
@@ -441,7 +444,6 @@ describe("platform Clerk entrypoint", () => {
     {
       authOrigin: "https://app.vm0.ai",
       domain: PRODUCTION_SATELLITE_DOMAIN,
-      productionPublishableKey: PRODUCTION_PUBLISHABLE_KEY,
       publishableKey: PRODUCTION_PUBLISHABLE_KEY,
       scriptUrl: expectedClerkScriptUrl(),
       url: "https://app.okou.ai/",
@@ -449,23 +451,22 @@ describe("platform Clerk entrypoint", () => {
     {
       authOrigin: "https://app.okou.ai",
       domain: null,
-      productionPublishableKey: OKOU_PRODUCTION_PUBLISHABLE_KEY,
-      publishableKey: OKOU_PRODUCTION_PUBLISHABLE_KEY,
+      productionSatelliteDomain: CUTOVER_SATELLITE_DOMAIN,
+      publishableKey: PRODUCTION_PUBLISHABLE_KEY,
       scriptUrl: expectedClerkScriptUrl(),
       url: "https://app.okou.ai/",
     },
     {
       authOrigin: "https://app.okou.ai",
       domain: "vm0.ai",
-      productionPublishableKey: OKOU_PRODUCTION_PUBLISHABLE_KEY,
-      publishableKey: OKOU_PRODUCTION_PUBLISHABLE_KEY,
+      productionSatelliteDomain: CUTOVER_SATELLITE_DOMAIN,
+      publishableKey: PRODUCTION_PUBLISHABLE_KEY,
       scriptUrl: expectedClerkScriptUrl(),
       url: "https://app.vm0.ai/",
     },
     {
       authOrigin: "https://okou.ai.evil.example",
       domain: null,
-      productionPublishableKey: PRODUCTION_PUBLISHABLE_KEY,
       publishableKey: PREVIEW_PUBLISHABLE_KEY,
       scriptUrl: expectedClerkScriptUrl(),
       url: "https://okou.ai.evil.example/",
@@ -475,13 +476,14 @@ describe("platform Clerk entrypoint", () => {
     ({
       authOrigin,
       domain,
-      productionPublishableKey,
+      productionSatelliteDomain,
       publishableKey,
       scriptUrl,
       url,
     }) => {
       const script = captureClerkBootstrapScript(url, {
-        productionPublishableKey,
+        productionSatelliteDomain:
+          productionSatelliteDomain as ClerkPageOptions["productionSatelliteDomain"],
       });
       const bootstrap = window.__vm0ClerkBootstrap;
       if (!bootstrap) {
@@ -504,6 +506,9 @@ describe("platform Clerk entrypoint", () => {
       expect(script.onload).toStrictEqual(expect.any(Function));
       expect(script.type).toBe("text/javascript");
       expect(bootstrap.publishableKey).toBe(publishableKey);
+      expect(bootstrap.productionSatelliteDomain).toBe(
+        productionSatelliteDomain ?? PRODUCTION_SATELLITE_DOMAIN,
+      );
       expect(bootstrap.domain ?? null).toBe(domain);
       expect(bootstrap.loadOptions).toStrictEqual({
         afterSignOutUrl: `${authOrigin}/sign-in`,

--- a/turbo/apps/platform/src/global.d.ts
+++ b/turbo/apps/platform/src/global.d.ts
@@ -31,6 +31,7 @@ interface VM0ClerkBootstrap {
   readonly loadOptions: VM0ClerkBootstrapLoadOptions;
   loaded?: Promise<void>;
   onboardingStatusPromise?: Promise<VM0ClerkBootstrapOnboardingStatus | null>;
+  readonly productionSatelliteDomain: "app.okou.ai" | "vm0.ai";
   readonly publishableKey: string;
 }
 

--- a/turbo/apps/platform/src/global.d.ts
+++ b/turbo/apps/platform/src/global.d.ts
@@ -31,7 +31,7 @@ interface VM0ClerkBootstrap {
   readonly loadOptions: VM0ClerkBootstrapLoadOptions;
   loaded?: Promise<void>;
   onboardingStatusPromise?: Promise<VM0ClerkBootstrapOnboardingStatus | null>;
-  readonly productionSatelliteDomain: "app.okou.ai" | "vm0.ai";
+  readonly productionPrimaryAppDomain: "app.okou.ai" | "app.vm0.ai";
   readonly publishableKey: string;
 }
 

--- a/turbo/apps/platform/src/lib/__tests__/clerk-production-topology.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/clerk-production-topology.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from "vitest";
 import {
-  normalizeClerkProductionSatelliteDomain,
+  normalizeClerkProductionPrimaryAppDomain,
   resolveClerkProductionSatelliteDomain,
   resolveClerkProductionTopology,
 } from "../clerk-production-topology.ts";
 
-const CURRENT_SATELLITE_DOMAIN = "app.okou.ai";
-const CUTOVER_SATELLITE_DOMAIN = "vm0.ai";
+const CURRENT_PRIMARY_APP_DOMAIN = "app.vm0.ai";
+const CUTOVER_PRIMARY_APP_DOMAIN = "app.okou.ai";
 
 describe("clerk production topology", () => {
   it("keeps the deployed VM0 primary topology for the current satellite", () => {
     expect(
-      resolveClerkProductionTopology(CURRENT_SATELLITE_DOMAIN),
+      resolveClerkProductionTopology(CURRENT_PRIMARY_APP_DOMAIN),
     ).toStrictEqual({
       primaryAppOrigin: "https://app.vm0.ai",
       primaryBrand: "vm0",
@@ -20,20 +20,20 @@ describe("clerk production topology", () => {
     expect(
       resolveClerkProductionSatelliteDomain(
         "app.okou.ai",
-        CURRENT_SATELLITE_DOMAIN,
+        CURRENT_PRIMARY_APP_DOMAIN,
       ),
     ).toBe("app.okou.ai");
     expect(
       resolveClerkProductionSatelliteDomain(
         "app.vm0.ai",
-        CURRENT_SATELLITE_DOMAIN,
+        CURRENT_PRIMARY_APP_DOMAIN,
       ),
     ).toBeNull();
   });
 
   it("switches VM0 hosts to the root satellite when Okou is primary", () => {
     expect(
-      resolveClerkProductionTopology(CUTOVER_SATELLITE_DOMAIN),
+      resolveClerkProductionTopology(CUTOVER_PRIMARY_APP_DOMAIN),
     ).toStrictEqual({
       primaryAppOrigin: "https://app.okou.ai",
       primaryBrand: "okou",
@@ -42,32 +42,32 @@ describe("clerk production topology", () => {
     expect(
       resolveClerkProductionSatelliteDomain(
         "app.okou.ai",
-        CUTOVER_SATELLITE_DOMAIN,
+        CUTOVER_PRIMARY_APP_DOMAIN,
       ),
     ).toBeNull();
     expect(
       resolveClerkProductionSatelliteDomain(
         "app.vm0.ai",
-        CUTOVER_SATELLITE_DOMAIN,
+        CUTOVER_PRIMARY_APP_DOMAIN,
       ),
     ).toBe("vm0.ai");
     expect(
       resolveClerkProductionSatelliteDomain(
         "www.vm0.ai",
-        CUTOVER_SATELLITE_DOMAIN,
+        CUTOVER_PRIMARY_APP_DOMAIN,
       ),
     ).toBe("vm0.ai");
     expect(
       resolveClerkProductionSatelliteDomain(
         "vm0.ai.evil.example",
-        CUTOVER_SATELLITE_DOMAIN,
+        CUTOVER_PRIMARY_APP_DOMAIN,
       ),
     ).toBeNull();
   });
 
   it("falls back to the rollback-safe current topology for an unknown value", () => {
-    expect(normalizeClerkProductionSatelliteDomain("invalid-domain")).toBe(
-      CURRENT_SATELLITE_DOMAIN,
+    expect(normalizeClerkProductionPrimaryAppDomain("invalid-domain")).toBe(
+      CURRENT_PRIMARY_APP_DOMAIN,
     );
     expect(resolveClerkProductionTopology("invalid-domain")).toMatchObject({
       primaryAppOrigin: "https://app.vm0.ai",

--- a/turbo/apps/platform/src/lib/__tests__/clerk-production-topology.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/clerk-production-topology.test.ts
@@ -1,16 +1,17 @@
 import { describe, expect, it } from "vitest";
 import {
+  normalizeClerkProductionSatelliteDomain,
   resolveClerkProductionSatelliteDomain,
   resolveClerkProductionTopology,
 } from "../clerk-production-topology.ts";
 
-const VM0_PRIMARY_PUBLISHABLE_KEY = "pk_live_Y2xlcmsudm0wLmFpJA";
-const OKOU_PRIMARY_PUBLISHABLE_KEY = "pk_live_Y2xlcmsuYXBwLm9rb3UuYWkk";
+const CURRENT_SATELLITE_DOMAIN = "app.okou.ai";
+const CUTOVER_SATELLITE_DOMAIN = "vm0.ai";
 
 describe("clerk production topology", () => {
-  it("keeps the deployed VM0 primary topology for the legacy key", () => {
+  it("keeps the deployed VM0 primary topology for the current satellite", () => {
     expect(
-      resolveClerkProductionTopology(VM0_PRIMARY_PUBLISHABLE_KEY),
+      resolveClerkProductionTopology(CURRENT_SATELLITE_DOMAIN),
     ).toStrictEqual({
       primaryAppOrigin: "https://app.vm0.ai",
       primaryBrand: "vm0",
@@ -19,53 +20,56 @@ describe("clerk production topology", () => {
     expect(
       resolveClerkProductionSatelliteDomain(
         "app.okou.ai",
-        VM0_PRIMARY_PUBLISHABLE_KEY,
+        CURRENT_SATELLITE_DOMAIN,
       ),
     ).toBe("app.okou.ai");
     expect(
       resolveClerkProductionSatelliteDomain(
         "app.vm0.ai",
-        VM0_PRIMARY_PUBLISHABLE_KEY,
+        CURRENT_SATELLITE_DOMAIN,
       ),
     ).toBeNull();
   });
 
   it("switches VM0 hosts to the root satellite when Okou is primary", () => {
     expect(
-      resolveClerkProductionTopology(OKOU_PRIMARY_PUBLISHABLE_KEY),
+      resolveClerkProductionTopology(CUTOVER_SATELLITE_DOMAIN),
     ).toStrictEqual({
       primaryAppOrigin: "https://app.okou.ai",
       primaryBrand: "okou",
-      primaryUserProfileUrl: "https://accounts.app.okou.ai/user",
+      primaryUserProfileUrl: "https://accounts.vm0.ai/user",
     });
     expect(
       resolveClerkProductionSatelliteDomain(
         "app.okou.ai",
-        OKOU_PRIMARY_PUBLISHABLE_KEY,
+        CUTOVER_SATELLITE_DOMAIN,
       ),
     ).toBeNull();
     expect(
       resolveClerkProductionSatelliteDomain(
         "app.vm0.ai",
-        OKOU_PRIMARY_PUBLISHABLE_KEY,
+        CUTOVER_SATELLITE_DOMAIN,
       ),
     ).toBe("vm0.ai");
     expect(
       resolveClerkProductionSatelliteDomain(
         "www.vm0.ai",
-        OKOU_PRIMARY_PUBLISHABLE_KEY,
+        CUTOVER_SATELLITE_DOMAIN,
       ),
     ).toBe("vm0.ai");
     expect(
       resolveClerkProductionSatelliteDomain(
         "vm0.ai.evil.example",
-        OKOU_PRIMARY_PUBLISHABLE_KEY,
+        CUTOVER_SATELLITE_DOMAIN,
       ),
     ).toBeNull();
   });
 
-  it("falls back to the rollback-safe VM0 topology for an unknown key", () => {
-    expect(resolveClerkProductionTopology("invalid-key")).toMatchObject({
+  it("falls back to the rollback-safe current topology for an unknown value", () => {
+    expect(normalizeClerkProductionSatelliteDomain("invalid-domain")).toBe(
+      CURRENT_SATELLITE_DOMAIN,
+    );
+    expect(resolveClerkProductionTopology("invalid-domain")).toMatchObject({
       primaryAppOrigin: "https://app.vm0.ai",
       primaryBrand: "vm0",
     });

--- a/turbo/apps/platform/src/lib/clerk-production-topology.ts
+++ b/turbo/apps/platform/src/lib/clerk-production-topology.ts
@@ -1,11 +1,9 @@
-import { parsePublishableKey } from "@clerk/shared/keys";
-
 export const OKOU_CLERK_PRIMARY_APP_ORIGIN = "https://app.okou.ai";
 export const VM0_CLERK_PRIMARY_APP_ORIGIN = "https://app.vm0.ai";
 
-const OKOU_CLERK_FRONTEND_API = "clerk.app.okou.ai";
-const OKOU_CLERK_PRIMARY_USER_PROFILE_URL = "https://accounts.app.okou.ai/user";
-const VM0_CLERK_PRIMARY_USER_PROFILE_URL = "https://accounts.vm0.ai/user";
+export const CURRENT_CLERK_PRODUCTION_SATELLITE_DOMAIN = "app.okou.ai";
+export const CUTOVER_CLERK_PRODUCTION_SATELLITE_DOMAIN = "vm0.ai";
+const CLERK_PRIMARY_USER_PROFILE_URL = "https://accounts.vm0.ai/user";
 
 export type ClerkProductionDomain = "app.okou.ai" | "vm0.ai";
 
@@ -13,9 +11,7 @@ interface ClerkProductionTopology {
   readonly primaryAppOrigin:
     | typeof OKOU_CLERK_PRIMARY_APP_ORIGIN
     | typeof VM0_CLERK_PRIMARY_APP_ORIGIN;
-  readonly primaryUserProfileUrl:
-    | typeof OKOU_CLERK_PRIMARY_USER_PROFILE_URL
-    | typeof VM0_CLERK_PRIMARY_USER_PROFILE_URL;
+  readonly primaryUserProfileUrl: typeof CLERK_PRIMARY_USER_PROFILE_URL;
   readonly primaryBrand: "okou" | "vm0";
 }
 
@@ -23,40 +19,46 @@ function isDomainOrSubdomain(hostname: string, domain: string): boolean {
   return hostname === domain || hostname.endsWith(`.${domain}`);
 }
 
-// The production domain change generates a new publishable key whose decoded
-// Frontend API hostname identifies the active primary. Keeping the legacy VM0
-// fallback makes the same artifact safe before the cutover and during rollback.
+export function normalizeClerkProductionSatelliteDomain(
+  value: unknown,
+): ClerkProductionDomain {
+  return value === CUTOVER_CLERK_PRODUCTION_SATELLITE_DOMAIN
+    ? CUTOVER_CLERK_PRODUCTION_SATELLITE_DOMAIN
+    : CURRENT_CLERK_PRODUCTION_SATELLITE_DOMAIN;
+}
+
+// The Clerk instance and publishable key remain on clerk.vm0.ai. The explicit
+// satellite-domain deployment value is the source of truth for which app owns
+// primary auth. Unknown values fail closed to the currently deployed topology.
 export function resolveClerkProductionTopology(
-  publishableKey: string,
+  satelliteDomain: unknown,
 ): ClerkProductionTopology {
-  const frontendApi = parsePublishableKey(publishableKey)?.frontendApi;
-  if (frontendApi === OKOU_CLERK_FRONTEND_API) {
+  if (
+    normalizeClerkProductionSatelliteDomain(satelliteDomain) ===
+    CUTOVER_CLERK_PRODUCTION_SATELLITE_DOMAIN
+  ) {
     return {
       primaryAppOrigin: OKOU_CLERK_PRIMARY_APP_ORIGIN,
       primaryBrand: "okou",
-      primaryUserProfileUrl: OKOU_CLERK_PRIMARY_USER_PROFILE_URL,
+      primaryUserProfileUrl: CLERK_PRIMARY_USER_PROFILE_URL,
     };
   }
 
   return {
     primaryAppOrigin: VM0_CLERK_PRIMARY_APP_ORIGIN,
     primaryBrand: "vm0",
-    primaryUserProfileUrl: VM0_CLERK_PRIMARY_USER_PROFILE_URL,
+    primaryUserProfileUrl: CLERK_PRIMARY_USER_PROFILE_URL,
   };
 }
 
 export function resolveClerkProductionSatelliteDomain(
   hostname: string,
-  publishableKey: string,
+  satelliteDomain: unknown,
 ): ClerkProductionDomain | null {
   const normalizedHostname = hostname.toLowerCase();
-  const topology = resolveClerkProductionTopology(publishableKey);
-
-  if (topology.primaryBrand === "okou") {
-    return isDomainOrSubdomain(normalizedHostname, "vm0.ai") ? "vm0.ai" : null;
-  }
-
-  return isDomainOrSubdomain(normalizedHostname, "app.okou.ai")
-    ? "app.okou.ai"
+  const normalizedSatelliteDomain =
+    normalizeClerkProductionSatelliteDomain(satelliteDomain);
+  return isDomainOrSubdomain(normalizedHostname, normalizedSatelliteDomain)
+    ? normalizedSatelliteDomain
     : null;
 }

--- a/turbo/apps/platform/src/lib/clerk-production-topology.ts
+++ b/turbo/apps/platform/src/lib/clerk-production-topology.ts
@@ -25,6 +25,10 @@ function isDomainOrSubdomain(hostname: string, domain: string): boolean {
 export function normalizeClerkProductionPrimaryAppDomain(
   value: unknown,
 ): ClerkProductionPrimaryAppDomain {
+  // Web/app rollout fallback: production clients and retained rollback builds
+  // can straddle the Clerk primary/satellite cutover for about two days.
+  // Remove the VM0-primary branch only after #27750 records that replacement
+  // builds are live, auth verification passed, and the rollback gate closed.
   return value === CUTOVER_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN
     ? CUTOVER_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN
     : CURRENT_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN;

--- a/turbo/apps/platform/src/lib/clerk-production-topology.ts
+++ b/turbo/apps/platform/src/lib/clerk-production-topology.ts
@@ -1,11 +1,14 @@
 export const OKOU_CLERK_PRIMARY_APP_ORIGIN = "https://app.okou.ai";
 export const VM0_CLERK_PRIMARY_APP_ORIGIN = "https://app.vm0.ai";
 
-export const CURRENT_CLERK_PRODUCTION_SATELLITE_DOMAIN = "app.okou.ai";
-export const CUTOVER_CLERK_PRODUCTION_SATELLITE_DOMAIN = "vm0.ai";
+export const CURRENT_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN = "app.vm0.ai";
+export const CUTOVER_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN = "app.okou.ai";
 const CLERK_PRIMARY_USER_PROFILE_URL = "https://accounts.vm0.ai/user";
 
 export type ClerkProductionDomain = "app.okou.ai" | "vm0.ai";
+export type ClerkProductionPrimaryAppDomain =
+  | typeof CURRENT_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN
+  | typeof CUTOVER_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN;
 
 interface ClerkProductionTopology {
   readonly primaryAppOrigin:
@@ -19,23 +22,23 @@ function isDomainOrSubdomain(hostname: string, domain: string): boolean {
   return hostname === domain || hostname.endsWith(`.${domain}`);
 }
 
-export function normalizeClerkProductionSatelliteDomain(
+export function normalizeClerkProductionPrimaryAppDomain(
   value: unknown,
-): ClerkProductionDomain {
-  return value === CUTOVER_CLERK_PRODUCTION_SATELLITE_DOMAIN
-    ? CUTOVER_CLERK_PRODUCTION_SATELLITE_DOMAIN
-    : CURRENT_CLERK_PRODUCTION_SATELLITE_DOMAIN;
+): ClerkProductionPrimaryAppDomain {
+  return value === CUTOVER_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN
+    ? CUTOVER_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN
+    : CURRENT_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN;
 }
 
 // The Clerk instance and publishable key remain on clerk.vm0.ai. The explicit
-// satellite-domain deployment value is the source of truth for which app owns
+// primary-app deployment value is the source of truth for which app owns
 // primary auth. Unknown values fail closed to the currently deployed topology.
 export function resolveClerkProductionTopology(
-  satelliteDomain: unknown,
+  primaryAppDomain: unknown,
 ): ClerkProductionTopology {
   if (
-    normalizeClerkProductionSatelliteDomain(satelliteDomain) ===
-    CUTOVER_CLERK_PRODUCTION_SATELLITE_DOMAIN
+    normalizeClerkProductionPrimaryAppDomain(primaryAppDomain) ===
+    CUTOVER_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN
   ) {
     return {
       primaryAppOrigin: OKOU_CLERK_PRIMARY_APP_ORIGIN,
@@ -53,12 +56,17 @@ export function resolveClerkProductionTopology(
 
 export function resolveClerkProductionSatelliteDomain(
   hostname: string,
-  satelliteDomain: unknown,
+  primaryAppDomain: unknown,
 ): ClerkProductionDomain | null {
   const normalizedHostname = hostname.toLowerCase();
-  const normalizedSatelliteDomain =
-    normalizeClerkProductionSatelliteDomain(satelliteDomain);
-  return isDomainOrSubdomain(normalizedHostname, normalizedSatelliteDomain)
-    ? normalizedSatelliteDomain
+  if (
+    normalizeClerkProductionPrimaryAppDomain(primaryAppDomain) ===
+    CUTOVER_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN
+  ) {
+    return isDomainOrSubdomain(normalizedHostname, "vm0.ai") ? "vm0.ai" : null;
+  }
+
+  return isDomainOrSubdomain(normalizedHostname, "app.okou.ai")
+    ? "app.okou.ai"
     : null;
 }

--- a/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
@@ -1,5 +1,5 @@
 import { waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { detachedSetupPage, setupPage } from "../../__tests__/page-helper.ts";
 import {
@@ -154,10 +154,9 @@ describe("platform auth URLs", () => {
   });
 
   it("uses Okou auth and the VM0 root satellite after the cutover", () => {
-    vi.stubEnv(
-      "VITE_CLERK_PUBLISHABLE_KEY_PROD",
-      "pk_live_Y2xlcmsuYXBwLm9rb3UuYWkk",
-    );
+    Reflect.set(window, "__vm0ClerkBootstrap", {
+      productionSatelliteDomain: "vm0.ai",
+    });
     try {
       setBrowserUrl("https://app.okou.ai/agents");
       expect(resolveAppAuthUrl("/sign-in")).toBe("https://app.okou.ai/sign-in");
@@ -172,7 +171,7 @@ describe("platform auth URLs", () => {
         satelliteAutoSync: true,
       });
     } finally {
-      vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PROD", "test_production_key");
+      Reflect.deleteProperty(window, "__vm0ClerkBootstrap");
     }
   });
 

--- a/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
@@ -155,7 +155,7 @@ describe("platform auth URLs", () => {
 
   it("uses Okou auth and the VM0 root satellite after the cutover", () => {
     Reflect.set(window, "__vm0ClerkBootstrap", {
-      productionSatelliteDomain: "vm0.ai",
+      productionPrimaryAppDomain: "app.okou.ai",
     });
     try {
       setBrowserUrl("https://app.okou.ai/agents");

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -20,6 +20,7 @@ import {
   resolvePlatformRuntimeConfig,
 } from "../lib/platform-host.ts";
 import {
+  CURRENT_CLERK_PRODUCTION_SATELLITE_DOMAIN,
   resolveClerkProductionSatelliteDomain,
   resolveClerkProductionTopology,
   type ClerkProductionDomain,
@@ -97,17 +98,27 @@ const MAX_URL_PORT = 65_535;
 export function deriveServiceOrigin(
   currentOrigin: string,
   service: Extract<PlatformService, "www" | "app" | "api">,
-  publishableKey = resolvePlatformRuntimeConfig().clerkPublishableKey,
+  satelliteDomain = resolveConfiguredProductionSatelliteDomain(),
 ): string {
   const currentUrl = new URL(currentOrigin);
   if (
     isOkouProductionHostname(currentUrl.hostname) &&
-    resolveClerkProductionTopology(publishableKey).primaryBrand === "okou"
+    resolveClerkProductionTopology(satelliteDomain).primaryBrand === "okou"
   ) {
     currentUrl.hostname = `${service}.okou.ai`;
     return currentUrl.origin;
   }
   return derivePlatformServiceOrigin(currentOrigin, service);
+}
+
+function resolveConfiguredProductionSatelliteDomain(): ClerkProductionDomain {
+  if (typeof window === "undefined") {
+    return CURRENT_CLERK_PRODUCTION_SATELLITE_DOMAIN;
+  }
+  return (
+    window.__vm0ClerkBootstrap?.productionSatelliteDomain ??
+    CURRENT_CLERK_PRODUCTION_SATELLITE_DOMAIN
+  );
 }
 
 // The WWW origin sibling of the current host.
@@ -129,10 +140,9 @@ export function resolveClerkSatelliteConfig(): ClerkSatelliteConfig | null {
     return null;
   }
 
-  const publishableKey = resolvePlatformRuntimeConfig().clerkPublishableKey;
   const domain = resolveClerkProductionSatelliteDomain(
     location.hostname,
-    publishableKey,
+    resolveConfiguredProductionSatelliteDomain(),
   );
   if (!domain) {
     return null;
@@ -146,18 +156,18 @@ export function resolveClerkSatelliteConfig(): ClerkSatelliteConfig | null {
 }
 
 function resolveAuthOrigin(): string {
-  const publishableKey = resolvePlatformRuntimeConfig().clerkPublishableKey;
+  const satelliteDomain = resolveConfiguredProductionSatelliteDomain();
   return resolveClerkProductionSatelliteDomain(
     location.hostname,
-    publishableKey,
+    satelliteDomain,
   )
-    ? resolveClerkProductionTopology(publishableKey).primaryAppOrigin
+    ? resolveClerkProductionTopology(satelliteDomain).primaryAppOrigin
     : resolveAppOrigin();
 }
 
 export function resolvePrimaryClerkUserProfileUrl(): string {
   return resolveClerkProductionTopology(
-    resolvePlatformRuntimeConfig().clerkPublishableKey,
+    resolveConfiguredProductionSatelliteDomain(),
   ).primaryUserProfileUrl;
 }
 

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -20,10 +20,11 @@ import {
   resolvePlatformRuntimeConfig,
 } from "../lib/platform-host.ts";
 import {
-  CURRENT_CLERK_PRODUCTION_SATELLITE_DOMAIN,
+  CURRENT_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN,
   resolveClerkProductionSatelliteDomain,
   resolveClerkProductionTopology,
   type ClerkProductionDomain,
+  type ClerkProductionPrimaryAppDomain,
   VM0_CLERK_PRIMARY_APP_ORIGIN,
 } from "../lib/clerk-production-topology.ts";
 import { resolveBrandNameForHostname, type BrandName } from "./branding.ts";
@@ -98,12 +99,12 @@ const MAX_URL_PORT = 65_535;
 export function deriveServiceOrigin(
   currentOrigin: string,
   service: Extract<PlatformService, "www" | "app" | "api">,
-  satelliteDomain = resolveConfiguredProductionSatelliteDomain(),
+  primaryAppDomain = resolveConfiguredProductionPrimaryAppDomain(),
 ): string {
   const currentUrl = new URL(currentOrigin);
   if (
     isOkouProductionHostname(currentUrl.hostname) &&
-    resolveClerkProductionTopology(satelliteDomain).primaryBrand === "okou"
+    resolveClerkProductionTopology(primaryAppDomain).primaryBrand === "okou"
   ) {
     currentUrl.hostname = `${service}.okou.ai`;
     return currentUrl.origin;
@@ -111,13 +112,13 @@ export function deriveServiceOrigin(
   return derivePlatformServiceOrigin(currentOrigin, service);
 }
 
-function resolveConfiguredProductionSatelliteDomain(): ClerkProductionDomain {
+function resolveConfiguredProductionPrimaryAppDomain(): ClerkProductionPrimaryAppDomain {
   if (typeof window === "undefined") {
-    return CURRENT_CLERK_PRODUCTION_SATELLITE_DOMAIN;
+    return CURRENT_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN;
   }
   return (
-    window.__vm0ClerkBootstrap?.productionSatelliteDomain ??
-    CURRENT_CLERK_PRODUCTION_SATELLITE_DOMAIN
+    window.__vm0ClerkBootstrap?.productionPrimaryAppDomain ??
+    CURRENT_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN
   );
 }
 
@@ -142,7 +143,7 @@ export function resolveClerkSatelliteConfig(): ClerkSatelliteConfig | null {
 
   const domain = resolveClerkProductionSatelliteDomain(
     location.hostname,
-    resolveConfiguredProductionSatelliteDomain(),
+    resolveConfiguredProductionPrimaryAppDomain(),
   );
   if (!domain) {
     return null;
@@ -156,18 +157,18 @@ export function resolveClerkSatelliteConfig(): ClerkSatelliteConfig | null {
 }
 
 function resolveAuthOrigin(): string {
-  const satelliteDomain = resolveConfiguredProductionSatelliteDomain();
+  const primaryAppDomain = resolveConfiguredProductionPrimaryAppDomain();
   return resolveClerkProductionSatelliteDomain(
     location.hostname,
-    satelliteDomain,
+    primaryAppDomain,
   )
-    ? resolveClerkProductionTopology(satelliteDomain).primaryAppOrigin
+    ? resolveClerkProductionTopology(primaryAppDomain).primaryAppOrigin
     : resolveAppOrigin();
 }
 
 export function resolvePrimaryClerkUserProfileUrl(): string {
   return resolveClerkProductionTopology(
-    resolveConfiguredProductionSatelliteDomain(),
+    resolveConfiguredProductionPrimaryAppDomain(),
   ).primaryUserProfileUrl;
 }
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
@@ -1299,7 +1299,7 @@ describe("zero sidebar account menu", () => {
 
   it("keeps the VM0 satellite on the existing hosted profile after cutover", async () => {
     Reflect.set(window, "__vm0ClerkBootstrap", {
-      productionSatelliteDomain: "vm0.ai",
+      productionPrimaryAppDomain: "app.okou.ai",
     });
     try {
       context.mocks.browser.url("https://app.vm0.ai/");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
@@ -1297,11 +1297,10 @@ describe("zero sidebar account menu", () => {
     );
   });
 
-  it("links the VM0 satellite to the Okou hosted user profile after cutover", async () => {
-    vi.stubEnv(
-      "VITE_CLERK_PUBLISHABLE_KEY_PROD",
-      "pk_live_Y2xlcmsuYXBwLm9rb3UuYWkk",
-    );
+  it("keeps the VM0 satellite on the existing hosted profile after cutover", async () => {
+    Reflect.set(window, "__vm0ClerkBootstrap", {
+      productionSatelliteDomain: "vm0.ai",
+    });
     try {
       context.mocks.browser.url("https://app.vm0.ai/");
       prepareDefaultAgent();
@@ -1322,10 +1321,10 @@ describe("zero sidebar account menu", () => {
       await screen.findByRole("dialog", { name: "Settings" });
       expect(linkByText("Manage")).toHaveAttribute(
         "href",
-        "https://accounts.app.okou.ai/user",
+        "https://accounts.vm0.ai/user",
       );
     } finally {
-      vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PROD", "test_production_key");
+      Reflect.deleteProperty(window, "__vm0ClerkBootstrap");
     }
   });
 


### PR DESCRIPTION
## Summary

- replace the publishable-key-derived Clerk topology selector from #30723 with an explicit primary auth application selector
- keep the shared production publishable key, `clerk.vm0.ai` Frontend API, secret key, and `accounts.vm0.ai` Account Portal unchanged
- default fail-closed to `CLERK_PRODUCTION_PRIMARY_APP_DOMAIN=app.vm0.ai`; select the Okou-primary topology only with `app.okou.ai`
- derive the corresponding Clerk satellite domain from the selected primary app instead of asking deployment operators to configure an inverse value
- inject the selector into preview, production, and rollback Pages packaging so the same immutable app artifact remains rollback-safe
- cover app bootstrap, auth URL selection, Clerk callbacks/session sync, Account Portal links, and both brands with targeted tests

## Functional dependency and rollout

Paired Marketing PR: https://github.com/vm0-ai/vm0-marketing/pull/521

1. Merge and deploy both repair PRs while `CLERK_PRODUCTION_PRIMARY_APP_DOMAIN` is unset or `app.vm0.ai`; this is behavior-neutral.
2. Confirm both deployed builds still use `app.vm0.ai` as the primary auth application.
3. Prepare the Clerk satellite-domain transition without rotating the publishable key or changing `clerk.vm0.ai`, Google OAuth callback URLs, or `accounts.vm0.ai`.
4. Set `CLERK_PRODUCTION_PRIMARY_APP_DOMAIN=app.okou.ai` in both repositories and redeploy both builds in one coordinated cutover.
5. Verify real sign-up, sign-in, callback, session sync, and post-auth redirects on both brands.

Rollback: restore `CLERK_PRODUCTION_PRIMARY_APP_DOMAIN=app.vm0.ai` in both repositories and redeploy. Retain the dual branch until live verification succeeds and the rollback window closes.

## Fallbacks

- `.github/scripts/prepare-okou-pages-dist.sh:production_primary_app_domain`, `turbo/apps/platform/index.html:productionPrimaryAppDomain`, and `turbo/apps/platform/src/lib/clerk-production-topology.ts:normalizeClerkProductionPrimaryAppDomain` preserve the current VM0-primary topology while allowing the explicit Okou-primary cutover and VM0 rollback. Surface: web/app deployment paired with the externally managed Clerk primary/satellite topology; stale browser clients may remain for about two days, and retained rollback builds may still require the current topology. Remove the VM0-primary branch only after replacement builds are live, live authentication verification succeeds, the stale-client and rollback gates are closed, and #27750 records that evidence; follow-up: #27750.

## Tests

- targeted App Vitest: 5 files, 85 tests passed
- `prepare-okou-pages-dist-test.sh`
- `deploy-okou-pages-workflow-test.sh`
- `okou-app-worker-test.sh`
- `pnpm --filter @okouai/app check-types`
- `pnpm --filter @okouai/app lint`
- targeted Prettier check

Related: #27750
