### PR TITLE
feat(connectors): route github oauth callback directly to okou

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts
@@ -37,6 +37,9 @@ const BOX_OAUTH_TOKEN_URL = "https://api.box.com/oauth2/token";
 const BOX_CURRENT_USER_URL = "https://api.box.com/2.0/users/me";
 const CLOUDFLARE_OAUTH_TOKEN_URL = "https://dash.cloudflare.com/oauth2/token";
 const CLOUDFLARE_USERINFO_URL = "https://dash.cloudflare.com/oauth2/userinfo";
+const GITHUB_OAUTH_TOKEN_URL = "https://github.com/login/oauth/access_token";
+const GITHUB_USER_URL = "https://api.github.com/user";
+const GITHUB_OAUTH_SCOPES = ["repo", "project", "workflow"] as const;
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const GOOGLE_OPENID_USERINFO_URL =
   "https://openidconnect.googleapis.com/v1/userinfo";
@@ -899,6 +902,9 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
     const callbackLocation = async (
       publicBrand: "vm0" | "okou",
       connectorSlug = "google-maps",
+      expectedCallbackAppOrigin = publicBrand === "okou"
+        ? "https://app.okou.ai"
+        : "https://app.vm0.ai",
     ): Promise<{ readonly state: string; readonly location: URL }> => {
       mockAuthenticatedSession();
       const response = await requestOauthStart(connectorSlug, {
@@ -909,9 +915,7 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
       expect(response.status).toBe(200);
       const authorizationUrl = await authorizationUrlFromResponse(response);
       expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
-        connectorSlug === "github"
-          ? "https://app.vm0.ai/connectors/github/callback"
-          : `https://app.${publicBrand === "okou" ? "okou" : "vm0"}.ai/connectors/google-maps/callback`,
+        `${expectedCallbackAppOrigin}/connectors/${connectorSlug}/callback`,
       );
       const state = authorizationUrl.searchParams.get("state") ?? "";
 
@@ -940,7 +944,11 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
     expect(okou.location.origin).toBe("https://app.okou.ai");
     expect(okou.location.pathname).toBe("/connector/error");
 
-    const notDirectReady = await callbackLocation("okou", "github");
+    const notDirectReady = await callbackLocation(
+      "okou",
+      "test-oauth",
+      "https://app.vm0.ai",
+    );
     expect(notDirectReady.state).toMatch(/^okou\.[0-9a-f]{64}$/u);
     expect(notDirectReady.location.origin).toBe("https://app.okou.ai");
 
@@ -948,6 +956,129 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
     expect(vm0.state).toMatch(/^[0-9a-f]{64}$/u);
     expect(vm0.location.origin).toBe("https://app.vm0.ai");
     expect(vm0.location.pathname).toBe("/connector/error");
+  });
+
+  it("uses the direct Okou App callback for GitHub and reuses its exact redirect URI", async () => {
+    const tokenBodies: URLSearchParams[] = [];
+    server.use(
+      http.post(GITHUB_OAUTH_TOKEN_URL, async ({ request }) => {
+        tokenBodies.push(new URLSearchParams(await request.text()));
+        return HttpResponse.json({
+          access_token: "github-test-token",
+          scope: GITHUB_OAUTH_SCOPES.join(","),
+        });
+      }),
+      http.get(GITHUB_USER_URL, () => {
+        return HttpResponse.json({
+          id: 4242,
+          login: "github-test-user",
+          email: "github@example.test",
+        });
+      }),
+    );
+    mockEnv("APP_URL", "https://app.vm0.ai");
+    mockAuthenticatedSession();
+
+    const response = await requestOauthStart("github", {
+      callbackTarget: "app",
+      headers: authHeaders(),
+      origin: OKOU_API_ORIGIN,
+    });
+
+    expect(response.status).toBe(200);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+    expect(`${authorizationUrl.origin}${authorizationUrl.pathname}`).toBe(
+      "https://github.com/login/oauth/authorize",
+    );
+    expect(authorizationUrl.searchParams.get("client_id")).toBe(
+      "test-client-id",
+    );
+    const redirectUri = authorizationUrl.searchParams.get("redirect_uri");
+    expect(redirectUri).toBe("https://app.okou.ai/connectors/github/callback");
+    expect(
+      authorizationUrl.searchParams.get("scope")?.split(" "),
+    ).toStrictEqual([...GITHUB_OAUTH_SCOPES]);
+    const state = expectOkouOauthState(authorizationUrl);
+
+    const app = createApp({ signal: context.signal, routes: TEST_APP_ROUTES });
+    const callback = await app.request(
+      `${OKOU_API_ORIGIN}/api/connectors/github/callback?${new URLSearchParams({
+        code: "github-authorization-code",
+        state,
+      })}`,
+      { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+    );
+
+    expect(callback.status).toBe(307);
+    const callbackLocation = new URL(callback.headers.get("location") ?? "");
+    expect(callbackLocation.origin).toBe("https://app.okou.ai");
+    expect(callbackLocation.pathname).toBe("/connector/success");
+    expect(tokenBodies).toHaveLength(1);
+    expect(tokenBodies[0]?.get("redirect_uri")).toBe(redirectUri);
+  });
+
+  it("keeps the VM0 App callback for GitHub", async () => {
+    mockEnv("APP_URL", "https://app.vm0.ai");
+    mockAuthenticatedSession();
+
+    const response = await requestOauthStart("github", {
+      callbackTarget: "app",
+      headers: authHeaders(),
+      origin: API_ORIGIN,
+    });
+
+    expect(response.status).toBe(200);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+      "https://app.vm0.ai/connectors/github/callback",
+    );
+    expectOauthState(authorizationUrl);
+    await rejectProviderAuthorization(authorizationUrl);
+  });
+
+  it("keeps GitHub denial redirects on the brand that started the flow", async () => {
+    mockEnv("APP_URL", "https://app.vm0.ai");
+
+    const denialLocation = async (
+      publicBrand: "vm0" | "okou",
+    ): Promise<URL> => {
+      mockAuthenticatedSession();
+      const response = await requestOauthStart("github", {
+        callbackTarget: "app",
+        headers: authHeaders(),
+        origin: publicBrand === "okou" ? OKOU_API_ORIGIN : API_ORIGIN,
+      });
+      expect(response.status).toBe(200);
+      const authorizationUrl = await authorizationUrlFromResponse(response);
+      const state =
+        publicBrand === "okou"
+          ? expectOkouOauthState(authorizationUrl)
+          : expectOauthState(authorizationUrl);
+
+      const app = createApp({
+        signal: context.signal,
+        routes: TEST_APP_ROUTES,
+      });
+      const callback = await app.request(
+        `${OKOU_API_ORIGIN}/api/connectors/github/callback?${new URLSearchParams(
+          {
+            error: "access_denied",
+            state,
+          },
+        )}`,
+        { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+      );
+      expect(callback.status).toBe(307);
+      return new URL(callback.headers.get("location") ?? "");
+    };
+
+    const okou = await denialLocation("okou");
+    expect(okou.origin).toBe("https://app.okou.ai");
+    expect(okou.pathname).toBe("/connector/error");
+
+    const vm0 = await denialLocation("vm0");
+    expect(vm0.origin).toBe("https://app.vm0.ai");
+    expect(vm0.pathname).toBe("/connector/error");
   });
 
   it("reuses the persisted exact redirect URI for a PKCE token exchange", async () => {

--- a/turbo/packages/connectors/src/__tests__/app-oauth-callback.test.ts
+++ b/turbo/packages/connectors/src/__tests__/app-oauth-callback.test.ts
@@ -17,6 +17,7 @@ const DIRECT_OKOU_READY_CONNECTORS = [
   "dropbox",
   "figma",
   "garmin-connect",
+  "github",
   "gmail",
   "google-ads",
   "google-analytics",
@@ -77,7 +78,7 @@ describe("direct Okou OAuth callback readiness", () => {
     },
   );
 
-  it.each(["github", "quickbooks", "test-oauth"])(
+  it.each(["quickbooks", "test-oauth"])(
     "keeps %s on its existing callback",
     (connectorSlug) => {
       expect(isConnectorDirectOkouOauthCallbackReady(connectorSlug)).toBe(

--- a/turbo/packages/connectors/src/app-oauth-callback.ts
+++ b/turbo/packages/connectors/src/app-oauth-callback.ts
@@ -34,6 +34,7 @@ const DIRECT_OKOU_OAUTH_CALLBACK_READY_CONNECTOR_SLUGS: ReadonlySet<string> =
     "dropbox",
     "figma",
     "garmin-connect",
+    "github",
     "gmail",
     "google-ads",
     "google-analytics",


### PR DESCRIPTION
Closes #30867. Application-side GitHub cutover slice of EPIC #28381.

## What changed

1. `turbo/packages/connectors/src/app-oauth-callback.ts` — add exactly `github` to the direct Okou callback readiness set, in alphabetical order. A trusted Okou App OAuth start now emits `https://app.okou.ai/connectors/github/callback`.
2. `turbo/packages/connectors/src/__tests__/app-oauth-callback.test.ts` — the exact readiness-set assertion now includes GitHub, and GitHub is removed from the not-ready list.
3. `turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts` — focused route coverage for the changed behavior.

The production GitHub OAuth App (`client_id=Ov23liRCLaBgz3O7vFsS`) already allowlists `https://app.okou.ai/connectors/github/callback`. The addition was additive; existing callback URLs were retained and no other provider-console change was made (owner-confirmed evidence relayed in #30867).

## Not-ready sentinel

The route test used GitHub as its negative, not-ready sentinel. That assertion moves to the existing `test-oauth` fixture, which stays intentionally not ready. The helper's ad-hoc `connectorSlug === "github"` ternary is replaced with an explicit expected-App-origin parameter, so the not-ready case still pins the exact full redirect URI (`https://app.vm0.ai/connectors/test-oauth/callback`) under the Okou brand rather than a weaker check.

## New route coverage

- `uses the direct Okou App callback for GitHub and reuses its exact redirect URI` — asserts the authorization URL is `https://github.com/login/oauth/authorize` with `redirect_uri=https://app.okou.ai/connectors/github/callback` and unchanged scopes, then drives the callback and asserts the GitHub token request body replays that exact persisted URI (GitHub sends `redirect_uri` during exchange) and that success lands on `https://app.okou.ai/connector/success`.
- `keeps the VM0 App callback for GitHub` — a trusted VM0 App start still emits `https://app.vm0.ai/connectors/github/callback` with a VM0 state.
- `keeps GitHub denial redirects on the brand that started the flow` — `access_denied` returns to `https://app.okou.ai/connector/error` for an Okou start and `https://app.vm0.ai/connector/error` for a VM0 start.

The pre-existing omitted-target and local Web-origin GitHub tests are unchanged and still assert the Web callback (`${WEB_ORIGIN}/api/connectors/github/callback` and the configured local Web origin).

## Non-goals honored

No change to GitHub OAuth credentials, scopes, token handling, revocation, provider-console settings, or device authorization. No change to the separate GitHub App installation flow (`GITHUB_APP_*`, `/api/github/oauth/*`, `/api/github/app/setup/callback`, webhooks, installations) — `github-oauth.service.ts` computes its own redirect and is untouched. QuickBooks and the 12-provider scope of #30539 / #30562 are not absorbed. No migration, release, or generic callback-trust change. The persisted-redirect contract in `connectors.ts` and `connectors-slug-callback.ts` is preserved; the redirect URI is not recomputed at callback time.

## Verification

Focused, per the issue — no full local Vitest run and no local dev server.

- `pnpm -F @okouai/connectors exec vitest run` — 44 files, 1104 tests passed
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors-oauth-start.test.ts` — 102 passed
- `pnpm -F api exec vitest run` over the 9 other connector route suites plus `connectors.bdd.test.ts` — all passed
- `pnpm prettier --write` on the three changed files — already clean
- `pnpm -F @okouai/connectors run lint`, `pnpm -F api run lint` — exit 0
- `pnpm -F @okouai/connectors run check-types`, `pnpm -F api run check-types` — clean

Negative control: with the one-line source change reverted, `uses the direct Okou App callback for GitHub and reuses its exact redirect URI` fails with `expected 'https://app.vm0.ai/connectors/github/…' to be 'https://app.okou.ai/connectors/github…'`, confirming the test detects the cutover rather than passing vacuously.

#30562 overlaps these files but had not merged at branch time. If it merges first, this branch rebases and preserves its readiness entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)