### PR TITLE
fix(api): repair chained legacy snapshot revocations

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-event-snapshot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-event-snapshot.test.ts
@@ -86,6 +86,77 @@ function sanitizedLegacyControlRevokeLine(row: ChatEventRow): string {
   })}\n`;
 }
 
+function isSanitizedLegacyChainedRoot(
+  row: ChatEventRow,
+  root: ChatEventRow,
+): boolean {
+  return (
+    root.chatThreadId === row.chatThreadId &&
+    root.eventType === "input.prompt" &&
+    root.runId === null &&
+    root.revokesEventId === null &&
+    root.contextType === "morning_brief" &&
+    root.contextId === root.id &&
+    root.runEventSequenceNumber === null &&
+    root.runEventId === null
+  );
+}
+
+function isSanitizedLegacyChainedTarget(
+  row: ChatEventRow,
+  target: ChatEventRow,
+  root: ChatEventRow,
+): boolean {
+  return (
+    target.chatThreadId === row.chatThreadId &&
+    target.eventType === "input.rejected" &&
+    target.runId === null &&
+    target.revokesEventId === root.id &&
+    target.contextType === "morning_brief" &&
+    target.contextId === root.id &&
+    target.runEventSequenceNumber === 0 &&
+    target.runEventId === null &&
+    target.seqId < row.seqId
+  );
+}
+
+function sanitizedLegacyChainedControlRevokeLine(
+  row: ChatEventRow,
+  target: ChatEventRow,
+  root: ChatEventRow,
+): string {
+  if (
+    row.eventType !== "control.revoke" ||
+    row.runId !== null ||
+    row.revokesEventId !== target.id ||
+    row.contextType !== "morning_brief" ||
+    row.contextId !== root.id ||
+    row.contextId === row.revokesEventId ||
+    row.payload !== null ||
+    row.runEventSequenceNumber !== null ||
+    row.runEventId !== null ||
+    !isSanitizedLegacyChainedTarget(row, target, root) ||
+    !isSanitizedLegacyChainedRoot(row, root) ||
+    root.seqId >= target.seqId
+  ) {
+    throw new Error("Expected an exact historical chained recall row");
+  }
+  return `${JSON.stringify({
+    id: row.id,
+    chatThreadId: row.chatThreadId,
+    runId: null,
+    revokesEventId: target.id,
+    eventType: "control.revoke",
+    payload: null,
+    contextType: "morning_brief",
+    contextId: root.id,
+    runEventSequenceNumber: null,
+    runEventId: null,
+    seqId: row.seqId,
+    createdAt: row.createdAt,
+  })}\n`;
+}
+
 function mockR2GcWindowForKey(key: string, after: Date): Date {
   const prefixStart = "chat-events/".length;
   const shardGroup = Number.parseInt(
@@ -396,23 +467,31 @@ describe("chat event snapshot read endpoints", () => {
         return [row.id, index] as const;
       }),
     );
-    const contextOnlyRow = originalRows.find((row) => {
+    const rejectionRows = originalRows.filter((row) => {
       return row.eventType === "input.rejected";
     });
-    if (contextOnlyRow === undefined) {
-      throw new Error("Expected a context-only historical rejection row");
-    }
-    const contextCarryingRevokeRow = originalRows.find((row) => {
-      return row.eventType === "input.rejected" && row.id !== contextOnlyRow.id;
-    });
+    const contextOnlyRow = rejectionRows[0];
+    const directControlRevokeRow = rejectionRows[1];
+    const chainedRejectionRow = rejectionRows[2];
+    const chainedControlRevokeRow = rejectionRows[3];
     if (
-      contextCarryingRevokeRow === undefined ||
-      contextCarryingRevokeRow.revokesEventId === null
+      contextOnlyRow === undefined ||
+      directControlRevokeRow === undefined ||
+      directControlRevokeRow.revokesEventId === null ||
+      chainedRejectionRow === undefined ||
+      chainedRejectionRow.revokesEventId === null ||
+      chainedControlRevokeRow === undefined
     ) {
-      throw new Error("Expected a historical revocation source row");
+      throw new Error("Expected complete historical revocation source rows");
+    }
+    const chainedRootRow = originalRows.find((row) => {
+      return row.id === chainedRejectionRow.revokesEventId;
+    });
+    if (chainedRootRow?.eventType !== "input.prompt") {
+      throw new Error("Expected the chained rejection root prompt");
     }
     const expectedRows = originalRows.map((row): ChatEventRow => {
-      if (row.id === contextCarryingRevokeRow.id) {
+      if (row.id === directControlRevokeRow.id) {
         return chatEventRowSchema.parse({
           ...row,
           eventType: "control.revoke",
@@ -423,44 +502,84 @@ describe("chat event snapshot read endpoints", () => {
           runEventId: null,
         });
       }
+      if (row.id === chainedControlRevokeRow.id) {
+        return chatEventRowSchema.parse({
+          ...row,
+          eventType: "control.revoke",
+          payload: null,
+          revokesEventId: chainedRejectionRow.id,
+          contextType: "web",
+          contextId: null,
+          runEventSequenceNumber: null,
+          runEventId: null,
+        });
+      }
       const promptIndex = promptIndexById.get(row.id);
-      if (promptIndex === undefined) {
-        return row.id === contextOnlyRow.id
-          ? chatEventRowSchema.parse({
-              ...row,
-              contextType: "web",
-              contextId: null,
-            })
-          : row;
+      if (promptIndex !== undefined) {
+        const historicalDocument = historicalDocuments[promptIndex];
+        const runId = runIds[promptIndex];
+        if (historicalDocument === undefined || runId === undefined) {
+          throw new Error("Expected a complete historical shape fixture");
+        }
+        return chatEventRowSchema.parse({
+          ...row,
+          runId: row.id === chainedRootRow.id ? null : runId,
+          revokesEventId:
+            promptIndex === 1
+              ? (promptRows[0]?.id ?? null)
+              : row.revokesEventId,
+          contextType: "web",
+          contextId: null,
+          payload: {
+            ...row.payload,
+            userMessage: historicalDocument,
+          },
+        });
       }
-      const historicalDocument = historicalDocuments[promptIndex];
-      const runId = runIds[promptIndex];
-      if (historicalDocument === undefined || runId === undefined) {
-        throw new Error("Expected a complete historical shape fixture");
+      if (row.id === chainedRejectionRow.id) {
+        const rootPromptIndex = promptIndexById.get(chainedRootRow.id);
+        const historicalDocument =
+          rootPromptIndex === undefined
+            ? undefined
+            : historicalDocuments[rootPromptIndex];
+        if (historicalDocument === undefined) {
+          throw new Error("Expected the chained rejection root document");
+        }
+        return chatEventRowSchema.parse({
+          ...row,
+          contextType: "web",
+          contextId: null,
+          payload: {
+            ...row.payload,
+            userMessage: historicalDocument,
+          },
+        });
       }
-      return chatEventRowSchema.parse({
-        ...row,
-        runId,
-        revokesEventId:
-          promptIndex === 1 ? (promptRows[0]?.id ?? null) : row.revokesEventId,
-        contextType: "web",
-        contextId: null,
-        payload: {
-          ...row.payload,
-          userMessage: historicalDocument,
-        },
-      });
+      return row.id === contextOnlyRow.id
+        ? chatEventRowSchema.parse({
+            ...row,
+            contextType: "web",
+            contextId: null,
+          })
+        : row;
     });
     for (const row of expectedRows) {
       chatEventFromRow(row);
     }
 
     const staleRows = expectedRows.map((row): ChatEventRow => {
-      if (row.id === contextCarryingRevokeRow.id) {
+      if (row.id === directControlRevokeRow.id) {
         return chatEventRowSchema.parse({
           ...row,
           contextType: "morning_brief",
           contextId: row.revokesEventId,
+        });
+      }
+      if (row.id === chainedControlRevokeRow.id) {
+        return chatEventRowSchema.parse({
+          ...row,
+          contextType: "morning_brief",
+          contextId: chainedRootRow.id,
         });
       }
       const promptIndex = promptIndexById.get(row.id);
@@ -488,6 +607,34 @@ describe("chat event snapshot read endpoints", () => {
           },
         });
       }
+      if (row.id === chainedRejectionRow.id) {
+        const rootPromptIndex = promptIndexById.get(chainedRootRow.id);
+        const userMessage =
+          rootPromptIndex === undefined
+            ? undefined
+            : historicalDocuments[rootPromptIndex];
+        if (userMessage === undefined || rootPromptIndex === undefined) {
+          throw new Error("Expected a chained rejection document fixture");
+        }
+        return chatEventRowSchema.parse({
+          ...row,
+          contextType: "morning_brief",
+          contextId: chainedRootRow.id,
+          payload: {
+            ...row.payload,
+            userMessage: {
+              ...userMessage,
+              parts: [
+                ...userMessage.parts,
+                {
+                  type: "morning_brief",
+                  briefDate: `2026-08-${(20 + rootPromptIndex).toString()}`,
+                },
+              ],
+            },
+          },
+        });
+      }
       return row.id === contextOnlyRow.id
         ? chatEventRowSchema.parse({
             ...row,
@@ -496,26 +643,51 @@ describe("chat event snapshot read endpoints", () => {
           })
         : row;
     });
+    const staleDirectControlRevoke = staleRows.find((row) => {
+      return row.id === directControlRevokeRow.id;
+    });
+    const staleChainedRejection = staleRows.find((row) => {
+      return row.id === chainedRejectionRow.id;
+    });
+    const staleChainedControlRevoke = staleRows.find((row) => {
+      return row.id === chainedControlRevokeRow.id;
+    });
+    const staleChainedRoot = staleRows.find((row) => {
+      return row.id === chainedRootRow.id;
+    });
+    if (
+      staleDirectControlRevoke === undefined ||
+      staleChainedRejection === undefined ||
+      staleChainedControlRevoke === undefined ||
+      staleChainedRoot === undefined
+    ) {
+      throw new Error("Expected byte-exact historical revocation rows");
+    }
+    const byteExactDirectRevokeLine = sanitizedLegacyControlRevokeLine(
+      staleDirectControlRevoke,
+    );
+    const byteExactChainedRevokeLine = sanitizedLegacyChainedControlRevokeLine(
+      staleChainedControlRevoke,
+      staleChainedRejection,
+      staleChainedRoot,
+    );
     const staleArchive = Buffer.from(
       staleRows
         .map((row) => {
-          return row.id === contextCarryingRevokeRow.id
-            ? sanitizedLegacyControlRevokeLine(row)
+          if (row.id === directControlRevokeRow.id) {
+            return byteExactDirectRevokeLine;
+          }
+          return row.id === chainedControlRevokeRow.id
+            ? byteExactChainedRevokeLine
             : `${JSON.stringify(row)}\n`;
         })
         .join(""),
     );
-    const staleContextCarryingRevoke = staleRows.find((row) => {
-      return row.id === contextCarryingRevokeRow.id;
-    });
-    if (staleContextCarryingRevoke === undefined) {
-      throw new Error("Expected the byte-exact historical queue-discard row");
-    }
-    const byteExactRevokeLine = sanitizedLegacyControlRevokeLine(
-      staleContextCarryingRevoke,
-    );
     expect(
-      staleArchive.includes(Buffer.from(byteExactRevokeLine)),
+      staleArchive.includes(Buffer.from(byteExactDirectRevokeLine)),
+    ).toBeTruthy();
+    expect(
+      staleArchive.includes(Buffer.from(byteExactChainedRevokeLine)),
     ).toBeTruthy();
     const staleBody = gzipSync(staleArchive);
     const staleObjectKey = `chat-events/${threadId}/${originalHead.last_seq_id.toString()}-${createHash("sha256").update(staleBody).digest("hex")}.ndjson.gz`;
@@ -587,14 +759,25 @@ describe("chat event snapshot read endpoints", () => {
     );
     expect(
       repairedRows.find((row) => {
-        return row.id === contextCarryingRevokeRow.id;
+        return row.id === directControlRevokeRow.id;
       }),
     ).toMatchObject({
       eventType: "control.revoke",
       payload: null,
       contextType: "web",
       contextId: null,
-      revokesEventId: contextCarryingRevokeRow.revokesEventId,
+      revokesEventId: directControlRevokeRow.revokesEventId,
+    });
+    expect(
+      repairedRows.find((row) => {
+        return row.id === chainedControlRevokeRow.id;
+      }),
+    ).toMatchObject({
+      eventType: "control.revoke",
+      payload: null,
+      contextType: "web",
+      contextId: null,
+      revokesEventId: chainedRejectionRow.id,
     });
 
     const projectedSnapshot = repairedRows.map(chatEventFromRow);
@@ -605,7 +788,11 @@ describe("chat event snapshot read endpoints", () => {
       projectedPrompts.map((event) => {
         return event.runId;
       }),
-    ).toStrictEqual(runIds);
+    ).toStrictEqual(
+      promptRows.map((row, index) => {
+        return row.id === chainedRootRow.id ? undefined : runIds[index];
+      }),
+    );
     expect(
       projectedPrompts.map((event) => {
         return event.userMessage;
@@ -811,8 +998,15 @@ describe("chat event snapshot read endpoints", () => {
     const inputRow = originalRows.find((row) => {
       return row.eventType === "input.prompt";
     });
+    const rejectedRow = originalRows.find((row) => {
+      return row.eventType === "input.rejected";
+    });
     const firstRow = originalRows[0];
-    if (inputRow === undefined || firstRow === undefined) {
+    if (
+      inputRow === undefined ||
+      rejectedRow === undefined ||
+      firstRow === undefined
+    ) {
       throw new Error("Expected complete Snapshot decode fixtures");
     }
     const encodeRows = (rows: readonly unknown[]): Buffer => {
@@ -830,6 +1024,23 @@ describe("chat event snapshot read endpoints", () => {
     const projectionBody = encodeRows(
       originalRows.map((row) => {
         return row.id === inputRow.id ? { ...row, payload: null } : row;
+      }),
+    );
+    const unresolvedRevokeBody = encodeRows(
+      originalRows.map((row) => {
+        return row.id === rejectedRow.id
+          ? {
+              ...row,
+              eventType: "control.revoke",
+              runId: null,
+              revokesEventId: randomUUID(),
+              contextType: "morning_brief",
+              contextId: inputRow.id,
+              payload: null,
+              runEventSequenceNumber: null,
+              runEventId: null,
+            }
+          : row;
       }),
     );
     const prefixBody = encodeRows(
@@ -861,6 +1072,14 @@ describe("chat event snapshot read endpoints", () => {
       {
         failureClass: "projection",
         object: gzipSync(projectionBody),
+        projectionSubstage: "current_contract",
+        projectionVariant: "invalid_event_shape",
+      },
+      {
+        failureClass: "projection",
+        object: gzipSync(unresolvedRevokeBody),
+        projectionSubstage: "retired_event",
+        projectionVariant: "unresolved_revoke_chain",
       },
       {
         failureClass: "prefix",
@@ -914,9 +1133,24 @@ describe("chat event snapshot read endpoints", () => {
         reason: "undecodable",
         failureClass: testCase.failureClass,
         context: "api:cron:snapshot-chat-events",
+        ...("projectionSubstage" in testCase
+          ? {
+              projectionSubstage: testCase.projectionSubstage,
+              projectionVariant: testCase.projectionVariant,
+            }
+          : {}),
       });
       expect(Object.keys(fields).sort()).toStrictEqual(
-        ["chatThreadId", "context", "failureClass", "reason", "type"].sort(),
+        [
+          "chatThreadId",
+          "context",
+          "failureClass",
+          "reason",
+          "type",
+          ...("projectionSubstage" in testCase
+            ? ["projectionSubstage", "projectionVariant"]
+            : []),
+        ].sort(),
       );
     }
   }, 90_000);

--- a/turbo/apps/api/src/signals/services/chat-event-snapshot-body.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-snapshot-body.service.ts
@@ -4,7 +4,7 @@ import {
 } from "@okouai/api-contracts/contracts/chat-event-rows";
 import { chatEventFromRow } from "@okouai/api-contracts/contracts/chat-event-row-projection";
 
-import { safeJsonParse } from "../utils";
+import { safeJsonParse, safeSync } from "../utils";
 
 const RETIRED_MORNING_BRIEF_CONTEXT = "morning_brief";
 const RETIRED_MORNING_BRIEF_PART = "morning_brief";
@@ -15,6 +15,50 @@ interface MorningBriefSnapshotRepair {
   readonly rows: readonly ChatEventRow[];
   readonly repairedContextRows: number;
   readonly removedDocumentParts: number;
+}
+
+export type ChatEventSnapshotProjectionSubstage =
+  | "retired_event"
+  | "retired_document"
+  | "retired_context"
+  | "retired_part"
+  | "current_contract";
+
+export type ChatEventSnapshotProjectionVariant =
+  | "unsupported_event"
+  | "invalid_control_revoke"
+  | "unresolved_revoke_chain"
+  | "unexpected_document"
+  | "unscoped_part"
+  | "missing_context_id"
+  | "duplicate_part"
+  | "unexpected_part"
+  | "empty_message"
+  | "invalid_event_shape";
+
+export class ChatEventSnapshotProjectionError extends Error {
+  readonly projectionSubstage: ChatEventSnapshotProjectionSubstage;
+  readonly projectionVariant: ChatEventSnapshotProjectionVariant;
+
+  constructor(
+    projectionSubstage: ChatEventSnapshotProjectionSubstage,
+    projectionVariant: ChatEventSnapshotProjectionVariant,
+  ) {
+    super("Chat Event Snapshot projection failed");
+    this.name = "ChatEventSnapshotProjectionError";
+    this.projectionSubstage = projectionSubstage;
+    this.projectionVariant = projectionVariant;
+  }
+}
+
+function failProjection(
+  projectionSubstage: ChatEventSnapshotProjectionSubstage,
+  projectionVariant: ChatEventSnapshotProjectionVariant,
+): never {
+  throw new ChatEventSnapshotProjectionError(
+    projectionSubstage,
+    projectionVariant,
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -44,30 +88,121 @@ function assertExactRetiredMorningBriefPart(part: unknown): void {
     typeof part.briefDate !== "string" ||
     !ISO_DATE_PATTERN.test(part.briefDate)
   ) {
-    throw new Error(
-      "Chat Event snapshot has an unexpected retired Morning Brief part",
-    );
+    failProjection("retired_part", "unexpected_part");
   }
 }
 
-function isRepairableRetiredMorningBriefEvent(row: ChatEventRow): boolean {
-  if (row.eventType === "input.prompt" || row.eventType === "input.rejected") {
-    return true;
-  }
-  // The historical queue-discard path copied its target context onto this
-  // payload-free tombstone. Keep the one-way exception exact to that shape.
+function isPayloadFreeControlRevoke(row: ChatEventRow): boolean {
   return (
     row.eventType === "control.revoke" &&
     row.runId === null &&
     row.revokesEventId !== null &&
-    row.revokesEventId === row.contextId &&
     row.payload === null &&
     row.runEventSequenceNumber === null &&
     row.runEventId === null
   );
 }
 
-function repairMorningBriefRow(row: ChatEventRow): {
+function isExactRetiredMorningBriefRoot(
+  row: ChatEventRow,
+  root: ChatEventRow | null | undefined,
+): root is ChatEventRow {
+  return (
+    root !== undefined &&
+    root !== null &&
+    root.chatThreadId === row.chatThreadId &&
+    root.eventType === "input.prompt" &&
+    root.runId === null &&
+    root.revokesEventId === null &&
+    root.contextType === RETIRED_MORNING_BRIEF_CONTEXT &&
+    root.contextId === root.id &&
+    root.runEventSequenceNumber === null &&
+    root.runEventId === null
+  );
+}
+
+function isExactRetiredMorningBriefRejection(
+  row: ChatEventRow,
+  target: ChatEventRow | null | undefined,
+  root: ChatEventRow,
+): boolean {
+  return (
+    target !== undefined &&
+    target !== null &&
+    target.chatThreadId === row.chatThreadId &&
+    target.eventType === "input.rejected" &&
+    target.runId === null &&
+    target.revokesEventId === root.id &&
+    target.contextType === RETIRED_MORNING_BRIEF_CONTEXT &&
+    target.contextId === root.id &&
+    target.runEventSequenceNumber === 0 &&
+    target.runEventId === null
+  );
+}
+
+function isExactRetiredMorningBriefRevokeChain(
+  row: ChatEventRow,
+  priorRowsById: ReadonlyMap<string, ChatEventRow | null>,
+): boolean {
+  if (
+    row.contextId === null ||
+    row.revokesEventId === null ||
+    row.contextId === row.revokesEventId
+  ) {
+    return false;
+  }
+  const target = priorRowsById.get(row.revokesEventId);
+  const root = priorRowsById.get(row.contextId);
+  return (
+    isExactRetiredMorningBriefRoot(row, root) &&
+    isExactRetiredMorningBriefRejection(row, target, root)
+  );
+}
+
+function assertRepairableRetiredMorningBriefEvent(
+  row: ChatEventRow,
+  priorRowsById: ReadonlyMap<string, ChatEventRow | null>,
+): void {
+  if (row.eventType === "input.prompt" || row.eventType === "input.rejected") {
+    return;
+  }
+  if (!isPayloadFreeControlRevoke(row)) {
+    failProjection(
+      "retired_event",
+      row.eventType === "control.revoke"
+        ? "invalid_control_revoke"
+        : "unsupported_event",
+    );
+  }
+  // Queue discard copied the prompt context directly. Recall after the
+  // insufficient-credit replacement copied the same root context while its
+  // revoke edge targeted the intermediate rejection. Require that complete
+  // ordered archive-local chain before accepting the second legacy shape.
+  // This is limited to immutable legacy V7 Snapshot state. Remove it after all
+  // surviving V7 heads have converged to r1 and the retired writer's rollback
+  // window has closed; removal is tracked by #30369 and #28905.
+  if (
+    row.contextId === row.revokesEventId ||
+    isExactRetiredMorningBriefRevokeChain(row, priorRowsById)
+  ) {
+    return;
+  }
+  failProjection("retired_event", "unresolved_revoke_chain");
+}
+
+function assertCurrentProjection(row: ChatEventRow): void {
+  const projected = safeSync(() => {
+    chatEventFromRow(row);
+  });
+  if ("error" in projected) {
+    failProjection("current_contract", "invalid_event_shape");
+  }
+}
+
+function repairMorningBriefRow(
+  row: ChatEventRow,
+  priorRowsById: ReadonlyMap<string, ChatEventRow | null>,
+): {
   readonly row: ChatEventRow;
   readonly removedDocumentParts: number;
 } {
@@ -76,18 +211,14 @@ function repairMorningBriefRow(row: ChatEventRow): {
   let legacyParts: readonly unknown[] = [];
   let parts: readonly unknown[] | undefined;
 
-  if (hasRetiredContext && !isRepairableRetiredMorningBriefEvent(row)) {
-    throw new Error(
-      "Chat Event snapshot has an unexpected retired Morning Brief event",
-    );
+  if (hasRetiredContext) {
+    assertRepairableRetiredMorningBriefEvent(row, priorRowsById);
   }
 
   if (userMessage !== undefined) {
     if (!isRecord(userMessage) || !Array.isArray(userMessage.parts)) {
       if (hasRetiredContext) {
-        throw new Error(
-          "Chat Event snapshot has an unexpected retired Morning Brief document",
-        );
+        failProjection("retired_document", "unexpected_document");
       }
     } else {
       parts = userMessage.parts;
@@ -97,22 +228,16 @@ function repairMorningBriefRow(row: ChatEventRow): {
 
   if (!hasRetiredContext) {
     if (legacyParts.length > 0) {
-      throw new Error(
-        "Chat Event snapshot has an unscoped retired Morning Brief part",
-      );
+      failProjection("retired_document", "unscoped_part");
     }
-    chatEventFromRow(row);
+    assertCurrentProjection(row);
     return { row, removedDocumentParts: 0 };
   }
   if (row.contextId === null) {
-    throw new Error(
-      "Chat Event snapshot has an incomplete retired Morning Brief context",
-    );
+    failProjection("retired_context", "missing_context_id");
   }
   if (legacyParts.length > 1) {
-    throw new Error(
-      "Chat Event snapshot has duplicate retired Morning Brief parts",
-    );
+    failProjection("retired_part", "duplicate_part");
   }
 
   const removedDocumentParts = legacyParts.length;
@@ -121,17 +246,13 @@ function repairMorningBriefRow(row: ChatEventRow): {
     const retiredPart = legacyParts[0];
     assertExactRetiredMorningBriefPart(retiredPart);
     if (!isRecord(userMessage) || userMessage.version !== 1 || !parts) {
-      throw new Error(
-        "Chat Event snapshot has an unexpected retired Morning Brief document",
-      );
+      failProjection("retired_document", "unexpected_document");
     }
     const currentParts = parts.filter((part) => {
       return part !== retiredPart;
     });
     if (currentParts.length === 0) {
-      throw new Error(
-        "Chat Event snapshot Morning Brief repair would empty a message",
-      );
+      failProjection("retired_part", "empty_message");
     }
     payload = {
       ...row.payload,
@@ -145,7 +266,7 @@ function repairMorningBriefRow(row: ChatEventRow): {
     contextId: null,
     payload,
   });
-  chatEventFromRow(repaired);
+  assertCurrentProjection(repaired);
   return { row: repaired, removedDocumentParts };
 }
 
@@ -178,13 +299,15 @@ export function repairMorningBriefPhaseBSnapshot(
     throw new Error("Chat Event snapshot decoded row count changed");
   }
   const rows: ChatEventRow[] = [];
+  const priorRowsById = new Map<string, ChatEventRow | null>();
   const repairedLines = rawLines.map((raw, index) => {
     const row = decodedRows[index];
     if (row === undefined) {
       throw new Error("Chat Event snapshot decoded row is missing");
     }
-    const repaired = repairMorningBriefRow(row);
+    const repaired = repairMorningBriefRow(row, priorRowsById);
     rows.push(repaired.row);
+    priorRowsById.set(row.id, priorRowsById.has(row.id) ? null : row);
     if (repaired.row === row) {
       return Buffer.from(`${raw}\n`);
     }

--- a/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
@@ -46,8 +46,11 @@ import {
   type DuplicateEventIdNormalizationStats,
 } from "./chat-event-snapshot-duplicate-id-normalization";
 import {
+  ChatEventSnapshotProjectionError,
   decodeChatEventSnapshotBody,
   repairMorningBriefPhaseBSnapshot,
+  type ChatEventSnapshotProjectionSubstage,
+  type ChatEventSnapshotProjectionVariant,
 } from "./chat-event-snapshot-body.service";
 
 const log = logger("api:cron:snapshot-chat-events");
@@ -306,11 +309,18 @@ type SnapshotDecodeFailureClass =
 
 class SnapshotDecodeFailure extends Error {
   readonly failureClass: SnapshotDecodeFailureClass;
+  readonly projectionSubstage: ChatEventSnapshotProjectionSubstage | undefined;
+  readonly projectionVariant: ChatEventSnapshotProjectionVariant | undefined;
 
-  constructor(failureClass: SnapshotDecodeFailureClass) {
+  constructor(
+    failureClass: SnapshotDecodeFailureClass,
+    projectionFailure?: ChatEventSnapshotProjectionError,
+  ) {
     super("Chat Event Snapshot decode failed");
     this.name = "SnapshotDecodeFailure";
     this.failureClass = failureClass;
+    this.projectionSubstage = projectionFailure?.projectionSubstage;
+    this.projectionVariant = projectionFailure?.projectionVariant;
   }
 }
 
@@ -323,6 +333,8 @@ type SnapshotSkippedResolution =
       readonly kind: "skipped";
       readonly reason: "undecodable";
       readonly failureClass: SnapshotDecodeFailureClass;
+      readonly projectionSubstage?: ChatEventSnapshotProjectionSubstage;
+      readonly projectionVariant?: ChatEventSnapshotProjectionVariant;
     };
 
 type SnapshotSourceResolution =
@@ -467,7 +479,12 @@ async function decodeSnapshotStage<T>(
     })(),
   );
   if (!decoded.ok) {
-    throw new SnapshotDecodeFailure(failureClass);
+    throw new SnapshotDecodeFailure(
+      failureClass,
+      decoded.error instanceof ChatEventSnapshotProjectionError
+        ? decoded.error
+        : undefined,
+    );
   }
   return decoded.value;
 }
@@ -546,6 +563,13 @@ function readSnapshotPrefix(
       kind: "skipped",
       reason: "undecodable",
       failureClass: decoded.error.failureClass,
+      ...(decoded.error.projectionSubstage === undefined ||
+      decoded.error.projectionVariant === undefined
+        ? {}
+        : {
+            projectionSubstage: decoded.error.projectionSubstage,
+            projectionVariant: decoded.error.projectionVariant,
+          }),
     };
   });
 }
@@ -647,7 +671,16 @@ function skippedArchivedThread(
     chatThreadId: candidate.chatThreadId,
     reason: resolution.reason,
     ...(resolution.reason === "undecodable"
-      ? { failureClass: resolution.failureClass }
+      ? {
+          failureClass: resolution.failureClass,
+          ...(resolution.projectionSubstage === undefined ||
+          resolution.projectionVariant === undefined
+            ? {}
+            : {
+                projectionSubstage: resolution.projectionSubstage,
+                projectionVariant: resolution.projectionVariant,
+              }),
+        }
       : {}),
   });
   return {


### PR DESCRIPTION
## Summary

- repair the exact legacy Morning Brief recall chain whose payload-free `control.revoke` targets an intermediate insufficient-credit `input.rejected` while retaining the root prompt context
- require the complete ordered archive-local prompt -> rejection -> revoke structure before rewriting only the retired context pointer
- add bounded `projectionSubstage` and `projectionVariant` diagnostics without logging archive rows, payloads, message text, attachments, source contents, or user data
- preserve the byte-exact direct `control.revoke` regression from #30754 and all five historical user-message document shapes

## Diagnosis

The retired replacement writer copied the root Morning Brief context through every immutable replacement. An insufficient-credit `input.rejected` revoked the root prompt, and a later recall revoked that rejection. The resulting tombstone therefore has `contextId` equal to the root prompt ID and `revokesEventId` equal to the intermediate rejection ID. This differs from the direct queue-discard shape repaired by #30754, where the two fields are equal.

The repair accepts the chained shape only when both predecessor rows occur earlier in the same archive, every revoke edge and retired context pointer matches, the root is an unowned `input.prompt`, the intermediate row is the exact sequence-zero `input.rejected`, and the terminal row is an exact payload-free `control.revoke`. All other shapes continue to fail closed.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/db run test:morning-brief-phase-b-cleanup`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-event-snapshot.test.ts` (8 passed)
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-thread-idb.test.tsx` (7 passed)

## Fallbacks

- `repairMorningBriefPhaseBSnapshot` remains a one-way compatibility fallback for immutable legacy V7 Snapshot objects. Its persisted-state surface is limited to publishing a new immutable current-`r1` object through the existing exact-pointer CAS; it never mutates the source object or canonical `chat_events`. Strict current-row projection gates every output row. Remove this fallback only after every surviving legacy V7 head has converged to `r1` and the rollback window for the retired writer has closed, tracked by #30369 and #28905.

Closes #30779
