### PR TITLE
fix(api): reject reordered legacy snapshot chains

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-event-snapshot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-event-snapshot.test.ts
@@ -980,6 +980,11 @@ describe("chat event snapshot read endpoints", () => {
       agentId: agent.agentId,
       prompt: `snapshot-decode-classification-${randomUUID()}`,
     });
+    await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      threadId,
+      prompt: `snapshot-semantic-reorder-${randomUUID()}`,
+    });
     await projectChatEventSearch(threadId);
     await runSnapshotCron([threadId]);
     const originalHead = await readChatEventSnapshotHead(context, threadId);
@@ -995,16 +1000,24 @@ describe("chat event snapshot read endpoints", () => {
       .map((line) => {
         return chatEventRowSchema.parse(JSON.parse(line));
       });
-    const inputRow = originalRows.find((row) => {
+    const inputRows = originalRows.filter((row) => {
       return row.eventType === "input.prompt";
     });
-    const rejectedRow = originalRows.find((row) => {
+    const rejectedRows = originalRows.filter((row) => {
       return row.eventType === "input.rejected";
     });
+    const inputRow = inputRows[0];
+    const rejectedRow = rejectedRows[0];
+    const semanticRootRow = inputRows[1];
+    const semanticTerminalRow = rejectedRows[1];
     const firstRow = originalRows[0];
     if (
       inputRow === undefined ||
       rejectedRow === undefined ||
+      semanticRootRow === undefined ||
+      semanticTerminalRow === undefined ||
+      rejectedRow.seqId >= semanticRootRow.seqId ||
+      semanticRootRow.seqId >= semanticTerminalRow.seqId ||
       firstRow === undefined
     ) {
       throw new Error("Expected complete Snapshot decode fixtures");
@@ -1043,6 +1056,52 @@ describe("chat event snapshot read endpoints", () => {
           : row;
       }),
     );
+    const semanticReorderRows = originalRows.map((row): ChatEventRow => {
+      if (row.id === rejectedRow.id) {
+        return chatEventRowSchema.parse({
+          ...row,
+          runId: null,
+          revokesEventId: semanticRootRow.id,
+          eventType: "input.rejected",
+          contextType: "morning_brief",
+          contextId: semanticRootRow.id,
+          runEventSequenceNumber: 0,
+          runEventId: null,
+        });
+      }
+      if (row.id === semanticRootRow.id) {
+        return chatEventRowSchema.parse({
+          ...row,
+          runId: null,
+          revokesEventId: null,
+          eventType: "input.prompt",
+          contextType: "morning_brief",
+          contextId: row.id,
+          runEventSequenceNumber: null,
+          runEventId: null,
+        });
+      }
+      return row.id === semanticTerminalRow.id
+        ? chatEventRowSchema.parse({
+            ...row,
+            runId: null,
+            revokesEventId: rejectedRow.id,
+            eventType: "control.revoke",
+            payload: null,
+            contextType: "morning_brief",
+            contextId: semanticRootRow.id,
+            runEventSequenceNumber: null,
+            runEventId: null,
+          })
+        : row;
+    });
+    expect(
+      semanticReorderRows.every((row, index) => {
+        const prior = semanticReorderRows[index - 1];
+        return prior === undefined || row.seqId > prior.seqId;
+      }),
+    ).toBeTruthy();
+    const semanticReorderBody = encodeRows(semanticReorderRows);
     const prefixBody = encodeRows(
       originalRows.map((row) => {
         return row.id === firstRow.id
@@ -1078,6 +1137,12 @@ describe("chat event snapshot read endpoints", () => {
       {
         failureClass: "projection",
         object: gzipSync(unresolvedRevokeBody),
+        projectionSubstage: "retired_event",
+        projectionVariant: "unresolved_revoke_chain",
+      },
+      {
+        failureClass: "projection",
+        object: gzipSync(semanticReorderBody),
         projectionSubstage: "retired_event",
         projectionVariant: "unresolved_revoke_chain",
       },

--- a/turbo/apps/api/src/signals/services/chat-event-snapshot-body.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-snapshot-body.service.ts
@@ -136,7 +136,9 @@ function isExactRetiredMorningBriefRejection(
     target.contextType === RETIRED_MORNING_BRIEF_CONTEXT &&
     target.contextId === root.id &&
     target.runEventSequenceNumber === 0 &&
-    target.runEventId === null
+    target.runEventId === null &&
+    root.seqId < target.seqId &&
+    target.seqId < row.seqId
   );
 }
 


### PR DESCRIPTION
## Summary

- require `root.seqId < rejection.seqId < terminalRevoke.seqId` before accepting the exact retired Morning Brief chained-revoke repair
- add a prefix-sorted, byte-accurate route regression where the rejection semantically revokes a later root and must fail as `projection / retired_event / unresolved_revoke_chain`
- preserve valid chained and direct legacy repairs, bounded diagnostics, exact-pointer publication, source and canonical immutability, hot-tail compatibility, all five historical documents, and current r1 idempotency

## Diagnosis

`priorRowsById` proved that both the rejection and root appeared before the terminal revoke, but did not prove that the root preceded the rejection. A prefix-sorted archive could therefore place an exact-looking rejection before its root and still satisfy the legacy compatibility predicate once the terminal revoke was decoded.

The repair predicate now checks the complete semantic chronology. The route regression retains strictly increasing NDJSON `seqId` values while arranging the chain as rejection, root, terminal revoke, and verifies the same fail-closed pointer, source-byte, and bounded-classification behavior as the other malformed fixtures.

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/chat-event-snapshot-body.service.ts apps/api/src/signals/routes/__tests__/chat-event-snapshot.test.ts`
- `pnpm --filter api run lint`
- `pnpm knip`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-event-snapshot.test.ts` (8 passed)

Closes #30822
