### PR TITLE
fix(app): point status widget to status.okou.ai

### DIFF
--- a/turbo/apps/platform/src/__tests__/instatus-widget.test.ts
+++ b/turbo/apps/platform/src/__tests__/instatus-widget.test.ts
@@ -6,9 +6,9 @@ import { testContext } from "../signals/__tests__/test-helpers.ts";
 const context = testContext();
 
 const INSTATUS_SCRIPT_URL =
-  "https://api.dashboard.instatus.com/widget?host=status.vm0.ai&code=02c0ef5a&locale=en";
+  "https://api.dashboard.instatus.com/widget?host=status.okou.ai&code=02c0ef5a&locale=en";
 const INSTATUS_SCRIPT_INTEGRITY =
-  "sha384-ZW3eZwADOMdlg2fdvESPD7jguK16IC/edxNFakKs81D2lkNdi3BXRmx/g331lkD3";
+  "sha384-YU7+0Wj4uP1wkywaN92wj9+XhrCKLPHapq5vtxjnjEQU401q3xFgN4JNkMWcBHOW";
 
 function loadInstatusScripts(hostname: string): HTMLScriptElement[] {
   context.mocks.browser.url(`https://${hostname}/`);

--- a/turbo/apps/platform/src/lib/instatus-widget.ts
+++ b/turbo/apps/platform/src/lib/instatus-widget.ts
@@ -1,7 +1,7 @@
 const INSTATUS_SCRIPT_URL =
-  "https://api.dashboard.instatus.com/widget?host=status.vm0.ai&code=02c0ef5a&locale=en";
+  "https://api.dashboard.instatus.com/widget?host=status.okou.ai&code=02c0ef5a&locale=en";
 const INSTATUS_SCRIPT_INTEGRITY =
-  "sha384-ZW3eZwADOMdlg2fdvESPD7jguK16IC/edxNFakKs81D2lkNdi3BXRmx/g331lkD3";
+  "sha384-YU7+0Wj4uP1wkywaN92wj9+XhrCKLPHapq5vtxjnjEQU401q3xFgN4JNkMWcBHOW";
 
 export function initInstatusWidget(): void {
   const hostname = window.location.hostname.toLowerCase();


### PR DESCRIPTION
## Summary

- point the App Instatus widget at `status.okou.ai`
- update the widget Subresource Integrity hash for the new response
- update the focused widget test expectation

## Verification

- `pnpm exec prettier --check apps/platform/src/lib/instatus-widget.ts apps/platform/src/__tests__/instatus-widget.test.ts`
- `pnpm -F @okouai/app exec vitest run src/__tests__/instatus-widget.test.ts --maxWorkers=4 --silent=passed-only` (6 tests passed)
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- confirmed the new Instatus widget endpoint returns HTTP 200 and matches the committed SHA-384 integrity value
- confirmed `status.vm0.ai` has no remaining repository matches
