### PR TITLE
fix(official-workflows): derive schedule timezone from preferences

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
@@ -55,13 +55,6 @@ function scheduleBlueprint(
     key,
     parameters: [
       {
-        key: "time-zone",
-        type: "string",
-        format: "timezone",
-        required: true,
-        derivation: { kind: "user-timezone" },
-      },
-      {
         key: "include-weekends",
         type: "boolean",
         required: false,
@@ -73,7 +66,6 @@ function scheduleBlueprint(
       schedule: {
         type: "cron",
         cronExpression,
-        timezone: { parameter: "time-zone" },
       },
     },
     runtime: { resultEmail: false },
@@ -421,21 +413,12 @@ describe.sequential("Official Workflow catalog release boundary", () => {
       blueprints: [
         {
           key: "daily-delivery",
-          parameters: [
-            {
-              key: "timezone",
-              type: "string",
-              format: "timezone",
-              required: true,
-              derivation: { kind: "user-timezone" },
-            },
-          ],
+          parameters: [],
           desiredState: {
             kind: "schedule",
             schedule: {
               type: "cron",
               cronExpression: "0 7 * * *",
-              timezone: { parameter: "timezone" },
             },
           },
           runtime: { resultEmail: true },
@@ -448,21 +431,12 @@ describe.sequential("Official Workflow catalog release boundary", () => {
       blueprints: [
         {
           key: "weekly-check",
-          parameters: [
-            {
-              key: "timezone",
-              type: "string",
-              format: "timezone",
-              required: true,
-              derivation: { kind: "user-timezone" },
-            },
-          ],
+          parameters: [],
           desiredState: {
             kind: "schedule",
             schedule: {
               type: "cron",
               cronExpression: "0 9 * * 1",
-              timezone: { parameter: "timezone" },
             },
           },
           runtime: { resultEmail: false },
@@ -1081,7 +1055,7 @@ describe.sequential("Official Workflow catalog release boundary", () => {
       ],
     });
     expect(invalidParameter.body.diagnostics).toContainEqual(
-      expect.objectContaining({ code: "invalid-parameter-declaration" }),
+      expect.objectContaining({ code: "invalid-candidate" }),
     );
 
     const unknownRuntimeSetting = await syncCatalog({

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
@@ -1042,11 +1042,11 @@ describe.sequential("Official Workflow catalog release boundary", () => {
               ...scheduleBlueprint("daily"),
               parameters: [
                 {
-                  key: "time-zone",
+                  key: "callback-url",
                   type: "string",
-                  format: "text",
+                  format: "url",
                   required: true,
-                  derivation: { kind: "user-timezone" },
+                  default: "not-a-url",
                 },
               ],
             },
@@ -1055,7 +1055,7 @@ describe.sequential("Official Workflow catalog release boundary", () => {
       ],
     });
     expect(invalidParameter.body.diagnostics).toContainEqual(
-      expect.objectContaining({ code: "invalid-candidate" }),
+      expect.objectContaining({ code: "invalid-parameter-declaration" }),
     );
 
     const unknownRuntimeSetting = await syncCatalog({

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
@@ -345,6 +345,31 @@ beforeEach(async () => {
 });
 
 describe.sequential("Official Workflow catalog release boundary", () => {
+  it("replaces a previous schema release through the current source boundary", async () => {
+    const seeded = await stateAction({
+      action: "seed-previous-schema-release",
+    });
+    expect(seeded.body).toMatchObject({
+      catalog: null,
+      counts: { releases: 1 },
+    });
+
+    const synced = await syncCatalog(catalog([]));
+    expect(synced.body).toMatchObject({
+      outcome: "accepted",
+      diagnostics: [],
+    });
+
+    const state = await readState();
+    expect(state.body.catalog).toMatchObject({
+      releaseId: synced.body.releaseId,
+      payload: {
+        schemaVersion: OFFICIAL_WORKFLOW_CATALOG_SCHEMA_VERSION,
+        definitions: [],
+      },
+    });
+  });
+
   it("authenticates sync and accepts an idempotent empty initial catalog", async () => {
     const unauthorized = await syncCatalogUnauthorized(catalog([]));
     expect(unauthorized.status).toBe(401);

--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -144,13 +144,6 @@ function scheduledBlueprint(resultEmail = false): OfficialWorkflowBlueprint {
     key: "daily",
     parameters: [
       {
-        key: "time-zone",
-        type: "string",
-        format: "timezone",
-        required: true,
-        derivation: { kind: "user-timezone" },
-      },
-      {
         key: "cron-expression",
         type: "string",
         format: "text",
@@ -169,7 +162,6 @@ function scheduledBlueprint(resultEmail = false): OfficialWorkflowBlueprint {
       schedule: {
         type: "cron",
         cronExpression: { parameter: "cron-expression" },
-        timezone: { parameter: "time-zone" },
       },
       autonomyBudget: 4,
     },
@@ -216,13 +208,6 @@ function onceBlueprint(resultEmail = false): OfficialWorkflowBlueprint {
         required: true,
       },
       {
-        key: "time-zone",
-        type: "string",
-        format: "timezone",
-        required: true,
-        derivation: { kind: "user-timezone" },
-      },
-      {
         key: "callback-url",
         type: "string",
         format: "url",
@@ -240,7 +225,6 @@ function onceBlueprint(resultEmail = false): OfficialWorkflowBlueprint {
       schedule: {
         type: "once",
         atTime: { parameter: "at-time" },
-        timezone: { parameter: "time-zone" },
       },
     },
     runtime: { resultEmail },
@@ -407,13 +391,6 @@ function evolvedScheduledBlueprint(): OfficialWorkflowBlueprint {
     key: "daily",
     parameters: [
       {
-        key: "time-zone",
-        type: "string",
-        format: "timezone",
-        required: true,
-        derivation: { kind: "user-timezone" },
-      },
-      {
         key: "cron-expression",
         type: "string",
         format: "text",
@@ -432,7 +409,6 @@ function evolvedScheduledBlueprint(): OfficialWorkflowBlueprint {
       schedule: {
         type: "cron",
         cronExpression: { parameter: "cron-expression" },
-        timezone: { parameter: "time-zone" },
       },
       autonomyBudget: { parameter: "autonomy-budget" },
     },
@@ -518,20 +494,12 @@ function pulseOnceBlueprint(atTime: string): OfficialWorkflowBlueprint {
         required: false,
         default: atTime,
       },
-      {
-        key: "time-zone",
-        type: "string",
-        format: "timezone",
-        required: true,
-        derivation: { kind: "user-timezone" },
-      },
     ],
     desiredState: {
       kind: "schedule",
       schedule: {
         type: "once",
         atTime: { parameter: "at-time" },
-        timezone: { parameter: "time-zone" },
       },
     },
     runtime: { resultEmail: false },
@@ -1356,7 +1324,7 @@ describe.sequential("Official Workflow installations", () => {
         blueprintKey: "daily-delivery",
         reconciliationStatus: "current",
         intendedEnabled: true,
-        parameterBindings: [{ key: "timezone", value: "Asia/Shanghai" }],
+        parameterBindings: [],
       },
     });
     if (!morningBriefAutomation) {
@@ -1414,7 +1382,7 @@ describe.sequential("Official Workflow installations", () => {
         blueprintKey: "weekly-check",
         reconciliationStatus: "current",
         intendedEnabled: true,
-        parameterBindings: [{ key: "timezone", value: "Asia/Shanghai" }],
+        parameterBindings: [],
       },
     });
     if (!connectorDoctorAutomation?.chatThreadId) {
@@ -1448,6 +1416,71 @@ describe.sequential("Official Workflow installations", () => {
       officialBlueprintKey: "weekly-check",
       officialResultEmailEnabled: false,
     });
+  });
+
+  it("requires a Preference timezone only when a schedule Blueprint omits one", async () => {
+    installCatalogStorageFixture();
+    const suffix = randomUUID().replaceAll("-", "").slice(0, 10);
+    const defaultTimezoneDefinition = `api-test-default-timezone-${suffix}`;
+    const fixedTimezoneDefinition = `api-test-fixed-timezone-${suffix}`;
+    const fixedTimezoneBlueprint: OfficialWorkflowBlueprint = {
+      ...scheduledBlueprint(),
+      desiredState: {
+        kind: "schedule",
+        schedule: {
+          type: "cron",
+          cronExpression: "0 8 * * *",
+          timezone: "UTC",
+        },
+        autonomyBudget: 4,
+      },
+    };
+    await syncCatalog(
+      catalog([
+        activeDefinition(defaultTimezoneDefinition, [scheduledBlueprint()]),
+        activeDefinition(fixedTimezoneDefinition, [fixedTimezoneBlueprint]),
+      ]),
+    );
+
+    const { actor } = await workflowBdd.setupWorkflowOrg();
+    const { agentId } = await workflowBdd.createAgent(actor);
+    onTestFinished(async () => {
+      installCatalogStorageFixture();
+      await bdd.deleteAgent(actor, agentId);
+      await cleanupCatalog();
+    });
+    const headers = authHeaders(actor);
+    await setOfficialWorkflowsEnabled(actor, true);
+
+    const missingPreference = await accept(
+      officialClient().install({
+        headers,
+        params: { definitionName: defaultTimezoneDefinition },
+        body: {
+          agentId,
+          blueprints: [{ blueprintKey: "daily", bindings: [] }],
+        },
+      }),
+      [400],
+    );
+    expect(missingPreference.body.error.message).toBe(
+      "A valid user timezone preference is required for Blueprint: daily",
+    );
+
+    const fixedTimezone = await accept(
+      officialClient().install({
+        headers,
+        params: { definitionName: fixedTimezoneDefinition },
+        body: {
+          agentId,
+          blueprints: [{ blueprintKey: "daily", bindings: [] }],
+        },
+      }),
+      [201],
+    );
+    expect(fixedTimezone.body.workflow.automations).toMatchObject([
+      { schedule: { type: "cron", timezone: "UTC" } },
+    ]);
   });
 
   it("guards access and validates concurrent installations through public boundaries", async () => {
@@ -1969,13 +2002,12 @@ describe.sequential("Official Workflow installations", () => {
         reconciliationStatus: "current",
         intendedEnabled: true,
         parameterBindings: expect.arrayContaining([
-          { key: "time-zone", value: "Asia/Shanghai" },
           { key: "cron-expression", value: "0 7 * * *" },
           { key: "include-weekends", value: true },
         ]),
       },
     });
-    expect(dailyAutomation.official?.parameterBindings).toHaveLength(3);
+    expect(dailyAutomation.official?.parameterBindings).toHaveLength(2);
     await expect(
       readWorkflowAutomationAutonomyFixture(context, dailyAutomation.id),
     ).resolves.toMatchObject({
@@ -3575,7 +3607,6 @@ describe.sequential("Official Workflow installations", () => {
         intendedEnabled: false,
         reconciliationStatus: "current",
         parameterBindings: expect.arrayContaining([
-          { key: "time-zone", value: "Asia/Shanghai" },
           { key: "cron-expression", value: "0 6 * * *" },
           { key: "autonomy-budget", value: 7 },
         ]),

--- a/turbo/apps/api/src/signals/routes/test-official-workflow-catalog-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-official-workflow-catalog-state.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 
+import { OFFICIAL_WORKFLOW_CATALOG_SCHEMA_VERSION } from "@okouai/api-contracts/contracts/official-workflow-catalog";
 import {
   testOfficialWorkflowCatalogStateContract,
   type TestOfficialWorkflowCatalogStateActionBody,
@@ -23,7 +24,7 @@ import {
 } from "@okouai/db/schema/workflow";
 import { storages, storageVersions } from "@okouai/db/schema/storage";
 import { command } from "ccstate";
-import { and, asc, count, eq, inArray, like, or } from "drizzle-orm";
+import { and, asc, count, eq, inArray, like, or, sql } from "drizzle-orm";
 
 import { nowDate } from "../../lib/time";
 import { testOverride } from "../../lib/singleton";
@@ -57,6 +58,7 @@ const DEPLOYED_TEST_STORAGE_NAMES = [
   getOfficialWorkflowDefinitionStorageName("connector-doctor"),
   getOfficialWorkflowDefinitionStorageName("morning-brief"),
 ] as const;
+const PREVIOUS_SCHEMA_RELEASE_ID = "f".repeat(64);
 
 interface DormantMaterializationPause {
   readonly reached: ReturnType<typeof createDeferredPromise<void>>;
@@ -170,6 +172,31 @@ async function cleanupTestState(db: Db, signal: AbortSignal): Promise<void> {
         ),
       ),
     );
+  signal.throwIfAborted();
+}
+
+async function seedPreviousSchemaRelease(
+  db: Db,
+  signal: AbortSignal,
+): Promise<void> {
+  const previousSchemaVersion = OFFICIAL_WORKFLOW_CATALOG_SCHEMA_VERSION - 1;
+  if (previousSchemaVersion < 1) {
+    throw new Error("Official Workflow catalog has no previous schema version");
+  }
+  const payload = JSON.stringify({
+    schemaVersion: previousSchemaVersion,
+    definitions: [],
+  });
+  await db.transaction(async (tx) => {
+    await tx.execute(sql`
+      INSERT INTO ${officialWorkflowCatalogReleases} (id, payload)
+      VALUES (${PREVIOUS_SCHEMA_RELEASE_ID}, ${payload}::jsonb)
+    `);
+    await tx.insert(officialWorkflowCatalogState).values({
+      authority: "official",
+      acceptedReleaseId: PREVIOUS_SCHEMA_RELEASE_ID,
+    });
+  });
   signal.throwIfAborted();
 }
 
@@ -724,6 +751,10 @@ const officialWorkflowCatalogTestStateRoute$ = command(
     const db = set(writeDb$);
     if (bodyResult.data.action === "cleanup") {
       await cleanupTestState(db, signal);
+      return await stateResponse(db, undefined, null, signal);
+    }
+    if (bodyResult.data.action === "seed-previous-schema-release") {
+      await seedPreviousSchemaRelease(db, signal);
       return await stateResponse(db, undefined, null, signal);
     }
     if (

--- a/turbo/apps/api/src/signals/routes/workflows.ts
+++ b/turbo/apps/api/src/signals/routes/workflows.ts
@@ -898,7 +898,7 @@ async function resolveOfficialCopyMaterialization(
       blueprint,
       row.officialParameterBindings,
       [],
-      null,
+      row.timezone,
     );
     if (!resolved.ok) {
       return { kind: "conflict", message: OFFICIAL_COPY_RECONFIGURE_MESSAGE };

--- a/turbo/apps/api/src/signals/services/official-workflow-catalog-read.service.ts
+++ b/turbo/apps/api/src/signals/services/official-workflow-catalog-read.service.ts
@@ -1,4 +1,5 @@
 import {
+  OFFICIAL_WORKFLOW_CATALOG_SCHEMA_VERSION,
   officialWorkflowAcceptedRevisionSchema,
   officialWorkflowCatalogReleasePayloadSchema,
   officialWorkflowDefinitionRevisionPayloadSchema,
@@ -31,6 +32,21 @@ interface OfficialWorkflowRevisionRow {
   readonly storageName: string;
   readonly storageId: string;
   readonly storageVersion: string;
+}
+
+function catalogSchemaVersion(payload: unknown): number {
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    Array.isArray(payload) ||
+    !("schemaVersion" in payload) ||
+    typeof payload.schemaVersion !== "number" ||
+    !Number.isSafeInteger(payload.schemaVersion) ||
+    payload.schemaVersion < 1
+  ) {
+    throw new Error("Official Workflow catalog payload version is invalid");
+  }
+  return payload.schemaVersion;
 }
 
 function acceptedRevisionFromRow(
@@ -81,6 +97,11 @@ export async function readAcceptedOfficialWorkflowCatalog(
     .limit(1);
   signal?.throwIfAborted();
   if (!row) {
+    return null;
+  }
+  if (
+    catalogSchemaVersion(row.payload) < OFFICIAL_WORKFLOW_CATALOG_SCHEMA_VERSION
+  ) {
     return null;
   }
   return {

--- a/turbo/apps/api/src/signals/services/official-workflow-catalog-source.ts
+++ b/turbo/apps/api/src/signals/services/official-workflow-catalog-source.ts
@@ -90,21 +90,12 @@ export const OFFICIAL_WORKFLOW_SOURCE_CATALOG: OfficialWorkflowSourceCatalog =
         blueprints: [
           {
             key: "daily-delivery",
-            parameters: [
-              {
-                key: "timezone",
-                type: "string",
-                format: "timezone",
-                required: true,
-                derivation: { kind: "user-timezone" },
-              },
-            ],
+            parameters: [],
             desiredState: {
               kind: "schedule",
               schedule: {
                 type: "cron",
                 cronExpression: "0 7 * * *",
-                timezone: { parameter: "timezone" },
               },
             },
             runtime: { resultEmail: true },
@@ -125,21 +116,12 @@ export const OFFICIAL_WORKFLOW_SOURCE_CATALOG: OfficialWorkflowSourceCatalog =
         blueprints: [
           {
             key: "weekly-check",
-            parameters: [
-              {
-                key: "timezone",
-                type: "string",
-                format: "timezone",
-                required: true,
-                derivation: { kind: "user-timezone" },
-              },
-            ],
+            parameters: [],
             desiredState: {
               kind: "schedule",
               schedule: {
                 type: "cron",
                 cronExpression: "0 9 * * 1",
-                timezone: { parameter: "timezone" },
               },
             },
             runtime: { resultEmail: false },

--- a/turbo/apps/api/src/signals/services/official-workflow-catalog-validation.service.ts
+++ b/turbo/apps/api/src/signals/services/official-workflow-catalog-validation.service.ts
@@ -345,6 +345,20 @@ function resolveTemplateValue(
   return value;
 }
 
+function withValidationScheduleTimezone(value: unknown): unknown {
+  if (!isJsonObject(value) || !isJsonObject(value.schedule)) {
+    return value;
+  }
+  const schedule = value.schedule;
+  if (
+    (schedule.type === "cron" || schedule.type === "once") &&
+    schedule.timezone === undefined
+  ) {
+    return { ...value, schedule: { ...schedule, timezone: "UTC" } };
+  }
+  return value;
+}
+
 function canonicalizeSetLikeArrays(
   value: OfficialWorkflowTemplateJsonValue,
 ): OfficialWorkflowTemplateJsonValue {
@@ -576,32 +590,6 @@ function validateBlueprintParameters(
       );
     }
     parameters.set(parameter.key, parameter);
-    if (
-      parameter.type === "string" &&
-      parameter.derivation !== undefined &&
-      parameter.format !== "timezone"
-    ) {
-      args.diagnostics.push(
-        diagnostic(
-          "invalid-parameter-declaration",
-          [...parameterPath, "derivation"],
-          args.context,
-        ),
-      );
-    }
-    if (
-      parameter.type === "string" &&
-      parameter.default !== undefined &&
-      parameter.derivation !== undefined
-    ) {
-      args.diagnostics.push(
-        diagnostic(
-          "invalid-parameter-declaration",
-          parameterPath,
-          args.context,
-        ),
-      );
-    }
     if (parameter.type === "string" && !stringDefaultIsValid(parameter)) {
       args.diagnostics.push(
         diagnostic(
@@ -658,9 +646,11 @@ function validateBlueprintDesiredState(
       );
     }
   }
-  const desiredState = resolveTemplateValue(
-    blueprint.desiredState as OfficialWorkflowTemplateJsonValue,
-    parameters,
+  const desiredState = withValidationScheduleTimezone(
+    resolveTemplateValue(
+      blueprint.desiredState as OfficialWorkflowTemplateJsonValue,
+      parameters,
+    ),
   );
   let structurallyValid = false;
   if (isJsonObject(desiredState)) {

--- a/turbo/apps/api/src/signals/services/official-workflow-installation.service.ts
+++ b/turbo/apps/api/src/signals/services/official-workflow-installation.service.ts
@@ -299,6 +299,8 @@ function resolveParameterBindings(
       parameter.type === "string" &&
       parameter.derivation?.kind === "user-timezone"
     ) {
+      // Immutable accepted revisions published before owner-timezone schedule
+      // defaults still resolve through their historical parameter contract.
       if (!userTimezone || !isValidTimeZone(userTimezone)) {
         return {
           ok: false,
@@ -370,6 +372,37 @@ function materializeTemplate(
   return { ok: true, value };
 }
 
+function withOwnerScheduleTimezone(
+  desiredState: Record<string, unknown>,
+  userTimezone: string | null,
+  blueprintKey: string,
+):
+  | { readonly ok: true; readonly value: Record<string, unknown> }
+  | { readonly ok: false; readonly message: string } {
+  if (
+    desiredState.kind !== "schedule" ||
+    !isJsonObject(desiredState.schedule) ||
+    (desiredState.schedule.type !== "cron" &&
+      desiredState.schedule.type !== "once") ||
+    desiredState.schedule.timezone !== undefined
+  ) {
+    return { ok: true, value: desiredState };
+  }
+  if (!userTimezone || !isValidTimeZone(userTimezone)) {
+    return {
+      ok: false,
+      message: `A valid user timezone preference is required for Blueprint: ${blueprintKey}`,
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      ...desiredState,
+      schedule: { ...desiredState.schedule, timezone: userTimezone },
+    },
+  };
+}
+
 function resolveBlueprint(
   blueprint: OfficialWorkflowAcceptedBlueprint,
   supplied: OfficialWorkflowBlueprintBindings,
@@ -403,7 +436,15 @@ function resolveBlueprint(
   if (!isJsonObject(desired.value)) {
     return { ok: false, message: `Invalid Blueprint: ${blueprint.key}` };
   }
-  const { autonomyBudget, ...createDesiredState } = desired.value;
+  const desiredWithTimezone = withOwnerScheduleTimezone(
+    desired.value,
+    userTimezone,
+    blueprint.key,
+  );
+  if (!desiredWithTimezone.ok) {
+    return desiredWithTimezone;
+  }
+  const { autonomyBudget, ...createDesiredState } = desiredWithTimezone.value;
   if (
     autonomyBudget !== undefined &&
     (typeof autonomyBudget !== "number" ||
@@ -521,6 +562,8 @@ export function resolveOfficialWorkflowBlueprintForReconciliation(
       userTimezone !== null &&
       isValidTimeZone(userTimezone)
     ) {
+      // See resolveParameterBindings: this branch only serves immutable legacy
+      // accepted revisions until they are reconciled to a current Definition.
       value = userTimezone;
     }
     if (value === undefined) {

--- a/turbo/apps/api/src/signals/services/official-workflow-installation.service.ts
+++ b/turbo/apps/api/src/signals/services/official-workflow-installation.service.ts
@@ -252,7 +252,6 @@ function validParameterValue(
 function resolveParameterBindings(
   blueprint: OfficialWorkflowAcceptedBlueprint,
   supplied: OfficialWorkflowBlueprintBindings,
-  userTimezone: string | null,
 ):
   | {
       readonly ok: true;
@@ -293,21 +292,6 @@ function resolveParameterBindings(
     let value = suppliedByKey.get(parameter.key);
     if (value === undefined && parameter.default !== undefined) {
       value = parameter.default;
-    }
-    if (
-      value === undefined &&
-      parameter.type === "string" &&
-      parameter.derivation?.kind === "user-timezone"
-    ) {
-      // Immutable accepted revisions published before owner-timezone schedule
-      // defaults still resolve through their historical parameter contract.
-      if (!userTimezone || !isValidTimeZone(userTimezone)) {
-        return {
-          ok: false,
-          message: `A valid user timezone is required for parameter: ${blueprint.key}.${parameter.key}`,
-        };
-      }
-      value = userTimezone;
     }
     if (value === undefined) {
       if (parameter.required) {
@@ -372,9 +356,9 @@ function materializeTemplate(
   return { ok: true, value };
 }
 
-function withOwnerScheduleTimezone(
+function withScheduleTimezoneDefault(
   desiredState: Record<string, unknown>,
-  userTimezone: string | null,
+  defaultTimezone: string | null,
   blueprintKey: string,
 ):
   | { readonly ok: true; readonly value: Record<string, unknown> }
@@ -388,7 +372,7 @@ function withOwnerScheduleTimezone(
   ) {
     return { ok: true, value: desiredState };
   }
-  if (!userTimezone || !isValidTimeZone(userTimezone)) {
+  if (!defaultTimezone || !isValidTimeZone(defaultTimezone)) {
     return {
       ok: false,
       message: `A valid user timezone preference is required for Blueprint: ${blueprintKey}`,
@@ -398,7 +382,7 @@ function withOwnerScheduleTimezone(
     ok: true,
     value: {
       ...desiredState,
-      schedule: { ...desiredState.schedule, timezone: userTimezone },
+      schedule: { ...desiredState.schedule, timezone: defaultTimezone },
     },
   };
 }
@@ -406,15 +390,11 @@ function withOwnerScheduleTimezone(
 function resolveBlueprint(
   blueprint: OfficialWorkflowAcceptedBlueprint,
   supplied: OfficialWorkflowBlueprintBindings,
-  userTimezone: string | null,
+  defaultTimezone: string | null,
 ):
   | { readonly ok: true; readonly blueprint: ResolvedBlueprint }
   | { readonly ok: false; readonly message: string } {
-  const resolvedBindings = resolveParameterBindings(
-    blueprint,
-    supplied,
-    userTimezone,
-  );
+  const resolvedBindings = resolveParameterBindings(blueprint, supplied);
   if (!resolvedBindings.ok) {
     return resolvedBindings;
   }
@@ -436,9 +416,9 @@ function resolveBlueprint(
   if (!isJsonObject(desired.value)) {
     return { ok: false, message: `Invalid Blueprint: ${blueprint.key}` };
   }
-  const desiredWithTimezone = withOwnerScheduleTimezone(
+  const desiredWithTimezone = withScheduleTimezoneDefault(
     desired.value,
-    userTimezone,
+    defaultTimezone,
     blueprint.key,
   );
   if (!desiredWithTimezone.ok) {
@@ -482,7 +462,7 @@ function resolveBlueprint(
 /**
  * Resolve one current Blueprint from a prior Installation projection. Values
  * for removed or now-invalid parameter keys are deliberately discarded before
- * current defaults and derivations are applied.
+ * current defaults are applied.
  */
 function reconciliationParameterValues(
   blueprint: OfficialWorkflowAcceptedBlueprint,
@@ -537,7 +517,7 @@ export function resolveOfficialWorkflowBlueprintForReconciliation(
   blueprint: OfficialWorkflowAcceptedBlueprint,
   existing: readonly OfficialWorkflowParameterBinding[],
   overrides: readonly OfficialWorkflowParameterBinding[],
-  userTimezone: string | null,
+  defaultTimezone: string | null,
 ): OfficialWorkflowBlueprintReconciliationResolution {
   const parameterValues = reconciliationParameterValues(
     blueprint,
@@ -555,17 +535,6 @@ export function resolveOfficialWorkflowBlueprintForReconciliation(
     if (value === undefined && parameter.default !== undefined) {
       value = parameter.default;
     }
-    if (
-      value === undefined &&
-      parameter.type === "string" &&
-      parameter.derivation?.kind === "user-timezone" &&
-      userTimezone !== null &&
-      isValidTimeZone(userTimezone)
-    ) {
-      // See resolveParameterBindings: this branch only serves immutable legacy
-      // accepted revisions until they are reconciled to a current Definition.
-      value = userTimezone;
-    }
     if (value === undefined) {
       if (parameter.required && unresolvedMessage === undefined) {
         unresolvedMessage = `Missing parameter: ${blueprint.key}.${parameter.key}`;
@@ -580,7 +549,7 @@ export function resolveOfficialWorkflowBlueprintForReconciliation(
   const resolved = resolveBlueprint(
     blueprint,
     { blueprintKey: blueprint.key, bindings },
-    userTimezone,
+    defaultTimezone,
   );
   return resolved.ok
     ? { ok: true, resolved: resolved.blueprint }
@@ -590,7 +559,7 @@ export function resolveOfficialWorkflowBlueprintForReconciliation(
 function resolveAllBlueprints(
   blueprints: readonly OfficialWorkflowAcceptedBlueprint[],
   supplied: readonly OfficialWorkflowBlueprintBindings[],
-  userTimezone: string | null,
+  defaultTimezone: string | null,
 ): ResolveResult {
   const suppliedByKey = new Map<string, OfficialWorkflowBlueprintBindings>();
   for (const entry of supplied) {
@@ -627,7 +596,7 @@ function resolveAllBlueprints(
     if (!entry) {
       throw new Error("Resolved Blueprint binding disappeared");
     }
-    const result = resolveBlueprint(blueprint, entry, userTimezone);
+    const result = resolveBlueprint(blueprint, entry, defaultTimezone);
     if (!result.ok) {
       return result;
     }

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -634,13 +634,6 @@ function officialCatalogDetail(
         fingerprint: OFFICIAL_BLUEPRINT_FINGERPRINT,
         parameters: [
           {
-            key: "time-zone",
-            type: "string",
-            format: "timezone",
-            required: true,
-            derivation: { kind: "user-timezone" },
-          },
-          {
             key: "interval-seconds",
             type: "integer",
             required: true,
@@ -705,7 +698,6 @@ function officialSalesResearch(
           reconciliationStatus,
           intendedEnabled: true,
           parameterBindings: [
-            { key: "time-zone", value: "UTC" },
             { key: "interval-seconds", value: 3600 },
             { key: "include-weekends", value: false },
           ],
@@ -1570,7 +1562,7 @@ describe("workflows routes", () => {
     expect(queryButtonByText("Install")).toBeNull();
   });
 
-  it("preselects the default Agent and hides legacy derived timezone parameters", async () => {
+  it("preselects the default Agent and installs every Blueprint with typed parameters", async () => {
     const definition = officialCatalogDetail();
     const installBodies: unknown[] = [];
     mockAgentPageApis();
@@ -1607,7 +1599,6 @@ describe("workflows routes", () => {
     );
     const dialog = await screen.findByRole("dialog");
     expect(within(dialog).getByText("Research Bot")).toBeInTheDocument();
-    expect(within(dialog).queryByLabelText("time-zone (required)")).toBeNull();
     expect(
       within(dialog).getByLabelText("interval-seconds (required)"),
     ).toHaveValue(3600);
@@ -2749,7 +2740,6 @@ describe("workflow detail page", () => {
     expect(
       within(dialog).getByLabelText("interval-seconds (required)"),
     ).toHaveValue(3600);
-    expect(within(dialog).queryByLabelText("time-zone (required)")).toBeNull();
     fireEvent.change(
       within(dialog).getByLabelText("interval-seconds (required)"),
       { target: { value: "1800" } },
@@ -2814,7 +2804,6 @@ describe("workflow detail page", () => {
           official: {
             ...secondAutomation.official,
             parameterBindings: [
-              { key: "time-zone", value: "America/New_York" },
               { key: "interval-seconds", value: 7200 },
               { key: "include-weekends", value: true },
             ],
@@ -2883,9 +2872,6 @@ describe("workflow detail page", () => {
       }),
     );
     const firstDialog = await screen.findByRole("dialog");
-    expect(
-      within(firstDialog).queryByLabelText("time-zone (required)"),
-    ).toBeNull();
     fireEvent.change(
       within(firstDialog).getByLabelText("interval-seconds (required)"),
       { target: { value: "1800" } },
@@ -2911,9 +2897,6 @@ describe("workflow detail page", () => {
 
     click(buttonByText("Reconfigure"));
     const secondDialog = await screen.findByRole("dialog");
-    expect(
-      within(secondDialog).queryByLabelText("time-zone (required)"),
-    ).toBeNull();
     expect(
       within(secondDialog).getByLabelText("interval-seconds (required)"),
     ).toHaveValue(7200);

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -1570,12 +1570,11 @@ describe("workflows routes", () => {
     expect(queryButtonByText("Install")).toBeNull();
   });
 
-  it("preselects the default Agent and installs every Blueprint with typed parameters", async () => {
+  it("preselects the default Agent and hides legacy derived timezone parameters", async () => {
     const definition = officialCatalogDetail();
     const installBodies: unknown[] = [];
     mockAgentPageApis();
     context.mocks.data.onboardingStatus({ defaultAgentId: AGENT_ID });
-    context.mocks.data.userPreferences({ timezone: "UTC" });
     mockWorkflowApis([officialSalesResearch()]);
     context.mocks.api(officialWorkflowsContract.get, ({ respond }) => {
       return respond(200, definition);
@@ -1608,9 +1607,7 @@ describe("workflows routes", () => {
     );
     const dialog = await screen.findByRole("dialog");
     expect(within(dialog).getByText("Research Bot")).toBeInTheDocument();
-    expect(within(dialog).getByLabelText("time-zone (required)")).toHaveValue(
-      "UTC",
-    );
+    expect(within(dialog).queryByLabelText("time-zone (required)")).toBeNull();
     expect(
       within(dialog).getByLabelText("interval-seconds (required)"),
     ).toHaveValue(3600);
@@ -1639,7 +1636,6 @@ describe("workflows routes", () => {
             {
               blueprintKey: "daily",
               bindings: [
-                { key: "time-zone", value: "UTC" },
                 { key: "interval-seconds", value: 7200 },
                 { key: "include-weekends", value: true },
               ],
@@ -2638,6 +2634,49 @@ describe("workflow detail page", () => {
     expect(buttonByText("Uninstall")).toBeEnabled();
   });
 
+  it("omits reconfiguration when the Definition has no configurable parameters", async () => {
+    const workflow = officialSalesResearch();
+    const definition = officialCatalogDetail();
+    const parameterlessBlueprints = definition.blueprints.map((blueprint) => {
+      return {
+        ...blueprint,
+        parameters: [],
+        desiredState: {
+          kind: "schedule" as const,
+          schedule: {
+            type: "cron" as const,
+            cronExpression: "0 8 * * *",
+          },
+        },
+      };
+    });
+    let installationRead = false;
+    mockWorkflowApis([workflow]);
+    context.mocks.api(
+      officialWorkflowInstallationsContract.get,
+      ({ respond }) => {
+        installationRead = true;
+        return respond(200, {
+          workflow,
+          definition: {
+            name: definition.name,
+            revision: definition.revision,
+            lifecycle: "active",
+            blueprints: parameterlessBlueprints,
+          },
+        });
+      },
+    );
+
+    detachedSetupWorkflowDetailPage(workflowDetailPath("info"));
+
+    await waitFor(() => {
+      expect(installationRead).toBeTruthy();
+      expect(queryButtonByText("Reconfigure")).toBeNull();
+    });
+    expect(buttonByText("Uninstall")).toBeEnabled();
+  });
+
   it.each([
     ["current", "Current · intended on"],
     ["reconciling", "Reconciling · intended on"],
@@ -2710,9 +2749,7 @@ describe("workflow detail page", () => {
     expect(
       within(dialog).getByLabelText("interval-seconds (required)"),
     ).toHaveValue(3600);
-    fireEvent.change(within(dialog).getByLabelText("time-zone (required)"), {
-      target: { value: "Asia/Shanghai" },
-    });
+    expect(within(dialog).queryByLabelText("time-zone (required)")).toBeNull();
     fireEvent.change(
       within(dialog).getByLabelText("interval-seconds (required)"),
       { target: { value: "1800" } },
@@ -2731,7 +2768,6 @@ describe("workflow detail page", () => {
             {
               blueprintKey: "daily",
               bindings: [
-                { key: "time-zone", value: "Asia/Shanghai" },
                 { key: "interval-seconds", value: 1800 },
                 { key: "include-weekends", value: true },
               ],
@@ -2790,7 +2826,6 @@ describe("workflow detail page", () => {
     const installationReads: string[] = [];
     const reconfigureRequests: unknown[] = [];
     mockAgentPageApis();
-    context.mocks.data.userPreferences({ timezone: "UTC" });
     mockWorkflowApis(workflows);
     context.mocks.api(
       officialWorkflowInstallationsContract.get,
@@ -2848,10 +2883,9 @@ describe("workflow detail page", () => {
       }),
     );
     const firstDialog = await screen.findByRole("dialog");
-    fireEvent.change(
-      within(firstDialog).getByLabelText("time-zone (required)"),
-      { target: { value: "Asia/Shanghai" } },
-    );
+    expect(
+      within(firstDialog).queryByLabelText("time-zone (required)"),
+    ).toBeNull();
     fireEvent.change(
       within(firstDialog).getByLabelText("interval-seconds (required)"),
       { target: { value: "1800" } },
@@ -2878,8 +2912,8 @@ describe("workflow detail page", () => {
     click(buttonByText("Reconfigure"));
     const secondDialog = await screen.findByRole("dialog");
     expect(
-      within(secondDialog).getByLabelText("time-zone (required)"),
-    ).toHaveValue("America/New_York");
+      within(secondDialog).queryByLabelText("time-zone (required)"),
+    ).toBeNull();
     expect(
       within(secondDialog).getByLabelText("interval-seconds (required)"),
     ).toHaveValue(7200);
@@ -2888,10 +2922,6 @@ describe("workflow detail page", () => {
         name: "include-weekends (required)",
       }),
     ).toHaveTextContent("Yes");
-    fireEvent.change(
-      within(secondDialog).getByLabelText("time-zone (required)"),
-      { target: { value: "Europe/London" } },
-    );
     click(buttonByText("Reconfigure", secondDialog));
 
     await waitFor(() => {
@@ -2905,7 +2935,6 @@ describe("workflow detail page", () => {
                 bindings: [
                   { key: "interval-seconds", value: 7200 },
                   { key: "include-weekends", value: true },
-                  { key: "time-zone", value: "Europe/London" },
                 ],
               },
             ],

--- a/turbo/apps/platform/src/views/workflows-page/official-workflow-configuration.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/official-workflow-configuration.tsx
@@ -1,5 +1,6 @@
 import type {
   OfficialWorkflowAcceptedBlueprint,
+  OfficialWorkflowInstallationParameter,
   OfficialWorkflowParameterBinding,
   OfficialWorkflowParameterValue,
 } from "@okouai/api-contracts/contracts/official-workflow-catalog";
@@ -26,36 +27,16 @@ interface ConfigurationAgent {
   readonly displayName?: string | null;
 }
 
-type AcceptedInstallationParameter =
-  OfficialWorkflowAcceptedBlueprint["parameters"][number];
-
-function isLegacyUserTimezoneParameter(
-  parameter: AcceptedInstallationParameter,
-): boolean {
-  return (
-    parameter.type === "string" &&
-    parameter.derivation?.kind === "user-timezone"
-  );
-}
-
-function configurableParameters(
-  blueprint: OfficialWorkflowAcceptedBlueprint,
-): readonly AcceptedInstallationParameter[] {
-  return blueprint.parameters.filter((parameter) => {
-    return !isLegacyUserTimezoneParameter(parameter);
-  });
-}
-
 export function officialWorkflowHasConfigurableParameters(
   blueprints: readonly OfficialWorkflowAcceptedBlueprint[],
 ): boolean {
   return blueprints.some((blueprint) => {
-    return configurableParameters(blueprint).length > 0;
+    return blueprint.parameters.length > 0;
   });
 }
 
 function parameterInitialValue(
-  parameter: AcceptedInstallationParameter,
+  parameter: OfficialWorkflowInstallationParameter,
   current: ReadonlyMap<string, OfficialWorkflowParameterValue>,
 ): OfficialWorkflowParameterValue | undefined {
   const currentValue = current.get(parameter.key);
@@ -78,9 +59,6 @@ function initialBlueprintBindings(
     }),
   );
   return blueprint.parameters.flatMap((parameter) => {
-    if (isLegacyUserTimezoneParameter(parameter)) {
-      return [];
-    }
     const value = parameterInitialValue(parameter, currentByKey);
     return value === undefined ? [] : [{ key: parameter.key, value }];
   });
@@ -140,7 +118,6 @@ export function officialWorkflowConfigurationComplete(
   return blueprints.every((blueprint) => {
     return blueprint.parameters.every((parameter) => {
       return (
-        isLegacyUserTimezoneParameter(parameter) ||
         !parameter.required ||
         bindingValue(form, blueprint.key, parameter.key) !== undefined
       );
@@ -155,7 +132,7 @@ function ParameterField({
   disabled,
 }: {
   readonly blueprintKey: string;
-  readonly parameter: AcceptedInstallationParameter;
+  readonly parameter: OfficialWorkflowInstallationParameter;
   readonly value: OfficialWorkflowParameterValue | undefined;
   readonly disabled: boolean;
 }) {
@@ -298,7 +275,6 @@ export function OfficialWorkflowConfigurationFields({
         </div>
       ) : null}
       {blueprints.map((blueprint) => {
-        const parameters = configurableParameters(blueprint);
         return (
           <section
             key={blueprint.key}
@@ -313,13 +289,13 @@ export function OfficialWorkflowConfigurationFields({
                   ($) => {
                     return $.workflows.official.parameterCount;
                   },
-                  { count: parameters.length },
+                  { count: blueprint.parameters.length },
                 )}
               </p>
             </div>
-            {parameters.length > 0 ? (
+            {blueprint.parameters.length > 0 ? (
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                {parameters.map((parameter) => {
+                {blueprint.parameters.map((parameter) => {
                   return (
                     <ParameterField
                       key={parameter.key}

--- a/turbo/apps/platform/src/views/workflows-page/official-workflow-configuration.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/official-workflow-configuration.tsx
@@ -1,6 +1,5 @@
 import type {
   OfficialWorkflowAcceptedBlueprint,
-  OfficialWorkflowInstallationParameter,
   OfficialWorkflowParameterBinding,
   OfficialWorkflowParameterValue,
 } from "@okouai/api-contracts/contracts/official-workflow-catalog";
@@ -27,10 +26,37 @@ interface ConfigurationAgent {
   readonly displayName?: string | null;
 }
 
+type AcceptedInstallationParameter =
+  OfficialWorkflowAcceptedBlueprint["parameters"][number];
+
+function isLegacyUserTimezoneParameter(
+  parameter: AcceptedInstallationParameter,
+): boolean {
+  return (
+    parameter.type === "string" &&
+    parameter.derivation?.kind === "user-timezone"
+  );
+}
+
+function configurableParameters(
+  blueprint: OfficialWorkflowAcceptedBlueprint,
+): readonly AcceptedInstallationParameter[] {
+  return blueprint.parameters.filter((parameter) => {
+    return !isLegacyUserTimezoneParameter(parameter);
+  });
+}
+
+export function officialWorkflowHasConfigurableParameters(
+  blueprints: readonly OfficialWorkflowAcceptedBlueprint[],
+): boolean {
+  return blueprints.some((blueprint) => {
+    return configurableParameters(blueprint).length > 0;
+  });
+}
+
 function parameterInitialValue(
-  parameter: OfficialWorkflowInstallationParameter,
+  parameter: AcceptedInstallationParameter,
   current: ReadonlyMap<string, OfficialWorkflowParameterValue>,
-  userTimezone: string,
 ): OfficialWorkflowParameterValue | undefined {
   const currentValue = current.get(parameter.key);
   if (currentValue !== undefined) {
@@ -39,16 +65,12 @@ function parameterInitialValue(
   if (parameter.default !== undefined) {
     return parameter.default;
   }
-  return parameter.type === "string" &&
-    parameter.derivation?.kind === "user-timezone"
-    ? userTimezone
-    : undefined;
+  return undefined;
 }
 
 function initialBlueprintBindings(
   blueprint: OfficialWorkflowAcceptedBlueprint,
   current: readonly OfficialWorkflowParameterBinding[],
-  userTimezone: string,
 ) {
   const currentByKey = new Map(
     current.map((binding) => {
@@ -56,7 +78,10 @@ function initialBlueprintBindings(
     }),
   );
   return blueprint.parameters.flatMap((parameter) => {
-    const value = parameterInitialValue(parameter, currentByKey, userTimezone);
+    if (isLegacyUserTimezoneParameter(parameter)) {
+      return [];
+    }
+    const value = parameterInitialValue(parameter, currentByKey);
     return value === undefined ? [] : [{ key: parameter.key, value }];
   });
 }
@@ -67,7 +92,6 @@ export function createOfficialWorkflowConfigurationForm(args: {
   readonly agentId: string;
   readonly blueprints: readonly OfficialWorkflowAcceptedBlueprint[];
   readonly automations?: readonly WorkflowAutomationSummary[];
-  readonly userTimezone: string;
 }): OfficialWorkflowConfigurationForm {
   const automationByBlueprint = new Map(
     (args.automations ?? []).flatMap((automation) => {
@@ -86,11 +110,7 @@ export function createOfficialWorkflowConfigurationForm(args: {
         [];
       return {
         blueprintKey: blueprint.key,
-        bindings: initialBlueprintBindings(
-          blueprint,
-          current,
-          args.userTimezone,
-        ),
+        bindings: initialBlueprintBindings(blueprint, current),
       };
     }),
   };
@@ -120,6 +140,7 @@ export function officialWorkflowConfigurationComplete(
   return blueprints.every((blueprint) => {
     return blueprint.parameters.every((parameter) => {
       return (
+        isLegacyUserTimezoneParameter(parameter) ||
         !parameter.required ||
         bindingValue(form, blueprint.key, parameter.key) !== undefined
       );
@@ -134,7 +155,7 @@ function ParameterField({
   disabled,
 }: {
   readonly blueprintKey: string;
-  readonly parameter: OfficialWorkflowInstallationParameter;
+  readonly parameter: AcceptedInstallationParameter;
   readonly value: OfficialWorkflowParameterValue | undefined;
   readonly disabled: boolean;
 }) {
@@ -277,6 +298,7 @@ export function OfficialWorkflowConfigurationFields({
         </div>
       ) : null}
       {blueprints.map((blueprint) => {
+        const parameters = configurableParameters(blueprint);
         return (
           <section
             key={blueprint.key}
@@ -291,13 +313,13 @@ export function OfficialWorkflowConfigurationFields({
                   ($) => {
                     return $.workflows.official.parameterCount;
                   },
-                  { count: blueprint.parameters.length },
+                  { count: parameters.length },
                 )}
               </p>
             </div>
-            {blueprint.parameters.length > 0 ? (
+            {parameters.length > 0 ? (
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                {blueprint.parameters.map((parameter) => {
+                {parameters.map((parameter) => {
                   return (
                     <ParameterField
                       key={parameter.key}

--- a/turbo/apps/platform/src/views/workflows-page/official-workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/official-workflows-page.tsx
@@ -48,7 +48,6 @@ import {
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { ROUTES } from "../../signals/route-paths.ts";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
-import { userPreferences$ } from "../../signals/okou-page/settings/user-preferences.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
 import {
@@ -403,15 +402,10 @@ function InstallDialog({
 function OfficialWorkflowDefinitionPage() {
   const definitionLoadable = useLoadable(currentOfficialWorkflowDefinition$);
   const defaultAgentId = useLastResolved(defaultAgentId$) ?? "";
-  const preferences = useLastResolved(userPreferences$);
   const setForm = useSet(setOfficialWorkflowConfigurationForm$);
   const reload = useSet(reloadOfficialWorkflows$);
   const definition =
     definitionLoadable.state === "hasData" ? definitionLoadable.data : null;
-  const userTimezone =
-    preferences?.timezone ??
-    new Intl.DateTimeFormat().resolvedOptions().timeZone;
-
   return (
     <DetailPageShell>
       <DetailPageBreadcrumbBar>
@@ -449,7 +443,6 @@ function OfficialWorkflowDefinitionPage() {
                       definitionName: definition.name,
                       agentId: defaultAgentId,
                       blueprints: definition.blueprints,
-                      userTimezone,
                     }),
                   );
                 }}

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -270,6 +270,7 @@ import {
   createOfficialWorkflowConfigurationForm,
   OfficialWorkflowConfigurationFields,
   officialWorkflowConfigurationComplete,
+  officialWorkflowHasConfigurableParameters,
 } from "./official-workflow-configuration.tsx";
 
 const AUTOMATION_FIELD_CLASS = "h-8 px-2 text-xs";
@@ -1584,15 +1585,20 @@ function OfficialWorkflowInstallationSettings({
   const installation =
     installationLoadable.state === "hasData" ? installationLoadable.data : null;
   const definition = installation?.definition;
+  const canReconfigure =
+    definition === undefined ||
+    officialWorkflowHasConfigurableParameters(definition.blueprints);
   return (
     <>
-      <OfficialWorkflowReconfigureCard
-        detail={detail}
-        definition={definition}
-        loading={installationLoadable.state === "loading"}
-      />
+      {canReconfigure ? (
+        <OfficialWorkflowReconfigureCard
+          detail={detail}
+          definition={definition}
+          loading={installationLoadable.state === "loading"}
+        />
+      ) : null}
       <OfficialWorkflowUninstallCard />
-      {definition ? (
+      {definition && canReconfigure ? (
         <OfficialWorkflowReconfigureDialog
           detail={detail}
           definition={definition}
@@ -1612,10 +1618,6 @@ function OfficialWorkflowReconfigureCard({
   readonly loading: boolean;
 }) {
   const setForm = useSet(setOfficialWorkflowConfigurationForm$);
-  const preferences = useLastResolved(userPreferences$);
-  const userTimezone =
-    preferences?.timezone ??
-    new Intl.DateTimeFormat().resolvedOptions().timeZone;
   const description = definition
     ? i18n.t(($) => {
         return $.workflows.official.reconfigureDescription;
@@ -1638,9 +1640,7 @@ function OfficialWorkflowReconfigureCard({
             variant="outline"
             size="sm"
             className="zero-btn-morandi h-9 rounded-lg"
-            disabled={
-              !definition || definition.blueprints.length === 0 || loading
-            }
+            disabled={!definition || loading}
             onClick={() => {
               if (!definition) {
                 return;
@@ -1655,7 +1655,6 @@ function OfficialWorkflowReconfigureCard({
                   agentId: detail.agentId,
                   blueprints: definition.blueprints,
                   automations: detail.automations,
-                  userTimezone,
                 }),
               );
             }}

--- a/turbo/packages/api-contracts/src/contracts/__tests__/official-workflows.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/official-workflows.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  officialWorkflowAcceptedBlueprintSchema,
+  officialWorkflowBlueprintSchema,
+} from "../official-workflow-catalog";
+import {
   officialWorkflowCatalogDetailSchema,
   officialWorkflowInstallationDefinitionSchema,
 } from "../official-workflows";
@@ -80,6 +84,40 @@ describe("Official Workflow product contracts", () => {
         ...definition,
         lifecycle: "unavailable",
       }).success,
+    ).toBe(false);
+  });
+
+  it("reads legacy accepted timezone derivations without allowing new source declarations", () => {
+    const legacyBlueprint = {
+      key: "daily-brief",
+      parameters: [
+        {
+          key: "timezone",
+          type: "string" as const,
+          format: "timezone" as const,
+          required: true,
+          derivation: { kind: "user-timezone" as const },
+        },
+      ],
+      desiredState: {
+        kind: "schedule" as const,
+        schedule: {
+          type: "cron" as const,
+          cronExpression: "0 8 * * *",
+          timezone: { parameter: "timezone" },
+        },
+      },
+      runtime: { resultEmail: true },
+    };
+
+    expect(
+      officialWorkflowAcceptedBlueprintSchema.safeParse({
+        ...legacyBlueprint,
+        fingerprint: FINGERPRINT,
+      }).success,
+    ).toBe(true);
+    expect(
+      officialWorkflowBlueprintSchema.safeParse(legacyBlueprint).success,
     ).toBe(false);
   });
 });

--- a/turbo/packages/api-contracts/src/contracts/__tests__/official-workflows.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/official-workflows.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  officialWorkflowAcceptedBlueprintSchema,
-  officialWorkflowBlueprintSchema,
-} from "../official-workflow-catalog";
-import {
   officialWorkflowCatalogDetailSchema,
   officialWorkflowInstallationDefinitionSchema,
 } from "../official-workflows";
@@ -84,40 +80,6 @@ describe("Official Workflow product contracts", () => {
         ...definition,
         lifecycle: "unavailable",
       }).success,
-    ).toBe(false);
-  });
-
-  it("reads legacy accepted timezone derivations without allowing new source declarations", () => {
-    const legacyBlueprint = {
-      key: "daily-brief",
-      parameters: [
-        {
-          key: "timezone",
-          type: "string" as const,
-          format: "timezone" as const,
-          required: true,
-          derivation: { kind: "user-timezone" as const },
-        },
-      ],
-      desiredState: {
-        kind: "schedule" as const,
-        schedule: {
-          type: "cron" as const,
-          cronExpression: "0 8 * * *",
-          timezone: { parameter: "timezone" },
-        },
-      },
-      runtime: { resultEmail: true },
-    };
-
-    expect(
-      officialWorkflowAcceptedBlueprintSchema.safeParse({
-        ...legacyBlueprint,
-        fingerprint: FINGERPRINT,
-      }).success,
-    ).toBe(true);
-    expect(
-      officialWorkflowBlueprintSchema.safeParse(legacyBlueprint).success,
     ).toBe(false);
   });
 });

--- a/turbo/packages/api-contracts/src/contracts/official-workflow-catalog.ts
+++ b/turbo/packages/api-contracts/src/contracts/official-workflow-catalog.ts
@@ -266,30 +266,8 @@ export type OfficialWorkflowArtifactReference = z.infer<
   typeof officialWorkflowArtifactReferenceSchema
 >;
 
-const legacyOfficialWorkflowUserTimezoneDerivationSchema = z
-  .object({ kind: z.literal("user-timezone") })
-  .strict();
-
-// Accepted revisions are immutable persisted data. Revisions published before
-// schedule timezones became owner defaults can still contain this field, while
-// current source Definitions cannot declare it through the source schema above.
-const acceptedOfficialWorkflowStringParameterSchema =
-  officialWorkflowStringParameterSchema.extend({
-    derivation: legacyOfficialWorkflowUserTimezoneDerivationSchema.optional(),
-  });
-
-const acceptedOfficialWorkflowInstallationParameterSchema =
-  z.discriminatedUnion("type", [
-    acceptedOfficialWorkflowStringParameterSchema,
-    officialWorkflowIntegerParameterSchema,
-    officialWorkflowBooleanParameterSchema,
-  ]);
-
 export const officialWorkflowAcceptedBlueprintSchema =
-  officialWorkflowBlueprintSchema.extend({
-    parameters: z.array(acceptedOfficialWorkflowInstallationParameterSchema),
-    fingerprint: fingerprintSchema,
-  });
+  officialWorkflowBlueprintSchema.extend({ fingerprint: fingerprintSchema });
 export type OfficialWorkflowAcceptedBlueprint = z.infer<
   typeof officialWorkflowAcceptedBlueprintSchema
 >;

--- a/turbo/packages/api-contracts/src/contracts/official-workflow-catalog.ts
+++ b/turbo/packages/api-contracts/src/contracts/official-workflow-catalog.ts
@@ -19,7 +19,7 @@ export type {
   OfficialWorkflowBlueprintBindings,
 } from "./official-workflow-bindings";
 
-export const OFFICIAL_WORKFLOW_CATALOG_SCHEMA_VERSION = 1 as const;
+export const OFFICIAL_WORKFLOW_CATALOG_SCHEMA_VERSION = 2 as const;
 
 export const officialWorkflowLifecycleSchema = z.enum(["active", "retired"]);
 export type OfficialWorkflowLifecycle = z.infer<

--- a/turbo/packages/api-contracts/src/contracts/official-workflow-catalog.ts
+++ b/turbo/packages/api-contracts/src/contracts/official-workflow-catalog.ts
@@ -26,10 +26,6 @@ export type OfficialWorkflowLifecycle = z.infer<
   typeof officialWorkflowLifecycleSchema
 >;
 
-const officialWorkflowUserTimezoneDerivationSchema = z
-  .object({ kind: z.literal("user-timezone") })
-  .strict();
-
 const officialWorkflowParameterBaseShape = {
   key: officialWorkflowParameterKeySchema,
   required: z.boolean(),
@@ -43,7 +39,6 @@ const officialWorkflowStringParameterSchema = z
       .enum(["text", "uuid", "timezone", "date-time", "url"])
       .default("text"),
     default: z.string().optional(),
-    derivation: officialWorkflowUserTimezoneDerivationSchema.optional(),
   })
   .strict();
 
@@ -120,7 +115,7 @@ export const officialWorkflowScheduleTemplateSchema = z.discriminatedUnion(
       .object({
         type: z.literal("cron"),
         cronExpression: templatedStringSchema,
-        timezone: templatedStringSchema,
+        timezone: templatedStringSchema.optional(),
       })
       .strict(),
     z
@@ -133,7 +128,7 @@ export const officialWorkflowScheduleTemplateSchema = z.discriminatedUnion(
       .object({
         type: z.literal("once"),
         atTime: templatedStringSchema,
-        timezone: templatedStringSchema,
+        timezone: templatedStringSchema.optional(),
       })
       .strict(),
   ],
@@ -271,8 +266,30 @@ export type OfficialWorkflowArtifactReference = z.infer<
   typeof officialWorkflowArtifactReferenceSchema
 >;
 
+const legacyOfficialWorkflowUserTimezoneDerivationSchema = z
+  .object({ kind: z.literal("user-timezone") })
+  .strict();
+
+// Accepted revisions are immutable persisted data. Revisions published before
+// schedule timezones became owner defaults can still contain this field, while
+// current source Definitions cannot declare it through the source schema above.
+const acceptedOfficialWorkflowStringParameterSchema =
+  officialWorkflowStringParameterSchema.extend({
+    derivation: legacyOfficialWorkflowUserTimezoneDerivationSchema.optional(),
+  });
+
+const acceptedOfficialWorkflowInstallationParameterSchema =
+  z.discriminatedUnion("type", [
+    acceptedOfficialWorkflowStringParameterSchema,
+    officialWorkflowIntegerParameterSchema,
+    officialWorkflowBooleanParameterSchema,
+  ]);
+
 export const officialWorkflowAcceptedBlueprintSchema =
-  officialWorkflowBlueprintSchema.extend({ fingerprint: fingerprintSchema });
+  officialWorkflowBlueprintSchema.extend({
+    parameters: z.array(acceptedOfficialWorkflowInstallationParameterSchema),
+    fingerprint: fingerprintSchema,
+  });
 export type OfficialWorkflowAcceptedBlueprint = z.infer<
   typeof officialWorkflowAcceptedBlueprintSchema
 >;

--- a/turbo/packages/api-contracts/src/contracts/test-official-workflow-catalog-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-official-workflow-catalog-state.ts
@@ -19,6 +19,11 @@ export const testOfficialWorkflowCatalogStateActionBodySchema =
       .strict(),
     z
       .object({
+        action: z.literal("seed-previous-schema-release"),
+      })
+      .strict(),
+    z
+      .object({
         action: z.literal("read"),
         definitionName: workflowNameSchema.optional(),
         workflowId: z.uuid().optional(),


### PR DESCRIPTION
## Summary

- Allow Official cron and once Blueprints to omit `timezone`, then materialize a concrete schedule timezone from the owner's saved Preference during installation and reconciliation.
- Remove the `user-timezone` installation parameter and its UI from the deployed Morning Brief and Connector Doctor Definitions while preserving explicit fixed timezones.
- Keep copied ordinary Workflows on their already-materialized schedule timezone, and omit Reconfigure when a Definition has no user-configurable parameters.
- Advance the non-GA catalog to schema v2 so older accepted releases are treated as empty and rebuilt from the current source instead of retaining the removed parameter shape.

## Rollout

- Official Workflows remains behind a non-GA feature switch and existing installations are developer-only, so this is an intentional versioned cutover with no legacy parser, dual-read path, migration, or backfill.
- The normal API-before-App deployment order publishes the parameterless Blueprint contract before the new App consumes it.
- Catalog schema upgrades are forward-only: older releases are unavailable until the catalog sync rebuilds them, while malformed current-version and future-version payloads still fail closed.

## Verification

- `pnpm exec prettier --write <changed files>` (Prettier 3.8.1)
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/app lint`
- `pnpm -F api lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F @okouai/app check-types`
- `pnpm -F api check-types`
- `pnpm knip`
- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/official-workflows.test.ts` (2 passed)
- `pnpm -F @okouai/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx -t 'preselects the default Agent|omits reconfiguration|reconfigures typed Official parameters|discards an open Official reconfiguration draft'` (4 passed)
- API route tests could not initialize locally because PostgreSQL is not running (`ECONNREFUSED 127.0.0.1/::1:5432`); PR CI owns those integration runs, including catalog v1-to-v2 replacement, installation, reconciliation, and ordinary-copy coverage.
