### PR TITLE
fix: share attachments by their public artifacts url

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/web-file-url.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/web-file-url.test.ts
@@ -203,6 +203,26 @@ describe("GET /api/web/file-url", () => {
     expect(signedOptions()).toStrictEqual([{ expiresIn: 7200 }]);
   });
 
+  it("reports the public artifacts url for the same object", async () => {
+    const fileId = randomUUID();
+    const { token, userId } = await mintFileReadToken();
+    const key = artifactKey(userId, fileId, "photo.png");
+    mockS3Objects([key]);
+    context.mocks.s3.getSignedUrl.mockResolvedValue(PRESIGNED_URL);
+
+    const response = await accept(
+      client().fileUrl({
+        headers: authHeaders(token),
+        query: { file_id: fileId },
+      }),
+      [200],
+    );
+
+    // A shared link has to outlive the presigned window and carry no
+    // credential, so it addresses the object on the public artifacts domain.
+    expect(response.body.publicUrl).toBe(`https://cdn.vm7.io/${key}`);
+  });
+
   it("signs an inline URL without a download disposition", async () => {
     const fileId = randomUUID();
     const { token, userId } = await mintFileReadToken();

--- a/turbo/apps/api/src/signals/routes/web-file-url.ts
+++ b/turbo/apps/api/src/signals/routes/web-file-url.ts
@@ -35,7 +35,10 @@ const fileUrlInner$ = computed(async (get) => {
     ),
   );
 
-  return { status: 200 as const, body: { url } };
+  // `object.url` addresses the same object on the public artifacts domain. It
+  // carries no credential and does not expire, so it is the form to hand to
+  // someone else; the presigned URL stays the one this browser renders from.
+  return { status: 200 as const, body: { url, publicUrl: object.url } };
 });
 
 export const webFileUrlRoutes: readonly RouteEntry[] = [

--- a/turbo/apps/platform/src/mocks/handlers/api-web-files.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-web-files.ts
@@ -12,6 +12,7 @@ export const apiWebFilesHandlers = [
   mockApi(webFilesContract.fileUrl, ({ query, respond }) => {
     return respond(200, {
       url: `https://cdn.vm0.io/artifacts/${query.file_id}`,
+      publicUrl: `https://cdn.vm0.io/artifacts/${query.file_id}`,
     });
   }),
 ];

--- a/turbo/apps/platform/src/signals/attachment-download.ts
+++ b/turbo/apps/platform/src/signals/attachment-download.ts
@@ -21,7 +21,7 @@ export const downloadAttachment$ = command(
     signal: AbortSignal,
   ): Promise<void> => {
     const resolveResourceUrl = get(pageAttachmentResourceUrlResolver$);
-    const resourceUrl = await get(
+    const { resourceUrl } = await get(
       resolveResourceUrl(publicAttachmentUrl(attachment.url)),
     );
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/attachment-resource-url.ts
+++ b/turbo/apps/platform/src/signals/attachment-resource-url.ts
@@ -7,7 +7,7 @@ import { apiClient$ } from "./api-client.ts";
 
 const AUTHENTICATED_FILE_PATH = "/api/web/download-file";
 
-function isAuthenticatedAttachmentUrl(url: string): boolean {
+export function isAuthenticatedAttachmentUrl(url: string): boolean {
   if (!URL.canParse(url)) {
     return false;
   }
@@ -18,17 +18,33 @@ function isAuthenticatedAttachmentUrl(url: string): boolean {
   );
 }
 
+export interface AttachmentUrls {
+  /**
+   * URL this browser can load right now. Presigned for a private attachment,
+   * so it expires and is scoped to the viewer.
+   */
+  readonly resourceUrl: string;
+  /**
+   * URL that still works for whoever receives it, or null when the attachment
+   * has no such address. Never the canonical API URL: that one answers only to
+   * the owner's credentials, so a recipient gets a 401 instead of the file.
+   */
+  readonly shareUrl: string | null;
+}
+
 /**
- * Persisted chat attachments live in a private bucket behind an authenticated
- * API route, and a bare `src` attribute cannot carry an Authorization header.
- * Exchange the canonical API URL for a short-lived presigned object URL the
- * browser can load on its own; the API still runs the ownership check before
- * signing.
+ * Persisted chat attachments live behind an authenticated API route, and a bare
+ * `src` attribute cannot carry an Authorization header. Exchange the canonical
+ * API URL for the URLs the browser can actually use; the API still runs the
+ * ownership check before answering.
  */
-function createAttachmentResourceUrl$(url: string): Computed<Promise<string>> {
+function createAttachmentResourceUrl$(
+  url: string,
+): Computed<Promise<AttachmentUrls>> {
   return computed(async (get) => {
     if (!isAuthenticatedAttachmentUrl(url)) {
-      return url;
+      // Already a public address, so it both renders and shares as-is.
+      return { resourceUrl: url, shareUrl: url };
     }
 
     const sourceUrl = new URL(url);
@@ -46,21 +62,27 @@ function createAttachmentResourceUrl$(url: string): Computed<Promise<string>> {
       [200],
       signal,
     );
-    return response.body.url;
+    return {
+      resourceUrl: response.body.url,
+      // Absent against an API that predates the field. Report no share URL
+      // rather than falling back to a presigned one that expires under the
+      // recipient.
+      shareUrl: response.body.publicUrl ?? null,
+    };
   });
 }
 
 export type AttachmentResourceUrlResolver = (
   url: string,
-) => Computed<Promise<string>>;
+) => Computed<Promise<AttachmentUrls>>;
 
 /**
  * Create the URL join owned by one thread or page. The returned map is private:
  * consumers only receive the resolved item's computed, never the keyed store.
  */
 export function createAttachmentResourceUrlResolver(): AttachmentResourceUrlResolver {
-  const resourceUrlByUrl = new Map<string, Computed<Promise<string>>>();
-  return (url: string): Computed<Promise<string>> => {
+  const resourceUrlByUrl = new Map<string, Computed<Promise<AttachmentUrls>>>();
+  return (url: string): Computed<Promise<AttachmentUrls>> => {
     const existing = resourceUrlByUrl.get(url);
     if (existing) {
       return existing;

--- a/turbo/apps/platform/src/signals/attachment-resource-url.ts
+++ b/turbo/apps/platform/src/signals/attachment-resource-url.ts
@@ -7,7 +7,7 @@ import { apiClient$ } from "./api-client.ts";
 
 const AUTHENTICATED_FILE_PATH = "/api/web/download-file";
 
-export function isAuthenticatedAttachmentUrl(url: string): boolean {
+function isAuthenticatedAttachmentUrl(url: string): boolean {
   if (!URL.canParse(url)) {
     return false;
   }
@@ -64,9 +64,11 @@ function createAttachmentResourceUrl$(
     );
     return {
       resourceUrl: response.body.url,
-      // Absent against an API that predates the field. Report no share URL
-      // rather than falling back to a presigned one that expires under the
-      // recipient.
+      // Rollout fallback, surface new web/app -> old API: a newly promoted app
+      // can reach an API deployed before `publicUrl` existed. Report no share
+      // URL rather than a presigned one that expires under the recipient.
+      // Remove once that API is no longer serving and is no longer retained as
+      // a rollback target; follow-up #30847.
       shareUrl: response.body.publicUrl ?? null,
     };
   });

--- a/turbo/apps/platform/src/signals/chat-page/artifact-card-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/artifact-card-signals.ts
@@ -53,7 +53,10 @@ function createArtifactSignals(
   previewImageUrlsByUrl$: Computed<Promise<ReadonlyMap<string, string>>>,
   resolveResourceUrl: AttachmentResourceUrlResolver,
 ): ArtifactSignals {
-  const resourceUrl$ = resolveResourceUrl(descriptor.url);
+  const attachmentUrls$ = resolveResourceUrl(descriptor.url);
+  const resourceUrl$ = computed(async (get) => {
+    return (await get(attachmentUrls$)).resourceUrl;
+  });
   const previewImageLoad = createImageLoadSignals();
   const previewImageUrl$ = computed(async (get) => {
     if (descriptor.kind !== "html" && descriptor.kind !== "video") {

--- a/turbo/apps/platform/src/signals/text-preview.ts
+++ b/turbo/apps/platform/src/signals/text-preview.ts
@@ -71,7 +71,7 @@ export function createTextPreviewComputed(
     // does not carry, so read the presigned object URL instead.
     const resourceUrl = resourceUrl$
       ? await get(resourceUrl$)
-      : await get(get(pageAttachmentResourceUrlResolver$)(url));
+      : (await get(get(pageAttachmentResourceUrlResolver$)(url))).resourceUrl;
     return fetchPreviewText(resourceUrl);
   });
 }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/attachment-chips.test.tsx
@@ -41,6 +41,11 @@ function presignedFileUrl(fileId: string): string {
 /** Matches presignedFileUrl so a preview body can be served from that URL. */
 const PRESIGNED_FILE_PATTERN = "https://r2.example.com/artifacts/:fileId";
 
+/** Mirrors the public artifacts URL the API reports for the same object. */
+function publicFileUrl(fileId: string): string {
+  return `https://cdn.vm7.io/artifacts/${fileId}.bin`;
+}
+
 function artifactFile(
   url: string,
   overrides: Partial<ChatThreadArtifactFile> = {},
@@ -145,7 +150,10 @@ beforeEach(() => {
   });
   context.mocks.http.get("/api/web/file-url", ({ request }) => {
     const fileId = new URL(request.url).searchParams.get("file_id") ?? "";
-    return HttpResponse.json({ url: presignedFileUrl(fileId) });
+    return HttpResponse.json({
+      url: presignedFileUrl(fileId),
+      publicUrl: publicFileUrl(fileId),
+    });
   });
 });
 
@@ -3356,10 +3364,56 @@ describe("zero attachment chips", () => {
     expect(screen.queryByAltText("1280x720")).toBeNull();
   });
 
+  it("hides the share action when the api reports no public attachment url", async () => {
+    context.mocks.http.get("/api/web/file-url", ({ request }) => {
+      const fileId = new URL(request.url).searchParams.get("file_id") ?? "";
+      return HttpResponse.json({ url: presignedFileUrl(fileId) });
+    });
+    context.mocks.http.get(PRESIGNED_FILE_PATTERN, () => {
+      return new Response("# Release notes\n\nThe rollout is ready.", {
+        headers: { "Content-Type": "text/markdown" },
+      });
+    });
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      chatEvents: [
+        {
+          id: "msg-no-public-url",
+          role: "user",
+          content: "Review this attachment",
+          fileParts: [
+            {
+              type: "file",
+              fileId: "attachment-markdown",
+              filenameSnapshot: "release-notes.md",
+              contentType: "text/markdown",
+            },
+          ],
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    click(
+      await screen.findByLabelText(
+        "Open markdown preview for release-notes.md",
+      ),
+    );
+
+    // The body renders from the same resolution that would have carried a
+    // share URL, so its arrival means "no share URL" is settled, not pending.
+    await waitFor(() => {
+      expect(screen.getByText("The rollout is ready.")).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText("Share")).toBeNull();
+  });
+
   it("opens canonical text previews and downloads a private presentation from its presigned url", async () => {
     const releaseNotesUrl = canonicalUserMessageFileUrl("attachment-markdown");
     const browser = context.mocks.browser.blobDownload();
-    context.mocks.browser.clipboardWriteText();
+    const clipboard = context.mocks.browser.clipboardWriteText();
     context.mocks.http.get(PRESIGNED_FILE_PATTERN, ({ params }) => {
       const fileId = params.fileId;
       if (fileId === "attachment-markdown") {
@@ -3446,13 +3500,22 @@ describe("zero attachment chips", () => {
 
     const shareLink = screen.getByLabelText("Share");
     expect(shareLink.tagName).toBe("A");
-    expect(shareLink).toHaveAttribute("href", releaseNotesUrl);
+    // The canonical URL answers only to the owner's credentials, so sharing it
+    // hands the recipient a 401 instead of the file.
+    expect(shareLink).not.toHaveAttribute("href", releaseNotesUrl);
+    expect(shareLink).toHaveAttribute(
+      "href",
+      publicFileUrl("attachment-markdown"),
+    );
 
     click(shareLink);
 
     await waitFor(() => {
       expect(screen.getByText("Link copied")).toBeInTheDocument();
     });
+    expect(clipboard.writes).toStrictEqual([
+      publicFileUrl("attachment-markdown"),
+    ]);
 
     click(screen.getByLabelText("Close"));
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/attachment-chips.test.tsx
@@ -3410,6 +3410,30 @@ describe("zero attachment chips", () => {
     expect(screen.queryByLabelText("Share")).toBeNull();
   });
 
+  it("shares a public artifact by its cdn url", async () => {
+    const clipboard = context.mocks.browser.clipboardWriteText();
+    context.mocks.browser.blobDownload();
+    await setupBodyLinkPreviews();
+
+    click(screen.getByLabelText("Open markdown preview for release-notes.md"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("attachment-lightbox")).toBeInTheDocument();
+    });
+
+    // An artifact that already carries a public address shares that address
+    // directly, without waiting on the private-attachment resolution.
+    const shareLink = screen.getByLabelText("Share");
+    expect(shareLink).toHaveAttribute("href", BODY_LINK_PREVIEWS.markdown);
+
+    click(shareLink);
+
+    await waitFor(() => {
+      expect(screen.getByText("Link copied")).toBeInTheDocument();
+    });
+    expect(clipboard.writes).toStrictEqual([BODY_LINK_PREVIEWS.markdown]);
+  });
+
   it("opens canonical text previews and downloads a private presentation from its presigned url", async () => {
     const releaseNotesUrl = canonicalUserMessageFileUrl("attachment-markdown");
     const browser = context.mocks.browser.blobDownload();

--- a/turbo/apps/platform/src/views/okou-page/artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/okou-page/artifact-actions.tsx
@@ -53,10 +53,8 @@ import {
 } from "../../signals/okou-page/settings/connectors.ts";
 import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
 import { defaultBuiltinConnectorAccountOptions } from "../../signals/okou-page/settings/connector-account-dialogs.ts";
-import {
-  copyAttachmentLinkToClipboard,
-  publicAttachmentUrl,
-} from "./attachment-url.ts";
+import { copyAttachmentLinkToClipboard } from "./attachment-url.ts";
+import { useAttachmentShareUrl } from "./attachment-resource.ts";
 
 const GOOGLE_DRIVE_CONNECTOR_SLUG = "google-drive";
 const ARTIFACT_FLOATING_TRANSITION_CLASS =
@@ -324,21 +322,31 @@ export function ArtifactShareButton({
   url: string;
 }) {
   const { t } = useTranslation();
+  const shareUrl = useAttachmentShareUrl(url);
   const label =
     ariaLabel ??
     t(($) => {
       return $.artifacts.actions.share;
     });
+  if (shareUrl === null) {
+    // No address a recipient could open. Offering the action anyway would hand
+    // out a link that only works for the person who copied it.
+    return null;
+  }
   return (
     <ArtifactActionTooltip label={label}>
       <a
-        href={publicAttachmentUrl(url)}
+        href={shareUrl}
         onClick={(event) => {
           if (!isPlainPrimaryLinkClick(event)) {
             return;
           }
           event.preventDefault();
-          detach(shareArtifactUrl(url), Reason.DomCallback, "artifact share");
+          detach(
+            shareArtifactUrl(shareUrl),
+            Reason.DomCallback,
+            "artifact share",
+          );
         }}
         aria-label={label}
         className={iconButtonClassName(className)}

--- a/turbo/apps/platform/src/views/okou-page/attachment-resource.ts
+++ b/turbo/apps/platform/src/views/okou-page/attachment-resource.ts
@@ -1,5 +1,8 @@
 import { useGet, useLastResolved } from "ccstate-react";
-import { pageAttachmentResourceUrlResolver$ } from "../../signals/attachment-resource-url.ts";
+import {
+  isAuthenticatedAttachmentUrl,
+  pageAttachmentResourceUrlResolver$,
+} from "../../signals/attachment-resource-url.ts";
 import { publicAttachmentUrl } from "./attachment-url";
 
 /**
@@ -12,5 +15,23 @@ import { publicAttachmentUrl } from "./attachment-url";
  */
 export function useResolvedAttachmentUrl(url: string): string | null {
   const resolveResourceUrl = useGet(pageAttachmentResourceUrlResolver$);
-  return useLastResolved(resolveResourceUrl(publicAttachmentUrl(url))) ?? null;
+  return (
+    useLastResolved(resolveResourceUrl(publicAttachmentUrl(url)))
+      ?.resourceUrl ?? null
+  );
+}
+
+/**
+ * Resolves the URL that keeps working for whoever receives it, or null when
+ * there is none to offer yet. A public CDN URL is already that address, so it
+ * answers without a round trip; a private attachment has to ask the API, which
+ * only then reveals the public address of the object it just authorized.
+ */
+export function useAttachmentShareUrl(url: string): string | null {
+  const normalizedUrl = publicAttachmentUrl(url);
+  const resolveResourceUrl = useGet(pageAttachmentResourceUrlResolver$);
+  const resolved = useLastResolved(resolveResourceUrl(normalizedUrl));
+  return isAuthenticatedAttachmentUrl(normalizedUrl)
+    ? (resolved?.shareUrl ?? null)
+    : normalizedUrl;
 }

--- a/turbo/apps/platform/src/views/okou-page/attachment-resource.ts
+++ b/turbo/apps/platform/src/views/okou-page/attachment-resource.ts
@@ -1,8 +1,5 @@
 import { useGet, useLastResolved } from "ccstate-react";
-import {
-  isAuthenticatedAttachmentUrl,
-  pageAttachmentResourceUrlResolver$,
-} from "../../signals/attachment-resource-url.ts";
+import { pageAttachmentResourceUrlResolver$ } from "../../signals/attachment-resource-url.ts";
 import { publicAttachmentUrl } from "./attachment-url";
 
 /**
@@ -23,15 +20,14 @@ export function useResolvedAttachmentUrl(url: string): string | null {
 
 /**
  * Resolves the URL that keeps working for whoever receives it, or null when
- * there is none to offer yet. A public CDN URL is already that address, so it
- * answers without a round trip; a private attachment has to ask the API, which
- * only then reveals the public address of the object it just authorized.
+ * there is none to offer yet. A public CDN URL resolves to itself; a private
+ * attachment has to ask the API, which only then reveals the public address of
+ * the object it just authorized.
  */
 export function useAttachmentShareUrl(url: string): string | null {
-  const normalizedUrl = publicAttachmentUrl(url);
   const resolveResourceUrl = useGet(pageAttachmentResourceUrlResolver$);
-  const resolved = useLastResolved(resolveResourceUrl(normalizedUrl));
-  return isAuthenticatedAttachmentUrl(normalizedUrl)
-    ? (resolved?.shareUrl ?? null)
-    : normalizedUrl;
+  return (
+    useLastResolved(resolveResourceUrl(publicAttachmentUrl(url)))?.shareUrl ??
+    null
+  );
 }

--- a/turbo/packages/api-contracts/src/contracts/web-files.ts
+++ b/turbo/packages/api-contracts/src/contracts/web-files.ts
@@ -29,7 +29,15 @@ export const webFilesContract = c.router({
     headers: authHeadersSchema,
     query: z.object({ file_id: z.string().min(1) }),
     responses: {
-      200: z.object({ url: z.string() }),
+      200: z.object({
+        url: z.string(),
+        /**
+         * Stable public artifacts URL for the same object, suitable for a link
+         * handed to someone else. Optional so a web client that already knows
+         * about it keeps rendering attachments against an API that does not.
+         */
+        publicUrl: z.string().optional(),
+      }),
       400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,

--- a/turbo/packages/api-contracts/src/contracts/web-files.ts
+++ b/turbo/packages/api-contracts/src/contracts/web-files.ts
@@ -33,8 +33,15 @@ export const webFilesContract = c.router({
         url: z.string(),
         /**
          * Stable public artifacts URL for the same object, suitable for a link
-         * handed to someone else. Optional so a web client that already knows
-         * about it keeps rendering attachments against an API that does not.
+         * handed to someone else.
+         *
+         * Rollout fallback, surface new web/app -> old API: this route also
+         * resolves the URL attachments render from, and the contract client
+         * rejects a response missing a required field. Keeping `publicUrl`
+         * optional means a newly promoted app reaching an API deployed before
+         * this field loses only the share action instead of all attachment
+         * rendering. Make it required once that API is no longer serving and is
+         * no longer retained as a rollback target; follow-up #30847.
          */
         publicUrl: z.string().optional(),
       }),


### PR DESCRIPTION
## Summary

The attachment share action copied the canonical API URL (`/api/web/download-file?file_id=…`). That URL only answers to the owner's credentials, so a recipient opening it gets a `401` instead of the file — while the person who copied it sees a green "Link copied" toast. Verified against production: the endpoint returns `401` without auth.

The render and download paths were already moved onto the resolved-URL signal by #25815; only the share button was left on the synchronous `publicAttachmentUrl()` rewrite, which passes the API URL through untouched because it matches neither legacy file path shape (`/f/…`, `/artifacts/<user>/<id>/<file>`). The visible symptom is that the *same file* shares correctly from the composer (the draft holds a CDN URL) and breaks once sent (the sent message holds only a `fileId`, re-expanded into the API URL).

## What changed

- `GET /api/web/file-url` also reports `publicUrl` — the stable public artifacts address of the object it just authorized. `ResolvedArtifactObject.url` already carried it; it was being dropped.
- `createAttachmentResourceUrl$` now resolves `{ resourceUrl, shareUrl }` from one request. The presigned URL stays the one the browser renders from; the public URL is the one handed to someone else.
- `ArtifactShareButton` resolves its own share URL and hides itself when there is none, rather than offering a link that only works for the person who copied it.

This covers both share entry points (lightbox toolbar and the artifact split view), and every attachment type, because they share `ArtifactShareButton`.

## Fallbacks

- `turbo/apps/platform/src/signals/attachment-resource-url.ts:createAttachmentResourceUrl$` — reads `response.body.publicUrl ?? null` and reports no share URL when the field is absent. Its contract half is `turbo/packages/api-contracts/src/contracts/web-files.ts:webFilesContract.fileUrl`, where the 200 body declares `publicUrl: z.string().optional()`. Protects a newly promoted app calling an API deployed before this field existed; because the contract client hard-fails response validation, a required field would break attachment rendering and download, not only sharing. Surface: **new web/app -> old API**. Remove once that API is no longer serving and is no longer retained as a rollback target; follow-up #30847.

## Notes for review

- **A shared link is now permanent rather than expiring in 2h.** That is the intended semantics of a share action and matches how agent-produced artifacts already behave. It exposes nothing new: these objects are already served publicly at `cdn.vm0.io/artifacts/<hash>.<ext>` — the same bucket and domain that serve agent artifacts. The auth on `/api/web/download-file` protects the `fileId → object key` mapping, not the object.
- Side effect: on PR previews, `canonicalUserMessageFileUrl` appends the Vercel `x-vercel-protection-bypass` token, so the old share action copied that token into the clipboard. The share action no longer touches that URL.

## Verification

- [x] `pnpm -F @okouai/app run check-types`, `pnpm -F api run check-types`, `pnpm -F @okouai/api-contracts run check-types`
- [x] `pnpm -F @okouai/app run lint`, `pnpm -F api run lint`, `pnpm -F @okouai/api-contracts run lint`
- [x] `pnpm knip`
- [x] `prettier --write` on changed files
- [x] API: 9 tests in `web-file-url.test.ts`, including a new one asserting the public artifacts URL
- [x] Platform: 50 tests in `attachment-chips.test.tsx` (updated share assertion, new hidden-when-unavailable test, new public-artifact share regression test), plus `artifact-image-navigation`, `image-annotation`, `chat-draft`, `chat-event-action-cards`, `markdown`, `shared-thread-page`, `chat-thread-sharing`, `presentation-html-preview`

Closes #30816

🤖 Generated with [Claude Code](https://claude.com/claude-code)
