### PR TITLE
fix(mail): use thread gmail account for draft handoff

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
@@ -28,6 +28,7 @@ import {
   seedBuiltinThreadConnectorSelection,
   seedCustomConnectorRuntimeConnectors,
   seedCustomThreadConnectorSelection,
+  setConnectorAccountState,
   setBuiltinOAuthScopeFacts,
   setConnectorDefaultState,
   setConnectorCredentialStorageState,
@@ -176,10 +177,12 @@ interface GmailDraftTestState {
 }
 
 function mockGmailDraftApi(options?: {
+  readonly accessToken?: string;
   readonly inlineImageData?: boolean;
   readonly regularAttachmentData?: boolean;
   readonly textAttachmentData?: boolean;
 }): GmailDraftTestState {
+  const accessToken = options?.accessToken ?? "gmail-mail-card-token";
   const state: GmailDraftTestState = {
     exists: true,
     insufficientScope: false,
@@ -197,7 +200,7 @@ function mockGmailDraftApi(options?: {
     http.get(`${GMAIL_API_BASE}/drafts/:draftId`, ({ params, request }) => {
       expect(params.draftId).toBe(GMAIL_DRAFT_ID);
       expect(request.headers.get("authorization")).toBe(
-        "Bearer gmail-mail-card-token",
+        `Bearer ${accessToken}`,
       );
       expect(new URL(request.url).searchParams.get("format")).toBe("full");
       state.draftReadCount += 1;
@@ -289,7 +292,7 @@ function mockGmailDraftApi(options?: {
         expect(params.messageId).toBe(GMAIL_MESSAGE_ID);
         expect(params.attachmentId).toBe(currentImageAttachmentId);
         expect(request.headers.get("authorization")).toBe(
-          "Bearer gmail-mail-card-token",
+          `Bearer ${accessToken}`,
         );
         return HttpResponse.json({
           size: GMAIL_IMAGE_BYTES.byteLength,
@@ -384,7 +387,112 @@ async function setGmailOAuthScopeFacts(
   });
 }
 
+async function addGmailAccount(
+  fixture: Awaited<ReturnType<typeof seedGmailMailCardFixture>>,
+  args: {
+    readonly accessToken: string;
+    readonly email: string;
+    readonly subject: string;
+  },
+): Promise<string> {
+  await connectors.updateFeatureSwitches(fixture.actor, {
+    [FeatureSwitchKey.ConnectorAccounts]: true,
+  });
+  mockGmailConnectorOAuth(args);
+  const start = await connectors.startOauth(
+    fixture.actor,
+    "gmail",
+    "oauth",
+    fixture.agent.agentId,
+    { intent: "add", displayName: "Selected Gmail" },
+  );
+  const state = new URL(start.authorizationUrl).searchParams.get("state");
+  if (!state) {
+    throw new Error("Expected Gmail OAuth state");
+  }
+  await connectors.completeOauthCallback("gmail", {
+    code: "selected-gmail-code",
+    state,
+  });
+  const account = (
+    await connectors.listBuiltinConnectorAccounts(fixture.actor, "gmail")
+  ).find((candidate) => {
+    return candidate.externalEmail === args.email;
+  });
+  if (!account) {
+    throw new Error("Expected the selected Gmail account");
+  }
+  return account.id;
+}
+
 describe("POST /api/mail/drafts/link", () => {
+  it("uses the thread-selected Gmail account without probing the default", async () => {
+    const fixture = await seedGmailMailCardFixture();
+    const selectedAccessToken = "selected-gmail-token";
+    const selectedConnectorId = await addGmailAccount(fixture, {
+      accessToken: selectedAccessToken,
+      email: "selected@example.com",
+      subject: "selected-gmail-account",
+    });
+    await seedBuiltinThreadConnectorSelection(context, {
+      chatThreadId: fixture.thread.id,
+      connectorId: selectedConnectorId,
+      connectorSlug: "gmail",
+    });
+    const gmail = mockGmailDraftApi({ accessToken: selectedAccessToken });
+
+    const linked = await linkDraft(fixture);
+    expect(gmail.draftReadCount).toBe(1);
+
+    await accept(
+      client().getDraft({
+        headers: authHeaders(),
+        params: { mailDraftId: linked.body.mailDraftId },
+      }),
+      [200],
+    );
+    expect(gmail.draftReadCount).toBe(2);
+  });
+
+  it("does not fall back from a reconnect-required thread selection", async () => {
+    const fixture = await seedGmailMailCardFixture();
+    const selectedConnectorId = await addGmailAccount(fixture, {
+      accessToken: "unavailable-selected-gmail-token",
+      email: "unavailable-selected@example.com",
+      subject: "unavailable-selected-gmail-account",
+    });
+    await seedBuiltinThreadConnectorSelection(context, {
+      chatThreadId: fixture.thread.id,
+      connectorId: selectedConnectorId,
+      connectorSlug: "gmail",
+    });
+    await setConnectorAccountState(context, {
+      orgId: fixture.actor.orgId ?? "",
+      userId: fixture.actor.userId,
+      connectorId: selectedConnectorId,
+      needsReconnect: true,
+    });
+    const gmail = mockGmailDraftApi({
+      accessToken: "unavailable-selected-gmail-token",
+    });
+
+    const response = await accept(
+      client().linkDraft({
+        headers: authHeaders(),
+        body: {
+          threadId: fixture.thread.id,
+          agentId: fixture.agent.agentId,
+          gmailDraftId: GMAIL_DRAFT_ID,
+        },
+      }),
+      [409],
+    );
+    expect(response.body.error.message).toBe(
+      "Connect and authorize Gmail for this agent first",
+    );
+    expect(gmail.draftReadCount).toBe(0);
+  });
+
   it("uses a healthy Gmail connection with unknown historical grants", async () => {
     const fixture = await seedGmailMailCardFixture();
     await setGmailOAuthScopeFacts(fixture, null);

--- a/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 
+import { chatThreadConnectorSelectionContract } from "@okouai/api-contracts/contracts/chat-threads";
 import { testMailDraftStateContract } from "@okouai/api-contracts/contracts/test-mail-draft-state";
 import { mailContract } from "@okouai/api-contracts/contracts/mail";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
@@ -35,6 +36,7 @@ import {
   setConnectorSecretOwner,
 } from "./helpers/connector-credential-storage-state";
 import { mailRoutes } from "../mail";
+import { chatThreadRoutes } from "../chat-threads";
 
 const context = testContext();
 const bdd = createBddApi(context);
@@ -347,6 +349,12 @@ function client() {
   return setupApp({ context, routes: mailRoutes })(mailContract);
 }
 
+function connectorSelectionsClient() {
+  return setupApp({ context, routes: chatThreadRoutes })(
+    chatThreadConnectorSelectionContract,
+  );
+}
+
 function stateClient() {
   return setupApp({ context, routes: testMailDraftStateRoutes })(
     testMailDraftStateContract,
@@ -425,6 +433,23 @@ async function addGmailAccount(
   return account.id;
 }
 
+async function selectGmailAccount(
+  fixture: Awaited<ReturnType<typeof seedGmailMailCardFixture>>,
+  connectorId: string,
+): Promise<void> {
+  await accept(
+    connectorSelectionsClient().update({
+      headers: authHeaders(),
+      params: { id: fixture.thread.id },
+      body: {
+        connectionId: connectorId,
+        target: { kind: "builtin", connectorSlug: "gmail" },
+      },
+    }),
+    [200],
+  );
+}
+
 describe("POST /api/mail/drafts/link", () => {
   it("uses the thread-selected Gmail account without probing the default", async () => {
     const fixture = await seedGmailMailCardFixture();
@@ -434,11 +459,7 @@ describe("POST /api/mail/drafts/link", () => {
       email: "selected@example.com",
       subject: "selected-gmail-account",
     });
-    await seedBuiltinThreadConnectorSelection(context, {
-      chatThreadId: fixture.thread.id,
-      connectorId: selectedConnectorId,
-      connectorSlug: "gmail",
-    });
+    await selectGmailAccount(fixture, selectedConnectorId);
     const gmail = mockGmailDraftApi({ accessToken: selectedAccessToken });
 
     const linked = await linkDraft(fixture);
@@ -461,11 +482,7 @@ describe("POST /api/mail/drafts/link", () => {
       email: "unavailable-selected@example.com",
       subject: "unavailable-selected-gmail-account",
     });
-    await seedBuiltinThreadConnectorSelection(context, {
-      chatThreadId: fixture.thread.id,
-      connectorId: selectedConnectorId,
-      connectorSlug: "gmail",
-    });
+    await selectGmailAccount(fixture, selectedConnectorId);
     const orgId = fixture.actor.orgId;
     if (!orgId) {
       throw new Error("Expected an organization-scoped mail fixture");

--- a/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
@@ -466,8 +466,12 @@ describe("POST /api/mail/drafts/link", () => {
       connectorId: selectedConnectorId,
       connectorSlug: "gmail",
     });
+    const orgId = fixture.actor.orgId;
+    if (!orgId) {
+      throw new Error("Expected an organization-scoped mail fixture");
+    }
     await setConnectorAccountState(context, {
-      orgId: fixture.actor.orgId ?? "",
+      orgId,
       userId: fixture.actor.userId,
       connectorId: selectedConnectorId,
       needsReconnect: true,

--- a/turbo/apps/api/src/signals/services/mail-draft.service.ts
+++ b/turbo/apps/api/src/signals/services/mail-draft.service.ts
@@ -13,6 +13,7 @@ import {
 import { connectorAuthMethodHasRequiredScopes } from "@okouai/connectors/connector-auth-method";
 import { agents } from "@okouai/db/schema/agent";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
+import { chatThreadConnectorSelections } from "@okouai/db/schema/chat-thread-connector-selection";
 import { connectors } from "@okouai/db/schema/connector";
 import { mailDrafts } from "@okouai/db/schema/mail-draft";
 import { userConnectors } from "@okouai/db/schema/user-connector";
@@ -385,16 +386,31 @@ async function loadMailConnections(args: {
   });
 }
 
-async function ownedThreadAgentId(args: {
+interface OwnedMailThreadContext {
+  readonly agentId: string;
+  readonly gmailConnectorId: string | null;
+}
+
+async function loadOwnedMailThreadContext(args: {
   readonly db: ReadonlyDb;
   readonly orgId: string;
   readonly userId: string;
   readonly threadId: string;
-}): Promise<string | null> {
+}): Promise<OwnedMailThreadContext | null> {
   const [row] = await args.db
-    .select({ agentId: agents.id })
+    .select({
+      agentId: agents.id,
+      gmailConnectorId: chatThreadConnectorSelections.connectorId,
+    })
     .from(chatThreads)
     .innerJoin(agents, eq(agents.id, chatThreads.agentId))
+    .leftJoin(
+      chatThreadConnectorSelections,
+      and(
+        eq(chatThreadConnectorSelections.chatThreadId, chatThreads.id),
+        eq(chatThreadConnectorSelections.connectorSlug, "gmail"),
+      ),
+    )
     .where(
       and(
         eq(chatThreads.id, args.threadId),
@@ -403,7 +419,7 @@ async function ownedThreadAgentId(args: {
       ),
     )
     .limit(1);
-  return row?.agentId ?? null;
+  return row ?? null;
 }
 
 async function loadOwnedMailDraft(args: {
@@ -1531,9 +1547,9 @@ export const linkMailDraft$ = command(
     const db = get(db$);
     const snapshot = await loadConnectorRuntimeSnapshot(db);
     signal.throwIfAborted();
-    const threadAgentId = await ownedThreadAgentId({ db, ...args });
+    const thread = await loadOwnedMailThreadContext({ db, ...args });
     signal.throwIfAborted();
-    if (!threadAgentId || (args.agentId && threadAgentId !== args.agentId)) {
+    if (!thread || (args.agentId && thread.agentId !== args.agentId)) {
       return { kind: "not_found", message: "Chat thread not found" };
     }
     const connections = (
@@ -1542,7 +1558,8 @@ export const linkMailDraft$ = command(
         snapshot,
         orgId: args.orgId,
         userId: args.userId,
-        agentId: threadAgentId,
+        agentId: thread.agentId,
+        sourceId: thread.gmailConnectorId ?? undefined,
       })
     ).filter((connection) => {
       return !connection.needsReconnect && connection.scopesReady;

--- a/turbo/apps/cli/src/commands/mail/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/mail/__tests__/index.test.ts
@@ -147,8 +147,6 @@ describe("okou mail", () => {
           });
         },
       ),
-      mailCatalog(),
-      ...stubAgentContext(["gmail"]),
     );
 
     await mailCommand.parseAsync(["node", "cli", "list"]);
@@ -161,6 +159,7 @@ describe("okou mail", () => {
     expect(listOutput).toContain("outlook");
     expect(listOutput).toContain("unavailable");
 
+    server.use(mailCatalog(), ...stubAgentContext(["gmail"]));
     mockConsoleLog.mockClear();
     await mailCommand.parseAsync([
       "node",

--- a/turbo/apps/cli/src/commands/mail/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/mail/__tests__/index.test.ts
@@ -1,3 +1,8 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
 import chalk from "chalk";
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -5,14 +10,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { server } from "../../../mocks/server";
 import {
   authCodeMethod,
+  catalogItem,
   catalogStatusItem,
+  stubConnectorCatalog,
   stubConnectorCatalogStatus,
 } from "../../__tests__/helpers/connector-catalog";
+import { stubCustomConnectors } from "../../__tests__/helpers/custom-connectors";
 import { mailCommand } from "../index";
 
 const AGENT_ID = "550e8400-e29b-41d4-a716-446655440000";
 const THREAD_ID = "550e8400-e29b-41d4-a716-446655440001";
 const MAIL_DRAFT_ID = "550e8400-e29b-41d4-a716-446655440002";
+const RUN_GMAIL_CONNECTION_ID = "550e8400-e29b-41d4-a716-446655440003";
 
 function stubAgentContext(enabledConnectorSlugs: readonly string[]) {
   return [
@@ -62,31 +71,95 @@ function mailCatalog() {
 
 describe("okou mail", () => {
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  let directory = "";
+  let contextPath = "";
+
+  function writeRunContext(): void {
+    writeFileSync(
+      contextPath,
+      JSON.stringify({
+        schemaVersion: 1,
+        targets: [
+          {
+            kind: "builtin",
+            connectorSlug: "gmail",
+            connectionId: RUN_GMAIL_CONNECTION_ID,
+          },
+          {
+            kind: "builtin",
+            connectorSlug: "outlook-mail",
+            connectionId: null,
+          },
+        ],
+      }),
+      "utf8",
+    );
+  }
 
   beforeEach(() => {
+    directory = mkdtempSync(join(tmpdir(), "okou-mail-account-"));
+    contextPath = join(directory, "context.json");
+    writeRunContext();
     chalk.level = 0;
     vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
     vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
+    vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", contextPath);
   });
 
   afterEach(() => {
     mockConsoleLog.mockClear();
     vi.unstubAllEnvs();
+    rmSync(directory, { recursive: true, force: true });
   });
 
-  it("lists agent-authorized mail accounts and returns a connect link", async () => {
-    server.use(mailCatalog(), ...stubAgentContext(["gmail"]));
+  it("lists the exact mail account used by the run and returns a connect link", async () => {
+    server.use(
+      stubConnectorCatalog([
+        catalogItem({ connectorSlug: "gmail", label: "Gmail" }),
+        catalogItem({
+          connectorSlug: "outlook-mail",
+          label: "Outlook Mail",
+        }),
+      ]),
+      stubCustomConnectors([]),
+      http.post(
+        "http://localhost:3000/api/connector-accounts/inspect",
+        async ({ request }) => {
+          const body = connectorAccountsContract.inspect.body.parse(
+            await request.json(),
+          );
+          return HttpResponse.json({
+            results: body.selections.map((selection) => {
+              return {
+                kind: "available" as const,
+                ...selection,
+                authMethod: "oauth" as const,
+                displayName: "Selected Gmail",
+                externalId: "selected-gmail-account",
+                externalUsername: null,
+                externalEmail: "selected@example.com",
+                connectionStatus: "connected" as const,
+                reconnectReason: null,
+              };
+            }),
+          });
+        },
+      ),
+      mailCatalog(),
+      ...stubAgentContext(["gmail"]),
+    );
 
     await mailCommand.parseAsync(["node", "cli", "list"]);
 
     const listOutput = mockConsoleLog.mock.calls.flat().join("\n");
     expect(listOutput).toContain("gmail");
-    expect(listOutput).toContain("sender@example.com");
+    expect(listOutput).toContain("selected@example.com");
+    expect(listOutput).not.toContain("sender@example.com");
     expect(listOutput).toContain("ready");
     expect(listOutput).toContain("outlook");
-    expect(listOutput).toContain("connect");
+    expect(listOutput).toContain("unavailable");
 
     mockConsoleLog.mockClear();
     await mailCommand.parseAsync([
@@ -104,6 +177,40 @@ describe("okou mail", () => {
         url: `http://localhost:3000/connectors/outlook-mail/connect?agentId=${AGENT_ID}`,
       },
     );
+  });
+
+  it("does not show a sibling sender when run account metadata is unavailable", async () => {
+    server.use(
+      stubConnectorCatalog([
+        catalogItem({ connectorSlug: "gmail", label: "Gmail" }),
+        catalogItem({
+          connectorSlug: "outlook-mail",
+          label: "Outlook Mail",
+        }),
+      ]),
+      stubCustomConnectors([]),
+      http.post(
+        "http://localhost:3000/api/connector-accounts/inspect",
+        async ({ request }) => {
+          const body = connectorAccountsContract.inspect.body.parse(
+            await request.json(),
+          );
+          return HttpResponse.json({
+            results: body.selections.map((selection) => {
+              return { kind: "unavailable" as const, ...selection };
+            }),
+          });
+        },
+      ),
+    );
+
+    await mailCommand.parseAsync(["node", "cli", "list"]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("gmail");
+    expect(output).toContain("unavailable");
+    expect(output).not.toContain("sender@example.com");
+    expect(output).not.toContain("ready");
   });
 
   it("links an existing Gmail draft and prints only the review URL", async () => {

--- a/turbo/apps/cli/src/commands/mail/list.ts
+++ b/turbo/apps/cli/src/commands/mail/list.ts
@@ -5,7 +5,129 @@ import { listConnectorCatalogStatus } from "../../lib/api/domains/connectors";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { resolveAgentContext } from "../connector/agent-context";
 import { findConnectorStatusItem } from "../connector/public-catalog";
+import {
+  isRunBoundConnectorContext,
+  resolveRunConnectorAccountView,
+  runConnectorAccountUnavailableMessage,
+  type RunConnectorAccountEntry,
+} from "../connector/run-account-context";
 import { MAIL_CONNECTOR_SLUG_BY_PROVIDER, currentAgentId } from "./shared";
+
+interface MailListRow {
+  readonly provider: string;
+  readonly sender: string;
+  readonly status: string;
+}
+
+function printMailRows(rows: readonly MailListRow[]): void {
+  const providerWidth = Math.max(
+    "PROVIDER".length,
+    ...rows.map((row) => {
+      return row.provider.length;
+    }),
+  );
+  const senderWidth = Math.max(
+    "SENDER".length,
+    ...rows.map((row) => {
+      return row.sender.length;
+    }),
+  );
+  console.log(
+    chalk.dim(
+      [
+        "PROVIDER".padEnd(providerWidth),
+        "SENDER".padEnd(senderWidth),
+        "STATUS",
+      ].join("  "),
+    ),
+  );
+  for (const row of rows) {
+    console.log(
+      [
+        row.provider.padEnd(providerWidth),
+        row.sender.padEnd(senderWidth),
+        row.status,
+      ].join("  "),
+    );
+  }
+  console.log();
+  console.log(chalk.dim("  Run: okou mail connect gmail|outlook when needed"));
+}
+
+function runMailRow(
+  provider: string,
+  connector: RunConnectorAccountEntry | undefined,
+): MailListRow {
+  if (connector?.account.state !== "available") {
+    return {
+      provider,
+      sender: "-",
+      status: chalk.dim("unavailable"),
+    };
+  }
+  return {
+    provider,
+    sender: connector.account.metadata.externalEmail ?? "-",
+    status:
+      connector.account.metadata.connectionStatus === "connected"
+        ? chalk.green("ready")
+        : chalk.yellow("reconnect"),
+  };
+}
+
+async function printRunMailList(): Promise<void> {
+  const view = await resolveRunConnectorAccountView();
+  if (view.state === "unavailable") {
+    console.log(runConnectorAccountUnavailableMessage(view.reason));
+    return;
+  }
+  printMailRows(
+    Object.entries(MAIL_CONNECTOR_SLUG_BY_PROVIDER).map(
+      ([provider, connectorSlug]) => {
+        const connector = view.connectors.find((candidate) => {
+          return candidate.slug === connectorSlug;
+        });
+        return runMailRow(provider, connector);
+      },
+    ),
+  );
+}
+
+async function printCurrentMailList(): Promise<void> {
+  const agentId = currentAgentId();
+  const [{ connectors }, agent] = await Promise.all([
+    listConnectorCatalogStatus(),
+    resolveAgentContext(agentId),
+  ]);
+  if (!agent) {
+    throw new Error("Agent context could not be loaded");
+  }
+
+  printMailRows(
+    Object.entries(MAIL_CONNECTOR_SLUG_BY_PROVIDER).map(
+      ([provider, connectorSlug]) => {
+        const connector = findConnectorStatusItem(connectors, connectorSlug);
+        const authorized = agent.authorizedConnectorSlugs.has(connectorSlug);
+        const ready =
+          authorized &&
+          connector?.connected === true &&
+          connector.connectionStatus === "connected";
+        const sender = authorized
+          ? (connector?.connection?.externalEmail ?? "-")
+          : "-";
+        const status = ready
+          ? chalk.green("ready")
+          : connector?.connectionStatus === "reconnect-required" ||
+              connector?.connectionStatus === "scope-mismatch"
+            ? chalk.yellow("reconnect")
+            : connector?.connected
+              ? chalk.yellow("authorize")
+              : chalk.dim("connect");
+        return { provider, sender, status };
+      },
+    ),
+  );
+}
 
 export const listCommand = new Command()
   .name("list")
@@ -13,71 +135,10 @@ export const listCommand = new Command()
   .description("List Gmail and Outlook Mail availability for the current agent")
   .action(
     withErrorHandler(async () => {
-      const agentId = currentAgentId();
-      const [{ connectors }, agent] = await Promise.all([
-        listConnectorCatalogStatus(),
-        resolveAgentContext(agentId),
-      ]);
-      if (!agent) {
-        throw new Error("Agent context could not be loaded");
+      if (isRunBoundConnectorContext()) {
+        await printRunMailList();
+        return;
       }
-
-      const rows = Object.entries(MAIL_CONNECTOR_SLUG_BY_PROVIDER).map(
-        ([provider, connectorSlug]) => {
-          const connector = findConnectorStatusItem(connectors, connectorSlug);
-          const authorized = agent.authorizedConnectorSlugs.has(connectorSlug);
-          const ready =
-            authorized &&
-            connector?.connected === true &&
-            connector.connectionStatus === "connected";
-          const sender = authorized
-            ? (connector?.connection?.externalEmail ?? "-")
-            : "-";
-          const status = ready
-            ? chalk.green("ready")
-            : connector?.connectionStatus === "reconnect-required" ||
-                connector?.connectionStatus === "scope-mismatch"
-              ? chalk.yellow("reconnect")
-              : connector?.connected
-                ? chalk.yellow("authorize")
-                : chalk.dim("connect");
-          return { provider, sender, status };
-        },
-      );
-
-      const providerWidth = Math.max(
-        "PROVIDER".length,
-        ...rows.map((row) => {
-          return row.provider.length;
-        }),
-      );
-      const senderWidth = Math.max(
-        "SENDER".length,
-        ...rows.map((row) => {
-          return row.sender.length;
-        }),
-      );
-      console.log(
-        chalk.dim(
-          [
-            "PROVIDER".padEnd(providerWidth),
-            "SENDER".padEnd(senderWidth),
-            "STATUS",
-          ].join("  "),
-        ),
-      );
-      for (const row of rows) {
-        console.log(
-          [
-            row.provider.padEnd(providerWidth),
-            row.sender.padEnd(senderWidth),
-            row.status,
-          ].join("  "),
-        );
-      }
-      console.log();
-      console.log(
-        chalk.dim("  Run: okou mail connect gmail|outlook when needed"),
-      );
+      await printCurrentMailList();
     }),
   );


### PR DESCRIPTION
## Summary

- resolve new Gmail draft links through the owning chat thread's exact account selection, falling back to the default only when the thread has no Gmail override
- render `okou mail list` from the exact account materialized into a run and fail closed when that account's metadata is unavailable
- add multi-account API and CLI regression coverage for selected, unavailable, and non-default Gmail accounts

## Exclusions

- no mail API, database schema, runner context, or connector-account protocol changes
- no changes to the existing exact-account behavior for already linked drafts

## Fallbacks

- `mail-draft.service.ts:linkMailDraft$` preserves the existing exact owner-default Gmail lookup when the owning thread legitimately has no sparse Gmail selection. Surface and rollout gate: none; this is a genuinely optional persisted preference and permanent product behavior. Removal condition and follow-up: none.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm -F @okouai/cli exec vitest run src/commands/mail/__tests__/index.test.ts --maxWorkers=1` (4 tests passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/mail.test.ts --maxWorkers=1` (20 tests passed)

Closes #30823

Parent context: #30585
