### PR TITLE
refactor(python): centralize tcp message size accumulation

### DIFF
--- a/crates/runner/mitm-addon/src/tcp_logging.py
+++ b/crates/runner/mitm-addon/src/tcp_logging.py
@@ -92,11 +92,24 @@ def _has_tcp_size_counters(flow: tcp.TCPFlow) -> bool:
     )
 
 
-def _add_tcp_size(flow: tcp.TCPFlow, key: str, delta: int) -> None:
-    flow.metadata[key] = min(
-        logging_utils.NETWORK_LOG_MAX_SAFE_SIZE,
-        _tcp_counter_value(flow, key) + delta,
-    )
+def _accumulate_tcp_message_sizes(
+    messages: list[tcp.TCPMessage],
+    *,
+    request_size: int = 0,
+    response_size: int = 0,
+) -> tuple[int, int]:
+    for message in messages:
+        if message.from_client:
+            request_size = min(
+                logging_utils.NETWORK_LOG_MAX_SAFE_SIZE,
+                request_size + len(message.content),
+            )
+        else:
+            response_size = min(
+                logging_utils.NETWORK_LOG_MAX_SAFE_SIZE,
+                response_size + len(message.content),
+            )
+    return request_size, response_size
 
 
 def _schedule_tcp_message_drain(flow: tcp.TCPFlow) -> None:
@@ -115,27 +128,14 @@ def _drain_tcp_messages(flow: tcp.TCPFlow) -> None:
     if not flow.messages:
         return
 
-    for message in flow.messages:
-        key = _TCP_REQUEST_SIZE if message.from_client else _TCP_RESPONSE_SIZE
-        _add_tcp_size(flow, key, len(message.content))
+    request_size, response_size = _accumulate_tcp_message_sizes(
+        flow.messages,
+        request_size=_tcp_counter_value(flow, _TCP_REQUEST_SIZE),
+        response_size=_tcp_counter_value(flow, _TCP_RESPONSE_SIZE),
+    )
+    flow.metadata[_TCP_REQUEST_SIZE] = request_size
+    flow.metadata[_TCP_RESPONSE_SIZE] = response_size
     flow.messages.clear()
-
-
-def _sum_tcp_messages(flow: tcp.TCPFlow) -> tuple[int, int]:
-    request_size = 0
-    response_size = 0
-    for message in flow.messages:
-        if message.from_client:
-            request_size = min(
-                logging_utils.NETWORK_LOG_MAX_SAFE_SIZE,
-                request_size + len(message.content),
-            )
-        else:
-            response_size = min(
-                logging_utils.NETWORK_LOG_MAX_SAFE_SIZE,
-                response_size + len(message.content),
-            )
-    return request_size, response_size
 
 
 def _tcp_log_sizes(flow: tcp.TCPFlow) -> tuple[int, int]:
@@ -146,7 +146,7 @@ def _tcp_log_sizes(flow: tcp.TCPFlow) -> tuple[int, int]:
             _tcp_counter_value(flow, _TCP_RESPONSE_SIZE),
         )
 
-    request_size, response_size = _sum_tcp_messages(flow)
+    request_size, response_size = _accumulate_tcp_message_sizes(flow.messages)
     flow.messages.clear()
     return request_size, response_size
 

--- a/crates/runner/mitm-addon/tests/test_tcp_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_tcp_hooks.py
@@ -282,38 +282,58 @@ class TestTcpLog:
         assert scheduled == []
         assert flow.messages == messages
 
-    def test_tcp_size_counter_saturates_at_network_log_max(
-        self, tmp_path, monkeypatch, mitm_ctx, real_tcp_flow
+    @pytest.mark.parametrize(
+        "drain_before_end",
+        [
+            pytest.param(False, id="one-shot"),
+            pytest.param(True, id="deferred"),
+        ],
+    )
+    def test_tcp_size_accumulation_matches_across_drain_paths(
+        self,
+        tmp_path,
+        monkeypatch,
+        mitm_ctx,
+        real_tcp_flow,
+        drain_before_end: bool,
     ):
         max_log_size = 8
-        first_client = tcp.TCPMessage(True, b"first")
-        second_client = tcp.TCPMessage(True, b"later")
-        flow = real_tcp_flow(messages=[first_client])
+        first_messages = [
+            tcp.TCPMessage(True, b"first"),
+            tcp.TCPMessage(False, b"reply"),
+        ]
+        second_messages = [
+            tcp.TCPMessage(True, b"later"),
+            tcp.TCPMessage(False, b"again"),
+        ]
+        flow = real_tcp_flow(messages=first_messages)
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata[metadata_keys.SANDBOX_RUN_ID] = "run-abc-123"
         flow.metadata[metadata_keys.SANDBOX_NETWORK_LOG_PATH] = log_path
         monkeypatch.setattr(logging_utils, "NETWORK_LOG_MAX_SAFE_SIZE", max_log_size)
         scheduled = capture_deferred_callbacks(monkeypatch)
 
-        with mitm_ctx():
-            mitm_addon.tcp_message(flow)
+        if drain_before_end:
+            with mitm_ctx():
+                mitm_addon.tcp_message(flow)
 
-        assert len(scheduled) == 1
-
-        run_deferred_callbacks(scheduled)
-        assert flow.messages == []
-
-        flow.messages.append(second_client)
-
-        with mitm_ctx():
-            mitm_addon.tcp_message(flow)
             assert len(scheduled) == 1
-            assert flow.messages == [second_client]
+
+            run_deferred_callbacks(scheduled)
+            assert flow.messages == []
+
+        flow.messages.extend(second_messages)
+
+        with mitm_ctx():
+            if drain_before_end:
+                mitm_addon.tcp_message(flow)
+                assert len(scheduled) == 1
+                assert flow.messages == second_messages
             mitm_addon.tcp_end(flow)
 
         [entry] = read_jsonl_entries_after_flush(Path(log_path))
         assert entry["request_size"] == max_log_size
-        assert entry["response_size"] == 0
+        assert entry["response_size"] == max_log_size
         assert flow.messages == []
 
         run_deferred_callbacks(scheduled)


### PR DESCRIPTION
## Summary

- centralize TCP message direction classification and bounded byte accumulation in one seeded batch helper
- preserve deferred metadata counters, one-shot terminal totals, and processed-message clearing
- compare mixed-direction saturation through both accounting lifecycles at the public hook boundary

## Exclusions

- no network-log schema, API, protocol, persistence, dependency, migration, workflow, or rollout changes
- no compatibility fallback or feature-switch behavior

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_tcp_hooks.py` (17 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (7271 passed)

Closes #30832
