### PR TITLE
fix: scope connector doctor to its host agent

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
@@ -542,8 +542,13 @@ describe.sequential("Official Workflow catalog release boundary", () => {
       files: [],
     });
     expect(
-      connectorDoctorInstruction.match(/okou doctor connectors --json/gu),
+      connectorDoctorInstruction.match(
+        /okou doctor connectors --agent "\$OKOU_AGENT_ID" --json/gu,
+      ),
     ).toHaveLength(1);
+    expect(connectorDoctorInstruction).not.toMatch(
+      /okou doctor connectors --json/gu,
+    );
     expect(connectorDoctorInstruction).toContain(
       "unique sandbox-local report file with `mktemp`",
     );
@@ -554,7 +559,16 @@ describe.sequential("Official Workflow catalog release boundary", () => {
       `report_file="$(mktemp "\${TMPDIR:-/tmp}/connector-doctor.XXXXXX.json")"`,
     );
     expect(connectorDoctorInstruction).toContain(
-      'okou doctor connectors --json >"$report_file"',
+      `if [ -z "\${OKOU_AGENT_ID:-}" ]; then`,
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "status=failed reason=missing-agent-id",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      'okou doctor connectors --agent "$OKOU_AGENT_ID" --json >"$report_file"',
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "Require a non-empty `OKOU_AGENT_ID` before running the Doctor command",
     );
     expect(connectorDoctorInstruction).toContain(
       "do not rerun it, split it into per-workflow diagnoses, or call connector-readiness APIs separately",
@@ -570,6 +584,12 @@ describe.sequential("Official Workflow catalog release boundary", () => {
     );
     expect(connectorDoctorInstruction).toContain(
       "all five non-negative integer summary counts",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "every returned workflow's `agent.id` exactly matches the runtime `OKOU_AGENT_ID`",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "A missing runtime Agent identity or any cross-Agent workflow entry makes the diagnosis unavailable",
     );
     expect(connectorDoctorInstruction).toContain(
       "A truncated or empty file, invalid JSON, an unsupported schema version, a missing required field",
@@ -614,7 +634,13 @@ describe.sequential("Official Workflow catalog release boundary", () => {
     expect(connectorDoctorInstruction).toContain("Unknown is never healthy");
     expect(connectorDoctorInstruction).toContain("summary.checked === 0");
     expect(connectorDoctorInstruction).toContain(
-      "no effective visible workflows were available to check",
+      "Describe every valid report as covering effective workflows on the current Agent, including both public and private workflows hosted there",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "Never describe this Agent-scoped result as coverage across visible Agents",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "no effective workflows on the current Agent were available to check",
     );
     expect(connectorDoctorInstruction).toContain(
       "not an all-clear over diagnosed workflows",
@@ -623,10 +649,13 @@ describe.sequential("Official Workflow catalog release boundary", () => {
       "summary.attention === 0`, and `summary.unknown === 0",
     );
     expect(connectorDoctorInstruction).toContain(
-      "aggregate covered effective visible workflows",
+      "aggregate covered effective workflows on the current Agent, including its public and private workflows",
     );
     expect(connectorDoctorInstruction).toContain(
-      "compact inventory of every checked entry in `workflows`, grouped by its returned Agent identity",
+      "compact inventory of every checked entry in `workflows`",
+    );
+    expect(connectorDoctorInstruction).toContain(
+      "Do not apply a visibility filter to any valid report branch",
     );
     expect(connectorDoctorInstruction).toContain(
       "page through a projection of every connector entry with a non-null action",

--- a/turbo/apps/api/src/signals/services/official-workflow-catalog-source.ts
+++ b/turbo/apps/api/src/signals/services/official-workflow-catalog-source.ts
@@ -33,8 +33,12 @@ Produce a concise Markdown connector-readiness report in this Official Workflow'
 In one shell tool call, create a unique sandbox-local report file with \`mktemp\`, then run the aggregate diagnosis exactly once per scheduled or manual run and redirect its complete standard output directly into that file. Use this capture shape so the tool result contains only the path and status:
 
 \`\`\`sh
+if [ -z "\${OKOU_AGENT_ID:-}" ]; then
+  printf 'status=failed reason=missing-agent-id\\n' >&2
+  exit 1
+fi
 report_file="$(mktemp "\${TMPDIR:-/tmp}/connector-doctor.XXXXXX.json")" &&
-if okou doctor connectors --json >"$report_file"; then
+if okou doctor connectors --agent "$OKOU_AGENT_ID" --json >"$report_file"; then
   printf 'report_file=%s status=ok\\n' "$report_file"
 else
   doctor_status=$?
@@ -43,13 +47,13 @@ else
 fi
 \`\`\`
 
-Do not use \`tee\`, echo the raw output, switch to the human-readable CLI output, or depend on compact JSON whitespace or a higher tool-output limit. Check the command's exit status and do not rerun it, split it into per-workflow diagnoses, or call connector-readiness APIs separately. The capture call may return only the unique file path and a small success or failure status, never the report body.
+Require a non-empty \`OKOU_AGENT_ID\` before running the Doctor command. Do not use \`tee\`, echo the raw output, switch to the human-readable CLI output, or depend on compact JSON whitespace or a higher tool-output limit. Check the command's exit status and do not rerun it, split it into per-workflow diagnoses, or call connector-readiness APIs separately. The capture call may return only the unique file path and a small success or failure status, never the report body.
 
 All later commands must be local parsers against that same sandbox file. Treat that one captured report as the sole source of diagnostic facts. Do not supplement, verify, or reinterpret it from any other source. Keep the file sandbox-local; do not upload, attach, or send it.
 
 ## Validate locally and read the summary first
 
-Before making any health claim, use a non-emitting local \`jq\` check or equivalent local parser against the file. It must parse the entire file successfully, prove that the root is an object with \`schemaVersion === 1\`, and validate the required schema-version-1 fields and types used below: all five non-negative integer summary counts, the \`workflows\` array, workflow and Agent identities, outcomes, connector statuses and reasons, exact action kinds and URLs, and workflow errors. A truncated or empty file, invalid JSON, an unsupported schema version, a missing required field, a type or value mismatch, or any local parsing or projection failure makes the diagnosis unavailable.
+Before making any health claim, use a non-emitting local \`jq\` check or equivalent local parser against the file. It must parse the entire file successfully, prove that the root is an object with \`schemaVersion === 1\`, and validate the required schema-version-1 fields and types used below: all five non-negative integer summary counts, the \`workflows\` array, workflow and Agent identities, outcomes, connector statuses and reasons, exact action kinds and URLs, and workflow errors. It must also prove that every returned workflow's \`agent.id\` exactly matches the runtime \`OKOU_AGENT_ID\`. A missing runtime Agent identity or any cross-Agent workflow entry makes the diagnosis unavailable. A truncated or empty file, invalid JSON, an unsupported schema version, a missing required field, a type or value mismatch, or any local parsing or projection failure makes the diagnosis unavailable.
 
 After validation, the first data-returning projection must contain only \`schemaVersion\` and \`summary\`. Never make a tool call that prints, reads, or returns the whole raw file; in particular, do not use \`cat\`, \`tee\`, an unfiltered \`jq\` query, or an equivalent whole-file read. Every later data-returning projection must select only the fields required by the chosen report branch and return at most 20 records per tool result. Use a count-only projection to determine whether paging is needed, then advance explicit offsets until every projected record for that branch has been consumed. Local parsers may scan the complete file internally, but the raw document must never cross the tool-return boundary.
 
@@ -57,10 +61,12 @@ If the Doctor command or local capture fails, or any validation condition above 
 
 ## Report valid results
 
-- If \`summary.checked === 0\`, report that no effective visible workflows were available to check. Treat this as a distinct no-workflows result, not an all-clear over diagnosed workflows. The validated summary is sufficient for this branch.
-- Emit a short all-clear only when \`summary.checked > 0\`, \`summary.attention === 0\`, and \`summary.unknown === 0\`. For this branch, page through a projection containing only each checked workflow's returned identity and returned Agent identity. State that the aggregate covered effective visible workflows and include a compact inventory of every checked entry in \`workflows\`, grouped by its returned Agent identity. Use only workflow and Agent names or IDs present in the JSON.
+- Describe every valid report as covering effective workflows on the current Agent, including both public and private workflows hosted there. Never describe this Agent-scoped result as coverage across visible Agents.
+- If \`summary.checked === 0\`, report that no effective workflows on the current Agent were available to check. Treat this as a distinct no-workflows result, not an all-clear over diagnosed workflows. The validated summary is sufficient for this branch.
+- Emit a short all-clear only when \`summary.checked > 0\`, \`summary.attention === 0\`, and \`summary.unknown === 0\`. For this branch, page through a projection containing only each checked workflow's returned identity and returned Agent identity. State that the aggregate covered effective workflows on the current Agent, including its public and private workflows, and include a compact inventory of every checked entry in \`workflows\`. Use only workflow and Agent names or IDs present in the JSON.
 - Otherwise, page through a projection of every connector entry with a non-null action, selecting only the workflow identity, connector status and reason, and exact \`action.kind\`, \`action.label\`, and \`action.url\`. Group entries by identical \`action.kind\` and exact \`action.url\`. Include the repair link once for each group, then list every affected workflow with the connector's returned readiness status and reason. Never merge entries whose exact URLs differ, even when their action kinds or connector labels match, because the URL identifies the target Agent.
 - For the same non-all-clear branch, separately page through a projection of every connector whose status is \`unavailable\` and every workflow with a non-null \`error\`. Under **Unknown**, include the returned workflow identity and reason or error message. Unknown is never healthy.
+- Do not apply a visibility filter to any valid report branch. The Agent-scoped aggregate already includes both public and private effective workflows on the current Agent.
 - Keep the report concise and include only facts, counts, statuses, reasons, and repair links present in the returned JSON.
 
 ## Safety boundaries

--- a/turbo/apps/cli/src/commands/doctor/__tests__/connectors.test.ts
+++ b/turbo/apps/cli/src/commands/doctor/__tests__/connectors.test.ts
@@ -810,15 +810,96 @@ describe("okou doctor connectors command", () => {
     );
   });
 
-  it("fails when --agent is passed without a workflow argument", async () => {
-    await expect(run(["--agent", AGENT_ID])).rejects.toThrow(
-      "process.exit called",
+  it("checks only effective public and private workflows on an aggregate Agent scope", async () => {
+    const privateWinner = workflow(
+      PRIVATE_WINNER_WORKFLOW_ID,
+      "shared-workflow",
+      { displayName: "Private Winner" },
+    );
+    const publicWorkflow = workflow(FOREIGN_WORKFLOW_ID, "public-workflow", {
+      visibility: "public",
+      ownerUserId: OTHER_USER_ID,
+    });
+    const shadowedPublic = workflow(SHADOWED_WORKFLOW_ID, "shared-workflow", {
+      visibility: "public",
+      ownerUserId: OTHER_USER_ID,
+      shadowedBy: {
+        id: privateWinner.id,
+        name: privateWinner.name,
+        displayName: privateWinner.displayName,
+      },
+    });
+    const otherAgentWorkflow = workflow(
+      UNKNOWN_WORKFLOW_ID,
+      "other-agent-workflow",
+      {
+        agentId: SECOND_AGENT_ID,
+        agentName: "other-agent",
+        agentDisplayName: "Other Agent",
+      },
+    );
+    let requestedAgentId: string | null = null;
+    server.use(
+      http.get(`${API_ORIGIN}/api/workflows`, ({ request }) => {
+        requestedAgentId = new URL(request.url).searchParams.get("agentId");
+        return HttpResponse.json([
+          shadowedPublic,
+          privateWinner,
+          publicWorkflow,
+          otherAgentWorkflow,
+        ]);
+      }),
+    );
+    const checkedWorkflowIds = new Set<string>();
+    server.use(
+      http.post(
+        `${API_ORIGIN}/api/workflows/:workflowId/connector-readiness`,
+        ({ params }) => {
+          const workflowId = String(params.workflowId);
+          checkedWorkflowIds.add(workflowId);
+          return HttpResponse.json({
+            connectors: [
+              {
+                connectorSlug:
+                  workflowId === privateWinner.id ? "gmail" : "slack",
+                label: workflowId === privateWinner.id ? "Gmail" : "Slack",
+                reason: "The workflow uses an external connector.",
+                status: "not-connected",
+              },
+            ] satisfies WorkflowConnectorReadinessEntry[],
+          });
+        },
+      ),
     );
 
-    expect(mockExit).toHaveBeenCalledWith(1);
-    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
-      "--agent requires a workflow argument",
+    await run(["--agent", AGENT_ID, "--json"]);
+
+    const printed = output();
+    const report = reportFromOutput(printed);
+    expect(requestedAgentId).toBe(AGENT_ID);
+    expect(checkedWorkflowIds).toStrictEqual(
+      new Set([PRIVATE_WINNER_WORKFLOW_ID, FOREIGN_WORKFLOW_ID]),
     );
+    expect(report.summary).toStrictEqual({
+      checked: 2,
+      attention: 2,
+      unknown: 0,
+      ready: 0,
+      noConnectors: 0,
+    });
+    expect(
+      report.workflows.map((item) => {
+        return item.id;
+      }),
+    ).toStrictEqual([PRIVATE_WINNER_WORKFLOW_ID, FOREIGN_WORKFLOW_ID]);
+    for (const item of report.workflows) {
+      expect(item.agent.id).toBe(AGENT_ID);
+      expect(item.connectors[0]?.action?.url).toMatch(
+        new RegExp(`\\?agentId=${AGENT_ID}$`, "u"),
+      );
+    }
+    expect(printed).not.toContain(SECOND_AGENT_ID);
+    expect(mockExit).not.toHaveBeenCalled();
   });
 
   it("documents the effective visible aggregate scope", () => {
@@ -832,10 +913,13 @@ describe("okou doctor connectors command", () => {
     help = help.replace(/\s+/gu, " ");
 
     expect(help).toContain(
-      "every effective visible workflow across all visible Agents is checked; shadowed workflows are skipped",
+      "Without a workflow argument or --agent, every effective visible workflow across all visible Agents is checked; shadowed workflows are skipped",
     );
     expect(help).toContain(
-      "Aggregate mode is not limited by OKOU_AGENT_ID; each workflow's Agent is used for connector authorization",
+      "With --agent and no workflow argument, every effective workflow hosted by that Agent is checked; public and private workflows are included; shadowed workflows are skipped",
+    );
+    expect(help).toContain(
+      "With a workflow argument, --agent scopes workflow slug resolution; slugs otherwise use OKOU_AGENT_ID, while workflow IDs retain their existing direct lookup behavior",
     );
   });
 });

--- a/turbo/apps/cli/src/commands/doctor/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/doctor/__tests__/index.test.ts
@@ -18,7 +18,10 @@ describe("okou doctor command", () => {
       "Diagnose stored connector readiness across workflows",
     );
     expect(normalizedHelp).toContain(
-      "stored connector readiness across effective visible workflows on every visible Agent",
+      "without --agent for stored connector readiness across effective visible workflows on every visible Agent",
+    );
+    expect(normalizedHelp).toContain(
+      "--agent <agent-id> for every effective public or private workflow hosted by one Agent",
     );
     expect(normalizedHelp).toContain(
       "Use okou connector check for one current-run URL, environment name, firewall decision, or permission failure",

--- a/turbo/apps/cli/src/commands/doctor/connectors.ts
+++ b/turbo/apps/cli/src/commands/doctor/connectors.ts
@@ -549,12 +549,13 @@ async function selectedWorkflows(
     const workflowId = await resolveWorkflowRef(workflowRef, options);
     return [await getWorkflow(workflowId)];
   }
-  if (options.agent) {
-    throw new Error("--agent requires a workflow argument");
-  }
-  const workflows = await listWorkflows({});
+  const workflows = await listWorkflows({ agentId: options.agent });
   return workflows.filter((workflow) => {
-    return workflow.shadowedBy == null;
+    return (
+      workflow.shadowedBy == null &&
+      (options.agent === undefined ||
+        workflow.agentId.toLowerCase() === options.agent.toLowerCase())
+    );
   });
 }
 
@@ -564,21 +565,23 @@ export const connectorsCommand = new Command()
   .argument("[workflow]", "Workflow ID or slug name")
   .option(
     "--agent <id>",
-    "Agent scope for a workflow slug (defaults to OKOU_AGENT_ID)",
+    "Agent scope for aggregate diagnosis or workflow slug resolution (slugs default to OKOU_AGENT_ID)",
   )
   .option("--json", "Print a versioned machine-readable report")
   .addHelpText(
     "after",
     `
 Examples:
-  Check effective visible workflows: okou doctor connectors
+  Check effective visible workflows across Agents: okou doctor connectors
+  Check effective workflows on one Agent: okou doctor connectors --agent <agent-id>
   Check one workflow ID: okou doctor connectors <workflow-id>
   Check one workflow name: okou doctor connectors <workflow-name> --agent <agent-id>
-  Print JSON: okou doctor connectors --json
+  Print Agent-scoped JSON: okou doctor connectors --agent <agent-id> --json
 
 Notes:
-  - Without a workflow argument, every effective visible workflow across all visible Agents is checked; shadowed workflows are skipped
-  - Aggregate mode is not limited by OKOU_AGENT_ID; each workflow's Agent is used for connector authorization
+  - Without a workflow argument or --agent, every effective visible workflow across all visible Agents is checked; shadowed workflows are skipped
+  - With --agent and no workflow argument, every effective workflow hosted by that Agent is checked; public and private workflows are included; shadowed workflows are skipped
+  - With a workflow argument, --agent scopes workflow slug resolution; slugs otherwise use OKOU_AGENT_ID, while workflow IDs retain their existing direct lookup behavior
   - Each workflow is checked through its stored connector-readiness route
   - Findings and per-workflow unknowns are report data and do not fail the command
   - Use okou connector check for one current-run URL, firewall decision, or permission failure`,

--- a/turbo/apps/cli/src/commands/doctor/index.ts
+++ b/turbo/apps/cli/src/commands/doctor/index.ts
@@ -12,13 +12,15 @@ export const doctorCommand = new Command()
     `
 Examples:
   Check credits? okou doctor credit
-  Check workflow connectors? okou doctor connectors
+  Check workflow connectors across Agents? okou doctor connectors
+  Check workflow connectors on one Agent? okou doctor connectors --agent <agent-id>
   Check one workflow? okou doctor connectors <workflow> --agent <agent-id>
-  Print a structured report? okou doctor connectors --json
+  Print an Agent-scoped structured report? okou doctor connectors --agent <agent-id> --json
 
 Notes:
   - Use okou doctor credit when a run or generation fails because the org has insufficient credits, when a user asks how to recharge, or before trying to buy credits
   - Use okou generate <type> (no --prompt) to see every provider available for a given generation type
-  - Use okou doctor connectors for stored connector readiness across effective visible workflows on every visible Agent
+  - Use okou doctor connectors without --agent for stored connector readiness across effective visible workflows on every visible Agent
+  - Use okou doctor connectors --agent <agent-id> for every effective public or private workflow hosted by one Agent
   - Use okou connector check for one current-run URL, environment name, firewall decision, or permission failure`,
   );


### PR DESCRIPTION
## Summary

- add Agent-scoped aggregate Connector Doctor behavior for every effective public or private workflow hosted by the requested Agent
- update the weekly Connector Doctor Official Workflow to run one Agent-scoped JSON diagnosis and fail closed on missing or mismatched Agent identity
- preserve unscoped cross-Agent aggregation, single-workflow resolution, and the existing bounded local-file projection safety contract

## Verification

- `pnpm --filter @okouai/cli exec vitest run src/commands/doctor/__tests__/connectors.test.ts src/commands/doctor/__tests__/index.test.ts` (13 passed)
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts` (13 passed)
- `pnpm --filter @okouai/cli lint`
- `pnpm --filter api lint`
- `pnpm --filter @okouai/cli check-types`
- `pnpm --filter api check-types`
- `pnpm knip`
- focused Prettier formatting and `git diff --check`

Closes #30792

Parent EPIC: #30469