### PR TITLE
perf(runner): specialize reused codex cleanup lifecycle

### DIFF
--- a/crates/guest-agent/scripts/codex-session-cleanup.sh
+++ b/crates/guest-agent/scripts/codex-session-cleanup.sh
@@ -1,16 +1,17 @@
-# Codex restore cleanup contract
+# Fixed Codex restore cleanup contract
 #
-# This helper is embedded by the runner and runs before history restoration
-# only when an idle sandbox is reused. It is destructive within the canonical
-# $codex_home/sessions tree: matching regular files and symlinks are removed,
-# while unrelated entries and directories are preserved.
+# This helper is embedded by guest-agent and launched only through the fixed
+# reused-Codex cleanup operation before history restoration. It is destructive
+# within the canonical $codex_home/sessions tree: matching regular files and
+# symlinks are removed, while unrelated entries and directories are preserved.
 #
 # OKOU_CODEX_RESTORE_SESSION_ID and
 # OKOU_CODEX_RESTORE_SESSION_FILENAME_KEY identify the dashed and undashed
-# session-name forms. OKOU_CODEX_RESTORE_SESSION_PATH supplies the caller's
-# canonical sessions/YYYY/MM/DD restore path. The helper validates these
-# inputs' shape and the session root's directory components before scanning;
-# Rust independently validates any logical path returned by the helper.
+# session-name forms. OKOU_CODEX_RESTORE_SESSION_PATH supplies the validated
+# canonical sessions/YYYY/MM/DD restore path. The fixed guest entry point owns
+# these values, the Codex home, and the scan budget. The helper validates their
+# shape and the session root's directory components before scanning; Rust
+# independently validates any logical path returned by the helper.
 #
 # The collection pass walks the whole sessions tree, not only the fallback date
 # directory, and is bounded by OKOU_CODEX_SESSION_CLEANUP_SCAN_BUDGET (default

--- a/crates/guest-agent/src/codex_session_cleanup.rs
+++ b/crates/guest-agent/src/codex_session_cleanup.rs
@@ -1,0 +1,42 @@
+//! Fixed reused-Codex session cleanup helper.
+
+use std::io;
+use std::process::Command;
+
+use api_contracts::generated::constants::runners::paths::CANONICAL_CODEX_HOME_DIR;
+use guest_contracts::codex_session_cleanup::{
+    CODEX_SESSION_CLEANUP_SCAN_BUDGET, CodexSessionCleanupRequest,
+};
+
+const CODEX_SESSION_CLEANUP_SCRIPT: &str = include_str!("../scripts/codex-session-cleanup.sh");
+
+/// Execute the fixed cleanup shell contract and return its exit code.
+pub fn run(request: &CodexSessionCleanupRequest) -> io::Result<i32> {
+    request
+        .validate()
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error.to_string()))?;
+    let filename_key = request
+        .filename_key()
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error.to_string()))?;
+    let restore_path = format!(
+        "{CANONICAL_CODEX_HOME_DIR}/{}",
+        request.fallback_relative_path
+    );
+    let command =
+        format!("codex_home='{CANONICAL_CODEX_HOME_DIR}'\n{CODEX_SESSION_CLEANUP_SCRIPT}");
+    let status = Command::new("/bin/sh")
+        .arg("-c")
+        .arg(command)
+        .env_clear()
+        .env("LANG", "C.UTF-8")
+        .env("PATH", "/usr/local/bin:/usr/bin:/bin")
+        .env("OKOU_CODEX_RESTORE_SESSION_ID", &request.session_id)
+        .env("OKOU_CODEX_RESTORE_SESSION_FILENAME_KEY", filename_key)
+        .env("OKOU_CODEX_RESTORE_SESSION_PATH", restore_path)
+        .env(
+            "OKOU_CODEX_SESSION_CLEANUP_SCAN_BUDGET",
+            CODEX_SESSION_CLEANUP_SCAN_BUDGET.to_string(),
+        )
+        .status()?;
+    Ok(status.code().unwrap_or(1))
+}

--- a/crates/guest-agent/src/lib.rs
+++ b/crates/guest-agent/src/lib.rs
@@ -178,6 +178,7 @@ mod artifact;
 pub mod checkpoint;
 pub mod cli;
 mod codex_auth;
+pub mod codex_session_cleanup;
 pub mod complete;
 mod constants;
 mod content_hash;

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -15,9 +15,9 @@ use guest_agent::metrics;
 use guest_agent::paths;
 use guest_agent::reuse_preparation;
 use guest_agent::run_context::GuestRuntime;
-use guest_agent::session_history_identity;
 use guest_agent::session_metadata;
 use guest_agent::telemetry::{Telemetry, UploadMode};
+use guest_agent::{codex_session_cleanup, session_history_identity};
 
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info, log_warn};
@@ -160,6 +160,30 @@ fn helper_exit_code_from_args() -> Option<i32> {
                 Err(error) => {
                     eprintln!("{error}");
                     error.exit_code()
+                }
+            })
+        }
+        "cleanup-codex-session" => {
+            let Some(session_id) = args.next().and_then(|value| value.into_string().ok()) else {
+                return Some(1);
+            };
+            let Some(fallback_relative_path) =
+                args.next().and_then(|value| value.into_string().ok())
+            else {
+                return Some(1);
+            };
+            if args.next().is_some() {
+                return Some(1);
+            }
+            let request = guest_contracts::codex_session_cleanup::CodexSessionCleanupRequest {
+                session_id,
+                fallback_relative_path,
+            };
+            Some(match codex_session_cleanup::run(&request) {
+                Ok(exit_code) => exit_code,
+                Err(error) => {
+                    eprintln!("{error}");
+                    1
                 }
             })
         }

--- a/crates/guest-agent/tests/integration_cases/codex_session_cleanup.rs
+++ b/crates/guest-agent/tests/integration_cases/codex_session_cleanup.rs
@@ -1,0 +1,565 @@
+use std::fs;
+use std::io;
+use std::os::unix::fs::{PermissionsExt, symlink};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use api_contracts::generated::constants::runners::paths::CANONICAL_CODEX_HOME_DIR;
+use shell_quote::quote_shell_arg;
+
+const CODEX_SESSION_CLEANUP_SCRIPT: &str = include_str!("../../scripts/codex-session-cleanup.sh");
+
+fn codex_session_cleanup_command(codex_home: &str) -> String {
+    let codex_home = quote_shell_arg(codex_home);
+    format!("codex_home={codex_home}\n{CODEX_SESSION_CLEANUP_SCRIPT}")
+}
+
+const SESSION_ID: &str = "019e9154-c304-70f0-adde-36efb1be1701";
+const SESSION_ID_NO_DASHES: &str = "019e9154c30470f0adde36efb1be1701";
+
+fn restore_path(codex_home: &Path) -> PathBuf {
+    codex_home.join(format!(
+        "sessions/2026/06/04/rollout-2026-06-04T07-18-08-{SESSION_ID}.jsonl"
+    ))
+}
+
+fn create_file(path: &Path) -> io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("test path should have a parent: {}", path.display()),
+        )
+    })?;
+    fs::create_dir_all(parent)?;
+    fs::write(path, "test")
+}
+
+fn canonical_path(codex_home: &Path, date: &str, time: &str) -> PathBuf {
+    let date_components: Vec<_> = date.split('-').collect();
+    let [year, month, day] = date_components.as_slice() else {
+        assert_eq!(date_components.len(), 3, "test date should be YYYY-MM-DD");
+        return codex_home.to_path_buf();
+    };
+    codex_home.join(format!(
+        "sessions/{year}/{month}/{day}/rollout-{date}T{time}-{SESSION_ID}.jsonl"
+    ))
+}
+
+fn run_cleanup(codex_home: &Path, restore_path: &Path) -> io::Result<Output> {
+    run_cleanup_with_session_id(codex_home, restore_path, SESSION_ID)
+}
+
+fn run_cleanup_with_session_id(
+    codex_home: &Path,
+    restore_path: &Path,
+    session_id: &str,
+) -> io::Result<Output> {
+    let session_filename_key = session_id.replace('-', "");
+    run_cleanup_with_session_identity(codex_home, restore_path, session_id, &session_filename_key)
+}
+
+fn run_cleanup_with_session_identity(
+    codex_home: &Path,
+    restore_path: &Path,
+    session_id: &str,
+    session_filename_key: &str,
+) -> io::Result<Output> {
+    cleanup_command(codex_home, restore_path, session_id, session_filename_key).output()
+}
+
+fn run_cleanup_with_budget(
+    codex_home: &Path,
+    restore_path: &Path,
+    budget: &str,
+) -> io::Result<Output> {
+    cleanup_command(codex_home, restore_path, SESSION_ID, SESSION_ID_NO_DASHES)
+        .env("OKOU_CODEX_SESSION_CLEANUP_SCAN_BUDGET", budget)
+        .output()
+}
+
+fn cleanup_command(
+    codex_home: &Path,
+    restore_path: &Path,
+    session_id: &str,
+    session_filename_key: &str,
+) -> Command {
+    let mut command = Command::new("sh");
+    command
+        .arg("-c")
+        .arg(codex_session_cleanup_command(
+            codex_home.to_string_lossy().as_ref(),
+        ))
+        .env("OKOU_CODEX_RESTORE_SESSION_ID", session_id)
+        .env(
+            "OKOU_CODEX_RESTORE_SESSION_FILENAME_KEY",
+            session_filename_key,
+        )
+        .env("OKOU_CODEX_RESTORE_SESSION_PATH", restore_path);
+    command
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "stderr={} stdout={}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+fn assert_failure_contains(output: &Output, expected: &str) {
+    assert!(
+        !output.status.success(),
+        "expected command to fail; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(expected),
+        "expected stderr to contain {expected:?}, got {stderr:?}"
+    );
+}
+
+#[test]
+fn cleanup_command_uses_fixed_codex_home_prelude() {
+    let command = codex_session_cleanup_command(CANONICAL_CODEX_HOME_DIR);
+
+    assert!(command.contains("codex_home='/home/user/.codex'"));
+    assert!(command.contains("root=\"$codex_home/sessions\""));
+    assert!(command.contains("scan_budget="));
+    assert!(command.contains("collect_matching_session_entries"));
+    assert!(command.contains("find \"$root\" -mindepth 1 -printf '%y%p\\0'"));
+    assert!(command.contains("canonical_logical_path"));
+    assert!(command.contains("candidate_ambiguous"));
+    assert!(command.contains("delete_matching_session_entries"));
+    assert!(command.contains("xargs -0"));
+    assert!(!command.contains("-delete"));
+    assert!(!command.contains("for path in \"$dir\"/*"));
+}
+
+#[test]
+fn cleanup_script_deletes_matching_session_files_and_symlinks() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_home = temp.path().join(".codex");
+    let restore_path = restore_path(&codex_home);
+    let restore_dir = restore_path.parent().unwrap();
+    fs::create_dir_all(restore_dir).unwrap();
+
+    let matching_jsonl = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl"));
+    let matching_zst = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl.zst"));
+    let matching_tmp = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl.vm0tmp-123"));
+    let matching_no_dash = codex_home.join("sessions/2026/06/05").join(format!(
+        "rollout-b-{SESSION_ID_NO_DASHES}.jsonl.zst.vm0tmp-456"
+    ));
+    let matching_newline = restore_dir.join(format!("rollout-line\nbreak-{SESSION_ID}.jsonl"));
+    let matching_non_layout = codex_home
+        .join("sessions/not-layout/deep")
+        .join(format!("rollout-c-{SESSION_ID}.jsonl"));
+    let matching_symlink = restore_dir.join(format!("rollout-link-{SESSION_ID}.jsonl"));
+    let matching_directory = restore_dir.join(format!("rollout-dir-{SESSION_ID}.jsonl"));
+    let unrelated = restore_dir.join("rollout-other-session.jsonl");
+
+    create_file(&matching_jsonl).unwrap();
+    create_file(&matching_zst).unwrap();
+    create_file(&matching_tmp).unwrap();
+    create_file(&matching_no_dash).unwrap();
+    create_file(&matching_newline).unwrap();
+    create_file(&matching_non_layout).unwrap();
+    create_file(&unrelated).unwrap();
+    fs::create_dir(&matching_directory).unwrap();
+    symlink(&unrelated, &matching_symlink).unwrap();
+
+    let output = run_cleanup(&codex_home, &restore_path).unwrap();
+
+    assert_success(&output);
+    assert!(output.stdout.is_empty());
+    assert!(!matching_jsonl.exists());
+    assert!(!matching_zst.exists());
+    assert!(!matching_tmp.exists());
+    assert!(!matching_no_dash.exists());
+    assert!(!matching_newline.exists());
+    assert!(!matching_non_layout.exists());
+    assert!(!matching_symlink.exists());
+    assert!(matching_directory.exists());
+    assert!(unrelated.exists());
+}
+
+#[test]
+fn cleanup_script_returns_existing_canonical_logical_path() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_home = temp.path().join(".codex");
+    let fallback_path = restore_path(&codex_home);
+    let existing_path = canonical_path(&codex_home, "2026-07-23", "04-01-04");
+    create_file(&existing_path).unwrap();
+
+    let output = run_cleanup(&codex_home, &fallback_path).unwrap();
+
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        format!("{}\n", existing_path.display())
+    );
+    assert!(!existing_path.exists());
+}
+
+#[test]
+fn cleanup_script_normalizes_existing_zstd_path_to_logical_path() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_home = temp.path().join(".codex");
+    let fallback_path = restore_path(&codex_home);
+    let logical_path = canonical_path(&codex_home, "2026-07-23", "04-01-04");
+    let compressed_path = PathBuf::from(format!("{}.zst", logical_path.display()));
+    create_file(&compressed_path).unwrap();
+
+    let output = run_cleanup(&codex_home, &fallback_path).unwrap();
+
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        format!("{}\n", logical_path.display())
+    );
+    assert!(!compressed_path.exists());
+}
+
+#[test]
+fn cleanup_script_treats_raw_and_zstd_siblings_as_one_logical_path() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_home = temp.path().join(".codex");
+    let fallback_path = restore_path(&codex_home);
+    let logical_path = canonical_path(&codex_home, "2026-07-23", "04-01-04");
+    let compressed_path = PathBuf::from(format!("{}.zst", logical_path.display()));
+    create_file(&logical_path).unwrap();
+    create_file(&compressed_path).unwrap();
+
+    let output = run_cleanup(&codex_home, &fallback_path).unwrap();
+
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        format!("{}\n", logical_path.display())
+    );
+    assert!(!logical_path.exists());
+    assert!(!compressed_path.exists());
+}
+
+#[test]
+fn cleanup_script_rejects_distinct_canonical_paths_without_deleting_them() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_home = temp.path().join(".codex");
+    let fallback_path = restore_path(&codex_home);
+    let first_path = canonical_path(&codex_home, "2026-07-23", "04-01-04");
+    let second_path = canonical_path(&codex_home, "2026-07-24", "05-02-05");
+    create_file(&first_path).unwrap();
+    create_file(&second_path).unwrap();
+
+    let output = run_cleanup(&codex_home, &fallback_path).unwrap();
+
+    assert_failure_contains(&output, "ambiguous codex session restore path");
+    assert!(output.stdout.is_empty());
+    assert!(first_path.exists());
+    assert!(second_path.exists());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(!stderr.contains(first_path.to_str().unwrap()));
+    assert!(!stderr.contains(second_path.to_str().unwrap()));
+}
+
+#[test]
+fn cleanup_script_does_not_disclose_candidate_when_deletion_fails() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_home = temp.path().join(".codex");
+    let fallback_path = restore_path(&codex_home);
+    let existing_path = canonical_path(&codex_home, "2026-07-23", "04-01-04");
+    create_file(&existing_path).unwrap();
+
+    let fake_bin = temp.path().join("fake-bin");
+    fs::create_dir(&fake_bin).unwrap();
+    let fake_rm = fake_bin.join("rm");
+    fs::write(&fake_rm, "#!/bin/sh\nprintf '%s\\n' \"$*\" >&2\nexit 1\n").unwrap();
+    let mut permissions = fs::metadata(&fake_rm).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_rm, permissions).unwrap();
+    let path = format!("{}:{}", fake_bin.display(), std::env::var("PATH").unwrap());
+
+    let output = cleanup_command(
+        &codex_home,
+        &fallback_path,
+        SESSION_ID,
+        SESSION_ID_NO_DASHES,
+    )
+    .env("PATH", path)
+    .output()
+    .unwrap();
+
+    assert_failure_contains(&output, "failed to delete codex session files");
+    assert!(output.stdout.is_empty());
+    assert!(existing_path.exists());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(!stderr.contains(existing_path.to_str().unwrap()));
+}
+
+#[test]
+fn cleanup_script_does_not_select_noncanonical_date_or_time() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_home = temp.path().join(".codex");
+    let fallback_path = restore_path(&codex_home);
+    let invalid_date = canonical_path(&codex_home, "2026-02-31", "04-01-04");
+    let invalid_time = canonical_path(&codex_home, "2026-07-23", "24-01-04");
+    create_file(&invalid_date).unwrap();
+    create_file(&invalid_time).unwrap();
+
+    let output = run_cleanup(&codex_home, &fallback_path).unwrap();
+
+    assert_success(&output);
+    assert!(output.stdout.is_empty());
+    assert!(!invalid_date.exists());
+    assert!(!invalid_time.exists());
+}
+
+#[test]
+fn cleanup_script_does_not_follow_symlinked_date_directory() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_home = temp.path().join(".codex");
+    let fallback_path = restore_path(&codex_home);
+    let external_root = temp.path().join("external");
+    let external_path = canonical_path(&external_root, "2026-07-23", "04-01-04");
+    create_file(&external_path).unwrap();
+    let sessions_year = codex_home.join("sessions/2026");
+    fs::create_dir_all(&sessions_year).unwrap();
+    symlink(
+        external_root.join("sessions/2026/07"),
+        sessions_year.join("07"),
+    )
+    .unwrap();
+
+    let output = run_cleanup(&codex_home, &fallback_path).unwrap();
+
+    assert_success(&output);
+    assert!(output.stdout.is_empty());
+    assert!(external_path.exists());
+}
+
+#[test]
+fn cleanup_script_does_not_select_canonical_symlink() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_home = temp.path().join(".codex");
+    let fallback_path = restore_path(&codex_home);
+    let symlink_path = canonical_path(&codex_home, "2026-07-23", "04-01-04");
+    let target = temp.path().join("target.jsonl");
+    create_file(&target).unwrap();
+    fs::create_dir_all(symlink_path.parent().unwrap()).unwrap();
+    symlink(&target, &symlink_path).unwrap();
+
+    let output = run_cleanup(&codex_home, &fallback_path).unwrap();
+
+    assert_success(&output);
+    assert!(output.stdout.is_empty());
+    assert!(!symlink_path.exists());
+    assert!(target.exists());
+}
+
+#[test]
+fn cleanup_script_fails_when_scan_budget_exceeded_without_deleting_sessions() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_home = temp.path().join(".codex");
+    let restore_path = restore_path(&codex_home);
+    let restore_dir = restore_path.parent().unwrap();
+    fs::create_dir_all(restore_dir).unwrap();
+    let matching_jsonl = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl"));
+    create_file(&matching_jsonl).unwrap();
+
+    let output = run_cleanup_with_budget(&codex_home, &restore_path, "1").unwrap();
+
+    assert_failure_contains(&output, "codex session cleanup exceeded scan budget");
+    assert!(matching_jsonl.exists());
+}
+
+#[test]
+fn cleanup_script_rejects_invalid_scan_budget_without_deleting_sessions() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_home = temp.path().join(".codex");
+    let restore_path = restore_path(&codex_home);
+    let restore_dir = restore_path.parent().unwrap();
+    fs::create_dir_all(restore_dir).unwrap();
+    let matching_jsonl = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl"));
+    create_file(&matching_jsonl).unwrap();
+
+    for budget in ["0", "1000000", "not-a-number"] {
+        let output = run_cleanup_with_budget(&codex_home, &restore_path, budget).unwrap();
+
+        assert_failure_contains(&output, "invalid codex session cleanup scan budget");
+        assert!(matching_jsonl.exists());
+    }
+}
+
+#[test]
+fn cleanup_script_accepts_uppercase_session_id() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_home = temp.path().join(".codex");
+    let restore_path = restore_path(&codex_home);
+    let restore_dir = restore_path.parent().unwrap();
+    fs::create_dir_all(restore_dir).unwrap();
+    let matching_jsonl = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl"));
+    create_file(&matching_jsonl).unwrap();
+
+    let output =
+        run_cleanup_with_session_id(&codex_home, &restore_path, &SESSION_ID.to_ascii_uppercase())
+            .unwrap();
+
+    assert_success(&output);
+    assert!(!matching_jsonl.exists());
+}
+
+#[test]
+fn cleanup_script_rejects_failed_session_id_normalization_without_deleting_sessions() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_home = temp.path().join(".codex");
+    let restore_path = restore_path(&codex_home);
+    let restore_dir = restore_path.parent().unwrap();
+    fs::create_dir_all(restore_dir).unwrap();
+    let matching_jsonl = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl"));
+    create_file(&matching_jsonl).unwrap();
+
+    let fake_bin = temp.path().join("fake-bin");
+    fs::create_dir(&fake_bin).unwrap();
+    symlink("/bin/sh", fake_bin.join("sh")).unwrap();
+    let fake_tr = fake_bin.join("tr");
+    fs::write(&fake_tr, "#!/bin/sh\nexit 1\n").unwrap();
+    let mut permissions = fs::metadata(&fake_tr).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_tr, permissions).unwrap();
+
+    let output = cleanup_command(&codex_home, &restore_path, SESSION_ID, SESSION_ID_NO_DASHES)
+        .env("PATH", &fake_bin)
+        .output()
+        .unwrap();
+
+    assert_failure_contains(&output, "failed to normalize codex restore session id");
+    assert!(matching_jsonl.exists());
+}
+
+#[test]
+fn cleanup_script_rejects_restore_path_outside_sessions_root() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_home = temp.path().join(".codex");
+    fs::create_dir_all(codex_home.join("sessions")).unwrap();
+    let outside_restore_path = temp
+        .path()
+        .join(format!("outside/rollout-{SESSION_ID}.jsonl"));
+
+    let output = run_cleanup(&codex_home, &outside_restore_path).unwrap();
+
+    assert_failure_contains(&output, "invalid codex restore directory");
+}
+
+#[test]
+fn cleanup_script_rejects_symlink_codex_home() {
+    let temp = tempfile::tempdir().unwrap();
+    let real_codex_home = temp.path().join("real-codex");
+    let codex_home = temp.path().join(".codex");
+    fs::create_dir_all(real_codex_home.join("sessions/2026/06/04")).unwrap();
+    symlink(&real_codex_home, &codex_home).unwrap();
+    let restore_path = restore_path(&codex_home);
+
+    let output = run_cleanup(&codex_home, &restore_path).unwrap();
+
+    assert_failure_contains(&output, "codex restore directory is a symlink");
+}
+
+#[test]
+fn cleanup_script_rejects_non_directory_restore_component() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_home = temp.path().join(".codex");
+    let root = codex_home.join("sessions");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("2026"), "not a directory").unwrap();
+    let restore_path = restore_path(&codex_home);
+
+    let output = run_cleanup(&codex_home, &restore_path).unwrap();
+
+    assert_failure_contains(&output, "codex restore path component is not a directory");
+}
+
+#[test]
+fn cleanup_script_succeeds_when_sessions_root_is_missing() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_home = temp.path().join(".codex");
+    fs::create_dir_all(&codex_home).unwrap();
+    let restore_path = restore_path(&codex_home);
+
+    let output = cleanup_command(&codex_home, &restore_path, SESSION_ID, SESSION_ID_NO_DASHES)
+        .env("TMPDIR", temp.path().join("missing-tmp"))
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+}
+
+#[test]
+fn cleanup_script_rejects_restore_path_without_date_depth() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_home = temp.path().join(".codex");
+    let root = codex_home.join("sessions");
+    fs::create_dir_all(&root).unwrap();
+    let shallow_restore_path = root.join(format!("rollout-{SESSION_ID}.jsonl"));
+
+    let output = run_cleanup(&codex_home, &shallow_restore_path).unwrap();
+
+    assert_failure_contains(&output, "invalid codex restore directory");
+}
+
+#[test]
+fn cleanup_script_rejects_empty_session_id_without_deleting_sessions() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_home = temp.path().join(".codex");
+    let restore_path = restore_path(&codex_home);
+    let restore_dir = restore_path.parent().unwrap();
+    fs::create_dir_all(restore_dir).unwrap();
+    let existing_session = restore_dir.join("rollout-existing-session.jsonl");
+    create_file(&existing_session).unwrap();
+
+    let output = run_cleanup_with_session_id(&codex_home, &restore_path, "").unwrap();
+
+    assert_failure_contains(&output, "invalid codex restore session id");
+    assert!(existing_session.exists());
+}
+
+#[test]
+fn cleanup_script_rejects_invalid_session_id_with_valid_filename_key_without_deleting_sessions() {
+    for invalid_session_id in ["", "*"] {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_home = temp.path().join(".codex");
+        let restore_path = restore_path(&codex_home);
+        let restore_dir = restore_path.parent().unwrap();
+        fs::create_dir_all(restore_dir).unwrap();
+        let existing_session = restore_dir.join("rollout-existing-session.jsonl");
+        create_file(&existing_session).unwrap();
+
+        let output = run_cleanup_with_session_identity(
+            &codex_home,
+            &restore_path,
+            invalid_session_id,
+            SESSION_ID_NO_DASHES,
+        )
+        .unwrap();
+
+        assert_failure_contains(&output, "invalid codex restore session id");
+        assert!(existing_session.exists());
+    }
+}
+
+#[test]
+fn cleanup_script_rejects_glob_session_id_without_deleting_sessions() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_home = temp.path().join(".codex");
+    let restore_path = restore_path(&codex_home);
+    let restore_dir = restore_path.parent().unwrap();
+    fs::create_dir_all(restore_dir).unwrap();
+    let existing_session = restore_dir.join("rollout-existing-session.jsonl");
+    create_file(&existing_session).unwrap();
+
+    let output = run_cleanup_with_session_id(&codex_home, &restore_path, "*").unwrap();
+
+    assert_failure_contains(&output, "invalid codex restore session id");
+    assert!(existing_session.exists());
+}

--- a/crates/guest-agent/tests/integration_cases/mod.rs
+++ b/crates/guest-agent/tests/integration_cases/mod.rs
@@ -7,6 +7,7 @@
 pub(crate) mod support;
 
 mod checkpoint;
+mod codex_session_cleanup;
 mod complete;
 mod events;
 mod guest_config;

--- a/crates/guest-contracts/src/codex_session_cleanup.rs
+++ b/crates/guest-contracts/src/codex_session_cleanup.rs
@@ -1,0 +1,74 @@
+//! Fixed reused-Codex session cleanup contract.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::codex_session_path::is_canonical_codex_rollout_relative_path;
+use crate::codex_thread_id::CodexThreadId;
+
+/// Stable diagnostic label for the fixed reused-Codex cleanup operation.
+pub const CODEX_SESSION_CLEANUP_DIAGNOSTIC_LABEL: &str = "codex-session-cleanup";
+/// Maximum captured bytes for each cleanup output stream.
+pub const CODEX_SESSION_CLEANUP_OUTPUT_LIMIT_BYTES: u32 = 64 * 1024;
+/// Maximum number of session-tree entries inspected by the fixed helper.
+pub const CODEX_SESSION_CLEANUP_SCAN_BUDGET: u32 = 16_384;
+/// Maximum encoded length accepted for the fallback relative rollout path.
+pub const CODEX_SESSION_CLEANUP_MAX_PATH_BYTES: usize = 4_096;
+
+/// Structured request carried by the fixed reused-Codex cleanup role.
+///
+/// Runner and the bundled guest are deployed atomically. This shape prevents
+/// cleanup from accepting an executable, arbitrary environment, Codex home,
+/// scan budget, sudo choice, or containment policy from the caller.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct CodexSessionCleanupRequest {
+    /// Canonical lowercase hyphenated Codex thread identifier.
+    pub session_id: String,
+    /// Canonical logical rollout path relative to the fixed Codex home.
+    pub fallback_relative_path: String,
+}
+
+impl CodexSessionCleanupRequest {
+    /// Validate the fixed helper inputs before selecting process containment.
+    pub fn validate(&self) -> Result<(), CodexSessionCleanupRequestError> {
+        let thread_id = CodexThreadId::parse(&self.session_id)
+            .filter(|thread_id| thread_id.as_str() == self.session_id)
+            .ok_or(CodexSessionCleanupRequestError::InvalidSessionId)?;
+        if self.fallback_relative_path.len() > CODEX_SESSION_CLEANUP_MAX_PATH_BYTES
+            || !is_canonical_codex_rollout_relative_path(&self.fallback_relative_path, &thread_id)
+        {
+            return Err(CodexSessionCleanupRequestError::InvalidFallbackPath);
+        }
+        Ok(())
+    }
+
+    /// Return the filename key derived from the validated canonical thread id.
+    pub fn filename_key(&self) -> Result<String, CodexSessionCleanupRequestError> {
+        let thread_id = CodexThreadId::parse(&self.session_id)
+            .filter(|thread_id| thread_id.as_str() == self.session_id)
+            .ok_or(CodexSessionCleanupRequestError::InvalidSessionId)?;
+        Ok(thread_id.filename_key())
+    }
+}
+
+/// Validation failure for the fixed reused-Codex cleanup request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CodexSessionCleanupRequestError {
+    /// The session id is not canonical lowercase hyphenated UUID text.
+    InvalidSessionId,
+    /// The fallback path is not the matching canonical logical rollout path.
+    InvalidFallbackPath,
+}
+
+impl fmt::Display for CodexSessionCleanupRequestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidSessionId => f.write_str("Codex cleanup session id is invalid"),
+            Self::InvalidFallbackPath => f.write_str("Codex cleanup fallback path is invalid"),
+        }
+    }
+}
+
+impl std::error::Error for CodexSessionCleanupRequestError {}

--- a/crates/guest-contracts/src/codex_session_path.rs
+++ b/crates/guest-contracts/src/codex_session_path.rs
@@ -19,6 +19,76 @@ pub fn codex_rollout_relative_path(thread_id: &CodexThreadId, timestamp: DateTim
     )
 }
 
+/// Return whether a path is one canonical logical Codex rollout path for the
+/// supplied thread id, relative to the fixed Codex home.
+pub fn is_canonical_codex_rollout_relative_path(path: &str, thread_id: &CodexThreadId) -> bool {
+    let Some(relative) = path.strip_prefix("sessions/") else {
+        return false;
+    };
+    let mut components = relative.split('/');
+    let (Some(year), Some(month), Some(day), Some(filename), None) = (
+        components.next(),
+        components.next(),
+        components.next(),
+        components.next(),
+        components.next(),
+    ) else {
+        return false;
+    };
+    if !fixed_ascii_digits(year, 4) || !fixed_ascii_digits(month, 2) || !fixed_ascii_digits(day, 2)
+    {
+        return false;
+    }
+    let (Ok(year_number), Ok(month_number), Ok(day_number)) = (
+        year.parse::<i32>(),
+        month.parse::<u32>(),
+        day.parse::<u32>(),
+    ) else {
+        return false;
+    };
+    if year_number < 1
+        || chrono::NaiveDate::from_ymd_opt(year_number, month_number, day_number).is_none()
+    {
+        return false;
+    }
+
+    let prefix = format!("rollout-{year}-{month}-{day}T");
+    let suffix = format!("-{}.jsonl", thread_id.as_str());
+    let Some(time) = filename
+        .strip_prefix(&prefix)
+        .and_then(|filename| filename.strip_suffix(&suffix))
+    else {
+        return false;
+    };
+    let mut time_components = time.split('-');
+    let (Some(hour), Some(minute), Some(second), None) = (
+        time_components.next(),
+        time_components.next(),
+        time_components.next(),
+        time_components.next(),
+    ) else {
+        return false;
+    };
+    if !fixed_ascii_digits(hour, 2)
+        || !fixed_ascii_digits(minute, 2)
+        || !fixed_ascii_digits(second, 2)
+    {
+        return false;
+    }
+    let (Ok(hour), Ok(minute), Ok(second)) = (
+        hour.parse::<u32>(),
+        minute.parse::<u32>(),
+        second.parse::<u32>(),
+    ) else {
+        return false;
+    };
+    hour <= 23 && minute <= 59 && second <= 59
+}
+
+fn fixed_ascii_digits(value: &str, length: usize) -> bool {
+    value.len() == length && value.bytes().all(|byte| byte.is_ascii_digit())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/guest-contracts/src/lib.rs
+++ b/crates/guest-contracts/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod active_input;
 pub mod active_input_receipts;
 pub mod cli_agent_session_id;
+pub mod codex_session_cleanup;
 pub mod codex_session_path;
 pub mod codex_thread_id;
 pub mod connector_account_context;

--- a/crates/runner/build.rs
+++ b/crates/runner/build.rs
@@ -28,7 +28,6 @@ fn main() {
     // but CI artifact caches may not — explicit rerun-if-changed ensures correctness).
     println!("cargo::rerun-if-changed=scripts/agent-abnormal-exit-diagnostics.sh");
     println!("cargo::rerun-if-changed=scripts/build-template.sh");
-    println!("cargo::rerun-if-changed=scripts/codex-session-cleanup.sh");
     println!("cargo::rerun-if-changed=scripts/customize-rootfs.sh");
     println!("cargo::rerun-if-changed=scripts/freeze-workspace-drive.sh");
     println!("cargo::rerun-if-changed=scripts/mount-workspace-drive.sh");

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -1,10 +1,9 @@
-use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecResult, Sandbox};
-use shell_quote::quote_shell_arg;
+use sandbox::{CodexSessionCleanupRequest, ExecResult, Sandbox};
 use tracing::info;
 
-use api_contracts::generated::constants::runners::paths::{
-    CANONICAL_CODEX_HOME_DIR, CANONICAL_CODEX_SESSIONS_DIR,
-};
+use api_contracts::generated::constants::runners::paths::CANONICAL_CODEX_HOME_DIR;
+#[cfg(test)]
+use api_contracts::generated::constants::runners::paths::CANONICAL_CODEX_SESSIONS_DIR;
 
 use super::{MaterializedResumeSession, SessionRestoreDiagnostics, write_session_history_file};
 use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
@@ -12,11 +11,10 @@ use crate::types::{ExecutionContext, SandboxReuseResult};
 
 use super::super::{DEFAULT_EXEC_TIMEOUT, RunnerError, RunnerResult};
 use guest_contracts::{
-    codex_session_path::codex_rollout_relative_path, codex_thread_id::CodexThreadId,
+    codex_session_path::{codex_rollout_relative_path, is_canonical_codex_rollout_relative_path},
+    codex_thread_id::CodexThreadId,
 };
 
-const CODEX_SESSION_CLEANUP_SCRIPT: &str =
-    include_str!("../../../scripts/codex-session-cleanup.sh");
 const INVALID_CODEX_CLEANUP_OUTPUT: &str = "invalid codex session cleanup output";
 
 fn codex_restore_rollout_timestamp(
@@ -68,7 +66,6 @@ pub(super) async fn restore_codex_session(
     let thread_id = CodexThreadId::parse(original_session_id)
         .ok_or_else(|| RunnerError::Internal("invalid codex session_id".into()))?;
     let session_id = thread_id.as_str();
-    let session_filename_key = thread_id.filename_key();
 
     let timestamp = codex_restore_rollout_timestamp(session, chrono::Utc::now());
     let (session_history, physical_suffix) = if let Some(bytes) = session.codex_zstd_history() {
@@ -76,10 +73,8 @@ pub(super) async fn restore_codex_session(
     } else {
         (session.history_bytes(), "")
     };
-    let fallback_logical_path = format!(
-        "{CANONICAL_CODEX_HOME_DIR}/{}",
-        codex_rollout_relative_path(&thread_id, timestamp)
-    );
+    let fallback_relative_path = codex_rollout_relative_path(&thread_id, timestamp);
+    let fallback_logical_path = format!("{CANONICAL_CODEX_HOME_DIR}/{fallback_relative_path}");
 
     // Only an idle-reused sandbox can retain a prior framework home. Fresh
     // sandboxes may attach a cached workspace drive, but that drive contains
@@ -89,8 +84,7 @@ pub(super) async fn restore_codex_session(
             sandbox,
             context,
             session_id,
-            &session_filename_key,
-            &fallback_logical_path,
+            &fallback_relative_path,
         )
         .await?
         .unwrap_or(fallback_logical_path),
@@ -123,31 +117,14 @@ async fn cleanup_existing_codex_session_files(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
     session_id: &str,
-    session_filename_key: &str,
-    fallback_logical_path: &str,
+    fallback_relative_path: &str,
 ) -> RunnerResult<Option<String>> {
-    let cleanup_cmd = codex_session_cleanup_command(CANONICAL_CODEX_HOME_DIR);
-    let env = [
-        ("OKOU_CODEX_RESTORE_SESSION_ID", session_id),
-        (
-            "OKOU_CODEX_RESTORE_SESSION_FILENAME_KEY",
-            session_filename_key,
-        ),
-        ("OKOU_CODEX_RESTORE_SESSION_PATH", fallback_logical_path),
-    ];
     let result = sandbox
-        .exec_with_diagnostic_label(
-            &ExecRequest {
-                cmd: &cleanup_cmd,
-                timeout: DEFAULT_EXEC_TIMEOUT,
-                env: &env,
-                sudo: false,
-                expected_exit_codes: &[],
-                stdin_bytes: None,
-                output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
-            },
-            "codex-session-cleanup",
-        )
+        .cleanup_codex_session(&CodexSessionCleanupRequest {
+            session_id,
+            fallback_relative_path,
+            timeout: DEFAULT_EXEC_TIMEOUT,
+        })
         .await?;
     if !helper_exec_succeeded(&result) {
         return Err(RunnerError::Internal(format_helper_exec_failure(
@@ -187,200 +164,24 @@ fn parse_codex_cleanup_output(
 
 fn is_canonical_codex_logical_path(path: &str, session_id: &str) -> bool {
     let Some(relative) = path
-        .strip_prefix(CANONICAL_CODEX_SESSIONS_DIR)
+        .strip_prefix(CANONICAL_CODEX_HOME_DIR)
         .and_then(|path| path.strip_prefix('/'))
     else {
         return false;
     };
-    let mut components = relative.split('/');
-    let (Some(year), Some(month), Some(day), Some(filename), None) = (
-        components.next(),
-        components.next(),
-        components.next(),
-        components.next(),
-        components.next(),
-    ) else {
-        return false;
-    };
-    if !fixed_ascii_digits(year, 4) || !fixed_ascii_digits(month, 2) || !fixed_ascii_digits(day, 2)
-    {
-        return false;
-    }
-    let (Ok(year_number), Ok(month_number), Ok(day_number)) = (
-        year.parse::<i32>(),
-        month.parse::<u32>(),
-        day.parse::<u32>(),
-    ) else {
-        return false;
-    };
-    if year_number < 1
-        || chrono::NaiveDate::from_ymd_opt(year_number, month_number, day_number).is_none()
-    {
-        return false;
-    }
-
-    let prefix = format!("rollout-{year}-{month}-{day}T");
-    let suffix = format!("-{session_id}.jsonl");
-    let Some(time) = filename
-        .strip_prefix(&prefix)
-        .and_then(|filename| filename.strip_suffix(&suffix))
-    else {
-        return false;
-    };
-    let mut time_components = time.split('-');
-    let (Some(hour), Some(minute), Some(second), None) = (
-        time_components.next(),
-        time_components.next(),
-        time_components.next(),
-        time_components.next(),
-    ) else {
-        return false;
-    };
-    if !fixed_ascii_digits(hour, 2)
-        || !fixed_ascii_digits(minute, 2)
-        || !fixed_ascii_digits(second, 2)
-    {
-        return false;
-    }
-    let (Ok(hour), Ok(minute), Ok(second)) = (
-        hour.parse::<u32>(),
-        minute.parse::<u32>(),
-        second.parse::<u32>(),
-    ) else {
-        return false;
-    };
-    hour <= 23 && minute <= 59 && second <= 59
-}
-
-fn fixed_ascii_digits(value: &str, length: usize) -> bool {
-    value.len() == length && value.bytes().all(|byte| byte.is_ascii_digit())
-}
-
-fn codex_session_cleanup_command(codex_home: &str) -> String {
-    let codex_home = quote_shell_arg(codex_home);
-    format!("codex_home={codex_home}\n{CODEX_SESSION_CLEANUP_SCRIPT}")
+    CodexThreadId::parse(session_id)
+        .is_some_and(|thread_id| is_canonical_codex_rollout_relative_path(relative, &thread_id))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use std::fs;
-    use std::os::unix::fs::{PermissionsExt, symlink};
-    use std::path::{Path, PathBuf};
-    use std::process::{Command, Output};
-
     use sandbox::{ExecResult, ExecTermination};
 
     use crate::error::RunnerError;
 
     const SESSION_ID: &str = "019e9154-c304-70f0-adde-36efb1be1701";
-    const SESSION_ID_NO_DASHES: &str = "019e9154c30470f0adde36efb1be1701";
-
-    fn restore_path(codex_home: &Path) -> PathBuf {
-        codex_home.join(format!(
-            "sessions/2026/06/04/rollout-2026-06-04T07-18-08-{SESSION_ID}.jsonl"
-        ))
-    }
-
-    fn create_file(path: &Path) {
-        fs::create_dir_all(path.parent().expect("test path should have parent")).unwrap();
-        fs::write(path, "test").unwrap();
-    }
-
-    fn canonical_path(codex_home: &Path, date: &str, time: &str) -> PathBuf {
-        let mut date_components = date.split('-');
-        let year = date_components.next().unwrap();
-        let month = date_components.next().unwrap();
-        let day = date_components.next().unwrap();
-        assert!(date_components.next().is_none());
-        codex_home.join(format!(
-            "sessions/{year}/{month}/{day}/rollout-{date}T{time}-{SESSION_ID}.jsonl"
-        ))
-    }
-
-    fn run_cleanup(codex_home: &Path, restore_path: &Path) -> Output {
-        run_cleanup_with_session_id(codex_home, restore_path, SESSION_ID)
-    }
-
-    fn run_cleanup_with_session_id(
-        codex_home: &Path,
-        restore_path: &Path,
-        session_id: &str,
-    ) -> Output {
-        let session_filename_key = session_id.replace('-', "");
-        run_cleanup_with_session_identity(
-            codex_home,
-            restore_path,
-            session_id,
-            &session_filename_key,
-        )
-    }
-
-    fn run_cleanup_with_session_identity(
-        codex_home: &Path,
-        restore_path: &Path,
-        session_id: &str,
-        session_filename_key: &str,
-    ) -> Output {
-        cleanup_command(codex_home, restore_path, session_id, session_filename_key)
-            .output()
-            .unwrap()
-    }
-
-    fn run_cleanup_with_budget(codex_home: &Path, restore_path: &Path, budget: &str) -> Output {
-        cleanup_command(codex_home, restore_path, SESSION_ID, SESSION_ID_NO_DASHES)
-            .env("OKOU_CODEX_SESSION_CLEANUP_SCAN_BUDGET", budget)
-            .output()
-            .unwrap()
-    }
-
-    fn cleanup_command(
-        codex_home: &Path,
-        restore_path: &Path,
-        session_id: &str,
-        session_filename_key: &str,
-    ) -> Command {
-        let mut command = Command::new("sh");
-        command
-            .arg("-c")
-            .arg(codex_session_cleanup_command(
-                codex_home.to_str().expect("test path should be utf-8"),
-            ))
-            .env("OKOU_CODEX_RESTORE_SESSION_ID", session_id)
-            .env(
-                "OKOU_CODEX_RESTORE_SESSION_FILENAME_KEY",
-                session_filename_key,
-            )
-            .env(
-                "OKOU_CODEX_RESTORE_SESSION_PATH",
-                restore_path.to_str().expect("test path should be utf-8"),
-            );
-        command
-    }
-
-    fn assert_success(output: &Output) {
-        assert!(
-            output.status.success(),
-            "stderr={} stdout={}",
-            String::from_utf8_lossy(&output.stderr),
-            String::from_utf8_lossy(&output.stdout)
-        );
-    }
-
-    fn assert_failure_contains(output: &Output, expected: &str) {
-        assert!(
-            !output.status.success(),
-            "expected command to fail; stdout={} stderr={}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        assert!(
-            stderr.contains(expected),
-            "expected stderr to contain {expected:?}, got {stderr:?}"
-        );
-    }
 
     fn exec_result(stdout: Vec<u8>, stdout_truncated: bool) -> ExecResult {
         ExecResult {
@@ -557,450 +358,5 @@ mod tests {
                 },
             }
         }
-    }
-
-    #[test]
-    fn cleanup_command_uses_fixed_codex_home_prelude() {
-        let command = codex_session_cleanup_command(CANONICAL_CODEX_HOME_DIR);
-
-        assert!(command.contains("codex_home='/home/user/.codex'"));
-        assert!(command.contains("root=\"$codex_home/sessions\""));
-        assert!(command.contains("scan_budget="));
-        assert!(command.contains("collect_matching_session_entries"));
-        assert!(command.contains("find \"$root\" -mindepth 1 -printf '%y%p\\0'"));
-        assert!(command.contains("canonical_logical_path"));
-        assert!(command.contains("candidate_ambiguous"));
-        assert!(command.contains("delete_matching_session_entries"));
-        assert!(command.contains("xargs -0"));
-        assert!(!command.contains("-delete"));
-        assert!(!command.contains("for path in \"$dir\"/*"));
-    }
-
-    #[test]
-    fn cleanup_script_deletes_matching_session_files_and_symlinks() {
-        let temp = tempfile::tempdir().unwrap();
-        let codex_home = temp.path().join(".codex");
-        let restore_path = restore_path(&codex_home);
-        let restore_dir = restore_path.parent().unwrap();
-        fs::create_dir_all(restore_dir).unwrap();
-
-        let matching_jsonl = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl"));
-        let matching_zst = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl.zst"));
-        let matching_tmp = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl.vm0tmp-123"));
-        let matching_no_dash = codex_home.join("sessions/2026/06/05").join(format!(
-            "rollout-b-{SESSION_ID_NO_DASHES}.jsonl.zst.vm0tmp-456"
-        ));
-        let matching_newline = restore_dir.join(format!("rollout-line\nbreak-{SESSION_ID}.jsonl"));
-        let matching_non_layout = codex_home
-            .join("sessions/not-layout/deep")
-            .join(format!("rollout-c-{SESSION_ID}.jsonl"));
-        let matching_symlink = restore_dir.join(format!("rollout-link-{SESSION_ID}.jsonl"));
-        let matching_directory = restore_dir.join(format!("rollout-dir-{SESSION_ID}.jsonl"));
-        let unrelated = restore_dir.join("rollout-other-session.jsonl");
-
-        create_file(&matching_jsonl);
-        create_file(&matching_zst);
-        create_file(&matching_tmp);
-        create_file(&matching_no_dash);
-        create_file(&matching_newline);
-        create_file(&matching_non_layout);
-        create_file(&unrelated);
-        fs::create_dir(&matching_directory).unwrap();
-        symlink(&unrelated, &matching_symlink).unwrap();
-
-        let output = run_cleanup(&codex_home, &restore_path);
-
-        assert_success(&output);
-        assert!(output.stdout.is_empty());
-        assert!(!matching_jsonl.exists());
-        assert!(!matching_zst.exists());
-        assert!(!matching_tmp.exists());
-        assert!(!matching_no_dash.exists());
-        assert!(!matching_newline.exists());
-        assert!(!matching_non_layout.exists());
-        assert!(!matching_symlink.exists());
-        assert!(matching_directory.exists());
-        assert!(unrelated.exists());
-    }
-
-    #[test]
-    fn cleanup_script_returns_existing_canonical_logical_path() {
-        let temp = tempfile::tempdir().unwrap();
-        let codex_home = temp.path().join(".codex");
-        let fallback_path = restore_path(&codex_home);
-        let existing_path = canonical_path(&codex_home, "2026-07-23", "04-01-04");
-        create_file(&existing_path);
-
-        let output = run_cleanup(&codex_home, &fallback_path);
-
-        assert_success(&output);
-        assert_eq!(
-            String::from_utf8(output.stdout).unwrap(),
-            format!("{}\n", existing_path.display())
-        );
-        assert!(!existing_path.exists());
-    }
-
-    #[test]
-    fn cleanup_script_normalizes_existing_zstd_path_to_logical_path() {
-        let temp = tempfile::tempdir().unwrap();
-        let codex_home = temp.path().join(".codex");
-        let fallback_path = restore_path(&codex_home);
-        let logical_path = canonical_path(&codex_home, "2026-07-23", "04-01-04");
-        let compressed_path = PathBuf::from(format!("{}.zst", logical_path.display()));
-        create_file(&compressed_path);
-
-        let output = run_cleanup(&codex_home, &fallback_path);
-
-        assert_success(&output);
-        assert_eq!(
-            String::from_utf8(output.stdout).unwrap(),
-            format!("{}\n", logical_path.display())
-        );
-        assert!(!compressed_path.exists());
-    }
-
-    #[test]
-    fn cleanup_script_treats_raw_and_zstd_siblings_as_one_logical_path() {
-        let temp = tempfile::tempdir().unwrap();
-        let codex_home = temp.path().join(".codex");
-        let fallback_path = restore_path(&codex_home);
-        let logical_path = canonical_path(&codex_home, "2026-07-23", "04-01-04");
-        let compressed_path = PathBuf::from(format!("{}.zst", logical_path.display()));
-        create_file(&logical_path);
-        create_file(&compressed_path);
-
-        let output = run_cleanup(&codex_home, &fallback_path);
-
-        assert_success(&output);
-        assert_eq!(
-            String::from_utf8(output.stdout).unwrap(),
-            format!("{}\n", logical_path.display())
-        );
-        assert!(!logical_path.exists());
-        assert!(!compressed_path.exists());
-    }
-
-    #[test]
-    fn cleanup_script_rejects_distinct_canonical_paths_without_deleting_them() {
-        let temp = tempfile::tempdir().unwrap();
-        let codex_home = temp.path().join(".codex");
-        let fallback_path = restore_path(&codex_home);
-        let first_path = canonical_path(&codex_home, "2026-07-23", "04-01-04");
-        let second_path = canonical_path(&codex_home, "2026-07-24", "05-02-05");
-        create_file(&first_path);
-        create_file(&second_path);
-
-        let output = run_cleanup(&codex_home, &fallback_path);
-
-        assert_failure_contains(&output, "ambiguous codex session restore path");
-        assert!(output.stdout.is_empty());
-        assert!(first_path.exists());
-        assert!(second_path.exists());
-        let stderr = String::from_utf8(output.stderr).unwrap();
-        assert!(!stderr.contains(first_path.to_str().unwrap()));
-        assert!(!stderr.contains(second_path.to_str().unwrap()));
-    }
-
-    #[test]
-    fn cleanup_script_does_not_disclose_candidate_when_deletion_fails() {
-        let temp = tempfile::tempdir().unwrap();
-        let codex_home = temp.path().join(".codex");
-        let fallback_path = restore_path(&codex_home);
-        let existing_path = canonical_path(&codex_home, "2026-07-23", "04-01-04");
-        create_file(&existing_path);
-
-        let fake_bin = temp.path().join("fake-bin");
-        fs::create_dir(&fake_bin).unwrap();
-        let fake_rm = fake_bin.join("rm");
-        fs::write(&fake_rm, "#!/bin/sh\nprintf '%s\\n' \"$*\" >&2\nexit 1\n").unwrap();
-        let mut permissions = fs::metadata(&fake_rm).unwrap().permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(&fake_rm, permissions).unwrap();
-        let path = format!("{}:{}", fake_bin.display(), std::env::var("PATH").unwrap());
-
-        let output = cleanup_command(
-            &codex_home,
-            &fallback_path,
-            SESSION_ID,
-            SESSION_ID_NO_DASHES,
-        )
-        .env("PATH", path)
-        .output()
-        .unwrap();
-
-        assert_failure_contains(&output, "failed to delete codex session files");
-        assert!(output.stdout.is_empty());
-        assert!(existing_path.exists());
-        let stderr = String::from_utf8(output.stderr).unwrap();
-        assert!(!stderr.contains(existing_path.to_str().unwrap()));
-    }
-
-    #[test]
-    fn cleanup_script_does_not_select_noncanonical_date_or_time() {
-        let temp = tempfile::tempdir().unwrap();
-        let codex_home = temp.path().join(".codex");
-        let fallback_path = restore_path(&codex_home);
-        let invalid_date = canonical_path(&codex_home, "2026-02-31", "04-01-04");
-        let invalid_time = canonical_path(&codex_home, "2026-07-23", "24-01-04");
-        create_file(&invalid_date);
-        create_file(&invalid_time);
-
-        let output = run_cleanup(&codex_home, &fallback_path);
-
-        assert_success(&output);
-        assert!(output.stdout.is_empty());
-        assert!(!invalid_date.exists());
-        assert!(!invalid_time.exists());
-    }
-
-    #[test]
-    fn cleanup_script_does_not_follow_symlinked_date_directory() {
-        let temp = tempfile::tempdir().unwrap();
-        let codex_home = temp.path().join(".codex");
-        let fallback_path = restore_path(&codex_home);
-        let external_root = temp.path().join("external");
-        let external_path = canonical_path(&external_root, "2026-07-23", "04-01-04");
-        create_file(&external_path);
-        let sessions_year = codex_home.join("sessions/2026");
-        fs::create_dir_all(&sessions_year).unwrap();
-        symlink(
-            external_root.join("sessions/2026/07"),
-            sessions_year.join("07"),
-        )
-        .unwrap();
-
-        let output = run_cleanup(&codex_home, &fallback_path);
-
-        assert_success(&output);
-        assert!(output.stdout.is_empty());
-        assert!(external_path.exists());
-    }
-
-    #[test]
-    fn cleanup_script_does_not_select_canonical_symlink() {
-        let temp = tempfile::tempdir().unwrap();
-        let codex_home = temp.path().join(".codex");
-        let fallback_path = restore_path(&codex_home);
-        let symlink_path = canonical_path(&codex_home, "2026-07-23", "04-01-04");
-        let target = temp.path().join("target.jsonl");
-        create_file(&target);
-        fs::create_dir_all(symlink_path.parent().unwrap()).unwrap();
-        symlink(&target, &symlink_path).unwrap();
-
-        let output = run_cleanup(&codex_home, &fallback_path);
-
-        assert_success(&output);
-        assert!(output.stdout.is_empty());
-        assert!(!symlink_path.exists());
-        assert!(target.exists());
-    }
-
-    #[test]
-    fn cleanup_script_fails_when_scan_budget_exceeded_without_deleting_sessions() {
-        let temp = tempfile::tempdir().unwrap();
-        let codex_home = temp.path().join(".codex");
-        let restore_path = restore_path(&codex_home);
-        let restore_dir = restore_path.parent().unwrap();
-        fs::create_dir_all(restore_dir).unwrap();
-        let matching_jsonl = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl"));
-        create_file(&matching_jsonl);
-
-        let output = run_cleanup_with_budget(&codex_home, &restore_path, "1");
-
-        assert_failure_contains(&output, "codex session cleanup exceeded scan budget");
-        assert!(matching_jsonl.exists());
-    }
-
-    #[test]
-    fn cleanup_script_rejects_invalid_scan_budget_without_deleting_sessions() {
-        let temp = tempfile::tempdir().unwrap();
-        let codex_home = temp.path().join(".codex");
-        let restore_path = restore_path(&codex_home);
-        let restore_dir = restore_path.parent().unwrap();
-        fs::create_dir_all(restore_dir).unwrap();
-        let matching_jsonl = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl"));
-        create_file(&matching_jsonl);
-
-        for budget in ["0", "1000000", "not-a-number"] {
-            let output = run_cleanup_with_budget(&codex_home, &restore_path, budget);
-
-            assert_failure_contains(&output, "invalid codex session cleanup scan budget");
-            assert!(matching_jsonl.exists());
-        }
-    }
-
-    #[test]
-    fn cleanup_script_accepts_uppercase_session_id() {
-        let temp = tempfile::tempdir().unwrap();
-        let codex_home = temp.path().join(".codex");
-        let restore_path = restore_path(&codex_home);
-        let restore_dir = restore_path.parent().unwrap();
-        fs::create_dir_all(restore_dir).unwrap();
-        let matching_jsonl = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl"));
-        create_file(&matching_jsonl);
-
-        let output = run_cleanup_with_session_id(
-            &codex_home,
-            &restore_path,
-            &SESSION_ID.to_ascii_uppercase(),
-        );
-
-        assert_success(&output);
-        assert!(!matching_jsonl.exists());
-    }
-
-    #[test]
-    fn cleanup_script_rejects_failed_session_id_normalization_without_deleting_sessions() {
-        let temp = tempfile::tempdir().unwrap();
-        let codex_home = temp.path().join(".codex");
-        let restore_path = restore_path(&codex_home);
-        let restore_dir = restore_path.parent().unwrap();
-        fs::create_dir_all(restore_dir).unwrap();
-        let matching_jsonl = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl"));
-        create_file(&matching_jsonl);
-
-        let fake_bin = temp.path().join("fake-bin");
-        fs::create_dir(&fake_bin).unwrap();
-        symlink("/bin/sh", fake_bin.join("sh")).unwrap();
-        let fake_tr = fake_bin.join("tr");
-        fs::write(&fake_tr, "#!/bin/sh\nexit 1\n").unwrap();
-        let mut permissions = fs::metadata(&fake_tr).unwrap().permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(&fake_tr, permissions).unwrap();
-
-        let output = cleanup_command(&codex_home, &restore_path, SESSION_ID, SESSION_ID_NO_DASHES)
-            .env("PATH", &fake_bin)
-            .output()
-            .unwrap();
-
-        assert_failure_contains(&output, "failed to normalize codex restore session id");
-        assert!(matching_jsonl.exists());
-    }
-
-    #[test]
-    fn cleanup_script_rejects_restore_path_outside_sessions_root() {
-        let temp = tempfile::tempdir().unwrap();
-        let codex_home = temp.path().join(".codex");
-        fs::create_dir_all(codex_home.join("sessions")).unwrap();
-        let outside_restore_path = temp
-            .path()
-            .join(format!("outside/rollout-{SESSION_ID}.jsonl"));
-
-        let output = run_cleanup(&codex_home, &outside_restore_path);
-
-        assert_failure_contains(&output, "invalid codex restore directory");
-    }
-
-    #[test]
-    fn cleanup_script_rejects_symlink_codex_home() {
-        let temp = tempfile::tempdir().unwrap();
-        let real_codex_home = temp.path().join("real-codex");
-        let codex_home = temp.path().join(".codex");
-        fs::create_dir_all(real_codex_home.join("sessions/2026/06/04")).unwrap();
-        symlink(&real_codex_home, &codex_home).unwrap();
-        let restore_path = restore_path(&codex_home);
-
-        let output = run_cleanup(&codex_home, &restore_path);
-
-        assert_failure_contains(&output, "codex restore directory is a symlink");
-    }
-
-    #[test]
-    fn cleanup_script_rejects_non_directory_restore_component() {
-        let temp = tempfile::tempdir().unwrap();
-        let codex_home = temp.path().join(".codex");
-        let root = codex_home.join("sessions");
-        fs::create_dir_all(&root).unwrap();
-        fs::write(root.join("2026"), "not a directory").unwrap();
-        let restore_path = restore_path(&codex_home);
-
-        let output = run_cleanup(&codex_home, &restore_path);
-
-        assert_failure_contains(&output, "codex restore path component is not a directory");
-    }
-
-    #[test]
-    fn cleanup_script_succeeds_when_sessions_root_is_missing() {
-        let temp = tempfile::tempdir().unwrap();
-        let codex_home = temp.path().join(".codex");
-        fs::create_dir_all(&codex_home).unwrap();
-        let restore_path = restore_path(&codex_home);
-
-        let output = cleanup_command(&codex_home, &restore_path, SESSION_ID, SESSION_ID_NO_DASHES)
-            .env("TMPDIR", temp.path().join("missing-tmp"))
-            .output()
-            .unwrap();
-
-        assert_success(&output);
-    }
-
-    #[test]
-    fn cleanup_script_rejects_restore_path_without_date_depth() {
-        let temp = tempfile::tempdir().unwrap();
-        let codex_home = temp.path().join(".codex");
-        let root = codex_home.join("sessions");
-        fs::create_dir_all(&root).unwrap();
-        let shallow_restore_path = root.join(format!("rollout-{SESSION_ID}.jsonl"));
-
-        let output = run_cleanup(&codex_home, &shallow_restore_path);
-
-        assert_failure_contains(&output, "invalid codex restore directory");
-    }
-
-    #[test]
-    fn cleanup_script_rejects_empty_session_id_without_deleting_sessions() {
-        let temp = tempfile::tempdir().unwrap();
-        let codex_home = temp.path().join(".codex");
-        let restore_path = restore_path(&codex_home);
-        let restore_dir = restore_path.parent().unwrap();
-        fs::create_dir_all(restore_dir).unwrap();
-        let existing_session = restore_dir.join("rollout-existing-session.jsonl");
-        create_file(&existing_session);
-
-        let output = run_cleanup_with_session_id(&codex_home, &restore_path, "");
-
-        assert_failure_contains(&output, "invalid codex restore session id");
-        assert!(existing_session.exists());
-    }
-
-    #[test]
-    fn cleanup_script_rejects_invalid_session_id_with_valid_filename_key_without_deleting_sessions()
-    {
-        for invalid_session_id in ["", "*"] {
-            let temp = tempfile::tempdir().unwrap();
-            let codex_home = temp.path().join(".codex");
-            let restore_path = restore_path(&codex_home);
-            let restore_dir = restore_path.parent().unwrap();
-            fs::create_dir_all(restore_dir).unwrap();
-            let existing_session = restore_dir.join("rollout-existing-session.jsonl");
-            create_file(&existing_session);
-
-            let output = run_cleanup_with_session_identity(
-                &codex_home,
-                &restore_path,
-                invalid_session_id,
-                SESSION_ID_NO_DASHES,
-            );
-
-            assert_failure_contains(&output, "invalid codex restore session id");
-            assert!(existing_session.exists());
-        }
-    }
-
-    #[test]
-    fn cleanup_script_rejects_glob_session_id_without_deleting_sessions() {
-        let temp = tempfile::tempdir().unwrap();
-        let codex_home = temp.path().join(".codex");
-        let restore_path = restore_path(&codex_home);
-        let restore_dir = restore_path.parent().unwrap();
-        fs::create_dir_all(restore_dir).unwrap();
-        let existing_session = restore_dir.join("rollout-existing-session.jsonl");
-        create_file(&existing_session);
-
-        let output = run_cleanup_with_session_id(&codex_home, &restore_path, "*");
-
-        assert_failure_contains(&output, "invalid codex restore session id");
-        assert!(existing_session.exists());
     }
 }

--- a/crates/runner/src/executor/tests/session_restore_tests/codex.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests/codex.rs
@@ -35,6 +35,7 @@ fn restore_session_skips_codex_cleanup_in_fresh_sandbox() {
         run_restore_session(restore_session_in_fresh_sandbox(&sandbox, &ctx, &session)).unwrap();
 
     assert!(sandbox.exec_calls().is_empty());
+    assert!(sandbox.codex_session_cleanup_calls().is_empty());
     let writes = sandbox.write_file_calls();
     assert_eq!(writes.len(), 1);
     assert_eq!(writes[0].path, CODEX_CANONICAL_ROLLOUT_PATH);

--- a/crates/runner/src/executor/tests/session_restore_tests/mod.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests/mod.rs
@@ -4,7 +4,6 @@ mod identity;
 mod pi;
 mod validation;
 
-use sandbox::EXEC_OUTPUT_LIMIT_64_KIB;
 use sandbox_mock::MockSandbox;
 use sha2::{Digest, Sha256};
 use std::sync::Mutex;
@@ -161,63 +160,19 @@ async fn restore_session_in_fresh_sandbox(
 }
 
 fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
-    let exec_calls = sandbox.exec_calls();
-    assert_eq!(exec_calls.len(), 1);
-    assert_eq!(
-        exec_calls[0].env_keys,
-        [
-            "OKOU_CODEX_RESTORE_SESSION_ID".to_string(),
-            "OKOU_CODEX_RESTORE_SESSION_FILENAME_KEY".to_string(),
-            "OKOU_CODEX_RESTORE_SESSION_PATH".to_string()
-        ]
-    );
-    assert_eq!(exec_calls[0].timeout, DEFAULT_EXEC_TIMEOUT);
-    assert_eq!(exec_calls[0].output_limits, EXEC_OUTPUT_LIMIT_64_KIB);
-    assert!(!exec_calls[0].sudo);
-    assert!(exec_calls[0].stdin_bytes.is_none());
-    assert!(exec_calls[0].cmd.contains("codex_home='/home/user/.codex'"));
-    assert!(exec_calls[0].cmd.contains("root=\"$codex_home/sessions\""));
-    assert!(exec_calls[0].cmd.contains("check_restore_dir_component"));
+    assert!(sandbox.exec_calls().is_empty());
+    let calls = sandbox.codex_session_cleanup_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].session_id, CODEX_SESSION_ID);
+    let thread_id = guest_contracts::codex_thread_id::CodexThreadId::parse(CODEX_SESSION_ID)
+        .expect("test Codex session id");
     assert!(
-        exec_calls[0]
-            .cmd
-            .contains("check_restore_dir_component \"$codex_home\"")
+        guest_contracts::codex_session_path::is_canonical_codex_rollout_relative_path(
+            &calls[0].fallback_relative_path,
+            &thread_id,
+        )
     );
-    assert!(
-        exec_calls[0]
-            .cmd
-            .contains("codex restore directory is a symlink")
-    );
-    assert!(exec_calls[0].cmd.contains("scan_budget="));
-    assert!(
-        exec_calls[0]
-            .cmd
-            .contains("collect_matching_session_entries")
-    );
-    assert!(
-        exec_calls[0]
-            .cmd
-            .contains("find \"$root\" -mindepth 1 -printf '%y%p\\0'")
-    );
-    assert!(exec_calls[0].cmd.contains("canonical_logical_path"));
-    assert!(exec_calls[0].cmd.contains("candidate_ambiguous"));
-    assert!(
-        exec_calls[0]
-            .cmd
-            .contains("delete_matching_session_entries")
-    );
-    assert!(exec_calls[0].cmd.contains("xargs -0"));
-    assert!(exec_calls[0].cmd.contains("\\\\.jsonl\\\\.zst"));
-    assert!(exec_calls[0].cmd.contains("\\\\.jsonl\\\\.vm0tmp-"));
-    assert!(exec_calls[0].cmd.contains("id_no_dashes"));
-    assert!(
-        exec_calls[0]
-            .cmd
-            .contains("OKOU_CODEX_RESTORE_SESSION_FILENAME_KEY")
-    );
-    assert!(!exec_calls[0].cmd.contains("tr -d"));
-    assert!(!exec_calls[0].cmd.contains("-delete"));
-    assert!(!exec_calls[0].cmd.contains("for path in \"$dir\"/*"));
+    assert_eq!(calls[0].timeout, DEFAULT_EXEC_TIMEOUT);
 }
 
 fn capture_restore_events<F>(future: F) -> (F::Output, Vec<CapturedEvent>)

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -7,8 +7,8 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use sandbox::{
-    CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestAgentProcessHandle,
-    GuestAgentStartTiming, GuestMemorySnapshot, GuestProcessCancelHandle,
+    CodexSessionCleanupRequest, CopyFileOptions, CopyFileResult, ExecRequest, ExecResult,
+    GuestAgentProcessHandle, GuestAgentStartTiming, GuestMemorySnapshot, GuestProcessCancelHandle,
     GuestProcessControlHandle, GuestProcessHandle, GuestProcessWaiter, GuestStateRestoreRequest,
     GuestStateRestoreTimezone, ProcessControlAck, ProcessControlFailureKind,
     ProcessControlGuestStatus, ProcessControlOutcome, ProcessControlWriteState, ProcessExit,
@@ -2509,6 +2509,28 @@ impl Sandbox for FirecrackerSandbox {
                     history_ref_kind: request.history_ref_kind,
                     history_hash: request.history_hash,
                     history_size_bytes: request.history_size_bytes,
+                    timeout_ms,
+                    wait_timeout: Duration::from_millis(u64::from(timeout_ms) + 5_000),
+                })
+                .await
+                .and_then(exec_result_from_operation_result)
+        })
+        .await
+    }
+
+    async fn cleanup_codex_session(
+        &self,
+        request: &CodexSessionCleanupRequest<'_>,
+    ) -> sandbox::Result<ExecResult> {
+        let operation = SandboxOperation::CleanupCodexSession;
+        let timeout_ms = request.timeout_ms();
+
+        self.run_bounded_guest_operation(operation, |guest| async move {
+            validate_exec_capture_timeout(timeout_ms)?;
+            guest
+                .cleanup_codex_session(vsock_host::CodexSessionCleanupRequest {
+                    session_id: request.session_id,
+                    fallback_relative_path: request.fallback_relative_path,
                     timeout_ms,
                     wait_timeout: Duration::from_millis(u64::from(timeout_ms) + 5_000),
                 })

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -2686,6 +2686,67 @@ async fn verify_session_history_identity_maps_fixed_request_and_terminal_metadat
 }
 
 #[tokio::test]
+async fn cleanup_codex_session_maps_fixed_request_and_terminal_metadata() {
+    let sandbox = test_sandbox_with_state(SandboxState::Running);
+    let mut guest = attach_mock_shutdown_guest(&sandbox).await;
+    let request = CodexSessionCleanupRequest {
+        session_id: "019e9154-c304-70f0-adde-36efb1be1701",
+        fallback_relative_path: "sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl",
+        timeout: Duration::from_secs(5),
+    };
+
+    let cleanup = sandbox.cleanup_codex_session(&request);
+    let respond = async {
+        let request = read_vsock_message(&mut guest).await;
+        assert_eq!(request.msg_type, vsock_proto::MSG_EXEC_START);
+        let decoded = vsock_proto::decode_exec_start(&request.payload).unwrap();
+        assert_eq!(
+            decoded.role,
+            vsock_proto::ExecProcessRole::CodexSessionCleanup
+        );
+        assert_eq!(
+            decoded.timeout,
+            vsock_proto::ExecTimeoutPolicy::Duration { timeout_ms: 5_000 }
+        );
+        let cleanup: guest_contracts::codex_session_cleanup::CodexSessionCleanupRequest =
+            serde_json::from_str(decoded.command).unwrap();
+        assert_eq!(cleanup.session_id, "019e9154-c304-70f0-adde-36efb1be1701");
+        assert_eq!(
+            cleanup.fallback_relative_path,
+            "sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl"
+        );
+
+        let payload = vsock_proto::encode_exec_result(
+            vsock_proto::ExecTermination::Exited { exit_code: 0 },
+            19,
+            vsock_proto::ExecCapturedOutput::Captured {
+                bytes: b"out",
+                truncated: true,
+            },
+            vsock_proto::ExecCapturedOutput::Captured {
+                bytes: b"err",
+                truncated: false,
+            },
+            "cleanup diagnostic",
+        )
+        .unwrap();
+        let response =
+            vsock_proto::encode(vsock_proto::MSG_EXEC_RESULT, request.seq, &payload).unwrap();
+        guest.write_all(&response).await.unwrap();
+    };
+    let (result, ()) = tokio::join!(cleanup, respond);
+    let result = result.unwrap();
+
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(result.guest_duration_ms, Some(19));
+    assert_eq!(result.stdout, b"out");
+    assert_eq!(result.stderr, b"err");
+    assert!(result.stdout_truncated);
+    assert!(!result.stderr_truncated);
+    assert_eq!(result.diagnostic, "cleanup diagnostic");
+}
+
+#[tokio::test]
 async fn restore_guest_state_preserves_fixed_request_and_terminal_metadata() {
     let sandbox = test_sandbox_with_state(SandboxState::Running);
     let mut guest = attach_mock_shutdown_guest(&sandbox).await;

--- a/crates/sandbox-mock/src/call_records.rs
+++ b/crates/sandbox-mock/src/call_records.rs
@@ -91,6 +91,17 @@ pub struct SessionHistoryIdentityVerifyCall {
     pub timeout: Duration,
 }
 
+/// Captured fixed reused-Codex session cleanup request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CodexSessionCleanupCall {
+    /// Canonical Codex thread identifier supplied to the cleanup helper.
+    pub session_id: String,
+    /// Canonical logical rollout path relative to the fixed Codex home.
+    pub fallback_relative_path: String,
+    /// Helper timeout supplied by the caller.
+    pub timeout: Duration,
+}
+
 /// Owned timezone behavior recorded for a fixed guest-state restore call.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum GuestStateRestoreTimezoneCall {

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -30,10 +30,10 @@ mod snapshot;
 mod support;
 
 pub use call_records::{
-    CopyFileCall, ExecCall, ExecMatcher, GuestStateRestoreCall, GuestStateRestoreTimezoneCall,
-    ProcessCancelCall, ProcessControlCall, ReadFileCall, RemoteExecCall,
-    SessionHistoryIdentityVerifyCall, StartAgentProcessCall, StartProcessCall, StorageManifestCall,
-    WaitProcessCall, WriteFileCall, WriteFilesCall,
+    CodexSessionCleanupCall, CopyFileCall, ExecCall, ExecMatcher, GuestStateRestoreCall,
+    GuestStateRestoreTimezoneCall, ProcessCancelCall, ProcessControlCall, ReadFileCall,
+    RemoteExecCall, SessionHistoryIdentityVerifyCall, StartAgentProcessCall, StartProcessCall,
+    StorageManifestCall, WaitProcessCall, WriteFileCall, WriteFilesCall,
 };
 pub use control::MockSandboxControl;
 pub use factory_runtime::{MockRuntimeProvider, MockSandboxFactory, MockSandboxRuntime};

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -6,9 +6,9 @@ use ::sandbox::*;
 use tokio_util::sync::CancellationToken;
 
 use crate::call_records::{
-    CopyFileCall, ExecCall, ExecMatcher, GuestStateRestoreCall, ProcessCancelCall,
-    ProcessControlCall, SessionHistoryIdentityVerifyCall, StartAgentProcessCall, StartProcessCall,
-    StorageManifestCall, WaitProcessCall, WriteFileCall, WriteFilesCall,
+    CodexSessionCleanupCall, CopyFileCall, ExecCall, ExecMatcher, GuestStateRestoreCall,
+    ProcessCancelCall, ProcessControlCall, SessionHistoryIdentityVerifyCall, StartAgentProcessCall,
+    StartProcessCall, StorageManifestCall, WaitProcessCall, WriteFileCall, WriteFilesCall,
 };
 use crate::lifecycle::{DestroyBehavior, LifecycleBehaviors, MockLifecycleGate};
 use crate::support::LockIgnoringPoison;
@@ -57,6 +57,8 @@ pub(crate) struct ExecOverrideState {
     pub(crate) storage_manifest_calls: Mutex<Vec<StorageManifestCall>>,
     /// Recorded fixed live identity verifier calls across attached sandboxes.
     pub(crate) session_history_identity_verify_calls: Mutex<Vec<SessionHistoryIdentityVerifyCall>>,
+    /// Recorded fixed reused-Codex cleanup calls across attached sandboxes.
+    pub(crate) codex_session_cleanup_calls: Mutex<Vec<CodexSessionCleanupCall>>,
     /// Recorded fixed guest-state restore calls across all attached sandboxes.
     pub(crate) guest_state_restore_calls: Mutex<Vec<GuestStateRestoreCall>>,
     /// FIFO behaviors for fixed guest-state restore operations.
@@ -497,6 +499,14 @@ impl MockSandboxOverrides {
     pub fn session_history_identity_verify_calls(&self) -> Vec<SessionHistoryIdentityVerifyCall> {
         self.exec
             .session_history_identity_verify_calls
+            .lock_ignoring_poison()
+            .clone()
+    }
+
+    /// Return fixed reused-Codex cleanup calls across all attached sandboxes.
+    pub fn codex_session_cleanup_calls(&self) -> Vec<CodexSessionCleanupCall> {
+        self.exec
+            .codex_session_cleanup_calls
             .lock_ignoring_poison()
             .clone()
     }

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -10,10 +10,10 @@ use ::sandbox::*;
 use async_trait::async_trait;
 
 use crate::call_records::{
-    CopyFileCall, ExecCall, GuestStateRestoreCall, GuestStateRestoreTimezoneCall,
-    ProcessCancelCall, ProcessControlCall, ReadFileCall, SessionHistoryIdentityVerifyCall,
-    StartAgentProcessCall, StartProcessCall, StorageManifestCall, WaitProcessCall, WriteFileCall,
-    WriteFilesCall,
+    CodexSessionCleanupCall, CopyFileCall, ExecCall, GuestStateRestoreCall,
+    GuestStateRestoreTimezoneCall, ProcessCancelCall, ProcessControlCall, ReadFileCall,
+    SessionHistoryIdentityVerifyCall, StartAgentProcessCall, StartProcessCall, StorageManifestCall,
+    WaitProcessCall, WriteFileCall, WriteFilesCall,
 };
 use crate::lifecycle::{MockLifecycleGate, wait_lifecycle_gate};
 use crate::overrides::{ExecMatcherOutcome, GuestStateRestoreBehavior, MockSandboxOverrides};
@@ -39,6 +39,7 @@ pub struct MockSandbox {
     exec_calls: Mutex<Vec<ExecCall>>,
     storage_manifest_calls: Mutex<Vec<StorageManifestCall>>,
     session_history_identity_verify_calls: Mutex<Vec<SessionHistoryIdentityVerifyCall>>,
+    codex_session_cleanup_calls: Mutex<Vec<CodexSessionCleanupCall>>,
     guest_state_restore_calls: Mutex<Vec<GuestStateRestoreCall>>,
     read_file_results: Mutex<VecDeque<Result<Option<Vec<u8>>>>>,
     read_file_calls: Mutex<Vec<ReadFileCall>>,
@@ -85,6 +86,7 @@ impl MockSandbox {
             exec_calls: Mutex::new(Vec::new()),
             storage_manifest_calls: Mutex::new(Vec::new()),
             session_history_identity_verify_calls: Mutex::new(Vec::new()),
+            codex_session_cleanup_calls: Mutex::new(Vec::new()),
             guest_state_restore_calls: Mutex::new(Vec::new()),
             read_file_results: Mutex::new(VecDeque::new()),
             read_file_calls: Mutex::new(Vec::new()),
@@ -244,6 +246,13 @@ impl MockSandbox {
     /// Return this sandbox's recorded fixed live identity verifier calls.
     pub fn session_history_identity_verify_calls(&self) -> Vec<SessionHistoryIdentityVerifyCall> {
         self.session_history_identity_verify_calls
+            .lock_ignoring_poison()
+            .clone()
+    }
+
+    /// Return this sandbox's recorded fixed reused-Codex cleanup calls.
+    pub fn codex_session_cleanup_calls(&self) -> Vec<CodexSessionCleanupCall> {
+        self.codex_session_cleanup_calls
             .lock_ignoring_poison()
             .clone()
     }
@@ -840,6 +849,33 @@ impl Sandbox for MockSandbox {
             overrides
                 .exec
                 .session_history_identity_verify_calls
+                .lock_ignoring_poison()
+                .push(call);
+        }
+        let result = self
+            .exec_results
+            .lock_ignoring_poison()
+            .pop_front()
+            .unwrap_or_else(|| Ok(default_exec_result()))?;
+        Ok(apply_exec_output_limits(result, EXEC_OUTPUT_LIMIT_64_KIB))
+    }
+
+    async fn cleanup_codex_session(
+        &self,
+        request: &CodexSessionCleanupRequest<'_>,
+    ) -> Result<ExecResult> {
+        let call = CodexSessionCleanupCall {
+            session_id: request.session_id.to_owned(),
+            fallback_relative_path: request.fallback_relative_path.to_owned(),
+            timeout: request.timeout,
+        };
+        self.codex_session_cleanup_calls
+            .lock_ignoring_poison()
+            .push(call.clone());
+        if let Some(overrides) = &self.overrides {
+            overrides
+                .exec
+                .codex_session_cleanup_calls
                 .lock_ignoring_poison()
                 .push(call);
         }

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -127,6 +127,8 @@ pub enum SandboxOperation {
     StartAgentProcess,
     /// [`Sandbox::verify_session_history_identity`](crate::Sandbox::verify_session_history_identity).
     VerifySessionHistoryIdentity,
+    /// [`Sandbox::cleanup_codex_session`](crate::Sandbox::cleanup_codex_session).
+    CleanupCodexSession,
     /// [`GuestProcessControlHandle::control`](crate::GuestProcessControlHandle::control).
     ProcessControl,
     /// [`Sandbox::wait_process`](crate::Sandbox::wait_process).
@@ -143,6 +145,7 @@ impl fmt::Display for SandboxOperation {
             Self::StartProcess => f.write_str("start process"),
             Self::StartAgentProcess => f.write_str("start Agent process"),
             Self::VerifySessionHistoryIdentity => f.write_str("verify session history identity"),
+            Self::CleanupCodexSession => f.write_str("clean up Codex session"),
             Self::ProcessControl => f.write_str("process control"),
             Self::WaitProcess => f.write_str("wait process"),
         }

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -55,9 +55,9 @@ pub use snapshot::{
     PendingSnapshotPublish, SnapshotCreateConfig, SnapshotError, SnapshotOutput, SnapshotProvider,
 };
 pub use types::{
-    CopyFileOptions, CopyFileResult, EXEC_OUTPUT_LIMIT_1_MIB, EXEC_OUTPUT_LIMIT_7_MIB,
-    EXEC_OUTPUT_LIMIT_64_KIB, ExecOutputLimits, ExecRequest, ExecResult, ExecTermination,
-    GuestAgentProcessHandle, GuestAgentStartTiming, GuestProcessCancelHandle,
+    CodexSessionCleanupRequest, CopyFileOptions, CopyFileResult, EXEC_OUTPUT_LIMIT_1_MIB,
+    EXEC_OUTPUT_LIMIT_7_MIB, EXEC_OUTPUT_LIMIT_64_KIB, ExecOutputLimits, ExecRequest, ExecResult,
+    ExecTermination, GuestAgentProcessHandle, GuestAgentStartTiming, GuestProcessCancelHandle,
     GuestProcessControlHandle, GuestProcessControlOutcomeFuture, GuestProcessHandle,
     GuestProcessWaiter, GuestStateRestoreRequest, GuestStateRestoreTimezone, ProcessControlAck,
     ProcessControlFailureKind, ProcessControlGuestStatus, ProcessControlOutcome,

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -9,9 +9,10 @@ use tokio::sync::Notify;
 
 use crate::error::{Result, SandboxError, SandboxIdleTransition};
 use crate::types::{
-    CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestAgentProcessHandle,
-    GuestProcessHandle, GuestStateRestoreRequest, ProcessExit, SessionHistoryIdentityVerifyRequest,
-    StartAgentProcessRequest, StartProcessRequest, StorageManifestRequest, WriteFileEntry,
+    CodexSessionCleanupRequest, CopyFileOptions, CopyFileResult, ExecRequest, ExecResult,
+    GuestAgentProcessHandle, GuestProcessHandle, GuestStateRestoreRequest, ProcessExit,
+    SessionHistoryIdentityVerifyRequest, StartAgentProcessRequest, StartProcessRequest,
+    StorageManifestRequest, WriteFileEntry,
 };
 
 /// Eligibility result after a sandbox successfully reaches the parked state.
@@ -751,6 +752,23 @@ pub trait Sandbox: Send + Sync + Any {
             operation: crate::SandboxOperation::VerifySessionHistoryIdentity,
             reason: crate::SandboxOperationReason::Other,
             message: "fixed session history identity verifier is unsupported".to_string(),
+        })
+    }
+
+    /// Clean retained Codex rollout files through the provider's fixed helper.
+    ///
+    /// Implementations select the executable and fixed subcommand and must not
+    /// expose arbitrary command, environment, sudo, stdin, output, or lifecycle
+    /// authority. The result stdout remains untrusted and must be validated by
+    /// the session-restore owner before it becomes a write destination.
+    async fn cleanup_codex_session(
+        &self,
+        _request: &CodexSessionCleanupRequest<'_>,
+    ) -> Result<ExecResult> {
+        Err(SandboxError::Operation {
+            operation: crate::SandboxOperation::CleanupCodexSession,
+            reason: crate::SandboxOperationReason::Other,
+            message: "fixed Codex session cleanup is unsupported".to_string(),
         })
     }
 

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -116,6 +116,20 @@ pub struct SessionHistoryIdentityVerifyRequest<'a> {
     pub timeout: Duration,
 }
 
+/// Request for the fixed reused-Codex session cleanup helper.
+///
+/// The provider selects the executable, subcommand, process identity,
+/// containment, output bounds, and transport lifecycle. Callers supply only
+/// the canonical session identity and fallback logical rollout path.
+pub struct CodexSessionCleanupRequest<'a> {
+    /// Canonical lowercase hyphenated Codex thread identifier.
+    pub session_id: &'a str,
+    /// Canonical logical rollout path relative to the fixed Codex home.
+    pub fallback_relative_path: &'a str,
+    /// Guest-side helper timeout.
+    pub timeout: Duration,
+}
+
 /// Timezone behavior for a fixed guest-state restore operation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum GuestStateRestoreTimezone<'a> {
@@ -166,6 +180,16 @@ impl StorageManifestRequest<'_> {
 }
 
 impl SessionHistoryIdentityVerifyRequest<'_> {
+    /// Return the timeout as milliseconds, saturating at `u32::MAX`.
+    ///
+    /// Non-zero sub-millisecond durations round up to 1ms so callers do not
+    /// accidentally turn a bounded operation into a zero-timeout request.
+    pub fn timeout_ms(&self) -> u32 {
+        duration_ms(self.timeout)
+    }
+}
+
+impl CodexSessionCleanupRequest<'_> {
     /// Return the timeout as milliseconds, saturating at `u32::MAX`.
     ///
     /// Non-zero sub-millisecond durations round up to 1ms so callers do not

--- a/crates/vsock-guest/src/agent_command.rs
+++ b/crates/vsock-guest/src/agent_command.rs
@@ -12,6 +12,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{ChildStderr, ChildStdout, Command, Stdio};
 
+use guest_contracts::codex_session_cleanup::CodexSessionCleanupRequest;
 use guest_contracts::session_history_identity::SessionHistoryIdentityVerifyRequest;
 
 use crate::process_containment::{ExecProcessContainment, ProcessContainmentCleanupMode};
@@ -75,6 +76,41 @@ pub(crate) fn spawn_session_history_identity_verifier_with_pipes(
                 guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
                 &request.runtime_dir,
             )
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        crate::user::configure_guest_agent_command_environment(&mut command)?;
+        spawn_command_in_containment(&mut command, false, &process_containment)
+    })();
+
+    match spawn_result {
+        Ok(child) => Ok(SpawnedCommand {
+            child,
+            env_script: None,
+            process_containment,
+        }),
+        Err(error) => {
+            let _ = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
+            Err(error)
+        }
+    }
+}
+
+pub(crate) fn spawn_codex_session_cleanup_with_pipes(
+    request: &CodexSessionCleanupRequest,
+    process_containment: ExecProcessContainment,
+    program: &GuestAgentProgram,
+) -> io::Result<SpawnedCommand> {
+    request
+        .validate()
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error.to_string()))?;
+    let spawn_result = (|| {
+        validate_agent_executable(program.executable())?;
+        let mut command = Command::new(program.executable());
+        command
+            .arg("cleanup-codex-session")
+            .arg(&request.session_id)
+            .arg(&request.fallback_relative_path)
+            .env_clear()
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
         crate::user::configure_guest_agent_command_environment(&mut command)?;

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -66,7 +66,7 @@ use vsock_proto::{
 use vsock_proto::MSG_EXEC_RESULT;
 
 use crate::agent_command::{
-    GuestAgentProgram, spawn_agent_command_with_pipes,
+    GuestAgentProgram, spawn_agent_command_with_pipes, spawn_codex_session_cleanup_with_pipes,
     spawn_session_history_identity_verifier_with_pipes,
 };
 use crate::drain::{
@@ -252,6 +252,8 @@ pub(crate) struct ExecOperationWorkerRequest {
     guest_agent_program: GuestAgentProgram,
     session_history_identity_verify_request:
         Option<guest_contracts::session_history_identity::SessionHistoryIdentityVerifyRequest>,
+    codex_session_cleanup_request:
+        Option<guest_contracts::codex_session_cleanup::CodexSessionCleanupRequest>,
     process_containment_mode: ProcessContainmentMode,
     drain_deadline: Duration,
 }
@@ -262,6 +264,7 @@ impl ExecOperationWorkerRequest {
             ExecProcessRole::Workload => "contained_workload",
             ExecProcessRole::Agent => "controlled_agent",
             ExecProcessRole::SessionHistoryIdentityVerifier => "session_history_identity_verifier",
+            ExecProcessRole::CodexSessionCleanup => "codex_session_cleanup",
         }
     }
 
@@ -278,6 +281,10 @@ impl ExecOperationWorkerRequest {
                 ExecProcessRole::SessionHistoryIdentityVerifier,
                 ExecOperationLifecycle::Supervised,
             ) => "invalid",
+            (ExecProcessRole::CodexSessionCleanup, ExecOperationLifecycle::OneShot) => {
+                "cleanup_codex_session"
+            }
+            (ExecProcessRole::CodexSessionCleanup, ExecOperationLifecycle::Supervised) => "invalid",
         }
     }
 
@@ -326,31 +333,32 @@ impl ExecOperationWorkerRequest {
                 "exec control policy requires supervised lifecycle",
             ));
         }
-        let session_history_identity_verify_request = match decoded.role {
-            ExecProcessRole::Agent => {
-                if !decoded.command.is_empty() {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "Agent process cannot select a command",
-                    ));
+        let (session_history_identity_verify_request, codex_session_cleanup_request) =
+            match decoded.role {
+                ExecProcessRole::Agent => {
+                    if !decoded.command.is_empty() {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "Agent process cannot select a command",
+                        ));
+                    }
+                    if decoded.sudo {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "Agent process cannot select sudo execution",
+                        ));
+                    }
+                    if decoded.stdin_bytes.is_some() {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "Agent process cannot provide stdin",
+                        ));
+                    }
+                    (None, None)
                 }
-                if decoded.sudo {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "Agent process cannot select sudo execution",
-                    ));
-                }
-                if decoded.stdin_bytes.is_some() {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "Agent process cannot provide stdin",
-                    ));
-                }
-                None
-            }
-            ExecProcessRole::SessionHistoryIdentityVerifier => {
-                validate_session_history_identity_verifier_contract(&decoded)?;
-                let request = serde_json::from_str::<
+                ExecProcessRole::SessionHistoryIdentityVerifier => {
+                    validate_session_history_identity_verifier_contract(&decoded)?;
+                    let request = serde_json::from_str::<
                     guest_contracts::session_history_identity::SessionHistoryIdentityVerifyRequest,
                 >(decoded.command)
                 .map_err(|_| {
@@ -359,16 +367,35 @@ impl ExecOperationWorkerRequest {
                         "session history identity verifier payload is invalid",
                     )
                 })?;
-                request.validate().map_err(|_| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "session history identity verifier payload is invalid",
-                    )
-                })?;
-                Some(request)
-            }
-            ExecProcessRole::Workload => None,
-        };
+                    request.validate().map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "session history identity verifier payload is invalid",
+                        )
+                    })?;
+                    (Some(request), None)
+                }
+                ExecProcessRole::CodexSessionCleanup => {
+                    validate_codex_session_cleanup_contract(&decoded)?;
+                    let request = serde_json::from_str::<
+                        guest_contracts::codex_session_cleanup::CodexSessionCleanupRequest,
+                    >(decoded.command)
+                    .map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "Codex session cleanup payload is invalid",
+                        )
+                    })?;
+                    request.validate().map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "Codex session cleanup payload is invalid",
+                        )
+                    })?;
+                    (None, Some(request))
+                }
+                ExecProcessRole::Workload => (None, None),
+            };
 
         Ok(Self {
             seq,
@@ -392,6 +419,7 @@ impl ExecOperationWorkerRequest {
             exec_control_bootstrap_endpoint: None,
             guest_agent_program,
             session_history_identity_verify_request,
+            codex_session_cleanup_request,
             process_containment_mode,
             drain_deadline,
         })
@@ -421,7 +449,8 @@ impl ExecOperationWorkerRequest {
         match (self.role, self.exec_control_bootstrap_endpoint.is_some()) {
             (ExecProcessRole::Workload, false)
             | (ExecProcessRole::Agent, true)
-            | (ExecProcessRole::SessionHistoryIdentityVerifier, false) => Ok(()),
+            | (ExecProcessRole::SessionHistoryIdentityVerifier, false)
+            | (ExecProcessRole::CodexSessionCleanup, false) => Ok(()),
             (ExecProcessRole::Workload, true) => Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "workload process received an Agent control bootstrap endpoint",
@@ -433,6 +462,10 @@ impl ExecOperationWorkerRequest {
             (ExecProcessRole::SessionHistoryIdentityVerifier, true) => Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "session history identity verifier received a control bootstrap endpoint",
+            )),
+            (ExecProcessRole::CodexSessionCleanup, true) => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Codex session cleanup received a control bootstrap endpoint",
             )),
         }
     }
@@ -465,6 +498,36 @@ fn validate_session_history_identity_verifier_contract(
         Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "session history identity verifier process contract is invalid",
+        ))
+    }
+}
+
+fn validate_codex_session_cleanup_contract(
+    decoded: &vsock_proto::DecodedExecStart<'_>,
+) -> io::Result<()> {
+    use guest_contracts::codex_session_cleanup::{
+        CODEX_SESSION_CLEANUP_DIAGNOSTIC_LABEL, CODEX_SESSION_CLEANUP_OUTPUT_LIMIT_BYTES,
+    };
+
+    let fixed_capture = ExecOutputPolicy::Capture {
+        limit_bytes: CODEX_SESSION_CLEANUP_OUTPUT_LIMIT_BYTES,
+    };
+    let valid = decoded.lifecycle == ExecLifecyclePolicy::OneShot
+        && decoded.control == ExecControlPolicy::Disabled
+        && !decoded.command.is_empty()
+        && decoded.env.is_empty()
+        && !decoded.sudo
+        && decoded.label == CODEX_SESSION_CLEANUP_DIAGNOSTIC_LABEL
+        && decoded.stdout == fixed_capture
+        && decoded.stderr == fixed_capture
+        && decoded.expected_exit_codes.is_empty()
+        && decoded.stdin_bytes.is_none();
+    if valid {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Codex session cleanup process contract is invalid",
         ))
     }
 }
@@ -1441,6 +1504,18 @@ fn run_exec_operation_worker<S>(
                 &request.guest_agent_program,
             )
         }
+        ExecProcessRole::CodexSessionCleanup => {
+            let Some(cleanup_request) = request.codex_session_cleanup_request.as_ref() else {
+                let _ = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
+                completion.start_failed("Codex session cleanup payload is missing");
+                return;
+            };
+            spawn_codex_session_cleanup_with_pipes(
+                cleanup_request,
+                process_containment,
+                &request.guest_agent_program,
+            )
+        }
     };
     let spawned = match spawn_result {
         Ok(spawned) => spawned,
@@ -1453,6 +1528,9 @@ fn run_exec_operation_worker<S>(
                 ExecProcessRole::Agent => format!("Failed to execute controlled Agent: {e}"),
                 ExecProcessRole::SessionHistoryIdentityVerifier => {
                     format!("Failed to execute session history identity verifier: {e}")
+                }
+                ExecProcessRole::CodexSessionCleanup => {
+                    format!("Failed to execute Codex session cleanup: {e}")
                 }
             };
             completion.start_failed(&diagnostic);
@@ -2332,6 +2410,7 @@ mod tests {
             exec_control_bootstrap_endpoint: None,
             guest_agent_program: GuestAgentProgram::production(),
             session_history_identity_verify_request: None,
+            codex_session_cleanup_request: None,
             process_containment_mode: ProcessContainmentMode::BuildConfigured,
             drain_deadline: EXEC_OUTPUT_DRAIN_DEADLINE,
         }

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -264,7 +264,10 @@ impl ExecProcessContainment {
         // The exec request parser admits this role only after validating its
         // fixed Runner-owned helper contract. Workload and Agent roles retain
         // workload cgroup containment.
-        if role == ExecProcessRole::SessionHistoryIdentityVerifier {
+        if matches!(
+            role,
+            ExecProcessRole::SessionHistoryIdentityVerifier | ExecProcessRole::CodexSessionCleanup
+        ) {
             return Ok(Self {
                 backend: ContainmentBackend::ProcessGroup,
             });

--- a/crates/vsock-guest/tests/connection/exec_validation.rs
+++ b/crates/vsock-guest/tests/connection/exec_validation.rs
@@ -4,8 +4,8 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
 use guest_contracts::codex_session_cleanup::{
-    CODEX_SESSION_CLEANUP_DIAGNOSTIC_LABEL, CODEX_SESSION_CLEANUP_OUTPUT_LIMIT_BYTES,
-    CodexSessionCleanupRequest,
+    CODEX_SESSION_CLEANUP_DIAGNOSTIC_LABEL, CODEX_SESSION_CLEANUP_MAX_PATH_BYTES,
+    CODEX_SESSION_CLEANUP_OUTPUT_LIMIT_BYTES, CodexSessionCleanupRequest,
 };
 use guest_contracts::session_history_identity::{
     SESSION_HISTORY_IDENTITY_VERIFY_DIAGNOSTIC_LABEL,
@@ -628,6 +628,16 @@ fn codex_session_cleanup_rejects_generic_exec_authority_and_invalid_payload() {
         "Codex session cleanup payload is invalid"
     );
 
+    send_exec_start_request(
+        &mut host_stream,
+        160,
+        codex_cleanup_exec_request("{not-json"),
+    );
+    assert_eq!(
+        read_error_response(&mut host_stream, 160),
+        "Codex session cleanup payload is invalid"
+    );
+
     let invalid_path_payload = serde_json::to_string(&CodexSessionCleanupRequest {
         session_id: CODEX_SESSION_ID.to_owned(),
         fallback_relative_path: "../../tmp/session.jsonl".to_owned(),
@@ -635,15 +645,45 @@ fn codex_session_cleanup_rejects_generic_exec_authority_and_invalid_payload() {
     .unwrap();
     send_exec_start_request(
         &mut host_stream,
-        160,
+        161,
         codex_cleanup_exec_request(&invalid_path_payload),
     );
     assert_eq!(
-        read_error_response(&mut host_stream, 160),
+        read_error_response(&mut host_stream, 161),
         "Codex session cleanup payload is invalid"
     );
 
-    assert_ping_pong(&mut host_stream, 161);
+    let noncanonical_id_payload = serde_json::to_string(&CodexSessionCleanupRequest {
+        session_id: CODEX_SESSION_ID.to_ascii_uppercase(),
+        fallback_relative_path: CODEX_FALLBACK_RELATIVE_PATH.to_owned(),
+    })
+    .unwrap();
+    send_exec_start_request(
+        &mut host_stream,
+        162,
+        codex_cleanup_exec_request(&noncanonical_id_payload),
+    );
+    assert_eq!(
+        read_error_response(&mut host_stream, 162),
+        "Codex session cleanup payload is invalid"
+    );
+
+    let oversized_path_payload = serde_json::to_string(&CodexSessionCleanupRequest {
+        session_id: CODEX_SESSION_ID.to_owned(),
+        fallback_relative_path: "x".repeat(CODEX_SESSION_CLEANUP_MAX_PATH_BYTES + 1),
+    })
+    .unwrap();
+    send_exec_start_request(
+        &mut host_stream,
+        163,
+        codex_cleanup_exec_request(&oversized_path_payload),
+    );
+    assert_eq!(
+        read_error_response(&mut host_stream, 163),
+        "Codex session cleanup payload is invalid"
+    );
+
+    assert_ping_pong(&mut host_stream, 164);
     finish_guest_connection(handle, host_stream);
 }
 

--- a/crates/vsock-guest/tests/connection/exec_validation.rs
+++ b/crates/vsock-guest/tests/connection/exec_validation.rs
@@ -3,6 +3,10 @@ use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
+use guest_contracts::codex_session_cleanup::{
+    CODEX_SESSION_CLEANUP_DIAGNOSTIC_LABEL, CODEX_SESSION_CLEANUP_OUTPUT_LIMIT_BYTES,
+    CodexSessionCleanupRequest,
+};
 use guest_contracts::session_history_identity::{
     SESSION_HISTORY_IDENTITY_VERIFY_DIAGNOSTIC_LABEL,
     SESSION_HISTORY_IDENTITY_VERIFY_OUTPUT_LIMIT_BYTES, SessionHistoryFramework,
@@ -54,6 +58,46 @@ fn verifier_exec_request_with_timeout(
         },
         stderr: ExecOutputPolicy::Capture {
             limit_bytes: SESSION_HISTORY_IDENTITY_VERIFY_OUTPUT_LIMIT_BYTES,
+        },
+        expected_exit_codes: &[],
+        control: ExecControlPolicy::Disabled,
+        stdin_bytes: None,
+    }
+}
+
+const CODEX_SESSION_ID: &str = "019e9154-c304-70f0-adde-36efb1be1701";
+const CODEX_FALLBACK_RELATIVE_PATH: &str =
+    "sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl";
+
+fn codex_session_cleanup_payload() -> String {
+    serde_json::to_string(&CodexSessionCleanupRequest {
+        session_id: CODEX_SESSION_ID.to_owned(),
+        fallback_relative_path: CODEX_FALLBACK_RELATIVE_PATH.to_owned(),
+    })
+    .unwrap()
+}
+
+fn codex_cleanup_exec_request(command: &str) -> vsock_proto::ExecStartEncodeRequest<'_> {
+    codex_cleanup_exec_request_with_timeout(command, 5000)
+}
+
+fn codex_cleanup_exec_request_with_timeout(
+    command: &str,
+    timeout_ms: u32,
+) -> vsock_proto::ExecStartEncodeRequest<'_> {
+    vsock_proto::ExecStartEncodeRequest {
+        lifecycle: ExecLifecyclePolicy::OneShot,
+        role: vsock_proto::ExecProcessRole::CodexSessionCleanup,
+        timeout: ExecTimeoutPolicy::Duration { timeout_ms },
+        command,
+        env: &[],
+        sudo: false,
+        label: CODEX_SESSION_CLEANUP_DIAGNOSTIC_LABEL,
+        stdout: ExecOutputPolicy::Capture {
+            limit_bytes: CODEX_SESSION_CLEANUP_OUTPUT_LIMIT_BYTES,
+        },
+        stderr: ExecOutputPolicy::Capture {
+            limit_bytes: CODEX_SESSION_CLEANUP_OUTPUT_LIMIT_BYTES,
         },
         expected_exit_codes: &[],
         control: ExecControlPolicy::Disabled,
@@ -413,6 +457,193 @@ fn session_history_identity_verifier_rejects_generic_exec_authority() {
     );
 
     assert_ping_pong(&mut host_stream, 145);
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn codex_session_cleanup_directly_launches_fixed_helper_arguments() {
+    let agent_path = unique_tmp_path("codex-session-cleanup", ".sh");
+    write_executable_script(
+        agent_path.as_str(),
+        r#"#!/bin/sh
+printf 'args'
+for arg in "$@"; do printf ' <%s>' "$arg"; done
+printf '\n'
+"#,
+    );
+    let payload = codex_session_cleanup_payload();
+    let (handle, mut host_stream) =
+        start_guest_connection_with_guest_agent_program(PathBuf::from(agent_path.as_str()));
+
+    send_exec_start_request(&mut host_stream, 149, codex_cleanup_exec_request(&payload));
+    let (chunks, result) = read_exec_result(&mut host_stream, 149);
+
+    assert!(chunks.is_empty());
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(
+        String::from_utf8(result.stdout.unwrap()).unwrap(),
+        format!(
+            "args <cleanup-codex-session> <{CODEX_SESSION_ID}> <{CODEX_FALLBACK_RELATIVE_PATH}>\n"
+        )
+    );
+    assert_eq!(result.stderr, Some(Vec::new()));
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn codex_session_cleanup_natural_exit_cleans_descendants() {
+    let agent_path = unique_tmp_path("codex-cleanup-descendant", ".sh");
+    let pid_path = unique_pid_path("codex-cleanup-descendant");
+    let mut group_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    write_executable_script(
+        agent_path.as_str(),
+        &format!(
+            "#!/bin/sh\nprintf '%s' \"$$\" > '{}'\nsleep 30 >/dev/null 2>&1 &\nexit 0\n",
+            pid_path.as_str(),
+        ),
+    );
+    let payload = codex_session_cleanup_payload();
+    let (handle, mut host_stream) =
+        start_guest_connection_with_guest_agent_program(PathBuf::from(agent_path.as_str()));
+
+    send_exec_start_request(&mut host_stream, 150, codex_cleanup_exec_request(&payload));
+    let (chunks, result) = read_exec_result(&mut host_stream, 150);
+    let pid = group_guard.read_pid();
+
+    assert!(chunks.is_empty());
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    wait_for_pid_exit(pid, "Codex cleanup natural exit");
+    group_guard.disarm();
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn codex_session_cleanup_timeout_cleans_process_group() {
+    let agent_path = unique_tmp_path("codex-cleanup-timeout", ".sh");
+    let pid_path = unique_pid_path("codex-cleanup-timeout");
+    let mut group_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    write_executable_script(
+        agent_path.as_str(),
+        &format!(
+            "#!/bin/sh\nprintf '%s' \"$$\" > '{}'\nsleep 30\n",
+            pid_path.as_str(),
+        ),
+    );
+    let payload = codex_session_cleanup_payload();
+    let (handle, mut host_stream) =
+        start_guest_connection_with_guest_agent_program(PathBuf::from(agent_path.as_str()));
+
+    send_exec_start_request(
+        &mut host_stream,
+        151,
+        codex_cleanup_exec_request_with_timeout(&payload, 200),
+    );
+    let (chunks, result) = read_exec_result(&mut host_stream, 151);
+    let pid = group_guard.read_pid();
+
+    assert!(chunks.is_empty());
+    assert_eq!(result.termination, ExecTermination::TimedOut);
+    wait_for_pid_exit(pid, "Codex cleanup timeout");
+    group_guard.disarm();
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn codex_session_cleanup_disconnect_cleans_process_group() {
+    let agent_path = unique_tmp_path("codex-cleanup-disconnect", ".sh");
+    let pid_path = unique_pid_path("codex-cleanup-disconnect");
+    let mut group_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    write_executable_script(
+        agent_path.as_str(),
+        &format!(
+            "#!/bin/sh\nprintf '%s' \"$$\" > '{}'\nsleep 30\n",
+            pid_path.as_str(),
+        ),
+    );
+    let payload = codex_session_cleanup_payload();
+    let (handle, mut host_stream) =
+        start_guest_connection_with_guest_agent_program(PathBuf::from(agent_path.as_str()));
+
+    send_exec_start_request(
+        &mut host_stream,
+        152,
+        codex_cleanup_exec_request_with_timeout(&payload, 60_000),
+    );
+    let pid = group_guard.read_pid();
+
+    drop(host_stream);
+    join_guest_connection(handle);
+    wait_for_pid_exit(pid, "Codex cleanup disconnect");
+    group_guard.disarm();
+}
+
+#[test]
+fn codex_session_cleanup_rejects_generic_exec_authority_and_invalid_payload() {
+    enum Mutation {
+        Environment,
+        Sudo,
+        Stdin,
+        Label,
+        Output,
+        ExpectedExit,
+    }
+
+    let payload = codex_session_cleanup_payload();
+    let (handle, mut host_stream) = start_guest_connection();
+
+    for (seq, mutate) in [
+        (153, Mutation::Environment),
+        (154, Mutation::Sudo),
+        (155, Mutation::Stdin),
+        (156, Mutation::Label),
+        (157, Mutation::Output),
+        (158, Mutation::ExpectedExit),
+    ] {
+        let mut request = codex_cleanup_exec_request(&payload);
+        let env = [("UNTRUSTED", "value")];
+        let expected_exit_codes = [7];
+        match mutate {
+            Mutation::Environment => request.env = &env,
+            Mutation::Sudo => request.sudo = true,
+            Mutation::Stdin => request.stdin_bytes = Some(b"stdin"),
+            Mutation::Label => request.label = "caller-selected-label",
+            Mutation::Output => request.stdout = ExecOutputPolicy::Discard,
+            Mutation::ExpectedExit => request.expected_exit_codes = &expected_exit_codes,
+        }
+        send_exec_start_request(&mut host_stream, seq, request);
+        assert_eq!(
+            read_error_response(&mut host_stream, seq),
+            "Codex session cleanup process contract is invalid"
+        );
+    }
+
+    send_exec_start_request(
+        &mut host_stream,
+        159,
+        codex_cleanup_exec_request("{\"unexpected\":true}"),
+    );
+    assert_eq!(
+        read_error_response(&mut host_stream, 159),
+        "Codex session cleanup payload is invalid"
+    );
+
+    let invalid_path_payload = serde_json::to_string(&CodexSessionCleanupRequest {
+        session_id: CODEX_SESSION_ID.to_owned(),
+        fallback_relative_path: "../../tmp/session.jsonl".to_owned(),
+    })
+    .unwrap();
+    send_exec_start_request(
+        &mut host_stream,
+        160,
+        codex_cleanup_exec_request(&invalid_path_payload),
+    );
+    assert_eq!(
+        read_error_response(&mut host_stream, 160),
+        "Codex session cleanup payload is invalid"
+    );
+
+    assert_ping_pong(&mut host_stream, 161);
     finish_guest_connection(handle, host_stream);
 }
 

--- a/crates/vsock-host/src/exec_operation/diagnostics.rs
+++ b/crates/vsock-host/src/exec_operation/diagnostics.rs
@@ -104,6 +104,7 @@ impl ExecOperationDiagnostic {
             ExecProcessRole::Workload => "contained_workload",
             ExecProcessRole::Agent => "controlled_agent",
             ExecProcessRole::SessionHistoryIdentityVerifier => "session_history_identity_verifier",
+            ExecProcessRole::CodexSessionCleanup => "codex_session_cleanup",
         };
         let operation_kind = match (role, supervised) {
             (ExecProcessRole::Workload, false) => "exec",
@@ -114,6 +115,8 @@ impl ExecOperationDiagnostic {
                 "verify_session_history_identity"
             }
             (ExecProcessRole::SessionHistoryIdentityVerifier, true) => "invalid",
+            (ExecProcessRole::CodexSessionCleanup, false) => "cleanup_codex_session",
+            (ExecProcessRole::CodexSessionCleanup, true) => "invalid",
         };
         Self {
             seq,

--- a/crates/vsock-host/src/exec_operation/dispatch.rs
+++ b/crates/vsock-host/src/exec_operation/dispatch.rs
@@ -326,6 +326,11 @@ fn dispatch_started(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Re
                                     "supervised start cannot use session history identity verifier role",
                                 ));
                             }
+                            vsock_proto::ExecProcessRole::CodexSessionCleanup => {
+                                return Err(exec_operation_protocol_error(
+                                    "supervised start cannot use Codex session cleanup role",
+                                ));
+                            }
                         }
                     }
                     lifecycle @ ExecOperationLifecycle::SupervisedAwaitingAgentReady {

--- a/crates/vsock-host/src/exec_operation/mod.rs
+++ b/crates/vsock-host/src/exec_operation/mod.rs
@@ -13,17 +13,17 @@ pub use handle::{
     ExecControlHandle, ExecOperationHandle, SupervisedExecCancelHandle, SupervisedExecHandle,
 };
 pub use types::{
-    ExecCaptureRequest, ExecControlAck, ExecControlGuestStatus, ExecControlOutcome,
-    ExecOperationRequest, ExecOperationResult, ExecOutputEvent, ExecOwnedCapturedOutput,
-    ExecStreamRequest, SessionHistoryIdentityVerifyRequest, SupervisedExecControl,
-    SupervisedExecRequest, SupervisedExecStartTiming,
+    CodexSessionCleanupRequest, ExecCaptureRequest, ExecControlAck, ExecControlGuestStatus,
+    ExecControlOutcome, ExecOperationRequest, ExecOperationResult, ExecOutputEvent,
+    ExecOwnedCapturedOutput, ExecStreamRequest, SessionHistoryIdentityVerifyRequest,
+    SupervisedExecControl, SupervisedExecRequest, SupervisedExecStartTiming,
 };
 
 pub(crate) use diagnostics::log_operations_closed;
 pub(crate) use dispatch::dispatch_incoming_frame;
 pub(crate) use handle::{ExecOperationCancelOnDropGuard, ExecOperationWaitOutcome};
 pub(crate) use start::{
-    append_diagnostic, exec_operation_capture_on_shared,
+    append_diagnostic, codex_session_cleanup_on_shared, exec_operation_capture_on_shared,
     exec_operation_capture_on_shared_with_write_admission,
     exec_operation_capture_on_shared_with_write_observer,
     exec_operation_capture_with_composite_on_shared_and_observer,

--- a/crates/vsock-host/src/exec_operation/start.rs
+++ b/crates/vsock-host/src/exec_operation/start.rs
@@ -3,6 +3,10 @@ use std::io;
 use std::sync::Arc;
 use std::time::Duration;
 
+use guest_contracts::codex_session_cleanup::{
+    CODEX_SESSION_CLEANUP_DIAGNOSTIC_LABEL, CODEX_SESSION_CLEANUP_OUTPUT_LIMIT_BYTES,
+    CodexSessionCleanupRequest as GuestCodexSessionCleanupRequest,
+};
 use guest_contracts::session_history_identity::{
     SESSION_HISTORY_IDENTITY_VERIFY_DIAGNOSTIC_LABEL,
     SESSION_HISTORY_IDENTITY_VERIFY_OUTPUT_LIMIT_BYTES, SessionHistoryFramework,
@@ -30,8 +34,9 @@ use super::state::{
     register_exec_operation_start, stream_queue_capacity_for,
 };
 use super::types::{
-    ExecCaptureRequest, ExecOperationRequest, ExecOperationResult, ExecStreamRequest,
-    SessionHistoryIdentityVerifyRequest, SupervisedExecControl, SupervisedExecRequest,
+    CodexSessionCleanupRequest, ExecCaptureRequest, ExecOperationRequest, ExecOperationResult,
+    ExecStreamRequest, SessionHistoryIdentityVerifyRequest, SupervisedExecControl,
+    SupervisedExecRequest,
 };
 use super::{EXEC_OPERATION_START_TIMEOUT_CANCEL_WRITE_TIMEOUT, SMALL_EXEC_CAPTURE_LIMIT_BYTES};
 
@@ -486,6 +491,49 @@ pub(crate) async fn session_history_identity_verify_on_shared(
             start_write_timeout: request.wait_timeout,
         },
         ExecProcessRole::SessionHistoryIdentityVerifier,
+        ExecOperationTracking::Tracked,
+        FrameWriteObserver::default(),
+        FrameWriteObserver::default(),
+    )
+    .await;
+    let (handle, deadline) = start_result?;
+    handle.wait_until_outcome(deadline).await.into_result()
+}
+
+pub(crate) async fn codex_session_cleanup_on_shared(
+    shared: &Arc<Shared>,
+    request: CodexSessionCleanupRequest<'_>,
+) -> io::Result<ExecOperationResult> {
+    let guest_request = GuestCodexSessionCleanupRequest {
+        session_id: request.session_id.to_owned(),
+        fallback_relative_path: request.fallback_relative_path.to_owned(),
+    };
+    guest_request
+        .validate()
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error.to_string()))?;
+    let payload = serde_json::to_string(&guest_request)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error.to_string()))?;
+
+    let start_result = start_exec_operation_on_shared_with_tracking_and_admission(
+        shared,
+        ExecOperationRequest {
+            timeout_ms: request.timeout_ms,
+            command: &payload,
+            env: &[],
+            sudo: false,
+            label: CODEX_SESSION_CLEANUP_DIAGNOSTIC_LABEL,
+            stdout: ExecOutputPolicy::Capture {
+                limit_bytes: CODEX_SESSION_CLEANUP_OUTPUT_LIMIT_BYTES,
+            },
+            stderr: ExecOutputPolicy::Capture {
+                limit_bytes: CODEX_SESSION_CLEANUP_OUTPUT_LIMIT_BYTES,
+            },
+            expected_exit_codes: &[],
+            stdin_bytes: None,
+            stream_queue_capacity: None,
+            start_write_timeout: request.wait_timeout,
+        },
+        ExecProcessRole::CodexSessionCleanup,
         ExecOperationTracking::Tracked,
         FrameWriteObserver::default(),
         FrameWriteObserver::default(),

--- a/crates/vsock-host/src/exec_operation/types.rs
+++ b/crates/vsock-host/src/exec_operation/types.rs
@@ -187,6 +187,21 @@ pub struct SessionHistoryIdentityVerifyRequest<'a> {
     pub wait_timeout: Duration,
 }
 
+/// Fixed-purpose reused-Codex session cleanup request.
+///
+/// The host selects the executable, process role, label, output bounds, and
+/// one-shot lifecycle. Callers can supply only validated cleanup inputs.
+pub struct CodexSessionCleanupRequest<'a> {
+    /// Canonical lowercase hyphenated Codex thread identifier.
+    pub session_id: &'a str,
+    /// Canonical logical rollout path relative to the fixed Codex home.
+    pub fallback_relative_path: &'a str,
+    /// Positive guest-side process timeout in milliseconds.
+    pub timeout_ms: u32,
+    /// Total host-side request deadline.
+    pub wait_timeout: Duration,
+}
+
 /// Request parameters for a streaming exec operation helper.
 pub struct ExecStreamRequest<'a> {
     /// Positive guest-side process timeout in milliseconds.

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -95,9 +95,9 @@ use connection::{RequestWriteGuard, write_request_frame_with_builder};
 use operation_tracker::NormalOperationFenceRejection as TrackerNormalOperationFenceRejection;
 
 pub use exec_operation::{
-    ExecCaptureRequest, ExecControlAck, ExecControlGuestStatus, ExecControlHandle,
-    ExecControlOutcome, ExecOperationHandle, ExecOperationRequest, ExecOperationResult,
-    ExecOutputEvent, ExecOwnedCapturedOutput, ExecStreamRequest,
+    CodexSessionCleanupRequest, ExecCaptureRequest, ExecControlAck, ExecControlGuestStatus,
+    ExecControlHandle, ExecControlOutcome, ExecOperationHandle, ExecOperationRequest,
+    ExecOperationResult, ExecOutputEvent, ExecOwnedCapturedOutput, ExecStreamRequest,
     SessionHistoryIdentityVerifyRequest, SupervisedExecCancelHandle, SupervisedExecControl,
     SupervisedExecHandle, SupervisedExecRequest, SupervisedExecStartTiming,
 };
@@ -421,6 +421,14 @@ impl VsockHost {
         request: SessionHistoryIdentityVerifyRequest<'_>,
     ) -> io::Result<ExecOperationResult> {
         exec_operation::session_history_identity_verify_on_shared(&self.shared, request).await
+    }
+
+    /// Run the fixed reused-Codex session cleanup helper.
+    pub async fn cleanup_codex_session(
+        &self,
+        request: CodexSessionCleanupRequest<'_>,
+    ) -> io::Result<ExecOperationResult> {
+        exec_operation::codex_session_cleanup_on_shared(&self.shared, request).await
     }
 
     /// Run a capture-only exec operation with a synchronous admission check at

--- a/crates/vsock-host/src/tests/exec_operation/exec.rs
+++ b/crates/vsock-host/src/tests/exec_operation/exec.rs
@@ -5,6 +5,10 @@ use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 use vsock_proto::{ExecTermination, MSG_ERROR, MSG_EXEC_START};
 
+use guest_contracts::codex_session_cleanup::{
+    CODEX_SESSION_CLEANUP_DIAGNOSTIC_LABEL, CODEX_SESSION_CLEANUP_OUTPUT_LIMIT_BYTES,
+    CodexSessionCleanupRequest,
+};
 use guest_contracts::session_history_identity::{
     SESSION_HISTORY_IDENTITY_VERIFY_DIAGNOSTIC_LABEL,
     SESSION_HISTORY_IDENTITY_VERIFY_OUTPUT_LIMIT_BYTES, SessionHistoryIdentityVerifyRequest,
@@ -16,6 +20,7 @@ use super::super::support::{
     set_next_route_id, setup_host_and_guest, wait_for_operation_count,
 };
 use super::start_capture_operation;
+use crate::CodexSessionCleanupRequest as HostCodexSessionCleanupRequest;
 use crate::SessionHistoryIdentityVerifyRequest as HostSessionHistoryIdentityVerifyRequest;
 use crate::operation_tracker::NormalOperationReadiness;
 
@@ -129,6 +134,68 @@ async fn session_history_identity_verifier_encodes_fixed_process_contract() {
         .unwrap();
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 8 });
     assert_eq!(captured_output_bytes(&result.stderr), b"mismatch");
+    await_mock_guest(guest_task).await;
+}
+
+#[tokio::test]
+async fn codex_session_cleanup_encodes_fixed_process_contract() {
+    let (host_stream, guest) = make_pair();
+    let guest_task = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
+        let msg = guest.expect_message(MSG_EXEC_START).await;
+        let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
+
+        assert_eq!(
+            decoded.role,
+            vsock_proto::ExecProcessRole::CodexSessionCleanup
+        );
+        assert_eq!(decoded.lifecycle, vsock_proto::ExecLifecyclePolicy::OneShot);
+        assert_eq!(decoded.control, vsock_proto::ExecControlPolicy::Disabled);
+        assert!(decoded.env.is_empty());
+        assert!(!decoded.sudo);
+        assert!(decoded.stdin_bytes.is_none());
+        assert!(decoded.expected_exit_codes.is_empty());
+        assert_eq!(decoded.label, CODEX_SESSION_CLEANUP_DIAGNOSTIC_LABEL);
+        assert_eq!(
+            decoded.stdout,
+            vsock_proto::ExecOutputPolicy::Capture {
+                limit_bytes: CODEX_SESSION_CLEANUP_OUTPUT_LIMIT_BYTES,
+            }
+        );
+        assert_eq!(decoded.stdout, decoded.stderr);
+        let request: CodexSessionCleanupRequest = serde_json::from_str(decoded.command).unwrap();
+        assert_eq!(request.session_id, "019e9154-c304-70f0-adde-36efb1be1701");
+        assert_eq!(
+            request.fallback_relative_path,
+            "sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl"
+        );
+
+        guest
+            .send_exec_result(
+                msg.seq,
+                ExecTermination::Exited { exit_code: 0 },
+                b"/home/user/.codex/sessions/existing.jsonl\n",
+                b"",
+            )
+            .await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let result = host
+        .cleanup_codex_session(HostCodexSessionCleanupRequest {
+            session_id: "019e9154-c304-70f0-adde-36efb1be1701",
+            fallback_relative_path: "sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl",
+            timeout_ms: 5000,
+            wait_timeout: Duration::from_secs(5),
+        })
+        .await
+        .unwrap();
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(
+        captured_output_bytes(&result.stdout),
+        b"/home/user/.codex/sessions/existing.jsonl\n"
+    );
     await_mock_guest(guest_task).await;
 }
 

--- a/crates/vsock-proto/src/payloads/exec_operation/start.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/start.rs
@@ -19,6 +19,7 @@ pub(super) const EXEC_LIFECYCLE_SUPERVISED: u8 = 0x01;
 pub(super) const EXEC_PROCESS_ROLE_WORKLOAD: u8 = 0x00;
 pub(super) const EXEC_PROCESS_ROLE_AGENT: u8 = 0x01;
 pub(super) const EXEC_PROCESS_ROLE_SESSION_HISTORY_IDENTITY_VERIFIER: u8 = 0x02;
+pub(super) const EXEC_PROCESS_ROLE_CODEX_SESSION_CLEANUP: u8 = 0x03;
 
 pub(super) const EXEC_TIMEOUT_DURATION: u8 = 0x00;
 pub(super) const EXEC_TIMEOUT_NONE: u8 = 0x01;
@@ -90,6 +91,8 @@ pub enum ExecProcessRole {
     Agent,
     /// Fixed one-shot session-history identity verifier.
     SessionHistoryIdentityVerifier,
+    /// Fixed one-shot reused-Codex session cleanup helper.
+    CodexSessionCleanup,
 }
 
 /// Exec timeout policy.
@@ -132,6 +135,7 @@ pub enum ExecControlPolicy {
 /// | [`ExecProcessRole::Workload`] | [`ExecLifecyclePolicy::Supervised`] | `Enabled { sink: false, .. }` | Controlled supervised workload without a guest sink |
 /// | [`ExecProcessRole::Agent`] | [`ExecLifecyclePolicy::Supervised`] | `Enabled { sink: true, .. }` | Controlled Agent operation with a guest sink |
 /// | [`ExecProcessRole::SessionHistoryIdentityVerifier`] | [`ExecLifecyclePolicy::OneShot`] | [`ExecControlPolicy::Disabled`] | Fixed one-shot live identity verifier |
+/// | [`ExecProcessRole::CodexSessionCleanup`] | [`ExecLifecyclePolicy::OneShot`] | [`ExecControlPolicy::Disabled`] | Fixed one-shot reused-Codex cleanup helper |
 ///
 /// An `Agent` therefore requires a supervised lifecycle and an enabled control
 /// sink. A controlled `Workload` is supervised with an enabled control channel
@@ -274,6 +278,7 @@ fn append_exec_process_role(p: &mut Vec<u8>, role: ExecProcessRole) {
         ExecProcessRole::SessionHistoryIdentityVerifier => {
             EXEC_PROCESS_ROLE_SESSION_HISTORY_IDENTITY_VERIFIER
         }
+        ExecProcessRole::CodexSessionCleanup => EXEC_PROCESS_ROLE_CODEX_SESSION_CLEANUP,
     });
 }
 
@@ -349,6 +354,11 @@ pub fn validate_exec_process_contract(
         )
         | (
             ExecProcessRole::SessionHistoryIdentityVerifier,
+            ExecLifecyclePolicy::OneShot,
+            ExecControlPolicy::Disabled,
+        )
+        | (
+            ExecProcessRole::CodexSessionCleanup,
             ExecLifecyclePolicy::OneShot,
             ExecControlPolicy::Disabled,
         ) => Ok(()),
@@ -575,6 +585,7 @@ fn decode_exec_process_role(
         EXEC_PROCESS_ROLE_SESSION_HISTORY_IDENTITY_VERIFIER => {
             Ok(ExecProcessRole::SessionHistoryIdentityVerifier)
         }
+        EXEC_PROCESS_ROLE_CODEX_SESSION_CLEANUP => Ok(ExecProcessRole::CodexSessionCleanup),
         _ => Err(ProtocolError::InvalidPayload(
             "exec start process role invalid",
         )),

--- a/crates/vsock-proto/src/payloads/exec_operation/tests/exec_start.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests/exec_start.rs
@@ -382,6 +382,11 @@ fn exec_start_accepts_every_valid_process_contract() {
             ExecLifecyclePolicy::OneShot,
             ExecControlPolicy::Disabled,
         ),
+        (
+            ExecProcessRole::CodexSessionCleanup,
+            ExecLifecyclePolicy::OneShot,
+            ExecControlPolicy::Disabled,
+        ),
     ] {
         let timeout = match lifecycle {
             ExecLifecyclePolicy::OneShot => ExecTimeoutPolicy::Duration { timeout_ms: 1 },
@@ -461,6 +466,19 @@ fn exec_start_encoder_rejects_every_invalid_process_contract() {
         ),
         (
             ExecProcessRole::SessionHistoryIdentityVerifier,
+            ExecLifecyclePolicy::OneShot,
+            ExecControlPolicy::Enabled {
+                control_nonce: NONCE,
+                sink: false,
+            },
+        ),
+        (
+            ExecProcessRole::CodexSessionCleanup,
+            ExecLifecyclePolicy::Supervised,
+            ExecControlPolicy::Disabled,
+        ),
+        (
+            ExecProcessRole::CodexSessionCleanup,
             ExecLifecyclePolicy::OneShot,
             ExecControlPolicy::Enabled {
                 control_nonce: NONCE,

--- a/crates/vsock-proto/src/payloads/exec_operation/tests/exec_start_properties.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests/exec_start_properties.rs
@@ -281,6 +281,11 @@ fn process_contract_strategy()
             ExecLifecyclePolicy::OneShot,
             ExecControlPolicy::Disabled,
         )),
+        Just((
+            ExecProcessRole::CodexSessionCleanup,
+            ExecLifecyclePolicy::OneShot,
+            ExecControlPolicy::Disabled,
+        )),
     ]
 }
 

--- a/docs/runner-guest-process-lifecycle.md
+++ b/docs/runner-guest-process-lifecycle.md
@@ -27,7 +27,8 @@ bounded-helper placement, or an arbitrary containment policy.
 | DNS `getent ahostsv4` | Bounded setup helper selected only by the typed DNS handler | Bounded hostname and deadline; no caller-selected program | Guest root in an owned process group | Single-active DNS worker, operation guard, kill, and reap | Required for a fresh sandbox; serial before Agent start |
 | `guest-reseed --restore-state` | Bounded setup helper selected only by the typed guest-state handler | Typed time, entropy, and timezone request with a deadline | Guest root in an owned process group | Single-active restore worker, operation guard, kill, and reap | Required state preparation; serial before Agent start |
 | `guest-write-file` single, batch, and private variants | Bounded setup helper selected only by typed file handlers | Typed path/content request with handler validation and deadline | Guest root in an owned process group | File worker, operation guard, kill, and reap | Required when its prepared input exists; serial before Agent start |
-| Generic one-shot shell operations, including mount, timezone, cleanup, and verification fallbacks | Contained workload selected by `Sandbox::exec` | Caller command and environment are untrusted workload input | Per-operation `workload` cgroup with the standard CPU, memory, PID, and OOM policy | Exec worker and `ExecProcessContainment`; terminal result or forced cleanup removes descendants and hierarchy | Required or optional by caller; serial when part of preparation |
+| `guest-agent cleanup-codex-session` and its fixed shell helper | Bounded setup helper selected only by `Sandbox::cleanup_codex_session` | Canonical thread ID and matching relative rollout path; fixed Codex home, 16,384-entry scan budget, program, and environment | Sandbox user in an owned process group | Exec worker and `ExecProcessContainment`; natural or forced cleanup kills and reaps the complete group | Required only for an actually reused Codex sandbox; serial before restored history publication and Agent start |
+| Generic one-shot shell operations, including mount, timezone, cleanup fallbacks, and verification fallbacks | Contained workload selected by `Sandbox::exec` | Caller command and environment are untrusted workload input | Per-operation `workload` cgroup with the standard CPU, memory, PID, and OOM policy | Exec worker and `ExecProcessContainment`; terminal result or forced cleanup removes descendants and hierarchy | Required or optional by caller; serial when part of preparation |
 | `guest-download --manifest-stdin` | Contained workload selected only by the typed storage-manifest handler | User-influenced manifest, download, extraction, cache, and filesystem work | Per-operation `workload` cgroup with the standard workload policy | Storage worker, operation guard, output drains, and containment cleanup | Required when storage preparation is requested; serial, with deferred background fill allowed only after Agent readiness |
 | Codex model-catalog prefetch | Contained workload selected by ordinary `Sandbox::start_process` | Fixed prefetch shell, but network response and process execution remain workload data | Per-operation `workload` cgroup; no Agent control or placement capability | Prefetch task owns process wait/cancel; guest exec worker owns containment cleanup | Optional and deferrable; may run concurrently with later preparation and Agent start |
 | Agent wrapper shell and Guest Agent | Controlled Agent selected only by `Sandbox::start_agent_process` | Runner constructs the command/environment; the Agent subsequently handles user-controlled work | Per-operation `control` cgroup; the outer containment owns the standard workload resource hierarchy | Runner owns the typed process handle, readiness timing, and mandatory control capability; guest control registry, placement brokers, exec worker, and containment own guest cleanup | Required final pre-spawn operation; `exec_started` records shell spawn and `exec_agent_ready` completes the typed Agent start |
@@ -78,10 +79,13 @@ responsible for graceful or forced cleanup and hierarchy removal.
 
 Storage remains contained even though it has a typed entry point because its
 download, extraction, cache, and filesystem work is user influenced. The DNS,
-state, and file helpers use process groups at guest root only because their
-typed handlers select fixed programs, validate bounded inputs, enforce
-single-active admission and deadlines, and own kill/reap. That authority is
-not available through generic exec APIs.
+state, and file helpers use process groups at guest root; reused Codex cleanup
+uses a process group as the sandbox user. Their typed handlers select fixed
+programs, validate bounded inputs before containment selection, enforce
+deadlines, and own kill/reap. Codex cleanup additionally fixes the target home,
+scan budget, environment, and helper script while retaining independent Runner
+validation of its path output. That authority is not available through generic
+exec APIs, and generic cleanup and storage operations retain workload cgroups.
 
 ## Agent Start Timing
 


### PR DESCRIPTION
## Summary

- add a fixed `CodexSessionCleanup` guest operation for reused Codex sessions
- run cleanup under process-group containment instead of the generic workload cgroup lifecycle
- move cleanup ownership and real-shell integration coverage into `guest-agent`
- keep fresh-session behavior and the generic workload operation unchanged

## Safety boundary

The host sends only a validated canonical session ID and its matching relative rollout path. The guest derives the cleanup key, uses a fixed home directory, scan budget, command, environment, timeout, output limit, and process-containment policy. Generic command, environment, sudo, stdin, label, output-limit, expected-exit, and control overrides are rejected for this role.

## Performance evidence

On the representative reused-session fixture (15 interleaved pairs), p90 cleanup latency decreased from 129.868 ms to 78.710 ms, a 51.158 ms (39.4%) improvement. No-match and near-scan-budget fixtures completed without failures, and additional host measurements showed no material CPU or RSS regression.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-contracts -p sandbox -p sandbox-mock -p vsock-proto -p vsock-host -p vsock-guest -p sandbox-fc -p guest-agent -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p guest-contracts -p sandbox -p sandbox-mock -p vsock-proto -p vsock-host -p vsock-guest -p sandbox-fc -p guest-agent -p runner --all-features --no-deps`
- `cargo test -p guest-contracts`
- `cargo test -p sandbox -p sandbox-mock`
- `cargo test -p vsock-proto`
- `cargo test -p vsock-host`
- `cargo test -p vsock-guest`
- `cargo test -p sandbox-fc`
- `cargo test -p guest-agent --test integration`
- `cargo test -p runner`
- `git diff --check`

Closes #30871

Parent context: #24203
