### PR TITLE
refactor(platform): simplify bootstrap monitoring

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -139,13 +139,8 @@
       #app-bootstrap-skeleton {
         position: fixed;
         inset: 0;
-        /* Fixed insets follow WebKit's reachable layout viewport. Avoid the
-           standalone viewport unit, which can resolve after first paint. */
         z-index: 60;
         box-sizing: border-box;
-        display: flex;
-        align-items: center;
-        justify-content: center;
         background: #fdfdfe;
         opacity: 1;
         transition: opacity 300ms ease;
@@ -162,7 +157,8 @@
 
       .app-bootstrap-skeleton__content {
         position: fixed;
-        top: var(--app-bootstrap-skeleton-center-y, 50dvh);
+        /* Small viewport units stay stable during iOS standalone launch. */
+        top: 50svh;
         left: 50%;
         transform: translate(-50%, -50%);
       }
@@ -710,24 +706,6 @@
         gtagScript.src =
           "https://www.googletagmanager.com/gtag/js?id=AW-18144854014";
         document.head.appendChild(gtagScript);
-      })();
-    </script>
-    <script>
-      (function () {
-        var skeleton = document.getElementById("app-bootstrap-skeleton");
-        // iOS standalone can expand the fixed containing viewport one frame
-        // after launch. Pin the content to the initially reachable viewport
-        // so that later geometry resolution cannot visibly recenter it.
-        var viewportHeight =
-          window.visualViewport && window.visualViewport.height > 0
-            ? window.visualViewport.height
-            : window.innerHeight;
-        if (viewportHeight > 0) {
-          skeleton.style.setProperty(
-            "--app-bootstrap-skeleton-center-y",
-            viewportHeight / 2 + "px",
-          );
-        }
       })();
     </script>
   </body>

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -208,8 +208,6 @@
         var CLIENT_SESSION_ID_HEADER = "X-Client-Session-Id";
         var CLIENT_TYPE_HEADER = "X-Client-Type";
         var CLIENT_VERSION_HEADER = "X-Client-Version";
-        var CLERK_LOAD_COMPLETED_MARK = "vm0:bootstrap:clerk-load-completed";
-        var CLERK_LOAD_STARTED_MARK = "vm0:bootstrap:clerk-load-started";
         var OKOU_PAGES_PREVIEW_HOST_SUFFIX = ".okou-app.pages.dev";
         var OKOU_PREVIEW_ROOT_DOMAIN = "omby.ai";
         var PREVIEW_API_HOSTNAME_PATTERN =
@@ -545,18 +543,6 @@
           );
         }
 
-        function markClerkLoadCompleted() {
-          bootstrap.clerkLoadCompletedAt = performance.now();
-          if (
-            performance.getEntriesByName(CLERK_LOAD_COMPLETED_MARK, "mark")
-              .length === 0
-          ) {
-            performance.mark(CLERK_LOAD_COMPLETED_MARK, {
-              startTime: bootstrap.clerkLoadCompletedAt,
-            });
-          }
-        }
-
         function startClerk() {
           var clerk = window.Clerk;
           if (
@@ -585,19 +571,9 @@
           };
 
           bootstrap.clerk = clerk;
-          bootstrap.clerkLoadStartedAt = performance.now();
-          if (
-            performance.getEntriesByName(CLERK_LOAD_STARTED_MARK, "mark")
-              .length === 0
-          ) {
-            performance.mark(CLERK_LOAD_STARTED_MARK, {
-              startTime: bootstrap.clerkLoadStartedAt,
-            });
-          }
           bootstrap.loaded = clerk.load(loadOptions);
           bootstrap.onboardingStatusPromise = bootstrap.loaded
             .then(function () {
-              markClerkLoadCompleted();
               return startOnboardingStatus(clerk);
             })
             .catch(function () {
@@ -729,39 +705,11 @@
         window.gtag("config", "AW-18144854014");
         window.gtag("config", "AW-18407336975");
 
-        var initialized = false;
-
-        function loadMarketingScripts() {
-          var gtagScript = document.createElement("script");
-          gtagScript.async = true;
-          gtagScript.src =
-            "https://www.googletagmanager.com/gtag/js?id=AW-18144854014";
-          document.head.appendChild(gtagScript);
-        }
-
-        function scheduleMarketingScripts() {
-          if (initialized) return;
-          initialized = true;
-
-          if (typeof window.requestIdleCallback === "function") {
-            window.requestIdleCallback(loadMarketingScripts, {
-              timeout: 1500,
-            });
-            return;
-          }
-
-          window.setTimeout(loadMarketingScripts, 0);
-        }
-
-        // Keep vendor work outside the first-content critical path. The
-        // 30-second guard exceeds the observed mobile P90 startup window and
-        // still bounds bootstraps that never reach real app content.
-        window.addEventListener(
-          "vm0:app-first-content-visible",
-          scheduleMarketingScripts,
-          { once: true },
-        );
-        window.setTimeout(scheduleMarketingScripts, 30000);
+        var gtagScript = document.createElement("script");
+        gtagScript.async = true;
+        gtagScript.src =
+          "https://www.googletagmanager.com/gtag/js?id=AW-18144854014";
+        document.head.appendChild(gtagScript);
       })();
     </script>
     <script>

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -730,20 +730,5 @@
         }
       })();
     </script>
-    <script>
-      (function () {
-        var hostname = window.location.hostname.toLowerCase();
-        if (hostname !== "app.vm0.ai" && hostname !== "app.okou.ai") return;
-
-        var instatusScript = document.createElement("script");
-        instatusScript.src =
-          "https://api.dashboard.instatus.com/widget?host=status.vm0.ai&code=02c0ef5a&locale=en";
-        instatusScript.integrity =
-          "sha384-ZW3eZwADOMdlg2fdvESPD7jguK16IC/edxNFakKs81D2lkNdi3BXRmx/g331lkD3";
-        instatusScript.crossOrigin = "anonymous";
-        instatusScript.defer = true;
-        document.body.appendChild(instatusScript);
-      })();
-    </script>
   </body>
 </html>

--- a/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
@@ -27,8 +27,6 @@ const CLERK_BOOTSTRAP_SELECTOR = "script[data-vm0-clerk-bootstrap]";
 const CLERK_CORE_SCRIPT_ID = "vm0-clerk-core-script";
 const CLERK_SCRIPT_SELECTOR = "script[data-clerk-js-script]";
 const TEST_APP_VERSION = "0.812.5-test";
-const CLERK_LOAD_COMPLETED_MARK = "vm0:bootstrap:clerk-load-completed";
-const CLERK_LOAD_STARTED_MARK = "vm0:bootstrap:clerk-load-started";
 
 const PREFETCHED_ONBOARDING_STATUS: OnboardingStatusResponse = {
   defaultAgentId: "c0000000-0000-4000-a000-000000000101",
@@ -179,8 +177,6 @@ function captureClerkBootstrapScript(
       window.dispatchEvent(new Event("pagehide"));
       Reflect.deleteProperty(globalThis, "Clerk");
       Reflect.deleteProperty(window, "__vm0ClerkBootstrap");
-      performance.clearMarks(CLERK_LOAD_STARTED_MARK);
-      performance.clearMarks(CLERK_LOAD_COMPLETED_MARK);
     },
     { once: true },
   );
@@ -280,8 +276,6 @@ function startClerkPage(
           }
           Reflect.deleteProperty(globalThis, "Clerk");
           Reflect.deleteProperty(window, "__vm0ClerkBootstrap");
-          performance.clearMarks(CLERK_LOAD_STARTED_MARK);
-          performance.clearMarks(CLERK_LOAD_COMPLETED_MARK);
         },
         { once: true },
       );
@@ -526,8 +520,6 @@ describe("platform Clerk entrypoint", () => {
     if (!bootstrap?.loaded || !bootstrap.onboardingStatusPromise) {
       throw new Error("Clerk bootstrap did not start its shared promises");
     }
-    const startedAt = bootstrap.clerkLoadStartedAt;
-    expect(startedAt).toStrictEqual(expect.any(Number));
     expect(mockedClerkLoad).toHaveBeenCalledOnce();
     expect(bootstrap.loaded).toBe(loadCanFinish.promise);
     const onboardingStatusPromise = bootstrap.onboardingStatusPromise;
@@ -545,17 +537,7 @@ describe("platform Clerk entrypoint", () => {
     loadCanFinish.resolve(undefined);
     await Promise.all([setup, bootstrap.onboardingStatusPromise]);
 
-    const completedAt = bootstrap.clerkLoadCompletedAt;
-    expect(completedAt).toStrictEqual(expect.any(Number));
     expect(mockedClerkLoad).toHaveBeenCalledOnce();
-    expect(
-      performance.getEntriesByName(CLERK_LOAD_STARTED_MARK, "mark")[0]
-        ?.startTime,
-    ).toBe(startedAt);
-    expect(
-      performance.getEntriesByName(CLERK_LOAD_COMPLETED_MARK, "mark")[0]
-        ?.startTime,
-    ).toBe(completedAt);
   });
 
   it("does not start onboarding after a final pagehide during Clerk.load", async () => {

--- a/turbo/apps/platform/src/__tests__/instatus-widget.test.ts
+++ b/turbo/apps/platform/src/__tests__/instatus-widget.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import indexHtml from "../../index.html?raw";
+import { initInstatusWidget } from "../lib/instatus-widget.ts";
 import { testContext } from "../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
@@ -9,31 +9,6 @@ const INSTATUS_SCRIPT_URL =
   "https://api.dashboard.instatus.com/widget?host=status.vm0.ai&code=02c0ef5a&locale=en";
 const INSTATUS_SCRIPT_INTEGRITY =
   "sha384-ZW3eZwADOMdlg2fdvESPD7jguK16IC/edxNFakKs81D2lkNdi3BXRmx/g331lkD3";
-
-type EntrypointScript = (
-  windowObject: Window,
-  documentObject: Document,
-) => void;
-
-function getInstatusLoaderSource(): string {
-  const inlineScripts = [
-    ...indexHtml.matchAll(/<script>([\s\S]*?)<\/script>/gi),
-  ]
-    .map((match) => {
-      return match[1];
-    })
-    .filter((script): script is string => {
-      return script !== undefined;
-    });
-  const source = inlineScripts.find((script) => {
-    return script.includes(INSTATUS_SCRIPT_URL);
-  });
-
-  if (source === undefined) {
-    throw new Error("Unable to locate the Instatus loader in index.html");
-  }
-  return source;
-}
 
 function loadInstatusScripts(hostname: string): HTMLScriptElement[] {
   context.mocks.browser.url(`https://${hostname}/`);
@@ -46,13 +21,7 @@ function loadInstatusScripts(hostname: string): HTMLScriptElement[] {
       return node;
     },
   );
-  const executeEntrypointScript = new Function(
-    "window",
-    "document",
-    `${getInstatusLoaderSource()}\n//# sourceURL=platform-instatus-widget-test.js`,
-  ) as EntrypointScript;
-
-  executeEntrypointScript(window, document);
+  initInstatusWidget();
   return appendedScripts;
 }
 

--- a/turbo/apps/platform/src/__tests__/marketing-scripts.test.ts
+++ b/turbo/apps/platform/src/__tests__/marketing-scripts.test.ts
@@ -3,11 +3,8 @@ import { describe, expect, it, vi } from "vitest";
 import indexHtml from "../../index.html?raw";
 import { testContext } from "../signals/__tests__/test-helpers.ts";
 
-const APP_SKELETON_VISIBLE_EVENT = "vm0:app-skeleton-visible";
-const APP_FIRST_CONTENT_VISIBLE_EVENT = "vm0:app-first-content-visible";
 const GOOGLE_TAG_SCRIPT_URL =
   "https://www.googletagmanager.com/gtag/js?id=AW-18144854014";
-const MARKETING_FALLBACK_DELAY_MS = 30_000;
 
 type MarketingWindow = Window & {
   dataLayer?: IArguments[];
@@ -19,17 +16,14 @@ type MarketingEntrypointScript = (
   documentObject: Document,
 ) => void;
 
-interface ScheduledTimeout {
-  readonly callback: () => void;
-  readonly delay: number | undefined;
+interface RequestedScript {
+  readonly async: boolean;
+  readonly url: string;
 }
 
 interface MarketingHarness {
-  readonly fallbackDelay: number | undefined;
   readonly marketingWindow: MarketingWindow;
-  readonly requestedScriptUrls: string[];
-  readonly flushIdleCallbacks: () => void;
-  readonly runFallback: () => void;
+  readonly requestedScripts: RequestedScript[];
 }
 
 const context = testContext();
@@ -53,36 +47,13 @@ function executeMarketingEntrypoint(hostname: string): MarketingHarness {
   context.mocks.browser.url(`https://${hostname}/`);
   vi.stubGlobal("dataLayer", undefined);
   vi.stubGlobal("gtag", undefined);
-  const requestedScriptUrls: string[] = [];
+  const requestedScripts: RequestedScript[] = [];
   vi.spyOn(document.head, "appendChild").mockImplementation(
     <T extends Node>(node: T): T => {
       if (node instanceof HTMLScriptElement) {
-        requestedScriptUrls.push(node.src);
+        requestedScripts.push({ async: node.async, url: node.src });
       }
       return node;
-    },
-  );
-
-  const scheduledTimeouts: ScheduledTimeout[] = [];
-  vi.spyOn(window, "setTimeout").mockImplementation((handler, delay) => {
-    if (typeof handler !== "function") {
-      throw new Error("Expected a function timeout handler");
-    }
-    scheduledTimeouts.push({
-      callback: () => {
-        handler();
-      },
-      delay,
-    });
-    return scheduledTimeouts.length;
-  });
-
-  const idleCallbacks: IdleRequestCallback[] = [];
-  vi.stubGlobal(
-    "requestIdleCallback",
-    (callback: IdleRequestCallback): number => {
-      idleCallbacks.push(callback);
-      return idleCallbacks.length;
     },
   );
 
@@ -93,104 +64,38 @@ function executeMarketingEntrypoint(hostname: string): MarketingHarness {
   ) as MarketingEntrypointScript;
   executeEntrypointScript(window, document);
 
-  const fallback = scheduledTimeouts.find(({ delay }) => {
-    return delay === MARKETING_FALLBACK_DELAY_MS;
-  });
-
-  return {
-    get fallbackDelay() {
-      return fallback?.delay;
-    },
-    flushIdleCallbacks: () => {
-      for (const callback of idleCallbacks.splice(0)) {
-        callback({
-          didTimeout: false,
-          timeRemaining: () => {
-            return 50;
-          },
-        });
-      }
-    },
-    marketingWindow,
-    requestedScriptUrls,
-    runFallback: () => {
-      if (!fallback) {
-        throw new Error("Marketing fallback was not scheduled");
-      }
-      fallback.callback();
-    },
-  };
+  return { marketingWindow, requestedScripts };
 }
 
 describe("platform marketing scripts", () => {
-  it("loads Google Ads after first app content", () => {
-    const harness = executeMarketingEntrypoint("app.vm0.ai");
+  it.each(["vm0.ai", "app.vm0.ai", "okou.ai", "app.okou.ai"])(
+    "initializes Google Ads immediately on %s",
+    (hostname) => {
+      const harness = executeMarketingEntrypoint(hostname);
 
-    expect(
-      harness.marketingWindow.dataLayer?.map((entry) => {
-        return [...entry];
-      }),
-    ).toStrictEqual([
-      ["js", expect.any(Date)],
-      ["config", "AW-18144854014"],
-      ["config", "AW-18407336975"],
-    ]);
-
-    window.dispatchEvent(new Event(APP_FIRST_CONTENT_VISIBLE_EVENT));
-    harness.flushIdleCallbacks();
-
-    expect(harness.requestedScriptUrls).toStrictEqual([GOOGLE_TAG_SCRIPT_URL]);
-  });
-
-  it("waits 30 seconds before falling back when content never becomes ready", () => {
-    const harness = executeMarketingEntrypoint("app.vm0.ai");
-
-    expect(harness.fallbackDelay).toBe(MARKETING_FALLBACK_DELAY_MS);
-    expect(harness.requestedScriptUrls).toStrictEqual([]);
-    harness.runFallback();
-    harness.flushIdleCallbacks();
-
-    expect(harness.requestedScriptUrls).toStrictEqual([GOOGLE_TAG_SCRIPT_URL]);
-
-    window.dispatchEvent(new Event(APP_FIRST_CONTENT_VISIBLE_EVENT));
-  });
-
-  it("loads Google Ads once across duplicate readiness and fallback signals", () => {
-    const harness = executeMarketingEntrypoint("app.vm0.ai");
-
-    window.dispatchEvent(new Event(APP_FIRST_CONTENT_VISIBLE_EVENT));
-    window.dispatchEvent(new Event(APP_FIRST_CONTENT_VISIBLE_EVENT));
-    harness.runFallback();
-    harness.flushIdleCallbacks();
-
-    expect(harness.requestedScriptUrls).toStrictEqual([GOOGLE_TAG_SCRIPT_URL]);
-  });
-
-  it("does not request scripts when only the app skeleton is visible", () => {
-    const harness = executeMarketingEntrypoint("app.vm0.ai");
-
-    window.dispatchEvent(new Event(APP_SKELETON_VISIBLE_EVENT));
-    harness.flushIdleCallbacks();
-
-    expect(harness.requestedScriptUrls).toStrictEqual([]);
-
-    window.dispatchEvent(new Event(APP_FIRST_CONTENT_VISIBLE_EVENT));
-    harness.flushIdleCallbacks();
-  });
+      expect(
+        harness.marketingWindow.dataLayer?.map((entry) => {
+          return [...entry];
+        }),
+      ).toStrictEqual([
+        ["js", expect.any(Date)],
+        ["config", "AW-18144854014"],
+        ["config", "AW-18407336975"],
+      ]);
+      expect(harness.requestedScripts).toStrictEqual([
+        { async: true, url: GOOGLE_TAG_SCRIPT_URL },
+      ]);
+    },
+  );
 
   it.each(["localhost", "pr-29576-app.vm6.ai", "app.vm0.ai.example.com"])(
     "does not initialize or request scripts on %s",
     (hostname) => {
       const harness = executeMarketingEntrypoint(hostname);
 
-      window.dispatchEvent(new Event(APP_SKELETON_VISIBLE_EVENT));
-      window.dispatchEvent(new Event(APP_FIRST_CONTENT_VISIBLE_EVENT));
-      harness.flushIdleCallbacks();
-
-      expect(harness.fallbackDelay).toBeUndefined();
       expect(harness.marketingWindow.dataLayer).toBeUndefined();
       expect(harness.marketingWindow.gtag).toBeUndefined();
-      expect(harness.requestedScriptUrls).toStrictEqual([]);
+      expect(harness.requestedScripts).toStrictEqual([]);
     },
   );
 });

--- a/turbo/apps/platform/src/global.d.ts
+++ b/turbo/apps/platform/src/global.d.ts
@@ -25,8 +25,6 @@ interface VM0ClerkBootstrap {
   readonly abortOnboarding: () => void;
   readonly clientSessionId?: string;
   clerk?: PlatformClerk;
-  clerkLoadCompletedAt?: number;
-  clerkLoadStartedAt?: number;
   readonly domain?: string;
   readonly loadOptions: VM0ClerkBootstrapLoadOptions;
   loaded?: Promise<void>;

--- a/turbo/apps/platform/src/lib/instatus-widget.ts
+++ b/turbo/apps/platform/src/lib/instatus-widget.ts
@@ -1,0 +1,18 @@
+const INSTATUS_SCRIPT_URL =
+  "https://api.dashboard.instatus.com/widget?host=status.vm0.ai&code=02c0ef5a&locale=en";
+const INSTATUS_SCRIPT_INTEGRITY =
+  "sha384-ZW3eZwADOMdlg2fdvESPD7jguK16IC/edxNFakKs81D2lkNdi3BXRmx/g331lkD3";
+
+export function initInstatusWidget(): void {
+  const hostname = window.location.hostname.toLowerCase();
+  if (hostname !== "app.vm0.ai" && hostname !== "app.okou.ai") {
+    return;
+  }
+
+  const script = document.createElement("script");
+  script.src = INSTATUS_SCRIPT_URL;
+  script.integrity = INSTATUS_SCRIPT_INTEGRITY;
+  script.crossOrigin = "anonymous";
+  script.defer = true;
+  document.body.appendChild(script);
+}

--- a/turbo/apps/platform/src/lib/posthog.ts
+++ b/turbo/apps/platform/src/lib/posthog.ts
@@ -9,6 +9,8 @@ const POSTHOG_KEY = RUNTIME_CONFIG.postHogKey;
 
 export const AUTH_V2_DIAGNOSTIC_EVENT = "auth_v2_diagnostic";
 const AUTH_V2_DIAGNOSTIC_DISTINCT_ID = "auth-v2";
+export const APP_FIRST_SKELETON_PAINT_EVENT = "app_first_skeleton_paint";
+const APP_FIRST_SKELETON_PAINT_DISTINCT_ID = "app-bootstrap";
 
 export type AuthV2DiagnosticFlow = "sign-in" | "sign-up" | "unknown";
 
@@ -162,11 +164,46 @@ function authV2DiagnosticErrorCategory(
   }
 }
 
+function finiteNonNegativeNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+}
+
 function sanitizePostHogCaptureResult(
   captureResult: CaptureResult | null,
 ): CaptureResult | null {
   if (captureResult === null) {
     return null;
+  }
+  if (captureResult.event === APP_FIRST_SKELETON_PAINT_EVENT) {
+    const properties = captureResult.properties;
+    const sanitizedProperties: Record<string, boolean | number | string> = {
+      $process_person_profile: false,
+      distinct_id: APP_FIRST_SKELETON_PAINT_DISTINCT_ID,
+      paint_metric: "first-contentful-paint",
+      public_brand: RUNTIME_CONFIG.publicBrand,
+      token: POSTHOG_KEY ?? "",
+    };
+    for (const name of [
+      "navigation_response_end_ms",
+      "navigation_response_start_ms",
+      "response_end_to_skeleton_paint_ms",
+      "skeleton_paint_ms",
+    ]) {
+      const value = finiteNonNegativeNumber(properties[name]);
+      if (value !== undefined) {
+        sanitizedProperties[name] = value;
+      }
+    }
+    return {
+      event: APP_FIRST_SKELETON_PAINT_EVENT,
+      properties: sanitizedProperties,
+      ...(captureResult.timestamp
+        ? { timestamp: captureResult.timestamp }
+        : {}),
+      uuid: captureResult.uuid,
+    };
   }
   if (captureResult.event !== AUTH_V2_DIAGNOSTIC_EVENT) {
     return captureResult;
@@ -222,6 +259,59 @@ export function initPostHog(): void {
         }
         return { ...properties, public_brand: RUNTIME_CONFIG.publicBrand };
       },
+    });
+  });
+}
+
+function navigationTimingEntry(): PerformanceNavigationTiming | undefined {
+  return performance
+    .getEntriesByType("navigation")
+    .find((entry): entry is PerformanceNavigationTiming => {
+      return (
+        entry.entryType === "navigation" &&
+        "responseStart" in entry &&
+        "responseEnd" in entry
+      );
+    });
+}
+
+function firstContentfulPaintTime(): number | undefined {
+  return performance.getEntriesByType("paint").find((entry) => {
+    return entry.name === "first-contentful-paint";
+  })?.startTime;
+}
+
+/**
+ * Capture an anonymous, allowlisted measurement of the navigation response and
+ * the first frame that can contain the inline bootstrap skeleton.
+ */
+export function captureFirstSkeletonPaint(): void {
+  const navigation = navigationTimingEntry();
+  if (!navigation) {
+    return;
+  }
+  const responseStart = finiteNonNegativeNumber(navigation.responseStart);
+  const responseEnd = finiteNonNegativeNumber(navigation.responseEnd);
+  const skeletonPaint = finiteNonNegativeNumber(firstContentfulPaintTime());
+  if (
+    responseStart === undefined ||
+    responseEnd === undefined ||
+    skeletonPaint === undefined ||
+    responseEnd < responseStart ||
+    skeletonPaint < responseEnd
+  ) {
+    return;
+  }
+
+  runPostHog(() => {
+    posthog.capture(APP_FIRST_SKELETON_PAINT_EVENT, {
+      navigation_response_end_ms: Math.round(responseEnd),
+      navigation_response_start_ms: Math.round(responseStart),
+      paint_metric: "first-contentful-paint",
+      response_end_to_skeleton_paint_ms: Math.round(
+        skeletonPaint - responseEnd,
+      ),
+      skeleton_paint_ms: Math.round(skeletonPaint),
     });
   });
 }

--- a/turbo/apps/platform/src/lib/posthog.ts
+++ b/turbo/apps/platform/src/lib/posthog.ts
@@ -9,8 +9,6 @@ const POSTHOG_KEY = RUNTIME_CONFIG.postHogKey;
 
 export const AUTH_V2_DIAGNOSTIC_EVENT = "auth_v2_diagnostic";
 const AUTH_V2_DIAGNOSTIC_DISTINCT_ID = "auth-v2";
-export const APP_FIRST_SKELETON_PAINT_EVENT = "app_first_skeleton_paint";
-const APP_FIRST_SKELETON_PAINT_DISTINCT_ID = "app-bootstrap";
 
 export type AuthV2DiagnosticFlow = "sign-in" | "sign-up" | "unknown";
 
@@ -164,46 +162,11 @@ function authV2DiagnosticErrorCategory(
   }
 }
 
-function finiteNonNegativeNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value >= 0
-    ? value
-    : undefined;
-}
-
 function sanitizePostHogCaptureResult(
   captureResult: CaptureResult | null,
 ): CaptureResult | null {
   if (captureResult === null) {
     return null;
-  }
-  if (captureResult.event === APP_FIRST_SKELETON_PAINT_EVENT) {
-    const properties = captureResult.properties;
-    const sanitizedProperties: Record<string, boolean | number | string> = {
-      $process_person_profile: false,
-      distinct_id: APP_FIRST_SKELETON_PAINT_DISTINCT_ID,
-      paint_metric: "first-contentful-paint",
-      public_brand: RUNTIME_CONFIG.publicBrand,
-      token: POSTHOG_KEY ?? "",
-    };
-    for (const name of [
-      "navigation_response_end_ms",
-      "navigation_response_start_ms",
-      "response_end_to_skeleton_paint_ms",
-      "skeleton_paint_ms",
-    ]) {
-      const value = finiteNonNegativeNumber(properties[name]);
-      if (value !== undefined) {
-        sanitizedProperties[name] = value;
-      }
-    }
-    return {
-      event: APP_FIRST_SKELETON_PAINT_EVENT,
-      properties: sanitizedProperties,
-      ...(captureResult.timestamp
-        ? { timestamp: captureResult.timestamp }
-        : {}),
-      uuid: captureResult.uuid,
-    };
   }
   if (captureResult.event !== AUTH_V2_DIAGNOSTIC_EVENT) {
     return captureResult;
@@ -259,59 +222,6 @@ export function initPostHog(): void {
         }
         return { ...properties, public_brand: RUNTIME_CONFIG.publicBrand };
       },
-    });
-  });
-}
-
-function navigationTimingEntry(): PerformanceNavigationTiming | undefined {
-  return performance
-    .getEntriesByType("navigation")
-    .find((entry): entry is PerformanceNavigationTiming => {
-      return (
-        entry.entryType === "navigation" &&
-        "responseStart" in entry &&
-        "responseEnd" in entry
-      );
-    });
-}
-
-function firstContentfulPaintTime(): number | undefined {
-  return performance.getEntriesByType("paint").find((entry) => {
-    return entry.name === "first-contentful-paint";
-  })?.startTime;
-}
-
-/**
- * Capture an anonymous, allowlisted measurement of the navigation response and
- * the first frame that can contain the inline bootstrap skeleton.
- */
-export function captureFirstSkeletonPaint(): void {
-  const navigation = navigationTimingEntry();
-  if (!navigation) {
-    return;
-  }
-  const responseStart = finiteNonNegativeNumber(navigation.responseStart);
-  const responseEnd = finiteNonNegativeNumber(navigation.responseEnd);
-  const skeletonPaint = finiteNonNegativeNumber(firstContentfulPaintTime());
-  if (
-    responseStart === undefined ||
-    responseEnd === undefined ||
-    skeletonPaint === undefined ||
-    responseEnd < responseStart ||
-    skeletonPaint < responseEnd
-  ) {
-    return;
-  }
-
-  runPostHog(() => {
-    posthog.capture(APP_FIRST_SKELETON_PAINT_EVENT, {
-      navigation_response_end_ms: Math.round(responseEnd),
-      navigation_response_start_ms: Math.round(responseStart),
-      paint_metric: "first-contentful-paint",
-      response_end_to_skeleton_paint_ms: Math.round(
-        skeletonPaint - responseEnd,
-      ),
-      skeleton_paint_ms: Math.round(skeletonPaint),
     });
   });
 }
@@ -496,32 +406,8 @@ const bootstrapPhaseTimingState$ = state<BootstrapPhaseTimingState | null>(
 );
 const bootstrapPhaseTimingReported$ = state(false);
 
-const BOOTSTRAP_CLERK_LOAD_STARTED_MARK = "vm0:bootstrap:clerk-load-started";
-const BOOTSTRAP_CLERK_LOAD_COMPLETED_MARK =
-  "vm0:bootstrap:clerk-load-completed";
-
-function resetBootstrapClerkLoadMarks(): void {
-  performance.clearMarks(BOOTSTRAP_CLERK_LOAD_STARTED_MARK);
-  performance.clearMarks(BOOTSTRAP_CLERK_LOAD_COMPLETED_MARK);
-
-  const bootstrap = window.__vm0ClerkBootstrap;
-  const startedAt = bootstrap?.clerkLoadStartedAt;
-  if (typeof startedAt === "number" && Number.isFinite(startedAt)) {
-    performance.mark(BOOTSTRAP_CLERK_LOAD_STARTED_MARK, {
-      startTime: startedAt,
-    });
-  }
-  const completedAt = bootstrap?.clerkLoadCompletedAt;
-  if (typeof completedAt === "number" && Number.isFinite(completedAt)) {
-    performance.mark(BOOTSTRAP_CLERK_LOAD_COMPLETED_MARK, {
-      startTime: completedAt,
-    });
-  }
-}
-
 export const initBootstrapPhaseTiming$ = command(
   ({ set }, signal: AbortSignal) => {
-    resetBootstrapClerkLoadMarks();
     set(bootstrapPhaseTimingState$, {
       initialVisibilityState: document.visibilityState,
       wasHidden: document.visibilityState !== "visible",
@@ -567,27 +453,6 @@ export const markBootstrapLocaleInitCompleted$ = command(({ get, set }) => {
     ),
   });
 });
-
-export function markBootstrapClerkLoadStarted(): void {
-  if (
-    performance.getEntriesByName(BOOTSTRAP_CLERK_LOAD_STARTED_MARK, "mark")
-      .length === 0
-  ) {
-    performance.mark(BOOTSTRAP_CLERK_LOAD_STARTED_MARK);
-  }
-}
-
-export function markBootstrapClerkLoadCompleted(): void {
-  if (
-    performance.getEntriesByName(BOOTSTRAP_CLERK_LOAD_STARTED_MARK, "mark")
-      .length === 0 ||
-    performance.getEntriesByName(BOOTSTRAP_CLERK_LOAD_COMPLETED_MARK, "mark")
-      .length > 0
-  ) {
-    return;
-  }
-  performance.mark(BOOTSTRAP_CLERK_LOAD_COMPLETED_MARK);
-}
 
 export const markBootstrapRouteSetup$ = command(
   ({ get, set }, route: string) => {
@@ -645,10 +510,6 @@ function elapsedDuration(
   return Math.round(completedAt - startedAt);
 }
 
-function markStartTime(markName: string): number | undefined {
-  return performance.getEntriesByName(markName, "mark").at(-1)?.startTime;
-}
-
 function setDurationProperty(
   properties: Record<string, string | number | boolean>,
   name: string,
@@ -671,10 +532,6 @@ export const captureBootstrapPhaseTiming$ = command(({ get, set }) => {
     const entryModuleReadyDurationMs = elapsedDuration(
       window.__appBootstrapStart,
       window.__appBootstrapModuleReady,
-    );
-    const clerkLoadDurationMs = elapsedDuration(
-      markStartTime(BOOTSTRAP_CLERK_LOAD_STARTED_MARK),
-      markStartTime(BOOTSTRAP_CLERK_LOAD_COMPLETED_MARK),
     );
     const routeSetupDurationMs = elapsedDuration(
       current?.routeSetupStartedAt,
@@ -704,7 +561,6 @@ export const captureBootstrapPhaseTiming$ = command(({ get, set }) => {
       "locale_init_ms",
       current?.localeInitDurationMs,
     );
-    setDurationProperty(properties, "clerk_load_ms", clerkLoadDurationMs);
     setDurationProperty(properties, "route_setup_ms", routeSetupDurationMs);
     setDurationProperty(
       properties,

--- a/turbo/apps/platform/src/main.ts
+++ b/turbo/apps/platform/src/main.ts
@@ -2,7 +2,7 @@ import "./lib/preview-bypass-cookie-bootstrap.ts";
 import "./lib/accept-browser.ts";
 import { browserUpgradeForUserAgent } from "./lib/browser-support.ts";
 import { initSentry } from "./lib/sentry.ts";
-import { captureFirstSkeletonPaint, initPostHog } from "./lib/posthog.ts";
+import { initPostHog } from "./lib/posthog.ts";
 import { initPlausible } from "./lib/plausible.ts";
 import { setupVisualViewportKeyboardState } from "./lib/visual-viewport-keyboard.ts";
 import "./polyfill.ts";
@@ -23,7 +23,6 @@ function startApplication(): void {
   // Initialize Sentry before bootstrap so errors during startup are captured
   initSentry();
   initPostHog();
-  captureFirstSkeletonPaint();
 
   async function main() {
     const store = createStore();

--- a/turbo/apps/platform/src/main.ts
+++ b/turbo/apps/platform/src/main.ts
@@ -3,7 +3,7 @@ import "./lib/accept-browser.ts";
 import { browserUpgradeForUserAgent } from "./lib/browser-support.ts";
 import { initInstatusWidget } from "./lib/instatus-widget.ts";
 import { initSentry } from "./lib/sentry.ts";
-import { initPostHog } from "./lib/posthog.ts";
+import { captureFirstSkeletonPaint, initPostHog } from "./lib/posthog.ts";
 import { initPlausible } from "./lib/plausible.ts";
 import { setupVisualViewportKeyboardState } from "./lib/visual-viewport-keyboard.ts";
 import "./polyfill.ts";
@@ -24,6 +24,7 @@ function startApplication(): void {
   // Initialize Sentry before bootstrap so errors during startup are captured
   initSentry();
   initPostHog();
+  captureFirstSkeletonPaint();
 
   async function main() {
     const store = createStore();

--- a/turbo/apps/platform/src/main.ts
+++ b/turbo/apps/platform/src/main.ts
@@ -1,6 +1,7 @@
 import "./lib/preview-bypass-cookie-bootstrap.ts";
 import "./lib/accept-browser.ts";
 import { browserUpgradeForUserAgent } from "./lib/browser-support.ts";
+import { initInstatusWidget } from "./lib/instatus-widget.ts";
 import { initSentry } from "./lib/sentry.ts";
 import { initPostHog } from "./lib/posthog.ts";
 import { initPlausible } from "./lib/plausible.ts";
@@ -68,6 +69,7 @@ function startApplication(): void {
 }
 
 window.__appBootstrapModuleReady = performance.now();
+initInstatusWidget();
 const browserUpgrade = browserUpgradeForUserAgent(navigator.userAgent);
 if (browserUpgrade) {
   const rootElement = document.getElementById("root");

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-phase-telemetry.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-phase-telemetry.test.ts
@@ -4,11 +4,8 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { detachedSetupPage, setupPage } from "../../__tests__/page-helper.ts";
 import {
-  APP_FIRST_SKELETON_PAINT_EVENT,
   BOOTSTRAP_PHASE_TIMING_EVENT,
   type BootstrapThreadMetadataSource,
-  captureFirstSkeletonPaint,
-  initPostHog,
 } from "../../lib/posthog.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { detachedNavigateTo$ } from "../route.ts";
@@ -116,95 +113,6 @@ function mockEmptyThreadMetadata(): void {
 }
 
 describe("bootstrap phase telemetry", () => {
-  it("captures response-to-skeleton paint from navigation and FCP entries", () => {
-    const navigationEntry = {
-      entryType: "navigation",
-      name: "https://private.example/path?token=private",
-      responseEnd: 86.6,
-      responseStart: 41.2,
-    } as PerformanceNavigationTiming;
-    const paintEntry = {
-      entryType: "paint",
-      name: "first-contentful-paint",
-      startTime: 98.4,
-    } as PerformanceEntry;
-    const entriesSpy = vi
-      .spyOn(performance, "getEntriesByType")
-      .mockImplementation((entryType) => {
-        if (entryType === "navigation") {
-          return [navigationEntry];
-        }
-        if (entryType === "paint") {
-          return [paintEntry];
-        }
-        return [];
-      });
-
-    try {
-      captureFirstSkeletonPaint();
-    } finally {
-      entriesSpy.mockRestore();
-    }
-
-    expect(posthog.capture).toHaveBeenCalledWith(
-      APP_FIRST_SKELETON_PAINT_EVENT,
-      {
-        navigation_response_end_ms: 87,
-        navigation_response_start_ms: 41,
-        paint_metric: "first-contentful-paint",
-        response_end_to_skeleton_paint_ms: 12,
-        skeleton_paint_ms: 98,
-      },
-    );
-    expect(JSON.stringify(posthog.capture.mock.lastCall)).not.toContain(
-      "private.example",
-    );
-  });
-
-  it("strips identifiers, URLs, and arbitrary paint properties at ingest", () => {
-    initPostHog();
-    const [, config] = posthog.init.mock.lastCall ?? [];
-    const beforeSend = config?.before_send;
-    if (!beforeSend) {
-      throw new Error("PostHog before_send was not configured");
-    }
-
-    const sanitized = beforeSend({
-      event: APP_FIRST_SKELETON_PAINT_EVENT,
-      properties: {
-        $current_url: "https://private.example/path?token=private",
-        arbitrary_payload: { secret: "private" },
-        distinct_id: "user_private",
-        navigation_response_end_ms: 87,
-        navigation_response_start_ms: 41,
-        paint_metric: "first-contentful-paint",
-        response_end_to_skeleton_paint_ms: 12,
-        skeleton_paint_ms: 98,
-        token: "attacker_private",
-      },
-      timestamp: "2026-08-31T00:00:00.000Z",
-      uuid: "event_public_uuid",
-    });
-
-    expect(sanitized).toStrictEqual({
-      event: APP_FIRST_SKELETON_PAINT_EVENT,
-      properties: {
-        $process_person_profile: false,
-        distinct_id: "app-bootstrap",
-        navigation_response_end_ms: 87,
-        navigation_response_start_ms: 41,
-        paint_metric: "first-contentful-paint",
-        public_brand: "vm0",
-        response_end_to_skeleton_paint_ms: 12,
-        skeleton_paint_ms: 98,
-        token: "phc_bootstrap_phase_telemetry_test",
-      },
-      timestamp: "2026-08-31T00:00:00.000Z",
-      uuid: "event_public_uuid",
-    });
-    expect(JSON.stringify(sanitized)).not.toContain("private");
-  });
-
   it("captures bounded bootstrap and cold thread metadata phases", async () => {
     mockEmptyThreadMetadata();
 
@@ -218,7 +126,6 @@ describe("bootstrap phase telemetry", () => {
     const properties = timingEvents()[0];
     expect(properties).toStrictEqual(
       expect.objectContaining({
-        clerk_load_ms: expect.any(Number),
         entry_module_ready_ms: 10,
         final_route: ROUTES.chat,
         initial_route: ROUTES.chat,

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-phase-telemetry.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-phase-telemetry.test.ts
@@ -4,8 +4,11 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { detachedSetupPage, setupPage } from "../../__tests__/page-helper.ts";
 import {
+  APP_FIRST_SKELETON_PAINT_EVENT,
   BOOTSTRAP_PHASE_TIMING_EVENT,
   type BootstrapThreadMetadataSource,
+  captureFirstSkeletonPaint,
+  initPostHog,
 } from "../../lib/posthog.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { detachedNavigateTo$ } from "../route.ts";
@@ -113,6 +116,95 @@ function mockEmptyThreadMetadata(): void {
 }
 
 describe("bootstrap phase telemetry", () => {
+  it("captures response-to-skeleton paint from navigation and FCP entries", () => {
+    const navigationEntry = {
+      entryType: "navigation",
+      name: "https://private.example/path?token=private",
+      responseEnd: 86.6,
+      responseStart: 41.2,
+    } as PerformanceNavigationTiming;
+    const paintEntry = {
+      entryType: "paint",
+      name: "first-contentful-paint",
+      startTime: 98.4,
+    } as PerformanceEntry;
+    const entriesSpy = vi
+      .spyOn(performance, "getEntriesByType")
+      .mockImplementation((entryType) => {
+        if (entryType === "navigation") {
+          return [navigationEntry];
+        }
+        if (entryType === "paint") {
+          return [paintEntry];
+        }
+        return [];
+      });
+
+    try {
+      captureFirstSkeletonPaint();
+    } finally {
+      entriesSpy.mockRestore();
+    }
+
+    expect(posthog.capture).toHaveBeenCalledWith(
+      APP_FIRST_SKELETON_PAINT_EVENT,
+      {
+        navigation_response_end_ms: 87,
+        navigation_response_start_ms: 41,
+        paint_metric: "first-contentful-paint",
+        response_end_to_skeleton_paint_ms: 12,
+        skeleton_paint_ms: 98,
+      },
+    );
+    expect(JSON.stringify(posthog.capture.mock.lastCall)).not.toContain(
+      "private.example",
+    );
+  });
+
+  it("strips identifiers, URLs, and arbitrary paint properties at ingest", () => {
+    initPostHog();
+    const [, config] = posthog.init.mock.lastCall ?? [];
+    const beforeSend = config?.before_send;
+    if (!beforeSend) {
+      throw new Error("PostHog before_send was not configured");
+    }
+
+    const sanitized = beforeSend({
+      event: APP_FIRST_SKELETON_PAINT_EVENT,
+      properties: {
+        $current_url: "https://private.example/path?token=private",
+        arbitrary_payload: { secret: "private" },
+        distinct_id: "user_private",
+        navigation_response_end_ms: 87,
+        navigation_response_start_ms: 41,
+        paint_metric: "first-contentful-paint",
+        response_end_to_skeleton_paint_ms: 12,
+        skeleton_paint_ms: 98,
+        token: "attacker_private",
+      },
+      timestamp: "2026-08-31T00:00:00.000Z",
+      uuid: "event_public_uuid",
+    });
+
+    expect(sanitized).toStrictEqual({
+      event: APP_FIRST_SKELETON_PAINT_EVENT,
+      properties: {
+        $process_person_profile: false,
+        distinct_id: "app-bootstrap",
+        navigation_response_end_ms: 87,
+        navigation_response_start_ms: 41,
+        paint_metric: "first-contentful-paint",
+        public_brand: "vm0",
+        response_end_to_skeleton_paint_ms: 12,
+        skeleton_paint_ms: 98,
+        token: "phc_bootstrap_phase_telemetry_test",
+      },
+      timestamp: "2026-08-31T00:00:00.000Z",
+      uuid: "event_public_uuid",
+    });
+    expect(JSON.stringify(sanitized)).not.toContain("private");
+  });
+
   it("captures bounded bootstrap and cold thread metadata phases", async () => {
     mockEmptyThreadMetadata();
 

--- a/turbo/apps/platform/src/signals/app-skeleton.ts
+++ b/turbo/apps/platform/src/signals/app-skeleton.ts
@@ -12,12 +12,6 @@ import {
 const internalVisible$ = state(true);
 const internalOverlayMounted$ = state(true);
 
-const APP_SKELETON_VISIBLE_EVENT = "vm0:app-skeleton-visible";
-const APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY =
-  "vm0AppSkeletonVisibleEventQueued";
-const APP_FIRST_CONTENT_VISIBLE_EVENT = "vm0:app-first-content-visible";
-const APP_FIRST_CONTENT_VISIBLE_EVENT_DISPATCHED_KEY =
-  "vm0AppFirstContentVisibleEventDispatched";
 const APP_BOOTSTRAP_SKELETON_ID = "app-bootstrap-skeleton";
 const APP_BOOTSTRAP_SKELETON_HIDDEN_CLASS = "app-bootstrap-skeleton--hidden";
 
@@ -29,48 +23,9 @@ export const bootstrapSkeletonActive$ = computed((get) => {
 
 export const initBootstrapSkeleton$ = command(({ set }) => {
   const active = document.getElementById(APP_BOOTSTRAP_SKELETON_ID) !== null;
-  if (active) {
-    queueAppSkeletonVisibleEvent();
-  }
   set(internalOverlayMounted$, !active);
   set(internalBootstrapSkeletonActive$, active);
 });
-
-function queueAppSkeletonVisibleEvent(): void {
-  if (
-    document.documentElement.dataset[APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY] ===
-    "true"
-  ) {
-    return;
-  }
-  document.documentElement.dataset[APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY] =
-    "true";
-  queueMicrotask(() => {
-    window.dispatchEvent(new Event(APP_SKELETON_VISIBLE_EVENT));
-  });
-}
-
-export const appSkeletonVisibleEventRef$ = onRef(
-  command((_visitor, _element: HTMLDivElement, _signal: AbortSignal) => {
-    queueAppSkeletonVisibleEvent();
-  }),
-);
-
-export const firstAppContentVisibleEventRef$ = onRef(
-  command((_visitor, _element: HTMLSpanElement, _signal: AbortSignal) => {
-    if (
-      document.documentElement.dataset[
-        APP_FIRST_CONTENT_VISIBLE_EVENT_DISPATCHED_KEY
-      ] === "true"
-    ) {
-      return;
-    }
-    document.documentElement.dataset[
-      APP_FIRST_CONTENT_VISIBLE_EVENT_DISPATCHED_KEY
-    ] = "true";
-    window.dispatchEvent(new Event(APP_FIRST_CONTENT_VISIBLE_EVENT));
-  }),
-);
 
 export function hideBootstrapSkeleton(): void {
   const skeleton = document.getElementById(APP_BOOTSTRAP_SKELETON_ID);

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -6,8 +6,6 @@ import {
 import { clearSentryUser, setSentryUser } from "../lib/sentry.ts";
 import {
   clearPostHogUser,
-  markBootstrapClerkLoadCompleted,
-  markBootstrapClerkLoadStarted,
   setPostHogOrganization,
   setPostHogUser,
 } from "../lib/posthog.ts";
@@ -407,7 +405,6 @@ export const initClerkRuntime$ = command(
     signal.throwIfAborted();
     const publishableKey = resolvePlatformRuntimeConfig().clerkPublishableKey;
     const satelliteConfig = resolveClerkSatelliteConfig();
-    markBootstrapClerkLoadStarted();
     set(
       internalClerkRuntime$,
       startClerkBrowserRuntime(
@@ -450,7 +447,6 @@ export const clerkInstance$ = computed(async (get) => {
 export const clerk$ = computed(async (get) => {
   const runtime = await get(clerkRuntime$);
   await runtime.loaded;
-  markBootstrapClerkLoadCompleted();
 
   return runtime.clerk;
 });

--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -50,8 +50,6 @@ describe("platform entrypoint safe area behavior", () => {
     expect(contentRule).toMatch(/top:\s*50svh;/);
     expect(contentRule).toMatch(/left:\s*50%;/);
     expect(contentRule).toMatch(/transform:\s*translate\(-50%,\s*-50%\);/);
-    expect(indexHtml).not.toContain("window.visualViewport.height");
-    expect(indexHtml).not.toContain("--app-bootstrap-skeleton-center-y");
   });
 
   it("suppresses the bottom safe-area inset only while the keyboard is open", () => {

--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -33,7 +33,7 @@ describe("platform entrypoint safe area behavior", () => {
     ).toBeFalsy();
   });
 
-  it("pins the bootstrap skeleton to the initial reachable viewport", () => {
+  it("centers the bootstrap skeleton in the stable small viewport", () => {
     const rule = /#app-bootstrap-skeleton\s*{([^}]*)}/.exec(indexHtml)?.[1];
     const contentRule = /\.app-bootstrap-skeleton__content\s*{([^}]*)}/.exec(
       indexHtml,
@@ -47,13 +47,11 @@ describe("platform entrypoint safe area behavior", () => {
     expect(rule).not.toMatch(/(?:^|[;\s])(?:min-)?height\s*:/);
     expect(contentRule).toBeDefined();
     expect(contentRule).toMatch(/position:\s*fixed;/);
-    expect(contentRule).toMatch(
-      /top:\s*var\(--app-bootstrap-skeleton-center-y,\s*50dvh\);/,
-    );
+    expect(contentRule).toMatch(/top:\s*50svh;/);
     expect(contentRule).toMatch(/left:\s*50%;/);
     expect(contentRule).toMatch(/transform:\s*translate\(-50%,\s*-50%\);/);
-    expect(indexHtml).toContain("window.visualViewport.height");
-    expect(indexHtml).toContain('viewportHeight / 2 + "px"');
+    expect(indexHtml).not.toContain("window.visualViewport.height");
+    expect(indexHtml).not.toContain("--app-bootstrap-skeleton-center-y");
   });
 
   it("suppresses the bottom safe-area inset only while the keyboard is open", () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/app-skeleton.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/app-skeleton.test.tsx
@@ -4,83 +4,9 @@ import { describe, expect, it } from "vitest";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
-const APP_SKELETON_VISIBLE_EVENT = "vm0:app-skeleton-visible";
-const APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY =
-  "vm0AppSkeletonVisibleEventQueued";
-const APP_FIRST_CONTENT_VISIBLE_EVENT = "vm0:app-first-content-visible";
-const APP_FIRST_CONTENT_VISIBLE_EVENT_DISPATCHED_KEY =
-  "vm0AppFirstContentVisibleEventDispatched";
-
 const context = testContext();
 
 describe("app skeleton", () => {
-  it("dispatches one visible event after the skeleton mounts", async () => {
-    delete document.documentElement.dataset[
-      APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY
-    ];
-    context.signal.addEventListener("abort", () => {
-      delete document.documentElement.dataset[
-        APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY
-      ];
-    });
-
-    let eventCount = 0;
-    let skeletonMountedAtDispatch = false;
-    window.addEventListener(
-      APP_SKELETON_VISIBLE_EVENT,
-      () => {
-        eventCount += 1;
-        skeletonMountedAtDispatch =
-          document.querySelector('[data-testid="app-skeleton"]') !== null;
-      },
-      { signal: context.signal },
-    );
-
-    detachedSetupPage({ context, path: "/_/skeleton" });
-
-    await screen.findAllByTestId("app-skeleton");
-    await waitFor(() => {
-      expect(eventCount).toBe(1);
-    });
-    expect(skeletonMountedAtDispatch).toBeTruthy();
-  });
-
-  it("dispatches one first-content event after the ready page commits", async () => {
-    delete document.documentElement.dataset[
-      APP_FIRST_CONTENT_VISIBLE_EVENT_DISPATCHED_KEY
-    ];
-    context.signal.addEventListener("abort", () => {
-      delete document.documentElement.dataset[
-        APP_FIRST_CONTENT_VISIBLE_EVENT_DISPATCHED_KEY
-      ];
-    });
-
-    let eventCount = 0;
-    let contentMountedAtDispatch = false;
-    let skeletonHiddenAtDispatch = false;
-    window.addEventListener(
-      APP_FIRST_CONTENT_VISIBLE_EVENT,
-      () => {
-        eventCount += 1;
-        contentMountedAtDispatch =
-          document.querySelector('a[href^="mailto:"]') !== null;
-        skeletonHiddenAtDispatch =
-          document
-            .querySelector('[data-testid="app-skeleton"]')
-            ?.getAttribute("aria-hidden") === "true";
-      },
-      { signal: context.signal },
-    );
-
-    detachedSetupPage({ context, path: "/_/error" });
-
-    await waitFor(() => {
-      expect(eventCount).toBe(1);
-    });
-    expect(contentMountedAtDispatch).toBeTruthy();
-    expect(skeletonHiddenAtDispatch).toBeTruthy();
-  });
-
   it("removes the inline loading surface after the page is ready", async () => {
     const bootstrapSkeleton = document.createElement("div");
     bootstrapSkeleton.id = "app-bootstrap-skeleton";

--- a/turbo/apps/platform/src/views/okou-page/app-skeleton.tsx
+++ b/turbo/apps/platform/src/views/okou-page/app-skeleton.tsx
@@ -1,6 +1,4 @@
-import { useSet } from "ccstate-react";
 import { AvatarSvgPreview } from "./avatar-svg-preview.tsx";
-import { appSkeletonVisibleEventRef$ } from "../../signals/app-skeleton.ts";
 import { getAvatarPresets } from "./avatars.ts";
 
 const firstAvatarPreset = getAvatarPresets()[0]!;
@@ -12,11 +10,8 @@ export function AppSkeleton({
   onHidden?: () => void;
   visible?: boolean;
 }) {
-  const visibleEventRef = useSet(appSkeletonVisibleEventRef$);
-
   return (
     <div
-      ref={visible ? visibleEventRef : undefined}
       data-testid="app-skeleton"
       aria-hidden={visible ? undefined : true}
       aria-label="Loading"

--- a/turbo/apps/platform/src/views/router.tsx
+++ b/turbo/apps/platform/src/views/router.tsx
@@ -5,7 +5,6 @@ import {
   appSkeletonOverlayMounted$,
   appSkeletonVisible$,
   bootstrapSkeletonActive$,
-  firstAppContentVisibleEventRef$,
   unmountAppSkeletonOverlay$,
 } from "../signals/app-skeleton.ts";
 import { AppSkeleton } from "./okou-page/app-skeleton.tsx";
@@ -14,17 +13,7 @@ import { MinimalSidebarLayout } from "./okou-page/directed-shared.tsx";
 
 function PageSlot() {
   const page = useGet(page$);
-  const skeletonVisible = useGet(appSkeletonVisible$);
-  const firstContentVisibleEventRef = useSet(firstAppContentVisibleEventRef$);
-
-  return (
-    <>
-      {page ?? null}
-      {page !== undefined && !skeletonVisible ? (
-        <span ref={firstContentVisibleEventRef} hidden />
-      ) : null}
-    </>
-  );
+  return page ?? null;
 }
 
 function LayoutHost({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary

- restore the production Google Ads bootstrap to one immediately requested async `gtag.js` script while preserving the `vm0.ai` and `okou.ai` hostname gate
- remove the retired app-content/skeleton visibility event chain and its idle/timer scheduling
- remove all Clerk bootstrap load timestamps, Performance Marks, PostHog duration fields, and related tests while retaining the anonymous `app_first_skeleton_paint` FCP measurement
- preserve the functional early Clerk `loaded`/onboarding Promise handoff and the content-ready skeleton dismissal
- move the production-gated Instatus widget injection from `index.html` into the application entry, removing it from the synchronous HTML bootstrap path
- replace the synchronous initial visual-viewport snapshot with pure CSS `50svh` positioning while retaining the fixed full-screen skeleton background

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged Turbo, Platform, and API type checks from `commit-check`
- `pnpm --filter @okouai/app exec vitest run src/__tests__/marketing-scripts.test.ts` (7 passed)
- `pnpm --filter @okouai/app exec vitest run src/__tests__/clerk-entrypoint.test.ts` (23 passed)
- `pnpm --filter @okouai/app exec vitest run src/signals/__tests__/bootstrap-phase-telemetry.test.ts` (7 passed)
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/app-skeleton.test.tsx` (3 passed)
- `pnpm --filter @okouai/app exec vitest run src/__tests__/instatus-widget.test.ts` (6 passed)
- `pnpm --filter @okouai/app exec vitest run src/views/css/__tests__/entrypoint-safe-area.test.ts` (5 passed)
- `git diff --check`

## Notes

PostHog Web Vitals is not enabled in this change. The Platform currently imports `posthog-js/dist/module.slim`, which does not register `WebVitalsAutocapture`; enabling it would be a separate SDK extension and bundle decision. This PR retains the existing anonymous, allowlisted `app_first_skeleton_paint` measurement instead.

Native iOS standalone testing confirmed that fixed and `svh` positioning remained visually stable while `dvh` jumped. This PR selects `svh`, removes the synchronous geometry read, and keeps the outer `position: fixed; inset: 0` skeleton responsible for full-screen background coverage.