### PR TITLE
perf(platform): start app resources after first contentful paint

### DIFF
--- a/.github/scripts/tests/verify-okou-app-runtime-test.sh
+++ b/.github/scripts/tests/verify-okou-app-runtime-test.sh
@@ -20,6 +20,7 @@ fail() {
 
 for file_name in \
   app-AbCd1234.js \
+  index-QrSt7890.css \
   vendor-EfGh5678.js \
   rolldown-runtime-IjKl9012.js \
   shared-database-worker-MnOp3456.js; do
@@ -30,18 +31,16 @@ cat > "$html_source" <<'HTML'
 <!doctype html>
 <meta name="okou-app-git-commit-sha" content="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
 <meta name="okou-app-version" content="0.812.5">
-<script type="module" crossorigin src="https://static.test/okou-app/assets/app-AbCd1234.js"></script>
-<link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/rolldown-runtime-IjKl9012.js">
-<link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/vendor-EfGh5678.js">
+<script id="vm0-deferred-application-resources" type="application/json">{"applicationModule":"https://static.test/okou-app/assets/app-AbCd1234.js","modulePreloads":["https://static.test/okou-app/assets/rolldown-runtime-IjKl9012.js","https://static.test/okou-app/assets/vendor-EfGh5678.js"],"stylesheet":"https://static.test/okou-app/assets/index-QrSt7890.css"}</script>
+<script id="vm0-after-first-paint"></script>
 HTML
 
 cat > "$old_html_source" <<'HTML'
 <!doctype html>
 <meta name="okou-app-git-commit-sha" content="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb">
 <meta name="okou-app-version" content="0.812.4">
-<script type="module" crossorigin src="https://static.test/okou-app/assets/app-Old12345.js"></script>
-<link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/rolldown-runtime-Old12345.js">
-<link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/vendor-Old12345.js">
+<script id="vm0-deferred-application-resources" type="application/json">{"applicationModule":"https://static.test/okou-app/assets/app-Old12345.js","modulePreloads":["https://static.test/okou-app/assets/rolldown-runtime-Old12345.js","https://static.test/okou-app/assets/vendor-Old12345.js"],"stylesheet":"https://static.test/okou-app/assets/index-Old12345.css"}</script>
+<script id="vm0-after-first-paint"></script>
 HTML
 
 cat > "${fake_bin}/curl" <<'BASH'
@@ -102,10 +101,11 @@ output="$({
 } 2>&1)"
 
 grep -Fq \
-  'Verified app runtime: app=https://static.test/okou-app/assets/app-AbCd1234.js vendor=https://static.test/okou-app/assets/vendor-EfGh5678.js runtime=https://static.test/okou-app/assets/rolldown-runtime-IjKl9012.js worker=https://app.test/okou-app/assets/shared-database-worker-MnOp3456.js' \
+  'Verified app runtime: stylesheet=https://static.test/okou-app/assets/index-QrSt7890.css app=https://static.test/okou-app/assets/app-AbCd1234.js vendor=https://static.test/okou-app/assets/vendor-EfGh5678.js runtime=https://static.test/okou-app/assets/rolldown-runtime-IjKl9012.js worker=https://app.test/okou-app/assets/shared-database-worker-MnOp3456.js' \
   <<< "$output" || fail "runtime verification summary is incorrect"
 for expected_url in \
   https://app.test/sign-up \
+  https://static.test/okou-app/assets/index-QrSt7890.css \
   https://static.test/okou-app/assets/app-AbCd1234.js \
   https://static.test/okou-app/assets/vendor-EfGh5678.js \
   https://static.test/okou-app/assets/rolldown-runtime-IjKl9012.js \
@@ -222,7 +222,7 @@ fi
 grep -Fq 'SharedWorker same-origin proxy returned HTTP 200' \
   "${test_root}/worker-failure.log" || fail "worker failure was not identified"
 
-sed -i '/vendor-EfGh5678/d' "$html_source"
+sed -i 's/vendor-EfGh5678/vendor-Missing00/' "$html_source"
 : > "$curl_log"
 : > "$sleep_log"
 if PATH="${fake_bin}:$PATH" \
@@ -233,9 +233,9 @@ if PATH="${fake_bin}:$PATH" \
     https://app.test \
     https://static.test/okou-app/assets \
     "$assets_directory" > "${test_root}/html-failure.log" 2>&1; then
-  fail "missing vendor preload did not fail HTML verification"
+  fail "incorrect deferred vendor did not fail HTML verification"
 fi
-grep -Fq 'Expected CDN runtime/vendor modulepreloads' \
+grep -Fq 'Expected canonical deferred resources' \
   "${test_root}/html-failure.log" || fail "HTML failure was not identified"
 grep -Fq 'App runtime document did not converge for https://app.test after probe 1/1' \
   "${test_root}/html-failure.log" ||

--- a/.github/scripts/verify-okou-app-runtime.sh
+++ b/.github/scripts/verify-okou-app-runtime.sh
@@ -32,13 +32,15 @@ probe_evidence="$(mktemp)"
 trap 'rm -f "$layout_files" "$document_body" "$curl_error" "$probe_evidence"' EXIT
 
 declare -a app_files=()
+declare -a stylesheet_files=()
 declare -a vendor_files=()
 declare -a runtime_files=()
 declare -a worker_files=()
-find "$assets_directory" -type f -name '*.js' -print0 > "$layout_files"
+find "$assets_directory" -type f \( -name '*.js' -o -name '*.css' \) -print0 > "$layout_files"
 while IFS= read -r -d '' source_path; do
   relative_path="${source_path#"$assets_directory"/}"
   case "$relative_path" in
+    index-*.css) stylesheet_files+=("$relative_path") ;;
     vendor-*.js) vendor_files+=("$relative_path") ;;
     rolldown-runtime-*.js) runtime_files+=("$relative_path") ;;
     shared-database-worker-*.js) worker_files+=("$relative_path") ;;
@@ -48,15 +50,17 @@ done < "$layout_files"
 
 if ((
   ${#app_files[@]} != 1 ||
+  ${#stylesheet_files[@]} != 1 ||
   ${#vendor_files[@]} != 1 ||
   ${#runtime_files[@]} != 1 ||
   ${#worker_files[@]} != 1
 )); then
-  echo "Expected exactly one app, vendor, Rolldown runtime, and SharedWorker JavaScript asset" >&2
+  echo "Expected exactly one app stylesheet plus one app, vendor, Rolldown runtime, and SharedWorker JavaScript asset" >&2
   exit 1
 fi
 
 app_asset_url="${public_assets_url}/${app_files[0]}"
+stylesheet_asset_url="${public_assets_url}/${stylesheet_files[0]}"
 vendor_asset_url="${public_assets_url}/${vendor_files[0]}"
 runtime_asset_url="${public_assets_url}/${runtime_files[0]}"
 worker_asset_url="${app_url}/okou-app/assets/${worker_files[0]}"
@@ -86,9 +90,11 @@ for ((attempt = 1; attempt <= document_max_attempts; attempt++)); do
       "$canonical_document" \
       "$app_asset_url" \
       "$runtime_asset_url" \
-      "$vendor_asset_url" 2>"$probe_evidence" <<'PY'
+      "$vendor_asset_url" \
+      "$stylesheet_asset_url" 2>"$probe_evidence" <<'PY'
 from html.parser import HTMLParser
 from pathlib import Path
+import json
 import re
 import sys
 
@@ -96,6 +102,8 @@ COMMIT_SHA_META_NAME = "okou-app-git-commit-sha"
 VERSION_META_NAME = "okou-app-version"
 RUNTIME_META_NAMES = {COMMIT_SHA_META_NAME, VERSION_META_NAME}
 COMMIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+AFTER_FIRST_PAINT_SCRIPT_ID = "vm0-after-first-paint"
+DEFERRED_RESOURCES_SCRIPT_ID = "vm0-deferred-application-resources"
 
 
 class AppDocumentParser(HTMLParser):
@@ -103,6 +111,9 @@ class AppDocumentParser(HTMLParser):
         super().__init__()
         self.module_scripts: list[str] = []
         self.module_preloads: list[str] = []
+        self.after_first_paint_script_count = 0
+        self.deferred_resource_scripts: list[str] = []
+        self.capturing_deferred_resources = False
         self.runtime_metadata: dict[str, list[str | None]] = {
             name: [] for name in RUNTIME_META_NAMES
         }
@@ -111,6 +122,15 @@ class AppDocumentParser(HTMLParser):
         self, tag: str, attrs: list[tuple[str, str | None]]
     ) -> None:
         attributes = dict(attrs)
+        if tag == "script" and attributes.get("id") == AFTER_FIRST_PAINT_SCRIPT_ID:
+            self.after_first_paint_script_count += 1
+        if (
+            tag == "script"
+            and attributes.get("id") == DEFERRED_RESOURCES_SCRIPT_ID
+            and attributes.get("type") == "application/json"
+        ):
+            self.deferred_resource_scripts.append("")
+            self.capturing_deferred_resources = True
         if tag == "script" and attributes.get("type") == "module":
             source = attributes.get("src")
             if source:
@@ -123,6 +143,14 @@ class AppDocumentParser(HTMLParser):
             name = attributes["name"]
             if name is not None:
                 self.runtime_metadata[name].append(attributes.get("content"))
+
+    def handle_data(self, data: str) -> None:
+        if self.capturing_deferred_resources:
+            self.deferred_resource_scripts[-1] += data
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "script" and self.capturing_deferred_resources:
+            self.capturing_deferred_resources = False
 
 
 def parse_document(path: str) -> AppDocumentParser:
@@ -149,6 +177,18 @@ def runtime_metadata(parser: AppDocumentParser, label: str) -> dict[str, str]:
     return metadata
 
 
+def deferred_resources(parser: AppDocumentParser, label: str) -> dict[str, object]:
+    scripts = parser.deferred_resource_scripts
+    if len(scripts) != 1:
+        raise RuntimeError(
+            f"Expected exactly one {label} deferred resource metadata script, got {len(scripts)}"
+        )
+    resources = json.loads(scripts[0])
+    if not isinstance(resources, dict):
+        raise RuntimeError(f"Invalid {label} deferred resource metadata")
+    return resources
+
+
 parser = parse_document(sys.argv[1])
 canonical_parser = parse_document(sys.argv[2])
 expected_metadata = runtime_metadata(canonical_parser, "canonical")
@@ -158,17 +198,38 @@ if observed_metadata != expected_metadata:
         f"Expected runtime build metadata {expected_metadata}, got {observed_metadata}"
     )
 
-expected_script = [sys.argv[3]]
-expected_preloads = {sys.argv[4], sys.argv[5]}
-if parser.module_scripts != expected_script:
-    raise RuntimeError(
-        f"Expected one CDN app module script {expected_script}, got {parser.module_scripts}"
-    )
-if len(parser.module_preloads) != 2 or set(parser.module_preloads) != expected_preloads:
-    raise RuntimeError(
-        f"Expected CDN runtime/vendor modulepreloads {sorted(expected_preloads)}, "
-        f"got {parser.module_preloads}"
-    )
+expected_script = sys.argv[3]
+expected_stylesheet = sys.argv[6]
+expected_resources = {
+    "applicationModule": expected_script,
+    "modulePreloads": [sys.argv[4], sys.argv[5]],
+    "stylesheet": expected_stylesheet,
+}
+for document_parser, label in (
+    (canonical_parser, "canonical"),
+    (parser, "served"),
+):
+    if document_parser.after_first_paint_script_count != 1:
+        raise RuntimeError(
+            f"Expected exactly one {label} after-first-paint scheduler, "
+            f"got {document_parser.after_first_paint_script_count}"
+        )
+    if document_parser.module_scripts:
+        raise RuntimeError(
+            f"Expected no statically discovered {label} app modules, "
+            f"got {document_parser.module_scripts}"
+        )
+    if document_parser.module_preloads:
+        raise RuntimeError(
+            f"Expected no statically discovered {label} module preloads, "
+            f"got {document_parser.module_preloads}"
+        )
+    observed_resources = deferred_resources(document_parser, label)
+    if observed_resources != expected_resources:
+        raise RuntimeError(
+            f"Expected {label} deferred resources {expected_resources}, "
+            f"got {observed_resources}"
+        )
 PY
     then
       break
@@ -211,6 +272,7 @@ PY
 done
 
 for asset_url in \
+  "$stylesheet_asset_url" \
   "$app_asset_url" \
   "$vendor_asset_url" \
   "$runtime_asset_url"; do
@@ -249,7 +311,8 @@ if [[ "$worker_status" != "206" ]]; then
   exit 1
 fi
 
-printf 'Verified app runtime: app=%s vendor=%s runtime=%s worker=%s\n' \
+printf 'Verified app runtime: stylesheet=%s app=%s vendor=%s runtime=%s worker=%s\n' \
+  "$stylesheet_asset_url" \
   "$app_asset_url" \
   "$vendor_asset_url" \
   "$runtime_asset_url" \

--- a/turbo/apps/platform/scripts/app-resource-priority-html.ts
+++ b/turbo/apps/platform/scripts/app-resource-priority-html.ts
@@ -2,6 +2,7 @@ import type { Plugin } from "vite";
 
 const CRITICAL_STYLE_ID = "app-bootstrap-critical-styles";
 const AFTER_FIRST_PAINT_SCRIPT_ID = "vm0-after-first-paint";
+const DEFERRED_RESOURCES_SCRIPT_ID = "vm0-deferred-application-resources";
 
 function matchingTags(
   htmlSource: string,
@@ -70,9 +71,14 @@ function afterFirstPaintScript(resources: {
   readonly modulePreloads: readonly string[];
   readonly stylesheet: string;
 }): string {
-  return `    <script id="${AFTER_FIRST_PAINT_SCRIPT_ID}">
+  return `    <script id="${DEFERRED_RESOURCES_SCRIPT_ID}" type="application/json">${inlineJson(resources)}</script>
+    <script id="${AFTER_FIRST_PAINT_SCRIPT_ID}">
       (function () {
-        var resources = ${inlineJson(resources)};
+        var resourceMetadata = document.getElementById("${DEFERRED_RESOURCES_SCRIPT_ID}");
+        if (!resourceMetadata) {
+          throw new Error("Deferred application resource metadata is unavailable");
+        }
+        var resources = JSON.parse(resourceMetadata.textContent);
 
         function appendModulePreload(source) {
           var preload = document.createElement("link");

--- a/turbo/apps/platform/scripts/app-resource-priority-html.ts
+++ b/turbo/apps/platform/scripts/app-resource-priority-html.ts
@@ -113,6 +113,26 @@ function afterFirstPaintScript(resources: {
           }
         }
 
+        var PaintObserver = window.PerformanceObserver;
+        if (
+          PaintObserver &&
+          PaintObserver.supportedEntryTypes &&
+          PaintObserver.supportedEntryTypes.indexOf("paint") !== -1
+        ) {
+          var observer = new PaintObserver(function (entryList) {
+            var entries = entryList.getEntries();
+            for (var i = 0; i < entries.length; i += 1) {
+              if (entries[i].name === "first-contentful-paint") {
+                observer.disconnect();
+                activateApplicationResources();
+                return;
+              }
+            }
+          });
+          observer.observe({ type: "paint", buffered: true });
+          return;
+        }
+
         requestAnimationFrame(function () {
           requestAnimationFrame(activateApplicationResources);
         });

--- a/turbo/apps/platform/scripts/app-resource-priority-html.ts
+++ b/turbo/apps/platform/scripts/app-resource-priority-html.ts
@@ -1,6 +1,7 @@
 import type { Plugin } from "vite";
 
 const CRITICAL_STYLE_ID = "app-bootstrap-critical-styles";
+const AFTER_FIRST_PAINT_SCRIPT_ID = "vm0-after-first-paint";
 
 function matchingTags(
   htmlSource: string,
@@ -31,23 +32,6 @@ function singleAssetTag(
   return tags[0];
 }
 
-function withFetchPriority(tag: string, priority: "high" | "low"): string {
-  if (/\sfetchpriority=/u.test(tag)) {
-    return tag.replace(
-      /\sfetchpriority="[^"]*"/u,
-      ` fetchpriority="${priority}"`,
-    );
-  }
-
-  const startTagEnd = tag.indexOf(">");
-  if (startTagEnd === -1) {
-    throw new Error(
-      `Generated asset tag is missing its closing bracket: ${tag}`,
-    );
-  }
-  return `${tag.slice(0, startTagEnd)} fetchpriority="${priority}"${tag.slice(startTagEnd)}`;
-}
-
 function removeTag(htmlSource: string, tag: string): string {
   const firstIndex = htmlSource.indexOf(tag);
   const lastIndex = htmlSource.lastIndexOf(tag);
@@ -57,7 +41,80 @@ function removeTag(htmlSource: string, tag: string): string {
   return `${htmlSource.slice(0, firstIndex)}${htmlSource.slice(firstIndex + tag.length)}`;
 }
 
-function prioritizeApplicationResources(htmlSource: string): string {
+function hrefFromLink(tag: string): string {
+  const match = /\shref="([^"]+)"/u.exec(tag);
+  if (!match?.[1]) {
+    throw new Error(`Generated link tag is missing href: ${tag}`);
+  }
+  return match[1];
+}
+
+function srcFromScript(tag: string): string {
+  const match = /\ssrc="([^"]+)"/u.exec(tag);
+  if (!match?.[1]) {
+    throw new Error(`Generated script tag is missing src: ${tag}`);
+  }
+  return match[1];
+}
+
+function inlineJson(value: unknown): string {
+  const json = JSON.stringify(value);
+  if (json === undefined) {
+    throw new Error("Application resource metadata is not serializable");
+  }
+  return json.replaceAll("<", String.raw`\u003c`);
+}
+
+function afterFirstPaintScript(resources: {
+  readonly applicationModule: string;
+  readonly modulePreloads: readonly string[];
+  readonly stylesheet: string;
+}): string {
+  return `    <script id="${AFTER_FIRST_PAINT_SCRIPT_ID}">
+      (function () {
+        var resources = ${inlineJson(resources)};
+
+        function appendModulePreload(source) {
+          var preload = document.createElement("link");
+          preload.rel = "modulepreload";
+          preload.href = source;
+          preload.crossOrigin = "anonymous";
+          preload.fetchPriority = "low";
+          document.head.appendChild(preload);
+        }
+
+        function appendApplicationModule() {
+          var application = document.createElement("script");
+          application.type = "module";
+          application.src = resources.applicationModule;
+          application.crossOrigin = "anonymous";
+          application.fetchPriority = "low";
+          document.body.appendChild(application);
+        }
+
+        function activateApplicationResources() {
+          var stylesheet = document.createElement("link");
+          stylesheet.rel = "stylesheet";
+          stylesheet.href = resources.stylesheet;
+          stylesheet.crossOrigin = "anonymous";
+          stylesheet.fetchPriority = "high";
+          stylesheet.onload = appendApplicationModule;
+          document.head.appendChild(stylesheet);
+
+          appendModulePreload(resources.applicationModule);
+          for (var i = 0; i < resources.modulePreloads.length; i += 1) {
+            appendModulePreload(resources.modulePreloads[i]);
+          }
+        }
+
+        requestAnimationFrame(function () {
+          requestAnimationFrame(activateApplicationResources);
+        });
+      })();
+    </script>`;
+}
+
+function deferApplicationResourcesUntilFirstPaint(htmlSource: string): string {
   const linkTagPattern = /<link\b[^>]*>/gu;
   const scriptTagPattern = /<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/giu;
   const stylesheet = singleAssetTag(
@@ -109,42 +166,32 @@ function prioritizeApplicationResources(htmlSource: string): string {
   if (criticalStyleEnd === -1) {
     throw new Error("Critical application stylesheet is missing </style>");
   }
-  const headResources = [
-    withFetchPriority(stylesheet, "high"),
-    withFetchPriority(runtimePreload, "low"),
-    withFetchPriority(vendorPreload, "low"),
-  ]
-    .map((tag) => {
-      return `    ${tag}`;
-    })
-    .join("\n");
-  const criticalStyleInsertion = criticalStyleEnd + "</style>".length;
-  prioritizedHtml = `${prioritizedHtml.slice(0, criticalStyleInsertion)}\n${headResources}${prioritizedHtml.slice(criticalStyleInsertion)}`;
 
   const bodyEnd = prioritizedHtml.lastIndexOf("</body>");
   if (bodyEnd === -1) {
     throw new Error("Application HTML is missing </body>");
   }
-  const lowPriorityApplicationModule = withFetchPriority(
-    applicationModule,
-    "low",
-  );
+  const bootstrapScript = afterFirstPaintScript({
+    applicationModule: srcFromScript(applicationModule),
+    modulePreloads: [hrefFromLink(runtimePreload), hrefFromLink(vendorPreload)],
+    stylesheet: hrefFromLink(stylesheet),
+  });
   const bodyClosingLineStart = prioritizedHtml.lastIndexOf("\n", bodyEnd) + 1;
   if (prioritizedHtml.slice(bodyClosingLineStart, bodyEnd).trim()) {
-    return `${prioritizedHtml.slice(0, bodyEnd)}${lowPriorityApplicationModule}${prioritizedHtml.slice(bodyEnd)}`;
+    return `${prioritizedHtml.slice(0, bodyEnd)}${bootstrapScript}${prioritizedHtml.slice(bodyEnd)}`;
   }
-  return `${prioritizedHtml.slice(0, bodyClosingLineStart)}    ${lowPriorityApplicationModule}\n${prioritizedHtml.slice(bodyClosingLineStart)}`;
+  return `${prioritizedHtml.slice(0, bodyClosingLineStart)}${bootstrapScript}\n${prioritizedHtml.slice(bodyClosingLineStart)}`;
 }
 
-export function applicationResourcePriorityHtmlPlugin(): Plugin {
+export function applicationAfterFirstPaintHtmlPlugin(): Plugin {
   return {
     apply: "build",
     enforce: "post",
-    name: "platform-application-resource-priority-html",
+    name: "platform-application-after-first-paint-html",
     transformIndexHtml: {
       order: "post",
       handler(htmlSource) {
-        return prioritizeApplicationResources(htmlSource);
+        return deferApplicationResourcesUntilFirstPaint(htmlSource);
       },
     },
   };

--- a/turbo/apps/platform/scripts/check-build-config.node.ts
+++ b/turbo/apps/platform/scripts/check-build-config.node.ts
@@ -7,7 +7,7 @@ import { URL } from "node:url";
 
 import { build, loadConfigFromFile } from "vite";
 
-import { applicationResourcePriorityHtmlPlugin } from "./app-resource-priority-html.ts";
+import { applicationAfterFirstPaintHtmlPlugin } from "./app-resource-priority-html.ts";
 import {
   RAW_JAVASCRIPT_OUTPUT_LIMIT_BYTES,
   VENDOR_MODULE_PATTERN,
@@ -368,46 +368,40 @@ function clerkDiscoveryFixture(): string {
 function assertClerkDiscoveryOrder(htmlSource: string): void {
   const clerkCoreIndex = htmlSource.indexOf('id="vm0-clerk-core-script"');
   const clerkBootstrapIndex = htmlSource.indexOf('data-vm0-clerk-bootstrap=""');
-  const appModuleIndex = htmlSource.indexOf('<script type="module"');
+  const afterFirstPaintIndex = htmlSource.indexOf('id="vm0-after-first-paint"');
   assert.notEqual(clerkCoreIndex, -1);
   assert.ok(clerkBootstrapIndex > clerkCoreIndex);
-  assert.ok(appModuleIndex > clerkBootstrapIndex);
+  assert.ok(afterFirstPaintIndex > clerkBootstrapIndex);
 }
 
-function assertApplicationResourcePriority(htmlSource: string): void {
+function assertApplicationResourcesStartAfterFirstPaint(
+  htmlSource: string,
+): void {
   const criticalStyleIndex = htmlSource.indexOf(
     '<style id="app-bootstrap-critical-styles">',
   );
-  const stylesheetIndex = htmlSource.indexOf('rel="stylesheet"');
-  const runtimePreloadIndex = htmlSource.indexOf("assets/rolldown-runtime-");
-  const vendorPreloadIndex = htmlSource.indexOf("assets/vendor-");
   const clerkCoreIndex = htmlSource.indexOf('id="vm0-clerk-core-script"');
   const skeletonIndex = htmlSource.indexOf('id="app-bootstrap-skeleton"');
-  const appModuleIndex = htmlSource.indexOf('<script type="module"');
+  const bootstrapIndex = htmlSource.indexOf('id="vm0-after-first-paint"');
   const bodyEndIndex = htmlSource.indexOf("</body>");
 
   assert.ok(criticalStyleIndex !== -1);
-  assert.ok(stylesheetIndex > criticalStyleIndex);
-  assert.ok(runtimePreloadIndex > stylesheetIndex);
-  assert.ok(vendorPreloadIndex > runtimePreloadIndex);
-  assert.ok(clerkCoreIndex > vendorPreloadIndex);
-  assert.ok(appModuleIndex > skeletonIndex);
-  assert.ok(bodyEndIndex > appModuleIndex);
-  assert.match(
-    htmlSource,
-    /<link rel="stylesheet"[^>]*fetchpriority="high"[^>]*>/u,
-  );
+  assert.ok(clerkCoreIndex > criticalStyleIndex);
+  assert.ok(bootstrapIndex > skeletonIndex);
+  assert.ok(bodyEndIndex > bootstrapIndex);
+  assert.equal((htmlSource.match(/<script type="module"/gu) ?? []).length, 0);
   assert.equal(
-    (
-      htmlSource.match(
-        /<link rel="modulepreload"[^>]*fetchpriority="low"[^>]*>/gu,
-      ) ?? []
-    ).length,
-    2,
+    (htmlSource.match(/<link rel="modulepreload"/gu) ?? []).length,
+    0,
   );
+  assert.equal((htmlSource.match(/<link rel="stylesheet"/gu) ?? []).length, 0);
+  assert.match(htmlSource, /stylesheet\.fetchPriority = "high"/u);
+  assert.match(htmlSource, /preload\.fetchPriority = "low"/u);
+  assert.match(htmlSource, /application\.fetchPriority = "low"/u);
+  assert.match(htmlSource, /stylesheet\.onload = appendApplicationModule/u);
   assert.match(
     htmlSource,
-    /<script type="module"[^>]*fetchpriority="low"[^>]*><\/script>/u,
+    /requestAnimationFrame\(function \(\) \{\s*requestAnimationFrame\(activateApplicationResources\);/u,
   );
 }
 
@@ -469,7 +463,7 @@ await test("emits the fixed page topology and one external worker", async () => 
       },
       plugins: [
         applicationJavaScriptBundlePlugin(),
-        applicationResourcePriorityHtmlPlugin(),
+        applicationAfterFirstPaintHtmlPlugin(),
       ],
       worker: {
         plugins: () => {
@@ -528,9 +522,7 @@ await test("emits the fixed page topology and one external worker", async () => 
     assert.ok(html?.type === "asset");
     const htmlSource = String(html.source);
     assertClerkDiscoveryOrder(htmlSource);
-    assert.equal((htmlSource.match(/<script type="module"/gu) ?? []).length, 1);
-    assert.equal((htmlSource.match(/rel="modulepreload"/gu) ?? []).length, 2);
-    assertApplicationResourcePriority(htmlSource);
+    assertApplicationResourcesStartAfterFirstPaint(htmlSource);
     assert.ok(
       result.output.some((item) => {
         return item.type === "asset" && item.fileName.endsWith(".json");

--- a/turbo/apps/platform/scripts/check-build-config.node.ts
+++ b/turbo/apps/platform/scripts/check-build-config.node.ts
@@ -406,6 +406,15 @@ function assertApplicationResourcesStartAfterFirstPaint(
   assert.match(htmlSource, /JSON\.parse\(resourceMetadata\.textContent\)/u);
   assert.match(
     htmlSource,
+    /PaintObserver\.supportedEntryTypes\.indexOf\("paint"\) !== -1/u,
+  );
+  assert.match(htmlSource, /entries\[i\]\.name === "first-contentful-paint"/u);
+  assert.match(
+    htmlSource,
+    /observer\.observe\(\{ type: "paint", buffered: true \}\)/u,
+  );
+  assert.match(
+    htmlSource,
     /requestAnimationFrame\(function \(\) \{\s*requestAnimationFrame\(activateApplicationResources\);/u,
   );
 }

--- a/turbo/apps/platform/scripts/check-build-config.node.ts
+++ b/turbo/apps/platform/scripts/check-build-config.node.ts
@@ -382,12 +382,16 @@ function assertApplicationResourcesStartAfterFirstPaint(
   );
   const clerkCoreIndex = htmlSource.indexOf('id="vm0-clerk-core-script"');
   const skeletonIndex = htmlSource.indexOf('id="app-bootstrap-skeleton"');
+  const resourceMetadataIndex = htmlSource.indexOf(
+    'id="vm0-deferred-application-resources"',
+  );
   const bootstrapIndex = htmlSource.indexOf('id="vm0-after-first-paint"');
   const bodyEndIndex = htmlSource.indexOf("</body>");
 
   assert.ok(criticalStyleIndex !== -1);
   assert.ok(clerkCoreIndex > criticalStyleIndex);
-  assert.ok(bootstrapIndex > skeletonIndex);
+  assert.ok(resourceMetadataIndex > skeletonIndex);
+  assert.ok(bootstrapIndex > resourceMetadataIndex);
   assert.ok(bodyEndIndex > bootstrapIndex);
   assert.equal((htmlSource.match(/<script type="module"/gu) ?? []).length, 0);
   assert.equal(
@@ -399,6 +403,7 @@ function assertApplicationResourcesStartAfterFirstPaint(
   assert.match(htmlSource, /preload\.fetchPriority = "low"/u);
   assert.match(htmlSource, /application\.fetchPriority = "low"/u);
   assert.match(htmlSource, /stylesheet\.onload = appendApplicationModule/u);
+  assert.match(htmlSource, /JSON\.parse\(resourceMetadata\.textContent\)/u);
   assert.match(
     htmlSource,
     /requestAnimationFrame\(function \(\) \{\s*requestAnimationFrame\(activateApplicationResources\);/u,

--- a/turbo/apps/platform/vite.config.ts
+++ b/turbo/apps/platform/vite.config.ts
@@ -7,7 +7,7 @@ import { defineConfig, type Plugin } from "vite";
 
 import { devArtifactFetchProxy } from "./dev-artifact-fetch-proxy.ts";
 import platformPackage from "./package.json";
-import { applicationResourcePriorityHtmlPlugin } from "./scripts/app-resource-priority-html.ts";
+import { applicationAfterFirstPaintHtmlPlugin } from "./scripts/app-resource-priority-html.ts";
 import { clerkCoreHtmlPlugin } from "./scripts/clerk-html.ts";
 import {
   VENDOR_MODULE_PATTERN,
@@ -78,7 +78,7 @@ export default defineConfig(({ command }) => ({
     clerkCoreHtmlPlugin(APP_VERSION),
     runtimeBuildInfoHtmlPlugin,
     applicationJavaScriptBundlePlugin(),
-    applicationResourcePriorityHtmlPlugin(),
+    applicationAfterFirstPaintHtmlPlugin(),
     // Sentry source map upload (production builds only)
     process.env.SENTRY_AUTH_TOKEN &&
       sentryVitePlugin({


### PR DESCRIPTION
## Summary

- keep the inline bootstrap skeleton as the only application render dependency until the browser reports `first-contentful-paint`
- remove the generated app stylesheet, module preloads, and entry module from the browser's initial resource-discovery path
- use a buffered Paint Timing observer, with nested animation frames only as the compatibility fallback
- after FCP, start the unchanged app graph immediately: fetch CSS at high priority, module-preload the existing entry/runtime/vendor at low priority, and execute the entry once CSS is ready
- preserve the existing bundle topology; this adds no code splitting, route lazy loading, or interaction-triggered loading

## Verification

- `pnpm --dir apps/platform lint`
- `pnpm --dir apps/platform check-types`
- `pnpm --dir apps/platform lint:build-config` (12/12)
- `VITE_CLERK_PUBLISHABLE_KEY_PREVIEW=... VITE_CLERK_PUBLISHABLE_KEY_PROD=... pnpm --dir apps/platform build`
- `.github/scripts/tests/verify-okou-app-runtime-test.sh`
- standard pre-commit hooks, including repository-wide type checking

## Mobile Lighthouse

Three cold Lighthouse 13.4.1 mobile runs against each direct `/sign-in` URL, using simulated throttling:

| Metric | Production median | Preview median | Change |
|---|---:|---:|---:|
| FCP | 1.926s | 0.862s | **-55.3%** |
| LCP | 16.438s | 11.995s | **-27.0%** |
| TBT | 3.356s | 3.417s | +1.8% |
| Performance score | 0.13 | 0.31 | +0.18 |

Resource Timing also confirmed that App CSS and the entry module began after the observed FCP in all three Preview runs. Full per-run results and boundary timings: https://github.com/vm0-ai/vm0/pull/30879#issuecomment-5494488439

## Fallbacks

Paint Timing is supported by current Chromium browsers. If it is unavailable, the bootstrap scheduler falls back to a nested animation-frame boundary so older browsers still start the application.
