### PR TITLE
fix(ci): give the superseded-run barrier its own terminal-state budget

### DIFF
--- a/.github/scripts/cancel-superseded-merge-group-runs.sh
+++ b/.github/scripts/cancel-superseded-merge-group-runs.sh
@@ -93,7 +93,21 @@ fi
 
 poll_seconds=${SUPERSEDED_RUN_POLL_SECONDS:-2}
 timeout_seconds=${SUPERSEDED_RUN_TIMEOUT_SECONDS:-180}
-if [[ ! "$poll_seconds" =~ ^[0-9]+$ || ! "$timeout_seconds" =~ ^[0-9]+$ ]]; then
+# Discovery and the terminal-state barrier wait for different things, so they
+# get different ceilings. Force-cancel only *requests* termination: when a
+# superseded job is wedged in a step that never returns, GitHub reaps it on its
+# own hard-kill schedule, bounded at five minutes from when cancellation began,
+# and force-cancel does not shorten that. Superseded runs that wind down
+# normally still clear this barrier in a couple of seconds, so the larger
+# ceiling only covers the wedged case instead of relaxing the healthy one.
+if [ "$owner_scope" = "superseded" ]; then
+  completion_timeout_seconds=${SUPERSEDED_RUN_COMPLETION_TIMEOUT_SECONDS:-420}
+else
+  completion_timeout_seconds=${SUPERSEDED_RUN_COMPLETION_TIMEOUT_SECONDS:-$timeout_seconds}
+fi
+if [[ ! "$poll_seconds" =~ ^[0-9]+$ ||
+  ! "$timeout_seconds" =~ ^[0-9]+$ ||
+  ! "$completion_timeout_seconds" =~ ^[0-9]+$ ]]; then
   echo "superseded run polling values must be non-negative integers" >&2
   exit 2
 fi
@@ -253,8 +267,8 @@ while true; do
     exit 0
   fi
 
-  if ((SECONDS - started_at >= timeout_seconds)); then
-    echo "::error::Timed out waiting for ${selected_runs_label} to complete: ${pending_runs[*]}" >&2
+  if ((SECONDS - started_at >= completion_timeout_seconds)); then
+    echo "::error::Timed out after ${completion_timeout_seconds}s waiting for ${selected_runs_label} to complete: ${pending_runs[*]}" >&2
     exit 1
   fi
 

--- a/.github/scripts/tests/cancel-superseded-merge-group-runs-test.sh
+++ b/.github/scripts/tests/cancel-superseded-merge-group-runs-test.sh
@@ -247,6 +247,32 @@ grep -q "Waiting for superseded CI runs" <<<"$output" ||
 : >"${tmp_dir}/cancel.log"
 : >"${tmp_dir}/sleep.log"
 rm -f "${tmp_dir}/runs-released"
+output=$(run_cancel MOCK_DELAY_COMPLETION=1 SUPERSEDED_RUN_TIMEOUT_SECONDS=0)
+grep -q "All superseded CI runs completed" <<<"$output" ||
+  fail "superseded barrier must not inherit the discovery-stabilization budget"
+[ "$(wc -l <"${tmp_dir}/sleep.log")" -eq 1 ] ||
+  fail "expected one poll before superseded runs completed"
+
+: >"${tmp_dir}/gh.log"
+: >"${tmp_dir}/cancel.log"
+: >"${tmp_dir}/sleep.log"
+rm -f "${tmp_dir}/runs-released"
+if run_cancel \
+  MOCK_DELAY_COMPLETION=1 \
+  SUPERSEDED_RUN_COMPLETION_TIMEOUT_SECONDS=0 \
+  >"${tmp_dir}/superseded-timeout.out" 2>"${tmp_dir}/superseded-timeout.err"; then
+  fail "superseded barrier must fail closed when its own budget expires"
+fi
+grep -q "Timed out after 0s waiting for superseded CI runs to complete" \
+  "${tmp_dir}/superseded-timeout.err" ||
+  fail "superseded barrier timeout must report the exhausted budget"
+[ ! -s "${tmp_dir}/sleep.log" ] ||
+  fail "zero-budget superseded barrier must fail before polling"
+
+: >"${tmp_dir}/gh.log"
+: >"${tmp_dir}/cancel.log"
+: >"${tmp_dir}/sleep.log"
+rm -f "${tmp_dir}/runs-released"
 output=$(
   run_cancel \
     MOCK_DELAY_COMPLETION=1 \

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -16,7 +16,9 @@ jobs:
     name: Cancel superseded merge-group CI
     if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Checkout, plus the script's 180s discovery ceiling and its 420s
+    # terminal-state barrier, so the job never dies before the barrier it owns.
+    timeout-minutes: 12
     permissions:
       actions: write
       contents: read


### PR DESCRIPTION
## Problem

Turbo merge-group run [33525374413](https://github.com/vm0-ai/vm0/actions/runs/33525374413) (PR #30890, SHA `e6808d1`) failed and ejected the merge group. The failure was a cascade from a housekeeping job.

### Causal chain, end to end

1. **Reported red:** Turbo [`deploy-runner-prepare`](https://github.com/vm0-ai/vm0/actions/runs/33525374413/job/99914951080) gave up polling for the runner image artifact only because its producer failed:
   `producer_run=33525374396 status=completed conclusion=failure`. This is a consequence, not the defect.
2. **Producer:** `Runner Image` run [33525374396](https://github.com/vm0-ai/vm0/actions/runs/33525374396) on the same merge-group branch. Its only failed job is [`Cancel superseded merge-group CI`](https://github.com/vm0-ai/vm0/actions/runs/33525374396/job/99914733744); every other job was skipped by the `needs.cancel-superseded.result == 'success'` gate, so no runner image manifest was ever published.
3. **First cause:** that job timed out waiting for the superseded run to reach a terminal state:
   `##[error]Timed out waiting for superseded CI runs to complete: 33523694046:in_progress`
4. **Blast radius:** the missing artifact also failed Crates run [33525374443](https://github.com/vm0-ai/vm0/actions/runs/33525374443) (`runner-build`, both `runner-image-architecture-manifest` jobs).

### The decisive measurement

- Force-cancel of superseded run [33523694046](https://github.com/vm0-ai/vm0/actions/runs/33523694046) was issued at `15:23:05`.
- The barrier's 180s budget expired at `15:26:05`.
- The superseded run reached `status: completed, conclusion: cancelled` at `15:26:50` — **45 seconds after the waiter gave up**. Nothing was stuck; the budget was simply shorter than this run's wind-down.

### Why that run needed 226s

The superseded run's last job to terminate was `cli-e2e-02-playwright-finalize` ([job 99911544207](https://github.com/vm0-ai/vm0/actions/runs/33523694046/job/99911544207)). Its `Cleanup Playwright E2E accounts` step produced zero output from `15:14:03` onward, so the job hit its own `timeout-minutes: 8` at `15:21:48` (annotation: `The job has exceeded the maximum execution time of 8m0s`). GitHub then reaped the wedged process on its hard-kill schedule and the step ended with `exit code 143` / `The runner has received a shutdown signal` at `15:26:51` — **exactly 5m01s after cancellation began**.

`force-cancel` at `15:23:05` did not shorten that window: it requests termination, it does not preempt GitHub's reaping schedule.

### Why this is timing-dependent, not deterministic

Wind-down data over the last ~3 days of merge-group runs:

| sample | result |
| --- | --- |
| 200 most recent `Runner Image` merge_group `Cancel superseded merge-group CI` jobs | 199 finished in **13-27s**; 1 failure at **194s** |
| Every case where a superseded run was actually force-cancelled and still active (e.g. [PR #30591](https://github.com/vm0-ai/vm0/actions/runs/33465492294), [PR #30861](https://github.com/vm0-ai/vm0/actions/runs/33499425641)) | barrier cleared in **2-3s** |
| This failure | **226s** from force-cancel |

So the distribution is bimodal: healthy wind-down is ~2-3s, and the only slow case is "a job in the superseded run was wedged", which GitHub bounds at ~5 minutes. The 180s budget sits below that bound, so the barrier fails whenever a superseded run happens to contain a wedged step — a repo-owned timing dependency, not an external incident.

## Fix

- `.github/scripts/cancel-superseded-merge-group-runs.sh`: the terminal-state barrier no longer reuses the discovery-stabilization budget. In the `superseded` scope it gets its own ceiling (`SUPERSEDED_RUN_COMPLETION_TIMEOUT_SECONDS`, default 420s) that clears GitHub's ~5-minute reaping bound with margin. Discovery keeps its unchanged 180s budget, and the `closed-pr-cleanup` scope inherits `SUPERSEDED_RUN_TIMEOUT_SECONDS` exactly as before. The timeout error now names the exhausted budget.
- `.github/workflows/runner-image.yml`: `timeout-minutes` on `cancel-superseded` raised 5 → 12 so the job cannot die before the barrier it owns (checkout + 180s discovery + 420s barrier ≈ 610s).
- `.github/scripts/tests/cancel-superseded-merge-group-runs-test.sh`: regression coverage for both halves — the superseded barrier must not inherit the discovery budget, and it must still fail closed when its own budget expires.

### What is preserved

- Superseded runs are still force-cancelled; nothing was made unconditionally successful.
- The terminal-state barrier is still a hard gate: a superseded run that never terminates still fails the job, so it can never publish an artifact that a newer run consumes.
- No sleeps and no blind retries were added. The barrier still waits on the real terminal signal (`run.status == "completed"`); only its ceiling changed, and only for the scope where we ourselves requested the cancellation.

### On the blast radius

Gating `prepare` on `needs.cancel-superseded.result == 'success'` is deliberate and is kept: building and publishing a runner image while the previous owner of the shared `pr-<n>` namespace and Clerk E2E accounts is still alive is exactly what the barrier exists to prevent. The problem was the ceiling, not the coupling. Making the housekeeping job non-fatal would trade a rare false red for a rare shared-resource corruption, which is the worse failure.

### Follow-up worth tracking separately

`Cleanup Playwright E2E accounts` ran silently for 8 minutes and then ignored cancellation for 5 more. That is a separate defect (an unbounded Clerk cleanup call with no request timeout) with its own fingerprint; this PR does not change it. With this fix a wedged cleanup no longer reds an unrelated merge group.

## Validation

- `bash .github/scripts/tests/cancel-superseded-merge-group-runs-test.sh` — passes.
- Same test run against the **pre-fix** script reproduces the exact production signature and fails:
  `::error::Timed out waiting for superseded CI runs to complete: 100:in_progress 110:in_progress 120:in_progress`
- `bash .github/scripts/tests/runner-image-workflow-test.sh` and `runner-lifecycle-ownership-workflow-test.sh` — pass.
- `shellcheck` on both changed shell scripts — clean.
- `actionlint` — no findings for `runner-image.yml`.
- `.github/scripts/check-workflow-shell-compatibility.sh` — clean.
- `git diff --check` — clean.
- The original invariant is validated by the producing workflow: `Runner Image` and Turbo `deploy-runner-prepare` must go green on this PR.

No preview/browser validation applies; this change is CI-workflow only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
