### PR TITLE
test(sandbox-fc): remove duplicate no-guest exec test

### DIFF
--- a/crates/sandbox-fc/src/control/server/tests.rs
+++ b/crates/sandbox-fc/src/control/server/tests.rs
@@ -411,26 +411,6 @@ async fn client_server_no_guest() {
     handle.shutdown().await;
 }
 
-#[tokio::test]
-async fn client_receives_raw_server_error() {
-    let fixture = ControlServerFixture::new();
-    let mut handle = fixture.spawn_default(CancellationToken::new());
-
-    let response = send_exec(
-        &fixture.sock_path,
-        &exec_request("ps aux"),
-        Duration::from_secs(5),
-    )
-    .await
-    .unwrap();
-
-    let ExecResult::Error { error } = response else {
-        panic!("server should return a raw error");
-    };
-    assert!(error.contains("not running"), "unexpected error: {error}");
-    handle.shutdown().await;
-}
-
 // Terminate protocol behavior.
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- remove the redundant `client_receives_raw_server_error` integration test
- retain `client_server_no_guest` as the canonical end-to-end no-guest contract test
- preserve existing raw success/error codec coverage and distinct control-server response coverage

## Scope

This is a test-only cleanup. It does not change production client, server, wire-protocol, dependency, configuration, migration, compatibility, or rollout behavior, and it does not add a speculative replacement scenario.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p sandbox-fc --all-features --no-deps`
- `cargo test -p sandbox-fc --all-features client_server_no_guest` (1 passed)
- `cargo test -p sandbox-fc --all-features` (822 unit tests and 1 integration test passed)

The test commands used a short private `TMPDIR` and included `/usr/sbin` in `PATH` for the repository's Unix-socket and filesystem-tool requirements.

Closes #30828
