### PR TITLE
fix(api): avoid connector doctor output truncation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
@@ -545,9 +545,60 @@ describe.sequential("Official Workflow catalog release boundary", () => {
       connectorDoctorInstruction.match(/okou doctor connectors --json/gu),
     ).toHaveLength(1);
     expect(connectorDoctorInstruction).toContain(
+      "unique sandbox-local report file with `mktemp`",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "redirect its complete standard output directly into that file",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      `report_file="$(mktemp "\${TMPDIR:-/tmp}/connector-doctor.XXXXXX.json")"`,
+    );
+    expect(connectorDoctorInstruction).toContain(
+      'okou doctor connectors --json >"$report_file"',
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "do not rerun it, split it into per-workflow diagnoses, or call connector-readiness APIs separately",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "All later commands must be local parsers against that same sandbox file",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "Keep the file sandbox-local; do not upload, attach, or send it",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "use a non-emitting local `jq` check or equivalent local parser",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "all five non-negative integer summary counts",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "A truncated or empty file, invalid JSON, an unsupported schema version, a missing required field",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "any local parsing or projection failure makes the diagnosis unavailable",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "the first data-returning projection must contain only `schemaVersion` and `summary`",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "Never make a tool call that prints, reads, or returns the whole raw file",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "return at most 20 records per tool result",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "Use a count-only projection to determine whether paging is needed",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "advance explicit offsets until every projected record for that branch has been consumed",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "If the Doctor command or local capture fails",
+    );
+    expect(connectorDoctorInstruction).toContain(
       "sole source of diagnostic facts",
     );
-    expect(connectorDoctorInstruction).toContain("schemaVersion` is `1");
+    expect(connectorDoctorInstruction).toContain("schemaVersion === 1");
     expect(connectorDoctorInstruction).toContain(
       "identical `action.kind` and exact `action.url`",
     );
@@ -578,7 +629,13 @@ describe.sequential("Official Workflow catalog release boundary", () => {
       "compact inventory of every checked entry in `workflows`, grouped by its returned Agent identity",
     );
     expect(connectorDoctorInstruction).toContain(
-      "command fails, its output is not valid JSON, or its schema version is unsupported",
+      "page through a projection of every connector entry with a non-null action",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "separately page through a projection of every connector whose status is `unavailable` and every workflow with a non-null `error`",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "Do not use `tee`, echo the raw output, switch to the human-readable CLI output, or depend on compact JSON whitespace or a higher tool-output limit",
     );
     expect(connectorDoctorInstruction).toContain(
       "Do not invoke connector or provider skills, third-party provider APIs",
@@ -590,7 +647,17 @@ describe.sequential("Official Workflow catalog release boundary", () => {
       "Do not write to or mutate application or provider state",
     );
     expect(connectorDoctorInstruction).toContain(
+      "application-internal APIs, or application database tables",
+    );
+    expect(connectorDoctorInstruction).toContain(
       "Do not connect, reconnect, authorize, start OAuth flows, request permissions, create callbacks, mutate connectors",
+    );
+    expect(connectorDoctorInstruction).toContain("or follow repair links");
+    expect(connectorDoctorInstruction).toContain(
+      "Do not select or recommend models, and do not recommend workflow or Automation cleanup",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "Return only the Markdown report. The platform delivers it to the shared automation thread",
     );
     expect(connectorDoctorInstruction).toContain(
       "Do not send email or directly send any chat or other message",

--- a/turbo/apps/api/src/signals/services/official-workflow-catalog-source.ts
+++ b/turbo/apps/api/src/signals/services/official-workflow-catalog-source.ts
@@ -28,18 +28,39 @@ const CONNECTOR_DOCTOR_INSTRUCTION = `# Connector Doctor
 
 Produce a concise Markdown connector-readiness report in this Official Workflow's shared automation thread.
 
-## Diagnose once
+## Capture the diagnosis once
 
-Run \`okou doctor connectors --json\` exactly once per scheduled or manual run. Parse its standard output as JSON and accept it only when \`schemaVersion\` is \`1\`. Treat that one report as the sole source of diagnostic facts. Do not supplement, verify, or reinterpret it from any other source.
+In one shell tool call, create a unique sandbox-local report file with \`mktemp\`, then run the aggregate diagnosis exactly once per scheduled or manual run and redirect its complete standard output directly into that file. Use this capture shape so the tool result contains only the path and status:
 
-If the command fails, its output is not valid JSON, or its schema version is unsupported, return a diagnosis-unavailable report under an **Unknown** heading. State the observed failure without claiming that any connector or workflow is healthy.
+\`\`\`sh
+report_file="$(mktemp "\${TMPDIR:-/tmp}/connector-doctor.XXXXXX.json")" &&
+if okou doctor connectors --json >"$report_file"; then
+  printf 'report_file=%s status=ok\\n' "$report_file"
+else
+  doctor_status=$?
+  printf 'report_file=%s status=failed exit=%s\\n' "$report_file" "$doctor_status" >&2
+  exit "$doctor_status"
+fi
+\`\`\`
+
+Do not use \`tee\`, echo the raw output, switch to the human-readable CLI output, or depend on compact JSON whitespace or a higher tool-output limit. Check the command's exit status and do not rerun it, split it into per-workflow diagnoses, or call connector-readiness APIs separately. The capture call may return only the unique file path and a small success or failure status, never the report body.
+
+All later commands must be local parsers against that same sandbox file. Treat that one captured report as the sole source of diagnostic facts. Do not supplement, verify, or reinterpret it from any other source. Keep the file sandbox-local; do not upload, attach, or send it.
+
+## Validate locally and read the summary first
+
+Before making any health claim, use a non-emitting local \`jq\` check or equivalent local parser against the file. It must parse the entire file successfully, prove that the root is an object with \`schemaVersion === 1\`, and validate the required schema-version-1 fields and types used below: all five non-negative integer summary counts, the \`workflows\` array, workflow and Agent identities, outcomes, connector statuses and reasons, exact action kinds and URLs, and workflow errors. A truncated or empty file, invalid JSON, an unsupported schema version, a missing required field, a type or value mismatch, or any local parsing or projection failure makes the diagnosis unavailable.
+
+After validation, the first data-returning projection must contain only \`schemaVersion\` and \`summary\`. Never make a tool call that prints, reads, or returns the whole raw file; in particular, do not use \`cat\`, \`tee\`, an unfiltered \`jq\` query, or an equivalent whole-file read. Every later data-returning projection must select only the fields required by the chosen report branch and return at most 20 records per tool result. Use a count-only projection to determine whether paging is needed, then advance explicit offsets until every projected record for that branch has been consumed. Local parsers may scan the complete file internally, but the raw document must never cross the tool-return boundary.
+
+If the Doctor command or local capture fails, or any validation condition above fails, return a diagnosis-unavailable report under an **Unknown** heading. State the observed failure without claiming that any connector or workflow is healthy.
 
 ## Report valid results
 
-- If \`summary.checked === 0\`, report that no effective visible workflows were available to check. Treat this as a distinct no-workflows result, not an all-clear over diagnosed workflows.
-- Group every connector entry with a non-null action by identical \`action.kind\` and exact \`action.url\`. Include the repair link once for each group, then list every affected workflow with the connector's returned readiness status and reason. Never merge entries whose exact URLs differ, even when their action kinds or connector labels match, because the URL identifies the target Agent.
-- Under **Unknown**, list every connector whose status is \`unavailable\` and every workflow with a non-null \`error\`. Include the returned workflow identity and reason or error message. Unknown is never healthy.
-- Emit a short all-clear only when \`summary.checked > 0\`, \`summary.attention === 0\`, and \`summary.unknown === 0\`. State that the aggregate covered effective visible workflows and include a compact inventory of every checked entry in \`workflows\`, grouped by its returned Agent identity. Use only workflow and Agent names or IDs present in the JSON.
+- If \`summary.checked === 0\`, report that no effective visible workflows were available to check. Treat this as a distinct no-workflows result, not an all-clear over diagnosed workflows. The validated summary is sufficient for this branch.
+- Emit a short all-clear only when \`summary.checked > 0\`, \`summary.attention === 0\`, and \`summary.unknown === 0\`. For this branch, page through a projection containing only each checked workflow's returned identity and returned Agent identity. State that the aggregate covered effective visible workflows and include a compact inventory of every checked entry in \`workflows\`, grouped by its returned Agent identity. Use only workflow and Agent names or IDs present in the JSON.
+- Otherwise, page through a projection of every connector entry with a non-null action, selecting only the workflow identity, connector status and reason, and exact \`action.kind\`, \`action.label\`, and \`action.url\`. Group entries by identical \`action.kind\` and exact \`action.url\`. Include the repair link once for each group, then list every affected workflow with the connector's returned readiness status and reason. Never merge entries whose exact URLs differ, even when their action kinds or connector labels match, because the URL identifies the target Agent.
+- For the same non-all-clear branch, separately page through a projection of every connector whose status is \`unavailable\` and every workflow with a non-null \`error\`. Under **Unknown**, include the returned workflow identity and reason or error message. Unknown is never healthy.
 - Keep the report concise and include only facts, counts, statuses, reasons, and repair links present in the returned JSON.
 
 ## Safety boundaries


### PR DESCRIPTION
## Summary

- capture the single aggregate Connector Doctor JSON report in a unique sandbox-local file so raw output never crosses the bounded tool-return boundary
- validate schema version 1 locally, read the summary first, and page bounded branch-specific projections for all-clear, actionable, and Unknown reporting
- keep grouping, all-clear semantics, shared-thread delivery, schedule, result email, and every existing safety boundary covered by the deployed-catalog regression test

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts` (13 tests)
- `git diff --check`

## Scope

- no CLI JSON, workflow selection, visibility, shadowing, connector inference, readiness, action-link, Morning Brief, or delivery behavior changes
- no database migration or compatibility fallback

Closes #30761

Parent EPIC: #30469
