### PR TITLE
test(platform): stabilize cloud browser opt-out flow

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-computer-use-and-voice.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-computer-use-and-voice.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { voiceIoQuotaContract } from "@okouai/api-contracts/contracts/voice-io-quota";
 import { computerUseHostsContract } from "@okouai/api-contracts/contracts/computer-use";
 import { billingStatusContract } from "@okouai/api-contracts/contracts/billing";
-import { fill } from "../../../__tests__/page-helper.ts";
+import { click, fill } from "../../../__tests__/page-helper.ts";
 import {
   mockChatLifecycle,
   PLACEHOLDER,
@@ -280,9 +280,11 @@ describe("chat lifecycle", () => {
 
   it("creates a new chat thread without Cloud browser after turning it off", async () => {
     const user = userEvent.setup({ delay: null });
+    let runCreated = false;
     let sentCloudBrowserEnabled: boolean | undefined;
     mockChatLifecycle(context, {
       onRunCreate: (body) => {
+        runCreated = true;
         sentCloudBrowserEnabled = body.cloudBrowserEnabled;
       },
     });
@@ -296,20 +298,17 @@ describe("chat lifecycle", () => {
     });
 
     const textarea = await screen.findByPlaceholderText(PLACEHOLDER);
-    await user.click(await composerConnectorsButton());
-    await user.click(
-      screen.getByRole("switch", { name: "Disable Cloud browser" }),
-    );
+    click(await composerConnectorsButton());
+    click(screen.getByRole("switch", { name: "Disable Cloud browser" }));
     await waitFor(() => {
       expect(
         screen.getByRole("switch", { name: "Enable Cloud browser" }),
       ).toHaveAttribute("aria-checked", "false");
     });
-    await user.keyboard("{Escape}");
-
     await sendMessageInUI(user, textarea, "Keep the cloud browser closed");
 
     await waitFor(() => {
+      expect(runCreated).toBeTruthy();
       expect(sentCloudBrowserEnabled).toBeUndefined();
     });
   });


### PR DESCRIPTION
## Summary

- use the repository's lightweight click helper for the Cloud browser opt-out interactions instead of full `userEvent` pointer simulation
- let the composer interaction close the connectors popover naturally instead of sending a redundant Escape key event
- wait until the run-create handler is observed before asserting that `cloudBrowserEnabled` is omitted

## Root cause

The affected integration test performed two full pointer simulations plus an explicit popover-close keyboard event before submitting the message. Under the 21-file app shard's scheduling contention, that serial interaction path could exceed Vitest's 5-second per-test budget. The final assertion also compared an initially undefined capture, so it did not prove that the run-create request had happened.

This is a test-only stabilization. It does not change production behavior, increase a timeout, add a retry, or weaken the payload assertion.

Original failure: https://github.com/vm0-ai/vm0/actions/runs/33502068248/job/99837542432?pr=30848

## Validation

- `pnpm vitest run --project=@okouai/app apps/platform/src/views/okou-page/__tests__/chat-computer-use-and-voice.test.tsx -t "creates a new chat thread without Cloud browser after turning it off" --reporter=dot --silent=passed-only` (5 consecutive runs)
- `pnpm vitest run --project=@okouai/app --shard=5/8 --reporter=verbose` (234 passed)
- `pnpm exec prettier --check apps/platform/src/views/okou-page/__tests__/chat-computer-use-and-voice.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace apps/platform`
