### PR TITLE
feat: support automatic oauth for mcp connectors

### DIFF
--- a/turbo/apps/api/src/lib/error.ts
+++ b/turbo/apps/api/src/lib/error.ts
@@ -22,6 +22,10 @@ export function conflict(message: string) {
   return httpError(409, "CONFLICT", message);
 }
 
+export function badGateway(message: string) {
+  return httpError(502, "UPSTREAM_UNAVAILABLE", message);
+}
+
 export const AUTONOMY_BUDGET_EXHAUSTED_MESSAGE =
   "Maximum autonomous delegation depth reached. Send a new human message or confirm a permission request to continue.";
 

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -3394,6 +3394,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     mockEnv("APP_URL", "https://app.vm0.ai");
     const provider = mockAutomaticMcpOAuthProvider(context, {
       registration: "dcr",
+      synchronizeAuthorizationServerDiscovery: true,
     });
     const admin = createBddApi(context).user({ orgRole: "org:admin" });
     await connectorsApi.updateFeatureSwitches(admin, {
@@ -3422,6 +3423,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       connectorsApi.startCustomConnectorOAuth2(admin, connector.id),
     ]);
     expect(authorizationUrls).toHaveLength(2);
+    expect(provider.authorizationServerDiscoveryCalls()).toBe(2);
     expect(provider.registrationBodies).toHaveLength(1);
 
     await connectorsApi.deleteCustomConnector(admin, connector.id);

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -3472,25 +3472,27 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     expect(discoveryProvider.registrationBodies).toHaveLength(0);
     await connectorsApi.deleteCustomConnector(admin, discoveryConnector.id);
 
-    const dcrProvider = mockAutomaticMcpOAuthProvider(context, {
-      registration: "dcr",
-      dcrFailureStatus: 503,
-    });
-    const dcrConnector = await connectorsApi.createCustomConnector(admin, {
-      ...connectorBody,
-      displayName: "BDD Temporary Automatic DCR",
-    });
-    const dcrFailure = await connectorsApi.requestStartCustomConnectorOAuth2(
-      admin,
-      dcrConnector.id,
-      [502],
-    );
-    expectApiError(dcrFailure.body);
-    expect(dcrFailure.body.error).toMatchObject({
-      code: "UPSTREAM_UNAVAILABLE",
-    });
-    expect(dcrProvider.registrationBodies).toHaveLength(1);
-    await connectorsApi.deleteCustomConnector(admin, dcrConnector.id);
+    for (const status of [429, 503]) {
+      const dcrProvider = mockAutomaticMcpOAuthProvider(context, {
+        registration: "dcr",
+        dcrFailureStatus: status,
+      });
+      const dcrConnector = await connectorsApi.createCustomConnector(admin, {
+        ...connectorBody,
+        displayName: `BDD Temporary Automatic DCR ${status}`,
+      });
+      const dcrFailure = await connectorsApi.requestStartCustomConnectorOAuth2(
+        admin,
+        dcrConnector.id,
+        [502],
+      );
+      expectApiError(dcrFailure.body);
+      expect(dcrFailure.body.error).toMatchObject({
+        code: "UPSTREAM_UNAVAILABLE",
+      });
+      expect(dcrProvider.registrationBodies).toHaveLength(1);
+      await connectorsApi.deleteCustomConnector(admin, dcrConnector.id);
+    }
   });
 
   it.each([

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { randomInt, randomUUID } from "node:crypto";
+import { Buffer } from "node:buffer";
 
 import type { ConnectorResponse } from "@okouai/api-contracts/contracts/connector-schemas";
 import { connectorCatalogContract } from "@okouai/api-contracts/contracts/connector-catalog";
@@ -40,6 +41,7 @@ import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
 import {
   createConnectorBddApi,
   manualHttpCustomConnectorCreateBody,
+  mockAutomaticMcpOAuthProvider,
   mockBase44OAuthProvider,
   mockCustomConnectorOAuth2Provider,
   mockDatadogConnectorOAuth,
@@ -3033,7 +3035,526 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     await bdd.deleteAgent(member, agent.agentId);
   });
 
-  it("models Automatic OAuth without enabling incomplete production writes", async () => {
+  it("connects an Automatic MCP OAuth account through Okou CIMD", async () => {
+    mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+    mockEnv("OKOU_WEB_URL", "https://www.vm0.ai");
+    mockEnv("APP_URL", "https://app.vm0.ai");
+    const provider = mockAutomaticMcpOAuthProvider(context, {
+      registration: "cimd",
+    });
+    const admin = createBddApi(context).user({ orgRole: "org:admin" });
+    await connectorsApi.updateFeatureSwitches(admin, {
+      [FeatureSwitchKey.CustomConnectorMcp]: true,
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
+    const connector = await connectorsApi.createCustomConnector(admin, {
+      kind: "mcp",
+      displayName: "BDD Automatic CIMD",
+      endpoint: provider.endpoint,
+      transport: "streamable-http",
+      fields: [],
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{oauth.access_token}}",
+        },
+      ],
+      queryInjections: [],
+      authMode: "oauth",
+      oauthSetup: "automatic",
+    });
+
+    const authorizationUrl = new URL(
+      await connectorsApi.startCustomConnectorOAuth2(admin, connector.id),
+    );
+    expect(authorizationUrl.origin + authorizationUrl.pathname).toBe(
+      `${provider.issuer}/authorize`,
+    );
+    expect(authorizationUrl.searchParams.get("client_id")).toBe(
+      "https://api.okou.ai/api/oauth/mcp/client-metadata/okou.json",
+    );
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+      "https://app.okou.ai/connectors/custom/callback",
+    );
+    expect(authorizationUrl.searchParams.get("resource")).toBe(
+      provider.endpoint,
+    );
+    expect(authorizationUrl.searchParams.get("scope")).toBe("read write");
+    expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe(
+      "S256",
+    );
+
+    const completed =
+      await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
+        code: "automatic-cimd-code",
+        state: stateFromAuthorizationUrl(authorizationUrl.toString()),
+        iss: provider.issuer,
+      });
+    expect(completed.body).toStrictEqual({
+      status: "success",
+      username: null,
+    });
+    expect(provider.registrationBodies).toHaveLength(0);
+    expect(provider.tokenBodies).toHaveLength(1);
+    expect(provider.tokenBodies[0]?.get("resource")).toBe(provider.endpoint);
+    expect(provider.tokenBodies[0]?.get("client_id")).toBe(
+      "https://api.okou.ai/api/oauth/mcp/client-metadata/okou.json",
+    );
+    await expect(
+      connectorsApi.readCustomConnector(admin, connector.id),
+    ).resolves.toMatchObject({ connected: true, oauthSetup: "automatic" });
+    const accounts = await connectorsApi.listCustomConnectorAccounts(
+      admin,
+      connector.id,
+    );
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0]?.oauthScopes).toStrictEqual(["read", "write"]);
+
+    await connectorsApi.deleteCustomConnector(admin, connector.id);
+  });
+
+  it("rejects Automatic OAuth callback authority drift before token exchange", async () => {
+    mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+    mockEnv("OKOU_WEB_URL", "https://www.vm0.ai");
+    mockEnv("APP_URL", "https://app.vm0.ai");
+    const provider = mockAutomaticMcpOAuthProvider(context, {
+      registration: "cimd",
+    });
+    const admin = createBddApi(context).user({ orgRole: "org:admin" });
+    await connectorsApi.updateFeatureSwitches(admin, {
+      [FeatureSwitchKey.CustomConnectorMcp]: true,
+    });
+    const definition = {
+      kind: "mcp" as const,
+      displayName: "BDD Automatic Callback Binding",
+      endpoint: provider.endpoint,
+      transport: "streamable-http" as const,
+      fields: [],
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{oauth.access_token}}",
+        },
+      ],
+      queryInjections: [],
+      authMode: "oauth" as const,
+      oauthSetup: "automatic" as const,
+    };
+    const connector = await connectorsApi.createCustomConnector(
+      admin,
+      definition,
+    );
+
+    const missingIssuerAuthorization =
+      await connectorsApi.startCustomConnectorOAuth2(admin, connector.id);
+    const missingIssuer =
+      await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
+        code: "automatic-missing-issuer-code",
+        state: stateFromAuthorizationUrl(missingIssuerAuthorization),
+      });
+    expect(missingIssuer.body).toStrictEqual({
+      status: "error",
+      message: "OAuth authorization issuer did not match - please try again",
+    });
+
+    const wrongIssuerAuthorization =
+      await connectorsApi.startCustomConnectorOAuth2(admin, connector.id);
+    const wrongIssuer =
+      await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
+        code: "automatic-wrong-issuer-code",
+        state: stateFromAuthorizationUrl(wrongIssuerAuthorization),
+        iss: "https://other-issuer.example.test",
+      });
+    expect(wrongIssuer.body).toStrictEqual({
+      status: "error",
+      message: "OAuth authorization issuer did not match - please try again",
+    });
+
+    const changedEndpointAuthorization =
+      await connectorsApi.startCustomConnectorOAuth2(admin, connector.id);
+    await expect(
+      connectorsApi.updateCustomConnector(admin, connector.id, {
+        ...definition,
+        endpoint: "https://replacement-mcp.example.test/server",
+      }),
+    ).resolves.toMatchObject({ storageVersion: 2 });
+    const changedEndpoint =
+      await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
+        code: "automatic-changed-endpoint-code",
+        state: stateFromAuthorizationUrl(changedEndpointAuthorization),
+        iss: provider.issuer,
+      });
+    expect(changedEndpoint.body).toStrictEqual({
+      status: "error",
+      message:
+        "Custom connector OAuth configuration changed - please try again",
+    });
+    expect(provider.tokenBodies).toHaveLength(0);
+
+    await connectorsApi.deleteCustomConnector(admin, connector.id);
+  });
+
+  it("reuses one DCR client across Automatic MCP OAuth accounts", async () => {
+    mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+    mockEnv("OKOU_WEB_URL", "https://www.vm0.ai");
+    mockEnv("APP_URL", "https://app.vm0.ai");
+    const provider = mockAutomaticMcpOAuthProvider(context, {
+      registration: "dcr",
+    });
+    const admin = createBddApi(context).user({ orgRole: "org:admin" });
+    await connectorsApi.updateFeatureSwitches(admin, {
+      [FeatureSwitchKey.CustomConnectorMcp]: true,
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
+    const connector = await connectorsApi.createCustomConnector(admin, {
+      kind: "mcp",
+      displayName: "BDD Automatic DCR",
+      endpoint: provider.endpoint,
+      transport: "streamable-http",
+      fields: [],
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{oauth.access_token}}",
+        },
+      ],
+      queryInjections: [],
+      authMode: "oauth",
+      oauthSetup: "automatic",
+    });
+
+    const firstAuthorization = await connectorsApi.startCustomConnectorOAuth2(
+      admin,
+      connector.id,
+    );
+    expect(new URL(firstAuthorization).searchParams.get("client_id")).toBe(
+      "automatic-dcr-client",
+    );
+    await connectorsApi.completeCustomConnectorOAuth2Callback({
+      code: "automatic-dcr-first-code",
+      state: stateFromAuthorizationUrl(firstAuthorization),
+      iss: provider.issuer,
+    });
+    const secondAuthorization = await connectorsApi.startCustomConnectorOAuth2(
+      admin,
+      connector.id,
+      undefined,
+      { intent: "add", displayName: "Second" },
+    );
+    await connectorsApi.completeCustomConnectorOAuth2Callback({
+      code: "automatic-dcr-second-code",
+      state: stateFromAuthorizationUrl(secondAuthorization),
+      iss: provider.issuer,
+    });
+
+    expect(provider.registrationBodies).toHaveLength(1);
+    expect(provider.registrationBodies[0]).toMatchObject({
+      redirect_uris: ["https://app.okou.ai/connectors/custom/callback"],
+      scope: "read write",
+    });
+    expect(provider.tokenBodies).toHaveLength(2);
+    expect(provider.tokenAuthorizationHeaders).toStrictEqual([
+      `Basic ${Buffer.from(
+        "automatic-dcr-client:automatic-dcr-secret",
+        "utf8",
+      ).toString("base64")}`,
+      `Basic ${Buffer.from(
+        "automatic-dcr-client:automatic-dcr-secret",
+        "utf8",
+      ).toString("base64")}`,
+    ]);
+    await expect(
+      connectorsApi.listCustomConnectorAccounts(admin, connector.id),
+    ).resolves.toHaveLength(2);
+
+    await connectorsApi.deleteCustomConnector(admin, connector.id);
+  });
+
+  it.each([
+    {
+      tokenEndpointAuthMethod: "none" as const,
+      expectedAuthorization: null,
+      expectedClientSecret: null,
+    },
+    {
+      tokenEndpointAuthMethod: "client_secret_post" as const,
+      expectedAuthorization: null,
+      expectedClientSecret: "automatic-dcr-secret",
+    },
+  ])(
+    "connects an Automatic DCR client using $tokenEndpointAuthMethod",
+    async ({
+      tokenEndpointAuthMethod,
+      expectedAuthorization,
+      expectedClientSecret,
+    }) => {
+      mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+      mockEnv("OKOU_WEB_URL", "https://www.vm0.ai");
+      mockEnv("APP_URL", "https://app.vm0.ai");
+      const provider = mockAutomaticMcpOAuthProvider(context, {
+        registration: "dcr",
+        dcrTokenEndpointAuthMethod: tokenEndpointAuthMethod,
+      });
+      const admin = createBddApi(context).user({ orgRole: "org:admin" });
+      await connectorsApi.updateFeatureSwitches(admin, {
+        [FeatureSwitchKey.CustomConnectorMcp]: true,
+      });
+      const connector = await connectorsApi.createCustomConnector(admin, {
+        kind: "mcp",
+        displayName: `BDD Automatic DCR ${tokenEndpointAuthMethod}`,
+        endpoint: provider.endpoint,
+        transport: "streamable-http",
+        fields: [],
+        headerInjections: [
+          {
+            name: "Authorization",
+            valueTemplate: "Bearer {{oauth.access_token}}",
+          },
+        ],
+        queryInjections: [],
+        authMode: "oauth",
+        oauthSetup: "automatic",
+      });
+
+      const authorizationUrl = await connectorsApi.startCustomConnectorOAuth2(
+        admin,
+        connector.id,
+      );
+      await connectorsApi.completeCustomConnectorOAuth2Callback({
+        code: `automatic-${tokenEndpointAuthMethod}-code`,
+        state: stateFromAuthorizationUrl(authorizationUrl),
+        iss: provider.issuer,
+      });
+
+      expect(provider.registrationBodies).toHaveLength(1);
+      expect(provider.tokenAuthorizationHeaders).toStrictEqual([
+        expectedAuthorization,
+      ]);
+      expect(provider.tokenBodies[0]?.get("client_id")).toBe(
+        "automatic-dcr-client",
+      );
+      expect(provider.tokenBodies[0]?.get("client_secret")).toBe(
+        expectedClientSecret,
+      );
+
+      await connectorsApi.deleteCustomConnector(admin, connector.id);
+    },
+  );
+
+  it("discovers Automatic OAuth through RFC 9728 and OIDC fallbacks", async () => {
+    mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+    mockEnv("OKOU_WEB_URL", "https://www.vm0.ai");
+    mockEnv("APP_URL", "https://app.vm0.ai");
+    const provider = mockAutomaticMcpOAuthProvider(context, {
+      registration: "cimd",
+      discovery: "well-known-oidc",
+      challengeScope: null,
+      metadataScopes: ["metadata-read", "metadata-write"],
+      issuerParameterSupported: false,
+    });
+    const admin = createBddApi(context).user({ orgRole: "org:admin" });
+    await connectorsApi.updateFeatureSwitches(admin, {
+      [FeatureSwitchKey.CustomConnectorMcp]: true,
+    });
+    const connector = await connectorsApi.createCustomConnector(admin, {
+      kind: "mcp",
+      displayName: "BDD Automatic Discovery Fallback",
+      endpoint: provider.endpoint,
+      transport: "streamable-http",
+      fields: [],
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{oauth.access_token}}",
+        },
+      ],
+      queryInjections: [],
+      authMode: "oauth",
+      oauthSetup: "automatic",
+    });
+
+    const authorizationUrl = new URL(
+      await connectorsApi.startCustomConnectorOAuth2(admin, connector.id),
+    );
+    expect(authorizationUrl.searchParams.get("scope")).toBe(
+      "metadata-read metadata-write",
+    );
+    await connectorsApi.completeCustomConnectorOAuth2Callback({
+      code: "automatic-discovery-fallback-code",
+      state: stateFromAuthorizationUrl(authorizationUrl.toString()),
+    });
+    expect(provider.tokenBodies).toHaveLength(1);
+
+    await connectorsApi.deleteCustomConnector(admin, connector.id);
+  });
+
+  it("serializes concurrent first Automatic DCR registrations", async () => {
+    mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+    mockEnv("OKOU_WEB_URL", "https://www.vm0.ai");
+    mockEnv("APP_URL", "https://app.vm0.ai");
+    const provider = mockAutomaticMcpOAuthProvider(context, {
+      registration: "dcr",
+    });
+    const admin = createBddApi(context).user({ orgRole: "org:admin" });
+    await connectorsApi.updateFeatureSwitches(admin, {
+      [FeatureSwitchKey.CustomConnectorMcp]: true,
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
+    const connector = await connectorsApi.createCustomConnector(admin, {
+      kind: "mcp",
+      displayName: "BDD Concurrent Automatic DCR",
+      endpoint: provider.endpoint,
+      transport: "streamable-http",
+      fields: [],
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{oauth.access_token}}",
+        },
+      ],
+      queryInjections: [],
+      authMode: "oauth",
+      oauthSetup: "automatic",
+    });
+
+    const authorizationUrls = await Promise.all([
+      connectorsApi.startCustomConnectorOAuth2(admin, connector.id),
+      connectorsApi.startCustomConnectorOAuth2(admin, connector.id),
+    ]);
+    expect(authorizationUrls).toHaveLength(2);
+    expect(provider.registrationBodies).toHaveLength(1);
+
+    await connectorsApi.deleteCustomConnector(admin, connector.id);
+  });
+
+  it("maps temporary Automatic OAuth discovery and DCR failures to 502", async () => {
+    mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+    mockEnv("OKOU_WEB_URL", "https://www.vm0.ai");
+    mockEnv("APP_URL", "https://app.vm0.ai");
+    const admin = createBddApi(context).user({ orgRole: "org:admin" });
+    await connectorsApi.updateFeatureSwitches(admin, {
+      [FeatureSwitchKey.CustomConnectorMcp]: true,
+    });
+    const connectorBody = {
+      kind: "mcp" as const,
+      displayName: "BDD Temporary Automatic OAuth",
+      endpoint: "https://automatic-mcp.example.test/server",
+      transport: "streamable-http" as const,
+      fields: [],
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{oauth.access_token}}",
+        },
+      ],
+      queryInjections: [],
+      authMode: "oauth" as const,
+      oauthSetup: "automatic" as const,
+    };
+    const discoveryProvider = mockAutomaticMcpOAuthProvider(context, {
+      registration: "cimd",
+      resourceMetadataStatus: 503,
+    });
+    const discoveryConnector = await connectorsApi.createCustomConnector(
+      admin,
+      connectorBody,
+    );
+    const discoveryFailure =
+      await connectorsApi.requestStartCustomConnectorOAuth2(
+        admin,
+        discoveryConnector.id,
+        [502],
+      );
+    expectApiError(discoveryFailure.body);
+    expect(discoveryFailure.body.error).toMatchObject({
+      code: "UPSTREAM_UNAVAILABLE",
+    });
+    expect(discoveryProvider.registrationBodies).toHaveLength(0);
+    await connectorsApi.deleteCustomConnector(admin, discoveryConnector.id);
+
+    const dcrProvider = mockAutomaticMcpOAuthProvider(context, {
+      registration: "dcr",
+      dcrFailureStatus: 503,
+    });
+    const dcrConnector = await connectorsApi.createCustomConnector(admin, {
+      ...connectorBody,
+      displayName: "BDD Temporary Automatic DCR",
+    });
+    const dcrFailure = await connectorsApi.requestStartCustomConnectorOAuth2(
+      admin,
+      dcrConnector.id,
+      [502],
+    );
+    expectApiError(dcrFailure.body);
+    expect(dcrFailure.body.error).toMatchObject({
+      code: "UPSTREAM_UNAVAILABLE",
+    });
+    expect(dcrProvider.registrationBodies).toHaveLength(1);
+    await connectorsApi.deleteCustomConnector(admin, dcrConnector.id);
+  });
+
+  it.each([
+    {
+      boundary: "a mismatched protected resource",
+      providerOptions: {
+        registration: "cimd" as const,
+        resource: "https://automatic-mcp.example.test/other-resource",
+      },
+    },
+    {
+      boundary: "an unsafe authorization endpoint",
+      providerOptions: {
+        registration: "cimd" as const,
+        authorizationEndpoint: "https://localhost/authorize",
+      },
+    },
+    {
+      boundary: "a mismatched metadata issuer",
+      providerOptions: {
+        registration: "cimd" as const,
+        metadataIssuer: "https://other-issuer.example.test",
+      },
+    },
+  ])("rejects Automatic OAuth with $boundary", async ({ providerOptions }) => {
+    mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+    mockEnv("OKOU_WEB_URL", "https://www.vm0.ai");
+    mockEnv("APP_URL", "https://app.vm0.ai");
+    const provider = mockAutomaticMcpOAuthProvider(context, providerOptions);
+    const admin = createBddApi(context).user({ orgRole: "org:admin" });
+    await connectorsApi.updateFeatureSwitches(admin, {
+      [FeatureSwitchKey.CustomConnectorMcp]: true,
+    });
+    const connector = await connectorsApi.createCustomConnector(admin, {
+      kind: "mcp",
+      displayName: "BDD Rejected Automatic OAuth",
+      endpoint: provider.endpoint,
+      transport: "streamable-http",
+      fields: [],
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{oauth.access_token}}",
+        },
+      ],
+      queryInjections: [],
+      authMode: "oauth",
+      oauthSetup: "automatic",
+    });
+
+    const rejected = await connectorsApi.requestStartCustomConnectorOAuth2(
+      admin,
+      connector.id,
+      [400],
+    );
+    expectApiError(rejected.body);
+    expect(rejected.body.error.code).toBe("BAD_REQUEST");
+    expect(provider.registrationBodies).toHaveLength(0);
+    expect(provider.tokenBodies).toHaveLength(0);
+
+    await connectorsApi.deleteCustomConnector(admin, connector.id);
+  });
+
+  it("models Automatic OAuth definitions, bindings, and state", async () => {
     mockEnv("APP_URL", "https://app.vm0.test");
     const bdd = createBddApi(context);
     const admin = bdd.user({ orgRole: "org:admin" });
@@ -3057,31 +3578,28 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       oauthSetup: "automatic" as const,
     };
 
-    const before = await connectorsApi.listCustomConnectors(admin);
-    const rejected = await connectorsApi.requestCreateCustomConnector(
+    const createdDefinition = await connectorsApi.createCustomConnector(
       admin,
       definition,
-      [400],
     );
-    expectApiError(rejected.body);
-    expect(rejected.body.error.message).toBe(
-      "Automatic OAuth connector setup is not enabled yet",
-    );
-    await expect(
-      connectorsApi.listCustomConnectors(admin),
-    ).resolves.toHaveLength(before.length);
+    expect(createdDefinition).toMatchObject({
+      authMode: "oauth",
+      oauthSetup: "automatic",
+    });
+    await connectorsApi.deleteCustomConnector(admin, createdDefinition.id);
 
     const customConnectorId = randomUUID();
     const connectorAccountId = randomUUID();
     const dcrRegistrationId = randomUUID();
     const encryptedClientSecret = "encrypted-dcr-client-secret";
+    const seededEndpoint = "https://mcp.example.test/";
     await seedAutomaticOAuthBindingState(context, {
       orgId: requiredOrgId(admin),
       userId: admin.userId,
       customConnectorId,
       connectorAccountId,
       issuer: "https://issuer.example.test",
-      resource: definition.endpoint,
+      resource: seededEndpoint,
       resourceMetadataUrl:
         "https://automatic-mcp.example.test/.well-known/oauth-protected-resource",
       tokenEndpoint: "https://issuer.example.test/token",
@@ -3187,10 +3705,12 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
         connectorId: customConnectorId,
         storageVersion: 1,
         issuer: "https://issuer.example.test",
-        resource: definition.endpoint,
+        resource: seededEndpoint,
         resourceMetadataUrl:
           "https://automatic-mcp.example.test/.well-known/oauth-protected-resource",
+        authorizationEndpoint: "https://issuer.example.test/authorize",
         tokenEndpoint: "https://issuer.example.test/token",
+        authorizationResponseIssParameterSupported: true,
         clientId: "automatic-dcr-client",
         tokenEndpointAuthMethod: "client_secret_basic",
         registrationMethod: "dcr",
@@ -3209,11 +3729,11 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
         code: "automatic-oauth-code",
         state: validState,
+        iss: "https://issuer.example.test",
       });
     expect(callback.body).toStrictEqual({
       status: "error",
-      message:
-        "Custom connector OAuth configuration changed - please try again",
+      message: "OAuth token exchange failed - please try again",
     });
 
     const malformedState = `malformed-automatic-oauth-${randomUUID()}`;
@@ -3277,19 +3797,15 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       valid: false,
       registration_method: null,
     });
-    const rejectedUpdate = await connectorsApi.requestUpdateCustomConnector(
+    const automaticUpdate = await connectorsApi.updateCustomConnector(
       admin,
       customConnectorId,
       definition,
-      [400],
     );
-    expectApiError(rejectedUpdate.body);
-    expect(rejectedUpdate.body.error.message).toBe(
-      "Automatic OAuth connector setup is not enabled yet",
-    );
-    await expect(
-      connectorsApi.readCustomConnector(admin, customConnectorId),
-    ).resolves.toMatchObject({ oauthSetup: "custom", storageVersion: 2 });
+    expect(automaticUpdate).toMatchObject({
+      oauthSetup: "automatic",
+      storageVersion: 3,
+    });
     await connectorsApi.deleteCustomConnector(admin, customConnectorId);
 
     const invalidConnectorId = randomUUID();

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -281,6 +281,7 @@ interface AutomaticMcpOAuthProviderOptions {
     | "none"
     | "client_secret_basic"
     | "client_secret_post";
+  readonly synchronizeAuthorizationServerDiscovery?: boolean;
   readonly dcrFailureStatus?: number;
   readonly discovery?: "challenge" | "well-known-oidc";
   readonly resourceMetadataStatus?: number;
@@ -305,6 +306,7 @@ interface AutomaticMcpOAuthProviderRecorder {
   readonly endpoint: string;
   readonly issuer: string;
   readonly registrationBodies: readonly Record<string, unknown>[];
+  authorizationServerDiscoveryCalls(): number;
   readonly tokenBodies: readonly URLSearchParams[];
   readonly tokenAuthorizationHeaders: readonly (string | null)[];
 }
@@ -359,7 +361,32 @@ export function mockAutomaticMcpOAuthProvider(
   const registrationBodies: Record<string, unknown>[] = [];
   const tokenBodies: URLSearchParams[] = [];
   const tokenAuthorizationHeaders: (string | null)[] = [];
+  let authorizationServerDiscoveryCallCount = 0;
   let refreshAttempts = 0;
+  const authorizationServerDiscoveryBarrier =
+    options.synchronizeAuthorizationServerDiscovery
+      ? createDeferredPromise<void>(AbortSignal.any([]))
+      : null;
+  if (authorizationServerDiscoveryBarrier) {
+    onTestFinished(() => {
+      if (!authorizationServerDiscoveryBarrier.settled()) {
+        authorizationServerDiscoveryBarrier.resolve(undefined);
+      }
+    });
+  }
+  const recordAuthorizationServerDiscovery = async (): Promise<void> => {
+    authorizationServerDiscoveryCallCount += 1;
+    if (
+      authorizationServerDiscoveryBarrier &&
+      authorizationServerDiscoveryCallCount >= 2 &&
+      !authorizationServerDiscoveryBarrier.settled()
+    ) {
+      authorizationServerDiscoveryBarrier.resolve(undefined);
+    }
+    if (authorizationServerDiscoveryBarrier) {
+      await authorizationServerDiscoveryBarrier.promise;
+    }
+  };
   server.use(
     http.post(endpoint, () => {
       const challengeScope =
@@ -404,12 +431,14 @@ export function mockAutomaticMcpOAuthProvider(
           : HttpResponse.json(resourceMetadata);
       },
     ),
-    http.get(`${issuer}/.well-known/oauth-authorization-server`, () => {
+    http.get(`${issuer}/.well-known/oauth-authorization-server`, async () => {
+      await recordAuthorizationServerDiscovery();
       return options.discovery === "well-known-oidc"
         ? new HttpResponse(null, { status: 404 })
         : HttpResponse.json(authorizationServerMetadata);
     }),
-    http.get(`${issuer}/.well-known/openid-configuration`, () => {
+    http.get(`${issuer}/.well-known/openid-configuration`, async () => {
+      await recordAuthorizationServerDiscovery();
       return HttpResponse.json({
         ...authorizationServerMetadata,
         jwks_uri: `${issuer}/jwks.json`,
@@ -475,6 +504,9 @@ export function mockAutomaticMcpOAuthProvider(
     endpoint,
     issuer,
     registrationBodies,
+    authorizationServerDiscoveryCalls: () => {
+      return authorizationServerDiscoveryCallCount;
+    },
     tokenBodies,
     tokenAuthorizationHeaders,
   };

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -156,6 +156,7 @@ type CallbackQuery = {
   readonly domain?: string;
   readonly error?: string;
   readonly error_description?: string;
+  readonly iss?: string;
 };
 
 const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
@@ -270,6 +271,212 @@ export function mockCustomConnectorOAuth2Provider(
     tokenUrl: CUSTOM_CONNECTOR_OAUTH2_TOKEN_URL,
     tokenBodies,
     authorizationHeaders,
+  };
+}
+
+interface AutomaticMcpOAuthProviderOptions {
+  readonly registration: "cimd" | "dcr";
+  readonly issuerParameterSupported?: boolean;
+  readonly dcrTokenEndpointAuthMethod?:
+    | "none"
+    | "client_secret_basic"
+    | "client_secret_post";
+  readonly dcrFailureStatus?: number;
+  readonly discovery?: "challenge" | "well-known-oidc";
+  readonly resourceMetadataStatus?: number;
+  readonly challengeScope?: string | null;
+  readonly metadataScopes?: readonly string[];
+  readonly refreshError?:
+    | "invalid_client"
+    | "invalid_grant"
+    | "temporarily_unavailable";
+  readonly refreshErrors?: readonly (
+    | "invalid_client"
+    | "invalid_grant"
+    | "temporarily_unavailable"
+  )[];
+  readonly initialExpiresIn?: number;
+  readonly resource?: string;
+  readonly authorizationEndpoint?: string;
+  readonly metadataIssuer?: string;
+}
+
+interface AutomaticMcpOAuthProviderRecorder {
+  readonly endpoint: string;
+  readonly issuer: string;
+  readonly registrationBodies: readonly Record<string, unknown>[];
+  readonly tokenBodies: readonly URLSearchParams[];
+  readonly tokenAuthorizationHeaders: readonly (string | null)[];
+}
+
+const automaticDcrRequestSchema = z.object({
+  redirect_uris: z.array(z.string()).min(1),
+  scope: z.string().optional(),
+});
+
+export function mockAutomaticMcpOAuthProvider(
+  context: TestContext,
+  options: AutomaticMcpOAuthProviderOptions,
+): AutomaticMcpOAuthProviderRecorder {
+  const endpoint = "https://automatic-mcp.example.test/server";
+  const resourceMetadataUrl =
+    "https://automatic-mcp.example.test/oauth-resource";
+  const issuer = "https://automatic-issuer.example.test";
+  const authorizationUrl = `${issuer}/authorize`;
+  const tokenUrl = `${issuer}/token`;
+  const registrationUrl = `${issuer}/register`;
+  const resourceMetadata = {
+    resource: options.resource ?? endpoint,
+    authorization_servers: [issuer],
+    scopes_supported: [...(options.metadataScopes ?? ["metadata-fallback"])],
+  };
+  const tokenEndpointAuthMethod =
+    options.dcrTokenEndpointAuthMethod ?? "client_secret_basic";
+  const authorizationServerMetadata = {
+    issuer: options.metadataIssuer ?? issuer,
+    authorization_endpoint: options.authorizationEndpoint ?? authorizationUrl,
+    token_endpoint: tokenUrl,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    code_challenge_methods_supported: ["S256"],
+    token_endpoint_auth_methods_supported:
+      options.registration === "cimd" ? ["none"] : [tokenEndpointAuthMethod],
+    authorization_response_iss_parameter_supported:
+      options.issuerParameterSupported ?? true,
+    client_id_metadata_document_supported: options.registration === "cimd",
+    ...(options.registration === "dcr"
+      ? { registration_endpoint: registrationUrl }
+      : {}),
+  };
+  for (const hostname of [
+    "automatic-mcp.example.test",
+    "automatic-issuer.example.test",
+  ]) {
+    context.mocks.dns.lookupOverrides.set(hostname, [
+      { address: "93.184.216.34", family: 4 },
+    ]);
+  }
+  const registrationBodies: Record<string, unknown>[] = [];
+  const tokenBodies: URLSearchParams[] = [];
+  const tokenAuthorizationHeaders: (string | null)[] = [];
+  let refreshAttempts = 0;
+  server.use(
+    http.post(endpoint, () => {
+      const challengeScope =
+        options.challengeScope === undefined
+          ? "read write"
+          : options.challengeScope;
+      const resourceMetadataParameter =
+        options.discovery === "well-known-oidc"
+          ? ""
+          : ` resource_metadata="${resourceMetadataUrl}",`;
+      return new HttpResponse(null, {
+        status: 401,
+        headers: {
+          "www-authenticate": `Bearer${resourceMetadataParameter}${
+            challengeScope === null ? "" : ` scope="${challengeScope}"`
+          }`,
+        },
+      });
+    }),
+    http.get(resourceMetadataUrl, () => {
+      return options.resourceMetadataStatus
+        ? HttpResponse.json(
+            { error: "resource_metadata_unavailable" },
+            { status: options.resourceMetadataStatus },
+          )
+        : HttpResponse.json(resourceMetadata);
+    }),
+    http.get(
+      "https://automatic-mcp.example.test/.well-known/oauth-protected-resource/server",
+      () => {
+        return new HttpResponse(null, { status: 404 });
+      },
+    ),
+    http.get(
+      "https://automatic-mcp.example.test/.well-known/oauth-protected-resource",
+      () => {
+        return options.resourceMetadataStatus
+          ? HttpResponse.json(
+              { error: "resource_metadata_unavailable" },
+              { status: options.resourceMetadataStatus },
+            )
+          : HttpResponse.json(resourceMetadata);
+      },
+    ),
+    http.get(`${issuer}/.well-known/oauth-authorization-server`, () => {
+      return options.discovery === "well-known-oidc"
+        ? new HttpResponse(null, { status: 404 })
+        : HttpResponse.json(authorizationServerMetadata);
+    }),
+    http.get(`${issuer}/.well-known/openid-configuration`, () => {
+      return HttpResponse.json({
+        ...authorizationServerMetadata,
+        jwks_uri: `${issuer}/jwks.json`,
+        subject_types_supported: ["public"],
+        id_token_signing_alg_values_supported: ["RS256"],
+      });
+    }),
+    http.post(registrationUrl, async ({ request }) => {
+      const body = automaticDcrRequestSchema.parse(await request.json());
+      registrationBodies.push(body);
+      if (options.dcrFailureStatus) {
+        return HttpResponse.json(
+          {
+            error:
+              options.dcrFailureStatus >= 500
+                ? "temporarily_unavailable"
+                : "invalid_client_metadata",
+          },
+          { status: options.dcrFailureStatus },
+        );
+      }
+      return HttpResponse.json({
+        ...body,
+        client_id: "automatic-dcr-client",
+        ...(tokenEndpointAuthMethod === "none"
+          ? {}
+          : { client_secret: "automatic-dcr-secret" }),
+        client_id_issued_at: Math.floor(now() / 1000),
+        token_endpoint_auth_method: tokenEndpointAuthMethod,
+      });
+    }),
+    http.post(tokenUrl, async ({ request }) => {
+      const body = new URLSearchParams(await request.text());
+      tokenBodies.push(body);
+      tokenAuthorizationHeaders.push(request.headers.get("authorization"));
+      const refresh = body.get("grant_type") === "refresh_token";
+      if (refresh) {
+        refreshAttempts += 1;
+      }
+      const refreshError = refresh
+        ? (options.refreshErrors?.[refreshAttempts - 1] ?? options.refreshError)
+        : undefined;
+      if (refreshError) {
+        return HttpResponse.json(
+          { error: refreshError },
+          {
+            status: refreshError === "temporarily_unavailable" ? 503 : 400,
+          },
+        );
+      }
+      return HttpResponse.json({
+        access_token: refresh
+          ? "automatic-refreshed-access-token"
+          : "automatic-initial-access-token",
+        ...(!refresh ? { refresh_token: "automatic-refresh-token" } : {}),
+        token_type: "Bearer",
+        expires_in: refresh ? 3600 : (options.initialExpiresIn ?? 0),
+        scope: "read write",
+      });
+    }),
+  );
+  return {
+    endpoint,
+    issuer,
+    registrationBodies,
+    tokenBodies,
+    tokenAuthorizationHeaders,
   };
 }
 
@@ -2315,7 +2522,7 @@ export function createConnectorBddApi(context: TestContext) {
     async requestStartCustomConnectorOAuth2(
       actor: ApiTestUser | null,
       connectorId: string,
-      statuses: readonly (200 | 400 | 401 | 403 | 404 | 409 | 500)[],
+      statuses: readonly (200 | 400 | 401 | 403 | 404 | 409 | 500 | 502)[],
       agentId?: string,
       account: ConnectorAccountMutationIntent = { intent: "single-account" },
     ) {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it, onTestFinished } from "vitest";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
 
-import { mockOptionalEnv } from "../../../lib/env";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import {
   setSecretKmsClientForTests,
   type SecretKmsClient,
@@ -34,6 +34,7 @@ import {
 import {
   awsVerificationCode,
   createConnectorBddApi,
+  mockAutomaticMcpOAuthProvider,
   mockAwsExternalCodeProvider,
   mockTestOAuthAuthCodeProvider,
 } from "./helpers/api-bdd-connectors";
@@ -899,6 +900,193 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     expect(refreshed.body.headers.Authorization).toBe("Bearer forced-access");
     expect(refreshed.body.refreshedConnectors).toStrictEqual(["test-oauth"]);
   });
+
+  it.each([
+    {
+      registration: "cimd" as const,
+      refreshError: "invalid_grant" as const,
+      failureReason: "reconnect_required",
+      connectedAfterFailure: false,
+    },
+    {
+      registration: "cimd" as const,
+      refreshError: "temporarily_unavailable" as const,
+      failureReason: "upstream_provider",
+      connectedAfterFailure: true,
+    },
+    {
+      registration: "dcr" as const,
+      refreshError: "invalid_client" as const,
+      failureReason: "reconnect_required",
+      connectedAfterFailure: false,
+    },
+  ])(
+    "classifies Automatic MCP OAuth $refreshError refresh failures",
+    async ({
+      registration,
+      refreshError,
+      failureReason,
+      connectedAfterFailure,
+    }) => {
+      mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+      mockEnv("OKOU_WEB_URL", "https://www.vm0.ai");
+      mockEnv("APP_URL", "https://app.vm0.ai");
+      const provider = mockAutomaticMcpOAuthProvider(context, {
+        registration,
+        initialExpiresIn: 3600,
+        ...(refreshError === "temporarily_unavailable"
+          ? { refreshErrors: [refreshError] }
+          : { refreshError }),
+      });
+      const fw = createFirewallApi(context);
+      const connectors = createConnectorBddApi(context);
+      const { actor, headers } = await firewallRun();
+      await connectors.updateFeatureSwitches(actor, {
+        [FeatureSwitchKey.CustomConnectorMcp]: true,
+        [FeatureSwitchKey.ConnectorAccounts]: true,
+      });
+      const mcp = await connectors.createCustomConnector(actor, {
+        kind: "mcp",
+        displayName: `BDD Automatic MCP ${refreshError}`,
+        endpoint: provider.endpoint,
+        transport: "streamable-http",
+        fields: [],
+        headerInjections: [
+          {
+            name: "Authorization",
+            valueTemplate: "Bearer {{oauth.access_token}}",
+          },
+        ],
+        queryInjections: [],
+        authMode: "oauth",
+        oauthSetup: "automatic",
+      });
+      const authorizationUrl = await connectors.startCustomConnectorOAuth2(
+        actor,
+        mcp.id,
+      );
+      const state = new URL(authorizationUrl).searchParams.get("state");
+      if (!state) {
+        throw new Error("Expected Automatic MCP OAuth state");
+      }
+      await connectors.completeCustomConnectorOAuth2Callback({
+        code: `automatic-mcp-${refreshError}-code`,
+        state,
+        iss: provider.issuer,
+      });
+      if (refreshError === "invalid_client") {
+        const secondAuthorization = await connectors.startCustomConnectorOAuth2(
+          actor,
+          mcp.id,
+          undefined,
+          { intent: "add", displayName: "Second" },
+        );
+        const secondState = new URL(secondAuthorization).searchParams.get(
+          "state",
+        );
+        if (!secondState) {
+          throw new Error("Expected second Automatic MCP OAuth state");
+        }
+        await connectors.completeCustomConnectorOAuth2Callback({
+          code: "automatic-mcp-invalid-client-second-code",
+          state: secondState,
+          iss: provider.issuer,
+        });
+      }
+      const accounts = await connectors.listCustomConnectorAccounts(
+        actor,
+        mcp.id,
+      );
+      const [account] = accounts;
+      if (!account) {
+        throw new Error("Expected an Automatic MCP OAuth account");
+      }
+      const internalName = `custom_connector_${mcp.id.replaceAll("-", "")}`;
+      const secretKey = `CUSTOM_${mcp.id.replaceAll("-", "")}_S___OAUTH_ACCESS_TOKEN`;
+      const authBody = {
+        encryptedSecrets: fw.encryptedSecretsBody({}),
+        authHeaders: {
+          Authorization: `Bearer ${secretTemplate(secretKey)}`,
+        },
+        matchedFirewall: {
+          name: internalName,
+          apiId: `${internalName}:0`,
+          customConnectorId: mcp.id,
+          sourceId: account.id,
+          routingVariables: {},
+        },
+        forceRefresh: true,
+      };
+
+      const failed = await fw.requestFirewallAuth(headers, authBody, [502]);
+      if (failed.status !== 502) {
+        throw new Error("Expected Automatic MCP OAuth refresh failure");
+      }
+      expect(failed.body.error).toMatchObject({
+        code: "TOKEN_REFRESH_FAILED",
+        connectors: [mcp.id],
+        failureReason,
+      });
+      await expect(
+        connectors.readCustomConnector(actor, mcp.id),
+      ).resolves.toMatchObject({
+        connected: connectedAfterFailure,
+      });
+      expect(
+        provider.tokenBodies.map((body) => {
+          return body.get("grant_type");
+        }),
+      ).toStrictEqual(
+        refreshError === "invalid_client"
+          ? ["authorization_code", "authorization_code", "refresh_token"]
+          : ["authorization_code", "refresh_token"],
+      );
+      const verifyOutcome: Record<typeof refreshError, () => Promise<void>> = {
+        invalid_grant: () => {
+          return Promise.resolve();
+        },
+        invalid_client: async () => {
+          const retiredAccounts = await connectors.listCustomConnectorAccounts(
+            actor,
+            mcp.id,
+          );
+          expect(retiredAccounts).toHaveLength(2);
+          expect(
+            retiredAccounts.map((item) => {
+              return item.connectionStatus;
+            }),
+          ).toStrictEqual(["reconnect-required", "reconnect-required"]);
+          await connectors.startCustomConnectorOAuth2(
+            actor,
+            mcp.id,
+            undefined,
+            { intent: "reconnect", connectionId: account.id },
+          );
+          expect(provider.registrationBodies).toHaveLength(2);
+        },
+        temporarily_unavailable: async () => {
+          const recovered = await fw.requestFirewallAuth(
+            headers,
+            authBody,
+            [200],
+          );
+          expect(recovered.body).toMatchObject({
+            headers: {
+              Authorization: "Bearer automatic-refreshed-access-token",
+            },
+            refreshedConnectors: [mcp.id],
+          });
+          expect(provider.tokenBodies[2]?.get("grant_type")).toBe(
+            "refresh_token",
+          );
+          expect(provider.tokenBodies[2]?.get("resource")).toBe(
+            provider.endpoint,
+          );
+        },
+      };
+      await verifyOutcome[refreshError]();
+    },
+  );
 
   it("maintains authoritative and unknown OAuth grants across refresh", async () => {
     const fw = createFirewallApi(context);

--- a/turbo/apps/api/src/signals/routes/custom-connectors-oauth2.ts
+++ b/turbo/apps/api/src/signals/routes/custom-connectors-oauth2.ts
@@ -8,7 +8,7 @@ import { appUrlForPublicBrand } from "@okouai/core/public-brand";
 import { badRequestMessage } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { publicBrand$, setResHeader$ } from "../context/hono";
+import { publicBrand$, request$, setResHeader$ } from "../context/hono";
 import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
 import { writeDb$, type Db } from "../external/db";
 import {
@@ -20,6 +20,7 @@ import { validateConnectorAuthorizationTarget$ } from "../services/connected-con
 import {
   customConnectorOAuth2EffectiveInitialToken as effectiveInitialToken,
   customConnectorOAuthStateMatchesDefinition,
+  isCustomConnectorAutomaticOAuthStateContext,
   isCustomConnectorCustomOAuthStateContext,
   decryptCustomConnectorOAuth2Credentials,
   exchangeCustomConnectorOAuth2Code,
@@ -28,6 +29,12 @@ import {
   storeCustomConnectorOAuth2Connection,
   type OAuthTokenResult,
 } from "../services/custom-connector-oauth2.service";
+import {
+  CustomConnectorAutomaticOAuthError,
+  customConnectorAutomaticOAuthResourceMatchesEndpoint,
+  exchangeCustomConnectorAutomaticOAuthCode,
+  validateCustomConnectorAutomaticOAuthCallbackIssuer,
+} from "../services/custom-connector-automatic-oauth.service";
 import { userFeatureSwitchContext } from "../services/feature-switches.service";
 import { addUserCustomConnector } from "../services/user-connectors.service";
 import { commitConnectorRuntimeMutation } from "../services/connector-runtime-wakeup.service";
@@ -38,7 +45,7 @@ import {
   type CustomConnectorOAuthConfigRow,
   type CustomConnectorRow,
 } from "../services/custom-connector.service";
-import { tapError } from "../utils";
+import { safeSync, tapError } from "../utils";
 import type { RouteEntry } from "../route-entry";
 import {
   connectorOAuthRedirectResponse,
@@ -46,6 +53,10 @@ import {
 } from "../../lib/connector-oauth-state";
 import { env } from "../../lib/env";
 import { connectorConnectionWriteFailureMessage } from "../services/connector-data.service";
+import {
+  okouMcpOAuthClientMetadata,
+  okouMcpOAuthDynamicClientMetadata,
+} from "../services/mcp-oauth-client-metadata.service";
 
 const CUSTOM_CONNECTOR_OAUTH_CALLBACK_PATH = "/connectors/custom/callback";
 
@@ -72,6 +83,14 @@ function callbackError(origin: string, message: string): Response {
 
 function appOriginForPublicBrand(publicBrand: "vm0" | "okou"): string {
   return new URL(appUrlForPublicBrand(env("APP_URL"), publicBrand)).origin;
+}
+
+function okouOAuthRedirectUri(request: Request): string {
+  const [redirectUri] = okouMcpOAuthClientMetadata(request).redirect_uris;
+  if (!redirectUri) {
+    throw new Error("Okou MCP OAuth callback is unavailable");
+  }
+  return redirectUri;
 }
 
 function callbackResultFromRedirect(
@@ -121,6 +140,7 @@ const startOAuth2Inner$ = command(async ({ get, set }, signal: AbortSignal) => {
     CUSTOM_CONNECTOR_OAUTH_CALLBACK_PATH,
     env("APP_URL"),
   ).toString();
+  const okouClientMetadata = okouMcpOAuthClientMetadata(get(request$).raw);
   const result = await set(
     startCustomConnectorOAuth2$,
     {
@@ -129,6 +149,11 @@ const startOAuth2Inner$ = command(async ({ get, set }, signal: AbortSignal) => {
       connectorId: params.id,
       redirectUri,
       publicBrand: get(publicBrand$),
+      automaticOAuthClient: {
+        redirectUri: okouOAuthRedirectUri(get(request$).raw),
+        cimdClientId: okouClientMetadata.client_id,
+        dcrClientMetadata: okouMcpOAuthDynamicClientMetadata(get(request$).raw),
+      },
       agentId: body.data.agentId,
       account: body.data.account,
     },
@@ -169,6 +194,30 @@ function isCurrentOAuthCustomConnector(
     connector.authMode === "oauth" &&
     connector.oauthSetup === "custom" &&
     connector.oauthConfig &&
+    customConnectorOAuthStateMatchesDefinition(context, connector),
+  );
+}
+
+function isCurrentAutomaticOAuthCustomConnector(
+  connector: CustomConnectorRow | null,
+  context: NonNullable<ReturnType<typeof parseValidCustomConnectorOAuthState>>,
+): connector is CustomConnectorRow & {
+  readonly kind: "mcp";
+  readonly authMode: "oauth";
+  readonly oauthSetup: "automatic";
+  readonly oauthConfig: null;
+} {
+  return Boolean(
+    connector &&
+    isCustomConnectorAutomaticOAuthStateContext(context) &&
+    connector.kind === "mcp" &&
+    connector.authMode === "oauth" &&
+    connector.oauthSetup === "automatic" &&
+    connector.oauthConfig === null &&
+    customConnectorAutomaticOAuthResourceMatchesEndpoint(
+      context.resource,
+      connector.endpoint,
+    ) &&
     customConnectorOAuthStateMatchesDefinition(context, connector),
   );
 }
@@ -224,6 +273,19 @@ async function persistCustomConnectorOAuth2Connection(
     readonly featureContext: FeatureSwitchContext;
     readonly account: ConnectorAccountMutationIntent;
     readonly insertConnectionId?: string;
+    readonly automaticOAuthBinding?: {
+      readonly issuer: string;
+      readonly resource: string;
+      readonly resourceMetadataUrl: string | null;
+      readonly tokenEndpoint: string;
+      readonly clientId: string;
+      readonly tokenEndpointAuthMethod:
+        | "none"
+        | "client_secret_basic"
+        | "client_secret_post";
+      readonly registrationMethod: "cimd" | "dcr";
+      readonly dcrRegistrationId: string | null;
+    };
   },
   signal: AbortSignal,
 ): Promise<
@@ -282,6 +344,205 @@ async function codeLessCustomOAuthCallbackResponse(
     : callbackError(args.origin, "Invalid OAuth state - please try again");
 }
 
+async function completeAutomaticOAuthCallback(
+  args: {
+    readonly db: Db;
+    readonly request: Request;
+    readonly state: StoredCustomConnectorOAuthState;
+    readonly connector: CustomConnectorRow & {
+      readonly kind: "mcp";
+      readonly authMode: "oauth";
+      readonly oauthSetup: "automatic";
+      readonly oauthConfig: null;
+    };
+    readonly context: NonNullable<
+      ReturnType<typeof parseValidCustomConnectorOAuthState>
+    > & { readonly oauthSetup: "automatic" };
+    readonly authorizationCode: string;
+    readonly iss: string | undefined;
+    readonly featureContext: FeatureSwitchContext;
+  },
+  signal: AbortSignal,
+): Promise<string | null> {
+  const completed = await tapError(
+    (async () => {
+      if (!args.state.codeVerifier) {
+        throw new CustomConnectorAutomaticOAuthError(
+          "binding-drift",
+          "Automatic OAuth state is missing its PKCE verifier",
+        );
+      }
+      const clientMetadata = okouMcpOAuthClientMetadata(args.request);
+      if (args.state.redirectUri !== okouOAuthRedirectUri(args.request)) {
+        throw new CustomConnectorAutomaticOAuthError(
+          "binding-drift",
+          "Automatic OAuth callback changed",
+        );
+      }
+      const token = await exchangeCustomConnectorAutomaticOAuthCode(
+        {
+          db: args.db,
+          context: args.context,
+          redirectUri: args.state.redirectUri,
+          cimdClientId: clientMetadata.client_id,
+          code: args.authorizationCode,
+          iss: args.iss,
+          codeVerifier: args.state.codeVerifier,
+          featureContext: args.featureContext,
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+      return await persistCustomConnectorOAuth2Connection(
+        {
+          db: args.db,
+          orgId: args.state.orgId,
+          userId: args.state.userId,
+          connectorId: args.connector.id,
+          storageVersion: args.connector.storageVersion,
+          token: effectiveInitialToken(token, args.state.authorizationUrl),
+          featureContext: args.featureContext,
+          account: args.state.accountMutation,
+          insertConnectionId:
+            args.state.accountMutation.intent === "add"
+              ? args.state.id
+              : undefined,
+          automaticOAuthBinding: {
+            issuer: args.context.issuer,
+            resource: args.context.resource,
+            resourceMetadataUrl: args.context.resourceMetadataUrl,
+            tokenEndpoint: args.context.tokenEndpoint,
+            clientId: args.context.clientId,
+            tokenEndpointAuthMethod: args.context.tokenEndpointAuthMethod,
+            registrationMethod: args.context.registrationMethod,
+            dcrRegistrationId:
+              args.context.registrationMethod === "dcr"
+                ? args.context.dcrRegistrationId
+                : null,
+          },
+        },
+        signal,
+      );
+    })(),
+  );
+  signal.throwIfAborted();
+  return customConnectorOAuthPersistenceFailure(completed);
+}
+
+async function completeCustomOAuthCallback(
+  args: {
+    readonly db: Db;
+    readonly state: StoredCustomConnectorOAuthState;
+    readonly connector: CustomConnectorRow & {
+      readonly authMode: "oauth";
+      readonly oauthConfig: CustomConnectorOAuthConfigRow;
+    };
+    readonly authorizationCode: string;
+    readonly featureContext: FeatureSwitchContext;
+  },
+  signal: AbortSignal,
+): Promise<string | null> {
+  if (args.connector.oauthConfig.providerAdapter !== "standard") {
+    return "OAuth callback was sent to the wrong connector endpoint";
+  }
+  const credentials = await tapError(
+    decryptCustomConnectorOAuth2Credentials(
+      args.connector,
+      args.featureContext,
+    ),
+  );
+  signal.throwIfAborted();
+  if (!credentials) {
+    return "Could not read OAuth client credentials";
+  }
+  const completed = await tapError(
+    (async () => {
+      const token = await exchangeCustomConnectorOAuth2Code(
+        {
+          config: args.connector.oauthConfig,
+          clientSecret: credentials.clientSecret,
+          code: args.authorizationCode,
+          codeVerifier: args.state.codeVerifier,
+          redirectUri: args.state.redirectUri,
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+      return await persistCustomConnectorOAuth2Connection(
+        {
+          db: args.db,
+          orgId: args.state.orgId,
+          userId: args.state.userId,
+          connectorId: args.connector.id,
+          storageVersion: args.connector.storageVersion,
+          token: effectiveInitialToken(token, args.state.authorizationUrl),
+          featureContext: args.featureContext,
+          account: args.state.accountMutation,
+          insertConnectionId:
+            args.state.accountMutation.intent === "add"
+              ? args.state.id
+              : undefined,
+        },
+        signal,
+      );
+    })(),
+  );
+  signal.throwIfAborted();
+  return customConnectorOAuthPersistenceFailure(completed);
+}
+
+async function completeCurrentOAuthCallback(
+  args: {
+    readonly db: Db;
+    readonly request: Request;
+    readonly state: StoredCustomConnectorOAuthState;
+    readonly connector: CustomConnectorRow;
+    readonly context: NonNullable<
+      ReturnType<typeof parseValidCustomConnectorOAuthState>
+    >;
+    readonly authorizationCode: string;
+    readonly iss: string | undefined;
+    readonly featureContext: FeatureSwitchContext;
+  },
+  signal: AbortSignal,
+): Promise<string | null> {
+  if (isCustomConnectorAutomaticOAuthStateContext(args.context)) {
+    if (!isCurrentAutomaticOAuthCustomConnector(args.connector, args.context)) {
+      throw new Error(
+        "Custom connector OAuth configuration changed during callback",
+      );
+    }
+    return await completeAutomaticOAuthCallback(
+      {
+        db: args.db,
+        request: args.request,
+        state: args.state,
+        connector: args.connector,
+        context: args.context,
+        authorizationCode: args.authorizationCode,
+        iss: args.iss,
+        featureContext: args.featureContext,
+      },
+      signal,
+    );
+  }
+  if (!isCurrentOAuthCustomConnector(args.connector, args.context)) {
+    throw new Error(
+      "Custom connector OAuth configuration changed during callback",
+    );
+  }
+  return await completeCustomOAuthCallback(
+    {
+      db: args.db,
+      state: args.state,
+      connector: args.connector,
+      authorizationCode: args.authorizationCode,
+      featureContext: args.featureContext,
+    },
+    signal,
+  );
+}
+
 const completeOAuth2Callback$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<Response> => {
     const query = get(queryOf(customConnectorOAuth2Contract.callback));
@@ -311,12 +572,32 @@ const completeOAuth2Callback$ = command(
       );
     }
     const origin = appOriginForPublicBrand(claimed.state.publicBrand);
-    if (providerError) {
-      return callbackError(origin, query.error_description ?? providerError);
-    }
     const state = validateClaimedState(claimed.state);
     if (!state.ok) {
       return callbackError(origin, "Invalid OAuth state - please try again");
+    }
+    const automaticContext = isCustomConnectorAutomaticOAuthStateContext(
+      state.context,
+    )
+      ? state.context
+      : null;
+    if (automaticContext) {
+      const issuerValidation = safeSync(() => {
+        validateCustomConnectorAutomaticOAuthCallbackIssuer(
+          automaticContext,
+          query.iss,
+        );
+        return true;
+      });
+      if (!("ok" in issuerValidation)) {
+        return callbackError(
+          origin,
+          "OAuth authorization issuer did not match - please try again",
+        );
+      }
+    }
+    if (providerError) {
+      return callbackError(origin, query.error_description ?? providerError);
     }
     const connector = await get(
       getCustomConnectorById({
@@ -325,18 +606,21 @@ const completeOAuth2Callback$ = command(
       }),
     );
     signal.throwIfAborted();
-    if (!isCurrentOAuthCustomConnector(connector, state.context)) {
+    const currentCustom = isCurrentOAuthCustomConnector(
+      connector,
+      state.context,
+    );
+    const currentAutomatic = automaticContext
+      ? isCurrentAutomaticOAuthCustomConnector(connector, automaticContext)
+      : false;
+    if (!currentCustom && !currentAutomatic) {
       return callbackError(
         origin,
         "Custom connector OAuth configuration changed - please try again",
       );
     }
-    const oauthConfig = connector.oauthConfig;
-    if (oauthConfig.providerAdapter !== "standard") {
-      return callbackError(
-        origin,
-        "OAuth callback was sent to the wrong connector endpoint",
-      );
+    if (!connector) {
+      throw new Error("Validated custom connector is unavailable");
     }
     const featureContext = await get(
       userFeatureSwitchContext(claimed.state.orgId, claimed.state.userId),
@@ -351,48 +635,20 @@ const completeOAuth2Callback$ = command(
         "MCP custom connector management is not enabled",
       );
     }
-    const credentials = await tapError(
-      decryptCustomConnectorOAuth2Credentials(connector, featureContext),
+    const persistenceFailure = await completeCurrentOAuthCallback(
+      {
+        db: set(writeDb$),
+        request: get(request$).raw,
+        state: claimed.state,
+        connector,
+        context: state.context,
+        authorizationCode,
+        iss: query.iss,
+        featureContext,
+      },
+      signal,
     );
     signal.throwIfAborted();
-    if (!credentials) {
-      return callbackError(origin, "Could not read OAuth client credentials");
-    }
-    const completed = await tapError(
-      (async () => {
-        const token = await exchangeCustomConnectorOAuth2Code(
-          {
-            config: oauthConfig,
-            clientSecret: credentials.clientSecret,
-            code: authorizationCode,
-            codeVerifier: claimed.state.codeVerifier,
-            redirectUri: claimed.state.redirectUri,
-          },
-          signal,
-        );
-        signal.throwIfAborted();
-        return await persistCustomConnectorOAuth2Connection(
-          {
-            db: set(writeDb$),
-            orgId: claimed.state.orgId,
-            userId: claimed.state.userId,
-            connectorId: connector.id,
-            storageVersion: connector.storageVersion,
-            token: effectiveInitialToken(token, claimed.state.authorizationUrl),
-            featureContext,
-            account: claimed.state.accountMutation,
-            insertConnectionId:
-              claimed.state.accountMutation.intent === "add"
-                ? claimed.state.id
-                : undefined,
-          },
-          signal,
-        );
-      })(),
-    );
-    signal.throwIfAborted();
-    const persistenceFailure =
-      customConnectorOAuthPersistenceFailure(completed);
     if (persistenceFailure) {
       return callbackError(origin, persistenceFailure);
     }

--- a/turbo/apps/api/src/signals/services/custom-connector-automatic-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-automatic-oauth.service.ts
@@ -268,6 +268,10 @@ function externalErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function temporaryUpstreamStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500;
+}
+
 function automaticOAuthRemoteFailure(
   operation: string,
   error: unknown,
@@ -277,7 +281,7 @@ function automaticOAuthRemoteFailure(
   }
   if (error instanceof RegistrationRejectedError) {
     return new CustomConnectorAutomaticOAuthError(
-      error.status >= 500 ? "temporary" : "incompatible",
+      temporaryUpstreamStatus(error.status) ? "temporary" : "incompatible",
       `MCP OAuth ${operation} failed`,
       error,
     );
@@ -307,7 +311,7 @@ function automaticOAuthRemoteFailure(
     code === "ENETUNREACH" ||
     code === "ENOTFOUND" ||
     code === "ETIMEDOUT" ||
-    /HTTP 5\d\d/u.test(message) ||
+    /HTTP (?:408|429|5\d\d)/u.test(message) ||
     /timed? ?out|aborted|socket|network/iu.test(message)
   ) {
     return new CustomConnectorAutomaticOAuthError(

--- a/turbo/apps/api/src/signals/services/custom-connector-automatic-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-automatic-oauth.service.ts
@@ -1,11 +1,46 @@
-import { and, eq, isNotNull } from "drizzle-orm";
+import {
+  Client,
+  IssuerMismatchError,
+  OAuthError,
+  RegistrationRejectedError,
+  StreamableHTTPClientTransport,
+  discoverAuthorizationServerMetadata,
+  discoverOAuthProtectedResourceMetadata,
+  exchangeAuthorization,
+  extractWWWAuthenticateParams,
+  refreshAuthorization,
+  registerClient,
+  resourceUrlFromServerUrl,
+  selectClientAuthMethod,
+  startAuthorization,
+  validateAuthorizationResponseIssuer,
+  type AuthProvider,
+  type AuthorizationServerMetadata,
+  type OAuthClientInformationMixed,
+  type OAuthClientMetadata,
+  type OAuthProtectedResourceMetadata,
+  type OAuthTokens,
+  type FetchLike,
+} from "@modelcontextprotocol/client";
+import { and, eq, inArray, isNotNull } from "drizzle-orm";
 import { z } from "zod";
 import { connectors } from "@okouai/db/schema/connector";
 import { customConnectorAccountOauthBindings } from "@okouai/db/schema/custom-connector-account-oauth-binding";
 import { orgCustomConnectors } from "@okouai/db/schema/org-custom-connector";
 import { orgCustomConnectorDcrRegistrations } from "@okouai/db/schema/org-custom-connector-dcr-registration";
+import type { FeatureSwitchContext } from "@okouai/core/feature-switch";
 
+import { nowDate } from "../../lib/time";
 import type { Db } from "../external/db";
+import { settle } from "../utils";
+import {
+  decryptStoredSecretValue,
+  encryptStoredSecretValue,
+} from "./crypto.utils";
+import {
+  mcpOAuthSafeFetch,
+  validateMcpOAuthPublicUrl,
+} from "./mcp-oauth-safe-fetch.service";
 
 const oauthHttpsUrlSchema = z
   .string()
@@ -39,6 +74,7 @@ const dcrRegistrationSchema = z
     clientId: z.string().min(1),
     tokenEndpointAuthMethod: tokenEndpointAuthMethodSchema,
     hasClientSecret: z.boolean(),
+    encryptedClientSecret: z.string().min(1).nullable(),
     registeredScopes: z.array(z.string().min(1)),
     redirectUri: oauthHttpsUrlSchema,
     issuedAt: z.date(),
@@ -46,8 +82,10 @@ const dcrRegistrationSchema = z
   })
   .refine((registration) => {
     return registration.tokenEndpointAuthMethod === "none"
-      ? !registration.hasClientSecret
-      : registration.hasClientSecret;
+      ? !registration.hasClientSecret &&
+          registration.encryptedClientSecret === null
+      : registration.hasClientSecret &&
+          registration.encryptedClientSecret !== null;
   })
   .refine((registration) => {
     return (
@@ -79,7 +117,7 @@ const customConnectorAutomaticOAuthBindingSchema = z.union([
     }),
 ]);
 
-type CustomConnectorAutomaticOAuthBinding = z.infer<
+export type CustomConnectorAutomaticOAuthBinding = z.infer<
   typeof customConnectorAutomaticOAuthBindingSchema
 >;
 
@@ -135,6 +173,8 @@ export async function readCustomConnectorAutomaticOAuthBinding(
         hasClientSecret: isNotNull(
           orgCustomConnectorDcrRegistrations.encryptedClientSecret,
         ),
+        encryptedClientSecret:
+          orgCustomConnectorDcrRegistrations.encryptedClientSecret,
         registeredScopes: orgCustomConnectorDcrRegistrations.registeredScopes,
         redirectUri: orgCustomConnectorDcrRegistrations.redirectUri,
         issuedAt: orgCustomConnectorDcrRegistrations.issuedAt,
@@ -190,4 +230,1117 @@ export async function readCustomConnectorAutomaticOAuthBinding(
   }
   const parsed = automaticOAuthBindingPersistenceSchema.safeParse(row);
   return parsed.success ? parsed.data : null;
+}
+
+type AutomaticOAuthFailureKind =
+  | "unsafe"
+  | "incompatible"
+  | "temporary"
+  | "binding-drift";
+
+export class CustomConnectorAutomaticOAuthError extends Error {
+  readonly kind: AutomaticOAuthFailureKind;
+
+  constructor(
+    kind: AutomaticOAuthFailureKind,
+    message: string,
+    cause?: unknown,
+  ) {
+    super(message, cause === undefined ? undefined : { cause });
+    this.name = "CustomConnectorAutomaticOAuthError";
+    this.kind = kind;
+  }
+}
+
+function externalErrorCode(error: unknown): string | null {
+  if (
+    typeof error !== "object" ||
+    error === null ||
+    !("code" in error) ||
+    typeof error.code !== "string"
+  ) {
+    return null;
+  }
+  return error.code;
+}
+
+function externalErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function automaticOAuthRemoteFailure(
+  operation: string,
+  error: unknown,
+): CustomConnectorAutomaticOAuthError {
+  if (error instanceof CustomConnectorAutomaticOAuthError) {
+    return error;
+  }
+  if (error instanceof RegistrationRejectedError) {
+    return new CustomConnectorAutomaticOAuthError(
+      error.status >= 500 ? "temporary" : "incompatible",
+      `MCP OAuth ${operation} failed`,
+      error,
+    );
+  }
+  if (error instanceof IssuerMismatchError || error instanceof z.ZodError) {
+    return new CustomConnectorAutomaticOAuthError(
+      "incompatible",
+      `MCP OAuth ${operation} returned incompatible metadata`,
+      error,
+    );
+  }
+  const message = externalErrorMessage(error);
+  if (message.includes("MCP OAuth URL is not allowed")) {
+    return new CustomConnectorAutomaticOAuthError(
+      "unsafe",
+      `MCP OAuth ${operation} used an unsafe URL`,
+      error,
+    );
+  }
+  const code = externalErrorCode(error);
+  if (
+    code === "server_error" ||
+    code === "temporarily_unavailable" ||
+    code === "ECONNREFUSED" ||
+    code === "ECONNRESET" ||
+    code === "EHOSTUNREACH" ||
+    code === "ENETUNREACH" ||
+    code === "ENOTFOUND" ||
+    code === "ETIMEDOUT" ||
+    /HTTP 5\d\d/u.test(message) ||
+    /timed? ?out|aborted|socket|network/iu.test(message)
+  ) {
+    return new CustomConnectorAutomaticOAuthError(
+      "temporary",
+      `MCP OAuth ${operation} is temporarily unavailable`,
+      error,
+    );
+  }
+  return new CustomConnectorAutomaticOAuthError(
+    "incompatible",
+    `MCP OAuth ${operation} is not compatible with Automatic OAuth`,
+    error,
+  );
+}
+
+async function automaticOAuthRemote<T>(
+  operation: string,
+  signal: AbortSignal,
+  task: () => Promise<T>,
+): Promise<T> {
+  const result = await settle(task(), signal);
+  if (!result.ok) {
+    throw automaticOAuthRemoteFailure(operation, result.error);
+  }
+  return result.value;
+}
+
+function fetchWithSignal(signal: AbortSignal): typeof mcpOAuthSafeFetch {
+  return async (input, init) => {
+    const requestSignal = new Request(input, init).signal;
+    return await mcpOAuthSafeFetch(input, {
+      ...init,
+      signal: AbortSignal.any([requestSignal, signal]),
+    });
+  };
+}
+
+class AutomaticOAuthChallengeCaptured extends Error {
+  readonly context: CapturedUnauthorizedContext;
+
+  constructor(context: CapturedUnauthorizedContext) {
+    super("MCP OAuth challenge captured");
+    this.name = "AutomaticOAuthChallengeCaptured";
+    this.context = context;
+  }
+}
+
+interface CapturedUnauthorizedContext {
+  readonly response: Response;
+  readonly serverUrl: URL;
+  readonly fetchFn: FetchLike;
+}
+
+async function probeAutomaticOAuthChallenge(
+  endpoint: string,
+  signal: AbortSignal,
+): Promise<CapturedUnauthorizedContext> {
+  const authProvider: AuthProvider = {
+    token: () => {
+      return Promise.resolve(undefined);
+    },
+    onUnauthorized: (context) => {
+      return Promise.reject(new AutomaticOAuthChallengeCaptured(context));
+    },
+  };
+  const transport = new StreamableHTTPClientTransport(new URL(endpoint), {
+    authProvider,
+    fetch: fetchWithSignal(signal),
+    onInsufficientScope: "throw",
+  });
+  const client = new Client({ name: "Okou", version: "1.0.0" });
+  const connection = await settle(client.connect(transport), signal);
+  await transport.close();
+  signal.throwIfAborted();
+  if (!connection.ok) {
+    if (connection.error instanceof AutomaticOAuthChallengeCaptured) {
+      return connection.error.context;
+    }
+    throw connection.error;
+  }
+  throw new CustomConnectorAutomaticOAuthError(
+    "incompatible",
+    "MCP server did not request OAuth authentication",
+  );
+}
+
+function requiredHttpsUrl(value: string, field: string): string {
+  const parsed = z.string().url().safeParse(value);
+  if (!parsed.success) {
+    throw new CustomConnectorAutomaticOAuthError(
+      "incompatible",
+      `MCP OAuth ${field} must be a URL`,
+    );
+  }
+  if (new URL(parsed.data).protocol !== "https:") {
+    throw new CustomConnectorAutomaticOAuthError(
+      "unsafe",
+      `MCP OAuth ${field} must use HTTPS`,
+    );
+  }
+  return parsed.data;
+}
+
+function scopeTokens(scope: string | undefined): readonly string[] {
+  if (!scope) {
+    return [];
+  }
+  return [...new Set(scope.split(/\s+/u).filter(Boolean))];
+}
+
+function selectedScope(
+  challengeScope: string | undefined,
+  metadata: OAuthProtectedResourceMetadata,
+): string | undefined {
+  if (challengeScope) {
+    return scopeTokens(challengeScope).join(" ");
+  }
+  const supported = metadata.scopes_supported;
+  return supported && supported.length > 0
+    ? scopeTokens(supported.join(" ")).join(" ")
+    : undefined;
+}
+
+interface DiscoveredAutomaticOAuthAuthority {
+  readonly issuer: string;
+  readonly resource: string;
+  readonly resourceMetadataUrl: string | null;
+  readonly authorizationEndpoint: string;
+  readonly tokenEndpoint: string;
+  readonly authorizationResponseIssParameterSupported: boolean;
+  readonly scope: string | undefined;
+  readonly protectedResourceMetadata: OAuthProtectedResourceMetadata;
+  readonly authorizationServerMetadata: AuthorizationServerMetadata;
+}
+
+async function discoverAutomaticOAuthAuthority(
+  args: {
+    readonly endpoint: string;
+    readonly resourceMetadataUrl: URL | null;
+    readonly challengeScope?: string;
+  },
+  signal: AbortSignal,
+): Promise<DiscoveredAutomaticOAuthAuthority> {
+  const fetchFn = fetchWithSignal(signal);
+  const protectedResourceMetadata = await automaticOAuthRemote(
+    "protected resource discovery",
+    signal,
+    async () => {
+      return await discoverOAuthProtectedResourceMetadata(
+        args.endpoint,
+        args.resourceMetadataUrl
+          ? { resourceMetadataUrl: args.resourceMetadataUrl }
+          : undefined,
+        fetchFn,
+      );
+    },
+  );
+  const expectedResource = resourceUrlFromServerUrl(args.endpoint).href;
+  const resource = new URL(
+    requiredHttpsUrl(protectedResourceMetadata.resource, "protected resource"),
+  ).href;
+  if (resource !== expectedResource) {
+    throw new CustomConnectorAutomaticOAuthError(
+      "incompatible",
+      "MCP OAuth protected resource metadata does not match the connector endpoint",
+    );
+  }
+  const advertisedIssuer = protectedResourceMetadata.authorization_servers?.[0];
+  if (!advertisedIssuer) {
+    throw new CustomConnectorAutomaticOAuthError(
+      "incompatible",
+      "MCP OAuth protected resource metadata does not advertise an authorization server",
+    );
+  }
+  const issuer = requiredHttpsUrl(advertisedIssuer, "issuer");
+  const authorizationServerMetadata = await automaticOAuthRemote(
+    "authorization server discovery",
+    signal,
+    async () => {
+      return await discoverAuthorizationServerMetadata(issuer, {
+        fetchFn,
+      });
+    },
+  );
+  if (!authorizationServerMetadata) {
+    throw new CustomConnectorAutomaticOAuthError(
+      "incompatible",
+      "MCP OAuth authorization server metadata was not found",
+    );
+  }
+  if (
+    requiredHttpsUrl(authorizationServerMetadata.issuer, "metadata issuer") !==
+    issuer
+  ) {
+    throw new CustomConnectorAutomaticOAuthError(
+      "incompatible",
+      "MCP OAuth authorization server metadata issuer does not match",
+    );
+  }
+  const authorizationEndpoint = await automaticOAuthRemote(
+    "authorization endpoint validation",
+    signal,
+    async () => {
+      return await validateMcpOAuthPublicUrl(
+        requiredHttpsUrl(
+          authorizationServerMetadata.authorization_endpoint,
+          "authorization endpoint",
+        ),
+        signal,
+      );
+    },
+  );
+  const tokenEndpointValue = authorizationServerMetadata.token_endpoint;
+  if (!tokenEndpointValue) {
+    throw new CustomConnectorAutomaticOAuthError(
+      "incompatible",
+      "MCP OAuth authorization server does not advertise a token endpoint",
+    );
+  }
+  const tokenEndpoint = requiredHttpsUrl(tokenEndpointValue, "token endpoint");
+  if (
+    !authorizationServerMetadata.response_types_supported.includes("code") ||
+    !authorizationServerMetadata.code_challenge_methods_supported?.includes(
+      "S256",
+    )
+  ) {
+    throw new CustomConnectorAutomaticOAuthError(
+      "incompatible",
+      "MCP OAuth authorization server does not support authorization code with PKCE S256",
+    );
+  }
+  return {
+    issuer,
+    resource,
+    resourceMetadataUrl: args.resourceMetadataUrl?.toString() ?? null,
+    authorizationEndpoint,
+    tokenEndpoint,
+    authorizationResponseIssParameterSupported:
+      authorizationServerMetadata.authorization_response_iss_parameter_supported ===
+      true,
+    scope: selectedScope(args.challengeScope, protectedResourceMetadata),
+    protectedResourceMetadata,
+    authorizationServerMetadata,
+  };
+}
+
+export function customConnectorAutomaticOAuthResourceMatchesEndpoint(
+  resource: string,
+  endpoint: string,
+): boolean {
+  return resource === resourceUrlFromServerUrl(endpoint).href;
+}
+
+type PersistedDcrRegistration =
+  typeof orgCustomConnectorDcrRegistrations.$inferSelect;
+
+async function readDcrRegistration(args: {
+  readonly db: Db;
+  readonly customConnectorId: string;
+  readonly issuer: string;
+}): Promise<PersistedDcrRegistration | null> {
+  const [registration] = await args.db
+    .select()
+    .from(orgCustomConnectorDcrRegistrations)
+    .where(
+      and(
+        eq(
+          orgCustomConnectorDcrRegistrations.customConnectorId,
+          args.customConnectorId,
+        ),
+        eq(orgCustomConnectorDcrRegistrations.issuer, args.issuer),
+      ),
+    )
+    .limit(1);
+  return registration ?? null;
+}
+
+function supportedTokenAuthMethods(
+  metadata: AuthorizationServerMetadata,
+): readonly string[] {
+  return metadata.token_endpoint_auth_methods_supported ?? [];
+}
+
+function registrationCoversScope(
+  registration: PersistedDcrRegistration,
+  scope: string | undefined,
+): boolean {
+  const registered = new Set(registration.registeredScopes);
+  return scopeTokens(scope).every((item) => {
+    return registered.has(item);
+  });
+}
+
+function reusableDcrRegistration(args: {
+  readonly registration: PersistedDcrRegistration;
+  readonly redirectUri: string;
+  readonly scope: string | undefined;
+  readonly metadata: AuthorizationServerMetadata;
+}): boolean {
+  const hasSecret = args.registration.encryptedClientSecret !== null;
+  const secretShapeMatches =
+    args.registration.tokenEndpointAuthMethod === "none"
+      ? !hasSecret
+      : hasSecret;
+  const supportedMethods = supportedTokenAuthMethods(args.metadata);
+  return (
+    args.registration.redirectUri === args.redirectUri &&
+    (args.registration.expiresAt === null ||
+      args.registration.expiresAt > nowDate()) &&
+    secretShapeMatches &&
+    (supportedMethods.length === 0 ||
+      supportedMethods.includes(args.registration.tokenEndpointAuthMethod)) &&
+    registrationCoversScope(args.registration, args.scope)
+  );
+}
+
+async function linkedDcrAccountIds(
+  db: Db,
+  registrationId: string,
+): Promise<readonly string[]> {
+  const rows = await db
+    .select({ id: customConnectorAccountOauthBindings.connectorAccountId })
+    .from(customConnectorAccountOauthBindings)
+    .where(
+      eq(customConnectorAccountOauthBindings.dcrRegistrationId, registrationId),
+    );
+  return rows.map((row) => {
+    return row.id;
+  });
+}
+
+export async function retireCustomConnectorDcrRegistration(
+  db: Db,
+  registrationId: string,
+): Promise<void> {
+  const accountIds = await linkedDcrAccountIds(db, registrationId);
+  if (accountIds.length > 0) {
+    await db
+      .update(connectors)
+      .set({
+        needsReconnect: true,
+        reconnectReason: "authorization_expired_or_revoked",
+        updatedAt: nowDate(),
+      })
+      .where(inArray(connectors.id, accountIds));
+    await db
+      .delete(customConnectorAccountOauthBindings)
+      .where(
+        eq(
+          customConnectorAccountOauthBindings.dcrRegistrationId,
+          registrationId,
+        ),
+      );
+  }
+  await db
+    .delete(orgCustomConnectorDcrRegistrations)
+    .where(eq(orgCustomConnectorDcrRegistrations.id, registrationId));
+}
+
+type AutomaticOAuthClientSelection =
+  | {
+      readonly clientId: string;
+      readonly tokenEndpointAuthMethod: "none";
+      readonly registrationMethod: "cimd";
+    }
+  | {
+      readonly clientId: string;
+      readonly tokenEndpointAuthMethod:
+        | "none"
+        | "client_secret_basic"
+        | "client_secret_post";
+      readonly registrationMethod: "dcr";
+      readonly dcrRegistrationId: string;
+    };
+
+function dcrSelection(
+  registration: PersistedDcrRegistration,
+): AutomaticOAuthClientSelection {
+  return {
+    clientId: registration.clientId,
+    tokenEndpointAuthMethod: registration.tokenEndpointAuthMethod,
+    registrationMethod: "dcr",
+    dcrRegistrationId: registration.id,
+  };
+}
+
+const dcrClientInformationSchema = z.object({
+  client_id: z.string().min(1).max(255),
+  client_secret: z.string().min(1).optional(),
+  client_id_issued_at: z.number().finite().nonnegative().optional(),
+  client_secret_expires_at: z.number().finite().nonnegative().optional(),
+  token_endpoint_auth_method: tokenEndpointAuthMethodSchema.optional(),
+  scope: z.string().optional(),
+});
+
+function dcrRegistrationTimes(client: {
+  readonly client_id_issued_at?: number;
+  readonly client_secret_expires_at?: number;
+}): { readonly issuedAt: Date; readonly expiresAt: Date | null } {
+  const issuedAt =
+    client.client_id_issued_at === undefined
+      ? nowDate()
+      : new Date(client.client_id_issued_at * 1000);
+  const expiresAt =
+    client.client_secret_expires_at === undefined ||
+    client.client_secret_expires_at === 0
+      ? null
+      : new Date(client.client_secret_expires_at * 1000);
+  if (
+    !Number.isFinite(issuedAt.getTime()) ||
+    (expiresAt !== null &&
+      (!Number.isFinite(expiresAt.getTime()) || expiresAt <= issuedAt))
+  ) {
+    throw new CustomConnectorAutomaticOAuthError(
+      "incompatible",
+      "MCP OAuth dynamic registration returned invalid lifetime values",
+    );
+  }
+  return { issuedAt, expiresAt };
+}
+
+function dcrTokenAuthMethod(args: {
+  readonly client: z.infer<typeof dcrClientInformationSchema>;
+  readonly metadata: AuthorizationServerMetadata;
+}): AutomaticOAuthClientSelection["tokenEndpointAuthMethod"] {
+  const supportedMethods = supportedTokenAuthMethods(args.metadata);
+  const selected =
+    args.client.token_endpoint_auth_method ??
+    selectClientAuthMethod(args.client, [...supportedMethods]);
+  if (
+    (supportedMethods.length > 0 && !supportedMethods.includes(selected)) ||
+    (selected === "none") !== (args.client.client_secret === undefined)
+  ) {
+    throw new CustomConnectorAutomaticOAuthError(
+      "incompatible",
+      "MCP OAuth dynamic registration returned incompatible client authentication",
+    );
+  }
+  return selected;
+}
+
+async function createDcrRegistration(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly customConnectorId: string;
+    readonly issuer: string;
+    readonly redirectUri: string;
+    readonly scope: string | undefined;
+    readonly metadata: AuthorizationServerMetadata;
+    readonly clientMetadata: OAuthClientMetadata;
+    readonly featureContext: FeatureSwitchContext;
+  },
+  signal: AbortSignal,
+): Promise<PersistedDcrRegistration> {
+  const registered = await automaticOAuthRemote(
+    "dynamic client registration",
+    signal,
+    async () => {
+      return await registerClient(args.issuer, {
+        metadata: args.metadata,
+        clientMetadata: args.clientMetadata,
+        scope: args.scope,
+        fetchFn: fetchWithSignal(signal),
+      });
+    },
+  );
+  const client = dcrClientInformationSchema.parse(registered);
+  const tokenEndpointAuthMethod = dcrTokenAuthMethod({
+    client,
+    metadata: args.metadata,
+  });
+  const encryptedClientSecret = client.client_secret
+    ? await encryptStoredSecretValue(client.client_secret, args.featureContext)
+    : null;
+  signal.throwIfAborted();
+  const times = dcrRegistrationTimes(client);
+  const [stored] = await args.db
+    .insert(orgCustomConnectorDcrRegistrations)
+    .values({
+      orgId: args.orgId,
+      customConnectorId: args.customConnectorId,
+      issuer: args.issuer,
+      clientId: client.client_id,
+      encryptedClientSecret,
+      tokenEndpointAuthMethod,
+      registeredScopes: [...scopeTokens(client.scope ?? args.scope)],
+      redirectUri: args.redirectUri,
+      issuedAt: times.issuedAt,
+      expiresAt: times.expiresAt,
+    })
+    .returning();
+  if (!stored) {
+    throw new Error("Failed to persist MCP OAuth dynamic registration");
+  }
+  return stored;
+}
+
+async function resolveAutomaticOAuthClient(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly customConnectorId: string;
+    readonly storageVersion: number;
+    readonly endpoint: string;
+    readonly issuer: string;
+    readonly redirectUri: string;
+    readonly scope: string | undefined;
+    readonly metadata: AuthorizationServerMetadata;
+    readonly cimdClientId: string;
+    readonly dcrClientMetadata: OAuthClientMetadata;
+    readonly featureContext: FeatureSwitchContext;
+  },
+  signal: AbortSignal,
+): Promise<AutomaticOAuthClientSelection> {
+  const existing = await readDcrRegistration(args);
+  if (
+    existing &&
+    reusableDcrRegistration({
+      registration: existing,
+      redirectUri: args.redirectUri,
+      scope: args.scope,
+      metadata: args.metadata,
+    })
+  ) {
+    return dcrSelection(existing);
+  }
+  if (args.metadata.client_id_metadata_document_supported === true) {
+    return {
+      clientId: requiredHttpsUrl(args.cimdClientId, "Okou client ID"),
+      tokenEndpointAuthMethod: "none",
+      registrationMethod: "cimd",
+    };
+  }
+  if (!args.metadata.registration_endpoint) {
+    throw new CustomConnectorAutomaticOAuthError(
+      "incompatible",
+      "MCP OAuth server requires a Custom OAuth app",
+    );
+  }
+  return await args.db.transaction(async (tx) => {
+    const [definition] = await tx
+      .select({
+        authMode: orgCustomConnectors.authMode,
+        oauthSetup: orgCustomConnectors.oauthSetup,
+        storageVersion: orgCustomConnectors.storageVersion,
+        endpoint: orgCustomConnectors.mcpEndpoint,
+      })
+      .from(orgCustomConnectors)
+      .where(
+        and(
+          eq(orgCustomConnectors.id, args.customConnectorId),
+          eq(orgCustomConnectors.orgId, args.orgId),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (
+      !definition ||
+      definition.authMode !== "oauth" ||
+      definition.oauthSetup !== "automatic" ||
+      definition.storageVersion !== args.storageVersion ||
+      definition.endpoint !== args.endpoint
+    ) {
+      throw new Error(
+        "Custom connector credential contract changed during Automatic OAuth registration",
+      );
+    }
+    const lockedExisting = await readDcrRegistration({ ...args, db: tx });
+    if (
+      lockedExisting &&
+      reusableDcrRegistration({
+        registration: lockedExisting,
+        redirectUri: args.redirectUri,
+        scope: args.scope,
+        metadata: args.metadata,
+      })
+    ) {
+      return dcrSelection(lockedExisting);
+    }
+    if (lockedExisting) {
+      const linkedAccounts = await linkedDcrAccountIds(tx, lockedExisting.id);
+      const expired =
+        lockedExisting.expiresAt !== null &&
+        lockedExisting.expiresAt <= nowDate();
+      if (linkedAccounts.length > 0 && !expired) {
+        throw new CustomConnectorAutomaticOAuthError(
+          "incompatible",
+          "Existing MCP OAuth registration is not compatible with the requested scopes",
+        );
+      }
+      await retireCustomConnectorDcrRegistration(tx, lockedExisting.id);
+    }
+    const created = await createDcrRegistration(
+      {
+        ...args,
+        db: tx,
+        clientMetadata: args.dcrClientMetadata,
+      },
+      signal,
+    );
+    return dcrSelection(created);
+  });
+}
+
+export type CustomConnectorAutomaticOAuthStateContext = {
+  readonly version: 1;
+  readonly oauthSetup: "automatic";
+  readonly connectorId: string;
+  readonly storageVersion: number;
+  readonly issuer: string;
+  readonly resource: string;
+  readonly resourceMetadataUrl: string | null;
+  readonly authorizationEndpoint: string;
+  readonly tokenEndpoint: string;
+  readonly authorizationResponseIssParameterSupported: boolean;
+  readonly clientId: string;
+  readonly tokenEndpointAuthMethod:
+    | "none"
+    | "client_secret_basic"
+    | "client_secret_post";
+} & (
+  | {
+      readonly registrationMethod: "cimd";
+      readonly dcrRegistrationId?: never;
+    }
+  | {
+      readonly registrationMethod: "dcr";
+      readonly dcrRegistrationId: string;
+    }
+);
+
+interface CustomConnectorAutomaticOAuthAuthorization {
+  readonly authorizationUrl: string;
+  readonly codeVerifier: string;
+  readonly requestedScope: string | null;
+  readonly context: CustomConnectorAutomaticOAuthStateContext;
+}
+
+type AutomaticOAuthBoundClientContext = {
+  readonly connectorId: string;
+  readonly issuer: string;
+  readonly clientId: string;
+  readonly tokenEndpointAuthMethod:
+    | "none"
+    | "client_secret_basic"
+    | "client_secret_post";
+} & (
+  | {
+      readonly registrationMethod: "cimd";
+    }
+  | {
+      readonly registrationMethod: "dcr";
+      readonly dcrRegistrationId: string;
+    }
+);
+
+export async function prepareCustomConnectorAutomaticOAuthAuthorization(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly customConnectorId: string;
+    readonly storageVersion: number;
+    readonly endpoint: string;
+    readonly redirectUri: string;
+    readonly state: string;
+    readonly cimdClientId: string;
+    readonly dcrClientMetadata: OAuthClientMetadata;
+    readonly featureContext: FeatureSwitchContext;
+  },
+  signal: AbortSignal,
+): Promise<CustomConnectorAutomaticOAuthAuthorization> {
+  const challenge = await automaticOAuthRemote(
+    "MCP authorization challenge",
+    signal,
+    async () => {
+      return await probeAutomaticOAuthChallenge(args.endpoint, signal);
+    },
+  );
+  const challengeParameters = extractWWWAuthenticateParams(challenge.response);
+  const authority = await discoverAutomaticOAuthAuthority(
+    {
+      endpoint: args.endpoint,
+      resourceMetadataUrl: challengeParameters.resourceMetadataUrl ?? null,
+      challengeScope: challengeParameters.scope,
+    },
+    signal,
+  );
+  const client = await resolveAutomaticOAuthClient(
+    {
+      ...args,
+      issuer: authority.issuer,
+      scope: authority.scope,
+      metadata: authority.authorizationServerMetadata,
+    },
+    signal,
+  );
+  const clientInformation: OAuthClientInformationMixed = {
+    client_id: client.clientId,
+  };
+  const authorization = await automaticOAuthRemote(
+    "authorization request",
+    signal,
+    async () => {
+      return await startAuthorization(authority.issuer, {
+        metadata: authority.authorizationServerMetadata,
+        clientInformation,
+        redirectUrl: args.redirectUri,
+        scope: authority.scope,
+        state: args.state,
+        resource: new URL(authority.resource),
+      });
+    },
+  );
+  const contextBase = {
+    version: 1,
+    oauthSetup: "automatic",
+    connectorId: args.customConnectorId,
+    storageVersion: args.storageVersion,
+    issuer: authority.issuer,
+    resource: authority.resource,
+    resourceMetadataUrl: authority.resourceMetadataUrl,
+    authorizationEndpoint: authority.authorizationEndpoint,
+    tokenEndpoint: authority.tokenEndpoint,
+    authorizationResponseIssParameterSupported:
+      authority.authorizationResponseIssParameterSupported,
+    clientId: client.clientId,
+    tokenEndpointAuthMethod: client.tokenEndpointAuthMethod,
+  } as const;
+  const context: CustomConnectorAutomaticOAuthStateContext =
+    client.registrationMethod === "dcr"
+      ? {
+          ...contextBase,
+          registrationMethod: "dcr",
+          dcrRegistrationId: client.dcrRegistrationId,
+        }
+      : { ...contextBase, registrationMethod: "cimd" };
+  return {
+    authorizationUrl: authorization.authorizationUrl.toString(),
+    codeVerifier: authorization.codeVerifier,
+    requestedScope: authority.scope ?? null,
+    context,
+  };
+}
+
+function frozenAuthorizationServerMetadata(
+  context: Pick<
+    CustomConnectorAutomaticOAuthStateContext,
+    | "issuer"
+    | "authorizationEndpoint"
+    | "tokenEndpoint"
+    | "tokenEndpointAuthMethod"
+    | "authorizationResponseIssParameterSupported"
+  >,
+): AuthorizationServerMetadata {
+  return {
+    issuer: context.issuer,
+    authorization_endpoint: context.authorizationEndpoint,
+    token_endpoint: context.tokenEndpoint,
+    response_types_supported: ["code"],
+    code_challenge_methods_supported: ["S256"],
+    token_endpoint_auth_methods_supported: [context.tokenEndpointAuthMethod],
+    authorization_response_iss_parameter_supported:
+      context.authorizationResponseIssParameterSupported,
+  };
+}
+
+async function boundClientInformation(args: {
+  readonly db: Db;
+  readonly context: AutomaticOAuthBoundClientContext;
+  readonly redirectUri: string;
+  readonly cimdClientId: string;
+  readonly featureContext: FeatureSwitchContext;
+}): Promise<OAuthClientInformationMixed> {
+  if (args.context.registrationMethod === "cimd") {
+    if (
+      args.context.clientId !== args.cimdClientId ||
+      args.context.tokenEndpointAuthMethod !== "none"
+    ) {
+      throw new CustomConnectorAutomaticOAuthError(
+        "binding-drift",
+        "MCP OAuth client binding changed",
+      );
+    }
+    return { client_id: args.context.clientId };
+  }
+  const [registration] = await args.db
+    .select()
+    .from(orgCustomConnectorDcrRegistrations)
+    .where(
+      and(
+        eq(
+          orgCustomConnectorDcrRegistrations.id,
+          args.context.dcrRegistrationId,
+        ),
+        eq(
+          orgCustomConnectorDcrRegistrations.customConnectorId,
+          args.context.connectorId,
+        ),
+      ),
+    )
+    .limit(1);
+  if (
+    !registration ||
+    registration.issuer !== args.context.issuer ||
+    registration.clientId !== args.context.clientId ||
+    registration.redirectUri !== args.redirectUri ||
+    registration.tokenEndpointAuthMethod !==
+      args.context.tokenEndpointAuthMethod ||
+    (registration.expiresAt !== null && registration.expiresAt <= nowDate())
+  ) {
+    throw new CustomConnectorAutomaticOAuthError(
+      "binding-drift",
+      "MCP OAuth dynamic registration changed",
+    );
+  }
+  const clientSecret = registration.encryptedClientSecret
+    ? await decryptStoredSecretValue(
+        registration.encryptedClientSecret,
+        args.featureContext,
+      )
+    : undefined;
+  if (
+    (registration.tokenEndpointAuthMethod === "none") !==
+    (clientSecret === undefined)
+  ) {
+    throw new Error("MCP OAuth dynamic registration secret is inconsistent");
+  }
+  return {
+    client_id: registration.clientId,
+    ...(clientSecret ? { client_secret: clientSecret } : {}),
+    token_endpoint_auth_method: registration.tokenEndpointAuthMethod,
+  };
+}
+
+interface CustomConnectorAutomaticOAuthTokenResult {
+  readonly accessToken: string;
+  readonly refreshToken: string | null;
+  readonly idToken: string | null;
+  readonly expiresAt: Date | null;
+  readonly scopes: readonly string[] | null;
+}
+
+function automaticOAuthTokenResult(
+  tokens: OAuthTokens,
+): CustomConnectorAutomaticOAuthTokenResult {
+  const expiresIn = tokens.expires_in;
+  return {
+    accessToken: tokens.access_token,
+    refreshToken: tokens.refresh_token ?? null,
+    idToken: tokens.id_token ?? null,
+    expiresAt:
+      expiresIn === undefined
+        ? null
+        : new Date(nowDate().getTime() + expiresIn * 1000),
+    scopes: tokens.scope === undefined ? null : scopeTokens(tokens.scope),
+  };
+}
+
+export async function exchangeCustomConnectorAutomaticOAuthCode(
+  args: {
+    readonly db: Db;
+    readonly context: CustomConnectorAutomaticOAuthStateContext;
+    readonly redirectUri: string;
+    readonly cimdClientId: string;
+    readonly code: string;
+    readonly iss: string | undefined;
+    readonly codeVerifier: string;
+    readonly featureContext: FeatureSwitchContext;
+  },
+  signal: AbortSignal,
+): Promise<CustomConnectorAutomaticOAuthTokenResult> {
+  const clientInformation = await boundClientInformation(args);
+  signal.throwIfAborted();
+  const tokens = await exchangeAuthorization(args.context.issuer, {
+    metadata: frozenAuthorizationServerMetadata(args.context),
+    clientInformation,
+    authorizationCode: args.code,
+    iss: args.iss,
+    codeVerifier: args.codeVerifier,
+    redirectUri: args.redirectUri,
+    resource: new URL(args.context.resource),
+    fetchFn: fetchWithSignal(signal),
+  });
+  signal.throwIfAborted();
+  return automaticOAuthTokenResult(tokens);
+}
+
+export function validateCustomConnectorAutomaticOAuthCallbackIssuer(
+  context: CustomConnectorAutomaticOAuthStateContext,
+  iss: string | undefined,
+): void {
+  validateAuthorizationResponseIssuer({
+    iss,
+    expectedIssuer: context.issuer,
+    issParameterSupported: context.authorizationResponseIssParameterSupported,
+  });
+}
+
+function boundClientContext(
+  binding: CustomConnectorAutomaticOAuthBinding,
+): AutomaticOAuthBoundClientContext {
+  const base = {
+    connectorId: binding.customConnectorId,
+    issuer: binding.issuer,
+    clientId: binding.clientId,
+    tokenEndpointAuthMethod: binding.tokenEndpointAuthMethod,
+  } as const;
+  return binding.registrationMethod === "dcr"
+    ? {
+        ...base,
+        registrationMethod: "dcr",
+        dcrRegistrationId: binding.dcrRegistration.id,
+      }
+    : { ...base, registrationMethod: "cimd" };
+}
+
+export async function refreshCustomConnectorAutomaticOAuthToken(
+  args: {
+    readonly db: Db;
+    readonly binding: CustomConnectorAutomaticOAuthBinding;
+    readonly endpoint: string;
+    readonly redirectUri: string;
+    readonly cimdClientId: string;
+    readonly refreshToken: string;
+    readonly featureContext: FeatureSwitchContext;
+  },
+  signal: AbortSignal,
+): Promise<CustomConnectorAutomaticOAuthTokenResult> {
+  const discovered = await settle(
+    discoverAutomaticOAuthAuthority(
+      {
+        endpoint: args.endpoint,
+        resourceMetadataUrl: args.binding.resourceMetadataUrl
+          ? new URL(args.binding.resourceMetadataUrl)
+          : null,
+      },
+      signal,
+    ),
+    signal,
+  );
+  if (!discovered.ok) {
+    const error = discovered.error;
+    if (
+      error instanceof CustomConnectorAutomaticOAuthError &&
+      error.kind === "temporary"
+    ) {
+      throw error;
+    }
+    if (error instanceof CustomConnectorAutomaticOAuthError) {
+      throw new CustomConnectorAutomaticOAuthError(
+        "binding-drift",
+        "MCP OAuth authority changed",
+        error,
+      );
+    }
+    throw error;
+  }
+  const authority = discovered.value;
+  if (
+    authority.issuer !== args.binding.issuer ||
+    authority.resource !== args.binding.resource ||
+    authority.tokenEndpoint !== args.binding.tokenEndpoint ||
+    (args.binding.registrationMethod === "cimd" &&
+      authority.authorizationServerMetadata
+        .client_id_metadata_document_supported !== true) ||
+    !(
+      supportedTokenAuthMethods(authority.authorizationServerMetadata)
+        .length === 0 ||
+      supportedTokenAuthMethods(authority.authorizationServerMetadata).includes(
+        args.binding.tokenEndpointAuthMethod,
+      )
+    )
+  ) {
+    throw new CustomConnectorAutomaticOAuthError(
+      "binding-drift",
+      "MCP OAuth authority changed",
+    );
+  }
+  const clientInformation = await boundClientInformation({
+    ...args,
+    context: boundClientContext(args.binding),
+  });
+  signal.throwIfAborted();
+  const refreshed = await settle(
+    refreshAuthorization(args.binding.issuer, {
+      metadata: frozenAuthorizationServerMetadata({
+        issuer: args.binding.issuer,
+        authorizationEndpoint: authority.authorizationEndpoint,
+        tokenEndpoint: args.binding.tokenEndpoint,
+        tokenEndpointAuthMethod: args.binding.tokenEndpointAuthMethod,
+        authorizationResponseIssParameterSupported:
+          authority.authorizationResponseIssParameterSupported,
+      }),
+      clientInformation,
+      refreshToken: args.refreshToken,
+      resource: new URL(args.binding.resource),
+      fetchFn: fetchWithSignal(signal),
+    }),
+    signal,
+  );
+  if (!refreshed.ok) {
+    const error = refreshed.error;
+    if (error instanceof OAuthError) {
+      if (
+        error.code === "server_error" ||
+        error.code === "temporarily_unavailable"
+      ) {
+        throw new CustomConnectorAutomaticOAuthError(
+          "temporary",
+          "MCP OAuth token refresh is temporarily unavailable",
+          error,
+        );
+      }
+      throw error;
+    }
+    const remoteFailure = automaticOAuthRemoteFailure("token refresh", error);
+    if (remoteFailure.kind === "temporary") {
+      throw remoteFailure;
+    }
+    throw new CustomConnectorAutomaticOAuthError(
+      "binding-drift",
+      "MCP OAuth token authority changed",
+      remoteFailure,
+    );
+  }
+  return automaticOAuthTokenResult(refreshed.value);
+}
+
+export function isAutomaticOAuthInvalidClient(error: unknown): boolean {
+  return error instanceof OAuthError && error.code === "invalid_client";
+}
+
+export function isAutomaticOAuthInvalidGrant(error: unknown): boolean {
+  return error instanceof OAuthError && error.code === "invalid_grant";
 }

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -6,6 +6,7 @@ import { and, eq, exists } from "drizzle-orm";
 import { z } from "zod";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
+import type { OAuthClientMetadata } from "@modelcontextprotocol/client";
 import {
   isIntegrationManagedCustomConnector,
   isIntegrationManagedCustomConnectorProviderAdapter,
@@ -17,11 +18,17 @@ import {
   OAuthProviderHttpError,
 } from "@okouai/connectors/auth-providers/oauth/error";
 import { connectors } from "@okouai/db/schema/connector";
+import { customConnectorAccountOauthBindings } from "@okouai/db/schema/custom-connector-account-oauth-binding";
 import { orgCustomConnectorOauthConfigs } from "@okouai/db/schema/org-custom-connector-oauth-config";
 import { orgCustomConnectors } from "@okouai/db/schema/org-custom-connector";
 import { secrets } from "@okouai/db/schema/secret";
 
-import { badRequestMessage, conflict, notFound } from "../../lib/error";
+import {
+  badGateway,
+  badRequestMessage,
+  conflict,
+  notFound,
+} from "../../lib/error";
 import { nowDate } from "../../lib/time";
 import {
   connectorOAuthStateExpiresAt,
@@ -58,12 +65,25 @@ import {
   isCustomConnectorMcpEnabled,
 } from "./custom-connector-mcp-feature.service";
 import {
+  type ConnectorConnectionMutationResolution,
   replaceConnectorConnection,
   resolveConnectorConnectionMutation,
 } from "./connector-connection-write.service";
 import { connectorAccountSiblingWritesEnabled } from "./connector-account-mutation.service";
 import { userFeatureSwitchContext } from "./feature-switches.service";
 import { mcpOAuthSafeFetch } from "./mcp-oauth-safe-fetch.service";
+import {
+  CustomConnectorAutomaticOAuthError,
+  isAutomaticOAuthInvalidClient,
+  isAutomaticOAuthInvalidGrant,
+  prepareCustomConnectorAutomaticOAuthAuthorization,
+  readCustomConnectorAutomaticOAuthBinding,
+  refreshCustomConnectorAutomaticOAuthToken,
+  retireCustomConnectorDcrRegistration,
+  type CustomConnectorAutomaticOAuthBinding,
+  type CustomConnectorAutomaticOAuthStateContext as PreparedCustomConnectorAutomaticOAuthStateContext,
+} from "./custom-connector-automatic-oauth.service";
+import { configuredOkouMcpOAuthClientMetadata } from "./mcp-oauth-client-metadata.service";
 
 const TOKEN_REFRESH_LEEWAY_MS = 60 * 1000;
 
@@ -100,7 +120,9 @@ const customConnectorAutomaticOAuthStateContextBaseSchema = z.object({
   issuer: oauthHttpsUrlSchema,
   resource: oauthHttpsUrlSchema,
   resourceMetadataUrl: oauthHttpsUrlSchema.nullable(),
+  authorizationEndpoint: oauthHttpsUrlSchema,
   tokenEndpoint: oauthHttpsUrlSchema,
+  authorizationResponseIssParameterSupported: z.boolean(),
   clientId: z.string().min(1),
   tokenEndpointAuthMethod: z.enum([
     "none",
@@ -138,10 +160,20 @@ export type CustomConnectorCustomOAuthStateContext = z.infer<
   typeof customConnectorCustomOAuthStateContextSchema
 >;
 
+type CustomConnectorAutomaticOAuthStateContext = z.infer<
+  typeof customConnectorAutomaticOAuthStateContextSchema
+>;
+
 export function isCustomConnectorCustomOAuthStateContext(
   context: CustomConnectorOAuthStateContext,
 ): context is CustomConnectorCustomOAuthStateContext {
   return context.oauthSetup !== "automatic";
+}
+
+export function isCustomConnectorAutomaticOAuthStateContext(
+  context: CustomConnectorOAuthStateContext,
+): context is CustomConnectorAutomaticOAuthStateContext {
+  return context.oauthSetup === "automatic";
 }
 
 const oauthTokenResponseSchema = z.object({
@@ -491,22 +523,264 @@ function isCustomOAuthConnector(
   );
 }
 
+function isAutomaticOAuthConnector(
+  connector: CustomConnectorRow,
+): connector is CustomConnectorRow & {
+  readonly kind: "mcp";
+  readonly authMode: "oauth";
+  readonly oauthSetup: "automatic";
+  readonly oauthConfig: null;
+} {
+  return (
+    connector.kind === "mcp" &&
+    connector.authMode === "oauth" &&
+    connector.oauthSetup === "automatic" &&
+    connector.oauthConfig === null
+  );
+}
+
+interface AutomaticOAuthClientPresentation {
+  readonly redirectUri: string;
+  readonly cimdClientId: string;
+  readonly dcrClientMetadata: OAuthClientMetadata;
+}
+
+interface StartCustomConnectorOAuth2Args {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly connectorId: string;
+  readonly redirectUri: string;
+  readonly publicBrand: PublicBrand;
+  readonly automaticOAuthClient?: AutomaticOAuthClientPresentation;
+  readonly agentId?: string;
+  readonly account: ConnectorAccountMutationIntent;
+  readonly feishuContext?: {
+    readonly installationId?: string;
+    readonly expectedOpenId?: string;
+  };
+}
+
+interface PreparedOAuthStart {
+  readonly oauthSetup: "custom" | "automatic";
+  readonly redirectUri: string;
+  readonly state: string;
+  readonly authorizationUrl: string;
+  readonly codeVerifier: string | null;
+  readonly oauthRequestedScopes: string | null;
+  readonly context: CustomConnectorOAuthStateContext;
+}
+
+function connectorConnectionMutationFailure(
+  resolution: ConnectorConnectionMutationResolution,
+) {
+  if (resolution.kind === "ready") {
+    return null;
+  }
+  return resolution.kind === "missing"
+    ? notFound("Connector account not found")
+    : conflict(
+        resolution.kind === "ambiguous"
+          ? "Multiple connector accounts require an exact choice"
+          : "Additional connector accounts are not enabled yet",
+      );
+}
+
+function prepareCustomOAuthStart(
+  connector: CustomConnectorRow & {
+    readonly authMode: "oauth";
+    readonly oauthSetup: "custom";
+    readonly oauthConfig: CustomConnectorOAuthConfigRow;
+  },
+  args: StartCustomConnectorOAuth2Args,
+): PreparedOAuthStart {
+  const state = generateConnectorOAuthState(args.publicBrand);
+  const codeVerifier =
+    connector.oauthConfig.pkceMethod === "S256" ? createPkceVerifier() : null;
+  return {
+    oauthSetup: "custom",
+    redirectUri: args.redirectUri,
+    state,
+    authorizationUrl: buildCustomConnectorOAuth2AuthorizationUrl({
+      config: connector.oauthConfig,
+      redirectUri: args.redirectUri,
+      state,
+      codeVerifier,
+    }),
+    codeVerifier,
+    oauthRequestedScopes: null,
+    context: {
+      oauthSetup: "custom",
+      connectorId: connector.id,
+      storageVersion: connector.storageVersion,
+      ...(connector.oauthConfig.providerAdapter === "feishu" &&
+      args.feishuContext
+        ? {
+            providerContext: {
+              provider: "feishu" as const,
+              completionTarget: "feishu" as const,
+              ...(args.feishuContext.installationId
+                ? { installationId: args.feishuContext.installationId }
+                : {}),
+              ...(args.feishuContext.expectedOpenId
+                ? { expectedOpenId: args.feishuContext.expectedOpenId }
+                : {}),
+            },
+          }
+        : {}),
+    },
+  };
+}
+
+async function prepareAutomaticOAuthStart(
+  context: {
+    readonly db: Db;
+    readonly connector: CustomConnectorRow & {
+      readonly kind: "mcp";
+      readonly authMode: "oauth";
+      readonly oauthSetup: "automatic";
+      readonly oauthConfig: null;
+    };
+    readonly args: StartCustomConnectorOAuth2Args;
+    readonly featureContext: FeatureSwitchContext;
+    readonly client: AutomaticOAuthClientPresentation;
+  },
+  signal: AbortSignal,
+) {
+  const { db, connector, args, featureContext, client } = context;
+  const preflight = await db.transaction(async (tx) => {
+    await lockCustomConnectorOAuth2CredentialContract({
+      db: tx,
+      orgId: args.orgId,
+      connectorId: connector.id,
+      storageVersion: connector.storageVersion,
+      oauthSetup: "automatic",
+    });
+    return await resolveConnectorConnectionMutation(tx, {
+      orgId: args.orgId,
+      userId: args.userId,
+      target: { kind: "custom", customConnectorId: connector.id },
+      mutation: args.account,
+      allowSiblings: connectorAccountSiblingWritesEnabled(featureContext),
+    });
+  });
+  signal.throwIfAborted();
+  const preflightFailure = connectorConnectionMutationFailure(preflight);
+  if (preflightFailure) {
+    return { ok: false as const, response: preflightFailure };
+  }
+  const state = generateConnectorOAuthState("okou");
+  const automatic = await settle(
+    prepareCustomConnectorAutomaticOAuthAuthorization(
+      {
+        db,
+        orgId: args.orgId,
+        customConnectorId: connector.id,
+        storageVersion: connector.storageVersion,
+        endpoint: connector.endpoint,
+        redirectUri: client.redirectUri,
+        state,
+        cimdClientId: client.cimdClientId,
+        dcrClientMetadata: client.dcrClientMetadata,
+        featureContext,
+      },
+      signal,
+    ),
+    signal,
+  );
+  if (!automatic.ok) {
+    const error = automatic.error;
+    if (!(error instanceof CustomConnectorAutomaticOAuthError)) {
+      throw error;
+    }
+    const response =
+      error.kind === "temporary"
+        ? badGateway(
+            "MCP OAuth provider is temporarily unavailable. Please try again.",
+          )
+        : badRequestMessage(
+            error.kind === "unsafe"
+              ? "MCP OAuth provider uses an unsafe URL"
+              : "MCP OAuth provider is not compatible with Automatic OAuth. Configure a Custom OAuth app instead.",
+          );
+    return { ok: false as const, response };
+  }
+  const prepared = automatic.value;
+  return {
+    ok: true as const,
+    value: {
+      oauthSetup: "automatic",
+      redirectUri: client.redirectUri,
+      state,
+      authorizationUrl: prepared.authorizationUrl,
+      codeVerifier: prepared.codeVerifier,
+      oauthRequestedScopes: prepared.requestedScope,
+      context:
+        prepared.context satisfies PreparedCustomConnectorAutomaticOAuthStateContext,
+    } satisfies PreparedOAuthStart,
+  };
+}
+
+async function persistCustomConnectorOAuthStart(
+  context: {
+    readonly db: Db;
+    readonly connector: CustomConnectorRow;
+    readonly args: StartCustomConnectorOAuth2Args;
+    readonly featureContext: FeatureSwitchContext;
+    readonly prepared: PreparedOAuthStart;
+  },
+  signal: AbortSignal,
+) {
+  const { db, connector, args, featureContext, prepared } = context;
+  const result = await db.transaction(async (tx) => {
+    await lockCustomConnectorOAuth2CredentialContract({
+      db: tx,
+      orgId: args.orgId,
+      connectorId: connector.id,
+      storageVersion: connector.storageVersion,
+      oauthSetup: prepared.oauthSetup,
+    });
+    const resolution = await resolveConnectorConnectionMutation(tx, {
+      orgId: args.orgId,
+      userId: args.userId,
+      target: { kind: "custom", customConnectorId: connector.id },
+      mutation: args.account,
+      allowSiblings:
+        !isIntegrationManagedCustomConnector(connector) &&
+        connectorAccountSiblingWritesEnabled(featureContext),
+    });
+    if (resolution.kind !== "ready") {
+      return { resolution, connectionId: null };
+    }
+    const oauthStateId = await insertConnectorOAuthState(tx, {
+      state: prepared.state,
+      customConnectorId: connector.id,
+      storageVersion: connector.storageVersion,
+      authMethod: "oauth",
+      userId: args.userId,
+      orgId: args.orgId,
+      agentId: args.agentId,
+      authorizeAgent: args.agentId !== undefined,
+      redirectUri: prepared.redirectUri,
+      authorizationUrl: prepared.authorizationUrl,
+      oauthRequestedScopes: prepared.oauthRequestedScopes,
+      codeVerifier: prepared.codeVerifier,
+      oauthContext: JSON.stringify(prepared.context),
+      accountMutation: args.account,
+      expiresAt: connectorOAuthStateExpiresAt(),
+    });
+    return {
+      resolution,
+      connectionId: args.account.intent === "add" ? oauthStateId : null,
+    };
+  });
+  signal.throwIfAborted();
+  return result;
+}
+
 export const startCustomConnectorOAuth2$ = command(
   async (
     { get, set },
-    args: {
-      readonly orgId: string;
-      readonly userId: string;
-      readonly connectorId: string;
-      readonly redirectUri: string;
-      readonly publicBrand: PublicBrand;
-      readonly agentId?: string;
-      readonly account: ConnectorAccountMutationIntent;
-      readonly feishuContext?: {
-        readonly installationId?: string;
-        readonly expectedOpenId?: string;
-      };
-    },
+    args: StartCustomConnectorOAuth2Args,
     signal: AbortSignal,
   ) => {
     const connector = await get(
@@ -519,7 +793,9 @@ export const startCustomConnectorOAuth2$ = command(
     if (!connector) {
       return notFound("Custom connector not found");
     }
-    if (!isCustomOAuthConnector(connector)) {
+    const customOAuth = isCustomOAuthConnector(connector);
+    const automaticOAuth = isAutomaticOAuthConnector(connector);
+    if (!customOAuth && !automaticOAuth) {
       return badRequestMessage(
         "Custom connector does not support OAuth 2.0 authentication",
       );
@@ -534,88 +810,50 @@ export const startCustomConnectorOAuth2$ = command(
     if (customConnectorOAuthMcpIsDisabled(connector, featureContext)) {
       return customConnectorMcpDisabledResponse();
     }
-    const providerAdapter = connector.oauthConfig.providerAdapter;
-    const redirectUri = args.redirectUri;
-    const state = generateConnectorOAuthState(args.publicBrand);
-    const codeVerifier =
-      connector.oauthConfig.pkceMethod === "S256" ? createPkceVerifier() : null;
-    const authorizationUrl = buildCustomConnectorOAuth2AuthorizationUrl({
-      config: connector.oauthConfig,
-      redirectUri,
-      state,
-      codeVerifier,
-    });
-    const context: CustomConnectorOAuthStateContext = {
-      oauthSetup: "custom",
-      connectorId: connector.id,
-      storageVersion: connector.storageVersion,
-      ...(providerAdapter === "feishu" && args.feishuContext
-        ? {
-            providerContext: {
-              provider: "feishu" as const,
-              completionTarget: "feishu" as const,
-              ...(args.feishuContext.installationId
-                ? { installationId: args.feishuContext.installationId }
-                : {}),
-              ...(args.feishuContext.expectedOpenId
-                ? { expectedOpenId: args.feishuContext.expectedOpenId }
-                : {}),
-            },
-          }
-        : {}),
-    };
-    const mutationStart = await set(writeDb$).transaction(async (tx) => {
-      await lockCustomConnectorOAuth2CredentialContract({
-        db: tx,
-        orgId: args.orgId,
-        connectorId: connector.id,
-        storageVersion: connector.storageVersion,
-      });
-      const resolution = await resolveConnectorConnectionMutation(tx, {
-        orgId: args.orgId,
-        userId: args.userId,
-        target: { kind: "custom", customConnectorId: connector.id },
-        mutation: args.account,
-        allowSiblings:
-          !isIntegrationManagedCustomConnector(connector) &&
-          connectorAccountSiblingWritesEnabled(featureContext),
-      });
-      if (resolution.kind !== "ready") {
-        return { resolution, connectionId: null };
+    if (automaticOAuth && !args.automaticOAuthClient) {
+      return badRequestMessage(
+        "Automatic OAuth client identity is unavailable",
+      );
+    }
+    let prepared: PreparedOAuthStart;
+    if (customOAuth) {
+      prepared = prepareCustomOAuthStart(connector, args);
+    } else if (automaticOAuth && args.automaticOAuthClient) {
+      const automatic = await prepareAutomaticOAuthStart(
+        {
+          db: set(writeDb$),
+          connector,
+          args,
+          featureContext,
+          client: args.automaticOAuthClient,
+        },
+        signal,
+      );
+      if (!automatic.ok) {
+        return automatic.response;
       }
-      const oauthStateId = await insertConnectorOAuthState(tx, {
-        state,
-        customConnectorId: connector.id,
-        storageVersion: connector.storageVersion,
-        authMethod: "oauth",
-        userId: args.userId,
-        orgId: args.orgId,
-        agentId: args.agentId,
-        authorizeAgent: args.agentId !== undefined,
-        redirectUri,
-        authorizationUrl,
-        codeVerifier,
-        oauthContext: JSON.stringify(context),
-        accountMutation: args.account,
-        expiresAt: connectorOAuthStateExpiresAt(),
-      });
-      return {
-        resolution,
-        connectionId: args.account.intent === "add" ? oauthStateId : null,
-      };
-    });
-    signal.throwIfAborted();
-    if (mutationStart.resolution.kind !== "ready") {
-      return mutationStart.resolution.kind === "missing"
-        ? notFound("Connector account not found")
-        : conflict(
-            mutationStart.resolution.kind === "ambiguous"
-              ? "Multiple connector accounts require an exact choice"
-              : "Additional connector accounts are not enabled yet",
-          );
+      prepared = automatic.value;
+    } else {
+      throw new Error("OAuth connector mode changed during authorization");
+    }
+    const mutationStart = await persistCustomConnectorOAuthStart(
+      {
+        db: set(writeDb$),
+        connector,
+        args,
+        featureContext,
+        prepared,
+      },
+      signal,
+    );
+    const mutationFailure = connectorConnectionMutationFailure(
+      mutationStart.resolution,
+    );
+    if (mutationFailure) {
+      return mutationFailure;
     }
     return {
-      authorizationUrl,
+      authorizationUrl: prepared.authorizationUrl,
       connectionId: mutationStart.connectionId ?? undefined,
     };
   },
@@ -791,6 +1029,7 @@ export async function lockCustomConnectorOAuth2CredentialContract(args: {
   readonly orgId: string;
   readonly connectorId: string;
   readonly storageVersion: number;
+  readonly oauthSetup?: "custom" | "automatic";
 }): Promise<{
   readonly providerAdapter: CustomConnectorOAuthProviderAdapter | null;
 }> {
@@ -820,7 +1059,9 @@ export async function lockCustomConnectorOAuth2CredentialContract(args: {
   if (
     !definition ||
     definition.authMode !== "oauth" ||
-    (definition.oauthSetup !== null && definition.oauthSetup !== "custom") ||
+    (args.oauthSetup === "automatic"
+      ? definition.oauthSetup !== "automatic"
+      : definition.oauthSetup !== null && definition.oauthSetup !== "custom") ||
     definition.storageVersion !== args.storageVersion
   ) {
     throw new Error(
@@ -841,6 +1082,19 @@ export async function storeCustomConnectorOAuth2Connection(
     readonly featureContext: FeatureSwitchContext;
     readonly account: ConnectorAccountMutationIntent;
     readonly insertConnectionId?: string;
+    readonly automaticOAuthBinding?: {
+      readonly issuer: string;
+      readonly resource: string;
+      readonly resourceMetadataUrl: string | null;
+      readonly tokenEndpoint: string;
+      readonly clientId: string;
+      readonly tokenEndpointAuthMethod:
+        | "none"
+        | "client_secret_basic"
+        | "client_secret_post";
+      readonly registrationMethod: "cimd" | "dcr";
+      readonly dcrRegistrationId: string | null;
+    };
   },
   signal: AbortSignal,
 ): Promise<
@@ -855,6 +1109,7 @@ export async function storeCustomConnectorOAuth2Connection(
       orgId: args.orgId,
       connectorId: args.connectorId,
       storageVersion: args.storageVersion,
+      oauthSetup: args.automaticOAuthBinding ? "automatic" : "custom",
     });
     signal.throwIfAborted();
     const resolution = await resolveConnectorConnectionMutation(tx, {
@@ -894,6 +1149,21 @@ export async function storeCustomConnectorOAuth2Connection(
               encrypted,
             }),
           );
+          await db
+            .delete(customConnectorAccountOauthBindings)
+            .where(
+              eq(
+                customConnectorAccountOauthBindings.connectorAccountId,
+                connectorId,
+              ),
+            );
+          if (args.automaticOAuthBinding) {
+            await db.insert(customConnectorAccountOauthBindings).values({
+              connectorAccountId: connectorId,
+              customConnectorId: args.connectorId,
+              ...args.automaticOAuthBinding,
+            });
+          }
         },
       },
       signal,
@@ -1078,7 +1348,11 @@ async function resolveCustomConnectorOAuth2AccessToken(
   args: ResolveCustomConnectorOAuth2AccessTokenArgs,
   signal: AbortSignal,
 ): Promise<CustomConnectorOAuth2AccessTokenResolution> {
-  if (args.connector.authMode !== "oauth" || !args.connector.oauthConfig) {
+  if (
+    args.connector.authMode !== "oauth" ||
+    args.connector.oauthSetup !== "custom" ||
+    !args.connector.oauthConfig
+  ) {
     return { kind: "unavailable" };
   }
   const oauthConfig = args.connector.oauthConfig;
@@ -1199,6 +1473,212 @@ async function resolveCustomConnectorOAuth2AccessToken(
   });
 }
 
+async function handleAutomaticOAuthRefreshFailure(args: {
+  readonly db: Db;
+  readonly connectionId: string;
+  readonly binding: CustomConnectorAutomaticOAuthBinding;
+  readonly error: unknown;
+}): Promise<{ readonly kind: "reconnect-required" }> {
+  if (
+    isAutomaticOAuthInvalidClient(args.error) &&
+    args.binding.registrationMethod === "dcr"
+  ) {
+    await retireCustomConnectorDcrRegistration(
+      args.db,
+      args.binding.dcrRegistration.id,
+    );
+    return { kind: "reconnect-required" };
+  }
+  if (
+    isAutomaticOAuthInvalidGrant(args.error) ||
+    isAutomaticOAuthInvalidClient(args.error) ||
+    (args.error instanceof CustomConnectorAutomaticOAuthError &&
+      args.error.kind === "binding-drift")
+  ) {
+    await markCustomConnectorNeedsReconnect(
+      args.db,
+      args.connectionId,
+      "authorization_expired_or_revoked",
+    );
+    return { kind: "reconnect-required" };
+  }
+  if (
+    args.error instanceof CustomConnectorAutomaticOAuthError &&
+    args.error.kind === "temporary"
+  ) {
+    throw new CustomConnectorOAuth2TokenRefreshError(args.error);
+  }
+  throw args.error;
+}
+
+async function refreshLockedAutomaticOAuthAccessToken(
+  context: {
+    readonly db: Db;
+    readonly args: ResolveCustomConnectorOAuth2AccessTokenArgs;
+    readonly connector: CustomConnectorRow & {
+      readonly kind: "mcp";
+      readonly authMode: "oauth";
+      readonly oauthSetup: "automatic";
+    };
+    readonly initialConnection: StoredConnection;
+    readonly initialAccessToken: ReturnType<typeof storedConnectionAccessToken>;
+  },
+  signal: AbortSignal,
+): Promise<CustomConnectorOAuth2AccessTokenResolution> {
+  const { db, args, connector, initialConnection, initialAccessToken } =
+    context;
+  const lockedConnection = await loadConnection({
+    db,
+    orgId: args.orgId,
+    userId: args.userId,
+    customConnectorId: connector.id,
+    memberConnectorId: args.memberConnectorId,
+    storageVersion: connector.storageVersion,
+    lockRow: true,
+  });
+  signal.throwIfAborted();
+  if (!lockedConnection) {
+    return { kind: "unavailable" };
+  }
+  const lockedAccessToken = storedConnectionAccessToken(lockedConnection);
+  const recoveredSinceInitialRead =
+    initialConnection.needsReconnect ||
+    initialAccessToken.kind !== "available" ||
+    (lockedAccessToken.kind === "available" &&
+      lockedAccessToken.encryptedAccessToken !==
+        initialAccessToken.encryptedAccessToken);
+  if (
+    !lockedConnection.needsReconnect &&
+    lockedAccessToken.kind === "available" &&
+    (!args.forceRefresh || recoveredSinceInitialRead) &&
+    connectionAccessTokenIsCurrent(lockedConnection)
+  ) {
+    return lockedAccessToken;
+  }
+  if (!lockedConnection.encryptedRefreshToken) {
+    await markCustomConnectorNeedsReconnect(
+      db,
+      lockedConnection.id,
+      "missing_refresh_token",
+    );
+    return { kind: "reconnect-required" };
+  }
+  const binding = await readCustomConnectorAutomaticOAuthBinding(
+    db,
+    lockedConnection.id,
+  );
+  signal.throwIfAborted();
+  if (!binding) {
+    await markCustomConnectorNeedsReconnect(
+      db,
+      lockedConnection.id,
+      "authorization_expired_or_revoked",
+    );
+    return { kind: "reconnect-required" };
+  }
+  if (
+    binding.registrationMethod === "dcr" &&
+    binding.dcrRegistration.expiresAt !== null &&
+    binding.dcrRegistration.expiresAt <= nowDate()
+  ) {
+    await retireCustomConnectorDcrRegistration(db, binding.dcrRegistration.id);
+    return { kind: "reconnect-required" };
+  }
+  const refreshToken = await decryptStoredSecretValue(
+    lockedConnection.encryptedRefreshToken,
+    args.featureContext,
+  );
+  signal.throwIfAborted();
+  const okouClientMetadata = configuredOkouMcpOAuthClientMetadata();
+  const [okouRedirectUri] = okouClientMetadata.redirect_uris;
+  if (!okouRedirectUri) {
+    throw new Error("Okou MCP OAuth callback is unavailable");
+  }
+  const refreshResult = await settle(
+    refreshCustomConnectorAutomaticOAuthToken(
+      {
+        db,
+        binding,
+        endpoint: connector.endpoint,
+        redirectUri: okouRedirectUri,
+        cimdClientId: okouClientMetadata.client_id,
+        refreshToken,
+        featureContext: args.featureContext,
+      },
+      signal,
+    ),
+    signal,
+  );
+  if (!refreshResult.ok) {
+    return await handleAutomaticOAuthRefreshFailure({
+      db,
+      connectionId: lockedConnection.id,
+      binding,
+      error: refreshResult.error,
+    });
+  }
+  const encryptedAccessToken = await replaceConnectionTokens({
+    db,
+    connectionId: lockedConnection.id,
+    orgId: args.orgId,
+    userId: args.userId,
+    token: refreshResult.value,
+    fallbackRefreshToken: refreshToken,
+    fallbackEncryptedIdToken: lockedConnection.encryptedIdToken ?? undefined,
+    featureContext: args.featureContext,
+  });
+  signal.throwIfAborted();
+  return {
+    kind: "available",
+    encryptedAccessToken,
+    tokenExpiresAt: refreshResult.value.expiresAt,
+    status: "refreshed",
+  };
+}
+
+async function resolveAutomaticCustomConnectorOAuth2AccessToken(
+  args: ResolveCustomConnectorOAuth2AccessTokenArgs,
+  signal: AbortSignal,
+): Promise<CustomConnectorOAuth2AccessTokenResolution> {
+  if (!isAutomaticOAuthConnector(args.connector)) {
+    return { kind: "unavailable" };
+  }
+  const connector = args.connector;
+  const connection = await loadConnection({
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    customConnectorId: connector.id,
+    memberConnectorId: args.memberConnectorId,
+    storageVersion: connector.storageVersion,
+  });
+  signal.throwIfAborted();
+  if (!connection) {
+    return { kind: "unavailable" };
+  }
+  const accessToken = storedConnectionAccessToken(connection);
+  if (
+    !args.forceRefresh &&
+    !connection.needsReconnect &&
+    accessToken.kind === "available" &&
+    connectionAccessTokenIsCurrent(connection)
+  ) {
+    return accessToken;
+  }
+  return await args.db.transaction(async (tx) => {
+    return await refreshLockedAutomaticOAuthAccessToken(
+      {
+        db: tx,
+        args,
+        connector,
+        initialConnection: connection,
+        initialAccessToken: accessToken,
+      },
+      signal,
+    );
+  });
+}
+
 async function loadLiveCustomConnector(args: {
   readonly db: Db;
   readonly orgId: string;
@@ -1247,7 +1727,11 @@ export async function resolveCurrentCustomConnectorOAuth2AccessToken(
   if (!connector || connector.authMode !== "oauth") {
     return { kind: "unavailable" };
   }
-  return await resolveCustomConnectorOAuth2AccessToken(
+  const resolve =
+    connector.oauthSetup === "automatic"
+      ? resolveAutomaticCustomConnectorOAuth2AccessToken
+      : resolveCustomConnectorOAuth2AccessToken;
+  return await resolve(
     {
       ...args,
       connector,

--- a/turbo/apps/api/src/signals/services/custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector.service.ts
@@ -636,7 +636,14 @@ function credentialContractChanged(args: {
   readonly definition: ValidatedDefinition;
   readonly nextOAuthConfig: CustomConnectorOAuthConfigRow | null;
 }): boolean {
+  const automaticMcpEndpointChanged =
+    args.existing.kind === "mcp" &&
+    args.definition.kind === "mcp" &&
+    args.existing.oauthSetup === "automatic" &&
+    args.definition.oauthSetup === "automatic" &&
+    args.existing.endpoint !== args.definition.endpoint;
   return (
+    automaticMcpEndpointChanged ||
     args.existing.authMode !== args.definition.authMode ||
     args.existing.oauthSetup !== args.definition.oauthSetup ||
     !credentialFieldsEqual(args.existing.fields, args.definition.fields) ||
@@ -1920,11 +1927,6 @@ export const createCustomConnector$ = command(
     if (isBadRequest(oauthConfigUpdate)) {
       return oauthConfigUpdate;
     }
-    if (v.oauthSetup === "automatic") {
-      return badRequestMessage(
-        "Automatic OAuth connector setup is not enabled yet",
-      );
-    }
     signal.throwIfAborted();
 
     let encryptedClientSecret: string | null = null;
@@ -2271,11 +2273,6 @@ function prepareCustomConnectorUpdate(args: {
   );
   if (isBadRequest(definition)) {
     return definition;
-  }
-  if (definition.oauthSetup === "automatic") {
-    return badRequestMessage(
-      "Automatic OAuth connector setup is not enabled yet",
-    );
   }
   const oauthConfigUpdate = validateOAuthConfigUpdate({
     authMode: definition.authMode,

--- a/turbo/apps/api/src/signals/services/mcp-oauth-client-metadata.service.ts
+++ b/turbo/apps/api/src/signals/services/mcp-oauth-client-metadata.service.ts
@@ -34,3 +34,22 @@ export function okouMcpOAuthClientMetadata(
   };
   return metadata;
 }
+
+export function okouMcpOAuthDynamicClientMetadata(
+  request: Request,
+): OAuthClientMetadata {
+  const metadata = okouMcpOAuthClientMetadata(request);
+  return {
+    client_name: metadata.client_name,
+    client_uri: metadata.client_uri,
+    redirect_uris: metadata.redirect_uris,
+    grant_types: metadata.grant_types,
+    response_types: metadata.response_types,
+    application_type: metadata.application_type,
+  };
+}
+
+export function configuredOkouMcpOAuthClientMetadata(): OkouMcpOAuthClientMetadata &
+  OAuthClientMetadata {
+  return okouMcpOAuthClientMetadata(new Request(env("APP_URL")));
+}

--- a/turbo/apps/api/src/signals/services/mcp-oauth-safe-fetch.service.ts
+++ b/turbo/apps/api/src/signals/services/mcp-oauth-safe-fetch.service.ts
@@ -101,6 +101,16 @@ async function resolvePublicAddress(
   return address;
 }
 
+export async function validateMcpOAuthPublicUrl(
+  input: string | URL,
+  signal: AbortSignal,
+): Promise<string> {
+  const url = allowedUrl(input);
+  await resolvePublicAddress(url, signal);
+  signal.throwIfAborted();
+  return url.href;
+}
+
 function requestMethod(
   method: string | undefined,
 ): SerializedRequest["method"] {

--- a/turbo/packages/api-contracts/src/contracts/custom-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/custom-connectors.ts
@@ -605,6 +605,7 @@ export const customConnectorOAuth2Contract = c.router({
       404: apiErrorSchema,
       409: apiErrorSchema,
       500: apiErrorSchema,
+      502: apiErrorSchema,
     },
     summary: "Start OAuth 2.0 for a custom connector",
   },
@@ -617,6 +618,7 @@ export const customConnectorOAuth2Contract = c.router({
         state: z.string().optional(),
         error: z.string().optional(),
         error_description: z.string().optional(),
+        iss: z.string().optional(),
         responseMode: z.literal("json").optional(),
       })
       .catchall(z.string()),


### PR DESCRIPTION
## Summary

- make MCP custom connectors with `oauthSetup: automatic` operational through protocol-aware OAuth discovery
- support canonical Okou CIMD clients and connector-scoped reusable DCR clients, including public, `client_secret_basic`, and `client_secret_post` token authentication
- bind issuer, resource, endpoints, client identity, and registration method across callback and refresh; fail closed on drift and retire invalid shared DCR registrations
- preserve the existing OAuth account, callback, firewall injection, and multi-account flows

## Scope exclusions

- no Platform UI or setup-selector changes
- no interactive scope step-up after `403 insufficient_scope`
- no authorization-server selector, global DCR sharing, remote registration management, or stdio/desktop MCP OAuth

## Validation

- `pnpm turbo run lint --filter=api --filter=@okouai/api-contracts`
- `pnpm -F api check-types`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/mcp-oauth-foundations.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts --maxWorkers=4 --silent=passed-only` (168 passed)
- `pnpm knip --workspace api`
- pre-commit hook: Prettier, repository Knip, repository type checks, file-size check

Closes #30488

Parent delivery issue: #30466
