### PR TITLE
feat: manage morning brief from preferences

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -133,6 +133,7 @@ import { browserRoutes } from "./routes/browser";
 import { browserAuthorizationRoutes } from "./routes/browser-authorization";
 import { workflowsRoutes } from "./routes/workflows";
 import { officialWorkflowRoutes } from "./routes/official-workflows";
+import { morningBriefPreferenceRoutes } from "./routes/morning-brief-preference";
 import { workflowAutomationsRoutes } from "./routes/workflow-automations";
 import { strapiIntegrationsRoutes } from "./routes/strapi-integrations";
 import { strapiEventsRoutes } from "./routes/strapi-events";
@@ -334,6 +335,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...userPermissionGrantsRoutes,
   ...userPreferencesRoutes,
   ...userModelPreferenceRoutes,
+  ...morningBriefPreferenceRoutes,
   ...workflowsRoutes,
   ...officialWorkflowRoutes,
   ...workflowAutomationsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/official-automation-result-email.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-automation-result-email.test.ts
@@ -17,6 +17,7 @@ import {
   clearResultEmailUserStateFixture,
   completeResultEmailRunWithoutCallbacksFixture,
   holdResultEmailClaimBoundaryFixture,
+  markWorkflowAsMorningBriefResultEmailFixture,
   readResultEmailPreferenceFixture,
 } from "../../../test-fixtures/official-automation-result-email";
 import { flushWaitUntilForTest } from "../../context/wait-until";
@@ -343,6 +344,64 @@ describe.sequential("Official Automation result email callbacks", () => {
     );
     await runs.requestCancelRun(scenario.actor, agentRun.body.runId, [200]);
     await flushWaitUntilForTest();
+  });
+
+  it("links Morning Brief management to Preferences without changing account unsubscribe", async () => {
+    const scenario = await setupScenario();
+    const runId = await startRun(scenario, "https://app.okou.ai");
+    await seedResultCallback({
+      runId,
+      automationId: scenario.automationId,
+      publicBrand: "okou",
+      workflowName: "Morning Brief",
+    });
+    await completeResultEmailRunWithoutCallbacksFixture(runId);
+    await markWorkflowAsMorningBriefResultEmailFixture(scenario.workflowId);
+    await accept(
+      executionClient().interruptResultEmailCallback({
+        body: { run_id: runId },
+      }),
+      [200],
+    );
+    const source = await outbox.findSourceState({
+      sourceRunId: runId,
+      sourceWorkflowAutomationId: scenario.automationId,
+    });
+    const item = source.items[0];
+    if (!item) {
+      throw new Error("Expected a Morning Brief result email");
+    }
+    const manageUrl =
+      "https://app.okou.ai/settings?tab=timezone&focus=morning-brief";
+    const accountUnsubscribeUrl = `https://app.okou.ai/email/unsubscribe?token=${unsubscribeToken(
+      scenario.actor.userId,
+    )}`;
+    expect(item.template).toMatchObject({
+      template: "official-automation-result",
+      props: { manageUrl },
+    });
+    expect(item.headers).toStrictEqual({
+      "List-Unsubscribe": `<https://api.okou.ai/api/email/unsubscribe?token=${unsubscribeToken(
+        scenario.actor.userId,
+      )}>`,
+      "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+    });
+
+    await expect(outbox.drainItems([item.id])).resolves.toBe(1);
+    const send = context.mocks.resend.send.mock.calls[0]?.[0];
+    const html =
+      typeof send === "object" &&
+      send !== null &&
+      "html" in send &&
+      typeof send.html === "string"
+        ? send.html
+        : "";
+    expect(html).toContain(
+      'href="https://app.okou.ai/settings?tab=timezone&amp;focus=morning-brief"',
+    );
+    expect(html).toContain(
+      `>Manage this automation</a> &middot; <a href="${accountUnsubscribeUrl}"`,
+    );
   });
 
   it("retries independently of Run success and renders bounded Okou Markdown multipart output for a VM0 snapshot", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -19,6 +19,7 @@ import {
   officialWorkflowInstallationsContract,
   officialWorkflowsContract,
 } from "@okouai/api-contracts/contracts/official-workflows";
+import { morningBriefPreferenceContract } from "@okouai/api-contracts/contracts/morning-brief-preference";
 import { testOfficialWorkflowCatalogStateContract } from "@okouai/api-contracts/contracts/test-official-workflow-catalog-state";
 import { testSystemStoragePresignedUrlCacheStateContract } from "@okouai/api-contracts/contracts/test-system-storage-presigned-url-cache-state";
 import { testWorkflowAutomationExecutionContract } from "@okouai/api-contracts/contracts/test-workflow-automation-execution";
@@ -76,6 +77,7 @@ import {
   cronOfficialWorkflowCatalogRoutes,
 } from "../cron-official-workflow-catalog";
 import { officialWorkflowRoutes } from "../official-workflows";
+import { morningBriefPreferenceRoutes } from "../morning-brief-preference";
 import { testOfficialWorkflowCatalogStateRoutes } from "../test-official-workflow-catalog-state";
 import { testSystemStoragePresignedUrlCacheStateRoutes } from "../test-system-storage-presigned-url-cache-state";
 import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
@@ -811,6 +813,12 @@ function officialClient() {
   );
 }
 
+function morningBriefPreferenceClient() {
+  return setupApp({ context, routes: morningBriefPreferenceRoutes })(
+    morningBriefPreferenceContract,
+  );
+}
+
 function installationClient() {
   return setupApp({ context, routes: officialWorkflowRoutes })(
     officialWorkflowInstallationsContract,
@@ -1274,6 +1282,286 @@ beforeEach(async () => {
   );
   await installApiTestConnectorCatalog();
   await cleanupCatalog();
+});
+
+describe.sequential("Morning Brief preference", () => {
+  it("installs idempotently without the Official Workflows feature and preserves identities across disable and re-enable", async () => {
+    installCatalogStorageFixture();
+    const synced = await syncDeployedCatalog();
+    expect(synced.body).toMatchObject({ outcome: "accepted", diagnostics: [] });
+
+    const { actor } = await workflowBdd.setupWorkflowOrg({
+      timezone: "Asia/Shanghai",
+    });
+    if (!actor.orgId) {
+      throw new Error("Expected organization-scoped actor");
+    }
+    const onboarding = await bdd.readOnboardingStatus(actor);
+    if (!onboarding.defaultAgentId) {
+      throw new Error("Expected a default Agent");
+    }
+    onTestFinished(async () => {
+      installCatalogStorageFixture();
+      await cleanupCatalog();
+    });
+    const headers = authHeaders(actor);
+    await setOfficialWorkflowsEnabled(actor, false);
+
+    const initial = await accept(
+      morningBriefPreferenceClient().get({ headers }),
+      [200],
+    );
+    expect(initial.body).toStrictEqual({
+      enabled: false,
+      nextRunAt: null,
+      timezone: "Asia/Shanghai",
+      unavailableReason: null,
+    });
+
+    const enabledResponses = await Promise.all([
+      accept(
+        morningBriefPreferenceClient().update({
+          headers,
+          body: { enabled: true },
+        }),
+        [200],
+      ),
+      accept(
+        morningBriefPreferenceClient().update({
+          headers,
+          body: { enabled: true },
+        }),
+        [200],
+      ),
+    ]);
+    for (const response of enabledResponses) {
+      expect(response.body).toMatchObject({
+        enabled: true,
+        nextRunAt: expect.any(String),
+        timezone: "Asia/Shanghai",
+        unavailableReason: null,
+      });
+    }
+
+    const installed = await accept(
+      workflowCollectionClient().list({ headers, query: {} }),
+      [200],
+    );
+    const morningBriefs = installed.body.filter((workflow) => {
+      return workflow.official?.definitionName === "morning-brief";
+    });
+    expect(morningBriefs).toHaveLength(1);
+    const morningBrief = morningBriefs[0];
+    if (!morningBrief) {
+      throw new Error("Expected one Morning Brief installation");
+    }
+    expect(morningBrief.agentId).toBe(onboarding.defaultAgentId);
+    const detail = await accept(
+      installationClient().get({
+        headers,
+        params: { workflowId: morningBrief.id },
+      }),
+      [200],
+    );
+    expect(detail.body.workflow.automations).toHaveLength(1);
+    const automation = detail.body.workflow.automations[0];
+    if (!automation?.chatThreadId) {
+      throw new Error("Expected Morning Brief automation identities");
+    }
+    expect(automation).toMatchObject({
+      kind: "schedule",
+      enabled: true,
+      schedule: {
+        type: "cron",
+        cronExpression: "0 7 * * *",
+        timezone: "Asia/Shanghai",
+      },
+      official: {
+        blueprintKey: "daily-delivery",
+        reconciliationStatus: "current",
+      },
+    });
+    const identities = {
+      workflowId: morningBrief.id,
+      automationId: automation.id,
+      chatThreadId: automation.chatThreadId,
+    };
+    await expect(
+      readWorkflowAutomationAutonomyFixture(context, automation.id),
+    ).resolves.toMatchObject({
+      officialBlueprintKey: "daily-delivery",
+      officialResultEmailEnabled: true,
+    });
+
+    const disabled = await accept(
+      morningBriefPreferenceClient().update({
+        headers,
+        body: { enabled: false },
+      }),
+      [200],
+    );
+    expect(disabled.body).toStrictEqual({
+      enabled: false,
+      nextRunAt: null,
+      timezone: "Asia/Shanghai",
+      unavailableReason: null,
+    });
+
+    const reenabled = await accept(
+      morningBriefPreferenceClient().update({
+        headers,
+        body: { enabled: true },
+      }),
+      [200],
+    );
+    expect(reenabled.body).toMatchObject({
+      enabled: true,
+      nextRunAt: expect.any(String),
+      timezone: "Asia/Shanghai",
+      unavailableReason: null,
+    });
+    const after = await accept(
+      installationClient().get({
+        headers,
+        params: { workflowId: morningBrief.id },
+      }),
+      [200],
+    );
+    expect(after.body.workflow.automations).toMatchObject([
+      {
+        id: identities.automationId,
+        chatThreadId: identities.chatThreadId,
+        enabled: true,
+      },
+    ]);
+    expect(after.body.workflow.id).toBe(identities.workflowId);
+  });
+
+  it("returns typed missing-timezone and missing-default-Agent states without mutation", async () => {
+    const missingTimezone = await workflowBdd.setupWorkflowOrg();
+    const timezoneHeaders = authHeaders(missingTimezone.actor);
+    const unavailableTimezone = await accept(
+      morningBriefPreferenceClient().get({ headers: timezoneHeaders }),
+      [200],
+    );
+    expect(unavailableTimezone.body).toMatchObject({
+      enabled: false,
+      unavailableReason: "missing-timezone",
+    });
+    const rejectedTimezone = await accept(
+      morningBriefPreferenceClient().update({
+        headers: timezoneHeaders,
+        body: { enabled: true },
+      }),
+      [400],
+    );
+    expect(rejectedTimezone.body.error.code).toBe(
+      "MORNING_BRIEF_MISSING_TIMEZONE",
+    );
+
+    const missingAgent = bdd.user();
+    await bdd.updateUserTimezone(missingAgent, "Asia/Shanghai");
+    const agentHeaders = authHeaders(missingAgent);
+    const unavailableAgent = await accept(
+      morningBriefPreferenceClient().get({ headers: agentHeaders }),
+      [200],
+    );
+    expect(unavailableAgent.body).toMatchObject({
+      enabled: false,
+      timezone: "Asia/Shanghai",
+      unavailableReason: "missing-default-agent",
+    });
+    const rejectedAgent = await accept(
+      morningBriefPreferenceClient().update({
+        headers: agentHeaders,
+        body: { enabled: true },
+      }),
+      [400],
+    );
+    expect(rejectedAgent.body.error.code).toBe(
+      "MORNING_BRIEF_MISSING_DEFAULT_AGENT",
+    );
+
+    for (const fixture of [missingTimezone.actor, missingAgent]) {
+      const listed = await accept(
+        workflowCollectionClient().list({
+          headers: authHeaders(fixture),
+          query: {},
+        }),
+        [200],
+      );
+      expect(
+        listed.body.filter((workflow) => {
+          return workflow.official?.definitionName === "morning-brief";
+        }),
+      ).toHaveLength(0);
+    }
+  });
+
+  it("fails closed when generic installations already exist across Agents", async () => {
+    installCatalogStorageFixture();
+    await syncDeployedCatalog();
+    const { actor } = await workflowBdd.setupWorkflowOrg({
+      timezone: "Asia/Shanghai",
+    });
+    if (!actor.orgId) {
+      throw new Error("Expected organization-scoped actor");
+    }
+    const onboarding = await bdd.readOnboardingStatus(actor);
+    if (!onboarding.defaultAgentId) {
+      throw new Error("Expected a default Agent");
+    }
+    const alternate = await workflowBdd.createAgent(actor);
+    onTestFinished(async () => {
+      installCatalogStorageFixture();
+      await bdd.deleteAgent(actor, alternate.agentId);
+      await cleanupCatalog();
+    });
+    await setOfficialWorkflowsEnabled(actor, true);
+    const headers = authHeaders(actor);
+    const installations = await Promise.all(
+      [onboarding.defaultAgentId, alternate.agentId].map(async (agentId) => {
+        return await accept(
+          officialClient().install({
+            headers,
+            params: { definitionName: "morning-brief" },
+            body: {
+              agentId,
+              blueprints: [{ blueprintKey: "daily-delivery", bindings: [] }],
+            },
+          }),
+          [201],
+        );
+      }),
+    );
+
+    const read = await accept(
+      morningBriefPreferenceClient().get({ headers }),
+      [409],
+    );
+    expect(read.body.error.code).toBe("MORNING_BRIEF_MULTIPLE_INSTALLATIONS");
+    const update = await accept(
+      morningBriefPreferenceClient().update({
+        headers,
+        body: { enabled: false },
+      }),
+      [409],
+    );
+    expect(update.body.error.code).toBe("MORNING_BRIEF_MULTIPLE_INSTALLATIONS");
+
+    for (const installation of installations) {
+      const unchanged = await accept(
+        installationClient().get({
+          headers,
+          params: { workflowId: installation.body.workflow.id },
+        }),
+        [200],
+      );
+      expect(unchanged.body.workflow.automations).toMatchObject([
+        { enabled: true },
+      ]);
+    }
+  });
 });
 
 describe.sequential("Official Workflow installations", () => {

--- a/turbo/apps/api/src/signals/routes/morning-brief-preference.ts
+++ b/turbo/apps/api/src/signals/routes/morning-brief-preference.ts
@@ -1,0 +1,101 @@
+import { morningBriefPreferenceContract } from "@okouai/api-contracts/contracts/morning-brief-preference";
+import { command } from "ccstate";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { publicBrand$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route-entry";
+import {
+  morningBriefPreference$,
+  updateMorningBriefPreference$,
+  type MorningBriefPreferenceFailure,
+} from "../services/morning-brief-preference.service";
+
+const morningBriefPreferenceReadAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+  requiredCapability: "agent:read",
+} as const;
+
+const morningBriefPreferenceWriteAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+  requiredCapability: "agent:write",
+} as const;
+
+function memberFromAuth(auth: {
+  readonly userId: string;
+  readonly orgRole?: string | null;
+}) {
+  return { userId: auth.userId, role: auth.orgRole ?? "member" };
+}
+
+function failureResponse(failure: MorningBriefPreferenceFailure) {
+  return {
+    status: failure.kind === "bad-request" ? (400 as const) : (409 as const),
+    body: { error: { code: failure.code, message: failure.message } },
+  };
+}
+
+const getMorningBriefPreferenceInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const result = await set(
+      morningBriefPreference$,
+      {
+        orgId: auth.orgId,
+        member: memberFromAuth(auth),
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    return result.kind === "ok"
+      ? { status: 200 as const, body: result.preference }
+      : failureResponse(result);
+  },
+);
+
+const updateBody$ = bodyResultOf(morningBriefPreferenceContract.update);
+const updateMorningBriefPreferenceInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const body = await get(updateBody$);
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+    const result = await set(
+      updateMorningBriefPreference$,
+      {
+        orgId: auth.orgId,
+        member: memberFromAuth(auth),
+        enabled: body.data.enabled,
+        publicBrand:
+          auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$),
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    return result.kind === "ok"
+      ? { status: 200 as const, body: result.preference }
+      : failureResponse(result);
+  },
+);
+
+export const morningBriefPreferenceRoutes: readonly RouteEntry[] = [
+  {
+    route: morningBriefPreferenceContract.get,
+    handler: authRoute(
+      morningBriefPreferenceReadAuth,
+      getMorningBriefPreferenceInner$,
+    ),
+  },
+  {
+    route: morningBriefPreferenceContract.update,
+    handler: authRoute(
+      morningBriefPreferenceWriteAuth,
+      updateMorningBriefPreferenceInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/internal-workflow-automation-result-email-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-workflow-automation-result-email-callback.service.ts
@@ -1,10 +1,14 @@
 import { publicBrandSchema } from "@okouai/api-contracts/contracts/public-brand";
+import {
+  MORNING_BRIEF_OFFICIAL_DEFINITION_NAME,
+  MORNING_BRIEF_PREFERENCES_PATH,
+} from "@okouai/api-contracts/contracts/morning-brief-preference";
 import { appUrlForPublicBrand } from "@okouai/core/public-brand";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { emailOutbox } from "@okouai/db/schema/email-outbox";
 import { officialAutomationResultEmailClaims } from "@okouai/db/schema/official-automation-result-email-claim";
 import { users } from "@okouai/db/schema/user";
-import { workflowAutomations } from "@okouai/db/schema/workflow";
+import { workflowAutomations, workflows } from "@okouai/db/schema/workflow";
 import { command, createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
@@ -107,8 +111,12 @@ async function workflowAutomationManageUrl(
   signal: AbortSignal,
 ): Promise<string> {
   const [automation] = await db
-    .select({ workflowId: workflowAutomations.workflowId })
+    .select({
+      workflowId: workflowAutomations.workflowId,
+      officialDefinitionName: workflows.officialDefinitionName,
+    })
     .from(workflowAutomations)
+    .innerJoin(workflows, eq(workflows.id, workflowAutomations.workflowId))
     .where(
       and(
         eq(workflowAutomations.id, args.automationId),
@@ -117,6 +125,12 @@ async function workflowAutomationManageUrl(
     )
     .limit(1);
   signal.throwIfAborted();
+  if (
+    automation?.officialDefinitionName ===
+    MORNING_BRIEF_OFFICIAL_DEFINITION_NAME
+  ) {
+    return `${args.productUrl}${MORNING_BRIEF_PREFERENCES_PATH}`;
+  }
   return automation
     ? `${args.productUrl}/workflows/${encodeURIComponent(
         automation.workflowId,

--- a/turbo/apps/api/src/signals/services/morning-brief-preference.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-preference.service.ts
@@ -1,0 +1,453 @@
+import {
+  MORNING_BRIEF_OFFICIAL_BLUEPRINT_KEY,
+  MORNING_BRIEF_OFFICIAL_DEFINITION_NAME,
+  type MorningBriefPreferenceErrorCode,
+  type MorningBriefPreferenceResponse,
+} from "@okouai/api-contracts/contracts/morning-brief-preference";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
+import { isValidTimeZone } from "@okouai/core/timezone";
+import { agents } from "@okouai/db/schema/agent";
+import { orgMetadata } from "@okouai/db/schema/org-metadata";
+import { workflowAutomations, workflows } from "@okouai/db/schema/workflow";
+import { command } from "ccstate";
+import { and, eq, sql } from "drizzle-orm";
+import { delay } from "signal-timers";
+import { z } from "zod";
+
+import { executeRawRows } from "../../lib/db-raw-rows";
+import { writeDb$, type Db, type ReadonlyDb } from "../external/db";
+import {
+  installOfficialWorkflow$,
+  loadOfficialWorkflowUserTimezone,
+} from "./official-workflow-installation.service";
+import { reconcileOfficialWorkflowInstallation$ } from "./official-workflow-reconciliation.service";
+import {
+  disableWorkflowAutomation$,
+  enableWorkflowAutomation$,
+} from "./workflow-automation.service";
+import type { WorkflowMember } from "./workflow-data.service";
+
+const MORNING_BRIEF_LOCK_RETRY_MS = 25;
+
+export type MorningBriefPreferenceFailure = {
+  readonly kind: "bad-request" | "conflict";
+  readonly code: MorningBriefPreferenceErrorCode;
+  readonly message: string;
+};
+
+type MorningBriefPreferenceResult =
+  | {
+      readonly kind: "ok";
+      readonly preference: MorningBriefPreferenceResponse;
+    }
+  | MorningBriefPreferenceFailure;
+
+interface MorningBriefPreferenceArgs {
+  readonly orgId: string;
+  readonly member: WorkflowMember;
+}
+
+interface MorningBriefPreferenceMutationArgs extends MorningBriefPreferenceArgs {
+  readonly enabled: boolean;
+  readonly publicBrand: PublicBrand;
+}
+
+function conflict(
+  code: Extract<
+    MorningBriefPreferenceErrorCode,
+    "MORNING_BRIEF_MULTIPLE_INSTALLATIONS" | "MORNING_BRIEF_STATE_CONFLICT"
+  >,
+  message: string,
+): MorningBriefPreferenceFailure {
+  return { kind: "conflict", code, message };
+}
+
+function unavailableFailure(
+  reason: NonNullable<MorningBriefPreferenceResponse["unavailableReason"]>,
+): MorningBriefPreferenceFailure {
+  return reason === "missing-timezone"
+    ? {
+        kind: "bad-request",
+        code: "MORNING_BRIEF_MISSING_TIMEZONE",
+        message: "Set a valid time zone before enabling Morning Brief.",
+      }
+    : {
+        kind: "bad-request",
+        code: "MORNING_BRIEF_MISSING_DEFAULT_AGENT",
+        message: "Choose a usable default Agent before enabling Morning Brief.",
+      };
+}
+
+async function loadUnavailableReason(
+  db: ReadonlyDb,
+  args: MorningBriefPreferenceArgs,
+): Promise<MorningBriefPreferenceResponse["unavailableReason"]> {
+  const timezone = await loadOfficialWorkflowUserTimezone(db, {
+    orgId: args.orgId,
+    userId: args.member.userId,
+  });
+  if (timezone === null || !isValidTimeZone(timezone)) {
+    return "missing-timezone";
+  }
+
+  const [defaultAgent] = await db
+    .select({
+      id: agents.id,
+      owner: agents.owner,
+      visibility: agents.visibility,
+    })
+    .from(orgMetadata)
+    .leftJoin(
+      agents,
+      and(
+        eq(agents.id, orgMetadata.defaultAgentId),
+        eq(agents.orgId, orgMetadata.orgId),
+      ),
+    )
+    .where(eq(orgMetadata.orgId, args.orgId))
+    .limit(1);
+  const usable =
+    defaultAgent?.id !== null &&
+    defaultAgent?.id !== undefined &&
+    (defaultAgent.visibility === "public" ||
+      defaultAgent.owner === args.member.userId);
+  return usable ? null : "missing-default-agent";
+}
+
+async function loadDefaultAgentId(
+  db: ReadonlyDb,
+  args: MorningBriefPreferenceArgs,
+): Promise<string | null> {
+  const [defaultAgent] = await db
+    .select({
+      id: agents.id,
+      owner: agents.owner,
+      visibility: agents.visibility,
+    })
+    .from(orgMetadata)
+    .leftJoin(
+      agents,
+      and(
+        eq(agents.id, orgMetadata.defaultAgentId),
+        eq(agents.orgId, orgMetadata.orgId),
+      ),
+    )
+    .where(eq(orgMetadata.orgId, args.orgId))
+    .limit(1);
+  if (
+    !defaultAgent?.id ||
+    (defaultAgent.visibility === "private" &&
+      defaultAgent.owner !== args.member.userId)
+  ) {
+    return null;
+  }
+  return defaultAgent.id;
+}
+
+async function loadMorningBriefWorkflowIds(
+  db: ReadonlyDb,
+  args: MorningBriefPreferenceArgs,
+): Promise<
+  readonly {
+    readonly id: string;
+    readonly installationState: "installing" | "installed" | null;
+  }[]
+> {
+  return await db
+    .select({
+      id: workflows.id,
+      installationState: workflows.officialInstallationState,
+    })
+    .from(workflows)
+    .where(
+      and(
+        eq(workflows.orgId, args.orgId),
+        eq(workflows.ownerUserId, args.member.userId),
+        eq(workflows.visibility, "private"),
+        eq(
+          workflows.officialDefinitionName,
+          MORNING_BRIEF_OFFICIAL_DEFINITION_NAME,
+        ),
+      ),
+    );
+}
+
+async function loadInstalledPreference(
+  db: ReadonlyDb,
+  args: MorningBriefPreferenceArgs,
+): Promise<MorningBriefPreferenceResult & { readonly workflowId?: string }> {
+  const installations = await loadMorningBriefWorkflowIds(db, args);
+  if (installations.length > 1) {
+    return conflict(
+      "MORNING_BRIEF_MULTIPLE_INSTALLATIONS",
+      "Multiple Morning Brief installations exist. Resolve the conflict before changing this preference.",
+    );
+  }
+  const installation = installations[0];
+  if (!installation) {
+    const [timezone, unavailableReason] = await Promise.all([
+      loadOfficialWorkflowUserTimezone(db, {
+        orgId: args.orgId,
+        userId: args.member.userId,
+      }),
+      loadUnavailableReason(db, args),
+    ]);
+    return {
+      kind: "ok",
+      preference: {
+        enabled: false,
+        nextRunAt: null,
+        timezone,
+        unavailableReason,
+      },
+    };
+  }
+  if (installation.installationState !== "installed") {
+    return conflict(
+      "MORNING_BRIEF_STATE_CONFLICT",
+      "Morning Brief installation is not ready. Retry after installation completes.",
+    );
+  }
+
+  const automations = await db
+    .select({
+      id: workflowAutomations.id,
+      enabled: workflowAutomations.enabled,
+      nextRunAt: workflowAutomations.nextRunAt,
+      timezone: workflowAutomations.timezone,
+      kind: workflowAutomations.kind,
+      scheduleType: workflowAutomations.scheduleType,
+      blueprintKey: workflowAutomations.officialBlueprintKey,
+      reconciliationStatus: workflowAutomations.officialReconciliationStatus,
+      resultEmailEnabled: workflowAutomations.officialResultEmailEnabled,
+    })
+    .from(workflowAutomations)
+    .where(
+      and(
+        eq(workflowAutomations.orgId, args.orgId),
+        eq(workflowAutomations.ownerUserId, args.member.userId),
+        eq(workflowAutomations.workflowId, installation.id),
+      ),
+    );
+  const automation = automations[0];
+  if (
+    automations.length !== 1 ||
+    !automation ||
+    automation.kind !== "schedule" ||
+    automation.scheduleType !== "cron" ||
+    automation.blueprintKey !== MORNING_BRIEF_OFFICIAL_BLUEPRINT_KEY ||
+    automation.reconciliationStatus !== "current" ||
+    automation.resultEmailEnabled !== true
+  ) {
+    return conflict(
+      "MORNING_BRIEF_STATE_CONFLICT",
+      "Morning Brief installation state is inconsistent. Retry after reconciliation completes.",
+    );
+  }
+  return {
+    kind: "ok",
+    workflowId: installation.id,
+    preference: {
+      enabled: automation.enabled,
+      nextRunAt: automation.nextRunAt?.toISOString() ?? null,
+      timezone: automation.timezone,
+      unavailableReason: null,
+    },
+  };
+}
+
+const lockRowSchema = z.object({ acquired: z.boolean() });
+
+async function withMorningBriefPreferenceLock<T>(
+  db: Db,
+  args: MorningBriefPreferenceArgs,
+  signal: AbortSignal,
+  operation: () => Promise<T>,
+): Promise<T> {
+  while (true) {
+    const result = await db.transaction(async (tx) => {
+      const rows = await executeRawRows(
+        tx,
+        sql`SELECT pg_try_advisory_xact_lock(
+          hashtextextended(
+            ${`morning_brief_preference:${args.orgId}:${args.member.userId}`},
+            0
+          )
+        ) AS acquired`,
+        lockRowSchema,
+      );
+      if (rows[0]?.acquired !== true) {
+        return { acquired: false as const };
+      }
+      signal.throwIfAborted();
+      return { acquired: true as const, value: await operation() };
+    });
+    if (result.acquired) {
+      return result.value;
+    }
+    await delay(MORNING_BRIEF_LOCK_RETRY_MS, { signal });
+  }
+}
+
+export const morningBriefPreference$ = command(
+  async (
+    { set },
+    args: MorningBriefPreferenceArgs,
+    signal: AbortSignal,
+  ): Promise<MorningBriefPreferenceResult> => {
+    const db = set(writeDb$);
+    signal.throwIfAborted();
+    return await loadInstalledPreference(db, args);
+  },
+);
+
+async function loadMorningBriefAutomationId(
+  db: ReadonlyDb,
+  workflowId: string,
+): Promise<string | null> {
+  const [automation] = await db
+    .select({ id: workflowAutomations.id })
+    .from(workflowAutomations)
+    .where(
+      and(
+        eq(workflowAutomations.workflowId, workflowId),
+        eq(
+          workflowAutomations.officialBlueprintKey,
+          MORNING_BRIEF_OFFICIAL_BLUEPRINT_KEY,
+        ),
+      ),
+    )
+    .limit(1);
+  return automation?.id ?? null;
+}
+
+export const updateMorningBriefPreference$ = command(
+  async (
+    { set },
+    args: MorningBriefPreferenceMutationArgs,
+    signal: AbortSignal,
+  ): Promise<MorningBriefPreferenceResult> => {
+    const db = set(writeDb$);
+    return await withMorningBriefPreferenceLock(db, args, signal, async () => {
+      const installations = await loadMorningBriefWorkflowIds(db, args);
+      signal.throwIfAborted();
+      if (installations.length > 1) {
+        return conflict(
+          "MORNING_BRIEF_MULTIPLE_INSTALLATIONS",
+          "Multiple Morning Brief installations exist. Resolve the conflict before changing this preference.",
+        );
+      }
+
+      const installation = installations[0];
+      if (!installation) {
+        if (!args.enabled) {
+          return await loadInstalledPreference(db, args);
+        }
+        const unavailableReason = await loadUnavailableReason(db, args);
+        signal.throwIfAborted();
+        if (unavailableReason !== null) {
+          return unavailableFailure(unavailableReason);
+        }
+        const agentId = await loadDefaultAgentId(db, args);
+        signal.throwIfAborted();
+        if (agentId === null) {
+          return unavailableFailure("missing-default-agent");
+        }
+        const installed = await set(
+          installOfficialWorkflow$,
+          {
+            orgId: args.orgId,
+            member: args.member,
+            agentId,
+            definitionName: MORNING_BRIEF_OFFICIAL_DEFINITION_NAME,
+            blueprints: [
+              {
+                blueprintKey: MORNING_BRIEF_OFFICIAL_BLUEPRINT_KEY,
+                bindings: [],
+              },
+            ],
+          },
+          args.publicBrand,
+          signal,
+        );
+        signal.throwIfAborted();
+        if (installed.kind !== "ok") {
+          const raced = await loadInstalledPreference(db, args);
+          signal.throwIfAborted();
+          return raced.kind === "ok" && raced.workflowId
+            ? raced
+            : conflict(
+                "MORNING_BRIEF_STATE_CONFLICT",
+                "Morning Brief could not be installed. Retry the preference update.",
+              );
+        }
+        return await loadInstalledPreference(db, args);
+      }
+
+      if (installation.installationState !== "installed") {
+        return conflict(
+          "MORNING_BRIEF_STATE_CONFLICT",
+          "Morning Brief installation is not ready. Retry after installation completes.",
+        );
+      }
+
+      if (args.enabled) {
+        const reconciliation = await set(
+          reconcileOfficialWorkflowInstallation$,
+          {
+            orgId: args.orgId,
+            member: args.member,
+            workflowId: installation.id,
+            publicBrand: args.publicBrand,
+          },
+          signal,
+        );
+        signal.throwIfAborted();
+        if (reconciliation.kind !== "current") {
+          return conflict(
+            "MORNING_BRIEF_STATE_CONFLICT",
+            "Morning Brief could not be reconciled. Retry the preference update.",
+          );
+        }
+      }
+
+      const current = await loadInstalledPreference(db, args);
+      signal.throwIfAborted();
+      if (current.kind !== "ok" || current.workflowId === undefined) {
+        return current;
+      }
+      if (current.preference.enabled === args.enabled) {
+        return current;
+      }
+
+      const automationId = await loadMorningBriefAutomationId(
+        db,
+        current.workflowId,
+      );
+      signal.throwIfAborted();
+      if (automationId === null) {
+        return conflict(
+          "MORNING_BRIEF_STATE_CONFLICT",
+          "Morning Brief automation is unavailable. Retry after reconciliation completes.",
+        );
+      }
+      const changed = await set(
+        args.enabled ? enableWorkflowAutomation$ : disableWorkflowAutomation$,
+        {
+          orgId: args.orgId,
+          member: args.member,
+          automationId,
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+      if (changed.kind !== "ok") {
+        return conflict(
+          "MORNING_BRIEF_STATE_CONFLICT",
+          "Morning Brief automation could not be updated. Retry the preference update.",
+        );
+      }
+      return await loadInstalledPreference(db, args);
+    });
+  },
+);

--- a/turbo/apps/api/src/test-fixtures/official-automation-result-email.ts
+++ b/turbo/apps/api/src/test-fixtures/official-automation-result-email.ts
@@ -2,6 +2,7 @@ import { agentRuns } from "@okouai/db/schema/agent-run";
 import { officialAutomationResultEmailClaims } from "@okouai/db/schema/official-automation-result-email-claim";
 import { userCache } from "@okouai/db/schema/user-cache";
 import { users } from "@okouai/db/schema/user";
+import { workflows } from "@okouai/db/schema/workflow";
 import { and, count, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 
@@ -43,6 +44,30 @@ export async function completeResultEmailRunWithoutCallbacksFixture(
     .returning({ id: agentRuns.id });
   if (rows.length !== 1) {
     throw new Error("Expected one result-email Run to complete");
+  }
+}
+
+export async function markWorkflowAsMorningBriefResultEmailFixture(
+  workflowId: string,
+): Promise<void> {
+  const rows = await db()
+    .update(workflows)
+    .set({
+      name: "morning-brief",
+      visibility: "private",
+      instruction: null,
+      displayName: null,
+      description: null,
+      officialDefinitionName: "morning-brief",
+      officialInstallationState: "installed",
+      updatedAt: nowDate(),
+    })
+    .where(eq(workflows.id, workflowId))
+    .returning({ id: workflows.id });
+  if (rows.length !== 1) {
+    throw new Error(
+      "Expected one result-email Workflow to become Morning Brief",
+    );
   }
 }
 

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -5158,6 +5158,18 @@
         },
         "title": "Sprache"
       },
+      "morningBrief": {
+        "conflict": "Morning Brief ist vorübergehend nicht verfügbar, da der Installationsstatus inkonsistent ist. Versuchen Sie es erneut, wenn die Abstimmung abgeschlossen ist.",
+        "description": "Erhalten Sie täglich um 7:00 Uhr in Ihrer Zeitzone eine E-Mail mit Prioritäten aus Gmail, GitHub, Kalender und ungelesenen Chats.",
+        "loading": "Morning-Brief-Einstellungen werden geladen...",
+        "missingDefaultAgent": "Wählen Sie einen verwendbaren Standard-Agenten aus, bevor Sie Morning Brief aktivieren.",
+        "missingTimezone": "Legen Sie eine gültige Zeitzone fest, bevor Sie Morning Brief aktivieren.",
+        "multipleInstallations": "Es sind mehrere Morning-Brief-Installationen vorhanden. Beheben Sie den Konflikt, bevor Sie diese Einstellung ändern.",
+        "nextEmail": "Nächste E-Mail: {{date}} ({{timezone}})",
+        "retry": "Erneut versuchen",
+        "retryMessage": "Die Morning-Brief-Einstellungen konnten nicht geladen oder aktualisiert werden. Versuchen Sie es erneut.",
+        "title": "Morgenbrief"
+      },
       "pageDescription": "Verwalten Sie Ihr Erscheinungsbild und die Laufzeiteinstellungen Ihres Agenten",
       "pageTitle": "Präferenzen",
       "send": {

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -5150,6 +5150,18 @@
         },
         "title": "Language"
       },
+      "morningBrief": {
+        "conflict": "Morning Brief is temporarily unavailable because its installation state is inconsistent. Retry when reconciliation finishes.",
+        "description": "Get a daily email at 7:00 AM in your time zone with priorities from Gmail, GitHub, Calendar, and unread Chats.",
+        "loading": "Loading Morning Brief settings...",
+        "missingDefaultAgent": "Choose a usable default Agent before enabling Morning Brief.",
+        "missingTimezone": "Set a valid time zone before enabling Morning Brief.",
+        "multipleInstallations": "Multiple Morning Brief installations exist. Resolve the conflict before changing this preference.",
+        "nextEmail": "Next email {{date}} ({{timezone}})",
+        "retry": "Retry",
+        "retryMessage": "Morning Brief settings could not be loaded or updated. Retry to continue.",
+        "title": "Morning Brief"
+      },
       "pageDescription": "Manage your appearance and agent runtime preferences",
       "pageTitle": "Preferences",
       "send": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -5217,6 +5217,18 @@
         },
         "title": "Idioma"
       },
+      "morningBrief": {
+        "conflict": "Morning Brief no está disponible temporalmente porque el estado de su instalación no es coherente. Vuelve a intentarlo cuando finalice la conciliación.",
+        "description": "Recibe un correo diario a las 7:00 en tu zona horaria con prioridades de Gmail, GitHub, Calendar y Chats sin leer.",
+        "loading": "Cargando la configuración de Morning Brief...",
+        "missingDefaultAgent": "Elige un Agente predeterminado que se pueda utilizar antes de activar Morning Brief.",
+        "missingTimezone": "Establece una zona horaria válida antes de activar Morning Brief.",
+        "multipleInstallations": "Hay varias instalaciones de Morning Brief. Resuelve el conflicto antes de cambiar esta preferencia.",
+        "nextEmail": "Siguiente correo: {{date}} ({{timezone}})",
+        "retry": "Reintentar",
+        "retryMessage": "No se pudo cargar o actualizar la configuración de Morning Brief. Vuelve a intentarlo para continuar.",
+        "title": "Resumen matutino"
+      },
       "pageDescription": "Gestiona la apariencia y las preferencias de ejecución de tus agentes",
       "pageTitle": "Preferencias",
       "send": {

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -5217,6 +5217,18 @@
         },
         "title": "Langue"
       },
+      "morningBrief": {
+        "conflict": "Morning Brief est temporairement indisponible, car l'état de son installation est incohérent. Réessayez une fois la réconciliation terminée.",
+        "description": "Recevez chaque jour à 7 h, dans votre fuseau horaire, un e-mail présentant les priorités de Gmail, GitHub, Calendar et des Chats non lus.",
+        "loading": "Chargement des paramètres de Morning Brief...",
+        "missingDefaultAgent": "Choisissez un Agent par défaut utilisable avant d'activer Morning Brief.",
+        "missingTimezone": "Définissez un fuseau horaire valide avant d'activer Morning Brief.",
+        "multipleInstallations": "Plusieurs installations de Morning Brief existent. Résolvez le conflit avant de modifier cette préférence.",
+        "nextEmail": "Prochain e-mail : {{date}} ({{timezone}})",
+        "retry": "Réessayer",
+        "retryMessage": "Les paramètres de Morning Brief n'ont pas pu être chargés ou mis à jour. Réessayez pour continuer.",
+        "title": "Résumé du matin"
+      },
       "pageDescription": "Gérez vos préférences d'apparence et d'exécution de l'agent",
       "pageTitle": "Préférences",
       "send": {

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -5158,6 +5158,18 @@
         },
         "title": "भाषा"
       },
+      "morningBrief": {
+        "conflict": "इंस्टॉलेशन स्थिति असंगत होने के कारण Morning Brief अस्थायी रूप से उपलब्ध नहीं है। मिलान पूरा होने पर फिर से कोशिश करें।",
+        "description": "अपने समय क्षेत्र में हर दिन सुबह 7:00 बजे Gmail, GitHub, Calendar और बिना पढ़े Chats की प्राथमिकताओं वाला ईमेल पाएँ।",
+        "loading": "Morning Brief सेटिंग लोड हो रही हैं...",
+        "missingDefaultAgent": "Morning Brief चालू करने से पहले उपयोग योग्य डिफ़ॉल्ट Agent चुनें।",
+        "missingTimezone": "Morning Brief चालू करने से पहले एक मान्य समय क्षेत्र सेट करें।",
+        "multipleInstallations": "Morning Brief के कई इंस्टॉलेशन मौजूद हैं। इस प्राथमिकता को बदलने से पहले विरोध हल करें।",
+        "nextEmail": "अगला ईमेल: {{date}} ({{timezone}})",
+        "retry": "फिर से कोशिश करें",
+        "retryMessage": "Morning Brief सेटिंग लोड या अपडेट नहीं हो सकीं। जारी रखने के लिए फिर से कोशिश करें।",
+        "title": "सुबह की संक्षिप्त जानकारी"
+      },
       "pageDescription": "अपनी उपस्थिति और एजेंट रनटाइम प्राथमिकताएँ प्रबंधित करें।",
       "pageTitle": "प्राथमिकताएँ",
       "send": {

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -5150,6 +5150,18 @@
         },
         "title": "Bahasa"
       },
+      "morningBrief": {
+        "conflict": "Morning Brief untuk sementara tidak tersedia karena status instalasinya tidak konsisten. Coba lagi setelah rekonsiliasi selesai.",
+        "description": "Dapatkan email harian pukul 07.00 di zona waktu Anda dengan prioritas dari Gmail, GitHub, Calendar, dan Chats yang belum dibaca.",
+        "loading": "Memuat pengaturan Morning Brief...",
+        "missingDefaultAgent": "Pilih Agent default yang dapat digunakan sebelum mengaktifkan Morning Brief.",
+        "missingTimezone": "Tetapkan zona waktu yang valid sebelum mengaktifkan Morning Brief.",
+        "multipleInstallations": "Ada beberapa instalasi Morning Brief. Selesaikan konflik sebelum mengubah preferensi ini.",
+        "nextEmail": "Email berikutnya: {{date}} ({{timezone}})",
+        "retry": "Coba lagi",
+        "retryMessage": "Pengaturan Morning Brief tidak dapat dimuat atau diperbarui. Coba lagi untuk melanjutkan.",
+        "title": "Brief Pagi"
+      },
       "pageDescription": "Kelola tampilan dan preferensi runtime agen Anda",
       "pageTitle": "Preferensi",
       "send": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -5217,6 +5217,18 @@
         },
         "title": "Lingua"
       },
+      "morningBrief": {
+        "conflict": "Morning Brief non è temporaneamente disponibile perché lo stato dell'installazione non è coerente. Riprova al termine della riconciliazione.",
+        "description": "Ricevi ogni giorno alle 7:00, nel tuo fuso orario, un'email con le priorità da Gmail, GitHub, Calendar e Chats non lette.",
+        "loading": "Caricamento delle impostazioni di Morning Brief...",
+        "missingDefaultAgent": "Scegli un Agent predefinito utilizzabile prima di attivare Morning Brief.",
+        "missingTimezone": "Imposta un fuso orario valido prima di attivare Morning Brief.",
+        "multipleInstallations": "Esistono più installazioni di Morning Brief. Risolvi il conflitto prima di modificare questa preferenza.",
+        "nextEmail": "Prossima email: {{date}} ({{timezone}})",
+        "retry": "Riprova",
+        "retryMessage": "Non è stato possibile caricare o aggiornare le impostazioni di Morning Brief. Riprova per continuare.",
+        "title": "Riepilogo mattutino"
+      },
       "pageDescription": "Gestisci l'aspetto e le preferenze di esecuzione degli agenti",
       "pageTitle": "Preferenze",
       "send": {

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -5150,6 +5150,18 @@
         },
         "title": "言語"
       },
+      "morningBrief": {
+        "conflict": "インストール状態に不整合があるため、Morning Brief は一時的に利用できません。調整が完了したら再試行してください。",
+        "description": "タイムゾーンの午前 7 時に、Gmail、GitHub、Calendar、未読 Chats の優先事項をまとめたメールを毎日受け取ります。",
+        "loading": "Morning Brief の設定を読み込んでいます...",
+        "missingDefaultAgent": "Morning Brief を有効にする前に、使用可能なデフォルト Agent を選択してください。",
+        "missingTimezone": "Morning Brief を有効にする前に、有効なタイムゾーンを設定してください。",
+        "multipleInstallations": "Morning Brief のインストールが複数あります。この設定を変更する前に競合を解決してください。",
+        "nextEmail": "次のメール: {{date}} ({{timezone}})",
+        "retry": "再試行",
+        "retryMessage": "Morning Brief の設定を読み込むか更新できませんでした。再試行してください。",
+        "title": "モーニングブリーフ"
+      },
       "pageDescription": "外観とエージェントの実行時の設定を管理する",
       "pageTitle": "設定",
       "send": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -5150,6 +5150,18 @@
         },
         "title": "언어"
       },
+      "morningBrief": {
+        "conflict": "설치 상태가 일관되지 않아 Morning Brief를 일시적으로 사용할 수 없습니다. 조정이 완료되면 다시 시도하세요.",
+        "description": "매일 오전 7시에 현재 시간대를 기준으로 Gmail, GitHub, Calendar 및 읽지 않은 Chats의 우선순위를 이메일로 받아보세요.",
+        "loading": "Morning Brief 설정을 불러오는 중...",
+        "missingDefaultAgent": "Morning Brief를 활성화하기 전에 사용 가능한 기본 Agent를 선택하세요.",
+        "missingTimezone": "Morning Brief를 활성화하기 전에 유효한 시간대를 설정하세요.",
+        "multipleInstallations": "Morning Brief 설치가 여러 개 있습니다. 이 환경설정을 변경하기 전에 충돌을 해결하세요.",
+        "nextEmail": "다음 이메일: {{date}} ({{timezone}})",
+        "retry": "다시 시도",
+        "retryMessage": "Morning Brief 설정을 불러오거나 업데이트할 수 없습니다. 계속하려면 다시 시도하세요.",
+        "title": "모닝 브리프"
+      },
       "pageDescription": "외관 및 에이전트 실행 환경설정을 관리하세요",
       "pageTitle": "환경설정",
       "send": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -5217,6 +5217,18 @@
         },
         "title": "Idioma"
       },
+      "morningBrief": {
+        "conflict": "O Morning Brief está temporariamente indisponível porque o estado da instalação está inconsistente. Tente novamente quando a reconciliação terminar.",
+        "description": "Receba um e-mail diário às 7h no seu fuso horário com prioridades do Gmail, GitHub, Calendar e Chats não lidos.",
+        "loading": "Carregando as configurações do Morning Brief...",
+        "missingDefaultAgent": "Escolha um Agent padrão utilizável antes de ativar o Morning Brief.",
+        "missingTimezone": "Defina um fuso horário válido antes de ativar o Morning Brief.",
+        "multipleInstallations": "Existem várias instalações do Morning Brief. Resolva o conflito antes de alterar esta preferência.",
+        "nextEmail": "Próximo e-mail: {{date}} ({{timezone}})",
+        "retry": "Tentar novamente",
+        "retryMessage": "Não foi possível carregar ou atualizar as configurações do Morning Brief. Tente novamente para continuar.",
+        "title": "Resumo matinal"
+      },
       "pageDescription": "Gerencie suas preferências de aparência e de execução dos agentes",
       "pageTitle": "Preferências",
       "send": {

--- a/turbo/apps/platform/src/mocks/handlers/api-morning-brief-preference.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-morning-brief-preference.ts
@@ -1,0 +1,36 @@
+import {
+  morningBriefPreferenceContract,
+  type MorningBriefPreferenceResponse,
+} from "@okouai/api-contracts/contracts/morning-brief-preference";
+
+import { mockApi } from "../msw-contract.ts";
+
+let preference: MorningBriefPreferenceResponse = {
+  enabled: false,
+  nextRunAt: null,
+  timezone: "UTC",
+  unavailableReason: null,
+};
+
+export function resetMockMorningBriefPreference(): void {
+  preference = {
+    enabled: false,
+    nextRunAt: null,
+    timezone: "UTC",
+    unavailableReason: null,
+  };
+}
+
+export const apiMorningBriefPreferenceHandlers = [
+  mockApi(morningBriefPreferenceContract.get, ({ respond }) => {
+    return respond(200, preference);
+  }),
+  mockApi(morningBriefPreferenceContract.update, ({ body, respond }) => {
+    preference = {
+      ...preference,
+      enabled: body.enabled,
+      nextRunAt: body.enabled ? "2099-01-01T07:00:00.000Z" : null,
+    };
+    return respond(200, preference);
+  }),
+];

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -72,6 +72,10 @@ import {
   resetMockUserPreferences,
 } from "./api-user-preferences.ts";
 import {
+  apiMorningBriefPreferenceHandlers,
+  resetMockMorningBriefPreference,
+} from "./api-morning-brief-preference.ts";
+import {
   apiUserModelPreferenceHandlers,
   resetMockUserModelPreference,
 } from "./api-user-model-preference.ts";
@@ -121,6 +125,7 @@ export const handlers = [
   ...apiWorkflowsHandlers,
   ...apiRunsHandlers,
   ...apiUserPreferencesHandlers,
+  ...apiMorningBriefPreferenceHandlers,
   ...apiUserModelPreferenceHandlers,
   ...apiOnboardingHandlers,
   ...apiBillingHandlers,
@@ -142,6 +147,7 @@ export function resetAllMockHandlers(): void {
   resetMockAgentPhoneIntegration();
   resetMockGithubIntegration();
   resetMockUserPreferences();
+  resetMockMorningBriefPreference();
   resetMockUserModelPreference();
   resetMockOrgModelProviders();
   resetMockOrgModelPolicies();

--- a/turbo/apps/platform/src/signals/okou-page/settings/preferences-page.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/preferences-page.ts
@@ -1,9 +1,18 @@
 import { command, computed, state } from "ccstate";
+import {
+  morningBriefPreferenceContract,
+  MORNING_BRIEF_PREFERENCES_FOCUS,
+  type MorningBriefPreferenceErrorCode,
+  type MorningBriefPreferenceResponse,
+} from "@okouai/api-contracts/contracts/morning-brief-preference";
 import type { SendMode } from "@okouai/api-contracts/contracts/user-preferences";
+import { accept } from "../../../lib/accept.ts";
+import { apiClient$ } from "../../api-client.ts";
 import { updateUserPreference$, userPreferences$ } from "./user-preferences.ts";
 import { sendMode$ } from "../../send-mode.ts";
 import { searchParams$, updateSearchParams$ } from "../../route.ts";
 import { reloadPersonalModelProviders$ } from "../../external/personal-model-providers.ts";
+import { onRef } from "../../utils.ts";
 
 // ---------------------------------------------------------------------------
 // Preferences tab state
@@ -48,6 +57,87 @@ export const setPreferencesTab$ = command(({ get, set }, value: string) => {
   }
   set(updateSearchParams$, next);
 });
+
+// ---------------------------------------------------------------------------
+// Morning Brief
+// ---------------------------------------------------------------------------
+
+export type MorningBriefPreferenceState =
+  | {
+      readonly kind: "ready";
+      readonly preference: MorningBriefPreferenceResponse;
+    }
+  | {
+      readonly kind: "error";
+      readonly code: MorningBriefPreferenceErrorCode;
+      readonly message: string;
+    };
+
+const morningBriefPreferenceVersion$ = state(0);
+
+function preferenceState(
+  result:
+    | { readonly status: 200; readonly body: MorningBriefPreferenceResponse }
+    | {
+        readonly status: 400 | 409;
+        readonly body: {
+          readonly error: {
+            readonly code: MorningBriefPreferenceErrorCode;
+            readonly message: string;
+          };
+        };
+      },
+): MorningBriefPreferenceState {
+  return result.status === 200
+    ? { kind: "ready", preference: result.body }
+    : {
+        kind: "error",
+        code: result.body.error.code,
+        message: result.body.error.message,
+      };
+}
+
+export const morningBriefPreference$ = computed(async (get) => {
+  get(morningBriefPreferenceVersion$);
+  const client = get(apiClient$)(morningBriefPreferenceContract);
+  const result = await accept(client.get(), [200, 409]);
+  return preferenceState(result);
+});
+
+export const updateMorningBriefPreference$ = command(
+  async ({ get, set }, enabled: boolean, signal: AbortSignal) => {
+    const client = get(apiClient$)(morningBriefPreferenceContract);
+    const result = await accept(
+      client.update({
+        body: { enabled },
+        fetchOptions: { signal },
+      }),
+      [200, 400, 409],
+    );
+    signal.throwIfAborted();
+    set(morningBriefPreferenceVersion$, (version) => {
+      return version + 1;
+    });
+    return preferenceState(result);
+  },
+);
+
+export const retryMorningBriefPreference$ = command(({ set }) => {
+  set(morningBriefPreferenceVersion$, (version) => {
+    return version + 1;
+  });
+});
+
+export const morningBriefPreferenceCardRef$ = onRef(
+  command(({ get }, element: HTMLElement, signal: AbortSignal) => {
+    signal.throwIfAborted();
+    if (get(searchParams$).get("focus") !== MORNING_BRIEF_PREFERENCES_FOCUS) {
+      return;
+    }
+    element.scrollIntoView({ block: "center" });
+    element.focus({ preventScroll: true });
+  }),
+);
 
 // ---------------------------------------------------------------------------
 // Send mode

--- a/turbo/apps/platform/src/signals/workflows-page/workflow-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflow-detail-page-setup.ts
@@ -1,19 +1,42 @@
 import { command } from "ccstate";
 import { createElement } from "react";
+import {
+  MORNING_BRIEF_PREFERENCES_FOCUS,
+  MORNING_BRIEF_PREFERENCES_TAB,
+} from "@okouai/api-contracts/contracts/morning-brief-preference";
 
 import { i18n } from "../../i18n/index.ts";
 import { WorkflowDetailPage } from "../../views/workflows-page/workflow-detail-page.tsx";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
-import { resetWorkflowDetailUiState$ } from "./workflows-signals.ts";
+import {
+  currentWorkflowDetail$,
+  isMorningBriefWorkflow,
+  resetWorkflowDetailUiState$,
+} from "./workflows-signals.ts";
 import { onboardGuard$ } from "../okou-page/onboard-guard.ts";
 import { setOfficialWorkflowConfigurationForm$ } from "./official-workflows-signals.ts";
+import { detachedNavigateTo$ } from "../route.ts";
+import { ROUTES } from "../route-paths.ts";
 
 export const setupWorkflowDetailPage$ = command(
-  async ({ set }, signal: AbortSignal) => {
+  async ({ get, set }, signal: AbortSignal) => {
     set(setOfficialWorkflowConfigurationForm$, null);
     set(resetWorkflowDetailUiState$);
+    const detail = await get(currentWorkflowDetail$);
+    signal.throwIfAborted();
+    if (detail && isMorningBriefWorkflow(detail)) {
+      const searchParams = new URLSearchParams({
+        tab: MORNING_BRIEF_PREFERENCES_TAB,
+        focus: MORNING_BRIEF_PREFERENCES_FOCUS,
+      });
+      set(detachedNavigateTo$, ROUTES.settings, {
+        searchParams,
+        replace: true,
+      });
+      return;
+    }
     set(updatePage$, createElement(WorkflowDetailPage), "sidebar");
     set(
       updateDocumentTitle$,

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -33,6 +33,7 @@ import {
   type WorkflowAutomationSummary,
   type WorkflowUpdateRequest,
 } from "@okouai/api-contracts/contracts/workflows";
+import { MORNING_BRIEF_OFFICIAL_DEFINITION_NAME } from "@okouai/api-contracts/contracts/morning-brief-preference";
 
 import { accept } from "../../lib/accept.ts";
 import { apiClient$ } from "../api-client.ts";
@@ -735,6 +736,14 @@ export const reloadWorkflows$ = command(({ set }) => {
   set(internalWorkflowConnectorReadiness$, null);
 });
 
+export function isMorningBriefWorkflow(
+  workflow: Pick<WorkflowSummary, "official">,
+): boolean {
+  return (
+    workflow.official?.definitionName === MORNING_BRIEF_OFFICIAL_DEFINITION_NAME
+  );
+}
+
 /** The current agent detail route's visible workflows. */
 export const currentAgentVisibleWorkflows$ = computed(
   async (get): Promise<readonly WorkflowSummary[]> => {
@@ -745,7 +754,9 @@ export const currentAgentVisibleWorkflows$ = computed(
     }
     const client = get(apiClient$)(workflowsCollectionContract);
     const result = await accept(client.list({ query: { agentId } }), [200]);
-    return result.body;
+    return result.body.filter((workflow) => {
+      return !isMorningBriefWorkflow(workflow);
+    });
   },
 );
 
@@ -755,14 +766,18 @@ export const allVisibleWorkflows$ = computed(
     const locale = get(locale$);
     const client = get(apiClient$)(workflowsCollectionContract);
     const result = await accept(client.list({ query: {} }), [200]);
-    return [...result.body].sort((a, b) => {
-      if (a.visibility !== b.visibility) {
-        return a.visibility === "public" ? -1 : 1;
-      }
-      const aTitle = a.displayName ?? a.name;
-      const bTitle = b.displayName ?? b.name;
-      return aTitle.localeCompare(bTitle, locale);
-    });
+    return result.body
+      .filter((workflow) => {
+        return !isMorningBriefWorkflow(workflow);
+      })
+      .sort((a, b) => {
+        if (a.visibility !== b.visibility) {
+          return a.visibility === "public" ? -1 : 1;
+        }
+        const aTitle = a.displayName ?? a.name;
+        const bTitle = b.displayName ?? b.name;
+        return aTitle.localeCompare(bTitle, locale);
+      });
   },
 );
 
@@ -775,22 +790,26 @@ export const allWorkflowAutomationEntries$ = computed(
       automationClient.listWorkspace(),
       [200],
     );
-    return [...automationResult.body].sort((a, b) => {
-      if (a.automation.enabled !== b.automation.enabled) {
-        return a.automation.enabled ? -1 : 1;
-      }
-      const aNext = a.automation.nextRunAt ?? "";
-      const bNext = b.automation.nextRunAt ?? "";
-      if (aNext && bNext && aNext !== bNext) {
-        return aNext.localeCompare(bNext);
-      }
-      if (aNext !== bNext) {
-        return aNext ? -1 : 1;
-      }
-      const aTitle = a.workflow.displayName ?? a.workflow.name;
-      const bTitle = b.workflow.displayName ?? b.workflow.name;
-      return aTitle.localeCompare(bTitle, locale);
-    });
+    return automationResult.body
+      .filter((entry) => {
+        return !isMorningBriefWorkflow(entry.workflow);
+      })
+      .sort((a, b) => {
+        if (a.automation.enabled !== b.automation.enabled) {
+          return a.automation.enabled ? -1 : 1;
+        }
+        const aNext = a.automation.nextRunAt ?? "";
+        const bNext = b.automation.nextRunAt ?? "";
+        if (aNext && bNext && aNext !== bNext) {
+          return aNext.localeCompare(bNext);
+        }
+        if (aNext !== bNext) {
+          return aNext ? -1 : 1;
+        }
+        const aTitle = a.workflow.displayName ?? a.workflow.name;
+        const bTitle = b.workflow.displayName ?? b.workflow.name;
+        return aTitle.localeCompare(bTitle, locale);
+      });
   },
 );
 

--- a/turbo/apps/platform/src/views/okou-page/components/settings/morning-brief-settings.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/morning-brief-settings.tsx
@@ -1,0 +1,213 @@
+import { Button } from "@okouai/ui/components/ui/button";
+import { Switch } from "@okouai/ui/components/ui/switch";
+import { useGet, useLoadable, useSet } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
+import { AlertCircle, Loader2, RotateCcw, Sunrise } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { currentLocale } from "../../../../i18n/index.ts";
+import {
+  morningBriefPreference$,
+  morningBriefPreferenceCardRef$,
+  retryMorningBriefPreference$,
+  updateMorningBriefPreference$,
+  type MorningBriefPreferenceState,
+} from "../../../../signals/okou-page/settings/preferences-page.ts";
+import { pageSignal$ } from "../../../../signals/page-signal.ts";
+import { detach, Reason } from "../../../../signals/utils.ts";
+
+function nextEmailText(
+  state: MorningBriefPreferenceState,
+  format: (date: string, timezone: string) => string,
+): string | null {
+  if (
+    state.kind !== "ready" ||
+    !state.preference.enabled ||
+    !state.preference.nextRunAt ||
+    !state.preference.timezone
+  ) {
+    return null;
+  }
+  return format(state.preference.nextRunAt, state.preference.timezone);
+}
+
+function MorningBriefStatus({
+  state,
+  loading,
+  loadFailed,
+  mutationFailed,
+}: {
+  readonly state: MorningBriefPreferenceState | undefined;
+  readonly loading: boolean;
+  readonly loadFailed: boolean;
+  readonly mutationFailed: boolean;
+}) {
+  const { t } = useTranslation();
+  const unavailable =
+    state?.kind === "ready" ? state.preference.unavailableReason : null;
+  const conflicted = state?.kind === "error";
+  const nextEmail = state
+    ? nextEmailText(state, (date, timezone) => {
+        const formatted = new Intl.DateTimeFormat(currentLocale(), {
+          dateStyle: "medium",
+          timeStyle: "short",
+          timeZone: timezone,
+        }).format(new Date(date));
+        return t(
+          ($) => {
+            return $.settings.preferences.morningBrief.nextEmail;
+          },
+          { date: formatted, timezone },
+        );
+      })
+    : null;
+
+  let status = nextEmail;
+  if (loading) {
+    status = t(($) => {
+      return $.settings.preferences.morningBrief.loading;
+    });
+  } else if (loadFailed || mutationFailed) {
+    status = t(($) => {
+      return $.settings.preferences.morningBrief.retryMessage;
+    });
+  } else if (state?.kind === "error") {
+    status =
+      state.code === "MORNING_BRIEF_MULTIPLE_INSTALLATIONS"
+        ? t(($) => {
+            return $.settings.preferences.morningBrief.multipleInstallations;
+          })
+        : t(($) => {
+            return $.settings.preferences.morningBrief.conflict;
+          });
+  } else if (unavailable === "missing-timezone") {
+    status = t(($) => {
+      return $.settings.preferences.morningBrief.missingTimezone;
+    });
+  } else if (unavailable === "missing-default-agent") {
+    status = t(($) => {
+      return $.settings.preferences.morningBrief.missingDefaultAgent;
+    });
+  }
+
+  if (!status) {
+    return null;
+  }
+  const showAlert =
+    loadFailed || mutationFailed || conflicted || unavailable !== null;
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      {showAlert && <AlertCircle className="size-3.5 shrink-0" />}
+      {loading && <Loader2 className="size-3.5 animate-spin" />}
+      <span>{status}</span>
+    </div>
+  );
+}
+
+export function MorningBriefSettings() {
+  const { t } = useTranslation();
+  const preferenceLoadable = useLoadable(morningBriefPreference$);
+  const [mutationLoadable, updatePreference] = useLoadableSet(
+    updateMorningBriefPreference$,
+  );
+  const retryPreference = useSet(retryMorningBriefPreference$);
+  const cardRef = useSet(morningBriefPreferenceCardRef$);
+  const pageSignal = useGet(pageSignal$);
+  const state =
+    preferenceLoadable.state === "hasData"
+      ? preferenceLoadable.data
+      : undefined;
+  const preference = state?.kind === "ready" ? state.preference : undefined;
+  const loading = preferenceLoadable.state === "loading";
+  const mutating = mutationLoadable.state === "loading";
+  const loadFailed = preferenceLoadable.state === "hasError";
+  const mutationFailed = mutationLoadable.state === "hasError";
+  const unavailable = preference?.unavailableReason ?? null;
+  const conflicted = state?.kind === "error";
+  const enabled = preference?.enabled ?? false;
+
+  const handleToggle = (checked: boolean) => {
+    detach(updatePreference(checked, pageSignal), Reason.DomCallback);
+  };
+
+  const handleRetry = () => {
+    if (mutationFailed && preference) {
+      detach(
+        updatePreference(!preference.enabled, pageSignal),
+        Reason.DomCallback,
+      );
+      return;
+    }
+    retryPreference();
+  };
+
+  const showRetry = loadFailed || mutationFailed || conflicted;
+
+  return (
+    <div
+      ref={cardRef}
+      tabIndex={-1}
+      data-testid="morning-brief-preference"
+      className="flex flex-col gap-3 rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <div className="flex flex-col gap-3 bg-card p-4 rounded-xl zero-border sm:flex-row sm:items-center sm:gap-4">
+        <div className="flex flex-1 items-center gap-4 min-w-0">
+          <div className="shrink-0">
+            <div className="flex h-7 w-7 items-center justify-center">
+              <Sunrise size={22} className="text-muted-foreground" />
+            </div>
+          </div>
+          <div className="flex flex-1 flex-col gap-1 min-w-0">
+            <div className="text-sm font-medium text-foreground">
+              {t(($) => {
+                return $.settings.preferences.morningBrief.title;
+              })}
+            </div>
+            <div className="text-sm text-muted-foreground">
+              {t(($) => {
+                return $.settings.preferences.morningBrief.description;
+              })}
+            </div>
+            <MorningBriefStatus
+              state={state}
+              loading={loading}
+              loadFailed={loadFailed}
+              mutationFailed={mutationFailed}
+            />
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {showRetry && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={handleRetry}
+              disabled={loading || mutating}
+            >
+              <RotateCcw />
+              {t(($) => {
+                return $.settings.preferences.morningBrief.retry;
+              })}
+            </Button>
+          )}
+          <Switch
+            aria-label={t(($) => {
+              return $.settings.preferences.morningBrief.title;
+            })}
+            checked={enabled}
+            onCheckedChange={handleToggle}
+            disabled={
+              loading ||
+              mutating ||
+              loadFailed ||
+              conflicted ||
+              unavailable !== null ||
+              preference === undefined
+            }
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/okou-page/preferences-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/preferences-page.tsx
@@ -38,6 +38,7 @@ import {
 import { BuildInfoBlock } from "./components/settings/build-info-block.tsx";
 import { LanguageSettings } from "./components/settings/language-settings.tsx";
 import { ColorThemeSettings } from "./components/settings/color-theme-settings.tsx";
+import { MorningBriefSettings } from "./components/settings/morning-brief-settings.tsx";
 
 function AppearanceSettings() {
   const { t } = useTranslation();
@@ -353,7 +354,12 @@ export function PreferencesPage() {
                   <SendModeSettings />
                 </div>
               )}
-              {activeTab === "timezone" && <TimezoneSettings />}
+              {activeTab === "timezone" && (
+                <div className="flex flex-col gap-6">
+                  <TimezoneSettings />
+                  <MorningBriefSettings />
+                </div>
+              )}
               {activeTab === "model-configuration" &&
                 showModelConfiguration && <PersonalProvidersTab />}
               {activeTab === "debug" && showDebug && (

--- a/turbo/apps/platform/src/views/preferences-page/__tests__/preferences-page.test.tsx
+++ b/turbo/apps/platform/src/views/preferences-page/__tests__/preferences-page.test.tsx
@@ -4,8 +4,12 @@ import {
   type UserPreferencesResponse,
   userPreferencesContract,
 } from "@okouai/api-contracts/contracts/user-preferences";
+import {
+  morningBriefPreferenceContract,
+  type MorningBriefPreferenceResponse,
+} from "@okouai/api-contracts/contracts/morning-brief-preference";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   MOCK_BACKEND_COMMIT_SHA,
@@ -290,6 +294,112 @@ describe("preferences page", () => {
           expect.objectContaining({ timezone: "America/New_York" }),
         ]),
       );
+    });
+  });
+
+  it("deep-links to Morning Brief and displays the persisted next run in its persisted time zone", async () => {
+    const scrollIntoView = vi.fn<HTMLElement["scrollIntoView"]>();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    const nextRunAt = "2030-01-02T23:30:00.000Z";
+    context.mocks.api(morningBriefPreferenceContract.get, ({ respond }) => {
+      return respond(200, {
+        enabled: true,
+        nextRunAt,
+        timezone: "Asia/Shanghai",
+        unavailableReason: null,
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/settings?tab=timezone&focus=morning-brief",
+    });
+
+    const card = await screen.findByTestId("morning-brief-preference");
+    const formatted = new Intl.DateTimeFormat("en-US", {
+      dateStyle: "medium",
+      timeStyle: "short",
+      timeZone: "Asia/Shanghai",
+    }).format(new Date(nextRunAt));
+    expect(
+      screen.getByText(`Next email ${formatted} (Asia/Shanghai)`),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: "Morning Brief" })).toBeChecked();
+    expect(screen.queryByText("Send now")).not.toBeInTheDocument();
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "center" });
+    expect(card).toHaveFocus();
+  });
+
+  it("updates Morning Brief through the preference facade and renders actionable unavailable and conflict states", async () => {
+    const captured: boolean[] = [];
+    let preference: MorningBriefPreferenceResponse = {
+      enabled: false,
+      nextRunAt: null,
+      timezone: "Asia/Shanghai",
+      unavailableReason: null,
+    };
+    let conflicted = false;
+    context.mocks.api(morningBriefPreferenceContract.get, ({ respond }) => {
+      if (conflicted) {
+        return respond(409, {
+          error: {
+            code: "MORNING_BRIEF_MULTIPLE_INSTALLATIONS",
+            message: "conflict",
+          },
+        });
+      }
+      return respond(200, preference);
+    });
+    context.mocks.api(
+      morningBriefPreferenceContract.update,
+      ({ body, respond }) => {
+        captured.push(body.enabled);
+        if (!body.enabled) {
+          conflicted = true;
+          return respond(409, {
+            error: {
+              code: "MORNING_BRIEF_MULTIPLE_INSTALLATIONS",
+              message: "conflict",
+            },
+          });
+        }
+        preference = body.enabled
+          ? {
+              enabled: true,
+              nextRunAt: "2030-01-02T23:00:00.000Z",
+              timezone: "Asia/Shanghai",
+              unavailableReason: null,
+            }
+          : {
+              enabled: false,
+              nextRunAt: null,
+              timezone: "Asia/Shanghai",
+              unavailableReason: null,
+            };
+        return respond(200, preference);
+      },
+    );
+
+    detachedSetupPage({ context, path: "/settings?tab=timezone" });
+    click(await screen.findByRole("switch", { name: "Morning Brief" }));
+    await waitFor(() => {
+      expect(captured).toStrictEqual([true]);
+      expect(
+        screen.getByRole("switch", { name: "Morning Brief" }),
+      ).toBeChecked();
+    });
+
+    click(screen.getByRole("switch", { name: "Morning Brief" }));
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Multiple Morning Brief installations exist/),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("switch", { name: "Morning Brief" }),
+      ).toHaveAttribute("aria-disabled", "true");
     });
   });
 

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -59,6 +59,8 @@ const OPS_WORKFLOW_ID = "d0000000-0000-4000-a000-000000000202";
 const OTHER_WORKFLOW_ID = "d0000000-0000-4000-a000-000000000203";
 const CHECKLIST_WORKFLOW_ID = "d0000000-0000-4000-a000-000000000204";
 const COPIED_WORKFLOW_ID = "d0000000-0000-4000-a000-000000000205";
+const MORNING_BRIEF_WORKFLOW_ID = "d0000000-0000-4000-a000-000000000206";
+const CONNECTOR_DOCTOR_WORKFLOW_ID = "d0000000-0000-4000-a000-000000000207";
 const GMAIL_AUTOMATION_ID = "workflow-automation-gmail-new-message";
 const GMAIL_LABEL_AUTOMATION_ID = "workflow-automation-gmail-label-applied";
 const GITHUB_PULL_REQUEST_AUTOMATION_ID =
@@ -712,6 +714,39 @@ function officialSalesResearch(
         },
       },
     ],
+  };
+}
+
+function namedOfficialWorkflow(
+  definitionName: "morning-brief" | "connector-doctor",
+): WorkflowDetailResponse {
+  const base = officialSalesResearch();
+  if (!base.official) {
+    throw new Error("Expected an Official Workflow fixture");
+  }
+  const morningBrief = definitionName === "morning-brief";
+  const displayName = morningBrief ? "Morning Brief" : "Connector Doctor";
+  return {
+    ...base,
+    id: morningBrief ? MORNING_BRIEF_WORKFLOW_ID : CONNECTOR_DOCTOR_WORKFLOW_ID,
+    name: definitionName,
+    displayName,
+    official: {
+      ...base.official,
+      definitionName,
+    },
+    automations: base.automations.map((automation) => {
+      return {
+        ...automation,
+        id: `workflow-automation-${definitionName}`,
+        official: automation.official
+          ? {
+              ...automation.official,
+              blueprintKey: morningBrief ? "daily-delivery" : "weekly-check",
+            }
+          : undefined,
+      };
+    }),
   };
 }
 
@@ -1516,6 +1551,40 @@ describe("workflows routes", () => {
 
     await user.hover(linkByAriaLabel("Open Sales Research"));
     await expect(screen.findByText("TU")).resolves.toBeInTheDocument();
+  });
+
+  it("hides Morning Brief from App workflow lists and counts without hiding other Official Workflows", async () => {
+    mockWorkflowApis([
+      salesResearch(),
+      namedOfficialWorkflow("morning-brief"),
+      namedOfficialWorkflow("connector-doctor"),
+    ]);
+
+    detachedSetupPage({ context, path: "/workflows" });
+
+    await screen.findByRole("heading", { name: "Workflows" });
+    expect(screen.getByText("Sales Research")).toBeInTheDocument();
+    expect(screen.getByText("Connector Doctor")).toBeInTheDocument();
+    expect(screen.queryByText("Morning Brief")).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Open Morning Brief"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("redirects a cold Morning Brief workflow detail URL to the stable Preferences deep link", async () => {
+    mockWorkflowApis([namedOfficialWorkflow("morning-brief")]);
+
+    detachedSetupWorkflowDetailPage(
+      `/workflows/${MORNING_BRIEF_WORKFLOW_ID}/automations`,
+    );
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/settings");
+      expect(search()).toBe("?tab=timezone&focus=morning-brief");
+    });
+    const preference = await screen.findByTestId("morning-brief-preference");
+    expect(preference).toHaveFocus();
+    expect(screen.queryByText("Instructions")).not.toBeInTheDocument();
   });
 
   it("hides Official discovery when the feature switch is disabled", async () => {

--- a/turbo/packages/api-contracts/src/contracts/morning-brief-preference.ts
+++ b/turbo/packages/api-contracts/src/contracts/morning-brief-preference.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+export const MORNING_BRIEF_OFFICIAL_DEFINITION_NAME = "morning-brief";
+export const MORNING_BRIEF_OFFICIAL_BLUEPRINT_KEY = "daily-delivery";
+export const MORNING_BRIEF_PREFERENCES_TAB = "timezone";
+export const MORNING_BRIEF_PREFERENCES_FOCUS = "morning-brief";
+export const MORNING_BRIEF_PREFERENCES_PATH =
+  "/settings?tab=timezone&focus=morning-brief";
+
+export const morningBriefUnavailableReasonSchema = z.enum([
+  "missing-timezone",
+  "missing-default-agent",
+]);
+
+export const morningBriefPreferenceResponseSchema = z.object({
+  enabled: z.boolean(),
+  nextRunAt: z.string().datetime().nullable(),
+  timezone: z.string().nullable(),
+  unavailableReason: morningBriefUnavailableReasonSchema.nullable(),
+});
+
+export type MorningBriefPreferenceResponse = z.infer<
+  typeof morningBriefPreferenceResponseSchema
+>;
+
+export const morningBriefPreferenceUpdateSchema = z.object({
+  enabled: z.boolean(),
+});
+
+export type MorningBriefPreferenceUpdate = z.infer<
+  typeof morningBriefPreferenceUpdateSchema
+>;
+
+export const morningBriefPreferenceErrorCodeSchema = z.enum([
+  "MORNING_BRIEF_MISSING_TIMEZONE",
+  "MORNING_BRIEF_MISSING_DEFAULT_AGENT",
+  "MORNING_BRIEF_MULTIPLE_INSTALLATIONS",
+  "MORNING_BRIEF_STATE_CONFLICT",
+]);
+
+export type MorningBriefPreferenceErrorCode = z.infer<
+  typeof morningBriefPreferenceErrorCodeSchema
+>;
+
+export const morningBriefPreferenceErrorSchema = z.object({
+  error: z.object({
+    code: morningBriefPreferenceErrorCodeSchema,
+    message: z.string(),
+  }),
+});
+
+export const morningBriefPreferenceContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/preferences/morning-brief",
+    headers: authHeadersSchema,
+    responses: {
+      200: morningBriefPreferenceResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      409: morningBriefPreferenceErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get the Morning Brief preference",
+  },
+  update: {
+    method: "PUT",
+    path: "/api/preferences/morning-brief",
+    headers: authHeadersSchema,
+    body: morningBriefPreferenceUpdateSchema,
+    responses: {
+      200: morningBriefPreferenceResponseSchema,
+      400: morningBriefPreferenceErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      409: morningBriefPreferenceErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Update the Morning Brief preference",
+  },
+});
+
+export type MorningBriefPreferenceContract =
+  typeof morningBriefPreferenceContract;


### PR DESCRIPTION
## Summary

- add a narrow authenticated Morning Brief preference facade backed by Official Workflow installation, reconciliation, and automation services
- render the Morning Brief switch and authoritative next email under Time zone Preferences with a stable focused deep link
- hide only Morning Brief from App workflow and automation surfaces and redirect its generic detail route to Preferences
- route Morning Brief result-email management to Preferences while preserving other automation links and account-wide unsubscribe behavior

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged workspace, API, contracts, and Platform type checks
- `vitest run src/signals/routes/__tests__/official-workflows.test.ts -t "Morning Brief preference"`
- `vitest run src/signals/routes/__tests__/official-automation-result-email.test.ts -t "Morning Brief"`
- `vitest run src/views/preferences-page/__tests__/preferences-page.test.tsx -t "Morning Brief"`
- `vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx -t "Morning Brief"`

Closes #30771