### PR TITLE
refactor(cli): retire legacy api backend url input

### DIFF
--- a/docs/okou-protocol-migration.md
+++ b/docs/okou-protocol-migration.md
@@ -61,11 +61,12 @@ and the retirement needed no separate window. A token presenting the legacy
 `zero` scope now fails verification.
 
 The current CLI defaults to `https://api.okou.ai` and sends branded requests
-through `/api/okou/**`. Merging that host change requires the custom domain to
-have valid TLS and to reach the production API boundary; static App HTML,
-redirects, and an unreachable hostname do not pass the gate. The existing
-`VM0_API_BACKEND_URL` override remains available for development, previews,
-and operational rollback.
+through `/api/okou/**`. It reads only `OKOU_API_BACKEND_URL` for an explicit API
+override; when that variable is unset or empty, the production default remains
+in effect. Merging a host change requires the custom domain to have valid TLS
+and to reach the production API boundary; static App HTML, redirects, and an
+unreachable hostname do not pass the gate. Historical commit-addressed CLI
+artifacts remain immutable and retain the contracts they shipped with.
 
 Removing any other fallback reader, `/api/zero/**` route, historical artifact,
 callback, Desktop identity, or persisted object requires a separate drain gate.
@@ -79,8 +80,11 @@ drained.
 ## Rollback
 
 Roll the writer stop back to the Phase B release target above to restore dual
-emission. Roll the current CLI source back by selecting the last verified
-dual-reader commit-addressed artifact and restoring the previous API origin.
+emission. Operational rollback for the current Product CLI keeps the
+canonical-only API URL input: select a verified artifact and configure any
+previous API origin through `OKOU_API_BACKEND_URL`. Do not restore
+`VM0_API_BACKEND_URL`; its support cutoff is a product contract, not a rollout
+fallback.
 Leave both namespace routes, server-side environment readers, both Desktop
 identities, stored callbacks, queued contexts, and immutable historical
 artifacts in place. Restoring the `zero` token scope is not part of that

--- a/docs/testing/cli-testing.md
+++ b/docs/testing/cli-testing.md
@@ -33,15 +33,17 @@ Product CLI requests read `OKOU_TOKEN` and nothing else. `getToken()` in
 `src/lib/api/config.ts` delegates to `getOkouToken()` in `src/lib/okou-env.ts`,
 which reads only `OKOU_TOKEN`. The retired `ZERO_TOKEN` and `VM0_TOKEN` names
 are not honored, and there is no fallback to them when `OKOU_TOKEN` is unset or
-empty. Routing is the one place a legacy name survives: `getApiUrl()` prefers
-`OKOU_API_BACKEND_URL` and falls back to `VM0_API_BACKEND_URL`.
+empty. Routing reads only `OKOU_API_BACKEND_URL`; when it is unset or empty,
+the CLI defaults to `https://api.okou.ai`. A configured host without a protocol
+receives `https://`, while an explicit protocol and trailing slash are
+preserved.
 
 Set the canonical token explicitly together with the API URL:
 
 ```typescript
 beforeEach(() => {
   vi.stubEnv("OKOU_TOKEN", "test-okou-token");
-  vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+  vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
 });
 
 afterEach(() => {

--- a/turbo/apps/cli/src/lib/api/__tests__/config.test.ts
+++ b/turbo/apps/cli/src/lib/api/__tests__/config.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getActiveOrg, getActiveToken, getApiUrl, getToken } from "../config";
+import {
+  getActiveOrg,
+  getActiveToken,
+  getApiUrl,
+  getCliPublicBrand,
+  getToken,
+} from "../config";
 
 function buildFakeZeroJwt(payload: Record<string, unknown>): string {
   const header = Buffer.from(
@@ -78,36 +84,62 @@ describe("Okou configuration", () => {
     await expect(getActiveOrg()).resolves.toBeUndefined();
   });
 
-  it("prefers OKOU_API_BACKEND_URL when both backend names are set", async () => {
+  it("adds https to a canonical API URL without a protocol", async () => {
     vi.stubEnv("OKOU_API_BACKEND_URL", "canonical.example.test");
-    vi.stubEnv("VM0_API_BACKEND_URL", "https://legacy.example.test");
 
     await expect(getApiUrl()).resolves.toBe("https://canonical.example.test");
   });
 
+  it.each([
+    "http://canonical.example.test/",
+    "https://canonical.example.test/",
+  ])("preserves the configured API URL %s", async (canonicalUrl) => {
+    vi.stubEnv("OKOU_API_BACKEND_URL", canonicalUrl);
+
+    await expect(getApiUrl()).resolves.toBe(canonicalUrl);
+  });
+
   it.each([undefined, ""])(
-    "uses VM0_API_BACKEND_URL when OKOU_API_BACKEND_URL is %s",
+    "defaults routing to the production API when the canonical URL is %s",
     async (canonicalUrl) => {
       vi.stubEnv("OKOU_API_BACKEND_URL", canonicalUrl);
-      vi.stubEnv("VM0_API_BACKEND_URL", "preview.vm0.ai");
 
-      await expect(getApiUrl()).resolves.toBe("https://preview.vm0.ai");
+      await expect(getApiUrl()).resolves.toBe("https://api.okou.ai");
     },
   );
 
-  it("preserves configured protocols and trailing slashes", async () => {
-    vi.stubEnv("OKOU_API_BACKEND_URL", "http://canonical.example.test/");
+  it("prefers the run-token public brand over the configured API URL", () => {
+    vi.stubEnv(
+      "OKOU_TOKEN",
+      buildFakeZeroJwt({
+        scope: "okou",
+        capabilities: [],
+        publicBrand: "okou",
+      }),
+    );
+    vi.stubEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
 
-    await expect(getApiUrl()).resolves.toBe("http://canonical.example.test/");
+    expect(getCliPublicBrand()).toBe("okou");
   });
 
-  it("uses VM0_API_BACKEND_URL for routing", async () => {
-    vi.stubEnv("VM0_API_BACKEND_URL", "preview.vm0.ai");
+  it.each([
+    ["api.vm0.ai", "vm0"],
+    ["https://api.okou.ai", "okou"],
+  ] as const)(
+    "selects the %s API URL brand as %s",
+    (canonicalUrl, expectedBrand) => {
+      vi.stubEnv("OKOU_API_BACKEND_URL", canonicalUrl);
 
-    await expect(getApiUrl()).resolves.toBe("https://preview.vm0.ai");
-  });
+      expect(getCliPublicBrand()).toBe(expectedBrand);
+    },
+  );
 
-  it("defaults routing to the production API", async () => {
-    await expect(getApiUrl()).resolves.toBe("https://api.okou.ai");
-  });
+  it.each([undefined, ""])(
+    "defaults the public brand to Okou when the canonical URL is %s",
+    (canonicalUrl) => {
+      vi.stubEnv("OKOU_API_BACKEND_URL", canonicalUrl);
+
+      expect(getCliPublicBrand()).toBe("okou");
+    },
+  );
 });

--- a/turbo/apps/cli/src/lib/api/config.ts
+++ b/turbo/apps/cli/src/lib/api/config.ts
@@ -15,8 +15,7 @@ export async function getActiveToken(): Promise<string | undefined> {
 }
 
 export async function getApiUrl(): Promise<string> {
-  const apiUrl =
-    process.env.OKOU_API_BACKEND_URL || process.env.VM0_API_BACKEND_URL;
+  const apiUrl = process.env.OKOU_API_BACKEND_URL;
   if (apiUrl) {
     // Add protocol if missing
     return apiUrl.startsWith("http") ? apiUrl : `https://${apiUrl}`;
@@ -30,8 +29,7 @@ export function getCliPublicBrand(): PublicBrand {
     return runToken.publicBrand ?? "vm0";
   }
 
-  const configuredApiUrl =
-    process.env.OKOU_API_BACKEND_URL || process.env.VM0_API_BACKEND_URL;
+  const configuredApiUrl = process.env.OKOU_API_BACKEND_URL;
   if (!configuredApiUrl) {
     return "okou";
   }

--- a/turbo/apps/cli/src/test/setup.ts
+++ b/turbo/apps/cli/src/test/setup.ts
@@ -9,7 +9,6 @@ beforeAll(() => {
 // Baseline: no auth, no API URL. Test files override in their own beforeEach.
 beforeEach(() => {
   vi.stubEnv("OKOU_API_BACKEND_URL", undefined);
-  vi.stubEnv("VM0_API_BACKEND_URL", undefined);
   vi.stubEnv("OKOU_APP_URL", undefined);
   vi.stubEnv("OKOU_TOKEN", "");
   vi.stubEnv("ZERO_TOKEN", "");


### PR DESCRIPTION
## Summary

- stop the Product CLI API URL and public-brand resolvers from reading `VM0_API_BACKEND_URL`
- preserve canonical URL normalization, the production default, run-token brand precedence, and canonical hostname brand selection with focused positive coverage
- remove the obsolete legacy test setup and document the canonical-only support and rollback boundary

Historical commit-addressed CLI artifacts remain unchanged. The sibling E2E resolver, `turbo/turbo.json`, and all other environment migrations are out of scope.

## Testing

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter=!api --filter=!@okouai/app`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/cli exec vitest run src/lib/api/__tests__/config.test.ts`
- `pnpm --filter @okouai/cli exec vitest run src/commands/generate/__tests__/website.test.ts`
- `git diff --check`

Closes #30759