### PR TITLE
perf(guest-agent): expose control-path scheduling metrics

### DIFF
--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -322,10 +322,17 @@ async fn run(runtime: GuestRuntime) -> i32 {
     record_sandbox_op("heartbeat_start", t.elapsed(), true, None);
 
     let t = Instant::now();
+    let metrics_sources = metrics::MetricsSources::new(
+        std::path::PathBuf::from("/proc/stat"),
+        runtime
+            .workload_containment
+            .as_ref()
+            .map(guest_agent::workload_containment::WorkloadContainment::cpu_stat_paths),
+    );
     let metrics_handle = tokio::spawn({
         let shutdown = shutdown.clone();
         let metrics_log_file = runtime.paths.metrics_log_file().to_string();
-        async move { metrics::metrics_loop_for_path(shutdown, metrics_log_file).await }
+        async move { metrics::metrics_loop_for_path(shutdown, metrics_log_file, metrics_sources).await }
     });
     log_info!(LOG_TAG, "Metrics collector started");
     record_sandbox_op("metrics_collector_start", t.elapsed(), true, None);

--- a/crates/guest-agent/src/metrics.rs
+++ b/crates/guest-agent/src/metrics.rs
@@ -38,7 +38,7 @@ struct MetricsEntry {
 }
 
 /// Fixed metric sources for one Guest metrics task.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct MetricsSources {
     proc_stat: PathBuf,
     cgroup_cpu_stat: Option<CgroupCpuStatPaths>,

--- a/crates/guest-agent/src/metrics.rs
+++ b/crates/guest-agent/src/metrics.rs
@@ -4,20 +4,54 @@
 //! `libc::statvfs` for disk. Writes JSONL to the metrics log file.
 
 use crate::constants;
+use crate::workload_containment::CgroupCpuStatPaths;
 use serde::Serialize;
 use std::fs::File;
 use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
+use tokio::time::{Instant, MissedTickBehavior};
 use tokio_util::sync::CancellationToken;
 
 #[derive(Serialize)]
 struct MetricsEntry {
     ts: String,
     cpu: f64,
+    cpu_steal_percent: f64,
+    scheduled_lag_ms: u64,
     mem_used: u64,
     mem_total: u64,
     disk_used: u64,
     disk_total: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    control_cpu_usage_usec: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    control_cpu_nr_throttled: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    control_cpu_throttled_usec: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workload_cpu_usage_usec: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workload_cpu_nr_throttled: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workload_cpu_throttled_usec: Option<u64>,
+}
+
+/// Fixed metric sources for one Guest metrics task.
+#[derive(Clone, Debug)]
+pub struct MetricsSources {
+    proc_stat: PathBuf,
+    cgroup_cpu_stat: Option<CgroupCpuStatPaths>,
+}
+
+impl MetricsSources {
+    /// Build metric sources from an aggregate proc-stat path and optional cgroups.
+    pub fn new(proc_stat: PathBuf, cgroup_cpu_stat: Option<CgroupCpuStatPaths>) -> Self {
+        Self {
+            proc_stat,
+            cgroup_cpu_stat,
+        }
+    }
 }
 
 /// Loop-owned metrics destination with a lazily opened append handle.
@@ -57,63 +91,83 @@ impl MetricsSink {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct CpuCounters {
+    idle: u64,
+    total: u64,
+    steal: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+struct CpuPercentages {
+    busy: f64,
+    steal: f64,
+}
+
 /// Tracks previous `/proc/stat` counters for delta-based CPU measurement.
 struct CpuTracker {
-    prev_idle: u64,
-    prev_total: u64,
+    previous: CpuCounters,
 }
 
 impl CpuTracker {
     fn new() -> Self {
         Self {
-            prev_idle: 0,
-            prev_total: 0,
+            previous: CpuCounters::default(),
         }
     }
 
     /// Read `/proc/stat` and compute CPU usage over the interval since the
     /// last call. The first call returns the cumulative average since boot
     /// (acceptable); subsequent calls return the delta-based percentage.
-    fn get_cpu_percent(&mut self) -> f64 {
-        let content = match std::fs::read_to_string("/proc/stat") {
+    fn get_cpu_percentages(&mut self, proc_stat: &Path) -> CpuPercentages {
+        let content = match std::fs::read_to_string(proc_stat) {
             Ok(c) => c,
-            Err(_) => return 0.0,
+            Err(_) => return CpuPercentages::default(),
         };
         let first_line = match content.lines().next() {
             Some(l) => l,
-            None => return 0.0,
+            None => return CpuPercentages::default(),
         };
-        self.get_cpu_percent_from_stat_line(first_line)
+        self.get_cpu_percentages_from_stat_line(first_line)
     }
 
-    fn get_cpu_percent_from_stat_line(&mut self, line: &str) -> f64 {
-        let (idle, total) = match parse_cpu_stat_line(line) {
+    fn get_cpu_percentages_from_stat_line(&mut self, line: &str) -> CpuPercentages {
+        let current = match parse_cpu_stat_line(line) {
             Some(cpu_stat) => cpu_stat,
-            None => return 0.0,
+            None => return CpuPercentages::default(),
         };
 
-        if idle < self.prev_idle || total < self.prev_total {
-            self.prev_idle = idle;
-            self.prev_total = total;
-            return 0.0;
+        let Some(delta_idle) = current.idle.checked_sub(self.previous.idle) else {
+            return CpuPercentages::default();
+        };
+        let Some(delta_total) = current.total.checked_sub(self.previous.total) else {
+            return CpuPercentages::default();
+        };
+        let Some(delta_steal) = current.steal.checked_sub(self.previous.steal) else {
+            return CpuPercentages::default();
+        };
+        let Some(delta_busy) = delta_total.checked_sub(delta_idle) else {
+            return CpuPercentages::default();
+        };
+        if delta_total == 0 || delta_steal > delta_busy {
+            return CpuPercentages::default();
         }
 
-        let delta_idle = idle - self.prev_idle;
-        let delta_total = total - self.prev_total;
+        self.previous = current;
 
-        if delta_total == 0 || delta_idle > delta_total {
-            return 0.0;
+        CpuPercentages {
+            busy: percentage(delta_busy, delta_total),
+            steal: percentage(delta_steal, delta_total),
         }
-
-        self.prev_idle = idle;
-        self.prev_total = total;
-
-        let pct = 100.0 * (1.0 - delta_idle as f64 / delta_total as f64);
-        (pct * 100.0).round() / 100.0
     }
 }
 
-fn parse_cpu_stat_line(line: &str) -> Option<(u64, u64)> {
+fn percentage(part: u64, total: u64) -> f64 {
+    let value = 100.0 * part as f64 / total as f64;
+    (value * 100.0).round() / 100.0
+}
+
+fn parse_cpu_stat_line(line: &str) -> Option<CpuCounters> {
     let mut fields = line.split_whitespace();
     if fields.next()? != "cpu" {
         return None;
@@ -121,8 +175,8 @@ fn parse_cpu_stat_line(line: &str) -> Option<(u64, u64)> {
 
     let values: Vec<u64> = fields.map(|v| v.parse()).collect::<Result<_, _>>().ok()?;
 
-    // idle and iowait are zero-based fields 3 and 4 after the cpu label.
-    let [_, _, _, idle_ticks, iowait_ticks, ..] = values.as_slice() else {
+    // idle, iowait, and steal are zero-based fields 3, 4, and 7 after the label.
+    let [_, _, _, idle_ticks, iowait_ticks, _, _, steal_ticks, ..] = values.as_slice() else {
         return None;
     };
     let idle = idle_ticks.checked_add(*iowait_ticks)?;
@@ -130,7 +184,50 @@ fn parse_cpu_stat_line(line: &str) -> Option<(u64, u64)> {
         .iter()
         .try_fold(0u64, |total, value| total.checked_add(*value))?;
 
-    Some((idle, total))
+    Some(CpuCounters {
+        idle,
+        total,
+        steal: *steal_ticks,
+    })
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct CgroupCpuStat {
+    usage_usec: u64,
+    nr_throttled: u64,
+    throttled_usec: u64,
+}
+
+fn read_cgroup_cpu_stat(path: &Path) -> Option<CgroupCpuStat> {
+    let content = std::fs::read_to_string(path).ok()?;
+    parse_cgroup_cpu_stat(&content)
+}
+
+fn parse_cgroup_cpu_stat(content: &str) -> Option<CgroupCpuStat> {
+    let mut usage_usec = None;
+    let mut nr_throttled = None;
+    let mut throttled_usec = None;
+
+    for line in content.lines() {
+        let mut fields = line.split_ascii_whitespace();
+        let key = fields.next()?;
+        let value = fields.next()?.parse::<u64>().ok()?;
+        if fields.next().is_some() {
+            return None;
+        }
+        match key {
+            "usage_usec" => usage_usec = Some(value),
+            "nr_throttled" => nr_throttled = Some(value),
+            "throttled_usec" => throttled_usec = Some(value),
+            _ => {}
+        }
+    }
+
+    Some(CgroupCpuStat {
+        usage_usec: usage_usec?,
+        nr_throttled: nr_throttled?,
+        throttled_usec: throttled_usec?,
+    })
 }
 
 /// Parse `/proc/meminfo` to get (used, total) in bytes.
@@ -189,31 +286,66 @@ fn disk_usage_from_blocks(blocks: u64, free_blocks: u64, block_size: u64) -> Opt
     Some((used, total))
 }
 
+fn elapsed_ms_since(scheduled_at: Instant) -> u64 {
+    u64::try_from(
+        Instant::now()
+            .saturating_duration_since(scheduled_at)
+            .as_millis(),
+    )
+    .unwrap_or(u64::MAX)
+}
+
 /// Collect one snapshot of system metrics.
-fn collect_metrics(cpu_tracker: &mut CpuTracker) -> MetricsEntry {
-    let cpu = cpu_tracker.get_cpu_percent();
+fn collect_metrics(
+    cpu_tracker: &mut CpuTracker,
+    sources: &MetricsSources,
+    scheduled_lag_ms: u64,
+) -> MetricsEntry {
+    let cpu = cpu_tracker.get_cpu_percentages(&sources.proc_stat);
     let (mem_used, mem_total) = get_memory_info();
     let (disk_used, disk_total) = get_disk_info();
+    let control_cpu = sources
+        .cgroup_cpu_stat
+        .as_ref()
+        .and_then(|paths| read_cgroup_cpu_stat(paths.control()));
+    let workload_cpu = sources
+        .cgroup_cpu_stat
+        .as_ref()
+        .and_then(|paths| read_cgroup_cpu_stat(paths.workload()));
     MetricsEntry {
         ts: guest_common::log::timestamp(),
-        cpu,
+        cpu: cpu.busy,
+        cpu_steal_percent: cpu.steal,
+        scheduled_lag_ms,
         mem_used,
         mem_total,
         disk_used,
         disk_total,
+        control_cpu_usage_usec: control_cpu.map(|stat| stat.usage_usec),
+        control_cpu_nr_throttled: control_cpu.map(|stat| stat.nr_throttled),
+        control_cpu_throttled_usec: control_cpu.map(|stat| stat.throttled_usec),
+        workload_cpu_usage_usec: workload_cpu.map(|stat| stat.usage_usec),
+        workload_cpu_nr_throttled: workload_cpu.map(|stat| stat.nr_throttled),
+        workload_cpu_throttled_usec: workload_cpu.map(|stat| stat.throttled_usec),
     }
 }
 
 /// Background loop writing metrics JSONL to an explicit runtime metrics file.
-pub async fn metrics_loop_for_path(shutdown: CancellationToken, metrics_log_file: String) {
+pub async fn metrics_loop_for_path(
+    shutdown: CancellationToken,
+    metrics_log_file: String,
+    sources: MetricsSources,
+) {
     let mut interval = tokio::time::interval(Duration::from_secs(constants::METRICS_INTERVAL_SECS));
+    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
     let mut cpu_tracker = CpuTracker::new();
     let mut metrics_sink = MetricsSink::new(metrics_log_file);
     loop {
         tokio::select! {
             _ = shutdown.cancelled() => break,
-            _ = interval.tick() => {
-                let entry = collect_metrics(&mut cpu_tracker);
+            scheduled_at = interval.tick() => {
+                let scheduled_lag_ms = elapsed_ms_since(scheduled_at);
+                let entry = collect_metrics(&mut cpu_tracker, &sources, scheduled_lag_ms);
                 metrics_sink.append(&entry);
             }
         }
@@ -228,20 +360,36 @@ mod tests {
     fn cpu_tracker_returns_valid_range() {
         // First call returns cumulative average, subsequent calls return delta
         let mut tracker = CpuTracker::new();
-        let pct1 = tracker.get_cpu_percent();
-        assert!((0.0..=100.0).contains(&pct1));
-        let pct2 = tracker.get_cpu_percent();
-        assert!((0.0..=100.0).contains(&pct2));
+        let pct1 = tracker.get_cpu_percentages(Path::new("/proc/stat"));
+        assert!((0.0..=100.0).contains(&pct1.busy));
+        assert!((0.0..=100.0).contains(&pct1.steal));
+        let pct2 = tracker.get_cpu_percentages(Path::new("/proc/stat"));
+        assert!((0.0..=100.0).contains(&pct2.busy));
+        assert!((0.0..=100.0).contains(&pct2.steal));
     }
 
     #[test]
     fn parse_cpu_stat_line_accepts_valid_aggregate_line() {
-        assert_eq!(parse_cpu_stat_line("cpu 1 2 3 4 5 6 7 8"), Some((9, 36)));
+        assert_eq!(
+            parse_cpu_stat_line("cpu 1 2 3 4 5 6 7 8"),
+            Some(CpuCounters {
+                idle: 9,
+                total: 36,
+                steal: 8,
+            })
+        );
     }
 
     #[test]
     fn parse_cpu_stat_line_accepts_whitespace_separated_fields() {
-        assert_eq!(parse_cpu_stat_line("cpu\t1 2 3 4 5 6"), Some((9, 21)));
+        assert_eq!(
+            parse_cpu_stat_line("cpu\t1 2 3 4 5 6 7 8"),
+            Some(CpuCounters {
+                idle: 9,
+                total: 36,
+                steal: 8,
+            })
+        );
     }
 
     #[test]
@@ -251,23 +399,23 @@ mod tests {
 
     #[test]
     fn parse_cpu_stat_line_rejects_wrong_prefix() {
-        assert_eq!(parse_cpu_stat_line("cpu0 1 2 3 4 5"), None);
+        assert_eq!(parse_cpu_stat_line("cpu0 1 2 3 4 5 6 7 8"), None);
     }
 
     #[test]
     fn parse_cpu_stat_line_rejects_malformed_field() {
-        assert_eq!(parse_cpu_stat_line("cpu 1 2 bad 4 5 6"), None);
+        assert_eq!(parse_cpu_stat_line("cpu 1 2 bad 4 5 6 7 8"), None);
     }
 
     #[test]
     fn parse_cpu_stat_line_rejects_idle_overflow() {
-        let line = format!("cpu 0 0 0 {} 1", u64::MAX);
+        let line = format!("cpu 0 0 0 {} 1 0 0 0", u64::MAX);
         assert_eq!(parse_cpu_stat_line(&line), None);
     }
 
     #[test]
     fn parse_cpu_stat_line_rejects_total_overflow() {
-        let line = format!("cpu {} 1 0 0 0", u64::MAX);
+        let line = format!("cpu {} 1 0 0 0 0 0 0", u64::MAX);
         assert_eq!(parse_cpu_stat_line(&line), None);
     }
 
@@ -275,44 +423,74 @@ mod tests {
     fn cpu_tracker_does_not_update_state_for_invalid_stat_line() {
         let mut tracker = CpuTracker::new();
         assert_eq!(
-            tracker.get_cpu_percent_from_stat_line("cpu 0 0 0 10 0"),
-            0.0
+            tracker.get_cpu_percentages_from_stat_line("cpu 0 0 0 10 0 0 0 0"),
+            CpuPercentages::default()
         );
 
-        let line = format!("cpu 0 0 0 {} 1", u64::MAX);
-        assert_eq!(tracker.get_cpu_percent_from_stat_line(&line), 0.0);
+        let line = format!("cpu 0 0 0 {} 1 0 0 0", u64::MAX);
+        assert_eq!(
+            tracker.get_cpu_percentages_from_stat_line(&line),
+            CpuPercentages::default()
+        );
 
-        assert_eq!(tracker.prev_idle, 10);
-        assert_eq!(tracker.prev_total, 10);
+        assert_eq!(
+            tracker.previous,
+            CpuCounters {
+                idle: 10,
+                total: 10,
+                steal: 0,
+            }
+        );
     }
 
     #[test]
     fn cpu_tracker_rejects_inconsistent_delta_without_updating_state() {
         let mut tracker = CpuTracker::new();
         assert_eq!(
-            tracker.get_cpu_percent_from_stat_line("cpu 0 90 0 10 0"),
-            90.0
+            tracker.get_cpu_percentages_from_stat_line("cpu 0 90 0 10 0 0 0 0"),
+            CpuPercentages {
+                busy: 90.0,
+                steal: 0.0,
+            }
         );
 
         assert_eq!(
-            tracker.get_cpu_percent_from_stat_line("cpu 0 75 0 30 0"),
-            0.0
+            tracker.get_cpu_percentages_from_stat_line("cpu 0 75 0 30 0 0 0 0"),
+            CpuPercentages::default()
         );
-        assert_eq!(tracker.prev_idle, 10);
-        assert_eq!(tracker.prev_total, 100);
+        assert_eq!(
+            tracker.previous,
+            CpuCounters {
+                idle: 10,
+                total: 100,
+                steal: 0,
+            }
+        );
     }
 
     #[test]
-    fn cpu_tracker_resets_state_when_counters_regress() {
+    fn cpu_tracker_preserves_state_when_counters_regress() {
         let mut tracker = CpuTracker::new();
         assert_eq!(
-            tracker.get_cpu_percent_from_stat_line("cpu 0 90 0 10 0"),
-            90.0
+            tracker.get_cpu_percentages_from_stat_line("cpu 0 90 0 10 0 0 0 0"),
+            CpuPercentages {
+                busy: 90.0,
+                steal: 0.0,
+            }
         );
 
-        assert_eq!(tracker.get_cpu_percent_from_stat_line("cpu 0 5 0 5 0"), 0.0);
-        assert_eq!(tracker.prev_idle, 5);
-        assert_eq!(tracker.prev_total, 10);
+        assert_eq!(
+            tracker.get_cpu_percentages_from_stat_line("cpu 0 5 0 5 0 0 0 0"),
+            CpuPercentages::default()
+        );
+        assert_eq!(
+            tracker.previous,
+            CpuCounters {
+                idle: 10,
+                total: 100,
+                steal: 0,
+            }
+        );
     }
 
     #[test]
@@ -379,10 +557,16 @@ mod tests {
     fn cpu_tracker_multiple_reads_are_consistent() {
         let mut tracker = CpuTracker::new();
         for i in 0..5 {
-            let pct = tracker.get_cpu_percent();
+            let pct = tracker.get_cpu_percentages(Path::new("/proc/stat"));
             assert!(
-                (0.0..=100.0).contains(&pct),
-                "read {i}: pct={pct} out of range"
+                (0.0..=100.0).contains(&pct.busy),
+                "read {i}: busy={} out of range",
+                pct.busy
+            );
+            assert!(
+                (0.0..=100.0).contains(&pct.steal),
+                "read {i}: steal={} out of range",
+                pct.steal
             );
         }
     }
@@ -407,9 +591,11 @@ mod tests {
     #[test]
     fn collect_metrics_returns_complete_entry() {
         let mut tracker = CpuTracker::new();
-        let entry = collect_metrics(&mut tracker);
+        let sources = MetricsSources::new(PathBuf::from("/proc/stat"), None);
+        let entry = collect_metrics(&mut tracker, &sources, 0);
         assert!(!entry.ts.is_empty());
         assert!((0.0..=100.0).contains(&entry.cpu));
+        assert!((0.0..=100.0).contains(&entry.cpu_steal_percent));
         assert!(entry.mem_total > 0);
         assert!(entry.disk_total > 0);
     }
@@ -417,13 +603,18 @@ mod tests {
     #[test]
     fn collect_metrics_serializes_to_valid_jsonl() {
         let mut tracker = CpuTracker::new();
-        let entry = collect_metrics(&mut tracker);
+        let sources = MetricsSources::new(PathBuf::from("/proc/stat"), None);
+        let entry = collect_metrics(&mut tracker, &sources, 0);
         let json = serde_json::to_string(&entry).unwrap();
         // Verify it round-trips through the same path metrics_loop uses.
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert!(parsed["ts"].is_string());
         assert!(parsed["cpu"].is_f64());
+        assert!(parsed["cpu_steal_percent"].is_f64());
+        assert!(parsed["scheduled_lag_ms"].is_u64());
         assert!(parsed["mem_total"].is_u64());
         assert!(parsed["disk_total"].is_u64());
+        assert!(parsed.get("control_cpu_usage_usec").is_none());
+        assert!(parsed.get("workload_cpu_usage_usec").is_none());
     }
 }

--- a/crates/guest-agent/src/workload_containment.rs
+++ b/crates/guest-agent/src/workload_containment.rs
@@ -27,6 +27,7 @@ use guest_contracts::process_containment::{
 };
 
 const CGROUP_PROCS_FILE: &str = "cgroup.procs";
+const CPU_STAT_FILE: &str = "cpu.stat";
 const PROC_SELF_CGROUP: &str = "/proc/self/cgroup";
 const CGROUP2_SUPER_MAGIC: u64 = 0x6367_7270;
 const WORKLOAD_BOOTSTRAP_IO_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
@@ -39,6 +40,28 @@ pub struct WorkloadContainment {
     placement: Arc<OwnedFd>,
     workload_path: Arc<PathBuf>,
     tool_placement_endpoint: Arc<str>,
+}
+
+/// Read-only paths used to sample control and workload CPU accounting.
+#[derive(Clone, Debug)]
+pub struct CgroupCpuStatPaths {
+    control: PathBuf,
+    workload: PathBuf,
+}
+
+impl CgroupCpuStatPaths {
+    /// Build a sampler description from explicit `cpu.stat` paths.
+    pub fn new(control: PathBuf, workload: PathBuf) -> Self {
+        Self { control, workload }
+    }
+
+    pub(crate) fn control(&self) -> &Path {
+        &self.control
+    }
+
+    pub(crate) fn workload(&self) -> &Path {
+        &self.workload
+    }
 }
 
 /// Resource enforcement observed for a completed workload.
@@ -139,6 +162,16 @@ impl WorkloadContainment {
             hard_limit,
             pressure,
         })
+    }
+
+    /// Describe the validated cgroups without transferring placement access.
+    pub fn cpu_stat_paths(&self) -> CgroupCpuStatPaths {
+        CgroupCpuStatPaths::new(
+            self.workload_path
+                .with_file_name(CONTROL_CGROUP_NAME)
+                .join(CPU_STAT_FILE),
+            self.workload_path.join(CPU_STAT_FILE),
+        )
     }
 
     /// Runner-owned endpoint injected into managed CLI environments.

--- a/crates/guest-agent/src/workload_containment.rs
+++ b/crates/guest-agent/src/workload_containment.rs
@@ -43,7 +43,7 @@ pub struct WorkloadContainment {
 }
 
 /// Read-only paths used to sample control and workload CPU accounting.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct CgroupCpuStatPaths {
     control: PathBuf,
     workload: PathBuf,

--- a/crates/guest-agent/tests/integration_cases/metrics.rs
+++ b/crates/guest-agent/tests/integration_cases/metrics.rs
@@ -55,25 +55,37 @@ fn assert_valid_metrics_entries(path: &Path, expected: usize) -> TestResult {
     for entry in entries {
         assert!(entry.get("ts").is_some_and(Value::is_string));
         assert!(entry.get("cpu").is_some_and(Value::is_f64));
+        assert!(entry.get("cpu_steal_percent").is_some_and(Value::is_f64));
+        assert!(entry.get("scheduled_lag_ms").is_some_and(Value::is_u64));
         assert!(entry.get("mem_used").is_some_and(Value::is_u64));
         assert!(entry.get("mem_total").is_some_and(Value::is_u64));
         assert!(entry.get("disk_used").is_some_and(Value::is_u64));
         assert!(entry.get("disk_total").is_some_and(Value::is_u64));
+        assert!(entry.get("control_cpu_usage_usec").is_none());
+        assert!(entry.get("workload_cpu_usage_usec").is_none());
     }
     Ok(())
 }
 
-fn spawn_metrics_loop(path: PathBuf) -> (CancellationToken, JoinHandle<()>) {
+fn spawn_metrics_loop(
+    path: PathBuf,
+    sources: guest_agent::metrics::MetricsSources,
+) -> (CancellationToken, JoinHandle<()>) {
     let shutdown = CancellationToken::new();
     let task_shutdown = shutdown.clone();
     let handle = tokio::spawn(async move {
         guest_agent::metrics::metrics_loop_for_path(
             task_shutdown,
             path.to_string_lossy().into_owned(),
+            sources,
         )
         .await;
     });
     (shutdown, handle)
+}
+
+fn system_metrics_sources() -> guest_agent::metrics::MetricsSources {
+    guest_agent::metrics::MetricsSources::new(PathBuf::from("/proc/stat"), None)
 }
 
 async fn stop_metrics_loop(shutdown: CancellationToken, handle: JoinHandle<()>) -> TestResult {
@@ -96,7 +108,7 @@ async fn metrics_loop_reuses_retained_handle_across_ticks() -> TestResult {
     let temp = tempfile::tempdir()?;
     let metrics_path = temp.path().join("runtime").join("metrics.jsonl");
     let moved_path = temp.path().join("runtime").join("moved-metrics.jsonl");
-    let (shutdown, handle) = spawn_metrics_loop(metrics_path.clone());
+    let (shutdown, handle) = spawn_metrics_loop(metrics_path.clone(), system_metrics_sources());
 
     wait_for_line_count(&metrics_path, 1).await?;
     std::fs::rename(&metrics_path, &moved_path)?;
@@ -106,6 +118,201 @@ async fn metrics_loop_reuses_retained_handle_across_ticks() -> TestResult {
 
     assert!(!metrics_path.exists());
     assert_valid_metrics_entries(&moved_path, 2)?;
+
+    stop_metrics_loop(shutdown, handle).await?;
+    clock_guard.abort();
+    let _ = clock_guard.await;
+    Ok(())
+}
+
+#[tokio::test(start_paused = true)]
+async fn metrics_loop_reports_steal_and_preserves_cpu_state_across_invalid_samples() -> TestResult {
+    let clock_guard = keep_paused_clock_stable();
+    let temp = tempfile::tempdir()?;
+    let metrics_path = temp.path().join("runtime").join("metrics.jsonl");
+    let proc_stat = temp.path().join("proc-stat");
+    std::fs::write(&proc_stat, "cpu 10 0 0 90 0 0 0 0\n")?;
+    let sources = guest_agent::metrics::MetricsSources::new(proc_stat.clone(), None);
+    let (shutdown, handle) = spawn_metrics_loop(metrics_path.clone(), sources);
+
+    wait_for_line_count(&metrics_path, 1).await?;
+    std::fs::write(&proc_stat, "cpu 20 0 0 170 0 0 0 10\n")?;
+    tokio::time::advance(METRICS_INTERVAL).await;
+    wait_for_line_count(&metrics_path, 2).await?;
+
+    std::fs::write(&proc_stat, "cpu malformed\n")?;
+    tokio::time::advance(METRICS_INTERVAL).await;
+    wait_for_line_count(&metrics_path, 3).await?;
+
+    std::fs::write(&proc_stat, format!("cpu {} 1 0 0 0 0 0 0\n", u64::MAX))?;
+    tokio::time::advance(METRICS_INTERVAL).await;
+    wait_for_line_count(&metrics_path, 4).await?;
+
+    std::fs::write(&proc_stat, "cpu 1 0 0 9 0 0 0 0\n")?;
+    tokio::time::advance(METRICS_INTERVAL).await;
+    wait_for_line_count(&metrics_path, 5).await?;
+
+    std::fs::write(&proc_stat, "cpu 30 0 0 250 0 0 0 20\n")?;
+    tokio::time::advance(METRICS_INTERVAL).await;
+    wait_for_line_count(&metrics_path, 6).await?;
+
+    let entries = metrics_entries(&metrics_path)?;
+    let [initial, updated, malformed, overflow, regressed, restored] = entries.as_slice() else {
+        return Err(std::io::Error::other("expected six CPU metric entries").into());
+    };
+    assert_eq!(initial["cpu"].as_f64(), Some(10.0));
+    assert_eq!(initial["cpu_steal_percent"].as_f64(), Some(0.0));
+    assert_eq!(updated["cpu"].as_f64(), Some(20.0));
+    assert_eq!(updated["cpu_steal_percent"].as_f64(), Some(10.0));
+    for entry in [malformed, overflow, regressed] {
+        assert_eq!(entry["cpu"].as_f64(), Some(0.0));
+        assert_eq!(entry["cpu_steal_percent"].as_f64(), Some(0.0));
+    }
+    assert_eq!(restored["cpu"].as_f64(), Some(20.0));
+    assert_eq!(restored["cpu_steal_percent"].as_f64(), Some(10.0));
+
+    stop_metrics_loop(shutdown, handle).await?;
+    clock_guard.abort();
+    let _ = clock_guard.await;
+    Ok(())
+}
+
+#[tokio::test(start_paused = true)]
+async fn metrics_loop_emits_only_complete_cgroup_cpu_samples() -> TestResult {
+    let clock_guard = keep_paused_clock_stable();
+    let temp = tempfile::tempdir()?;
+    let metrics_path = temp.path().join("runtime").join("metrics.jsonl");
+    let proc_stat = temp.path().join("proc-stat");
+    let control = temp.path().join("control").join("cpu.stat");
+    let workload = temp.path().join("workload").join("cpu.stat");
+    std::fs::create_dir_all(
+        control
+            .parent()
+            .ok_or_else(|| std::io::Error::other("control path has no parent"))?,
+    )?;
+    std::fs::create_dir_all(
+        workload
+            .parent()
+            .ok_or_else(|| std::io::Error::other("workload path has no parent"))?,
+    )?;
+    std::fs::write(&proc_stat, "cpu 10 0 0 90 0 0 0 0\n")?;
+    std::fs::write(
+        &control,
+        "usage_usec 11\nuser_usec 7\nnr_throttled 12\nthrottled_usec 13\n",
+    )?;
+    std::fs::write(
+        &workload,
+        "usage_usec 21\nnr_throttled 22\nthrottled_usec 23\n",
+    )?;
+    let cgroups = guest_agent::workload_containment::CgroupCpuStatPaths::new(
+        control.clone(),
+        workload.clone(),
+    );
+    let sources = guest_agent::metrics::MetricsSources::new(proc_stat, Some(cgroups));
+    let (shutdown, handle) = spawn_metrics_loop(metrics_path.clone(), sources);
+
+    wait_for_line_count(&metrics_path, 1).await?;
+    std::fs::write(
+        &control,
+        "usage_usec 31\nnr_throttled 32\nthrottled_usec 33\n",
+    )?;
+    std::fs::remove_file(&workload)?;
+    tokio::time::advance(METRICS_INTERVAL).await;
+    wait_for_line_count(&metrics_path, 2).await?;
+
+    std::fs::write(&control, "usage_usec invalid\n")?;
+    std::fs::write(
+        &workload,
+        "usage_usec 41\nnr_throttled 42\nthrottled_usec 43\n",
+    )?;
+    tokio::time::advance(METRICS_INTERVAL).await;
+    wait_for_line_count(&metrics_path, 3).await?;
+
+    let entries = metrics_entries(&metrics_path)?;
+    let [complete, missing_workload, malformed_control] = entries.as_slice() else {
+        return Err(std::io::Error::other("expected three cgroup metric entries").into());
+    };
+    assert_eq!(complete["control_cpu_usage_usec"].as_u64(), Some(11));
+    assert_eq!(complete["control_cpu_nr_throttled"].as_u64(), Some(12));
+    assert_eq!(complete["control_cpu_throttled_usec"].as_u64(), Some(13));
+    assert_eq!(complete["workload_cpu_usage_usec"].as_u64(), Some(21));
+    assert_eq!(complete["workload_cpu_nr_throttled"].as_u64(), Some(22));
+    assert_eq!(complete["workload_cpu_throttled_usec"].as_u64(), Some(23));
+
+    assert_eq!(
+        missing_workload["control_cpu_usage_usec"].as_u64(),
+        Some(31)
+    );
+    assert_eq!(
+        missing_workload["control_cpu_nr_throttled"].as_u64(),
+        Some(32)
+    );
+    assert_eq!(
+        missing_workload["control_cpu_throttled_usec"].as_u64(),
+        Some(33)
+    );
+    assert!(missing_workload.get("workload_cpu_usage_usec").is_none());
+    assert!(missing_workload.get("workload_cpu_nr_throttled").is_none());
+    assert!(
+        missing_workload
+            .get("workload_cpu_throttled_usec")
+            .is_none()
+    );
+
+    assert!(malformed_control.get("control_cpu_usage_usec").is_none());
+    assert!(malformed_control.get("control_cpu_nr_throttled").is_none());
+    assert!(
+        malformed_control
+            .get("control_cpu_throttled_usec")
+            .is_none()
+    );
+    assert_eq!(
+        malformed_control["workload_cpu_usage_usec"].as_u64(),
+        Some(41)
+    );
+    assert_eq!(
+        malformed_control["workload_cpu_nr_throttled"].as_u64(),
+        Some(42)
+    );
+    assert_eq!(
+        malformed_control["workload_cpu_throttled_usec"].as_u64(),
+        Some(43)
+    );
+
+    stop_metrics_loop(shutdown, handle).await?;
+    clock_guard.abort();
+    let _ = clock_guard.await;
+    Ok(())
+}
+
+#[tokio::test(start_paused = true)]
+async fn metrics_loop_delays_after_a_missed_tick_without_catching_up() -> TestResult {
+    let clock_guard = keep_paused_clock_stable();
+    let temp = tempfile::tempdir()?;
+    let metrics_path = temp.path().join("runtime").join("metrics.jsonl");
+    let (shutdown, handle) = spawn_metrics_loop(metrics_path.clone(), system_metrics_sources());
+
+    wait_for_line_count(&metrics_path, 1).await?;
+    tokio::time::advance(METRICS_INTERVAL * 3).await;
+    settle_runnable_tasks().await;
+
+    let delayed_entries = metrics_entries(&metrics_path)?;
+    let [_, delayed] = delayed_entries.as_slice() else {
+        return Err(std::io::Error::other("expected one delayed metric entry").into());
+    };
+    assert_eq!(delayed["scheduled_lag_ms"].as_u64(), Some(10_000));
+
+    tokio::time::advance(Duration::from_millis(4_999)).await;
+    settle_runnable_tasks().await;
+    assert_eq!(metrics_entries(&metrics_path)?.len(), 2);
+
+    tokio::time::advance(Duration::from_millis(1)).await;
+    wait_for_line_count(&metrics_path, 3).await?;
+    let restored_entries = metrics_entries(&metrics_path)?;
+    let [_, _, restored] = restored_entries.as_slice() else {
+        return Err(std::io::Error::other("expected restored metric cadence").into());
+    };
+    assert_eq!(restored["scheduled_lag_ms"].as_u64(), Some(0));
 
     stop_metrics_loop(shutdown, handle).await?;
     clock_guard.abort();
@@ -151,7 +358,7 @@ async fn run_cached_write_failure_scenario() -> TestResult {
     let temp = tempfile::tempdir()?;
     let metrics_path = temp.path().join("runtime").join("metrics.jsonl");
     let moved_path = temp.path().join("runtime").join("moved-metrics.jsonl");
-    let (shutdown, handle) = spawn_metrics_loop(metrics_path.clone());
+    let (shutdown, handle) = spawn_metrics_loop(metrics_path.clone(), system_metrics_sources());
 
     wait_for_line_count(&metrics_path, 1).await?;
     std::fs::rename(&metrics_path, &moved_path)?;

--- a/crates/guest-agent/tests/integration_cases/telemetry.rs
+++ b/crates/guest-agent/tests/integration_cases/telemetry.rs
@@ -548,7 +548,22 @@ async fn flush_reports_position_persistence_status_after_upload_then_recovers() 
     let metrics_log = paths.metrics_log_file();
     let metrics_pos = paths.telemetry_metrics_pos_file();
     let marker = "position-persistence-upload";
-    let metric = serde_json::json!({"name": "position-persistence-metric"});
+    let metric = serde_json::json!({
+        "ts": "2026-09-01T00:00:00.000Z",
+        "cpu": 91.25,
+        "cpu_steal_percent": 12.5,
+        "scheduled_lag_ms": 17,
+        "mem_used": 1024,
+        "mem_total": 2048,
+        "disk_used": 4096,
+        "disk_total": 8192,
+        "control_cpu_usage_usec": 101,
+        "control_cpu_nr_throttled": 2,
+        "control_cpu_throttled_usec": 3,
+        "workload_cpu_usage_usec": 201,
+        "workload_cpu_nr_throttled": 4,
+        "workload_cpu_throttled_usec": 5,
+    });
     ensure_parent_dir(system_log);
     ensure_parent_dir(system_log_pos);
     std::fs::write(system_log, format!("{marker}\n")).expect("system log should be written");

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -2124,6 +2124,122 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
     ).toBeFalsy();
   });
 
+  it("projects only present control-path metric fields", async () => {
+    const { actor, runId, headers } = await createEventWebhookRun(
+      `control-path metrics ${randomUUID()}`,
+    );
+    const oldTimestamp = "2026-09-01T00:00:00.000Z";
+    const fullTimestamp = "2026-09-01T00:00:05.000Z";
+    const partialTimestamp = "2026-09-01T00:00:10.000Z";
+    const metricIngests: unknown[][] = [];
+    mockOptionalEnv(
+      "AXIOM_TOKEN_TELEMETRY",
+      `xaat-control-path-metrics-${randomUUID()}`,
+    );
+    server.use(
+      http.post(
+        "https://api.axiom.co/v1/datasets/sandbox-telemetry-metrics/ingest",
+        async ({ request }) => {
+          const events: unknown = await request.json();
+          if (!Array.isArray(events)) {
+            throw new Error("Expected an Axiom telemetry metric array");
+          }
+          metricIngests.push(events);
+          return HttpResponse.json(successfulAxiomIngestStatus(events.length));
+        },
+      ),
+    );
+
+    await api.requestAgentTelemetry(
+      {
+        runId,
+        metrics: [
+          {
+            ts: oldTimestamp,
+            cpu: 80,
+            mem_used: 100,
+            mem_total: 200,
+            disk_used: 300,
+            disk_total: 400,
+          },
+          {
+            ts: fullTimestamp,
+            cpu: 91.25,
+            cpu_steal_percent: 12.5,
+            scheduled_lag_ms: 17,
+            mem_used: 1024,
+            mem_total: 2048,
+            disk_used: 4096,
+            disk_total: 8192,
+            control_cpu_usage_usec: 101,
+            control_cpu_nr_throttled: 2,
+            control_cpu_throttled_usec: 3,
+            workload_cpu_usage_usec: 201,
+            workload_cpu_nr_throttled: 4,
+            workload_cpu_throttled_usec: 5,
+          },
+          {
+            ts: partialTimestamp,
+            cpu: 70,
+            scheduled_lag_ms: 29,
+            mem_used: 500,
+            mem_total: 600,
+            disk_used: 700,
+            disk_total: 800,
+            workload_cpu_usage_usec: 301,
+          },
+        ],
+      },
+      headers,
+      [200],
+    );
+
+    expect(metricIngests).toStrictEqual([
+      [
+        {
+          _time: oldTimestamp,
+          runId,
+          userId: actor.userId,
+          cpu: 80,
+          mem_used: 100,
+          mem_total: 200,
+          disk_used: 300,
+          disk_total: 400,
+        },
+        {
+          _time: fullTimestamp,
+          runId,
+          userId: actor.userId,
+          cpu: 91.25,
+          cpu_steal_percent: 12.5,
+          scheduled_lag_ms: 17,
+          mem_used: 1024,
+          mem_total: 2048,
+          disk_used: 4096,
+          disk_total: 8192,
+          control_cpu_usage_usec: 101,
+          control_cpu_nr_throttled: 2,
+          control_cpu_throttled_usec: 3,
+          workload_cpu_usage_usec: 201,
+          workload_cpu_nr_throttled: 4,
+          workload_cpu_throttled_usec: 5,
+        },
+        {
+          _time: partialTimestamp,
+          runId,
+          userId: actor.userId,
+          cpu: 70,
+          scheduled_lag_ms: 29,
+          mem_used: 500,
+          mem_total: 600,
+          disk_used: 700,
+          disk_total: 800,
+          workload_cpu_usage_usec: 301,
+        },
+      ],
+    ]);
+  });
+
   it("attributes sandbox operations to canonical runner dimensions across overlap", async () => {
     const { runId, headers } = await createEventWebhookRun(
       `runner-name telemetry ${randomUUID()}`,

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -13,6 +13,7 @@ import { agentRuns } from "@okouai/db/schema/agent-run";
 import { usageEvent } from "@okouai/db/schema/usage-event";
 import { and, eq, inArray, isNotNull } from "drizzle-orm";
 import { isBuiltInModelProviderType } from "@okouai/api-contracts/contracts/model-providers";
+import type { z } from "zod";
 
 import { notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
@@ -296,6 +297,50 @@ const usageEvent$ = command(async ({ get, set }, signal: AbortSignal) => {
   };
 });
 
+type TelemetryBody = z.infer<(typeof webhookTelemetryContract.send)["body"]>;
+type TelemetryMetric = NonNullable<TelemetryBody["metrics"]>[number];
+
+function telemetryMetricEvent(
+  metric: TelemetryMetric,
+  runId: string,
+  userId: string,
+): Record<string, unknown> {
+  return {
+    _time: metric.ts,
+    runId,
+    userId,
+    cpu: metric.cpu,
+    ...(metric.cpu_steal_percent === undefined
+      ? {}
+      : { cpu_steal_percent: metric.cpu_steal_percent }),
+    ...(metric.scheduled_lag_ms === undefined
+      ? {}
+      : { scheduled_lag_ms: metric.scheduled_lag_ms }),
+    mem_used: metric.mem_used,
+    mem_total: metric.mem_total,
+    disk_used: metric.disk_used,
+    disk_total: metric.disk_total,
+    ...(metric.control_cpu_usage_usec === undefined
+      ? {}
+      : { control_cpu_usage_usec: metric.control_cpu_usage_usec }),
+    ...(metric.control_cpu_nr_throttled === undefined
+      ? {}
+      : { control_cpu_nr_throttled: metric.control_cpu_nr_throttled }),
+    ...(metric.control_cpu_throttled_usec === undefined
+      ? {}
+      : { control_cpu_throttled_usec: metric.control_cpu_throttled_usec }),
+    ...(metric.workload_cpu_usage_usec === undefined
+      ? {}
+      : { workload_cpu_usage_usec: metric.workload_cpu_usage_usec }),
+    ...(metric.workload_cpu_nr_throttled === undefined
+      ? {}
+      : { workload_cpu_nr_throttled: metric.workload_cpu_nr_throttled }),
+    ...(metric.workload_cpu_throttled_usec === undefined
+      ? {}
+      : { workload_cpu_throttled_usec: metric.workload_cpu_throttled_usec }),
+  };
+}
+
 const telemetryBody$ = bodyResultOf(webhookTelemetryContract.send);
 const telemetry$ = command(async ({ get }, signal: AbortSignal) => {
   const bodyResult = await get(telemetryBody$);
@@ -349,16 +394,7 @@ const telemetry$ = command(async ({ get }, signal: AbortSignal) => {
     telemetryBatches.push({
       dataset: getDatasetName(SANDBOX_TELEMETRY_METRICS_DATASET),
       events: body.metrics.map((metric) => {
-        return {
-          _time: metric.ts,
-          runId: body.runId,
-          userId: auth.userId,
-          cpu: metric.cpu,
-          mem_used: metric.mem_used,
-          mem_total: metric.mem_total,
-          disk_used: metric.disk_used,
-          disk_total: metric.disk_total,
-        };
+        return telemetryMetricEvent(metric, body.runId, auth.userId);
       }),
     });
   }

--- a/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 
 import { SESSION_HISTORY_DOWNLOAD_SOURCE_CONFIGURED_PUBLIC_ENDPOINT } from "../runners";
 import {
@@ -268,6 +269,69 @@ describe("agent completion active input receipts", () => {
 });
 
 describe("webhook telemetry contract", () => {
+  it("preserves metric payload compatibility across Guest and API rollout", () => {
+    const runId = "00000000-0000-4000-8000-000000000000";
+    const oldMetric = {
+      ts: "2026-09-01T00:00:00.000Z",
+      cpu: 91.25,
+      mem_used: 1024,
+      mem_total: 2048,
+      disk_used: 4096,
+      disk_total: 8192,
+    };
+    const fullMetric = {
+      ...oldMetric,
+      cpu_steal_percent: 12.5,
+      scheduled_lag_ms: 17,
+      control_cpu_usage_usec: 101,
+      control_cpu_nr_throttled: 2,
+      control_cpu_throttled_usec: 3,
+      workload_cpu_usage_usec: 201,
+      workload_cpu_nr_throttled: 4,
+      workload_cpu_throttled_usec: 5,
+    };
+    const partialMetric = {
+      ...oldMetric,
+      scheduled_lag_ms: 29,
+      workload_cpu_usage_usec: 301,
+    };
+
+    expect(
+      webhookTelemetryContract.send.body.parse({
+        runId,
+        metrics: [oldMetric],
+      }).metrics,
+    ).toStrictEqual([oldMetric]);
+    expect(
+      webhookTelemetryContract.send.body.parse({
+        runId,
+        metrics: [fullMetric],
+      }).metrics,
+    ).toStrictEqual([fullMetric]);
+    expect(
+      webhookTelemetryContract.send.body.parse({
+        runId,
+        metrics: [partialMetric],
+      }).metrics,
+    ).toStrictEqual([partialMetric]);
+
+    const legacyMetricSchema = z.object({
+      ts: z.string(),
+      cpu: z.number(),
+      mem_used: z.number(),
+      mem_total: z.number(),
+      disk_used: z.number(),
+      disk_total: z.number(),
+    });
+    expect(legacyMetricSchema.parse(fullMetric)).toStrictEqual(oldMetric);
+    expect(
+      webhookTelemetryContract.send.body.parse({
+        runId,
+        metrics: [{ ...fullMetric, future_scheduler_queue_depth: 7 }],
+      }).metrics,
+    ).toStrictEqual([fullMetric]);
+  });
+
   it("accepts optional bounded canonical runner dimensions", () => {
     const runId = "00000000-0000-4000-8000-000000000000";
     const minimalPayload = webhookTelemetryContract.send.body.parse({ runId });

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -779,10 +779,18 @@ export const webhookHeartbeatContract = c.router({
 const metricDataSchema = z.object({
   ts: z.string(),
   cpu: z.number(),
+  cpu_steal_percent: z.number().optional(),
+  scheduled_lag_ms: z.number().optional(),
   mem_used: z.number(),
   mem_total: z.number(),
   disk_used: z.number(),
   disk_total: z.number(),
+  control_cpu_usage_usec: z.number().optional(),
+  control_cpu_nr_throttled: z.number().optional(),
+  control_cpu_throttled_usec: z.number().optional(),
+  workload_cpu_usage_usec: z.number().optional(),
+  workload_cpu_nr_throttled: z.number().optional(),
+  workload_cpu_throttled_usec: z.number().optional(),
 });
 
 const sessionHistoryCompressionRatioBucketSchema = z.enum([


### PR DESCRIPTION
## Summary

- report Guest Agent CPU steal percentage and metric scheduling lag on the existing five-second metric stream
- sample control and workload `cpu.stat` accounting without transferring the workload placement capability
- project the new optional fields through the telemetry contract and Axiom ingest boundary

## Compatibility and scope

- keeps every new API contract field optional so old Guests work with the new API and new Guests remain accepted by an old API
- preserves the existing `cpu` meaning, immediate first sample, sampling interval, telemetry endpoint, and user workflow
- omits each cgroup field group when its source is unavailable or malformed; does not add a second sampler or persistence path

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p guest-agent --all-targets --all-features`
- `cd crates && cargo doc -p guest-agent --all-features --no-deps`
- `cd crates && cargo test -p guest-agent -- --test-threads=1`
- `cd turbo && pnpm format`
- `cd turbo && pnpm -F @okouai/api-contracts lint`
- `cd turbo && pnpm -F @okouai/api-contracts check-types`
- `cd turbo && pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/webhooks.test.ts`
- `cd turbo && pnpm -F @okouai/api-contracts generate:rust`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts`
- `cd turbo && pnpm knip --workspace @okouai/api-contracts`
- `cd turbo && pnpm knip --workspace api`
- pre-commit hook: full Turbo Knip and type checks, Rust formatting, docs, and Clippy

Closes #30769

Parent: #30682
