### PR TITLE
perf(runner): specialize session identity verifier lifecycle

### DIFF
--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -941,7 +941,7 @@ impl RunningExec {
 
         let cleanup_process_group_before_reap =
             process_containment.requires_pre_reap_process_group_cleanup();
-        let prepare_stdin_writer_for_pre_reap = || {
+        let prepare_for_pre_reap = || {
             let stdin_writer_cancelled = stdin_writer.as_ref().is_some_and(|writer| {
                 if matches!(writer.done_rx.try_recv(), Err(mpsc::TryRecvError::Empty)) {
                     request_stdin_writer_cancel(writer);
@@ -957,7 +957,7 @@ impl RunningExec {
             request.timeout.wait_timeout_ms(),
             connection_cancel,
             exec_cancel,
-            prepare_stdin_writer_for_pre_reap,
+            prepare_for_pre_reap,
         );
         if let Some(writer) = stdin_writer.as_ref()
             && matches!(writer.done_rx.try_recv(), Err(mpsc::TryRecvError::Empty))

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -939,16 +939,18 @@ impl RunningExec {
             drain_done_rx,
         } = self;
 
+        let cleanup_process_group_before_reap =
+            process_containment.requires_pre_reap_process_group_cleanup();
         let prepare_stdin_writer_for_pre_reap = || {
-            let Some(writer) = stdin_writer.as_ref() else {
-                return false;
-            };
-            if matches!(writer.done_rx.try_recv(), Err(mpsc::TryRecvError::Empty)) {
-                request_stdin_writer_cancel(writer);
-                true
-            } else {
-                false
-            }
+            let stdin_writer_cancelled = stdin_writer.as_ref().is_some_and(|writer| {
+                if matches!(writer.done_rx.try_recv(), Err(mpsc::TryRecvError::Empty)) {
+                    request_stdin_writer_cancel(writer);
+                    true
+                } else {
+                    false
+                }
+            });
+            cleanup_process_group_before_reap || stdin_writer_cancelled
         };
         let outcome = wait_with_kill_timeout_or_cancelled_either(
             child,

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -941,15 +941,19 @@ impl RunningExec {
 
         let cleanup_process_group_before_reap =
             process_containment.requires_pre_reap_process_group_cleanup();
+        let prepare_stdin_writer_for_pre_reap = || {
+            let Some(writer) = stdin_writer.as_ref() else {
+                return false;
+            };
+            if matches!(writer.done_rx.try_recv(), Err(mpsc::TryRecvError::Empty)) {
+                request_stdin_writer_cancel(writer);
+                true
+            } else {
+                false
+            }
+        };
         let prepare_for_pre_reap = || {
-            let stdin_writer_cancelled = stdin_writer.as_ref().is_some_and(|writer| {
-                if matches!(writer.done_rx.try_recv(), Err(mpsc::TryRecvError::Empty)) {
-                    request_stdin_writer_cancel(writer);
-                    true
-                } else {
-                    false
-                }
-            });
+            let stdin_writer_cancelled = prepare_stdin_writer_for_pre_reap();
             cleanup_process_group_before_reap || stdin_writer_cancelled
         };
         let outcome = wait_with_kill_timeout_or_cancelled_either(

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -1723,32 +1723,6 @@ mod tests {
     }
 
     #[test]
-    fn process_group_backend_is_limited_to_session_identity_verifier() {
-        let verifier = ExecProcessContainment::create(
-            1,
-            ProcessContainmentMode::TestNoop,
-            ExecProcessRole::SessionHistoryIdentityVerifier,
-        )
-        .unwrap();
-        let workload = ExecProcessContainment::create(
-            2,
-            ProcessContainmentMode::TestNoop,
-            ExecProcessRole::Workload,
-        )
-        .unwrap();
-        let agent = ExecProcessContainment::create(
-            3,
-            ProcessContainmentMode::TestNoop,
-            ExecProcessRole::Agent,
-        )
-        .unwrap();
-
-        assert!(verifier.requires_pre_reap_process_group_cleanup());
-        assert!(!workload.requires_pre_reap_process_group_cleanup());
-        assert!(!agent.requires_pre_reap_process_group_cleanup());
-    }
-
-    #[test]
     fn parses_recursive_populated_state() {
         assert_eq!(parse_populated("populated 0\nfrozen 0\n"), Some(false));
         assert_eq!(parse_populated("populated 1\nfrozen 0\n"), Some(true));

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -71,6 +71,7 @@ pub(crate) enum ProcessContainmentMode {
 
 enum ContainmentBackend {
     Cgroup(CgroupGuard),
+    ProcessGroup,
     TestNoop,
     #[cfg(test)]
     TestDirectory(PathBuf),
@@ -260,6 +261,14 @@ impl ExecProcessContainment {
         mode: ProcessContainmentMode,
         role: ExecProcessRole,
     ) -> Result<Self, ProcessContainmentError> {
+        // The exec request parser admits this role only after validating its
+        // fixed Runner-owned helper contract. Workload and Agent roles retain
+        // workload cgroup containment.
+        if role == ExecProcessRole::SessionHistoryIdentityVerifier {
+            return Ok(Self {
+                backend: ContainmentBackend::ProcessGroup,
+            });
+        }
         if use_test_noop_backend(mode) {
             return Ok(Self {
                 backend: ContainmentBackend::TestNoop,
@@ -276,10 +285,12 @@ impl ExecProcessContainment {
     ) -> Result<PreparedProcessContainmentCommand, ProcessContainmentError> {
         match &self.backend {
             ContainmentBackend::Cgroup(guard) => guard.prepare_command(),
-            ContainmentBackend::TestNoop => Ok(PreparedProcessContainmentCommand {
-                outer_placement: None,
-                deny_process_inspection: false,
-            }),
+            ContainmentBackend::ProcessGroup | ContainmentBackend::TestNoop => {
+                Ok(PreparedProcessContainmentCommand {
+                    outer_placement: None,
+                    deny_process_inspection: false,
+                })
+            }
             #[cfg(test)]
             ContainmentBackend::TestDirectory(_) => Ok(PreparedProcessContainmentCommand {
                 outer_placement: None,
@@ -291,10 +302,14 @@ impl ExecProcessContainment {
     pub(crate) fn create_elapsed(&self) -> Duration {
         match &self.backend {
             ContainmentBackend::Cgroup(guard) => guard.create_elapsed,
-            ContainmentBackend::TestNoop => Duration::ZERO,
+            ContainmentBackend::ProcessGroup | ContainmentBackend::TestNoop => Duration::ZERO,
             #[cfg(test)]
             ContainmentBackend::TestDirectory(_) => Duration::ZERO,
         }
+    }
+
+    pub(crate) fn requires_pre_reap_process_group_cleanup(&self) -> bool {
+        matches!(self.backend, ContainmentBackend::ProcessGroup)
     }
 
     pub(crate) fn start_workload_placement_bootstrap(
@@ -306,7 +321,7 @@ impl ExecProcessContainment {
             ContainmentBackend::Cgroup(guard) => guard
                 .start_workload_placement_bootstrap(control_endpoint, expected_uid)
                 .map(Some),
-            ContainmentBackend::TestNoop => Ok(None),
+            ContainmentBackend::ProcessGroup | ContainmentBackend::TestNoop => Ok(None),
             #[cfg(test)]
             ContainmentBackend::TestDirectory(_) => Ok(None),
         }
@@ -325,7 +340,7 @@ impl ExecProcessContainment {
     ) -> Result<Option<String>, ProcessContainmentError> {
         match self.backend {
             ContainmentBackend::Cgroup(guard) => guard.cleanup(mode),
-            ContainmentBackend::TestNoop => Ok(None),
+            ContainmentBackend::ProcessGroup | ContainmentBackend::TestNoop => Ok(None),
             #[cfg(test)]
             ContainmentBackend::TestDirectory(group_path) => fs::remove_dir(group_path)
                 .map(|()| None)
@@ -1705,6 +1720,32 @@ mod tests {
             let _ = self.0.kill();
             let _ = self.0.wait();
         }
+    }
+
+    #[test]
+    fn process_group_backend_is_limited_to_session_identity_verifier() {
+        let verifier = ExecProcessContainment::create(
+            1,
+            ProcessContainmentMode::TestNoop,
+            ExecProcessRole::SessionHistoryIdentityVerifier,
+        )
+        .unwrap();
+        let workload = ExecProcessContainment::create(
+            2,
+            ProcessContainmentMode::TestNoop,
+            ExecProcessRole::Workload,
+        )
+        .unwrap();
+        let agent = ExecProcessContainment::create(
+            3,
+            ProcessContainmentMode::TestNoop,
+            ExecProcessRole::Agent,
+        )
+        .unwrap();
+
+        assert!(verifier.requires_pre_reap_process_group_cleanup());
+        assert!(!workload.requires_pre_reap_process_group_cleanup());
+        assert!(!agent.requires_pre_reap_process_group_cleanup());
     }
 
     #[test]

--- a/crates/vsock-guest/tests/connection/exec_validation.rs
+++ b/crates/vsock-guest/tests/connection/exec_validation.rs
@@ -34,10 +34,17 @@ fn session_history_identity_verify_payload(metadata_path: &str, runtime_dir: &st
 }
 
 fn verifier_exec_request<'a>(command: &'a str) -> vsock_proto::ExecStartEncodeRequest<'a> {
+    verifier_exec_request_with_timeout(command, 5000)
+}
+
+fn verifier_exec_request_with_timeout(
+    command: &str,
+    timeout_ms: u32,
+) -> vsock_proto::ExecStartEncodeRequest<'_> {
     vsock_proto::ExecStartEncodeRequest {
         lifecycle: ExecLifecyclePolicy::OneShot,
         role: vsock_proto::ExecProcessRole::SessionHistoryIdentityVerifier,
-        timeout: ExecTimeoutPolicy::Duration { timeout_ms: 5000 },
+        timeout: ExecTimeoutPolicy::Duration { timeout_ms },
         command,
         env: &[],
         sudo: false,
@@ -52,6 +59,13 @@ fn verifier_exec_request<'a>(command: &'a str) -> vsock_proto::ExecStartEncodeRe
         control: ExecControlPolicy::Disabled,
         stdin_bytes: None,
     }
+}
+
+fn write_executable_script(path: &str, contents: &str) {
+    fs::write(path, contents).unwrap();
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
 }
 
 #[test]
@@ -227,7 +241,7 @@ fn controlled_agent_rejects_command_sudo_and_stdin_authority() {
 #[test]
 fn session_history_identity_verifier_directly_launches_fixed_helper_arguments() {
     let agent_path = unique_tmp_path("session-history-identity-verifier", ".sh");
-    fs::write(
+    write_executable_script(
         agent_path.as_str(),
         r#"#!/bin/sh
 printf 'runtime=%s\n' "$OKOU_GUEST_RUNTIME_DIR"
@@ -235,11 +249,7 @@ printf 'args'
 for arg in "$@"; do printf ' <%s>' "$arg"; done
 printf '\n'
 "#,
-    )
-    .unwrap();
-    let mut permissions = fs::metadata(agent_path.as_str()).unwrap().permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(agent_path.as_str(), permissions).unwrap();
+    );
     let metadata_path = "/tmp/final identity;printf should-not-run";
     let runtime_dir = "/tmp/runtime $(printf should-not-run)";
     let payload = session_history_identity_verify_payload(metadata_path, runtime_dir);
@@ -263,6 +273,93 @@ printf '\n'
     assert_eq!(result.stderr, Some(Vec::new()));
 
     finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn session_history_identity_verifier_natural_exit_cleans_descendants() {
+    let agent_path = unique_tmp_path("session-history-verifier-descendant", ".sh");
+    let pid_path = unique_pid_path("session-history-verifier-descendant");
+    let mut group_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    write_executable_script(
+        agent_path.as_str(),
+        &format!(
+            "#!/bin/sh\nprintf '%s' \"$$\" > '{}'\nsleep 30 >/dev/null 2>&1 &\nexit 0\n",
+            pid_path.as_str(),
+        ),
+    );
+    let payload = session_history_identity_verify_payload("/tmp/metadata", "/tmp/runtime");
+    let (handle, mut host_stream) =
+        start_guest_connection_with_guest_agent_program(PathBuf::from(agent_path.as_str()));
+
+    send_exec_start_request(&mut host_stream, 146, verifier_exec_request(&payload));
+    let (chunks, result) = read_exec_result(&mut host_stream, 146);
+    let pid = group_guard.read_pid();
+
+    assert!(chunks.is_empty());
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    wait_for_pid_exit(pid, "session history verifier natural exit");
+    group_guard.disarm();
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn session_history_identity_verifier_timeout_cleans_process_group() {
+    let agent_path = unique_tmp_path("session-history-verifier-timeout", ".sh");
+    let pid_path = unique_pid_path("session-history-verifier-timeout");
+    let mut group_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    write_executable_script(
+        agent_path.as_str(),
+        &format!(
+            "#!/bin/sh\nprintf '%s' \"$$\" > '{}'\nsleep 30\n",
+            pid_path.as_str(),
+        ),
+    );
+    let payload = session_history_identity_verify_payload("/tmp/metadata", "/tmp/runtime");
+    let (handle, mut host_stream) =
+        start_guest_connection_with_guest_agent_program(PathBuf::from(agent_path.as_str()));
+
+    send_exec_start_request(
+        &mut host_stream,
+        147,
+        verifier_exec_request_with_timeout(&payload, 200),
+    );
+    let (chunks, result) = read_exec_result(&mut host_stream, 147);
+    let pid = group_guard.read_pid();
+
+    assert!(chunks.is_empty());
+    assert_eq!(result.termination, ExecTermination::TimedOut);
+    wait_for_pid_exit(pid, "session history verifier timeout");
+    group_guard.disarm();
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn session_history_identity_verifier_disconnect_cleans_process_group() {
+    let agent_path = unique_tmp_path("session-history-verifier-disconnect", ".sh");
+    let pid_path = unique_pid_path("session-history-verifier-disconnect");
+    let mut group_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    write_executable_script(
+        agent_path.as_str(),
+        &format!(
+            "#!/bin/sh\nprintf '%s' \"$$\" > '{}'\nsleep 30\n",
+            pid_path.as_str(),
+        ),
+    );
+    let payload = session_history_identity_verify_payload("/tmp/metadata", "/tmp/runtime");
+    let (handle, mut host_stream) =
+        start_guest_connection_with_guest_agent_program(PathBuf::from(agent_path.as_str()));
+
+    send_exec_start_request(
+        &mut host_stream,
+        148,
+        verifier_exec_request_with_timeout(&payload, 60_000),
+    );
+    let pid = group_guard.read_pid();
+
+    drop(host_stream);
+    join_guest_connection(handle);
+    wait_for_pid_exit(pid, "session history verifier disconnect");
+    group_guard.disarm();
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- select a process-group-only containment backend for the already validated, fixed session-history identity verifier role
- preserve generic workload cgroup containment for Workload and Agent roles and keep the existing host/guest protocol unchanged
- clean verifier descendants before reaping the direct child on natural exit, while retaining timeout, cancellation, disconnect, and failure cleanup
- add connection-level coverage for fixed helper authority, natural-exit descendants, timeout cleanup, and host-disconnect cleanup

## Performance evidence

The controlled comparison ran on the same metal host and `vm0/default` profile with the same base image template, helper input, and temporary harness. Each sample restored a new Firecracker VM and measured only its first verifier call, matching the production reuse lifecycle.

| Build | p50 | p90 | p95/p99 | Success |
| --- | ---: | ---: | ---: | ---: |
| main `38d8a89803` | 66.6 ms | 82.3 ms | 86.7 ms | 15/15 |
| candidate | 34.8 ms | 40.7 ms | 40.8 ms | 15/15 |

The candidate reduces p90 by 41.6 ms, exceeding the 25 ms retention gate. The benchmark-only harness and logging were removed before submission.

## Compatibility and risk

No wire, API, queue, database, or telemetry contract changes. The specialized helper no longer receives cgroup resource ceilings, but its executable, subcommand, arguments, environment, output bounds, timeout, role, and payload remain fixed and Runner-owned. The process group is killed and reaped on every terminal path; caller-controlled roles remain cgroup-contained.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-guest --no-deps`
- `git diff --check`
- repository pre-commit hook: workspace Cargo fmt, docs, Clippy (`--all-targets --all-features`), and file-size checks

Closes #30785

Parent context: #24203
