### PR TITLE
test(runner): execute workspace mount helpers

### DIFF
--- a/crates/runner/scripts/freeze-workspace-drive.sh
+++ b/crates/runner/scripts/freeze-workspace-drive.sh
@@ -36,4 +36,4 @@ if [ -z "$workspace_dev" ] || [ "$target_dev" != "$workspace_dev" ]; then
   exit 64
 fi
 
-/usr/sbin/fsfreeze --freeze "$workspace_fd_path"
+"$workspace_fsfreeze_path" --freeze "$workspace_fd_path"

--- a/crates/runner/scripts/mount-workspace-drive.sh
+++ b/crates/runner/scripts/mount-workspace-drive.sh
@@ -24,7 +24,7 @@ workspace_device_mounted_elsewhere() {
     if [ "$mount_dev" = "$workspace_dev" ]; then
       return 0
     fi
-  done < /proc/self/mountinfo
+  done < "$workspace_mountinfo_path"
   return 1
 }
 

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -1984,7 +1984,11 @@ mod tests {
         let exec_calls = sandbox.exec_calls();
         assert_eq!(exec_calls.len(), 1);
         assert!(exec_calls[0].sudo);
-        assert!(exec_calls[0].cmd.contains("fsfreeze --freeze"));
+        assert!(
+            exec_calls[0]
+                .cmd
+                .contains("\"$workspace_fsfreeze_path\" --freeze")
+        );
     }
 
     #[tokio::test]
@@ -2106,7 +2110,11 @@ mod tests {
                 assert!(promoted);
                 let exec_calls = sandbox.exec_calls();
                 assert_eq!(exec_calls.len(), 1);
-                assert!(exec_calls[0].cmd.contains("fsfreeze --freeze"));
+                assert!(
+                    exec_calls[0]
+                        .cmd
+                        .contains("\"$workspace_fsfreeze_path\" --freeze")
+                );
                 assert!(!exec_calls[0].cmd.contains("export-session-history-sidecar"));
                 let checkout = cache
                     .prepare(WorkspaceImagePrepareRequest {
@@ -2824,7 +2832,11 @@ mod tests {
 
         let exec_calls = overrides.exec_calls();
         assert_eq!(exec_calls.len(), 1);
-        assert!(exec_calls[0].cmd.contains("fsfreeze --freeze"));
+        assert!(
+            exec_calls[0]
+                .cmd
+                .contains("\"$workspace_fsfreeze_path\" --freeze")
+        );
         assert_eq!(overrides.destroy_call_count(), 1);
         assert!(cache.held_workspace_states().await.is_empty());
         assert_eq!(fixture.idle_pool.lock().await.len(), 0);

--- a/crates/runner/src/idle_pool/destroy_tests.rs
+++ b/crates/runner/src/idle_pool/destroy_tests.rs
@@ -119,7 +119,11 @@ async fn idle_destroy_job_destroy_panic_preserves_workspace_cache_and_releases_b
     assert!(result.workspace_cache_promoted);
     let exec_calls = overrides.exec_calls();
     assert_eq!(exec_calls.len(), 1);
-    assert!(exec_calls[0].cmd.contains("fsfreeze --freeze"));
+    assert!(
+        exec_calls[0]
+            .cmd
+            .contains("\"$workspace_fsfreeze_path\" --freeze")
+    );
     assert_eq!(overrides.destroy_call_count(), 1);
     assert_eq!(budget.allocated(), (2, 4096, 1));
     drop(result.budget_lease);
@@ -163,7 +167,11 @@ async fn idle_destroy_job_stop_panic_still_attempts_destroy_and_releases_budget_
     assert!(!promoted);
     let exec_calls = overrides.exec_calls();
     assert_eq!(exec_calls.len(), 1);
-    assert!(exec_calls[0].cmd.contains("fsfreeze --freeze"));
+    assert!(
+        exec_calls[0]
+            .cmd
+            .contains("\"$workspace_fsfreeze_path\" --freeze")
+    );
     assert_eq!(overrides.destroy_call_count(), 1);
     assert_eq!(budget.allocated(), (0, 0, 0));
     assert!(fixture.cache.held_workspace_states().await.is_empty());
@@ -204,7 +212,11 @@ async fn idle_destroy_job_publishes_frozen_workspace_only_after_successful_stop(
     assert!(promoted);
     let exec_calls = overrides.exec_calls();
     assert_eq!(exec_calls.len(), 1);
-    assert!(exec_calls[0].cmd.contains("fsfreeze --freeze"));
+    assert!(
+        exec_calls[0]
+            .cmd
+            .contains("\"$workspace_fsfreeze_path\" --freeze")
+    );
     assert_eq!(overrides.destroy_call_count(), 1);
     assert_eq!(budget.allocated(), (0, 0, 0));
     let states = fixture.cache.held_workspace_states().await;
@@ -248,7 +260,11 @@ async fn idle_destroy_job_stop_error_abandons_frozen_workspace_and_still_destroy
     assert!(!promoted);
     let exec_calls = overrides.exec_calls();
     assert_eq!(exec_calls.len(), 1);
-    assert!(exec_calls[0].cmd.contains("fsfreeze --freeze"));
+    assert!(
+        exec_calls[0]
+            .cmd
+            .contains("\"$workspace_fsfreeze_path\" --freeze")
+    );
     assert_eq!(overrides.destroy_call_count(), 1);
     assert_eq!(budget.allocated(), (0, 0, 0));
     assert!(fixture.cache.held_workspace_states().await.is_empty());
@@ -279,7 +295,11 @@ async fn idle_destroy_job_publication_failure_after_stop_still_destroys() {
     assert_eq!(overrides.unpark_call_count(), 1);
     let exec_calls = overrides.exec_calls();
     assert_eq!(exec_calls.len(), 1);
-    assert!(exec_calls[0].cmd.contains("fsfreeze --freeze"));
+    assert!(
+        exec_calls[0]
+            .cmd
+            .contains("\"$workspace_fsfreeze_path\" --freeze")
+    );
     assert_eq!(overrides.destroy_call_count(), 1);
     assert_eq!(budget.allocated(), (0, 0, 0));
     assert!(fixture.cache.held_workspace_states().await.is_empty());

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -22,6 +22,8 @@ use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
 pub(crate) const WORKSPACE_MOUNT_TIMEOUT: Duration = Duration::from_secs(30);
 const WORKSPACE_FREEZE_TIMEOUT: Duration = Duration::from_secs(30);
 const WORKSPACE_DEVICE: &str = "/dev/vdb";
+const WORKSPACE_MOUNTINFO_PATH: &str = "/proc/self/mountinfo";
+const WORKSPACE_FSFREEZE_PATH: &str = "/usr/sbin/fsfreeze";
 const WORKSPACE_MOUNT_SCRIPT: &str = include_str!("../scripts/mount-workspace-drive.sh");
 const WORKSPACE_FREEZE_SCRIPT: &str = include_str!("../scripts/freeze-workspace-drive.sh");
 
@@ -105,17 +107,45 @@ async fn run_workspace_drive_command(
 }
 
 pub(crate) fn workspace_mount_command() -> String {
-    workspace_command(WORKSPACE_MOUNT_SCRIPT)
+    workspace_mount_command_for(
+        CANONICAL_WORKING_DIR,
+        WORKSPACE_DEVICE,
+        WORKSPACE_MOUNTINFO_PATH,
+    )
 }
 
 fn workspace_freeze_command() -> String {
-    workspace_command(WORKSPACE_FREEZE_SCRIPT)
+    workspace_freeze_command_for(
+        CANONICAL_WORKING_DIR,
+        WORKSPACE_DEVICE,
+        WORKSPACE_FSFREEZE_PATH,
+    )
 }
 
-fn workspace_command(script: &str) -> String {
-    let workspace_dir = quote_shell_arg(CANONICAL_WORKING_DIR);
-    let workspace_device = quote_shell_arg(WORKSPACE_DEVICE);
-    format!("workspace_dir={workspace_dir}\nworkspace_device={workspace_device}\n{script}")
+fn workspace_mount_command_for(
+    workspace_dir: &str,
+    workspace_device: &str,
+    workspace_mountinfo_path: &str,
+) -> String {
+    let workspace_dir = quote_shell_arg(workspace_dir);
+    let workspace_device = quote_shell_arg(workspace_device);
+    let workspace_mountinfo_path = quote_shell_arg(workspace_mountinfo_path);
+    format!(
+        "workspace_dir={workspace_dir}\nworkspace_device={workspace_device}\nworkspace_mountinfo_path={workspace_mountinfo_path}\n{WORKSPACE_MOUNT_SCRIPT}"
+    )
+}
+
+fn workspace_freeze_command_for(
+    workspace_dir: &str,
+    workspace_device: &str,
+    workspace_fsfreeze_path: &str,
+) -> String {
+    let workspace_dir = quote_shell_arg(workspace_dir);
+    let workspace_device = quote_shell_arg(workspace_device);
+    let workspace_fsfreeze_path = quote_shell_arg(workspace_fsfreeze_path);
+    format!(
+        "workspace_dir={workspace_dir}\nworkspace_device={workspace_device}\nworkspace_fsfreeze_path={workspace_fsfreeze_path}\n{WORKSPACE_FREEZE_SCRIPT}"
+    )
 }
 
 #[cfg(test)]
@@ -151,66 +181,16 @@ mod tests {
     }
 
     #[test]
-    fn mount_command_uses_canonical_workspace_and_workspace_device() {
-        let cmd = workspace_mount_command();
+    fn workspace_commands_use_canonical_paths() {
+        let mount_cmd = workspace_mount_command();
+        let freeze_cmd = workspace_freeze_command();
 
-        assert!(cmd.contains("workspace_dir='/home/user/workspace'"));
-        assert!(cmd.contains("workspace_device='/dev/vdb'"));
-        assert!(cmd.contains("mount -t ext4 -- \"$workspace_device\" \"$workspace_dir\""));
-    }
-
-    #[test]
-    fn mount_command_is_idempotent_for_existing_workspace_mount() {
-        let cmd = workspace_mount_command();
-
-        assert!(cmd.contains("mountpoint -q -- \"$workspace_dir\""));
-        assert!(cmd.contains("mountpoint -x -- \"$workspace_device\""));
-        assert!(cmd.contains("[ \"$target_dev\" = \"$workspace_dev\" ]"));
-        assert!(cmd.contains("exit 0"));
-    }
-
-    #[test]
-    fn mount_command_rejects_unrelated_mountpoints_and_symlink_components() {
-        let cmd = workspace_mount_command();
-
-        assert!(cmd.contains("refusing to mount workspace drive over existing mountpoint"));
-        assert!(cmd.contains("refuse_workspace_symlink_path()"));
-        assert!(cmd.contains("refusing to use symlink workspace path component"));
-        assert!(cmd.contains("workspace_device_mounted_elsewhere()"));
-        assert!(cmd.contains("already mounted outside"));
-        assert_eq!(
-            cmd.matches("refuse_workspace_symlink_path").count(),
-            3,
-            "definition plus pre-mount and post-mkdir checks should be present"
-        );
-    }
-
-    #[test]
-    fn mount_command_checks_elsewhere_mount_after_idempotent_path_and_before_mount() {
-        let cmd = workspace_mount_command();
-        let idempotent_check = cmd
-            .find("if mountpoint -q -- \"$workspace_dir\"")
-            .expect("canonical mountpoint check");
-        let elsewhere_check = cmd
-            .find("if workspace_device_mounted_elsewhere")
-            .expect("elsewhere device mount check");
-        let mkdir = cmd.find("mkdir -p -- \"$workspace_dir\"").expect("mkdir");
-        let mount = cmd
-            .find("mount -t ext4 -- \"$workspace_device\" \"$workspace_dir\"")
-            .expect("mount");
-
-        assert!(
-            idempotent_check < elsewhere_check,
-            "canonical idempotent mount check must run before elsewhere guard"
-        );
-        assert!(
-            elsewhere_check < mkdir,
-            "elsewhere guard must run before creating the workspace directory"
-        );
-        assert!(
-            elsewhere_check < mount,
-            "elsewhere guard must run before attempting a new mount"
-        );
+        for cmd in [&mount_cmd, &freeze_cmd] {
+            assert!(cmd.contains("workspace_dir='/home/user/workspace'"));
+            assert!(cmd.contains("workspace_device='/dev/vdb'"));
+        }
+        assert!(mount_cmd.contains("workspace_mountinfo_path='/proc/self/mountinfo'"));
+        assert!(freeze_cmd.contains("workspace_fsfreeze_path='/usr/sbin/fsfreeze'"));
     }
 
     #[test]
@@ -220,5 +200,502 @@ mod tests {
         assert!(!cmd.contains("fsfreeze"));
         assert!(!cmd.contains("umount"));
         assert!(!cmd.contains("\nsync"));
+    }
+
+    #[cfg(target_os = "linux")]
+    mod behavior {
+        use std::fs;
+        use std::os::unix::fs::{PermissionsExt, symlink};
+        use std::path::{Path, PathBuf};
+        use std::process::{Command, Output};
+
+        use super::*;
+
+        const WORKSPACE_DEV: &str = "8:16";
+
+        struct WorkspaceScriptFixture {
+            temp: tempfile::TempDir,
+            workspace_dir: PathBuf,
+            workspace_device: PathBuf,
+            fake_bin: PathBuf,
+            calls_path: PathBuf,
+            mountinfo_path: PathBuf,
+            fsfreeze_path: PathBuf,
+            outside_dir: PathBuf,
+        }
+
+        impl WorkspaceScriptFixture {
+            fn new() -> Self {
+                let temp = tempfile::tempdir().unwrap();
+                let workspace_dir = temp.path().join("workspace");
+                let workspace_device = temp.path().join("vdb");
+                let fake_bin = temp.path().join("bin");
+                let calls_path = temp.path().join("calls.log");
+                let mountinfo_path = temp.path().join("mountinfo");
+                let fsfreeze_path = fake_bin.join("fsfreeze");
+                let outside_dir = temp.path().join("outside");
+
+                fs::create_dir(&fake_bin).unwrap();
+                fs::create_dir(&outside_dir).unwrap();
+                fs::write(&workspace_device, b"").unwrap();
+                fs::write(&calls_path, b"").unwrap();
+                fs::write(&mountinfo_path, b"").unwrap();
+
+                let fixture = Self {
+                    temp,
+                    workspace_dir,
+                    workspace_device,
+                    fake_bin,
+                    calls_path,
+                    mountinfo_path,
+                    fsfreeze_path,
+                    outside_dir,
+                };
+                fixture.write_mountpoint(false, None, None);
+                fixture.write_mkdir(false);
+                fixture.write_mount();
+                fixture.write_chown();
+                fixture.write_fsfreeze(0, "");
+                fixture
+            }
+
+            fn create_workspace(&self) {
+                fs::create_dir(&self.workspace_dir).unwrap();
+            }
+
+            fn write_mountinfo_device(&self, device: &str) {
+                fs::write(
+                    &self.mountinfo_path,
+                    format!("1 2 {device} / /elsewhere rw,relatime - ext4 /dev/vdb rw\n"),
+                )
+                .unwrap();
+            }
+
+            fn write_mountpoint(
+                &self,
+                workspace_mounted: bool,
+                workspace_dev: Option<&str>,
+                target_dev: Option<&str>,
+            ) {
+                let workspace_dir = quoted_path(&self.workspace_dir);
+                let workspace_device = quoted_path(&self.workspace_device);
+                let workspace_mounted = if workspace_mounted { "1" } else { "0" };
+                let workspace_dev = quote_shell_arg(workspace_dev.unwrap_or_default());
+                let target_dev = quote_shell_arg(target_dev.unwrap_or_default());
+                let body = format!(
+                    r#"workspace_dir={workspace_dir}
+workspace_device={workspace_device}
+workspace_mounted={workspace_mounted}
+workspace_dev={workspace_dev}
+target_dev={target_dev}
+log_call mountpoint "$@"
+if [ "$#" -ne 3 ] || [ "$2" != "--" ]; then
+  exit 97
+fi
+case "$1" in
+  -x)
+    [ "$3" = "$workspace_device" ] || exit 97
+    [ -n "$workspace_dev" ] || exit 1
+    printf '%s\n' "$workspace_dev"
+    ;;
+  -q)
+    [ "$3" = "$workspace_dir" ] || exit 97
+    [ "$workspace_mounted" = 1 ]
+    ;;
+  -d)
+    if [ "$3" != "$workspace_dir" ]; then
+      case "$3" in
+        /proc/[0-9]*/fd/3) ;;
+        *) exit 97 ;;
+      esac
+      [ "$(readlink -- "$3")" = "$workspace_dir" ] || exit 97
+    fi
+    [ -n "$target_dev" ] || exit 1
+    printf '%s\n' "$target_dev"
+    ;;
+  *)
+    exit 97
+    ;;
+esac
+"#
+                );
+                self.write_fake("mountpoint", &body);
+            }
+
+            fn write_mkdir(&self, replace_with_symlink: bool) {
+                let workspace_dir = quoted_path(&self.workspace_dir);
+                let outside_dir = quoted_path(&self.outside_dir);
+                let replace_with_symlink = if replace_with_symlink { "1" } else { "0" };
+                let body = format!(
+                    r#"workspace_dir={workspace_dir}
+outside_dir={outside_dir}
+log_call mkdir "$@"
+if [ "$#" -ne 3 ] || [ "$1" != "-p" ] || [ "$2" != "--" ] || [ "$3" != "$workspace_dir" ]; then
+  exit 97
+fi
+if [ {replace_with_symlink} = 1 ]; then
+  /bin/ln -s -- "$outside_dir" "$workspace_dir"
+else
+  /bin/mkdir -p -- "$workspace_dir"
+fi
+"#
+                );
+                self.write_fake("mkdir", &body);
+            }
+
+            fn write_mount(&self) {
+                let workspace_dir = quoted_path(&self.workspace_dir);
+                let workspace_device = quoted_path(&self.workspace_device);
+                let body = format!(
+                    r#"workspace_dir={workspace_dir}
+workspace_device={workspace_device}
+log_call mount "$@"
+if [ "$#" -ne 5 ] || [ "$1" != "-t" ] || [ "$2" != "ext4" ] || [ "$3" != "--" ] || [ "$4" != "$workspace_device" ] || [ "$5" != "$workspace_dir" ]; then
+  exit 97
+fi
+"#
+                );
+                self.write_fake("mount", &body);
+            }
+
+            fn write_chown(&self) {
+                let workspace_dir = quoted_path(&self.workspace_dir);
+                let body = format!(
+                    r#"workspace_dir={workspace_dir}
+log_call chown "$@"
+if [ "$#" -ne 4 ] || [ "$1" != "-h" ] || [ "$2" != "user:user" ] || [ "$3" != "--" ] || [ "$4" != "$workspace_dir" ]; then
+  exit 97
+fi
+"#
+                );
+                self.write_fake("chown", &body);
+            }
+
+            fn write_fsfreeze(&self, exit_code: i32, stderr: &str) {
+                let workspace_dir = quoted_path(&self.workspace_dir);
+                let stderr = quote_shell_arg(stderr);
+                let body = format!(
+                    r#"workspace_dir={workspace_dir}
+error={stderr}
+log_call fsfreeze "$@"
+if [ "$#" -ne 2 ] || [ "$1" != "--freeze" ]; then
+  exit 97
+fi
+case "$2" in
+  /proc/[0-9]*/fd/3) ;;
+  *) exit 97 ;;
+esac
+[ "$(readlink -- "$2")" = "$workspace_dir" ] || exit 97
+if [ -n "$error" ]; then
+  printf '%s\n' "$error" >&2
+fi
+exit {exit_code}
+"#
+                );
+                self.write_fake_path(&self.fsfreeze_path, &body);
+            }
+
+            fn run_mount(&self) -> Output {
+                let command = workspace_mount_command_for(
+                    self.workspace_dir.to_str().unwrap(),
+                    self.workspace_device.to_str().unwrap(),
+                    self.mountinfo_path.to_str().unwrap(),
+                );
+                self.run(command)
+            }
+
+            fn run_freeze(&self) -> Output {
+                let command = workspace_freeze_command_for(
+                    self.workspace_dir.to_str().unwrap(),
+                    self.workspace_device.to_str().unwrap(),
+                    self.fsfreeze_path.to_str().unwrap(),
+                );
+                self.run(command)
+            }
+
+            fn run(&self, command: String) -> Output {
+                Command::new("sh")
+                    .arg("-c")
+                    .arg(command)
+                    .current_dir(self.temp.path())
+                    .env_clear()
+                    .env("PATH", format!("{}:/usr/bin:/bin", self.fake_bin.display()))
+                    .output()
+                    .unwrap()
+            }
+
+            fn calls(&self) -> String {
+                fs::read_to_string(&self.calls_path).unwrap()
+            }
+
+            fn write_fake(&self, name: &str, body: &str) {
+                self.write_fake_path(&self.fake_bin.join(name), body);
+            }
+
+            fn write_fake_path(&self, path: &Path, body: &str) {
+                let calls_path = quoted_path(&self.calls_path);
+                let script = format!(
+                    r#"#!/bin/sh
+set -eu
+calls_path={calls_path}
+log_call() {{
+  name=$1
+  shift
+  {{
+    printf '%s' "$name"
+    for arg in "$@"; do
+      printf '\t%s' "$arg"
+    done
+    printf '\n'
+  }} >> "$calls_path"
+}}
+{body}"#
+                );
+                write_executable(path, &script);
+            }
+        }
+
+        fn quoted_path(path: &Path) -> String {
+            quote_shell_arg(path.to_str().unwrap())
+        }
+
+        fn write_executable(path: &Path, content: &str) {
+            fs::write(path, content).unwrap();
+            let mut permissions = fs::metadata(path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(path, permissions).unwrap();
+        }
+
+        fn assert_exit(output: &Output, expected: i32) -> String {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+            assert_eq!(
+                output.status.code(),
+                Some(expected),
+                "stdout={stdout} stderr={stderr}"
+            );
+            assert!(stdout.is_empty(), "unexpected stdout: {stdout}");
+            stderr
+        }
+
+        fn assert_descriptor_path(path: &str) {
+            let pid = path
+                .strip_prefix("/proc/")
+                .and_then(|path| path.strip_suffix("/fd/3"))
+                .expect("descriptor path should be /proc/<pid>/fd/3");
+            assert!(!pid.is_empty());
+            assert!(pid.chars().all(|character| character.is_ascii_digit()));
+        }
+
+        #[test]
+        fn mount_script_accepts_matching_existing_mount() {
+            let fixture = WorkspaceScriptFixture::new();
+            fixture.create_workspace();
+            fixture.write_mountpoint(true, Some(WORKSPACE_DEV), Some(WORKSPACE_DEV));
+
+            let output = fixture.run_mount();
+
+            assert_eq!(assert_exit(&output, 0), "");
+            assert_eq!(
+                fixture.calls(),
+                format!(
+                    "mountpoint\t-x\t--\t{}\nmountpoint\t-q\t--\t{}\nmountpoint\t-d\t--\t{}\nchown\t-h\tuser:user\t--\t{}\n",
+                    fixture.workspace_device.display(),
+                    fixture.workspace_dir.display(),
+                    fixture.workspace_dir.display(),
+                    fixture.workspace_dir.display()
+                )
+            );
+        }
+
+        #[test]
+        fn mount_script_rejects_mismatched_existing_mount() {
+            let fixture = WorkspaceScriptFixture::new();
+            fixture.create_workspace();
+            fixture.write_mountpoint(true, Some(WORKSPACE_DEV), Some("8:32"));
+
+            let output = fixture.run_mount();
+
+            let stderr = assert_exit(&output, 64);
+            assert!(stderr.contains("refusing to mount workspace drive over existing mountpoint"));
+            assert_eq!(
+                fixture.calls(),
+                format!(
+                    "mountpoint\t-x\t--\t{}\nmountpoint\t-q\t--\t{}\nmountpoint\t-d\t--\t{}\n",
+                    fixture.workspace_device.display(),
+                    fixture.workspace_dir.display(),
+                    fixture.workspace_dir.display()
+                )
+            );
+        }
+
+        #[test]
+        fn mount_script_rejects_workspace_device_mounted_elsewhere() {
+            let fixture = WorkspaceScriptFixture::new();
+            fixture.write_mountpoint(false, Some(WORKSPACE_DEV), None);
+            fixture.write_mountinfo_device(WORKSPACE_DEV);
+
+            let output = fixture.run_mount();
+
+            let stderr = assert_exit(&output, 64);
+            assert!(stderr.contains("already mounted outside"));
+            assert_eq!(
+                fixture.calls(),
+                format!(
+                    "mountpoint\t-x\t--\t{}\nmountpoint\t-q\t--\t{}\n",
+                    fixture.workspace_device.display(),
+                    fixture.workspace_dir.display()
+                )
+            );
+            assert!(!fixture.workspace_dir.exists());
+        }
+
+        #[test]
+        fn mount_script_rejects_existing_symlink_before_state_checks() {
+            let fixture = WorkspaceScriptFixture::new();
+            symlink(&fixture.outside_dir, &fixture.workspace_dir).unwrap();
+
+            let output = fixture.run_mount();
+
+            let stderr = assert_exit(&output, 64);
+            assert!(stderr.contains("refusing to use symlink workspace path component"));
+            assert_eq!(fixture.calls(), "");
+        }
+
+        #[test]
+        fn mount_script_rejects_symlink_created_by_mkdir() {
+            let fixture = WorkspaceScriptFixture::new();
+            fixture.write_mountpoint(false, Some(WORKSPACE_DEV), None);
+            fixture.write_mkdir(true);
+
+            let output = fixture.run_mount();
+
+            let stderr = assert_exit(&output, 64);
+            assert!(stderr.contains("refusing to use symlink workspace path component"));
+            assert!(
+                fs::symlink_metadata(&fixture.workspace_dir)
+                    .unwrap()
+                    .file_type()
+                    .is_symlink()
+            );
+            assert_eq!(
+                fixture.calls(),
+                format!(
+                    "mountpoint\t-x\t--\t{}\nmountpoint\t-q\t--\t{}\nmkdir\t-p\t--\t{}\n",
+                    fixture.workspace_device.display(),
+                    fixture.workspace_dir.display(),
+                    fixture.workspace_dir.display()
+                )
+            );
+        }
+
+        #[test]
+        fn mount_script_mounts_new_workspace_and_sets_owner() {
+            let fixture = WorkspaceScriptFixture::new();
+            fixture.write_mountpoint(false, Some(WORKSPACE_DEV), None);
+
+            let output = fixture.run_mount();
+
+            assert_eq!(assert_exit(&output, 0), "");
+            assert!(fixture.workspace_dir.is_dir());
+            assert_eq!(
+                fixture.calls(),
+                format!(
+                    "mountpoint\t-x\t--\t{}\nmountpoint\t-q\t--\t{}\nmkdir\t-p\t--\t{}\nmount\t-t\text4\t--\t{}\t{}\nchown\t-h\tuser:user\t--\t{}\n",
+                    fixture.workspace_device.display(),
+                    fixture.workspace_dir.display(),
+                    fixture.workspace_dir.display(),
+                    fixture.workspace_device.display(),
+                    fixture.workspace_dir.display(),
+                    fixture.workspace_dir.display()
+                )
+            );
+        }
+
+        #[test]
+        fn freeze_script_rejects_unmounted_workspace() {
+            let fixture = WorkspaceScriptFixture::new();
+            fixture.create_workspace();
+            fixture.write_mountpoint(false, Some(WORKSPACE_DEV), None);
+
+            let output = fixture.run_freeze();
+
+            let stderr = assert_exit(&output, 65);
+            assert!(stderr.contains("workspace drive is not mounted"));
+            assert_eq!(
+                fixture.calls(),
+                format!(
+                    "mountpoint\t-x\t--\t{}\nmountpoint\t-q\t--\t{}\n",
+                    fixture.workspace_device.display(),
+                    fixture.workspace_dir.display()
+                )
+            );
+        }
+
+        #[test]
+        fn freeze_script_rejects_descriptor_device_mismatch() {
+            let fixture = WorkspaceScriptFixture::new();
+            fixture.create_workspace();
+            fixture.write_mountpoint(true, Some(WORKSPACE_DEV), Some("8:32"));
+
+            let output = fixture.run_freeze();
+
+            let stderr = assert_exit(&output, 64);
+            assert!(stderr.contains("refusing to freeze non-workspace mountpoint"));
+            let calls = fixture.calls();
+            let lines: Vec<_> = calls.lines().collect();
+            assert_eq!(lines.len(), 3);
+            assert_eq!(
+                lines[0],
+                format!("mountpoint\t-x\t--\t{}", fixture.workspace_device.display())
+            );
+            assert_eq!(
+                lines[1],
+                format!("mountpoint\t-q\t--\t{}", fixture.workspace_dir.display())
+            );
+            let descriptor = lines[2]
+                .strip_prefix("mountpoint\t-d\t--\t")
+                .expect("descriptor mountpoint call");
+            assert_descriptor_path(descriptor);
+        }
+
+        #[test]
+        fn freeze_script_freezes_matching_descriptor() {
+            let fixture = WorkspaceScriptFixture::new();
+            fixture.create_workspace();
+            fixture.write_mountpoint(true, Some(WORKSPACE_DEV), Some(WORKSPACE_DEV));
+
+            let output = fixture.run_freeze();
+
+            assert_eq!(assert_exit(&output, 0), "");
+            let calls = fixture.calls();
+            let lines: Vec<_> = calls.lines().collect();
+            assert_eq!(lines.len(), 4);
+            let descriptor = lines[2]
+                .strip_prefix("mountpoint\t-d\t--\t")
+                .expect("descriptor mountpoint call");
+            assert_descriptor_path(descriptor);
+            assert_eq!(lines[3], format!("fsfreeze\t--freeze\t{descriptor}"));
+        }
+
+        #[test]
+        fn freeze_script_propagates_fsfreeze_failure() {
+            let fixture = WorkspaceScriptFixture::new();
+            fixture.create_workspace();
+            fixture.write_mountpoint(true, Some(WORKSPACE_DEV), Some(WORKSPACE_DEV));
+            fixture.write_fsfreeze(73, "freeze failed");
+
+            let output = fixture.run_freeze();
+
+            assert_eq!(assert_exit(&output, 73), "freeze failed\n");
+            let calls = fixture.calls();
+            let lines: Vec<_> = calls.lines().collect();
+            assert_eq!(lines.len(), 4);
+            let descriptor = lines[2]
+                .strip_prefix("mountpoint\t-d\t--\t")
+                .expect("descriptor mountpoint call");
+            assert_descriptor_path(descriptor);
+            assert_eq!(lines[3], format!("fsfreeze\t--freeze\t{descriptor}"));
+        }
     }
 }

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -308,7 +308,7 @@ case "$1" in
         /proc/[0-9]*/fd/3) ;;
         *) exit 97 ;;
       esac
-      [ "$(readlink -- "$3")" = "$workspace_dir" ] || exit 97
+      [ "$(/usr/bin/readlink -- "$3")" = "$workspace_dir" ] || exit 97
     fi
     [ -n "$target_dev" ] || exit 1
     printf '%s\n' "$target_dev"
@@ -385,7 +385,7 @@ case "$2" in
   /proc/[0-9]*/fd/3) ;;
   *) exit 97 ;;
 esac
-[ "$(readlink -- "$2")" = "$workspace_dir" ] || exit 97
+[ "$(/usr/bin/readlink -- "$2")" = "$workspace_dir" ] || exit 97
 if [ -n "$error" ]; then
   printf '%s\n' "$error" >&2
 fi
@@ -414,12 +414,12 @@ exit {exit_code}
             }
 
             fn run(&self, command: String) -> Output {
-                Command::new("sh")
+                Command::new("/bin/sh")
                     .arg("-c")
                     .arg(command)
                     .current_dir(self.temp.path())
                     .env_clear()
-                    .env("PATH", format!("{}:/usr/bin:/bin", self.fake_bin.display()))
+                    .env("PATH", &self.fake_bin)
                     .output()
                     .unwrap()
             }

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -335,7 +335,10 @@ async fn parked_workspace_promotion_unparks_and_freezes_before_publish() {
     assert!(freeze_command.contains("mountpoint -q -- \"$workspace_dir\""));
     assert!(freeze_command.contains("exec 3< \"$workspace_dir\""));
     assert!(freeze_command.contains("mountpoint -d -- \"$workspace_fd_path\""));
-    assert!(freeze_command.contains("fsfreeze --freeze \"$workspace_fd_path\""));
+    assert!(freeze_command.contains("workspace_fsfreeze_path='/usr/sbin/fsfreeze'"));
+    assert!(
+        freeze_command.contains("\"$workspace_fsfreeze_path\" --freeze \"$workspace_fd_path\"")
+    );
     assert!(!freeze_command.contains("--unfreeze"));
     assert!(!freeze_command.contains("umount"));
     assert!(!freeze_command.contains("kill "));
@@ -951,7 +954,7 @@ async fn session_history_sidecar_staging_cleans_source_and_unlocks_after_freeze_
     let cache = fixture.cache.clone();
     let overrides = Arc::new(MockSandboxOverrides::new());
     overrides.add_exec_matcher(ExecMatcher {
-        pattern: "fsfreeze --freeze".into(),
+        pattern: "\"$workspace_fsfreeze_path\" --freeze".into(),
         exit_code: 64,
         stdout: Vec::new(),
         stderr: b"not mounted".to_vec(),
@@ -1115,7 +1118,7 @@ async fn parked_workspace_promotion_guest_freeze_failure_skips_cache() {
     let fixture = WorkspacePromotionFixture::new("sess-parked-freeze-fail").await;
     let overrides = Arc::new(MockSandboxOverrides::new());
     overrides.add_exec_matcher(ExecMatcher {
-        pattern: "fsfreeze --freeze".into(),
+        pattern: "\"$workspace_fsfreeze_path\" --freeze".into(),
         exit_code: 64,
         stdout: Vec::new(),
         stderr: b"not mounted".to_vec(),


### PR DESCRIPTION
## Summary

- bind the production mountinfo and fsfreeze paths explicitly in rendered workspace helper commands
- execute the checked-in mount and freeze scripts in isolated Linux fixtures with fail-closed fake privileged utilities
- replace branch-text assertions with behavior coverage for mount identity, mounted-elsewhere, symlink races, descriptor-pinned freeze, and fsfreeze outcomes
- update adjacent runner lifecycle assertions and failure matchers for the bound fsfreeze invocation

## Scope

- preserves the canonical workspace, `/dev/vdb`, `/proc/self/mountinfo`, and `/usr/sbin/fsfreeze` production values
- leaves fresh-start, idle-reuse, benchmark, promotion, API, storage, and deployment contracts unchanged

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner workspace_mount::tests::behavior -- --nocapture` (10 passed)
- `sh -n crates/runner/scripts/mount-workspace-drive.sh crates/runner/scripts/freeze-workspace-drive.sh`
- `git diff --check`

Closes #30830
