### PR TITLE
refactor(api): drop the computer-use and feature-switch compatibility rows

### DIFF
--- a/docs/okou-cli-cutover.md
+++ b/docs/okou-cli-cutover.md
@@ -61,7 +61,7 @@ identifiers, the Slack `/zero model` interaction, and the separate Desktop
 identity. These are not executable CLI producers.
 
 `/api/okou/**` is not a preserved identity. It is a compatibility surface being
-drained under #26701: it is down to 58 rows in `MIGRATED_BRANDED_PATHS`, and
+drained under #26701: it is down to 53 rows in `MIGRATED_BRANDED_PATHS`, and
 after #28984 no contract declares a branded path, so those rows are the only
 thing still registering one.
 

--- a/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
+++ b/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
@@ -5,7 +5,6 @@ import { z } from "zod";
 import { createAppWithRoutes } from "../app-factory-core";
 import { ROUTES } from "../signals/route";
 import { billingStatusRoutes } from "../signals/routes/billing-status";
-import { featureSwitchesRoutes } from "../signals/routes/feature-switches";
 import { orgReadRoutes } from "../signals/routes/org-read";
 import { slackChannelsRoutes } from "../signals/routes/slack-channels";
 import { slackConnectRoutes } from "../signals/routes/slack-connect";
@@ -211,29 +210,13 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/computer-use/audit-events",
     "/api/zero/computer-use/audit-events",
   ],
-  "/api/computer-use/heartbeat": [
-    "/api/okou/computer-use/heartbeat",
-    "/api/zero/computer-use/heartbeat",
-  ],
   "/api/computer-use/host/commands/:commandId/complete": [
     "/api/okou/computer-use/host/commands/:commandId/complete",
     "/api/zero/computer-use/host/commands/:commandId/complete",
   ],
-  "/api/computer-use/host/commands/next": [
-    "/api/okou/computer-use/host/commands/next",
-    "/api/zero/computer-use/host/commands/next",
-  ],
-  "/api/computer-use/host/stop": [
-    "/api/okou/computer-use/host/stop",
-    "/api/zero/computer-use/host/stop",
-  ],
   "/api/computer-use/hosts": [
     "/api/okou/computer-use/hosts",
     "/api/zero/computer-use/hosts",
-  ],
-  "/api/computer-use/hosts/start": [
-    "/api/okou/computer-use/hosts/start",
-    "/api/zero/computer-use/hosts/start",
   ],
   // #28423
   "/api/integrations/slack": [
@@ -302,10 +285,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   // #28462: feature switches, model policies, org model providers and their
   // device-auth sessions, the org profile and membership routes, and the usage
   // reads.
-  "/api/feature-switches": [
-    "/api/okou/feature-switches",
-    "/api/zero/feature-switches",
-  ],
   "/api/model-policies": [
     "/api/okou/model-policies",
     "/api/zero/model-policies",
@@ -629,10 +608,11 @@ describe("branded paths for migrated neutral routes", () => {
   // to 184, #28711 kept when it took the 42 drained rows that left 142, #28917
   // kept when it took 53 more and left 89, #28974 kept when it took
   // `uploads/prepare` and left 88, #28916 kept when it took the 26 cut-over
-  // rows that left 62, and #30668 kept when it took the four Slack rows whose
-  // producer moved and left 58. None of them left a case asserting the
-  // removed rows now 404: `docs/fallback.md` section 1 rules that class out,
-  // and the route table already proves the registration is gone.
+  // rows that left 62, #30668 kept when it took the four Slack rows whose
+  // producer moved and left 58, and #30804 kept when it took the four Computer
+  // Use host rows and `feature-switches` and left 53. None of them left a case
+  // asserting the removed rows now 404: `docs/fallback.md` section 1 rules that
+  // class out, and the route table already proves the registration is gone.
   // What needs a test is the opposite direction — a row disappearing without
   // the request-log evidence #26701 requires — which is what this count and the
   // per-family cases catch.
@@ -644,7 +624,7 @@ describe("branded paths for migrated neutral routes", () => {
   // whole table. Raise the number only with that evidence; an unexplained edit
   // here is the failure this is for.
   it("holds the branded rows this suite has evidence for and no others", () => {
-    const MIGRATED_BRANDED_ROW_COUNT = 58;
+    const MIGRATED_BRANDED_ROW_COUNT = 53;
 
     expect(Object.keys(MIGRATED_ROUTE_PATHS)).toHaveLength(
       MIGRATED_BRANDED_ROW_COUNT,
@@ -733,21 +713,20 @@ describe("branded paths for migrated neutral routes", () => {
   });
 
   // The #28462 twin, driven through the same production app factory. An
-  // installed desktop build hardcodes `/api/okou/org` and
-  // `/api/okou/feature-switches` rather than deriving them from a contract, and
-  // it has no expiry window, so these are the two rows a dropped registration
-  // would strand longest. Requests are unauthenticated, so the status is
-  // whatever the auth layer returns — the point is that all three forms reach
-  // the same handler instead of falling through to 404.
-  it("serves the migrated org and feature-switch paths through the production app factory", async () => {
+  // installed desktop build hardcodes `/api/okou/org` rather than deriving it
+  // from a contract, and a `CLI_PKG_URL`-pinned CLI was still reading
+  // `/api/zero/org` when #30804 measured the table, so this is the row a
+  // dropped registration would strand longest. That slice also covered
+  // `feature-switches`, whose row #30804 retired, which is why only `org` is
+  // exercised here now. Requests are unauthenticated, so the status is whatever
+  // the auth layer returns — the point is that all three forms reach the same
+  // handler instead of falling through to 404.
+  it("serves the migrated org paths through the production app factory", async () => {
     context.mocks.clerk.authenticateRequest.mockResolvedValue({
       isAuthenticated: false,
     });
 
-    const families = [
-      { routes: orgReadRoutes, suffix: "org" },
-      { routes: featureSwitchesRoutes, suffix: "feature-switches" },
-    ];
+    const families = [{ routes: orgReadRoutes, suffix: "org" }];
 
     for (const { routes, suffix } of families) {
       const app = createAppWithRoutes({ signal: context.signal, routes });

--- a/turbo/apps/api/src/signals/route-entry.ts
+++ b/turbo/apps/api/src/signals/route-entry.ts
@@ -169,8 +169,9 @@ export function withApiNamespaceAliases(
  * shipped CLI, desktop or platform build emits a branded literal for any of
  * them. The desktop build's entire hardcoded surface is `auth/me`,
  * `computer-use/{heartbeat,host/*,hosts/start}`, `desktop/{updates,
- * migration-policy}`, `feature-switches` and `org`, and every one of those
- * rows is kept.
+ * migration-policy}`, `feature-switches` and `org`, and #28917 kept every one
+ * of those rows; #30804 later retired the Computer Use host rows and
+ * `feature-switches` from it.
  *
  * Three rows the #28917 inventory listed were held back, and each names a way
  * a zero-count reading fails:
@@ -210,10 +211,10 @@ export function withApiNamespaceAliases(
  * - A conditional endpoint is quiet for reasons that have nothing to do with a
  *   drain. `computer-use/host/commands/:commandId/complete` is called only when
  *   a write command finishes, so its silence measures how often that happened,
- *   not whether the caller of `host/commands/next` — which this table still
- *   holds — is still there. Read a row against the traffic of the loop it
- *   belongs to, not only against its own. This is #28917's call-rate rule
- *   reached from the other direction.
+ *   not whether the caller of `host/commands/next` — which this table held at
+ *   the time, and #30804 has since removed — is still there. Read a row against
+ *   the traffic of the loop it belongs to, not only against its own. This is
+ *   #28917's call-rate rule reached from the other direction.
  *
  * A production traffic sweep does not see this repository's own CI. E2E runs
  * against preview deployments, so a row called only by a workflow step or an
@@ -242,6 +243,26 @@ export function withApiNamespaceAliases(
  * browser and crawler requests ten hours after the deploy that was supposed to
  * have drained it. Ask which of the two a producer is before reading a deploy
  * as a drain.
+ *
+ * #30804 then took the four Computer Use host rows and `feature-switches`,
+ * leaving 53. Those five held the last branded traffic an installed Okou
+ * Desktop build produced, and the reading that retired them is neither a
+ * silence nor a repointed producer: every branded request in the window came
+ * from a machine that was already running a current build on the neutral paths
+ * on either side of it. Two addresses emitted all eighteen, one at
+ * `x_client_version` 0.38.2 over thirty-four seconds on 08-30 and one at
+ * 0.34.0 for a single `feature-switches` read on 09-01, and both addresses
+ * report 0.40.4 by the end of the window. An old build launched briefly beside
+ * a current one is not a caller with a window to wait out, which is why this
+ * removal is an owner decision — recorded on #30804 — rather than a drain.
+ *
+ * What that leaves for the next sweep to reuse: read `x_client_version`
+ * per address over the whole window, not only on the branded requests. A
+ * version far below the current one looks like a stranded install until the
+ * same address is seen on the current version an hour later. The host
+ * inventory does not settle it either — the two `computer_use_hosts` rows below
+ * 0.38.100 that were active in the same week sent no request in this window at
+ * all, and the versions that did send one have no row.
  */
 type MigratedBrandedPathTable = Readonly<Record<string, readonly string[]>>;
 
@@ -418,7 +439,7 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   // endpoints, and an installed build updates on its owner's schedule rather
   // than on a deploy, so it has no window at all. The `zero` form carried
   // measured traffic of its own and was reachable through the blanket expansion
-  // until the contract moved. Both are owed on all seven remaining paths.
+  // until the contract moved. Both are owed on all three remaining paths.
   //
   // The slice had sixteen. #28709 removed the three authorization-request rows,
   // `commands/:commandId/plugin-content` and `plugin-commands` on zero-traffic
@@ -448,6 +469,22 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   // them. Removal of these follows #26701's evidence rules like every other row
   // here.
   //
+  // #30804 removed `heartbeat`, `host/commands/next`, `hosts/start` and
+  // `host/stop` together, so #28917's reason for holding start and stop no
+  // longer applies: the loop they open and close is not registered on a branded
+  // form any more either. All four were still measured, and what retired them is
+  // what the measurement said about the caller rather than its size. Every
+  // branded request in the 2026-08-27 22:19Z to 2026-09-01 08:26Z window came
+  // from one address at `x_client_version` 0.38.2 inside thirty-four seconds
+  // on 08-30 — `feature-switches` 09:17:31, `hosts/start` 09:17:42, `heartbeat`
+  // and `host/commands/next` through 09:18:04, `host/stop` 09:18:05 — and that
+  // same address ran 0.38.106 through 0.40.4 on the neutral paths continuously
+  // either side of it, including 0.38.121 at that minute. It is an old build
+  // launched next to a current one, not an install that never updated, so there
+  // is no drain to wait for; the two colleagues who can launch it were told
+  // directly. The neutral paths carried 329,913 heartbeats and 155,949 command
+  // polls in the same window.
+  //
   // #28916 listed `audit-events` and `host/commands/:commandId/complete` for
   // removal and both were kept, for the mirror image of #28917's reason. All of
   // their branded traffic came from the desktop host loop, which sends no
@@ -455,10 +492,12 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   // `x_client_type` — the same installed build this comment names, not the
   // anonymous caller an `x_client_type`-only grouping reported. `complete` is
   // worse than quiet: it is only called when a write command finishes, so its
-  // silence measures how often that happened while `host/commands/next`, which
-  // this table still holds for the same build, kept being polled. Removing it
-  // would 404 the completion half of a loop whose polling half is kept on
-  // purpose, which is the same failure `hosts/start` and `host/stop` avoid.
+  // silence measures how often that happened rather than whether its caller is
+  // there. #30804 did not list either one, so both stay; over-retention is the
+  // safe direction, and neither has been measured under the reading that
+  // retired the four rows above. `hosts` stays for a different caller
+  // altogether — the platform host list, 17,207 neutral requests in the same
+  // window, not the desktop host loop.
   //
   // A key holds its path parameter verbatim, because the lookup below matches
   // `entry.route.path` exactly rather than an expanded request path.
@@ -466,29 +505,13 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/computer-use/audit-events",
     "/api/zero/computer-use/audit-events",
   ],
-  "/api/computer-use/heartbeat": [
-    "/api/okou/computer-use/heartbeat",
-    "/api/zero/computer-use/heartbeat",
-  ],
   "/api/computer-use/host/commands/:commandId/complete": [
     "/api/okou/computer-use/host/commands/:commandId/complete",
     "/api/zero/computer-use/host/commands/:commandId/complete",
   ],
-  "/api/computer-use/host/commands/next": [
-    "/api/okou/computer-use/host/commands/next",
-    "/api/zero/computer-use/host/commands/next",
-  ],
-  "/api/computer-use/host/stop": [
-    "/api/okou/computer-use/host/stop",
-    "/api/zero/computer-use/host/stop",
-  ],
   "/api/computer-use/hosts": [
     "/api/okou/computer-use/hosts",
     "/api/zero/computer-use/hosts",
-  ],
-  "/api/computer-use/hosts/start": [
-    "/api/okou/computer-use/hosts/start",
-    "/api/zero/computer-use/hosts/start",
   ],
   // #28423: the integration control plane and the CLI messaging and file
   // surfaces. The slice covered Feishu, Slack, Microsoft Teams, Telegram,
@@ -649,9 +672,9 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   ],
   // #28462: feature switches, model policies, org-level model providers and
   // their device-auth sessions, the org profile and membership routes, and the
-  // usage reads, of which only feature switches, model policies and the org
-  // profile are still owed. Three surfaces hold these branded paths open, and
-  // the widest one is why the rows matter more here than in most slices:
+  // usage reads, of which only model policies and the org profile are still
+  // owed. Three surfaces held these branded paths open, and the widest one is
+  // why the rows matter more here than in most slices:
   //
   // - An installed desktop build, which hardcodes `/api/okou/org` and
   //   `/api/okou/feature-switches` rather than deriving them from a contract.
@@ -665,8 +688,21 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   // #28917 removed the three `model-providers/codex/device-auth/sessions`
   // rows, the three `org/invite` rows, and `usage/members`. None of them has a
   // desktop caller — the installed build hardcodes only `/api/okou/org` and
-  // `/api/okou/feature-switches`, both kept — and every one was silent on both
-  // branded forms across the retained window.
+  // `/api/okou/feature-switches`, both kept then — and every one was silent on
+  // both branded forms across the retained window.
+  //
+  // #30804 removed `feature-switches` and kept `org`, which is the whole point
+  // of measuring the first surface per row rather than per slice. The desktop
+  // build hardcodes both, and in the 2026-08-27 22:19Z to 2026-09-01 08:26Z
+  // window both took branded requests from it — three on `feature-switches`,
+  // four on `org` — but only `org` has a second producer. A `CLI_PKG_URL`-pinned
+  // CLI at 9.279.3 read `/api/zero/org` on 08-31 03:58, 08-31 08:52 and 09-01
+  // 02:10, each answered 200, so that row still serves a caller with a live
+  // pinning window. The `feature-switches` requests came from the two desktop
+  // addresses alone — 0.38.2 at 08-30 09:17:31 and 0.34.0 at 09-01 03:11:31 —
+  // and both addresses were running 0.40.4 on the neutral path by the end of the
+  // window, so what the row was holding open was a briefly launched old build
+  // rather than an install still on its way to updating.
   //
   // #28916 removed the four that were not silent — the `model-providers`
   // collection, `org/logo`, `org/members` and `usage/record`. All four were
@@ -681,10 +717,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   //
   // A key holds its path parameter verbatim, because the lookup below matches
   // `entry.route.path` exactly rather than an expanded request path.
-  "/api/feature-switches": [
-    "/api/okou/feature-switches",
-    "/api/zero/feature-switches",
-  ],
   "/api/model-policies": [
     "/api/okou/model-policies",
     "/api/zero/model-policies",

--- a/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
@@ -1691,32 +1691,4 @@ describe("FILE-03 desktop computer-use runtime", () => {
     }
     expect(resweep.body.cleaned).toBe(0);
   });
-
-  // #28466 moved this contract to `/api/computer-use/**`. The heartbeat is the
-  // busiest path in the family and its caller is an installed Desktop build
-  // that hardcodes the branded form and updates on its owner's schedule, so
-  // the `MIGRATED_BRANDED_PATHS` rows have to keep both branded paths
-  // registered. The registration-level assertions live in
-  // `migrated-branded-paths.test.ts`; this is the executed request that proves
-  // an old build still reaches the handler and gets its host back.
-  it("serves the migrated heartbeat on the neutral path and both branded paths", async () => {
-    const actor = bdd.user({ orgId: `org_${randomUUID()}` });
-    const host = await api.startComputerUseHost(actor, {
-      hostName: "Studio Mac",
-    });
-
-    const responses = [];
-    for (const path of [
-      "/api/computer-use/heartbeat",
-      "/api/okou/computer-use/heartbeat",
-      "/api/zero/computer-use/heartbeat",
-    ]) {
-      responses.push(
-        await api.requestComputerUseHeartbeatAtPath(host.hostToken, path),
-      );
-    }
-
-    const served = { status: 200, body: { ok: true, hostId: host.hostId } };
-    expect(responses).toStrictEqual([served, served, served]);
-  });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
@@ -32,10 +32,7 @@ import type { ComputerUseAnyPluginCallBody } from "@okouai/api-contracts/contrac
 
 import { now } from "../../../../lib/time";
 import { accept, type TestContext } from "../../../../__tests__/test-context";
-import {
-  setupApp,
-  setupRawAppRequest,
-} from "../../../../__tests__/test-helpers";
+import { setupApp } from "../../../../__tests__/test-helpers";
 import { signSandboxJwtForTests } from "../../../auth/tokens";
 import type { ApiTestUser } from "./api-bdd";
 import { createRouteMocks } from "./route-test";
@@ -549,28 +546,6 @@ export function createComputerUseBddApi(context: TestContext) {
           body: hostRuntimeBody(),
         }),
         statuses,
-      );
-    },
-
-    /**
-     * Heartbeats at an explicit path instead of through the contract client.
-     * The clients above build their URL from the path the contract declares,
-     * so after #28466 moved this contract to `/api/computer-use/heartbeat`
-     * they can no longer reach the branded paths an installed Desktop build
-     * still hardcodes — which is exactly what the `MIGRATED_BRANDED_PATHS`
-     * rows keep registered.
-     */
-    async requestComputerUseHeartbeatAtPath(hostToken: string, path: string) {
-      return await setupRawAppRequest({ context, routes: computerUseRoutes })(
-        path,
-        {
-          method: "POST",
-          headers: {
-            "content-type": "application/json",
-            ...hostHeaders(hostToken),
-          },
-          body: JSON.stringify(hostRuntimeBody()),
-        },
       );
     },
 


### PR DESCRIPTION
Part of #26701. Closes #30804.

Removes the four Computer Use host rows and `feature-switches` from `MIGRATED_BRANDED_PATHS`. The table goes from **58 rows to 53**.

The re-derivation confirms the five rows the issue lists, and disagrees with the issue about *who* was holding them open. That changes the argument for removing them, not the list, and it is set out below.

## What was removed

```
/api/computer-use/heartbeat
/api/computer-use/host/commands/next
/api/computer-use/hosts/start
/api/computer-use/host/stop
/api/feature-switches
```

## Evidence

Re-derived per row against `vm0-request-log-prod` over the whole currently retained window — **2026-08-27 22:19:57Z → 2026-09-01 08:26:07Z, 4.42 days** — with `:param` rewritten to `[^/]+`, the full untruncated set of branded `path_template` values pulled (14 distinct values, no top-N), and `user_agent` containing `curl` excluded so this migration's own probes are not counted.

| branded form | n | addrs | first → last | caller |
| --- | --- | --- | --- | --- |
| `/api/okou/computer-use/heartbeat` | 9 | 1 | 08-30 09:17:45 → 09:18:04 | `Desktop` / `okou` / 0.38.2 / `ua: node` |
| `/api/okou/computer-use/host/commands/next` | 4 | 1 | 08-30 09:17:47 → 09:18:04 | same |
| `/api/okou/computer-use/hosts/start` | 1 | 1 | 08-30 09:17:42 | same |
| `/api/okou/computer-use/host/stop` | 1 | 1 | 08-30 09:18:05 | same |
| `/api/okou/feature-switches` | 3 | 2 | 08-30 09:17:31, 09:17:40; 09-01 03:11:31 | 0.38.2 (×2) and 0.34.0 (×1) |

No `/api/zero/**` form of any of the five took a single request. Eighteen branded requests in total; seventeen of them are one machine's startup handshake inside thirty-four seconds on 08-30, which is a session opening and closing, not a client polling.

Neutral counterparts over the same window: `heartbeat` 329,913 · `host/commands/next` 155,949 · `hosts/start` 102 · `host/stop` 98 · `feature-switches` 3,284.

**The call-rate objection that kept `hosts/start` and `host/stop` in #28917 is answered directly rather than argued around.** Both branded forms were actually observed this time — start at 09:17:42, stop at 09:18:05 — so the reading is a measurement, not a zero count without statistical power. And the loop they open and close is being retired in the same commit, so nothing is left half-registered.

**CI callers.** As the table header instructs, `e2e/`, `.github/scripts/` and `.github/workflows/` were grepped for both branded forms of all five rows. No hits, and no `api/okou` or `api/zero` literal appears anywhere in those trees.

## Where the re-derivation disagrees with the issue

The issue attributes the branded traffic to two stale installs — `computer_use_hosts` rows at 0.7.0 and 0.38.85 — and frames the removal as knowingly 404ing two machines until their owners update. **Neither version sent a request in the retained window.** `x_client_version` 0.7.0 and 0.38.85 do not appear on any path, branded or neutral; those two rows last heartbeated on 08-27 07:25 and 08-26 02:09, both before the window opens. The versions that did emit the branded requests, 0.38.2 and 0.34.0, have no matching host row at all.

Tracing the two emitting addresses across the whole window instead of only across their branded requests gives the actual picture:

- **Address A** (17 of the 18 requests, `x_client_version` 0.38.2) ran neutral-path Desktop traffic continuously from 0.38.106 at 08-27 22:19 through 0.40.4 at 09-01 08:28 — and was on 0.38.121 at the very minute it emitted the branded burst, back on 0.38.122 fourteen seconds after it.
- **Address B** (the single 0.34.0 `feature-switches` read, a 401, at 09-01 03:11:31) is on 0.40.0 two minutes later at 03:13 and on 0.40.4 by 08:12.

So both are an old build launched briefly beside a current one on an already-updated machine, not an install that never updated. The consequence stated in the issue — "those two machines get 404s until they upgrade" — does not describe anything the log shows; there is no install left with a window to drain. The owner's acceptance recorded on #30804 still governs, since a colleague can launch that old build again, but the removal rests on a stronger reading than the issue claimed.

The issue also counts nine table rows with branded traffic in the window. The re-derivation counts nine as well, but not the same nine: `/api/integrations/teams/oauth/callback` has fallen out of the retained window entirely, and `/api/org` — which the issue does not mention — took 4 `okou` requests from the same 0.38.2 handshake plus 3 `zero` requests. Both rows stay either way.

`x_client_product` on all five rows' traffic is `okou`, so the `desktop-migration-policy` hard stop that went live on 08-31 is unrelated to any of it: that policy stops **Zero** Desktop, and Okou ignores it by design. It is not a cause of these counts and is not claimed as one.

## Rows deliberately kept

- **`/api/org`** — the desktop build hardcodes it alongside `feature-switches`, but unlike `feature-switches` it has a second producer: a `CLI_PKG_URL`-pinned CLI at 9.279.3 read `/api/zero/org` on 08-31 03:58, 08-31 08:52 and 09-01 02:10, each answered 200. That is a live caller with a real pinning window.
- **`/api/computer-use/audit-events`** and **`/api/computer-use/host/commands/:commandId/complete`** — not in this issue's list, both silent, both belonging to the same host loop. #28916 kept them and #30804 does not re-measure them, so they stay; over-retention is the safe direction. Their row comment no longer claims "the polling half is kept on purpose", which stopped being true with this commit.
- **`/api/computer-use/hosts`** — a different caller altogether, the platform host list, 17,207 neutral requests in the same window.
- `/api/slack/oauth/install`, `/api/workflows`, `/api/logs/:id` and `/api/integrations/teams/oauth/callback` stay for the reasons the issue gives. The 48 rows with no branded traffic stay too: silence is not the bar, as the table header now records.

## Changes

- `signals/route-entry.ts` — five rows out. The table header gains the #30804 paragraph and the reusable lesson (read `x_client_version` per address across the whole window, not only on the branded requests; the host inventory does not settle it). Three earlier statements that this commit falsifies are corrected in place: the #28917 note that "every one of those rows is kept", the note that the table "still holds" `host/commands/next`, and the `complete` row's rationale.
- `__tests__/migrated-branded-paths.test.ts` — five entries out of the restated inventory, count literal `58` → `53`, and `feature-switches` dropped from the #28462 app-factory case, which now exercises `org` only.
- `routes/__tests__/computer-use.bdd.test.ts` — the executed branded-heartbeat case removed, and with it the now-unused `requestComputerUseHeartbeatAtPath` helper in `helpers/api-bdd-computer-use.ts`. No case asserts the removed paths now 404: `docs/fallback.md` section 1 rules that class out, and the route table already proves the registration is gone.
- `docs/okou-cli-cutover.md` — the row count it quotes.

## Verification

Run in the sandbox against a live PostgreSQL 18:

- `pnpm -F api exec vitest run` — `migrated-branded-paths` + `computer-use.bdd` 33 passed; `api-namespace-compatibility` + `api-namespace-legacy-paths` + `provider-console-paths` 24 passed; `feature-switches` + `desktop-updates` passed.
- `teams-bot.test.ts` fails 6 cases in this sandbox on the known `claimRunnerJob` / "Job not found in queue" breakage. That file is untouched by this diff and the signature is the documented sandbox failure, not a regression.
- `pnpm prettier --check` on every changed file, `pnpm -F api check-types` (5/5 projects), `pnpm -F api lint` (0 errors), `pnpm knip --workspace apps/api` (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
