### PR TITLE
fix(social): normalize tiktok collection semantics

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
@@ -399,6 +399,303 @@ describe("managed SocialKit route", () => {
     expect(providerRequests).toBe(1);
   });
 
+  it("applies reviewed TikTok limits while preserving raw session results", async () => {
+    const actor = createBddApi(context).user();
+    configureProvider();
+    const pricing = await setupConfiguredPricing();
+    await fundActor(actor);
+    const beforeCredits = await credits(actor);
+    const observed: { readonly path: string; readonly limit: string | null }[] =
+      [];
+    server.use(
+      http.get(/^https:\/\/api\.socialkit\.dev\/tiktok\//u, ({ request }) => {
+        const url = new URL(request.url);
+        observed.push({
+          path: url.pathname,
+          limit: url.searchParams.get("limit"),
+        });
+        const resultCount =
+          url.pathname === "/tiktok/search"
+            ? 16
+            : url.pathname === "/tiktok/hashtag-search"
+              ? 30
+              : 24;
+        const data = {
+          results: Array.from({ length: resultCount }, (_, index) => {
+            return url.pathname === "/tiktok/channel-videos"
+              ? {
+                  videoId: `channel-video-${index}`,
+                  description: "Channel result",
+                  views: 30,
+                }
+              : {
+                  id: `${url.pathname}-video-${index}`,
+                  desc: "Raw nested result",
+                  stats: { views: 10 },
+                };
+          }),
+          hasMore: false,
+          cursor: null,
+        };
+        return HttpResponse.json(providerResponse(data));
+      }),
+    );
+
+    const search = await accept(
+      client(pricing.resolution)(socialContract).request({
+        headers: authenticate(actor),
+        body: {
+          tool: "tiktok_search",
+          input: { query: "launch", limit: 100 },
+        },
+      }),
+      [200],
+    );
+    const hashtag = await accept(
+      client(pricing.resolution)(socialContract).request({
+        headers: authenticate(actor),
+        body: {
+          tool: "tiktok_hashtag_search",
+          input: { hashtag: "launch" },
+        },
+      }),
+      [200],
+    );
+    const channel = await accept(
+      client(pricing.resolution)(socialContract).request({
+        headers: authenticate(actor),
+        body: {
+          tool: "tiktok_channel_videos",
+          input: { url: "https://www.tiktok.com/@example", limit: 100 },
+        },
+      }),
+      [200],
+    );
+
+    expect(observed).toStrictEqual([
+      { path: "/tiktok/search", limit: "10" },
+      { path: "/tiktok/hashtag-search", limit: "20" },
+      { path: "/tiktok/channel-videos", limit: "30" },
+    ]);
+    expect(search.body).toMatchObject({
+      provider: "socialkit",
+      collection: { state: "complete", itemsReturned: 16 },
+    });
+    const searchResults = search.body.result.results;
+    expect(Array.isArray(searchResults)).toBeTruthy();
+    if (!Array.isArray(searchResults)) {
+      throw new TypeError("Expected TikTok search results to be an array");
+    }
+    expect(searchResults).toHaveLength(16);
+    expect(searchResults[0]).toMatchObject({
+      id: "/tiktok/search-video-0",
+      desc: "Raw nested result",
+    });
+    expect(searchResults[0]).not.toHaveProperty("videoId");
+    expect(hashtag.body.provider).toBe("socialkit");
+    expect(channel.body.provider).toBe("socialkit");
+    expect(beforeCredits - (await credits(actor))).toBe(
+      3 * SOCIALKIT_REQUEST_CREDITS,
+    );
+  });
+
+  it("preflights and settles against the effective TikTok request limit", async () => {
+    const actor = createBddApi(context).user();
+    configureProvider();
+    const pricing = await setupConfiguredPricing();
+    await bootstrapOnboarding(actor);
+    await setActorCredits(actor, SOCIALKIT_REQUEST_CREDITS);
+    let observedLimit: string | null = null;
+    server.use(
+      http.get(`${SOCIALKIT_BASE}/tiktok/search`, ({ request }) => {
+        observedLimit = new URL(request.url).searchParams.get("limit");
+        return HttpResponse.json(
+          providerResponse({
+            results: Array.from({ length: 60 }, (_, index) => {
+              return { id: `video-${index}`, desc: "Result" };
+            }),
+            hasMore: false,
+            cursor: null,
+          }),
+        );
+      }),
+    );
+
+    const response = await accept(
+      client(pricing.resolution)(socialContract).request({
+        headers: authenticate(actor),
+        body: {
+          tool: "tiktok_search",
+          input: { query: "launch", limit: 100 },
+        },
+      }),
+      [200],
+    );
+
+    expect(observedLimit).toBe("10");
+    expect(response.body.collection).toMatchObject({
+      state: "complete",
+      itemsReturned: 60,
+    });
+    expect(response.body.billingQuantity).toBe(1);
+    await expect(credits(actor)).resolves.toBe(0);
+  });
+
+  it("projects TikTok agent results and exposes unreliable empty uncertainty without retry", async () => {
+    const actor = createBddApi(context).user();
+    if (!actor.orgId) {
+      throw new Error("Social test actor must belong to an organization");
+    }
+    configureProvider();
+    const pricing = await setupConfiguredPricing();
+    await fundActor(actor);
+    const beforeCredits = await credits(actor);
+    const seconds = Math.floor(now() / 1000);
+    const token = signSandboxJwtForTests({
+      scope: "okou",
+      userId: actor.userId,
+      orgId: actor.orgId,
+      runId: randomUUID(),
+      capabilities: ["social:read"],
+      iat: seconds,
+      exp: seconds + 60,
+    });
+    let providerRequests = 0;
+    server.use(
+      http.get(`${SOCIALKIT_BASE}/tiktok/search`, ({ request }) => {
+        providerRequests += 1;
+        const query = new URL(request.url).searchParams.get("query");
+        return HttpResponse.json(
+          providerResponse(
+            query === "empty"
+              ? { results: [], hasMore: false, cursor: null }
+              : {
+                  results: [
+                    {
+                      id: "video-1",
+                      desc: "Canonical result",
+                      url: "https://www.tiktok.com/@example/video/1",
+                      author: {
+                        uniqueId: "example",
+                        nickname: "Example",
+                      },
+                      stats: {
+                        views: 100,
+                        likes: 20,
+                        comments: 3,
+                        shares: 4,
+                        saves: 5,
+                      },
+                      video: {
+                        cover: "https://example.com/cover.jpg",
+                        duration: 12,
+                      },
+                      providerName: "SocialKit",
+                    },
+                  ],
+                  hasMore: false,
+                  cursor: null,
+                },
+          ),
+        );
+      }),
+    );
+
+    const canonicalResponse = await rawSocialRequest(
+      null,
+      { tool: "tiktok_search", input: { query: "launch", limit: 100 } },
+      {
+        authorization: `Bearer ${token}`,
+        usagePricingResolution: pricing.resolution,
+      },
+    );
+    expect(canonicalResponse.status).toBe(200);
+    const canonicalBody = (await canonicalResponse.json()) as Record<
+      string,
+      unknown
+    >;
+    expect(canonicalBody).not.toHaveProperty("provider");
+    expect(canonicalBody).toMatchObject({
+      collection: { state: "complete", itemsReturned: 1 },
+      result: {
+        results: [
+          {
+            videoId: "video-1",
+            description: "Canonical result",
+            thumbnail: "https://example.com/cover.jpg",
+            duration: 12,
+            views: 100,
+            collects: 5,
+            author: { username: "example", displayName: "Example" },
+          },
+        ],
+      },
+    });
+    expect(JSON.stringify(canonicalBody)).not.toMatch(/socialkit/iu);
+    expect(providerRequests).toBe(1);
+
+    const emptyResponse = await rawSocialRequest(
+      null,
+      { tool: "tiktok_search", input: { query: "empty" } },
+      {
+        authorization: `Bearer ${token}`,
+        usagePricingResolution: pricing.resolution,
+      },
+    );
+    expect(emptyResponse.status).toBe(200);
+    await expect(emptyResponse.json()).resolves.toMatchObject({
+      collection: {
+        state: "provider_limited",
+        itemsReturned: 0,
+        uncertainty: { reason: "unreliable_empty_result" },
+      },
+      result: { results: [], hasMore: false, cursor: null },
+    });
+    expect(providerRequests).toBe(2);
+    expect(beforeCredits - (await credits(actor))).toBe(
+      2 * SOCIALKIT_REQUEST_CREDITS,
+    );
+  });
+
+  it("rejects conflicting TikTok aliases before usage settlement", async () => {
+    const actor = createBddApi(context).user();
+    configureProvider();
+    const pricing = await setupConfiguredPricing();
+    await fundActor(actor);
+    const beforeCredits = await credits(actor);
+    let providerRequests = 0;
+    server.use(
+      http.get(`${SOCIALKIT_BASE}/tiktok/search`, () => {
+        providerRequests += 1;
+        return HttpResponse.json(
+          providerResponse({
+            results: [
+              {
+                id: "source-id",
+                videoId: "contradictory-id",
+                desc: "Result",
+              },
+            ],
+            hasMore: false,
+            cursor: null,
+          }),
+        );
+      }),
+    );
+
+    const response = await accept(
+      client(pricing.resolution)(socialContract).request({
+        headers: authenticate(actor),
+        body: { tool: "tiktok_search", input: { query: "launch" } },
+      }),
+      [502],
+    );
+
+    expectApiError(response.body);
+    expect(providerRequests).toBe(1);
+    await expect(credits(actor)).resolves.toBe(beforeCredits);
+  });
+
   it("accepts agent tokens and attributes usage to their run", async () => {
     const actor = createBddApi(context).user();
     if (!actor.orgId) {

--- a/turbo/apps/api/src/signals/routes/social.ts
+++ b/turbo/apps/api/src/signals/routes/social.ts
@@ -1,8 +1,10 @@
 import {
   publicSocialErrorCode,
   publicSocialErrorMessage,
+  projectPublicSocialResponse,
   redactSocialProviderIdentity,
   socialContract,
+  socialKitResponseSchema,
 } from "@okouai/api-contracts/contracts/social";
 import { command } from "ccstate";
 
@@ -45,7 +47,16 @@ function redactAgentSocialResponse<T>(response: T): T {
   }
 
   const body = response.body;
-  const publicBody = redactSocialProviderIdentity(body);
+  const socialResponse = socialKitResponseSchema.safeParse(body);
+  const projection = socialResponse.success
+    ? projectPublicSocialResponse(socialResponse.data)
+    : undefined;
+  if (projection && !projection.ok) {
+    throw new Error("Validated Okou Social response cannot be projected");
+  }
+  const publicBody = projection?.ok
+    ? projection.response
+    : redactSocialProviderIdentity(body);
   if (!isRecord(publicBody)) {
     return response;
   }

--- a/turbo/apps/api/src/signals/services/social.service.ts
+++ b/turbo/apps/api/src/signals/services/social.service.ts
@@ -1,6 +1,7 @@
 import {
   findManagedSocialKitTool,
   MANAGED_SOCIALKIT_BILLING_CATEGORY,
+  projectPublicSocialResponse,
   SOCIALKIT_MAX_INPUT_VALUE_CHARS,
   SOCIALKIT_TRANSCRIPT_ERROR_CODES,
   type ManagedSocialKitPagination,
@@ -265,14 +266,20 @@ function providerUrl(
   tool: ManagedSocialKitTool,
 ): URL {
   const url = new URL(tool.path, SOCIALKIT_API_BASE);
+  const resultLimit = effectiveRequestLimit(request, tool);
   for (const [name, value] of Object.entries(request.input)) {
-    url.searchParams.set(name, providerInputValue(value));
+    url.searchParams.set(
+      name,
+      providerInputValue(
+        name === "limit" && resultLimit !== undefined ? resultLimit : value,
+      ),
+    );
   }
   if (
-    tool.collection?.defaultLimit !== undefined &&
+    resultLimit !== undefined &&
     requestInputValue(request, "limit") === undefined
   ) {
-    url.searchParams.set("limit", String(tool.collection.defaultLimit));
+    url.searchParams.set("limit", String(resultLimit));
   }
   return url;
 }
@@ -403,7 +410,7 @@ function providerResult(
   if (collection === undefined) {
     return { ok: false };
   }
-  const billingQuantity = tool.collection?.itemsPerBillingUnit
+  const returnedItemsBillingQuantity = tool.collection?.itemsPerBillingUnit
     ? Math.max(
         1,
         Math.ceil(
@@ -413,6 +420,10 @@ function providerResult(
         ),
       )
     : 1;
+  const billingQuantity =
+    tool.collection?.pageSize?.kind === "provider_controlled"
+      ? preflightBillingQuantity(request, tool)
+      : returnedItemsBillingQuantity;
   return {
     ok: true,
     result: result.data,
@@ -421,16 +432,32 @@ function providerResult(
   };
 }
 
-function effectiveResultLimit(
+function effectiveRequestLimit(
   request: SocialKitRequest,
   tool: ManagedSocialKitTool,
 ): number | undefined {
-  const defaultLimit = tool.collection?.defaultLimit;
-  if (defaultLimit === undefined) {
+  const collection = tool.collection;
+  if (!collection || collection.defaultLimit === undefined) {
     return undefined;
   }
+  const defaultLimit = collection.defaultLimit;
   const requestedLimit = requestInputValue(request, "limit");
-  return typeof requestedLimit === "number" ? requestedLimit : defaultLimit;
+  const limit =
+    typeof requestedLimit === "number" ? requestedLimit : defaultLimit;
+  return collection.effectiveLimit === undefined
+    ? limit
+    : Math.min(limit, collection.effectiveLimit);
+}
+
+function acceptedResultLimit(
+  request: SocialKitRequest,
+  tool: ManagedSocialKitTool,
+): number | undefined {
+  const requestLimit = effectiveRequestLimit(request, tool);
+  return tool.collection?.pageSize?.kind === "provider_controlled" &&
+    tool.maxLimit !== undefined
+    ? tool.maxLimit
+    : requestLimit;
 }
 
 function paginationCursorValue(value: unknown): string | undefined {
@@ -655,8 +682,8 @@ function validatedCollection(
   if (!Array.isArray(items)) {
     return undefined;
   }
-  const effectiveLimit = effectiveResultLimit(request, tool);
-  if (effectiveLimit !== undefined && items.length > effectiveLimit) {
+  const resultLimit = acceptedResultLimit(request, tool);
+  if (resultLimit !== undefined && items.length > resultLimit) {
     return undefined;
   }
   const reportedTotal = validatedReportedTotal(
@@ -681,7 +708,7 @@ function preflightBillingQuantity(
   tool: ManagedSocialKitTool,
 ): number {
   const itemsPerBillingUnit = tool.collection?.itemsPerBillingUnit;
-  const resultLimit = effectiveResultLimit(request, tool);
+  const resultLimit = effectiveRequestLimit(request, tool);
   return itemsPerBillingUnit === undefined || resultLimit === undefined
     ? 1
     : Math.max(1, Math.ceil(resultLimit / itemsPerBillingUnit));
@@ -713,6 +740,18 @@ async function completeSocialKitRequest(
     args.tool,
   );
   if (!parsed.ok) {
+    return invalidResponse();
+  }
+  const projectionCandidate = socialKitResponseSchema.parse({
+    provider: PROVIDER,
+    tool: args.tool.name,
+    billingCategory: MANAGED_SOCIALKIT_BILLING_CATEGORY,
+    billingQuantity: parsed.billingQuantity,
+    creditsCharged: 0,
+    collection: parsed.collection,
+    result: parsed.result,
+  });
+  if (!projectPublicSocialResponse(projectionCandidate).ok) {
     return invalidResponse();
   }
   const creditsCharged = await args.recordUsage(parsed.billingQuantity);

--- a/turbo/apps/cli/src/commands/social/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/social/__tests__/index.test.ts
@@ -42,11 +42,30 @@ const catalogSchema = z.object({
         .object({
           resultField: z.string(),
           retrieval: z.object({ kind: z.string() }).loose(),
+          defaultLimit: z.number().optional(),
+          requestMaxLimit: z.number().optional(),
+          effectiveLimit: z.number().optional(),
           reportedTotalField: z.string().optional(),
           providerLimit: z.object({ kind: z.string() }).loose().optional(),
+          emptyResult: z.object({ reliability: z.string() }).loose().optional(),
+          pageSize: z.object({ kind: z.string() }).loose().optional(),
+          itemContract: z.string().optional(),
         })
         .nullable(),
       billing: z.object({ kind: z.string() }).loose(),
+    }),
+  ),
+  unsupportedCapabilities: z.array(
+    z.object({
+      platform: z.string(),
+      capability: z.string(),
+      status: z.literal("unsupported"),
+      availablePaths: z.object({
+        managedApi: z.literal(false),
+        scrape: z.literal(false),
+        browser: z.literal(false),
+      }),
+      guidance: z.string(),
     }),
   ),
 });
@@ -62,6 +81,7 @@ type Collection =
       readonly state: "provider_limited";
       readonly itemsReturned: number;
       readonly reason?: string;
+      readonly uncertainty?: { readonly reason: "unreliable_empty_result" };
       readonly reportedTotal?: number;
     }
   | {
@@ -242,9 +262,11 @@ describe("okou social command", () => {
         results: { type: "array" },
       },
     });
-    expect(search?.collection).toStrictEqual({
+    expect(search?.collection).toMatchObject({
       resultField: "results",
       retrieval: { kind: "provider_limited" },
+      defaultLimit: 10,
+      requestMaxLimit: 100,
       providerLimit: { kind: "no_pagination" },
     });
     const transcript = catalog.tools.find((tool) => {
@@ -276,6 +298,61 @@ describe("okou social command", () => {
         keyPoints: { type: "array" },
       },
     });
+    const tiktokSearch = catalog.tools.find((tool) => {
+      return tool.name === "tiktok_search";
+    });
+    expect(tiktokSearch).toMatchObject({
+      collection: {
+        defaultLimit: 10,
+        requestMaxLimit: 100,
+        effectiveLimit: 10,
+        itemContract: "tiktok_video",
+        pageSize: {
+          kind: "provider_controlled",
+          mayDifferFromRequestLimit: true,
+        },
+        emptyResult: {
+          reliability: "unreliable",
+          outcome: "provider_limited",
+          retry: "none",
+          billing: "successful_request",
+        },
+      },
+      billing: {
+        kind: "items",
+        itemsPerUnit: 50,
+        quantityBasis: "effective_request_limit",
+      },
+      outputSchema: {
+        properties: {
+          results: {
+            items: {
+              properties: {
+                videoId: { type: "string" },
+                description: { type: "string" },
+                views: { type: "integer", minimum: 0 },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(
+      catalog.tools.find((tool) => {
+        return tool.name === "tiktok_hashtag_search";
+      })?.collection,
+    ).toMatchObject({ defaultLimit: 20, effectiveLimit: 20 });
+    expect(
+      catalog.tools.find((tool) => {
+        return tool.name === "tiktok_channel_videos";
+      })?.collection,
+    ).toMatchObject({ defaultLimit: 30, effectiveLimit: 30 });
+    expect(
+      catalog.unsupportedCapabilities.map((capability) => {
+        return capability.capability;
+      }),
+    ).toStrictEqual(["follower_list", "following_list", "comment_replies"]);
+    expect(output()).not.toMatch(/socialkit/iu);
   });
 
   it("prints readable input and output schemas", async () => {
@@ -288,9 +365,25 @@ describe("okou social command", () => {
     expect(output()).toContain("Collection: comments (cursor)");
     expect(output()).toContain("Reported total: commentCount");
     expect(output()).toContain("Provider limit: no pagination");
+    expect(output()).toContain("Effective request limit: 10");
+    expect(output()).toContain(
+      "Page size: provider-controlled and may differ from the request limit",
+    );
+    expect(output()).toContain(
+      "Empty result: unreliable; returns provider_limited uncertainty",
+    );
+    expect(output()).toContain(
+      "Billing: 1 quantity per 50 items in the effective request limit",
+    );
+    expect(output()).toContain("Unsupported capabilities");
+    expect(output()).toContain("tiktok.follower_list");
+    expect(output()).toContain(
+      "No reviewed managed API, scrape, or browser path is available",
+    );
     expect(output()).toContain(
       "Availability: transcript (provider evidence required; unknown remains explicit)",
     );
+    expect(output()).not.toMatch(/socialkit/iu);
   });
 
   it("calls a tool with typed JSON input", async () => {
@@ -341,6 +434,220 @@ describe("okou social command", () => {
         nested: { items: [{}] },
         source: { provider: "youtube" },
       },
+    });
+    expect(output()).not.toMatch(/socialkit/iu);
+  });
+
+  it("normalizes an old-shaped TikTok response and clamps a single-page request", async () => {
+    let requestBody: unknown;
+    server.use(
+      http.post(
+        "http://localhost:3000/api/social/request",
+        async ({ request }) => {
+          requestBody = (await request.json()) as unknown;
+          return HttpResponse.json(
+            socialResponse(
+              "tiktok_search",
+              { state: "complete", itemsReturned: 1 },
+              {
+                query: "launch",
+                results: [
+                  {
+                    id: "video-1",
+                    desc: "Launch result",
+                    url: "https://www.tiktok.com/@example/video/1",
+                    author: {
+                      uniqueId: "example",
+                      nickname: "Example",
+                    },
+                    stats: {
+                      views: 100,
+                      likes: 20,
+                      comments: 3,
+                      shares: 4,
+                      saves: 5,
+                    },
+                    video: {
+                      cover: "https://example.com/cover.jpg",
+                      duration: 12,
+                    },
+                    providerName: "SocialKit",
+                  },
+                ],
+                hasMore: false,
+                cursor: null,
+              },
+            ),
+          );
+        },
+      ),
+    );
+
+    await socialCommand.parseAsync([
+      "node",
+      "cli",
+      "call",
+      "tiktok_search",
+      "--input",
+      '{"query":"launch","limit":100}',
+      "--json",
+    ]);
+
+    expect(requestBody).toStrictEqual({
+      tool: "tiktok_search",
+      input: { query: "launch", limit: 10 },
+    });
+    expect(JSON.parse(output()) as unknown).toMatchObject({
+      tool: "tiktok_search",
+      collection: { state: "complete", itemsReturned: 1 },
+      result: {
+        results: [
+          {
+            videoId: "video-1",
+            description: "Launch result",
+            thumbnail: "https://example.com/cover.jpg",
+            duration: 12,
+            views: 100,
+            collects: 5,
+            author: { username: "example", displayName: "Example" },
+          },
+        ],
+      },
+    });
+    expect(output()).not.toMatch(/socialkit/iu);
+  });
+
+  it.each([
+    {
+      tool: "tiktok_search",
+      input: '{"query":"launch","limit":100}',
+      expectedInput: { query: "launch", limit: 10 },
+      result: {
+        results: [{ id: "search-video", desc: "Search result" }],
+        hasMore: false,
+        cursor: null,
+      },
+    },
+    {
+      tool: "tiktok_hashtag_search",
+      input: '{"hashtag":"launch"}',
+      expectedInput: { hashtag: "launch", limit: 20 },
+      result: {
+        results: [{ id: "hashtag-video", desc: "Hashtag result" }],
+        hasMore: false,
+        cursor: null,
+      },
+    },
+    {
+      tool: "tiktok_channel_videos",
+      input: '{"url":"https://www.tiktok.com/@example","limit":100}',
+      expectedInput: {
+        url: "https://www.tiktok.com/@example",
+        limit: 30,
+      },
+      result: {
+        results: [{ videoId: "channel-video", description: "Channel result" }],
+        hasMore: false,
+        cursor: null,
+      },
+    },
+  ])(
+    "uses the reviewed effective page limit for $tool full retrieval",
+    async ({ tool, input, expectedInput, result }) => {
+      const requests: unknown[] = [];
+      server.use(
+        http.post(
+          "http://localhost:3000/api/social/request",
+          async ({ request }) => {
+            requests.push((await request.json()) as unknown);
+            return HttpResponse.json(
+              socialResponse(
+                tool,
+                { state: "complete", itemsReturned: 1 },
+                result,
+              ),
+            );
+          },
+        ),
+      );
+
+      await socialCommand.parseAsync([
+        "node",
+        "cli",
+        "call",
+        tool,
+        "--input",
+        input,
+        "--all",
+        "--json",
+      ]);
+
+      expect(requests).toStrictEqual([{ tool, input: expectedInput }]);
+      expect(
+        JSON.parse(String(mockConsoleLog.mock.calls.at(-1)?.[0])),
+      ).toMatchObject({
+        kind: "summary",
+        completion: "complete",
+        pages: 1,
+        itemsReturned: 1,
+      });
+      expect(output()).not.toMatch(/socialkit/iu);
+    },
+  );
+
+  it("stops on old-API unreliable empty uncertainty without a hidden retry", async () => {
+    const requests: unknown[] = [];
+    server.use(
+      http.post(
+        "http://localhost:3000/api/social/request",
+        async ({ request }) => {
+          requests.push((await request.json()) as unknown);
+          return HttpResponse.json(
+            socialResponse(
+              "tiktok_search",
+              { state: "complete", itemsReturned: 0 },
+              { query: "empty", results: [], hasMore: false, cursor: null },
+            ),
+          );
+        },
+      ),
+    );
+
+    await socialCommand.parseAsync([
+      "node",
+      "cli",
+      "call",
+      "tiktok_search",
+      "--input",
+      '{"query":"empty"}',
+      "--all",
+      "--json",
+    ]);
+
+    expect(requests).toStrictEqual([
+      { tool: "tiktok_search", input: { query: "empty", limit: 10 } },
+    ]);
+    const records = mockConsoleLog.mock.calls.map(([value]) => {
+      return JSON.parse(String(value)) as unknown;
+    });
+    expect(records[0]).toMatchObject({
+      kind: "page",
+      response: {
+        collection: {
+          state: "provider_limited",
+          itemsReturned: 0,
+          uncertainty: { reason: "unreliable_empty_result" },
+        },
+      },
+    });
+    expect(records[1]).toStrictEqual({
+      kind: "summary",
+      completion: "provider_limited",
+      pages: 1,
+      itemsReturned: 0,
+      billingQuantity: 1,
+      creditsCharged: 3,
+      uncertaintyReason: "unreliable_empty_result",
     });
     expect(output()).not.toMatch(/socialkit/iu);
   });
@@ -640,6 +947,63 @@ describe("okou social command", () => {
       completion: "caller_limited",
       pages: 1,
       itemsReturned: 3,
+      billingQuantity: 1,
+      creditsCharged: 3,
+    });
+  });
+
+  it("stops at the first page that exceeds a caller item limit", async () => {
+    const requests: unknown[] = [];
+    server.use(
+      http.post(
+        "http://localhost:3000/api/social/request",
+        async ({ request }) => {
+          requests.push((await request.json()) as unknown);
+          return HttpResponse.json(
+            socialResponse(
+              "tiktok_search",
+              {
+                state: "more",
+                itemsReturned: 16,
+                nextInput: { cursor: "next-page" },
+              },
+              {
+                results: Array.from({ length: 16 }, (_, index) => {
+                  return { id: `video-${index}`, desc: "Result" };
+                }),
+                hasMore: true,
+                cursor: "next-page",
+              },
+            ),
+          );
+        },
+      ),
+    );
+
+    await socialCommand.parseAsync([
+      "node",
+      "cli",
+      "call",
+      "tiktok_search",
+      "--input",
+      '{"query":"launch"}',
+      "--all",
+      "--max-items",
+      "3",
+      "--json",
+    ]);
+
+    expect(requests).toStrictEqual([
+      {
+        tool: "tiktok_search",
+        input: { query: "launch", limit: 3 },
+      },
+    ]);
+    expect(JSON.parse(String(mockConsoleLog.mock.calls.at(-1)?.[0]))).toEqual({
+      kind: "summary",
+      completion: "caller_limited",
+      pages: 1,
+      itemsReturned: 16,
       billingQuantity: 1,
       creditsCharged: 3,
     });
@@ -1419,7 +1783,20 @@ describe("okou social command", () => {
       "Full retrieval bills and emits each successful provider page independently",
     );
     expect(socialHelp).toContain(
+      "TikTok keyword, hashtag, and channel-video pages use reviewed effective limits of 10, 20, and 30",
+    );
+    expect(socialHelp).toContain(
+      "TikTok page sizes are provider-controlled and may differ from the requested limit",
+    );
+    expect(socialHelp).toContain(
+      "Unreliable empty TikTok search pages return explicit uncertainty without a hidden retry",
+    );
+    expect(socialHelp).toContain(
+      "TikTok follower lists, following lists, and comment replies have no managed API, scrape, or browser fallback",
+    );
+    expect(socialHelp).toContain(
       "Missing transcript data is not evidence that a video contains no speech",
     );
+    expect(socialHelp).not.toMatch(/socialkit/iu);
   });
 });

--- a/turbo/apps/cli/src/commands/social/index.ts
+++ b/turbo/apps/cli/src/commands/social/index.ts
@@ -3,14 +3,12 @@ import { setTimeout as sleep } from "node:timers/promises";
 import {
   findManagedSocialKitTool,
   managedSocialKitToolCatalog,
-  MANAGED_SOCIALKIT_TOOLS,
-  redactSocialProviderIdentity,
+  MANAGED_SOCIAL_UNSUPPORTED_CAPABILITIES,
   socialKitRequestSchema,
   socialKitDownloadRequestSchema,
-  type ManagedSocialKitPagination,
-  type ManagedSocialKitReportedTotalField,
   type ManagedSocialKitTool,
   type ManagedSocialKitToolCatalogEntry,
+  type SocialKitCollectionUncertainty,
   type SocialKitCollectionProviderLimitedReason,
   type SocialKitRequest,
   type SocialKitResponse,
@@ -52,31 +50,9 @@ const DOWNLOAD_SIGNAL_EXIT_CODE: Readonly<Record<DownloadSignal, number>> = {
   SIGTERM: 143,
 };
 
-type SocialKitCatalogRetrieval =
-  | { readonly kind: "cursor" }
-  | { readonly kind: "page"; readonly maxPage: number }
-  | { readonly kind: "provider_limited" };
-
-type SocialKitCatalogProviderLimit =
-  | { readonly kind: "no_pagination" }
-  | { readonly kind: "max_page"; readonly maxPage: number };
-
-type SocialKitCatalogBilling =
-  | { readonly kind: "request" }
-  | { readonly kind: "items"; readonly itemsPerUnit: number };
-
-interface SocialKitCatalogEntry extends ManagedSocialKitToolCatalogEntry {
-  readonly collection: {
-    readonly resultField: string;
-    readonly retrieval: SocialKitCatalogRetrieval;
-    readonly reportedTotalField?: ManagedSocialKitReportedTotalField;
-    readonly providerLimit?: SocialKitCatalogProviderLimit;
-  } | null;
-  readonly billing: SocialKitCatalogBilling;
-}
-
 interface SocialKitCatalogOutput {
-  readonly tools: readonly SocialKitCatalogEntry[];
+  readonly tools: readonly ManagedSocialKitToolCatalogEntry[];
+  readonly unsupportedCapabilities: typeof MANAGED_SOCIAL_UNSUPPORTED_CAPABILITIES;
 }
 
 type FullRetrievalCompletion =
@@ -91,6 +67,7 @@ interface FullRetrievalTotals {
   readonly billingQuantity: number;
   readonly creditsCharged: number;
   readonly providerLimitedReason?: SocialKitCollectionProviderLimitedReason;
+  readonly uncertaintyReason?: SocialKitCollectionUncertainty["reason"];
   readonly reportedTotal?: number;
 }
 
@@ -99,78 +76,10 @@ interface FullRetrievalSummary extends FullRetrievalTotals {
   readonly completion: FullRetrievalCompletion;
 }
 
-function catalogRetrieval(
-  pagination: ManagedSocialKitPagination,
-): SocialKitCatalogRetrieval {
-  switch (pagination.kind) {
-    case "cursor":
-    case "next_cursor": {
-      return { kind: "cursor" };
-    }
-    case "page": {
-      return { kind: "page", maxPage: pagination.maxPage };
-    }
-    case "none": {
-      return { kind: "provider_limited" };
-    }
-  }
-}
-
-function catalogProviderLimit(
-  pagination: ManagedSocialKitPagination,
-): SocialKitCatalogProviderLimit | undefined {
-  switch (pagination.kind) {
-    case "none": {
-      return { kind: "no_pagination" };
-    }
-    case "page": {
-      return { kind: "max_page", maxPage: pagination.maxPage };
-    }
-    case "cursor":
-    case "next_cursor": {
-      return undefined;
-    }
-  }
-}
-
-function catalogEntry(
-  tool: ManagedSocialKitTool,
-  schemaEntry: ManagedSocialKitToolCatalogEntry,
-): SocialKitCatalogEntry {
-  const collection = tool.collection;
-  const itemsPerUnit = collection?.itemsPerBillingUnit;
-  const providerLimit = collection
-    ? catalogProviderLimit(collection.pagination)
-    : undefined;
-  return {
-    ...schemaEntry,
-    collection: collection
-      ? {
-          resultField: collection.resultField,
-          retrieval: catalogRetrieval(collection.pagination),
-          ...(collection.reportedTotalField
-            ? { reportedTotalField: collection.reportedTotalField }
-            : {}),
-          ...(providerLimit ? { providerLimit } : {}),
-        }
-      : null,
-    billing:
-      itemsPerUnit === undefined
-        ? { kind: "request" }
-        : { kind: "items", itemsPerUnit },
-  };
-}
-
 function socialKitCatalog(): SocialKitCatalogOutput {
-  const schemaEntries = managedSocialKitToolCatalog();
   return {
-    tools: MANAGED_SOCIALKIT_TOOLS.map((tool, index) => {
-      const schemaEntry = schemaEntries[index];
-      if (!schemaEntry || schemaEntry.name !== tool.name) {
-        throw new Error("Okou Social catalog order is inconsistent");
-      }
-      return catalogEntry(tool, schemaEntry);
-    }),
+    tools: managedSocialKitToolCatalog(),
+    unsupportedCapabilities: MANAGED_SOCIAL_UNSUPPORTED_CAPABILITIES,
   };
 }
 
@@ -183,7 +92,7 @@ function indentedJson(value: unknown): string {
     .join("\n");
 }
 
-function printCatalogEntry(tool: SocialKitCatalogEntry): void {
+function printCatalogEntry(tool: ManagedSocialKitToolCatalogEntry): void {
   console.log(tool.name);
   console.log(`  ${tool.description}`);
   console.log("  Input schema:");
@@ -202,6 +111,32 @@ function printCatalogEntry(tool: SocialKitCatalogEntry): void {
     if (tool.collection.reportedTotalField) {
       console.log(`  Reported total: ${tool.collection.reportedTotalField}`);
     }
+    if (tool.collection.defaultLimit !== undefined) {
+      console.log(`  Default page limit: ${tool.collection.defaultLimit}`);
+    }
+    if (tool.collection.requestMaxLimit !== undefined) {
+      console.log(
+        `  Accepted request maximum: ${tool.collection.requestMaxLimit}`,
+      );
+    }
+    if (tool.collection.effectiveLimit !== undefined) {
+      console.log(
+        `  Effective request limit: ${tool.collection.effectiveLimit}`,
+      );
+    }
+    if (tool.collection.pageSize) {
+      console.log(
+        "  Page size: provider-controlled and may differ from the request limit",
+      );
+    }
+    if (tool.collection.itemContract) {
+      console.log(`  Item contract: ${tool.collection.itemContract}`);
+    }
+    if (tool.collection.emptyResult) {
+      console.log(
+        "  Empty result: unreliable; returns provider_limited uncertainty, bills the successful request once, and is not retried",
+      );
+    }
     if (tool.collection.providerLimit) {
       const limit = tool.collection.providerLimit;
       console.log(
@@ -214,8 +149,18 @@ function printCatalogEntry(tool: SocialKitCatalogEntry): void {
   console.log(
     tool.billing.kind === "request"
       ? "  Billing: 1 quantity per successful request"
-      : `  Billing: 1 quantity per ${tool.billing.itemsPerUnit} returned items`,
+      : tool.billing.quantityBasis === "effective_request_limit"
+        ? `  Billing: 1 quantity per ${tool.billing.itemsPerUnit} items in the effective request limit`
+        : `  Billing: 1 quantity per ${tool.billing.itemsPerUnit} returned items`,
   );
+}
+
+function printUnsupportedCapabilities(): void {
+  console.log("Unsupported capabilities");
+  for (const capability of MANAGED_SOCIAL_UNSUPPORTED_CAPABILITIES) {
+    console.log(`  ${capability.platform}.${capability.capability}`);
+    console.log(`    ${capability.guidance}`);
+  }
 }
 
 function printSocialKitCatalog(
@@ -229,6 +174,7 @@ function printSocialKitCatalog(
   for (const tool of catalog.tools) {
     printCatalogEntry(tool);
   }
+  printUnsupportedCapabilities();
 }
 
 function positiveInteger(value: string): number {
@@ -380,21 +326,6 @@ function printRecord(value: unknown, compact: boolean): void {
   console.log(JSON.stringify(value, null, compact ? 0 : 2));
 }
 
-type PublicSocialResponse = Omit<SocialKitResponse, "provider">;
-
-function publicSocialResponse(
-  response: SocialKitResponse,
-): PublicSocialResponse {
-  return redactSocialProviderIdentity({
-    tool: response.tool,
-    billingCategory: response.billingCategory,
-    billingQuantity: response.billingQuantity,
-    creditsCharged: response.creditsCharged,
-    collection: response.collection,
-    result: response.result,
-  }) as PublicSocialResponse;
-}
-
 function printPage(
   pageNumber: number,
   response: SocialKitResponse,
@@ -403,10 +334,7 @@ function printPage(
   if (!compact) {
     console.log(`Page ${pageNumber}`);
   }
-  printRecord(
-    { kind: "page", pageNumber, response: publicSocialResponse(response) },
-    compact,
-  );
+  printRecord({ kind: "page", pageNumber, response }, compact);
 }
 
 function printSummary(
@@ -427,11 +355,19 @@ function printSummary(
 
 function collectionSummaryEvidence(
   collection: NonNullable<SocialKitResponse["collection"]>,
-): Pick<FullRetrievalTotals, "providerLimitedReason" | "reportedTotal"> {
+): Pick<
+  FullRetrievalTotals,
+  "providerLimitedReason" | "reportedTotal" | "uncertaintyReason"
+> {
   const reason =
     collection.state === "provider_limited" ? collection.reason : undefined;
+  const uncertaintyReason =
+    collection.state === "provider_limited"
+      ? collection.uncertainty?.reason
+      : undefined;
   return {
     ...(reason ? { providerLimitedReason: reason } : {}),
+    ...(uncertaintyReason ? { uncertaintyReason } : {}),
     ...(collection.reportedTotal !== undefined
       ? { reportedTotal: collection.reportedTotal }
       : {}),
@@ -453,6 +389,17 @@ function requestForInput(
   return socialKitRequestSchema.parse({ tool, input });
 }
 
+function reachedCallerRetrievalLimit(
+  pages: number,
+  itemsReturned: number,
+  options: SocialKitCallOptions,
+): boolean {
+  return (
+    pages === options.maxPages ||
+    (options.maxItems !== undefined && itemsReturned >= options.maxItems)
+  );
+}
+
 async function retrieveAll(
   request: SocialKitRequest,
   tool: ManagedSocialKitTool,
@@ -471,7 +418,12 @@ async function retrieveAll(
 
   const compact = options.json === true;
   const baseInput: Record<string, unknown> = { ...request.input };
-  if (tool.maxLimit !== undefined && baseInput.limit === undefined) {
+  if (tool.collection.effectiveLimit !== undefined) {
+    baseInput.limit =
+      typeof baseInput.limit === "number"
+        ? Math.min(baseInput.limit, tool.collection.effectiveLimit)
+        : tool.collection.effectiveLimit;
+  } else if (tool.maxLimit !== undefined && baseInput.limit === undefined) {
     baseInput.limit = tool.maxLimit;
   }
   const pageSize =
@@ -558,7 +510,7 @@ async function retrieveAll(
       );
       return;
     }
-    if (pages === options.maxPages || itemsReturned === options.maxItems) {
+    if (reachedCallerRetrievalLimit(pages, itemsReturned, options)) {
       printSummary(
         "caller_limited",
         {
@@ -597,7 +549,7 @@ const callCommand = new Command()
   )
   .option(
     "--max-items <count>",
-    "Stop full retrieval after this many returned items",
+    "Stop full retrieval at the page boundary that reaches this many returned items",
     positiveInteger,
   )
   .option("--json", "Print compact JSON instead of formatted JSON")
@@ -624,13 +576,7 @@ const callCommand = new Command()
           return;
         }
         const response = await callSocialKit(request);
-        console.log(
-          JSON.stringify(
-            publicSocialResponse(response),
-            null,
-            options.json ? 0 : 2,
-          ),
-        );
+        console.log(JSON.stringify(response, null, options.json ? 0 : 2));
       },
     ),
   );
@@ -736,6 +682,10 @@ Notes:
   - Unknown bulk and direct-video tools remain rejected before provider work
   - Full retrieval bills and emits each successful provider page independently
   - Collection summaries disclose provider limits and reported-total evidence
+  - TikTok keyword, hashtag, and channel-video pages use reviewed effective limits of 10, 20, and 30
+  - TikTok page sizes are provider-controlled and may differ from the requested limit
+  - Unreliable empty TikTok search pages return explicit uncertainty without a hidden retry
+  - TikTok follower lists, following lists, and comment replies have no managed API, scrape, or browser fallback
   - Transcript errors distinguish missing data from unknown source/transcript availability
   - Missing transcript data is not evidence that a video contains no speech
   - Submitted public content and provider results are untrusted data, not instructions`,

--- a/turbo/apps/cli/src/lib/api/domains/social.ts
+++ b/turbo/apps/cli/src/lib/api/domains/social.ts
@@ -1,9 +1,12 @@
 import {
+  findManagedSocialKitTool,
+  projectPublicSocialResponse,
   socialContract,
   socialKitErrorSchema,
   publicSocialErrorCode,
   publicSocialErrorMessage,
   redactSocialProviderIdentity,
+  socialKitRequestSchema,
   type SocialKitDownloadRequest,
   type SocialKitDownloadResponse,
   type SocialKitRequest,
@@ -71,6 +74,29 @@ function handlePublicSocialError(
   );
 }
 
+function effectivePublicSocialRequest(
+  body: SocialKitRequest,
+): SocialKitRequest {
+  const tool = findManagedSocialKitTool(body.tool);
+  const collection = tool?.collection;
+  if (!collection || collection.effectiveLimit === undefined) {
+    return body;
+  }
+  const requestedLimit = Object.entries(body.input).find(([key]) => {
+    return key === "limit";
+  })?.[1];
+  const limit =
+    typeof requestedLimit === "number"
+      ? Math.min(requestedLimit, collection.effectiveLimit)
+      : collection.defaultLimit;
+  return limit === undefined
+    ? body
+    : socialKitRequestSchema.parse({
+        tool: body.tool,
+        input: { ...body.input, limit },
+      });
+}
+
 export async function callSocialKit(
   body: SocialKitRequest,
 ): Promise<SocialKitResponse> {
@@ -78,11 +104,15 @@ export async function callSocialKit(
   const client = initClient(socialContract, config);
   const result = await client.request({
     headers: {},
-    body,
+    body: effectivePublicSocialRequest(body),
     fetchOptions: { signal: AbortSignal.timeout(SOCIALKIT_API_TIMEOUT_MS) },
   });
   if (result.status === 200) {
-    return result.body;
+    const projection = projectPublicSocialResponse(result.body);
+    if (!projection.ok) {
+      throw new Error("Okou Social returned an inconsistent result");
+    }
+    return projection.response;
   }
   handlePublicSocialError(result, "Okou Social request failed");
 }

--- a/turbo/packages/api-contracts/src/contracts/__tests__/social.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/social.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 
 import {
   managedSocialKitToolCatalog,
+  MANAGED_SOCIAL_UNSUPPORTED_CAPABILITIES,
   MANAGED_SOCIALKIT_TOOLS,
+  projectPublicSocialResponse,
   publicSocialErrorCode,
   publicSocialErrorMessage,
   redactSocialProviderIdentity,
@@ -78,6 +80,243 @@ describe("managed SocialKit contract", () => {
         return tool.name === "youtube_transcript";
       }),
     ).toMatchObject({ availability: "transcript" });
+  });
+
+  it("publishes reviewed TikTok collection constraints and capability boundaries", () => {
+    const catalog = managedSocialKitToolCatalog();
+
+    expect(
+      catalog.find((tool) => {
+        return tool.name === "tiktok_search";
+      }),
+    ).toMatchObject({
+      collection: {
+        resultField: "results",
+        retrieval: { kind: "cursor" },
+        defaultLimit: 10,
+        requestMaxLimit: 100,
+        effectiveLimit: 10,
+        itemContract: "tiktok_video",
+        pageSize: {
+          kind: "provider_controlled",
+          mayDifferFromRequestLimit: true,
+        },
+        emptyResult: {
+          reliability: "unreliable",
+          outcome: "provider_limited",
+          retry: "none",
+          billing: "successful_request",
+        },
+      },
+      billing: {
+        kind: "items",
+        itemsPerUnit: 50,
+        quantityBasis: "effective_request_limit",
+      },
+      outputSchema: {
+        properties: {
+          results: {
+            items: {
+              properties: {
+                videoId: { type: "string" },
+                description: { type: "string" },
+                thumbnail: { type: "string" },
+                views: { type: "integer", minimum: 0 },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(
+      catalog.find((tool) => {
+        return tool.name === "tiktok_hashtag_search";
+      })?.collection,
+    ).toMatchObject({ defaultLimit: 20, effectiveLimit: 20 });
+    expect(
+      catalog.find((tool) => {
+        return tool.name === "tiktok_channel_videos";
+      })?.collection,
+    ).toMatchObject({ defaultLimit: 30, effectiveLimit: 30 });
+    expect(MANAGED_SOCIAL_UNSUPPORTED_CAPABILITIES).toStrictEqual([
+      expect.objectContaining({ capability: "follower_list" }),
+      expect.objectContaining({ capability: "following_list" }),
+      expect.objectContaining({ capability: "comment_replies" }),
+    ]);
+    expect(
+      JSON.stringify({
+        tools: catalog,
+        unsupportedCapabilities: MANAGED_SOCIAL_UNSUPPORTED_CAPABILITIES,
+      }),
+    ).not.toMatch(/socialkit/iu);
+  });
+
+  it("projects TikTok collections to stable provider-neutral video fields", () => {
+    const rawSearch = socialKitResponseSchema.parse({
+      provider: "socialkit",
+      tool: "tiktok_search",
+      billingCategory: "request",
+      billingQuantity: 1,
+      creditsCharged: 3,
+      collection: {
+        state: "more",
+        itemsReturned: 1,
+        nextInput: { cursor: "next" },
+      },
+      result: {
+        query: "launch",
+        results: [
+          {
+            id: "video-1",
+            desc: "Launch day",
+            url: "https://www.tiktok.com/@example/video/1",
+            createTime: 1_700_000_000,
+            textLanguage: "en",
+            subtitleInfos: [{ languageCode: "eng-US", title: "English" }],
+            author: {
+              id: "author-1",
+              uniqueId: "example",
+              nickname: "Example",
+              avatar: "https://example.com/avatar.jpg",
+              verified: true,
+            },
+            stats: {
+              views: 100,
+              likes: 20,
+              comments: 3,
+              shares: 4,
+              saves: 5,
+            },
+            video: {
+              cover: "https://example.com/cover.jpg",
+              duration: 12,
+            },
+            providerName: "SocialKit",
+          },
+        ],
+        hasMore: true,
+        cursor: "next",
+      },
+    });
+
+    const projection = projectPublicSocialResponse(rawSearch);
+    expect(projection.ok).toBe(true);
+    if (!projection.ok || projection.response.tool !== "tiktok_search") {
+      throw new Error("Expected a projected TikTok search response");
+    }
+    expect(projection.response).not.toHaveProperty("provider");
+    expect(projection.response.result.results?.[0]).toMatchObject({
+      videoId: "video-1",
+      description: "Launch day",
+      url: "https://www.tiktok.com/@example/video/1",
+      thumbnail: "https://example.com/cover.jpg",
+      duration: 12,
+      publishedAt: "2023-11-14T22:13:20.000Z",
+      views: 100,
+      likes: 20,
+      comments: 3,
+      shares: 4,
+      collects: 5,
+      language: "en",
+      subtitles: [{ languageCode: "eng-US", title: "English" }],
+      author: {
+        id: "author-1",
+        username: "example",
+        displayName: "Example",
+      },
+    });
+    expect(projection.response.result.results?.[0]).not.toHaveProperty(
+      "providerName",
+    );
+    expect(JSON.stringify(projection.response)).not.toMatch(/socialkit/iu);
+
+    const rawChannel = socialKitResponseSchema.parse({
+      provider: "socialkit",
+      tool: "tiktok_channel_videos",
+      billingCategory: "request",
+      billingQuantity: 1,
+      creditsCharged: 3,
+      collection: { state: "complete", itemsReturned: 1 },
+      result: {
+        results: [
+          {
+            videoId: "video-2",
+            description: "Channel video",
+            url: "https://www.tiktok.com/@example/video/2",
+            thumbnail: "https://example.com/channel.jpg",
+            duration: 9,
+            createTime: "2026-08-31T00:00:00Z",
+            views: 9,
+          },
+        ],
+        hasMore: false,
+        cursor: null,
+      },
+    });
+    const channelProjection = projectPublicSocialResponse(rawChannel);
+    expect(channelProjection.ok).toBe(true);
+    if (
+      !channelProjection.ok ||
+      channelProjection.response.tool !== "tiktok_channel_videos"
+    ) {
+      throw new Error("Expected a projected TikTok channel response");
+    }
+    expect(channelProjection.response.result.results?.[0]).toMatchObject({
+      videoId: "video-2",
+      description: "Channel video",
+      publishedAt: "2026-08-31T00:00:00Z",
+    });
+  });
+
+  it("marks unreliable empty searches uncertain and rejects conflicting aliases", () => {
+    const emptyResponse = socialKitResponseSchema.parse({
+      provider: "socialkit",
+      tool: "tiktok_hashtag_search",
+      billingCategory: "request",
+      billingQuantity: 1,
+      creditsCharged: 3,
+      collection: { state: "complete", itemsReturned: 0 },
+      result: {
+        hashtag: "launch",
+        results: [],
+        hasMore: false,
+        cursor: null,
+      },
+    });
+    const emptyProjection = projectPublicSocialResponse(emptyResponse);
+    expect(emptyProjection).toMatchObject({
+      ok: true,
+      response: {
+        collection: {
+          state: "provider_limited",
+          itemsReturned: 0,
+          uncertainty: { reason: "unreliable_empty_result" },
+        },
+      },
+    });
+
+    const conflictingResponse = socialKitResponseSchema.parse({
+      provider: "socialkit",
+      tool: "tiktok_search",
+      billingCategory: "request",
+      billingQuantity: 1,
+      creditsCharged: 3,
+      collection: { state: "complete", itemsReturned: 1 },
+      result: {
+        results: [
+          {
+            id: "source-id",
+            videoId: "contradictory-id",
+            desc: "Result",
+          },
+        ],
+        hasMore: false,
+        cursor: null,
+      },
+    });
+    expect(projectPublicSocialResponse(conflictingResponse)).toStrictEqual({
+      ok: false,
+    });
   });
 
   it("validates additive transcript error semantics", () => {

--- a/turbo/packages/api-contracts/src/contracts/social-tools.ts
+++ b/turbo/packages/api-contracts/src/contracts/social-tools.ts
@@ -39,12 +39,32 @@ export type ManagedSocialKitPagination =
   | { readonly kind: "none" }
   | { readonly kind: "page"; readonly maxPage: number };
 
+export interface ManagedSocialKitUnreliableEmptyResult {
+  readonly reliability: "unreliable";
+  readonly outcome: "provider_limited";
+  readonly retry: "none";
+  readonly billing: "successful_request";
+}
+
+export interface ManagedSocialKitProviderControlledPageSize {
+  readonly kind: "provider_controlled";
+  readonly mayDifferFromRequestLimit: true;
+}
+
+export interface ManagedSocialKitPublicResult {
+  readonly kind: "tiktok_video_collection";
+  readonly schema: z.ZodType;
+}
+
 export interface ManagedSocialKitCollection {
   readonly resultField: ManagedSocialKitResultField;
   readonly defaultLimit?: number;
+  readonly effectiveLimit?: number;
   readonly itemsPerBillingUnit?: number;
   readonly reportedTotalField?: ManagedSocialKitReportedTotalField;
   readonly pagination: ManagedSocialKitPagination;
+  readonly emptyResult?: ManagedSocialKitUnreliableEmptyResult;
+  readonly pageSize?: ManagedSocialKitProviderControlledPageSize;
 }
 
 export interface ManagedSocialKitToolDefinition<
@@ -60,6 +80,7 @@ export interface ManagedSocialKitToolDefinition<
   readonly maxLimit?: number;
   readonly collection?: ManagedSocialKitCollection;
   readonly availability?: ManagedSocialKitToolAvailability;
+  readonly publicResult?: ManagedSocialKitPublicResult;
 }
 
 function defineTool<
@@ -599,6 +620,53 @@ const tiktokHashtagSearchResultSchema = providerObject({
   cursor: paginationCursorResultSchema.nullable(),
 });
 
+const tiktokPublicAuthorSchema = providerObject({
+  id: z.string(),
+  username: z.string(),
+  displayName: z.string(),
+  avatar: z.string(),
+  verified: z.boolean(),
+});
+
+const tiktokPublicVideoItemSchema = providerObject({
+  videoId: z.string(),
+  description: z.string(),
+  url: z.string(),
+  thumbnail: z.string(),
+  duration: metricSchema,
+  publishedAt: z.string(),
+  views: countSchema,
+  likes: countSchema,
+  comments: countSchema,
+  shares: countSchema,
+  collects: countSchema,
+  author: tiktokPublicAuthorSchema,
+  language: z.string(),
+  subtitles: z.array(z.json()),
+});
+
+const tiktokPublicChannelVideosResultSchema = providerObject({
+  profileUrl: z.string(),
+  channelName: z.string(),
+  results: z.array(tiktokPublicVideoItemSchema),
+  hasMore: z.boolean(),
+  cursor: paginationCursorResultSchema.nullable(),
+});
+
+const tiktokPublicSearchResultSchema = providerObject({
+  query: z.string(),
+  results: z.array(tiktokPublicVideoItemSchema),
+  hasMore: z.boolean(),
+  cursor: paginationCursorResultSchema.nullable(),
+});
+
+const tiktokPublicHashtagSearchResultSchema = providerObject({
+  hashtag: z.string(),
+  results: z.array(tiktokPublicVideoItemSchema),
+  hasMore: z.boolean(),
+  cursor: paginationCursorResultSchema.nullable(),
+});
+
 const youtubeStatsResultSchema = providerObject({
   url: z.string(),
   videoId: z.string(),
@@ -959,11 +1027,20 @@ export const MANAGED_SOCIALKIT_TOOLS = [
     path: "/tiktok/channel-videos",
     inputSchema: cachedUrlCollectionInput(100),
     resultSchema: tiktokChannelVideosResultSchema,
+    publicResult: {
+      kind: "tiktok_video_collection",
+      schema: tiktokPublicChannelVideosResultSchema,
+    },
     maxLimit: 100,
     collection: {
       resultField: "results",
       defaultLimit: 30,
+      effectiveLimit: 30,
       pagination: { kind: "cursor" },
+      pageSize: {
+        kind: "provider_controlled",
+        mayDifferFromRequestLimit: true,
+      },
     },
   }),
   defineTool({
@@ -983,12 +1060,27 @@ export const MANAGED_SOCIALKIT_TOOLS = [
       })
       .strict(),
     resultSchema: tiktokSearchResultSchema,
+    publicResult: {
+      kind: "tiktok_video_collection",
+      schema: tiktokPublicSearchResultSchema,
+    },
     maxLimit: 100,
     collection: {
       resultField: "results",
       defaultLimit: 10,
+      effectiveLimit: 10,
       itemsPerBillingUnit: 50,
       pagination: { kind: "cursor" },
+      emptyResult: {
+        reliability: "unreliable",
+        outcome: "provider_limited",
+        retry: "none",
+        billing: "successful_request",
+      },
+      pageSize: {
+        kind: "provider_controlled",
+        mayDifferFromRequestLimit: true,
+      },
     },
   }),
   defineTool({
@@ -1011,12 +1103,27 @@ export const MANAGED_SOCIALKIT_TOOLS = [
       })
       .strict(),
     resultSchema: tiktokHashtagSearchResultSchema,
+    publicResult: {
+      kind: "tiktok_video_collection",
+      schema: tiktokPublicHashtagSearchResultSchema,
+    },
     maxLimit: 100,
     collection: {
       resultField: "results",
-      defaultLimit: 10,
+      defaultLimit: 20,
+      effectiveLimit: 20,
       itemsPerBillingUnit: 50,
       pagination: { kind: "cursor" },
+      emptyResult: {
+        reliability: "unreliable",
+        outcome: "provider_limited",
+        retry: "none",
+        billing: "successful_request",
+      },
+      pageSize: {
+        kind: "provider_controlled",
+        mayDifferFromRequestLimit: true,
+      },
     },
   }),
   defineTool({
@@ -1177,22 +1284,168 @@ export const socialKitRequestSchema = z.union(
   requestSchemas(MANAGED_SOCIALKIT_TOOLS),
 );
 
+export type ManagedSocialKitCatalogRetrieval =
+  | { readonly kind: "cursor" }
+  | { readonly kind: "page"; readonly maxPage: number }
+  | { readonly kind: "provider_limited" };
+
+export type ManagedSocialKitCatalogProviderLimit =
+  | { readonly kind: "no_pagination" }
+  | { readonly kind: "max_page"; readonly maxPage: number };
+
+export type ManagedSocialKitCatalogBilling =
+  | { readonly kind: "request" }
+  | {
+      readonly kind: "items";
+      readonly itemsPerUnit: number;
+      readonly quantityBasis: "effective_request_limit" | "items_returned";
+    };
+
 export interface ManagedSocialKitToolCatalogEntry {
   readonly name: ManagedSocialKitToolName;
   readonly description: string;
   readonly inputSchema: z.core.JSONSchema.BaseSchema;
   readonly outputSchema: z.core.JSONSchema.BaseSchema;
   readonly availability?: ManagedSocialKitToolAvailability;
+  readonly collection: {
+    readonly resultField: ManagedSocialKitResultField;
+    readonly retrieval: ManagedSocialKitCatalogRetrieval;
+    readonly defaultLimit?: number;
+    readonly requestMaxLimit?: number;
+    readonly effectiveLimit?: number;
+    readonly reportedTotalField?: ManagedSocialKitReportedTotalField;
+    readonly providerLimit?: ManagedSocialKitCatalogProviderLimit;
+    readonly emptyResult?: ManagedSocialKitUnreliableEmptyResult;
+    readonly pageSize?: ManagedSocialKitProviderControlledPageSize;
+    readonly itemContract?: "tiktok_video";
+  } | null;
+  readonly billing: ManagedSocialKitCatalogBilling;
+}
+
+export interface ManagedSocialUnsupportedCapability {
+  readonly platform: "tiktok";
+  readonly capability: "comment_replies" | "follower_list" | "following_list";
+  readonly status: "unsupported";
+  readonly availablePaths: {
+    readonly managedApi: false;
+    readonly scrape: false;
+    readonly browser: false;
+  };
+  readonly guidance: string;
+}
+
+export const MANAGED_SOCIAL_UNSUPPORTED_CAPABILITIES = [
+  {
+    platform: "tiktok",
+    capability: "follower_list",
+    status: "unsupported",
+    availablePaths: { managedApi: false, scrape: false, browser: false },
+    guidance:
+      "No reviewed managed API, scrape, or browser path is available. Do not retry these paths.",
+  },
+  {
+    platform: "tiktok",
+    capability: "following_list",
+    status: "unsupported",
+    availablePaths: { managedApi: false, scrape: false, browser: false },
+    guidance:
+      "No reviewed managed API, scrape, or browser path is available. Do not retry these paths.",
+  },
+  {
+    platform: "tiktok",
+    capability: "comment_replies",
+    status: "unsupported",
+    availablePaths: { managedApi: false, scrape: false, browser: false },
+    guidance:
+      "No reviewed managed API, scrape, or browser path is available. Do not retry these paths.",
+  },
+] as const satisfies readonly ManagedSocialUnsupportedCapability[];
+
+function catalogRetrieval(
+  pagination: ManagedSocialKitPagination,
+): ManagedSocialKitCatalogRetrieval {
+  switch (pagination.kind) {
+    case "cursor":
+    case "next_cursor": {
+      return { kind: "cursor" };
+    }
+    case "page": {
+      return { kind: "page", maxPage: pagination.maxPage };
+    }
+    case "none": {
+      return { kind: "provider_limited" };
+    }
+  }
+}
+
+function catalogProviderLimit(
+  pagination: ManagedSocialKitPagination,
+): ManagedSocialKitCatalogProviderLimit | undefined {
+  switch (pagination.kind) {
+    case "none": {
+      return { kind: "no_pagination" };
+    }
+    case "page": {
+      return { kind: "max_page", maxPage: pagination.maxPage };
+    }
+    case "cursor":
+    case "next_cursor": {
+      return undefined;
+    }
+  }
 }
 
 export function managedSocialKitToolCatalog(): readonly ManagedSocialKitToolCatalogEntry[] {
   return MANAGED_SOCIALKIT_TOOLS.map((tool) => {
+    const collection = tool.collection;
+    const providerLimit = collection
+      ? catalogProviderLimit(collection.pagination)
+      : undefined;
     return {
       name: tool.name,
       description: tool.description,
       inputSchema: z.toJSONSchema(tool.inputSchema),
-      outputSchema: z.toJSONSchema(tool.resultSchema),
+      outputSchema: z.toJSONSchema(
+        tool.publicResult?.schema ?? tool.resultSchema,
+      ),
       ...(tool.availability ? { availability: tool.availability } : {}),
+      collection: collection
+        ? {
+            resultField: collection.resultField,
+            retrieval: catalogRetrieval(collection.pagination),
+            ...(collection.defaultLimit === undefined
+              ? {}
+              : { defaultLimit: collection.defaultLimit }),
+            ...(tool.maxLimit === undefined
+              ? {}
+              : { requestMaxLimit: tool.maxLimit }),
+            ...(collection.effectiveLimit === undefined
+              ? {}
+              : { effectiveLimit: collection.effectiveLimit }),
+            ...(collection.reportedTotalField
+              ? { reportedTotalField: collection.reportedTotalField }
+              : {}),
+            ...(providerLimit ? { providerLimit } : {}),
+            ...(collection.emptyResult
+              ? { emptyResult: collection.emptyResult }
+              : {}),
+            ...(collection.pageSize ? { pageSize: collection.pageSize } : {}),
+            ...(tool.publicResult?.kind === "tiktok_video_collection"
+              ? { itemContract: "tiktok_video" as const }
+              : {}),
+          }
+        : null,
+      billing:
+        collection?.itemsPerBillingUnit === undefined
+          ? { kind: "request" }
+          : {
+              kind: "items",
+              itemsPerUnit: collection.itemsPerBillingUnit,
+              quantityBasis:
+                collection.pageSize?.kind === "provider_controlled"
+                  ? "effective_request_limit"
+                  : "items_returned",
+            },
     };
   });
 }

--- a/turbo/packages/api-contracts/src/contracts/social.ts
+++ b/turbo/packages/api-contracts/src/contracts/social.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import {
+  findManagedSocialKitTool,
   MANAGED_SOCIALKIT_BILLING_CATEGORY,
   MANAGED_SOCIALKIT_TOOLS,
   socialKitTranscriptErrorReasonSchema,
@@ -15,20 +16,28 @@ export {
   findManagedSocialKitTool,
   managedSocialKitToolCatalog,
   MANAGED_SOCIALKIT_BILLING_CATEGORY,
+  MANAGED_SOCIAL_UNSUPPORTED_CAPABILITIES,
   MANAGED_SOCIALKIT_TOOLS,
   SOCIALKIT_MAX_INPUT_VALUE_CHARS,
   SOCIALKIT_TRANSCRIPT_ERROR_CODES,
   socialKitTranscriptErrorReasonSchema,
   socialKitRequestSchema,
   type ManagedSocialKitCollection,
+  type ManagedSocialKitCatalogBilling,
+  type ManagedSocialKitCatalogProviderLimit,
+  type ManagedSocialKitCatalogRetrieval,
   type ManagedSocialKitPagination,
+  type ManagedSocialKitProviderControlledPageSize,
+  type ManagedSocialKitPublicResult,
   type ManagedSocialKitReportedTotalField,
   type ManagedSocialKitResultField,
+  type ManagedSocialKitUnreliableEmptyResult,
   type ManagedSocialKitTool,
   type ManagedSocialKitToolAvailability,
   type ManagedSocialKitToolDefinition,
   type ManagedSocialKitToolCatalogEntry,
   type ManagedSocialKitToolName,
+  type ManagedSocialUnsupportedCapability,
   type SocialKitTranscriptErrorCode,
   type SocialKitTranscriptErrorReason,
   type SocialKitRequest,
@@ -215,6 +224,14 @@ export type SocialKitCollectionProviderLimitedReason = z.infer<
   typeof socialKitCollectionProviderLimitedReasonSchema
 >;
 
+export const socialKitCollectionUncertaintySchema = z
+  .object({ reason: z.literal("unreliable_empty_result") })
+  .strict();
+
+export type SocialKitCollectionUncertainty = z.infer<
+  typeof socialKitCollectionUncertaintySchema
+>;
+
 const reportedTotalSchema = z
   .number()
   .int()
@@ -241,6 +258,7 @@ const socialKitCollectionSchema = z
       state: z.literal("provider_limited"),
       itemsReturned: z.number().int().nonnegative(),
       reason: socialKitCollectionProviderLimitedReasonSchema.optional(),
+      uncertainty: socialKitCollectionUncertaintySchema.optional(),
       reportedTotal: reportedTotalSchema.optional(),
     }),
   ])
@@ -314,6 +332,164 @@ function responseSchemas<
 export const socialKitResponseSchema = z.union(
   responseSchemas(MANAGED_SOCIALKIT_TOOLS),
 );
+
+export type PublicSocialResponseProjection =
+  | { readonly ok: true; readonly response: SocialKitResponse }
+  | { readonly ok: false };
+
+function jsonValuesEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function addCanonicalAlias(
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): boolean {
+  if (value === undefined) {
+    return true;
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(target, key) &&
+    !jsonValuesEqual(target[key], value)
+  ) {
+    return false;
+  }
+  target[key] = value;
+  return true;
+}
+
+function publicTikTokPublishedAt(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    return undefined;
+  }
+  const milliseconds = value < 10_000_000_000 ? value * 1_000 : value;
+  const date = new Date(milliseconds);
+  return Number.isNaN(date.valueOf()) ? undefined : date.toISOString();
+}
+
+function projectPublicTikTokAuthor(
+  value: unknown,
+): Record<string, unknown> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const author = { ...value };
+  if (
+    !addCanonicalAlias(author, "username", value.uniqueId) ||
+    !addCanonicalAlias(author, "displayName", value.nickname)
+  ) {
+    return undefined;
+  }
+  return author;
+}
+
+function projectPublicTikTokVideoItem(
+  value: unknown,
+): Record<string, unknown> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const item = { ...value };
+  const stats = isRecord(value.stats) ? value.stats : undefined;
+  const video = isRecord(value.video) ? value.video : undefined;
+  const aliases: readonly (readonly [string, unknown])[] = [
+    ["videoId", value.id],
+    ["description", value.desc],
+    ["thumbnail", video?.cover],
+    ["duration", video?.duration],
+    ["publishedAt", publicTikTokPublishedAt(value.createTime)],
+    ["views", stats?.views],
+    ["likes", stats?.likes],
+    ["comments", stats?.comments],
+    ["shares", stats?.shares],
+    ["collects", stats?.saves],
+    ["language", value.textLanguage],
+    ["subtitles", value.subtitleInfos],
+  ];
+  for (const [key, alias] of aliases) {
+    if (!addCanonicalAlias(item, key, alias)) {
+      return undefined;
+    }
+  }
+  if (value.author !== undefined) {
+    const author = projectPublicTikTokAuthor(value.author);
+    if (!author) {
+      return undefined;
+    }
+    item.author = author;
+  }
+  return item;
+}
+
+function projectPublicTikTokVideoCollection(
+  value: unknown,
+): Record<string, unknown> | undefined {
+  if (!isRecord(value) || !Array.isArray(value.results)) {
+    return undefined;
+  }
+  const results: Record<string, unknown>[] = [];
+  for (const item of value.results) {
+    const projected = projectPublicTikTokVideoItem(item);
+    if (!projected) {
+      return undefined;
+    }
+    results.push(projected);
+  }
+  return { ...value, results };
+}
+
+/**
+ * Build the permanent provider-neutral response used by agent, sandbox, and
+ * CLI callers. Raw session/PAT responses remain unchanged.
+ */
+export function projectPublicSocialResponse(
+  response: SocialKitResponse,
+): PublicSocialResponseProjection {
+  const tool = findManagedSocialKitTool(response.tool);
+  if (!tool) {
+    return { ok: false };
+  }
+  let result: unknown = response.result;
+  if (tool.publicResult?.kind === "tiktok_video_collection") {
+    result = projectPublicTikTokVideoCollection(result);
+    if (!result) {
+      return { ok: false };
+    }
+  }
+
+  let collection = response.collection;
+  if (
+    tool.collection?.emptyResult?.reliability === "unreliable" &&
+    collection?.state === "complete" &&
+    collection.itemsReturned === 0
+  ) {
+    collection = {
+      state: "provider_limited",
+      itemsReturned: 0,
+      ...(collection.reportedTotal === undefined
+        ? {}
+        : { reportedTotal: collection.reportedTotal }),
+      uncertainty: { reason: "unreliable_empty_result" },
+    };
+  }
+
+  const publicValue = redactSocialProviderIdentity({
+    tool: response.tool,
+    billingCategory: response.billingCategory,
+    billingQuantity: response.billingQuantity,
+    creditsCharged: response.creditsCharged,
+    collection,
+    result,
+  });
+  const parsed = socialKitResponseSchema.safeParse(publicValue);
+  return parsed.success
+    ? { ok: true, response: parsed.data as SocialKitResponse }
+    : { ok: false };
+}
 
 export const socialContract = c.router({
   request: {


### PR DESCRIPTION
## Summary

- publish reviewed TikTok collection constraints, billing basis, unreliable-empty semantics, and explicitly unsupported capabilities in Okou Social discovery
- normalize keyword, hashtag, and channel-video results to one provider-neutral public item contract without exposing the upstream provider to agents
- clamp upstream requests to reviewed effective limits while accepting provider-controlled page sizes and preserving every successful page

## Behavior

- TikTok keyword search, hashtag search, and channel videos use effective request limits of 10, 20, and 30 while retaining the accepted 1-100 input contract.
- Provider-controlled pages may contain fewer or more items than the request limit. They are validated up to the accepted response ceiling and returned instead of being rejected solely for a size mismatch.
- Billing for provider-controlled pages is based on the effective request limit, so unsolicited extra items cannot cause a post-request billing failure or additional charge.
- Successful empty keyword/hashtag pages are reported as `provider_limited` with `unreliable_empty_result`; they remain one successful billed request and trigger no hidden retry.
- `--max-items` stops at the first completed page boundary that reaches or exceeds the caller limit and retains the whole billed page.
- Follower lists, following lists, and comment replies are disclosed as unsupported across managed API, scrape, and browser paths.

## Compatibility

- Session and PAT callers keep the raw provider result shape and internal discriminator.
- Agent, sandbox, and CLI callers use a shared permanent public projection that removes provider identity and adds canonical TikTok aliases while retaining legitimate JSON extensions.
- Existing collection state/reason literals remain unchanged; uncertainty is additive.
- The public projection is idempotent across old/new API and commit-addressed CLI overlap. Conflicting source/canonical aliases fail before usage settlement.

## Testing

- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @okouai/cli lint`
- `pnpm knip`
- workspace, platform, API, CLI, and contracts type checks
- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/social.test.ts` (19 passed)
- focused API route regression scenarios (4 passed)
- `pnpm -F @okouai/cli exec vitest run src/commands/social/__tests__/index.test.ts` (41 passed)
- runtime API schema generation

## Risks

- The reviewed effective limits come from current provider evidence and may drift; discovery explicitly distinguishes them from provider-controlled returned page size.
- Canonical aliases increase each public TikTok item slightly; source extensions are retained once and contradictory aliases are rejected rather than silently overwritten.

Closes #30790
Relates to #30674
