### PR TITLE
fix(python): report zstd model json failures

### DIFF
--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -138,12 +138,13 @@ Response streaming
   general response stream callback. Read for exact response-size logging and
   removed by stream cleanup.
 - ``STREAM_BUFFER``: capped ``bytearray`` written by ``responseheaders()`` via
-  response streaming setup only when body capture or usage fallback needs raw
-  response bytes. Read by body capture, model JSON fallback extraction, and
-  connector fallback parsing. Removed by stream cleanup after terminal hooks.
+  response streaming setup only when body capture or bounded terminal
+  inspection needs raw response bytes. Read by body capture, model JSON usage
+  and failure inspection, and connector fallback parsing. Removed by stream
+  cleanup after terminal hooks.
 - ``STREAM_BUFFER_STATE``: ``dict`` containing ``truncated``. Written only
-  with ``STREAM_BUFFER`` and read for capture truncation and connector fallback
-  parsing. Removed by stream cleanup.
+  with ``STREAM_BUFFER`` and read for capture truncation, model JSON terminal
+  inspection, and connector fallback parsing. Removed by stream cleanup.
 
 Request streaming
 -----------------

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -3,7 +3,7 @@
 Lifecycle:
 - ``mitm_addon.responseheaders()`` calls ``configure_response_stream()`` to
   install the streaming callback, exact byte accounting, optional capped body
-  buffer, and incremental usage parsers.
+  buffer, and incremental or bounded terminal response inspectors.
 - ``mitm_addon.response()`` finalizes HTTP model and connector usage before
   reporting it.
 - ``mitm_addon.error()`` may finalize partial SSE or opted-in connector usage
@@ -31,7 +31,7 @@ import model_websocket_usage
 import runtime_url_parsing
 import stream_capture
 import usage
-from body_limits import STREAM_BUFFER_LIMIT
+from body_limits import LARGE_RESPONSE_DECOMPRESS_LIMIT, STREAM_BUFFER_LIMIT
 from logging_utils import log_proxy_entry
 from usage.underbilling import log_usage_underbilling
 
@@ -342,27 +342,29 @@ def _configure_response_inspection_stream(
             response.headers,
             should_continue=extractor.accepts_more_input,
         )
+        needs_buffered_fallback = False
         if decode_session is None:
-            if failure_observer is not None:
-                model_provider_failure.register_response_finish(
-                    flow,
-                    failure_observer.finish,
+            needs_buffered_fallback = body_decoding.can_decode_json_usage_body(
+                response.headers
+            ) and (
+                failure_observer is not None
+                or (is_observable_model_provider and uses_model_json_fallback(flow))
+            )
+            if not needs_buffered_fallback:
+                if failure_observer is not None:
+                    model_provider_failure.register_response_finish(
+                        flow,
+                        failure_observer.finish,
+                    )
+                return _ResponseStreamSetup(
+                    None,
+                    False,
+                    reject_uninspectable=(
+                        is_billable_flow
+                        and is_observable_model_provider
+                        and _HTTP_STATUS_OK_MIN <= response.status_code < _HTTP_STATUS_REDIRECT_MIN
+                    ),
                 )
-            needs_buffered_fallback = (
-                is_observable_model_provider
-                and uses_model_json_fallback(flow)
-                and body_decoding.can_decode_json_usage_body(response.headers)
-            )
-            return _ResponseStreamSetup(
-                None,
-                needs_buffered_fallback,
-                reject_uninspectable=(
-                    is_billable_flow
-                    and is_observable_model_provider
-                    and _HTTP_STATUS_OK_MIN <= response.status_code < _HTTP_STATUS_REDIRECT_MIN
-                    and not needs_buffered_fallback
-                ),
-            )
 
         inspection: usage.ModelJsonResponseInspection | None = None
         decode_error: str | None = None
@@ -371,8 +373,27 @@ def _configure_response_inspection_stream(
         def finish_json_response() -> object:
             nonlocal decode_error, finished, inspection
             if not finished:
-                decode_error = decode_session.finish_error()
-                if decode_error is None:
+                if decode_session is not None:
+                    decode_error = decode_session.finish_error()
+                else:
+                    stream_body = captured_response_stream_body(flow)
+                    if stream_body is None:
+                        raise RuntimeError(
+                            "buffered model JSON finalizer requires a response stream buffer"
+                        )
+                    if stream_body.truncated:
+                        decode_error = body_decoding.INCOMPLETE_COMPRESSED_BODY
+                    elif stream_body.buffer:
+                        decoded_body, decode_error = body_decoding.decompress_json_usage_body(
+                            bytes(stream_body.buffer),
+                            response.headers,
+                            max_output=LARGE_RESPONSE_DECOMPRESS_LIMIT,
+                        )
+                        if decode_error is None:
+                            extractor.feed(decoded_body)
+                    else:
+                        finished = True
+                if not finished and decode_error is None:
                     inspection = extractor.finish()
                     if failure_observer is not None:
                         failure_observer.observe_json(inspection.failure)
@@ -396,8 +417,8 @@ def _configure_response_inspection_stream(
         if failure_observer is not None:
             model_provider_failure.register_response_finish(flow, finish_json_response)
         return _ResponseStreamSetup(
-            decode_session.feed,
-            False,
+            decode_session.feed if decode_session is not None else None,
+            needs_buffered_fallback,
             finish_json_stream if failure_observer is not None else None,
         )
 
@@ -512,8 +533,8 @@ def configure_response_stream(flow: http.HTTPFlow) -> None:
     """Enable pass-through response streaming and body consumers.
 
     Every configured response records exact streamed bytes. A capped raw-wire
-    body prefix is retained only for network capture or a terminal usage
-    fallback that cannot use incremental decoding.
+    body prefix is retained only for network capture or bounded terminal
+    inspection that cannot use incremental decoding.
     """
     if not flow.response:
         return

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -591,11 +591,11 @@ def streamed_response_size(flow: http.HTTPFlow) -> int | None:
 
 
 def captured_response_stream_body(flow: http.HTTPFlow) -> stream_capture.CapturedStreamBody | None:
-    """Return buffered response body bytes and truncation state for capture logging.
+    """Return buffered response body bytes and truncation state.
 
     ``configure_response_stream()`` writes ``STREAM_BUFFER`` and
     ``STREAM_BUFFER_STATE`` together. This read helper keeps the metadata
-    invariant next to the writer while staying neutral about capture log fields.
+    invariant next to the writer for capture logging and terminal inspection.
     """
     stream_buf = flow.metadata.get(metadata_keys.STREAM_BUFFER)
     stream_state = flow.metadata.get(metadata_keys.STREAM_BUFFER_STATE)
@@ -610,7 +610,7 @@ def captured_response_stream_body(flow: http.HTTPFlow) -> stream_capture.Capture
 
 
 def finalize_model_json_usage(flow: http.HTTPFlow, proxy_log_path: str) -> None:
-    """Finalize incremental JSON model-provider usage extraction.
+    """Finalize incremental or bounded terminal model-provider JSON usage extraction.
 
     Called from ``response()`` before usage reporting. Pops
     ``_MODEL_JSON_USAGE_FINISH``, so repeated calls after the first are no-ops.

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -1,6 +1,7 @@
 """Integration tests for trusted model-provider failure reduction."""
 
 import gzip
+import hashlib
 import json
 import threading
 import zlib
@@ -10,6 +11,7 @@ from typing import Literal
 from unittest.mock import patch
 
 import pytest
+import zstandard
 from mitmproxy import http
 from mitmproxy.connection import ConnectionState
 from mitmproxy.flow import Error
@@ -23,6 +25,7 @@ import platform_api
 import usage.anthropic_messages as anthropic_messages
 import usage.model_json as model_json
 import usage.openai_responses as openai_responses
+from body_limits import STREAM_BUFFER_LIMIT
 from tests.flow_helpers import header_map, response_stream
 from tests.jsonl_log_helpers import jsonl_exists_after_flush, read_jsonl_entries_after_flush
 from tests.model_provider_flow_helpers import make_openai_responses_websocket_flow
@@ -1148,10 +1151,12 @@ def test_combined_sse_response_uses_one_decoder_and_one_dense_event_parse(
     ]
 
 
+@pytest.mark.parametrize("content_encoding", ["", "zstd"])
 def test_combined_json_response_uses_one_decoder_and_one_parse(
     tmp_path,
     real_flow,
     mitm_ctx,
+    content_encoding: str,
     model_provider_failure_api,
 ):
     body = (
@@ -1159,12 +1164,16 @@ def test_combined_json_response_uses_one_decoder_and_one_parse(
         b'"usage":{"input_tokens":9,"output_tokens":4},'
         b'"error":{"code":"server_error"}}'
     )
+    wire_body = zstandard.ZstdCompressor().compress(body) if content_encoding else body
+    response_headers = {"content-type": "application/json"}
+    if content_encoding:
+        response_headers["content-encoding"] = content_encoding
     flow = _make_flow(
         real_flow,
         tmp_path / "proxy.jsonl",
         request_path="/v1/responses",
-        response_body=body,
-        response_headers=header_map({"content-type": "application/json"}),
+        response_body=wire_body,
+        response_headers=header_map(response_headers),
     )
     flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
     model_provider_failure.admit_flow(flow)
@@ -1185,10 +1194,20 @@ def test_combined_json_response_uses_one_decoder_and_one_parse(
             "JsonSelectiveExtractor",
             wraps=model_provider_failure.JsonSelectiveExtractor,
         ) as create_legacy_extractor,
+        patch.object(
+            openai_responses,
+            "JsonSelectiveExtractor",
+            wraps=openai_responses.JsonSelectiveExtractor,
+        ) as create_legacy_usage_extractor,
+        patch.object(
+            body_decoding,
+            "decompress_json_usage_body",
+            wraps=body_decoding.decompress_json_usage_body,
+        ) as decompress_body,
     ):
         mitm_addon.responseheaders(flow)
         stream = response_stream(flow)
-        stream(body)
+        stream(wire_body)
         stream(b"")
         with mitm_ctx():
             mitm_addon.response(flow)
@@ -1196,6 +1215,8 @@ def test_combined_json_response_uses_one_decoder_and_one_parse(
         assert create_decoder.call_count == 1
         assert create_extractor.call_count == 1
         assert create_legacy_extractor.call_count == 0
+        assert create_legacy_usage_extractor.call_count == 0
+        assert decompress_body.call_count == (1 if content_encoding else 0)
 
     assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {
         "message_id": "resp-json",
@@ -1206,6 +1227,76 @@ def test_combined_json_response_uses_one_decoder_and_one_parse(
     assert _reported_payloads(model_provider_failure_api) == [
         {"failureKind": "provider_unavailable"}
     ]
+
+
+def test_failure_only_zstd_json_response_uses_bounded_buffer(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    model_provider_failure_api,
+):
+    body = b'{"type":"response.failed","error":{"code":"server_error"}}'
+    wire_body = zstandard.ZstdCompressor().compress(body)
+    flow = _make_flow(
+        real_flow,
+        tmp_path / "proxy.jsonl",
+        request_path="/v1/responses",
+        response_body=wire_body,
+        response_headers=header_map(
+            {"content-type": "application/json", "content-encoding": "zstd"}
+        ),
+    )
+    model_provider_failure.admit_flow(flow)
+
+    mitm_addon.responseheaders(flow)
+
+    assert metadata_keys.MODEL_USAGE_PROVIDER not in flow.metadata
+    assert metadata_keys.STREAM_BUFFER in flow.metadata
+    stream = response_stream(flow)
+    stream(wire_body)
+    stream(b"")
+    with mitm_ctx():
+        mitm_addon.response(flow)
+
+    assert _reported_payloads(model_provider_failure_api) == [
+        {"failureKind": "provider_unavailable"}
+    ]
+
+
+def test_truncated_zstd_json_buffer_does_not_report_failure(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    model_provider_failure_api,
+):
+    padding = hashlib.shake_256(b"vm0-zstd-failure-buffer").hexdigest(STREAM_BUFFER_LIMIT * 2)
+    body = (
+        b'{"type":"response.failed","error":{"code":"server_error"},"padding":"'
+        + padding.encode()
+        + b'"}'
+    )
+    wire_body = zstandard.ZstdCompressor().compress(body)
+    assert len(wire_body) > STREAM_BUFFER_LIMIT
+    flow = _make_flow(
+        real_flow,
+        tmp_path / "proxy.jsonl",
+        request_path="/v1/responses",
+        response_body=wire_body,
+        response_headers=header_map(
+            {"content-type": "application/json", "content-encoding": "zstd"}
+        ),
+    )
+    model_provider_failure.admit_flow(flow)
+
+    mitm_addon.responseheaders(flow)
+    stream = response_stream(flow)
+    stream(wire_body)
+    assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
+    stream(b"")
+    with mitm_ctx():
+        mitm_addon.response(flow)
+
+    assert _reported_payloads(model_provider_failure_api) == []
 
 
 def test_combined_sse_known_ordinary_deltas_skip_full_json_parse(

--- a/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
@@ -396,7 +396,7 @@ class TestModelProviderJsonStreaming:
         )
 
         mitm_addon.responseheaders(flow)
-        assert "model_json_usage_finish" not in flow.metadata
+        assert "model_json_usage_finish" in flow.metadata
         response_stream(flow)(compressed)
         assert metadata_keys.STREAM_BUFFER in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE in flow.metadata
@@ -441,7 +441,7 @@ class TestModelProviderJsonStreaming:
         )
 
         mitm_addon.responseheaders(flow)
-        assert "model_json_usage_finish" not in flow.metadata
+        assert "model_json_usage_finish" in flow.metadata
         response_stream(flow)(compressed)
         assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
         assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True


### PR DESCRIPTION
## Summary

- route bounded terminal zstd model JSON responses through the existing combined usage and failure inspector
- retain response buffers for admitted failure-only flows and reject truncated buffers before body classification
- add hook-level integration coverage for combined, failure-only, and truncated zstd responses while preserving legacy fallback behavior

## Explicit exclusions

- no incremental zstd decoder or change to the existing decompression resource contract
- no API, database, persisted-state, queue, runner protocol, migration, or rollout changes
- no connector response parsing changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- focused mitm-addon integration suites (267 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (7270 passed)
- `lefthook run pre-commit`

Closes #30764
