### PR TITLE
test(api): scope chat event serialization waiter to its own writer

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -2154,16 +2154,24 @@ describe("CHAT-01 chat thread read state", () => {
       content: firstContent,
       signal: context.signal,
     });
-    const secondInsert = insertChatEventTransactionFixture({
+    const secondInsert = await insertChatEventTransactionFixture({
       threadId,
       content: secondContent,
+      signal: context.signal,
     });
     onTestFinished(async () => {
       held.release();
-      await Promise.allSettled([held.done, secondInsert]);
+      await Promise.allSettled([held.done, secondInsert.inserted]);
     });
 
-    await expect.poll(held.blockedWaiterCount).toBe(1);
+    // Every API test file in a shard shares one database, so a total waiter
+    // count is not owned by this test. Assert that this test's own writer is
+    // the backend the uncommitted holder blocks.
+    await expect
+      .poll(() => {
+        return held.blocksBackend(secondInsert.backendPid);
+      })
+      .toBe(true);
     const beforeCommit = await chat.listThreadEvents(owner, threadId);
     expect(
       beforeCommit.events.some((message) => {
@@ -2176,7 +2184,7 @@ describe("CHAT-01 chat thread read state", () => {
 
     held.release();
     await held.done;
-    const second = await secondInsert;
+    const second = await secondInsert.inserted;
     const committed = await chat.listThreadEvents(owner, threadId);
     const concurrentRows = committed.events.filter((message) => {
       return message.id === held.event.id || message.id === second.id;

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -2154,10 +2154,9 @@ describe("CHAT-01 chat thread read state", () => {
       content: firstContent,
       signal: context.signal,
     });
-    const secondInsert = await insertChatEventTransactionFixture({
+    const secondInsert = insertChatEventTransactionFixture({
       threadId,
       content: secondContent,
-      signal: context.signal,
     });
     onTestFinished(async () => {
       held.release();
@@ -2165,11 +2164,17 @@ describe("CHAT-01 chat thread read state", () => {
     });
 
     // Every API test file in a shard shares one database, so a total waiter
-    // count is not owned by this test. Assert that this test's own writer is
-    // the backend the uncommitted holder blocks.
+    // count is not owned by this test. Poll until this test's own writer is the
+    // backend the uncommitted holder blocks. Reading the writer pid
+    // synchronously keeps a stalled writer inside the poll budget instead of
+    // hanging the test.
     await expect
-      .poll(() => {
-        return held.blocksBackend(secondInsert.backendPid);
+      .poll(async () => {
+        const writerPid = secondInsert.backendPid();
+        if (writerPid === undefined) {
+          return false;
+        }
+        return await held.blocksBackend(writerPid);
       })
       .toBe(true);
     const beforeCommit = await chat.listThreadEvents(owner, threadId);

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -1593,6 +1593,25 @@ async function directBlockedWaiterCount(holderPid: number): Promise<number> {
   return rows[0]?.waiterCount ?? 0;
 }
 
+/**
+ * Whether one caller-owned backend is waiting on a lock the holder owns. Waiter
+ * counts span every backend in the shared test database, so a test that owns
+ * exactly one concurrent writer asserts on that writer instead of on a total.
+ */
+async function backendBlockedByHolder(
+  holderPid: number,
+  waiterPid: number,
+): Promise<boolean> {
+  const rows = await executeRawRows(
+    db(),
+    sql`
+      SELECT ${holderPid} = ANY(pg_blocking_pids(${waiterPid}::int)) AS "blocked"
+    `,
+    blockedByPidRowSchema,
+  );
+  return rows[0]?.blocked ?? false;
+}
+
 async function databaseOwnerHasBlockedWaiter(
   applicationName: string,
 ): Promise<boolean> {
@@ -2570,6 +2589,7 @@ export async function holdChatEventInsertTransactionFixture(args: {
   readonly release: () => void;
   readonly done: Promise<void>;
   readonly blockedWaiterCount: () => Promise<number>;
+  readonly blocksBackend: (waiterPid: number) => Promise<boolean>;
 }> {
   const started = createDeferredPromise<{
     readonly pid: number;
@@ -2612,6 +2632,9 @@ export async function holdChatEventInsertTransactionFixture(args: {
     done,
     blockedWaiterCount: async () => {
       return await transitiveBlockedWaiterCount(pid);
+    },
+    blocksBackend: async (waiterPid: number) => {
+      return await backendBlockedByHolder(pid, waiterPid);
     },
   };
 }
@@ -2666,23 +2689,45 @@ export async function holdRunOutputMaterializationRowFixture(args: {
   };
 }
 
-/** Inserts one event with reservation and persistence in one transaction. */
+/**
+ * Inserts one event with reservation and persistence in one transaction. The
+ * backend pid resolves before the sequence reservation runs, so a concurrent
+ * holder can observe that this writer is the backend waiting on it.
+ */
 export async function insertChatEventTransactionFixture(args: {
   readonly threadId: string;
   readonly content: string;
-}): Promise<{ readonly id: string; readonly seqId: number }> {
-  const event = await db().transaction(async (tx) => {
-    return await insertChatEvent(tx, {
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly backendPid: number;
+  readonly inserted: Promise<{ readonly id: string; readonly seqId: number }>;
+}> {
+  const started = createDeferredPromise<number>(args.signal);
+  const inserted = db().transaction(async (tx) => {
+    const pidRows = await executeRawRows(
+      tx,
+      sql`
+        SELECT pg_backend_pid() AS "pid"
+      `,
+      databasePidRowSchema,
+    );
+    const writerPid = pidRows[0]?.pid;
+    if (!writerPid) {
+      throw new Error("Expected the chat-message insert writer pid");
+    }
+    started.resolve(writerPid);
+    const event = await insertChatEvent(tx, {
       chatThreadId: args.threadId,
       eventType: "output.message",
       content: args.content,
       runId: null,
     });
+    if (!event) {
+      throw new Error("Expected the chat-message insert");
+    }
+    return event;
   });
-  if (!event) {
-    throw new Error("Expected the chat-message insert");
-  }
-  return event;
+  return { backendPid: await started.promise, inserted };
 }
 
 /**

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -2691,18 +2691,19 @@ export async function holdRunOutputMaterializationRowFixture(args: {
 
 /**
  * Inserts one event with reservation and persistence in one transaction. The
- * backend pid resolves before the sequence reservation runs, so a concurrent
- * holder can observe that this writer is the backend waiting on it.
+ * backend pid is published as soon as the writer transaction opens, before the
+ * sequence reservation can block, so a concurrent holder can observe that this
+ * writer is the backend waiting on it. The accessor is synchronous so a caller
+ * never waits on the writer outside its own polling budget.
  */
-export async function insertChatEventTransactionFixture(args: {
+export function insertChatEventTransactionFixture(args: {
   readonly threadId: string;
   readonly content: string;
-  readonly signal: AbortSignal;
-}): Promise<{
-  readonly backendPid: number;
+}): {
+  readonly backendPid: () => number | undefined;
   readonly inserted: Promise<{ readonly id: string; readonly seqId: number }>;
-}> {
-  const started = createDeferredPromise<number>(args.signal);
+} {
+  let openedBackendPid: number | undefined;
   const inserted = db().transaction(async (tx) => {
     const pidRows = await executeRawRows(
       tx,
@@ -2715,7 +2716,7 @@ export async function insertChatEventTransactionFixture(args: {
     if (!writerPid) {
       throw new Error("Expected the chat-message insert writer pid");
     }
-    started.resolve(writerPid);
+    openedBackendPid = writerPid;
     const event = await insertChatEvent(tx, {
       chatThreadId: args.threadId,
       eventType: "output.message",
@@ -2727,7 +2728,12 @@ export async function insertChatEventTransactionFixture(args: {
     }
     return event;
   });
-  return { backendPid: await started.promise, inserted };
+  return {
+    backendPid: () => {
+      return openedBackendPid;
+    },
+    inserted,
+  };
 }
 
 /**


### PR DESCRIPTION
## Problem

Turbo run [33475528807](https://github.com/vm0-ai/vm0/actions/runs/33475528807) (`merge_group`, SHA `8d07c37`) failed in [`test-api` shard 7](https://github.com/vm0-ai/vm0/actions/runs/33475528807/job/99753942621):

```
FAIL  api  src/signals/routes/__tests__/chat-threads.bdd.test.ts
  > CHAT-01 chat thread read state > serializes concurrent message sequence writes through commit
AssertionError: expected 3 to be 1 // Object.is equality
- Expected: 1
+ Received: 3
 ❯ src/signals/routes/__tests__/chat-threads.bdd.test.ts:2166:48
    2166|     await expect.poll(held.blockedWaiterCount).toBe(1);
Caused by: Error: Matcher did not succeed in time.
```

This is an **overshoot**, not a "nothing happened" timeout: waiters did block, there were simply more of them than the test expected, so `expect.poll` never observed `1` and exhausted its budget. Every other test in that shard passed (1 failed | 433 passed).

## Root cause

`blockedWaiterCount` resolves to `transitiveBlockedWaiterCount(holderPid)`, a `WITH RECURSIVE` closure over **`pg_stat_activity` for the entire database**:

```sql
WITH RECURSIVE blocked("pid") AS (
  SELECT activity.pid FROM pg_stat_activity AS activity
  WHERE <holderPid> = ANY(pg_blocking_pids(activity.pid))
  UNION
  SELECT activity.pid FROM pg_stat_activity AS activity
  INNER JOIN blocked AS blocker ON blocker.pid = ANY(pg_blocking_pids(activity.pid))
)
SELECT count(*) FROM blocked
```

`.github/workflows/turbo.yml` gives each `test-api` shard **one** Postgres service, and Vitest runs that shard's 27 files in parallel forks against it. The count is therefore a global property that this test does not own, while `docs/testing/api-testing.md` ("Shared Persistent State") requires a test to "be correct while other API tests execute concurrently" using "uniquely owned, explicitly addressable" observations.

Reproducing CI shard 7 locally and dumping the closure members confirms the counter is not scoped to the intended writer: for a `holdChatEventInsertTransactionFixture` holder it returned backends running unrelated `select ... from agent_runs ...` statements, not just the concurrent chat-event writer. Once any such backend joins the chain, `toBe(1)` can never be satisfied, because none of those waiters can proceed until the holder commits. Existing tests at this same boundary already avoid exact totals (`toBeGreaterThanOrEqual(1)` in `chat-callbacks.bdd.test.ts`, `toBeGreaterThan(0)` in `cron-cleanup-sandboxes.test.ts`).

## Fix

Observe the writer this test owns instead of a database-wide total.

- `insertChatEventTransactionFixture` now resolves its own backend pid with `pg_backend_pid()` **before** the sequence reservation blocks, and returns `{ backendPid, inserted }`.
- `holdChatEventInsertTransactionFixture` gains `blocksBackend(waiterPid)`, which asserts `holderPid = ANY(pg_blocking_pids(waiterPid))`.
- The test polls `held.blocksBackend(secondInsert.backendPid)`.

The product contract is preserved and the assertion is strictly more targeted than before. The test still requires that the concurrent writer is blocked while the first transaction is open, that neither message is visible before commit, and that both rows commit in `held.event.seqId < second.seqId` order. Nothing here would pass if writes interleaved incorrectly. `blockedWaiterCount` is untouched for its other callers.

No sleeps, retries, enlarged poll budgets, manual detached cleanup, or skipped tests.

## Validation

Local Postgres 18 + pgvector, migrations applied, `TZ=UTC`.

- Negative control: pointing `blocksBackend` at a pid that is not blocked makes the test fail with `Matcher did not succeed in time`, so the new assertion is load-bearing.
- `chat-threads.bdd.test.ts` (full file, 35 tests) run 5 times: 5/5 green.
- Regressions for the shared fixture's other consumers: `cron-project-chat-event-search.test.ts` (9 passed), `chat-callbacks.bdd.test.ts` (54 passed).
- `pnpm -F api lint`, `pnpm -F api check-types`, `prettier --write` (no changes), `git diff --check`: all clean.

Limitation: the CI overshoot itself did not reproduce on the 2-CPU sandbox (an isolated shard-7 run observed the expected single waiter). The fix removes the dependency on the global count regardless of which additional backend joined the chain on the CI runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
