### PR TITLE
perf(platform): prioritize bootstrap resources for first paint

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -22,8 +22,6 @@
     <link vite-ignore rel="manifest" href="/manifest.webmanifest" />
     <link rel="preconnect" href="https://cdn.vm0.io" crossorigin />
     <link rel="preconnect" href="https://static.vm0.io" crossorigin />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -101,7 +99,7 @@
         if (t === "dark") document.documentElement.classList.add("dark");
       })();
     </script>
-    <style>
+    <style id="app-bootstrap-critical-styles">
       :root {
         --zero-viewport-height: 100dvh;
       }
@@ -628,7 +626,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.ts"></script>
     <div
       id="app-bootstrap-skeleton"
       role="status"
@@ -710,6 +707,9 @@
     <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
+      media="print"
+      fetchpriority="low"
+      onload="this.media = 'all'"
     />
     <script>
       (function () {
@@ -797,5 +797,6 @@
         document.body.appendChild(instatusScript);
       })();
     </script>
+    <script type="module" src="/src/main.ts" fetchpriority="low"></script>
   </body>
 </html>

--- a/turbo/apps/platform/scripts/app-resource-priority-html.ts
+++ b/turbo/apps/platform/scripts/app-resource-priority-html.ts
@@ -59,7 +59,7 @@ function removeTag(htmlSource: string, tag: string): string {
 
 function prioritizeApplicationResources(htmlSource: string): string {
   const linkTagPattern = /<link\b[^>]*>/gu;
-  const scriptTagPattern = /<script\b[^>]*><\/script>/gu;
+  const scriptTagPattern = /<script\b[^>]*><\/script\s*>/giu;
   const stylesheet = singleAssetTag(
     htmlSource,
     "application stylesheet",

--- a/turbo/apps/platform/scripts/app-resource-priority-html.ts
+++ b/turbo/apps/platform/scripts/app-resource-priority-html.ts
@@ -59,7 +59,7 @@ function removeTag(htmlSource: string, tag: string): string {
 
 function prioritizeApplicationResources(htmlSource: string): string {
   const linkTagPattern = /<link\b[^>]*>/gu;
-  const scriptTagPattern = /<script\b[^>]*><\/script\b[^>]*>/giu;
+  const scriptTagPattern = /<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/giu;
   const stylesheet = singleAssetTag(
     htmlSource,
     "application stylesheet",

--- a/turbo/apps/platform/scripts/app-resource-priority-html.ts
+++ b/turbo/apps/platform/scripts/app-resource-priority-html.ts
@@ -1,0 +1,151 @@
+import type { Plugin } from "vite";
+
+const CRITICAL_STYLE_ID = "app-bootstrap-critical-styles";
+
+function matchingTags(
+  htmlSource: string,
+  tagPattern: RegExp,
+  assetPattern: RegExp,
+): string[] {
+  return [...htmlSource.matchAll(tagPattern)]
+    .map((match) => {
+      return match[0];
+    })
+    .filter((tag) => {
+      return assetPattern.test(tag);
+    });
+}
+
+function singleAssetTag(
+  htmlSource: string,
+  label: string,
+  tagPattern: RegExp,
+  assetPattern: RegExp,
+): string {
+  const tags = matchingTags(htmlSource, tagPattern, assetPattern);
+  if (tags.length !== 1 || !tags[0]) {
+    throw new Error(
+      `Expected exactly one generated ${label} tag, but found ${tags.length}`,
+    );
+  }
+  return tags[0];
+}
+
+function withFetchPriority(tag: string, priority: "high" | "low"): string {
+  if (/\sfetchpriority=/u.test(tag)) {
+    return tag.replace(
+      /\sfetchpriority="[^"]*"/u,
+      ` fetchpriority="${priority}"`,
+    );
+  }
+
+  const startTagEnd = tag.indexOf(">");
+  if (startTagEnd === -1) {
+    throw new Error(
+      `Generated asset tag is missing its closing bracket: ${tag}`,
+    );
+  }
+  return `${tag.slice(0, startTagEnd)} fetchpriority="${priority}"${tag.slice(startTagEnd)}`;
+}
+
+function removeTag(htmlSource: string, tag: string): string {
+  const firstIndex = htmlSource.indexOf(tag);
+  const lastIndex = htmlSource.lastIndexOf(tag);
+  if (firstIndex === -1 || firstIndex !== lastIndex) {
+    throw new Error("Generated application resource tag is not unique");
+  }
+  return `${htmlSource.slice(0, firstIndex)}${htmlSource.slice(firstIndex + tag.length)}`;
+}
+
+function prioritizeApplicationResources(htmlSource: string): string {
+  const linkTagPattern = /<link\b[^>]*>/gu;
+  const scriptTagPattern = /<script\b[^>]*><\/script>/gu;
+  const stylesheet = singleAssetTag(
+    htmlSource,
+    "application stylesheet",
+    linkTagPattern,
+    /\srel="stylesheet"[^>]*\shref="[^"]*\/assets\/index-[^"/]+\.css"/u,
+  );
+  const runtimePreload = singleAssetTag(
+    htmlSource,
+    "runtime module preload",
+    linkTagPattern,
+    /\srel="modulepreload"[^>]*\shref="[^"]*\/assets\/rolldown-runtime-[^"/]+\.js"/u,
+  );
+  const vendorPreload = singleAssetTag(
+    htmlSource,
+    "vendor module preload",
+    linkTagPattern,
+    /\srel="modulepreload"[^>]*\shref="[^"]*\/assets\/vendor-[^"/]+\.js"/u,
+  );
+  const applicationModule = singleAssetTag(
+    htmlSource,
+    "application module",
+    scriptTagPattern,
+    /\stype="module"[^>]*\ssrc="[^"]*\/assets\/index-[^"/]+\.js"/u,
+  );
+
+  let prioritizedHtml = htmlSource;
+  for (const tag of [
+    stylesheet,
+    runtimePreload,
+    vendorPreload,
+    applicationModule,
+  ]) {
+    prioritizedHtml = removeTag(prioritizedHtml, tag);
+  }
+
+  const criticalStyleOpeningTag = `<style id="${CRITICAL_STYLE_ID}">`;
+  const criticalStyleStart = prioritizedHtml.indexOf(criticalStyleOpeningTag);
+  if (criticalStyleStart === -1) {
+    throw new Error(
+      `Expected the critical stylesheet marker #${CRITICAL_STYLE_ID}`,
+    );
+  }
+  const criticalStyleEnd = prioritizedHtml.indexOf(
+    "</style>",
+    criticalStyleStart,
+  );
+  if (criticalStyleEnd === -1) {
+    throw new Error("Critical application stylesheet is missing </style>");
+  }
+  const headResources = [
+    withFetchPriority(stylesheet, "high"),
+    withFetchPriority(runtimePreload, "low"),
+    withFetchPriority(vendorPreload, "low"),
+  ]
+    .map((tag) => {
+      return `    ${tag}`;
+    })
+    .join("\n");
+  const criticalStyleInsertion = criticalStyleEnd + "</style>".length;
+  prioritizedHtml = `${prioritizedHtml.slice(0, criticalStyleInsertion)}\n${headResources}${prioritizedHtml.slice(criticalStyleInsertion)}`;
+
+  const bodyEnd = prioritizedHtml.lastIndexOf("</body>");
+  if (bodyEnd === -1) {
+    throw new Error("Application HTML is missing </body>");
+  }
+  const lowPriorityApplicationModule = withFetchPriority(
+    applicationModule,
+    "low",
+  );
+  const bodyClosingLineStart = prioritizedHtml.lastIndexOf("\n", bodyEnd) + 1;
+  if (prioritizedHtml.slice(bodyClosingLineStart, bodyEnd).trim()) {
+    return `${prioritizedHtml.slice(0, bodyEnd)}${lowPriorityApplicationModule}${prioritizedHtml.slice(bodyEnd)}`;
+  }
+  return `${prioritizedHtml.slice(0, bodyClosingLineStart)}    ${lowPriorityApplicationModule}\n${prioritizedHtml.slice(bodyClosingLineStart)}`;
+}
+
+export function applicationResourcePriorityHtmlPlugin(): Plugin {
+  return {
+    apply: "build",
+    enforce: "post",
+    name: "platform-application-resource-priority-html",
+    transformIndexHtml: {
+      order: "post",
+      handler(htmlSource) {
+        return prioritizeApplicationResources(htmlSource);
+      },
+    },
+  };
+}

--- a/turbo/apps/platform/scripts/app-resource-priority-html.ts
+++ b/turbo/apps/platform/scripts/app-resource-priority-html.ts
@@ -59,7 +59,7 @@ function removeTag(htmlSource: string, tag: string): string {
 
 function prioritizeApplicationResources(htmlSource: string): string {
   const linkTagPattern = /<link\b[^>]*>/gu;
-  const scriptTagPattern = /<script\b[^>]*><\/script\s*>/giu;
+  const scriptTagPattern = /<script\b[^>]*><\/script\b[^>]*>/giu;
   const stylesheet = singleAssetTag(
     htmlSource,
     "application stylesheet",

--- a/turbo/apps/platform/scripts/check-build-config.node.ts
+++ b/turbo/apps/platform/scripts/check-build-config.node.ts
@@ -7,6 +7,7 @@ import { URL } from "node:url";
 
 import { build, loadConfigFromFile } from "vite";
 
+import { applicationResourcePriorityHtmlPlugin } from "./app-resource-priority-html.ts";
 import {
   RAW_JAVASCRIPT_OUTPUT_LIMIT_BYTES,
   VENDOR_MODULE_PATTERN,
@@ -354,9 +355,11 @@ await test("rejects worker chunks with imports or forbidden packages", () => {
 function clerkDiscoveryFixture(): string {
   return [
     "<!doctype html><html><head>",
+    '<style id="app-bootstrap-critical-styles">body { color: black; }</style>',
     '<script id="vm0-clerk-core-script" src="https://cdn.example.test/clerk.js" defer></script>',
     '<script data-vm0-clerk-bootstrap="">window.__clerkConfigured = true;</script>',
     "</head><body>",
+    '<div id="app-bootstrap-skeleton"></div>',
     '<script type="module" src="/src/main.js"></script>',
     "</body></html>",
   ].join("");
@@ -369,6 +372,43 @@ function assertClerkDiscoveryOrder(htmlSource: string): void {
   assert.notEqual(clerkCoreIndex, -1);
   assert.ok(clerkBootstrapIndex > clerkCoreIndex);
   assert.ok(appModuleIndex > clerkBootstrapIndex);
+}
+
+function assertApplicationResourcePriority(htmlSource: string): void {
+  const criticalStyleIndex = htmlSource.indexOf(
+    '<style id="app-bootstrap-critical-styles">',
+  );
+  const stylesheetIndex = htmlSource.indexOf('rel="stylesheet"');
+  const runtimePreloadIndex = htmlSource.indexOf("assets/rolldown-runtime-");
+  const vendorPreloadIndex = htmlSource.indexOf("assets/vendor-");
+  const clerkCoreIndex = htmlSource.indexOf('id="vm0-clerk-core-script"');
+  const skeletonIndex = htmlSource.indexOf('id="app-bootstrap-skeleton"');
+  const appModuleIndex = htmlSource.indexOf('<script type="module"');
+  const bodyEndIndex = htmlSource.indexOf("</body>");
+
+  assert.ok(criticalStyleIndex !== -1);
+  assert.ok(stylesheetIndex > criticalStyleIndex);
+  assert.ok(runtimePreloadIndex > stylesheetIndex);
+  assert.ok(vendorPreloadIndex > runtimePreloadIndex);
+  assert.ok(clerkCoreIndex > vendorPreloadIndex);
+  assert.ok(appModuleIndex > skeletonIndex);
+  assert.ok(bodyEndIndex > appModuleIndex);
+  assert.match(
+    htmlSource,
+    /<link rel="stylesheet"[^>]*fetchpriority="high"[^>]*>/u,
+  );
+  assert.equal(
+    (
+      htmlSource.match(
+        /<link rel="modulepreload"[^>]*fetchpriority="low"[^>]*>/gu,
+      ) ?? []
+    ).length,
+    2,
+  );
+  assert.match(
+    htmlSource,
+    /<script type="module"[^>]*fetchpriority="low"[^>]*><\/script>/u,
+  );
 }
 
 await test("emits the fixed page topology and one external worker", async () => {
@@ -384,7 +424,11 @@ await test("emits the fixed page topology and one external worker", async () => 
     await writeFile(path.join(root, "index.html"), clerkDiscoveryFixture());
     await writeFile(
       path.join(sourceDirectory, "main.js"),
-      'import SharedDatabaseWorker from "./shared-database-worker.js?sharedworker"; import localeUrl from "./locale.json?url"; import mermaid from "../packages/mermaid-lite/dist/mermaid.esm.min.mjs"; import vendor from "fixture-vendor"; new SharedDatabaseWorker({ name: "test" }); console.log(localeUrl, mermaid.value, vendor.value);',
+      'import "./main.css"; import SharedDatabaseWorker from "./shared-database-worker.js?sharedworker"; import localeUrl from "./locale.json?url"; import mermaid from "../packages/mermaid-lite/dist/mermaid.esm.min.mjs"; import vendor from "fixture-vendor"; new SharedDatabaseWorker({ name: "test" }); console.log(localeUrl, mermaid.value, vendor.value);',
+    );
+    await writeFile(
+      path.join(sourceDirectory, "main.css"),
+      "body { color: red; }",
     );
     await writeFile(
       path.join(sourceDirectory, "shared-database-worker.js"),
@@ -423,7 +467,10 @@ await test("emits the fixed page topology and one external worker", async () => 
           },
         },
       },
-      plugins: [applicationJavaScriptBundlePlugin()],
+      plugins: [
+        applicationJavaScriptBundlePlugin(),
+        applicationResourcePriorityHtmlPlugin(),
+      ],
       worker: {
         plugins: () => {
           return [singleWorkerJavaScriptBundlePlugin()];
@@ -483,8 +530,7 @@ await test("emits the fixed page topology and one external worker", async () => 
     assertClerkDiscoveryOrder(htmlSource);
     assert.equal((htmlSource.match(/<script type="module"/gu) ?? []).length, 1);
     assert.equal((htmlSource.match(/rel="modulepreload"/gu) ?? []).length, 2);
-    assert.match(htmlSource, /assets\/vendor-[^/]+\.js/u);
-    assert.match(htmlSource, /assets\/rolldown-runtime-[^/]+\.js/u);
+    assertApplicationResourcePriority(htmlSource);
     assert.ok(
       result.output.some((item) => {
         return item.type === "asset" && item.fileName.endsWith(".json");

--- a/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
@@ -366,10 +366,10 @@ describe("platform Clerk entrypoint", () => {
     expect(bootstrap.compareDocumentPosition(mainScript)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
-    expect(mainScript.compareDocumentPosition(skeleton)).toBe(
+    expect(skeleton.compareDocumentPosition(fontStylesheet)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
-    expect(skeleton.compareDocumentPosition(fontStylesheet)).toBe(
+    expect(fontStylesheet.compareDocumentPosition(mainScript)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
     expect(html).not.toContain("__VM0_");
@@ -385,6 +385,7 @@ describe("platform Clerk entrypoint", () => {
     expect(criticalStyles.textContent).toContain(
       "@keyframes app-bootstrap-skeleton-avatar-pulse",
     );
+    expect(criticalStyles.id).toBe("app-bootstrap-critical-styles");
     expect(externalSkeletonImages).toHaveLength(0);
     expect(inlineAvatar).toBeInstanceOf(SVGSVGElement);
     expect(inlineAvatar?.querySelectorAll("path").length).toBeGreaterThan(0);
@@ -392,6 +393,14 @@ describe("platform Clerk entrypoint", () => {
     expect(skeleton).toHaveTextContent("");
     expect(fontStylesheet.rel).toBe("stylesheet");
     expect(fontStylesheet.hasAttribute("as")).toBeFalsy();
+    expect(fontStylesheet.media).toBe("print");
+    expect(fontStylesheet.getAttribute("fetchpriority")).toBe("low");
+    expect(fontStylesheet.getAttribute("onload")).toBe("this.media = 'all'");
+    expect(
+      parsedDocument.querySelector(
+        'link[rel="preconnect"][href*="fonts.googleapis.com"], link[rel="preconnect"][href*="fonts.gstatic.com"]',
+      ),
+    ).toBeNull();
     expect(html.indexOf("data-vm0-clerk-bootstrap")).toBeLessThan(
       html.indexOf('type="module" src="/src/main.ts"'),
     );

--- a/turbo/apps/platform/vite.config.ts
+++ b/turbo/apps/platform/vite.config.ts
@@ -7,6 +7,7 @@ import { defineConfig, type Plugin } from "vite";
 
 import { devArtifactFetchProxy } from "./dev-artifact-fetch-proxy.ts";
 import platformPackage from "./package.json";
+import { applicationResourcePriorityHtmlPlugin } from "./scripts/app-resource-priority-html.ts";
 import { clerkCoreHtmlPlugin } from "./scripts/clerk-html.ts";
 import {
   VENDOR_MODULE_PATTERN,
@@ -77,6 +78,7 @@ export default defineConfig(({ command }) => ({
     clerkCoreHtmlPlugin(APP_VERSION),
     runtimeBuildInfoHtmlPlugin,
     applicationJavaScriptBundlePlugin(),
+    applicationResourcePriorityHtmlPlugin(),
     // Sentry source map upload (production builds only)
     process.env.SENTRY_AUTH_TOKEN &&
       sentryVitePlugin({


### PR DESCRIPTION
## Summary

- emit the application stylesheet immediately after inline skeleton CSS with high fetch priority
- keep runtime and vendor module preloads eager but low priority, and place the low-priority main module at the end of the body
- load Google Fonts as a non-render-blocking stylesheet while preserving the existing font swap behavior
- fail the build if Vite resource topology or priority ordering drifts

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged TypeScript checks for non-API packages, Platform, and API
- `pnpm --filter @okouai/app run lint:build-config` (12 passed)
- `pnpm --filter @okouai/app exec vitest run src/__tests__/clerk-entrypoint.test.ts` (23 passed)
- production Vite build with test Clerk environment values