### PR TITLE
fix: tidy emoji picker spacing onto one rail

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -1214,10 +1214,11 @@ function ChatThreadEmojiPicker({
       <div
         className={cn(
           "flex items-center gap-2 px-2 pt-2",
-          // In rail mode every section carries its own top margin, so this row
-          // adds nothing: the first title then sits the same 16px below the
-          // search field as every later title sits below the grid above it.
-          railEnabled ? "pb-0" : "pb-2",
+          // The gap below the field belongs to this row, because a search hides
+          // the sections and puts a bare result grid under it. 12px here plus
+          // the title's own pt-1 puts the first title the same 16px below the
+          // field as every later title sits below the grid above it.
+          railEnabled ? "pb-3" : "pb-2",
         )}
       >
         <div className="relative flex-1">
@@ -1444,8 +1445,9 @@ function ChatThreadEmojiSection({
       // separates it from the previous grid cannot come from the sticky box
       // itself. Carry it here instead, at twice the 8px left under the label,
       // so the title reads as a heading for its own grid and not as a caption
-      // for the one above it.
-      className={cn(pinnedTitle && "mt-3")}
+      // for the one above it. The first section has no grid above it — the
+      // search row already spaces it off the field.
+      className={cn(pinnedTitle && "mt-3 first:mt-0")}
     >
       <div
         className={cn(

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -1214,10 +1214,10 @@ function ChatThreadEmojiPicker({
       <div
         className={cn(
           "flex items-center gap-2 px-2 pt-2",
-          // Pull the first section title up towards the search field. The title
-          // keeps its own box height so the fade under it is unchanged; only
-          // the gap above it closes.
-          railEnabled ? "pb-1" : "pb-2",
+          // In rail mode every section carries its own top margin, so this row
+          // adds nothing: the first title then sits the same 16px below the
+          // search field as every later title sits below the grid above it.
+          railEnabled ? "pb-0" : "pb-2",
         )}
       >
         <div className="relative flex-1">
@@ -1271,7 +1271,7 @@ function ChatThreadEmojiPreview() {
   const preview = useGet(chatThreadEmojiPreview$);
 
   return (
-    <div className="flex h-10 shrink-0 items-center gap-2 border-t border-border px-3">
+    <div className="flex h-10 shrink-0 items-center gap-2 border-t border-border px-2">
       {preview ? (
         <>
           <span aria-hidden="true" className="zero-emoji text-lg leading-none">
@@ -1440,17 +1440,23 @@ function ChatThreadEmojiSection({
     <div
       id={chatThreadEmojiSectionId(categoryKey)}
       data-chat-thread-emoji-section={categoryKey}
+      // The pinned title's fade has to sit below its text, so the space that
+      // separates it from the previous grid cannot come from the sticky box
+      // itself. Carry it here instead, at twice the 8px left under the label,
+      // so the title reads as a heading for its own grid and not as a caption
+      // for the one above it.
+      className={cn(pinnedTitle && "mt-3")}
     >
       <div
         className={cn(
-          "flex items-baseline justify-between gap-2 px-1 pb-1 pt-2",
+          "flex items-baseline justify-between gap-2 pb-1 pt-2",
           // Fade to transparent at the lower edge so emoji dissolve as they
-          // scroll under the pinned title instead of colliding with it.
-          // pt-1/pb-3 shifts the label up towards the search field while
-          // keeping the box — and so the painted fade — the same 32px tall as
-          // the pt-2/pb-2 it replaces.
+          // scroll under the pinned title instead of colliding with it. The
+          // fade has to live below the text, so pb-2 doubles as the gap to the
+          // grid; from-75% keeps the whole label — descenders included — on the
+          // solid part of that 28px box rather than over the fading part.
           pinnedTitle &&
-            "sticky top-0 z-10 bg-gradient-to-b from-popover from-60% to-transparent pb-3 pt-1",
+            "sticky top-0 z-10 bg-gradient-to-b from-popover from-75% to-transparent pb-2 pt-1",
         )}
       >
         <span className="text-xs font-medium text-muted-foreground">


### PR DESCRIPTION
## Problem

Measured off a 2x screenshot of the picker (320px popover, rail mode).

**Two left rails.** The category rail, the search field and the emoji grid all sit at 8px from the popover edge. Section titles and the shortcut hint sat at 12px (`px-1` on the header) and the preview bar at 12px (`px-3`), so the title hung 4px right of the search box it follows.

**Section titles bound to the wrong group.** In rail mode a title had 4px above it and 12px below, so `Smileys & Emotion` read as a caption for the frequently-used grid it followed rather than a heading for its own.

## Change

| | before | after |
|---|---|---|
| section title / shortcut hint, left+right | 12px | 8px |
| preview bar, left+right | 12px | 8px |
| gap above a section title | 4px | 16px |
| gap below a section title | 12px | 8px |
| gap between search field and first title | 8px | 16px |

The pinned title's fade has to sit below its text, so the space above it cannot come from the sticky box. Between sections the wrapper carries it as `mt-3`; under the search field the search row carries it as `pb-3`, because a query replaces the sections with a bare result grid that no section margin would reach. The first section drops its own margin with `first:mt-0`, so every title sits 16px below what precedes it and a result grid sits 12px below the field. `pb-3` -> `pb-2` on the title makes its box 28px, and the gradient moves `from-60%` -> `from-75%` so descenders stay on the solid part of it.

Dropping `px-1` also widens the pinned title's painted fade to the full grid width. Previously it stopped 4px short on each side, which left the 9th column's shortcut digit (2px from the cell edge) scrolling past the header uncovered.

The non-rail path keeps its own vertical rhythm; only the shared horizontal `px-1` changes there.

## Verification

`pnpm -F @okouai/app run lint`, `check-types` and `prettier --check` pass locally. Layout numbers were derived from the shipping build and confirmed against a pixel-accurate static reproduction of the popover before and after.