### PR TITLE
fix(platform): retry recoverable indexeddb transactions

### DIFF
--- a/turbo/apps/platform/src/shared-database/__tests__/worker-runtime.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/worker-runtime.test.ts
@@ -413,6 +413,79 @@ describe("shared database worker runtime", () => {
     expect(networkRequests).toBe(0);
   });
 
+  it.each(["UnknownError", "TransactionInactiveError", "InvalidStateError"])(
+    "reopens IndexedDB and retries a %s transaction once",
+    async (errorName) => {
+      const { runtime } = startRuntime();
+      const dataKey = chatEventKey(crypto.randomUUID());
+      const cachedRow = chatEventRow(dataKey.threadId, 1);
+      context.mocks.api(chatThreadEventsContract.snapshot, ({ respond }) => {
+        return respond(404, {
+          error: {
+            code: "CHAT_EVENT_SNAPSHOT_NOT_FOUND",
+            message: "Chat event snapshot not found",
+          },
+        });
+      });
+      context.mocks.api(chatThreadEventsContract.rows, ({ query, respond }) => {
+        return respond(
+          200,
+          chatEventRowsResponse(
+            query.sinceSeqId === 0 ? [cachedRow] : [],
+            query,
+          ),
+        );
+      });
+      await queryRuntime(runtime, {
+        dataKey,
+        afterSeqId: null,
+        consistency: "catch-up",
+      });
+      const close = vi.spyOn(IDBDatabase.prototype, "close");
+      const transaction = vi.spyOn(IDBDatabase.prototype, "transaction");
+      transaction.mockImplementationOnce(() => {
+        throw new DOMException("Injected transaction failure", errorName);
+      });
+
+      await expect(
+        queryRuntime(runtime, {
+          dataKey,
+          afterSeqId: null,
+          consistency: "cache-only",
+        }),
+      ).resolves.toStrictEqual([cachedRow]);
+      expect(transaction).toHaveBeenCalledTimes(2);
+      expect(close).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("does not retry a failing IndexedDB transaction more than once", async () => {
+    const { runtime } = startRuntime();
+    const dataKey = chatEventKey(crypto.randomUUID());
+    await queryRuntime(runtime, {
+      dataKey,
+      afterSeqId: null,
+      consistency: "cache-only",
+    });
+    const close = vi.spyOn(IDBDatabase.prototype, "close");
+    const transaction = vi.spyOn(IDBDatabase.prototype, "transaction");
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      transaction.mockImplementationOnce(() => {
+        throw new DOMException("Injected transaction failure", "UnknownError");
+      });
+    }
+
+    await expect(
+      queryRuntime(runtime, {
+        dataKey,
+        afterSeqId: null,
+        consistency: "cache-only",
+      }),
+    ).resolves.toStrictEqual([]);
+    expect(transaction).toHaveBeenCalledTimes(2);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects missing and mismatched ChatEvent response schema versions", async () => {
     const missing = startRuntime().runtime;
     const missingKey = chatEventKey(crypto.randomUUID());

--- a/turbo/apps/platform/src/shared-database/__tests__/worker-runtime.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/worker-runtime.test.ts
@@ -483,7 +483,7 @@ describe("shared database worker runtime", () => {
       }),
     ).resolves.toStrictEqual([]);
     expect(transaction).toHaveBeenCalledTimes(2);
-    expect(close).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(2);
   });
 
   it("rejects missing and mismatched ChatEvent response schema versions", async () => {

--- a/turbo/apps/platform/src/shared-database/worker-runtime.ts
+++ b/turbo/apps/platform/src/shared-database/worker-runtime.ts
@@ -160,6 +160,15 @@ function dataKeyDiagnosticDetails(dataKey: ScopedSharedDatabaseDataKey): {
   };
 }
 
+function isRecoverableChatIdbTransactionError(error: unknown): boolean {
+  return (
+    error instanceof DOMException &&
+    (error.name === "UnknownError" ||
+      error.name === "TransactionInactiveError" ||
+      error.name === "InvalidStateError")
+  );
+}
+
 function reportDataKeyError(
   dataKey: ScopedSharedDatabaseDataKey,
   operation: string,
@@ -382,11 +391,14 @@ export class SharedDatabaseWorkerRuntime {
     dataKey: ScopedChatEventDataKey,
     signal: AbortSignal,
   ): Promise<readonly ChatEventRow[]> {
-    const stores = createIdbEventRowStores(() => {
-      return this.getDatabase(signal);
-    });
     const cachedCursorResult = await settle(
-      stores.readStore.readCursor(dataKey.threadId, signal),
+      this.runChatIdbOperation(
+        createIdbEventRowStores,
+        (stores) => {
+          return stores.readStore.readCursor(dataKey.threadId, signal);
+        },
+        signal,
+      ),
       signal,
     );
     const cachedCursor = cachedCursorResult.ok
@@ -443,12 +455,11 @@ export class SharedDatabaseWorkerRuntime {
       state,
       signal,
     );
-    await this.persistChatEventRows(stores, dataKey, state, signal);
+    await this.persistChatEventRows(dataKey, state, signal);
     return state.remoteRows;
   }
 
   private async persistChatEventRows(
-    stores: ReturnType<typeof createIdbEventRowStores>,
     dataKey: ScopedChatEventDataKey,
     state: ChatEventRemoteState,
     signal: AbortSignal,
@@ -456,20 +467,28 @@ export class SharedDatabaseWorkerRuntime {
     if (!state.replacedCache && state.remoteRows.length === 0) {
       return;
     }
-    const write = state.replacedCache
-      ? stores.writeStore.replaceRowsAndCursor(
-          dataKey.threadId,
-          state.remoteRows,
-          state.cursor,
-          signal,
-        )
-      : stores.writeStore.upsertRowsAndCursor(
-          dataKey.threadId,
-          state.remoteRows,
-          state.cursor,
-          signal,
-        );
-    const written = await settle(write, signal);
+    const written = await settle(
+      this.runChatIdbOperation(
+        createIdbEventRowStores,
+        (stores) => {
+          return state.replacedCache
+            ? stores.writeStore.replaceRowsAndCursor(
+                dataKey.threadId,
+                state.remoteRows,
+                state.cursor,
+                signal,
+              )
+            : stores.writeStore.upsertRowsAndCursor(
+                dataKey.threadId,
+                state.remoteRows,
+                state.cursor,
+                signal,
+              );
+        },
+        signal,
+      ),
+      signal,
+    );
     if (!written.ok) {
       reportDataKeyError(
         dataKey,
@@ -660,25 +679,30 @@ export class SharedDatabaseWorkerRuntime {
 
     const shouldWrite = state.replacement || state.newEvents.length > 0;
     if (shouldWrite) {
-      const stores = createStrictIdbChatThreadEventStores(() => {
-        return this.getDatabase(signal);
-      });
       const snapshot = state.result.snapshot;
       if (!snapshot) {
         throw new Error("ChatThreadEvent synchronization requires a snapshot");
       }
-      const write = state.replacement
-        ? stores.writeStore.replaceFromSnapshot(
-            {
-              chatThreads: snapshot.chatThreads,
-              latestEventId: snapshot.latestEventId,
-              latestSeqId: snapshot.latestSeqId,
-            },
-            state.result.events,
-            signal,
-          )
-        : stores.writeStore.upsertEvents(state.newEvents, signal);
-      const written = await settle(write, signal);
+      const written = await settle(
+        this.runChatIdbOperation(
+          createStrictIdbChatThreadEventStores,
+          (stores) => {
+            return state.replacement
+              ? stores.writeStore.replaceFromSnapshot(
+                  {
+                    chatThreads: snapshot.chatThreads,
+                    latestEventId: snapshot.latestEventId,
+                    latestSeqId: snapshot.latestSeqId,
+                  },
+                  state.result.events,
+                  signal,
+                )
+              : stores.writeStore.upsertEvents(state.newEvents, signal);
+          },
+          signal,
+        ),
+        signal,
+      );
       if (!written.ok) {
         reportDataKeyError(
           dataKey,
@@ -822,11 +846,18 @@ export class SharedDatabaseWorkerRuntime {
     afterSeqId: number | null,
     signal: AbortSignal,
   ): Promise<ChatEventRow[]> {
-    const stores = createIdbEventRowStores(() => {
-      return this.getDatabase(signal);
-    });
     const result = await settle(
-      stores.readStore.readRowsAfter(dataKey.threadId, afterSeqId, signal),
+      this.runChatIdbOperation(
+        createIdbEventRowStores,
+        (stores) => {
+          return stores.readStore.readRowsAfter(
+            dataKey.threadId,
+            afterSeqId,
+            signal,
+          );
+        },
+        signal,
+      ),
       signal,
     );
     if (!result.ok) {
@@ -844,14 +875,17 @@ export class SharedDatabaseWorkerRuntime {
     dataKey: ScopedChatThreadEventDataKey,
     signal: AbortSignal,
   ): Promise<ChatThreadEventCache> {
-    const stores = createStrictIdbChatThreadEventStores(() => {
-      return this.getDatabase(signal);
-    });
     const result = await settle(
-      Promise.all([
-        stores.readStore.readSnapshot(signal),
-        stores.readStore.readEventLog(signal),
-      ]),
+      this.runChatIdbOperation(
+        createStrictIdbChatThreadEventStores,
+        (stores) => {
+          return Promise.all([
+            stores.readStore.readSnapshot(signal),
+            stores.readStore.readEventLog(signal),
+          ]);
+        },
+        signal,
+      ),
       signal,
     );
     if (!result.ok) {
@@ -882,7 +916,43 @@ export class SharedDatabaseWorkerRuntime {
     };
   }
 
-  private async getDatabase(signal: AbortSignal): Promise<IDBPDatabase> {
+  private async runChatIdbOperation<TStores, TResult>(
+    createStores: (getDatabase: () => Promise<IDBPDatabase>) => TStores,
+    operation: (stores: TStores) => Promise<TResult>,
+    signal: AbortSignal,
+  ): Promise<TResult> {
+    const run = (database: IDBPDatabase): Promise<TResult> => {
+      return operation(
+        createStores(() => {
+          return Promise.resolve(database);
+        }),
+      );
+    };
+    const firstConnection = await this.getDatabaseConnection(signal);
+    const firstResult = await settle(run(firstConnection.database), signal);
+    if (firstResult.ok) {
+      return firstResult.value;
+    }
+    if (!isRecoverableChatIdbTransactionError(firstResult.error)) {
+      throw firstResult.error;
+    }
+    this.discardDatabase(firstConnection.entry);
+    const retryConnection = await this.getDatabaseConnection(signal);
+    return await run(retryConnection.database);
+  }
+
+  private discardDatabase(entry: ChatDatabaseEntry): void {
+    if (this.databaseEntry !== entry) {
+      return;
+    }
+    entry.database?.close();
+    this.databaseEntry = null;
+  }
+
+  private async getDatabaseConnection(signal: AbortSignal): Promise<{
+    readonly entry: ChatDatabaseEntry;
+    readonly database: IDBPDatabase;
+  }> {
     let entry = this.databaseEntry;
     if (!entry) {
       const opener = createChatIdbOpener({
@@ -913,7 +983,7 @@ export class SharedDatabaseWorkerRuntime {
     if (entry.invalidated) {
       throw new Error("Chat IndexedDB version changed; reload is required");
     }
-    return database;
+    return { entry, database };
   }
 
   private blockCredential(rejectedToken: string): void {

--- a/turbo/apps/platform/src/shared-database/worker-runtime.ts
+++ b/turbo/apps/platform/src/shared-database/worker-runtime.ts
@@ -938,7 +938,14 @@ export class SharedDatabaseWorkerRuntime {
     }
     this.discardDatabase(firstConnection.entry);
     const retryConnection = await this.getDatabaseConnection(signal);
-    return await run(retryConnection.database);
+    const retryResult = await settle(run(retryConnection.database), signal);
+    if (retryResult.ok) {
+      return retryResult.value;
+    }
+    if (isRecoverableChatIdbTransactionError(retryResult.error)) {
+      this.discardDatabase(retryConnection.entry);
+    }
+    throw retryResult.error;
   }
 
   private discardDatabase(entry: ChatDatabaseEntry): void {


### PR DESCRIPTION
## Summary

- close and discard the cached chat IndexedDB connection when a transaction fails with `UnknownError`, `TransactionInactiveError`, or `InvalidStateError`
- reopen the database and recreate the full read or write operation exactly once for both ChatEvent and ChatThreadEvent stores
- preserve the existing fallback and Sentry reporting behavior when the retry also fails; leave `versionchange` behavior unchanged

## Testing

- `pnpm --filter @okouai/app exec vitest run src/shared-database/__tests__/worker-runtime.test.ts` (18 tests)
- `pnpm --filter @okouai/app exec tsc -p tsconfig.tests.json --noEmit --pretty false`
- `pnpm --filter @okouai/app exec eslint src/shared-database/worker-runtime.ts src/shared-database/__tests__/worker-runtime.test.ts --max-warnings 0 --no-cache`
- `pnpm exec prettier --check apps/platform/src/shared-database/worker-runtime.ts apps/platform/src/shared-database/__tests__/worker-runtime.test.ts`
