### PR TITLE
test(api): stabilize dispatch timing fixture

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1897,14 +1897,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(claim).not.toHaveProperty("connectorPermissionBaseline");
     expectClaimNetworkPolicyRefreshPath(created.runId, "no_builtin_targets");
 
-    const {
-      actor: warmActor,
-      agentId: warmAgentId,
-      runnerGroup: warmRunnerGroup,
-    } = await entitledRunActor();
     const warmPrompt = "repeated empty timing should not leak prompt";
-    const warmCreated = await api.createRun(warmActor, {
-      agentId: warmAgentId,
+    const warmCreated = await api.createRun(actor, {
+      agentId,
       prompt: warmPrompt,
       modelProvider: "anthropic-api-key",
     });
@@ -1922,14 +1917,14 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     for (const event of warmTimingEvents) {
       expect(event).toStrictEqual(
         expect.objectContaining({
-          runner_group: warmRunnerGroup,
+          runner_group: runnerGroup,
           run_id: warmCreated.runId,
         }),
       );
     }
     expectApiDispatchTimingEventsNotToLeak(warmTimingEvents, [
       warmPrompt,
-      warmAgentId,
+      agentId,
       "test-oauth-secret",
       "fixture-confidential-secret",
     ]);


### PR DESCRIPTION
## Summary

- reuse the existing entitled actor, agent, and runner group for the repeated API dispatch timing assertion
- preserve the process-ordinal, telemetry-shape, and sensitive-data coverage while removing redundant fixture setup
- keep the normal 5-second timeout and production dispatch behavior unchanged

## Root cause

The warm dispatch assertion created a second complete `entitledRunActor()` fixture even though it only needed another dispatch in the same API process. That repeated organization entitlement, model-provider, storage, and agent setup added unrelated database and mocked integration work to the test's critical path. Under concurrent API shard load, the otherwise sub-second test could exhaust Vitest's 5-second timeout.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- 6 consecutive targeted runs of `pnpm vitest run --project=api apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "emits api dispatch timing for exact-empty direct dispatch runs"` (584-972 ms)
