### PR TITLE
feat: graduate built-in model provider fallback

### DIFF
--- a/.claude/skills/feature-switch/SKILL.md
+++ b/.claude/skills/feature-switch/SKILL.md
@@ -164,7 +164,7 @@ Evaluation has two layers (lowest to highest priority):
    `user_feature_switches` keyed by `(orgId, userId)`. Some switches are
    org-scoped and stored under the org sentinel user id (`ORG_SENTINEL_USER_ID`,
    `"__org__"`); `ORG_SCOPED_FEATURE_SWITCH_KEYS` currently holds
-   `ChatErrorRecovery`, `BuiltInModelProviderFallback`, and `PiLoop`. Written
+   `ChatErrorRecovery`, `PiLoop`, and `PresentationTemplates`. Written
    via the Lab page toggles or
    `window._vm0.featureSwitches.myFeature = true` (both call
    `POST /api/feature-switches`). Cleared via the Lab page "Reset all"

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -560,7 +560,6 @@ claude_script = claude_step.fetch("run")
   /api/model-policies
   /api/feature-switches
   realAgentInPreview
-  builtInModelProviderFallback
 ].each do |required_fragment|
   unless claude_script.include?(required_fragment)
     raise "real Claude bootstrap must include #{required_fragment}"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2671,11 +2671,10 @@ jobs:
 
           curl -fsS "${headers[@]}" \
             -X POST \
-            -d '{"switches":{"realAgentInPreview":true,"builtInModelProviderFallback":true}}' \
+            -d '{"switches":{"realAgentInPreview":true}}' \
             "${api_url}/api/feature-switches" \
             | jq -e '
-                .effectiveSwitches.realAgentInPreview == true and
-                .effectiveSwitches.builtInModelProviderFallback == true
+                .effectiveSwitches.realAgentInPreview == true
               ' \
             >/dev/null
         env:

--- a/e2e/tests/03-runner/run-t24-built-in-provider-fallback.bats
+++ b/e2e/tests/03-runner/run-t24-built-in-provider-fallback.bats
@@ -21,8 +21,7 @@ setup() {
     local feature_switches
     feature_switches="$(runner_api_curl "/api/feature-switches")"
     jq -e '
-        .effectiveSwitches.realAgentInPreview == true and
-        .effectiveSwitches.builtInModelProviderFallback == true
+        .effectiveSwitches.realAgentInPreview == true
     ' <<<"$feature_switches" >/dev/null
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -90,7 +90,6 @@ const GOAL_SCHEDULER_TIMING_ACTION_TYPES = [
   "api_dispatch_pre_create_zero_goal_drain_scheduler_goal_handoff",
 ] as const;
 const GOAL_DRAIN_BUILT_IN_MODEL_CONTEXT_TIMING_ACTION_TYPES = [
-  "api_dispatch_pre_create_zero_goal_drain_model_context_reload_fallback_feature_switches",
   "api_dispatch_pre_create_zero_goal_drain_model_context_resolve_built_in_route",
 ] as const;
 const GOAL_DRAIN_SUCCESS_TIMING_ACTION_TYPES = [
@@ -4406,7 +4405,7 @@ describe("CHAT-02: drain-time admission failure", () => {
     90_000,
   );
 
-  it("terminalizes a queued Web message with neutral built-in model copy when the key is unavailable", async () => {
+  it("terminalizes a queued Web message with neutral copy when every built-in route is unavailable", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
@@ -4454,13 +4453,13 @@ describe("CHAT-02: drain-time admission failure", () => {
             return (
               event.eventType === "input.rejected" &&
               event.revokesEventId === queuedEventId &&
-              event.error === "provider_unavailable"
+              event.error === "model_provider_unavailable"
             );
           }) &&
           assistantMessages(events).some((event) => {
             return (
               event.eventType === "output.error" &&
-              event.error === "provider_unavailable"
+              event.error === "model_provider_unavailable"
             );
           })
         );
@@ -4475,16 +4474,16 @@ describe("CHAT-02: drain-time admission failure", () => {
     if (rejected?.eventType !== "input.rejected") {
       throw new Error("Expected the queued Web message to be rejected");
     }
-    expect(rejected.error).toBe("provider_unavailable");
+    expect(rejected.error).toBe("model_provider_unavailable");
     const errors = assistantMessages(terminal.events).filter((event) => {
       return (
         event.eventType === "output.error" &&
-        event.error === "provider_unavailable"
+        event.error === "model_provider_unavailable"
       );
     });
     expect(errors).toHaveLength(1);
     expect(errors[0]?.content).toBe(
-      "No model provider configured: no built-in model key is configured",
+      "Oops, something went wrong. Please try again later.",
     );
     expect(errors[0]?.content).not.toContain("VM0");
     expect(

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -5074,7 +5074,7 @@ describe("CHAT-02: model-first provider policies", () => {
     if (vm0Send.status === 503) {
       expectApiError(vm0Send.body);
       expect(vm0Send.body.error.message).toBe(
-        "No model provider configured: no built-in model key is configured",
+        "Every built-in model route for this model is temporarily unavailable",
       );
     } else {
       const vm0Body = vm0Send.body as { readonly runId: string | null };

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -155,12 +155,10 @@ type BuiltInModelRuntimeRouteFixture = NonNullable<
 export async function resolveVm0BuiltInModelRouteFixture(
   context: TestContext,
   selectedModel: string,
-  fallbackEnabled: boolean,
 ): Promise<BuiltInModelRuntimeRouteFixture | null> {
   const response = await postAction(context, {
     action: "resolve-vm0-built-in-model-route",
     selected_model: selectedModel,
-    fallback_enabled: fallbackEnabled,
   });
   return response.built_in_model_route ?? null;
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
@@ -202,7 +202,6 @@ describe("OPS-01: feature switch routes", () => {
         body: {
           switches: {
             [FeatureSwitchKey.ChatErrorRecovery]: true,
-            [FeatureSwitchKey.BuiltInModelProviderFallback]: true,
             [FeatureSwitchKey.PresentationTemplates]: true,
             [FeatureSwitchKey.Dummy]: false,
           },
@@ -212,9 +211,6 @@ describe("OPS-01: feature switch routes", () => {
     );
     expect(
       ownerUpdate.body.switches[FeatureSwitchKey.ChatErrorRecovery],
-    ).toBeTruthy();
-    expect(
-      ownerUpdate.body.switches[FeatureSwitchKey.BuiltInModelProviderFallback],
     ).toBeTruthy();
     expect(
       ownerUpdate.body.switches[FeatureSwitchKey.PresentationTemplates],
@@ -229,9 +225,6 @@ describe("OPS-01: feature switch routes", () => {
       peerRead.body.switches[FeatureSwitchKey.ChatErrorRecovery],
     ).toBeTruthy();
     expect(
-      peerRead.body.switches[FeatureSwitchKey.BuiltInModelProviderFallback],
-    ).toBeTruthy();
-    expect(
       peerRead.body.switches[FeatureSwitchKey.PresentationTemplates],
     ).toBeTruthy();
     expect(peerRead.body.switches[FeatureSwitchKey.Dummy]).toBeUndefined();
@@ -244,9 +237,6 @@ describe("OPS-01: feature switch routes", () => {
       outsiderRead.body.switches[FeatureSwitchKey.ChatErrorRecovery],
     ).toBeUndefined();
     expect(
-      outsiderRead.body.switches[FeatureSwitchKey.BuiltInModelProviderFallback],
-    ).toBeUndefined();
-    expect(
       outsiderRead.body.switches[FeatureSwitchKey.PresentationTemplates],
     ).toBeUndefined();
     const peerUpdate = await accept(
@@ -255,7 +245,6 @@ describe("OPS-01: feature switch routes", () => {
         body: {
           switches: {
             [FeatureSwitchKey.ChatErrorRecovery]: false,
-            [FeatureSwitchKey.BuiltInModelProviderFallback]: false,
             [FeatureSwitchKey.PresentationTemplates]: false,
           },
         },
@@ -264,9 +253,6 @@ describe("OPS-01: feature switch routes", () => {
     );
     expect(
       peerUpdate.body.switches[FeatureSwitchKey.ChatErrorRecovery],
-    ).toBeFalsy();
-    expect(
-      peerUpdate.body.switches[FeatureSwitchKey.BuiltInModelProviderFallback],
     ).toBeFalsy();
     expect(
       peerUpdate.body.switches[FeatureSwitchKey.PresentationTemplates],
@@ -280,11 +266,6 @@ describe("OPS-01: feature switch routes", () => {
     expect(
       ownerReadAfterPeerUpdate.body.switches[
         FeatureSwitchKey.ChatErrorRecovery
-      ],
-    ).toBeFalsy();
-    expect(
-      ownerReadAfterPeerUpdate.body.switches[
-        FeatureSwitchKey.BuiltInModelProviderFallback
       ],
     ).toBeFalsy();
     expect(
@@ -308,11 +289,6 @@ describe("OPS-01: feature switch routes", () => {
     );
     expect(
       peerReadAfterDelete.body.switches[FeatureSwitchKey.ChatErrorRecovery],
-    ).toBeUndefined();
-    expect(
-      peerReadAfterDelete.body.switches[
-        FeatureSwitchKey.BuiltInModelProviderFallback
-      ],
     ).toBeUndefined();
     expect(
       peerReadAfterDelete.body.switches[FeatureSwitchKey.PresentationTemplates],

--- a/turbo/apps/api/src/signals/routes/__tests__/model-providers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/model-providers.test.ts
@@ -532,7 +532,7 @@ describe("GET /api/model-providers/cooldown-diagnostics", () => {
     });
   });
 
-  it("returns active global cooldowns and the effective org fallback state", async () => {
+  it("returns active global cooldowns with fallback enabled", async () => {
     const fixture = uniqueOrgUser("cooldown-active");
     const selectedModelPrefix = `diagnostic-${randomUUID()}`;
     const startedAt = Date.UTC(2026, 7, 23, 12, 0, 0);
@@ -580,7 +580,6 @@ describe("GET /api/model-providers/cooldown-diagnostics", () => {
     );
     await updateFeatureSwitchesForUser(context, fixture, {
       [FeatureSwitchKey.OkouDebug]: true,
-      [FeatureSwitchKey.BuiltInModelProviderFallback]: false,
     });
     onTestFinished(async () => {
       await deleteFeatureSwitchesForUser(context, fixture);
@@ -590,7 +589,7 @@ describe("GET /api/model-providers/cooldown-diagnostics", () => {
       modelProviderCooldownDiagnosticsContract,
     );
 
-    const disabledResponse = await withMockNowForTest(startedAt, async () => {
+    const response = await withMockNowForTest(startedAt, async () => {
       return await accept(
         client.get({
           headers: { authorization: "Bearer clerk-session" },
@@ -598,14 +597,12 @@ describe("GET /api/model-providers/cooldown-diagnostics", () => {
         [200],
       );
     });
-    const ownedCooldowns = disabledResponse.body.activeCooldowns.filter(
-      (cooldown) => {
-        return cooldown.selectedModel.startsWith(selectedModelPrefix);
-      },
-    );
+    const ownedCooldowns = response.body.activeCooldowns.filter((cooldown) => {
+      return cooldown.selectedModel.startsWith(selectedModelPrefix);
+    });
 
-    expect(disabledResponse.body.fallbackEnabled).toBeFalsy();
-    expect(disabledResponse.body.canCancelCooldowns).toBeFalsy();
+    expect(response.body.fallbackEnabled).toBeTruthy();
+    expect(response.body.canCancelCooldowns).toBeFalsy();
     expect(ownedCooldowns).toStrictEqual([
       {
         selectedModel: `${selectedModelPrefix}-a`,
@@ -620,23 +617,6 @@ describe("GET /api/model-providers/cooldown-diagnostics", () => {
         unavailableUntil: laterDeadline.toISOString(),
       },
     ]);
-
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.OkouDebug]: true,
-      [FeatureSwitchKey.BuiltInModelProviderFallback]: true,
-    });
-    mocks.clerk.session(fixture.userId, fixture.orgId);
-
-    const enabledResponse = await withMockNowForTest(startedAt, async () => {
-      return await accept(
-        client.get({
-          headers: { authorization: "Bearer clerk-session" },
-        }),
-        [200],
-      );
-    });
-
-    expect(enabledResponse.body.fallbackEnabled).toBeTruthy();
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
@@ -92,11 +92,7 @@ describe("POST /api/test/runtime-state/action", () => {
       const startedAt = Date.UTC(2026, 7, 23, 0, 0, 0);
       const primaryCooldownUntil = new Date(startedAt + 60 * 1000);
       const primary = await withMockNowForTest(startedAt, async () => {
-        return await resolveVm0BuiltInModelRouteFixture(
-          context,
-          selectedModel,
-          true,
-        );
+        return await resolveVm0BuiltInModelRouteFixture(context, selectedModel);
       });
       if (!primary) {
         throw new Error(`Expected a primary route for ${selectedModel}`);
@@ -108,11 +104,7 @@ describe("POST /api/test/runtime-state/action", () => {
         primaryCooldownUntil,
       );
       const fallback = await withMockNowForTest(startedAt, async () => {
-        return await resolveVm0BuiltInModelRouteFixture(
-          context,
-          selectedModel,
-          true,
-        );
+        return await resolveVm0BuiltInModelRouteFixture(context, selectedModel);
       });
       if (!fallback || fallback.provider_type !== "openrouter-codex") {
         throw new Error(`Expected an OpenRouter fallback for ${selectedModel}`);
@@ -139,14 +131,6 @@ describe("POST /api/test/runtime-state/action", () => {
           modelProviderId: null,
         },
       ]);
-      await updateFeatureSwitchesForUser(
-        context,
-        { ...actor, orgId: actor.orgId },
-        {
-          [FeatureSwitchKey.BuiltInModelProviderFallback]: true,
-        },
-      );
-
       const sent = await withMockNowForTest(startedAt, async () => {
         return await chat.requestSendEvent(
           actor,
@@ -191,11 +175,7 @@ describe("POST /api/test/runtime-state/action", () => {
     await seedVm0BuiltInModelCandidateKeys(context, selectedModel);
     const startedAt = Date.UTC(2026, 8, 1, 0, 0, 0);
     const primary = await withMockNowForTest(startedAt, async () => {
-      return await resolveVm0BuiltInModelRouteFixture(
-        context,
-        selectedModel,
-        true,
-      );
+      return await resolveVm0BuiltInModelRouteFixture(context, selectedModel);
     });
     if (!primary || primary.provider_type !== "openai-api-key") {
       throw new Error("Expected the managed OpenAI Terra primary route");
@@ -207,11 +187,7 @@ describe("POST /api/test/runtime-state/action", () => {
       new Date(startedAt + 60_000),
     );
     const fallback = await withMockNowForTest(startedAt, async () => {
-      return await resolveVm0BuiltInModelRouteFixture(
-        context,
-        selectedModel,
-        true,
-      );
+      return await resolveVm0BuiltInModelRouteFixture(context, selectedModel);
     });
     if (!fallback || fallback.provider_type !== "openrouter-codex") {
       throw new Error("Expected the managed OpenRouter Terra fallback route");
@@ -242,7 +218,6 @@ describe("POST /api/test/runtime-state/action", () => {
       context,
       { ...actor, orgId: actor.orgId },
       {
-        [FeatureSwitchKey.BuiltInModelProviderFallback]: true,
         [FeatureSwitchKey.PiLoop]: true,
         [FeatureSwitchKey.CodexFastMode]: true,
       },
@@ -295,11 +270,7 @@ describe("POST /api/test/runtime-state/action", () => {
     const routeCooldownUntil = new Date(startedAt + 60 * 1000);
 
     const gptPrimary = await withMockNowForTest(startedAt, async () => {
-      return await resolveVm0BuiltInModelRouteFixture(
-        context,
-        "gpt-5.6-sol",
-        true,
-      );
+      return await resolveVm0BuiltInModelRouteFixture(context, "gpt-5.6-sol");
     });
     expect(gptPrimary).toMatchObject({
       provider_type: "openai-api-key",
@@ -316,11 +287,7 @@ describe("POST /api/test/runtime-state/action", () => {
       routeCooldownUntil,
     );
     const gptFallback = await withMockNowForTest(startedAt, async () => {
-      return await resolveVm0BuiltInModelRouteFixture(
-        context,
-        "gpt-5.6-sol",
-        true,
-      );
+      return await resolveVm0BuiltInModelRouteFixture(context, "gpt-5.6-sol");
     });
     expect(gptFallback?.provider_type).toBe("openrouter-codex");
     if (!gptFallback) {
@@ -336,22 +303,15 @@ describe("POST /api/test/runtime-state/action", () => {
 
     await withMockNowForTest(startedAt, async () => {
       await expect(
-        resolveVm0BuiltInModelRouteFixture(context, "gpt-5.6-sol", false),
-      ).resolves.toMatchObject({ provider_type: "openai-api-key" });
-      await expect(
-        resolveVm0BuiltInModelRouteFixture(context, "gpt-5.6-sol", true),
+        resolveVm0BuiltInModelRouteFixture(context, "gpt-5.6-sol"),
       ).resolves.toBeNull();
       await expect(
-        resolveVm0BuiltInModelRouteFixture(context, "gpt-5.6-terra", true),
+        resolveVm0BuiltInModelRouteFixture(context, "gpt-5.6-terra"),
       ).resolves.toMatchObject({ provider_type: "openai-api-key" });
     });
 
     const gptTerraPrimary = await withMockNowForTest(startedAt, async () => {
-      return await resolveVm0BuiltInModelRouteFixture(
-        context,
-        "gpt-5.6-terra",
-        true,
-      );
+      return await resolveVm0BuiltInModelRouteFixture(context, "gpt-5.6-terra");
     });
     if (!gptTerraPrimary) {
       throw new Error("Expected a primary GPT Terra route");
@@ -364,7 +324,7 @@ describe("POST /api/test/runtime-state/action", () => {
     );
     await withMockNowForTest(startedAt, async () => {
       await expect(
-        resolveVm0BuiltInModelRouteFixture(context, "gpt-5.6-terra", true),
+        resolveVm0BuiltInModelRouteFixture(context, "gpt-5.6-terra"),
       ).resolves.toMatchObject({ provider_type: "openrouter-codex" });
     });
 
@@ -372,7 +332,6 @@ describe("POST /api/test/runtime-state/action", () => {
       return await resolveVm0BuiltInModelRouteFixture(
         context,
         "claude-fable-5",
-        true,
       );
     });
     expect(claudePrimary?.provider_type).toBe("anthropic-api-key");
@@ -389,7 +348,6 @@ describe("POST /api/test/runtime-state/action", () => {
       return await resolveVm0BuiltInModelRouteFixture(
         context,
         "claude-fable-5",
-        true,
       );
     });
     expect(claudeFallback?.provider_type).toBe("openrouter-api-key");
@@ -421,13 +379,6 @@ describe("POST /api/test/runtime-state/action", () => {
     if (!actor.orgId) {
       throw new Error("Expected built-in fallback actor to have an org");
     }
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId: actor.orgId },
-      {
-        [FeatureSwitchKey.BuiltInModelProviderFallback]: true,
-      },
-    );
     const rejected = await withMockNowForTest(startedAt, async () => {
       return await chat.requestSendEvent(
         actor,
@@ -456,10 +407,10 @@ describe("POST /api/test/runtime-state/action", () => {
 
     await withMockNowForTest(routeCooldownUntil.getTime(), async () => {
       await expect(
-        resolveVm0BuiltInModelRouteFixture(context, "gpt-5.6-sol", true),
+        resolveVm0BuiltInModelRouteFixture(context, "gpt-5.6-sol"),
       ).resolves.toMatchObject({ provider_type: "openai-api-key" });
       await expect(
-        resolveVm0BuiltInModelRouteFixture(context, "claude-fable-5", true),
+        resolveVm0BuiltInModelRouteFixture(context, "claude-fable-5"),
       ).resolves.toMatchObject({ provider_type: "anthropic-api-key" });
     });
   });
@@ -469,11 +420,7 @@ describe("POST /api/test/runtime-state/action", () => {
     const startedAt = Date.UTC(2026, 7, 20, 2, 0, 0);
     await seedVm0BuiltInModelCandidateKeys(context, selectedModel);
     const primary = await withMockNowForTest(startedAt, async () => {
-      return await resolveVm0BuiltInModelRouteFixture(
-        context,
-        selectedModel,
-        true,
-      );
+      return await resolveVm0BuiltInModelRouteFixture(context, selectedModel);
     });
     if (!primary) {
       throw new Error("Expected a primary GPT Terra route");
@@ -487,7 +434,7 @@ describe("POST /api/test/runtime-state/action", () => {
     );
     await withMockNowForTest(startedAt, async () => {
       await expect(
-        resolveVm0BuiltInModelRouteFixture(context, selectedModel, true),
+        resolveVm0BuiltInModelRouteFixture(context, selectedModel),
       ).resolves.toMatchObject({ provider_type: "openrouter-codex" });
     });
 
@@ -498,7 +445,7 @@ describe("POST /api/test/runtime-state/action", () => {
     );
     await withMockNowForTest(startedAt, async () => {
       await expect(
-        resolveVm0BuiltInModelRouteFixture(context, selectedModel, true),
+        resolveVm0BuiltInModelRouteFixture(context, selectedModel),
       ).resolves.toMatchObject({ provider_type: "openai-api-key" });
     });
   });
@@ -560,7 +507,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
         const primary = await resolveVm0BuiltInModelRouteFixture(
           context,
           claimed.selectedModel,
-          true,
         );
         if (!primary) {
           throw new Error("Expected a built-in model primary route");
@@ -596,21 +542,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
           runs.readRun(claimed.actor, claimed.runId),
         ).resolves.toMatchObject({ status: "running" });
         await expect(
-          resolveVm0BuiltInModelRouteFixture(
-            context,
-            claimed.selectedModel,
-            false,
-          ),
-        ).resolves.toMatchObject({
-          provider_type: primary.provider_type,
-          upstream_model: primary.upstream_model,
-        });
-        await expect(
-          resolveVm0BuiltInModelRouteFixture(
-            context,
-            claimed.selectedModel,
-            true,
-          ),
+          resolveVm0BuiltInModelRouteFixture(context, claimed.selectedModel),
         ).resolves.not.toMatchObject({
           provider_type: primary.provider_type,
           upstream_model: primary.upstream_model,
@@ -618,7 +550,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
 
         await seedVm0BuiltInModelCandidateKeys(context, "deepseek-v4-pro");
         await expect(
-          resolveVm0BuiltInModelRouteFixture(context, "deepseek-v4-pro", true),
+          resolveVm0BuiltInModelRouteFixture(context, "deepseek-v4-pro"),
         ).resolves.toMatchObject({ provider_type: "deepseek" });
 
         await withMockNowForTest(
@@ -628,7 +560,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
               resolveVm0BuiltInModelRouteFixture(
                 context,
                 claimed.selectedModel,
-                true,
               ),
             ).resolves.not.toMatchObject({
               provider_type: primary.provider_type,
@@ -643,7 +574,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
               resolveVm0BuiltInModelRouteFixture(
                 context,
                 claimed.selectedModel,
-                true,
               ),
             ).resolves.toMatchObject({
               provider_type: primary.provider_type,
@@ -662,7 +592,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     const primary = await resolveVm0BuiltInModelRouteFixture(
       context,
       claimed.selectedModel,
-      true,
     );
     if (!primary) {
       throw new Error("Expected a built-in model primary route");
@@ -681,11 +610,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
         }),
       ).resolves.toStrictEqual({ outcome: "observed" });
       await expect(
-        resolveVm0BuiltInModelRouteFixture(
-          context,
-          claimed.selectedModel,
-          true,
-        ),
+        resolveVm0BuiltInModelRouteFixture(context, claimed.selectedModel),
       ).resolves.toMatchObject({
         provider_type: primary.provider_type,
         upstream_model: primary.upstream_model,
@@ -701,11 +626,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
         }),
       ).resolves.toStrictEqual({ outcome: "recorded" });
       await expect(
-        resolveVm0BuiltInModelRouteFixture(
-          context,
-          claimed.selectedModel,
-          true,
-        ),
+        resolveVm0BuiltInModelRouteFixture(context, claimed.selectedModel),
       ).resolves.not.toMatchObject({
         provider_type: primary.provider_type,
         upstream_model: primary.upstream_model,
@@ -730,7 +651,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     const primary = await resolveVm0BuiltInModelRouteFixture(
       context,
       claimed.selectedModel,
-      true,
     );
     if (!primary) {
       throw new Error("Expected a built-in model primary route");
@@ -753,11 +673,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     // A resolver can capture time before the observation transaction commits.
     await withMockNowForTest(startedAt - 1, async () => {
       await expect(
-        resolveVm0BuiltInModelRouteFixture(
-          context,
-          claimed.selectedModel,
-          true,
-        ),
+        resolveVm0BuiltInModelRouteFixture(context, claimed.selectedModel),
       ).resolves.toMatchObject({
         provider_type: primary.provider_type,
         upstream_model: primary.upstream_model,
@@ -771,7 +687,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     const primary = await resolveVm0BuiltInModelRouteFixture(
       context,
       claimed.selectedModel,
-      true,
     );
     if (!primary) {
       throw new Error("Expected a built-in model primary route");
@@ -799,11 +714,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
     await withMockNowForTest(startedAt + 60_000, async () => {
       await expect(
-        resolveVm0BuiltInModelRouteFixture(
-          context,
-          claimed.selectedModel,
-          true,
-        ),
+        resolveVm0BuiltInModelRouteFixture(context, claimed.selectedModel),
       ).resolves.toMatchObject({
         provider_type: primary.provider_type,
         upstream_model: primary.upstream_model,
@@ -817,7 +728,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     const primary = await resolveVm0BuiltInModelRouteFixture(
       context,
       claimed.selectedModel,
-      true,
     );
     if (!primary) {
       throw new Error("Expected a built-in model primary route");
@@ -853,7 +763,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     const primary = await resolveVm0BuiltInModelRouteFixture(
       context,
       claimed.selectedModel,
-      true,
     );
     if (!primary) {
       throw new Error("Expected a built-in model primary route");
@@ -910,11 +819,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
     await withMockNowForTest(startedAt + 8 * 60_000, async () => {
       await expect(
-        resolveVm0BuiltInModelRouteFixture(
-          context,
-          claimed.selectedModel,
-          true,
-        ),
+        resolveVm0BuiltInModelRouteFixture(context, claimed.selectedModel),
       ).resolves.not.toMatchObject({
         provider_type: primary.provider_type,
         upstream_model: primary.upstream_model,
@@ -922,11 +827,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     });
     await withMockNowForTest(startedAt + 30 * 60_000, async () => {
       await expect(
-        resolveVm0BuiltInModelRouteFixture(
-          context,
-          claimed.selectedModel,
-          true,
-        ),
+        resolveVm0BuiltInModelRouteFixture(context, claimed.selectedModel),
       ).resolves.toMatchObject({
         provider_type: primary.provider_type,
         upstream_model: primary.upstream_model,
@@ -940,7 +841,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     const primary = await resolveVm0BuiltInModelRouteFixture(
       context,
       claimed.selectedModel,
-      true,
     );
     if (!primary) {
       throw new Error("Expected a built-in model primary route");
@@ -978,11 +878,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     });
     await withMockNowForTest(startedAt + 60_000, async () => {
       await expect(
-        resolveVm0BuiltInModelRouteFixture(
-          context,
-          claimed.selectedModel,
-          true,
-        ),
+        resolveVm0BuiltInModelRouteFixture(context, claimed.selectedModel),
       ).resolves.not.toMatchObject({
         provider_type: primary.provider_type,
         upstream_model: primary.upstream_model,
@@ -996,7 +892,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     const primary = await resolveVm0BuiltInModelRouteFixture(
       context,
       claimed.selectedModel,
-      true,
     );
     if (!primary) {
       throw new Error("Expected a built-in model primary route");
@@ -1047,7 +942,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
       const primary = await resolveVm0BuiltInModelRouteFixture(
         context,
         claimed.selectedModel,
-        true,
       );
       if (!primary) {
         throw new Error("Expected a built-in model primary route");
@@ -1099,11 +993,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
       });
       await withMockNowForTest(startedAt + cooldownExpiresAfterMs, async () => {
         await expect(
-          resolveVm0BuiltInModelRouteFixture(
-            context,
-            claimed.selectedModel,
-            true,
-          ),
+          resolveVm0BuiltInModelRouteFixture(context, claimed.selectedModel),
         ).resolves.toMatchObject({
           provider_type: primary.provider_type,
           upstream_model: primary.upstream_model,
@@ -1119,7 +1009,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
       const primary = await resolveVm0BuiltInModelRouteFixture(
         context,
         claimed.selectedModel,
-        true,
       );
       if (!primary) {
         throw new Error("Expected a built-in model primary route");
@@ -1145,11 +1034,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
         expiredDeadline,
       );
       await expect(
-        resolveVm0BuiltInModelRouteFixture(
-          context,
-          claimed.selectedModel,
-          true,
-        ),
+        resolveVm0BuiltInModelRouteFixture(context, claimed.selectedModel),
       ).resolves.toMatchObject({
         provider_type: primary.provider_type,
         upstream_model: primary.upstream_model,
@@ -1166,7 +1051,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     const primary = await resolveVm0BuiltInModelRouteFixture(
       context,
       claimed.selectedModel,
-      true,
     );
     if (!primary) {
       throw new Error("Expected a built-in model primary route");
@@ -1192,7 +1076,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
       const primary = await resolveVm0BuiltInModelRouteFixture(
         context,
         claimed.selectedModel,
-        true,
       );
       if (!primary) {
         throw new Error("Expected a built-in model primary route");
@@ -1230,11 +1113,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
 
       await withMockNowForTest(startedAt + 350_000, async () => {
         await expect(
-          resolveVm0BuiltInModelRouteFixture(
-            context,
-            claimed.selectedModel,
-            true,
-          ),
+          resolveVm0BuiltInModelRouteFixture(context, claimed.selectedModel),
         ).resolves.not.toMatchObject({
           provider_type: primary.provider_type,
           upstream_model: primary.upstream_model,
@@ -1242,11 +1121,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
       });
       await withMockNowForTest(startedAt + 401_000, async () => {
         await expect(
-          resolveVm0BuiltInModelRouteFixture(
-            context,
-            claimed.selectedModel,
-            true,
-          ),
+          resolveVm0BuiltInModelRouteFixture(context, claimed.selectedModel),
         ).resolves.toMatchObject({
           provider_type: primary.provider_type,
           upstream_model: primary.upstream_model,
@@ -1262,7 +1137,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
       const primary = await resolveVm0BuiltInModelRouteFixture(
         context,
         claimed.selectedModel,
-        true,
       );
       if (!primary) {
         throw new Error("Expected a built-in model primary route");
@@ -1384,11 +1258,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
       ).resolves.toStrictEqual({ outcome: "ignored" });
 
       await expect(
-        resolveVm0BuiltInModelRouteFixture(
-          context,
-          claimed.selectedModel,
-          true,
-        ),
+        resolveVm0BuiltInModelRouteFixture(context, claimed.selectedModel),
       ).resolves.toMatchObject({
         provider_type: primary.provider_type,
         upstream_model: primary.upstream_model,

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
@@ -73,8 +73,8 @@ const webhooksApi = createWebhookCallbackApi(context);
 const chatCallbacks = createChatCallbacksApi(context);
 
 const WORKFLOW_NAME = "workflow-queue-workflow";
-const NO_BUILT_IN_MODEL_KEY_MESSAGE =
-  "No model provider configured: no built-in model key is configured";
+const BUILT_IN_MODEL_ROUTES_UNAVAILABLE_MESSAGE =
+  "Every built-in model route for this model is temporarily unavailable";
 
 function it(name: string, test: () => Promise<void>, timeout?: number): void {
   vitestTest(
@@ -509,7 +509,7 @@ async function expectSweepLeftQueueUntouched(
 }
 
 describe("workflow queue", () => {
-  it("rejects a goal continuation with neutral built-in model copy when the key is unavailable", async () => {
+  it("rejects a goal continuation when every built-in route is unavailable", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);
     await chatCallbacks.updateOrgModelPolicies(scenario.actor, [
@@ -555,14 +555,14 @@ describe("workflow queue", () => {
     if (rejected?.eventType !== "input.rejected") {
       throw new Error("Expected the goal continuation to be rejected");
     }
-    expect(rejected.error).toBe(NO_BUILT_IN_MODEL_KEY_MESSAGE);
+    expect(rejected.error).toBe(BUILT_IN_MODEL_ROUTES_UNAVAILABLE_MESSAGE);
     expect(rejected.error).not.toContain("VM0");
     await expect(
       readGoalQueueStateFixture(automation.threadId),
     ).resolves.toMatchObject({ runIds: [] });
   });
 
-  it("rejects a workflow automation with neutral built-in model copy when the key is unavailable", async () => {
+  it("rejects a workflow automation when every built-in route is unavailable", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);
     await chatCallbacks.updateOrgModelPolicies(scenario.actor, [
@@ -601,7 +601,7 @@ describe("workflow queue", () => {
     if (rejected?.eventType !== "input.rejected") {
       throw new Error("Expected the workflow automation to be rejected");
     }
-    expect(rejected.error).toBe(NO_BUILT_IN_MODEL_KEY_MESSAGE);
+    expect(rejected.error).toBe(BUILT_IN_MODEL_ROUTES_UNAVAILABLE_MESSAGE);
     expect(rejected.error).not.toContain("VM0");
     await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(0);
   });

--- a/turbo/apps/api/src/signals/routes/model-providers.ts
+++ b/turbo/apps/api/src/signals/routes/model-providers.ts
@@ -105,8 +105,9 @@ const getBuiltInModelCooldownDiagnosticsInner$ = command(
     return {
       status: 200 as const,
       body: {
-        fallbackEnabled:
-          featureStates[FeatureSwitchKey.BuiltInModelProviderFallback],
+        // Previous web clients require this field. Keep it true until their
+        // compatibility window closes after the global rollout.
+        fallbackEnabled: true,
         canCancelCooldowns: isStaffOrg(auth.orgId),
         activeCooldowns: activeCooldowns.map((cooldown) => {
           return {

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -678,7 +678,6 @@ async function vm0BuiltInModelActionResponse(
       const route = await resolveBuiltInModelRuntimeRoute(
         db,
         body.selected_model,
-        body.fallback_enabled,
       );
       signal.throwIfAborted();
       return {

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -154,7 +154,6 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_pre_create_zero_goal_drain_resolve_model_context"
   | "api_dispatch_pre_create_zero_goal_drain_model_context_load_initial_feature_switches"
   | "api_dispatch_pre_create_zero_goal_drain_model_context_resolve_persisted_model_policy"
-  | "api_dispatch_pre_create_zero_goal_drain_model_context_reload_fallback_feature_switches"
   | "api_dispatch_pre_create_zero_goal_drain_model_context_resolve_built_in_route"
   | "api_dispatch_pre_create_zero_goal_drain_build_run_input"
   | "api_dispatch_pre_create_zero_goal_drain_handoff_run"

--- a/turbo/apps/api/src/signals/services/built-in-model-runtime-route.service.ts
+++ b/turbo/apps/api/src/signals/services/built-in-model-runtime-route.service.ts
@@ -79,29 +79,12 @@ export function builtInModelRuntimeTarget(
   return target;
 }
 
-async function resolvePrimaryRoute(
-  db: Db,
-  selectedModel: string,
-): Promise<BuiltInModelRuntimeRoute | null> {
-  const target = builtInModelRuntimeTarget(selectedModel);
-  const [key] = await db
-    .select({ id: builtInModelKeys.id })
-    .from(builtInModelKeys)
-    .where(eq(builtInModelKeys.vendor, target.vendor))
-    .limit(1);
-  return key ? routeFromTarget(target, key) : null;
-}
-
 export async function resolveBuiltInModelRuntimeRoute(
   db: Db,
   selectedModel: string,
-  fallbackEnabled = false,
 ): Promise<BuiltInModelRuntimeRoute | null> {
   if (runtimeRouteUnavailableForTest(selectedModel)) {
     return null;
-  }
-  if (!fallbackEnabled) {
-    return await resolvePrimaryRoute(db, selectedModel);
   }
 
   const timestamp = nowDate();

--- a/turbo/apps/api/src/signals/services/chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/chat-events.command.ts
@@ -460,7 +460,6 @@ interface NormalSendFeatureSwitches {
    * switches this request already read.
    */
   readonly featureSwitchContext: FeatureSwitchContext;
-  readonly builtInModelProviderFallbackEnabled: boolean;
 }
 
 interface RuntimeNormalSendBody extends Omit<
@@ -963,7 +962,6 @@ function emptyModelFirstThreadPin(): ThreadModelPin {
 async function withBuiltInModelRuntimeRoute(
   db: Db,
   configuration: ResolvedRunConfiguration,
-  fallbackEnabled: boolean,
 ): Promise<ResolvedRunConfiguration | NormalSendFailure> {
   if (
     configuration.providerAdmission.error ||
@@ -982,17 +980,12 @@ async function withBuiltInModelRuntimeRoute(
   const builtInModelRuntimeRoute = await resolveBuiltInModelRuntimeRoute(
     db,
     selectedModel,
-    fallbackEnabled,
   );
   return builtInModelRuntimeRoute
     ? { ...configuration, builtInModelRuntimeRoute }
-    : fallbackEnabled
-      ? modelProviderUnavailable(
-          "Every built-in model route for this model is temporarily unavailable",
-        )
-      : providerUnavailable(
-          "No model provider configured: no built-in model key is configured",
-        );
+    : modelProviderUnavailable(
+        "Every built-in model route for this model is temporarily unavailable",
+      );
 }
 
 async function resolveExplicitRunConfiguration(params: {
@@ -1001,7 +994,6 @@ async function resolveExplicitRunConfiguration(params: {
   readonly userId: string;
   readonly body: NormalSendBody;
   readonly codexFastModeEnabled: boolean;
-  readonly builtInModelProviderFallbackEnabled: boolean;
   readonly timing?: ApiDispatchTimingCollector;
 }): Promise<ResolvedRunConfiguration | NormalSendFailure | undefined> {
   const modelSelection = params.body.modelSelection;
@@ -1056,19 +1048,15 @@ async function resolveExplicitRunConfiguration(params: {
   if (codexServiceTierError) {
     return codexServiceTierError;
   }
-  return await withBuiltInModelRuntimeRoute(
-    params.db,
-    {
+  return await withBuiltInModelRuntimeRoute(params.db, {
+    modelPin,
+    providerAdmission,
+    codexServiceTier: codexServiceTierForRun({
+      body: params.body,
       modelPin,
-      providerAdmission,
-      codexServiceTier: codexServiceTierForRun({
-        body: params.body,
-        modelPin,
-        codexFastModeEnabled: params.codexFastModeEnabled,
-      }),
-    },
-    params.builtInModelProviderFallbackEnabled,
-  );
+      codexFastModeEnabled: params.codexFastModeEnabled,
+    }),
+  });
 }
 
 async function resolveNormalSendFeatureSwitches(
@@ -1087,10 +1075,6 @@ async function resolveNormalSendFeatureSwitches(
       context,
     ),
     featureSwitchContext: context,
-    builtInModelProviderFallbackEnabled: isFeatureEnabled(
-      FeatureSwitchKey.BuiltInModelProviderFallback,
-      context,
-    ),
   };
 }
 
@@ -1596,7 +1580,6 @@ async function resolveThread(params: {
   readonly requestedCodexServiceTier: CodexServiceTier | undefined;
   readonly persistRequestedCodexServiceTier: boolean;
   readonly codexFastModeEnabled: boolean;
-  readonly builtInModelProviderFallbackEnabled: boolean;
   readonly timing?: ApiDispatchTimingCollector;
 }): Promise<ResolvedThreadAndRunConfiguration | NormalSendFailure> {
   if (!params.existingThreadId) {
@@ -1675,7 +1658,6 @@ async function resolveThread(params: {
         providerAdmission: persisted.providerAdmission,
         codexServiceTier: persisted.runCodexServiceTier,
       },
-      params.builtInModelProviderFallbackEnabled,
     );
     if ("status" in resolvedRunConfiguration) {
       return resolvedRunConfiguration;
@@ -2434,8 +2416,6 @@ function resolveTimedExplicitRunConfiguration(
         userId: args.userId,
         body: args.body,
         codexFastModeEnabled: featureSwitches.codexFastModeEnabled,
-        builtInModelProviderFallbackEnabled:
-          featureSwitches.builtInModelProviderFallbackEnabled,
         timing: args.timing,
       });
     },
@@ -2501,8 +2481,6 @@ function resolveTimedThread(
           args.body.modelSelection !== undefined ||
           args.body.runOptions !== undefined,
         codexFastModeEnabled: featureSwitches.codexFastModeEnabled,
-        builtInModelProviderFallbackEnabled:
-          featureSwitches.builtInModelProviderFallbackEnabled,
         timing: args.timing,
       });
       if (!("status" in resolved)) {

--- a/turbo/apps/api/src/signals/services/feature-switches.service.ts
+++ b/turbo/apps/api/src/signals/services/feature-switches.service.ts
@@ -14,7 +14,6 @@ export const ORG_SENTINEL_USER_ID = "__org__";
 
 const ORG_SCOPED_FEATURE_SWITCH_KEYS: readonly string[] = [
   FeatureSwitchKey.ChatErrorRecovery,
-  FeatureSwitchKey.BuiltInModelProviderFallback,
   FeatureSwitchKey.PiLoop,
   FeatureSwitchKey.PresentationTemplates,
 ];

--- a/turbo/apps/api/src/signals/services/goal-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/goal-queue-drain.service.ts
@@ -310,34 +310,13 @@ async function resolveModelContext(
 
   const effectiveModelProvider = providerAdmission.effectiveModelProvider;
   const selectedModel = pin.selectedModel;
-  const fallbackEnabled = isBuiltInModelProviderType(effectiveModelProvider)
-    ? isFeatureEnabled(
-        FeatureSwitchKey.BuiltInModelProviderFallback,
-        await args.timing.measure(
-          "api_dispatch_pre_create_zero_goal_drain_model_context_reload_fallback_feature_switches",
-          "nested",
-          () => {
-            return loadUserFeatureSwitchContext(
-              args.db,
-              args.goal.orgId,
-              args.goal.userId,
-            );
-          },
-          args.timingDimensions,
-        ),
-      )
-    : false;
   const builtInModelRuntimeRoute =
     isBuiltInModelProviderType(effectiveModelProvider) && selectedModel
       ? await args.timing.measure(
           "api_dispatch_pre_create_zero_goal_drain_model_context_resolve_built_in_route",
           "nested",
           () => {
-            return resolveBuiltInModelRuntimeRoute(
-              args.db,
-              selectedModel,
-              fallbackEnabled,
-            );
+            return resolveBuiltInModelRuntimeRoute(args.db, selectedModel);
           },
           args.timingDimensions,
         )
@@ -355,12 +334,9 @@ async function resolveModelContext(
           status: 503,
           body: {
             error: {
-              code: fallbackEnabled
-                ? "MODEL_PROVIDER_UNAVAILABLE"
-                : "PROVIDER_UNAVAILABLE",
-              message: fallbackEnabled
-                ? "Every built-in model route for this model is temporarily unavailable"
-                : "No model provider configured: no built-in model key is configured",
+              code: "MODEL_PROVIDER_UNAVAILABLE",
+              message:
+                "Every built-in model route for this model is temporarily unavailable",
             },
           },
         },

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -2649,7 +2649,6 @@ async function resolveQueuedMessageModelRoute(args: {
   readonly orgId: string;
   readonly contextType: QueuedUserMessageContextType;
   readonly timing?: ChatCallbackPreCreateTimingCollector;
-  readonly fallbackEnabled: boolean;
 }): Promise<QueuedMessageModelRouteResolution> {
   const modelContext = await measureChatCallbackPreCreateTiming(
     args.timing,
@@ -2675,11 +2674,7 @@ async function resolveQueuedMessageModelRoute(args: {
   const selectedModel = modelContext.pin.selectedModel;
   const builtInModelRuntimeRoute =
     isBuiltInModelProviderType(effectiveModelProvider) && selectedModel
-      ? await resolveBuiltInModelRuntimeRoute(
-          args.db,
-          selectedModel,
-          args.fallbackEnabled,
-        )
+      ? await resolveBuiltInModelRuntimeRoute(args.db, selectedModel)
       : undefined;
   if (
     isBuiltInModelProviderType(effectiveModelProvider) &&
@@ -2687,12 +2682,9 @@ async function resolveQueuedMessageModelRoute(args: {
   ) {
     return {
       error: {
-        code: args.fallbackEnabled
-          ? "MODEL_PROVIDER_UNAVAILABLE"
-          : "PROVIDER_UNAVAILABLE",
-        message: args.fallbackEnabled
-          ? "Every built-in model route for this model is temporarily unavailable"
-          : "No model provider configured: no built-in model key is configured",
+        code: "MODEL_PROVIDER_UNAVAILABLE",
+        message:
+          "Every built-in model route for this model is temporarily unavailable",
       },
     };
   }
@@ -3219,10 +3211,6 @@ async function buildCreateQueuedChatRunInput(
     orgId: args.agent.orgId,
     contextType: args.queuedMessage.contextType,
     timing: args.timing,
-    fallbackEnabled: isFeatureEnabled(
-      FeatureSwitchKey.BuiltInModelProviderFallback,
-      featureSwitchContext,
-    ),
   });
   const userMessageProjection = queuedUserMessageProjection(
     args.queuedMessage.userMessage,

--- a/turbo/apps/api/src/signals/services/workflow-automation-launch.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation-launch.service.ts
@@ -5,8 +5,6 @@ import { isBuiltInModelProviderType } from "@okouai/api-contracts/contracts/mode
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { workflowAutomations } from "@okouai/db/schema/workflow";
 import { command } from "ccstate";
-import { isFeatureEnabled } from "@okouai/core/feature-switch";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { eq } from "drizzle-orm";
 import { writeDb$, type Db } from "../external/db";
 import { now, nowDate } from "../../lib/time";
@@ -30,7 +28,6 @@ import {
 } from "./api-dispatch-timing.service";
 import { createQueueFirstAgentRun$ } from "./agent-runs-create.service";
 import { workflowAutomationCanFire } from "./workflow-automation-access.service";
-import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { loadComputerUseHostGrantForAutoSend } from "./chat-computer-use-host.service";
 import type { WorkflowAutomationContext } from "./workflow-automation-context.service";
 import type { ChatAgentRunSourceAnnotation } from "./chat-user-message.service";
@@ -315,19 +312,9 @@ async function resolveModelContext(
 
   const effectiveModelProvider = providerAdmission.effectiveModelProvider;
   const selectedModel = pin.selectedModel;
-  const fallbackEnabled = isBuiltInModelProviderType(effectiveModelProvider)
-    ? isFeatureEnabled(
-        FeatureSwitchKey.BuiltInModelProviderFallback,
-        await loadUserFeatureSwitchContext(args.db, args.orgId, args.userId),
-      )
-    : false;
   const builtInModelRuntimeRoute =
     isBuiltInModelProviderType(effectiveModelProvider) && selectedModel
-      ? await resolveBuiltInModelRuntimeRoute(
-          args.db,
-          selectedModel,
-          fallbackEnabled,
-        )
+      ? await resolveBuiltInModelRuntimeRoute(args.db, selectedModel)
       : undefined;
   signal.throwIfAborted();
   if (
@@ -342,12 +329,9 @@ async function resolveModelContext(
           status: 503,
           body: {
             error: {
-              code: fallbackEnabled
-                ? "MODEL_PROVIDER_UNAVAILABLE"
-                : "PROVIDER_UNAVAILABLE",
-              message: fallbackEnabled
-                ? "Every built-in model route for this model is temporarily unavailable"
-                : "No model provider configured: no built-in model key is configured",
+              code: "MODEL_PROVIDER_UNAVAILABLE",
+              message:
+                "Every built-in model route for this model is temporarily unavailable",
             },
           },
         },

--- a/turbo/apps/platform/src/mocks/handlers/api-org-model-providers.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-org-model-providers.ts
@@ -26,7 +26,7 @@ export function resetMockOrgModelProviders(): void {
 export const apiOrgModelProvidersHandlers = [
   mockApi(modelProviderCooldownDiagnosticsContract.get, ({ respond }) => {
     return respond(200, {
-      fallbackEnabled: false,
+      fallbackEnabled: true,
       activeCooldowns: [],
     });
   }),

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -37,7 +37,6 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
   z.object({
     action: z.literal("resolve-vm0-built-in-model-route"),
     selected_model: z.string(),
-    fallback_enabled: z.boolean(),
   }),
   z.object({
     action: z.literal("set-vm0-built-in-candidate-cooldown"),

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -27,9 +27,6 @@ describe("isFeatureEnabled", () => {
 
   it("should return false for disabled switch without context", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.AhrefsConnector, {})).toBe(false);
-    expect(
-      isFeatureEnabled(FeatureSwitchKey.BuiltInModelProviderFallback, {}),
-    ).toBe(false);
   });
 
   it("should return false for disabled switch with non-matching userId", () => {
@@ -123,9 +120,6 @@ describe("getAllFeatureStates", () => {
     });
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.BuiltInModelProviderFallback]).toBe(
-      true,
-    );
     expect(staffOrgStates[FeatureSwitchKey.PiLoop]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       true,
@@ -151,9 +145,6 @@ describe("getAllFeatureStates", () => {
     });
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.BuiltInModelProviderFallback]).toBe(
-      false,
-    );
     expect(otherOrgStates[FeatureSwitchKey.PiLoop]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -50,7 +50,6 @@ export enum FeatureSwitchKey {
   ZapierConnector = "zapierConnector",
   ComputerUseDesktopPlugins = "computerUseDesktopPlugins",
   ChatErrorRecovery = "chatErrorRecovery",
-  BuiltInModelProviderFallback = "builtInModelProviderFallback",
   ResponsiveFollowupCards = "responsiveFollowupCards",
   ConnectorCatalogCount = "connectorCatalogCount",
   SidebarSubscriptionUsage = "sidebarSubscriptionUsage",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -325,12 +325,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.BuiltInModelProviderFallback]: {
-    maintainer: "liangyou@vm0.ai",
-    description: "Select healthy fallback routes for built-in platform models.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ComposerImageAnnotation]: {
     maintainer: "tongx@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- make built-in model provider fallback routing unconditional for chat sends, queued callbacks, goal drains, and workflow automations
- remove the `BuiltInModelProviderFallback` feature switch, runtime branches, test-only toggle input, and CI bootstrap configuration
- preserve the cooldown diagnostics response field as `fallbackEnabled: true` for cross-version web compatibility
- update integration coverage and failure expectations for the always-on routing behavior

## Exclusions

- keep the retired switch name in historical migration `0991_cutover_built_in_model_terminology.sql`
- keep the diagnostics API compatibility field until the independent frontend/backend deployment window has closed

## Validation

- `pnpm -F @okouai/db db:migrate`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-runtime-state.test.ts src/signals/routes/__tests__/model-providers.test.ts src/signals/routes/__tests__/hooks-ops.bdd.test.ts`
- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/settings-dialog.test.tsx`
- focused API Vitest coverage for chat callbacks, chat events, goal drains, and workflow automation failures
- `pnpm -F api check-types`
- `pnpm -F @okouai/app check-types`
- `pnpm -F api lint`
- `pnpm knip`
- `pnpm format`
- pre-commit `pnpm check-types` (14/14 workspaces passed)

The workflow assertion script could not complete locally because Ruby is not installed in the container. Runner BATS coverage remains delegated to CI because the required runner environment is not available locally.
