### PR TITLE
fix(platform): include root turbo jsonc in eslint cache key

### DIFF
--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -14,7 +14,7 @@ const eslintCacheInputPaths = globSync(
     "../../package.json",
     "../../pnpm-lock.yaml",
     "../../pnpm-workspace.yaml",
-    "../../turbo.json",
+    "../../turbo.{json,jsonc}",
     "../../{apps,packages}/*/turbo.{json,jsonc}",
     "../../packages/eslint-config/**/*.{js,cjs,mjs,json}",
     "../../packages/eslint-rules/package.json",


### PR DESCRIPTION
## Summary

- include both repository-root `turbo.json` and `turbo.jsonc` in the Platform ESLint calculated-config fingerprint
- preserve the existing workspace Turbo configuration coverage
- follow up on the cache invalidation boundary introduced in #30711

## Correctness

`eslint-plugin-turbo` can discover either root Turbo configuration extension. Matching both extensions ensures a future root JSONC configuration and its edits invalidate cached ESLint results instead of reusing results calculated from stale Turbo configuration.

## Validation

- `pnpm exec prettier --check apps/platform/eslint.config.js`
- Node `matchesGlob` and real `globSync` assertions for root `turbo.json` and `turbo.jsonc`
- `git diff --check`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`

Closes #30745

Parent context: #30676
