### PR TITLE
fix(api): keep a committed delete successful when storage cleanup fails

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agent-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-lifecycle.bdd.test.ts
@@ -1,10 +1,21 @@
+import { DeleteObjectsCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
 import { describe, expect, it } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
+import { nowDate } from "../../../lib/time";
 import { createBddApi, expectApiError } from "./helpers/api-bdd";
 
 const context = testContext();
 const api = createBddApi(context);
+
+/** Shape of the transient upstream failure R2 returns as an S3 `InternalError`. */
+function objectStoreInternalError(): Error {
+  const error = new Error(
+    "We encountered an internal error. Please try again.",
+  );
+  error.name = "InternalError";
+  return error;
+}
 
 describe("AGENT-01: agent lifecycle through public API", () => {
   it("creates, reads, lists, updates, deletes, and verifies removal through API-visible state", async () => {
@@ -75,6 +86,47 @@ describe("AGENT-01: agent lifecycle through public API", () => {
     });
 
     await api.deleteAgent(admin, created.agentId);
+
+    const missing = await api.requestReadAgent(admin, created.agentId, [404]);
+    expectApiError(missing.body);
+    expect(missing.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("still reports the agent as deleted when object storage cleanup fails after the delete commits", async () => {
+    const admin = api.user();
+    api.acceptAgentStorageWrites();
+
+    const created = await api.createAgent(admin, {
+      displayName: "BDD Storage Cleanup Agent",
+    });
+
+    const listedPrefixes: string[] = [];
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      if (command instanceof ListObjectsV2Command) {
+        const prefix = command.input.Prefix ?? "";
+        listedPrefixes.push(prefix);
+        return Promise.resolve({
+          Contents: [
+            {
+              Key: `${prefix}AGENTS.md`,
+              Size: 12,
+              LastModified: nowDate(),
+            },
+          ],
+        });
+      }
+      if (command instanceof DeleteObjectsCommand) {
+        return Promise.reject(objectStoreInternalError());
+      }
+      return Promise.resolve({ ContentLength: 1024 });
+    });
+
+    // The row deletion has already committed by the time the objects are
+    // released, so an upstream object-store failure must not be reported as a
+    // failed deletion. `deleteAgent` accepts only 204.
+    await api.deleteAgent(admin, created.agentId);
+
+    expect(listedPrefixes.length).toBeGreaterThan(0);
 
     const missing = await api.requestReadAgent(admin, created.agentId, [404]);
     expectApiError(missing.body);

--- a/turbo/apps/api/src/signals/services/agent-deletion.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-deletion.service.ts
@@ -7,7 +7,6 @@ import { and, asc, eq, inArray, sql } from "drizzle-orm";
 
 import { db$, writeDb$ } from "../external/db";
 import type { Tx } from "../../lib/db-types";
-import { deleteS3Objects, listS3ObjectsUnderPrefix } from "../external/s3";
 import { env } from "../../lib/env";
 import { conflict } from "../../lib/error";
 import { isLockNotAvailable } from "../../lib/pg-errors";
@@ -16,6 +15,7 @@ import { settle } from "../utils";
 import { lockCanonicalAgentMutation } from "./agent-mutation-lock.service";
 import { removeAgentInstructionsStorageInTransaction } from "./agent-instructions-storage-transaction.service";
 import { reconcileAutomationEventWatches } from "./automation-event-watch-lifecycle.service";
+import { purgeDeletedStoragePrefix$ } from "./storage-prefix-purge.service";
 
 export function agentExistsInOrg(args: {
   readonly orgId: string;
@@ -165,7 +165,7 @@ async function deleteAgentInTransaction(tx: Tx, args: DeleteAgentArgs) {
 }
 
 export const deleteAgentById$ = command(
-  async ({ get, set }, args: DeleteAgentArgs, signal: AbortSignal) => {
+  async ({ set }, args: DeleteAgentArgs, signal: AbortSignal) => {
     const writeDb = set(writeDb$);
 
     const transaction = await settle(
@@ -211,20 +211,14 @@ export const deleteAgentById$ = command(
     signal.throwIfAborted();
 
     if (result.s3Prefix) {
-      const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
-      const objects = await get(
-        listS3ObjectsUnderPrefix(bucket, result.s3Prefix),
+      await set(
+        purgeDeletedStoragePrefix$,
+        {
+          bucket: env("R2_USER_STORAGES_BUCKET_NAME"),
+          s3Prefix: result.s3Prefix,
+        },
+        signal,
       );
-      signal.throwIfAborted();
-      await get(
-        deleteS3Objects(
-          bucket,
-          objects.map((obj) => {
-            return obj.key;
-          }),
-        ),
-      );
-      signal.throwIfAborted();
     }
 
     return undefined;

--- a/turbo/apps/api/src/signals/services/storage-prefix-purge.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-prefix-purge.service.ts
@@ -1,0 +1,62 @@
+import { command } from "ccstate";
+
+import { logger } from "../../lib/log";
+import { deleteS3Objects, listS3ObjectsUnderPrefix } from "../external/s3";
+import { tapError } from "../utils";
+
+const L = logger("StoragePrefixPurge");
+
+interface StoragePrefixPurgeArgs {
+  readonly bucket: string;
+  readonly s3Prefix: string;
+}
+
+const listAndDeletePrefixObjects$ = command(
+  async (
+    { get },
+    args: StoragePrefixPurgeArgs,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const objects = await get(
+      listS3ObjectsUnderPrefix(args.bucket, args.s3Prefix),
+    );
+    signal.throwIfAborted();
+    await get(
+      deleteS3Objects(
+        args.bucket,
+        objects.map((object) => {
+          return object.key;
+        }),
+      ),
+    );
+    signal.throwIfAborted();
+  },
+);
+
+/**
+ * Release the objects under a storage prefix whose owning `storages` row was
+ * already deleted by a committed transaction.
+ *
+ * That commit is durable and it removed the only pointer to the prefix, so a
+ * caller retry can never reach this cleanup again. Reporting an upstream
+ * object-store failure as a failed deletion would therefore turn a committed
+ * success into a misleading 5xx while leaving the objects orphaned either way.
+ * Log the orphaned prefix instead so it stays auditable and recoverable. Abort
+ * still propagates.
+ */
+export const purgeDeletedStoragePrefix$ = command(
+  async (
+    { set },
+    args: StoragePrefixPurgeArgs,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    await tapError(set(listAndDeletePrefixObjects$, args, signal), (error) => {
+      L.warn("Failed to release objects under a deleted storage prefix", {
+        bucket: args.bucket,
+        s3Prefix: args.s3Prefix,
+        error,
+      });
+    });
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/services/workflow-delete.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-delete.service.ts
@@ -9,9 +9,9 @@ import { and, eq, sql } from "drizzle-orm";
 
 import { env } from "../../lib/env";
 import { writeDb$ } from "../external/db";
-import { deleteS3Objects, listS3ObjectsUnderPrefix } from "../external/s3";
 import { reconcileAutomationEventWatches } from "./automation-event-watch-lifecycle.service";
 import { OFFICIAL_WORKFLOW_CATALOG_ACTIVATION_LOCK } from "./official-workflow-constants";
+import { purgeDeletedStoragePrefix$ } from "./storage-prefix-purge.service";
 
 interface DeleteWorkflowInput {
   readonly orgId: string;
@@ -33,7 +33,7 @@ interface DeleteOrphanedWorkflowVolumeInput {
  */
 export const deleteOrphanedWorkflowVolume$ = command(
   async (
-    { get, set },
+    { set },
     args: DeleteOrphanedWorkflowVolumeInput,
     signal: AbortSignal,
   ): Promise<boolean> => {
@@ -80,27 +80,21 @@ export const deleteOrphanedWorkflowVolume$ = command(
       return false;
     }
 
-    const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
-    const objects = await get(
-      listS3ObjectsUnderPrefix(bucket, result.s3Prefix),
+    await set(
+      purgeDeletedStoragePrefix$,
+      {
+        bucket: env("R2_USER_STORAGES_BUCKET_NAME"),
+        s3Prefix: result.s3Prefix,
+      },
+      signal,
     );
-    signal.throwIfAborted();
-    await get(
-      deleteS3Objects(
-        bucket,
-        objects.map((object) => {
-          return object.key;
-        }),
-      ),
-    );
-    signal.throwIfAborted();
     return true;
   },
 );
 
 export const deleteWorkflow$ = command(
   async (
-    { get, set },
+    { set },
     args: DeleteWorkflowInput,
     signal: AbortSignal,
   ): Promise<boolean> => {
@@ -202,20 +196,14 @@ export const deleteWorkflow$ = command(
     signal.throwIfAborted();
 
     if (result.s3Prefix) {
-      const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
-      const objects = await get(
-        listS3ObjectsUnderPrefix(bucket, result.s3Prefix),
+      await set(
+        purgeDeletedStoragePrefix$,
+        {
+          bucket: env("R2_USER_STORAGES_BUCKET_NAME"),
+          s3Prefix: result.s3Prefix,
+        },
+        signal,
       );
-      signal.throwIfAborted();
-      await get(
-        deleteS3Objects(
-          bucket,
-          objects.map((object) => {
-            return object.key;
-          }),
-        ),
-      );
-      signal.throwIfAborted();
     }
 
     return true;


### PR DESCRIPTION
## Summary

`cli-e2e-03-runner` went red on a merge-queue Turbo run while **every product assertion passed**. The failure was entirely in `teardown_file`:

```
ok 1 vm0 built-in real claude returns a successful answer          # in 5637 ms
ok 2 vm0 built-in real pi loop returns a successful answer         # in 3893 ms
ok 3 vm0 built-in real claude steers an active run then starts a successor # in 24527 ms
not ok 4 teardown_file failed
# Stage 0 Runner E2E agent teardown failed with HTTP 500: {"error":"Internal server error"}
# requestHost:pr-30849-api.vm6.ai requestPath:/api/agents/2feabe94-3206-491c-8614-8b58547a1f7b status:500
```

Triggering run: https://github.com/vm0-ai/vm0/actions/runs/33496657496 (job [99822134815](https://github.com/vm0-ai/vm0/actions/runs/33496657496/job/99822134815), SHA `aac2b0e7401a107fb2cbb615bfcf5d5090a6152a`, queued PR #30849).

## Root cause

The API log for that exact request (`vm0-web-logs-dev`, `_time = 2026-09-01T10:25:24.623Z`, deployment `dpl_8n2H66X8SJQATbQfT5f24ApSMT2N`) shows the server-side error is **not** a lock conflict — it is a transient object-store failure:

```
route: /api/agents/:id      method: DELETE      type: unhandled_request_error
fields.error.Code:    "InternalError"
fields.error.$fault:  "server"
fields.error.$metadata.httpStatusCode: 500
fields.error.$metadata.attempts: 3        # AWS SDK retries already exhausted
fields.error.stack:   S3RestXmlProtocol.handleError ...
```

`deleteAgentById$` releases the deleted agent's instructions storage **after** the write transaction commits:

1. the transaction deletes the `agents` row *and* the `storages` row, then commits — durable and irreversible;
2. only then does it `ListObjectsV2` + `DeleteObjects` against R2;
3. R2 returned a server-fault `InternalError`, which propagated as an unhandled request error → `500`.

Because the `storages` row is already gone, the committed deletion has removed the only pointer to the prefix. A client retry gets `204`/`404` and never re-attempts the cleanup, so the objects are orphaned **whether or not** the request reports failure. The `500` therefore only misreports a committed success; it recovers nothing.

`workflow-delete.service.ts` has the identical shape and the identical failure:

| window | route | count |
|---|---|---|
| 2026-09-01 06:33 UTC (preview) | `DELETE /api/workflows/:workflowId` | 1 |
| 2026-09-01 06:33 UTC (preview) | `DELETE /api/agents/:id` | 3 |
| 2026-09-01 10:18–10:25 UTC (preview) | `DELETE /api/agents/:id` | 5 |
| 2026-08-07/08 (**production**) | `DELETE /api/zero/workflows/:workflowId` | 3 |

Over the last 7 days every single R2 `InternalError` in the API landed on one of these two post-commit cleanup paths, in short bursts across four different deployments — a transient upstream R2 condition, not a code path that fails deterministically.

## Fix

Add `purgeDeletedStoragePrefix$`, a shared command that lists and deletes the objects under a prefix whose owning `storages` row was already deleted by a committed transaction, and reports an upstream failure as a `warn` carrying the bucket and prefix instead of failing the request. `AbortError` still propagates, so a cancelled request is never reported as a success.

Both delete services now route through it. This is the same handling the repository already applies to post-commit R2 cleanup in `agent-run-lifecycle.service.ts:104`.

What deliberately did **not** change:

- **Cleanup is still real.** The purge still runs on every delete and is never a no-op; only its failure is downgraded from "the deletion failed" to "the objects leaked, here is the prefix".
- **No retry, sleep, or timeout change.** The AWS SDK had already spent its 3 attempts; adding more would not have helped a server-fault burst.
- **No change to `delete_runner_agent_for_stage0_teardown`.** Adding a bounded retry for arbitrary `500`s there would have hidden exactly the server defect this run exposed. The helper keeps failing loudly on an unexpected status.

## Validation

New integration test `still reports the agent as deleted when object storage cleanup fails after the delete commits` in `agent-lifecycle.bdd.test.ts` drives the public route with `DeleteObjectsCommand` rejecting as an R2 `InternalError`.

Against the pre-fix service it reproduces the CI failure exactly:

```
Error: Unknown response status 500 for DELETE /api/agents/:id
```

With the fix it asserts `204` and that the agent is subsequently `404`.

- `agent-lifecycle.bdd.test.ts` + `agent-deletion-interlock.bdd.test.ts`: 16 passed
- `workflows.test.ts` + `agent-lifecycle.bdd.test.ts`: 30 passed, repeated 5× consecutively, green every time
- `workflow-automations.test.ts`, `workflow-automation-scheduler.test.ts`, `agents-update.test.ts`, `misc-routes.bdd.test.ts`: 124 passed
- `pnpm -F api check-types`, `eslint` on the changed files, `pnpm knip --workspace apps/api`, `git diff --check`: clean

The end-to-end invariant is covered by this PR's own `cli-e2e-03-runner` shard, which exercises the real teardown against the deployed preview API.

## Follow-up (not in scope here)

Three more sites share the "commit, then release the prefix" shape but have no failure evidence and are not request-response endpoints returning a misleading 5xx: `agent-instructions-storage.service.ts:116`, `org-limited-free-bootstrap.service.ts:304`, and `cron-sync-skills.service.ts:660`. There is also no GC that reclaims R2 objects whose `storages` row is gone, so orphaned prefixes currently rely on the log line this PR adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
