### PR TITLE
feat(desktop): capture a selected screen region

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/CaptureArea.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/CaptureArea.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// A rectangle in global screen points, top-left origin.
+public struct AreaRect: Equatable, Sendable {
+    public let x: Double
+    public let y: Double
+    public let width: Double
+    public let height: Double
+
+    public init(x: Double, y: Double, width: Double, height: Double) {
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+    }
+
+    public var maxX: Double { x + width }
+    public var maxY: Double { y + height }
+}
+
+public enum CaptureAreaPolicy {
+    /// Smallest area worth capturing, in points. Anything thinner cannot encode
+    /// to the two-pixel floor `CaptureSizePolicy` enforces.
+    public static let minimumSidePoints = 2.0
+
+    /// Confines a requested area to the display it will be captured from.
+    ///
+    /// A selection dragged past the edge of the screen is ordinary, so the
+    /// overlap is captured rather than the request being rejected. `nil` means
+    /// there is nothing to capture: the areas do not overlap, or what remains is
+    /// too thin to encode.
+    public static func clamp(_ requested: AreaRect, toDisplay display: AreaRect) -> AreaRect? {
+        let left = max(requested.x, display.x)
+        let top = max(requested.y, display.y)
+        let right = min(requested.maxX, display.maxX)
+        let bottom = min(requested.maxY, display.maxY)
+
+        let width = right - left
+        let height = bottom - top
+        guard width >= minimumSidePoints, height >= minimumSidePoints else {
+            return nil
+        }
+        return AreaRect(x: left, y: top, width: width, height: height)
+    }
+
+    /// Re-expresses a global area in the display's own coordinate space, which
+    /// is what `SCStreamConfiguration.sourceRect` expects. Passing global
+    /// coordinates straight through crops the wrong region on every display
+    /// whose origin is not (0, 0).
+    public static func relativeToDisplay(_ area: AreaRect, display: AreaRect) -> AreaRect {
+        return AreaRect(
+            x: area.x - display.x,
+            y: area.y - display.y,
+            width: area.width,
+            height: area.height
+        )
+    }
+}

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
@@ -43,6 +43,47 @@ private func optionalBool(_ request: [String: Any], _ key: String) -> Bool {
     return (request[key] as? Bool) ?? false
 }
 
+private func requiredArea(_ request: [String: Any]) throws -> AreaRect {
+    guard
+        let area = request["area"] as? [String: Any],
+        let x = area["x"] as? Double,
+        let y = area["y"] as? Double,
+        let width = area["width"] as? Double,
+        let height = area["height"] as? Double
+    else {
+        throw HelperFailure(
+            code: "capture_failed",
+            message: "Recording an area requires an area rectangle in screen points"
+        )
+    }
+    return AreaRect(x: x, y: y, width: width, height: height)
+}
+
+private func displayArea(_ display: SCDisplay) -> AreaRect {
+    return AreaRect(
+        x: display.frame.origin.x,
+        y: display.frame.origin.y,
+        width: display.frame.width,
+        height: display.frame.height
+    )
+}
+
+private func resolveDisplay(
+    _ content: SCShareableContent,
+    sourceId: String
+) throws -> SCDisplay {
+    guard
+        let rawID = UInt32(sourceId.replacingOccurrences(of: "display:", with: "")),
+        let display = content.displays.first(where: { $0.displayID == rawID })
+    else {
+        throw HelperFailure(
+            code: "source_lost",
+            message: "Display is no longer available: \(sourceId)"
+        )
+    }
+    return display
+}
+
 // MARK: - Source discovery
 
 private func shareableContent(timeout: TimeInterval = 10) throws -> SCShareableContent {
@@ -606,22 +647,41 @@ private func handlePrepare(_ request: [String: Any]) throws -> [String: Any] {
     let filter: SCContentFilter
     let geometry: CaptureGeometry
 
+    var croppedArea: AreaRect?
+
     if sourceKind == "display" {
-        guard
-            let rawID = UInt32(sourceId.replacingOccurrences(of: "display:", with: "")),
-            let display = content.displays.first(where: { $0.displayID == rawID })
-        else {
-            throw HelperFailure(
-                code: "source_lost",
-                message: "Display is no longer available: \(sourceId)"
-            )
-        }
+        let display = try resolveDisplay(content, sourceId: sourceId)
         filter = SCContentFilter(display: display, excludingWindows: [])
         geometry = CaptureGeometry(
             originX: display.frame.origin.x,
             originY: display.frame.origin.y,
             widthPoints: display.frame.width,
             heightPoints: display.frame.height,
+            scale: backingScaleFactor(forDisplayID: display.displayID)
+        )
+    } else if sourceKind == "area" {
+        // An area is a display capture with a crop: ScreenCaptureKit has no
+        // region filter, so the whole display is filtered and `sourceRect`
+        // narrows it.
+        let display = try resolveDisplay(content, sourceId: sourceId)
+        let requested = try requiredArea(request)
+        guard
+            let area = CaptureAreaPolicy.clamp(requested, toDisplay: displayArea(display))
+        else {
+            throw HelperFailure(
+                code: "capture_failed",
+                message: "The selected area is not on this display, or is too small to record"
+            )
+        }
+        croppedArea = area
+        filter = SCContentFilter(display: display, excludingWindows: [])
+        // The geometry describes the crop, not the display, so clicks map into
+        // the cropped frame rather than the full screen.
+        geometry = CaptureGeometry(
+            originX: area.x,
+            originY: area.y,
+            widthPoints: area.width,
+            heightPoints: area.height,
             scale: backingScaleFactor(forDisplayID: display.displayID)
         )
     } else if sourceKind == "window" {
@@ -657,6 +717,19 @@ private func handlePrepare(_ request: [String: Any]) throws -> [String: Any] {
     configuration.showsCursor = true
     configuration.queueDepth = 6
     configuration.capturesAudio = systemAudio
+    if let croppedArea {
+        let display = try resolveDisplay(content, sourceId: sourceId)
+        let relative = CaptureAreaPolicy.relativeToDisplay(
+            croppedArea,
+            display: displayArea(display)
+        )
+        configuration.sourceRect = CGRect(
+            x: relative.x,
+            y: relative.y,
+            width: relative.width,
+            height: relative.height
+        )
+    }
 
     let session = RecorderSession(
         id: sessionStore.nextSessionID(),

--- a/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/CaptureAreaTests.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/CaptureAreaTests.swift
@@ -1,0 +1,102 @@
+import Testing
+
+@testable import ScreenRecorderCore
+
+/// A second display sitting to the right of and above the primary one, so a
+/// policy that confuses global and display-local coordinates fails visibly.
+private let secondaryDisplay = AreaRect(x: 1512, y: -200, width: 1000, height: 500)
+
+struct CaptureAreaTests {
+    @Test
+    func keepsAnAreaThatFitsInsideTheDisplay() {
+        let requested = AreaRect(x: 1600, y: -100, width: 400, height: 300)
+
+        #expect(
+            CaptureAreaPolicy.clamp(requested, toDisplay: secondaryDisplay) == requested
+        )
+    }
+
+    @Test
+    func confinesASelectionDraggedPastTheEdges() {
+        // Dragged off the top-left and past the bottom-right of the display.
+        let requested = AreaRect(x: 1000, y: -400, width: 2000, height: 1200)
+
+        #expect(
+            CaptureAreaPolicy.clamp(requested, toDisplay: secondaryDisplay)
+                == AreaRect(x: 1512, y: -200, width: 1000, height: 500)
+        )
+    }
+
+    @Test
+    func rejectsASelectionOnADifferentDisplay() {
+        let requested = AreaRect(x: 0, y: 0, width: 400, height: 300)
+
+        #expect(CaptureAreaPolicy.clamp(requested, toDisplay: secondaryDisplay) == nil)
+    }
+
+    @Test
+    func rejectsASelectionTooThinToEncode() {
+        // A stray click rather than a drag.
+        let sliver = AreaRect(x: 1600, y: -100, width: 1, height: 300)
+
+        #expect(CaptureAreaPolicy.clamp(sliver, toDisplay: secondaryDisplay) == nil)
+        #expect(
+            CaptureAreaPolicy.clamp(
+                AreaRect(x: 1600, y: -100, width: 300, height: 0),
+                toDisplay: secondaryDisplay
+            ) == nil
+        )
+    }
+
+    @Test
+    func rejectsASelectionThatOnlyTouchesTheDisplayEdge() {
+        // Sharing exactly one edge leaves nothing to capture.
+        let touching = AreaRect(x: 1112, y: -100, width: 400, height: 300)
+
+        #expect(CaptureAreaPolicy.clamp(touching, toDisplay: secondaryDisplay) == nil)
+    }
+
+    /// `sourceRect` is read in the display's own space, so the display origin
+    /// has to come back out of the global coordinates.
+    @Test
+    func rebasesTheAreaOntoTheDisplayOrigin() {
+        let area = AreaRect(x: 1600, y: -100, width: 400, height: 300)
+
+        #expect(
+            CaptureAreaPolicy.relativeToDisplay(area, display: secondaryDisplay)
+                == AreaRect(x: 88, y: 100, width: 400, height: 300)
+        )
+    }
+
+    @Test
+    func leavesAnAreaOnThePrimaryDisplayWhereItIs() {
+        let primary = AreaRect(x: 0, y: 0, width: 1512, height: 982)
+        let area = AreaRect(x: 100, y: 200, width: 400, height: 300)
+
+        #expect(CaptureAreaPolicy.relativeToDisplay(area, display: primary) == area)
+    }
+
+    /// The clamped area feeds `CaptureGeometry` directly, so a click inside the
+    /// selection has to land inside the cropped frame.
+    @Test
+    func clampedAreaMapsClicksIntoTheCroppedFrame() {
+        let area = AreaRect(x: 1600, y: -100, width: 400, height: 200)
+        let geometry = CaptureGeometry(
+            originX: area.x,
+            originY: area.y,
+            widthPoints: area.width,
+            heightPoints: area.height,
+            scale: 2
+        )
+        let outputSize = CaptureSizePolicy.outputSize(for: geometry)
+
+        let centre = geometry.mapClick(screenX: 1800, screenY: 0, outputSize: outputSize)
+
+        #expect(centre?.normalizedX == 0.5)
+        #expect(centre?.normalizedY == 0.5)
+        // A click on the display but outside the selection is not in the video.
+        #expect(
+            geometry.mapClick(screenX: 1550, screenY: 0, outputSize: outputSize) == nil
+        )
+    }
+}

--- a/turbo/apps/desktop/src/desktop-recorder-native.test.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-native.test.ts
@@ -155,6 +155,68 @@ async function readRequests(
     .map((line) => JSON.parse(line) as Record<string, unknown>);
 }
 
+describe("area capture", () => {
+  it("sends the selected region and reports the cropped geometry", async () => {
+    const { helperPath, requestLogPath } = await createHelper({
+      "recorder.prepare": {
+        result: {
+          sessionId: "session-1",
+          width: 800,
+          height: 400,
+          geometry: {
+            originX: 1600,
+            originY: -100,
+            widthPoints: 400,
+            heightPoints: 200,
+            scale: 2,
+          },
+        },
+      },
+    });
+    const backend = createBackend(helperPath);
+
+    const prepared = await backend.prepare({
+      sourceId: "display:1",
+      sourceKind: "area",
+      systemAudio: false,
+      area: { x: 1600, y: -100, width: 400, height: 200 },
+    });
+
+    const requests = await readRequests(requestLogPath);
+    expect(requests[0]?.payload).toEqual({
+      sourceId: "display:1",
+      sourceKind: "area",
+      systemAudio: false,
+      area: { x: 1600, y: -100, width: 400, height: 200 },
+    });
+    // The geometry describes the crop, not the display, so a click track built
+    // from it lands in the cropped frame.
+    expect(prepared.geometry).toEqual({
+      originX: 1600,
+      originY: -100,
+      widthPoints: 400,
+      heightPoints: 200,
+      scale: 2,
+    });
+  });
+
+  it("leaves the area out of a whole-display capture", async () => {
+    const { helperPath, requestLogPath } = await createHelper({
+      "recorder.prepare": PREPARE,
+    });
+    const backend = createBackend(helperPath);
+
+    await backend.prepare({
+      sourceId: "display:1",
+      sourceKind: "display",
+      systemAudio: true,
+    });
+
+    const requests = await readRequests(requestLogPath);
+    expect(requests[0]?.payload).not.toHaveProperty("area");
+  });
+});
+
 async function rejection(promise: Promise<unknown>): Promise<Error> {
   try {
     await promise;

--- a/turbo/apps/desktop/src/desktop-recorder-native.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-native.ts
@@ -382,6 +382,7 @@ export function createRecorderNativeBackend(
         sourceId: request.sourceId,
         sourceKind: request.sourceKind,
         systemAudio: request.systemAudio,
+        ...(request.area ? { area: request.area } : {}),
       });
       const geometry = isRecord(result.geometry) ? result.geometry : {};
       return {

--- a/turbo/apps/desktop/src/desktop-recorder-types.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-types.ts
@@ -27,7 +27,19 @@ export interface DesktopRecorderError {
   readonly message: string;
 }
 
+/** What `listSources` can enumerate. An area is a crop, not a listable source. */
 export type DesktopRecorderSourceKind = "display" | "window";
+
+/** What a capture can be aimed at. */
+export type DesktopRecorderCaptureKind = DesktopRecorderSourceKind | "area";
+
+/** A selected region in global screen points, top-left origin. */
+export interface DesktopRecorderArea {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
 
 export interface DesktopRecorderSource {
   readonly id: string;
@@ -74,8 +86,14 @@ export interface DesktopRecorderState {
 
 export interface DesktopRecorderPrepareRequest {
   readonly sourceId: string;
-  readonly sourceKind: DesktopRecorderSourceKind;
+  readonly sourceKind: DesktopRecorderCaptureKind;
   readonly systemAudio: boolean;
+  /**
+   * Required when `sourceKind` is `"area"`, and `sourceId` then names the
+   * display the region was drawn on. ScreenCaptureKit has no region filter, so
+   * the display is captured and this crops it.
+   */
+  readonly area?: DesktopRecorderArea;
 }
 
 export interface DesktopRecorderPrepareResult {


### PR DESCRIPTION
First half of the floating recorder bar you asked for: the capture side of
**Area**. Choosing the region is the bar itself, which is the next change.

## How an area is captured

ScreenCaptureKit has no region filter, so an area is a **display capture with a
crop**: the display is filtered as usual and `SCStreamConfiguration.sourceRect`
narrows it.

Two consequences of that are easy to get wrong, so both live in
`ScreenRecorderCore` as pure functions with tests:

- **`sourceRect` is read in the display's own coordinate space.** Passing global
  screen coordinates straight through crops the wrong region on every display
  whose origin is not `(0, 0)` — which is every secondary display. The tests use
  a display at `x: 1512, y: -200` so a policy that confuses the two fails
  visibly rather than passing by accident on the primary display.
- **The reported geometry describes the crop, not the display.** That is what
  makes the click track land in the cropped frame, and what makes a click
  outside the selection correctly count as outside the recording rather than
  being mapped to some point inside it.

## Edge handling

Dragging a selection past the edge of a screen is ordinary, so the overlap is
captured rather than the whole request being refused. A selection that misses
the display entirely, only touches its edge, or is too thin to encode is
refused with a message that says so.

## Scope

Capture side only. `prepare` accepts `sourceKind: "area"` with a rectangle in
global screen points and `sourceId` naming the display it was drawn on; nothing
in the UI produces one yet. The types keep the two ideas apart:
`DesktopRecorderSourceKind` is what `listSources` can enumerate, and an area is
not a listable source.

## Verification

`check-types`, `lint`, `knip`, desktop vitest (443 passed) locally, plus seven
new Swift tests on the area policy and two on the transport (the region reaches
the helper; a whole-display capture does not carry an empty one).

**Unverified on hardware**: that `sourceRect` crops where these coordinates say
it should. The conversion is tested, but the frame it produces is not something
CI can look at. Worth checking on the next dogfood run that a region drawn on a
secondary display records that region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)