### PR TITLE
fix(api): repair contextless legacy snapshots

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-event-snapshot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-event-snapshot.test.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
 import { gunzipSync, gzipSync } from "node:zlib";
 
 import { chatEventFromRow } from "@okouai/api-contracts/contracts/chat-event-row-projection";
@@ -157,6 +158,72 @@ function sanitizedLegacyChainedControlRevokeLine(
   })}\n`;
 }
 
+function isSanitizedContextlessMorningBriefRoot(row: ChatEventRow): boolean {
+  return (
+    row.eventType === "input.prompt" &&
+    row.runId === null &&
+    row.revokesEventId === null &&
+    row.contextType === "morning_brief" &&
+    row.contextId === null &&
+    row.runEventSequenceNumber === null &&
+    row.runEventId === null &&
+    row.payload !== null &&
+    Object.keys(row.payload).length === 1 &&
+    row.payload.userMessage !== undefined
+  );
+}
+
+function isSanitizedContextlessMorningBriefClaim(
+  row: ChatEventRow,
+  root: ChatEventRow,
+): boolean {
+  return (
+    row.id !== root.id &&
+    row.chatThreadId === root.chatThreadId &&
+    row.eventType === "input.prompt" &&
+    row.runId !== null &&
+    row.revokesEventId === root.id &&
+    row.contextType === "morning_brief" &&
+    row.contextId === null &&
+    row.runEventSequenceNumber === null &&
+    row.runEventId === null &&
+    row.seqId > root.seqId &&
+    row.createdAt > root.createdAt &&
+    isDeepStrictEqual(row.payload, root.payload)
+  );
+}
+
+function sanitizedLegacyContextlessMorningBriefClaimLines(
+  root: ChatEventRow,
+  claim: ChatEventRow,
+): { readonly root: string; readonly claim: string } {
+  if (
+    !isSanitizedContextlessMorningBriefRoot(root) ||
+    !isSanitizedContextlessMorningBriefClaim(claim, root)
+  ) {
+    throw new Error("Expected an exact historical contextless claim pair");
+  }
+  chatEventFromRow(root);
+  chatEventFromRow(claim);
+  const encode = (row: ChatEventRow): string => {
+    return `${JSON.stringify({
+      id: row.id,
+      chatThreadId: row.chatThreadId,
+      runId: row.runId,
+      revokesEventId: row.revokesEventId,
+      eventType: "input.prompt",
+      payload: row.payload,
+      contextType: "morning_brief",
+      contextId: null,
+      runEventSequenceNumber: null,
+      runEventId: null,
+      seqId: row.seqId,
+      createdAt: row.createdAt,
+    })}\n`;
+  };
+  return { root: encode(root), claim: encode(claim) };
+}
+
 function mockR2GcWindowForKey(key: string, after: Date): Date {
   const prefixStart = "chat-events/".length;
   const shardGroup = Number.parseInt(
@@ -241,6 +308,51 @@ async function sendNoCreditMessage(
     throw new Error("Expected a no-credit send without a run");
   }
   return sent.body.threadId;
+}
+
+function requiredValue<T>(value: T | undefined, message: string): T {
+  if (value === undefined) {
+    throw new Error(message);
+  }
+  return value;
+}
+
+type RevokingChatEventRow = ChatEventRow & {
+  readonly revokesEventId: string;
+};
+
+function isRevokingChatEventRow(
+  row: ChatEventRow,
+): row is RevokingChatEventRow {
+  return row.revokesEventId !== null;
+}
+
+function requiredRevokingRow(
+  row: ChatEventRow | undefined,
+  message: string,
+): RevokingChatEventRow {
+  if (row === undefined || !isRevokingChatEventRow(row)) {
+    throw new Error(message);
+  }
+  return row;
+}
+
+type PromptChatEventRow = ChatEventRow & {
+  readonly eventType: "input.prompt";
+};
+
+function isPromptChatEventRow(row: ChatEventRow): row is PromptChatEventRow {
+  return row.eventType === "input.prompt";
+}
+
+function requiredPromptRow(
+  row: ChatEventRow | undefined,
+  message: string,
+): PromptChatEventRow {
+  if (row === undefined || !isPromptChatEventRow(row)) {
+    throw new Error(message);
+  }
+  return row;
 }
 
 describe("chat event snapshot read endpoints", () => {
@@ -398,6 +510,7 @@ describe("chat event snapshot read endpoints", () => {
     const runIds = markers.map(() => {
       return randomUUID();
     });
+    const contextlessClaimRunId = randomUUID();
     const historicalDocuments: readonly UserMessageDocument[] = [
       {
         version: 1,
@@ -470,27 +583,62 @@ describe("chat event snapshot read endpoints", () => {
     const rejectionRows = originalRows.filter((row) => {
       return row.eventType === "input.rejected";
     });
-    const contextOnlyRow = rejectionRows[0];
-    const directControlRevokeRow = rejectionRows[1];
-    const chainedRejectionRow = rejectionRows[2];
-    const chainedControlRevokeRow = rejectionRows[3];
-    if (
-      contextOnlyRow === undefined ||
-      directControlRevokeRow === undefined ||
-      directControlRevokeRow.revokesEventId === null ||
-      chainedRejectionRow === undefined ||
-      chainedRejectionRow.revokesEventId === null ||
-      chainedControlRevokeRow === undefined
-    ) {
-      throw new Error("Expected complete historical revocation source rows");
-    }
-    const chainedRootRow = originalRows.find((row) => {
-      return row.id === chainedRejectionRow.revokesEventId;
-    });
-    if (chainedRootRow?.eventType !== "input.prompt") {
-      throw new Error("Expected the chained rejection root prompt");
-    }
+    const revocationFixtureMessage =
+      "Expected complete historical revocation source rows";
+    const contextlessClaimRow = requiredRevokingRow(
+      rejectionRows[0],
+      revocationFixtureMessage,
+    );
+    const directControlRevokeRow = requiredRevokingRow(
+      rejectionRows[1],
+      revocationFixtureMessage,
+    );
+    const chainedRejectionRow = requiredRevokingRow(
+      rejectionRows[2],
+      revocationFixtureMessage,
+    );
+    const chainedControlRevokeRow = requiredValue(
+      rejectionRows[3],
+      revocationFixtureMessage,
+    );
+    const contextOnlyRow = requiredValue(
+      rejectionRows[4],
+      revocationFixtureMessage,
+    );
+    const contextlessRootRow = requiredPromptRow(
+      originalRows.find((row) => {
+        return row.id === contextlessClaimRow.revokesEventId;
+      }),
+      "Expected the historical contextless root prompt",
+    );
+    const chainedRootRow = requiredPromptRow(
+      originalRows.find((row) => {
+        return row.id === chainedRejectionRow.revokesEventId;
+      }),
+      "Expected the historical chained root prompt",
+    );
+    const contextlessRootPromptIndex = promptIndexById.get(
+      contextlessRootRow.id,
+    );
+    const contextlessDocument = requiredValue(
+      contextlessRootPromptIndex === undefined
+        ? undefined
+        : historicalDocuments[contextlessRootPromptIndex],
+      "Expected the contextless root document",
+    );
     const expectedRows = originalRows.map((row): ChatEventRow => {
+      if (row.id === contextlessClaimRow.id) {
+        return chatEventRowSchema.parse({
+          ...row,
+          eventType: "input.prompt",
+          runId: contextlessClaimRunId,
+          contextType: "web",
+          contextId: null,
+          payload: { userMessage: contextlessDocument },
+          runEventSequenceNumber: null,
+          runEventId: null,
+        });
+      }
       if (row.id === directControlRevokeRow.id) {
         return chatEventRowSchema.parse({
           ...row,
@@ -523,11 +671,10 @@ describe("chat event snapshot read endpoints", () => {
         }
         return chatEventRowSchema.parse({
           ...row,
-          runId: row.id === chainedRootRow.id ? null : runId,
-          revokesEventId:
-            promptIndex === 1
-              ? (promptRows[0]?.id ?? null)
-              : row.revokesEventId,
+          runId:
+            row.id === contextlessRootRow.id || row.id === chainedRootRow.id
+              ? null
+              : runId,
           contextType: "web",
           contextId: null,
           payload: {
@@ -568,6 +715,16 @@ describe("chat event snapshot read endpoints", () => {
     }
 
     const staleRows = expectedRows.map((row): ChatEventRow => {
+      if (
+        row.id === contextlessRootRow.id ||
+        row.id === contextlessClaimRow.id
+      ) {
+        return chatEventRowSchema.parse({
+          ...row,
+          contextType: "morning_brief",
+          contextId: null,
+        });
+      }
       if (row.id === directControlRevokeRow.id) {
         return chatEventRowSchema.parse({
           ...row,
@@ -646,6 +803,12 @@ describe("chat event snapshot read endpoints", () => {
     const staleDirectControlRevoke = staleRows.find((row) => {
       return row.id === directControlRevokeRow.id;
     });
+    const staleContextlessRoot = staleRows.find((row) => {
+      return row.id === contextlessRootRow.id;
+    });
+    const staleContextlessClaim = staleRows.find((row) => {
+      return row.id === contextlessClaimRow.id;
+    });
     const staleChainedRejection = staleRows.find((row) => {
       return row.id === chainedRejectionRow.id;
     });
@@ -657,6 +820,8 @@ describe("chat event snapshot read endpoints", () => {
     });
     if (
       staleDirectControlRevoke === undefined ||
+      staleContextlessRoot === undefined ||
+      staleContextlessClaim === undefined ||
       staleChainedRejection === undefined ||
       staleChainedControlRevoke === undefined ||
       staleChainedRoot === undefined
@@ -671,9 +836,20 @@ describe("chat event snapshot read endpoints", () => {
       staleChainedRejection,
       staleChainedRoot,
     );
+    const byteExactContextlessClaimLines =
+      sanitizedLegacyContextlessMorningBriefClaimLines(
+        staleContextlessRoot,
+        staleContextlessClaim,
+      );
     const staleArchive = Buffer.from(
       staleRows
         .map((row) => {
+          if (row.id === contextlessRootRow.id) {
+            return byteExactContextlessClaimLines.root;
+          }
+          if (row.id === contextlessClaimRow.id) {
+            return byteExactContextlessClaimLines.claim;
+          }
           if (row.id === directControlRevokeRow.id) {
             return byteExactDirectRevokeLine;
           }
@@ -688,6 +864,13 @@ describe("chat event snapshot read endpoints", () => {
     ).toBeTruthy();
     expect(
       staleArchive.includes(Buffer.from(byteExactChainedRevokeLine)),
+    ).toBeTruthy();
+    expect(
+      staleArchive.includes(
+        Buffer.from(
+          `${byteExactContextlessClaimLines.root}${byteExactContextlessClaimLines.claim}`,
+        ),
+      ),
     ).toBeTruthy();
     const staleBody = gzipSync(staleArchive);
     const staleObjectKey = `chat-events/${threadId}/${originalHead.last_seq_id.toString()}-${createHash("sha256").update(staleBody).digest("hex")}.ndjson.gz`;
@@ -742,6 +925,8 @@ describe("chat event snapshot read endpoints", () => {
           seqId: row.seqId,
           runId: row.runId,
           revokesEventId: row.revokesEventId,
+          runEventSequenceNumber: row.runEventSequenceNumber,
+          runEventId: row.runEventId,
           payload: row.payload,
         };
       }),
@@ -753,6 +938,8 @@ describe("chat event snapshot read endpoints", () => {
           seqId: row.seqId,
           runId: row.runId,
           revokesEventId: row.revokesEventId,
+          runEventSequenceNumber: row.runEventSequenceNumber,
+          runEventId: row.runEventId,
           payload: row.payload,
         };
       }),
@@ -779,25 +966,58 @@ describe("chat event snapshot read endpoints", () => {
       contextId: null,
       revokesEventId: chainedRejectionRow.id,
     });
+    expect(
+      repairedRows.find((row) => {
+        return row.id === contextlessRootRow.id;
+      }),
+    ).toMatchObject({
+      eventType: "input.prompt",
+      runId: null,
+      revokesEventId: null,
+      contextType: "web",
+      contextId: null,
+      payload: { userMessage: contextlessDocument },
+    });
+    expect(
+      repairedRows.find((row) => {
+        return row.id === contextlessClaimRow.id;
+      }),
+    ).toMatchObject({
+      eventType: "input.prompt",
+      runId: contextlessClaimRunId,
+      revokesEventId: contextlessRootRow.id,
+      contextType: "web",
+      contextId: null,
+      payload: { userMessage: contextlessDocument },
+    });
 
     const projectedSnapshot = repairedRows.map(chatEventFromRow);
     const projectedPrompts = projectedSnapshot.filter((event) => {
       return event.eventType === "input.prompt";
     });
+    const expectedPromptRows = expectedRows.filter((row) => {
+      return row.eventType === "input.prompt";
+    });
+    expect(expectedPromptRows).toHaveLength(6);
     expect(
       projectedPrompts.map((event) => {
-        return event.runId;
+        return {
+          id: event.id,
+          runId: event.runId,
+          revokesEventId: event.revokesEventId,
+          userMessage: event.userMessage,
+        };
       }),
     ).toStrictEqual(
-      promptRows.map((row, index) => {
-        return row.id === chainedRootRow.id ? undefined : runIds[index];
+      expectedPromptRows.map((row) => {
+        return {
+          id: row.id,
+          runId: row.runId ?? undefined,
+          revokesEventId: row.revokesEventId ?? undefined,
+          userMessage: row.payload?.userMessage,
+        };
       }),
     );
-    expect(
-      projectedPrompts.map((event) => {
-        return event.userMessage;
-      }),
-    ).toStrictEqual(historicalDocuments);
 
     if (download.body.lastEventId === null) {
       throw new Error("Expected a non-empty repaired Snapshot cursor");
@@ -1039,6 +1259,127 @@ describe("chat event snapshot read endpoints", () => {
         return row.id === inputRow.id ? { ...row, payload: null } : row;
       }),
     );
+    const contextlessDocument: UserMessageDocument = {
+      version: 1,
+      parts: [
+        {
+          type: "text",
+          text: "Sanitized historical queued Morning Brief prompt.",
+        },
+      ],
+    };
+    const contextlessRoot = chatEventRowSchema.parse({
+      ...inputRow,
+      runId: null,
+      revokesEventId: null,
+      eventType: "input.prompt",
+      payload: { userMessage: contextlessDocument },
+      contextType: "morning_brief",
+      contextId: null,
+      runEventSequenceNumber: null,
+      runEventId: null,
+    });
+    const contextlessClaim = chatEventRowSchema.parse({
+      ...rejectedRow,
+      runId: randomUUID(),
+      revokesEventId: contextlessRoot.id,
+      eventType: "input.prompt",
+      payload: { userMessage: contextlessDocument },
+      contextType: "morning_brief",
+      contextId: null,
+      runEventSequenceNumber: null,
+      runEventId: null,
+    });
+    if (
+      contextlessRoot.seqId >= contextlessClaim.seqId ||
+      contextlessRoot.createdAt >= contextlessClaim.createdAt
+    ) {
+      throw new Error("Expected an ordered contextless claim fixture");
+    }
+    const contextlessRows = (
+      root: ChatEventRow,
+      claim: ChatEventRow,
+      additionalRevoker?: ChatEventRow,
+    ): readonly ChatEventRow[] => {
+      return originalRows.map((row) => {
+        if (row.id === root.id) {
+          return root;
+        }
+        if (row.id === claim.id) {
+          return claim;
+        }
+        return row.id === additionalRevoker?.id ? additionalRevoker : row;
+      });
+    };
+    const missingPredecessorBody = encodeRows(
+      contextlessRows(
+        contextlessRoot,
+        chatEventRowSchema.parse({
+          ...contextlessClaim,
+          revokesEventId: randomUUID(),
+        }),
+      ),
+    );
+    const mismatchedDocumentBody = encodeRows(
+      contextlessRows(
+        contextlessRoot,
+        chatEventRowSchema.parse({
+          ...contextlessClaim,
+          payload: {
+            userMessage: {
+              version: 1,
+              parts: [
+                {
+                  type: "text",
+                  text: "Sanitized mismatched historical prompt.",
+                },
+              ],
+            },
+          },
+        }),
+      ),
+    );
+    const unownedClaimBody = encodeRows(
+      contextlessRows(
+        contextlessRoot,
+        chatEventRowSchema.parse({ ...contextlessClaim, runId: null }),
+      ),
+    );
+    const invalidClaimOrderBody = encodeRows(
+      contextlessRows(
+        contextlessRoot,
+        chatEventRowSchema.parse({
+          ...contextlessClaim,
+          createdAt: contextlessRoot.createdAt,
+        }),
+      ),
+    );
+    const multipleRevokersBody = encodeRows(
+      contextlessRows(
+        contextlessRoot,
+        contextlessClaim,
+        chatEventRowSchema.parse({
+          ...semanticRootRow,
+          revokesEventId: contextlessRoot.id,
+        }),
+      ),
+    );
+    const duplicateContextlessIdBody = encodeRows(
+      originalRows.map((row) => {
+        if (row.id === contextlessRoot.id) {
+          return contextlessRoot;
+        }
+        if (row.id === contextlessClaim.id) {
+          return contextlessClaim;
+        }
+        return row.id === semanticRootRow.id
+          ? chatEventRowSchema.parse({
+              ...semanticRootRow,
+              id: contextlessRoot.id,
+            })
+          : row;
+      }),
+    );
     const unresolvedRevokeBody = encodeRows(
       originalRows.map((row) => {
         return row.id === rejectedRow.id
@@ -1133,6 +1474,42 @@ describe("chat event snapshot read endpoints", () => {
         object: gzipSync(projectionBody),
         projectionSubstage: "current_contract",
         projectionVariant: "invalid_event_shape",
+      },
+      {
+        failureClass: "projection",
+        object: gzipSync(missingPredecessorBody),
+        projectionSubstage: "retired_context",
+        projectionVariant: "missing_context_id",
+      },
+      {
+        failureClass: "projection",
+        object: gzipSync(mismatchedDocumentBody),
+        projectionSubstage: "retired_context",
+        projectionVariant: "missing_context_id",
+      },
+      {
+        failureClass: "projection",
+        object: gzipSync(unownedClaimBody),
+        projectionSubstage: "retired_context",
+        projectionVariant: "missing_context_id",
+      },
+      {
+        failureClass: "projection",
+        object: gzipSync(invalidClaimOrderBody),
+        projectionSubstage: "retired_context",
+        projectionVariant: "missing_context_id",
+      },
+      {
+        failureClass: "projection",
+        object: gzipSync(multipleRevokersBody),
+        projectionSubstage: "retired_context",
+        projectionVariant: "missing_context_id",
+      },
+      {
+        failureClass: "projection",
+        object: gzipSync(duplicateContextlessIdBody),
+        projectionSubstage: "retired_context",
+        projectionVariant: "missing_context_id",
       },
       {
         failureClass: "projection",

--- a/turbo/apps/api/src/signals/services/chat-event-snapshot-body.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-snapshot-body.service.ts
@@ -1,3 +1,5 @@
+import { isDeepStrictEqual } from "node:util";
+
 import {
   chatEventRowSchema,
   type ChatEventRow,
@@ -103,6 +105,100 @@ function isPayloadFreeControlRevoke(row: ChatEventRow): boolean {
   );
 }
 
+function hasExactContextlessMorningBriefPromptPayload(
+  row: ChatEventRow,
+): boolean {
+  const payload = row.payload;
+  if (
+    payload === null ||
+    Object.keys(payload).length !== 1 ||
+    payload.userMessage === undefined
+  ) {
+    return false;
+  }
+  const userMessage = payload.userMessage;
+  return (
+    isRecord(userMessage) &&
+    Object.keys(userMessage).length === 2 &&
+    userMessage.version === 1 &&
+    Array.isArray(userMessage.parts) &&
+    userMessage.parts.length > 0 &&
+    !userMessage.parts.some(retiredMorningBriefPart)
+  );
+}
+
+function isExactContextlessMorningBriefRoot(row: ChatEventRow): boolean {
+  return (
+    row.eventType === "input.prompt" &&
+    row.runId === null &&
+    row.revokesEventId === null &&
+    row.contextType === RETIRED_MORNING_BRIEF_CONTEXT &&
+    row.contextId === null &&
+    row.runEventSequenceNumber === null &&
+    row.runEventId === null &&
+    hasExactContextlessMorningBriefPromptPayload(row)
+  );
+}
+
+function isExactContextlessMorningBriefClaim(
+  row: ChatEventRow,
+  root: ChatEventRow,
+): boolean {
+  return (
+    row.id !== root.id &&
+    row.chatThreadId === root.chatThreadId &&
+    row.eventType === "input.prompt" &&
+    row.runId !== null &&
+    row.revokesEventId === root.id &&
+    row.contextType === RETIRED_MORNING_BRIEF_CONTEXT &&
+    row.contextId === null &&
+    row.runEventSequenceNumber === null &&
+    row.runEventId === null &&
+    root.seqId < row.seqId &&
+    root.createdAt < row.createdAt &&
+    hasExactContextlessMorningBriefPromptPayload(row) &&
+    isDeepStrictEqual(row.payload, root.payload)
+  );
+}
+
+function contextlessMorningBriefClaimIds(
+  rows: readonly ChatEventRow[],
+): ReadonlySet<string> {
+  const uniqueRowsById = new Map<string, ChatEventRow | null>();
+  const soleRevokerByTargetId = new Map<string, ChatEventRow | null>();
+  for (const row of rows) {
+    uniqueRowsById.set(row.id, uniqueRowsById.has(row.id) ? null : row);
+    if (row.revokesEventId !== null) {
+      soleRevokerByTargetId.set(
+        row.revokesEventId,
+        soleRevokerByTargetId.has(row.revokesEventId) ? null : row,
+      );
+    }
+  }
+
+  const acceptedIds = new Set<string>();
+  for (const root of rows) {
+    if (
+      !isExactContextlessMorningBriefRoot(root) ||
+      uniqueRowsById.get(root.id) !== root
+    ) {
+      continue;
+    }
+    const claim = soleRevokerByTargetId.get(root.id);
+    if (
+      claim === undefined ||
+      claim === null ||
+      uniqueRowsById.get(claim.id) !== claim ||
+      !isExactContextlessMorningBriefClaim(claim, root)
+    ) {
+      continue;
+    }
+    acceptedIds.add(root.id);
+    acceptedIds.add(claim.id);
+  }
+  return acceptedIds;
+}
+
 function isExactRetiredMorningBriefRoot(
   row: ChatEventRow,
   root: ChatEventRow | null | undefined,
@@ -204,6 +300,7 @@ function assertCurrentProjection(row: ChatEventRow): void {
 function repairMorningBriefRow(
   row: ChatEventRow,
   priorRowsById: ReadonlyMap<string, ChatEventRow | null>,
+  contextlessClaimIds: ReadonlySet<string>,
 ): {
   readonly row: ChatEventRow;
   readonly removedDocumentParts: number;
@@ -235,7 +332,15 @@ function repairMorningBriefRow(
     assertCurrentProjection(row);
     return { row, removedDocumentParts: 0 };
   }
-  if (row.contextId === null) {
+  // Before Morning Brief context rows existed, queue claim wrote an ordered,
+  // run-owned replacement prompt that revoked a run-less root and copied its
+  // exact document. Migration 0836 later classified both prompts while
+  // intentionally preserving their null context IDs. Accept only that complete
+  // archive-local pair; never derive or synthesize an ID. This persisted-state
+  // compatibility is limited to immutable legacy V7 Snapshots. Remove it after
+  // all surviving V7 heads converge to r1 and the retired writer rollback
+  // window closes; removal is tracked by #30369 and #28905.
+  if (row.contextId === null && !contextlessClaimIds.has(row.id)) {
     failProjection("retired_context", "missing_context_id");
   }
   if (legacyParts.length > 1) {
@@ -302,12 +407,17 @@ export function repairMorningBriefPhaseBSnapshot(
   }
   const rows: ChatEventRow[] = [];
   const priorRowsById = new Map<string, ChatEventRow | null>();
+  const contextlessClaimIds = contextlessMorningBriefClaimIds(decodedRows);
   const repairedLines = rawLines.map((raw, index) => {
     const row = decodedRows[index];
     if (row === undefined) {
       throw new Error("Chat Event snapshot decoded row is missing");
     }
-    const repaired = repairMorningBriefRow(row, priorRowsById);
+    const repaired = repairMorningBriefRow(
+      row,
+      priorRowsById,
+      contextlessClaimIds,
+    );
     rows.push(repaired.row);
     priorRowsById.set(row.id, priorRowsById.has(row.id) ? null : row);
     if (repaired.row === row) {


### PR DESCRIPTION
## Summary

- repair the exact archived Morning Brief queue-claim shape whose retired context was classified with a null context ID
- require one unique run-less root prompt and one unique later run-owned replacement prompt in the same thread, with an exact copied payload and revoke edge
- normalize only the matched pair to the current `web` / null context; never derive or synthesize a context ID
- add sanitized byte-accurate positive coverage plus fail-closed regressions for every ambiguous or incomplete near-match

## Safe structural diagnosis

The retired writer first persisted a run-less `input.prompt`. Queue claim later appended a run-owned replacement `input.prompt` that revoked the root and copied its exact document. Because the original prompt had no display-context pointer, both rows retained a null context ID. Migration 0836 subsequently classified those rows as `morning_brief` while deliberately preserving the null ID, and later V7 archive upgrades preserved the immutable prefix.

The compatibility matcher therefore accepts only the complete archive-local pair: unique IDs, a sole revoker, same thread, strict sequence and timestamp order, root without Run ownership, claim with Run ownership, exact payload equality, null Run-event fields, and no retired Morning Brief document part. Missing predecessors, payload drift, missing Run ownership, invalid order, multiple revokers, and duplicate IDs all continue to fail closed as `retired_context / missing_context_id`.

## Validation

- `pnpm format`
- `turbo run lint --concurrency=1 --log-order grouped` (13/13 tasks)
- `pnpm knip` (configuration hints only)
- `turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'` (12/12 tasks)
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-thread-idb.test.tsx` (7/7)
- `pnpm --filter @okouai/db test:morning-brief-phase-b-cleanup` against an isolated fully migrated PostgreSQL 18 database (6/6 invariants)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-event-snapshot.test.ts` against the same isolated database (8/8)
- `git diff --check origin/main...HEAD`

No full Vitest suite or local development server was run.

## Compatibility fallback

`contextlessMorningBriefClaimIds` and `repairMorningBriefRow` accept this exact persisted legacy V7 Snapshot state only. The removal gate is when all surviving V7 heads have converged to r1 and the retired writer rollback window has closed; that lifecycle remains tracked by #30369 and #28905.

## Scope

- `turbo/apps/api/src/signals/services/chat-event-snapshot-body.service.ts`
- `turbo/apps/api/src/signals/routes/__tests__/chat-event-snapshot.test.ts`

No schema, migration, public contract, canonical event row, production data, logging payload, or GitHub Actions change is included.

Closes #30898
