### PR TITLE
test(runner): assert multipart template request identity

### DIFF
--- a/crates/runner/src/r2_cache/tests/upload.rs
+++ b/crates/runner/src/r2_cache/tests/upload.rs
@@ -116,8 +116,25 @@ async fn upload_template_uses_template_prefix() {
                 .build()
         });
     let upload_part = mock!(Client::upload_part)
+        .match_requests(|req| {
+            req.bucket() == Some("test-bucket")
+                && req.key() == Some("runner-templates/abc.tar.zst")
+                && req.upload_id() == Some("test-upload-id")
+                && req.part_number() == Some(1)
+        })
         .then_output(|| UploadPartOutput::builder().e_tag("\"etag-123\"").build());
     let complete = mock!(Client::complete_multipart_upload)
+        .match_requests(|req| {
+            req.bucket() == Some("test-bucket")
+                && req.key() == Some("runner-templates/abc.tar.zst")
+                && req.upload_id() == Some("test-upload-id")
+                && req.multipart_upload().is_some_and(|multipart| {
+                    let parts = multipart.parts();
+                    parts.len() == 1
+                        && parts[0].part_number() == Some(1)
+                        && parts[0].e_tag() == Some("\"etag-123\"")
+                })
+        })
         .then_output(|| CompleteMultipartUploadOutput::builder().build());
     let cache = mock_cache("test-bucket", &[&create, &upload_part, &complete]);
 


### PR DESCRIPTION
## Summary

- constrain the template part-upload request to the expected bucket, prefixed key, upload ID, and part number
- constrain multipart completion to the same object identity and the exact part returned by upload
- retain existing call-count assertions and force/dedup lifecycle coverage

This is a test-only change; production R2 upload behavior is unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runner r2_cache::tests::upload::upload_template_uses_template_prefix -- --exact`
- `cargo test -p runner --quiet` (3401 passed, 24 ignored)
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`

Closes #30742
