### PR TITLE
fix(api): repair legacy snapshot revocation rows

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-event-snapshot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-event-snapshot.test.ts
@@ -54,6 +54,38 @@ const trackFakeChatEventObject = createFixtureTracker(
 const R2_GC_SLOT_MS = 10 * 60 * 1000;
 const R2_GC_SHARD_GROUP_COUNT = 16 ** 2;
 
+function sanitizedLegacyControlRevokeLine(row: ChatEventRow): string {
+  const invalidFields = [
+    ...(row.eventType === "control.revoke" ? [] : ["eventType"]),
+    ...(row.runId === null ? [] : ["runId"]),
+    ...(row.revokesEventId === null ? ["revokesEventId"] : []),
+    ...(row.contextType === "morning_brief" ? [] : ["contextType"]),
+    ...(row.contextId === row.revokesEventId ? [] : ["contextId"]),
+    ...(row.payload === null ? [] : ["payload"]),
+    ...(row.runEventSequenceNumber === null ? [] : ["runEventSequenceNumber"]),
+    ...(row.runEventId === null ? [] : ["runEventId"]),
+  ];
+  if (invalidFields.length > 0) {
+    throw new Error(
+      `Expected an exact historical queue-discard row; invalid fields: ${invalidFields.join(", ")}`,
+    );
+  }
+  return `${JSON.stringify({
+    id: row.id,
+    chatThreadId: row.chatThreadId,
+    runId: null,
+    revokesEventId: row.revokesEventId,
+    eventType: "control.revoke",
+    payload: null,
+    contextType: "morning_brief",
+    contextId: row.contextId,
+    runEventSequenceNumber: null,
+    runEventId: null,
+    seqId: row.seqId,
+    createdAt: row.createdAt,
+  })}\n`;
+}
+
 function mockR2GcWindowForKey(key: string, after: Date): Date {
   const prefixStart = "chat-events/".length;
   const shardGroup = Number.parseInt(
@@ -253,7 +285,7 @@ describe("chat event snapshot read endpoints", () => {
     });
   }, 60_000);
 
-  it("repairs all five retired Morning Brief archive shapes before cold download", async () => {
+  it("repairs retired Morning Brief documents and context-carrying revocations before cold download", async () => {
     const owner = bdd.user({ orgId: `org_${randomUUID()}` });
     const agent = await bdd.createAgent(owner, {
       displayName: "Morning Brief archive repair agent",
@@ -370,7 +402,27 @@ describe("chat event snapshot read endpoints", () => {
     if (contextOnlyRow === undefined) {
       throw new Error("Expected a context-only historical rejection row");
     }
+    const contextCarryingRevokeRow = originalRows.find((row) => {
+      return row.eventType === "input.rejected" && row.id !== contextOnlyRow.id;
+    });
+    if (
+      contextCarryingRevokeRow === undefined ||
+      contextCarryingRevokeRow.revokesEventId === null
+    ) {
+      throw new Error("Expected a historical revocation source row");
+    }
     const expectedRows = originalRows.map((row): ChatEventRow => {
+      if (row.id === contextCarryingRevokeRow.id) {
+        return chatEventRowSchema.parse({
+          ...row,
+          eventType: "control.revoke",
+          payload: null,
+          contextType: "web",
+          contextId: null,
+          runEventSequenceNumber: null,
+          runEventId: null,
+        });
+      }
       const promptIndex = promptIndexById.get(row.id);
       if (promptIndex === undefined) {
         return row.id === contextOnlyRow.id
@@ -404,6 +456,13 @@ describe("chat event snapshot read endpoints", () => {
     }
 
     const staleRows = expectedRows.map((row): ChatEventRow => {
+      if (row.id === contextCarryingRevokeRow.id) {
+        return chatEventRowSchema.parse({
+          ...row,
+          contextType: "morning_brief",
+          contextId: row.revokesEventId,
+        });
+      }
       const promptIndex = promptIndexById.get(row.id);
       if (promptIndex !== undefined) {
         const userMessage = historicalDocuments[promptIndex];
@@ -437,15 +496,28 @@ describe("chat event snapshot read endpoints", () => {
           })
         : row;
     });
-    const staleBody = gzipSync(
-      Buffer.from(
-        staleRows
-          .map((row) => {
-            return `${JSON.stringify(row)}\n`;
-          })
-          .join(""),
-      ),
+    const staleArchive = Buffer.from(
+      staleRows
+        .map((row) => {
+          return row.id === contextCarryingRevokeRow.id
+            ? sanitizedLegacyControlRevokeLine(row)
+            : `${JSON.stringify(row)}\n`;
+        })
+        .join(""),
     );
+    const staleContextCarryingRevoke = staleRows.find((row) => {
+      return row.id === contextCarryingRevokeRow.id;
+    });
+    if (staleContextCarryingRevoke === undefined) {
+      throw new Error("Expected the byte-exact historical queue-discard row");
+    }
+    const byteExactRevokeLine = sanitizedLegacyControlRevokeLine(
+      staleContextCarryingRevoke,
+    );
+    expect(
+      staleArchive.includes(Buffer.from(byteExactRevokeLine)),
+    ).toBeTruthy();
+    const staleBody = gzipSync(staleArchive);
     const staleObjectKey = `chat-events/${threadId}/${originalHead.last_seq_id.toString()}-${createHash("sha256").update(staleBody).digest("hex")}.ndjson.gz`;
     writeFakeChatEventObject(staleObjectKey, staleBody);
     await trackFakeChatEventObject(Promise.resolve(staleObjectKey));
@@ -494,21 +566,36 @@ describe("chat event snapshot read endpoints", () => {
       repairedRows.map((row) => {
         return {
           id: row.id,
+          eventType: row.eventType,
           seqId: row.seqId,
           runId: row.runId,
           revokesEventId: row.revokesEventId,
+          payload: row.payload,
         };
       }),
     ).toStrictEqual(
       expectedRows.map((row) => {
         return {
           id: row.id,
+          eventType: row.eventType,
           seqId: row.seqId,
           runId: row.runId,
           revokesEventId: row.revokesEventId,
+          payload: row.payload,
         };
       }),
     );
+    expect(
+      repairedRows.find((row) => {
+        return row.id === contextCarryingRevokeRow.id;
+      }),
+    ).toMatchObject({
+      eventType: "control.revoke",
+      payload: null,
+      contextType: "web",
+      contextId: null,
+      revokesEventId: contextCarryingRevokeRow.revokesEventId,
+    });
 
     const projectedSnapshot = repairedRows.map(chatEventFromRow);
     const projectedPrompts = projectedSnapshot.filter((event) => {
@@ -547,9 +634,24 @@ describe("chat event snapshot read endpoints", () => {
     await expect(
       readChatEventRowsAsPreviousApiFixture(context, threadId),
     ).resolves.toStrictEqual(canonicalRowsBeforeRepair);
+
+    const replay = await accept(
+      eventsClient().snapshot({
+        headers: authenticate(owner),
+        params: { threadId },
+      }),
+      [200],
+    );
+    expect(replay.body).toStrictEqual(download.body);
+    await expect(
+      readChatEventSnapshotHead(context, threadId),
+    ).resolves.toStrictEqual(repairedHead);
+    expect(readFakeChatEventObject(repairedHead.object_key)).toStrictEqual(
+      repairedObject,
+    );
   }, 90_000);
 
-  it("fails closed without moving the pointer for an unexpected retired archive part", async () => {
+  it("fails closed without moving the pointer for malformed or future archive shapes", async () => {
     const owner = bdd.user({ orgId: `org_${randomUUID()}` });
     const agent = await bdd.createAgent(owner, {
       displayName: "Malformed Morning Brief archive agent",
@@ -625,7 +727,199 @@ describe("chat event snapshot read endpoints", () => {
     await expect(
       readChatEventSnapshotHead(context, threadId),
     ).resolves.toStrictEqual(staleHead);
+
+    const rejected = rows.find((row) => {
+      return row.eventType === "input.rejected";
+    });
+    if (rejected === undefined || rejected.revokesEventId === null) {
+      throw new Error("Expected a malformed historical revocation fixture");
+    }
+    const broadControlBody = gzipSync(
+      Buffer.from(
+        rows
+          .map((row) => {
+            return `${JSON.stringify(
+              row.id === rejected.id
+                ? chatEventRowSchema.parse({
+                    ...row,
+                    eventType: "control.revoke",
+                    payload: {},
+                    contextType: "morning_brief",
+                    contextId: row.revokesEventId,
+                  })
+                : row,
+            )}\n`;
+          })
+          .join(""),
+      ),
+    );
+    const broadControlKey = `chat-events/${threadId}/${originalHead.last_seq_id.toString()}-${createHash("sha256").update(broadControlBody).digest("hex")}.ndjson.gz`;
+    writeFakeChatEventObject(broadControlKey, broadControlBody);
+    await trackFakeChatEventObject(Promise.resolve(broadControlKey));
+    await updateChatEventSnapshotHead(context, threadId, broadControlKey);
+    const broadControlHead = await readChatEventSnapshotHead(context, threadId);
+    await expect(
+      eventsClient().snapshot({
+        headers: authenticate(owner),
+        params: { threadId },
+      }),
+    ).rejects.toThrow("Unknown response status 500");
+    await expect(
+      readChatEventSnapshotHead(context, threadId),
+    ).resolves.toStrictEqual(broadControlHead);
+
+    const futureObjectKey = `chat-events/${threadId}/${originalHead.last_seq_id.toString()}-r2-${createHash("sha256").update(originalObject).digest("hex")}.ndjson.gz`;
+    writeFakeChatEventObject(futureObjectKey, originalObject);
+    await trackFakeChatEventObject(Promise.resolve(futureObjectKey));
+    await updateChatEventSnapshotHead(context, threadId, futureObjectKey);
+    const futureHead = await readChatEventSnapshotHead(context, threadId);
+    await expect(
+      eventsClient().snapshot({
+        headers: authenticate(owner),
+        params: { threadId },
+      }),
+    ).rejects.toThrow("Unknown response status 500");
+    await expect(
+      readChatEventSnapshotHead(context, threadId),
+    ).resolves.toStrictEqual(futureHead);
   }, 60_000);
+
+  it("classifies legacy Snapshot decode failures without logging row data", async () => {
+    const owner = bdd.user({ orgId: `org_${randomUUID()}` });
+    const agent = await bdd.createAgent(owner, {
+      displayName: "Snapshot decode classification agent",
+    });
+    const threadId = await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      prompt: `snapshot-decode-classification-${randomUUID()}`,
+    });
+    await projectChatEventSearch(threadId);
+    await runSnapshotCron([threadId]);
+    const originalHead = await readChatEventSnapshotHead(context, threadId);
+    const originalObject = readFakeChatEventObject(originalHead.object_key);
+    if (originalObject === undefined) {
+      throw new Error("Expected a Snapshot object for decode classification");
+    }
+    const originalBody = gunzipSync(originalObject);
+    const originalRows = originalBody
+      .toString("utf8")
+      .trimEnd()
+      .split("\n")
+      .map((line) => {
+        return chatEventRowSchema.parse(JSON.parse(line));
+      });
+    const inputRow = originalRows.find((row) => {
+      return row.eventType === "input.prompt";
+    });
+    const firstRow = originalRows[0];
+    if (inputRow === undefined || firstRow === undefined) {
+      throw new Error("Expected complete Snapshot decode fixtures");
+    }
+    const encodeRows = (rows: readonly unknown[]): Buffer => {
+      return Buffer.from(
+        rows
+          .map((row) => {
+            return `${JSON.stringify(row)}\n`;
+          })
+          .join(""),
+      );
+    };
+    const rawRowBody = Buffer.from(
+      `${JSON.stringify({ ...firstRow, unexpected: true })}\n`,
+    );
+    const projectionBody = encodeRows(
+      originalRows.map((row) => {
+        return row.id === inputRow.id ? { ...row, payload: null } : row;
+      }),
+    );
+    const prefixBody = encodeRows(
+      originalRows.map((row) => {
+        return row.id === firstRow.id
+          ? { ...row, chatThreadId: randomUUID() }
+          : row;
+      }),
+    );
+    const terminalBody = encodeRows(originalRows.slice(0, -1));
+    const invalidGzip = Buffer.from("sanitized invalid gzip fixture");
+    const cases = [
+      {
+        failureClass: "checksum",
+        object: originalObject,
+        keyDigest: createHash("sha256")
+          .update("different sanitized checksum fixture")
+          .digest("hex"),
+      },
+      {
+        failureClass: "gzip",
+        object: invalidGzip,
+        keyDigest: createHash("sha256").update(invalidGzip).digest("hex"),
+      },
+      {
+        failureClass: "raw_row",
+        object: gzipSync(rawRowBody),
+      },
+      {
+        failureClass: "projection",
+        object: gzipSync(projectionBody),
+      },
+      {
+        failureClass: "prefix",
+        object: gzipSync(prefixBody),
+      },
+      {
+        failureClass: "terminal",
+        object: gzipSync(terminalBody),
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      const digest =
+        "keyDigest" in testCase
+          ? testCase.keyDigest
+          : createHash("sha256").update(testCase.object).digest("hex");
+      const objectKey = `chat-events/${threadId}/${originalHead.last_seq_id.toString()}-${digest}.ndjson.gz`;
+      writeFakeChatEventObject(objectKey, testCase.object);
+      await trackFakeChatEventObject(Promise.resolve(objectKey));
+      await updateChatEventSnapshotHead(context, threadId, objectKey);
+      const staleHead = await readChatEventSnapshotHead(context, threadId);
+      context.mocks.axiomLogging.warn.mockClear();
+
+      await expect(
+        eventsClient().snapshot({
+          headers: authenticate(owner),
+          params: { threadId },
+        }),
+      ).rejects.toThrow("Unknown response status 500");
+      await expect(
+        readChatEventSnapshotHead(context, threadId),
+      ).resolves.toStrictEqual(staleHead);
+      expect(readFakeChatEventObject(objectKey)).toStrictEqual(testCase.object);
+
+      const skipLog = context.mocks.axiomLogging.warn.mock.calls.find(
+        ([message, fields]) => {
+          return (
+            message === "Skipped Chat Event Snapshot pointer" &&
+            (fields as Record<string, unknown> | undefined)?.type ===
+              "chat_event_snapshot_head_skipped"
+          );
+        },
+      );
+      const fields = skipLog?.[1];
+      if (typeof fields !== "object" || fields === null) {
+        throw new Error("Expected a bounded Snapshot decode failure log");
+      }
+      expect(fields).toMatchObject({
+        type: "chat_event_snapshot_head_skipped",
+        chatThreadId: threadId,
+        reason: "undecodable",
+        failureClass: testCase.failureClass,
+        context: "api:cron:snapshot-chat-events",
+      });
+      expect(Object.keys(fields).sort()).toStrictEqual(
+        ["chatThreadId", "context", "failureClass", "reason", "type"].sort(),
+      );
+    }
+  }, 90_000);
 
   it("applies the same schema-version errors to Snapshot and Raw Event reads", async () => {
     const owner = bdd.user({ orgId: `org_${randomUUID()}` });

--- a/turbo/apps/api/src/signals/services/chat-event-snapshot-body.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-snapshot-body.service.ts
@@ -10,11 +10,6 @@ const RETIRED_MORNING_BRIEF_CONTEXT = "morning_brief";
 const RETIRED_MORNING_BRIEF_PART = "morning_brief";
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
 
-interface SnapshotLine {
-  readonly raw: string;
-  readonly row: ChatEventRow;
-}
-
 interface MorningBriefSnapshotRepair {
   readonly body: Buffer;
   readonly rows: readonly ChatEventRow[];
@@ -26,7 +21,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function snapshotLines(body: Buffer): readonly SnapshotLine[] {
+function snapshotRawLines(body: Buffer): readonly string[] {
   const text = body.toString("utf8");
   if (text.length === 0) {
     return [];
@@ -34,16 +29,7 @@ function snapshotLines(body: Buffer): readonly SnapshotLine[] {
   if (!text.endsWith("\n")) {
     throw new Error("Chat Event snapshot must be newline-delimited JSON");
   }
-  return text
-    .slice(0, -1)
-    .split("\n")
-    .map((raw) => {
-      const parsed = safeJsonParse(raw);
-      if (parsed === undefined) {
-        throw new Error("Chat Event snapshot contains invalid JSON");
-      }
-      return { raw, row: chatEventRowSchema.parse(parsed) };
-    });
+  return text.slice(0, -1).split("\n");
 }
 
 function retiredMorningBriefPart(part: unknown): boolean {
@@ -64,6 +50,23 @@ function assertExactRetiredMorningBriefPart(part: unknown): void {
   }
 }
 
+function isRepairableRetiredMorningBriefEvent(row: ChatEventRow): boolean {
+  if (row.eventType === "input.prompt" || row.eventType === "input.rejected") {
+    return true;
+  }
+  // The historical queue-discard path copied its target context onto this
+  // payload-free tombstone. Keep the one-way exception exact to that shape.
+  return (
+    row.eventType === "control.revoke" &&
+    row.runId === null &&
+    row.revokesEventId !== null &&
+    row.revokesEventId === row.contextId &&
+    row.payload === null &&
+    row.runEventSequenceNumber === null &&
+    row.runEventId === null
+  );
+}
+
 function repairMorningBriefRow(row: ChatEventRow): {
   readonly row: ChatEventRow;
   readonly removedDocumentParts: number;
@@ -73,11 +76,7 @@ function repairMorningBriefRow(row: ChatEventRow): {
   let legacyParts: readonly unknown[] = [];
   let parts: readonly unknown[] | undefined;
 
-  if (
-    hasRetiredContext &&
-    row.eventType !== "input.prompt" &&
-    row.eventType !== "input.rejected"
-  ) {
+  if (hasRetiredContext && !isRepairableRetiredMorningBriefEvent(row)) {
     throw new Error(
       "Chat Event snapshot has an unexpected retired Morning Brief event",
     );
@@ -153,8 +152,12 @@ function repairMorningBriefRow(row: ChatEventRow): {
 export function decodeChatEventSnapshotBody(
   body: Buffer,
 ): readonly ChatEventRow[] {
-  return snapshotLines(body).map(({ row }) => {
-    return row;
+  return snapshotRawLines(body).map((raw) => {
+    const parsed = safeJsonParse(raw);
+    if (parsed === undefined) {
+      throw new Error("Chat Event snapshot contains invalid JSON");
+    }
+    return chatEventRowSchema.parse(parsed);
   });
 }
 
@@ -165,17 +168,25 @@ export function decodeChatEventSnapshotBody(
  */
 export function repairMorningBriefPhaseBSnapshot(
   body: Buffer,
+  decodedRows: readonly ChatEventRow[],
 ): MorningBriefSnapshotRepair {
   let repairedContextRows = 0;
   let removedDocumentParts = 0;
   let changed = false;
-  const lines = snapshotLines(body);
+  const rawLines = snapshotRawLines(body);
+  if (rawLines.length !== decodedRows.length) {
+    throw new Error("Chat Event snapshot decoded row count changed");
+  }
   const rows: ChatEventRow[] = [];
-  const repairedLines = lines.map((line) => {
-    const repaired = repairMorningBriefRow(line.row);
+  const repairedLines = rawLines.map((raw, index) => {
+    const row = decodedRows[index];
+    if (row === undefined) {
+      throw new Error("Chat Event snapshot decoded row is missing");
+    }
+    const repaired = repairMorningBriefRow(row);
     rows.push(repaired.row);
-    if (repaired.row === line.row) {
-      return Buffer.from(`${line.raw}\n`);
+    if (repaired.row === row) {
+      return Buffer.from(`${raw}\n`);
     }
     changed = true;
     repairedContextRows += 1;

--- a/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
@@ -296,11 +296,39 @@ interface SnapshotSource {
 }
 
 type SnapshotSkipReason = "unreadable" | "undecodable" | "incomplete";
+type SnapshotDecodeFailureClass =
+  | "checksum"
+  | "gzip"
+  | "raw_row"
+  | "projection"
+  | "prefix"
+  | "terminal";
+
+class SnapshotDecodeFailure extends Error {
+  readonly failureClass: SnapshotDecodeFailureClass;
+
+  constructor(failureClass: SnapshotDecodeFailureClass) {
+    super("Chat Event Snapshot decode failed");
+    this.name = "SnapshotDecodeFailure";
+    this.failureClass = failureClass;
+  }
+}
+
+type SnapshotSkippedResolution =
+  | {
+      readonly kind: "skipped";
+      readonly reason: "unreadable" | "incomplete";
+    }
+  | {
+      readonly kind: "skipped";
+      readonly reason: "undecodable";
+      readonly failureClass: SnapshotDecodeFailureClass;
+    };
 
 type SnapshotSourceResolution =
   | { readonly kind: "initial" }
   | { readonly kind: "reusable"; readonly source: SnapshotSource }
-  | { readonly kind: "skipped"; readonly reason: SnapshotSkipReason };
+  | SnapshotSkippedResolution;
 
 interface SnapshotSourceMetadata {
   readonly id: string;
@@ -391,10 +419,7 @@ type SnapshotPrefixResolution =
       readonly terminalSeqId: number;
       readonly terminalEventId: string | null;
     }
-  | {
-      readonly kind: "skipped";
-      readonly reason: "unreadable" | "undecodable";
-    };
+  | SnapshotSkippedResolution;
 
 interface SnapshotPrefixArgs {
   readonly bucket: string;
@@ -432,6 +457,21 @@ function validateSnapshotPrefixTerminal(
   }
 }
 
+async function decodeSnapshotStage<T>(
+  failureClass: SnapshotDecodeFailureClass,
+  decode: () => T | Promise<T>,
+): Promise<T> {
+  const decoded = await settle(
+    (async () => {
+      return await decode();
+    })(),
+  );
+  if (!decoded.ok) {
+    throw new SnapshotDecodeFailure(failureClass);
+  }
+  return decoded.value;
+}
+
 async function decodeSnapshotPrefix(
   compressed: Buffer,
   args: SnapshotPrefixArgs,
@@ -444,18 +484,27 @@ async function decodeSnapshotPrefix(
     args.source.objectKey,
   )?.[1];
   if (digest === undefined || sha256Hex(compressed) !== digest) {
-    throw new Error(
-      "Chat Event Snapshot object checksum does not match its key",
-    );
+    throw new SnapshotDecodeFailure("checksum");
   }
-  const decompressed = await gunzipAsync(compressed);
-  const repaired = repairMorningBriefPhaseBSnapshot(decompressed);
+  const decompressed = await decodeSnapshotStage("gzip", async () => {
+    return await gunzipAsync(compressed);
+  });
+  const decodedRows = await decodeSnapshotStage("raw_row", () => {
+    return decodeChatEventSnapshotBody(decompressed);
+  });
+  const repaired = await decodeSnapshotStage("projection", () => {
+    return repairMorningBriefPhaseBSnapshot(decompressed, decodedRows);
+  });
   const rows = repaired.rows;
-  validateSnapshotPrefixRows(rows, args);
+  await decodeSnapshotStage("prefix", () => {
+    validateSnapshotPrefixRows(rows, args);
+  });
   const terminal = rows.at(-1);
   const terminalSeqId = terminal?.seqId ?? 0;
   const terminalEventId = terminal?.id ?? null;
-  validateSnapshotPrefixTerminal(args, terminalSeqId, terminalEventId);
+  await decodeSnapshotStage("terminal", () => {
+    validateSnapshotPrefixTerminal(args, terminalSeqId, terminalEventId);
+  });
   if (repaired.repairedContextRows > 0) {
     log.debug("Repaired retired Morning Brief Chat Event Snapshot rows", {
       type: "chat_event_snapshot_morning_brief_rows_repaired",
@@ -487,9 +536,17 @@ function readSnapshotPrefix(
       decodeSnapshotPrefix(downloaded.value, args),
       signal,
     );
-    return decoded.ok
-      ? { kind: "reusable", ...decoded.value }
-      : { kind: "skipped", reason: "undecodable" };
+    if (decoded.ok) {
+      return { kind: "reusable", ...decoded.value };
+    }
+    if (!(decoded.error instanceof SnapshotDecodeFailure)) {
+      throw decoded.error;
+    }
+    return {
+      kind: "skipped",
+      reason: "undecodable",
+      failureClass: decoded.error.failureClass,
+    };
   });
 }
 
@@ -583,16 +640,19 @@ interface ArchivedThread {
 
 function skippedArchivedThread(
   candidate: SnapshotCandidate,
-  reason: SnapshotSkipReason,
+  resolution: SnapshotSkippedResolution,
 ): ArchivedThread {
   log.warn("Skipped Chat Event Snapshot pointer", {
     type: "chat_event_snapshot_head_skipped",
     chatThreadId: candidate.chatThreadId,
-    reason,
+    reason: resolution.reason,
+    ...(resolution.reason === "undecodable"
+      ? { failureClass: resolution.failureClass }
+      : {}),
   });
   return {
     archivedEvents: null,
-    skippedHead: reason,
+    skippedHead: resolution.reason,
     normalization: NO_DUPLICATE_EVENT_ID_NORMALIZATION,
   };
 }
@@ -605,7 +665,7 @@ type ArchivePrefixResolution =
       readonly terminalSeqId: number;
       readonly terminalEventId: string | null;
     }
-  | { readonly kind: "skipped"; readonly reason: SnapshotSkipReason };
+  | SnapshotSkippedResolution;
 
 function resolveArchivePrefix(
   args: {
@@ -805,7 +865,7 @@ const archiveThread$ = command(async function archiveThread(
   );
   signal.throwIfAborted();
   if (resolved.kind === "skipped") {
-    return skippedArchivedThread(candidate, resolved.reason);
+    return skippedArchivedThread(candidate, resolved);
   }
   const { source, prefix, terminalSeqId, terminalEventId } = resolved;
   const targetSeqId = Math.max(candidate.indexedSeqId, source?.lastSeqId ?? 0);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-thread-idb.test.tsx
@@ -846,6 +846,26 @@ describe("okou chat thread IndexedDB fallback", () => {
         error: "Historical Morning Brief rejection",
       },
     });
+    const discardedSourceMarker = "Superseded Morning Brief source 6";
+    revokedSourceMarkers.push(discardedSourceMarker);
+    const discardedSource = appendRow({
+      eventType: "input.prompt",
+      runId: null,
+      contextType: "web",
+      payload: {
+        userMessage: {
+          version: 1,
+          parts: [{ type: "text", text: discardedSourceMarker }],
+        },
+      },
+    });
+    appendRow({
+      eventType: "control.revoke",
+      runId: null,
+      revokesEventId: discardedSource.id,
+      contextType: "web",
+      payload: null,
+    });
     const terminalSnapshotRow = snapshotRows.at(-1);
     if (terminalSnapshotRow === undefined) {
       throw new Error("Expected repaired historical Snapshot rows");


### PR DESCRIPTION
## Summary

- classify legacy Chat Event Snapshot decode failures as `checksum`, `gzip`, `raw_row`, `projection`, `prefix`, or `terminal` while logging no archived row or payload data
- repair only the exact historical payload-free `control.revoke` tombstone whose copied retired context points at the revoked source, then publish the strict current V7 `r1` projection through the existing exact pointer CAS
- cover a sanitized byte-exact archive row, immutable source and canonical events, identity preservation, idempotent replay, malformed/future fail-closed behavior, cross-owner access control, paired hot rows, and the App/IndexedDB path

## Diagnosis

The historical queue-discard path revoked an unclaimed input and copied the target event's context onto the new tombstone. For retired Morning Brief inputs, that produced context-carrying `control.revoke` rows with null run and payload fields. The Phase B repair decoded every legacy row through the current raw-row schema, but only allowed retired context on `input.prompt` and `input.rejected`, so this exact tombstone reached projection repair and failed. The read path then collapsed that stage with checksum, gzip, row, prefix, and terminal failures into the single safe `undecodable` reason.

This change keeps the public contract current-only and makes no fallback: the legacy object remains immutable, the exact historical tombstone is normalized once into a new current-format object, and all broader or future shapes still fail closed.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- focused API Vitest: 4 passed (current snapshot/access control; legacy repair/idempotency; malformed and future fail-closed; bounded failure classification)
- focused App Vitest: 1 passed (cold Snapshot + paired hot rows + IndexedDB/current projection)
- `git diff --check origin/main...HEAD`

Closes #30733
