### PR TITLE
fix(runner): preserve heartbeat diagnostics and reject sandbox reuse

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -33,6 +33,7 @@ use crate::active_input::{ActiveInputController, ActiveInputFrame, ActiveInputWr
 use guest_common::{log_info, log_warn};
 use guest_contracts::diagnostics::{
     AGENT_EXECUTION_TIMEOUT_EXIT_CODE, CliTerminationDiagnostic, CliTerminationReason,
+    HeartbeatFailureDiagnostic,
 };
 
 const TURN_NOTIFICATION_LABEL: &str = "turn notification";
@@ -119,9 +120,45 @@ enum CodexRunEvent {
 }
 
 enum AppServerRunOutcome {
-    Completed(Box<Result<CliExecutionResult, AgentError>>),
+    Completed(Box<Result<CliExecutionResult, CodexRunError>>),
     ExecutionTimedOut { timeout_secs: u64 },
     UserCancelled,
+}
+
+enum CodexRunError {
+    Execution(AgentError),
+    Heartbeat(CodexHeartbeatFailure),
+}
+
+struct CodexHeartbeatFailure {
+    error: AgentError,
+    diagnostic: Option<HeartbeatFailureDiagnostic>,
+    termination_reason: CliTerminationReason,
+}
+
+impl From<AgentError> for CodexRunError {
+    fn from(error: AgentError) -> Self {
+        Self::Execution(error)
+    }
+}
+
+impl std::fmt::Display for CodexRunError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Execution(error) => error.fmt(formatter),
+            Self::Heartbeat(failure) => failure.error.fmt(formatter),
+        }
+    }
+}
+
+impl AppServerRunOutcome {
+    fn is_heartbeat_failure(&self) -> bool {
+        matches!(
+            self,
+            Self::Completed(result)
+                if matches!(result.as_ref(), Err(CodexRunError::Heartbeat(_)))
+        )
+    }
 }
 
 async fn settle_active_input_before_stop<Run>(
@@ -130,7 +167,7 @@ async fn settle_active_input_before_stop<Run>(
     stopped: AppServerRunOutcome,
 ) -> AppServerRunOutcome
 where
-    Run: Future<Output = Result<CliExecutionResult, AgentError>>,
+    Run: Future<Output = Result<CliExecutionResult, CodexRunError>>,
 {
     active_input.close_terminal();
     if !active_input.sink_in_flight() {
@@ -153,7 +190,7 @@ where
 }
 
 async fn run_with_execution_deadline(
-    run: impl Future<Output = Result<CliExecutionResult, AgentError>>,
+    run: impl Future<Output = Result<CliExecutionResult, CodexRunError>>,
     deadline: Option<AgentExecutionDeadline>,
     user_cancellation: &CancellationToken,
     active_input: &ActiveInputController,
@@ -486,7 +523,7 @@ async fn run_codex_app_server(
             }
         };
 
-        Ok::<CliExecutionResult, AgentError>(CliExecutionResult {
+        Ok::<CliExecutionResult, CodexRunError>(CliExecutionResult {
             exit_code,
             // App-server terminal events report a protocol-level turn status,
             // not the child process wait status.
@@ -494,6 +531,7 @@ async fn run_codex_app_server(
             stderr_lines: Vec::new(),
             last_event_sequence: None,
             event_delivery: None,
+            heartbeat: None,
             jsonl_result: None,
             post_result_cleanup_jsonl_result: None,
             failure_diagnostic: ingestor.failure_diagnostic(),
@@ -594,6 +632,14 @@ async fn run_codex_app_server(
     agent_log.flush().await;
     let active_input_delivery_ids = match active_input_delivery_ids {
         Ok(delivery_ids) => delivery_ids,
+        Err(active_input_error) if run_outcome.is_heartbeat_failure() => {
+            log_warn!(
+                LOG_TAG,
+                "Codex active-input cleanup failed after heartbeat failure: {}",
+                masker.mask_string(&active_input_error.to_string())
+            );
+            Vec::new()
+        }
         Err(active_input_error) => {
             if let Err(shutdown_error) = &shutdown_result {
                 return Err(AgentError::Execution(format!(
@@ -616,14 +662,39 @@ async fn run_codex_app_server(
                 "codex app-server shutdown failed: {}",
                 masker.mask_string(&error.to_string())
             ))),
-            (Err(error), Ok(())) => Err(error),
-            (Err(error), Err(shutdown_error)) => {
+            (Err(CodexRunError::Execution(error)), Ok(())) => Err(error),
+            (Err(CodexRunError::Execution(error)), Err(shutdown_error)) => {
                 let shutdown_error = masker.mask_string(&shutdown_error.to_string());
                 log_warn!(
                     LOG_TAG,
                     "codex app-server shutdown failed after run error: {shutdown_error}"
                 );
                 Err(error)
+            }
+            (Err(CodexRunError::Heartbeat(failure)), shutdown_result) => {
+                if let Err(shutdown_error) = shutdown_result {
+                    let shutdown_error = masker.mask_string(&shutdown_error.to_string());
+                    log_warn!(
+                        LOG_TAG,
+                        "codex app-server termination failed after heartbeat failure: {shutdown_error}"
+                    );
+                }
+                Ok(CliExecutionResult {
+                    exit_code: 1,
+                    cli_observed_exit: None,
+                    stderr_lines,
+                    last_event_sequence: None,
+                    event_delivery: None,
+                    heartbeat: failure.diagnostic,
+                    jsonl_result: None,
+                    post_result_cleanup_jsonl_result: None,
+                    failure_diagnostic: ingestor.failure_diagnostic(),
+                    control_error: Some(failure.error),
+                    cli_termination: Some(CliTerminationDiagnostic::new(
+                        failure.termination_reason,
+                    )),
+                    active_input_delivery_ids,
+                })
             }
         },
         AppServerRunOutcome::ExecutionTimedOut { timeout_secs } => {
@@ -640,6 +711,7 @@ async fn run_codex_app_server(
                 stderr_lines,
                 last_event_sequence: None,
                 event_delivery: None,
+                heartbeat: None,
                 jsonl_result: None,
                 post_result_cleanup_jsonl_result: None,
                 failure_diagnostic: ingestor.failure_diagnostic(),
@@ -666,6 +738,7 @@ async fn run_codex_app_server(
                 stderr_lines,
                 last_event_sequence: None,
                 event_delivery: None,
+                heartbeat: None,
                 jsonl_result: None,
                 post_result_cleanup_jsonl_result: None,
                 failure_diagnostic: ingestor.failure_diagnostic(),
@@ -839,7 +912,7 @@ async fn next_codex_run_event(
     heartbeat_monitor: &mut HeartbeatMonitor,
     heartbeat_done: &mut bool,
     masker: &SecretMasker,
-) -> Result<CodexRunEvent, AgentError> {
+) -> Result<CodexRunEvent, CodexRunError> {
     let active_input_can_be_read = can_read_active_input(active_input_open, active_input_ready);
     // Do not let buffered terminal notifications overtake input the control
     // path already accepted.
@@ -858,7 +931,7 @@ async fn next_codex_run_event(
         notification = client.next_notification(TURN_NOTIFICATION_LABEL) => {
             notification
                 .map(CodexRunEvent::Notification)
-                .map_err(|error| app_server_error(masker, error))
+                .map_err(|error| CodexRunError::Execution(app_server_error(masker, error)))
         }
         heartbeat_result = wait_for_heartbeat(heartbeat_monitor), if !*heartbeat_done => {
             *heartbeat_done = true;
@@ -879,7 +952,7 @@ async fn steer_active_input(
     heartbeat_monitor: &mut HeartbeatMonitor,
     heartbeat_done: &mut bool,
     masker: &SecretMasker,
-) -> Result<(), AgentError> {
+) -> Result<(), CodexRunError> {
     let thread_id = target.thread_id;
     let turn_id = target.turn_id;
     let params = turn_steer_params(thread_id, turn_id, &frame);
@@ -914,10 +987,15 @@ async fn steer_active_input(
                 "Codex active input steer: target_thread_id={thread_id} captured_active_turn_id={turn_id} expected_turn_id={turn_id} input_uuid={} outcome=failed error={error}",
                 frame.uuid
             );
-            Err(AgentError::Execution(format!(
-                "codex app-server active input steer failed for input {}: {error}",
-                frame.uuid
-            )))
+            match error {
+                CodexRunError::Execution(error) => {
+                    Err(CodexRunError::Execution(AgentError::Execution(format!(
+                        "codex app-server active input steer failed for input {}: {error}",
+                        frame.uuid
+                    ))))
+                }
+                CodexRunError::Heartbeat(failure) => Err(CodexRunError::Heartbeat(failure)),
+            }
         }
     }
 }
@@ -940,12 +1018,14 @@ async fn race_with_heartbeat<T>(
     heartbeat_monitor: &mut HeartbeatMonitor,
     heartbeat_done: &mut bool,
     masker: &SecretMasker,
-) -> Result<T, AgentError> {
+) -> Result<T, CodexRunError> {
     // If heartbeat wins, the caller exits the run and shuts the app-server
     // down. We intentionally do not try to reuse a possibly half-read JSON-RPC
     // stream after cancelling `app_server_wait`.
     tokio::select! {
-        result = app_server_wait => result.map_err(|error| app_server_error(masker, error)),
+        biased;
+        result = app_server_wait => result
+            .map_err(|error| CodexRunError::Execution(app_server_error(masker, error))),
         heartbeat_result = wait_for_heartbeat(heartbeat_monitor), if !*heartbeat_done => {
             *heartbeat_done = true;
             Err(heartbeat_error(heartbeat_result))
@@ -1039,18 +1119,30 @@ async fn wait_for_heartbeat(
     }
 }
 
-fn heartbeat_error(result: Result<HeartbeatStatus, oneshot::error::RecvError>) -> AgentError {
+fn heartbeat_error(result: Result<HeartbeatStatus, oneshot::error::RecvError>) -> CodexRunError {
     match result {
-        Ok(HeartbeatStatus::Failed(error)) => error,
-        Ok(HeartbeatStatus::Stopped) => {
-            AgentError::Execution("heartbeat stopped before codex app-server completed".to_string())
-        }
-        Ok(HeartbeatStatus::TaskFailed(message)) => {
-            AgentError::Execution(format!("heartbeat task panicked: {message}"))
-        }
-        Err(error) => AgentError::Execution(format!(
-            "heartbeat task stopped before reporting status: {error}"
+        Ok(HeartbeatStatus::Failed(failure)) => CodexRunError::Heartbeat(CodexHeartbeatFailure {
+            error: failure.error,
+            diagnostic: Some(failure.diagnostic),
+            termination_reason: CliTerminationReason::HeartbeatError,
+        }),
+        Ok(HeartbeatStatus::Stopped) => CodexRunError::Execution(AgentError::Execution(
+            "heartbeat stopped before codex app-server completed".to_string(),
         )),
+        Ok(HeartbeatStatus::TaskFailed(message)) => {
+            CodexRunError::Heartbeat(CodexHeartbeatFailure {
+                error: AgentError::Execution(format!("heartbeat task panicked: {message}")),
+                diagnostic: None,
+                termination_reason: CliTerminationReason::HeartbeatPanic,
+            })
+        }
+        Err(error) => CodexRunError::Heartbeat(CodexHeartbeatFailure {
+            error: AgentError::Execution(format!(
+                "heartbeat task stopped before reporting status: {error}"
+            )),
+            diagnostic: None,
+            termination_reason: CliTerminationReason::HeartbeatPanic,
+        }),
     }
 }
 

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -50,6 +50,7 @@ use crate::env;
 use crate::error::AgentError;
 use crate::events;
 use crate::failure_patterns;
+use crate::heartbeat::HeartbeatFailure;
 use crate::http::HttpClient;
 use crate::masker::SecretMasker;
 use crate::paths;
@@ -61,7 +62,7 @@ use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
 use guest_contracts::diagnostics::{
     CliObservedExitDiagnostic, CliTerminationDiagnostic, EventDeliveryDiagnostic,
-    FailureDetailSource, FailureReason,
+    FailureDetailSource, FailureReason, HeartbeatFailureDiagnostic,
 };
 use guest_contracts::stdout_framing::ORDINARY_CLI_STDOUT_MAX_LINE_BYTES;
 use process_group::ChildProcessGroup;
@@ -246,6 +247,9 @@ pub struct CliExecutionResult {
     /// Bounded event-delivery failure details, when delivery was terminally incomplete.
     pub event_delivery: Option<EventDeliveryDiagnostic>,
 
+    /// Bounded heartbeat failure details, when the control path stopped making progress.
+    pub heartbeat: Option<HeartbeatFailureDiagnostic>,
+
     /// Final JSONL result metadata, when a terminal result event was observed.
     /// Codex uses its own event schema and leaves this unset.
     pub jsonl_result: Option<JsonlResultSummary>,
@@ -288,7 +292,7 @@ pub enum HeartbeatStatus {
     /// CLI execution treats this as a guest-agent control-path failure and may
     /// terminate the CLI process group so final diagnostics can report the
     /// heartbeat failure.
-    Failed(AgentError),
+    Failed(HeartbeatFailure),
 
     /// The heartbeat loop stopped cleanly.
     ///
@@ -1196,6 +1200,7 @@ async fn execute_cli_inner(
     };
 
     let mut heartbeat_done = false;
+    let mut heartbeat_failure = None;
     let mut user_cancellation_handled = false;
     let mut pi_user_cancelled = false;
     let mut cli_exit_at: Option<Instant> = None;
@@ -1848,11 +1853,12 @@ async fn execute_cli_inner(
                     CliExitObservation::ExitedAndStdoutClosed => break Ok(()),
                 }
                 match heartbeat_result {
-                    Ok(HeartbeatStatus::Failed(e)) => {
+                    Ok(HeartbeatStatus::Failed(failure)) => {
                         // Heartbeat failed — kill process group
+                        heartbeat_failure = Some(failure.diagnostic);
                         termination_runtime.begin_control_failure(
                             TerminationReason::HeartbeatError,
-                            e,
+                            failure.error,
                             ControlTerminationLog::HeartbeatFailed,
                             termination_deadline.as_mut(),
                         );
@@ -2046,6 +2052,7 @@ async fn execute_cli_inner(
         stderr_lines: masked_stderr_lines,
         last_event_sequence: delivery_report.last_acknowledged_sequence,
         event_delivery: delivery_report.diagnostic,
+        heartbeat: heartbeat_failure,
         jsonl_result,
         post_result_cleanup_jsonl_result,
         failure_diagnostic,

--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -70,7 +70,12 @@ pub fn cli_control_failure_for_config(
     );
     let diagnostic =
         with_cli_observed_exit(diagnostic, cli_result.cli_observed_exit.as_ref().cloned());
-    with_cli_termination(diagnostic, cli_result.cli_termination)
+    let diagnostic = with_cli_termination(diagnostic, cli_result.cli_termination);
+    if let Some(heartbeat) = cli_result.heartbeat.clone() {
+        diagnostic.with_heartbeat(heartbeat)
+    } else {
+        diagnostic
+    }
 }
 
 /// Build the primary diagnostic for terminal event delivery after a CLI result.

--- a/crates/guest-agent/src/heartbeat.rs
+++ b/crates/guest-agent/src/heartbeat.rs
@@ -6,14 +6,96 @@
 
 use crate::constants;
 use crate::error::AgentError;
-use crate::http::HttpClient;
+use crate::http::{
+    HttpAttemptFailureKind, HttpAttemptFinished, HttpAttemptObserver, HttpAttemptOutcome,
+    HttpAttemptStarted, HttpClient,
+};
 use guest_common::{log_error, log_info, log_warn};
+use guest_contracts::diagnostics::{
+    HeartbeatAttemptFailureKind, HeartbeatCompletedAttemptDiagnostic,
+    HeartbeatFailedCycleDiagnostic, HeartbeatFailureDiagnostic,
+};
 use serde_json::json;
+use std::sync::Mutex;
 use std::time::Duration;
-use tokio::time::MissedTickBehavior;
+use tokio::time::{Instant, MissedTickBehavior};
 use tokio_util::sync::CancellationToken;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
+
+/// Terminal heartbeat control-path failure and its bounded HTTP evidence.
+#[derive(Debug)]
+pub struct HeartbeatFailure {
+    pub error: AgentError,
+    pub diagnostic: HeartbeatFailureDiagnostic,
+}
+
+impl std::fmt::Display for HeartbeatFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.error.fmt(formatter)
+    }
+}
+
+impl std::error::Error for HeartbeatFailure {}
+
+#[derive(Default)]
+struct HeartbeatAttemptCollector {
+    attempts: Mutex<Vec<HeartbeatCompletedAttemptDiagnostic>>,
+}
+
+impl HeartbeatAttemptCollector {
+    fn into_attempts(self) -> Vec<HeartbeatCompletedAttemptDiagnostic> {
+        self.attempts
+            .into_inner()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+impl HttpAttemptObserver for HeartbeatAttemptCollector {
+    fn attempt_started(&self, _attempt: HttpAttemptStarted) -> Result<(), AgentError> {
+        Ok(())
+    }
+
+    fn attempt_finished(&self, attempt: HttpAttemptFinished) -> Result<(), AgentError> {
+        let HttpAttemptOutcome::Failure {
+            kind,
+            http_status,
+            timeout_observed,
+            connect_observed,
+        } = attempt.outcome
+        else {
+            return Ok(());
+        };
+        let failure_kind = match kind {
+            HttpAttemptFailureKind::Timeout => HeartbeatAttemptFailureKind::Timeout,
+            HttpAttemptFailureKind::Connect => HeartbeatAttemptFailureKind::Connect,
+            HttpAttemptFailureKind::HttpStatus => HeartbeatAttemptFailureKind::HttpStatus,
+            HttpAttemptFailureKind::Transport => HeartbeatAttemptFailureKind::Transport,
+        };
+        self.attempts
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(HeartbeatCompletedAttemptDiagnostic {
+                attempt: attempt.attempt,
+                client_request_id: attempt.client_request_id,
+                elapsed_ms: attempt.elapsed_ms,
+                failure_kind,
+                http_status,
+                timeout_observed,
+                connect_observed,
+            });
+        Ok(())
+    }
+}
+
+fn elapsed_ms_since(scheduled_at: Instant) -> u64 {
+    u64::try_from(
+        Instant::now()
+            .saturating_duration_since(scheduled_at)
+            .as_millis(),
+    )
+    .unwrap_or(u64::MAX)
+}
 
 /// Run the heartbeat loop. Returns when:
 /// - The first heartbeat fails (returns `Err`)
@@ -27,7 +109,7 @@ pub async fn heartbeat_loop_for_run(
     run_id: String,
     http: HttpClient,
     shutdown: CancellationToken,
-) -> Result<(), AgentError> {
+) -> Result<(), HeartbeatFailure> {
     heartbeat_loop_for_run_with_interval(
         run_id,
         http,
@@ -59,27 +141,44 @@ pub async fn heartbeat_loop_for_run_with_interval(
     http: HttpClient,
     shutdown: CancellationToken,
     interval: Duration,
-) -> Result<(), AgentError> {
+) -> Result<(), HeartbeatFailure> {
     // No API token → local/test mode; heartbeat has no server to reach.
     if !http.has_api() {
         shutdown.cancelled().await;
         return Ok(());
     }
 
-    let heartbeat_url = http.heartbeat_url()?;
+    let heartbeat_url = http.heartbeat_url().map_err(|error| HeartbeatFailure {
+        error,
+        diagnostic: HeartbeatFailureDiagnostic {
+            failed_cycles: Vec::new(),
+        },
+    })?;
 
     let mut interval = tokio::time::interval(interval);
     // Drop timer debt after slow HTTP cycles and restore a full-period cadence.
     interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
     let mut is_first = true;
     let mut consecutive_failures: u32 = 0;
+    let mut failed_cycles = Vec::new();
 
     loop {
         tokio::select! {
             _ = shutdown.cancelled() => return Ok(()),
-            _ = interval.tick() => {
+            scheduled_at = interval.tick() => {
+                let scheduled_lag_ms = elapsed_ms_since(scheduled_at);
                 let payload = json!({ "runId": run_id.as_str() });
-                match http.post_json(heartbeat_url, &payload, constants::HTTP_MAX_ATTEMPTS).await {
+                let collector = HeartbeatAttemptCollector::default();
+                let heartbeat_result = http
+                    .post_json_observed(
+                        heartbeat_url,
+                        &payload,
+                        constants::HTTP_MAX_ATTEMPTS,
+                        &collector,
+                    )
+                    .await;
+                let attempts = collector.into_attempts();
+                match heartbeat_result {
                     Ok(_) => {
                         if is_first {
                             log_info!(LOG_TAG, "Heartbeat sent (initial)");
@@ -90,25 +189,40 @@ pub async fn heartbeat_loop_for_run_with_interval(
                         }
                         is_first = false;
                         consecutive_failures = 0;
+                        failed_cycles.clear();
                     }
                     Err(e) if is_first => {
+                        failed_cycles.push(HeartbeatFailedCycleDiagnostic {
+                            scheduled_lag_ms,
+                            attempts,
+                        });
                         log_error!(LOG_TAG, "Network connectivity check failed: {e}");
-                        return Err(AgentError::Execution(format!(
-                            "Network connectivity check failed - cannot reach API at {}",
-                            heartbeat_url
-                        )));
+                        return Err(HeartbeatFailure {
+                            error: AgentError::Execution(format!(
+                                "Network connectivity check failed - cannot reach API at {}",
+                                heartbeat_url
+                            )),
+                            diagnostic: HeartbeatFailureDiagnostic { failed_cycles },
+                        });
                     }
                     Err(e) => {
                         consecutive_failures += 1;
+                        failed_cycles.push(HeartbeatFailedCycleDiagnostic {
+                            scheduled_lag_ms,
+                            attempts,
+                        });
                         log_warn!(
                             LOG_TAG,
                             "Heartbeat failed ({consecutive_failures}/{}): {e}",
                             constants::MAX_CONSECUTIVE_HEARTBEAT_FAILURES,
                         );
                         if consecutive_failures >= constants::MAX_CONSECUTIVE_HEARTBEAT_FAILURES {
-                            return Err(AgentError::Execution(format!(
-                                "Heartbeat failed {consecutive_failures} consecutive times, terminating",
-                            )));
+                            return Err(HeartbeatFailure {
+                                error: AgentError::Execution(format!(
+                                    "Heartbeat failed {consecutive_failures} consecutive times, terminating",
+                                )),
+                                diagnostic: HeartbeatFailureDiagnostic { failed_cycles },
+                            });
                         }
                     }
                 }

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -43,7 +43,7 @@ enum ResponseBodyCollectionError {
     Transport(reqwest::Error),
 }
 
-/// Content-safe facts published before one event request is awaited.
+/// Content-safe facts published before one observed request is awaited.
 #[derive(Debug, Clone)]
 pub(crate) struct HttpAttemptStarted {
     pub attempt: u32,
@@ -51,7 +51,7 @@ pub(crate) struct HttpAttemptStarted {
     pub started_at: Instant,
 }
 
-/// Content-safe facts published after one event request completes.
+/// Content-safe facts published after one observed request completes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct HttpAttemptFinished {
     pub attempt: u32,
@@ -60,7 +60,7 @@ pub(crate) struct HttpAttemptFinished {
     pub outcome: HttpAttemptOutcome,
 }
 
-/// Transport outcome for an observed event request.
+/// Transport outcome for an observed request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum HttpAttemptOutcome {
     Success,
@@ -81,7 +81,7 @@ pub(crate) enum HttpAttemptFailureKind {
     Transport,
 }
 
-/// Synchronous observer for the event delivery request path.
+/// Synchronous observer for selected control and event request paths.
 pub(crate) trait HttpAttemptObserver: Send + Sync {
     fn attempt_started(&self, attempt: HttpAttemptStarted) -> Result<(), AgentError>;
     fn attempt_finished(&self, attempt: HttpAttemptFinished) -> Result<(), AgentError>;
@@ -580,6 +580,26 @@ impl HttpClient {
     ) -> Result<Option<Value>, AgentError> {
         let body = Bytes::from(serde_json::to_vec(body)?);
         self.post_json_bytes(url, body, max_attempts).await
+    }
+
+    pub(crate) async fn post_json_observed(
+        &self,
+        url: &str,
+        body: &impl Serialize,
+        max_attempts: u32,
+        observer: &dyn HttpAttemptObserver,
+    ) -> Result<Option<Value>, AgentError> {
+        let body = Bytes::from(serde_json::to_vec(body)?);
+        let resp = self
+            .post_json_response(url, body, max_attempts, Some(observer), None)
+            .await?;
+        let body = collect_api_success_body(resp).await?;
+        if body.is_empty() {
+            return Ok(None);
+        }
+        let value =
+            serde_json::from_slice(&body).map_err(|error| AgentError::Http(error.to_string()))?;
+        Ok(Some(value))
     }
 
     pub(crate) async fn post_json_bytes(

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1293,6 +1293,7 @@ mod tests {
                 stderr_lines: Vec::new(),
                 last_event_sequence: None,
                 event_delivery: None,
+                heartbeat: None,
                 jsonl_result: Some(jsonl_result),
                 post_result_cleanup_jsonl_result: Some(cleanup_result),
                 failure_diagnostic: None,

--- a/crates/guest-agent/tests/codex_app_server_backend_heartbeat.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_heartbeat.rs
@@ -7,6 +7,7 @@ mod common;
 
 use guest_agent::error::AgentError;
 use guest_agent::masker::SecretMasker;
+use guest_contracts::diagnostics::CliTerminationReason;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -53,11 +54,29 @@ async fn codex_app_server_backend_heartbeat_interrupts_hung_turn_start()
     .await
     .expect("execute_cli should return promptly");
 
-    let error = result.expect_err("heartbeat failure should fail the app-server backend");
+    let result = result.expect("heartbeat failure should return a controlled result");
+    assert_eq!(result.exit_code, 1);
+    let error = result
+        .control_error
+        .as_ref()
+        .expect("heartbeat failure should retain the control error");
     let message = error.to_string();
     assert!(
         message.contains("heartbeat failed during app-server turn/start"),
         "unexpected error: {message}"
+    );
+    assert_eq!(
+        result
+            .cli_termination
+            .expect("heartbeat failure should attach termination details")
+            .reason,
+        CliTerminationReason::HeartbeatError
+    );
+    assert_eq!(
+        result
+            .heartbeat
+            .expect("heartbeat failure should retain HTTP evidence"),
+        common::test_heartbeat_failure_diagnostic()
     );
 
     Ok(())

--- a/crates/guest-agent/tests/codex_app_server_backend_heartbeat_result_precedence.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_heartbeat_result_precedence.rs
@@ -1,0 +1,62 @@
+//! Codex terminal-result precedence when heartbeat becomes ready afterward.
+//!
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
+
+mod common;
+
+use guest_agent::error::AgentError;
+use guest_agent::masker::SecretMasker;
+use std::time::Duration;
+
+#[tokio::test]
+async fn codex_terminal_result_written_before_heartbeat_remains_authoritative()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+
+    unsafe {
+        common::setup_codex_app_server_env(
+            &mock,
+            tmp.path(),
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-heartbeat-result-precedence-test",
+                prompt: "complete before heartbeat becomes ready",
+                scenario: Some("runtime-turn-complete-before-heartbeat"),
+                resume_session_id: None,
+            },
+        )?;
+    }
+    let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let ready_path = tmp
+        .path()
+        .join(common::MOCK_CODEX_TURN_COMPLETE_BEFORE_HEARTBEAT_READY_FILE);
+    let heartbeat = common::spawn_heartbeat_monitor(async move {
+        common::wait_for_path(&ready_path, Duration::from_secs(5))
+            .await
+            .map_err(|error| {
+                AgentError::Execution(format!(
+                    "wait for terminal-result heartbeat boundary: {error}"
+                ))
+            })?;
+        Err(AgentError::Execution(
+            "heartbeat failed after terminal result was written".to_string(),
+        ))
+    });
+
+    let masker = SecretMasker::from_raw("");
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
+    )
+    .await
+    .expect("execute_cli should return promptly")?;
+
+    assert_eq!(result.exit_code, common::CLEAN_EXIT);
+    assert!(result.control_error.is_none());
+    assert!(result.cli_termination.is_none());
+    assert!(result.heartbeat.is_none());
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -67,6 +67,8 @@ pub const CLEAN_EXIT: i32 = 0;
 pub const MOCK_TERMINATION_READY_EVENT: &str = "vm0_mock_termination_ready";
 pub const MOCK_CODEX_TURN_START_READY_FILE: &str = ".vm0-mock-codex-turn-start-ready";
 pub const MOCK_CODEX_TURN_START_READY_EVENT: &str = "vm0_mock_codex_turn_start_ready";
+pub const MOCK_CODEX_TURN_COMPLETE_BEFORE_HEARTBEAT_READY_FILE: &str =
+    ".vm0-mock-codex-turn-complete-before-heartbeat-ready";
 pub const MOCK_CODEX_SESSION_HISTORY_READY_FILE: &str = ".vm0-mock-codex-session-history-ready";
 pub const MOCK_CODEX_SESSION_HISTORY_READY_EVENT: &str = "vm0_mock_codex_session_history_ready";
 pub const MOCK_CODEX_TURN_STEER_READY_FILE: &str = ".vm0-mock-codex-turn-steer-ready";
@@ -1409,12 +1411,40 @@ where
         let task = tokio::spawn(future);
         let status = match task.await {
             Ok(Ok(())) => guest_agent::cli::HeartbeatStatus::Stopped,
-            Ok(Err(error)) => guest_agent::cli::HeartbeatStatus::Failed(error),
+            Ok(Err(error)) => guest_agent::cli::HeartbeatStatus::Failed(
+                guest_agent::heartbeat::HeartbeatFailure {
+                    error,
+                    diagnostic: test_heartbeat_failure_diagnostic(),
+                },
+            ),
             Err(error) => guest_agent::cli::HeartbeatStatus::TaskFailed(error.to_string()),
         };
         let _ = tx.send(status);
     });
     Some(rx)
+}
+
+pub fn test_heartbeat_failure_diagnostic()
+-> guest_contracts::diagnostics::HeartbeatFailureDiagnostic {
+    use guest_contracts::diagnostics::{
+        HeartbeatAttemptFailureKind, HeartbeatCompletedAttemptDiagnostic,
+        HeartbeatFailedCycleDiagnostic, HeartbeatFailureDiagnostic,
+    };
+
+    HeartbeatFailureDiagnostic {
+        failed_cycles: vec![HeartbeatFailedCycleDiagnostic {
+            scheduled_lag_ms: 17,
+            attempts: vec![HeartbeatCompletedAttemptDiagnostic {
+                attempt: 3,
+                client_request_id: "11111111-1111-4111-8111-111111111111".to_string(),
+                elapsed_ms: 30_001,
+                failure_kind: HeartbeatAttemptFailureKind::Timeout,
+                http_status: None,
+                timeout_observed: Some(true),
+                connect_observed: Some(false),
+            }],
+        }],
+    }
 }
 
 /// Dummy heartbeat that never completes. The CLI-wait / reap-deadline

--- a/crates/guest-agent/tests/heartbeat_reap_sigkill.rs
+++ b/crates/guest-agent/tests/heartbeat_reap_sigkill.rs
@@ -66,5 +66,11 @@ async fn heartbeat_failure_reap_escalates_to_sigkill_when_sigterm_ignored()
     assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigkill));
     assert!(termination.escalated);
     assert_eq!(termination.observed_exit_code, Some(common::SIGKILL_EXIT));
+    assert_eq!(
+        result
+            .heartbeat
+            .expect("heartbeat failure should retain HTTP evidence"),
+        common::test_heartbeat_failure_diagnostic()
+    );
     Ok(())
 }

--- a/crates/guest-agent/tests/integration_cases/heartbeat.rs
+++ b/crates/guest-agent/tests/integration_cases/heartbeat.rs
@@ -1,4 +1,5 @@
 use crate::support::*;
+use guest_contracts::diagnostics::HeartbeatAttemptFailureKind;
 use httpmock::prelude::*;
 use serde_json::json;
 use std::time::Duration;
@@ -207,9 +208,28 @@ async fn heartbeat_first_failure_fatal() {
     let heartbeat_calls = mock.calls_async().await;
     mock.delete_async().await;
 
-    let result = result.expect("initial-failure heartbeat loop should stop within 30 seconds");
-    assert!(result.is_err());
+    let failure = result
+        .expect("initial-failure heartbeat loop should stop within 30 seconds")
+        .expect_err("initial heartbeat failure should be terminal");
     assert_eq!(heartbeat_calls, 3);
+    assert_eq!(failure.diagnostic.failed_cycles.len(), 1);
+    let cycle = &failure.diagnostic.failed_cycles[0];
+    assert_eq!(cycle.attempts.len(), 3);
+    for (index, attempt) in cycle.attempts.iter().enumerate() {
+        assert_eq!(attempt.attempt, u32::try_from(index + 1).unwrap());
+        assert!(!attempt.client_request_id.is_empty());
+        assert_eq!(
+            attempt.failure_kind,
+            HeartbeatAttemptFailureKind::HttpStatus
+        );
+        assert_eq!(attempt.http_status, Some(500));
+        assert_eq!(attempt.timeout_observed, None);
+        assert_eq!(attempt.connect_observed, None);
+    }
+    assert_ne!(
+        cycle.attempts[0].client_request_id,
+        cycle.attempts[1].client_request_id
+    );
 }
 
 #[tokio::test]
@@ -253,8 +273,8 @@ async fn heartbeat_consecutive_failures_fatal() {
     mock.delete_async().await;
     shutdown.cancel();
 
-    assert!(result.is_err());
-    let err = result.unwrap_err().to_string();
+    let failure = result.expect_err("consecutive heartbeat failures should be terminal");
+    let err = failure.to_string();
     assert!(
         err.contains("consecutive"),
         "error should mention consecutive failures: {err}"
@@ -263,6 +283,14 @@ async fn heartbeat_consecutive_failures_fatal() {
     // 401 is a 4xx error -> post_json returns immediately (no internal retries),
     // so the sequence is one success followed by the fatal failure window.
     assert_eq!(heartbeat_calls, 4);
+    assert_eq!(failure.diagnostic.failed_cycles.len(), 3);
+    assert!(
+        failure
+            .diagnostic
+            .failed_cycles
+            .iter()
+            .all(|cycle| cycle.attempts.len() == 1)
+    );
 }
 
 #[tokio::test]
@@ -275,7 +303,9 @@ async fn heartbeat_recovery_resets_counter() {
     let mock = server.mock(|when, then| {
         when.method(POST).path("/api/webhooks/agent/heartbeat");
         then.respond_with(move |_req| match observer_for_mock.record() {
-            2 | 3 | 5 | 6 => json_http_response(401, json!({"error": {"message": "Run expired"}})),
+            2 | 3 | 5 | 6 | 7 => {
+                json_http_response(401, json!({"error": {"message": "Run expired"}}))
+            }
             _ => http_status(200),
         });
     });
@@ -292,31 +322,24 @@ async fn heartbeat_recovery_resets_counter() {
         .await
     });
 
-    // Sequence: success -> 2 failures -> success -> 2 failures -> success.
-    // Without recovery resetting the failure counter, the second failure pair
-    // would reach the fatal threshold before call 7.
-    observer
-        .wait_for(
-            7,
-            MOCK_CALL_TIMEOUT,
-            "heartbeat_recovery_resets_counter full sequence",
-        )
-        .await;
-
-    let heartbeat_calls = observer.calls();
-
-    // The loop should still be running. Stop it before deleting the mock so no
-    // background heartbeat can race with mock teardown.
-    shutdown.cancel();
+    // Sequence: success -> 2 failures -> recovery -> 3 failures. The terminal
+    // diagnostic must retain only the failures after recovery.
     let result = tokio::time::timeout(Duration::from_secs(30), handle)
         .await
         .expect("heartbeat_loop should exit within timeout")
         .expect("task should not panic");
+    let heartbeat_calls = observer.calls();
     mock.delete_async().await;
+    shutdown.cancel();
 
+    let failure = result.expect_err("three failures after recovery should be terminal");
+    assert_eq!(heartbeat_calls, 7);
+    assert_eq!(failure.diagnostic.failed_cycles.len(), 3);
     assert!(
-        result.is_ok(),
-        "heartbeat_loop should exit Ok after shutdown, not Err"
+        failure
+            .diagnostic
+            .failed_cycles
+            .iter()
+            .all(|cycle| cycle.attempts.len() == 1)
     );
-    assert!(heartbeat_calls >= 7);
 }

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -45,6 +45,9 @@ pub struct FailureDiagnostic {
     /// Bounded event-delivery failure details, when delivery was terminally incomplete.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub event_delivery: Option<EventDeliveryDiagnostic>,
+    /// Bounded heartbeat failure details, when the control path stopped making progress.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub heartbeat: Option<HeartbeatFailureDiagnostic>,
     /// Workload-local hard-limit counters observed for the failed CLI process.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workload_resource_limit: Option<WorkloadResourceLimitDiagnostic>,
@@ -72,6 +75,7 @@ impl FailureDiagnostic {
             prompt_bytes: prompt.prompt_bytes,
             first_line_bytes: prompt.first_line_bytes,
             event_delivery: None,
+            heartbeat: None,
             workload_resource_limit: None,
         }
     }
@@ -138,6 +142,13 @@ impl FailureDiagnostic {
         self
     }
 
+    /// Attach bounded heartbeat failure details.
+    #[must_use]
+    pub fn with_heartbeat(mut self, heartbeat: HeartbeatFailureDiagnostic) -> Self {
+        self.heartbeat = Some(heartbeat);
+        self
+    }
+
     /// Attach workload-local hard-limit counters.
     #[must_use]
     pub fn with_workload_resource_limit(
@@ -146,6 +157,74 @@ impl FailureDiagnostic {
     ) -> Self {
         self.workload_resource_limit = Some(workload_resource_limit);
         self
+    }
+}
+
+/// Bounded structured details for terminal heartbeat failure.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HeartbeatFailureDiagnostic {
+    /// Consecutive failed heartbeat cycles since the last successful cycle.
+    pub failed_cycles: Vec<HeartbeatFailedCycleDiagnostic>,
+}
+
+/// One failed heartbeat cycle and its completed HTTP attempts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HeartbeatFailedCycleDiagnostic {
+    /// Delay between the scheduled interval tick and the start of this cycle.
+    pub scheduled_lag_ms: u64,
+    /// Completed failed attempts, bounded by the heartbeat retry budget.
+    pub attempts: Vec<HeartbeatCompletedAttemptDiagnostic>,
+}
+
+/// One completed failed HTTP attempt for a heartbeat cycle.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HeartbeatCompletedAttemptDiagnostic {
+    /// One-based attempt number.
+    pub attempt: u32,
+    /// Exact `x-client-request-id` value sent on the request.
+    pub client_request_id: String,
+    /// Monotonic elapsed request time in milliseconds.
+    pub elapsed_ms: u64,
+    /// Stable content-safe failure classification.
+    pub failure_kind: HeartbeatAttemptFailureKind,
+    /// HTTP response status, when a response was received.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_status: Option<u16>,
+    /// Whether Reqwest identified the response-less failure as timeout-related.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_observed: Option<bool>,
+    /// Whether Reqwest identified the response-less failure as connection-related.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connect_observed: Option<bool>,
+}
+
+/// Content-safe failure classification for a completed heartbeat HTTP attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HeartbeatAttemptFailureKind {
+    /// The request exceeded its transport timeout.
+    Timeout,
+    /// A connection could not be established.
+    Connect,
+    /// The API returned a non-success HTTP response.
+    HttpStatus,
+    /// Another transport failure occurred without an HTTP response.
+    Transport,
+}
+
+impl HeartbeatAttemptFailureKind {
+    /// Return the stable snake_case string representation.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Timeout => "timeout",
+            Self::Connect => "connect",
+            Self::HttpStatus => "http_status",
+            Self::Transport => "transport",
+        }
     }
 }
 
@@ -1581,6 +1660,57 @@ mod tests {
     }
 
     #[test]
+    fn failure_diagnostic_round_trips_bounded_heartbeat_details() {
+        let heartbeat = HeartbeatFailureDiagnostic {
+            failed_cycles: vec![HeartbeatFailedCycleDiagnostic {
+                scheduled_lag_ms: 25,
+                attempts: vec![
+                    HeartbeatCompletedAttemptDiagnostic {
+                        attempt: 1,
+                        client_request_id: "11111111-1111-4111-8111-111111111111".to_string(),
+                        elapsed_ms: 10_000,
+                        failure_kind: HeartbeatAttemptFailureKind::Timeout,
+                        http_status: None,
+                        timeout_observed: Some(true),
+                        connect_observed: Some(false),
+                    },
+                    HeartbeatCompletedAttemptDiagnostic {
+                        attempt: 2,
+                        client_request_id: "22222222-2222-4222-8222-222222222222".to_string(),
+                        elapsed_ms: 3,
+                        failure_kind: HeartbeatAttemptFailureKind::HttpStatus,
+                        http_status: Some(503),
+                        timeout_observed: None,
+                        connect_observed: None,
+                    },
+                ],
+            }],
+        };
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliExecutionError,
+            AgentFramework::Codex,
+            PromptMetadata::from_prompt("continue"),
+        )
+        .with_cli_exit_code(1)
+        .with_heartbeat(heartbeat);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(json["heartbeat"]["failedCycles"][0]["scheduledLagMs"], 25);
+        assert_eq!(
+            json["heartbeat"]["failedCycles"][0]["attempts"][0]["failureKind"],
+            "timeout"
+        );
+        assert_eq!(
+            json["heartbeat"]["failedCycles"][0]["attempts"][1]["httpStatus"],
+            503
+        );
+        assert_eq!(HeartbeatAttemptFailureKind::Transport.as_str(), "transport");
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
     fn failure_diagnostic_deserializes_without_optional_fields() {
         let json = serde_json::json!({
             "failureClass": "cli_nonzero",
@@ -1599,6 +1729,7 @@ mod tests {
         assert_eq!(diagnostic.failure_reason, None);
         assert_eq!(diagnostic.cli_termination, None);
         assert_eq!(diagnostic.event_delivery, None);
+        assert_eq!(diagnostic.heartbeat, None);
         assert_eq!(diagnostic.workload_resource_limit, None);
     }
 }

--- a/crates/guest-mock-codex/src/app_server/handlers.rs
+++ b/crates/guest-mock-codex/src/app_server/handlers.rs
@@ -25,6 +25,10 @@ use uuid::Uuid;
 
 const HANG_ON_TURN_START_READY_FILE: &str = ".vm0-mock-codex-turn-start-ready";
 const HANG_ON_TURN_START_READY_EVENT: &str = "vm0_mock_codex_turn_start_ready";
+const TURN_COMPLETE_BEFORE_HEARTBEAT_READY_FILE: &str =
+    ".vm0-mock-codex-turn-complete-before-heartbeat-ready";
+const TURN_COMPLETE_BEFORE_HEARTBEAT_READY_EVENT: &str =
+    "vm0_mock_codex_turn_complete_before_heartbeat_ready";
 const SESSION_HISTORY_READY_FILE: &str = ".vm0-mock-codex-session-history-ready";
 const SESSION_HISTORY_READY_EVENT: &str = "vm0_mock_codex_session_history_ready";
 const WAIT_ON_TURN_STEER_READY_FILE: &str = ".vm0-mock-codex-turn-steer-ready";
@@ -184,7 +188,9 @@ impl AppServerState {
                 )?;
                 write_success(output, id, result)?;
             }
-            Scenario::RuntimeTurnComplete | Scenario::SecondaryThreadNotifications => {
+            Scenario::RuntimeTurnComplete
+            | Scenario::RuntimeTurnCompleteBeforeHeartbeat
+            | Scenario::SecondaryThreadNotifications => {
                 write_json_line(output, &thread_started_notification(&thread_id))?;
                 write_success(output, id, result)?;
             }
@@ -397,6 +403,7 @@ impl AppServerState {
         if matches!(
             self.scenario,
             Scenario::RuntimeTurnComplete
+                | Scenario::RuntimeTurnCompleteBeforeHeartbeat
                 | Scenario::RuntimeTurnCompleteWithoutThreadStarted
                 | Scenario::RuntimeTurnUsageResumeNoReplay
                 | Scenario::RuntimeTurnUsageResumeReplay
@@ -416,6 +423,15 @@ impl AppServerState {
                         )?;
                     } else {
                         write_turn_notifications(output, &thread_id, &turn_id, &response_text)?;
+                        if self.scenario == Scenario::RuntimeTurnCompleteBeforeHeartbeat {
+                            let home = std::env::var_os("HOME").ok_or_else(|| {
+                                io::Error::new(io::ErrorKind::NotFound, "HOME is not set")
+                            })?;
+                            std::fs::write(
+                                PathBuf::from(home).join(TURN_COMPLETE_BEFORE_HEARTBEAT_READY_FILE),
+                                TURN_COMPLETE_BEFORE_HEARTBEAT_READY_EVENT,
+                            )?;
+                        }
                     }
                 }
                 MockTurnOutput::Checkpoint {

--- a/crates/guest-mock-codex/src/app_server/scenario.rs
+++ b/crates/guest-mock-codex/src/app_server/scenario.rs
@@ -28,6 +28,7 @@ pub(super) enum Scenario {
     NoActiveTurn,
     ExitOnTurnSteer,
     RuntimeTurnComplete,
+    RuntimeTurnCompleteBeforeHeartbeat,
     RuntimeTurnFailed,
     RuntimeTurnFailedContextWindowExceeded,
     RuntimeTurnFailedInternalServerError,
@@ -95,6 +96,9 @@ impl Scenario {
                 "no-active-turn" => Ok(Self::NoActiveTurn),
                 "exit-on-turn-steer" => Ok(Self::ExitOnTurnSteer),
                 "runtime-turn-complete" => Ok(Self::RuntimeTurnComplete),
+                "runtime-turn-complete-before-heartbeat" => {
+                    Ok(Self::RuntimeTurnCompleteBeforeHeartbeat)
+                }
                 "runtime-turn-failed" => Ok(Self::RuntimeTurnFailed),
                 "runtime-turn-failed-context-window-exceeded" => {
                     Ok(Self::RuntimeTurnFailedContextWindowExceeded)

--- a/crates/runner/src/cmd/start/job_terminal_log.rs
+++ b/crates/runner/src/cmd/start/job_terminal_log.rs
@@ -7,7 +7,7 @@
 use guest_contracts::diagnostics::{
     CliObservedExitDiagnostic, CliObservedExitKind, CliTerminationDiagnostic,
     EventDeliveryDiagnostic, FailureClass, FailureDiagnostic, FailureReason,
-    WorkloadResourceLimitDiagnostic,
+    HeartbeatFailureDiagnostic, WorkloadResourceLimitDiagnostic,
 };
 use tracing::info;
 
@@ -48,6 +48,9 @@ fn log_job_execution_failed(
     );
     let event_delivery_fields = JobEventDeliveryLogFields::from(
         diagnostic.and_then(|diagnostic| diagnostic.event_delivery.as_ref()),
+    );
+    let heartbeat_fields = JobHeartbeatLogFields::from(
+        diagnostic.and_then(|diagnostic| diagnostic.heartbeat.as_ref()),
     );
     let workload_resource_fields = JobWorkloadResourceLogFields::from(
         diagnostic.and_then(|diagnostic| diagnostic.workload_resource_limit.as_ref()),
@@ -159,6 +162,18 @@ fn log_job_execution_failed(
                     event_delivery_fields.drain_active_attempt_elapsed_ms,
                 event_delivery_drain_active_outcome =
                     event_delivery_fields.drain_active_outcome,
+                heartbeat_failed_cycle_count = heartbeat_fields.failed_cycle_count,
+                heartbeat_attempt_count = heartbeat_fields.attempt_count,
+                heartbeat_final_scheduled_lag_ms = heartbeat_fields.final_scheduled_lag_ms,
+                heartbeat_final_attempt_number = heartbeat_fields.final_attempt_number,
+                heartbeat_final_attempt_kind = heartbeat_fields.final_attempt_kind,
+                heartbeat_final_attempt_timeout_observed =
+                    heartbeat_fields.final_attempt_timeout_observed,
+                heartbeat_final_attempt_connect_observed =
+                    heartbeat_fields.final_attempt_connect_observed,
+                heartbeat_final_attempt_http_status = heartbeat_fields.final_attempt_http_status,
+                heartbeat_final_attempt_request_id = heartbeat_fields.final_attempt_request_id,
+                heartbeat_final_attempt_elapsed_ms = heartbeat_fields.final_attempt_elapsed_ms,
                 workload_memory_max_events = workload_resource_fields.memory_max_events,
                 workload_memory_oom_events = workload_resource_fields.memory_oom_events,
                 workload_memory_oom_kill_events =
@@ -265,6 +280,19 @@ struct JobEventDeliveryLogFields<'a> {
     drain_active_outcome: Option<&'static str>,
 }
 
+struct JobHeartbeatLogFields<'a> {
+    failed_cycle_count: Option<u64>,
+    attempt_count: Option<u64>,
+    final_scheduled_lag_ms: Option<u64>,
+    final_attempt_number: Option<u32>,
+    final_attempt_kind: Option<&'static str>,
+    final_attempt_timeout_observed: Option<bool>,
+    final_attempt_connect_observed: Option<bool>,
+    final_attempt_http_status: Option<u16>,
+    final_attempt_request_id: Option<&'a str>,
+    final_attempt_elapsed_ms: Option<u64>,
+}
+
 impl From<Option<&CliTerminationDiagnostic>> for JobCliTerminationLogFields {
     fn from(diagnostic: Option<&CliTerminationDiagnostic>) -> Self {
         Self {
@@ -359,6 +387,36 @@ impl<'a> From<Option<&'a EventDeliveryDiagnostic>> for JobEventDeliveryLogFields
     }
 }
 
+impl<'a> From<Option<&'a HeartbeatFailureDiagnostic>> for JobHeartbeatLogFields<'a> {
+    fn from(diagnostic: Option<&'a HeartbeatFailureDiagnostic>) -> Self {
+        let final_cycle = diagnostic.and_then(|diagnostic| diagnostic.failed_cycles.last());
+        let final_attempt = final_cycle.and_then(|cycle| cycle.attempts.last());
+        Self {
+            failed_cycle_count: diagnostic.map(|diagnostic| {
+                u64::try_from(diagnostic.failed_cycles.len()).unwrap_or(u64::MAX)
+            }),
+            attempt_count: diagnostic.map(|diagnostic| {
+                diagnostic
+                    .failed_cycles
+                    .iter()
+                    .map(|cycle| u64::try_from(cycle.attempts.len()).unwrap_or(u64::MAX))
+                    .fold(0_u64, u64::saturating_add)
+            }),
+            final_scheduled_lag_ms: final_cycle.map(|cycle| cycle.scheduled_lag_ms),
+            final_attempt_number: final_attempt.map(|attempt| attempt.attempt),
+            final_attempt_kind: final_attempt.map(|attempt| attempt.failure_kind.as_str()),
+            final_attempt_timeout_observed: final_attempt
+                .and_then(|attempt| attempt.timeout_observed),
+            final_attempt_connect_observed: final_attempt
+                .and_then(|attempt| attempt.connect_observed),
+            final_attempt_http_status: final_attempt.and_then(|attempt| attempt.http_status),
+            final_attempt_request_id: final_attempt
+                .map(|attempt| attempt.client_request_id.as_str()),
+            final_attempt_elapsed_ms: final_attempt.map(|attempt| attempt.elapsed_ms),
+        }
+    }
+}
+
 impl From<Option<executor::ResourceFailureDiagnostics>> for JobResourceLogFields {
     fn from(diagnostics: Option<executor::ResourceFailureDiagnostics>) -> Self {
         Self {
@@ -432,7 +490,9 @@ mod tests {
         EventDeliveryActiveBatchDiagnostic, EventDeliveryAttemptFailureKind,
         EventDeliveryCompletedAttemptDiagnostic, EventDeliveryDiagnostic,
         EventDeliveryDrainTimeoutDiagnostic, EventDeliveryFailedBatchDiagnostic, FailureClass,
-        FailureDetailSource, PromptMetadata, SessionHistoryStatus, WorkloadResourceLimitDiagnostic,
+        FailureDetailSource, HeartbeatAttemptFailureKind, HeartbeatCompletedAttemptDiagnostic,
+        HeartbeatFailedCycleDiagnostic, HeartbeatFailureDiagnostic, PromptMetadata,
+        SessionHistoryStatus, WorkloadResourceLimitDiagnostic,
     };
     use tracing::Level;
     use tracing_subscriber::prelude::*;
@@ -1042,6 +1102,72 @@ mod tests {
         }
         assert!(!event.fields.contains_key("event_delivery_attempts"));
         assert!(!event.fields.contains_key("event_delivery_body"));
+    }
+
+    #[test]
+    fn diagnostic_failure_logs_bounded_heartbeat_fields() {
+        let diagnostic = job_failure_diagnostic(None).with_heartbeat(HeartbeatFailureDiagnostic {
+            failed_cycles: vec![
+                HeartbeatFailedCycleDiagnostic {
+                    scheduled_lag_ms: 11,
+                    attempts: vec![HeartbeatCompletedAttemptDiagnostic {
+                        attempt: 1,
+                        client_request_id: "11111111-1111-4111-8111-111111111111".to_string(),
+                        elapsed_ms: 100,
+                        failure_kind: HeartbeatAttemptFailureKind::HttpStatus,
+                        http_status: Some(503),
+                        timeout_observed: None,
+                        connect_observed: None,
+                    }],
+                },
+                HeartbeatFailedCycleDiagnostic {
+                    scheduled_lag_ms: 27,
+                    attempts: vec![
+                        HeartbeatCompletedAttemptDiagnostic {
+                            attempt: 1,
+                            client_request_id: "22222222-2222-4222-8222-222222222222".to_string(),
+                            elapsed_ms: 30_000,
+                            failure_kind: HeartbeatAttemptFailureKind::Timeout,
+                            http_status: None,
+                            timeout_observed: Some(true),
+                            connect_observed: Some(false),
+                        },
+                        HeartbeatCompletedAttemptDiagnostic {
+                            attempt: 2,
+                            client_request_id: "33333333-3333-4333-8333-333333333333".to_string(),
+                            elapsed_ms: 30_001,
+                            failure_kind: HeartbeatAttemptFailureKind::Timeout,
+                            http_status: None,
+                            timeout_observed: Some(true),
+                            connect_observed: Some(false),
+                        },
+                    ],
+                },
+            ],
+        });
+        let failure = executor::ExecutionFailure::new(1, "heartbeat failed", Some(diagnostic));
+
+        let event = capture_job_failure_log(&failure);
+
+        assert_field_eq(&event, "heartbeat_failed_cycle_count", "2");
+        assert_field_eq(&event, "heartbeat_attempt_count", "3");
+        assert_field_eq(&event, "heartbeat_final_scheduled_lag_ms", "27");
+        assert_field_eq(&event, "heartbeat_final_attempt_number", "2");
+        assert_field_eq(&event, "heartbeat_final_attempt_kind", "timeout");
+        assert_field_eq(&event, "heartbeat_final_attempt_timeout_observed", "true");
+        assert_field_eq(&event, "heartbeat_final_attempt_connect_observed", "false");
+        assert!(
+            !event
+                .fields
+                .contains_key("heartbeat_final_attempt_http_status")
+        );
+        assert_field_eq(
+            &event,
+            "heartbeat_final_attempt_request_id",
+            "33333333-3333-4333-8333-333333333333",
+        );
+        assert_field_eq(&event, "heartbeat_final_attempt_elapsed_ms", "30001");
+        assert!(!event.fields.contains_key("heartbeat_failed_cycles"));
     }
 
     #[test]

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -978,6 +978,17 @@ fn diagnostic_is_agent_execution_timeout(diagnostic: Option<&FailureDiagnostic>)
         .is_some_and(|termination| termination.reason == CliTerminationReason::ExecutionTimeout)
 }
 
+fn diagnostic_is_control_path_failure(diagnostic: Option<&FailureDiagnostic>) -> bool {
+    diagnostic
+        .and_then(|diagnostic| diagnostic.cli_termination.as_ref())
+        .is_some_and(|termination| {
+            matches!(
+                termination.reason,
+                CliTerminationReason::HeartbeatError | CliTerminationReason::HeartbeatPanic
+            )
+        })
+}
+
 fn sandbox_reuse_disposition_for_process_exit(
     exit: &sandbox::ProcessExit,
     cancellation: CancellationDisposition,
@@ -1005,6 +1016,11 @@ fn sandbox_reuse_disposition_for_process_exit(
             return SandboxReuseDisposition::Ineligible(SandboxReuseRejection::ExecutionUncertain);
         }
     };
+    if failure
+        .is_some_and(|failure| diagnostic_is_control_path_failure(failure.diagnostic.as_ref()))
+    {
+        return SandboxReuseDisposition::Ineligible(SandboxReuseRejection::ControlPathFailure);
+    }
     if cancellation == CancellationDisposition::Cooperative {
         SandboxReuseDisposition::Eligible(SandboxReuseTerminal::CooperativeCancellation)
     } else if failure.is_some_and(|failure| {
@@ -2669,6 +2685,89 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use guest_contracts::diagnostics::{
+        AgentFramework, CliTerminationDiagnostic, FailureClass, PromptMetadata,
+    };
+
+    fn control_path_failure(reason: CliTerminationReason) -> ExecutionFailure {
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliExecutionError,
+            AgentFramework::Codex,
+            PromptMetadata::from_prompt("continue"),
+        )
+        .with_cli_exit_code(1)
+        .with_cli_termination(CliTerminationDiagnostic::new(reason));
+        ExecutionFailure::new(1, "heartbeat failed", Some(diagnostic))
+    }
+
+    fn nonzero_process_exit() -> sandbox::ProcessExit {
+        sandbox::ProcessExit::new(42, 1, Vec::new(), Vec::new())
+    }
+
+    #[test]
+    fn heartbeat_control_failures_reject_sandbox_reuse() {
+        for reason in [
+            CliTerminationReason::HeartbeatError,
+            CliTerminationReason::HeartbeatPanic,
+        ] {
+            let failure = control_path_failure(reason);
+            let disposition = sandbox_reuse_disposition_for_process_exit(
+                &nonzero_process_exit(),
+                CancellationDisposition::None,
+                Some(&failure),
+            );
+
+            assert_eq!(
+                disposition,
+                SandboxReuseDisposition::Ineligible(SandboxReuseRejection::ControlPathFailure)
+            );
+            assert_eq!(disposition.as_str(), "control_path_failure");
+            assert_eq!(
+                disposition.telemetry_action(),
+                "runner_terminal_sandbox_reuse_rejected_control_path_failure"
+            );
+        }
+    }
+
+    #[test]
+    fn ordinary_nonzero_exit_remains_reusable() {
+        let failure = ExecutionFailure::new(1, "ordinary failure", None);
+
+        assert_eq!(
+            sandbox_reuse_disposition_for_process_exit(
+                &nonzero_process_exit(),
+                CancellationDisposition::None,
+                Some(&failure),
+            ),
+            SandboxReuseDisposition::Eligible(SandboxReuseTerminal::NonzeroExit)
+        );
+    }
+
+    #[test]
+    fn hard_cancellation_and_resource_failure_precede_control_path_rejection() {
+        let failure = control_path_failure(CliTerminationReason::HeartbeatError);
+        assert_eq!(
+            sandbox_reuse_disposition_for_process_exit(
+                &nonzero_process_exit(),
+                CancellationDisposition::HardFallback,
+                Some(&failure),
+            ),
+            SandboxReuseDisposition::Ineligible(SandboxReuseRejection::HardCancellation)
+        );
+
+        let failure =
+            failure.with_resource_diagnostics(Some(ResourceFailureDiagnostics::from_failure_kind(
+                ResourceFailureKind::GuestMemoryOomKilled,
+            )));
+        assert_eq!(
+            sandbox_reuse_disposition_for_process_exit(
+                &nonzero_process_exit(),
+                CancellationDisposition::None,
+                Some(&failure),
+            ),
+            SandboxReuseDisposition::Ineligible(SandboxReuseRejection::ResourceFailure)
+        );
+    }
 
     fn exec_arg_aggregate_bytes(value: &str) -> usize {
         value.len() + 1

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -281,6 +281,7 @@ impl SandboxReuseDisposition {
             Self::Ineligible(SandboxReuseRejection::HardCancellation) => "hard_cancellation",
             Self::Ineligible(SandboxReuseRejection::UnconfirmedTimeout) => "unconfirmed_timeout",
             Self::Ineligible(SandboxReuseRejection::ResourceFailure) => "resource_failure",
+            Self::Ineligible(SandboxReuseRejection::ControlPathFailure) => "control_path_failure",
             Self::Ineligible(SandboxReuseRejection::PostJobCleanupFailure) => {
                 "post_job_cleanup_failure"
             }
@@ -314,6 +315,9 @@ impl SandboxReuseDisposition {
             Self::Ineligible(SandboxReuseRejection::ResourceFailure) => {
                 "runner_terminal_sandbox_reuse_rejected_resource_failure"
             }
+            Self::Ineligible(SandboxReuseRejection::ControlPathFailure) => {
+                "runner_terminal_sandbox_reuse_rejected_control_path_failure"
+            }
             Self::Ineligible(SandboxReuseRejection::PostJobCleanupFailure) => {
                 "runner_terminal_sandbox_reuse_rejected_post_job_cleanup_failure"
             }
@@ -341,6 +345,7 @@ pub(crate) enum SandboxReuseRejection {
     HardCancellation,
     UnconfirmedTimeout,
     ResourceFailure,
+    ControlPathFailure,
     PostJobCleanupFailure,
 }
 


### PR DESCRIPTION
## Summary

- retain bounded, content-safe failed heartbeat cycle and HTTP attempt diagnostics
- preserve heartbeat failures through Claude, Pi, and Codex termination while keeping terminal-result, cancellation, timeout, and resource-failure precedence
- expose bounded heartbeat correlation fields in Runner terminal logs and reject sandbox reuse after structured heartbeat failures

## Scope

- closes #30767
- delivery context: #30682

## Explicit exclusions

- no heartbeat interval, retry, timeout, cgroup, balloon, or resource-policy changes
- no host probe, automatic run retry, database migration, queue contract, or terminal-state reversal
- no URL, header, token, request body, prompt, or user output in diagnostics or logs

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p guest-contracts`
- `cargo test -p guest-agent`
- `cargo test -p guest-mock-codex`
- `cargo test -p runner`
- `cargo test -p runner --bin runner cmd::service::signal::tests::signal_service_main_bounded_times_out_systemctl -- --exact --nocapture`
- `cargo test -p vsock-guest --test connection guest_state_restore::guest_state_restore_timeout_kills_and_reaps_process_group -- --exact --nocapture`

`cargo test --workspace --quiet` was attempted twice. The first attempt failed only the unrelated Runner systemctl timing test above; the second passed the full Runner package and failed only the unrelated vsock pid-file timing test above. Both tests passed their targeted reruns, and all directly affected packages passed their full package suites.

Closes #30767
Parent: #30682
