### PR TITLE
fix(platform): reveal full pinned agent name on hover

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -3467,10 +3467,6 @@ describe("zero sidebar", () => {
     const card = await waitFor(() => {
       return within(grid).getByTestId("pinned-agent-card");
     });
-    expect(within(card).getByText("Growth Experiments Agent")).toHaveClass(
-      "truncate",
-    );
-
     await userEvent.setup().hover(card);
 
     const tooltip = await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -3442,6 +3443,46 @@ describe("zero sidebar", () => {
     expect(unread).toHaveAttribute("role", "img");
   });
 
+  // A grid tile is a fifth of the sidebar wide, so the caption below the avatar
+  // is truncated to a few characters. Hovering has to spell the name out.
+  it("reveals the full pinned agent name on hover", async () => {
+    context.mocks.data.agents([
+      {
+        agentId: AGENT_ID,
+        ownerId: "test-user-123",
+        displayName: "Growth Experiments Agent",
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        visibility: "public",
+      },
+    ]);
+
+    setupSidebarPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    const grid = await screen.findByTestId("pinned-agents-grid");
+    const card = await waitFor(() => {
+      return within(grid).getByTestId("pinned-agent-card");
+    });
+    expect(within(card).getByText("Growth Experiments Agent")).toHaveClass(
+      "truncate",
+    );
+
+    await userEvent.setup().hover(card);
+
+    const tooltip = await waitFor(() => {
+      const popup = document.querySelector('[data-slot="tooltip-content"]');
+      if (!(popup instanceof HTMLElement)) {
+        throw new Error("Pinned agent tooltip is not open");
+      }
+      return popup;
+    });
+    expect(within(tooltip).getByText("Growth Experiments Agent")).toBeVisible();
+  });
+
   it("searches chats and messages in the three-column spotlight", async () => {
     prepareAgents();
     mockSidebarThreadStory([
@@ -4175,9 +4216,6 @@ describe("zero sidebar", () => {
     // Billing, so Pin closes the first row and the rest wrap after it.
     const fourthAgent = pinnedAgentLink(grid, "Operations Agent");
     const fifthAgent = pinnedAgentLink(grid, "Analytics Agent");
-
-    expect(fourthAgent).toHaveAttribute("title", "Operations Agent");
-    expect(fifthAgent).toHaveAttribute("title", "Analytics Agent");
 
     expect(
       fourthAgent.compareDocumentPosition(pinAgent) &

--- a/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
@@ -294,6 +294,13 @@ function PinnedAgentDragHandle() {
   );
 }
 
+/**
+ * A grid tile is only a fifth of the sidebar wide, so almost every agent name
+ * is truncated down to a few characters. The tile carries a hover tooltip with
+ * the full name — a native `title` is too slow and too easy to miss for a label
+ * that is unreadable by default. The tooltip is disabled while a reorder drag
+ * is in flight so it never floats over the drop carets.
+ */
 function PinnedAgentGridCard({
   agent,
   isPrimarySelected,
@@ -323,12 +330,11 @@ function PinnedAgentGridCard({
     draggingAgentId !== null &&
     draggingAgentId !== agent.agentId;
 
-  return (
+  const card = (
     <Link
       pathname="/agents/:agentId/chat"
       options={{ pathParams: { agentId: agent.agentId } }}
       data-testid="pinned-agent-card"
-      title={displayName}
       draggable={isReorderable}
       onDragStart={(e) => {
         e.dataTransfer.clearData();
@@ -419,6 +425,17 @@ function PinnedAgentGridCard({
         {displayName}
       </span>
     </Link>
+  );
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip disabled={isDragInFlight}>
+        <TooltipTrigger asChild>{card}</TooltipTrigger>
+        <TooltipContent side="top">
+          <p className="text-xs">{displayName}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 


### PR DESCRIPTION
## Problem

Reported in chat: pinned agent names in the sidebar grid are cut off with no way to read them.

A grid tile is a fifth of the sidebar wide, so the caption under the avatar truncates to a few characters — five of the ten tiles in the report render as `GEO ...`. The tile carried a native `title`, which needs a ~1s idle hover and is easy to miss for a label that is unreadable by default.

## Change

- `PinnedAgentGridCard` now wraps the tile in the design-system `Tooltip` (200ms delay, same as the rest of the sidebar) showing the full display name, and drops the native `title` so the two do not stack.
- The tooltip is disabled while a reorder drag is in flight, so it never floats over the drop carets.

Only the horizontal pinned grid changes; the expanded sidebar rows already show a full-width name.

## Verification

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx` — 80 passed, including a new test that hovers a tile with a long name and asserts the tooltip spells it out.
- `pnpm -F @okouai/app lint`, `check-types`, and Prettier are clean.

Touches the same two files as #30413; whichever lands first, the other rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)