### PR TITLE
fix(runner): fail closed on unavailable mountinfo

### DIFF
--- a/crates/runner/scripts/mount-workspace-drive.sh
+++ b/crates/runner/scripts/mount-workspace-drive.sh
@@ -18,14 +18,14 @@ refuse_workspace_symlink_path() {
   done
 }
 
-workspace_device_mounted_elsewhere() {
-  [ -n "$workspace_dev" ] || return 1
+inspect_workspace_mountinfo() {
   while IFS=' ' read -r _ _ mount_dev _ _ _; do
     if [ "$mount_dev" = "$workspace_dev" ]; then
+      workspace_device_mounted_elsewhere=true
       return 0
     fi
-  done < "$workspace_mountinfo_path"
-  return 1
+  done <&3
+  return 0
 }
 
 ensure_workspace_owner() {
@@ -44,7 +44,15 @@ if mountpoint -q -- "$workspace_dir"; then
   exit 64
 fi
 
-if workspace_device_mounted_elsewhere; then
+workspace_device_mounted_elsewhere=false
+if [ -n "$workspace_dev" ]; then
+  if ! inspect_workspace_mountinfo 3< "$workspace_mountinfo_path"; then
+    echo "unable to inspect workspace mounts because mountinfo is unavailable: $workspace_mountinfo_path" >&2
+    exit 66
+  fi
+fi
+
+if [ "$workspace_device_mounted_elsewhere" = true ]; then
   echo "refusing to mount workspace drive because $workspace_device is already mounted outside $workspace_dir" >&2
   exit 64
 fi

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -551,6 +551,36 @@ log_call() {{
         }
 
         #[test]
+        fn mount_script_rejects_unavailable_mountinfo() {
+            let fixture = WorkspaceScriptFixture::new();
+            fixture.write_mountpoint(false, Some(WORKSPACE_DEV), None);
+            fs::remove_file(&fixture.mountinfo_path).unwrap();
+
+            let output = fixture.run_mount();
+
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert!(
+                !output.status.success(),
+                "mount should fail: stdout={stdout} stderr={stderr}"
+            );
+            assert!(stdout.is_empty(), "unexpected stdout: {stdout}");
+            assert!(
+                stderr.contains("mountinfo is unavailable"),
+                "unexpected stderr: {stderr}"
+            );
+            assert_eq!(
+                fixture.calls(),
+                format!(
+                    "mountpoint\t-x\t--\t{}\nmountpoint\t-q\t--\t{}\n",
+                    fixture.workspace_device.display(),
+                    fixture.workspace_dir.display()
+                )
+            );
+            assert!(!fixture.workspace_dir.exists());
+        }
+
+        #[test]
         fn mount_script_rejects_existing_symlink_before_state_checks() {
             let fixture = WorkspaceScriptFixture::new();
             symlink(&fixture.outside_dir, &fixture.workspace_dir).unwrap();


### PR DESCRIPTION
## Summary

- open the configured mountinfo source on the scan function invocation so access failures cannot be overwritten by a conditional function return
- separate successful scan completion from the mounted-elsewhere result, avoiding shell-specific numeric redirection status assumptions
- fail with a clear diagnostic before workspace filesystem side effects and cover the unavailable-source path through the checked-in helper

## Scope

- preserves the matching existing mount, mismatched mount, mounted-elsewhere, unresolved device identity, symlink, and successful new-mount behavior
- guarantees fail-closed behavior when the configured mountinfo source cannot be opened
- does not claim detection of a post-open I/O error that POSIX `read` cannot distinguish from normal EOF
- introduces no API, database, persisted-state, or cross-version protocol change

## Validation

- `sh -n runner/scripts/mount-workspace-drive.sh runner/scripts/freeze-workspace-drive.sh`
- `cargo test -p runner workspace_mount::tests::behavior -- --nocapture` (11 passed)
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-targets --all-features` (3388 passed, 24 ignored; guest inventory 1 passed)
- `git diff --check`
- pre-commit workspace Rust format, Clippy, documentation, and file-size checks

Closes #30878
