### PR TITLE
fix(api): clean up unused google meet subscriptions

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts
@@ -3,7 +3,7 @@ import { generateKeyPairSync, randomUUID, sign as signData } from "node:crypto";
 
 import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
 import { chatThreadConnectorSelectionContract } from "@okouai/api-contracts/contracts/chat-threads";
-import { cronRenewGoogleWorkspaceEventSubscriptionsContract } from "@okouai/api-contracts/contracts/cron";
+import { testGoogleMeetSubscriptionRenewalContract } from "@okouai/api-contracts/contracts/test-google-meet-subscription-renewal";
 import { workflowAutomationsContract } from "@okouai/api-contracts/contracts/workflows";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
@@ -24,7 +24,7 @@ import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { createRouteMocks } from "./helpers/route-test";
 import { chatThreadRoutes } from "../chat-threads";
 import { connectorAccountRoutes } from "../connector-accounts";
-import { cronRenewGoogleWorkspaceEventSubscriptionsRoutes } from "../cron-renew-google-workspace-event-subscriptions";
+import { testGoogleMeetSubscriptionRenewalRoutes } from "../test-google-meet-subscription-renewal";
 import { webhooksGoogleWorkspaceEventsRoutes } from "../webhooks-google-workspace-events";
 import { workflowAutomationsRoutes } from "../workflow-automations";
 
@@ -37,7 +37,6 @@ const PUSH_AUDIENCE = "https://api.vm0.ai/api/webhooks/google-workspace-events";
 const PUSH_SERVICE_ACCOUNT =
   "google-workspace-events-push@vm0-ai-488909.iam.gserviceaccount.com";
 const OIDC_CERT_KID = "google-workspace-events-test-key";
-const CRON_SECRET = "google-workspace-events-cron-secret";
 const oidcKeyPair = generateKeyPairSync("rsa", { modulusLength: 2048 });
 const oidcPublicKeyPem = oidcKeyPair.publicKey.export({
   type: "spki",
@@ -97,8 +96,8 @@ function connectorAccountsClient() {
 function renewalClient() {
   return setupApp({
     context,
-    routes: cronRenewGoogleWorkspaceEventSubscriptionsRoutes,
-  })(cronRenewGoogleWorkspaceEventSubscriptionsContract);
+    routes: testGoogleMeetSubscriptionRenewalRoutes,
+  })(testGoogleMeetSubscriptionRenewalContract);
 }
 
 function encodeJwtPart(value: unknown): string {
@@ -565,7 +564,6 @@ describe("Google Workspace Events subscription lifecycle", () => {
   });
 
   it("fails closed and does not retry after provider delete failure", async () => {
-    mockEnv("CRON_SECRET", CRON_SECRET);
     const fixture = await setupFixture({ deleteStatus: 503 });
     const created = await createMeetAutomation(fixture);
     const subscriptionName = fixture.provider.createdNames[0];
@@ -593,7 +591,10 @@ describe("Google Workspace Events subscription lifecycle", () => {
 
     const renewed = await accept(
       renewalClient().renew({
-        headers: { authorization: `Bearer ${CRON_SECRET}` },
+        body: {
+          org_id: fixture.actor.orgId,
+          user_id: fixture.actor.userId,
+        },
       }),
       [200],
     );
@@ -745,7 +746,6 @@ describe("Google Workspace Events subscription lifecycle", () => {
   });
 
   it("renews a due subscription while an enabled consumer remains", async () => {
-    mockEnv("CRON_SECRET", CRON_SECRET);
     const fixture = await setupFixture({
       expireTime: new Date(now() + 30 * 60 * 1000).toISOString(),
     });
@@ -753,13 +753,19 @@ describe("Google Workspace Events subscription lifecycle", () => {
 
     const renewed = await accept(
       renewalClient().renew({
-        headers: { authorization: `Bearer ${CRON_SECRET}` },
+        body: {
+          org_id: fixture.actor.orgId,
+          user_id: fixture.actor.userId,
+        },
       }),
       [200],
     );
     const unchanged = await accept(
       renewalClient().renew({
-        headers: { authorization: `Bearer ${CRON_SECRET}` },
+        body: {
+          org_id: fixture.actor.orgId,
+          user_id: fixture.actor.userId,
+        },
       }),
       [200],
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts
@@ -1,10 +1,13 @@
 import { Buffer } from "node:buffer";
-import { generateKeyPairSync, sign as signData } from "node:crypto";
+import { generateKeyPairSync, randomUUID, sign as signData } from "node:crypto";
 
+import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
 import { chatThreadConnectorSelectionContract } from "@okouai/api-contracts/contracts/chat-threads";
+import { cronRenewGoogleWorkspaceEventSubscriptionsContract } from "@okouai/api-contracts/contracts/cron";
 import { workflowAutomationsContract } from "@okouai/api-contracts/contracts/workflows";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
+import { onTestFinished } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
@@ -12,12 +15,16 @@ import { createApp } from "../../../app-factory";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
+import { createDeferredPromise } from "../../utils";
+import type { ApiTestUser } from "./helpers/api-bdd";
 import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
 import { chatEventDisplayText } from "./helpers/chat-event";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { createRouteMocks } from "./helpers/route-test";
 import { chatThreadRoutes } from "../chat-threads";
+import { connectorAccountRoutes } from "../connector-accounts";
+import { cronRenewGoogleWorkspaceEventSubscriptionsRoutes } from "../cron-renew-google-workspace-event-subscriptions";
 import { webhooksGoogleWorkspaceEventsRoutes } from "../webhooks-google-workspace-events";
 import { workflowAutomationsRoutes } from "../workflow-automations";
 
@@ -26,20 +33,45 @@ const connectors = createConnectorBddApi(context);
 const mocks = createRouteMocks(context);
 const workflows = createWorkflowsBddApi(context);
 
-const TOPIC_NAME = "projects/vm0-ai-488909/topics/google-workspace-events";
 const PUSH_AUDIENCE = "https://api.vm0.ai/api/webhooks/google-workspace-events";
 const PUSH_SERVICE_ACCOUNT =
   "google-workspace-events-push@vm0-ai-488909.iam.gserviceaccount.com";
 const OIDC_CERT_KID = "google-workspace-events-test-key";
-const SUBSCRIPTION_NAME = "subscriptions/google-meet-test";
-const TRANSCRIPT_NAME = "conferenceRecords/123/transcripts/456";
+const CRON_SECRET = "google-workspace-events-cron-secret";
 const oidcKeyPair = generateKeyPairSync("rsa", { modulusLength: 2048 });
 const oidcPublicKeyPem = oidcKeyPair.publicKey.export({
   type: "spki",
   format: "pem",
 });
 
-function authHeaders() {
+type OrgActor = ApiTestUser & { readonly orgId: string };
+
+interface GoogleMeetProviderOptions {
+  readonly createStatus?: number;
+  readonly deleteStatus?: number;
+  readonly expireTime?: string;
+  readonly onDelete?: () => Promise<void>;
+}
+
+interface GoogleMeetProviderRecorder {
+  readonly createdNames: string[];
+  readonly deletedUrls: string[];
+  readonly operations: string[];
+  readonly topicName: string;
+  readonly externalId: string;
+  renewCalls: number;
+  reactivateCalls: number;
+}
+
+interface GoogleMeetFixture {
+  readonly actor: OrgActor;
+  readonly workflowId: string;
+  readonly connectorId: string;
+  readonly provider: GoogleMeetProviderRecorder;
+}
+
+function authHeaders(actor: OrgActor) {
+  mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
   return { authorization: "Bearer clerk-session" };
 }
 
@@ -53,6 +85,19 @@ function chatThreadConnectorSelectionsClient() {
   return setupApp({ context, routes: chatThreadRoutes })(
     chatThreadConnectorSelectionContract,
   );
+}
+
+function connectorAccountsClient() {
+  return setupApp({ context, routes: connectorAccountRoutes })(
+    connectorAccountsContract,
+  );
+}
+
+function renewalClient() {
+  return setupApp({
+    context,
+    routes: cronRenewGoogleWorkspaceEventSubscriptionsRoutes,
+  })(cronRenewGoogleWorkspaceEventSubscriptionsContract);
 }
 
 function encodeJwtPart(value: unknown): string {
@@ -80,12 +125,32 @@ function signedGoogleIdToken(): string {
   return `${signedContent}.${signature.toString("base64url")}`;
 }
 
-function configureGoogleMeetBoundaries(): void {
+function configureGoogleMeetBoundaries(
+  options: GoogleMeetProviderOptions = {},
+): GoogleMeetProviderRecorder {
+  const testId = randomUUID();
+  const accessToken = `google-meet-access-${testId}`;
+  const recorder: GoogleMeetProviderRecorder = {
+    createdNames: [],
+    deletedUrls: [],
+    operations: [],
+    topicName: `projects/vm0-ai-488909/topics/google-workspace-events-${testId}`,
+    externalId: `google-meet-user-${testId}`,
+    renewCalls: 0,
+    reactivateCalls: 0,
+  };
+
   mockEnv("OKOU_WEB_URL", "https://www.vm0.ai");
   mockOptionalEnv("GOOGLE_OAUTH_CLIENT_ID", "google-client-id");
   mockOptionalEnv("GOOGLE_OAUTH_CLIENT_SECRET", "google-client-secret");
-  mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/google-workspace-events-test");
-  mockOptionalEnv("GOOGLE_WORKSPACE_EVENTS_PUBSUB_TOPIC_NAME", TOPIC_NAME);
+  mockOptionalEnv(
+    "RUNNER_DEFAULT_GROUP",
+    `vm0/google-workspace-events-${testId}`,
+  );
+  mockOptionalEnv(
+    "GOOGLE_WORKSPACE_EVENTS_PUBSUB_TOPIC_NAME",
+    recorder.topicName,
+  );
   mockOptionalEnv(
     "GOOGLE_WORKSPACE_EVENTS_PUBSUB_PUSH_AUDIENCE",
     PUSH_AUDIENCE,
@@ -98,8 +163,8 @@ function configureGoogleMeetBoundaries(): void {
   server.use(
     http.post("https://oauth2.googleapis.com/token", () => {
       return HttpResponse.json({
-        access_token: "google-meet-access-token",
-        refresh_token: "google-meet-refresh-token",
+        access_token: accessToken,
+        refresh_token: `google-meet-refresh-${testId}`,
         expires_in: 3600,
         token_type: "Bearer",
         scope:
@@ -108,34 +173,125 @@ function configureGoogleMeetBoundaries(): void {
     }),
     http.get("https://www.googleapis.com/oauth2/v2/userinfo", () => {
       return HttpResponse.json({
-        id: "google-meet-user-id",
-        email: "meet-user@example.test",
+        id: recorder.externalId,
+        email: `meet-${testId}@example.test`,
         name: "Google Meet User",
       });
     }),
     http.post(
       "https://workspaceevents.googleapis.com/v1/subscriptions",
       async ({ request }) => {
+        const requestText = await request.text();
+        if (
+          !requestText.includes(recorder.topicName) ||
+          !requestText.includes(recorder.externalId)
+        ) {
+          return HttpResponse.text("unowned test subscription", {
+            status: 503,
+          });
+        }
+        const call = recorder.createdNames.length + 1;
+        const subscriptionName = `subscriptions/google-meet-${testId}-${call}`;
+        recorder.createdNames.push(subscriptionName);
+        recorder.operations.push(`create:${subscriptionName}`);
         expect(request.headers.get("authorization")).toBe(
-          "Bearer google-meet-access-token",
+          `Bearer ${accessToken}`,
         );
-        await expect(request.json()).resolves.toStrictEqual({
-          targetResource:
-            "//cloudidentity.googleapis.com/users/google-meet-user-id",
+        const body: unknown = JSON.parse(requestText);
+        expect(body).toStrictEqual({
+          targetResource: `//cloudidentity.googleapis.com/users/${recorder.externalId}`,
           eventTypes: ["google.workspace.meet.transcript.v2.fileGenerated"],
-          notificationEndpoint: { pubsubTopic: TOPIC_NAME },
+          notificationEndpoint: { pubsubTopic: recorder.topicName },
+          ttl: "604800s",
+        });
+        if (options.createStatus !== undefined) {
+          return HttpResponse.text("create failed", {
+            status: options.createStatus,
+          });
+        }
+        return HttpResponse.json({
+          response: {
+            name: subscriptionName,
+            targetResource: `//cloudidentity.googleapis.com/users/${recorder.externalId}`,
+            eventTypes: ["google.workspace.meet.transcript.v2.fileGenerated"],
+            notificationEndpoint: { pubsubTopic: recorder.topicName },
+            state: "ACTIVE",
+            expireTime: options.expireTime ?? "2099-08-14T00:00:00.000Z",
+          },
+        });
+      },
+    ),
+    http.patch(
+      /^https:\/\/workspaceevents\.googleapis\.com\/v1\/subscriptions\/[^/]+$/,
+      async ({ request }) => {
+        const subscriptionName = new URL(request.url).pathname.slice(
+          "/v1/".length,
+        );
+        if (!subscriptionName.includes(testId)) {
+          return HttpResponse.text("unowned test subscription", {
+            status: 503,
+          });
+        }
+        recorder.renewCalls += 1;
+        recorder.operations.push(`renew:${subscriptionName}`);
+        expect(new URL(request.url).searchParams.get("updateMask")).toBe("ttl");
+        await expect(request.json()).resolves.toStrictEqual({
+          name: subscriptionName,
           ttl: "604800s",
         });
         return HttpResponse.json({
           response: {
-            name: SUBSCRIPTION_NAME,
-            targetResource:
-              "//cloudidentity.googleapis.com/users/google-meet-user-id",
-            eventTypes: ["google.workspace.meet.transcript.v2.fileGenerated"],
-            notificationEndpoint: { pubsubTopic: TOPIC_NAME },
+            name: subscriptionName,
             state: "ACTIVE",
             expireTime: "2099-08-14T00:00:00.000Z",
           },
+        });
+      },
+    ),
+    http.post(
+      /^https:\/\/workspaceevents\.googleapis\.com\/v1\/subscriptions\/[^/]+:reactivate$/,
+      ({ request }) => {
+        if (!request.url.includes(testId)) {
+          return HttpResponse.text("unowned test subscription", {
+            status: 503,
+          });
+        }
+        recorder.reactivateCalls += 1;
+        return HttpResponse.json({
+          response: {
+            name: recorder.createdNames.at(-1),
+            state: "ACTIVE",
+            expireTime: "2099-08-14T00:00:00.000Z",
+          },
+        });
+      },
+    ),
+    http.delete(
+      /^https:\/\/workspaceevents\.googleapis\.com\/v1\/subscriptions\/[^/]+$/,
+      async ({ request }) => {
+        const url = new URL(request.url);
+        const subscriptionName = url.pathname.slice("/v1/".length);
+        if (!subscriptionName.includes(testId)) {
+          return HttpResponse.text("unowned test subscription", {
+            status: 503,
+          });
+        }
+        recorder.deletedUrls.push(url.toString());
+        recorder.operations.push(`delete-start:${subscriptionName}`);
+        expect(request.headers.get("authorization")).toBe(
+          `Bearer ${accessToken}`,
+        );
+        expect(url.searchParams.get("allowMissing")).toBe("true");
+        await options.onDelete?.();
+        recorder.operations.push(`delete-end:${subscriptionName}`);
+        if (options.deleteStatus !== undefined) {
+          return HttpResponse.text("delete failed", {
+            status: options.deleteStatus,
+          });
+        }
+        return HttpResponse.json({
+          name: `operations/delete-google-meet-${testId}`,
+          done: true,
         });
       },
     ),
@@ -146,11 +302,10 @@ function configureGoogleMeetBoundaries(): void {
       );
     }),
   );
+  return recorder;
 }
 
-async function connectGoogleMeet(
-  actor: Parameters<typeof connectors.startOauth>[0],
-): Promise<void> {
+async function connectGoogleMeet(actor: OrgActor): Promise<string> {
   const started = await connectors.startOauth(actor, "google-meet", "oauth");
   const state = new URL(started.authorizationUrl).searchParams.get("state");
   if (!state) {
@@ -160,21 +315,81 @@ async function connectGoogleMeet(
     code: "google-meet-code",
     state,
   });
+  const accounts = await connectors.listBuiltinConnectorAccounts(
+    actor,
+    "google-meet",
+  );
+  const account = accounts[0];
+  if (accounts.length !== 1 || !account) {
+    throw new Error("Expected one Google Meet connector account");
+  }
+  return account.id;
 }
 
-function pubSubPushBody(): string {
+async function setupFixture(
+  options: GoogleMeetProviderOptions = {},
+): Promise<GoogleMeetFixture> {
+  const provider = configureGoogleMeetBoundaries(options);
+  const { actor } = await workflows.setupWorkflowOrg();
+  if (!actor.orgId) {
+    throw new Error("Expected an org-scoped workflow actor");
+  }
+  const orgActor: OrgActor = { ...actor, orgId: actor.orgId };
+  const agent = await workflows.createAgent(orgActor, {
+    displayName: "Google Meet automation agent",
+  });
+  const workflowId = await workflows.createWorkflow(orgActor, {
+    agentId: agent.agentId,
+    name: `google-meet-transcript-${randomUUID()}`,
+  });
+  await updateFeatureSwitchesForUser(
+    context,
+    { orgId: orgActor.orgId, userId: orgActor.userId },
+    { [FeatureSwitchKey.ConnectorAccounts]: true },
+  );
+  const connectorId = await connectGoogleMeet(orgActor);
+  context.mocks.s3.send.mockResolvedValue({});
+  return { actor: orgActor, workflowId, connectorId, provider };
+}
+
+async function createMeetAutomation(
+  fixture: GoogleMeetFixture,
+  enabled?: boolean,
+) {
+  return await accept(
+    automationsClient().create({
+      headers: authHeaders(fixture.actor),
+      params: { workflowId: fixture.workflowId },
+      body: {
+        kind: "event",
+        eventType: "google-meet-transcript-generated",
+        ...(enabled === undefined ? {} : { enabled }),
+      },
+    }),
+    [201],
+  );
+}
+
+function pubSubPushBody(
+  subscriptionName: string,
+  eventId: string = randomUUID(),
+): string {
   const cloudEvent = {
-    id: "google-meet-cloud-event",
-    source: `//workspaceevents.googleapis.com/${SUBSCRIPTION_NAME}`,
-    subject: "//meet.googleapis.com/conferenceRecords/123",
+    id: `google-meet-cloud-event-${eventId}`,
+    source: `//workspaceevents.googleapis.com/${subscriptionName}`,
+    subject: `//meet.googleapis.com/conferenceRecords/${eventId}`,
     type: "google.workspace.meet.transcript.v2.fileGenerated",
     time: "2026-08-14T01:00:00.000Z",
     specversion: "1.0",
-    data: { transcript: { name: TRANSCRIPT_NAME } },
+    data: {
+      transcript: {
+        name: `conferenceRecords/${eventId}/transcripts/${eventId}`,
+      },
+    },
   };
   return JSON.stringify({
     message: {
-      messageId: "google-meet-pubsub-message",
+      messageId: `google-meet-pubsub-${eventId}`,
       data: Buffer.from(JSON.stringify(cloudEvent), "utf8").toString("base64"),
     },
     subscription:
@@ -182,54 +397,33 @@ function pubSubPushBody(): string {
   });
 }
 
-describe("POST /api/webhooks/google-workspace-events", () => {
+async function postWorkspaceEvent(subscriptionName: string): Promise<Response> {
+  return await createApp({
+    signal: context.signal,
+    routes: webhooksGoogleWorkspaceEventsRoutes,
+  }).request("/api/webhooks/google-workspace-events", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${signedGoogleIdToken()}`,
+      "content-type": "application/json",
+    },
+    body: pubSubPushBody(subscriptionName),
+  });
+}
+
+describe("Google Workspace Events subscription lifecycle", () => {
   it("dispatches a visible Google Meet transcript message", async () => {
-    configureGoogleMeetBoundaries();
-    const { actor } = await workflows.setupWorkflowOrg();
-    if (!actor.orgId) {
-      throw new Error("Expected an org-scoped workflow actor");
-    }
-    const agent = await workflows.createAgent(actor, {
-      displayName: "Google Meet automation agent",
-    });
-    const workflowId = await workflows.createWorkflow(actor, {
-      agentId: agent.agentId,
-      name: "google-meet-transcript-workflow",
-    });
-    await updateFeatureSwitchesForUser(
-      context,
-      { orgId: actor.orgId, userId: actor.userId },
-      { [FeatureSwitchKey.ConnectorAccounts]: true },
-    );
-    await connectGoogleMeet(actor);
-    mocks.clerk.session(actor.userId, actor.orgId, "org:member");
-    context.mocks.s3.send.mockResolvedValue({});
-    const created = await accept(
-      automationsClient().create({
-        headers: authHeaders(),
-        params: { workflowId },
-        body: {
-          kind: "event",
-          eventType: "google-meet-transcript-generated",
-        },
-      }),
-      [201],
-    );
+    const fixture = await setupFixture();
+    const created = await createMeetAutomation(fixture);
     if (!created.body.chatThreadId) {
       throw new Error("Expected the automation to bind a chat thread");
     }
+    const subscriptionName = fixture.provider.createdNames[0];
+    if (!subscriptionName) {
+      throw new Error("Expected a Workspace Events subscription");
+    }
 
-    const response = await createApp({
-      signal: context.signal,
-      routes: webhooksGoogleWorkspaceEventsRoutes,
-    }).request("/api/webhooks/google-workspace-events", {
-      method: "POST",
-      headers: {
-        authorization: `Bearer ${signedGoogleIdToken()}`,
-        "content-type": "application/json",
-      },
-      body: pubSubPushBody(),
-    });
+    const response = await postWorkspaceEvent(subscriptionName);
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toStrictEqual({
       success: true,
@@ -253,11 +447,319 @@ describe("POST /api/webhooks/google-workspace-events", () => {
     );
     const selections = await accept(
       chatThreadConnectorSelectionsClient().get({
-        headers: authHeaders(),
+        headers: authHeaders(fixture.actor),
         params: { id: created.body.chatThreadId },
       }),
       [200],
     );
     expect(selections.body.selections).toStrictEqual([]);
+  });
+
+  it("does not create provider state for a disabled automation", async () => {
+    const fixture = await setupFixture();
+    const created = await createMeetAutomation(fixture, false);
+
+    expect(created.body.enabled).toBeFalsy();
+    expect(fixture.provider.operations).toStrictEqual([]);
+
+    await accept(
+      automationsClient().delete({
+        headers: authHeaders(fixture.actor),
+        params: { id: created.body.id },
+      }),
+      [204],
+    );
+    expect(fixture.provider.operations).toStrictEqual([]);
+  });
+
+  it("rolls back active create and enable when provider setup fails", async () => {
+    const fixture = await setupFixture({ createStatus: 503 });
+    const disabled = await createMeetAutomation(fixture, false);
+
+    const enableFailure = await accept(
+      automationsClient().enable({
+        headers: authHeaders(fixture.actor),
+        params: { id: disabled.body.id },
+      }),
+      [400],
+    );
+    expect(enableFailure.body.error.message).toContain(
+      "Failed to ensure Google Meet Workspace Events subscription",
+    );
+
+    const createFailure = await accept(
+      automationsClient().create({
+        headers: authHeaders(fixture.actor),
+        params: { workflowId: fixture.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-meet-transcript-generated",
+        },
+      }),
+      [400],
+    );
+    expect(createFailure.body.error.message).toContain(
+      "Failed to ensure Google Meet Workspace Events subscription",
+    );
+
+    const listed = await accept(
+      automationsClient().list({
+        headers: authHeaders(fixture.actor),
+        params: { workflowId: fixture.workflowId },
+      }),
+      [200],
+    );
+    expect(listed.body).toHaveLength(1);
+    expect(listed.body[0]).toMatchObject({
+      id: disabled.body.id,
+      enabled: false,
+    });
+    expect(fixture.provider.createdNames).toHaveLength(2);
+    expect(fixture.provider.deletedUrls).toStrictEqual([]);
+  });
+
+  it("keeps a shared subscription until the last enabled consumer", async () => {
+    const fixture = await setupFixture();
+    const first = await createMeetAutomation(fixture);
+    const second = await createMeetAutomation(fixture);
+    expect(fixture.provider.createdNames).toHaveLength(1);
+
+    await accept(
+      automationsClient().disable({
+        headers: authHeaders(fixture.actor),
+        params: { id: first.body.id },
+      }),
+      [200],
+    );
+    expect(fixture.provider.deletedUrls).toStrictEqual([]);
+
+    await accept(
+      automationsClient().delete({
+        headers: authHeaders(fixture.actor),
+        params: { id: second.body.id },
+      }),
+      [204],
+    );
+    expect(fixture.provider.deletedUrls).toHaveLength(1);
+    expect(fixture.provider.deletedUrls[0]).toContain(
+      `/${fixture.provider.createdNames[0]}?allowMissing=true`,
+    );
+
+    await accept(
+      automationsClient().delete({
+        headers: authHeaders(fixture.actor),
+        params: { id: first.body.id },
+      }),
+      [204],
+    );
+    expect(fixture.provider.deletedUrls).toHaveLength(1);
+  });
+
+  it("fails closed and does not retry after provider delete failure", async () => {
+    mockEnv("CRON_SECRET", CRON_SECRET);
+    const fixture = await setupFixture({ deleteStatus: 503 });
+    const created = await createMeetAutomation(fixture);
+    const subscriptionName = fixture.provider.createdNames[0];
+    if (!subscriptionName) {
+      throw new Error("Expected a Workspace Events subscription");
+    }
+
+    await accept(
+      automationsClient().disable({
+        headers: authHeaders(fixture.actor),
+        params: { id: created.body.id },
+      }),
+      [200],
+    );
+    expect(fixture.provider.deletedUrls).toHaveLength(1);
+
+    const delayed = await postWorkspaceEvent(subscriptionName);
+    expect(delayed.status).toBe(200);
+    await expect(delayed.json()).resolves.toStrictEqual({
+      success: true,
+      watchStates: 0,
+      dispatched: 0,
+      duplicates: 0,
+    });
+
+    const renewed = await accept(
+      renewalClient().renew({
+        headers: { authorization: `Bearer ${CRON_SECRET}` },
+      }),
+      [200],
+    );
+    expect(renewed.body).toMatchObject({
+      success: true,
+      renewed: 0,
+      repaired: 0,
+    });
+    expect(fixture.provider.createdNames).toHaveLength(1);
+    expect(fixture.provider.renewCalls).toBe(0);
+  });
+
+  it("commits connector deletion before one best-effort provider delete", async () => {
+    const deleteStarted = createDeferredPromise<void>(context.signal);
+    const deleteRelease = createDeferredPromise<void>(context.signal);
+    onTestFinished(() => {
+      if (!deleteRelease.settled()) {
+        deleteRelease.resolve();
+      }
+    });
+    const fixture = await setupFixture({
+      deleteStatus: 503,
+      onDelete: async () => {
+        deleteStarted.resolve();
+        await deleteRelease.promise;
+      },
+    });
+    await createMeetAutomation(fixture);
+
+    const deletion = connectorAccountsClient().delete({
+      headers: authHeaders(fixture.actor),
+      params: { connectionId: fixture.connectorId },
+      body: { target: { kind: "builtin", connectorSlug: "google-meet" } },
+    });
+    await deleteStarted.promise;
+    const accountsWhileDeleteIsPending =
+      await connectors.listBuiltinConnectorAccounts(
+        fixture.actor,
+        "google-meet",
+      );
+    expect(accountsWhileDeleteIsPending).toStrictEqual([]);
+    deleteRelease.resolve();
+
+    const deleted = await accept(deletion, [200]);
+    expect(deleted.body).toStrictEqual({
+      deletedConnectionId: fixture.connectorId,
+      resolvedSelectionCount: 0,
+      promotedDefaultConnectionId: null,
+    });
+    expect(fixture.provider.deletedUrls).toHaveLength(1);
+    const automations = await accept(
+      automationsClient().list({
+        headers: authHeaders(fixture.actor),
+        params: { workflowId: fixture.workflowId },
+      }),
+      [200],
+    );
+    const automation = automations.body[0];
+    if (!automation) {
+      throw new Error("Expected the Google Meet automation");
+    }
+    await accept(
+      automationsClient().delete({
+        headers: authHeaders(fixture.actor),
+        params: { id: automation.id },
+      }),
+      [204],
+    );
+  });
+
+  it("serializes last-consumer cleanup with a concurrent enable", async () => {
+    const deleteStarted = createDeferredPromise<void>(context.signal);
+    const deleteRelease = createDeferredPromise<void>(context.signal);
+    onTestFinished(() => {
+      if (!deleteRelease.settled()) {
+        deleteRelease.resolve();
+      }
+    });
+    const fixture = await setupFixture({
+      onDelete: async () => {
+        deleteStarted.resolve();
+        await deleteRelease.promise;
+      },
+    });
+    const active = await createMeetAutomation(fixture);
+    const disabled = await createMeetAutomation(fixture, false);
+
+    const disableRequest = automationsClient().disable({
+      headers: authHeaders(fixture.actor),
+      params: { id: active.body.id },
+    });
+    await deleteStarted.promise;
+    const enableRequest = automationsClient().enable({
+      headers: authHeaders(fixture.actor),
+      params: { id: disabled.body.id },
+    });
+
+    let enabledVisible = false;
+    for (let attempt = 0; attempt < 100 && !enabledVisible; attempt += 1) {
+      const listed = await accept(
+        automationsClient().list({
+          headers: authHeaders(fixture.actor),
+          params: { workflowId: fixture.workflowId },
+        }),
+        [200],
+      );
+      enabledVisible =
+        listed.body.find((automation) => {
+          return automation.id === disabled.body.id;
+        })?.enabled === true;
+    }
+    expect(enabledVisible).toBeTruthy();
+    expect(fixture.provider.createdNames).toHaveLength(1);
+    deleteRelease.resolve();
+
+    await accept(disableRequest, [200]);
+    await accept(enableRequest, [200]);
+    expect(fixture.provider.createdNames).toHaveLength(2);
+    expect(fixture.provider.operations).toStrictEqual([
+      `create:${fixture.provider.createdNames[0]}`,
+      `delete-start:${fixture.provider.createdNames[0]}`,
+      `delete-end:${fixture.provider.createdNames[0]}`,
+      `create:${fixture.provider.createdNames[1]}`,
+    ]);
+
+    await accept(
+      automationsClient().disable({
+        headers: authHeaders(fixture.actor),
+        params: { id: disabled.body.id },
+      }),
+      [200],
+    );
+    expect(fixture.provider.deletedUrls).toHaveLength(2);
+    expect(fixture.provider.deletedUrls[1]).toContain(
+      `/${fixture.provider.createdNames[1]}?allowMissing=true`,
+    );
+  });
+
+  it("renews a due subscription while an enabled consumer remains", async () => {
+    mockEnv("CRON_SECRET", CRON_SECRET);
+    const fixture = await setupFixture({
+      expireTime: new Date(now() + 30 * 60 * 1000).toISOString(),
+    });
+    const created = await createMeetAutomation(fixture);
+
+    const renewed = await accept(
+      renewalClient().renew({
+        headers: { authorization: `Bearer ${CRON_SECRET}` },
+      }),
+      [200],
+    );
+    const unchanged = await accept(
+      renewalClient().renew({
+        headers: { authorization: `Bearer ${CRON_SECRET}` },
+      }),
+      [200],
+    );
+    expect(renewed.body).toMatchObject({
+      success: true,
+      renewed: 1,
+      repaired: 0,
+    });
+    expect(unchanged.body).toMatchObject({
+      success: true,
+      renewed: 0,
+      repaired: 0,
+    });
+    expect(fixture.provider.renewCalls).toBe(1);
+
+    await accept(
+      automationsClient().delete({
+        headers: authHeaders(fixture.actor),
+        params: { id: created.body.id },
+      }),
+      [204],
+    );
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts
@@ -454,6 +454,14 @@ describe("Google Workspace Events subscription lifecycle", () => {
       [200],
     );
     expect(selections.body.selections).toStrictEqual([]);
+
+    await accept(
+      automationsClient().delete({
+        headers: authHeaders(fixture.actor),
+        params: { id: created.body.id },
+      }),
+      [204],
+    );
   });
 
   it("does not create provider state for a disabled automation", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts
@@ -50,6 +50,7 @@ interface GoogleMeetProviderOptions {
   readonly createStatus?: number;
   readonly deleteStatus?: number;
   readonly expireTime?: string;
+  readonly tokenExpiresInSeconds?: number;
   readonly onDelete?: () => Promise<void>;
 }
 
@@ -165,7 +166,7 @@ function configureGoogleMeetBoundaries(
       return HttpResponse.json({
         access_token: accessToken,
         refresh_token: `google-meet-refresh-${testId}`,
-        expires_in: 3600,
+        expires_in: options.tokenExpiresInSeconds ?? 3600,
         token_type: "Bearer",
         scope:
           "https://www.googleapis.com/auth/meetings.space.readonly https://www.googleapis.com/auth/userinfo.email",
@@ -607,6 +608,7 @@ describe("Google Workspace Events subscription lifecycle", () => {
     });
     const fixture = await setupFixture({
       deleteStatus: 503,
+      tokenExpiresInSeconds: 60,
       onDelete: async () => {
         deleteStarted.resolve();
         await deleteRelease.promise;

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts
@@ -613,6 +613,14 @@ describe("Google Workspace Events subscription lifecycle", () => {
       },
     });
     await createMeetAutomation(fixture);
+    const subscriptionName = fixture.provider.createdNames[0];
+    if (!subscriptionName) {
+      throw new Error("Expected a Workspace Events subscription");
+    }
+    mockOptionalEnv(
+      "GOOGLE_WORKSPACE_EVENTS_PUBSUB_TOPIC_NAME",
+      `${fixture.provider.topicName}-replacement`,
+    );
 
     const deletion = connectorAccountsClient().delete({
       headers: authHeaders(fixture.actor),
@@ -635,6 +643,9 @@ describe("Google Workspace Events subscription lifecycle", () => {
       promotedDefaultConnectionId: null,
     });
     expect(fixture.provider.deletedUrls).toHaveLength(1);
+    expect(fixture.provider.deletedUrls[0]).toContain(
+      `/${subscriptionName}?allowMissing=true`,
+    );
     const automations = await accept(
       automationsClient().list({
         headers: authHeaders(fixture.actor),

--- a/turbo/apps/api/src/signals/routes/test-google-meet-subscription-renewal.ts
+++ b/turbo/apps/api/src/signals/routes/test-google-meet-subscription-renewal.ts
@@ -1,0 +1,52 @@
+import { testGoogleMeetSubscriptionRenewalContract } from "@okouai/api-contracts/contracts/test-google-meet-subscription-renewal";
+import { command } from "ccstate";
+
+import { request$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route-entry";
+import { renewGoogleMeetSubscriptionScope$ } from "../services/google-meet-automation-event.service";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-endpoint-helpers";
+
+const body$ = bodyResultOf(testGoogleMeetSubscriptionRenewalContract.renew);
+
+const renewGoogleMeetSubscriptionScopeRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+
+    const bodyResult = await get(body$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const result = await set(
+      renewGoogleMeetSubscriptionScope$,
+      {
+        orgId: bodyResult.data.org_id,
+        userId: bodyResult.data.user_id,
+      },
+      signal,
+    );
+    return {
+      status: 200 as const,
+      body: {
+        success: true as const,
+        renewed: result.renewed,
+        repaired: result.repaired,
+        failed: result.failed,
+      },
+    };
+  },
+);
+
+export const testGoogleMeetSubscriptionRenewalRoutes: readonly RouteEntry[] = [
+  {
+    route: testGoogleMeetSubscriptionRenewalContract.renew,
+    handler: renewGoogleMeetSubscriptionScopeRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/automation-event-watch-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/automation-event-watch-lifecycle.service.ts
@@ -21,6 +21,10 @@ import {
   ensureGoogleFormsWatchForUser,
   reconcileGoogleFormsWatchesForUser,
 } from "./google-forms-automation-event.service";
+import {
+  ensureGoogleMeetTranscriptGeneratedSubscriptionForUser,
+  reconcileGoogleMeetSubscriptionsForUser,
+} from "./google-meet-automation-event.service";
 
 interface AutomationEventWatchAutomation {
   readonly orgId: string;
@@ -49,6 +53,11 @@ type AutomationEventWatchTarget =
       readonly userId: string;
       readonly formId: string;
       readonly connectorId: string;
+    }
+  | {
+      readonly provider: "google_meet";
+      readonly orgId: string;
+      readonly userId: string;
     };
 
 function googleCalendarId(
@@ -104,6 +113,13 @@ function automationEventWatchTarget(
       connectorId: config.data.connectorId,
     };
   }
+  if (automation.eventType === "google-meet-transcript-generated") {
+    return {
+      provider: "google_meet",
+      orgId: automation.orgId,
+      userId: automation.ownerUserId,
+    };
+  }
   const calendarId = googleCalendarId(automation);
   if (calendarId === null) {
     return null;
@@ -122,6 +138,9 @@ function targetKey(target: AutomationEventWatchTarget): string {
   }
   if (target.provider === "google_forms") {
     return `google_forms:${target.userId}:${target.formId}`;
+  }
+  if (target.provider === "google_meet") {
+    return `google_meet:${target.orgId}:${target.userId}`;
   }
   return `google_calendar:${target.orgId}:${target.userId}:${target.calendarId}`;
 }
@@ -168,6 +187,18 @@ export async function reconcileAutomationEventWatches(
       succeeded &&= reconciled;
       continue;
     }
+    if (target.provider === "google_meet") {
+      const reconciled = await reconcileGoogleMeetSubscriptionsForUser(
+        {
+          db: args.db,
+          orgId: target.orgId,
+          userId: target.userId,
+        },
+        signal,
+      );
+      succeeded &&= reconciled;
+      continue;
+    }
     const reconciled = await reconcileGoogleCalendarWatchesForUser(
       {
         db: args.db,
@@ -206,6 +237,11 @@ export async function reconcileAutomationEventWatchInventoryForOwner(
     signal,
   );
   signal.throwIfAborted();
+  const meet = await reconcileGoogleMeetSubscriptionsForUser(
+    { db, orgId: args.orgId, userId: args.userId },
+    signal,
+  );
+  signal.throwIfAborted();
   const forms = await db
     .selectDistinct({ formId: googleFormsWatchStates.formId })
     .from(googleFormsWatchStates)
@@ -216,7 +252,7 @@ export async function reconcileAutomationEventWatchInventoryForOwner(
       ),
     );
   signal.throwIfAborted();
-  let succeeded = gmail && calendar;
+  let succeeded = gmail && calendar && meet;
   for (const form of forms) {
     const reconciled = await reconcileGoogleFormsWatchesForUser(
       {
@@ -253,11 +289,14 @@ async function ensureNonFormsTarget(
   allowStagedOfficialTarget: boolean,
   signal: AbortSignal,
 ): Promise<AutomationEventWatchReconfigurationResult> {
-  const result =
-    target.provider === "gmail"
-      ? target.connectorId === null
+  let result:
+    | { readonly kind: "ok" }
+    | { readonly kind: "bad_request"; readonly message: string };
+  if (target.provider === "gmail") {
+    result =
+      target.connectorId === null
         ? {
-            kind: "bad_request" as const,
+            kind: "bad_request",
             message: "Connect Gmail before using Gmail event automations",
           }
         : await ensureGmailWatchForUser(
@@ -270,18 +309,30 @@ async function ensureNonFormsTarget(
               allowStagedOfficialTarget,
             },
             signal,
-          )
-      : await ensureGoogleCalendarWatchForUser(
-          {
-            db,
-            orgId: target.orgId,
-            userId: target.userId,
-            calendarId: target.calendarId,
-            forceRefresh: false,
-            allowStagedOfficialTarget,
-          },
-          signal,
-        );
+          );
+  } else if (target.provider === "google_meet") {
+    result = await ensureGoogleMeetTranscriptGeneratedSubscriptionForUser(
+      {
+        db,
+        orgId: target.orgId,
+        userId: target.userId,
+        allowStagedOfficialTarget,
+      },
+      signal,
+    );
+  } else {
+    result = await ensureGoogleCalendarWatchForUser(
+      {
+        db,
+        orgId: target.orgId,
+        userId: target.userId,
+        calendarId: target.calendarId,
+        forceRefresh: false,
+        allowStagedOfficialTarget,
+      },
+      signal,
+    );
+  }
   signal.throwIfAborted();
   return result.kind === "ok"
     ? result

--- a/turbo/apps/api/src/signals/services/connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-data.service.ts
@@ -85,6 +85,11 @@ import {
 } from "./gmail-automation-event.service";
 import { cleanupGoogleCalendarWatchesForConnector } from "./google-calendar-automation-event.service";
 import { cleanupGoogleFormsWatchesForConnector } from "./google-forms-automation-event.service";
+import {
+  deletePreparedGoogleMeetSubscriptionWithLifecycleLock,
+  prepareGoogleMeetSubscriptionDeleteForConnector,
+  type PendingGoogleMeetSubscriptionDelete,
+} from "./google-meet-automation-event.service";
 import { reconcileConnectorAccountState } from "./connector-account-state.service";
 import { reprojectGmailAutomationsForOwner } from "./gmail-automation-account.service";
 import { prepareConnectorAccountDeletion } from "./connector-account-lifecycle.service";
@@ -963,6 +968,7 @@ async function deleteConnectorAccountLocalState(
       kind: account.kind,
       pendingTokenRevoke: null,
       pendingGmailWatchStop: null,
+      pendingGoogleMeetSubscriptionDelete: null,
     };
   }
   const existing = account.connector;
@@ -976,6 +982,7 @@ async function deleteConnectorAccountLocalState(
       kind: deletion.kind,
       pendingTokenRevoke: null,
       pendingGmailWatchStop: null,
+      pendingGoogleMeetSubscriptionDelete: null,
     };
   }
 
@@ -1020,6 +1027,18 @@ async function deleteConnectorAccountLocalState(
           signal,
         )
       : null;
+  const pendingGoogleMeetSubscriptionDelete: PendingGoogleMeetSubscriptionDelete | null =
+    args.connectorSlug === "google-meet"
+      ? await prepareGoogleMeetSubscriptionDeleteForConnector(
+          {
+            db: tx,
+            orgId: args.orgId,
+            userId: args.userId,
+            connectorId: existing.id,
+          },
+          signal,
+        )
+      : null;
   if (args.connectorSlug !== "gmail") {
     await cleanupConnectorWatchesForDisconnect(
       tx,
@@ -1039,6 +1058,7 @@ async function deleteConnectorAccountLocalState(
     kind: "deleted" as const,
     pendingTokenRevoke,
     pendingGmailWatchStop,
+    pendingGoogleMeetSubscriptionDelete,
     deletion,
   };
 }
@@ -1102,6 +1122,26 @@ export const deleteConnectorLocalState$ = command(
       }
       if (!stopped.ok) {
         postCommitAbort ??= stopped.error;
+      }
+    }
+    if (deleteResult.pendingGoogleMeetSubscriptionDelete !== null) {
+      const deleted = await settleIncludingAbort(
+        bestEffort(
+          deletePreparedGoogleMeetSubscriptionWithLifecycleLock(
+            {
+              db: writeDb,
+              pending: deleteResult.pendingGoogleMeetSubscriptionDelete,
+            },
+            signal,
+          ),
+          signal,
+        ),
+      );
+      if (signal.aborted) {
+        postCommitAbort ??= signal.reason;
+      }
+      if (!deleted.ok) {
+        postCommitAbort ??= deleted.error;
       }
     }
     await finalizeConnectorStateChangeAfterCommit(

--- a/turbo/apps/api/src/signals/services/google-meet-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-meet-automation-event.service.ts
@@ -1843,6 +1843,60 @@ export const dispatchGoogleWorkspaceEventsPubSubPush$ = command(
   },
 );
 
+interface GoogleMeetSubscriptionOwnerScope {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+interface GoogleMeetSubscriptionRenewalSummary {
+  readonly renewed: number;
+  readonly repaired: number;
+  readonly failed: number;
+}
+
+async function renewGoogleMeetSubscriptionScopes(
+  args: {
+    readonly db: Db;
+    readonly scopes: Iterable<GoogleMeetSubscriptionOwnerScope>;
+  },
+  signal: AbortSignal,
+): Promise<GoogleMeetSubscriptionRenewalSummary> {
+  let renewed = 0;
+  let repaired = 0;
+  let failed = 0;
+  for (const scope of args.scopes) {
+    const result = await reconcileGoogleMeetSubscriptionLifecycle(
+      {
+        db: args.db,
+        orgId: scope.orgId,
+        userId: scope.userId,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    if (result.kind !== "ok") {
+      failed++;
+      continue;
+    }
+    renewed += result.action === "renewed" ? 1 : 0;
+    repaired += result.action === "created" ? 1 : 0;
+  }
+  return { renewed, repaired, failed };
+}
+
+export const renewGoogleMeetSubscriptionScope$ = command(
+  async (
+    { set },
+    scope: GoogleMeetSubscriptionOwnerScope,
+    signal: AbortSignal,
+  ): Promise<GoogleMeetSubscriptionRenewalSummary> => {
+    return await renewGoogleMeetSubscriptionScopes(
+      { db: set(writeDb$), scopes: [scope] },
+      signal,
+    );
+  },
+);
+
 export const renewGoogleWorkspaceEventSubscriptions$ = command(
   async ({ set }, signal: AbortSignal) => {
     const topicResult = googleWorkspaceEventsTopicName();
@@ -1886,35 +1940,14 @@ export const renewGoogleWorkspaceEventSubscriptions$ = command(
       );
     signal.throwIfAborted();
 
-    const scopes = new Map<
-      string,
-      { readonly orgId: string; readonly userId: string }
-    >();
+    const scopes = new Map<string, GoogleMeetSubscriptionOwnerScope>();
     for (const scope of [...states, ...automationRows]) {
       scopes.set(`${scope.orgId}\n${scope.userId}`, scope);
     }
 
-    let renewed = 0;
-    let repaired = 0;
-    let failed = 0;
-    for (const scope of scopes.values()) {
-      const result = await reconcileGoogleMeetSubscriptionLifecycle(
-        {
-          db,
-          orgId: scope.orgId,
-          userId: scope.userId,
-        },
-        signal,
-      );
-      signal.throwIfAborted();
-      if (result.kind !== "ok") {
-        failed++;
-        continue;
-      }
-      renewed += result.action === "renewed" ? 1 : 0;
-      repaired += result.action === "created" ? 1 : 0;
-    }
-
-    return { renewed, repaired, failed };
+    return await renewGoogleMeetSubscriptionScopes(
+      { db, scopes: scopes.values() },
+      signal,
+    );
   },
 );

--- a/turbo/apps/api/src/signals/services/google-meet-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-meet-automation-event.service.ts
@@ -306,7 +306,10 @@ async function resolveGoogleMeetAccess(
         "Reconnect Google Meet before using Google Meet event automations",
     };
   }
-  if (!tokenNeedsRefresh(connection.tokenExpiresAt, currentTime)) {
+  if (
+    !tokenNeedsRefresh(connection.tokenExpiresAt, currentTime) ||
+    args.refreshExpiredToken === false
+  ) {
     return {
       kind: "ok",
       access: {
@@ -315,13 +318,6 @@ async function resolveGoogleMeetAccess(
         emailAddress: connection.externalEmail,
         accessToken,
       },
-    };
-  }
-  if (args.refreshExpiredToken === false) {
-    return {
-      kind: "bad_request",
-      message:
-        "Reconnect Google Meet before using Google Meet event automations",
     };
   }
   const refreshed = await refreshConnectorCredentialAccess(

--- a/turbo/apps/api/src/signals/services/google-meet-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-meet-automation-event.service.ts
@@ -1,7 +1,7 @@
 import { Buffer } from "node:buffer";
 import { OAuth2Client } from "google-auth-library";
 import { command } from "ccstate";
-import { and, eq, lte, or } from "drizzle-orm";
+import { and, eq, isNotNull, or } from "drizzle-orm";
 import { z } from "zod";
 import { googleMeetTranscriptGeneratedEventConfigSchema } from "@okouai/api-contracts/contracts/workflows";
 import {
@@ -14,10 +14,14 @@ import {
   workflows,
 } from "@okouai/db/schema/workflow";
 import { optionalEnv } from "../../lib/env";
-import { logger } from "../../lib/log";
 import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../../lib/time";
-import { safeJsonParse, tapError } from "../utils";
+import {
+  bestEffort,
+  safeJsonParse,
+  settleIncludingAbort,
+  tapError,
+} from "../utils";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
 import { workflowAutomationColumns } from "./autonomy-budget-schema.service";
 import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
@@ -35,8 +39,7 @@ import { runWorkflowAutomationNow$ } from "./workflow-automation-run.service";
 import type { AutomationRow } from "./workflow-automation-launch.service";
 import type { WorkflowAutomationContext } from "./workflow-automation-context.service";
 import { ensureWorkflowUserAutomationThread } from "./workflow-user-automation-thread.service";
-
-const log = logger("api:google-meet-automation-event");
+import { lockConnectorState } from "./auth-state-lock.service";
 
 const GOOGLE_MEET_ACCESS_TOKEN_ENVIRONMENT_NAME = "GOOGLE_MEET_TOKEN";
 const GOOGLE_WORKSPACE_EVENTS_API_BASE =
@@ -133,6 +136,13 @@ interface GoogleMeetAccess {
   readonly accessToken: string;
 }
 
+export interface PendingGoogleMeetSubscriptionDelete {
+  readonly accessToken: string;
+  readonly orgId: string;
+  readonly subscriptionName: string;
+  readonly userId: string;
+}
+
 type GoogleMeetAccessResult =
   | { readonly kind: "ok"; readonly access: GoogleMeetAccess }
   | { readonly kind: "bad_request"; readonly message: string };
@@ -227,6 +237,7 @@ async function resolveGoogleMeetAccess(
     readonly orgId: string;
     readonly userId: string;
     readonly connectorId?: string;
+    readonly refreshExpiredToken?: boolean;
   },
   signal: AbortSignal,
 ): Promise<GoogleMeetAccessResult> {
@@ -293,6 +304,13 @@ async function resolveGoogleMeetAccess(
         emailAddress: connection.externalEmail,
         accessToken,
       },
+    };
+  }
+  if (args.refreshExpiredToken === false) {
+    return {
+      kind: "bad_request",
+      message:
+        "Reconnect Google Meet before using Google Meet event automations",
     };
   }
   const refreshed = await refreshConnectorCredentialAccess(
@@ -615,6 +633,63 @@ async function reactivateWorkspaceSubscription(
       };
 }
 
+async function deletePreparedGoogleMeetSubscription(
+  pending: PendingGoogleMeetSubscriptionDelete,
+  signal: AbortSignal,
+): Promise<void> {
+  const url = new URL(workspaceEventsApiUrl(`/${pending.subscriptionName}`));
+  url.searchParams.set("allowMissing", "true");
+  await workspaceEventsFetchJson(
+    workspaceOperationSchema,
+    pending.accessToken,
+    url.toString(),
+    { method: "DELETE" },
+    signal,
+  );
+  signal.throwIfAborted();
+}
+
+export async function deletePreparedGoogleMeetSubscriptionWithLifecycleLock(
+  args: {
+    readonly db: Db;
+    readonly pending: PendingGoogleMeetSubscriptionDelete;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  let cleanupError: unknown = null;
+  await args.db.transaction(async (tx) => {
+    await lockConnectorState(tx, {
+      orgId: args.pending.orgId,
+      userId: args.pending.userId,
+      connectorSlug: "google-meet",
+    });
+    signal.throwIfAborted();
+    const [adopted] = await tx
+      .select({ id: googleWorkspaceEventSubscriptionStates.id })
+      .from(googleWorkspaceEventSubscriptionStates)
+      .where(
+        eq(
+          googleWorkspaceEventSubscriptionStates.subscriptionName,
+          args.pending.subscriptionName,
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+    if (adopted) {
+      return;
+    }
+    const deleted = await settleIncludingAbort(
+      bestEffort(deletePreparedGoogleMeetSubscription(args.pending, signal)),
+    );
+    if (!deleted.ok) {
+      cleanupError = deleted.error;
+    }
+  });
+  if (cleanupError !== null) {
+    throw cleanupError;
+  }
+}
+
 async function listWorkspaceSubscriptions(
   args: {
     readonly accessToken: string;
@@ -732,7 +807,20 @@ async function createOrAdoptWorkspaceSubscription(
   return await adoptExistingWorkspaceSubscription(args, signal);
 }
 
-export async function ensureGoogleMeetTranscriptGeneratedSubscriptionForUser(
+type GoogleMeetSubscriptionReconcileAction =
+  | "unchanged"
+  | "created"
+  | "renewed"
+  | "removed";
+
+type GoogleMeetSubscriptionReconcileResult =
+  | {
+      readonly kind: "ok";
+      readonly action: GoogleMeetSubscriptionReconcileAction;
+    }
+  | { readonly kind: "bad_request"; readonly message: string };
+
+async function ensureGoogleMeetTranscriptGeneratedSubscriptionUnderLock(
   args: {
     readonly db: Db;
     readonly orgId: string;
@@ -740,7 +828,10 @@ export async function ensureGoogleMeetTranscriptGeneratedSubscriptionForUser(
   },
   signal: AbortSignal,
 ): Promise<
-  | { readonly kind: "ok" }
+  | {
+      readonly kind: "ok";
+      readonly action: "unchanged" | "created" | "renewed";
+    }
   | { readonly kind: "bad_request"; readonly message: string }
 > {
   const topicResult = googleWorkspaceEventsTopicName();
@@ -776,12 +867,13 @@ export async function ensureGoogleMeetTranscriptGeneratedSubscriptionForUser(
   );
   const currentTime = nowDate();
   if (existing && !subscriptionNeedsRenewal(existing, currentTime)) {
-    return { kind: "ok" };
+    return { kind: "ok", action: "unchanged" };
   }
 
   let subscription: WorkspaceEventsFetchResult<
     z.infer<typeof workspaceSubscriptionSchema>
   >;
+  let created = existing === null;
   if (existing) {
     if (existing.needsRepair) {
       await reactivateWorkspaceSubscription(
@@ -802,6 +894,7 @@ export async function ensureGoogleMeetTranscriptGeneratedSubscriptionForUser(
     );
     signal.throwIfAborted();
     if (subscription.kind !== "ok" && subscription.status === 404) {
+      created = true;
       subscription = await createOrAdoptWorkspaceSubscription(
         {
           accessToken: accessResult.access.accessToken,
@@ -846,7 +939,250 @@ export async function ensureGoogleMeetTranscriptGeneratedSubscriptionForUser(
     },
     signal,
   );
-  return { kind: "ok" };
+  return {
+    kind: "ok",
+    action: created ? "created" : "renewed",
+  };
+}
+
+export async function hasEnabledGoogleMeetConsumer(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly allowStagedOfficialTarget?: boolean;
+  },
+  signal: AbortSignal,
+): Promise<boolean> {
+  const consumerState = args.allowStagedOfficialTarget
+    ? or(
+        eq(workflowAutomations.enabled, true),
+        and(
+          eq(workflowAutomations.enabled, false),
+          eq(workflowAutomations.officialReconciliationStatus, "reconciling"),
+          isNotNull(workflowAutomations.officialBlueprintKey),
+        ),
+      )
+    : eq(workflowAutomations.enabled, true);
+  const [consumer] = await args.db
+    .select({ id: workflowAutomations.id })
+    .from(workflowAutomations)
+    .where(
+      and(
+        eq(workflowAutomations.orgId, args.orgId),
+        eq(workflowAutomations.ownerUserId, args.userId),
+        eq(workflowAutomations.kind, "event"),
+        eq(
+          workflowAutomations.eventType,
+          GOOGLE_MEET_TRANSCRIPT_GENERATED_EVENT_TYPE,
+        ),
+        consumerState,
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+  return consumer !== undefined;
+}
+
+async function loadGoogleMeetSubscriptionStatesForOwner(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+  signal: AbortSignal,
+): Promise<GoogleWorkspaceSubscriptionStateRow[]> {
+  const states = await args.db
+    .select()
+    .from(googleWorkspaceEventSubscriptionStates)
+    .where(
+      and(
+        eq(googleWorkspaceEventSubscriptionStates.orgId, args.orgId),
+        eq(googleWorkspaceEventSubscriptionStates.userId, args.userId),
+        eq(googleWorkspaceEventSubscriptionStates.provider, "google-meet"),
+      ),
+    );
+  signal.throwIfAborted();
+  return states;
+}
+
+async function pendingGoogleMeetSubscriptionDeleteForState(
+  args: {
+    readonly db: Db;
+    readonly state: GoogleWorkspaceSubscriptionStateRow;
+  },
+  signal: AbortSignal,
+): Promise<PendingGoogleMeetSubscriptionDelete | null> {
+  const access = await resolveGoogleMeetAccess(
+    {
+      db: args.db,
+      orgId: args.state.orgId,
+      userId: args.state.userId,
+      connectorId: args.state.connectorId,
+      refreshExpiredToken: false,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+  return access.kind === "ok"
+    ? {
+        accessToken: access.access.accessToken,
+        orgId: args.state.orgId,
+        subscriptionName: args.state.subscriptionName,
+        userId: args.state.userId,
+      }
+    : null;
+}
+
+export async function prepareGoogleMeetSubscriptionDeleteForConnector(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly connectorId: string;
+  },
+  signal: AbortSignal,
+): Promise<PendingGoogleMeetSubscriptionDelete | null> {
+  const states = await args.db
+    .select()
+    .from(googleWorkspaceEventSubscriptionStates)
+    .where(
+      and(
+        eq(googleWorkspaceEventSubscriptionStates.orgId, args.orgId),
+        eq(googleWorkspaceEventSubscriptionStates.userId, args.userId),
+        eq(
+          googleWorkspaceEventSubscriptionStates.connectorId,
+          args.connectorId,
+        ),
+        eq(googleWorkspaceEventSubscriptionStates.provider, "google-meet"),
+      ),
+    );
+  signal.throwIfAborted();
+  const topic = googleWorkspaceEventsTopicName();
+  const state =
+    topic.kind === "ok"
+      ? states.find((candidate) => {
+          return candidate.pubsubTopic === topic.topicName;
+        })
+      : states[0];
+  return state
+    ? await pendingGoogleMeetSubscriptionDeleteForState(
+        { db: args.db, state },
+        signal,
+      )
+    : null;
+}
+
+async function reconcileGoogleMeetSubscriptionLifecycle(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly allowStagedOfficialTarget?: boolean;
+  },
+  signal: AbortSignal,
+): Promise<GoogleMeetSubscriptionReconcileResult> {
+  const transition = await args.db.transaction(async (tx) => {
+    await lockConnectorState(tx, {
+      orgId: args.orgId,
+      userId: args.userId,
+      connectorSlug: "google-meet",
+    });
+    signal.throwIfAborted();
+    const hasConsumer = await hasEnabledGoogleMeetConsumer(
+      {
+        db: tx,
+        orgId: args.orgId,
+        userId: args.userId,
+        allowStagedOfficialTarget: args.allowStagedOfficialTarget === true,
+      },
+      signal,
+    );
+    if (hasConsumer) {
+      return {
+        result: await ensureGoogleMeetTranscriptGeneratedSubscriptionUnderLock(
+          {
+            db: tx,
+            orgId: args.orgId,
+            userId: args.userId,
+          },
+          signal,
+        ),
+        cleanupError: null,
+      };
+    }
+
+    const states = await loadGoogleMeetSubscriptionStatesForOwner(
+      { db: tx, orgId: args.orgId, userId: args.userId },
+      signal,
+    );
+    const topic = googleWorkspaceEventsTopicName();
+    const state =
+      topic.kind === "ok"
+        ? states.find((candidate) => {
+            return candidate.pubsubTopic === topic.topicName;
+          })
+        : states[0];
+    const pendingDelete = state
+      ? await pendingGoogleMeetSubscriptionDeleteForState(
+          { db: tx, state },
+          signal,
+        )
+      : null;
+    let cleanupError: unknown = null;
+    if (pendingDelete) {
+      const deleted = await settleIncludingAbort(
+        bestEffort(deletePreparedGoogleMeetSubscription(pendingDelete, signal)),
+      );
+      if (!deleted.ok) {
+        cleanupError = deleted.error;
+      }
+    }
+    await tx
+      .delete(googleWorkspaceEventSubscriptionStates)
+      .where(
+        and(
+          eq(googleWorkspaceEventSubscriptionStates.orgId, args.orgId),
+          eq(googleWorkspaceEventSubscriptionStates.userId, args.userId),
+          eq(googleWorkspaceEventSubscriptionStates.provider, "google-meet"),
+        ),
+      );
+    return {
+      result: {
+        kind: "ok" as const,
+        action: "removed" as const,
+      },
+      cleanupError,
+    };
+  });
+  if (transition.cleanupError !== null) {
+    throw transition.cleanupError;
+  }
+  return transition.result;
+}
+
+export async function ensureGoogleMeetTranscriptGeneratedSubscriptionForUser(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly allowStagedOfficialTarget?: boolean;
+  },
+  signal: AbortSignal,
+): Promise<GoogleMeetSubscriptionReconcileResult> {
+  return await reconcileGoogleMeetSubscriptionLifecycle(args, signal);
+}
+
+export async function reconcileGoogleMeetSubscriptionsForUser(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+  signal: AbortSignal,
+): Promise<boolean> {
+  const result = await reconcileGoogleMeetSubscriptionLifecycle(args, signal);
+  return result.kind === "ok";
 }
 
 async function defaultPubSubOidcVerifier(
@@ -1512,64 +1848,6 @@ export const dispatchGoogleWorkspaceEventsPubSubPush$ = command(
   },
 );
 
-async function repairEnabledGoogleMeetAutomations(
-  args: {
-    readonly db: Db;
-  },
-  signal: AbortSignal,
-): Promise<{ readonly repaired: number; readonly failed: number }> {
-  const automationRows = await args.db
-    .select({
-      orgId: workflowAutomations.orgId,
-      userId: workflowAutomations.ownerUserId,
-    })
-    .from(workflowAutomations)
-    .where(
-      and(
-        eq(workflowAutomations.enabled, true),
-        eq(workflowAutomations.kind, "event"),
-        eq(
-          workflowAutomations.eventType,
-          GOOGLE_MEET_TRANSCRIPT_GENERATED_EVENT_TYPE,
-        ),
-      ),
-    );
-  signal.throwIfAborted();
-
-  const seen = new Set<string>();
-  let repaired = 0;
-  let failed = 0;
-  for (const automation of automationRows) {
-    const key = `${automation.orgId}\n${automation.userId}`;
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    const ensured =
-      await ensureGoogleMeetTranscriptGeneratedSubscriptionForUser(
-        {
-          db: args.db,
-          orgId: automation.orgId,
-          userId: automation.userId,
-        },
-        signal,
-      );
-    signal.throwIfAborted();
-    if (ensured.kind === "ok") {
-      repaired++;
-    } else {
-      failed++;
-      log.warn("Failed to repair Google Meet Workspace Events subscription", {
-        orgId: automation.orgId,
-        userId: automation.userId,
-        message: ensured.message,
-      });
-    }
-  }
-
-  return { repaired, failed };
-}
-
 export const renewGoogleWorkspaceEventSubscriptions$ = command(
   async ({ set }, signal: AbortSignal) => {
     const topicResult = googleWorkspaceEventsTopicName();
@@ -1578,12 +1856,11 @@ export const renewGoogleWorkspaceEventSubscriptions$ = command(
     }
 
     const db = set(writeDb$);
-    const currentTime = nowDate();
-    const renewBefore = new Date(
-      currentTime.getTime() + GOOGLE_WORKSPACE_RENEWAL_WINDOW_MS,
-    );
     const states = await db
-      .select()
+      .select({
+        orgId: googleWorkspaceEventSubscriptionStates.orgId,
+        userId: googleWorkspaceEventSubscriptionStates.userId,
+      })
       .from(googleWorkspaceEventSubscriptionStates)
       .where(
         and(
@@ -1592,93 +1869,57 @@ export const renewGoogleWorkspaceEventSubscriptions$ = command(
             googleWorkspaceEventSubscriptionStates.pubsubTopic,
             topicResult.topicName,
           ),
-          or(
-            eq(googleWorkspaceEventSubscriptionStates.needsRepair, true),
-            lte(googleWorkspaceEventSubscriptionStates.expireTime, renewBefore),
+        ),
+      );
+    signal.throwIfAborted();
+
+    const automationRows = await db
+      .select({
+        orgId: workflowAutomations.orgId,
+        userId: workflowAutomations.ownerUserId,
+      })
+      .from(workflowAutomations)
+      .where(
+        and(
+          eq(workflowAutomations.enabled, true),
+          eq(workflowAutomations.kind, "event"),
+          eq(
+            workflowAutomations.eventType,
+            GOOGLE_MEET_TRANSCRIPT_GENERATED_EVENT_TYPE,
           ),
         ),
       );
     signal.throwIfAborted();
 
-    let renewed = 0;
-    let failed = 0;
-    for (const state of states) {
-      const access = await resolveGoogleMeetAccess(
-        {
-          db,
-          orgId: state.orgId,
-          userId: state.userId,
-          connectorId: state.connectorId,
-        },
-        signal,
-      );
-      signal.throwIfAborted();
-      if (access.kind !== "ok") {
-        failed++;
-        continue;
-      }
-
-      let subscription: WorkspaceEventsFetchResult<
-        z.infer<typeof workspaceSubscriptionSchema>
-      >;
-      if (state.needsRepair) {
-        await reactivateWorkspaceSubscription(
-          {
-            accessToken: access.access.accessToken,
-            subscriptionName: state.subscriptionName,
-          },
-          signal,
-        );
-        signal.throwIfAborted();
-      }
-      subscription = await renewWorkspaceSubscription(
-        {
-          accessToken: access.access.accessToken,
-          subscriptionName: state.subscriptionName,
-        },
-        signal,
-      );
-      signal.throwIfAborted();
-
-      if (subscription.kind !== "ok" && subscription.status === 404) {
-        subscription = await createOrAdoptWorkspaceSubscription(
-          {
-            accessToken: access.access.accessToken,
-            targetResource: state.targetResource,
-            eventTypes: state.eventTypes,
-            topicName: state.pubsubTopic,
-          },
-          signal,
-        );
-      }
-
-      if (subscription.kind !== "ok") {
-        failed++;
-        continue;
-      }
-      await persistWorkspaceSubscriptionState(
-        {
-          db,
-          orgId: state.orgId,
-          userId: state.userId,
-          connectorId: state.connectorId,
-          targetResource: state.targetResource,
-          eventTypes: state.eventTypes,
-          topicName: state.pubsubTopic,
-          subscription: subscription.value,
-          currentTime,
-        },
-        signal,
-      );
-      signal.throwIfAborted();
-      renewed++;
+    const scopes = new Map<
+      string,
+      { readonly orgId: string; readonly userId: string }
+    >();
+    for (const scope of [...states, ...automationRows]) {
+      scopes.set(`${scope.orgId}\n${scope.userId}`, scope);
     }
 
-    const repair = await repairEnabledGoogleMeetAutomations({ db }, signal);
-    return {
-      renewed,
-      repaired: repair.repaired,
-      failed: failed + repair.failed,
-    };
+    let renewed = 0;
+    let repaired = 0;
+    let failed = 0;
+    for (const scope of scopes.values()) {
+      const result = await reconcileGoogleMeetSubscriptionLifecycle(
+        {
+          db,
+          orgId: scope.orgId,
+          userId: scope.userId,
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+      if (result.kind !== "ok") {
+        failed++;
+        continue;
+      }
+      renewed += result.action === "renewed" ? 1 : 0;
+      repaired += result.action === "created" ? 1 : 0;
+    }
+
+    return { renewed, repaired, failed };
   },
 );

--- a/turbo/apps/api/src/signals/services/google-meet-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-meet-automation-event.service.ts
@@ -231,6 +231,17 @@ function googleWorkspaceEventsTopicName():
       };
 }
 
+function googleMeetSubscriptionStateForCleanup(
+  states: readonly GoogleWorkspaceSubscriptionStateRow[],
+): GoogleWorkspaceSubscriptionStateRow | undefined {
+  const topic = googleWorkspaceEventsTopicName();
+  return topic.kind === "ok"
+    ? (states.find((candidate) => {
+        return candidate.pubsubTopic === topic.topicName;
+      }) ?? states[0])
+    : states[0];
+}
+
 async function resolveGoogleMeetAccess(
   args: {
     readonly db: Db;
@@ -1058,13 +1069,7 @@ export async function prepareGoogleMeetSubscriptionDeleteForConnector(
       ),
     );
   signal.throwIfAborted();
-  const topic = googleWorkspaceEventsTopicName();
-  const state =
-    topic.kind === "ok"
-      ? states.find((candidate) => {
-          return candidate.pubsubTopic === topic.topicName;
-        })
-      : states[0];
+  const state = googleMeetSubscriptionStateForCleanup(states);
   return state
     ? await pendingGoogleMeetSubscriptionDeleteForState(
         { db: args.db, state },
@@ -1116,13 +1121,7 @@ async function reconcileGoogleMeetSubscriptionLifecycle(
       { db: tx, orgId: args.orgId, userId: args.userId },
       signal,
     );
-    const topic = googleWorkspaceEventsTopicName();
-    const state =
-      topic.kind === "ok"
-        ? states.find((candidate) => {
-            return candidate.pubsubTopic === topic.topicName;
-          })
-        : states[0];
+    const state = googleMeetSubscriptionStateForCleanup(states);
     const pendingDelete = state
       ? await pendingGoogleMeetSubscriptionDeleteForState(
           { db: tx, state },

--- a/turbo/apps/api/src/signals/services/workflow-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation.service.ts
@@ -102,7 +102,10 @@ import {
   hasEnabledGoogleFormsConsumer,
   prepareGoogleFormsResponseEventConfigForPersist,
 } from "./google-forms-automation-event.service";
-import { ensureGoogleMeetTranscriptGeneratedSubscriptionForUser } from "./google-meet-automation-event.service";
+import {
+  ensureGoogleMeetTranscriptGeneratedSubscriptionForUser,
+  hasEnabledGoogleMeetConsumer,
+} from "./google-meet-automation-event.service";
 import { prepareGithubWebhookEventConfigForPersist } from "./github-webhook-automation-event.service";
 import { prepareGithubWorkflowRunEventConfigForPersist } from "./github-workflow-run-event.service";
 import {
@@ -2372,20 +2375,6 @@ async function createGoogleMeetEventAutomationForWorkflow(
   const preparedConfig = googleMeetTranscriptGeneratedEventConfigSchema.parse(
     args.input.eventConfig,
   );
-  const subscriptionResult =
-    await ensureGoogleMeetTranscriptGeneratedSubscriptionForUser(
-      {
-        db: args.context.db,
-        orgId: args.input.orgId,
-        userId: args.input.member.userId,
-      },
-      signal,
-    );
-  signal.throwIfAborted();
-  if (subscriptionResult.kind !== "ok") {
-    return { kind: "bad-request", message: subscriptionResult.message };
-  }
-
   const summary = await insertEventAutomation(args.context.db, {
     input: { ...args.input, eventConfig: preparedConfig },
     workflowId: args.context.workflowId,
@@ -2394,8 +2383,48 @@ async function createGoogleMeetEventAutomationForWorkflow(
     automationId: args.context.automationId,
     currentTime: nowDate(),
   });
+  if (!args.input.enabled) {
+    return { kind: "ok", summary };
+  }
+
+  const rollback = async (): Promise<void> => {
+    const cleanupSignal = new AbortController().signal;
+    await args.context.db
+      .delete(workflowAutomations)
+      .where(eq(workflowAutomations.id, summary.id));
+    await reconcileAutomationEventWatches(
+      {
+        db: args.context.db,
+        automations: [
+          {
+            orgId: args.input.orgId,
+            ownerUserId: args.input.member.userId,
+            eventType: args.input.eventType,
+            eventConfig: preparedConfig,
+            eventConnectorId: null,
+          },
+        ],
+      },
+      cleanupSignal,
+    );
+  };
+  const subscriptionResult = await onRejection(
+    ensureGoogleMeetTranscriptGeneratedSubscriptionForUser(
+      {
+        db: args.context.db,
+        orgId: args.input.orgId,
+        userId: args.input.member.userId,
+      },
+      signal,
+    ),
+    rollback,
+  );
   signal.throwIfAborted();
-  return { kind: "ok", summary };
+  if (subscriptionResult.kind === "ok") {
+    return { kind: "ok", summary };
+  }
+  await rollback();
+  return { kind: "bad-request", message: subscriptionResult.message };
 }
 
 async function createNotionEventAutomationForWorkflow(
@@ -3611,27 +3640,13 @@ async function prepareOfficialGoogleFormsReconfiguration(
   );
 }
 
-async function prepareOfficialGoogleMeetEvent(
-  db: Db,
+function prepareOfficialGoogleMeetEvent(
   input: CreateGoogleMeetEventAutomationInput,
-  signal: AbortSignal,
-): Promise<OfficialAutomationEventPreparationResult> {
+): OfficialAutomationEventPreparationResult {
   const eventConfig = googleMeetTranscriptGeneratedEventConfigSchema.parse(
     input.eventConfig,
   );
-  const subscription =
-    await ensureGoogleMeetTranscriptGeneratedSubscriptionForUser(
-      {
-        db,
-        orgId: input.orgId,
-        userId: input.member.userId,
-      },
-      signal,
-    );
-  signal.throwIfAborted();
-  return subscription.kind === "ok"
-    ? preparedOfficialEvent(eventConfig)
-    : { kind: "bad-request", message: subscription.message };
+  return preparedOfficialEvent(eventConfig);
 }
 
 async function prepareOfficialStripeEvent(
@@ -3720,7 +3735,7 @@ export const prepareOfficialAutomationReconfiguration$ = command(
       );
     }
     if (automationCreateInputIsGoogleMeet(input)) {
-      return await prepareOfficialGoogleMeetEvent(db, input, signal);
+      return prepareOfficialGoogleMeetEvent(input);
     }
     if (automationCreateInputIsNotion(input)) {
       const enabled = await get(
@@ -4416,22 +4431,6 @@ const ensureEventAutomationCanBeEnabled$ = command(
       return preparedConfig.kind === "ok" ? null : preparedConfig;
     }
 
-    if (supportedGoogleMeetEventType(args.automation.eventType)) {
-      const subscriptionResult =
-        await ensureGoogleMeetTranscriptGeneratedSubscriptionForUser(
-          {
-            db: args.db,
-            orgId: args.orgId,
-            userId: args.member.userId,
-          },
-          signal,
-        );
-      signal.throwIfAborted();
-      if (subscriptionResult.kind !== "ok") {
-        return { kind: "bad-request", message: subscriptionResult.message };
-      }
-      return null;
-    }
     return null;
   },
 );
@@ -4453,6 +4452,16 @@ async function enabledWatchHadConsumer(
         orgId: args.automation.orgId,
         userId: args.automation.ownerUserId,
         connectorId: args.automation.eventConnectorId,
+      },
+      signal,
+    );
+  }
+  if (supportedGoogleMeetEventType(args.automation.eventType)) {
+    return await hasEnabledGoogleMeetConsumer(
+      {
+        db: args.db,
+        orgId: args.automation.orgId,
+        userId: args.automation.ownerUserId,
       },
       signal,
     );
@@ -4510,6 +4519,19 @@ async function ensureEnabledAutomationEventWatch(
         userId: args.automation.ownerUserId,
         connectorId: args.automation.eventConnectorId,
         forceRefresh: !args.hadConsumer,
+      },
+      signal,
+    );
+    return result.kind === "ok"
+      ? null
+      : { kind: "bad-request", message: result.message };
+  }
+  if (supportedGoogleMeetEventType(args.automation.eventType)) {
+    const result = await ensureGoogleMeetTranscriptGeneratedSubscriptionForUser(
+      {
+        db: args.db,
+        orgId: args.automation.orgId,
+        userId: args.automation.ownerUserId,
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/workflow-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation.service.ts
@@ -2419,12 +2419,13 @@ async function createGoogleMeetEventAutomationForWorkflow(
     ),
     rollback,
   );
-  signal.throwIfAborted();
-  if (subscriptionResult.kind === "ok") {
-    return { kind: "ok", summary };
+  if (subscriptionResult.kind !== "ok") {
+    await rollback();
+    signal.throwIfAborted();
+    return { kind: "bad-request", message: subscriptionResult.message };
   }
-  await rollback();
-  return { kind: "bad-request", message: subscriptionResult.message };
+  signal.throwIfAborted();
+  return { kind: "ok", summary };
 }
 
 async function createNotionEventAutomationForWorkflow(

--- a/turbo/packages/api-contracts/src/contracts/test-google-meet-subscription-renewal.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-google-meet-subscription-renewal.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+export const testGoogleMeetSubscriptionRenewalContract = c.router({
+  renew: {
+    method: "POST",
+    path: "/api/test/google-meet-subscription-renewal/renew",
+    body: z.object({
+      org_id: z.string().min(1),
+      user_id: z.string().min(1),
+    }),
+    responses: {
+      200: z.object({
+        success: z.literal(true),
+        renewed: z.number(),
+        repaired: z.number(),
+        failed: z.number(),
+      }),
+      400: apiErrorSchema,
+      404: z.string(),
+    },
+    summary: "Renew one Google Meet subscription scope in API tests",
+  },
+});
+
+export type TestGoogleMeetSubscriptionRenewalContract =
+  typeof testGoogleMeetSubscriptionRenewalContract;


### PR DESCRIPTION
## Summary

- make enabled Google Meet transcript automations the desired-state authority so disabled creation does not create a Workspace Events subscription and active setup rolls back on failure
- reconcile Meet create/adopt, renew, last-consumer cleanup, structural deletion, and connector disconnect under one lifecycle lock
- issue one best-effort exact-name provider DELETE, remove local state even when Google rejects it, and keep delayed delivery fail closed
- prevent post-disconnect cleanup from deleting a subscription name already adopted by a concurrent reconnect
- reconcile persisted no-consumer state during renewal without adding durable retry state or cleanup credentials

## Scope

- no database migration, public API contract, queue payload, runner protocol, or UI change
- no provider-operation polling or durable cleanup retry mechanism
- Google Meet multi-account projection remains owned by #30595

## Validation

- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- staged pre-commit checks, including full Turbo Knip and type checking (14/14 workspaces)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts` (8 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/workflow-automations.test.ts` (76 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connector-accounts.test.ts` (13 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-runtime-state.test.ts --silent=passed-only` (26 passed)

The unsharded local API suite accumulated unrelated five-second timeouts even
with one worker; each reported file passed in isolation. CI's eight independent
API shards remain the full-suite gate.

Closes #30813
