### PR TITLE
fix(platform): scope chat scroll preload to locator jumps

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
@@ -800,6 +800,7 @@ function createJump(
         {
           behavior: "smooth",
           viewportOffsetTop: container.clientHeight * JUMP_VIEWPORT_RATIO,
+          preloadPreviousRenderWindow: true,
         },
         signal,
       );

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -190,7 +190,11 @@ const resolvePaneThread$ = command(
         ? set(
             thread.scrollToEvent$,
             initialEventId,
-            { behavior: "instant", viewportOffsetTop: 0 },
+            {
+              behavior: "instant",
+              viewportOffsetTop: 0,
+              preloadPreviousRenderWindow: false,
+            },
             signal,
           )
         : Promise.resolve(),

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
@@ -18,6 +18,7 @@ export interface ThreadScrollPosition {
 export interface ScrollToEventOptions {
   readonly behavior: ScrollBehavior;
   readonly viewportOffsetTop: number;
+  readonly preloadPreviousRenderWindow: boolean;
 }
 
 export interface ScrollAfterRenderRequest {
@@ -71,6 +72,17 @@ const threadScrollPositions$ = state(new Map<string, ThreadScrollPosition>());
 interface ThreadScrollPositionSignals {
   readonly threadScrollPosition$: Computed<ThreadScrollPosition | null>;
   readonly awayFromBottom$: Computed<boolean>;
+}
+
+interface ChatThreadScrollRenderWindow {
+  readonly afterThreadScrollPositionChanged$: Command<
+    Promise<void>,
+    [AbortSignal]
+  >;
+  readonly preloadPreviousRenderWindowForEvent$: Command<
+    Promise<void>,
+    [string, AbortSignal]
+  >;
 }
 
 /**
@@ -767,7 +779,7 @@ function createScrollContentOnRef(
 export function createChatThreadScrollSignals(
   threadId: string,
   position: ThreadScrollPositionSignals,
-  afterThreadScrollPositionChanged$: Command<Promise<void>, [AbortSignal]>,
+  renderWindow: ChatThreadScrollRenderWindow,
   chatEvents$: Computed<readonly ChatEvent[]>,
   initialEventsReady$: Computed<boolean>,
 ): ChatThreadScrollSignals {
@@ -781,7 +793,7 @@ export function createChatThreadScrollSignals(
   const scroll = createInternalScrollSignals(
     threadId,
     position,
-    afterThreadScrollPositionChanged$,
+    renderWindow.afterThreadScrollPositionChanged$,
   );
   const render = createRenderScrollSignals(threadId, scroll, runtime);
   const navigation = createScrollNavigationSignals(
@@ -819,6 +831,14 @@ export function createChatThreadScrollSignals(
       if (!eventExists) {
         L.debug("scroll target event not found", { threadId, eventId });
         return;
+      }
+      if (options.preloadPreviousRenderWindow) {
+        await set(
+          renderWindow.preloadPreviousRenderWindowForEvent$,
+          eventId,
+          signal,
+        );
+        signal.throwIfAborted();
       }
       const position: ThreadScrollPosition = {
         targetEventId: eventId,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -2560,14 +2560,17 @@ function createChatThreadMessagePipeline(
       );
     },
   );
-  const ensureVisibleEventTreesAfterScroll$ =
-    createEnsureVisibleEventTreesAfterScroll(
-      renderWindow.ensureVisibleEventTrees$,
-    );
+  const afterPositionChanged$ = createEnsureVisibleEventTreesAfterScroll(
+    renderWindow.ensureVisibleEventTrees$,
+  );
   const scroll = createChatThreadScrollSignals(
     threadId,
     position,
-    ensureVisibleEventTreesAfterScroll$,
+    {
+      afterThreadScrollPositionChanged$: afterPositionChanged$,
+      preloadPreviousRenderWindowForEvent$:
+        renderWindow.preloadPreviousRenderWindowForEvent$,
+    },
     chatEvents.chatEvents$,
     initialEventsReadyView$,
   );
@@ -2721,23 +2724,20 @@ function setThreadRenderWindowState(
   return next;
 }
 
-function scrollTargetStartIndex(
+function eventRunStartIndex(
   groups: readonly ChatEventGroup[],
-  position: ThreadScrollPosition | null,
+  eventId: string,
 ): number | null {
-  if (position === null) {
-    return null;
-  }
   const targetGroupIndex = groups.findIndex((group) => {
     return group.events.some((event) => {
-      return event.id === position.targetEventId;
+      return event.id === eventId;
     });
   });
   if (targetGroupIndex === -1) {
     return null;
   }
   const targetRunId = groups[targetGroupIndex]?.events.find((event) => {
-    return event.id === position.targetEventId;
+    return event.id === eventId;
   })?.runId;
   let startIndex = targetGroupIndex;
   while (
@@ -2749,12 +2749,16 @@ function scrollTargetStartIndex(
   ) {
     startIndex--;
   }
-  // A positive viewport inset needs content before the target. Preload one
-  // established window so the smooth scroll cannot cross the top load-more
-  // threshold and replace its layout halfway through the animation.
-  return position.viewportOffsetTop > 0
-    ? previousRenderWindowStartIndex(groups, startIndex)
-    : startIndex;
+  return startIndex;
+}
+
+function scrollTargetStartIndex(
+  groups: readonly ChatEventGroup[],
+  position: ThreadScrollPosition | null,
+): number | null {
+  return position === null
+    ? null
+    : eventRunStartIndex(groups, position.targetEventId);
 }
 
 interface ChatRenderWindowOptions {
@@ -2767,6 +2771,68 @@ interface ChatRenderWindowOptions {
     [readonly ChatEvent[], AbortSignal]
   >;
   readonly initialEventsReady$: State<boolean>;
+}
+
+interface PreloadPreviousRenderWindowOptions {
+  readonly threadId: string;
+  readonly allRenderedChatGroups$: Computed<Promise<ChatEventGroup[]>>;
+  readonly ensureVisibleEventTrees$: Command<
+    Promise<void>,
+    [boolean, AbortSignal]
+  >;
+}
+
+function createPreloadPreviousRenderWindowForEvent({
+  threadId,
+  allRenderedChatGroups$,
+  ensureVisibleEventTrees$,
+}: PreloadPreviousRenderWindowOptions): Command<
+  Promise<void>,
+  [string, AbortSignal]
+> {
+  return command(
+    async (
+      { get, set },
+      eventId: string,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      const groups = await get(allRenderedChatGroups$);
+      signal.throwIfAborted();
+      const targetStartIndex = eventRunStartIndex(groups, eventId);
+      if (targetStartIndex === null) {
+        return;
+      }
+      const preloadStartIndex = previousRenderWindowStartIndex(
+        groups,
+        targetStartIndex,
+      );
+      const current = renderWindowStateForThread(
+        get(renderWindowStateByThreadId$),
+        threadId,
+      );
+      const requestedStartIndex = renderWindowStartIndex(
+        groups,
+        current.cursorGroupId,
+      );
+      const nextStartIndex = Math.min(requestedStartIndex, preloadStartIndex);
+      if (nextStartIndex < requestedStartIndex) {
+        set(
+          renderWindowStateByThreadId$,
+          setThreadRenderWindowState(
+            get(renderWindowStateByThreadId$),
+            threadId,
+            {
+              cursorGroupId: groups[nextStartIndex]?.beginEventId ?? null,
+            },
+          ),
+        );
+      }
+      // Locator jumps need stable content above the destination before their
+      // smooth-scroll request commits. Persist this one-time expansion in the
+      // cursor instead of deriving it from every live scroll position.
+      await set(ensureVisibleEventTrees$, false, signal);
+    },
+  );
 }
 
 function createChatRenderWindow({
@@ -2830,6 +2896,13 @@ function createChatRenderWindow({
       await richContentReady;
     },
   );
+
+  const preloadPreviousRenderWindowForEvent$ =
+    createPreloadPreviousRenderWindowForEvent({
+      threadId,
+      allRenderedChatGroups$,
+      ensureVisibleEventTrees$,
+    });
 
   const loadMoreRenderedChatGroups$ = command(
     async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
@@ -2899,6 +2972,7 @@ function createChatRenderWindow({
     visibleRenderedChatGroups$,
     visibleRenderedChatGroupsReady$,
     ensureVisibleEventTrees$,
+    preloadPreviousRenderWindowForEvent$,
     loadMoreRenderedChatGroups$,
     resetRenderedChatGroupsIfAtBottom$,
   };

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-scroll-position.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-scroll-position.test.tsx
@@ -423,6 +423,81 @@ function simpleUserEvents(
   });
 }
 
+function mockVirtualizedHistoryThread({
+  threadId,
+  prefix,
+}: {
+  readonly threadId: string;
+  readonly prefix: string;
+}): { readonly renderedStartIndex: () => number } {
+  const chatEvents: ChatEvent[] = Array.from({ length: 24 }, (_, index) => {
+    return {
+      id: `${prefix}-${index}`,
+      threadId,
+      eventType: "run.completed" as const,
+      content: `${prefix} reply ${index}`,
+      runId: `${prefix}-run-${index}`,
+      runLifecycleEvent: "completed",
+      createdAt: `2026-07-30T10:${String(index).padStart(2, "0")}:00Z`,
+      seqId: index + 1,
+    };
+  });
+  mockChatLifecycleWithoutBrowserSession({
+    threadId,
+    threadTitle: prefix,
+    chatEvents,
+  });
+  const renderedStartIndex = () => {
+    for (let index = 0; index <= 14; index++) {
+      if (
+        document.querySelector(
+          `[data-chat-scroll-anchor-event-id="${prefix}-${index}"]`,
+        )
+      ) {
+        return index;
+      }
+    }
+    return 14;
+  };
+  installChatLayout(
+    new Map([
+      [
+        threadId,
+        {
+          clientHeight: () => {
+            return 300;
+          },
+          scrollHeight: () => {
+            return 1200 + (14 - renderedStartIndex()) * 100;
+          },
+          eventRect: (eventId) => {
+            const index = Number(eventId.split("-").at(-1));
+            if (!Number.isFinite(index)) {
+              return undefined;
+            }
+            return {
+              top: 220 + (index - 14) * 100 + (14 - renderedStartIndex()) * 100,
+              height: 80,
+            };
+          },
+        },
+      ],
+    ]),
+  );
+  return { renderedStartIndex };
+}
+
+async function settleDetachedScrollWork(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 function mockLiveThread({
   threadId,
   initialEvents,
@@ -1456,6 +1531,78 @@ describe("chat scroll position", () => {
       expect(viewportOffsetTop("prepend-anchor-14")).toBe(-30);
       expect(container.scrollTop).toBe(1080);
     });
+  });
+
+  it("keeps a touch-driven history scroll on one prepend window", async () => {
+    const threadId = "e8000000-0000-4000-a000-000000000005";
+    const prefix = "touch-prepend";
+    const { renderedStartIndex } = mockVirtualizedHistoryThread({
+      threadId,
+      prefix,
+    });
+
+    await setupVisibleChatPage({ context, path: `/chats/${threadId}` });
+
+    const container = await waitFor(() => {
+      expect(screen.getByText(`${prefix} reply 23`)).toBeInTheDocument();
+      expect(renderedStartIndex()).toBe(14);
+      return chatScrollContainer();
+    });
+    fireEvent.touchStart(container, {
+      touches: [{ clientY: 500 }],
+    });
+    container.scrollTop = 80;
+    fireEvent.touchMove(container, {
+      touches: [{ clientY: 300 }],
+    });
+    fireEvent.scroll(container);
+
+    await screen.findByText(`${prefix} reply 4`);
+    await settleDetachedScrollWork();
+
+    expect(renderedStartIndex()).toBe(4);
+    expect(screen.queryByText(`${prefix} reply 3`)).toBeNull();
+    expect(viewportOffsetTop(`${prefix}-14`)).toBe(140);
+    fireEvent.touchEnd(container, { changedTouches: [{ clientY: 300 }] });
+  });
+
+  it("keeps momentum scrolling on the live history position", async () => {
+    const threadId = "e8000000-0000-4000-a000-000000000006";
+    const prefix = "momentum-prepend";
+    const { renderedStartIndex } = mockVirtualizedHistoryThread({
+      threadId,
+      prefix,
+    });
+
+    await setupVisibleChatPage({ context, path: `/chats/${threadId}` });
+
+    const container = await waitFor(() => {
+      expect(screen.getByText(`${prefix} reply 23`)).toBeInTheDocument();
+      expect(renderedStartIndex()).toBe(14);
+      return chatScrollContainer();
+    });
+    fireEvent.touchStart(container, {
+      touches: [{ clientY: 500 }],
+    });
+    container.scrollTop = 120;
+    fireEvent.touchMove(container, {
+      touches: [{ clientY: 300 }],
+    });
+    fireEvent.scroll(container);
+    fireEvent.touchEnd(container, { changedTouches: [{ clientY: 300 }] });
+
+    // Safari keeps moving the scroll container after touchend while momentum
+    // decays. This second scroll is browser-owned but still represents the
+    // reader's newest position.
+    container.scrollTop = 80;
+    fireEvent.scroll(container);
+
+    await screen.findByText(`${prefix} reply 4`);
+    await settleDetachedScrollWork();
+
+    expect(renderedStartIndex()).toBe(4);
+    expect(screen.queryByText(`${prefix} reply 3`)).toBeNull();
+    expect(viewportOffsetTop(`${prefix}-14`)).toBe(140);
   });
 
   it("restores a thread after its old DOM collapses", async () => {


### PR DESCRIPTION
## Summary

- stop treating every positive live scroll offset as a render-window preload request
- preload one prior render window only for Conversation Locator smooth jumps while keeping event deep links instant
- cover touch-driven upward scrolling and Safari-style momentum scrolling with regression tests

## Testing

- pnpm format
- NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- staged workspace, Platform, and API type checks
- pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-scroll-position.test.tsx
- pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-conversation-locator.test.tsx