### PR TITLE
fix(official-workflows): restore catalog schema cutovers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
@@ -345,13 +345,18 @@ beforeEach(async () => {
 });
 
 describe.sequential("Official Workflow catalog release boundary", () => {
-  it("replaces a previous schema release through the current source boundary", async () => {
+  it("replaces a previous schema release with retained historical revisions", async () => {
     const seeded = await stateAction({
       action: "seed-previous-schema-release",
     });
     expect(seeded.body).toMatchObject({
       catalog: null,
-      counts: { releases: 1 },
+      counts: {
+        releases: 1,
+        revisions: 1,
+        storages: 1,
+        storageVersions: 1,
+      },
     });
 
     const synced = await syncCatalog(catalog([]));
@@ -367,6 +372,12 @@ describe.sequential("Official Workflow catalog release boundary", () => {
         schemaVersion: OFFICIAL_WORKFLOW_CATALOG_SCHEMA_VERSION,
         definitions: [],
       },
+    });
+    expect(state.body.counts).toMatchObject({
+      releases: 2,
+      revisions: 1,
+      storages: 1,
+      storageVersions: 1,
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/test-official-workflow-catalog-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-official-workflow-catalog-state.ts
@@ -59,6 +59,10 @@ const DEPLOYED_TEST_STORAGE_NAMES = [
   getOfficialWorkflowDefinitionStorageName("morning-brief"),
 ] as const;
 const PREVIOUS_SCHEMA_RELEASE_ID = "f".repeat(64);
+const PREVIOUS_SCHEMA_DEFINITION_NAME = "api-test-legacy";
+const PREVIOUS_SCHEMA_REVISION = "e".repeat(64);
+const PREVIOUS_SCHEMA_STORAGE_VERSION = "d".repeat(64);
+const PREVIOUS_SCHEMA_BLUEPRINT_FINGERPRINT = "c".repeat(64);
 
 interface DormantMaterializationPause {
   readonly reached: ReturnType<typeof createDeferredPromise<void>>;
@@ -183,14 +187,107 @@ async function seedPreviousSchemaRelease(
   if (previousSchemaVersion < 1) {
     throw new Error("Official Workflow catalog has no previous schema version");
   }
-  const payload = JSON.stringify({
+  const storageName = getOfficialWorkflowDefinitionStorageName(
+    PREVIOUS_SCHEMA_DEFINITION_NAME,
+  );
+  const storageId = randomUUID();
+  const storagePrefix = `api-test/${storageId}`;
+  const blueprint = {
+    key: "daily-delivery",
+    parameters: [
+      {
+        key: "timezone",
+        type: "string",
+        format: "timezone",
+        required: true,
+        derivation: { kind: "user-timezone" },
+      },
+    ],
+    desiredState: {
+      kind: "schedule",
+      schedule: {
+        type: "cron",
+        cronExpression: "0 7 * * *",
+        timezone: { parameter: "timezone" },
+      },
+    },
+    runtime: { resultEmail: true },
+    fingerprint: PREVIOUS_SCHEMA_BLUEPRINT_FINGERPRINT,
+  };
+  const revisionPayload = JSON.stringify({
     schemaVersion: previousSchemaVersion,
-    definitions: [],
+    name: PREVIOUS_SCHEMA_DEFINITION_NAME,
+    revision: PREVIOUS_SCHEMA_REVISION,
+    workflow: {
+      displayName: "Legacy test workflow",
+      description: "Exercises a previous-schema catalog revision.",
+      instruction: "Use the legacy test workflow.",
+      files: [],
+    },
+    blueprints: [blueprint],
+  });
+  const releasePayload = JSON.stringify({
+    schemaVersion: previousSchemaVersion,
+    definitions: [
+      {
+        name: PREVIOUS_SCHEMA_DEFINITION_NAME,
+        lifecycle: "active",
+        revision: PREVIOUS_SCHEMA_REVISION,
+        artifact: {
+          storageName,
+          storageId,
+          storageVersion: PREVIOUS_SCHEMA_STORAGE_VERSION,
+        },
+        blueprints: [blueprint],
+        releasedBlueprintKeys: [blueprint.key],
+        presentation: { category: "productivity" },
+      },
+    ],
   });
   await db.transaction(async (tx) => {
+    await tx.insert(storages).values({
+      id: storageId,
+      orgId: SYSTEM_ORG_ID,
+      userId: VOLUME_ORG_USER_ID,
+      name: storageName,
+      s3Prefix: storagePrefix,
+      size: 0,
+      fileCount: 0,
+    });
+    await tx.insert(storageVersions).values({
+      id: PREVIOUS_SCHEMA_STORAGE_VERSION,
+      storageId,
+      s3Key: `${storagePrefix}/${PREVIOUS_SCHEMA_STORAGE_VERSION}`,
+      size: 0,
+      archiveSize: 0,
+      fileCount: 0,
+      message: "Previous-schema Official Workflow test revision",
+      createdBy: "system",
+    });
+    await tx
+      .update(storages)
+      .set({ headVersionId: PREVIOUS_SCHEMA_STORAGE_VERSION })
+      .where(eq(storages.id, storageId));
+    await tx.execute(sql`
+      INSERT INTO ${officialWorkflowDefinitionRevisions} (
+        definition_name,
+        revision,
+        payload,
+        storage_name,
+        storage_id,
+        storage_version
+      ) VALUES (
+        ${PREVIOUS_SCHEMA_DEFINITION_NAME},
+        ${PREVIOUS_SCHEMA_REVISION},
+        ${revisionPayload}::jsonb,
+        ${storageName},
+        ${storageId},
+        ${PREVIOUS_SCHEMA_STORAGE_VERSION}
+      )
+    `);
     await tx.execute(sql`
       INSERT INTO ${officialWorkflowCatalogReleases} (id, payload)
-      VALUES (${PREVIOUS_SCHEMA_RELEASE_ID}, ${payload}::jsonb)
+      VALUES (${PREVIOUS_SCHEMA_RELEASE_ID}, ${releasePayload}::jsonb)
     `);
     await tx.insert(officialWorkflowCatalogState).values({
       authority: "official",

--- a/turbo/apps/api/src/signals/services/official-workflow-catalog-read.service.ts
+++ b/turbo/apps/api/src/signals/services/official-workflow-catalog-read.service.ts
@@ -34,7 +34,7 @@ interface OfficialWorkflowRevisionRow {
   readonly storageVersion: string;
 }
 
-function catalogSchemaVersion(payload: unknown): number {
+function officialWorkflowPayloadSchemaVersion(payload: unknown): number {
   if (
     typeof payload !== "object" ||
     payload === null ||
@@ -44,7 +44,7 @@ function catalogSchemaVersion(payload: unknown): number {
     !Number.isSafeInteger(payload.schemaVersion) ||
     payload.schemaVersion < 1
   ) {
-    throw new Error("Official Workflow catalog payload version is invalid");
+    throw new Error("Official Workflow payload version is invalid");
   }
   return payload.schemaVersion;
 }
@@ -100,7 +100,8 @@ export async function readAcceptedOfficialWorkflowCatalog(
     return null;
   }
   if (
-    catalogSchemaVersion(row.payload) < OFFICIAL_WORKFLOW_CATALOG_SCHEMA_VERSION
+    officialWorkflowPayloadSchemaVersion(row.payload) <
+    OFFICIAL_WORKFLOW_CATALOG_SCHEMA_VERSION
   ) {
     return null;
   }
@@ -174,7 +175,7 @@ export async function readAcceptedOfficialWorkflowRevision(
   return acceptedRevisionFromRow(row);
 }
 
-export async function readAllAcceptedOfficialWorkflowRevisions(
+export async function readAllCurrentSchemaOfficialWorkflowRevisions(
   db: ReadonlyDb,
   signal?: AbortSignal,
 ): Promise<readonly OfficialWorkflowAcceptedRevision[]> {
@@ -217,7 +218,13 @@ export async function readAllAcceptedOfficialWorkflowRevisions(
       asc(officialWorkflowDefinitionRevisions.revision),
     );
   signal?.throwIfAborted();
-  return rows.map((row) => {
+  return rows.flatMap((row) => {
+    if (
+      officialWorkflowPayloadSchemaVersion(row.payload) !==
+      OFFICIAL_WORKFLOW_CATALOG_SCHEMA_VERSION
+    ) {
+      return [];
+    }
     if (
       row.verifiedStorageId !== row.storageId ||
       row.verifiedStorageVersion !== row.storageVersion
@@ -226,6 +233,6 @@ export async function readAllAcceptedOfficialWorkflowRevisions(
         "Official Workflow revision artifact registration is inconsistent",
       );
     }
-    return acceptedRevisionFromRow(row);
+    return [acceptedRevisionFromRow(row)];
   });
 }

--- a/turbo/apps/api/src/signals/services/official-workflow-catalog-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/official-workflow-catalog-sync.service.ts
@@ -28,7 +28,7 @@ import { settle } from "../utils";
 import { OFFICIAL_WORKFLOW_CATALOG_ACTIVATION_LOCK } from "./official-workflow-constants";
 import {
   OFFICIAL_WORKFLOW_CATALOG_AUTHORITY,
-  readAllAcceptedOfficialWorkflowRevisions,
+  readAllCurrentSchemaOfficialWorkflowRevisions,
   readAcceptedOfficialWorkflowCatalog,
   type AcceptedOfficialWorkflowCatalog,
 } from "./official-workflow-catalog-read.service";
@@ -402,7 +402,7 @@ const prepareDefinitions$ = command(
       }
   > => {
     const historicalResult = await settle(
-      readAllAcceptedOfficialWorkflowRevisions(db, signal),
+      readAllCurrentSchemaOfficialWorkflowRevisions(db, signal),
       signal,
     );
     if (!historicalResult.ok) {


### PR DESCRIPTION
## Summary

- ignore retained Official Workflow revisions from older catalog schemas when preparing a current-schema release
- preserve strict validation for current-schema revisions and their registered artifacts
- cover the v1-to-v2 cutover with a retained historical revision, storage, and storage version

## Root cause

The sync path parsed every immutable historical revision with the current schema. After the catalog schema advanced from v1 to v2, retained v1 revisions made preparation return `rejected`, so the accepted catalog remained v1. Current readers then treated it as unavailable, which emptied the Official Workflow catalog and blocked Agent Run admission.

## Test plan

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `DATABASE_URL=postgresql://localhost:5432/vm0_test_7c95_catalog_final pnpm -F api exec vitest run src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts --silent=passed-only` (14 passed)

## Local baseline note

`official-workflows.test.ts` has 9 runner-queue claim failures in this checkout. The identical failures reproduce on unmodified `origin/main` with the patch stashed and a freshly migrated database; they are not introduced by this change.