### PR TITLE
perf(platform): preload main stylesheet without blocking paint

### DIFF
--- a/.github/scripts/tests/verify-okou-app-runtime-test.sh
+++ b/.github/scripts/tests/verify-okou-app-runtime-test.sh
@@ -20,6 +20,7 @@ fail() {
 
 for file_name in \
   app-AbCd1234.js \
+  index-QrSt7890.css \
   vendor-EfGh5678.js \
   rolldown-runtime-IjKl9012.js \
   shared-database-worker-MnOp3456.js; do
@@ -30,6 +31,8 @@ cat > "$html_source" <<'HTML'
 <!doctype html>
 <meta name="okou-app-git-commit-sha" content="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
 <meta name="okou-app-version" content="0.812.5">
+<link id="vm0-main-stylesheet" rel="preload" as="style" crossorigin href="https://static.test/okou-app/assets/index-QrSt7890.css" fetchpriority="high">
+<script id="vm0-main-stylesheet-loader"></script>
 <script type="module" crossorigin src="https://static.test/okou-app/assets/app-AbCd1234.js"></script>
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/rolldown-runtime-IjKl9012.js">
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/vendor-EfGh5678.js">
@@ -39,6 +42,8 @@ cat > "$old_html_source" <<'HTML'
 <!doctype html>
 <meta name="okou-app-git-commit-sha" content="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb">
 <meta name="okou-app-version" content="0.812.4">
+<link id="vm0-main-stylesheet" rel="preload" as="style" crossorigin href="https://static.test/okou-app/assets/index-Old12345.css" fetchpriority="high">
+<script id="vm0-main-stylesheet-loader"></script>
 <script type="module" crossorigin src="https://static.test/okou-app/assets/app-Old12345.js"></script>
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/rolldown-runtime-Old12345.js">
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/vendor-Old12345.js">
@@ -102,10 +107,11 @@ output="$({
 } 2>&1)"
 
 grep -Fq \
-  'Verified app runtime: app=https://static.test/okou-app/assets/app-AbCd1234.js vendor=https://static.test/okou-app/assets/vendor-EfGh5678.js runtime=https://static.test/okou-app/assets/rolldown-runtime-IjKl9012.js worker=https://app.test/okou-app/assets/shared-database-worker-MnOp3456.js' \
+  'Verified app runtime: stylesheet=https://static.test/okou-app/assets/index-QrSt7890.css app=https://static.test/okou-app/assets/app-AbCd1234.js vendor=https://static.test/okou-app/assets/vendor-EfGh5678.js runtime=https://static.test/okou-app/assets/rolldown-runtime-IjKl9012.js worker=https://app.test/okou-app/assets/shared-database-worker-MnOp3456.js' \
   <<< "$output" || fail "runtime verification summary is incorrect"
 for expected_url in \
   https://app.test/sign-up \
+  https://static.test/okou-app/assets/index-QrSt7890.css \
   https://static.test/okou-app/assets/app-AbCd1234.js \
   https://static.test/okou-app/assets/vendor-EfGh5678.js \
   https://static.test/okou-app/assets/rolldown-runtime-IjKl9012.js \

--- a/.github/scripts/verify-okou-app-runtime.sh
+++ b/.github/scripts/verify-okou-app-runtime.sh
@@ -32,13 +32,15 @@ probe_evidence="$(mktemp)"
 trap 'rm -f "$layout_files" "$document_body" "$curl_error" "$probe_evidence"' EXIT
 
 declare -a app_files=()
+declare -a stylesheet_files=()
 declare -a vendor_files=()
 declare -a runtime_files=()
 declare -a worker_files=()
-find "$assets_directory" -type f -name '*.js' -print0 > "$layout_files"
+find "$assets_directory" -type f \( -name '*.js' -o -name '*.css' \) -print0 > "$layout_files"
 while IFS= read -r -d '' source_path; do
   relative_path="${source_path#"$assets_directory"/}"
   case "$relative_path" in
+    index-*.css) stylesheet_files+=("$relative_path") ;;
     vendor-*.js) vendor_files+=("$relative_path") ;;
     rolldown-runtime-*.js) runtime_files+=("$relative_path") ;;
     shared-database-worker-*.js) worker_files+=("$relative_path") ;;
@@ -48,15 +50,17 @@ done < "$layout_files"
 
 if ((
   ${#app_files[@]} != 1 ||
+  ${#stylesheet_files[@]} != 1 ||
   ${#vendor_files[@]} != 1 ||
   ${#runtime_files[@]} != 1 ||
   ${#worker_files[@]} != 1
 )); then
-  echo "Expected exactly one app, vendor, Rolldown runtime, and SharedWorker JavaScript asset" >&2
+  echo "Expected exactly one app stylesheet plus one app, vendor, Rolldown runtime, and SharedWorker JavaScript asset" >&2
   exit 1
 fi
 
 app_asset_url="${public_assets_url}/${app_files[0]}"
+stylesheet_asset_url="${public_assets_url}/${stylesheet_files[0]}"
 vendor_asset_url="${public_assets_url}/${vendor_files[0]}"
 runtime_asset_url="${public_assets_url}/${runtime_files[0]}"
 worker_asset_url="${app_url}/okou-app/assets/${worker_files[0]}"
@@ -86,7 +90,8 @@ for ((attempt = 1; attempt <= document_max_attempts; attempt++)); do
       "$canonical_document" \
       "$app_asset_url" \
       "$runtime_asset_url" \
-      "$vendor_asset_url" 2>"$probe_evidence" <<'PY'
+      "$vendor_asset_url" \
+      "$stylesheet_asset_url" 2>"$probe_evidence" <<'PY'
 from html.parser import HTMLParser
 from pathlib import Path
 import re
@@ -96,6 +101,8 @@ COMMIT_SHA_META_NAME = "okou-app-git-commit-sha"
 VERSION_META_NAME = "okou-app-version"
 RUNTIME_META_NAMES = {COMMIT_SHA_META_NAME, VERSION_META_NAME}
 COMMIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+MAIN_STYLESHEET_ID = "vm0-main-stylesheet"
+MAIN_STYLESHEET_LOADER_SCRIPT_ID = "vm0-main-stylesheet-loader"
 
 
 class AppDocumentParser(HTMLParser):
@@ -103,6 +110,8 @@ class AppDocumentParser(HTMLParser):
         super().__init__()
         self.module_scripts: list[str] = []
         self.module_preloads: list[str] = []
+        self.main_stylesheets: list[dict[str, str | None]] = []
+        self.main_stylesheet_loader_count = 0
         self.runtime_metadata: dict[str, list[str | None]] = {
             name: [] for name in RUNTIME_META_NAMES
         }
@@ -111,6 +120,13 @@ class AppDocumentParser(HTMLParser):
         self, tag: str, attrs: list[tuple[str, str | None]]
     ) -> None:
         attributes = dict(attrs)
+        if tag == "link" and attributes.get("id") == MAIN_STYLESHEET_ID:
+            self.main_stylesheets.append(attributes)
+        if (
+            tag == "script"
+            and attributes.get("id") == MAIN_STYLESHEET_LOADER_SCRIPT_ID
+        ):
+            self.main_stylesheet_loader_count += 1
         if tag == "script" and attributes.get("type") == "module":
             source = attributes.get("src")
             if source:
@@ -160,6 +176,7 @@ if observed_metadata != expected_metadata:
 
 expected_script = [sys.argv[3]]
 expected_preloads = {sys.argv[4], sys.argv[5]}
+expected_stylesheet = sys.argv[6]
 if parser.module_scripts != expected_script:
     raise RuntimeError(
         f"Expected one CDN app module script {expected_script}, got {parser.module_scripts}"
@@ -168,6 +185,30 @@ if len(parser.module_preloads) != 2 or set(parser.module_preloads) != expected_p
     raise RuntimeError(
         f"Expected CDN runtime/vendor modulepreloads {sorted(expected_preloads)}, "
         f"got {parser.module_preloads}"
+    )
+if len(parser.main_stylesheets) != 1:
+    raise RuntimeError(
+        f"Expected one main stylesheet preload, got {parser.main_stylesheets}"
+    )
+main_stylesheet = parser.main_stylesheets[0]
+expected_stylesheet_attributes = {
+    "as": "style",
+    "fetchpriority": "high",
+    "href": expected_stylesheet,
+    "rel": "preload",
+}
+observed_stylesheet_attributes = {
+    name: main_stylesheet.get(name) for name in expected_stylesheet_attributes
+}
+if observed_stylesheet_attributes != expected_stylesheet_attributes:
+    raise RuntimeError(
+        f"Expected main stylesheet preload {expected_stylesheet_attributes}, "
+        f"got {observed_stylesheet_attributes}"
+    )
+if parser.main_stylesheet_loader_count != 1:
+    raise RuntimeError(
+        "Expected exactly one main stylesheet loader, "
+        f"got {parser.main_stylesheet_loader_count}"
     )
 PY
     then
@@ -211,6 +252,7 @@ PY
 done
 
 for asset_url in \
+  "$stylesheet_asset_url" \
   "$app_asset_url" \
   "$vendor_asset_url" \
   "$runtime_asset_url"; do
@@ -249,7 +291,8 @@ if [[ "$worker_status" != "206" ]]; then
   exit 1
 fi
 
-printf 'Verified app runtime: app=%s vendor=%s runtime=%s worker=%s\n' \
+printf 'Verified app runtime: stylesheet=%s app=%s vendor=%s runtime=%s worker=%s\n' \
+  "$stylesheet_asset_url" \
   "$app_asset_url" \
   "$vendor_asset_url" \
   "$runtime_asset_url" \

--- a/turbo/apps/platform/scripts/app-resource-priority-html.ts
+++ b/turbo/apps/platform/scripts/app-resource-priority-html.ts
@@ -72,7 +72,7 @@ function mainStylesheetLoaderScript(): string {
               stylesheet.removeAttribute("as");
               requestAnimationFrame(function () {
                 requestAnimationFrame(function () {
-                  resolve();
+                  resolve("loaded");
                 });
               });
             },
@@ -81,8 +81,7 @@ function mainStylesheetLoaderScript(): string {
           stylesheet.addEventListener(
             "error",
             function () {
-              console.error("Failed to load the main application stylesheet");
-              resolve();
+              resolve("failed");
             },
             { once: true },
           );

--- a/turbo/apps/platform/scripts/app-resource-priority-html.ts
+++ b/turbo/apps/platform/scripts/app-resource-priority-html.ts
@@ -1,6 +1,8 @@
 import type { Plugin } from "vite";
 
 const CRITICAL_STYLE_ID = "app-bootstrap-critical-styles";
+const MAIN_STYLESHEET_ID = "vm0-main-stylesheet";
+const MAIN_STYLESHEET_LOADER_SCRIPT_ID = "vm0-main-stylesheet-loader";
 
 function matchingTags(
   htmlSource: string,
@@ -46,6 +48,47 @@ function withFetchPriority(tag: string, priority: "high" | "low"): string {
     );
   }
   return `${tag.slice(0, startTagEnd)} fetchpriority="${priority}"${tag.slice(startTagEnd)}`;
+}
+
+function mainStylesheetPreload(tag: string): string {
+  return withFetchPriority(
+    tag.replace(
+      /\srel="stylesheet"/u,
+      ` id="${MAIN_STYLESHEET_ID}" rel="preload" as="style"`,
+    ),
+    "high",
+  );
+}
+
+function mainStylesheetLoaderScript(): string {
+  return `<script id="${MAIN_STYLESHEET_LOADER_SCRIPT_ID}">
+      (function () {
+        var stylesheet = document.getElementById("${MAIN_STYLESHEET_ID}");
+        window.__mainStylesheetLoaded = new Promise(function (resolve) {
+          stylesheet.addEventListener(
+            "load",
+            function () {
+              stylesheet.rel = "stylesheet";
+              stylesheet.removeAttribute("as");
+              requestAnimationFrame(function () {
+                requestAnimationFrame(function () {
+                  resolve();
+                });
+              });
+            },
+            { once: true },
+          );
+          stylesheet.addEventListener(
+            "error",
+            function () {
+              console.error("Failed to load the main application stylesheet");
+              resolve();
+            },
+            { once: true },
+          );
+        });
+      })();
+    </script>`;
 }
 
 function removeTag(htmlSource: string, tag: string): string {
@@ -110,7 +153,8 @@ function prioritizeApplicationResources(htmlSource: string): string {
     throw new Error("Critical application stylesheet is missing </style>");
   }
   const headResources = [
-    withFetchPriority(stylesheet, "high"),
+    mainStylesheetPreload(stylesheet),
+    mainStylesheetLoaderScript(),
     withFetchPriority(runtimePreload, "low"),
     withFetchPriority(vendorPreload, "low"),
   ]

--- a/turbo/apps/platform/scripts/check-build-config.node.ts
+++ b/turbo/apps/platform/scripts/check-build-config.node.ts
@@ -409,11 +409,11 @@ function assertApplicationResourcePriority(htmlSource: string): void {
   assert.match(htmlSource, /stylesheet\.rel = "stylesheet"/u);
   assert.match(
     htmlSource,
-    /requestAnimationFrame\(function \(\) \{\s*requestAnimationFrame\(function \(\) \{\s*resolve\(\);/u,
+    /requestAnimationFrame\(function \(\) \{\s*requestAnimationFrame\(function \(\) \{\s*resolve\("loaded"\);/u,
   );
   assert.match(
     htmlSource,
-    /"error",\s*function \(\) \{\s*console\.error\("Failed to load the main application stylesheet"\);\s*resolve\(\);/u,
+    /"error",\s*function \(\) \{\s*resolve\("failed"\);/u,
   );
   assert.equal(
     (

--- a/turbo/apps/platform/scripts/check-build-config.node.ts
+++ b/turbo/apps/platform/scripts/check-build-config.node.ts
@@ -378,7 +378,10 @@ function assertApplicationResourcePriority(htmlSource: string): void {
   const criticalStyleIndex = htmlSource.indexOf(
     '<style id="app-bootstrap-critical-styles">',
   );
-  const stylesheetIndex = htmlSource.indexOf('rel="stylesheet"');
+  const stylesheetIndex = htmlSource.indexOf('id="vm0-main-stylesheet"');
+  const stylesheetLoaderIndex = htmlSource.indexOf(
+    'id="vm0-main-stylesheet-loader"',
+  );
   const runtimePreloadIndex = htmlSource.indexOf("assets/rolldown-runtime-");
   const vendorPreloadIndex = htmlSource.indexOf("assets/vendor-");
   const clerkCoreIndex = htmlSource.indexOf('id="vm0-clerk-core-script"');
@@ -388,14 +391,29 @@ function assertApplicationResourcePriority(htmlSource: string): void {
 
   assert.ok(criticalStyleIndex !== -1);
   assert.ok(stylesheetIndex > criticalStyleIndex);
-  assert.ok(runtimePreloadIndex > stylesheetIndex);
+  assert.ok(stylesheetLoaderIndex > stylesheetIndex);
+  assert.ok(runtimePreloadIndex > stylesheetLoaderIndex);
   assert.ok(vendorPreloadIndex > runtimePreloadIndex);
   assert.ok(clerkCoreIndex > vendorPreloadIndex);
   assert.ok(appModuleIndex > skeletonIndex);
   assert.ok(bodyEndIndex > appModuleIndex);
   assert.match(
     htmlSource,
-    /<link rel="stylesheet"[^>]*fetchpriority="high"[^>]*>/u,
+    /<link id="vm0-main-stylesheet" rel="preload" as="style"[^>]*fetchpriority="high"[^>]*>/u,
+  );
+  assert.equal((htmlSource.match(/<link rel="stylesheet"/gu) ?? []).length, 0);
+  assert.match(
+    htmlSource,
+    /window\.__mainStylesheetLoaded = new Promise\(function \(resolve\)/u,
+  );
+  assert.match(htmlSource, /stylesheet\.rel = "stylesheet"/u);
+  assert.match(
+    htmlSource,
+    /requestAnimationFrame\(function \(\) \{\s*requestAnimationFrame\(function \(\) \{\s*resolve\(\);/u,
+  );
+  assert.match(
+    htmlSource,
+    /"error",\s*function \(\) \{\s*console\.error\("Failed to load the main application stylesheet"\);\s*resolve\(\);/u,
   );
   assert.equal(
     (

--- a/turbo/apps/platform/src/global.d.ts
+++ b/turbo/apps/platform/src/global.d.ts
@@ -40,10 +40,10 @@ declare global {
     /** Set when the entry module graph has finished evaluating. */
     __appBootstrapModuleReady?: number;
     /**
-     * Resolves after the main stylesheet is active and has crossed a rendering
-     * opportunity, or after its preload fails so bootstrap can fail open.
+     * Reports whether the main stylesheet became active after crossing a
+     * rendering opportunity or failed to load.
      */
-    __mainStylesheetLoaded?: Promise<void>;
+    __mainStylesheetLoaded?: Promise<"failed" | "loaded">;
   }
 }
 

--- a/turbo/apps/platform/src/global.d.ts
+++ b/turbo/apps/platform/src/global.d.ts
@@ -39,6 +39,11 @@ declare global {
     __appBootstrapStart?: number;
     /** Set when the entry module graph has finished evaluating. */
     __appBootstrapModuleReady?: number;
+    /**
+     * Resolves after the main stylesheet is active and has crossed a rendering
+     * opportunity, or after its preload fails so bootstrap can fail open.
+     */
+    __mainStylesheetLoaded?: Promise<void>;
   }
 }
 

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-phase-telemetry.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-phase-telemetry.test.ts
@@ -246,8 +246,10 @@ describe("bootstrap phase telemetry", () => {
   it("reports the bootstrap event only once", async () => {
     await setupPage({ context, path: ROUTES.error, withoutRender: true });
 
-    context.store.set(hideAppSkeleton$, context.signal);
-    context.store.set(hideAppSkeleton$, context.signal);
+    await Promise.all([
+      context.store.set(hideAppSkeleton$, context.signal),
+      context.store.set(hideAppSkeleton$, context.signal),
+    ]);
 
     expect(timingEvents()).toHaveLength(1);
     expect(

--- a/turbo/apps/platform/src/signals/app-skeleton.ts
+++ b/turbo/apps/platform/src/signals/app-skeleton.ts
@@ -32,7 +32,10 @@ export async function hideBootstrapSkeleton(
 ): Promise<void> {
   const mainStylesheetLoaded = window.__mainStylesheetLoaded;
   if (mainStylesheetLoaded) {
-    await mainStylesheetLoaded;
+    const mainStylesheetStatus = await mainStylesheetLoaded;
+    if (mainStylesheetStatus === "failed") {
+      throw new Error("Failed to load the main application stylesheet");
+    }
   }
   signal?.throwIfAborted();
 

--- a/turbo/apps/platform/src/signals/app-skeleton.ts
+++ b/turbo/apps/platform/src/signals/app-skeleton.ts
@@ -27,7 +27,15 @@ export const initBootstrapSkeleton$ = command(({ set }) => {
   set(internalBootstrapSkeletonActive$, active);
 });
 
-export function hideBootstrapSkeleton(): void {
+export async function hideBootstrapSkeleton(
+  signal?: AbortSignal,
+): Promise<void> {
+  const mainStylesheetLoaded = window.__mainStylesheetLoaded;
+  if (mainStylesheetLoaded) {
+    await mainStylesheetLoaded;
+  }
+  signal?.throwIfAborted();
+
   const skeleton = document.getElementById(APP_BOOTSTRAP_SKELETON_ID);
   if (!skeleton) {
     return;
@@ -62,16 +70,18 @@ export const showAppSkeleton$ = command(({ get, set }) => {
   set(internalOverlayMounted$, !get(internalBootstrapSkeletonActive$));
 });
 
-export const hideAppSkeleton$ = command(({ set }, _signal: AbortSignal) => {
-  set(internalBootstrapSkeletonActive$, false);
-  set(internalVisible$, false);
-  hideBootstrapSkeleton();
-  set(captureFirstSkeletonHide$);
-  set(captureBootstrapPhaseTiming$);
-});
+export const hideAppSkeleton$ = command(
+  async ({ set }, signal: AbortSignal): Promise<void> => {
+    await hideBootstrapSkeleton(signal);
+    set(internalBootstrapSkeletonActive$, false);
+    set(internalVisible$, false);
+    set(captureFirstSkeletonHide$);
+    set(captureBootstrapPhaseTiming$);
+  },
+);
 
 export const hideAppSkeletonOnContentReadyRef$ = onRef(
-  command(({ set }, _element: HTMLSpanElement, signal: AbortSignal) => {
-    set(hideAppSkeleton$, signal);
+  command(async ({ set }, _element: HTMLSpanElement, signal: AbortSignal) => {
+    await set(hideAppSkeleton$, signal);
   }),
 );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/app-skeleton.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/app-skeleton.test.tsx
@@ -6,7 +6,6 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { hideBootstrapSkeleton } from "../../../signals/app-skeleton.ts";
 
 const context = testContext();
 
@@ -54,14 +53,23 @@ describe("app skeleton", () => {
   });
 
   it("keeps the inline loading surface when the main stylesheet fails", async () => {
-    vi.stubGlobal("__mainStylesheetLoaded", Promise.resolve("failed"));
+    const stylesheetLoaded = context.mocks.deferred<"failed" | "loaded">();
+    vi.stubGlobal("__mainStylesheetLoaded", stylesheetLoaded.promise);
     const bootstrapSkeleton = document.createElement("div");
     bootstrapSkeleton.id = "app-bootstrap-skeleton";
     document.body.append(bootstrapSkeleton);
 
-    await expect(hideBootstrapSkeleton()).rejects.toThrow(
-      "Failed to load the main application stylesheet",
-    );
+    // A stylesheet network failure happens before the app exposes a page
+    // interaction, so the build-installed promise is this scenario's
+    // production boundary. The page still enters through its real bootstrap.
+    detachedSetupPage({ context, path: "/_/error" });
+
+    await waitFor(() => {
+      expect(queryAllByRoleFast("link")).not.toHaveLength(0);
+    });
+
+    stylesheetLoaded.resolve("failed");
+    await stylesheetLoaded.promise;
 
     expect(bootstrapSkeleton).not.toHaveAttribute("aria-hidden");
     expect(document.getElementById("app-bootstrap-skeleton")).toBe(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/app-skeleton.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/app-skeleton.test.tsx
@@ -6,6 +6,7 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { hideBootstrapSkeleton } from "../../../signals/app-skeleton.ts";
 
 const context = testContext();
 
@@ -29,7 +30,7 @@ describe("app skeleton", () => {
   });
 
   it("keeps the inline loading surface until the main stylesheet is ready", async () => {
-    const stylesheetLoaded = context.mocks.deferred<void>();
+    const stylesheetLoaded = context.mocks.deferred<"failed" | "loaded">();
     vi.stubGlobal("__mainStylesheetLoaded", stylesheetLoaded.promise);
     const bootstrapSkeleton = document.createElement("div");
     bootstrapSkeleton.id = "app-bootstrap-skeleton";
@@ -40,16 +41,33 @@ describe("app skeleton", () => {
     await waitFor(() => {
       expect(queryAllByRoleFast("link")).not.toHaveLength(0);
     });
-    expect(bootstrapSkeleton).not.toHaveClass("app-bootstrap-skeleton--hidden");
+    expect(bootstrapSkeleton).not.toHaveAttribute("aria-hidden");
 
-    stylesheetLoaded.resolve(undefined);
+    stylesheetLoaded.resolve("loaded");
 
     await waitFor(() => {
-      expect(bootstrapSkeleton).toHaveClass("app-bootstrap-skeleton--hidden");
+      expect(bootstrapSkeleton).toHaveAttribute("aria-hidden", "true");
     });
 
     bootstrapSkeleton.dispatchEvent(new Event("transitionend"));
     expect(document.getElementById("app-bootstrap-skeleton")).toBeNull();
+  });
+
+  it("keeps the inline loading surface when the main stylesheet fails", async () => {
+    vi.stubGlobal("__mainStylesheetLoaded", Promise.resolve("failed"));
+    const bootstrapSkeleton = document.createElement("div");
+    bootstrapSkeleton.id = "app-bootstrap-skeleton";
+    document.body.append(bootstrapSkeleton);
+
+    await expect(hideBootstrapSkeleton()).rejects.toThrow(
+      "Failed to load the main application stylesheet",
+    );
+
+    expect(bootstrapSkeleton).not.toHaveAttribute("aria-hidden");
+    expect(document.getElementById("app-bootstrap-skeleton")).toBe(
+      bootstrapSkeleton,
+    );
+    bootstrapSkeleton.remove();
   });
 
   it("unmounts the app skeleton after its fade-out completes", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/app-skeleton.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/app-skeleton.test.tsx
@@ -1,7 +1,10 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
@@ -22,6 +25,30 @@ describe("app skeleton", () => {
 
     bootstrapSkeleton.dispatchEvent(new Event("transitionend"));
 
+    expect(document.getElementById("app-bootstrap-skeleton")).toBeNull();
+  });
+
+  it("keeps the inline loading surface until the main stylesheet is ready", async () => {
+    const stylesheetLoaded = context.mocks.deferred<void>();
+    vi.stubGlobal("__mainStylesheetLoaded", stylesheetLoaded.promise);
+    const bootstrapSkeleton = document.createElement("div");
+    bootstrapSkeleton.id = "app-bootstrap-skeleton";
+    document.body.append(bootstrapSkeleton);
+
+    detachedSetupPage({ context, path: "/_/error" });
+
+    await waitFor(() => {
+      expect(queryAllByRoleFast("link")).not.toHaveLength(0);
+    });
+    expect(bootstrapSkeleton).not.toHaveClass("app-bootstrap-skeleton--hidden");
+
+    stylesheetLoaded.resolve(undefined);
+
+    await waitFor(() => {
+      expect(bootstrapSkeleton).toHaveClass("app-bootstrap-skeleton--hidden");
+    });
+
+    bootstrapSkeleton.dispatchEvent(new Event("transitionend"));
     expect(document.getElementById("app-bootstrap-skeleton")).toBeNull();
   });
 

--- a/turbo/apps/platform/src/views/unsupported-browser-page.tsx
+++ b/turbo/apps/platform/src/views/unsupported-browser-page.tsx
@@ -6,6 +6,7 @@ import type {
 } from "../lib/browser-support.ts";
 import { hideBootstrapSkeleton } from "../signals/app-skeleton.ts";
 import type { AssistantName } from "../signals/branding.ts";
+import { detach, Reason } from "../signals/utils.ts";
 
 const UPGRADE_COPY = {
   browser: {
@@ -95,10 +96,14 @@ export function renderUnsupportedBrowserPage(
   assistantName: AssistantName,
   upgrade: BrowserUpgrade,
 ): void {
-  hideBootstrapSkeleton();
   const root = createRoot(rootElement);
   root.render(
     <UnsupportedBrowserPage assistantName={assistantName} upgrade={upgrade} />,
+  );
+  detach(
+    hideBootstrapSkeleton(),
+    Reason.Entrance,
+    "unsupported browser bootstrap skeleton",
   );
   function unmountOnFinalPageHide(event: PageTransitionEvent): void {
     if (event.persisted) {


### PR DESCRIPTION
## Summary

- keep the Vite-generated main stylesheet as a static `preload` tag so the browser preload scanner can discover and download it without blocking first paint
- inject an adjacent inline loader that publishes `window.__mainStylesheetLoaded`, activates the stylesheet after preload, and reports readiness after a rendered frame boundary
- wait for that readiness promise before dismissing both the bootstrap and React skeletons while leaving the app entry and module preloads statically discoverable
- preserve the bootstrap loading surface when the stylesheet fails instead of exposing the application without its main styles, and extend build/runtime verification to cover the stylesheet topology and asset

## Context

This is an alternative to #30879. It preserves early CSS and JavaScript discovery plus parallel app bootstrap instead of postponing the entire application resource graph until after first contentful paint. The skeleton remains visible until the main stylesheet is active and has crossed two animation-frame callbacks.

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm check-types`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/app-skeleton.test.tsx src/signals/__tests__/bootstrap-phase-telemetry.test.ts --maxWorkers=1 --silent=passed-only` (12/12)
- `bash .github/scripts/tests/verify-okou-app-runtime-test.sh`
- production `pnpm -F @okouai/app build` with test Clerk build inputs
