### PR TITLE
refactor(python): share bounded zlib member decoding

### DIFF
--- a/crates/runner/mitm-addon/src/billing_body.py
+++ b/crates/runner/mitm-addon/src/billing_body.py
@@ -5,50 +5,36 @@ import zlib
 from mitmproxy import http
 
 from body_limits import REQUEST_BODY_BILLING_INSPECTION_LIMIT
-from zlib_input import ZlibInputCursor
+from zlib_decoding import decode_zlib_bounded
 
 
 def _decode_gzip_request_body_for_billing(data: bytes, max_output: int) -> bytes | None:
     """Decode every gzip member under one output cap."""
-    input_cursor = ZlibInputCursor(data)
-    decoded = bytearray()
-    wbits = 16 + zlib.MAX_WBITS
-    obj = zlib.decompressobj(wbits)
-    while input_cursor:
-        input_chunk = input_cursor.take()
-        try:
-            decoded.extend(
-                obj.decompress(
-                    input_chunk,
-                    max_length=max_output - len(decoded) + 1,
-                )
-            )
-        except zlib.error:
-            return None
-        if len(decoded) > max_output:
-            return None
-        if obj.eof:
-            input_cursor.carry(obj.unused_data)
-            if not input_cursor:
-                return bytes(decoded)
-            obj = zlib.decompressobj(wbits)
-        elif obj.unconsumed_tail:
-            input_cursor.carry(obj.unconsumed_tail)
-    return None
+    if not data or max_output < 0:
+        return None
+    result = decode_zlib_bounded(
+        data,
+        wbits=16 + zlib.MAX_WBITS,
+        max_output=max_output,
+    )
+    return result.body if result.status == "complete" else None
 
 
 def _decode_deflate_request_body_for_billing(data: bytes, max_output: int) -> bytes | None:
     """Decode one zlib-wrapped or raw deflate stream under one output cap."""
+    if not data or max_output < 0:
+        return None
     for wbits in (zlib.MAX_WBITS, -zlib.MAX_WBITS):
-        obj = zlib.decompressobj(wbits)
-        try:
-            decoded = obj.decompress(data, max_length=max_output + 1)
-        except zlib.error:
-            continue
-        if len(decoded) > max_output:
+        result = decode_zlib_bounded(
+            data,
+            wbits=wbits,
+            max_output=max_output,
+            max_members=1,
+        )
+        if result.status == "complete":
+            return result.body
+        if result.status == "output_limit_exceeded":
             return None
-        if obj.eof and not obj.unused_data:
-            return decoded
     return None
 
 

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -23,6 +23,7 @@ from body_limits import (
     STREAM_DECODE_EXPANSION_GRACE,
     STREAM_DECODE_MAX_EXPANSION_RATIO,
 )
+from zlib_decoding import decode_zlib_bounded
 from zlib_input import ZlibInputCursor
 
 # Brotli 1.2's output_buffer_limit is a soft allocation threshold, not a hard
@@ -652,35 +653,16 @@ def _decompress_zlib_json_usage_body(
         return b"", DECODED_BODY_LIMIT_EXCEEDED if data else None
 
     wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
-    input_cursor = ZlibInputCursor(data)
-    out = bytearray()
-
-    while input_cursor:
-        remaining_output = max_output - len(out)
-        # One probe byte distinguishes exact completion from real overflow.
-        obj = zlib.decompressobj(wbits)
-
-        while input_cursor:
-            member_data = input_cursor.take()
-            try:
-                decoded = obj.decompress(member_data, max_length=remaining_output + 1)
-            except zlib.error:
-                return b"", INVALID_COMPRESSED_BODY
-
-            if len(decoded) > remaining_output:
-                out.extend(decoded[:remaining_output])
-                return bytes(out), DECODED_BODY_LIMIT_EXCEEDED
-            out.extend(decoded)
-            remaining_output -= len(decoded)
-            if obj.eof:
-                input_cursor.carry(obj.unused_data)
-                break
-            if obj.unconsumed_tail:
-                input_cursor.carry(obj.unconsumed_tail)
-        else:
-            return bytes(out), INCOMPLETE_COMPRESSED_BODY
-
-    return bytes(out), None
+    result = decode_zlib_bounded(data, wbits=wbits, max_output=max_output)
+    if result.status == "complete":
+        return result.body, None
+    if result.status == "incomplete":
+        return result.body, INCOMPLETE_COMPRESSED_BODY
+    if result.status == "output_limit_exceeded":
+        return result.body, DECODED_BODY_LIMIT_EXCEEDED
+    # Unlimited member traversal cannot produce ``trailing_data``. Treat it
+    # defensively like any other structurally invalid compressed body.
+    return b"", INVALID_COMPRESSED_BODY
 
 
 def _validate_complete_zstd_frames(data: bytes, max_output: int) -> str | None:

--- a/crates/runner/mitm-addon/src/zlib_decoding.py
+++ b/crates/runner/mitm-addon/src/zlib_decoding.py
@@ -1,0 +1,95 @@
+"""Bounded complete-stream traversal for zlib-backed encodings."""
+
+import zlib
+from dataclasses import dataclass
+from typing import Literal
+
+from zlib_input import ZlibInputCursor
+
+ZlibDecodeStatus = Literal[
+    "complete",
+    "invalid",
+    "incomplete",
+    "trailing_data",
+    "output_limit_exceeded",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ZlibDecodeResult:
+    """Structural result from bounded complete-stream zlib traversal.
+
+    ``body`` contains at most ``max_output`` decoded bytes produced before
+    ``status`` became terminal. ``completed_members`` advances only when a
+    decompressor reaches EOF. Caller-specific failure and compatibility policy
+    stays outside this result.
+    """
+
+    body: bytes
+    status: ZlibDecodeStatus
+    completed_members: int
+
+
+def decode_zlib_bounded(
+    data: bytes,
+    *,
+    wbits: int,
+    max_output: int,
+    max_members: int | None = None,
+) -> ZlibDecodeResult:
+    """Decode complete zlib-backed members under one output cap.
+
+    Input is traversed once in bounded chunks. At an exact output boundary,
+    each decompressor call may materialize one temporary probe byte so the
+    result can distinguish complete empty tails from real overflow. The probe
+    byte is never retained in ``body``.
+
+    When ``max_members`` is set, input remaining after that many complete
+    members is reported as ``trailing_data`` without interpreting another
+    member. Otherwise, remaining input starts another member with the same
+    ``wbits`` value.
+    """
+    if max_output < 0:
+        raise ValueError("max_output must be non-negative")
+    if max_members is not None and max_members <= 0:
+        raise ValueError("max_members must be positive")
+
+    input_cursor = ZlibInputCursor(data)
+    if not input_cursor:
+        return ZlibDecodeResult(b"", "complete", 0)
+
+    out = bytearray()
+    completed_members = 0
+    obj = zlib.decompressobj(wbits)
+
+    while input_cursor:
+        remaining_output = max_output - len(out)
+        try:
+            decoded = obj.decompress(
+                input_cursor.take(),
+                max_length=remaining_output + 1,
+            )
+        except zlib.error:
+            return ZlibDecodeResult(bytes(out), "invalid", completed_members)
+
+        if len(decoded) > remaining_output:
+            out.extend(decoded[:remaining_output])
+            return ZlibDecodeResult(
+                bytes(out),
+                "output_limit_exceeded",
+                completed_members,
+            )
+        out.extend(decoded)
+
+        if obj.eof:
+            completed_members += 1
+            input_cursor.carry(obj.unused_data)
+            if not input_cursor:
+                return ZlibDecodeResult(bytes(out), "complete", completed_members)
+            if max_members is not None and completed_members >= max_members:
+                return ZlibDecodeResult(bytes(out), "trailing_data", completed_members)
+            obj = zlib.decompressobj(wbits)
+        elif obj.unconsumed_tail:
+            input_cursor.carry(obj.unconsumed_tail)
+
+    return ZlibDecodeResult(bytes(out), "incomplete", completed_members)

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -48,7 +48,10 @@ def _many_empty_zlib_members(encoding: str) -> bytes:
     return member * (STREAM_BUFFER_LIMIT // len(member))
 
 
-def _track_zlib_decompressor(monkeypatch):
+def _track_zlib_decompressor(
+    monkeypatch,
+    target: str = "body_decoding.zlib.decompressobj",
+):
     real_factory = zlib.decompressobj
     stats = {
         "calls": 0,
@@ -90,7 +93,7 @@ def _track_zlib_decompressor(monkeypatch):
         stats["objects"] += 1
         return TrackingDecompressionObj(real_factory(*args, **kwargs))
 
-    monkeypatch.setattr("body_decoding.zlib.decompressobj", factory)
+    monkeypatch.setattr(target, factory)
     return stats
 
 
@@ -773,6 +776,13 @@ class TestDecodeRequestBodyForNetworkLogCapture:
         hdrs = headers(("Content-Encoding", encoding))
         assert decode_request_body_for_network_log_capture(compressed, hdrs) == b""
 
+    def test_raw_deflate_remains_unsupported(self, headers):
+        body = b'{"hello":"world"}'
+        compressed = zlib.compress(body, wbits=-zlib.MAX_WBITS)
+        hdrs = headers(("Content-Encoding", "deflate"))
+
+        assert decode_request_body_for_network_log_capture(compressed, hdrs) is None
+
     def test_unsupported_encoding_returns_none(self, headers):
         hdrs = headers(("Content-Encoding", "x-custom"))
         assert decode_request_body_for_network_log_capture(b"opaque", hdrs) is None
@@ -810,7 +820,10 @@ class TestDecompressJsonUsageBody:
     @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
     def test_many_empty_zlib_members_use_bounded_input(self, headers, monkeypatch, encoding):
         compressed = _many_empty_zlib_members(encoding)
-        stats = _track_zlib_decompressor(monkeypatch)
+        stats = _track_zlib_decompressor(
+            monkeypatch,
+            "zlib_decoding.zlib.decompressobj",
+        )
         hdrs = headers(("Content-Encoding", encoding))
 
         decoded, error = decompress_json_usage_body(compressed, hdrs, max_output=1)
@@ -818,6 +831,20 @@ class TestDecompressJsonUsageBody:
         assert decoded == b""
         assert error is None
         _assert_zlib_input_is_bounded(stats)
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_concatenated_zlib_members_return_complete_body(self, headers, encoding):
+        first = b'{"usage":'
+        second = b'{"input_tokens":1}}'
+        compressed = _compress_one_shot_body(encoding, first) + _compress_one_shot_body(
+            encoding, second
+        )
+        hdrs = headers(("Content-Encoding", encoding))
+
+        decoded, error = decompress_json_usage_body(compressed, hdrs, max_output=1024)
+
+        assert decoded == first + second
+        assert error is None
 
     def test_brotli_exact_limit_consumes_later_frame_trailer(self, headers, monkeypatch):
         body = pseudo_random_ascii(13)

--- a/crates/runner/mitm-addon/tests/test_zlib_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_zlib_decoding.py
@@ -1,0 +1,281 @@
+"""Tests for bounded complete-stream zlib traversal."""
+
+import zlib
+
+import pytest
+
+from zlib_decoding import decode_zlib_bounded
+
+_GZIP_WBITS = 16 + zlib.MAX_WBITS
+_ZLIB_WBITS = zlib.MAX_WBITS
+_RAW_WBITS = -zlib.MAX_WBITS
+_ZLIB_INPUT_BOUND = 1024
+
+
+def _compress(body: bytes, wbits: int) -> bytes:
+    return zlib.compress(body, wbits=wbits)
+
+
+@pytest.mark.parametrize("wbits", [_GZIP_WBITS, _ZLIB_WBITS, _RAW_WBITS])
+def test_complete_single_member(wbits):
+    body = b"complete body"
+
+    result = decode_zlib_bounded(_compress(body, wbits), wbits=wbits, max_output=len(body))
+
+    assert result.body == body
+    assert result.status == "complete"
+    assert result.completed_members == 1
+
+
+@pytest.mark.parametrize("wbits", [_GZIP_WBITS, _ZLIB_WBITS, _RAW_WBITS])
+def test_complete_concatenated_members(wbits):
+    first = b"first"
+    second = b"second"
+    compressed = _compress(first, wbits) + _compress(second, wbits)
+
+    result = decode_zlib_bounded(
+        compressed,
+        wbits=wbits,
+        max_output=len(first) + len(second),
+    )
+
+    assert result.body == first + second
+    assert result.status == "complete"
+    assert result.completed_members == 2
+
+
+@pytest.mark.parametrize("wbits", [_GZIP_WBITS, _ZLIB_WBITS, _RAW_WBITS])
+@pytest.mark.parametrize("tail_kind", ["garbage", "second-member"])
+def test_one_member_limit_reports_trailing_data(wbits, tail_kind):
+    first = b"first"
+    tail = b"trailing garbage" if tail_kind == "garbage" else _compress(b"second", wbits)
+
+    result = decode_zlib_bounded(
+        _compress(first, wbits) + tail,
+        wbits=wbits,
+        max_output=1024,
+        max_members=1,
+    )
+
+    assert result.body == first
+    assert result.status == "trailing_data"
+    assert result.completed_members == 1
+
+
+@pytest.mark.parametrize("wbits", [_GZIP_WBITS, _ZLIB_WBITS])
+def test_invalid_first_member(wbits):
+    result = decode_zlib_bounded(b"not compressed", wbits=wbits, max_output=1024)
+
+    assert result.body == b""
+    assert result.status == "invalid"
+    assert result.completed_members == 0
+
+
+@pytest.mark.parametrize("wbits", [_GZIP_WBITS, _ZLIB_WBITS, _RAW_WBITS])
+def test_incomplete_first_member_retains_bounded_prefix(wbits):
+    body = b"incomplete body" * 100
+    compressed = _compress(body, wbits)
+
+    result = decode_zlib_bounded(compressed[:-1], wbits=wbits, max_output=len(body))
+
+    assert body.startswith(result.body)
+    assert result.status == "incomplete"
+    assert result.completed_members == 0
+
+
+@pytest.mark.parametrize("wbits", [_GZIP_WBITS, _ZLIB_WBITS])
+def test_invalid_later_member_retains_structural_prefix(wbits):
+    first = b"first"
+    corrupt_member = bytearray(_compress(b"second" * 1024, wbits))
+    corrupt_member[-1] ^= 0xFF
+
+    result = decode_zlib_bounded(
+        _compress(first, wbits) + bytes(corrupt_member),
+        wbits=wbits,
+        max_output=16 * 1024,
+    )
+
+    assert result.body.startswith(first)
+    assert result.status == "invalid"
+    assert result.completed_members == 1
+
+
+@pytest.mark.parametrize("wbits", [_GZIP_WBITS, _ZLIB_WBITS, _RAW_WBITS])
+def test_incomplete_later_member_retains_bounded_prefix(wbits):
+    first = b"first"
+    second = b"second" * 100
+    compressed = _compress(first, wbits) + _compress(second, wbits)[:-1]
+
+    result = decode_zlib_bounded(compressed, wbits=wbits, max_output=1024)
+
+    assert result.body.startswith(first)
+    assert (first + second).startswith(result.body)
+    assert result.status == "incomplete"
+    assert result.completed_members == 1
+
+
+@pytest.mark.parametrize("wbits", [_GZIP_WBITS, _ZLIB_WBITS, _RAW_WBITS])
+def test_exact_limit_validates_empty_trailing_members(wbits):
+    body = b"A" * 32
+    compressed = _compress(body, wbits) + _compress(b"", wbits) + _compress(b"", wbits)
+
+    result = decode_zlib_bounded(compressed, wbits=wbits, max_output=len(body))
+
+    assert result.body == body
+    assert result.status == "complete"
+    assert result.completed_members == 3
+
+
+@pytest.mark.parametrize("wbits", [_GZIP_WBITS, _ZLIB_WBITS, _RAW_WBITS])
+def test_exact_limit_rejects_nonempty_trailing_member_without_retaining_probe(wbits):
+    body = b"A" * 32
+    compressed = _compress(body, wbits) + _compress(b"B", wbits)
+
+    result = decode_zlib_bounded(compressed, wbits=wbits, max_output=len(body))
+
+    assert result.body == body
+    assert result.status == "output_limit_exceeded"
+    assert result.completed_members == 1
+
+
+@pytest.mark.parametrize("wbits", [_GZIP_WBITS, _ZLIB_WBITS])
+def test_exact_limit_classifies_invalid_trailing_data(wbits):
+    body = b"A" * 32
+
+    result = decode_zlib_bounded(
+        _compress(body, wbits) + b"not compressed",
+        wbits=wbits,
+        max_output=len(body),
+    )
+
+    assert result.body == body
+    assert result.status == "invalid"
+    assert result.completed_members == 1
+
+
+@pytest.mark.parametrize("wbits", [_GZIP_WBITS, _ZLIB_WBITS, _RAW_WBITS])
+def test_exact_limit_classifies_incomplete_trailing_member(wbits):
+    body = b"A" * 32
+    trailing = _compress(b"", wbits)
+
+    result = decode_zlib_bounded(
+        _compress(body, wbits) + trailing[:-1],
+        wbits=wbits,
+        max_output=len(body),
+    )
+
+    assert result.body == body
+    assert result.status == "incomplete"
+    assert result.completed_members == 1
+
+
+@pytest.mark.parametrize("wbits", [_GZIP_WBITS, _ZLIB_WBITS, _RAW_WBITS])
+def test_single_member_output_over_limit_is_capped(wbits):
+    body = b"A" * 33
+
+    result = decode_zlib_bounded(_compress(body, wbits), wbits=wbits, max_output=32)
+
+    assert result.body == body[:32]
+    assert result.status == "output_limit_exceeded"
+    assert result.completed_members == 0
+
+
+@pytest.mark.parametrize("wbits", [_GZIP_WBITS, _ZLIB_WBITS, _RAW_WBITS])
+def test_concatenated_output_over_limit_is_capped(wbits):
+    first = b"A" * 16
+    second = b"B" * 17
+
+    result = decode_zlib_bounded(
+        _compress(first, wbits) + _compress(second, wbits),
+        wbits=wbits,
+        max_output=32,
+    )
+
+    assert result.body == first + second[:16]
+    assert result.status == "output_limit_exceeded"
+    assert result.completed_members == 1
+
+
+def test_empty_source_is_complete_without_members():
+    result = decode_zlib_bounded(b"", wbits=_GZIP_WBITS, max_output=0)
+
+    assert result.body == b""
+    assert result.status == "complete"
+    assert result.completed_members == 0
+
+
+@pytest.mark.parametrize("wbits", [_GZIP_WBITS, _ZLIB_WBITS, _RAW_WBITS])
+def test_zero_output_budget_accepts_empty_stream(wbits):
+    result = decode_zlib_bounded(_compress(b"", wbits), wbits=wbits, max_output=0)
+
+    assert result.body == b""
+    assert result.status == "complete"
+    assert result.completed_members == 1
+
+
+@pytest.mark.parametrize("wbits", [_GZIP_WBITS, _ZLIB_WBITS, _RAW_WBITS])
+def test_zero_output_budget_detects_output_without_retaining_probe(wbits):
+    result = decode_zlib_bounded(_compress(b"x", wbits), wbits=wbits, max_output=0)
+
+    assert result.body == b""
+    assert result.status == "output_limit_exceeded"
+    assert result.completed_members == 0
+
+
+def test_many_members_use_bounded_input_and_tail(monkeypatch):
+    member = _compress(b"", _GZIP_WBITS)
+    compressed = member * (64 * 1024 // len(member))
+    real_factory = zlib.decompressobj
+    stats = {"calls": 0, "max_input": 0, "max_unused_data": 0}
+
+    class NonConcatenableUnusedData(bytes):
+        def __add__(self, _other: object) -> bytes:
+            raise TypeError("zlib unused data must not be concatenated")
+
+    class TrackingDecompressionObj:
+        def __init__(self, wrapped):
+            self._wrapped = wrapped
+
+        def decompress(self, chunk, *args, **kwargs):
+            stats["calls"] += 1
+            stats["max_input"] = max(stats["max_input"], len(chunk))
+            return self._wrapped.decompress(chunk, *args, **kwargs)
+
+        @property
+        def eof(self):
+            return self._wrapped.eof
+
+        @property
+        def unused_data(self):
+            unused_data = NonConcatenableUnusedData(self._wrapped.unused_data)
+            stats["max_unused_data"] = max(stats["max_unused_data"], len(unused_data))
+            return unused_data
+
+        @property
+        def unconsumed_tail(self):
+            return self._wrapped.unconsumed_tail
+
+    def factory(*args, **kwargs):
+        return TrackingDecompressionObj(real_factory(*args, **kwargs))
+
+    monkeypatch.setattr("zlib_decoding.zlib.decompressobj", factory)
+
+    result = decode_zlib_bounded(compressed, wbits=_GZIP_WBITS, max_output=0)
+
+    assert result.status == "complete"
+    assert result.completed_members == len(compressed) // len(member)
+    assert stats["calls"] > 0
+    assert stats["max_input"] <= _ZLIB_INPUT_BOUND
+    assert stats["max_unused_data"] <= _ZLIB_INPUT_BOUND
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        pytest.param({"max_output": -1}, "max_output", id="negative-output"),
+        pytest.param({"max_output": 0, "max_members": 0}, "max_members", id="zero-members"),
+    ],
+)
+def test_invalid_bounds_raise_value_error(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        decode_zlib_bounded(b"", wbits=_GZIP_WBITS, **kwargs)

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -256,7 +256,7 @@ def test_tweet_create_many_gzip_members_use_bounded_input(x_usage, tmp_path, rea
     def factory(*args, **kwargs):
         return TrackingDecompressionObj(real_factory(*args, **kwargs))
 
-    with patch("billing_body.zlib.decompressobj", factory):
+    with patch("zlib_decoding.zlib.decompressobj", factory):
         p = x_usage.call_and_get_single_billing(flow)
 
     assert p["category"] == "content.create"
@@ -385,10 +385,14 @@ def test_tweet_create_deflate_enforces_decoded_cap(
         def unused_data(self):
             return self._wrapped.unused_data
 
+        @property
+        def unconsumed_tail(self):
+            return self._wrapped.unconsumed_tail
+
     def factory(*args, **kwargs):
         return TrackingDecompressionObj(real_factory(*args, **kwargs))
 
-    with patch("billing_body.zlib.decompressobj", factory):
+    with patch("zlib_decoding.zlib.decompressobj", factory):
         p = x_usage.call_and_get_single_billing(flow)
 
     assert p["category"] == expected_category

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -332,6 +332,7 @@ suites before committing the upgrade.
 | `test_body_capture_headers.py`                          | Captured network-log header sanitization                                                                             |
 | `test_body_capture_stream_buffer.py`                    | Body capture stream-buffer contracts                                                                                 |
 | `test_body_decoding.py`                                 | Shared body decoding, streaming decode, codec limits, and decompression errors                                       |
+| `test_zlib_decoding.py`                                 | Bounded complete-stream zlib traversal, member, tail, and output-limit contracts                                     |
 | `test_anthropic_messages.py`                            | Anthropic Messages SSE and JSON usage extraction                                                                     |
 | `test_openai_responses_event_json.py`                   | OpenAI Responses event JSON usage extraction and merge behavior                                                      |
 | `test_openai_responses_json.py`                         | OpenAI Responses non-SSE JSON usage extraction                                                                       |


### PR DESCRIPTION
## Summary

- add a neutral bounded zlib result that owns complete-stream input traversal, member transitions, completion, trailing input, and output-cap accounting
- route strict JSON/request capture and billing gzip/deflate decoding through the shared owner while preserving each wrapper's framing and failure policy
- add direct gzip, zlib-wrapped deflate, and raw-deflate contract coverage plus wrapper regressions for concatenated streams and raw-deflate compatibility

## Behavior

- strict JSON and request capture continue accepting concatenated gzip and zlib-wrapped deflate streams
- billing continues accepting concatenated gzip members and exactly one zlib-wrapped or raw-deflate stream
- request capture continues rejecting raw deflate; buffered response capture remains unchanged
- invalid, incomplete, exact-limit, over-limit, empty-tail, non-empty-tail, and arbitrary-trailing classifications remain unchanged
- the stateful streaming, best-effort retained-buffer, and buffered response compatibility loops remain separate because their lifecycle and output-commit policies differ from complete-input traversal

## Safety

- returned output never exceeds the configured cap
- exact-limit validation may materialize only one immediately discarded probe byte
- compressed input and decompressor tails remain bounded to 1 KiB chunks for member-heavy traversal
- X billing keeps ambiguous, incomplete, trailing, second-stream, and over-limit request bodies in the conservative category

## Exclusions

- no Brotli, zstd, streaming-decoder, API, schema, protocol, persistence, migration, deployment, or rollout changes
- no JavaScript changes or local Vitest run

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_zlib_decoding.py -q` (49 passed)
- `uv run --no-sync python -m pytest tests/test_body_decoding.py -q` (118 passed)
- `uv run --no-sync python -m pytest tests/x_connector_usage/test_writes.py -q` (126 passed)
- `uv run --no-sync python -m pytest tests/test_body_capture_fields.py -q` (55 passed)
- `uv run --no-sync python -m pytest tests/ -q` (7,322 passed)
- `git diff --check`

Closes #30831
