### PR TITLE
fix(platform): update favicon artwork

### DIFF
--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -377,7 +377,7 @@ assert.equal(
 );
 assert.ok(
   tagAttributeValues(vm0Page.html, "link", "href").includes(
-    "https://static.vm0.io/platform/icon.svg",
+    "https://static.vm0.io/public/okou-transparent.svg",
   ),
 );
 assertBootstrapAvatar(vm0Page.html);
@@ -418,7 +418,7 @@ assert.equal(
 );
 assert.ok(
   tagAttributeValues(okouPage.html, "link", "href").includes(
-    "https://static.okou.io/platform/icon.svg",
+    "https://static.okou.io/public/okou-transparent.svg",
   ),
 );
 assert.ok(

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -9,15 +9,17 @@
     <meta name="vm0-api-origin" content="" />
     <link
       rel="icon"
-      type="image/svg+xml"
-      href="https://static.vm0.io/platform/icon.svg"
-      integrity="sha384-ccZJ/dPMsNHiW8WF8/yNp+aD3sIwf2+1wy7fqvURH5oNrFX0sfNYTaXwTjyMhIjE"
+      type="image/x-icon"
+      sizes="16x16 32x32 48x48 64x64 128x128 256x256"
+      href="https://static.vm0.io/public/okou-transparent.ico"
+      integrity="sha384-arUP6RZ3+pTpC5fyAy4MZMAPloOdG9vLJWv2UidpXbcaltA32woK+3fz9RM+pAam"
     />
     <link
       rel="icon"
-      type="image/x-icon"
-      href="https://static.vm0.io/platform/favicon.ico"
-      integrity="sha384-Pe0cByX3KRkasDxciKVerqZSvuElddhe0ri32ym8ia9G/4BZcn2EhPYZI1n4jV3B"
+      type="image/svg+xml"
+      sizes="any"
+      href="https://static.vm0.io/public/okou-transparent.svg"
+      integrity="sha384-7sRGMm24rKKTHtMbyppyRU6B5l19DDUT9SODgfPRocth+7AB5N8rXNAMwmvR5RQ1"
     />
     <link vite-ignore rel="manifest" href="/manifest.webmanifest" />
     <link rel="preconnect" href="https://cdn.vm0.io" crossorigin />


### PR DESCRIPTION
## Summary

- replace the platform favicon SVG and ICO with the Okou avatar artwork
- declare the ICO raster sizes and SVG scalable sizing
- update SRI hashes for both static assets

## Testing

- pnpm exec prettier --write apps/platform/index.html
- pnpm -F @okouai/app lint
- pnpm -F @okouai/app check-types
- pnpm knip --workspace @okouai/app
- pnpm -F @okouai/app test
- pnpm -F @okouai/app build