### PR TITLE
feat(platform): log shared worker bridge messages

### DIFF
--- a/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
@@ -9,6 +9,7 @@ import {
   chatEventRowsResponse,
   testContext,
 } from "../../signals/__tests__/test-helpers.ts";
+import { Level, logger } from "../../signals/log.ts";
 import { createChildAbortController } from "../../signals/utils.ts";
 import { queryChatEventSharedDatabase$ } from "../../signals/shared-database.ts";
 import { installSharedDatabaseBridge$ } from "../../signals/shared-database-bridge-state.ts";
@@ -24,10 +25,9 @@ import type {
 } from "../data-key.ts";
 import { MessagePortSharedDatabaseBridge } from "../message-port-client.ts";
 import { SharedDatabaseMessagePortServer } from "../message-port-server.ts";
-import {
-  redactSharedDatabaseClientMessageForLog,
-  type SharedDatabaseClientMessage,
-  type SharedDatabaseConnectionStatus,
+import type {
+  SharedDatabaseClientMessage,
+  SharedDatabaseConnectionStatus,
 } from "../protocol.ts";
 import { SingleConnectionSharedDatabaseBridge } from "../single-connection-client.ts";
 import { SharedDatabaseWorkerContext } from "../worker-host-context.ts";
@@ -199,22 +199,80 @@ async function installProtocolBridge(): Promise<{
 }
 
 describe("shared database MessagePort protocol", () => {
-  it("redacts heartbeat credentials from bridge log messages", () => {
-    const message = {
-      type: "heartbeat",
-      requestId: crypto.randomUUID(),
-      token: "secret-heartbeat-token",
-      apiBaseUrl: location.origin,
-      vercelProtectionBypass: "secret-vercel-bypass",
-    } satisfies SharedDatabaseClientMessage;
+  it("logs app and worker bridge traffic without exposing heartbeat credentials", async () => {
+    const token = "secret-heartbeat-token";
+    const vercelProtectionBypass = "secret-vercel-bypass";
+    context.mocks.api(authContract.me, ({ request, respond }) => {
+      expect(request.headers.get("authorization")).toBe(`Bearer ${token}`);
+      expect(request.headers.get("x-vercel-protection-bypass")).toBe(
+        vercelProtectionBypass,
+      );
+      return respond(200, {
+        userId: identity().userId,
+        email: "message-port@example.com",
+        orgId: identity().orgId,
+      });
+    });
 
-    expect(redactSharedDatabaseClientMessageForLog(message)).toStrictEqual({
-      ...message,
+    const bridgeLogger = logger("SharedWorkerBridge");
+    const previousLevel = bridgeLogger.level;
+    bridgeLogger.level = Level.Debug;
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    context.signal.addEventListener(
+      "abort",
+      () => {
+        bridgeLogger.level = previousLevel;
+        consoleLog.mockRestore();
+      },
+      { once: true },
+    );
+
+    const workerContext = new SharedDatabaseWorkerContext(
+      context.signal,
+      WORKER_APP_VERSION,
+    );
+    const bridge = connectProtocolTransport(workerContext, bridgeEvents());
+    const owner = createChildAbortController(context.signal);
+
+    await expect(
+      bridge.heartbeat({ token, vercelProtectionBypass }, owner.signal),
+    ).resolves.toStrictEqual({ clientReconnected: false });
+
+    const redactedHeartbeat = expect.objectContaining({
+      type: "heartbeat",
       token: "[redacted]",
       vercelProtectionBypass: "[redacted]",
     });
-    expect(message.token).toBe("secret-heartbeat-token");
-    expect(message.vercelProtectionBypass).toBe("secret-vercel-bypass");
+    expect(consoleLog).toHaveBeenCalledWith(
+      "[D][SharedWorkerBridge]",
+      "send message to worker",
+      redactedHeartbeat,
+    );
+    expect(consoleLog).toHaveBeenCalledWith(
+      "[D][SharedWorkerBridge]",
+      "got message from app",
+      expect.any(String),
+      redactedHeartbeat,
+    );
+    expect(consoleLog).toHaveBeenCalledWith(
+      "[D][SharedWorkerBridge]",
+      "send message to app",
+      expect.any(String),
+      expect.objectContaining({ type: "result" }),
+    );
+    expect(consoleLog).toHaveBeenCalledWith(
+      "[D][SharedWorkerBridge]",
+      "got message from worker",
+      expect.objectContaining({ type: "result" }),
+    );
+    const serializedLogs = JSON.stringify(consoleLog.mock.calls);
+    expect(serializedLogs).not.toContain(token);
+    expect(serializedLogs).not.toContain(vercelProtectionBypass);
+
+    owner.abort();
+    await vi.waitFor(() => {
+      expect(workerContext.credentialStoreCount()).toBe(0);
+    });
   });
 
   it("completes the initial heartbeat before the credential realtime subscription", async () => {

--- a/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
@@ -24,9 +24,10 @@ import type {
 } from "../data-key.ts";
 import { MessagePortSharedDatabaseBridge } from "../message-port-client.ts";
 import { SharedDatabaseMessagePortServer } from "../message-port-server.ts";
-import type {
-  SharedDatabaseClientMessage,
-  SharedDatabaseConnectionStatus,
+import {
+  redactSharedDatabaseClientMessageForLog,
+  type SharedDatabaseClientMessage,
+  type SharedDatabaseConnectionStatus,
 } from "../protocol.ts";
 import { SingleConnectionSharedDatabaseBridge } from "../single-connection-client.ts";
 import { SharedDatabaseWorkerContext } from "../worker-host-context.ts";
@@ -198,6 +199,24 @@ async function installProtocolBridge(): Promise<{
 }
 
 describe("shared database MessagePort protocol", () => {
+  it("redacts heartbeat credentials from bridge log messages", () => {
+    const message = {
+      type: "heartbeat",
+      requestId: crypto.randomUUID(),
+      token: "secret-heartbeat-token",
+      apiBaseUrl: location.origin,
+      vercelProtectionBypass: "secret-vercel-bypass",
+    } satisfies SharedDatabaseClientMessage;
+
+    expect(redactSharedDatabaseClientMessageForLog(message)).toStrictEqual({
+      ...message,
+      token: "[redacted]",
+      vercelProtectionBypass: "[redacted]",
+    });
+    expect(message.token).toBe("secret-heartbeat-token");
+    expect(message.vercelProtectionBypass).toBe("secret-vercel-bypass");
+  });
+
   it("completes the initial heartbeat before the credential realtime subscription", async () => {
     installHeartbeatAuthentication();
     const initialAttachment = context.mocks.ably.deferNextSubscribe();

--- a/turbo/apps/platform/src/shared-database/message-port-client.ts
+++ b/turbo/apps/platform/src/shared-database/message-port-client.ts
@@ -18,7 +18,10 @@ import {
   type SharedDatabaseClientMessage,
   type SharedDatabaseHeartbeatResult,
 } from "./protocol.ts";
+import { logger } from "../signals/log.ts";
 import { createDeferredPromise, onDomEventFn } from "../signals/utils.ts";
+
+const L = logger("SharedWorkerBridge");
 
 interface PendingRequest {
   readonly resolve: (value: unknown) => void;
@@ -39,6 +42,7 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
   ) {
     this.handleMessage = onDomEventFn(async (event) => {
       const message = sharedDatabaseWorkerMessageSchema.parse(event.data);
+      L.debug("got message from worker", message);
       if (message.type === "invalidate") {
         await this.events.databaseInvalidated(message.dataKey);
         return;
@@ -119,7 +123,7 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
     if (this.closed) {
       throw this.closeReason;
     }
-    this.port.postMessage({ type: "reload-indicators" });
+    this.emit({ type: "reload-indicators" });
   }
 
   async query<TKey extends SharedDatabaseDataKey>(
@@ -186,8 +190,13 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
       reject: finish(deferred.reject),
     });
     signal.addEventListener("abort", abort, { once: true });
-    this.port.postMessage(message);
+    this.emit(message);
     return deferred.promise;
+  }
+
+  private emit(message: SharedDatabaseClientMessage): void {
+    L.debug("send message to worker", message);
+    this.port.postMessage(message);
   }
 
   private close(reason: unknown, reportDisconnected = true): void {
@@ -196,7 +205,7 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
     }
     this.closed = true;
     this.closeReason = reason;
-    this.port.postMessage({ type: "disconnect" });
+    this.emit({ type: "disconnect" });
     this.port.removeEventListener("message", this.handleMessage);
     this.port.close();
     for (const pending of this.pendingRequests.values()) {

--- a/turbo/apps/platform/src/shared-database/message-port-client.ts
+++ b/turbo/apps/platform/src/shared-database/message-port-client.ts
@@ -13,6 +13,7 @@ import type {
   SharedDatabasePortLike,
 } from "./bridge.ts";
 import {
+  redactSharedDatabaseClientMessageForLog,
   sharedDatabaseHeartbeatResultSchema,
   sharedDatabaseWorkerMessageSchema,
   type SharedDatabaseClientMessage,
@@ -195,7 +196,10 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
   }
 
   private emit(message: SharedDatabaseClientMessage): void {
-    L.debug("send message to worker", message);
+    L.debug(
+      "send message to worker",
+      redactSharedDatabaseClientMessageForLog(message),
+    );
     this.port.postMessage(message);
   }
 

--- a/turbo/apps/platform/src/shared-database/message-port-server.ts
+++ b/turbo/apps/platform/src/shared-database/message-port-server.ts
@@ -43,6 +43,7 @@ type RoutedMessage = Exclude<
 >;
 
 const L = logger("SharedDatabaseWorker");
+const BridgeL = logger("SharedWorkerBridge");
 
 function serializedError(error: unknown): { name: string; message: string } {
   if (error instanceof Error || error instanceof DOMException) {
@@ -145,6 +146,7 @@ export class SharedDatabaseMessagePortServer {
 
   private emit(message: SharedDatabaseWorkerMessage): void {
     if (!this.disconnected) {
+      BridgeL.debug("send message to app", this.connectionId, message);
       this.port.postMessage(message);
     }
   }
@@ -383,6 +385,7 @@ export class SharedDatabaseMessagePortServer {
         return;
       }
       const message = parsed.data;
+      BridgeL.debug("got message from app", this.connectionId, message);
       if (message.type === "disconnect") {
         this.disconnect("client-request");
         return;

--- a/turbo/apps/platform/src/shared-database/message-port-server.ts
+++ b/turbo/apps/platform/src/shared-database/message-port-server.ts
@@ -16,6 +16,7 @@ import {
   type SharedDatabaseIdentity,
 } from "./data-key.ts";
 import {
+  redactSharedDatabaseClientMessageForLog,
   sharedDatabaseClientMessageSchema,
   SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME,
   type SharedDatabaseClientMessage,
@@ -385,7 +386,11 @@ export class SharedDatabaseMessagePortServer {
         return;
       }
       const message = parsed.data;
-      BridgeL.debug("got message from app", this.connectionId, message);
+      BridgeL.debug(
+        "got message from app",
+        this.connectionId,
+        redactSharedDatabaseClientMessageForLog(message),
+      );
       if (message.type === "disconnect") {
         this.disconnect("client-request");
         return;

--- a/turbo/apps/platform/src/shared-database/protocol.ts
+++ b/turbo/apps/platform/src/shared-database/protocol.ts
@@ -65,6 +65,21 @@ export type SharedDatabaseClientMessage = z.infer<
   typeof sharedDatabaseClientMessageSchema
 >;
 
+export function redactSharedDatabaseClientMessageForLog(
+  message: SharedDatabaseClientMessage,
+): SharedDatabaseClientMessage {
+  if (message.type !== "heartbeat") {
+    return message;
+  }
+  return {
+    ...message,
+    token: "[redacted]",
+    ...(message.vercelProtectionBypass === undefined
+      ? {}
+      : { vercelProtectionBypass: "[redacted]" }),
+  };
+}
+
 const resultMessageSchema = z
   .object({
     type: z.literal("result"),

--- a/turbo/apps/platform/src/shared-database/worker-context.ts
+++ b/turbo/apps/platform/src/shared-database/worker-context.ts
@@ -1,6 +1,7 @@
 import { command, computed, state } from "ccstate";
 
 import { now } from "../lib/time.ts";
+import { logger } from "../signals/log.ts";
 import { rootSignal$ } from "../signals/root-signal.ts";
 import type { AuthRecovery } from "../signals/auth-retry.ts";
 import { createDeferredPromise, withCleanup } from "../signals/utils.ts";
@@ -10,6 +11,8 @@ import type {
   SharedDatabaseConnectionStatus,
   SharedDatabaseWorkerMessage,
 } from "./protocol.ts";
+
+const L = logger("SharedWorkerBridge");
 
 export type ConnectionId = string;
 
@@ -159,7 +162,8 @@ export const updateWorkerCredentialIdentity$ = command(
 
 export const broadcastSharedDatabaseWorkerMessage$ = command(
   ({ get }, message: WorkerBroadcastMessage): void => {
-    for (const port of get(connectionPortsState$).values()) {
+    for (const [connectionId, port] of get(connectionPortsState$)) {
+      L.debug("send message to app", connectionId, message);
       port.postMessage(message);
     }
   },


### PR DESCRIPTION
## Summary

- add a `SharedWorkerBridge` debug logger for app-side bridge sends and receives
- log worker-side inbound, response, and broadcast messages with the connection ID
- route app-side outbound messages through one logging path

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/shared-database/__tests__/message-port.test.ts`
- `pnpm --filter @okouai/app run build`