### PR TITLE
fix(runner): fail closed on incomplete config image refs

### DIFF
--- a/crates/runner/src/cmd/gc/image_refs.rs
+++ b/crates/runner/src/cmd/gc/image_refs.rs
@@ -31,14 +31,6 @@ impl ProtectedImageRefs {
     }
 
     #[cfg(test)]
-    pub(super) fn is_empty(&self) -> bool {
-        match self {
-            Self::Complete(refs) => refs.is_empty(),
-            Self::Incomplete => false,
-        }
-    }
-
-    #[cfg(test)]
     pub(super) const fn incomplete() -> Self {
         Self::Incomplete
     }
@@ -96,7 +88,9 @@ pub(super) async fn protected_image_refs_for_gc(
     }
 
     let mut refs = ProtectedImageRefs::new();
-    collect_retained_version_image_refs(home, version_analysis, &mut refs).await;
+    if !collect_retained_version_image_refs(home, version_analysis, &mut refs).await {
+        return ProtectedImageRefs::Incomplete;
+    }
     if !collect_enabled_service_image_refs(&mut refs).await {
         return ProtectedImageRefs::Incomplete;
     }
@@ -107,11 +101,14 @@ async fn collect_retained_version_image_refs(
     home: &HomePaths,
     version_analysis: &VersionGcAnalysis,
     refs: &mut ProtectedImageRefs,
-) {
+) -> bool {
     for name in version_analysis.retained_names() {
         let config_path = home.runners_dir().join(name).join("runner.yaml");
-        collect_config_image_refs(&config_path, "retained version", refs).await;
+        if !collect_config_image_refs(&config_path, "retained version", refs).await {
+            return false;
+        }
     }
+    true
 }
 
 async fn collect_enabled_service_image_refs(refs: &mut ProtectedImageRefs) -> bool {
@@ -123,10 +120,15 @@ async fn collect_enabled_service_image_refs_from_dir(
     refs: &mut ProtectedImageRefs,
 ) -> bool {
     let scan = enabled_runner_service_config_paths(system_dir).await;
-    for config_path in scan.paths {
-        collect_config_image_refs(&config_path, "enabled service", refs).await;
+    if !scan.inventory_complete {
+        return false;
     }
-    scan.inventory_complete
+    for config_path in scan.paths {
+        if !collect_config_image_refs(&config_path, "enabled service", refs).await {
+            return false;
+        }
+    }
+    true
 }
 
 struct EnabledRunnerServiceConfigPaths {
@@ -263,51 +265,52 @@ async fn collect_config_image_refs(
     config_path: &Path,
     source: &str,
     refs: &mut ProtectedImageRefs,
-) {
+) -> bool {
     let Some(content) = (match config::read_diagnostic_config_to_string(config_path).await {
         Ok(content) => content,
         Err(e) => {
             warn!(
-                "runner image refs: cannot read {source} config {} ({e}), skipping",
+                "runner image refs: cannot read {source} config {} ({e}), protection inventory incomplete",
                 config_path.display()
             );
-            return;
+            return false;
         }
     }) else {
         warn!(
-            "runner image refs: {source} config {} is missing, skipping",
+            "runner image refs: {source} config {} is missing, protection inventory incomplete",
             config_path.display()
         );
-        return;
+        return false;
     };
 
     let config = match serde_yaml_ng::from_str::<ConfigImageRefs>(&content) {
         Ok(config) => config,
         Err(_) => {
             warn!(
-                "runner image refs: cannot parse {source} config {}, skipping",
+                "runner image refs: cannot parse {source} config {}, protection inventory incomplete",
                 config_path.display()
             );
-            return;
+            return false;
         }
     };
     for (_, profile_ref) in config.profiles {
         if image_hash::validate_or_err(&profile_ref.rootfs_hash).is_err() {
             warn!(
-                "runner image refs: {source} config {} has a profile with an invalid rootfs hash, skipping profile",
+                "runner image refs: {source} config {} has a profile with an invalid rootfs hash, protection inventory incomplete",
                 config_path.display()
             );
-            continue;
+            return false;
         }
         if image_hash::validate_or_err(&profile_ref.snapshot_hash).is_err() {
             warn!(
-                "runner image refs: {source} config {} has a profile with an invalid snapshot hash, skipping profile",
+                "runner image refs: {source} config {} has a profile with an invalid snapshot hash, protection inventory incomplete",
                 config_path.display()
             );
-            continue;
+            return false;
         }
         insert_protected_image_ref(refs, profile_ref.rootfs_hash, profile_ref.snapshot_hash);
     }
+    true
 }
 
 #[cfg(test)]

--- a/crates/runner/src/cmd/gc/image_refs/tests.rs
+++ b/crates/runner/src/cmd/gc/image_refs/tests.rs
@@ -71,7 +71,7 @@ if [ "$1" = "--no-pager" ] && [ "$2" = "cat" ] && [ "$3" = "--" ]; then
         "ExecStart=/usr/bin/runner start --config /configs/$suffix.yaml"
       exit 0
       ;;
-    effective)
+    effective|malformed-config)
       printf '%s\n' \
         '# /etc/systemd/system/vm0-runner-test.service' \
         '[Service]' \
@@ -188,7 +188,7 @@ async fn protected_refs_from_versions(
         .await
         .unwrap();
     let mut refs = ProtectedImageRefs::new();
-    collect_retained_version_image_refs(home, &analysis, &mut refs).await;
+    assert!(collect_retained_version_image_refs(home, &analysis, &mut refs).await);
     refs
 }
 
@@ -365,26 +365,69 @@ async fn removable_version_config_does_not_protect_image_snapshot() {
 }
 
 #[tokio::test]
-async fn malformed_retained_version_config_is_ignored_for_image_refs() {
+async fn malformed_retained_version_config_skips_image_gc() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    let version = "v1.0.0";
+    let rootfs_hash = test_hash('a');
+    let snapshot_hash = test_hash('b');
+    let snapshot_dir = create_old_test_snapshot(&home, &rootfs_hash, &snapshot_hash);
+    let config_path = create_test_version_with_config(&home, version, &rootfs_hash, &snapshot_hash);
+    std::fs::write(
+        config_path,
+        "server:\n  token: should-not-appear-in-errors\nprofiles: [",
+    )
+    .unwrap();
+
+    let analysis = analyze_version_gc(&home, Some(version), None)
+        .await
+        .unwrap();
+    let refs = protected_image_refs_for_gc(&home, &analysis).await;
+
+    assert!(!refs.is_complete());
+    let report = gc_nested_images_with_protected_refs(&home, Some(0), false, &refs)
+        .await
+        .unwrap();
+
+    assert_eq!(report.freed_bytes, 0);
+    assert_eq!(report.activity_count, 0);
+    assert!(snapshot_dir.exists());
+    assert!(home.images_dir().join(rootfs_hash).exists());
+}
+
+#[tokio::test]
+async fn missing_retained_version_config_makes_protection_inventory_incomplete() {
     let dir = tempfile::tempdir().unwrap();
     let home = test_home(dir.path());
     let version = "v1.0.0";
     std::fs::create_dir_all(home.bin_dir().join(version)).unwrap();
-    let config_dir = home.runners_dir().join(version);
-    std::fs::create_dir_all(&config_dir).unwrap();
-    std::fs::write(
-        config_dir.join("runner.yaml"),
-        "server:\n  token: should-not-appear-in-errors\nprofiles: [",
-    )
-    .unwrap();
-    age_version_past_gc_min_age(&home, version);
+    let analysis = analyze_version_gc(&home, Some(version), None)
+        .await
+        .unwrap();
 
-    let refs = protected_refs_from_versions(&home, Some(version), None).await;
+    let refs = protected_image_refs_for_gc(&home, &analysis).await;
 
-    assert!(
-        refs.is_empty(),
-        "malformed retained config should be skipped instead of protecting images"
-    );
+    assert!(!refs.is_complete());
+}
+
+#[tokio::test]
+async fn invalid_retained_version_profile_hash_makes_protection_inventory_incomplete() {
+    for (rootfs_hash, snapshot_hash) in [
+        ("invalid".to_string(), test_hash('b')),
+        (test_hash('a'), "invalid".to_string()),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let version = "v1.0.0";
+        create_test_version_with_config(&home, version, &rootfs_hash, &snapshot_hash);
+        let analysis = analyze_version_gc(&home, Some(version), None)
+            .await
+            .unwrap();
+
+        let refs = protected_image_refs_for_gc(&home, &analysis).await;
+
+        assert!(!refs.is_complete());
+    }
 }
 
 #[tokio::test]
@@ -397,7 +440,7 @@ async fn service_config_image_ref_keeps_image_snapshot() {
     let config_path =
         write_test_runner_config(&home, "service-config", &rootfs_hash, &snapshot_hash);
     let mut refs = ProtectedImageRefs::new();
-    collect_config_image_refs(&config_path, "enabled service", &mut refs).await;
+    assert!(collect_config_image_refs(&config_path, "enabled service", &mut refs).await);
 
     let freed = gc_nested_images_with_protected_refs(&home, Some(0), false, &refs)
         .await
@@ -483,6 +526,11 @@ async fn enabled_service_discovery_failures_make_inventory_incomplete() {
 }
 
 #[tokio::test]
+async fn malformed_enabled_service_config_makes_inventory_incomplete() {
+    run_enabled_service_scenario("malformed-config").await;
+}
+
+#[tokio::test]
 async fn readable_unit_without_runner_config_remains_best_effort() {
     run_enabled_service_scenario("unparseable").await;
 }
@@ -512,6 +560,13 @@ async fn run_enabled_service_scenario(scenario: &str) -> Vec<String> {
     let snapshot_hash = test_hash('b');
     create_old_test_snapshot(&home, &rootfs_hash, &snapshot_hash);
     let config_path = write_test_runner_config(&home, "effective", &rootfs_hash, &snapshot_hash);
+    if scenario == "malformed-config" {
+        std::fs::write(
+            &config_path,
+            "server:\n  token: should-not-appear-in-errors\nprofiles: [",
+        )
+        .unwrap();
+    }
 
     let invocations_path = dir.path().join("invocations");
     let state_dir = dir.path().join("state");
@@ -585,6 +640,11 @@ async fn enabled_service_systemctl_child() {
 
             assert!(!scan.inventory_complete);
             assert!(scan.paths.is_empty());
+        }
+        "malformed-config" => {
+            let mut refs = ProtectedImageRefs::new();
+
+            assert!(!collect_enabled_service_image_refs_from_dir(&system_dir, &mut refs).await);
         }
         "unparseable" => {
             let scan = enabled_runner_service_config_paths(&system_dir).await;


### PR DESCRIPTION
## Summary

- propagate missing, unreadable, malformed, and hash-invalid config failures through the runner image-reference collectors
- mark the protection inventory incomplete before image GC can consume a partial reference map
- add retained-version and enabled-service regressions that preserve the existing no-config-path service policy

## Scope

- changes only runner image-reference inventory collection and its colocated tests
- does not change public APIs, persisted formats, runner protocols, migrations, or other GC phases
- keeps enabled services with no parseable runner config path as the existing best-effort discovery case

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo check -p runner --all-targets --all-features` — passed with one build job, incremental compilation disabled, and debug info disabled
- `cargo clippy -p runner --all-targets --all-features` — passed with the same low-memory settings
- `cargo doc -p runner --all-features --no-deps` — passed
- `cargo test -p runner cmd::gc::image_refs::tests` — attempted with one build job and debug info disabled; runner test-harness code generation was OOM-killed at approximately 3.74 GiB RSS in this 3.8 GiB cgroup (exit 137), including a second attempt with dynamic linking and GNU gold. CI must execute the linked regression tests.

Closes #30833
