### PR TITLE
fix(api): follow stripe workflow account selection

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -49,7 +49,11 @@ import { flushWaitUntilForTest } from "../../context/wait-until";
 import { installApiTestConnectorCatalog } from "../../../test-fixtures/connector-catalog";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
-import { mockGmailConnectorOAuth } from "./helpers/api-bdd-connectors";
+import {
+  createConnectorBddApi,
+  mockGmailConnectorOAuth,
+  mockStripeConnectorOAuth,
+} from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import {
@@ -94,6 +98,7 @@ import {
 
 const context = testContext();
 const bdd = createBddApi(context);
+const connectors = createConnectorBddApi(context);
 const workflowBdd = createWorkflowsBddApi(context);
 const runs = createRunsApi(context);
 const webhooks = createWebhookCallbackApi(context);
@@ -306,6 +311,19 @@ function structureTransitionGmailBlueprint(
               labelName: "Follow Up",
             },
           },
+    runtime: { resultEmail: false },
+  };
+}
+
+function structureTransitionStripeBlueprint(): OfficialWorkflowBlueprint {
+  return {
+    key: "lifecycle-transition",
+    parameters: [],
+    desiredState: {
+      kind: "event",
+      eventType: "stripe-invoice-paid",
+      eventConfig: { provider: "stripe", event: "invoice_paid" },
+    },
     runtime: { resultEmail: false },
   };
 }
@@ -1034,6 +1052,23 @@ async function setOfficialWorkflowsEnabled(
     { orgId: actor.orgId, userId: actor.userId },
     { [FeatureSwitchKey.OfficialWorkflows]: enabled },
   );
+}
+
+async function connectStripeOAuthForOfficialWorkflow(
+  actor: ApiTestUser,
+  args: { readonly accountId: string; readonly code: string },
+): Promise<string> {
+  mockStripeConnectorOAuth({ accountId: args.accountId, livemode: true });
+  const started = await connectors.startOauth(actor, "stripe", "oauth");
+  const state = new URL(started.authorizationUrl).searchParams.get("state");
+  if (!state) {
+    throw new Error("Expected Stripe OAuth state");
+  }
+  await connectors.completeOauthCallback("stripe", {
+    code: args.code,
+    state,
+  });
+  return (await connectors.readConnectorBySlug(actor, "stripe")).id;
 }
 
 function configureResultEmailRecipient(actor: ApiTestUser): void {
@@ -5539,6 +5574,121 @@ describe.sequential("Official Workflow installations", () => {
         automationId: automation.id,
         blueprintKey: "lifecycle-transition",
         state: "active",
+      }),
+    ]);
+  });
+
+  it("revalidates a prepared Stripe transition after the same connector changes accounts", async () => {
+    installCatalogStorageFixture();
+    const suffix = randomUUID().replaceAll("-", "").slice(0, 10);
+    const definitionName = `api-test-stripe-binding-race-${suffix}`;
+    await syncCatalog(
+      catalog([
+        activeDefinition(definitionName, [
+          structureTransitionScheduleBlueprint(),
+        ]),
+      ]),
+    );
+    const setup = await workflowBdd.setupWorkflowOrg();
+    const { actor } = setup;
+    if (!actor.orgId) {
+      throw new Error("Expected organization-scoped actor");
+    }
+    const { agentId } = await workflowBdd.createAgent(actor);
+    onTestFinished(async () => {
+      await resumeStructureTransitionPromotion();
+      installCatalogStorageFixture();
+      await bdd.deleteAgent(actor, agentId);
+      await cleanupCatalog();
+    });
+    await setOfficialWorkflowsEnabled(actor, true);
+    await updateFeatureSwitchesForUser(
+      context,
+      { orgId: actor.orgId, userId: actor.userId },
+      { [FeatureSwitchKey.StripeInvoicePaidWorkflowAutomations]: true },
+    );
+    const connectorId = await connectStripeOAuthForOfficialWorkflow(actor, {
+      accountId: "acct_official_before",
+      code: `stripe-before-${suffix}`,
+    });
+    const headers = authHeaders(actor);
+    const installed = await accept(
+      officialClient().install({
+        headers,
+        params: { definitionName },
+        body: {
+          agentId,
+          blueprints: [{ blueprintKey: "lifecycle-transition", bindings: [] }],
+        },
+      }),
+      [201],
+    );
+    const workflowId = installed.body.workflow.id;
+    const automation = installed.body.workflow.automations[0];
+    if (!automation) {
+      throw new Error("Expected Stripe structure-transition Automation");
+    }
+
+    await syncCatalog(
+      catalog([
+        activeDefinition(definitionName, [
+          structureTransitionStripeBlueprint(),
+        ]),
+      ]),
+    );
+    await pauseNextStructureTransitionPromotion();
+    const olderWorker = runOfficialWorkflowReconciliationWorker();
+    await waitForStructureTransitionPromotionPause();
+    const reconnectedId = await connectStripeOAuthForOfficialWorkflow(actor, {
+      accountId: "acct_official_after",
+      code: `stripe-after-${suffix}`,
+    });
+    expect(reconnectedId).toBe(connectorId);
+    await resumeStructureTransitionPromotion();
+    await olderWorker;
+
+    const rejected = await accept(
+      installationClient().get({ headers, params: { workflowId } }),
+      [200],
+    );
+    expect(rejected.body.workflow.automations).toStrictEqual([
+      expect.objectContaining({
+        id: automation.id,
+        kind: "schedule",
+        schedule: { type: "loop", intervalSeconds: 3600 },
+        enabled: false,
+        official: expect.objectContaining({
+          intendedEnabled: true,
+          reconciliationStatus: "reconciling",
+        }),
+      }),
+    ]);
+
+    await makeOfficialWorkflowReconciliationWorkDue(definitionName);
+    await expect(
+      runOfficialWorkflowReconciliationWorker(),
+    ).resolves.toStrictEqual(
+      expect.objectContaining({ claimed: 1, completed: 1, installations: 1 }),
+    );
+    const converged = await accept(
+      installationClient().get({ headers, params: { workflowId } }),
+      [200],
+    );
+    expect(converged.body.workflow.automations).toStrictEqual([
+      expect.objectContaining({
+        id: automation.id,
+        kind: "event",
+        eventType: "stripe-invoice-paid",
+        eventConfig: expect.objectContaining({
+          connectorId,
+          stripeAccountId: "acct_official_after",
+          mode: "live",
+        }),
+        enabled: true,
+        official: expect.objectContaining({
+          intendedEnabled: true,
+          reconciliationStatus: "current",
+        }),
       }),
     ]);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
@@ -6,7 +6,10 @@ import {
   type ConnectorAccountConnection,
 } from "@okouai/api-contracts/contracts/connector-accounts";
 import type { ConnectorResponse } from "@okouai/api-contracts/contracts/connector-schemas";
-import { testStripeAutomationEventFixtureContract } from "@okouai/api-contracts/contracts/test-stripe-automation-events";
+import {
+  testStripeAutomationEventFixtureContract,
+  type TestStripeAutomationEventFixtureAction,
+} from "@okouai/api-contracts/contracts/test-stripe-automation-events";
 import { testWorkflowAutomationExecutionContract } from "@okouai/api-contracts/contracts/test-workflow-automation-execution";
 import { workflowAutomationsContract } from "@okouai/api-contracts/contracts/workflows";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
@@ -123,8 +126,9 @@ async function connectStripeOAuth(
 async function addStripeOAuthAccount(
   actor: ApiTestUser,
   displayName: string,
+  accountId: string,
 ): Promise<ConnectorAccountConnection> {
-  mockStripeConnectorOAuth({ accountId: STRIPE_ACCOUNT_ID, livemode: true });
+  mockStripeConnectorOAuth({ accountId, livemode: true });
   const started = await connectors.startOauth(
     actor,
     "stripe",
@@ -155,6 +159,30 @@ async function addStripeOAuthAccount(
     throw new Error(`Expected Stripe account ${displayName}`);
   }
   return account;
+}
+
+async function reconnectStripeOAuthAccount(
+  actor: ApiTestUser,
+  connectorId: string,
+  accountId: string,
+  livemode: boolean,
+): Promise<void> {
+  mockStripeConnectorOAuth({ accountId, livemode });
+  const started = await connectors.startOauth(
+    actor,
+    "stripe",
+    "oauth",
+    undefined,
+    { intent: "reconnect", connectionId: connectorId },
+  );
+  const state = new URL(started.authorizationUrl).searchParams.get("state");
+  if (!state) {
+    throw new Error("Expected Stripe OAuth reconnect state");
+  }
+  await connectors.completeOauthCallback("stripe", {
+    code: `stripe-workflow-reconnect-${randomUUID()}`,
+    state,
+  });
 }
 
 async function setupScenario(
@@ -336,14 +364,7 @@ async function executeAutomation(scenario: Scenario) {
 
 async function applyDeliveryFixture(
   scenario: Scenario,
-  action:
-    | "corrupt-latest-snapshot"
-    | "hold-latest-claim"
-    | "expire-latest-retry-window"
-    | "make-latest-due"
-    | "fail-next-ingress-for-automation"
-    | "fail-next-queue-admission-for-automation"
-    | "clear-forced-failures",
+  action: TestStripeAutomationEventFixtureAction,
 ): Promise<void> {
   const response = await accept(
     setupApp({ context, routes: testStripeAutomationEventRoutes })(
@@ -691,8 +712,226 @@ describe("Stripe automation event webhook", () => {
     );
   });
 
-  it("orders distinct ingress, thread, and default Stripe accounts", async () => {
+  it("creates against the thread account and repairs after its Live reconnect", async () => {
+    const originalAccountId = `acct_stripe_create_original_${randomUUID()}`;
+    const threadAccountId = `acct_stripe_create_thread_${randomUUID()}`;
+    const scenario = await setupScenario({ accountId: originalAccountId });
+    const orgId = scenario.actor.orgId;
+    if (!orgId) {
+      throw new Error("Expected an organization-scoped workflow owner");
+    }
+    await connectors.updateFeatureSwitches(scenario.actor, {
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
+    await runs.enableAgentConnectors(scenario.actor, scenario.agentId, [
+      "stripe",
+    ]);
+    const threadAccount = await addStripeOAuthAccount(
+      scenario.actor,
+      "Creation thread account",
+      threadAccountId,
+    );
+    mocks.clerk.session(scenario.actor.userId, orgId);
+    await accept(
+      chatThreadConnectorSelectionsClient().update({
+        headers: authHeaders(),
+        params: { id: scenario.chatThreadId },
+        body: {
+          connectionId: threadAccount.id,
+          target: { kind: "builtin", connectorSlug: "stripe" },
+        },
+      }),
+      [200],
+    );
+    await deleteAutomation(scenario);
+
+    mocks.clerk.session(scenario.actor.userId, orgId);
+    const created = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: scenario.workflowId },
+        body: {
+          kind: "event",
+          eventType: "stripe-invoice-paid",
+          eventConfig: { provider: "stripe", event: "invoice_paid" },
+          enabled: true,
+        },
+      }),
+      [201],
+    );
+    expect(created.body).toMatchObject({
+      chatThreadId: scenario.chatThreadId,
+      eventConfig: {
+        connectorId: threadAccount.id,
+        stripeAccountId: threadAccountId,
+        mode: "live",
+      },
+    });
+    const recreatedScenario = { ...scenario, automationId: created.body.id };
+
+    await reconnectStripeOAuthAccount(
+      scenario.actor,
+      threadAccount.id,
+      threadAccountId,
+      false,
+    );
+    await postStripeAutomationEvent(
+      invoicePaidEvent({
+        accountId: originalAccountId,
+        eventId: "evt_thread_creation_default_fallback",
+      }),
+    );
+    await postStripeAutomationEvent(
+      invoicePaidEvent({
+        accountId: threadAccountId,
+        eventId: "evt_thread_creation_non_live",
+      }),
+    );
+    expect((await executeAutomation(recreatedScenario)).body).toStrictEqual(
+      NO_EXECUTION,
+    );
+
+    await reconnectStripeOAuthAccount(
+      scenario.actor,
+      threadAccount.id,
+      threadAccountId,
+      true,
+    );
+    const repairedEventId = "evt_thread_creation_repaired";
+    await postStripeAutomationEvent(
+      invoicePaidEvent({
+        accountId: threadAccountId,
+        eventId: repairedEventId,
+      }),
+    );
+    expect((await executeAutomation(recreatedScenario)).body).toStrictEqual(
+      EXECUTED_EXECUTION,
+    );
+    const claim = await claimScenarioRun(recreatedScenario, repairedEventId);
+    expect(
+      Object.values(claim.secretConnectorMetadataMap ?? {}),
+    ).toContainEqual(expect.objectContaining({ sourceId: threadAccount.id }));
+    const selections = await accept(
+      chatThreadConnectorSelectionsClient().get({
+        headers: authHeaders(),
+        params: { id: scenario.chatThreadId },
+      }),
+      [200],
+    );
+    expect(selections.body.selections).toStrictEqual([
+      {
+        connectionId: threadAccount.id,
+        target: { kind: "builtin", connectorSlug: "stripe" },
+      },
+    ]);
+  });
+
+  it("repairs a null legacy account projection before webhook ingress", async () => {
     const scenario = await setupScenario();
+    await applyDeliveryFixture(scenario, "clear-automation-account-projection");
+
+    await postStripeAutomationEvent(
+      invoicePaidEvent({ eventId: "evt_legacy_projection_ingress" }),
+    );
+
+    expect((await executeAutomation(scenario)).body).toStrictEqual(
+      EXECUTED_EXECUTION,
+    );
+  });
+
+  it("repairs a null legacy account projection before delivery", async () => {
+    const scenario = await setupScenario();
+    await postStripeAutomationEvent(
+      invoicePaidEvent({ eventId: "evt_legacy_projection_delivery" }),
+    );
+    await applyDeliveryFixture(scenario, "clear-automation-account-projection");
+
+    expect((await executeAutomation(scenario)).body).toStrictEqual(
+      EXECUTED_EXECUTION,
+    );
+  });
+
+  it("reprojects to the default account when the thread selection is cleared", async () => {
+    const originalAccountId = `acct_stripe_clear_original_${randomUUID()}`;
+    const threadAccountId = `acct_stripe_clear_thread_${randomUUID()}`;
+    const defaultAccountId = `acct_stripe_clear_default_${randomUUID()}`;
+    const scenario = await setupScenario({ accountId: originalAccountId });
+    const orgId = scenario.actor.orgId;
+    if (!orgId) {
+      throw new Error("Expected an organization-scoped workflow owner");
+    }
+    await connectors.updateFeatureSwitches(scenario.actor, {
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
+    await runs.enableAgentConnectors(scenario.actor, scenario.agentId, [
+      "stripe",
+    ]);
+    const threadAccount = await addStripeOAuthAccount(
+      scenario.actor,
+      "Cleared thread account",
+      threadAccountId,
+    );
+    const defaultAccount = await addStripeOAuthAccount(
+      scenario.actor,
+      "Cleared default account",
+      defaultAccountId,
+    );
+    mocks.clerk.session(scenario.actor.userId, orgId);
+    await accept(
+      connectorAccountsClient().setDefault({
+        headers: authHeaders(),
+        params: { connectionId: defaultAccount.id },
+        body: { target: { kind: "builtin", connectorSlug: "stripe" } },
+      }),
+      [200],
+    );
+    await accept(
+      chatThreadConnectorSelectionsClient().update({
+        headers: authHeaders(),
+        params: { id: scenario.chatThreadId },
+        body: {
+          connectionId: threadAccount.id,
+          target: { kind: "builtin", connectorSlug: "stripe" },
+        },
+      }),
+      [200],
+    );
+    await accept(
+      chatThreadConnectorSelectionsClient().clear({
+        headers: authHeaders(),
+        params: { id: scenario.chatThreadId },
+        body: { kind: "builtin", connectorSlug: "stripe" },
+      }),
+      [204],
+    );
+
+    await postStripeAutomationEvent(
+      invoicePaidEvent({
+        accountId: threadAccountId,
+        eventId: "evt_cleared_thread_source",
+      }),
+    );
+    expect((await executeAutomation(scenario)).body).toStrictEqual(
+      NO_EXECUTION,
+    );
+
+    await postStripeAutomationEvent(
+      invoicePaidEvent({
+        accountId: defaultAccountId,
+        eventId: "evt_cleared_default_source",
+      }),
+    );
+    expect((await executeAutomation(scenario)).body).toStrictEqual(
+      EXECUTED_EXECUTION,
+    );
+  });
+
+  it("source-gates ingress before preserving run connector fallback order", async () => {
+    const originalAccountId = `acct_stripe_original_${randomUUID()}`;
+    const threadAccountId = `acct_stripe_thread_${randomUUID()}`;
+    const defaultAccountId = `acct_stripe_default_${randomUUID()}`;
+    const scenario = await setupScenario({ accountId: originalAccountId });
+    const seenRunIds = new Set<string>();
     const orgId = scenario.actor.orgId;
     if (!orgId) {
       throw new Error("Expected an organization-scoped workflow owner");
@@ -706,10 +945,12 @@ describe("Stripe automation event webhook", () => {
     const threadAccount = await addStripeOAuthAccount(
       scenario.actor,
       "Thread account",
+      threadAccountId,
     );
     const defaultAccount = await addStripeOAuthAccount(
       scenario.actor,
       "Default account",
+      defaultAccountId,
     );
     mocks.clerk.session(scenario.actor.userId, orgId);
     await accept(
@@ -766,24 +1007,35 @@ describe("Stripe automation event webhook", () => {
       ]),
     );
 
-    const seenRunIds = new Set<string>();
-    const sourceEventId = "evt_connector_priority_source";
+    const oldSourceEventId = "evt_connector_projection_old_source";
     await postStripeAutomationEvent(
-      invoicePaidEvent({ eventId: sourceEventId }),
+      invoicePaidEvent({
+        accountId: originalAccountId,
+        eventId: oldSourceEventId,
+      }),
+    );
+    expect((await executeAutomation(scenario)).body).toStrictEqual(
+      NO_EXECUTION,
+    );
+
+    const threadEventId = "evt_connector_projection_thread";
+    await postStripeAutomationEvent(
+      invoicePaidEvent({ accountId: threadAccountId, eventId: threadEventId }),
     );
     expect((await executeAutomation(scenario)).body).toStrictEqual(
       EXECUTED_EXECUTION,
     );
-    const sourceClaim = await claimUnseenScenarioRun(scenario, seenRunIds);
+    const threadClaim = await claimUnseenScenarioRun(scenario, seenRunIds);
     expect(
-      Object.values(sourceClaim.secretConnectorMetadataMap ?? {}),
-    ).toContainEqual(
-      expect.objectContaining({ sourceId: scenario.connector.id }),
-    );
+      Object.values(threadClaim.secretConnectorMetadataMap ?? {}),
+    ).toContainEqual(expect.objectContaining({ sourceId: threadAccount.id }));
 
-    const threadEventId = "evt_connector_priority_thread";
+    const defaultFallbackEventId = "evt_connector_projection_default";
     await postStripeAutomationEvent(
-      invoicePaidEvent({ eventId: threadEventId }),
+      invoicePaidEvent({
+        accountId: threadAccountId,
+        eventId: defaultFallbackEventId,
+      }),
     );
     expect((await executeAutomation(scenario)).body).toStrictEqual(
       EXECUTED_EXECUTION,
@@ -791,49 +1043,10 @@ describe("Stripe automation event webhook", () => {
     await setConnectorAccountState(context, {
       orgId,
       userId: scenario.actor.userId,
-      connectorId: scenario.connector.id,
+      connectorId: threadAccount.id,
       needsReconnect: true,
       storageVersion: 1,
     });
-    await completeScenarioRun(sourceClaim);
-    const threadClaim = await claimUnseenScenarioRun(scenario, seenRunIds);
-    const threadSourceId = Object.values(
-      threadClaim.secretConnectorMetadataMap ?? {},
-    ).find((metadata) => {
-      return metadata.sourceType === "connector";
-    })?.sourceId;
-    expect(threadSourceId).toBe(threadAccount.id);
-
-    await setConnectorAccountState(context, {
-      orgId,
-      userId: scenario.actor.userId,
-      connectorId: scenario.connector.id,
-      needsReconnect: false,
-      storageVersion: 3,
-    });
-    const defaultEventId = "evt_connector_priority_default";
-    await postStripeAutomationEvent(
-      invoicePaidEvent({ eventId: defaultEventId }),
-    );
-    expect((await executeAutomation(scenario)).body).toStrictEqual(
-      EXECUTED_EXECUTION,
-    );
-    await Promise.all([
-      setConnectorAccountState(context, {
-        orgId,
-        userId: scenario.actor.userId,
-        connectorId: scenario.connector.id,
-        needsReconnect: true,
-        storageVersion: 1,
-      }),
-      setConnectorAccountState(context, {
-        orgId,
-        userId: scenario.actor.userId,
-        connectorId: threadAccount.id,
-        needsReconnect: true,
-        storageVersion: 1,
-      }),
-    ]);
     await completeScenarioRun(threadClaim);
     const defaultClaim = await claimUnseenScenarioRun(scenario, seenRunIds);
     expect(
@@ -843,13 +1056,16 @@ describe("Stripe automation event webhook", () => {
     await setConnectorAccountState(context, {
       orgId,
       userId: scenario.actor.userId,
-      connectorId: scenario.connector.id,
+      connectorId: threadAccount.id,
       needsReconnect: false,
       storageVersion: 3,
     });
-    const unavailableEventId = "evt_connector_priority_unavailable";
+    const unavailableEventId = "evt_connector_projection_unavailable";
     await postStripeAutomationEvent(
-      invoicePaidEvent({ eventId: unavailableEventId }),
+      invoicePaidEvent({
+        accountId: threadAccountId,
+        eventId: unavailableEventId,
+      }),
     );
     expect((await executeAutomation(scenario)).body).toStrictEqual(
       EXECUTED_EXECUTION,
@@ -858,7 +1074,7 @@ describe("Stripe automation event webhook", () => {
       setConnectorAccountState(context, {
         orgId,
         userId: scenario.actor.userId,
-        connectorId: scenario.connector.id,
+        connectorId: threadAccount.id,
         needsReconnect: true,
         storageVersion: 1,
       }),
@@ -874,9 +1090,6 @@ describe("Stripe automation event webhook", () => {
     const unavailableClaim = await claimUnseenScenarioRun(scenario, seenRunIds);
     const unavailableMetadata = Object.values(
       unavailableClaim.secretConnectorMetadataMap ?? {},
-    );
-    expect(unavailableMetadata).not.toContainEqual(
-      expect.objectContaining({ sourceId: scenario.connector.id }),
     );
     expect(unavailableMetadata).not.toContainEqual(
       expect.objectContaining({ sourceId: threadAccount.id }),
@@ -1391,6 +1604,42 @@ describe("Stripe automation event webhook", () => {
         lastDeliveryStatus: "skipped",
         warning: null,
       });
+      expect(result.inputEvents).toHaveLength(0);
+    });
+
+    it("when the thread account selection changes", async () => {
+      const { scenario } =
+        await setupPendingLifecycleDelivery("thread_selection");
+      const orgId = scenario.actor.orgId;
+      if (!orgId) {
+        throw new Error("Expected an organization-scoped workflow owner");
+      }
+      await connectors.updateFeatureSwitches(scenario.actor, {
+        [FeatureSwitchKey.ConnectorAccounts]: true,
+      });
+      await runs.enableAgentConnectors(scenario.actor, scenario.agentId, [
+        "stripe",
+      ]);
+      const replacementAccount = await addStripeOAuthAccount(
+        scenario.actor,
+        "Replacement thread account",
+        `acct_stripe_thread_replacement_${randomUUID()}`,
+      );
+      mocks.clerk.session(scenario.actor.userId, orgId);
+      await accept(
+        chatThreadConnectorSelectionsClient().update({
+          headers: authHeaders(),
+          params: { id: scenario.chatThreadId },
+          body: {
+            connectionId: replacementAccount.id,
+            target: { kind: "builtin", connectorSlug: "stripe" },
+          },
+        }),
+        [200],
+      );
+
+      const result = await executeLifecycleDelivery(scenario);
+      expect(result.execution).toStrictEqual(TERMINALLY_SKIPPED_EXECUTION);
       expect(result.inputEvents).toHaveLength(0);
     });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/stripe-invoice-paid-workflow-automation-readiness.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/stripe-invoice-paid-workflow-automation-readiness.test.ts
@@ -442,37 +442,54 @@ describe("Stripe invoice-paid workflow automation readiness", () => {
     expect(enabled.body.enabled).toBeTruthy();
   });
 
-  it.each([
-    {
-      name: "different account",
-      accountId: "acct_different_workflow",
-      livemode: true,
-      message: /delete and recreate/u,
-    },
-    {
-      name: "Test mode",
-      accountId: STRIPE_ACCOUNT_ID,
-      livemode: false,
-      message: /require Live mode/u,
-    },
-  ])("fails closed after a $name public OAuth reconnect", async (reconnect) => {
+  it("reprojects after a Live OAuth external account change", async () => {
     const scenario = await setupScenario();
     const initial = await connectStripeOAuth(scenario.actor);
     const created = await accept(
       createStripeAutomationRequest(scenario),
       [201],
     );
-    const reconnected = await connectStripeOAuth(scenario.actor, reconnect);
+    const reconnected = await connectStripeOAuth(scenario.actor, {
+      accountId: "acct_different_workflow",
+      livemode: true,
+    });
+    expect(reconnected.connector.id).toBe(initial.connector.id);
+
+    const enabled = await accept(
+      enableStripeAutomationRequest(scenario, created.body.id),
+      [200],
+    );
+    expect(enabled.body).toMatchObject({
+      enabled: true,
+      eventConfig: {
+        connectorId: initial.connector.id,
+        stripeAccountId: "acct_different_workflow",
+        mode: "live",
+      },
+    });
+  });
+
+  it("fails closed after a Test-mode public OAuth reconnect", async () => {
+    const scenario = await setupScenario();
+    const initial = await connectStripeOAuth(scenario.actor);
+    const created = await accept(
+      createStripeAutomationRequest(scenario),
+      [201],
+    );
+    const reconnected = await connectStripeOAuth(scenario.actor, {
+      accountId: STRIPE_ACCOUNT_ID,
+      livemode: false,
+    });
     expect(reconnected.connector.id).toBe(initial.connector.id);
 
     const rejected = await accept(
       enableStripeAutomationRequest(scenario, created.body.id),
       [400],
     );
-    expect(rejected.body.error.message).toMatch(reconnect.message);
+    expect(rejected.body.error.message).toMatch(/require Live mode/u);
   });
 
-  it("does not rebind after connector deletion and recreation", async () => {
+  it("reprojects after connector deletion and recreation", async () => {
     const scenario = await setupScenario();
     const initial = await connectStripeOAuth(scenario.actor);
     const created = await accept(
@@ -489,11 +506,18 @@ describe("Stripe invoice-paid workflow automation readiness", () => {
     });
     expect(replacement.connector.id).not.toBe(initial.connector.id);
 
-    const rejected = await accept(
+    const enabled = await accept(
       enableStripeAutomationRequest(scenario, created.body.id),
-      [400],
+      [200],
     );
-    expect(rejected.body.error.message).toMatch(/delete and recreate/u);
+    expect(enabled.body).toMatchObject({
+      enabled: true,
+      eventConfig: {
+        connectorId: replacement.connector.id,
+        stripeAccountId: STRIPE_ACCOUNT_ID,
+        mode: "live",
+      },
+    });
   });
 
   it("returns an explicit immutable error from the update route", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflows.test.ts
@@ -43,6 +43,7 @@ import { createRunsApi } from "./helpers/api-bdd-runs";
 import {
   createConnectorBddApi,
   mockGmailConnectorOAuth,
+  mockStripeConnectorOAuth,
 } from "./helpers/api-bdd-connectors";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
@@ -1706,6 +1707,147 @@ describe("workflows", () => {
       "Bearer gmail-copy-second-token",
       "Bearer gmail-copy-first-token",
     ]);
+  });
+
+  it("rebinds copied Stripe automations to the target thread default account", async () => {
+    const actor = user();
+    if (!actor.orgId) {
+      throw new Error(
+        "Expected Stripe workflow copy actor to belong to an org",
+      );
+    }
+    await api.grantProEntitlement(actor, { tier: "team" });
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId: actor.orgId },
+      {
+        [FeatureSwitchKey.ConnectorAccounts]: true,
+        [FeatureSwitchKey.StripeInvoicePaidWorkflowAutomations]: true,
+      },
+    );
+    const sourceAgent = await createAgent(actor, {
+      displayName: "Stripe Copy Source Agent",
+      visibility: "private",
+    });
+    const targetAgent = await createAgent(actor, {
+      displayName: "Stripe Copy Target Agent",
+      visibility: "private",
+    });
+    const workflow = await createWorkflow(actor, {
+      agentId: sourceAgent.agentId,
+      name: `stripe-copy-${randomUUID().slice(0, 8)}`,
+      instruction: "# Stripe copy source",
+    });
+
+    const defaultAccountId = `acct_stripe_copy_default_${randomUUID()}`;
+    mockStripeConnectorOAuth({ accountId: defaultAccountId, livemode: true });
+    const defaultStart = await connectorApi.startOauth(
+      actor,
+      "stripe",
+      "oauth",
+      sourceAgent.agentId,
+    );
+    const defaultState = new URL(
+      defaultStart.authorizationUrl,
+    ).searchParams.get("state");
+    if (!defaultState) {
+      throw new Error("Expected default Stripe OAuth state");
+    }
+    await connectorApi.completeOauthCallback("stripe", {
+      code: "stripe-copy-default-code",
+      state: defaultState,
+    });
+    const defaultAccount = await connectorApi.readConnectorBySlug(
+      actor,
+      "stripe",
+    );
+
+    const selectedAccountId = `acct_stripe_copy_selected_${randomUUID()}`;
+    mockStripeConnectorOAuth({ accountId: selectedAccountId, livemode: true });
+    const selectedStart = await connectorApi.startOauth(
+      actor,
+      "stripe",
+      "oauth",
+      sourceAgent.agentId,
+      { intent: "add", displayName: "Stripe Copy Selected" },
+    );
+    const selectedState = new URL(
+      selectedStart.authorizationUrl,
+    ).searchParams.get("state");
+    if (!selectedState) {
+      throw new Error("Expected selected Stripe OAuth state");
+    }
+    await connectorApi.completeOauthCallback("stripe", {
+      code: "stripe-copy-selected-code",
+      state: selectedState,
+    });
+    const accounts = await connectorApi.listBuiltinConnectorAccounts(
+      actor,
+      "stripe",
+    );
+    const selectedAccount = accounts.find((account) => {
+      return account.externalId === selectedAccountId;
+    });
+    if (!selectedAccount) {
+      throw new Error("Expected selected Stripe account");
+    }
+
+    const sourceAutomation = await accept(
+      automationsClient().create({
+        headers: authHeaders(actor),
+        params: { workflowId: workflow.body.id },
+        body: {
+          kind: "event",
+          eventType: "stripe-invoice-paid",
+          eventConfig: { provider: "stripe", event: "invoice_paid" },
+        },
+      }),
+      [201],
+    );
+    if (
+      sourceAutomation.body.kind !== "event" ||
+      sourceAutomation.body.eventType !== "stripe-invoice-paid" ||
+      !sourceAutomation.body.chatThreadId
+    ) {
+      throw new Error("Expected source Stripe automation thread");
+    }
+    await accept(
+      chatThreadConnectorSelectionsClient().update({
+        headers: authHeaders(actor),
+        params: { id: sourceAutomation.body.chatThreadId },
+        body: {
+          connectionId: selectedAccount.id,
+          target: { kind: "builtin", connectorSlug: "stripe" },
+        },
+      }),
+      [200],
+    );
+
+    const copied = await accept(
+      detailClient().copy({
+        headers: authHeaders(actor),
+        params: { workflowId: workflow.body.id },
+        body: { toAgentId: targetAgent.agentId },
+      }),
+      [201],
+    );
+    const copiedAutomations = await accept(
+      automationsClient().list({
+        headers: authHeaders(actor),
+        params: { workflowId: copied.body.id },
+      }),
+      [200],
+    );
+    expect(copiedAutomations.body).toContainEqual(
+      expect.objectContaining({
+        eventType: "stripe-invoice-paid",
+        eventConfig: expect.objectContaining({
+          connectorId: defaultAccount.id,
+          stripeAccountId: defaultAccountId,
+          mode: "live",
+        }),
+      }),
+    );
   });
 
   it("inherits copied automation budgets from agent callers and rejects exhausted runs", async () => {

--- a/turbo/apps/api/src/signals/routes/chat-threads-connector-selections.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-connector-selections.ts
@@ -65,12 +65,16 @@ const updateSelectionInner$ = command(
       return body.response;
     }
     const writeDb = set(writeDb$);
-    const result = await updateChatThreadConnectorSelection(writeDb, {
-      orgId: auth.orgId,
-      userId: auth.userId,
-      chatThreadId: params.id,
-      selection: body.data,
-    });
+    const result = await updateChatThreadConnectorSelection(
+      writeDb,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        chatThreadId: params.id,
+        selection: body.data,
+      },
+      signal,
+    );
     signal.throwIfAborted();
     if (result.kind === "not_found") {
       return notFound("Chat thread not found");
@@ -113,12 +117,16 @@ const clearSelectionInner$ = command(
       return body.response;
     }
     const writeDb = set(writeDb$);
-    const result = await clearChatThreadConnectorSelection(writeDb, {
-      orgId: auth.orgId,
-      userId: auth.userId,
-      chatThreadId: params.id,
-      target: body.data,
-    });
+    const result = await clearChatThreadConnectorSelection(
+      writeDb,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        chatThreadId: params.id,
+        target: body.data,
+      },
+      signal,
+    );
     signal.throwIfAborted();
     if (result.kind === "not_found") {
       return notFound("Chat thread not found");

--- a/turbo/apps/api/src/signals/routes/connector-accounts.ts
+++ b/turbo/apps/api/src/signals/routes/connector-accounts.ts
@@ -224,7 +224,7 @@ const setDefaultInner$ = command(
     }
     const writeDb = set(writeDb$);
     const updatedAt = await commitConnectorRuntimeMutation(
-      setDefaultConnectorAccount(writeDb, request),
+      setDefaultConnectorAccount(writeDb, request, signal),
       (changed) => {
         return changed
           ? {

--- a/turbo/apps/api/src/signals/routes/test-stripe-automation-events.ts
+++ b/turbo/apps/api/src/signals/routes/test-stripe-automation-events.ts
@@ -1,5 +1,6 @@
 import { testStripeAutomationEventFixtureContract } from "@okouai/api-contracts/contracts/test-stripe-automation-events";
 import { stripeWorkflowDeliveries } from "@okouai/db/schema/stripe-automation-event";
+import { workflowAutomations } from "@okouai/db/schema/workflow";
 import { command } from "ccstate";
 import { desc, eq, sql } from "drizzle-orm";
 
@@ -107,6 +108,18 @@ const applyStripeAutomationEventFixture$ = command(
       return bodyResult.response;
     }
     const db = set(writeDb$);
+    if (bodyResult.data.action === "clear-automation-account-projection") {
+      const [automation] = await db
+        .update(workflowAutomations)
+        .set({ eventConnectorId: null })
+        .where(eq(workflowAutomations.id, bodyResult.data.automation_id))
+        .returning({ id: workflowAutomations.id });
+      signal.throwIfAborted();
+      if (!automation) {
+        return testEndpointNotFoundResponse();
+      }
+      return { status: 200 as const, body: { ok: true as const } };
+    }
     const [delivery] = await db
       .select({ id: stripeWorkflowDeliveries.id })
       .from(stripeWorkflowDeliveries)

--- a/turbo/apps/api/src/signals/routes/workflows.ts
+++ b/turbo/apps/api/src/signals/routes/workflows.ts
@@ -77,6 +77,8 @@ import {
 } from "../services/autonomy-budget.service";
 import { bestEffort, onRejection, settle } from "../utils";
 import { reconcileGmailWatchesForUser } from "../services/gmail-automation-event.service";
+import { lockConnectorAccountTarget } from "../services/auth-state-lock.service";
+import { reprojectWorkflowAutomationsForOwner } from "../services/workflow-automation-account-projection.service";
 import {
   loadVisibleWorkflowById,
   requireWorkflowPermission,
@@ -1043,7 +1045,10 @@ async function copyWorkflowAutomationRow(
 async function copyWorkflowUserAutomations(
   tx: WorkflowCopyTransaction,
   args: CopyWorkflowAutomationRowsArgs,
-): Promise<boolean> {
+): Promise<{
+  readonly hasGmailAutomations: boolean;
+  readonly hasStripeAutomations: boolean;
+}> {
   const rows =
     args.sourceAutomations ??
     (await tx
@@ -1057,7 +1062,17 @@ async function copyWorkflowUserAutomations(
         ),
       ));
   if (rows.length === 0) {
-    return false;
+    return { hasGmailAutomations: false, hasStripeAutomations: false };
+  }
+  const hasStripeAutomations = rows.some((automation) => {
+    return automation.eventType === "stripe-invoice-paid";
+  });
+  if (hasStripeAutomations) {
+    await lockConnectorAccountTarget(tx, {
+      orgId: args.orgId,
+      userId: args.userId,
+      target: { kind: "builtin", connectorSlug: "stripe" },
+    });
   }
 
   await ensureWorkflowUserAutomationThread(tx, {
@@ -1071,12 +1086,15 @@ async function copyWorkflowUserAutomations(
   for (const automation of rows) {
     await copyWorkflowAutomationRow(tx, { ...args, automation });
   }
-  return rows.some((automation) => {
-    return (
-      automation.eventType === "gmail-new-message" ||
-      automation.eventType === "gmail-label-applied"
-    );
-  });
+  return {
+    hasGmailAutomations: rows.some((automation) => {
+      return (
+        automation.eventType === "gmail-new-message" ||
+        automation.eventType === "gmail-label-applied"
+      );
+    }),
+    hasStripeAutomations,
+  };
 }
 
 async function copyWorkflowRuntimeConfiguration(
@@ -1086,6 +1104,7 @@ async function copyWorkflowRuntimeConfiguration(
   | {
       readonly workflow: { readonly id: string };
       readonly hasGmailAutomations: boolean;
+      readonly hasStripeAutomations: boolean;
     }
   | undefined
 > {
@@ -1104,7 +1123,7 @@ async function copyWorkflowRuntimeConfiguration(
       ? {}
       : { inheritedAutonomyBudget: args.inheritedAutonomyBudget }),
   };
-  const hasGmailAutomations = await copyWorkflowUserAutomations(tx, {
+  const automationProviders = await copyWorkflowUserAutomations(tx, {
     ...scopedRowsArgs,
     targetAgentId: args.targetAgentId,
     workflowTitle: args.sourceWorkflow.displayName ?? args.sourceWorkflow.name,
@@ -1112,7 +1131,7 @@ async function copyWorkflowRuntimeConfiguration(
       ? { sourceAutomations: args.sourceAutomations }
       : {}),
   });
-  return { workflow, hasGmailAutomations };
+  return { workflow, ...automationProviders };
 }
 
 type CopyWorkflowDatabaseResult =
@@ -1121,6 +1140,7 @@ type CopyWorkflowDatabaseResult =
       readonly kind: "ok";
       readonly inserted: { readonly id: string };
       readonly hasGmailAutomations: boolean;
+      readonly hasStripeAutomations: boolean;
     };
 
 async function copyWorkflowDatabaseRows(
@@ -1150,6 +1170,7 @@ async function copyWorkflowDatabaseRows(
         | null,
     ) => Promise<void>;
   },
+  signal: AbortSignal,
 ): Promise<CopyWorkflowDatabaseResult> {
   return await db.transaction(async (tx) => {
     const officialResolution = args.sourceWorkflow.officialDefinitionName
@@ -1182,6 +1203,17 @@ async function copyWorkflowDatabaseRows(
     if (!inserted) {
       throw new Error("Failed to copy workflow");
     }
+    if (inserted.hasStripeAutomations) {
+      await reprojectWorkflowAutomationsForOwner(
+        tx,
+        {
+          orgId: args.orgId,
+          userId: args.userId,
+          target: { kind: "builtin", connectorSlug: "stripe" },
+        },
+        signal,
+      );
+    }
     await args.publishVolume(
       tx,
       sourceWorkflow,
@@ -1191,6 +1223,7 @@ async function copyWorkflowDatabaseRows(
       kind: "ok",
       inserted: inserted.workflow,
       hasGmailAutomations: inserted.hasGmailAutomations,
+      hasStripeAutomations: inserted.hasStripeAutomations,
     };
   });
 }
@@ -1252,39 +1285,43 @@ const publishCopiedWorkflow$ = command(
         );
         signal.throwIfAborted();
 
-        const copied = await copyWorkflowDatabaseRows(args.db, {
-          orgId: args.orgId,
-          userId: args.userId,
-          sourceWorkflow: args.sourceWorkflow,
-          sourceFiles: args.sourceFiles,
-          targetAgentId: args.targetAgentId,
-          targetWorkflowId,
-          currentTime: args.currentTime,
-          inheritedAutonomyBudget: args.inheritedAutonomyBudget,
-          publishVolume: async (
-            tx,
-            copiedSourceWorkflow,
-            copiedSourceFiles,
-          ) => {
-            const volume = await set(
-              prepareVolumeServerSideWithDb$,
-              {
-                db: tx,
-                input: {
-                  orgId: args.orgId,
-                  storageName: getCustomSkillStorageName(targetWorkflowId),
-                  files: copiedWorkflowVolumeFiles(
-                    copiedSourceWorkflow,
-                    copiedSourceFiles,
-                  ),
+        const copied = await copyWorkflowDatabaseRows(
+          args.db,
+          {
+            orgId: args.orgId,
+            userId: args.userId,
+            sourceWorkflow: args.sourceWorkflow,
+            sourceFiles: args.sourceFiles,
+            targetAgentId: args.targetAgentId,
+            targetWorkflowId,
+            currentTime: args.currentTime,
+            inheritedAutonomyBudget: args.inheritedAutonomyBudget,
+            publishVolume: async (
+              tx,
+              copiedSourceWorkflow,
+              copiedSourceFiles,
+            ) => {
+              const volume = await set(
+                prepareVolumeServerSideWithDb$,
+                {
+                  db: tx,
+                  input: {
+                    orgId: args.orgId,
+                    storageName: getCustomSkillStorageName(targetWorkflowId),
+                    files: copiedWorkflowVolumeFiles(
+                      copiedSourceWorkflow,
+                      copiedSourceFiles,
+                    ),
+                  },
                 },
-              },
-              signal,
-            );
-            await commitPreparedVolumeServerSide({ db: tx, volume }, signal);
-            signal.throwIfAborted();
+                signal,
+              );
+              await commitPreparedVolumeServerSide({ db: tx, volume }, signal);
+              signal.throwIfAborted();
+            },
           },
-        });
+          signal,
+        );
         signal.throwIfAborted();
         if (copied.kind === "conflict") {
           await set(

--- a/turbo/apps/api/src/signals/services/chat-thread-connector-selection.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-connector-selection.service.ts
@@ -27,7 +27,7 @@ import {
 } from "./connector-catalog-runtime.service";
 import { lockConnectorAccountTarget } from "./auth-state-lock.service";
 import { listConnectorAccountsByIds } from "./connector-account-lifecycle.service";
-import { reprojectGmailAutomationsForOwner } from "./gmail-automation-account.service";
+import { reprojectWorkflowAutomationsForOwner } from "./workflow-automation-account-projection.service";
 
 interface OwnedChatThread {
   readonly agentId: string;
@@ -474,6 +474,7 @@ export async function updateChatThreadConnectorSelection(
     readonly chatThreadId: string;
     readonly selection: ConnectorAccountSelection;
   },
+  signal: AbortSignal,
 ): Promise<UpdateChatThreadConnectorSelectionResult> {
   return await db.transaction(async (tx) => {
     const thread = await loadOwnedChatThread(tx, args);
@@ -494,12 +495,11 @@ export async function updateChatThreadConnectorSelection(
       throw new Error("Expected one prepared connector selection");
     }
     const updated = await upsertSelection(tx, args.chatThreadId, selection);
-    if (
-      selection.target.kind === "builtin" &&
-      selection.target.connectorSlug === "gmail"
-    ) {
-      await reprojectGmailAutomationsForOwner(tx, args);
-    }
+    await reprojectWorkflowAutomationsForOwner(
+      tx,
+      { ...args, target: selection.target },
+      signal,
+    );
     return {
       kind: "updated",
       selection: updated,
@@ -515,6 +515,7 @@ export async function clearChatThreadConnectorSelection(
     readonly chatThreadId: string;
     readonly target: ConnectorAccountTarget;
   },
+  signal: AbortSignal,
 ): Promise<ClearChatThreadConnectorSelectionResult> {
   return await db.transaction(async (tx) => {
     const thread = await loadOwnedChatThread(tx, args);
@@ -538,12 +539,7 @@ export async function clearChatThreadConnectorSelection(
               ),
         ),
       );
-    if (
-      args.target.kind === "builtin" &&
-      args.target.connectorSlug === "gmail"
-    ) {
-      await reprojectGmailAutomationsForOwner(tx, args);
-    }
+    await reprojectWorkflowAutomationsForOwner(tx, args, signal);
     return { kind: "cleared" };
   });
 }

--- a/turbo/apps/api/src/signals/services/connector-account-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-lifecycle.service.ts
@@ -43,7 +43,7 @@ import { nowDate } from "../../lib/time";
 import type { Db, ReadonlyDb } from "../external/db";
 import { safeJsonParse, settle } from "../utils";
 import { lockConnectorAccountTarget } from "./auth-state-lock.service";
-import { reprojectGmailAutomationsForOwner } from "./gmail-automation-account.service";
+import { reprojectWorkflowAutomationsForOwner } from "./workflow-automation-account-projection.service";
 import { isConnectorCatalogUnavailableError } from "./connector-catalog-reader.service";
 import {
   connectorCredentialStorageIsCompatible,
@@ -783,6 +783,7 @@ export async function setDefaultConnectorAccount(
     readonly target: ConnectorAccountTarget;
     readonly connectionId: string;
   },
+  signal: AbortSignal,
 ): Promise<Date | null> {
   return await db.transaction(async (tx) => {
     await lockConnectorAccountTarget(tx, args);
@@ -813,12 +814,7 @@ export async function setDefaultConnectorAccount(
       .set({ isDefault: true, updatedAt: sql`clock_timestamp()` })
       .where(eq(connectors.id, args.connectionId))
       .returning({ updatedAt: connectors.updatedAt });
-    if (
-      args.target.kind === "builtin" &&
-      args.target.connectorSlug === "gmail"
-    ) {
-      await reprojectGmailAutomationsForOwner(tx, args);
-    }
+    await reprojectWorkflowAutomationsForOwner(tx, args, signal);
     return updated?.updatedAt ?? null;
   });
 }
@@ -916,6 +912,7 @@ export async function prepareConnectorAccountDeletion(
     readonly target: ConnectorAccountTarget;
     readonly connectionId: string;
   },
+  signal: AbortSignal,
 ): Promise<PreparedConnectorAccountDeletion> {
   await lockConnectorAccountTarget(db, args);
   const [account] = await db
@@ -959,9 +956,7 @@ export async function prepareConnectorAccountDeletion(
     promotedDefaultConnectionId = sibling.id;
   }
 
-  if (args.target.kind === "builtin" && args.target.connectorSlug === "gmail") {
-    await reprojectGmailAutomationsForOwner(db, args);
-  }
+  await reprojectWorkflowAutomationsForOwner(db, args, signal);
 
   return {
     kind: "ready",

--- a/turbo/apps/api/src/signals/services/connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-data.service.ts
@@ -86,7 +86,6 @@ import {
 import { cleanupGoogleCalendarWatchesForConnector } from "./google-calendar-automation-event.service";
 import { cleanupGoogleFormsWatchesForConnector } from "./google-forms-automation-event.service";
 import { reconcileConnectorAccountState } from "./connector-account-state.service";
-import { reprojectGmailAutomationsForOwner } from "./gmail-automation-account.service";
 import { prepareConnectorAccountDeletion } from "./connector-account-lifecycle.service";
 import { resolveConnectorAccount } from "./connector-account-resolution.service";
 import {
@@ -99,6 +98,7 @@ import {
   connectorAccountSiblingWritesEnabled,
   normalizeConnectorAccountMutation,
 } from "./connector-account-mutation.service";
+import { reprojectWorkflowAutomationsForOwner } from "./workflow-automation-account-projection.service";
 
 const log = logger("api:connector-data");
 const oauthScopesSchema = z.array(z.string());
@@ -904,13 +904,18 @@ async function prepareBuiltinConnectorAccountDeletion(
     readonly connectorSlug: string;
     readonly connectionId: string;
   },
+  signal: AbortSignal,
 ) {
-  return await prepareConnectorAccountDeletion(db, {
-    orgId: args.orgId,
-    userId: args.userId,
-    target: { kind: "builtin", connectorSlug: args.connectorSlug },
-    connectionId: args.connectionId,
-  });
+  return await prepareConnectorAccountDeletion(
+    db,
+    {
+      orgId: args.orgId,
+      userId: args.userId,
+      target: { kind: "builtin", connectorSlug: args.connectorSlug },
+      connectionId: args.connectionId,
+    },
+    signal,
+  );
 }
 
 function completedConnectorDeletionResult(
@@ -966,10 +971,14 @@ async function deleteConnectorAccountLocalState(
     };
   }
   const existing = account.connector;
-  const deletion = await prepareBuiltinConnectorAccountDeletion(tx, {
-    ...args,
-    connectionId: existing.id,
-  });
+  const deletion = await prepareBuiltinConnectorAccountDeletion(
+    tx,
+    {
+      ...args,
+      connectionId: existing.id,
+    },
+    signal,
+  );
   signal.throwIfAborted();
   if (deletion.kind !== "ready") {
     return {
@@ -2043,6 +2052,26 @@ interface CommitConnectorTokenConnectionArgs {
   readonly insertConnectionId?: string;
 }
 
+async function reprojectConnectedWorkflowAutomations(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly connectorSlug: string;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  await reprojectWorkflowAutomationsForOwner(
+    args.db,
+    {
+      orgId: args.orgId,
+      userId: args.userId,
+      target: { kind: "builtin", connectorSlug: args.connectorSlug },
+    },
+    signal,
+  );
+}
+
 async function commitConnectorTokenConnection(
   args: CommitConnectorTokenConnectionArgs,
   signal: AbortSignal,
@@ -2155,12 +2184,10 @@ async function commitConnectorTokenConnection(
     },
     signal,
   );
-  if (args.runtimeMethod.connectorSlug === "gmail") {
-    await reprojectGmailAutomationsForOwner(args.db, {
-      orgId: args.orgId,
-      userId: args.userId,
-    });
-  }
+  await reprojectConnectedWorkflowAutomations(
+    { ...args, connectorSlug: args.runtimeMethod.connectorSlug },
+    signal,
+  );
 
   return {
     status: "connected",

--- a/turbo/apps/api/src/signals/services/custom-connector-credential-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-credential-storage.service.ts
@@ -174,12 +174,16 @@ export async function deleteCustomConnectorMemberConnectionExact(
       readonly promotedDefaultConnectionId: string | null;
     }
 > {
-  const deletion = await prepareConnectorAccountDeletion(db, {
-    orgId: args.orgId,
-    userId: args.userId,
-    target: { kind: "custom", customConnectorId: args.connectorId },
-    connectionId: args.memberConnectorId,
-  });
+  const deletion = await prepareConnectorAccountDeletion(
+    db,
+    {
+      orgId: args.orgId,
+      userId: args.userId,
+      target: { kind: "custom", customConnectorId: args.connectorId },
+      connectionId: args.memberConnectorId,
+    },
+    signal,
+  );
   signal.throwIfAborted();
   if (deletion.kind !== "ready") {
     return deletion;

--- a/turbo/apps/api/src/signals/services/gmail-automation-account.service.ts
+++ b/turbo/apps/api/src/signals/services/gmail-automation-account.service.ts
@@ -1,13 +1,9 @@
 import { gmailLabelAppliedEventConfigSchema } from "@okouai/api-contracts/contracts/workflows";
-import { chatThreadConnectorSelections } from "@okouai/db/schema/chat-thread-connector-selection";
-import { connectors } from "@okouai/db/schema/connector";
-import {
-  workflowAutomations,
-  workflowUserAutomationThreads,
-} from "@okouai/db/schema/workflow";
+import { workflowAutomations } from "@okouai/db/schema/workflow";
 import { and, eq, inArray, sql } from "drizzle-orm";
 
 import type { Db, ReadonlyDb } from "../external/db";
+import { resolveWorkflowAutomationConnectorId } from "./workflow-automation-account.service";
 
 const GMAIL_EVENT_TYPES = ["gmail-new-message", "gmail-label-applied"] as const;
 
@@ -36,44 +32,10 @@ export async function resolveGmailAutomationConnectorId(
     readonly workflowId: string;
   },
 ): Promise<string | null> {
-  const [selection] = await db
-    .select({ connectorId: chatThreadConnectorSelections.connectorId })
-    .from(workflowUserAutomationThreads)
-    .innerJoin(
-      chatThreadConnectorSelections,
-      and(
-        eq(
-          chatThreadConnectorSelections.chatThreadId,
-          workflowUserAutomationThreads.chatThreadId,
-        ),
-        eq(chatThreadConnectorSelections.connectorSlug, "gmail"),
-      ),
-    )
-    .where(
-      and(
-        eq(workflowUserAutomationThreads.orgId, args.orgId),
-        eq(workflowUserAutomationThreads.userId, args.userId),
-        eq(workflowUserAutomationThreads.workflowId, args.workflowId),
-      ),
-    )
-    .limit(1);
-  if (selection) {
-    return selection.connectorId;
-  }
-
-  const [defaultAccount] = await db
-    .select({ connectorId: connectors.id })
-    .from(connectors)
-    .where(
-      and(
-        eq(connectors.orgId, args.orgId),
-        eq(connectors.userId, args.userId),
-        eq(connectors.connectorSlug, "gmail"),
-        eq(connectors.isDefault, true),
-      ),
-    )
-    .limit(1);
-  return defaultAccount?.connectorId ?? null;
+  return await resolveWorkflowAutomationConnectorId(db, {
+    ...args,
+    connectorSlug: "gmail",
+  });
 }
 
 export async function reprojectGmailAutomationsForOwner(

--- a/turbo/apps/api/src/signals/services/official-workflow-reconciliation.service.ts
+++ b/turbo/apps/api/src/signals/services/official-workflow-reconciliation.service.ts
@@ -27,7 +27,6 @@ import {
   reconcileAutomationEventWatchReconfiguration,
 } from "./automation-event-watch-lifecycle.service";
 import { lockConnectorAccountTarget } from "./auth-state-lock.service";
-import { resolveGmailAutomationConnectorId } from "./gmail-automation-account.service";
 import { OFFICIAL_WORKFLOW_CATALOG_ACTIVATION_LOCK } from "./official-workflow-constants";
 import {
   readAcceptedOfficialWorkflowCatalog,
@@ -59,6 +58,7 @@ import {
 } from "./workflow-automation.service";
 import { lockWorkflowWebhookAutomationTierEligibleForOrg } from "./workflow-webhook-automation-entitlement.service";
 import type { WorkflowMember } from "./workflow-data.service";
+import { resolveWorkflowAutomationConnectorId } from "./workflow-automation-account.service";
 
 const DORMANT_CREATION_LEASE_MS = 5 * 60 * 1000;
 
@@ -143,10 +143,16 @@ function eventWatchFailureMessage(result: {
     : "Official Workflow event-watch reconciliation failed";
 }
 
-function isGmailAutomationEventType(eventType: string | null): boolean {
-  return (
-    eventType === "gmail-new-message" || eventType === "gmail-label-applied"
-  );
+function accountConnectorSlug(
+  eventType: string | null,
+): "gmail" | "stripe" | null {
+  if (
+    eventType === "gmail-new-message" ||
+    eventType === "gmail-label-applied"
+  ) {
+    return "gmail";
+  }
+  return eventType === "stripe-invoice-paid" ? "stripe" : null;
 }
 
 async function lockOfficialAutomationAccountProjection(
@@ -162,21 +168,37 @@ async function lockOfficialAutomationAccountProjection(
   | { readonly kind: "not-required" }
   | { readonly kind: "locked"; readonly eventConnectorId: string | null }
 > {
-  const currentUsesGmail = isGmailAutomationEventType(args.currentEventType);
-  const nextUsesGmail = isGmailAutomationEventType(args.nextEventType);
-  if (!currentUsesGmail && !nextUsesGmail) {
+  const currentConnectorSlug = accountConnectorSlug(args.currentEventType);
+  const nextConnectorSlug = accountConnectorSlug(args.nextEventType);
+  const connectorSlugs = [currentConnectorSlug, nextConnectorSlug]
+    .filter((slug): slug is "gmail" | "stripe" => {
+      return slug !== null;
+    })
+    .filter((slug, index, values) => {
+      return values.indexOf(slug) === index;
+    })
+    .sort();
+  if (connectorSlugs.length === 0) {
     return { kind: "not-required" };
   }
-  await lockConnectorAccountTarget(db, {
-    orgId: args.orgId,
-    userId: args.userId,
-    target: { kind: "builtin", connectorSlug: "gmail" },
-  });
+  for (const connectorSlug of connectorSlugs) {
+    await lockConnectorAccountTarget(db, {
+      orgId: args.orgId,
+      userId: args.userId,
+      target: { kind: "builtin", connectorSlug },
+    });
+  }
   return {
     kind: "locked",
-    eventConnectorId: nextUsesGmail
-      ? await resolveGmailAutomationConnectorId(db, args)
-      : null,
+    eventConnectorId:
+      nextConnectorSlug === null
+        ? null
+        : await resolveWorkflowAutomationConnectorId(db, {
+            orgId: args.orgId,
+            userId: args.userId,
+            workflowId: args.workflowId,
+            connectorSlug: nextConnectorSlug,
+          }),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/official-workflow-reconciliation.service.ts
+++ b/turbo/apps/api/src/signals/services/official-workflow-reconciliation.service.ts
@@ -6,6 +6,10 @@ import type {
   OfficialWorkflowParameterBinding,
 } from "@okouai/api-contracts/contracts/official-workflow-catalog";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
+import {
+  stripeInvoicePaidEventConfigSchema,
+  type StripeInvoicePaidEventConfig,
+} from "@okouai/api-contracts/contracts/workflows";
 import { googleFormsAutomationCursors } from "@okouai/db/schema/google-forms-event";
 import { strapiWorkflowAutomations } from "@okouai/db/schema/strapi-integration";
 import {
@@ -59,8 +63,14 @@ import {
 import { lockWorkflowWebhookAutomationTierEligibleForOrg } from "./workflow-webhook-automation-entitlement.service";
 import type { WorkflowMember } from "./workflow-data.service";
 import { resolveWorkflowAutomationConnectorId } from "./workflow-automation-account.service";
+import { resolveStripeInvoicePaidAutomationBinding } from "./stripe-invoice-paid-workflow-automation.service";
 
 const DORMANT_CREATION_LEASE_MS = 5 * 60 * 1000;
+
+type StripeAutomationBinding = Pick<
+  StripeInvoicePaidEventConfig,
+  "connectorId" | "stripeAccountId" | "mode"
+>;
 
 type DormantMaterializationReservedHook = (args: {
   readonly definitionName: string;
@@ -164,9 +174,15 @@ async function lockOfficialAutomationAccountProjection(
     readonly currentEventType: string | null;
     readonly nextEventType: string | null;
   },
+  signal: AbortSignal,
 ): Promise<
   | { readonly kind: "not-required" }
-  | { readonly kind: "locked"; readonly eventConnectorId: string | null }
+  | {
+      readonly kind: "locked";
+      readonly connectorSlug: "gmail" | "stripe" | null;
+      readonly eventConnectorId: string | null;
+      readonly stripeBinding: StripeAutomationBinding | null;
+    }
 > {
   const currentConnectorSlug = accountConnectorSlug(args.currentEventType);
   const nextConnectorSlug = accountConnectorSlug(args.nextEventType);
@@ -188,18 +204,66 @@ async function lockOfficialAutomationAccountProjection(
       target: { kind: "builtin", connectorSlug },
     });
   }
-  return {
-    kind: "locked",
-    eventConnectorId:
-      nextConnectorSlug === null
-        ? null
-        : await resolveWorkflowAutomationConnectorId(db, {
+  const stripeReadiness =
+    nextConnectorSlug === "stripe"
+      ? await resolveStripeInvoicePaidAutomationBinding(
+          {
+            db,
             orgId: args.orgId,
             userId: args.userId,
             workflowId: args.workflowId,
-            connectorSlug: nextConnectorSlug,
-          }),
+          },
+          signal,
+        )
+      : null;
+  signal.throwIfAborted();
+  const stripeBinding =
+    stripeReadiness?.kind === "ok" ? stripeReadiness.binding : null;
+  return {
+    kind: "locked",
+    connectorSlug: nextConnectorSlug,
+    eventConnectorId:
+      nextConnectorSlug === null
+        ? null
+        : stripeBinding
+          ? stripeBinding.connectorId
+          : await resolveWorkflowAutomationConnectorId(db, {
+              orgId: args.orgId,
+              userId: args.userId,
+              workflowId: args.workflowId,
+              connectorSlug: nextConnectorSlug,
+            }),
+    stripeBinding,
   };
+}
+
+function accountProjectionMatchesPatch(
+  projection: Awaited<
+    ReturnType<typeof lockOfficialAutomationAccountProjection>
+  >,
+  patch: OfficialAutomationPatch,
+): boolean {
+  if (projection.kind === "not-required") {
+    return true;
+  }
+  if (projection.eventConnectorId !== patch.eventConnectorId) {
+    return false;
+  }
+  if (projection.connectorSlug !== "stripe") {
+    return true;
+  }
+  if (projection.stripeBinding === null) {
+    return false;
+  }
+  const config = stripeInvoicePaidEventConfigSchema.safeParse(
+    patch.eventConfig,
+  );
+  return (
+    config.success &&
+    config.data.connectorId === projection.stripeBinding.connectorId &&
+    config.data.stripeAccountId === projection.stripeBinding.stripeAccountId &&
+    config.data.mode === projection.stripeBinding.mode
+  );
 }
 
 async function acquireReconciliationLocks(
@@ -492,6 +556,7 @@ async function persistReconfigurationPatch(
         currentEventType: args.expected.eventType,
         nextEventType: args.patch.eventType,
       },
+      signal,
     );
     if (
       !(await lockInstalledWorkflow(tx, {
@@ -515,10 +580,7 @@ async function persistReconfigurationPatch(
     ) {
       return null;
     }
-    if (
-      accountProjection.kind === "locked" &&
-      accountProjection.eventConnectorId !== args.patch.eventConnectorId
-    ) {
+    if (!accountProjectionMatchesPatch(accountProjection, args.patch)) {
       return null;
     }
     const [formsCursor] = await tx
@@ -586,6 +648,7 @@ async function restoreFailedReconfiguration(
     readonly persisted: PersistedReconfiguration;
   },
 ): Promise<void> {
+  const cleanupSignal = new AbortController().signal;
   const restored = await db.transaction(async (tx) => {
     await acquireReconciliationLocks(tx, args.orgId);
     const accountProjection = await lockOfficialAutomationAccountProjection(
@@ -597,6 +660,7 @@ async function restoreFailedReconfiguration(
         currentEventType: args.persisted.current.eventType,
         nextEventType: args.persisted.previous.eventType,
       },
+      cleanupSignal,
     );
     if (
       !(await lockInstalledWorkflow(tx, {
@@ -621,16 +685,31 @@ async function restoreFailedReconfiguration(
       return null;
     }
     const currentTime = nowDate();
+    const restorePatch = officialAutomationRestorePatch(
+      args.persisted.previous,
+      args.persisted.previous.nextRunAt,
+      currentTime,
+    );
+    const stripeBinding =
+      accountProjection.kind === "locked"
+        ? accountProjection.stripeBinding
+        : null;
     const [row] = await tx
       .update(workflowAutomations)
       .set({
-        ...officialAutomationRestorePatch(
-          args.persisted.previous,
-          args.persisted.previous.nextRunAt,
-          currentTime,
-        ),
+        ...restorePatch,
         ...(accountProjection.kind === "locked"
           ? { eventConnectorId: accountProjection.eventConnectorId }
+          : {}),
+        ...(stripeBinding
+          ? {
+              eventConfig: {
+                ...stripeInvoicePaidEventConfigSchema.parse(
+                  restorePatch.eventConfig,
+                ),
+                ...stripeBinding,
+              },
+            }
           : {}),
         enabled: args.persisted.previous.enabled,
         officialIntendedEnabled:
@@ -655,7 +734,6 @@ async function restoreFailedReconfiguration(
   if (!restored) {
     return;
   }
-  const cleanupSignal = new AbortController().signal;
   await reconcileAutomationEventWatchReconfiguration(
     db,
     {
@@ -1226,6 +1304,7 @@ async function finalizeAutomationStructureTransition(
         currentEventType: args.persisted.current.eventType,
         nextEventType: args.patch.eventType,
       },
+      signal,
     );
     if (
       !(await lockInstalledWorkflow(tx, {
@@ -1252,10 +1331,7 @@ async function finalizeAutomationStructureTransition(
     ) {
       return { kind: "superseded" };
     }
-    if (
-      accountProjection.kind === "locked" &&
-      accountProjection.eventConnectorId !== args.patch.eventConnectorId
-    ) {
+    if (!accountProjectionMatchesPatch(accountProjection, args.patch)) {
       return { kind: "superseded" };
     }
     const currentTime = nowDate();

--- a/turbo/apps/api/src/signals/services/stripe-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/stripe-automation-event.service.ts
@@ -29,10 +29,14 @@ import { now, nowDate } from "../../lib/time";
 import { writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { settle } from "../utils";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
+import { lockConnectorAccountTarget } from "./auth-state-lock.service";
 import { workflowAutomationColumns } from "./autonomy-budget-schema.service";
 import { ORG_SENTINEL_USER_ID } from "./feature-switches.service";
 import { stripeInvoicePaidWorkflowAutomationEnabledForOwnerInDb } from "./stripe-invoice-paid-workflow-automation-feature-switch.service";
-import { validateStripeInvoicePaidAutomationBinding } from "./stripe-invoice-paid-workflow-automation.service";
+import {
+  repairMissingStripeInvoicePaidAutomationProjection,
+  validateStripeInvoicePaidAutomationBinding,
+} from "./stripe-invoice-paid-workflow-automation.service";
 import { workflowAutomationCanFire } from "./workflow-automation-access.service";
 import { storedWorkflowAutomationContext } from "./workflow-automation-context.service";
 import type { WorkflowQueueAdmissionTransaction } from "./workflow-chat-event-queue.service";
@@ -279,6 +283,12 @@ interface StripeInvoiceFanoutResult {
 interface StripeInvoiceFanoutCandidate {
   readonly automation: AutomationRow;
   readonly connectorId: string;
+}
+
+interface StripeAutomationOwner {
+  readonly automationId: string;
+  readonly orgId: string;
+  readonly userId: string;
 }
 
 function identifier(value: unknown): string | null {
@@ -628,6 +638,67 @@ async function loadStripeInvoiceFanoutCandidates(
   return rows;
 }
 
+async function loadMissingStripeProjectionOwners(
+  db: ReadonlyDb,
+  accountId: string,
+  signal: AbortSignal,
+): Promise<readonly StripeAutomationOwner[]> {
+  const owners = await db
+    .selectDistinct({
+      automationId: workflowAutomations.id,
+      orgId: workflowAutomations.orgId,
+      userId: workflowAutomations.ownerUserId,
+    })
+    .from(connectors)
+    .innerJoin(
+      workflowAutomations,
+      and(
+        eq(workflowAutomations.orgId, connectors.orgId),
+        eq(workflowAutomations.ownerUserId, connectors.userId),
+      ),
+    )
+    .where(
+      and(
+        eq(connectors.connectorSlug, "stripe"),
+        eq(connectors.authMethod, "oauth"),
+        eq(connectors.externalId, accountId),
+        eq(workflowAutomations.kind, "event"),
+        eq(workflowAutomations.eventType, "stripe-invoice-paid"),
+        eq(workflowAutomations.enabled, true),
+        isNull(workflowAutomations.eventConnectorId),
+      ),
+    )
+    .orderBy(
+      asc(workflowAutomations.orgId),
+      asc(workflowAutomations.ownerUserId),
+      asc(workflowAutomations.id),
+    );
+  signal.throwIfAborted();
+  return owners;
+}
+
+async function repairMissingStripeIngressProjections(
+  db: Db,
+  accountId: string,
+  signal: AbortSignal,
+): Promise<void> {
+  const owners = await loadMissingStripeProjectionOwners(db, accountId, signal);
+  for (const owner of owners) {
+    await db.transaction(async (tx) => {
+      await lockConnectorAccountTarget(tx, {
+        ...owner,
+        target: { kind: "builtin", connectorSlug: "stripe" },
+      });
+      await repairMissingStripeInvoicePaidAutomationProjection(
+        tx,
+        owner,
+        signal,
+      );
+    });
+    signal.throwIfAborted();
+  }
+}
+
 async function recordInvoiceFanout(
   args: {
     readonly tx: StripeWorkflowTransaction;
@@ -673,6 +744,7 @@ async function recordInvoiceFanout(
     );
     if (
       !config.success ||
+      row.automation.eventConnectorId !== row.connectorId ||
       config.data.connectorId !== row.connectorId ||
       config.data.stripeAccountId !== args.snapshot.event.connectedAccountId ||
       !(await stripeInvoicePaidWorkflowAutomationEnabledForOwnerInDb(
@@ -830,6 +902,8 @@ async function dispatchStripeInvoice(
     });
     return { kind: "bad_request" };
   }
+  await repairMissingStripeIngressProjections(db, parsed.data.account, signal);
+  signal.throwIfAborted();
   const fanout = await db.transaction(async (tx) => {
     return await recordInvoiceFanout(
       {
@@ -1007,6 +1081,8 @@ async function loadDeliveryTarget(
     row.automation.kind !== "event" ||
     row.automation.eventType !== "stripe-invoice-paid" ||
     !row.automation.enabled ||
+    !delivery.livemode ||
+    row.automation.eventConnectorId !== delivery.connectorId ||
     config.data.connectorId !== delivery.connectorId ||
     config.data.stripeAccountId !== delivery.stripeAccountId ||
     row.connectorExternalId !== delivery.stripeAccountId ||
@@ -1058,6 +1134,48 @@ async function loadDeliveryTarget(
       chatThreadId: row.chatThreadId,
     },
   };
+}
+
+async function repairMissingStripeDeliveryProjection(
+  db: Db,
+  delivery: StripeWorkflowDeliveryRow,
+  signal: AbortSignal,
+): Promise<void> {
+  const [owner] = await db
+    .select({
+      orgId: workflowAutomations.orgId,
+      userId: workflowAutomations.ownerUserId,
+      eventConnectorId: workflowAutomations.eventConnectorId,
+      eventType: workflowAutomations.eventType,
+    })
+    .from(workflowAutomations)
+    .where(eq(workflowAutomations.id, delivery.automationId))
+    .limit(1);
+  signal.throwIfAborted();
+  if (
+    !owner ||
+    owner.eventType !== "stripe-invoice-paid" ||
+    owner.eventConnectorId !== null
+  ) {
+    return;
+  }
+  await db.transaction(async (tx) => {
+    await lockConnectorAccountTarget(tx, {
+      orgId: owner.orgId,
+      userId: owner.userId,
+      target: { kind: "builtin", connectorSlug: "stripe" },
+    });
+    await repairMissingStripeInvoicePaidAutomationProjection(
+      tx,
+      {
+        automationId: delivery.automationId,
+        orgId: owner.orgId,
+        userId: owner.userId,
+      },
+      signal,
+    );
+  });
+  signal.throwIfAborted();
 }
 
 async function updateLatestHealth(args: {
@@ -1322,6 +1440,7 @@ async function processClaimedDelivery(
   },
   signal: AbortSignal,
 ): Promise<"executed" | "skipped" | "failed" | "retried" | "lost"> {
+  await repairMissingStripeDeliveryProjection(args.db, args.delivery, signal);
   const validation = await loadDeliveryTarget(args.db, args.delivery, signal);
   if (validation.kind === "skip") {
     const skipped = await finishDelivery(

--- a/turbo/apps/api/src/signals/services/stripe-invoice-paid-workflow-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/stripe-invoice-paid-workflow-automation.service.ts
@@ -1,12 +1,18 @@
-import type { StripeInvoicePaidEventConfig } from "@okouai/api-contracts/contracts/workflows";
+import {
+  stripeInvoicePaidEventConfigSchema,
+  type StripeInvoicePaidEventConfig,
+} from "@okouai/api-contracts/contracts/workflows";
+import { workflowAutomations } from "@okouai/db/schema/workflow";
+import { and, eq, isNull } from "drizzle-orm";
 
-import type { ReadonlyDb } from "../external/db";
+import type { Db, ReadonlyDb } from "../external/db";
 import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
 import {
   loadConnectorCredentialConnection,
   loadConnectorCredentialValues,
   type ConnectorCredentialConnection,
 } from "./connector-credential-runtime.service";
+import { resolveWorkflowAutomationConnectorId } from "./workflow-automation-account.service";
 
 const STRIPE_CONNECTOR_SLUG = "stripe";
 const STRIPE_LIVEMODE_VALUE_REF = "$vars.STRIPE_LIVEMODE";
@@ -21,7 +27,9 @@ const STRIPE_OAUTH_REQUIRED_MESSAGE =
 const STRIPE_LIVE_MODE_REQUIRED_MESSAGE =
   "Stripe invoice-paid automations require Live mode; reconnect Stripe in Live mode";
 const STRIPE_BINDING_MISMATCH_MESSAGE =
-  "The Stripe connection no longer matches this automation; delete and recreate the automation to bind the current Live-mode Stripe account";
+  "The Stripe connection no longer matches this automation";
+const STRIPE_SELECTION_CHANGED_MESSAGE =
+  "The selected Stripe account changed; retry the operation";
 
 interface StripeInvoicePaidAutomationBinding {
   readonly connectorId: string;
@@ -50,8 +58,9 @@ function badRequest(message: string): ReadyStripeConnectionResult {
 
 async function loadReadyStripeConnection(
   args: {
-    readonly connectorId?: string;
+    readonly connectorId: string;
     readonly db: ReadonlyDb;
+    readonly missingMessage: string;
     readonly orgId: string;
     readonly userId: string;
   },
@@ -65,17 +74,11 @@ async function loadReadyStripeConnection(
     orgId: args.orgId,
     userId: args.userId,
     connectorSlug: STRIPE_CONNECTOR_SLUG,
-    ...(args.connectorId === undefined
-      ? {}
-      : { connectorId: args.connectorId }),
+    connectorId: args.connectorId,
   });
   signal.throwIfAborted();
   if (loaded.kind === "missing") {
-    return badRequest(
-      args.connectorId === undefined
-        ? CONNECT_STRIPE_OAUTH_MESSAGE
-        : STRIPE_BINDING_MISMATCH_MESSAGE,
-    );
+    return badRequest(args.missingMessage);
   }
   if (loaded.kind === "unavailable") {
     return badRequest(RECONNECT_STRIPE_OAUTH_MESSAGE);
@@ -122,10 +125,30 @@ export async function resolveStripeInvoicePaidAutomationBinding(
     readonly db: ReadonlyDb;
     readonly orgId: string;
     readonly userId: string;
+    readonly workflowId: string;
   },
   signal: AbortSignal,
 ): Promise<StripeInvoicePaidAutomationReadinessResult> {
-  const ready = await loadReadyStripeConnection(args, signal);
+  const connectorId = await resolveWorkflowAutomationConnectorId(args.db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    workflowId: args.workflowId,
+    connectorSlug: STRIPE_CONNECTOR_SLUG,
+  });
+  signal.throwIfAborted();
+  if (connectorId === null) {
+    return { kind: "bad_request", message: CONNECT_STRIPE_OAUTH_MESSAGE };
+  }
+  const ready = await loadReadyStripeConnection(
+    {
+      db: args.db,
+      orgId: args.orgId,
+      userId: args.userId,
+      connectorId,
+      missingMessage: STRIPE_SELECTION_CHANGED_MESSAGE,
+    },
+    signal,
+  );
   if (ready.kind === "bad_request") {
     return ready;
   }
@@ -154,6 +177,7 @@ export async function validateStripeInvoicePaidAutomationBinding(
       orgId: args.orgId,
       userId: args.userId,
       connectorId: args.eventConfig.connectorId,
+      missingMessage: STRIPE_BINDING_MISMATCH_MESSAGE,
     },
     signal,
   );
@@ -171,4 +195,182 @@ export async function validateStripeInvoicePaidAutomationBinding(
       mode: "live",
     },
   };
+}
+
+interface StripeAutomationProjectionRow {
+  readonly id: string;
+  readonly workflowId: string;
+  readonly eventConfig: unknown;
+  readonly eventConnectorId: string | null;
+}
+
+async function reprojectStripeAutomation(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly automation: StripeAutomationProjectionRow;
+    readonly readinessByConnectorId: Map<
+      string,
+      StripeInvoicePaidAutomationReadinessResult
+    >;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  const connectorId = await resolveWorkflowAutomationConnectorId(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    workflowId: args.automation.workflowId,
+    connectorSlug: STRIPE_CONNECTOR_SLUG,
+  });
+  signal.throwIfAborted();
+
+  if (connectorId === null) {
+    if (args.automation.eventConnectorId !== null) {
+      await db
+        .update(workflowAutomations)
+        .set({ eventConnectorId: null })
+        .where(eq(workflowAutomations.id, args.automation.id));
+    }
+    return;
+  }
+
+  let readiness = args.readinessByConnectorId.get(connectorId);
+  if (readiness === undefined) {
+    const ready = await loadReadyStripeConnection(
+      {
+        db,
+        orgId: args.orgId,
+        userId: args.userId,
+        connectorId,
+        missingMessage: STRIPE_SELECTION_CHANGED_MESSAGE,
+      },
+      signal,
+    );
+    readiness =
+      ready.kind === "ok"
+        ? {
+            kind: "ok",
+            binding: {
+              connectorId: ready.connection.connectorId,
+              stripeAccountId: ready.stripeAccountId,
+              mode: "live",
+            },
+          }
+        : ready;
+    args.readinessByConnectorId.set(connectorId, readiness);
+  }
+
+  if (readiness.kind !== "ok") {
+    if (args.automation.eventConnectorId !== connectorId) {
+      await db
+        .update(workflowAutomations)
+        .set({ eventConnectorId: connectorId })
+        .where(eq(workflowAutomations.id, args.automation.id));
+    }
+    return;
+  }
+
+  const config = stripeInvoicePaidEventConfigSchema.parse(
+    args.automation.eventConfig,
+  );
+  const binding = readiness.binding;
+  if (
+    args.automation.eventConnectorId === connectorId &&
+    config.connectorId === binding.connectorId &&
+    config.stripeAccountId === binding.stripeAccountId &&
+    config.mode === binding.mode
+  ) {
+    return;
+  }
+  await db
+    .update(workflowAutomations)
+    .set({
+      eventConnectorId: connectorId,
+      eventConfig: { ...config, ...binding },
+    })
+    .where(eq(workflowAutomations.id, args.automation.id));
+}
+
+export async function reprojectStripeInvoicePaidAutomationsForOwner(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  const automations = await db
+    .select({
+      id: workflowAutomations.id,
+      workflowId: workflowAutomations.workflowId,
+      eventConfig: workflowAutomations.eventConfig,
+      eventConnectorId: workflowAutomations.eventConnectorId,
+    })
+    .from(workflowAutomations)
+    .where(
+      and(
+        eq(workflowAutomations.orgId, args.orgId),
+        eq(workflowAutomations.ownerUserId, args.userId),
+        eq(workflowAutomations.kind, "event"),
+        eq(workflowAutomations.eventType, "stripe-invoice-paid"),
+      ),
+    );
+  signal.throwIfAborted();
+  const readinessByConnectorId = new Map<
+    string,
+    StripeInvoicePaidAutomationReadinessResult
+  >();
+  for (const automation of automations) {
+    await reprojectStripeAutomation(
+      db,
+      { ...args, automation, readinessByConnectorId },
+      signal,
+    );
+    signal.throwIfAborted();
+  }
+}
+
+export async function repairMissingStripeInvoicePaidAutomationProjection(
+  db: Db,
+  args: {
+    readonly automationId: string;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  const [automation] = await db
+    .select({
+      id: workflowAutomations.id,
+      workflowId: workflowAutomations.workflowId,
+      eventConfig: workflowAutomations.eventConfig,
+      eventConnectorId: workflowAutomations.eventConnectorId,
+    })
+    .from(workflowAutomations)
+    .where(
+      and(
+        eq(workflowAutomations.id, args.automationId),
+        eq(workflowAutomations.orgId, args.orgId),
+        eq(workflowAutomations.ownerUserId, args.userId),
+        eq(workflowAutomations.kind, "event"),
+        eq(workflowAutomations.eventType, "stripe-invoice-paid"),
+        isNull(workflowAutomations.eventConnectorId),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+  if (!automation) {
+    return;
+  }
+  await reprojectStripeAutomation(
+    db,
+    {
+      orgId: args.orgId,
+      userId: args.userId,
+      automation,
+      readinessByConnectorId: new Map(),
+    },
+    signal,
+  );
 }

--- a/turbo/apps/api/src/signals/services/workflow-automation-account-projection.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation-account-projection.service.ts
@@ -1,0 +1,27 @@
+import type { ConnectorAccountTarget } from "@okouai/api-contracts/contracts/connector-accounts";
+
+import type { Db } from "../external/db";
+import { reprojectGmailAutomationsForOwner } from "./gmail-automation-account.service";
+import { reprojectStripeInvoicePaidAutomationsForOwner } from "./stripe-invoice-paid-workflow-automation.service";
+
+export async function reprojectWorkflowAutomationsForOwner(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly target: ConnectorAccountTarget;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  if (args.target.kind !== "builtin") {
+    return;
+  }
+  if (args.target.connectorSlug === "gmail") {
+    await reprojectGmailAutomationsForOwner(db, args);
+    signal.throwIfAborted();
+    return;
+  }
+  if (args.target.connectorSlug === "stripe") {
+    await reprojectStripeInvoicePaidAutomationsForOwner(db, args, signal);
+  }
+}

--- a/turbo/apps/api/src/signals/services/workflow-automation-account.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation-account.service.ts
@@ -1,0 +1,56 @@
+import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
+import { chatThreadConnectorSelections } from "@okouai/db/schema/chat-thread-connector-selection";
+import { connectors } from "@okouai/db/schema/connector";
+import { workflowUserAutomationThreads } from "@okouai/db/schema/workflow";
+import { and, eq } from "drizzle-orm";
+
+import type { ReadonlyDb } from "../external/db";
+
+export async function resolveWorkflowAutomationConnectorId(
+  db: ReadonlyDb,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly workflowId: string;
+    readonly connectorSlug: ConnectorSlug;
+  },
+): Promise<string | null> {
+  const [selection] = await db
+    .select({ connectorId: chatThreadConnectorSelections.connectorId })
+    .from(workflowUserAutomationThreads)
+    .innerJoin(
+      chatThreadConnectorSelections,
+      and(
+        eq(
+          chatThreadConnectorSelections.chatThreadId,
+          workflowUserAutomationThreads.chatThreadId,
+        ),
+        eq(chatThreadConnectorSelections.connectorSlug, args.connectorSlug),
+      ),
+    )
+    .where(
+      and(
+        eq(workflowUserAutomationThreads.orgId, args.orgId),
+        eq(workflowUserAutomationThreads.userId, args.userId),
+        eq(workflowUserAutomationThreads.workflowId, args.workflowId),
+      ),
+    )
+    .limit(1);
+  if (selection) {
+    return selection.connectorId;
+  }
+
+  const [defaultAccount] = await db
+    .select({ connectorId: connectors.id })
+    .from(connectors)
+    .where(
+      and(
+        eq(connectors.orgId, args.orgId),
+        eq(connectors.userId, args.userId),
+        eq(connectors.connectorSlug, args.connectorSlug),
+        eq(connectors.isDefault, true),
+      ),
+    )
+    .limit(1);
+  return defaultAccount?.connectorId ?? null;
+}

--- a/turbo/apps/api/src/signals/services/workflow-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation.service.ts
@@ -112,10 +112,7 @@ import {
 } from "./notion-automation-event.service";
 import { notionWorkflowAutomationCreationEnabledForOwner } from "./notion-workflow-automation-feature-switch.service";
 import { googleFormsWorkflowAutomationCreationEnabledForOwner } from "./google-forms-workflow-automation-feature-switch.service";
-import {
-  resolveStripeInvoicePaidAutomationBinding,
-  validateStripeInvoicePaidAutomationBinding,
-} from "./stripe-invoice-paid-workflow-automation.service";
+import { resolveStripeInvoicePaidAutomationBinding } from "./stripe-invoice-paid-workflow-automation.service";
 import { stripeInvoicePaidWorkflowAutomationEnabledForOwner } from "./stripe-invoice-paid-workflow-automation-feature-switch.service";
 import { lockConnectorAccountTarget } from "./auth-state-lock.service";
 import { lockWorkflowWebhookAutomationTierEligibleForOrg } from "./workflow-webhook-automation-entitlement.service";
@@ -2606,32 +2603,70 @@ async function createStripeInvoicePaidEventAutomationForWorkflow(
   },
   signal: AbortSignal,
 ): Promise<AutomationResult> {
-  const readiness = await resolveStripeInvoicePaidAutomationBinding(
-    {
-      db: args.context.db,
+  const currentTime = nowDate();
+  const result = await args.context.db.transaction(async (tx) => {
+    await lockConnectorAccountTarget(tx, {
       orgId: args.input.orgId,
       userId: args.input.member.userId,
-    },
-    signal,
-  );
-  signal.throwIfAborted();
-  if (readiness.kind === "bad_request") {
-    return { kind: "bad-request", message: readiness.message };
-  }
-  const eventConfig = stripeInvoicePaidEventConfigSchema.parse({
-    ...args.input.eventConfig,
-    ...readiness.binding,
+      target: { kind: "builtin", connectorSlug: "stripe" },
+    });
+    const chatThreadId = await ensureWorkflowUserAutomationThread(tx, {
+      orgId: args.input.orgId,
+      userId: args.input.member.userId,
+      workflowId: args.context.workflowId,
+      agentId: args.context.agentId,
+      workflowTitle: args.context.workflowTitle,
+      currentTime,
+    });
+    const readiness = await resolveStripeInvoicePaidAutomationBinding(
+      {
+        db: tx,
+        orgId: args.input.orgId,
+        userId: args.input.member.userId,
+        workflowId: args.context.workflowId,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    if (readiness.kind === "bad_request") {
+      return { kind: "bad-request" as const, message: readiness.message };
+    }
+    const eventConfig = stripeInvoicePaidEventConfigSchema.parse({
+      ...args.input.eventConfig,
+      ...readiness.binding,
+    });
+    const row = await insertWorkflowAutomation(tx, {
+      id: args.context.automationId,
+      orgId: args.input.orgId,
+      workflowId: args.context.workflowId,
+      ownerUserId: args.input.member.userId,
+      kind: "event",
+      eventType: args.input.eventType,
+      eventConfig,
+      eventConnectorId: readiness.binding.connectorId,
+      scheduleType: null,
+      cronExpression: null,
+      intervalSeconds: null,
+      atTime: null,
+      timezone: "UTC",
+      enabled: args.input.enabled,
+      nextRunAt: null,
+      ...(args.input.autonomyBudget === undefined
+        ? {}
+        : { autonomyBudget: args.input.autonomyBudget }),
+      createdAt: currentTime,
+      updatedAt: currentTime,
+    });
+    if (!row) {
+      throw new Error("Failed to create Stripe workflow automation");
+    }
+    return {
+      kind: "ok" as const,
+      summary: await rowToSummary(tx, row, { chatThreadId }),
+    };
   });
-  const summary = await insertEventAutomation(args.context.db, {
-    input: { ...args.input, eventConfig },
-    workflowId: args.context.workflowId,
-    agentId: args.context.agentId,
-    workflowTitle: args.context.workflowTitle,
-    automationId: args.context.automationId,
-    currentTime: nowDate(),
-  });
   signal.throwIfAborted();
-  return { kind: "ok", summary };
+  return result;
 }
 
 const createStripeInvoicePaidEventAutomation$ = command(
@@ -3644,6 +3679,7 @@ async function prepareOfficialStripeEvent(
       db,
       orgId: input.orgId,
       userId: input.member.userId,
+      workflowId: input.workflowId,
     },
     signal,
   );
@@ -3656,6 +3692,7 @@ async function prepareOfficialStripeEvent(
       ...input.eventConfig,
       ...readiness.binding,
     }),
+    { eventConnectorId: readiness.binding.connectorId },
   );
 }
 
@@ -4780,10 +4817,12 @@ async function persistEnabledWorkflowAutomation(
   | { readonly status: "team-required" }
   | { readonly status: "conflict" }
   | { readonly status: "gmail-unavailable" }
+  | { readonly status: "stripe-unavailable"; readonly message: string }
   | { readonly status: "ok"; readonly row: AutomationRow | undefined }
 > {
   return await db.transaction(async (tx) => {
     let eventConnectorId = args.automation.eventConnectorId;
+    let eventConfig = args.automation.eventConfig;
     if (supportedGmailEventType(args.automation.eventType)) {
       await lockConnectorAccountTarget(tx, {
         orgId: args.automation.orgId,
@@ -4798,6 +4837,34 @@ async function persistEnabledWorkflowAutomation(
       if (eventConnectorId === null) {
         return { status: "gmail-unavailable" };
       }
+    } else if (args.automation.eventType === "stripe-invoice-paid") {
+      await lockConnectorAccountTarget(tx, {
+        orgId: args.automation.orgId,
+        userId: args.automation.ownerUserId,
+        target: { kind: "builtin", connectorSlug: "stripe" },
+      });
+      const readiness = await resolveStripeInvoicePaidAutomationBinding(
+        {
+          db: tx,
+          orgId: args.automation.orgId,
+          userId: args.automation.ownerUserId,
+          workflowId: args.automation.workflowId,
+        },
+        signal,
+      );
+      if (readiness.kind === "bad_request") {
+        return {
+          status: "stripe-unavailable",
+          message: readiness.message,
+        };
+      }
+      eventConnectorId = readiness.binding.connectorId;
+      eventConfig = {
+        ...stripeInvoicePaidEventConfigSchema.parse(
+          args.automation.eventConfig,
+        ),
+        ...readiness.binding,
+      };
     }
     if (
       args.automation.kind === "event" &&
@@ -4822,7 +4889,9 @@ async function persistEnabledWorkflowAutomation(
         enabled: true,
         ...(supportedGmailEventType(args.automation.eventType)
           ? { eventConnectorId }
-          : {}),
+          : args.automation.eventType === "stripe-invoice-paid"
+            ? { eventConnectorId, eventConfig }
+            : {}),
         nextRunAt: args.nextRunAt,
         consecutiveFailures: 0,
         updatedAt: args.now,
@@ -4918,6 +4987,10 @@ async function persistAndReconcileEnabledWorkflowAutomation(
       message: "Connect Gmail before using Gmail event automations",
     };
   }
+  if (enabled.status === "stripe-unavailable") {
+    signal.throwIfAborted();
+    return { kind: "bad-request", message: enabled.message };
+  }
   if (!enabled.row) {
     throw new Error("Failed to enable workflow automation");
   }
@@ -4955,33 +5028,12 @@ async function persistAndReconcileEnabledWorkflowAutomation(
   return { kind: "ok", summary };
 }
 
-async function validateEventAutomationEnableReadiness(
-  args: {
-    readonly automation: AutomationRow;
-    readonly db: Db;
-  },
-  signal: AbortSignal,
-): Promise<AutomationResult | null> {
-  if (args.automation.eventType === "stripe-invoice-paid") {
-    const readiness = await validateStripeInvoicePaidAutomationBinding(
-      {
-        db: args.db,
-        orgId: args.automation.orgId,
-        userId: args.automation.ownerUserId,
-        eventConfig: stripeInvoicePaidEventConfigSchema.parse(
-          args.automation.eventConfig,
-        ),
-      },
-      signal,
-    );
-    signal.throwIfAborted();
-    return readiness.kind === "bad_request"
-      ? { kind: "bad-request", message: readiness.message }
-      : null;
-  }
-  return args.automation.eventType === "strapi-entry-published" &&
+function validateEventAutomationEnableReadiness(
+  automation: AutomationRow,
+): AutomationResult | null {
+  return automation.eventType === "strapi-entry-published" &&
     !isFeatureEnabled(FeatureSwitchKey.StrapiIntegration, {
-      orgId: args.automation.orgId,
+      orgId: automation.orgId,
     })
     ? {
         kind: "bad-request",
@@ -5042,13 +5094,8 @@ export const enableWorkflowAutomation$ = command(
     if (stripeFailure) {
       return stripeFailure;
     }
-    const eventEnableFailure = await validateEventAutomationEnableReadiness(
-      {
-        automation,
-        db: writeDb,
-      },
-      signal,
-    );
+    const eventEnableFailure =
+      validateEventAutomationEnableReadiness(automation);
     signal.throwIfAborted();
     if (eventEnableFailure) {
       return eventEnableFailure;

--- a/turbo/packages/api-contracts/src/contracts/test-stripe-automation-events.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-stripe-automation-events.ts
@@ -9,6 +9,7 @@ export const testStripeAutomationEventFixtureActionSchema = z.enum([
   "hold-latest-claim",
   "expire-latest-retry-window",
   "make-latest-due",
+  "clear-automation-account-projection",
   "fail-next-ingress-for-automation",
   "fail-next-queue-admission-for-automation",
   "clear-forced-failures",


### PR DESCRIPTION
## Summary

- resolve Stripe invoice-paid automation accounts from the workflow thread selection, falling back to the owner default only when the thread has no selection
- keep the relational connector ID and strict Stripe event configuration synchronized across account, selection, automation, Official Workflow, and workflow-copy lifecycle changes
- reject stale ingress and durable deliveries after an account switch while preserving exact source/thread/default runner candidate ordering after projection validation
- add two-account integration coverage for creation, switching, reconnect, deletion, legacy repair, copy, and stale pending delivery behavior

## Scope

- no database migration or new persisted JSON compatibility fields
- legacy null projection repair is limited to the exact automation under the existing account-target lock; non-null mismatches fail closed
- shared account projection dispatch remains a no-op for connector types other than Gmail and Stripe

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/stripe-invoice-paid-workflow-automation-readiness.test.ts --maxWorkers=1`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/stripe-automation-events.test.ts --maxWorkers=1`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/workflows.test.ts --maxWorkers=1`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-gmail.test.ts --maxWorkers=1`
- focused Official Workflow connector projection and connector-account lifecycle tests
- pre-commit hook: repository Prettier, Knip, and all-workspace type checks

Closes #30598

Parent context: #30585
