### PR TITLE
fix(api): honor selected drive account for artifact sync

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -8,6 +8,7 @@ import {
 import { CANCELLATION_RECOVERY_STALE_AFTER_MS } from "@okouai/api-contracts/contracts/runners";
 import { testCronCleanupSandboxesStateContract } from "@okouai/api-contracts/contracts/test-cron-cleanup-sandboxes-state";
 import {
+  chatThreadConnectorSelectionContract,
   chatThreadsContract,
   type ChatEvent,
   type UserMessageInputDocument,
@@ -18,6 +19,7 @@ import {
   type SupportedRunModel,
 } from "@okouai/api-contracts/contracts/model-providers";
 import { goalsContract } from "@okouai/api-contracts/contracts/goals";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { describe, expect, it, onTestFinished } from "vitest";
 import { createApp } from "../../../app-factory";
 import { stubTestTimezone } from "../../../__tests__/env-stub";
@@ -68,6 +70,8 @@ import {
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { chatEventDisplayText } from "./helpers/chat-event";
+import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
+import { createRouteMocks } from "./helpers/route-test";
 import { seedVm0BuiltInDefaultModelKey } from "./helpers/runtime-state";
 import {
   generatedStripeCustomerId,
@@ -113,12 +117,24 @@ const chatCallbacks = createChatCallbacksApi(context);
 const cu = createComputerUseBddApi(context);
 const connectorsApi = createConnectorBddApi(context);
 const authOrg = createAuthOrgAgentsBddApi(context);
+const routeMocks = createRouteMocks(context);
 const store = createStore();
 const CHAT_THREAD_SNAPSHOT_CRON_SECRET = "chat-thread-snapshot-cron-secret";
 const DAY_MS = 24 * 60 * 60 * 1000;
 const FORWARD_CLEANUP_CUTOFF_MS = Date.parse("2026-08-03T05:40:26.000Z");
 const FORWARD_CLEANUP_TEST_CREATED_AT = "2026-08-03T05:40:26.001Z";
 const PRE_FORWARD_CLEANUP_TEST_CREATED_AT = "2026-08-03T05:40:25.999Z";
+
+function chatThreadConnectorSelectionsClient() {
+  return setupApp({ context, routes: chatThreadRoutes })(
+    chatThreadConnectorSelectionContract,
+  );
+}
+
+function authHeaders(actor: ApiTestUser) {
+  routeMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+  return { authorization: "Bearer clerk-session" };
+}
 
 type UserMessage = Extract<
   ChatEvent,
@@ -386,7 +402,7 @@ type ThreadArtifacts = Awaited<ReturnType<typeof chat.listThreadArtifacts>>;
 
 function expectDriveStatuses(
   artifacts: ThreadArtifacts,
-  status: "disconnected" | "unknown",
+  status: "disconnected" | "not_synced" | "unknown",
 ): void {
   const files = artifacts.runs.flatMap((run) => {
     return run.files;
@@ -3587,6 +3603,206 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
       connectionStatus: "reconnect-required",
       reconnectReason: null,
     });
+
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(run.runId, sandboxHeaders);
+  }, 120_000);
+
+  it("uses the selected google drive account for artifact status and sync", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor(
+      "Artifacts selected drive account agent",
+    );
+    if (!actor.orgId) {
+      throw new Error("Expected an entitled chat actor with an organization");
+    }
+    const actorWithOrg = { ...actor, orgId: actor.orgId };
+    await updateFeatureSwitchesForUser(context, actorWithOrg, {
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    const objectStore = chatCallbacks.acceptChatObjectStorage();
+
+    const run = await sendChatRun(actor, {
+      agentId,
+      prompt: "produce an account-bound artifact",
+    });
+    const { claim, sandboxHeaders } = await claimChatRun(
+      runnerGroup,
+      run.runId,
+    );
+    const runBearer = `Bearer ${okouTokenFromClaim(claim)}`;
+    const fileId = randomUUID();
+    objectStore.addObject({
+      bucket: "test-user-artifacts",
+      key: `artifacts/${actor.userId}/${fileId}/account.txt`,
+      size: 64,
+    });
+    await chat.completeUploadWithBearer(runBearer, { id: fileId }, [200]);
+
+    mockGoogleDriveConnectorOAuth({
+      userInfo: {
+        id: "bdd-drive-default-user-id",
+        email: "bdd-drive-default@example.test",
+        name: "BDD Drive Default",
+      },
+    });
+    const defaultStart = await connectorsApi.startOauth(
+      actor,
+      "google-drive",
+      "oauth",
+      undefined,
+      { intent: "add", displayName: "Default Drive" },
+    );
+    await connectorsApi.completeOauthCallback("google-drive", {
+      code: "drive-default",
+      state: stateFromAuthorizationUrl(defaultStart.authorizationUrl),
+    });
+
+    mockGoogleDriveConnectorOAuth({
+      userInfo: {
+        id: "bdd-drive-selected-user-id",
+        email: "bdd-drive-selected@example.test",
+        name: "BDD Drive Selected",
+      },
+    });
+    const selectedStart = await connectorsApi.startOauth(
+      actor,
+      "google-drive",
+      "oauth",
+      undefined,
+      { intent: "add", displayName: "Selected Drive" },
+    );
+    await connectorsApi.completeOauthCallback("google-drive", {
+      code: "drive-selected",
+      state: stateFromAuthorizationUrl(selectedStart.authorizationUrl),
+    });
+
+    const accounts = await connectorsApi.listBuiltinConnectorAccounts(
+      actor,
+      "google-drive",
+    );
+    expect(accounts).toHaveLength(2);
+    const defaultAccount = accounts.find((account) => {
+      return account.externalEmail === "bdd-drive-default@example.test";
+    });
+    const selectedAccount = accounts.find((account) => {
+      return account.externalEmail === "bdd-drive-selected@example.test";
+    });
+    if (!defaultAccount || !selectedAccount) {
+      throw new Error("Expected two distinct Google Drive accounts");
+    }
+    expect(defaultAccount).toMatchObject({
+      isDefault: true,
+      connectionStatus: "connected",
+    });
+    expect(selectedAccount).toMatchObject({
+      isDefault: false,
+      connectionStatus: "connected",
+    });
+    await api.enableAgentConnectors(actor, agentId, ["google-drive"]);
+
+    const defaultStatusRecorder = mockGoogleDriveFilesList(() => {
+      return { status: 200, files: [] };
+    });
+    let artifacts = await chat.listThreadArtifacts(actor, run.threadId);
+    expectDriveStatuses(artifacts, "not_synced");
+    expect(defaultStatusRecorder.authorizationHeaders).toStrictEqual([
+      "Bearer drive-access-drive-default",
+    ]);
+
+    const selected = await accept(
+      chatThreadConnectorSelectionsClient().update({
+        headers: authHeaders(actor),
+        params: { id: run.threadId },
+        body: {
+          connectionId: selectedAccount.id,
+          target: { kind: "builtin", connectorSlug: "google-drive" },
+        },
+      }),
+      [200],
+    );
+    expect(selected.body.connectionId).toBe(selectedAccount.id);
+
+    const selectedStatusRecorder = mockGoogleDriveFilesList(() => {
+      return { status: 200, files: [] };
+    });
+    artifacts = await chat.listThreadArtifacts(actor, run.threadId);
+    expectDriveStatuses(artifacts, "not_synced");
+    expect(selectedStatusRecorder.authorizationHeaders).toStrictEqual([
+      "Bearer drive-access-drive-selected",
+    ]);
+
+    const uploadRecorder = mockGoogleDriveArtifactUpload({
+      id: "drive-selected-upload",
+      name: "account.txt",
+      webViewLink: "https://drive.google.com/file/d/drive-selected-upload/view",
+    });
+    const synced = await chat.requestSyncThreadArtifact(
+      actor,
+      run.threadId,
+      { runId: run.runId, fileId },
+      [200],
+    );
+    expect(synced.body).toMatchObject({
+      id: "drive-selected-upload",
+      name: "account.txt",
+    });
+    expect(uploadRecorder.folderAuthorizationHeaders).toStrictEqual([
+      "Bearer drive-access-drive-selected",
+      "Bearer drive-access-drive-selected",
+    ]);
+    expect(uploadRecorder.authorizationHeaders).toStrictEqual([
+      "Bearer drive-access-drive-selected",
+    ]);
+
+    const terminalRefresh = mockGoogleDriveConnectorOAuth();
+    const terminalStatusRecorder = mockGoogleDriveFilesList(() => {
+      return { status: 401 };
+    });
+    artifacts = await chat.listThreadArtifacts(actor, run.threadId);
+    expectDriveStatuses(artifacts, "disconnected");
+    expect(terminalStatusRecorder.authorizationHeaders).toStrictEqual([
+      "Bearer drive-access-drive-selected",
+    ]);
+    expect(terminalRefresh.refreshBodies).toHaveLength(1);
+    expect(terminalRefresh.refreshBodies[0]?.get("refresh_token")).toBe(
+      "drive-refresh-drive-selected",
+    );
+
+    const refreshedAccounts = await connectorsApi.listBuiltinConnectorAccounts(
+      actor,
+      "google-drive",
+    );
+    expect(
+      refreshedAccounts.find((account) => {
+        return account.id === defaultAccount.id;
+      }),
+    ).toMatchObject({
+      connectionStatus: "connected",
+      reconnectReason: null,
+    });
+    expect(
+      refreshedAccounts.find((account) => {
+        return account.id === selectedAccount.id;
+      }),
+    ).toMatchObject({
+      connectionStatus: "reconnect-required",
+      reconnectReason: "authorization_expired_or_revoked",
+    });
+
+    const unavailable = await chat.requestSyncThreadArtifact(
+      actor,
+      run.threadId,
+      { runId: run.runId, fileId },
+      [400],
+    );
+    expectApiError(unavailable.body);
+    expect(unavailable.body.error.message).toBe(
+      "Connect Google Drive before syncing artifacts",
+    );
+    expect(terminalStatusRecorder.authorizationHeaders).toHaveLength(1);
+    expect(uploadRecorder.folderAuthorizationHeaders).toHaveLength(2);
+    expect(uploadRecorder.authorizationHeaders).toHaveLength(1);
 
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(run.runId, sandboxHeaders);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -501,6 +501,11 @@ interface GoogleDriveConnectorOAuthOptions {
    * connector has no refresh path (Drive 401s then resolve to "unknown").
    */
   readonly omitRefreshToken?: boolean;
+  readonly userInfo?: {
+    readonly id: string;
+    readonly email: string;
+    readonly name: string;
+  };
   readonly refreshOutcome?:
     | { readonly type: "ok"; readonly accessToken: string }
     | { readonly type: "server-error" }
@@ -575,11 +580,13 @@ export function mockGoogleDriveConnectorOAuth(
       });
     }),
     http.get(GOOGLE_USERINFO_URL, () => {
-      return HttpResponse.json({
-        id: "bdd-drive-user-id",
-        email: "bdd-drive@example.test",
-        name: "BDD Drive User",
-      });
+      return HttpResponse.json(
+        options.userInfo ?? {
+          id: "bdd-drive-user-id",
+          email: "bdd-drive@example.test",
+          name: "BDD Drive User",
+        },
+      );
     }),
   );
   return recorded;
@@ -716,6 +723,7 @@ interface GoogleDriveArtifactUploadRecorder {
   readonly authorizationHeaders: (string | null)[];
   readonly contentLengthHeaders: (string | null)[];
   readonly contentTypeHeaders: (string | null)[];
+  readonly folderAuthorizationHeaders: (string | null)[];
   readonly folderQueries: string[];
 }
 
@@ -731,12 +739,16 @@ export function mockGoogleDriveArtifactUpload(
     authorizationHeaders: [],
     contentLengthHeaders: [],
     contentTypeHeaders: [],
+    folderAuthorizationHeaders: [],
     folderQueries: [],
   };
 
   server.use(
     http.get(GOOGLE_DRIVE_FILES_URL, ({ request }) => {
       const query = new URL(request.url).searchParams.get("q") ?? "";
+      recorded.folderAuthorizationHeaders.push(
+        request.headers.get("authorization"),
+      );
       recorded.folderQueries.push(query);
       const rootFolder = query.includes("'root' in parents");
       return HttpResponse.json({

--- a/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
@@ -8,7 +8,9 @@ import type {
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import type { FeatureSwitchContext } from "@okouai/core/feature-switch";
 import { agentRuns } from "@okouai/db/schema/agent-run";
+import { agents } from "@okouai/db/schema/agent";
 import { chatEvents } from "@okouai/db/schema/chat-event";
+import { chatThreadConnectorSelections } from "@okouai/db/schema/chat-thread-connector-selection";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
 import { hostedDeployments } from "@okouai/db/schema/hosted-site";
 import {
@@ -35,6 +37,7 @@ import {
   loadConnectorRuntimeSnapshot,
   type ConnectorRuntimeSnapshot,
 } from "./connector-catalog-runtime.service";
+import { resolveConnectorAccount } from "./connector-account-resolution.service";
 import {
   connectorCredentialRuntimeValueRef,
   loadConnectorCredentialConnection,
@@ -127,19 +130,71 @@ async function threadAllowsGoogleDriveArtifactSync(
   return authorization !== undefined;
 }
 
-async function loadDriveTokens(
+async function resolveDriveConnectorId(
   db: ReadonlyDb,
-  orgId: string,
-  userId: string,
-  featureSwitchContext: FeatureSwitchContext,
-  snapshot: ConnectorRuntimeSnapshot,
-): Promise<ConnectorTokens | null> {
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly threadId: string;
+  },
+): Promise<string | null> {
+  const [selection] = await db
+    .select({ connectorId: chatThreadConnectorSelections.connectorId })
+    .from(chatThreads)
+    .innerJoin(
+      agents,
+      and(eq(agents.id, chatThreads.agentId), eq(agents.orgId, args.orgId)),
+    )
+    .innerJoin(
+      chatThreadConnectorSelections,
+      and(
+        eq(chatThreadConnectorSelections.chatThreadId, chatThreads.id),
+        eq(chatThreadConnectorSelections.connectorSlug, "google-drive"),
+      ),
+    )
+    .where(
+      and(
+        eq(chatThreads.id, args.threadId),
+        eq(chatThreads.userId, args.userId),
+      ),
+    )
+    .limit(1);
+  const resolution = await resolveConnectorAccount(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    request: {
+      target: { kind: "builtin", connectorSlug: "google-drive" },
+      selection: selection
+        ? { kind: "exact", sourceId: selection.connectorId }
+        : { kind: "default" },
+    },
+  });
+  return resolution.kind === "resolved" ? resolution.account.connectorId : null;
+}
+
+async function loadDriveTokens(args: {
+  readonly db: ReadonlyDb;
+  readonly featureSwitchContext: FeatureSwitchContext;
+  readonly orgId: string;
+  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly threadId: string;
+  readonly userId: string;
+}): Promise<ConnectorTokens | null> {
+  const connectorId = await resolveDriveConnectorId(args.db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    threadId: args.threadId,
+  });
+  if (connectorId === null) {
+    return null;
+  }
   const loaded = await loadConnectorCredentialConnection({
-    db,
-    snapshot,
-    orgId,
-    userId,
+    db: args.db,
+    snapshot: args.snapshot,
+    orgId: args.orgId,
+    userId: args.userId,
     connectorSlug: "google-drive",
+    connectorId,
   });
   if (loaded.kind !== "ok") {
     return null;
@@ -154,8 +209,8 @@ async function loadDriveTokens(
   }
   const values = await loadConnectorCredentialValues({
     connection,
-    db,
-    featureSwitchContext,
+    db: args.db,
+    featureSwitchContext: args.featureSwitchContext,
     valueRefs: [accessTokenValueRef],
   });
   const accessToken = values.get(accessTokenValueRef);
@@ -386,13 +441,14 @@ export function googleDriveArtifactStatusLookup(args: {
     };
     const snapshot = await loadConnectorRuntimeSnapshot(db);
     signal.throwIfAborted();
-    const tokens = await loadDriveTokens(
+    const tokens = await loadDriveTokens({
       db,
-      args.orgId,
-      args.userId,
+      orgId: args.orgId,
+      userId: args.userId,
+      threadId: args.threadId,
       featureSwitchContext,
       snapshot,
-    );
+    });
     signal.throwIfAborted();
     if (!tokens || tokens.needsReconnect) {
       return { type: "disconnected" };
@@ -1085,13 +1141,14 @@ export const syncArtifactToGoogleDrive$ = command(
     };
     const snapshot = await loadConnectorRuntimeSnapshot(db);
     signal.throwIfAborted();
-    const tokens = await loadDriveTokens(
+    const tokens = await loadDriveTokens({
       db,
-      args.orgId,
-      args.userId,
+      orgId: args.orgId,
+      userId: args.userId,
+      threadId: args.threadId,
       featureSwitchContext,
       snapshot,
-    );
+    });
     signal.throwIfAborted();
     if (!tokens || tokens.needsReconnect) {
       return badRequestMessage("Connect Google Drive before syncing artifacts");


### PR DESCRIPTION
## Summary

- Resolve Google Drive artifact status and sync credentials from the thread's selected connector account, falling back to the user's default only when the thread has no Drive selection.
- Keep the exact resolved account through Drive status lookup, token refresh, folder creation, and artifact upload, including reconnect-required persistence.
- Add two-account BDD coverage that proves the selected account is used and a terminal refresh failure never falls back to the connected default account.

## Exclusions

- No changes to connector-account selection APIs or UI behavior.
- No changes to artifact sync behavior for connectors other than Google Drive.

## Validation

- `pnpm exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts` (36 passed)
- `pnpm exec oxlint src/signals/services/google-drive-artifact-sync.service.ts src/signals/routes/__tests__/helpers/api-bdd-connectors.ts src/signals/routes/__tests__/chat-threads.bdd.test.ts`
- `GOMAXPROCS=1 pnpm exec oxlint src/signals/services/google-drive-artifact-sync.service.ts src/signals/routes/__tests__/helpers/api-bdd-connectors.ts src/signals/routes/__tests__/chat-threads.bdd.test.ts --type-aware -c ../../.oxlintrc.typeaware.json`
- `pnpm exec eslint src/signals/services/google-drive-artifact-sync.service.ts src/signals/routes/__tests__/helpers/api-bdd-connectors.ts src/signals/routes/__tests__/chat-threads.bdd.test.ts --max-warnings 0`
- `pnpm check-types`

Closes #30824

Delivery context: #30585
