### PR TITLE
ci: release orphaned runner lifecycle locks with a heartbeat lease

### DIFF
--- a/.github/scripts/tests/runner-lifecycle-lock-test.sh
+++ b/.github/scripts/tests/runner-lifecycle-lock-test.sh
@@ -57,14 +57,22 @@ cat >"${fake_bin}/ssh" <<'SH'
 set -euo pipefail
 
 remote=$1
+remote_command=$2
 host=${remote#*@}
 if [ -n "${MOCK_SSH_ATTEMPT_FIFO:-}" ]; then
   printf '%s\n' "${MOCK_OWNER:-unknown}" >"$MOCK_SSH_ATTEMPT_FIFO"
 fi
 mkdir -p "$MOCK_LOCK_ROOT"
 lock_file="${MOCK_LOCK_ROOT}/${host}-${JOB_REF}.lock"
-exec flock --exclusive --timeout 5 "$lock_file" \
-  bash -c 'printf "%s\n" VM0_RUNNER_LIFECYCLE_LOCK_ACQUIRED; cat >/dev/null'
+
+# Run the holder the script actually asks for, minus the privilege escalation
+# and the absolute lock path that only exist on a metal host.
+local_command=${remote_command#exec sudo }
+local_command=${local_command//"/var/lock/vm0-runner-lifecycle-${JOB_REF}.lock"/$lock_file}
+if [ -n "${MOCK_HOLDER_COMMAND_FILE:-}" ]; then
+  printf '%s\n' "$local_command" >"$MOCK_HOLDER_COMMAND_FILE"
+fi
+exec bash -c "$local_command"
 SH
 
 cat >"${fake_bin}/ansible-playbook" <<'SH'
@@ -174,5 +182,84 @@ background_pids=()
 
 [ "$(cat "$order_log")" = $'delete\nstart' ] ||
   fail "cleanup and late start did not serialize in ownership order"
+
+# A protected command that outlives the lease must keep its lock: the owner
+# heartbeats over the same channel that carries the release signal.
+lease_seconds=5
+holder_command_file="${tmp_dir}/holder-command"
+lease_lock_root="${tmp_dir}/lease-locks"
+mkdir -p "$lease_lock_root"
+
+PATH="${fake_bin}:$PATH" \
+  JOB_REF=pr-77 \
+  METAL_HOSTS=metal-lease.example.test \
+  METAL_USER=runner \
+  MOCK_LOCK_ROOT="$lease_lock_root" \
+  MOCK_HOLDER_COMMAND_FILE="$holder_command_file" \
+  RUNNER_LIFECYCLE_LOCK_TIMEOUT_SECONDS=5 \
+  RUNNER_LIFECYCLE_LOCK_LEASE_SECONDS="$lease_seconds" \
+  timeout "$((lease_seconds * 4))" "$lock_script" sleep "$((lease_seconds * 2))" \
+  >"${tmp_dir}/lease.out" 2>"${tmp_dir}/lease.err" || {
+  sed 's/^/  /' "${tmp_dir}/lease.err" >&2
+  fail "heartbeats did not keep the lock while the protected command ran"
+}
+! grep -q "was lost while the protected command was running" "${tmp_dir}/lease.err" ||
+  fail "the lease expired under an owner that was still heartbeating"
+
+lease_lock_file="${lease_lock_root}/metal-lease.example.test-pr-77.lock"
+flock --exclusive --timeout 5 "$lease_lock_file" true ||
+  fail "the lock was still held after the protected command completed"
+
+# Every host keeps its own heartbeat writer, so releasing must still reach
+# end-of-input on each channel once the protected command finishes.
+multi_lock_root="${tmp_dir}/multi-locks"
+mkdir -p "$multi_lock_root"
+PATH="${fake_bin}:$PATH" \
+  JOB_REF=pr-78 \
+  METAL_HOSTS=metal-one.example.test,metal-two.example.test \
+  METAL_USER=runner \
+  MOCK_LOCK_ROOT="$multi_lock_root" \
+  RUNNER_LIFECYCLE_LOCK_TIMEOUT_SECONDS=5 \
+  RUNNER_LIFECYCLE_LOCK_LEASE_SECONDS="$lease_seconds" \
+  timeout "$lease_seconds" "$lock_script" true \
+  >"${tmp_dir}/multi.out" 2>"${tmp_dir}/multi.err" || {
+  sed 's/^/  /' "${tmp_dir}/multi.err" >&2
+  fail "a multi-host lock did not release promptly after its protected command"
+}
+for multi_host in metal-one.example.test metal-two.example.test; do
+  flock --exclusive --timeout 5 \
+    "${multi_lock_root}/${multi_host}-pr-78.lock" true ||
+    fail "the lock on ${multi_host} was still held after release"
+done
+
+# An orphaned holder never sees end-of-input on a half-open transport, so the
+# lease is the only thing that stops it from blocking the host indefinitely.
+[ -s "$holder_command_file" ] || fail "the mock did not record the remote holder command"
+IFS= read -r holder_command <"$holder_command_file"
+orphan_fifo="${tmp_dir}/orphan-stdin"
+mkfifo "$orphan_fifo"
+exec {orphan_fd}<>"$orphan_fifo"
+bash -c "$holder_command" <"$orphan_fifo" >"${tmp_dir}/orphan.out" 2>&1 &
+orphan_pid=$!
+background_pids+=("$orphan_pid")
+
+orphan_marker=$(
+  # shellcheck disable=SC2016
+  timeout 5 bash -c '
+    until [ -s "$1" ]; do sleep 0.1; done
+    IFS= read -r line <"$1"
+    printf "%s\n" "$line"
+  ' bash "${tmp_dir}/orphan.out"
+) || fail "the orphaned holder never acquired the lock"
+[ "$orphan_marker" = "VM0_RUNNER_LIFECYCLE_LOCK_ACQUIRED" ] ||
+  fail "the orphaned holder reported an invalid acquisition marker"
+flock --exclusive --timeout 1 "$lease_lock_file" true &&
+  fail "the orphaned holder did not actually hold the lock"
+
+flock --exclusive --timeout "$((lease_seconds * 3))" "$lease_lock_file" true ||
+  fail "the orphaned holder kept the lock past its lease"
+wait "$orphan_pid" || fail "the orphaned holder exited abnormally"
+background_pids=()
+exec {orphan_fd}>&-
 
 echo "runner-lifecycle-lock-test: ok"

--- a/.github/scripts/with-runner-lifecycle-lock.sh
+++ b/.github/scripts/with-runner-lifecycle-lock.sh
@@ -69,10 +69,8 @@ if [[ ! "$lease_timeout" =~ ^[1-9][0-9]*$ ]] || [ "$lease_timeout" -lt 5 ] ||
   exit 2
 fi
 # Five heartbeats per lease keep a busy CI host from expiring a live holder.
+# The validated five-second floor above keeps this interval at one second or more.
 heartbeat_interval=$((lease_timeout / 5))
-if [ "$heartbeat_interval" -lt 1 ]; then
-  heartbeat_interval=1
-fi
 
 normalized_hosts=$(
   printf '%s\n' "$METAL_HOSTS" |

--- a/.github/scripts/with-runner-lifecycle-lock.sh
+++ b/.github/scripts/with-runner-lifecycle-lock.sh
@@ -8,10 +8,15 @@ Usage: with-runner-lifecycle-lock.sh <command> [args...]
 Acquires the per-runner-namespace lifecycle lock on every configured metal
 host, runs the command while every lock is held, then releases the locks.
 
+Each remote holder keeps the lock only while this script keeps heartbeating
+over the same SSH channel, so a holder that loses its owner releases the lock
+instead of blocking the host until the transport is reaped.
+
 Required env:
   JOB_REF, METAL_HOSTS, METAL_USER
 Optional env:
   RUNNER_LIFECYCLE_LOCK_TIMEOUT_SECONDS (default: 480)
+  RUNNER_LIFECYCLE_LOCK_LEASE_SECONDS (default: 150)
 USAGE
 }
 
@@ -55,6 +60,20 @@ if [[ ! "$lock_timeout" =~ ^[1-9][0-9]*$ ]] || [ "$lock_timeout" -gt 3600 ]; the
 fi
 ready_timeout=$((lock_timeout + 30))
 
+# A remote holder cannot observe a half-open SSH transport, so it releases the
+# lock once this many seconds pass without a heartbeat from its owner.
+lease_timeout=${RUNNER_LIFECYCLE_LOCK_LEASE_SECONDS:-150}
+if [[ ! "$lease_timeout" =~ ^[1-9][0-9]*$ ]] || [ "$lease_timeout" -lt 5 ] ||
+  [ "$lease_timeout" -gt 3600 ]; then
+  echo "runner lifecycle lock lease must be an integer from 5 through 3600 seconds" >&2
+  exit 2
+fi
+# Five heartbeats per lease keep a busy CI host from expiring a live holder.
+heartbeat_interval=$((lease_timeout / 5))
+if [ "$heartbeat_interval" -lt 1 ]; then
+  heartbeat_interval=1
+fi
+
 normalized_hosts=$(
   printf '%s\n' "$METAL_HOSTS" |
     tr ',' '\n' |
@@ -82,6 +101,7 @@ state_dir=$(mktemp -d)
 declare -a lock_fds=()
 declare -a lock_hosts=()
 declare -a lock_pids=()
+declare -a heartbeat_pids=()
 command_pid=""
 locks_released=false
 
@@ -100,6 +120,15 @@ terminate_command() {
   command_pid=""
 }
 
+stop_heartbeats() {
+  local pid
+  for pid in "${heartbeat_pids[@]}"; do
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  done
+  heartbeat_pids=()
+}
+
 release_locks() {
   if $locks_released; then
     return 0
@@ -107,6 +136,9 @@ release_locks() {
   locks_released=true
 
   local index status=0
+  # Heartbeat writers hold the release descriptors, so the remote holders only
+  # see end-of-input once every writer is gone.
+  stop_heartbeats
   for ((index = ${#lock_fds[@]} - 1; index >= 0; index--)); do
     close_fd "${lock_fds[$index]}"
   done
@@ -151,7 +183,7 @@ for host in "${hosts[@]}"; do
 
   lock_path="/var/lock/vm0-runner-lifecycle-${JOB_REF}.lock"
   remote="${METAL_USER}@${host}"
-  remote_command="exec sudo flock --exclusive --timeout ${lock_timeout} ${lock_path} bash -c 'printf \"%s\\n\" VM0_RUNNER_LIFECYCLE_LOCK_ACQUIRED; cat >/dev/null'"
+  remote_command="exec sudo flock --exclusive --timeout ${lock_timeout} ${lock_path} bash -c 'printf \"%s\\n\" VM0_RUNNER_LIFECYCLE_LOCK_ACQUIRED; while IFS= read -r -t ${lease_timeout} _; do :; done'"
   # The validated host, timeout, and lock path select the remote lock. The
   # command itself is static and receives no untrusted shell fragments.
   # shellcheck disable=SC2029
@@ -208,6 +240,22 @@ for host in "${hosts[@]}"; do
   fi
 
   rm -f "$ready_fifo" "$release_fifo" "$marker_file"
+
+  # Start heartbeating before the next host is acquired: a lock taken early
+  # must not expire while a later host is still waiting for its own lock.
+  # `sleep` runs without the release descriptor so stopping this writer frees
+  # the descriptor immediately.
+  (
+    for inherited_fd in "${lock_fds[@]}"; do
+      close_fd "$inherited_fd"
+    done
+    while :; do
+      sleep "$heartbeat_interval" {release_fd}>&-
+      printf '%s\n' VM0_RUNNER_LIFECYCLE_LOCK_HEARTBEAT >&"$release_fd" || exit 0
+    done
+  ) &
+  heartbeat_pids+=("$!")
+
   lock_fds+=("$release_fd")
   lock_hosts+=("$host")
   lock_pids+=("$ssh_pid")
@@ -232,12 +280,18 @@ if [ "$completed_pid" = "$command_pid" ]; then
   command_pid=""
   command_status=$completed_status
 else
-  echo "runner lifecycle lock was lost while the protected command was running" >&2
+  lost_index=""
+  lost_host="an unidentified host"
   for index in "${!lock_pids[@]}"; do
-    if [ "${lock_pids[$index]}" = "$completed_pid" ] && [ -s "${state_dir}/${index}.err" ]; then
-      sed 's/^/  /' "${state_dir}/${index}.err" >&2
+    if [ "${lock_pids[$index]}" = "$completed_pid" ]; then
+      lost_index=$index
+      lost_host="${lock_hosts[$index]}"
     fi
   done
+  echo "runner lifecycle lock on ${lost_host} was lost while the protected command was running" >&2
+  if [ -n "$lost_index" ] && [ -s "${state_dir}/${lost_index}.err" ]; then
+    sed 's/^/  /' "${state_dir}/${lost_index}.err" >&2
+  fi
   terminate_command
   command_status=1
 fi


### PR DESCRIPTION
## Triggering failure

Turbo run [33511100656](https://github.com/vm0-ai/vm0/actions/runs/33511100656) (`merge_group`, `pr-30818`, SHA `9367ae7`) failed in [`deploy-runner-start`](https://github.com/vm0-ai/vm0/actions/runs/33511100656/job/99867506546):

```
13:06:01.945  Acquired runner lifecycle lock for pr-30818 on dev-1.aws.vm3.ai
13:06:03.138  Acquired runner lifecycle lock for pr-30818 on dev-11.gcp.vm3.ai
13:06:06.067  recovery-needed=false
13:06:08.058  runner lifecycle lock was lost while the protected command was running
13:06:08.968  runner lifecycle lock holder exited unexpectedly on dev-1.aws.vm3.ai
```

The trigger itself is external: the SSH transport to `dev-1.aws.vm3.ai` dropped. The same host had already dropped an unrelated Ansible connection four minutes earlier, from a different GitHub runner, in run [33510853747](https://github.com/vm0-ai/vm0/actions/runs/33510853747): `fatal: [dev-1.aws.vm3.ai]: UNREACHABLE!` at 13:01:51Z after 14 successful tasks. Aborting on a lost lock is correct, and this PR does not change that.

## What this PR fixes

The transport drop left the **remote** holder running. The holder was

```sh
sudo flock --exclusive --timeout 480 /var/lock/vm0-runner-lifecycle-pr-30818.lock \
  bash -c 'printf "%s\n" VM0_RUNNER_LIFECYCLE_LOCK_ACQUIRED; cat >/dev/null'
```

so it released the lock only on end-of-input over its SSH channel. A half-open transport never delivers end-of-input, so the orphan kept the lock on the shared dev host.

Evidence that this actually happened: the next merge-group attempt, run [33511602139](https://github.com/vm0-ai/vm0/actions/runs/33511602139), started acquiring at 13:11:11Z and failed at **13:19:11Z** — exactly the 480s acquisition timeout — with `failed to acquire runner lifecycle lock on dev-1.aws.vm3.ai`. The orphan was still holding the lock 13 minutes after its owner died, so one transport blip cost two merge-queue ejections instead of one.

## Change

- The remote holder now reads with an idle timeout (`read -r -t <lease>`) instead of `cat`, so it releases when its owner goes silent. End-of-input still releases it exactly as before.
- The owner starts a heartbeat writer per host as soon as that host's lock is acquired (before the next host is acquired, so an early lock cannot expire while a later host is still waiting) and writes five heartbeats per lease. `sleep` runs without the release descriptor, so stopping a writer frees the descriptor immediately and release stays prompt.
- `RUNNER_LIFECYCLE_LOCK_LEASE_SECONDS` (default 150, so five 30s heartbeats) is validated like the existing timeout.
- The lost-lock message now names the host that dropped. In the triggering run it did not, which is why the failing host had to be recovered from the later `holder exited unexpectedly` line.

Mutual exclusion is preserved: acquisition still blocks on `flock`, the lock is not widened, and a lost lock still aborts the protected command. If a heartbeat writer dies while the transport is alive, the remote holder exits, the owner observes a completed lock PID, and the run aborts — it fails closed. No sleeps or retries were added around the runner start.

## Validation

`.github/scripts/tests/runner-lifecycle-lock-test.sh` now drives the real remote holder command through the mock instead of a hand-written copy, and adds three cases:

- a protected command that outlives the lease keeps its lock (fails without the heartbeat writer: `runner lifecycle lock on metal-lease.example.test was lost while the protected command was running`);
- a two-host lock releases both channels promptly after the protected command finishes;
- an orphaned holder with no end-of-input releases within the lease (fails against the old `cat >/dev/null` holder: `the orphaned holder kept the lock past its lease`).

Locally: 5 consecutive green runs of the lock test, plus `runner-lifecycle-ownership-workflow-test.sh`, the three `cloudflare-ssh-*` tests, `bash -n` over all workflow scripts, `shellcheck` on both changed files, `check-file-size.sh`, and `git diff --check`. The full `deploy-runner-start` invariant is exercised by this PR's own Turbo run.
