### PR TITLE
refactor(rust): share environment-key diagnostic sanitizer

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -796,13 +796,13 @@ fn validate_user_env(user_env: &HashMap<String, String>) -> Result<(), String> {
         if !guest_contracts::env::is_shell_identifier_env_key(key) {
             return Err(format!(
                 "{USER_ENV_FILE_ENV_KEY} contains invalid env key {:?}",
-                guest_contracts::env::sanitize_user_env_key_for_diagnostic(key)
+                guest_contracts::env::sanitize_env_key_for_diagnostic(key)
             ));
         }
         if value.contains('\0') {
             return Err(format!(
                 "{USER_ENV_FILE_ENV_KEY} contains NUL byte for env key {:?}",
-                guest_contracts::env::sanitize_user_env_key_for_diagnostic(key)
+                guest_contracts::env::sanitize_env_key_for_diagnostic(key)
             ));
         }
     }

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -491,7 +491,7 @@ const EXPLICIT_RUNNER_OWNED_ENV_KEYS: &[&str] = &[
     VERCEL_PROTECTION_BYPASS_ENV,
 ];
 
-const USER_ENV_KEY_DIAGNOSTIC_MAX_CHARS: usize = 128;
+const ENV_KEY_DIAGNOSTIC_MAX_CHARS: usize = 128;
 
 /// Returns whether `key` is supported by vm0 guest shell exec env injection.
 ///
@@ -538,7 +538,7 @@ pub fn is_runner_owned_env_key(key: &str) -> bool {
 pub fn sanitize_env_key_for_diagnostic(key: &str) -> String {
     let mut chars = key.escape_debug();
     let mut truncated = String::new();
-    for _ in 0..USER_ENV_KEY_DIAGNOSTIC_MAX_CHARS {
+    for _ in 0..ENV_KEY_DIAGNOSTIC_MAX_CHARS {
         let Some(ch) = chars.next() else {
             return truncated;
         };

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -530,12 +530,12 @@ pub fn is_runner_owned_env_key(key: &str) -> bool {
         || EXPLICIT_RUNNER_OWNED_ENV_KEYS.contains(&key)
 }
 
-/// Escapes and bounds a user-controlled env key for diagnostics.
+/// Escapes and bounds an environment key for diagnostics.
 ///
 /// The returned string contains `escape_debug` output truncated to 128
 /// characters, with `...` appended when truncation happens. This keeps control
 /// characters and very long keys from producing confusing errors or log lines.
-pub fn sanitize_user_env_key_for_diagnostic(key: &str) -> String {
+pub fn sanitize_env_key_for_diagnostic(key: &str) -> String {
     let mut chars = key.escape_debug();
     let mut truncated = String::new();
     for _ in 0..USER_ENV_KEY_DIAGNOSTIC_MAX_CHARS {
@@ -778,9 +778,9 @@ mod tests {
     }
 
     #[test]
-    fn user_env_key_diagnostic_escapes_and_truncates() {
+    fn env_key_diagnostic_escapes_and_truncates() {
         let key = format!("BAD\n{}", "X".repeat(200));
-        let diagnostic = sanitize_user_env_key_for_diagnostic(&key);
+        let diagnostic = sanitize_env_key_for_diagnostic(&key);
 
         assert!(diagnostic.starts_with(r"BAD\n"));
         assert!(diagnostic.ends_with("..."));

--- a/crates/runner/src/cmd/service/unit_file.rs
+++ b/crates/runner/src/cmd/service/unit_file.rs
@@ -128,7 +128,7 @@ pub(super) fn validate_env_vars(vars: &[String]) -> RunnerResult<()> {
             ));
         }
         if !guest_contracts::env::is_shell_identifier_env_key(key) {
-            let key = guest_contracts::env::sanitize_user_env_key_for_diagnostic(key);
+            let key = guest_contracts::env::sanitize_env_key_for_diagnostic(key);
             return Err(RunnerError::Config(format!(
                 "invalid --env key {key:?}: expected [_A-Za-z][_A-Za-z0-9]*"
             )));

--- a/crates/runner/src/executor/diagnostics/environment.rs
+++ b/crates/runner/src/executor/diagnostics/environment.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
+use guest_contracts::env::sanitize_env_key_for_diagnostic;
+
 use super::super::env::is_runner_owned_env_key;
-use super::super::{
-    AGENT_ENV_KEY_DIAGNOSTIC_LIMIT, AGENT_ENV_KEY_MAX_CHARS, BOOTSTRAP_SENSITIVE_ENV_KEYS,
-};
+use super::super::{AGENT_ENV_KEY_DIAGNOSTIC_LIMIT, BOOTSTRAP_SENSITIVE_ENV_KEYS};
 
 const AGENT_ENV_VALUE_SIZE_DIAGNOSTIC_LIMIT: usize = 5;
 
@@ -111,19 +111,4 @@ pub(in crate::executor) fn build_agent_env_key_diagnostics(
         logged_keys,
         omitted_key_count,
     }
-}
-
-fn sanitize_env_key_for_diagnostic(key: &str) -> String {
-    let mut chars = key.escape_debug();
-    let mut truncated = String::new();
-    for _ in 0..AGENT_ENV_KEY_MAX_CHARS {
-        let Some(ch) = chars.next() else {
-            return truncated;
-        };
-        truncated.push(ch);
-    }
-    if chars.next().is_some() {
-        truncated.push_str("...");
-    }
-    truncated
 }

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -263,13 +263,13 @@ fn validate_user_environment_for_guest(context: &ExecutionContext) -> Result<(),
         if !guest_contracts::env::is_shell_identifier_env_key(key) {
             return Err(format!(
                 "user environment contains invalid env key {:?}",
-                guest_contracts::env::sanitize_user_env_key_for_diagnostic(key)
+                guest_contracts::env::sanitize_env_key_for_diagnostic(key)
             ));
         }
         if value.contains('\0') {
             return Err(format!(
                 "user environment contains NUL byte for env key {:?}",
-                guest_contracts::env::sanitize_user_env_key_for_diagnostic(key)
+                guest_contracts::env::sanitize_env_key_for_diagnostic(key)
             ));
         }
     }
@@ -330,13 +330,13 @@ fn validate_bootstrap_environment_for_guest(
         if !guest_contracts::env::is_shell_identifier_env_key(key) {
             return Err(format!(
                 "bootstrap environment contains invalid env key {:?}",
-                guest_contracts::env::sanitize_user_env_key_for_diagnostic(key)
+                guest_contracts::env::sanitize_env_key_for_diagnostic(key)
             ));
         }
         if value.contains('\0') {
             return Err(format!(
                 "bootstrap environment contains NUL byte for env key {:?}",
-                guest_contracts::env::sanitize_user_env_key_for_diagnostic(key)
+                guest_contracts::env::sanitize_env_key_for_diagnostic(key)
             ));
         }
     }

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -119,7 +119,6 @@ const EXIT_SIGNAL_KILL: i32 = 9;
 const DEFAULT_EXEC_TIMEOUT: Duration = Duration::from_secs(300);
 const AGENT_ABNORMAL_EXIT_DIAGNOSTIC_TIMEOUT: Duration = Duration::from_secs(5);
 const AGENT_ENV_KEY_DIAGNOSTIC_LIMIT: usize = 128;
-const AGENT_ENV_KEY_MAX_CHARS: usize = 128;
 const SMALL_GUEST_FILE_MAX_BYTES: u64 = 64 * 1024;
 const GUEST_LOG_COPY_MAX_BYTES: u64 = 64 * 1024 * 1024;
 const STDOUT_STREAM_LIMIT_MARKER: &[u8] =

--- a/crates/runner/src/executor/tests/diagnostics_tests/environment.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests/environment.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
+use super::super::super::AGENT_ENV_KEY_DIAGNOSTIC_LIMIT;
 use super::super::super::diagnostics::{
     build_agent_env_diagnostics, build_agent_env_key_diagnostics,
 };
-use super::super::super::{AGENT_ENV_KEY_DIAGNOSTIC_LIMIT, AGENT_ENV_KEY_MAX_CHARS};
 
 #[test]
 fn agent_env_diagnostics_sort_bounds_and_never_include_values() {
@@ -26,19 +26,23 @@ fn agent_env_diagnostics_sort_bounds_and_never_include_values() {
         bootstrap_env.insert(format!("ZZZ_{index:03}"), format!("value-{index}"));
     }
     bootstrap_env.insert(
-        format!("AAA_{}", "x".repeat(AGENT_ENV_KEY_MAX_CHARS * 4)),
+        format!("AAA_{}", "x".repeat(512)),
         "long-secret-value".to_string(),
+    );
+    bootstrap_env.insert(
+        "AAB\nKEY".to_string(),
+        "escaped-key-secret-value".to_string(),
     );
     let user_env = HashMap::from([("BASH_ENV".to_string(), "user-secret-bash-env".to_string())]);
 
     let diagnostics = build_agent_env_diagnostics(&bootstrap_env, &user_env);
 
-    assert_eq!(diagnostics.env_count, AGENT_ENV_KEY_DIAGNOSTIC_LIMIT + 6);
+    assert_eq!(diagnostics.env_count, AGENT_ENV_KEY_DIAGNOSTIC_LIMIT + 7);
     assert!(diagnostics.env_bytes >= big_value_len);
     assert_eq!(diagnostics.runner_owned_count, 2);
     assert_eq!(
         diagnostics.external_count,
-        AGENT_ENV_KEY_DIAGNOSTIC_LIMIT + 4
+        AGENT_ENV_KEY_DIAGNOSTIC_LIMIT + 5
     );
     assert_eq!(diagnostics.suspicious_keys, vec!["BASH_ENV".to_string()]);
     assert_eq!(diagnostics.largest_entries[0].key, "BIG_VALUE");
@@ -49,7 +53,7 @@ fn agent_env_diagnostics_sort_bounds_and_never_include_values() {
         key_diagnostics.logged_keys.len(),
         AGENT_ENV_KEY_DIAGNOSTIC_LIMIT
     );
-    assert_eq!(key_diagnostics.omitted_key_count, 6);
+    assert_eq!(key_diagnostics.omitted_key_count, 7);
     let mut sorted_logged_keys = key_diagnostics.logged_keys.clone();
     sorted_logged_keys.sort();
     assert_eq!(key_diagnostics.logged_keys, sorted_logged_keys);
@@ -58,8 +62,13 @@ fn agent_env_diagnostics_sort_bounds_and_never_include_values() {
         .iter()
         .find(|key| key.starts_with("AAA_"))
         .expect("long key should be logged before the ZZZ keys");
-    assert_eq!(long_key.chars().count(), AGENT_ENV_KEY_MAX_CHARS + 3);
-    assert!(long_key.ends_with("..."));
+    assert_eq!(long_key, &format!("AAA_{}...", "x".repeat(124)));
+    assert!(
+        key_diagnostics
+            .logged_keys
+            .iter()
+            .any(|key| key == r"AAB\nKEY")
+    );
     let rendered = format!(
         "{} {} {}",
         diagnostics.suspicious_keys_csv(),
@@ -76,4 +85,5 @@ fn agent_env_diagnostics_sort_bounds_and_never_include_values() {
     assert!(!rendered.contains("runner-secret-value"));
     assert!(!rendered.contains("stored-secret-value"));
     assert!(!rendered.contains("long-secret-value"));
+    assert!(!rendered.contains("escaped-key-secret-value"));
 }


### PR DESCRIPTION
## Summary

- rename the shared guest-contracts environment-key diagnostic sanitizer and its character-limit constant to context-neutral APIs, updating guest-agent and runner validation callers
- reuse that sanitizer for runner abnormal-exit environment diagnostics, removing the duplicate implementation and per-key character limit
- cover exact newline escaping, overlong-key truncation, sorting and count bounds, and environment-value non-disclosure through executor diagnostics

## Compatibility

- preserves diagnostic strings, key sorting, logged-key count bounds, and privacy behavior
- does not change API or wire contracts, persisted data, migrations, feature flags, or runtime deployment behavior

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts env_key_diagnostic_escapes_and_truncates`
- `cargo test --manifest-path crates/Cargo.toml -p runner agent_env_diagnostics_sort_bounds_and_never_include_values`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner`
- `lefthook run pre-commit`

Closes #30736
