### PR TITLE
test(guest-agent): distinguish in-flight codex byte accounting

### DIFF
--- a/crates/guest-agent/tests/codex_app_server_event_delivery_byte_overload.rs
+++ b/crates/guest-agent/tests/codex_app_server_event_delivery_byte_overload.rs
@@ -5,9 +5,11 @@ mod common;
 
 use guest_agent::masker::SecretMasker;
 use httpmock::prelude::*;
+use std::os::unix::net::UnixStream;
 use std::time::Duration;
 
 const RUN_ID: &str = "codex-app-server-event-delivery-byte-overload-test";
+const WARNING_EVENT_BODY_MARKER: &str = r#""type":"warning""#;
 
 #[tokio::test]
 async fn codex_app_server_event_delivery_byte_overload_terminates_promptly()
@@ -43,19 +45,54 @@ async fn codex_app_server_event_delivery_byte_overload_terminates_promptly()
     )?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
+    let _lifecycle_events = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/events")
+            .body_excludes(WARNING_EVENT_BODY_MARKER);
+        then.status(200);
+    });
     let stalled_events = server.mock(|when, then| {
-        when.method(POST).path("/api/webhooks/agent/events");
+        when.method(POST)
+            .path("/api/webhooks/agent/events")
+            .body_includes(WARNING_EVENT_BODY_MARKER);
         then.status(200).delay(Duration::from_secs(30));
     });
 
     let masker = SecretMasker::from_raw("");
-    let error = tokio::time::timeout(
+    let execution = tokio::time::timeout(
         Duration::from_secs(10),
         common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
-    )
-    .await
-    .expect("app-server byte overload should not wait for the stalled request")
-    .expect_err("delivery byte overload should fail the app-server run");
+    );
+    tokio::pin!(execution);
+
+    let release_socket = tmp
+        .path()
+        .join(common::MOCK_CODEX_EVENT_DELIVERY_LARGE_RELEASE_SOCKET);
+    tokio::select! {
+        result = &mut execution => {
+            return Err(format!("app-server execution ended before the release socket was ready: {result:?}").into());
+        }
+        ready = common::wait_for_path(&release_socket, Duration::from_secs(5)) => ready?,
+    }
+    tokio::select! {
+        result = &mut execution => {
+            return Err(format!("app-server execution ended before the first warning was in flight: {result:?}").into());
+        }
+        observed = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if stalled_events.calls_async().await > 0 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }) => observed.expect("the first warning delivery should become in flight"),
+    }
+    UnixStream::connect(&release_socket)?;
+
+    let error = execution
+        .await
+        .expect("app-server byte overload should not wait for the stalled request")
+        .expect_err("delivery byte overload should fail the app-server run");
 
     let error = error.to_string();
     assert!(
@@ -66,9 +103,10 @@ async fn codex_app_server_event_delivery_byte_overload_terminates_promptly()
         !error.contains("server notification byte buffer exhausted"),
         "the test must exercise the downstream delivery byte budget: {error}"
     );
-    assert!(
-        stalled_events.calls() <= 1,
-        "the serial sender should have at most one stalled request in flight"
+    assert_eq!(
+        stalled_events.calls(),
+        1,
+        "the byte limit must include the one stalled request in flight"
     );
 
     Ok(())

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -72,6 +72,8 @@ pub const MOCK_CODEX_SESSION_HISTORY_READY_EVENT: &str = "vm0_mock_codex_session
 pub const MOCK_CODEX_TURN_STEER_READY_FILE: &str = ".vm0-mock-codex-turn-steer-ready";
 pub const MOCK_CODEX_TURN_STEER_READY_EVENT: &str = "vm0_mock_codex_turn_steer_ready";
 pub const MOCK_CODEX_TURN_STEER_RELEASE_SOCKET: &str = ".vm0-mock-codex-turn-steer-release.sock";
+pub const MOCK_CODEX_EVENT_DELIVERY_LARGE_RELEASE_SOCKET: &str =
+    ".vm0-mock-codex-event-delivery-large-release.sock";
 pub const MOCK_CODEX_ACTIVE_TURN_READY_FILE: &str = ".vm0-mock-codex-active-turn-ready";
 pub const MOCK_CODEX_ACTIVE_TURN_READY_EVENT: &str = "vm0_mock_codex_active_turn_ready";
 pub const MOCK_CODEX_TURN_INTERRUPT_READY_FILE: &str = ".vm0-mock-codex-turn-interrupt-ready";

--- a/crates/guest-mock-codex/src/app_server/handlers.rs
+++ b/crates/guest-mock-codex/src/app_server/handlers.rs
@@ -30,12 +30,15 @@ const SESSION_HISTORY_READY_EVENT: &str = "vm0_mock_codex_session_history_ready"
 const WAIT_ON_TURN_STEER_READY_FILE: &str = ".vm0-mock-codex-turn-steer-ready";
 const WAIT_ON_TURN_STEER_READY_EVENT: &str = "vm0_mock_codex_turn_steer_ready";
 const WAIT_ON_TURN_STEER_RELEASE_SOCKET: &str = ".vm0-mock-codex-turn-steer-release.sock";
+const EVENT_DELIVERY_LARGE_RELEASE_SOCKET: &str =
+    ".vm0-mock-codex-event-delivery-large-release.sock";
 const TURN_INTERRUPT_READY_FILE: &str = ".vm0-mock-codex-turn-interrupt-ready";
 const TURN_INTERRUPT_READY_EVENT: &str = "vm0_mock_codex_turn_interrupt_ready";
 const NOTIFICATION_OVERFLOW_COUNT: usize = 129;
 const STDOUT_STREAM_CHUNK_BYTES: usize = 8 * 1024;
 const EVENT_DELIVERY_FLOOD_COUNT: usize = 640;
-const EVENT_DELIVERY_LARGE_EVENT_COUNT: usize = 10;
+// One in-flight payload plus seven queued payloads crosses the shared 16 MiB budget.
+const EVENT_DELIVERY_LARGE_EVENT_COUNT: usize = 8;
 const EVENT_DELIVERY_LARGE_EVENT_BYTES: usize = 2 * 1024 * 1024;
 const SECONDARY_THREAD_ID: &str = "00000000-0000-4000-8000-000000000def";
 const SECONDARY_ITEM_STARTED_AT_MS: u64 = 1_700_000_000_000;
@@ -463,6 +466,10 @@ impl AppServerState {
             write_json_line(output, &turn_completed_notification(&thread_id, &turn_id))?;
         }
         if self.scenario == Scenario::RuntimeLargeEventFlood {
+            let home = std::env::var_os("HOME")
+                .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME is not set"))?;
+            let release =
+                UnixListener::bind(PathBuf::from(home).join(EVENT_DELIVERY_LARGE_RELEASE_SOCKET))?;
             write_json_line(output, &turn_started_notification(&thread_id, &turn_id))?;
             for index in 0..EVENT_DELIVERY_LARGE_EVENT_COUNT {
                 write_json_line(
@@ -473,6 +480,9 @@ impl AppServerState {
                         EVENT_DELIVERY_LARGE_EVENT_BYTES,
                     ),
                 )?;
+                if index == 0 {
+                    release.accept()?;
+                }
                 thread::sleep(std::time::Duration::from_millis(50));
             }
             write_json_line(output, &turn_completed_notification(&thread_id, &turn_id))?;


### PR DESCRIPTION
## Summary

- pause the large-event Codex mock after its first warning until the integration test confirms that delivery is in flight
- use eight 2 MiB warnings so queued events alone stay below the 16 MiB budget while the in-flight warning plus queued warnings exceed it
- deliver lifecycle events immediately and require exactly one stalled warning request

## Exclusions

- no production event-delivery behavior changes

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent -p guest-mock-codex --all-targets --all-features -- -D warnings`
- `cargo doc -p guest-agent -p guest-mock-codex --all-features --no-deps`
- `cargo test -p guest-agent --test codex_app_server_event_delivery_byte_overload -- --nocapture` (three consecutive passes)
- mutation check: releasing byte permits before the HTTP request completes makes the test fail at its 10-second deadline
- `cargo test -p guest-agent -p guest-mock-codex`

Closes #30795
