### PR TITLE
docs(mitm-addon): document the flow metadata key linter

### DIFF
--- a/crates/runner/mitm-addon/scripts/README.md
+++ b/crates/runner/mitm-addon/scripts/README.md
@@ -33,6 +33,25 @@ uv run --no-sync python -m pytest tests/test_update_x_tlds.py
 For a local or reproducible source file, pass `--source-file` to the updater instead
 of fetching IANA. The same generated-module and integrity-pin review applies.
 
+# Flow metadata key linter
+
+The flow metadata key linter checks shared `flow.metadata` keys for duplicate
+registry values and repository key-use diagnostics. Run it from the addon root:
+
+```bash
+cd crates/runner/mitm-addon
+./scripts/check-flow-metadata-keys.py
+```
+
+A clean run exits 0 without output. An exit code of 1 prints the diagnostics
+that need correction. The linter recursively scans Python files under `src/`
+and `tests/`, excludes the canonical [`src/flow_metadata_keys.py`](../src/flow_metadata_keys.py)
+registry, and does not inspect `scripts/`.
+
+When adding or renaming a shared metadata key, update the registry and use its
+`metadata_keys` constants instead of literal shared keys, then run this check
+before committing the related addon changes.
+
 # Chat Completions extractor benchmark
 
 The [Chat Completions extractor benchmark](benchmark_openai_chat_completions_usage.py)

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -191,6 +191,23 @@ uv run --no-sync ruff check .
 uv run --no-sync basedpyright -p .
 ```
 
+### Flow metadata key contract check
+
+Run the flow metadata key linter when adding or renaming shared metadata keys,
+and before committing related addon changes:
+
+```bash
+cd crates/runner/mitm-addon
+./scripts/check-flow-metadata-keys.py
+```
+
+A clean run exits 0 without output. An exit code of 1 prints duplicate
+registered metadata-key values or repository key-use diagnostics. The linter
+recursively scans Python files under `src/` and `tests/`, excludes the
+canonical [`src/flow_metadata_keys.py`](../../crates/runner/mitm-addon/src/flow_metadata_keys.py)
+registry, and does not inspect `scripts/`. Use the registry's `metadata_keys`
+constants instead of literal shared metadata keys.
+
 Pre-commit hooks verify the lockfile when dependency metadata changes and run
 Ruff from the locked environment for staged addon Python files. Run pytest
 manually before committing behavior changes.


### PR DESCRIPTION
## Summary

- Document the existing flow metadata key linter command in the addon scripts README and testing guide.
- Explain clean/diagnostic exit statuses, recursive `src/` and `tests/` coverage, intentional exclusions, and the canonical metadata-key registry.
- Keep the testing guide's CI wording accurate: the linter is documented as an adjacent repository contract check and does not change the CI workflow.

## Scope exclusions

This PR changes documentation only. It does not change the linter implementation, tests, dependencies, lockfiles, CI definitions, or runtime behavior.

## Validation

- `cd crates/runner/mitm-addon && ./scripts/check-flow-metadata-keys.py` — passed with exit code 0 and no output.
- Relative registry-link existence check for both Markdown files — passed.
- `git diff --check` — passed.
- `uv run --no-sync python -m pytest tests/test_flow_metadata_key_contract.py` — not run because `uv` is not installed in the environment; `/usr/bin/python3` also has no `pytest` module.

Closes #30827
