### PR TITLE
fix(api): use workflow account for connector readiness

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -6579,6 +6579,7 @@ describe("CONN-02: test-oauth auth-code journey", () => {
       orgId: actor.orgId ?? "",
       userId: actor.userId,
       connectorSlug: "test-oauth",
+      connectorId: supplemental.id,
       oauthScopes: ["read", "legacy-write"],
       oauthGrantedScopes: null,
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
@@ -406,7 +406,7 @@ export async function setBuiltinOAuthScopeFacts(
     readonly orgId: string;
     readonly userId: string;
     readonly connectorSlug: string;
-    readonly connectorId?: string;
+    readonly connectorId: string;
     readonly oauthScopes: readonly string[];
     readonly oauthGrantedScopes: readonly string[] | null;
   },
@@ -416,9 +416,7 @@ export async function setBuiltinOAuthScopeFacts(
     org_id: args.orgId,
     user_id: args.userId,
     connector_slug: args.connectorSlug,
-    ...(args.connectorId === undefined
-      ? {}
-      : { connector_id: args.connectorId }),
+    connector_id: args.connectorId,
     oauth_scopes: [...args.oauthScopes],
     oauth_granted_scopes:
       args.oauthGrantedScopes === null ? null : [...args.oauthGrantedScopes],

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
@@ -406,6 +406,7 @@ export async function setBuiltinOAuthScopeFacts(
     readonly orgId: string;
     readonly userId: string;
     readonly connectorSlug: string;
+    readonly connectorId?: string;
     readonly oauthScopes: readonly string[];
     readonly oauthGrantedScopes: readonly string[] | null;
   },
@@ -415,6 +416,9 @@ export async function setBuiltinOAuthScopeFacts(
     org_id: args.orgId,
     user_id: args.userId,
     connector_slug: args.connectorSlug,
+    ...(args.connectorId === undefined
+      ? {}
+      : { connector_id: args.connectorId }),
     oauth_scopes: [...args.oauthScopes],
     oauth_granted_scopes:
       args.oauthGrantedScopes === null ? null : [...args.oauthGrantedScopes],

--- a/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
@@ -335,9 +335,10 @@ async function seedGmailMailCardFixture() {
     code: "zero-mail-code",
     state,
   });
+  const gmail = await connectors.readConnectorBySlug(actor, "gmail");
   await runs.enableAgentConnectors(actor, agent.agentId, ["gmail"]);
   mocks.clerk.session(actor.userId, actorWithOrg.orgId);
-  return { actor, agent, thread };
+  return { actor, agent, thread, gmail };
 }
 
 function client() {
@@ -379,6 +380,7 @@ async function setGmailOAuthScopeFacts(
     orgId: fixture.actor.orgId ?? "",
     userId: fixture.actor.userId,
     connectorSlug: "gmail",
+    connectorId: fixture.gmail.id,
     oauthScopes: [GMAIL_MODIFY_SCOPE],
     oauthGrantedScopes,
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -995,6 +995,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
       orgId: actor.orgId,
       userId: actor.userId,
       connectorSlug: "test-oauth",
+      connectorId: connected.id,
       oauthScopes: ["legacy-requested"],
       oauthGrantedScopes: null,
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflows.test.ts
@@ -47,6 +47,10 @@ import {
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createFixtureTracker, createRouteMocks } from "./helpers/route-test";
+import {
+  setBuiltinOAuthScopeFacts,
+  setConnectorAccountState,
+} from "./helpers/connector-credential-storage-state";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { chatThreadRoutes } from "../chat-threads";
 import { workflowAutomationsRoutes } from "../workflow-automations";
@@ -371,6 +375,49 @@ async function connectManualGrant(
   return connector;
 }
 
+async function connectGmailAccount(
+  actor: ApiTestUser,
+  agentId: string,
+  args: {
+    readonly accessToken: string;
+    readonly email: string;
+    readonly subject: string;
+    readonly account?: { readonly intent: "add"; readonly displayName: string };
+  },
+) {
+  mockGmailConnectorOAuth({
+    accessToken: args.accessToken,
+    email: args.email,
+    subject: args.subject,
+  });
+  const start = await connectorApi.startOauth(
+    actor,
+    "gmail",
+    "oauth",
+    agentId,
+    args.account,
+  );
+  const state = new URL(start.authorizationUrl).searchParams.get("state");
+  if (!state) {
+    throw new Error("Expected Gmail OAuth state");
+  }
+  await connectorApi.completeOauthCallback("gmail", {
+    code: `gmail-readiness-${randomUUID()}`,
+    state,
+  });
+  const accounts = await connectorApi.listBuiltinConnectorAccounts(
+    actor,
+    "gmail",
+  );
+  const account = accounts.find((candidate) => {
+    return candidate.externalEmail === args.email;
+  });
+  if (!account) {
+    throw new Error(`Expected Gmail account ${args.email}`);
+  }
+  return account;
+}
+
 async function requestCreateWorkflow<
   TStatus extends 400 | 401 | 403 | 404 | 409,
 >(
@@ -582,6 +629,242 @@ describe("workflows", () => {
         },
         reason: "The workflow reads GitLab projects.",
         status: "connected",
+      },
+    ]);
+  });
+
+  it("uses workflow thread accounts for event and model connector readiness", async () => {
+    const actor = user();
+    if (!actor.orgId) {
+      throw new Error("Expected an organization-scoped readiness actor");
+    }
+    await api.grantProEntitlement(actor, { tier: "team" });
+    await updateFeatureSwitchesForUser(
+      context,
+      { orgId: actor.orgId, userId: actor.userId },
+      {
+        [FeatureSwitchKey.ConnectorAccounts]: true,
+        [FeatureSwitchKey.WorkflowConnectorReadiness]: true,
+      },
+    );
+    const agent = await createAgent(actor, {
+      displayName: "Account-aware Readiness Agent",
+      visibility: "private",
+    });
+
+    mockOptionalEnv(
+      "GMAIL_PUBSUB_TOPIC_NAME",
+      "projects/vm0-ai-488909/topics/gmail-events",
+    );
+    server.use(
+      http.post("https://gmail.googleapis.com/gmail/v1/users/me/watch", () => {
+        return HttpResponse.json({
+          historyId: "account-aware-readiness",
+          expiration: "4102444800000",
+        });
+      }),
+      http.post("https://gmail.googleapis.com/gmail/v1/users/me/stop", () => {
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    const defaultGmail = await connectGmailAccount(actor, agent.agentId, {
+      accessToken: "readiness-default-gmail-token",
+      email: `readiness-default-${randomUUID()}@example.test`,
+      subject: `readiness-default-${randomUUID()}`,
+    });
+    const selectedGmail = await connectGmailAccount(actor, agent.agentId, {
+      accessToken: "readiness-selected-gmail-token",
+      email: `readiness-selected-${randomUUID()}@example.test`,
+      subject: `readiness-selected-${randomUUID()}`,
+      account: { intent: "add", displayName: "Selected Gmail" },
+    });
+    expect(defaultGmail.isDefault).toBeTruthy();
+    expect(selectedGmail.isDefault).toBeFalsy();
+    await setBuiltinOAuthScopeFacts(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      connectorSlug: "gmail",
+      connectorId: selectedGmail.id,
+      oauthScopes: [],
+      oauthGrantedScopes: ["https://www.googleapis.com/auth/gmail.modify"],
+    });
+
+    const defaultRuntimeResult = await connectorApi.requestManualGrant(
+      actor,
+      "runtime",
+      "api-token",
+      { apiKey: "readiness-default-runtime-key" },
+      {
+        statuses: [200],
+        agentId: agent.agentId,
+        authorizeAgent: true,
+        account: { intent: "single-account" },
+      },
+    );
+    if (defaultRuntimeResult.status !== 200) {
+      throw new Error("Expected default Runtime account");
+    }
+    const selectedRuntimeResult = await connectorApi.requestManualGrant(
+      actor,
+      "runtime",
+      "api-token",
+      { apiKey: "readiness-selected-runtime-key" },
+      {
+        statuses: [200],
+        agentId: agent.agentId,
+        authorizeAgent: true,
+        account: { intent: "add", displayName: "Selected Runtime" },
+      },
+    );
+    if (selectedRuntimeResult.status !== 200) {
+      throw new Error("Expected selected Runtime account");
+    }
+    await api.enableAgentConnectors(actor, agent.agentId, ["gmail", "runtime"]);
+
+    const eventWorkflow = await createWorkflow(actor, {
+      agentId: agent.agentId,
+      name: `event-account-readiness-${randomUUID().slice(0, 8)}`,
+      instruction: "Summarize new Gmail messages.",
+    });
+    const automation = await accept(
+      automationsClient().create({
+        headers: authHeaders(actor),
+        params: { workflowId: eventWorkflow.body.id },
+        body: {
+          kind: "event",
+          eventType: "gmail-new-message",
+          eventConfig: { provider: "gmail", event: "new_message" },
+        },
+      }),
+      [201],
+    );
+    if (automation.body.kind !== "event" || !automation.body.chatThreadId) {
+      throw new Error("Expected Gmail automation thread");
+    }
+    await accept(
+      chatThreadConnectorSelectionsClient().update({
+        headers: authHeaders(actor),
+        params: { id: automation.body.chatThreadId },
+        body: {
+          connectionId: selectedGmail.id,
+          target: { kind: "builtin", connectorSlug: "gmail" },
+        },
+      }),
+      [200],
+    );
+    await setConnectorAccountState(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      connectorId: selectedGmail.id,
+      needsReconnect: true,
+    });
+    mockConnectorReadinessModel([]);
+
+    const eventReconnect = await accept(
+      detailClient().connectorReadiness({
+        headers: authHeaders(actor),
+        params: { workflowId: eventWorkflow.body.id },
+      }),
+      [200],
+    );
+    expect(eventReconnect.body.connectors).toMatchObject([
+      {
+        connectorSlug: "gmail",
+        reason: "This workflow has a Gmail event automation.",
+        status: "reconnect-required",
+      },
+    ]);
+
+    await setConnectorAccountState(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      connectorId: selectedGmail.id,
+      needsReconnect: false,
+    });
+    const eventScopeMismatch = await accept(
+      detailClient().connectorReadiness({
+        headers: authHeaders(actor),
+        params: { workflowId: eventWorkflow.body.id },
+      }),
+      [200],
+    );
+    expect(eventScopeMismatch.body.connectors).toMatchObject([
+      {
+        connectorSlug: "gmail",
+        reason: "This workflow has a Gmail event automation.",
+        status: "scope-mismatch",
+      },
+    ]);
+
+    await setConnectorAccountState(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      connectorId: defaultRuntimeResult.body.id,
+      needsReconnect: true,
+    });
+    const modelWorkflow = await createWorkflow(actor, {
+      agentId: agent.agentId,
+      name: `model-account-readiness-${randomUUID().slice(0, 8)}`,
+      instruction: "Read Runtime jobs.",
+    });
+    const modelThread = await accept(
+      detailClient().chatThread({
+        headers: authHeaders(actor),
+        params: { workflowId: modelWorkflow.body.id },
+      }),
+      [200],
+    );
+    await accept(
+      chatThreadConnectorSelectionsClient().update({
+        headers: authHeaders(actor),
+        params: { id: modelThread.body.chatThreadId },
+        body: {
+          connectionId: selectedRuntimeResult.body.id,
+          target: { kind: "builtin", connectorSlug: "runtime" },
+        },
+      }),
+      [200],
+    );
+    mockConnectorReadinessModel([
+      {
+        connectorSlug: "runtime",
+        reason: "The workflow reads Runtime jobs.",
+      },
+    ]);
+
+    const modelSelected = await accept(
+      detailClient().connectorReadiness({
+        headers: authHeaders(actor),
+        params: { workflowId: modelWorkflow.body.id },
+      }),
+      [200],
+    );
+    expect(modelSelected.body.connectors).toMatchObject([
+      {
+        connectorSlug: "runtime",
+        reason: "The workflow reads Runtime jobs.",
+        status: "connected",
+      },
+    ]);
+
+    const noThreadWorkflow = await createWorkflow(actor, {
+      agentId: agent.agentId,
+      name: `default-account-readiness-${randomUUID().slice(0, 8)}`,
+      instruction: "Read Runtime jobs without a prepared thread.",
+    });
+    const defaultFallback = await accept(
+      detailClient().connectorReadiness({
+        headers: authHeaders(actor),
+        params: { workflowId: noThreadWorkflow.body.id },
+      }),
+      [200],
+    );
+    expect(defaultFallback.body.connectors).toMatchObject([
+      {
+        connectorSlug: "runtime",
+        reason: "The workflow reads Runtime jobs.",
+        status: "reconnect-required",
       },
     ]);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflows.test.ts
@@ -48,8 +48,11 @@ import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createFixtureTracker, createRouteMocks } from "./helpers/route-test";
 import {
+  seedBuiltinThreadConnectorSelection,
+  seedConnectorStorageRow,
   setBuiltinOAuthScopeFacts,
   setConnectorAccountState,
+  setConnectorDefaultState,
 } from "./helpers/connector-credential-storage-state";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { chatThreadRoutes } from "../chat-threads";
@@ -720,6 +723,33 @@ describe("workflows", () => {
     if (selectedRuntimeResult.status !== 200) {
       throw new Error("Expected selected Runtime account");
     }
+    await setConnectorDefaultState(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      connectorId: defaultRuntimeResult.body.id,
+      isDefault: false,
+    });
+    // The production API cannot create an account for a retired catalog auth
+    // method, but an account can become unprojectable after the catalog changes.
+    const unprojectableRuntimeId = await seedConnectorStorageRow(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      connectorSlug: "runtime",
+      authMethod: "retired-runtime-method",
+      storageVersion: 1,
+    });
+    await setConnectorDefaultState(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      connectorId: unprojectableRuntimeId,
+      isDefault: false,
+    });
+    await setConnectorDefaultState(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      connectorId: defaultRuntimeResult.body.id,
+      isDefault: true,
+    });
     await api.enableAgentConnectors(actor, agent.agentId, ["gmail", "runtime"]);
 
     const eventWorkflow = await createWorkflow(actor, {
@@ -845,6 +875,38 @@ describe("workflows", () => {
         connectorSlug: "runtime",
         reason: "The workflow reads Runtime jobs.",
         status: "connected",
+      },
+    ]);
+
+    const unprojectableWorkflow = await createWorkflow(actor, {
+      agentId: agent.agentId,
+      name: `unprojectable-account-readiness-${randomUUID().slice(0, 8)}`,
+      instruction: "Read Runtime jobs with a retired account method.",
+    });
+    const unprojectableThread = await accept(
+      detailClient().chatThread({
+        headers: authHeaders(actor),
+        params: { workflowId: unprojectableWorkflow.body.id },
+      }),
+      [200],
+    );
+    await seedBuiltinThreadConnectorSelection(context, {
+      chatThreadId: unprojectableThread.body.chatThreadId,
+      connectorId: unprojectableRuntimeId,
+      connectorSlug: "runtime",
+    });
+    const unprojectableSelected = await accept(
+      detailClient().connectorReadiness({
+        headers: authHeaders(actor),
+        params: { workflowId: unprojectableWorkflow.body.id },
+      }),
+      [200],
+    );
+    expect(unprojectableSelected.body.connectors).toMatchObject([
+      {
+        connectorSlug: "runtime",
+        reason: "The workflow reads Runtime jobs.",
+        status: "not-connected",
       },
     ]);
 

--- a/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
@@ -740,6 +740,9 @@ async function setBuiltinOAuthScopeFacts(
         eq(connectors.orgId, body.org_id),
         eq(connectors.userId, body.user_id),
         eq(connectors.connectorSlug, body.connector_slug),
+        body.connector_id === undefined
+          ? undefined
+          : eq(connectors.id, body.connector_id),
       ),
     )
     .returning({ id: connectors.id });

--- a/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
@@ -740,9 +740,7 @@ async function setBuiltinOAuthScopeFacts(
         eq(connectors.orgId, body.org_id),
         eq(connectors.userId, body.user_id),
         eq(connectors.connectorSlug, body.connector_slug),
-        body.connector_id === undefined
-          ? undefined
-          : eq(connectors.id, body.connector_id),
+        eq(connectors.id, body.connector_id),
       ),
     )
     .returning({ id: connectors.id });

--- a/turbo/apps/api/src/signals/services/connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-data.service.ts
@@ -27,10 +27,12 @@ import {
   getAllFeatureStates,
   type FeatureSwitchContext,
 } from "@okouai/core/feature-switch";
+import { chatThreadConnectorSelections } from "@okouai/db/schema/chat-thread-connector-selection";
 import { connectors } from "@okouai/db/schema/connector";
 import { secrets } from "@okouai/db/schema/secret";
 import { variables } from "@okouai/db/schema/variable";
-import { and, eq, isNotNull, sql } from "drizzle-orm";
+import { workflowUserAutomationThreads } from "@okouai/db/schema/workflow";
+import { and, eq, inArray, isNotNull, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { optionalEnv } from "../../lib/env";
@@ -525,6 +527,64 @@ interface ConnectorListState {
   readonly catalogConnections: readonly ConnectorCatalogConnection[];
 }
 
+interface StoredBuiltinConnectorRow extends StoredConnectorRow {
+  readonly connectorSlug: string;
+}
+
+function storedBuiltinConnectorSelection() {
+  return {
+    id: connectors.id,
+    connectorSlug: sql`${connectors.connectorSlug}`
+      .mapWith(pgTextDecoder)
+      .as("connector_slug"),
+    authMethod: connectors.authMethod,
+    displayName: connectors.displayName,
+    isDefault: connectors.isDefault,
+    externalId: connectors.externalId,
+    externalUsername: connectors.externalUsername,
+    externalEmail: connectors.externalEmail,
+    oauthScopes: connectors.oauthScopes,
+    oauthGrantedScopes: connectors.oauthGrantedScopes,
+    needsReconnect: connectors.needsReconnect,
+    reconnectReason: connectors.reconnectReason,
+    storageVersion: connectors.storageVersion,
+    tokenExpiresAt: connectors.tokenExpiresAt,
+    createdAt: connectors.createdAt,
+    updatedAt: connectors.updatedAt,
+  };
+}
+
+function storedBuiltinConnectorsWithRuntimeMethods(args: {
+  readonly rows: readonly StoredBuiltinConnectorRow[];
+  readonly snapshot: ConnectorRuntimeSnapshot | null;
+}): readonly ConnectorWithRuntimeMethod[] {
+  const snapshot = args.snapshot;
+  if (snapshot === null) {
+    return [];
+  }
+  const now = nowDate();
+  return args.rows.flatMap((row) => {
+    const connector = storedConnectorRowWithRuntimeMethod({
+      connectorSlug: row.connectorSlug,
+      now,
+      row,
+      snapshot,
+    });
+    return connector === null ? [] : [connector];
+  });
+}
+
+function catalogConnectionsForStoredConnectors(
+  storedConnectors: readonly ConnectorWithRuntimeMethod[],
+): readonly ConnectorCatalogConnection[] {
+  return storedConnectors.map((connector) => {
+    return {
+      response: connector.response,
+      oauthRequestedScopes: connector.oauthRequestedScopes,
+    };
+  });
+}
+
 function connectorListState(args: {
   readonly orgId: string;
   readonly userId: string;
@@ -532,26 +592,7 @@ function connectorListState(args: {
   return computed(async (get): Promise<ConnectorListState> => {
     const db = get(db$);
     const storedRowsPromise = db
-      .select({
-        id: connectors.id,
-        connectorSlug: sql`${connectors.connectorSlug}`
-          .mapWith(pgTextDecoder)
-          .as("connector_slug"),
-        authMethod: connectors.authMethod,
-        displayName: connectors.displayName,
-        isDefault: connectors.isDefault,
-        externalId: connectors.externalId,
-        externalUsername: connectors.externalUsername,
-        externalEmail: connectors.externalEmail,
-        oauthScopes: connectors.oauthScopes,
-        oauthGrantedScopes: connectors.oauthGrantedScopes,
-        needsReconnect: connectors.needsReconnect,
-        reconnectReason: connectors.reconnectReason,
-        storageVersion: connectors.storageVersion,
-        tokenExpiresAt: connectors.tokenExpiresAt,
-        createdAt: connectors.createdAt,
-        updatedAt: connectors.updatedAt,
-      })
+      .select(storedBuiltinConnectorSelection())
       .from(connectors)
       .where(
         and(
@@ -565,19 +606,10 @@ function connectorListState(args: {
       storedRowsPromise,
       loadStoredConnectorRuntimeSnapshot(db),
     ]);
-    const now = nowDate();
-    const storedConnectors: ConnectorWithRuntimeMethod[] =
-      snapshot === null
-        ? []
-        : storedRows.flatMap((row) => {
-            const connector = storedConnectorRowWithRuntimeMethod({
-              connectorSlug: row.connectorSlug,
-              now,
-              row,
-              snapshot,
-            });
-            return connector === null ? [] : [connector];
-          });
+    const storedConnectors = storedBuiltinConnectorsWithRuntimeMethods({
+      rows: storedRows,
+      snapshot,
+    });
     const connectorProvidedBindings =
       connectorProvidedBindingsForStoredConnectors(storedConnectors);
 
@@ -588,12 +620,8 @@ function connectorListState(args: {
         }),
         connectorProvidedBindings,
       },
-      catalogConnections: storedConnectors.map((connector) => {
-        return {
-          response: connector.response,
-          oauthRequestedScopes: connector.oauthRequestedScopes,
-        };
-      }),
+      catalogConnections:
+        catalogConnectionsForStoredConnectors(storedConnectors),
     };
   });
 }
@@ -614,6 +642,107 @@ export function connectorCatalogConnectionList(args: {
   return computed(
     async (get): Promise<readonly ConnectorCatalogConnection[]> => {
       return (await get(connectorListState(args))).catalogConnections;
+    },
+  );
+}
+
+interface WorkflowBuiltinConnectorSelection {
+  readonly connectorId: string;
+  readonly connectorSlug: string;
+}
+
+async function loadWorkflowBuiltinConnectorSelections(
+  db: ReadonlyDb,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly workflowId: string;
+  },
+): Promise<readonly WorkflowBuiltinConnectorSelection[]> {
+  const rows = await db
+    .select({
+      connectorId: chatThreadConnectorSelections.connectorId,
+      connectorSlug: chatThreadConnectorSelections.connectorSlug,
+    })
+    .from(workflowUserAutomationThreads)
+    .innerJoin(
+      chatThreadConnectorSelections,
+      eq(
+        chatThreadConnectorSelections.chatThreadId,
+        workflowUserAutomationThreads.chatThreadId,
+      ),
+    )
+    .where(
+      and(
+        eq(workflowUserAutomationThreads.orgId, args.orgId),
+        eq(workflowUserAutomationThreads.userId, args.userId),
+        eq(workflowUserAutomationThreads.workflowId, args.workflowId),
+        isNotNull(chatThreadConnectorSelections.connectorSlug),
+      ),
+    );
+  return rows.flatMap((row) => {
+    return row.connectorSlug === null
+      ? []
+      : [{ connectorId: row.connectorId, connectorSlug: row.connectorSlug }];
+  });
+}
+
+function selectWorkflowStoredBuiltinConnectorRows(args: {
+  readonly rows: readonly StoredBuiltinConnectorRow[];
+  readonly selections: readonly WorkflowBuiltinConnectorSelection[];
+}): readonly StoredBuiltinConnectorRow[] {
+  const selectedIdBySlug = new Map(
+    args.selections.map((selection) => {
+      return [selection.connectorSlug, selection.connectorId];
+    }),
+  );
+  return args.rows.filter((row) => {
+    const selectedId = selectedIdBySlug.get(row.connectorSlug);
+    return selectedId === undefined ? row.isDefault : row.id === selectedId;
+  });
+}
+
+export function workflowConnectorCatalogConnectionList(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly workflowId: string;
+}): Computed<Promise<readonly ConnectorCatalogConnection[]>> {
+  return computed(
+    async (get): Promise<readonly ConnectorCatalogConnection[]> => {
+      const db = get(db$);
+      const [selections, snapshot] = await Promise.all([
+        loadWorkflowBuiltinConnectorSelections(db, args),
+        loadStoredConnectorRuntimeSnapshot(db),
+      ]);
+      const selectedIds = selections.map((selection) => {
+        return selection.connectorId;
+      });
+      const storedRows = await db
+        .select(storedBuiltinConnectorSelection())
+        .from(connectors)
+        .where(
+          and(
+            eq(connectors.orgId, args.orgId),
+            eq(connectors.userId, args.userId),
+            isNotNull(connectors.connectorSlug),
+            selectedIds.length === 0
+              ? eq(connectors.isDefault, true)
+              : or(
+                  eq(connectors.isDefault, true),
+                  inArray(connectors.id, selectedIds),
+                ),
+          ),
+        );
+      const selectedRows = selectWorkflowStoredBuiltinConnectorRows({
+        rows: storedRows,
+        selections,
+      });
+      return catalogConnectionsForStoredConnectors(
+        storedBuiltinConnectorsWithRuntimeMethods({
+          rows: selectedRows,
+          snapshot,
+        }),
+      );
     },
   );
 }

--- a/turbo/apps/api/src/signals/services/workflow-connector-readiness.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-connector-readiness.service.ts
@@ -22,7 +22,7 @@ import { generateText } from "../external/openrouter";
 import { safeJsonParse } from "../utils";
 import { loadAgentConnectorScope } from "./agent-connector-scope.service";
 import { readPublicConnectorCatalogStatus } from "./connector-catalog-reader.service";
-import { connectorCatalogConnectionList } from "./connector-data.service";
+import { workflowConnectorCatalogConnectionList } from "./connector-data.service";
 
 const CONNECTOR_READINESS_MODEL = "google/gemini-3.1-flash-lite-preview";
 const CONNECTOR_READINESS_TIMEOUT_MS = 30_000;
@@ -287,9 +287,10 @@ export const detectWorkflowConnectorReadiness$ = command(
     const [connectorState, agentScope, automationDependencies] =
       await Promise.all([
         get(
-          connectorCatalogConnectionList({
+          workflowConnectorCatalogConnectionList({
             orgId: args.orgId,
             userId: args.userId,
+            workflowId: args.workflowId,
           }),
         ),
         loadAgentConnectorScope(db, {

--- a/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
@@ -197,7 +197,7 @@ export const testConnectorCredentialStorageStateActionBodySchema =
       org_id: z.string(),
       user_id: z.string(),
       connector_slug: z.string(),
-      connector_id: z.uuid().optional(),
+      connector_id: z.uuid(),
       oauth_scopes: z.array(z.string()),
       oauth_granted_scopes: z.array(z.string()).nullable(),
     }),

--- a/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
@@ -197,6 +197,7 @@ export const testConnectorCredentialStorageStateActionBodySchema =
       org_id: z.string(),
       user_id: z.string(),
       connector_slug: z.string(),
+      connector_id: z.uuid().optional(),
       oauth_scopes: z.array(z.string()),
       oauth_granted_scopes: z.array(z.string()).nullable(),
     }),


### PR DESCRIPTION
## Summary

- Resolve workflow connector readiness against the built-in account selected on the workflow's automation thread.
- Preserve default-account resolution when a workflow has no thread selection.
- Fail closed when the selected account is unavailable or its catalog auth method has been retired instead of silently substituting the default account.
- Cover event-derived and model-derived readiness, including reconnect and OAuth scope mismatch states.

## Scope

- No database migration or public runtime contract change.
- The connector credential storage contract change is limited to the test-only endpoint so multi-account scope snapshots can be targeted precisely.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api lint`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/postgres pnpm --filter api exec vitest run src/signals/routes/__tests__/workflows.test.ts -t "uses workflow thread accounts for event and model connector readiness"`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/postgres pnpm --filter api exec vitest run src/signals/routes/__tests__/workflows.test.ts -t "lets any public workflow viewer detect connector readiness"`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/postgres pnpm --filter api exec vitest run src/signals/routes/__tests__/official-workflows.test.ts -t "uses accepted Official content and installation dependencies for connector readiness"`

Baseline note: running the complete `workflows.test.ts` file also reaches an existing runner timing test failure (`Job not found in queue`, HTTP 404). The same isolated failure reproduces on unmodified `origin/main`; the readiness regression tests pass.

Closes #30826

Parent context: #30585
