### PR TITLE
test(runner): synchronize draining heartbeat hard shutdown

### DIFF
--- a/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
@@ -400,22 +400,25 @@ async fn natural_shutdown_flushes_stopping_after_current_heartbeat() {
 /// had to be handled by the Draining-mode heartbeat branch.
 #[tokio::test]
 async fn heartbeat_fires_while_draining() {
-    let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
-        Arc::clone(&gate),
-    ));
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
     let (mut config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
     let (heartbeat_trigger, heartbeat_trigger_rx) = tokio::sync::mpsc::unbounded_channel();
     config.test_hooks.manual_routine_heartbeat_rx = Some(heartbeat_trigger_rx);
     let status_path = env._temp_dir.path().join("status.json");
     let run_handle = tokio::spawn(run(config));
 
-    // Claim a gated job so Draining mode has an active job to wait
-    // on — otherwise `jobs.is_empty()` auto-transitions straight to
-    // Stopping before the Draining wait path is exercised.
+    // Claim a job and wait until it is blocked in `wait_process` so Draining
+    // has an active job to wait on. Otherwise `jobs.is_empty()` auto-transitions
+    // straight to Stopping before the Draining wait path is exercised.
     let run_id = RunId::new_v4();
     push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
     let _token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("active job should enter wait_process before Draining heartbeat check");
 
     // Enter Draining before triggering the routine heartbeat. `status.json`
     // is updated only after the main loop observes the mode transition.


### PR DESCRIPTION
## Summary

- hold the draining heartbeat test's active job with the durable sandbox lifecycle gate
- wait until the job has entered `wait_process` before transitioning to `Draining`
- preserve cancellation-driven gate release and the existing five-second hard-shutdown assertion

## Why

The test only waited for cancellation registration, which occurs before claim completion and executor `wait_process`. It could therefore begin the Draining heartbeat and hard-stop sequence before the job reached the lifecycle point intended to keep it active. The pre-change test reproduced the reported hard-shutdown timeout on the first focused local invocation after compilation.

`MockLifecycleGate` makes the required entry observable and durable. The test still runs the real runner main loop, status persistence, production lifecycle handlers, heartbeat controller/provider path, and hard cancellation.

## Exclusions

- no production shutdown or cancellation changes
- no heartbeat cadence or status-persistence timeout changes
- no API, protocol, persisted-state, migration, or rollout changes

## Validation

- pre-change exact focused test: reproduced the reported timeout on the first invocation
- post-change exact focused test: passed 100 consecutive invocations
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner cmd::start::tests::main_loop::heartbeat --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `lefthook run pre-commit`

Closes #30744
