### PR TITLE
test(api): stabilize chat sequence lock synchronization

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -37,8 +37,8 @@ import {
 } from "../../../test-fixtures/system-config-seeds";
 import {
   holdChatEventInsertTransactionFixture,
-  insertChatEventTransactionFixture,
   insertOutputEventWithConflictingLegacyPayloadFixture,
+  startChatEventInsertTransactionFixture,
 } from "../../../test-fixtures/chat-events";
 import {
   holdChatThreadEventInsertTransactionFixture,
@@ -2154,16 +2154,21 @@ describe("CHAT-01 chat thread read state", () => {
       content: firstContent,
       signal: context.signal,
     });
-    const secondInsert = insertChatEventTransactionFixture({
+    const secondInsert = await startChatEventInsertTransactionFixture({
       threadId,
       content: secondContent,
+      signal: context.signal,
     });
     onTestFinished(async () => {
       held.release();
-      await Promise.allSettled([held.done, secondInsert]);
+      await Promise.allSettled([held.done, secondInsert.done]);
     });
 
-    await expect.poll(held.blockedWaiterCount).toBe(1);
+    await expect
+      .poll(() => {
+        return held.blocks(secondInsert.pid);
+      })
+      .toBe(true);
     const beforeCommit = await chat.listThreadEvents(owner, threadId);
     expect(
       beforeCommit.events.some((message) => {
@@ -2176,7 +2181,7 @@ describe("CHAT-01 chat thread read state", () => {
 
     held.release();
     await held.done;
-    const second = await secondInsert;
+    const second = await secondInsert.done;
     const committed = await chat.listThreadEvents(owner, threadId);
     const concurrentRows = committed.events.filter((message) => {
       return message.id === held.event.id || message.id === second.id;

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -1872,6 +1872,20 @@ async function pidIsBlocked(waiterPid: number): Promise<boolean> {
   return rows[0]?.blocked ?? false;
 }
 
+async function pidIsDirectlyBlockedBy(
+  waiterPid: number,
+  holderPid: number,
+): Promise<boolean> {
+  const rows = await executeRawRows(
+    db(),
+    sql`
+      SELECT ${holderPid} = ANY(pg_blocking_pids(${waiterPid})) AS "blocked"
+    `,
+    blockedByPidRowSchema,
+  );
+  return rows[0]?.blocked ?? false;
+}
+
 /**
  * Acquires bdd-scoped ownership of the platform-managed vm0 API key pool for
  * one vendor.
@@ -2570,6 +2584,7 @@ export async function holdChatEventInsertTransactionFixture(args: {
   readonly release: () => void;
   readonly done: Promise<void>;
   readonly blockedWaiterCount: () => Promise<number>;
+  readonly blocks: (waiterPid: number) => Promise<boolean>;
 }> {
   const started = createDeferredPromise<{
     readonly pid: number;
@@ -2612,6 +2627,9 @@ export async function holdChatEventInsertTransactionFixture(args: {
     done,
     blockedWaiterCount: async () => {
       return await transitiveBlockedWaiterCount(pid);
+    },
+    blocks: async (waiterPid) => {
+      return await pidIsDirectlyBlockedBy(waiterPid, pid);
     },
   };
 }
@@ -2666,23 +2684,48 @@ export async function holdRunOutputMaterializationRowFixture(args: {
   };
 }
 
-/** Inserts one event with reservation and persistence in one transaction. */
-export async function insertChatEventTransactionFixture(args: {
+/** Starts one event insert with reservation and persistence in one transaction. */
+export async function startChatEventInsertTransactionFixture(args: {
   readonly threadId: string;
   readonly content: string;
-}): Promise<{ readonly id: string; readonly seqId: number }> {
-  const event = await db().transaction(async (tx) => {
-    return await insertChatEvent(tx, {
-      chatThreadId: args.threadId,
-      eventType: "output.message",
-      content: args.content,
-      runId: null,
-    });
-  });
-  if (!event) {
-    throw new Error("Expected the chat-message insert");
-  }
-  return event;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly pid: number;
+  readonly done: Promise<{ readonly id: string; readonly seqId: number }>;
+}> {
+  const started = createDeferredPromise<number>(args.signal);
+  const done = onRejection(
+    db().transaction(async (tx) => {
+      const pidRows = await executeRawRows(
+        tx,
+        sql`
+          SELECT pg_backend_pid() AS "pid"
+        `,
+        databasePidRowSchema,
+      );
+      const pid = pidRows[0]?.pid;
+      if (!pid) {
+        throw new Error("Expected the chat-message insert pid");
+      }
+      started.resolve(pid);
+      const event = await insertChatEvent(tx, {
+        chatThreadId: args.threadId,
+        eventType: "output.message",
+        content: args.content,
+        runId: null,
+      });
+      if (!event) {
+        throw new Error("Expected the chat-message insert");
+      }
+      return event;
+    }),
+    (error) => {
+      if (!started.settled()) {
+        started.reject(error);
+      }
+    },
+  );
+  return { pid: await started.promise, done };
 }
 
 /**


### PR DESCRIPTION
## Summary

- expose the second chat-event insert transaction's PostgreSQL backend PID before it enters the production sequence writer
- wait for that exact backend to be directly blocked by the held writer instead of requiring the holder's complete blocking subtree to contain exactly one session
- preserve the existing pre-commit visibility and post-commit sequence-order assertions, with abort-aware startup failure propagation

## Scope

This changes API integration-test synchronization only. It does not change runtime chat sequencing, API contracts, persisted state, database schema, migrations, deployment behavior, test timeouts, or CI scheduling.

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts -t 'serializes concurrent message sequence writes through commit'` (6/6 focused runs passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts` (35/35 passed)
- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts apps/api/src/test-fixtures/chat-events.ts`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- pre-commit hook: full `pnpm knip`, full `pnpm check-types` (14/14 tasks), file-size check, and commitlint

Closes #30748
