### PR TITLE
fix(api): bind google meet triggers to selected account

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -464,6 +464,19 @@ export async function setOfficialWorkflowAutomationAdmissionStateFixture(
   });
 }
 
+export async function stageOfficialWorkflowAutomationFixture(
+  context: TestContext,
+  automationId: string,
+  blueprintKey: string,
+): Promise<void> {
+  await postAction(context, {
+    action: "set-official-workflow-automation-admission-state",
+    automation_id: automationId,
+    blueprint_key: blueprintKey,
+    reconciliation_status: "reconciling",
+  });
+}
+
 export async function retargetWorkflowAutomationFixture(
   context: TestContext,
   automationId: string,

--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -305,6 +305,26 @@ function googleFormsBlueprint(
   };
 }
 
+function googleMeetBlueprint(
+  autonomyBudget: number,
+): OfficialWorkflowBlueprint {
+  return {
+    key: "google-meet-trigger",
+    parameters: [],
+    desiredState: {
+      kind: "event",
+      eventType: "google-meet-transcript-generated",
+      eventConfig: {
+        provider: "google-meet",
+        event: "transcript_generated",
+        scope: { type: "organizer_user" },
+      },
+      autonomyBudget,
+    },
+    runtime: { resultEmail: false },
+  };
+}
+
 function configureOfficialGoogleFormsMock() {
   const recorder = { watchCalls: 0 };
   mockOptionalEnv("GOOGLE_FORMS_PUBSUB_TOPIC_NAME", GOOGLE_FORMS_TOPIC_NAME);
@@ -365,6 +385,82 @@ function configureOfficialGoogleFormsMock() {
       "https://forms.googleapis.com/v1/forms/:formId/watches/:watchId",
       () => {
         return HttpResponse.json({});
+      },
+    ),
+  );
+  return recorder;
+}
+
+function configureOfficialGoogleMeetMock() {
+  const testId = randomUUID();
+  const accessToken = `official-google-meet-access-${testId}`;
+  const externalId = `official-google-meet-user-${testId}`;
+  const topicName = `projects/vm0-ai-488909/topics/official-google-meet-${testId}`;
+  const recorder = { createCalls: 0 };
+  mockEnv("OKOU_WEB_URL", "https://www.vm0.ai");
+  mockOptionalEnv("GOOGLE_OAUTH_CLIENT_ID", "google-client-id");
+  mockOptionalEnv("GOOGLE_OAUTH_CLIENT_SECRET", "google-client-secret");
+  mockOptionalEnv("GOOGLE_WORKSPACE_EVENTS_PUBSUB_TOPIC_NAME", topicName);
+
+  server.use(
+    http.post("https://oauth2.googleapis.com/token", () => {
+      return HttpResponse.json({
+        access_token: accessToken,
+        refresh_token: `official-google-meet-refresh-${testId}`,
+        expires_in: 3600,
+        token_type: "Bearer",
+        scope:
+          "https://www.googleapis.com/auth/meetings.space.readonly https://www.googleapis.com/auth/userinfo.email",
+      });
+    }),
+    http.get("https://www.googleapis.com/oauth2/v2/userinfo", ({ request }) => {
+      expect(request.headers.get("authorization")).toBe(
+        `Bearer ${accessToken}`,
+      );
+      return HttpResponse.json({
+        id: externalId,
+        email: `official-google-meet-${testId}@example.test`,
+        name: "Official Google Meet User",
+      });
+    }),
+    http.post(
+      "https://workspaceevents.googleapis.com/v1/subscriptions",
+      async ({ request }) => {
+        expect(request.headers.get("authorization")).toBe(
+          `Bearer ${accessToken}`,
+        );
+        await expect(request.json()).resolves.toStrictEqual({
+          targetResource: `//cloudidentity.googleapis.com/users/${externalId}`,
+          eventTypes: ["google.workspace.meet.transcript.v2.fileGenerated"],
+          notificationEndpoint: { pubsubTopic: topicName },
+          ttl: "604800s",
+        });
+        recorder.createCalls += 1;
+        return HttpResponse.json({
+          response: {
+            name: `subscriptions/official-google-meet-${testId}`,
+            targetResource: `//cloudidentity.googleapis.com/users/${externalId}`,
+            eventTypes: ["google.workspace.meet.transcript.v2.fileGenerated"],
+            notificationEndpoint: { pubsubTopic: topicName },
+            state: "ACTIVE",
+            expireTime: "2099-09-01T00:00:00.000Z",
+          },
+        });
+      },
+    ),
+    http.delete(
+      /^https:\/\/workspaceevents\.googleapis\.com\/v1\/subscriptions\/[^/]+$/,
+      ({ request }) => {
+        expect(request.headers.get("authorization")).toBe(
+          `Bearer ${accessToken}`,
+        );
+        expect(new URL(request.url).searchParams.get("allowMissing")).toBe(
+          "true",
+        );
+        return HttpResponse.json({
+          name: `operations/delete-official-google-meet-${testId}`,
+          done: true,
+        });
       },
     ),
   );
@@ -1148,6 +1244,28 @@ async function setOfficialWorkflowsEnabled(
     { orgId: actor.orgId, userId: actor.userId },
     { [FeatureSwitchKey.OfficialWorkflows]: enabled },
   );
+}
+
+async function connectGoogleMeetForOfficialWorkflow(
+  actor: ApiTestUser,
+): Promise<void> {
+  const started = await connectors.startOauth(actor, "google-meet", "oauth");
+  const state = new URL(started.authorizationUrl).searchParams.get("state");
+  if (!state) {
+    throw new Error("Expected Google Meet OAuth state");
+  }
+  await connectors.completeOauthCallback("google-meet", {
+    code: "official-google-meet-code",
+    state,
+  });
+  const accounts = await connectors.listBuiltinConnectorAccounts(
+    actor,
+    "google-meet",
+  );
+  const account = accounts[0];
+  if (!account) {
+    throw new Error("Expected an Official Workflow Google Meet account");
+  }
 }
 
 async function connectStripeOAuthForOfficialWorkflow(
@@ -3867,6 +3985,91 @@ describe.sequential("Official Workflow installations", () => {
     });
     expect(current?.official?.appliedFingerprint).not.toBe(initialFingerprint);
     expect(forms.watchCalls).toBe(1);
+  });
+
+  it("projects the Google Meet account during installation and reconfiguration", async () => {
+    installCatalogStorageFixture();
+    const suffix = randomUUID().replaceAll("-", "").slice(0, 10);
+    const definitionName = `api-test-google-meet-${suffix}`;
+    await syncCatalog(
+      catalog([activeDefinition(definitionName, [googleMeetBlueprint(4)])]),
+    );
+
+    const { actor } = await workflowBdd.setupWorkflowOrg({
+      timezone: "Asia/Shanghai",
+    });
+    if (!actor.orgId) {
+      throw new Error("Expected organization-scoped actor");
+    }
+    const { agentId } = await workflowBdd.createAgent(actor);
+    onTestFinished(async () => {
+      installCatalogStorageFixture();
+      await bdd.deleteAgent(actor, agentId);
+      await cleanupCatalog();
+    });
+    const meet = configureOfficialGoogleMeetMock();
+    await updateFeatureSwitchesForUser(
+      context,
+      { orgId: actor.orgId, userId: actor.userId },
+      {
+        [FeatureSwitchKey.ConnectorAccounts]: true,
+        [FeatureSwitchKey.OfficialWorkflows]: true,
+      },
+    );
+    await connectGoogleMeetForOfficialWorkflow(actor);
+    const headers = authHeaders(actor);
+    const installed = await accept(
+      officialClient().install({
+        headers,
+        params: { definitionName },
+        body: {
+          agentId,
+          blueprints: [{ blueprintKey: "google-meet-trigger", bindings: [] }],
+        },
+      }),
+      [201],
+    );
+    const initial = installed.body.workflow.automations.find((automation) => {
+      return automation.official?.blueprintKey === "google-meet-trigger";
+    });
+    if (!initial?.official) {
+      throw new Error("Expected an Official Google Meet automation");
+    }
+    const initialFingerprint = initial.official.appliedFingerprint;
+    expect(initial).toMatchObject({
+      kind: "event",
+      eventType: "google-meet-transcript-generated",
+      enabled: true,
+      official: { reconciliationStatus: "current" },
+    });
+    expect(meet.createCalls).toBe(1);
+
+    await syncCatalog(
+      catalog([activeDefinition(definitionName, [googleMeetBlueprint(7)])]),
+    );
+    await expect(
+      runOfficialWorkflowReconciliationWorker(),
+    ).resolves.toMatchObject({ completed: 1, installations: 1, retried: 0 });
+
+    const reconciled = await accept(
+      installationClient().get({
+        headers,
+        params: { workflowId: installed.body.workflow.id },
+      }),
+      [200],
+    );
+    const current = reconciled.body.workflow.automations.find((automation) => {
+      return automation.id === initial.id;
+    });
+    expect(current).toMatchObject({
+      enabled: true,
+      official: { reconciliationStatus: "current" },
+    });
+    expect(current?.official?.appliedFingerprint).not.toBe(initialFingerprint);
+    await expect(
+      readWorkflowAutomationAutonomyFixture(context, initial.id),
+    ).resolves.toMatchObject({ autonomyBudget: 7, enabled: true });
+    expect(meet.createCalls).toBe(1);
   });
 
   it("records selective non-blocking work and converges schema changes per Blueprint", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts
@@ -33,6 +33,7 @@ import {
   holdOrgAdmissionLock,
   readOrgAdmissionLockState,
   releaseOrgAdmissionLock,
+  stageOfficialWorkflowAutomationFixture,
 } from "./helpers/runtime-state";
 import { createRouteMocks } from "./helpers/route-test";
 import { chatThreadRoutes } from "../chat-threads";
@@ -861,6 +862,38 @@ describe("Google Workspace Events subscription lifecycle", () => {
     );
     expect(fixture.provider.accounts.primary.deletedUrls).toHaveLength(2);
     expect(fixture.provider.accounts.secondary.createdNames).toHaveLength(2);
+  });
+
+  it("retains staged official subscriptions across default account changes", async () => {
+    const fixture = await setupFixture();
+    const staged = await createMeetAutomation(fixture, false);
+    await stageOfficialWorkflowAutomationFixture(
+      context,
+      staged.body.id,
+      "meet-transcript",
+    );
+    expect(fixture.provider.createdNames).toStrictEqual([]);
+
+    const secondaryConnectorId = await connectGoogleMeet(
+      fixture.actor,
+      fixture.provider,
+      "secondary",
+      fixture.agentId,
+      { intent: "add", displayName: "Secondary Google Meet" },
+    );
+    expect(fixture.provider.accounts.primary.createdNames).toHaveLength(1);
+    expect(fixture.provider.accounts.secondary.createdNames).toStrictEqual([]);
+
+    await accept(
+      connectorAccountsClient().setDefault({
+        headers: authHeaders(fixture.actor),
+        params: { connectionId: secondaryConnectorId },
+        body: { target: { kind: "builtin", connectorSlug: "google-meet" } },
+      }),
+      [200],
+    );
+    expect(fixture.provider.accounts.primary.deletedUrls).toHaveLength(1);
+    expect(fixture.provider.accounts.secondary.createdNames).toHaveLength(1);
   });
 
   it("supersedes an old source that changes before queue admission", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts
@@ -1,10 +1,16 @@
 import { Buffer } from "node:buffer";
 import { generateKeyPairSync, randomUUID, sign as signData } from "node:crypto";
 
-import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
+import {
+  connectorAccountsContract,
+  type ConnectorAccountMutationIntent,
+} from "@okouai/api-contracts/contracts/connector-accounts";
 import { chatThreadConnectorSelectionContract } from "@okouai/api-contracts/contracts/chat-threads";
 import { testGoogleMeetSubscriptionRenewalContract } from "@okouai/api-contracts/contracts/test-google-meet-subscription-renewal";
-import { workflowAutomationsContract } from "@okouai/api-contracts/contracts/workflows";
+import {
+  workflowAutomationsContract,
+  workflowsDetailContract,
+} from "@okouai/api-contracts/contracts/workflows";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
 import { onTestFinished } from "vitest";
@@ -18,19 +24,28 @@ import { server } from "../../../mocks/server";
 import { createDeferredPromise } from "../../utils";
 import type { ApiTestUser } from "./helpers/api-bdd";
 import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
+import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
 import { chatEventDisplayText } from "./helpers/chat-event";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
+import {
+  clearWorkflowAutomationEventConnectorAsPreviousApi,
+  holdOrgAdmissionLock,
+  readOrgAdmissionLockState,
+  releaseOrgAdmissionLock,
+} from "./helpers/runtime-state";
 import { createRouteMocks } from "./helpers/route-test";
 import { chatThreadRoutes } from "../chat-threads";
 import { connectorAccountRoutes } from "../connector-accounts";
 import { testGoogleMeetSubscriptionRenewalRoutes } from "../test-google-meet-subscription-renewal";
 import { webhooksGoogleWorkspaceEventsRoutes } from "../webhooks-google-workspace-events";
 import { workflowAutomationsRoutes } from "../workflow-automations";
+import { workflowsRoutes } from "../workflows";
 
 const context = testContext();
 const connectors = createConnectorBddApi(context);
 const mocks = createRouteMocks(context);
+const runs = createRunsApi(context);
 const workflows = createWorkflowsBddApi(context);
 
 const PUSH_AUDIENCE = "https://api.vm0.ai/api/webhooks/google-workspace-events";
@@ -54,17 +69,36 @@ interface GoogleMeetProviderOptions {
 }
 
 interface GoogleMeetProviderRecorder {
+  readonly accounts: Readonly<
+    Record<GoogleMeetProviderAccountKey, GoogleMeetProviderAccountRecorder>
+  >;
   readonly createdNames: string[];
   readonly deletedUrls: string[];
   readonly operations: string[];
+  readonly runnerGroup: string;
   readonly topicName: string;
   readonly externalId: string;
   renewCalls: number;
   reactivateCalls: number;
 }
 
+type GoogleMeetProviderAccountKey = "primary" | "secondary";
+
+interface GoogleMeetProviderAccountRecorder {
+  readonly accessToken: string;
+  readonly createdNames: string[];
+  readonly deletedUrls: string[];
+  readonly email: string;
+  readonly externalId: string;
+  readonly key: GoogleMeetProviderAccountKey;
+  readonly operations: string[];
+  renewCalls: number;
+  reactivateCalls: number;
+}
+
 interface GoogleMeetFixture {
   readonly actor: OrgActor;
+  readonly agentId: string;
   readonly workflowId: string;
   readonly connectorId: string;
   readonly provider: GoogleMeetProviderRecorder;
@@ -100,6 +134,12 @@ function renewalClient() {
   })(testGoogleMeetSubscriptionRenewalContract);
 }
 
+function workflowDetailClient() {
+  return setupApp({ context, routes: workflowsRoutes })(
+    workflowsDetailContract,
+  );
+}
+
 function encodeJwtPart(value: unknown): string {
   return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
 }
@@ -129,13 +169,37 @@ function configureGoogleMeetBoundaries(
   options: GoogleMeetProviderOptions = {},
 ): GoogleMeetProviderRecorder {
   const testId = randomUUID();
-  const accessToken = `google-meet-access-${testId}`;
+  const account = (
+    key: GoogleMeetProviderAccountKey,
+  ): GoogleMeetProviderAccountRecorder => {
+    return {
+      accessToken: `google-meet-access-${key}-${testId}`,
+      createdNames: [],
+      deletedUrls: [],
+      email: `meet-${key}-${testId}@example.test`,
+      externalId: `google-meet-user-${key}-${testId}`,
+      key,
+      operations: [],
+      renewCalls: 0,
+      reactivateCalls: 0,
+    };
+  };
+  const accounts = {
+    primary: account("primary"),
+    secondary: account("secondary"),
+  } as const;
+  const subscriptionAccounts = new Map<
+    string,
+    GoogleMeetProviderAccountRecorder
+  >();
   const recorder: GoogleMeetProviderRecorder = {
+    accounts,
     createdNames: [],
     deletedUrls: [],
     operations: [],
+    runnerGroup: `vm0/google-workspace-events-${testId}`,
     topicName: `projects/vm0-ai-488909/topics/google-workspace-events-${testId}`,
-    externalId: `google-meet-user-${testId}`,
+    externalId: accounts.primary.externalId,
     renewCalls: 0,
     reactivateCalls: 0,
   };
@@ -143,10 +207,7 @@ function configureGoogleMeetBoundaries(
   mockEnv("OKOU_WEB_URL", "https://www.vm0.ai");
   mockOptionalEnv("GOOGLE_OAUTH_CLIENT_ID", "google-client-id");
   mockOptionalEnv("GOOGLE_OAUTH_CLIENT_SECRET", "google-client-secret");
-  mockOptionalEnv(
-    "RUNNER_DEFAULT_GROUP",
-    `vm0/google-workspace-events-${testId}`,
-  );
+  mockOptionalEnv("RUNNER_DEFAULT_GROUP", recorder.runnerGroup);
   mockOptionalEnv(
     "GOOGLE_WORKSPACE_EVENTS_PUBSUB_TOPIC_NAME",
     recorder.topicName,
@@ -161,45 +222,77 @@ function configureGoogleMeetBoundaries(
   );
 
   server.use(
-    http.post("https://oauth2.googleapis.com/token", () => {
+    http.post("https://oauth2.googleapis.com/token", async ({ request }) => {
+      const requestBody = new URLSearchParams(await request.text());
+      const code = requestBody.get("code");
+      const refreshToken = requestBody.get("refresh_token");
+      const requestedAccount = Object.values(accounts).find((candidate) => {
+        return (
+          code === `google-meet-code-${candidate.key}` ||
+          refreshToken === `google-meet-refresh-${candidate.key}-${testId}`
+        );
+      });
+      if (!requestedAccount) {
+        return HttpResponse.text("unknown test Google Meet account", {
+          status: 503,
+        });
+      }
       return HttpResponse.json({
-        access_token: accessToken,
-        refresh_token: `google-meet-refresh-${testId}`,
+        access_token: requestedAccount.accessToken,
+        refresh_token: `google-meet-refresh-${requestedAccount.key}-${testId}`,
         expires_in: options.tokenExpiresInSeconds ?? 3600,
         token_type: "Bearer",
         scope:
           "https://www.googleapis.com/auth/meetings.space.readonly https://www.googleapis.com/auth/userinfo.email",
       });
     }),
-    http.get("https://www.googleapis.com/oauth2/v2/userinfo", () => {
+    http.get("https://www.googleapis.com/oauth2/v2/userinfo", ({ request }) => {
+      const requestedAccount = Object.values(accounts).find((candidate) => {
+        return (
+          request.headers.get("authorization") ===
+          `Bearer ${candidate.accessToken}`
+        );
+      });
+      if (!requestedAccount) {
+        return HttpResponse.text("unknown test Google Meet account", {
+          status: 503,
+        });
+      }
       return HttpResponse.json({
-        id: recorder.externalId,
-        email: `meet-${testId}@example.test`,
-        name: "Google Meet User",
+        id: requestedAccount.externalId,
+        email: requestedAccount.email,
+        name: `Google Meet ${requestedAccount.key} User`,
       });
     }),
     http.post(
       "https://workspaceevents.googleapis.com/v1/subscriptions",
       async ({ request }) => {
         const requestText = await request.text();
+        const requestedAccount = Object.values(accounts).find((candidate) => {
+          return (
+            request.headers.get("authorization") ===
+            `Bearer ${candidate.accessToken}`
+          );
+        });
         if (
+          !requestedAccount ||
           !requestText.includes(recorder.topicName) ||
-          !requestText.includes(recorder.externalId)
+          !requestText.includes(requestedAccount.externalId)
         ) {
           return HttpResponse.text("unowned test subscription", {
             status: 503,
           });
         }
-        const call = recorder.createdNames.length + 1;
-        const subscriptionName = `subscriptions/google-meet-${testId}-${call}`;
+        const call = requestedAccount.createdNames.length + 1;
+        const subscriptionName = `subscriptions/google-meet-${testId}-${requestedAccount.key}-${call}`;
+        subscriptionAccounts.set(subscriptionName, requestedAccount);
         recorder.createdNames.push(subscriptionName);
         recorder.operations.push(`create:${subscriptionName}`);
-        expect(request.headers.get("authorization")).toBe(
-          `Bearer ${accessToken}`,
-        );
+        requestedAccount.createdNames.push(subscriptionName);
+        requestedAccount.operations.push(`create:${subscriptionName}`);
         const body: unknown = JSON.parse(requestText);
         expect(body).toStrictEqual({
-          targetResource: `//cloudidentity.googleapis.com/users/${recorder.externalId}`,
+          targetResource: `//cloudidentity.googleapis.com/users/${requestedAccount.externalId}`,
           eventTypes: ["google.workspace.meet.transcript.v2.fileGenerated"],
           notificationEndpoint: { pubsubTopic: recorder.topicName },
           ttl: "604800s",
@@ -212,7 +305,7 @@ function configureGoogleMeetBoundaries(
         return HttpResponse.json({
           response: {
             name: subscriptionName,
-            targetResource: `//cloudidentity.googleapis.com/users/${recorder.externalId}`,
+            targetResource: `//cloudidentity.googleapis.com/users/${requestedAccount.externalId}`,
             eventTypes: ["google.workspace.meet.transcript.v2.fileGenerated"],
             notificationEndpoint: { pubsubTopic: recorder.topicName },
             state: "ACTIVE",
@@ -227,13 +320,19 @@ function configureGoogleMeetBoundaries(
         const subscriptionName = new URL(request.url).pathname.slice(
           "/v1/".length,
         );
-        if (!subscriptionName.includes(testId)) {
+        const requestedAccount = subscriptionAccounts.get(subscriptionName);
+        if (!requestedAccount) {
           return HttpResponse.text("unowned test subscription", {
             status: 503,
           });
         }
         recorder.renewCalls += 1;
         recorder.operations.push(`renew:${subscriptionName}`);
+        requestedAccount.renewCalls += 1;
+        requestedAccount.operations.push(`renew:${subscriptionName}`);
+        expect(request.headers.get("authorization")).toBe(
+          `Bearer ${requestedAccount.accessToken}`,
+        );
         expect(new URL(request.url).searchParams.get("updateMask")).toBe("ttl");
         await expect(request.json()).resolves.toStrictEqual({
           name: subscriptionName,
@@ -251,15 +350,20 @@ function configureGoogleMeetBoundaries(
     http.post(
       /^https:\/\/workspaceevents\.googleapis\.com\/v1\/subscriptions\/[^/]+:reactivate$/,
       ({ request }) => {
-        if (!request.url.includes(testId)) {
+        const subscriptionName = new URL(request.url).pathname
+          .slice("/v1/".length)
+          .replace(/:reactivate$/, "");
+        const requestedAccount = subscriptionAccounts.get(subscriptionName);
+        if (!requestedAccount) {
           return HttpResponse.text("unowned test subscription", {
             status: 503,
           });
         }
         recorder.reactivateCalls += 1;
+        requestedAccount.reactivateCalls += 1;
         return HttpResponse.json({
           response: {
-            name: recorder.createdNames.at(-1),
+            name: subscriptionName,
             state: "ACTIVE",
             expireTime: "2099-08-14T00:00:00.000Z",
           },
@@ -271,19 +375,23 @@ function configureGoogleMeetBoundaries(
       async ({ request }) => {
         const url = new URL(request.url);
         const subscriptionName = url.pathname.slice("/v1/".length);
-        if (!subscriptionName.includes(testId)) {
+        const requestedAccount = subscriptionAccounts.get(subscriptionName);
+        if (!requestedAccount) {
           return HttpResponse.text("unowned test subscription", {
             status: 503,
           });
         }
         recorder.deletedUrls.push(url.toString());
         recorder.operations.push(`delete-start:${subscriptionName}`);
+        requestedAccount.deletedUrls.push(url.toString());
+        requestedAccount.operations.push(`delete-start:${subscriptionName}`);
         expect(request.headers.get("authorization")).toBe(
-          `Bearer ${accessToken}`,
+          `Bearer ${requestedAccount.accessToken}`,
         );
         expect(url.searchParams.get("allowMissing")).toBe("true");
         await options.onDelete?.();
         recorder.operations.push(`delete-end:${subscriptionName}`);
+        requestedAccount.operations.push(`delete-end:${subscriptionName}`);
         if (options.deleteStatus !== undefined) {
           return HttpResponse.text("delete failed", {
             status: options.deleteStatus,
@@ -305,25 +413,39 @@ function configureGoogleMeetBoundaries(
   return recorder;
 }
 
-async function connectGoogleMeet(actor: OrgActor): Promise<string> {
-  const started = await connectors.startOauth(actor, "google-meet", "oauth");
+async function connectGoogleMeet(
+  actor: OrgActor,
+  provider: GoogleMeetProviderRecorder,
+  accountKey: GoogleMeetProviderAccountKey = "primary",
+  agentId?: string,
+  account?: ConnectorAccountMutationIntent,
+): Promise<string> {
+  const started = await connectors.startOauth(
+    actor,
+    "google-meet",
+    "oauth",
+    agentId,
+    account,
+  );
   const state = new URL(started.authorizationUrl).searchParams.get("state");
   if (!state) {
     throw new Error("Expected Google Meet OAuth state");
   }
   await connectors.completeOauthCallback("google-meet", {
-    code: "google-meet-code",
+    code: `google-meet-code-${accountKey}`,
     state,
   });
   const accounts = await connectors.listBuiltinConnectorAccounts(
     actor,
     "google-meet",
   );
-  const account = accounts[0];
-  if (accounts.length !== 1 || !account) {
-    throw new Error("Expected one Google Meet connector account");
+  const connectedAccount = accounts.find((candidate) => {
+    return candidate.externalEmail === provider.accounts[accountKey].email;
+  });
+  if (!connectedAccount) {
+    throw new Error(`Expected the ${accountKey} Google Meet connector account`);
   }
-  return account.id;
+  return connectedAccount.id;
 }
 
 async function setupFixture(
@@ -347,19 +469,26 @@ async function setupFixture(
     { orgId: orgActor.orgId, userId: orgActor.userId },
     { [FeatureSwitchKey.ConnectorAccounts]: true },
   );
-  const connectorId = await connectGoogleMeet(orgActor);
+  const connectorId = await connectGoogleMeet(orgActor, provider);
   context.mocks.s3.send.mockResolvedValue({});
-  return { actor: orgActor, workflowId, connectorId, provider };
+  return {
+    actor: orgActor,
+    agentId: agent.agentId,
+    workflowId,
+    connectorId,
+    provider,
+  };
 }
 
 async function createMeetAutomation(
   fixture: GoogleMeetFixture,
   enabled?: boolean,
+  workflowId: string = fixture.workflowId,
 ) {
   return await accept(
     automationsClient().create({
       headers: authHeaders(fixture.actor),
-      params: { workflowId: fixture.workflowId },
+      params: { workflowId },
       body: {
         kind: "event",
         eventType: "google-meet-transcript-generated",
@@ -563,6 +692,394 @@ describe("Google Workspace Events subscription lifecycle", () => {
     expect(fixture.provider.deletedUrls).toHaveLength(1);
   });
 
+  it("isolates simultaneous subscriptions and dispatch by selected account", async () => {
+    const fixture = await setupFixture();
+    const primary = await createMeetAutomation(fixture);
+    const secondaryConnectorId = await connectGoogleMeet(
+      fixture.actor,
+      fixture.provider,
+      "secondary",
+      fixture.agentId,
+      { intent: "add", displayName: "Secondary Google Meet" },
+    );
+    const secondaryWorkflowId = await workflows.createWorkflow(fixture.actor, {
+      agentId: fixture.agentId,
+      name: `google-meet-secondary-${randomUUID()}`,
+    });
+    const secondary = await createMeetAutomation(
+      fixture,
+      false,
+      secondaryWorkflowId,
+    );
+    if (!secondary.body.chatThreadId) {
+      throw new Error("Expected a secondary automation chat thread");
+    }
+    await accept(
+      chatThreadConnectorSelectionsClient().update({
+        headers: authHeaders(fixture.actor),
+        params: { id: secondary.body.chatThreadId },
+        body: {
+          connectionId: secondaryConnectorId,
+          target: { kind: "builtin", connectorSlug: "google-meet" },
+        },
+      }),
+      [200],
+    );
+    await accept(
+      automationsClient().enable({
+        headers: authHeaders(fixture.actor),
+        params: { id: secondary.body.id },
+      }),
+      [200],
+    );
+
+    const primarySubscription =
+      fixture.provider.accounts.primary.createdNames[0];
+    const secondarySubscription =
+      fixture.provider.accounts.secondary.createdNames[0];
+    if (!primarySubscription || !secondarySubscription) {
+      throw new Error("Expected one subscription for each Google Meet account");
+    }
+    expect(fixture.provider.accounts.primary.createdNames).toHaveLength(1);
+    expect(fixture.provider.accounts.secondary.createdNames).toHaveLength(1);
+
+    await runs.heartbeatRunner(fixture.provider.runnerGroup);
+    const primaryPush = await postWorkspaceEvent(primarySubscription);
+    expect(primaryPush.status).toBe(200);
+    await expect(primaryPush.json()).resolves.toMatchObject({
+      watchStates: 1,
+      dispatched: 1,
+    });
+    const primaryRunIds = new Set(
+      (
+        await runs.listAgentRuns(fixture.actor, {
+          agent: fixture.agentId,
+          limit: 20,
+        })
+      ).runs.map((run) => {
+        return run.id;
+      }),
+    );
+    const secondaryPush = await postWorkspaceEvent(secondarySubscription);
+    expect(secondaryPush.status).toBe(200);
+    await expect(secondaryPush.json()).resolves.toMatchObject({
+      watchStates: 1,
+      dispatched: 1,
+    });
+    const secondaryRunId = (
+      await runs.listAgentRuns(fixture.actor, {
+        agent: fixture.agentId,
+        limit: 20,
+      })
+    ).runs.find((run) => {
+      return !primaryRunIds.has(run.id);
+    })?.id;
+    if (!secondaryRunId) {
+      throw new Error("Expected a queued run for the secondary account");
+    }
+    const claim = await runs.claimRunnerJob(secondaryRunId);
+    expect(
+      Object.values(claim.secretConnectorMetadataMap ?? {}),
+    ).toContainEqual(
+      expect.objectContaining({ sourceId: secondaryConnectorId }),
+    );
+
+    await createMeetAutomation(fixture);
+    expect(fixture.provider.accounts.primary.createdNames).toHaveLength(1);
+    expect(fixture.provider.accounts.secondary.createdNames).toHaveLength(1);
+    expect(primary.body.chatThreadId).not.toBe(secondary.body.chatThreadId);
+  });
+
+  it("reconciles subscriptions when selection and default account change", async () => {
+    const fixture = await setupFixture();
+    const created = await createMeetAutomation(fixture);
+    if (!created.body.chatThreadId) {
+      throw new Error("Expected an automation chat thread");
+    }
+    const primarySubscription =
+      fixture.provider.accounts.primary.createdNames[0];
+    if (!primarySubscription) {
+      throw new Error("Expected a primary Google Meet subscription");
+    }
+    const secondaryConnectorId = await connectGoogleMeet(
+      fixture.actor,
+      fixture.provider,
+      "secondary",
+      fixture.agentId,
+      { intent: "add", displayName: "Secondary Google Meet" },
+    );
+
+    await accept(
+      chatThreadConnectorSelectionsClient().update({
+        headers: authHeaders(fixture.actor),
+        params: { id: created.body.chatThreadId },
+        body: {
+          connectionId: secondaryConnectorId,
+          target: { kind: "builtin", connectorSlug: "google-meet" },
+        },
+      }),
+      [200],
+    );
+    const firstSecondarySubscription =
+      fixture.provider.accounts.secondary.createdNames[0];
+    if (!firstSecondarySubscription) {
+      throw new Error("Expected a selected-account subscription");
+    }
+    expect(fixture.provider.accounts.primary.deletedUrls).toHaveLength(1);
+
+    const delayedPrimary = await postWorkspaceEvent(primarySubscription);
+    expect(delayedPrimary.status).toBe(200);
+    await expect(delayedPrimary.json()).resolves.toMatchObject({
+      watchStates: 0,
+      dispatched: 0,
+    });
+    const selectedPush = await postWorkspaceEvent(firstSecondarySubscription);
+    expect(selectedPush.status).toBe(200);
+    await expect(selectedPush.json()).resolves.toMatchObject({
+      watchStates: 1,
+      dispatched: 1,
+    });
+
+    await accept(
+      chatThreadConnectorSelectionsClient().clear({
+        headers: authHeaders(fixture.actor),
+        params: { id: created.body.chatThreadId },
+        body: { kind: "builtin", connectorSlug: "google-meet" },
+      }),
+      [204],
+    );
+    expect(fixture.provider.accounts.primary.createdNames).toHaveLength(2);
+    expect(fixture.provider.accounts.secondary.deletedUrls).toHaveLength(1);
+
+    await accept(
+      connectorAccountsClient().setDefault({
+        headers: authHeaders(fixture.actor),
+        params: { connectionId: secondaryConnectorId },
+        body: { target: { kind: "builtin", connectorSlug: "google-meet" } },
+      }),
+      [200],
+    );
+    expect(fixture.provider.accounts.primary.deletedUrls).toHaveLength(2);
+    expect(fixture.provider.accounts.secondary.createdNames).toHaveLength(2);
+  });
+
+  it("supersedes an old source that changes before queue admission", async () => {
+    const fixture = await setupFixture();
+    const created = await createMeetAutomation(fixture);
+    if (!created.body.chatThreadId) {
+      throw new Error("Expected an automation chat thread");
+    }
+    const primarySubscription =
+      fixture.provider.accounts.primary.createdNames[0];
+    if (!primarySubscription) {
+      throw new Error("Expected a primary Google Meet subscription");
+    }
+    const secondaryConnectorId = await connectGoogleMeet(
+      fixture.actor,
+      fixture.provider,
+      "secondary",
+      fixture.agentId,
+      { intent: "add", displayName: "Secondary Google Meet" },
+    );
+    const admissionLockRequest = holdOrgAdmissionLock(
+      context,
+      `chat_event_queue:${created.body.chatThreadId}`,
+    );
+    const cleanupRequests: Promise<unknown>[] = [admissionLockRequest];
+    onTestFinished(async () => {
+      const cleanupResults = await Promise.allSettled([
+        releaseOrgAdmissionLock(context),
+        ...cleanupRequests,
+      ]);
+      const cleanupFailure = cleanupResults.find((result) => {
+        return result.status === "rejected";
+      });
+      if (cleanupFailure?.status === "rejected") {
+        throw cleanupFailure.reason;
+      }
+    });
+    await expect
+      .poll(async () => {
+        return (await readOrgAdmissionLockState(context)).held;
+      })
+      .toBe(true);
+
+    const oldSourceRequest = postWorkspaceEvent(primarySubscription);
+    cleanupRequests.push(oldSourceRequest);
+    await expect
+      .poll(async () => {
+        return (await readOrgAdmissionLockState(context)).waiting;
+      })
+      .toBe(true);
+    await accept(
+      chatThreadConnectorSelectionsClient().update({
+        headers: authHeaders(fixture.actor),
+        params: { id: created.body.chatThreadId },
+        body: {
+          connectionId: secondaryConnectorId,
+          target: { kind: "builtin", connectorSlug: "google-meet" },
+        },
+      }),
+      [200],
+    );
+    await releaseOrgAdmissionLock(context);
+    await admissionLockRequest;
+
+    const oldSource = await oldSourceRequest;
+    expect(oldSource.status).toBe(200);
+    await expect(oldSource.json()).resolves.toStrictEqual({
+      success: true,
+      watchStates: 1,
+      dispatched: 0,
+      duplicates: 0,
+    });
+    const events = await workflows.readThreadEvents(created.body.chatThreadId);
+    expect(
+      events.filter((event) => {
+        return (
+          chatEventDisplayText(event) === "A Google Meet transcript is ready."
+        );
+      }),
+    ).toStrictEqual([]);
+
+    const secondarySubscription =
+      fixture.provider.accounts.secondary.createdNames[0];
+    if (!secondarySubscription) {
+      throw new Error("Expected a secondary Google Meet subscription");
+    }
+    const currentSource = await postWorkspaceEvent(secondarySubscription);
+    expect(currentSource.status).toBe(200);
+    await expect(currentSource.json()).resolves.toMatchObject({
+      watchStates: 1,
+      dispatched: 1,
+    });
+  });
+
+  it("reprojects a copied automation to the destination default account", async () => {
+    const fixture = await setupFixture();
+    const source = await createMeetAutomation(fixture);
+    if (!source.body.chatThreadId) {
+      throw new Error("Expected a source automation chat thread");
+    }
+    const secondaryConnectorId = await connectGoogleMeet(
+      fixture.actor,
+      fixture.provider,
+      "secondary",
+      fixture.agentId,
+      { intent: "add", displayName: "Secondary Google Meet" },
+    );
+    await accept(
+      chatThreadConnectorSelectionsClient().update({
+        headers: authHeaders(fixture.actor),
+        params: { id: source.body.chatThreadId },
+        body: {
+          connectionId: secondaryConnectorId,
+          target: { kind: "builtin", connectorSlug: "google-meet" },
+        },
+      }),
+      [200],
+    );
+    const sourceSubscription =
+      fixture.provider.accounts.secondary.createdNames[0];
+    if (!sourceSubscription) {
+      throw new Error("Expected a source-account subscription");
+    }
+
+    const targetAgent = await workflows.createAgent(fixture.actor, {
+      displayName: "Google Meet copy target agent",
+    });
+    const copied = await accept(
+      workflowDetailClient().copy({
+        headers: authHeaders(fixture.actor),
+        params: { workflowId: fixture.workflowId },
+        body: { toAgentId: targetAgent.agentId },
+      }),
+      [201],
+    );
+    const copiedAutomations = await accept(
+      automationsClient().list({
+        headers: authHeaders(fixture.actor),
+        params: { workflowId: copied.body.id },
+      }),
+      [200],
+    );
+    expect(copiedAutomations.body).toContainEqual(
+      expect.objectContaining({
+        kind: "event",
+        eventType: "google-meet-transcript-generated",
+        enabled: true,
+      }),
+    );
+    const copiedSubscription =
+      fixture.provider.accounts.primary.createdNames[1];
+    if (!copiedSubscription) {
+      throw new Error("Expected a destination-default subscription");
+    }
+    expect(fixture.provider.accounts.secondary.deletedUrls).toStrictEqual([]);
+
+    const sourcePush = await postWorkspaceEvent(sourceSubscription);
+    expect(sourcePush.status).toBe(200);
+    await expect(sourcePush.json()).resolves.toMatchObject({
+      watchStates: 1,
+      dispatched: 1,
+    });
+    const copiedPush = await postWorkspaceEvent(copiedSubscription);
+    expect(copiedPush.status).toBe(200);
+    await expect(copiedPush.json()).resolves.toMatchObject({
+      watchStates: 1,
+      dispatched: 1,
+    });
+  });
+
+  it("repairs a legacy null account projection before dispatch", async () => {
+    const fixture = await setupFixture();
+    const created = await createMeetAutomation(fixture);
+    const subscriptionName = fixture.provider.createdNames[0];
+    if (!subscriptionName) {
+      throw new Error("Expected a Workspace Events subscription");
+    }
+    await clearWorkflowAutomationEventConnectorAsPreviousApi(
+      context,
+      created.body.id,
+    );
+
+    const repairedPush = await postWorkspaceEvent(subscriptionName);
+    expect(repairedPush.status).toBe(200);
+    await expect(repairedPush.json()).resolves.toMatchObject({
+      watchStates: 1,
+      dispatched: 1,
+    });
+  });
+
+  it("retains the exact subscription after reconnecting the same account", async () => {
+    const fixture = await setupFixture();
+    await createMeetAutomation(fixture);
+    const originalSubscription =
+      fixture.provider.accounts.primary.createdNames[0];
+    if (!originalSubscription) {
+      throw new Error("Expected an original Google Meet subscription");
+    }
+
+    const reconnectedConnectorId = await connectGoogleMeet(
+      fixture.actor,
+      fixture.provider,
+      "primary",
+      fixture.agentId,
+      { intent: "reconnect", connectionId: fixture.connectorId },
+    );
+    expect(reconnectedConnectorId).toBe(fixture.connectorId);
+    expect(fixture.provider.accounts.primary.createdNames).toStrictEqual([
+      originalSubscription,
+    ]);
+
+    const reconnectedPush = await postWorkspaceEvent(originalSubscription);
+    expect(reconnectedPush.status).toBe(200);
+    await expect(reconnectedPush.json()).resolves.toMatchObject({
+      watchStates: 1,
+      dispatched: 1,
+    });
+  });
+
   it("fails closed and does not retry after provider delete failure", async () => {
     const fixture = await setupFixture({ deleteStatus: 503 });
     const created = await createMeetAutomation(fixture);
@@ -677,6 +1194,91 @@ describe("Google Workspace Events subscription lifecycle", () => {
     );
   });
 
+  it("promotes a sibling account and repairs after deleting and re-adding accounts", async () => {
+    const fixture = await setupFixture();
+    await createMeetAutomation(fixture);
+    const primarySubscription =
+      fixture.provider.accounts.primary.createdNames[0];
+    if (!primarySubscription) {
+      throw new Error("Expected a primary Google Meet subscription");
+    }
+    const secondaryConnectorId = await connectGoogleMeet(
+      fixture.actor,
+      fixture.provider,
+      "secondary",
+      fixture.agentId,
+      { intent: "add", displayName: "Secondary Google Meet" },
+    );
+
+    const deletedPrimary = await accept(
+      connectorAccountsClient().delete({
+        headers: authHeaders(fixture.actor),
+        params: { connectionId: fixture.connectorId },
+        body: { target: { kind: "builtin", connectorSlug: "google-meet" } },
+      }),
+      [200],
+    );
+    expect(deletedPrimary.body).toStrictEqual({
+      deletedConnectionId: fixture.connectorId,
+      resolvedSelectionCount: 0,
+      promotedDefaultConnectionId: secondaryConnectorId,
+    });
+    const secondarySubscription =
+      fixture.provider.accounts.secondary.createdNames[0];
+    if (!secondarySubscription) {
+      throw new Error("Expected a promoted-account subscription");
+    }
+    expect(fixture.provider.accounts.primary.deletedUrls).toHaveLength(1);
+
+    const delayedPrimary = await postWorkspaceEvent(primarySubscription);
+    expect(delayedPrimary.status).toBe(200);
+    await expect(delayedPrimary.json()).resolves.toMatchObject({
+      watchStates: 0,
+      dispatched: 0,
+    });
+    const promotedPush = await postWorkspaceEvent(secondarySubscription);
+    expect(promotedPush.status).toBe(200);
+    await expect(promotedPush.json()).resolves.toMatchObject({
+      watchStates: 1,
+      dispatched: 1,
+    });
+
+    const deletedLast = await accept(
+      connectorAccountsClient().delete({
+        headers: authHeaders(fixture.actor),
+        params: { connectionId: secondaryConnectorId },
+        body: { target: { kind: "builtin", connectorSlug: "google-meet" } },
+      }),
+      [200],
+    );
+    expect(deletedLast.body).toStrictEqual({
+      deletedConnectionId: secondaryConnectorId,
+      resolvedSelectionCount: 0,
+      promotedDefaultConnectionId: null,
+    });
+    expect(fixture.provider.accounts.secondary.deletedUrls).toHaveLength(1);
+
+    const readdedConnectorId = await connectGoogleMeet(
+      fixture.actor,
+      fixture.provider,
+      "primary",
+      fixture.agentId,
+    );
+    expect(readdedConnectorId).not.toBe(fixture.connectorId);
+    expect(fixture.provider.accounts.primary.createdNames).toHaveLength(2);
+    const readdedSubscription =
+      fixture.provider.accounts.primary.createdNames[1];
+    if (!readdedSubscription) {
+      throw new Error("Expected a re-added-account subscription");
+    }
+    const readdedPush = await postWorkspaceEvent(readdedSubscription);
+    expect(readdedPush.status).toBe(200);
+    await expect(readdedPush.json()).resolves.toMatchObject({
+      watchStates: 1,
+      dispatched: 1,
+    });
+  });
+
   it("serializes last-consumer cleanup with a concurrent enable", async () => {
     const deleteStarted = createDeferredPromise<void>(context.signal);
     const deleteRelease = createDeferredPromise<void>(context.signal);
@@ -704,21 +1306,18 @@ describe("Google Workspace Events subscription lifecycle", () => {
       params: { id: disabled.body.id },
     });
 
-    let enabledVisible = false;
-    for (let attempt = 0; attempt < 100 && !enabledVisible; attempt += 1) {
-      const listed = await accept(
-        automationsClient().list({
-          headers: authHeaders(fixture.actor),
-          params: { workflowId: fixture.workflowId },
-        }),
-        [200],
-      );
-      enabledVisible =
-        listed.body.find((automation) => {
-          return automation.id === disabled.body.id;
-        })?.enabled === true;
-    }
-    expect(enabledVisible).toBeTruthy();
+    const listed = await accept(
+      automationsClient().list({
+        headers: authHeaders(fixture.actor),
+        params: { workflowId: fixture.workflowId },
+      }),
+      [200],
+    );
+    expect(
+      listed.body.find((automation) => {
+        return automation.id === disabled.body.id;
+      })?.enabled,
+    ).toBeFalsy();
     expect(fixture.provider.createdNames).toHaveLength(1);
     deleteRelease.resolve();
 

--- a/turbo/apps/api/src/signals/routes/chat-threads-connector-selections.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-connector-selections.ts
@@ -18,6 +18,7 @@ import {
 import { userFeatureSwitchContext } from "../services/feature-switches.service";
 import { reconcileGmailWatchesForUser } from "../services/gmail-automation-event.service";
 import { reconcileGoogleFormsWatchesForUser } from "../services/google-forms-automation-event.service";
+import { reconcileGoogleMeetSubscriptionsForUser } from "../services/google-meet-automation-event.service";
 import type { RouteEntry } from "../route-entry";
 
 const connectorAccountsEnabled$ = computed(async (get) => {
@@ -86,7 +87,8 @@ const updateSelectionInner$ = command(
     if (
       body.data.target.kind === "builtin" &&
       (body.data.target.connectorSlug === "gmail" ||
-        body.data.target.connectorSlug === "google-forms")
+        body.data.target.connectorSlug === "google-forms" ||
+        body.data.target.connectorSlug === "google-meet")
     ) {
       await bestEffort(
         body.data.target.connectorSlug === "gmail"
@@ -94,10 +96,15 @@ const updateSelectionInner$ = command(
               { db: writeDb, orgId: auth.orgId, userId: auth.userId },
               signal,
             )
-          : reconcileGoogleFormsWatchesForUser(
-              { db: writeDb, orgId: auth.orgId, userId: auth.userId },
-              signal,
-            ),
+          : body.data.target.connectorSlug === "google-forms"
+            ? reconcileGoogleFormsWatchesForUser(
+                { db: writeDb, orgId: auth.orgId, userId: auth.userId },
+                signal,
+              )
+            : reconcileGoogleMeetSubscriptionsForUser(
+                { db: writeDb, orgId: auth.orgId, userId: auth.userId },
+                signal,
+              ),
         signal,
       );
     }
@@ -141,7 +148,8 @@ const clearSelectionInner$ = command(
     if (
       body.data.kind === "builtin" &&
       (body.data.connectorSlug === "gmail" ||
-        body.data.connectorSlug === "google-forms")
+        body.data.connectorSlug === "google-forms" ||
+        body.data.connectorSlug === "google-meet")
     ) {
       await bestEffort(
         body.data.connectorSlug === "gmail"
@@ -149,10 +157,15 @@ const clearSelectionInner$ = command(
               { db: writeDb, orgId: auth.orgId, userId: auth.userId },
               signal,
             )
-          : reconcileGoogleFormsWatchesForUser(
-              { db: writeDb, orgId: auth.orgId, userId: auth.userId },
-              signal,
-            ),
+          : body.data.connectorSlug === "google-forms"
+            ? reconcileGoogleFormsWatchesForUser(
+                { db: writeDb, orgId: auth.orgId, userId: auth.userId },
+                signal,
+              )
+            : reconcileGoogleMeetSubscriptionsForUser(
+                { db: writeDb, orgId: auth.orgId, userId: auth.userId },
+                signal,
+              ),
         signal,
       );
     }

--- a/turbo/apps/api/src/signals/routes/connector-accounts.ts
+++ b/turbo/apps/api/src/signals/routes/connector-accounts.ts
@@ -34,6 +34,7 @@ import {
 import { userFeatureSwitchContext } from "../services/feature-switches.service";
 import { reconcileGmailWatchesForUser } from "../services/gmail-automation-event.service";
 import { reconcileGoogleFormsWatchesForUser } from "../services/google-forms-automation-event.service";
+import { reconcileGoogleMeetSubscriptionsForUser } from "../services/google-meet-automation-event.service";
 
 const log = logger("api:connector-account-mutation");
 
@@ -243,7 +244,8 @@ const setDefaultInner$ = command(
     if (
       body.data.target.kind === "builtin" &&
       (body.data.target.connectorSlug === "gmail" ||
-        body.data.target.connectorSlug === "google-forms")
+        body.data.target.connectorSlug === "google-forms" ||
+        body.data.target.connectorSlug === "google-meet")
     ) {
       await bestEffort(
         body.data.target.connectorSlug === "gmail"
@@ -251,10 +253,15 @@ const setDefaultInner$ = command(
               { db: writeDb, orgId: auth.orgId, userId: auth.userId },
               signal,
             )
-          : reconcileGoogleFormsWatchesForUser(
-              { db: writeDb, orgId: auth.orgId, userId: auth.userId },
-              signal,
-            ),
+          : body.data.target.connectorSlug === "google-forms"
+            ? reconcileGoogleFormsWatchesForUser(
+                { db: writeDb, orgId: auth.orgId, userId: auth.userId },
+                signal,
+              )
+            : reconcileGoogleMeetSubscriptionsForUser(
+                { db: writeDb, orgId: auth.orgId, userId: auth.userId },
+                signal,
+              ),
         signal,
       );
     }

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -2325,6 +2325,16 @@ async function setOfficialWorkflowAutomationAdmissionStateActionResponse(
   const updated = await db
     .update(workflowAutomations)
     .set({
+      ...(body.blueprint_key === undefined
+        ? {}
+        : {
+            officialBlueprintKey: body.blueprint_key,
+            officialAppliedFingerprint:
+              body.applied_fingerprint ?? "0".repeat(64),
+            officialParameterBindings: [],
+            officialIntendedEnabled: true,
+            officialResultEmailEnabled: false,
+          }),
       officialReconciliationStatus: body.reconciliation_status,
       ...(body.applied_fingerprint
         ? { officialAppliedFingerprint: body.applied_fingerprint }

--- a/turbo/apps/api/src/signals/routes/workflows.ts
+++ b/turbo/apps/api/src/signals/routes/workflows.ts
@@ -80,6 +80,7 @@ import { reconcileGmailWatchesForUser } from "../services/gmail-automation-event
 import { lockConnectorAccountTarget } from "../services/auth-state-lock.service";
 import { reprojectWorkflowAutomationsForOwner } from "../services/workflow-automation-account-projection.service";
 import { reconcileGoogleFormsWatchesForUser } from "../services/google-forms-automation-event.service";
+import { reconcileGoogleMeetSubscriptionsForUser } from "../services/google-meet-automation-event.service";
 import {
   loadVisibleWorkflowById,
   requireWorkflowPermission,
@@ -1049,6 +1050,7 @@ async function copyWorkflowUserAutomations(
 ): Promise<{
   readonly hasGmailAutomations: boolean;
   readonly hasGoogleFormsAutomations: boolean;
+  readonly hasGoogleMeetAutomations: boolean;
   readonly hasStripeAutomations: boolean;
 }> {
   const rows =
@@ -1067,6 +1069,7 @@ async function copyWorkflowUserAutomations(
     return {
       hasGmailAutomations: false,
       hasGoogleFormsAutomations: false,
+      hasGoogleMeetAutomations: false,
       hasStripeAutomations: false,
     };
   }
@@ -1079,12 +1082,16 @@ async function copyWorkflowUserAutomations(
   const hasGoogleFormsAutomations = rows.some((automation) => {
     return automation.eventType === "google-forms-response-submitted";
   });
+  const hasGoogleMeetAutomations = rows.some((automation) => {
+    return automation.eventType === "google-meet-transcript-generated";
+  });
   const hasStripeAutomations = rows.some((automation) => {
     return automation.eventType === "stripe-invoice-paid";
   });
   const accountTargets = [
     ...(hasGmailAutomations ? (["gmail"] as const) : []),
     ...(hasGoogleFormsAutomations ? (["google-forms"] as const) : []),
+    ...(hasGoogleMeetAutomations ? (["google-meet"] as const) : []),
     ...(hasStripeAutomations ? (["stripe"] as const) : []),
   ].sort();
   for (const connectorSlug of accountTargets) {
@@ -1109,6 +1116,7 @@ async function copyWorkflowUserAutomations(
   return {
     hasGmailAutomations,
     hasGoogleFormsAutomations,
+    hasGoogleMeetAutomations,
     hasStripeAutomations,
   };
 }
@@ -1121,6 +1129,7 @@ async function copyWorkflowRuntimeConfiguration(
       readonly workflow: { readonly id: string };
       readonly hasGmailAutomations: boolean;
       readonly hasGoogleFormsAutomations: boolean;
+      readonly hasGoogleMeetAutomations: boolean;
       readonly hasStripeAutomations: boolean;
     }
   | undefined
@@ -1158,6 +1167,7 @@ type CopyWorkflowDatabaseResult =
       readonly inserted: { readonly id: string };
       readonly hasGmailAutomations: boolean;
       readonly hasGoogleFormsAutomations: boolean;
+      readonly hasGoogleMeetAutomations: boolean;
       readonly hasStripeAutomations: boolean;
     };
 
@@ -1226,6 +1236,7 @@ async function copyWorkflowDatabaseRows(
       ...(inserted.hasGoogleFormsAutomations
         ? (["google-forms"] as const)
         : []),
+      ...(inserted.hasGoogleMeetAutomations ? (["google-meet"] as const) : []),
       ...(inserted.hasStripeAutomations ? (["stripe"] as const) : []),
     ].sort();
     for (const connectorSlug of accountTargets) {
@@ -1249,6 +1260,7 @@ async function copyWorkflowDatabaseRows(
       inserted: inserted.workflow,
       hasGmailAutomations: inserted.hasGmailAutomations,
       hasGoogleFormsAutomations: inserted.hasGoogleFormsAutomations,
+      hasGoogleMeetAutomations: inserted.hasGoogleMeetAutomations,
       hasStripeAutomations: inserted.hasStripeAutomations,
     };
   });
@@ -1273,6 +1285,30 @@ function copiedWorkflowVolumeFiles(
       return { path: file.path, content: file.content };
     });
   return [{ path: "SKILL.md", content: skillMd }, ...attachedFiles];
+}
+
+async function reconcileCopiedWorkflowAutomationWatches(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly copied: Extract<CopyWorkflowDatabaseResult, { kind: "ok" }>;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  const owner = { db: args.db, orgId: args.orgId, userId: args.userId };
+  if (args.copied.hasGmailAutomations) {
+    await bestEffort(reconcileGmailWatchesForUser(owner, signal), signal);
+  }
+  if (args.copied.hasGoogleFormsAutomations) {
+    await bestEffort(reconcileGoogleFormsWatchesForUser(owner, signal), signal);
+  }
+  if (args.copied.hasGoogleMeetAutomations) {
+    await bestEffort(
+      reconcileGoogleMeetSubscriptionsForUser(owner, signal),
+      signal,
+    );
+  }
 }
 
 const publishCopiedWorkflow$ = command(
@@ -1357,24 +1393,15 @@ const publishCopiedWorkflow$ = command(
           );
           return conflict(copied.message);
         }
-        if (copied.hasGmailAutomations) {
-          await bestEffort(
-            reconcileGmailWatchesForUser(
-              { db: args.db, orgId: args.orgId, userId: args.userId },
-              signal,
-            ),
-            signal,
-          );
-        }
-        if (copied.hasGoogleFormsAutomations) {
-          await bestEffort(
-            reconcileGoogleFormsWatchesForUser(
-              { db: args.db, orgId: args.orgId, userId: args.userId },
-              signal,
-            ),
-            signal,
-          );
-        }
+        await reconcileCopiedWorkflowAutomationWatches(
+          {
+            db: args.db,
+            orgId: args.orgId,
+            userId: args.userId,
+            copied,
+          },
+          signal,
+        );
 
         const visible = await loadVisibleWorkflowById(args.db, {
           orgId: args.orgId,

--- a/turbo/apps/api/src/signals/services/automation-event-watch-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/automation-event-watch-lifecycle.service.ts
@@ -57,6 +57,7 @@ type AutomationEventWatchTarget =
       readonly provider: "google_meet";
       readonly orgId: string;
       readonly userId: string;
+      readonly connectorId: string;
     };
 
 function googleCalendarId(
@@ -117,10 +118,14 @@ function automationEventWatchTarget(
     };
   }
   if (automation.eventType === "google-meet-transcript-generated") {
+    if (automation.eventConnectorId === null) {
+      return null;
+    }
     return {
       provider: "google_meet",
       orgId: automation.orgId,
       userId: automation.ownerUserId,
+      connectorId: automation.eventConnectorId,
     };
   }
   const calendarId = googleCalendarId(automation);
@@ -143,7 +148,7 @@ function targetKey(target: AutomationEventWatchTarget): string {
     return `google_forms:${target.orgId}:${target.userId}`;
   }
   if (target.provider === "google_meet") {
-    return `google_meet:${target.orgId}:${target.userId}`;
+    return `google_meet:${target.orgId}:${target.userId}:${target.connectorId}`;
   }
   return `google_calendar:${target.orgId}:${target.userId}:${target.calendarId}`;
 }
@@ -299,6 +304,7 @@ async function ensureNonFormsTarget(
         db,
         orgId: target.orgId,
         userId: target.userId,
+        connectorId: target.connectorId,
         allowStagedOfficialTarget,
       },
       signal,

--- a/turbo/apps/api/src/signals/services/connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-data.service.ts
@@ -95,6 +95,7 @@ import {
 import {
   deletePreparedGoogleMeetSubscriptionWithLifecycleLock,
   prepareGoogleMeetSubscriptionDeleteForConnector,
+  reconcileGoogleMeetSubscriptionsForUser,
   type PendingGoogleMeetSubscriptionDelete,
 } from "./google-meet-automation-event.service";
 import { reconcileConnectorAccountState } from "./connector-account-state.service";
@@ -999,6 +1000,11 @@ async function reconcileAccountBoundAutomationWatches(
       reconcileGoogleFormsWatchesForUser({ db, ...args }, signal),
       signal,
     );
+  } else if (args.connectorSlug === "google-meet") {
+    await bestEffort(
+      reconcileGoogleMeetSubscriptionsForUser({ db, ...args }, signal),
+      signal,
+    );
   }
 }
 
@@ -1383,6 +1389,15 @@ export const deleteConnectorLocalState$ = command(
     if (args.connectorSlug === "google-forms") {
       await bestEffort(
         reconcileGoogleFormsWatchesForUser(
+          { db: writeDb, orgId: args.orgId, userId: args.userId },
+          signal,
+        ),
+        signal,
+      );
+    }
+    if (args.connectorSlug === "google-meet") {
+      await bestEffort(
+        reconcileGoogleMeetSubscriptionsForUser(
           { db: writeDb, orgId: args.orgId, userId: args.userId },
           signal,
         ),

--- a/turbo/apps/api/src/signals/services/google-meet-automation-account.service.ts
+++ b/turbo/apps/api/src/signals/services/google-meet-automation-account.service.ts
@@ -1,0 +1,57 @@
+import { workflowAutomations } from "@okouai/db/schema/workflow";
+import { and, eq } from "drizzle-orm";
+
+import type { Db, ReadonlyDb } from "../external/db";
+import { resolveWorkflowAutomationConnectorId } from "./workflow-automation-account.service";
+
+export async function resolveGoogleMeetAutomationConnectorId(
+  db: ReadonlyDb,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly workflowId: string;
+  },
+): Promise<string | null> {
+  return await resolveWorkflowAutomationConnectorId(db, {
+    ...args,
+    connectorSlug: "google-meet",
+  });
+}
+
+export async function reprojectGoogleMeetAutomationsForOwner(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+  },
+): Promise<void> {
+  const automations = await db
+    .select({
+      id: workflowAutomations.id,
+      workflowId: workflowAutomations.workflowId,
+      eventConnectorId: workflowAutomations.eventConnectorId,
+    })
+    .from(workflowAutomations)
+    .where(
+      and(
+        eq(workflowAutomations.orgId, args.orgId),
+        eq(workflowAutomations.ownerUserId, args.userId),
+        eq(workflowAutomations.kind, "event"),
+        eq(workflowAutomations.eventType, "google-meet-transcript-generated"),
+      ),
+    );
+
+  for (const automation of automations) {
+    const eventConnectorId = await resolveGoogleMeetAutomationConnectorId(db, {
+      ...args,
+      workflowId: automation.workflowId,
+    });
+    if (automation.eventConnectorId === eventConnectorId) {
+      continue;
+    }
+    await db
+      .update(workflowAutomations)
+      .set({ eventConnectorId })
+      .where(eq(workflowAutomations.id, automation.id));
+  }
+}

--- a/turbo/apps/api/src/signals/services/google-meet-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-meet-automation-event.service.ts
@@ -1217,7 +1217,17 @@ async function loadGoogleMeetConnectorInventory(
         and(
           eq(workflowAutomations.orgId, args.orgId),
           eq(workflowAutomations.ownerUserId, args.userId),
-          eq(workflowAutomations.enabled, true),
+          or(
+            eq(workflowAutomations.enabled, true),
+            and(
+              eq(workflowAutomations.enabled, false),
+              eq(
+                workflowAutomations.officialReconciliationStatus,
+                "reconciling",
+              ),
+              isNotNull(workflowAutomations.officialBlueprintKey),
+            ),
+          ),
           eq(workflowAutomations.kind, "event"),
           eq(
             workflowAutomations.eventType,
@@ -1279,7 +1289,7 @@ async function reconcileGoogleMeetSubscriptionInventory(
   for (const connectorId of connectorIds) {
     results.push(
       await reconcileGoogleMeetSubscriptionLifecycle(
-        { ...args, connectorId },
+        { ...args, connectorId, allowStagedOfficialTarget: true },
         signal,
       ),
     );

--- a/turbo/apps/api/src/signals/services/google-meet-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-meet-automation-event.service.ts
@@ -19,6 +19,7 @@ import { nowDate } from "../../lib/time";
 import {
   bestEffort,
   safeJsonParse,
+  settle,
   settleIncludingAbort,
   tapError,
 } from "../utils";
@@ -40,6 +41,8 @@ import type { AutomationRow } from "./workflow-automation-launch.service";
 import type { WorkflowAutomationContext } from "./workflow-automation-context.service";
 import { ensureWorkflowUserAutomationThread } from "./workflow-user-automation-thread.service";
 import { lockConnectorState } from "./auth-state-lock.service";
+import { reprojectGoogleMeetAutomationsForOwner } from "./google-meet-automation-account.service";
+import type { WorkflowQueueAdmissionTransaction } from "./workflow-chat-event-queue.service";
 
 const GOOGLE_MEET_ACCESS_TOKEN_ENVIRONMENT_NAME = "GOOGLE_MEET_TOKEN";
 const GOOGLE_WORKSPACE_EVENTS_API_BASE =
@@ -832,6 +835,7 @@ async function ensureGoogleMeetTranscriptGeneratedSubscriptionUnderLock(
     readonly db: Db;
     readonly orgId: string;
     readonly userId: string;
+    readonly connectorId: string;
   },
   signal: AbortSignal,
 ): Promise<
@@ -957,6 +961,7 @@ export async function hasEnabledGoogleMeetConsumer(
     readonly db: Db;
     readonly orgId: string;
     readonly userId: string;
+    readonly connectorId: string;
     readonly allowStagedOfficialTarget?: boolean;
   },
   signal: AbortSignal,
@@ -983,6 +988,7 @@ export async function hasEnabledGoogleMeetConsumer(
           workflowAutomations.eventType,
           GOOGLE_MEET_TRANSCRIPT_GENERATED_EVENT_TYPE,
         ),
+        eq(workflowAutomations.eventConnectorId, args.connectorId),
         consumerState,
       ),
     )
@@ -996,6 +1002,7 @@ async function loadGoogleMeetSubscriptionStatesForOwner(
     readonly db: Db;
     readonly orgId: string;
     readonly userId: string;
+    readonly connectorId?: string;
   },
   signal: AbortSignal,
 ): Promise<GoogleWorkspaceSubscriptionStateRow[]> {
@@ -1007,6 +1014,12 @@ async function loadGoogleMeetSubscriptionStatesForOwner(
         eq(googleWorkspaceEventSubscriptionStates.orgId, args.orgId),
         eq(googleWorkspaceEventSubscriptionStates.userId, args.userId),
         eq(googleWorkspaceEventSubscriptionStates.provider, "google-meet"),
+        args.connectorId === undefined
+          ? undefined
+          : eq(
+              googleWorkspaceEventSubscriptionStates.connectorId,
+              args.connectorId,
+            ),
       ),
     );
   signal.throwIfAborted();
@@ -1079,6 +1092,7 @@ async function reconcileGoogleMeetSubscriptionLifecycle(
     readonly db: Db;
     readonly orgId: string;
     readonly userId: string;
+    readonly connectorId: string;
     readonly allowStagedOfficialTarget?: boolean;
   },
   signal: AbortSignal,
@@ -1095,6 +1109,7 @@ async function reconcileGoogleMeetSubscriptionLifecycle(
         db: tx,
         orgId: args.orgId,
         userId: args.userId,
+        connectorId: args.connectorId,
         allowStagedOfficialTarget: args.allowStagedOfficialTarget === true,
       },
       signal,
@@ -1106,6 +1121,7 @@ async function reconcileGoogleMeetSubscriptionLifecycle(
             db: tx,
             orgId: args.orgId,
             userId: args.userId,
+            connectorId: args.connectorId,
           },
           signal,
         ),
@@ -1114,7 +1130,12 @@ async function reconcileGoogleMeetSubscriptionLifecycle(
     }
 
     const states = await loadGoogleMeetSubscriptionStatesForOwner(
-      { db: tx, orgId: args.orgId, userId: args.userId },
+      {
+        db: tx,
+        orgId: args.orgId,
+        userId: args.userId,
+        connectorId: args.connectorId,
+      },
       signal,
     );
     const state = googleMeetSubscriptionStateForCleanup(states);
@@ -1139,6 +1160,10 @@ async function reconcileGoogleMeetSubscriptionLifecycle(
         and(
           eq(googleWorkspaceEventSubscriptionStates.orgId, args.orgId),
           eq(googleWorkspaceEventSubscriptionStates.userId, args.userId),
+          eq(
+            googleWorkspaceEventSubscriptionStates.connectorId,
+            args.connectorId,
+          ),
           eq(googleWorkspaceEventSubscriptionStates.provider, "google-meet"),
         ),
       );
@@ -1161,11 +1186,106 @@ export async function ensureGoogleMeetTranscriptGeneratedSubscriptionForUser(
     readonly db: Db;
     readonly orgId: string;
     readonly userId: string;
+    readonly connectorId: string;
     readonly allowStagedOfficialTarget?: boolean;
   },
   signal: AbortSignal,
 ): Promise<GoogleMeetSubscriptionReconcileResult> {
   return await reconcileGoogleMeetSubscriptionLifecycle(args, signal);
+}
+
+async function loadGoogleMeetConnectorInventory(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+  signal: AbortSignal,
+): Promise<Set<string>> {
+  return await args.db.transaction(async (tx) => {
+    await lockConnectorState(tx, {
+      orgId: args.orgId,
+      userId: args.userId,
+      connectorSlug: "google-meet",
+    });
+    await reprojectGoogleMeetAutomationsForOwner(tx, args);
+    signal.throwIfAborted();
+    const automationRows = await tx
+      .selectDistinct({ connectorId: workflowAutomations.eventConnectorId })
+      .from(workflowAutomations)
+      .where(
+        and(
+          eq(workflowAutomations.orgId, args.orgId),
+          eq(workflowAutomations.ownerUserId, args.userId),
+          eq(workflowAutomations.enabled, true),
+          eq(workflowAutomations.kind, "event"),
+          eq(
+            workflowAutomations.eventType,
+            GOOGLE_MEET_TRANSCRIPT_GENERATED_EVENT_TYPE,
+          ),
+          isNotNull(workflowAutomations.eventConnectorId),
+        ),
+      );
+    const states = await tx
+      .select({
+        connectorId: googleWorkspaceEventSubscriptionStates.connectorId,
+      })
+      .from(googleWorkspaceEventSubscriptionStates)
+      .where(
+        and(
+          eq(googleWorkspaceEventSubscriptionStates.orgId, args.orgId),
+          eq(googleWorkspaceEventSubscriptionStates.userId, args.userId),
+          eq(googleWorkspaceEventSubscriptionStates.provider, "google-meet"),
+        ),
+      );
+    signal.throwIfAborted();
+    return new Set(
+      [...automationRows, ...states].flatMap((row) => {
+        return row.connectorId === null ? [] : [row.connectorId];
+      }),
+    );
+  });
+}
+
+async function repairGoogleMeetAutomationAccountProjectionsForOwner(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    await lockConnectorState(tx, {
+      orgId: args.orgId,
+      userId: args.userId,
+      connectorSlug: "google-meet",
+    });
+    await reprojectGoogleMeetAutomationsForOwner(tx, args);
+    signal.throwIfAborted();
+  });
+}
+
+async function reconcileGoogleMeetSubscriptionInventory(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+  signal: AbortSignal,
+): Promise<GoogleMeetSubscriptionReconcileResult[]> {
+  const connectorIds = await loadGoogleMeetConnectorInventory(args, signal);
+  const results: GoogleMeetSubscriptionReconcileResult[] = [];
+  for (const connectorId of connectorIds) {
+    results.push(
+      await reconcileGoogleMeetSubscriptionLifecycle(
+        { ...args, connectorId },
+        signal,
+      ),
+    );
+    signal.throwIfAborted();
+  }
+  return results;
 }
 
 export async function reconcileGoogleMeetSubscriptionsForUser(
@@ -1176,8 +1296,10 @@ export async function reconcileGoogleMeetSubscriptionsForUser(
   },
   signal: AbortSignal,
 ): Promise<boolean> {
-  const result = await reconcileGoogleMeetSubscriptionLifecycle(args, signal);
-  return result.kind === "ok";
+  const results = await reconcileGoogleMeetSubscriptionInventory(args, signal);
+  return results.every((result) => {
+    return result.kind === "ok";
+  });
 }
 
 async function defaultPubSubOidcVerifier(
@@ -1538,6 +1660,7 @@ async function loadGoogleMeetEventAutomations(
           workflowAutomations.eventType,
           GOOGLE_MEET_TRANSCRIPT_GENERATED_EVENT_TYPE,
         ),
+        eq(workflowAutomations.eventConnectorId, args.state.connectorId),
       ),
     );
   signal.throwIfAborted();
@@ -1636,6 +1759,76 @@ function googleMeetTriggerContext(args: {
   };
 }
 
+class GoogleMeetAutomationSourceChangedError extends Error {
+  constructor() {
+    super(
+      "Google Meet automation source changed before durable queue admission",
+    );
+    this.name = "GoogleMeetAutomationSourceChangedError";
+  }
+}
+
+async function persistCurrentGoogleMeetAutomationSource(
+  tx: WorkflowQueueAdmissionTransaction,
+  args: {
+    readonly automationId: string;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly connectorSourceId: string;
+    readonly subscriptionStateId: string;
+    readonly subscriptionName: string;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  await lockConnectorState(tx, {
+    orgId: args.orgId,
+    userId: args.userId,
+    connectorSlug: "google-meet",
+  });
+  const [currentState] = await tx
+    .select({ id: googleWorkspaceEventSubscriptionStates.id })
+    .from(googleWorkspaceEventSubscriptionStates)
+    .where(
+      and(
+        eq(googleWorkspaceEventSubscriptionStates.id, args.subscriptionStateId),
+        eq(
+          googleWorkspaceEventSubscriptionStates.subscriptionName,
+          args.subscriptionName,
+        ),
+        eq(
+          googleWorkspaceEventSubscriptionStates.connectorId,
+          args.connectorSourceId,
+        ),
+        eq(googleWorkspaceEventSubscriptionStates.provider, "google-meet"),
+      ),
+    )
+    .for("key share")
+    .limit(1);
+  const [currentAutomation] = await tx
+    .select({ id: workflowAutomations.id })
+    .from(workflowAutomations)
+    .where(
+      and(
+        eq(workflowAutomations.id, args.automationId),
+        eq(workflowAutomations.orgId, args.orgId),
+        eq(workflowAutomations.ownerUserId, args.userId),
+        eq(workflowAutomations.enabled, true),
+        eq(workflowAutomations.kind, "event"),
+        eq(
+          workflowAutomations.eventType,
+          GOOGLE_MEET_TRANSCRIPT_GENERATED_EVENT_TYPE,
+        ),
+        eq(workflowAutomations.eventConnectorId, args.connectorSourceId),
+      ),
+    )
+    .for("update")
+    .limit(1);
+  signal.throwIfAborted();
+  if (!currentState || !currentAutomation) {
+    throw new GoogleMeetAutomationSourceChangedError();
+  }
+}
+
 async function dispatchGoogleMeetTranscriptEventForState(
   args: {
     readonly db: Db;
@@ -1646,7 +1839,7 @@ async function dispatchGoogleMeetTranscriptEventForState(
       readonly automation: GoogleMeetEventAutomationRow;
       readonly event: GoogleMeetTranscriptEventContext;
       readonly timing: AutomationEventRunTiming;
-    }) => Promise<"ok" | "error">;
+    }) => Promise<"ok" | "error" | "superseded">;
     readonly sourceTiming: AutomationEventSourceTiming;
   },
   signal: AbortSignal,
@@ -1701,6 +1894,13 @@ async function dispatchGoogleMeetTranscriptEventForState(
       timing: runTiming,
     });
     signal.throwIfAborted();
+    if (started === "superseded") {
+      await args.db
+        .delete(googleWorkspaceProcessedEvents)
+        .where(eq(googleWorkspaceProcessedEvents.id, processedId));
+      signal.throwIfAborted();
+      continue;
+    }
     if (started !== "ok") {
       await args.db
         .delete(googleWorkspaceProcessedEvents)
@@ -1717,6 +1917,67 @@ async function dispatchGoogleMeetTranscriptEventForState(
   return { kind: "ok", dispatched, duplicates };
 }
 
+async function authenticateAndDecodeGoogleWorkspacePush(
+  args: {
+    readonly authorization: string | null;
+    readonly rawBody: string;
+  },
+  signal: AbortSignal,
+): Promise<DecodedWorkspacePubSubPush | GoogleWorkspaceWebhookResult> {
+  const auth = await verifyGoogleWorkspacePubSubOidc(
+    { authorization: args.authorization },
+    signal,
+  );
+  signal.throwIfAborted();
+  if (auth.kind !== "ok") {
+    return auth;
+  }
+  return decodeWorkspacePubSubPush(args.rawBody);
+}
+
+async function loadCurrentGoogleMeetSubscriptionState(
+  args: {
+    readonly db: Db;
+    readonly subscriptionName: string;
+    readonly sourceTiming: AutomationEventSourceTiming;
+  },
+  signal: AbortSignal,
+): Promise<GoogleWorkspaceSubscriptionStateRow | null> {
+  const state = await args.sourceTiming.measure(
+    "api_dispatch_pre_create_zero_automation_event_load_source_state",
+    async () => {
+      return await loadWorkspaceSubscriptionStateByName(
+        { db: args.db, subscriptionName: args.subscriptionName },
+        signal,
+      );
+    },
+  );
+  signal.throwIfAborted();
+  if (!state || state.provider !== "google-meet") {
+    return null;
+  }
+  await repairGoogleMeetAutomationAccountProjectionsForOwner(
+    args.db,
+    { orgId: state.orgId, userId: state.userId },
+    signal,
+  );
+  signal.throwIfAborted();
+  return state;
+}
+
+function completedGoogleMeetWebhookResult(
+  result: Awaited<ReturnType<typeof dispatchGoogleMeetTranscriptEventForState>>,
+): GoogleWorkspaceWebhookResult {
+  return result.kind === "ok"
+    ? {
+        kind: "ok",
+        watchStates: 1,
+        dispatched: result.dispatched,
+        duplicates: result.duplicates,
+      }
+    : result;
+}
+
 export const dispatchGoogleWorkspaceEventsPubSubPush$ = command(
   async (
     { set },
@@ -1727,18 +1988,10 @@ export const dispatchGoogleWorkspaceEventsPubSubPush$ = command(
     },
     signal: AbortSignal,
   ): Promise<GoogleWorkspaceWebhookResult> => {
-    const auth = await verifyGoogleWorkspacePubSubOidc(
-      {
-        authorization: args.authorization,
-      },
+    const decoded = await authenticateAndDecodeGoogleWorkspacePush(
+      args,
       signal,
     );
-    signal.throwIfAborted();
-    if (auth.kind !== "ok") {
-      return auth;
-    }
-
-    const decoded = decodeWorkspacePubSubPush(args.rawBody);
     if ("kind" in decoded) {
       return decoded;
     }
@@ -1765,20 +2018,15 @@ export const dispatchGoogleWorkspaceEventsPubSubPush$ = command(
       "google_meet",
       args.apiStartTime,
     );
-    const state = await sourceTiming.measure(
-      "api_dispatch_pre_create_zero_automation_event_load_source_state",
-      async () => {
-        return await loadWorkspaceSubscriptionStateByName(
-          {
-            db,
-            subscriptionName: event.context.subscriptionName,
-          },
-          signal,
-        );
+    const state = await loadCurrentGoogleMeetSubscriptionState(
+      {
+        db,
+        subscriptionName: event.context.subscriptionName,
+        sourceTiming,
       },
+      signal,
     );
-    signal.throwIfAborted();
-    if (!state || state.provider !== "google-meet") {
+    if (!state) {
       return { kind: "ok", watchStates: 0, dispatched: 0, duplicates: 0 };
     }
 
@@ -1804,42 +2052,59 @@ export const dispatchGoogleWorkspaceEventsPubSubPush$ = command(
               };
             },
           );
-          const result = await set(
-            runWorkflowAutomationNow$,
-            {
-              due: {
-                automation: automation.automation,
-                agentId: automation.agentId,
-                chatThreadId: automation.chatThreadId,
+          const started = await settle(
+            set(
+              runWorkflowAutomationNow$,
+              {
+                due: {
+                  automation: automation.automation,
+                  agentId: automation.agentId,
+                  chatThreadId: automation.chatThreadId,
+                },
+                automationContext: runInput.context,
+                connectorSourceId: state.connectorId,
+                apiStartTime: args.apiStartTime,
+                triggerSource: "automation-event",
+                triggerBrief: runInput.triggerBrief,
+                persistSourceTransition: async (tx) => {
+                  await persistCurrentGoogleMeetAutomationSource(
+                    tx,
+                    {
+                      automationId: automation.automation.id,
+                      orgId: automation.automation.orgId,
+                      userId: automation.automation.ownerUserId,
+                      connectorSourceId: state.connectorId,
+                      subscriptionStateId: state.id,
+                      subscriptionName: state.subscriptionName,
+                    },
+                    signal,
+                  );
+                },
+                dispatchFailedCallbacks: dispatchFailedRunCallbacks,
+                timing: timing.collectorForRunStart(),
               },
-              automationContext: runInput.context,
-              connectorSourceId: state.connectorId,
-              apiStartTime: args.apiStartTime,
-              triggerSource: "automation-event",
-              triggerBrief: runInput.triggerBrief,
-              dispatchFailedCallbacks: dispatchFailedRunCallbacks,
-              timing: timing.collectorForRunStart(),
-            },
+              signal,
+            ),
             signal,
           );
           signal.throwIfAborted();
-          return result.kind === "ok" || result.kind === "enqueued"
+          if (!started.ok) {
+            if (
+              started.error instanceof GoogleMeetAutomationSourceChangedError
+            ) {
+              return "superseded";
+            }
+            throw started.error;
+          }
+          return started.value.kind === "ok" ||
+            started.value.kind === "enqueued"
             ? "ok"
             : "error";
         },
       },
       signal,
     );
-    if (result.kind !== "ok") {
-      return result;
-    }
-
-    return {
-      kind: "ok",
-      watchStates: 1,
-      dispatched: result.dispatched,
-      duplicates: result.duplicates,
-    };
+    return completedGoogleMeetWebhookResult(result);
   },
 );
 
@@ -1865,21 +2130,19 @@ async function renewGoogleMeetSubscriptionScopes(
   let repaired = 0;
   let failed = 0;
   for (const scope of args.scopes) {
-    const result = await reconcileGoogleMeetSubscriptionLifecycle(
-      {
-        db: args.db,
-        orgId: scope.orgId,
-        userId: scope.userId,
-      },
+    const results = await reconcileGoogleMeetSubscriptionInventory(
+      { db: args.db, orgId: scope.orgId, userId: scope.userId },
       signal,
     );
     signal.throwIfAborted();
-    if (result.kind !== "ok") {
-      failed++;
-      continue;
+    for (const result of results) {
+      if (result.kind !== "ok") {
+        failed++;
+        continue;
+      }
+      renewed += result.action === "renewed" ? 1 : 0;
+      repaired += result.action === "created" ? 1 : 0;
     }
-    renewed += result.action === "renewed" ? 1 : 0;
-    repaired += result.action === "created" ? 1 : 0;
   }
   return { renewed, repaired, failed };
 }

--- a/turbo/apps/api/src/signals/services/workflow-automation-account-projection.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation-account-projection.service.ts
@@ -3,6 +3,7 @@ import type { ConnectorAccountTarget } from "@okouai/api-contracts/contracts/con
 import type { Db } from "../external/db";
 import { reprojectGmailAutomationsForOwner } from "./gmail-automation-account.service";
 import { reprojectGoogleFormsAutomationsForOwner } from "./google-forms-automation-account.service";
+import { reprojectGoogleMeetAutomationsForOwner } from "./google-meet-automation-account.service";
 import { reprojectNotionAutomationsForOwner } from "./notion-automation-account.service";
 import { reprojectStripeInvoicePaidAutomationsForOwner } from "./stripe-invoice-paid-workflow-automation.service";
 
@@ -30,6 +31,11 @@ export async function reprojectWorkflowAutomationsForOwner(
   }
   if (args.target.connectorSlug === "google-forms") {
     await reprojectGoogleFormsAutomationsForOwner(db, args);
+    signal.throwIfAborted();
+    return;
+  }
+  if (args.target.connectorSlug === "google-meet") {
+    await reprojectGoogleMeetAutomationsForOwner(db, args);
     signal.throwIfAborted();
     return;
   }

--- a/turbo/apps/api/src/signals/services/workflow-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation.service.ts
@@ -115,6 +115,7 @@ import {
   prepareGoogleFormsResponseEventConfigForPersist,
 } from "./google-forms-automation-event.service";
 import { resolveGoogleFormsAutomationConnectorId } from "./google-forms-automation-account.service";
+import { resolveGoogleMeetAutomationConnectorId } from "./google-meet-automation-account.service";
 import {
   ensureGoogleMeetTranscriptGeneratedSubscriptionForUser,
   hasEnabledGoogleMeetConsumer,
@@ -1684,7 +1685,9 @@ async function insertEventAutomation(
         ? "notion"
         : automationCreateInputIsGoogleForms(args.input)
           ? "google-forms"
-          : null;
+          : automationCreateInputIsGoogleMeet(args.input)
+            ? "google-meet"
+            : null;
     if (connectorSlug !== null) {
       await lockConnectorAccountTarget(tx, {
         orgId: args.input.orgId,
@@ -1703,7 +1706,9 @@ async function insertEventAutomation(
         ? await resolveNotionAutomationConnectorId(tx, connectorArgs)
         : automationCreateInputIsGoogleForms(args.input)
           ? await resolveGoogleFormsAutomationConnectorId(tx, connectorArgs)
-          : null;
+          : automationCreateInputIsGoogleMeet(args.input)
+            ? await resolveGoogleMeetAutomationConnectorId(tx, connectorArgs)
+            : null;
     if (
       args.expectedEventConnectorId !== undefined &&
       eventConnectorId !== args.expectedEventConnectorId
@@ -2463,6 +2468,22 @@ async function createGoogleMeetEventAutomationForWorkflow(
   const preparedConfig = googleMeetTranscriptGeneratedEventConfigSchema.parse(
     args.input.eventConfig,
   );
+  const connectorId = await resolveGoogleMeetAutomationConnectorId(
+    args.context.db,
+    {
+      orgId: args.input.orgId,
+      userId: args.input.member.userId,
+      workflowId: args.context.workflowId,
+    },
+  );
+  signal.throwIfAborted();
+  if (args.input.enabled && connectorId === null) {
+    return {
+      kind: "bad-request",
+      message:
+        "Connect Google Meet before adding a Google Meet event automation",
+    };
+  }
   const summary = await insertEventAutomation(args.context.db, {
     input: { ...args.input, eventConfig: preparedConfig },
     workflowId: args.context.workflowId,
@@ -2470,9 +2491,21 @@ async function createGoogleMeetEventAutomationForWorkflow(
     workflowTitle: args.context.workflowTitle,
     automationId: args.context.automationId,
     currentTime: nowDate(),
+    ...(args.input.enabled && connectorId !== null
+      ? { expectedEventConnectorId: connectorId }
+      : {}),
   });
+  if (summary === null) {
+    return {
+      kind: "bad-request",
+      message: "Google Meet account selection changed; retry the request",
+    };
+  }
   if (!args.input.enabled) {
     return { kind: "ok", summary };
+  }
+  if (connectorId === null) {
+    throw new Error("Enabled Google Meet automation lost account projection");
   }
 
   const rollback = async (): Promise<void> => {
@@ -2489,7 +2522,7 @@ async function createGoogleMeetEventAutomationForWorkflow(
             ownerUserId: args.input.member.userId,
             eventType: args.input.eventType,
             eventConfig: preparedConfig,
-            eventConnectorId: null,
+            eventConnectorId: connectorId,
           },
         ],
       },
@@ -2502,6 +2535,7 @@ async function createGoogleMeetEventAutomationForWorkflow(
         db: args.context.db,
         orgId: args.input.orgId,
         userId: args.input.member.userId,
+        connectorId,
       },
       signal,
     ),
@@ -3866,13 +3900,27 @@ async function prepareOfficialGoogleFormsReconfiguration(
   );
 }
 
-function prepareOfficialGoogleMeetEvent(
+async function prepareOfficialGoogleMeetEvent(
+  db: Db,
   input: CreateGoogleMeetEventAutomationInput,
-): OfficialAutomationEventPreparationResult {
+  signal: AbortSignal,
+): Promise<OfficialAutomationEventPreparationResult> {
+  const eventConnectorId = await resolveGoogleMeetAutomationConnectorId(db, {
+    orgId: input.orgId,
+    userId: input.member.userId,
+    workflowId: input.workflowId,
+  });
+  signal.throwIfAborted();
+  if (eventConnectorId === null) {
+    return {
+      kind: "bad-request",
+      message: "Connect Google Meet before using Google Meet event automations",
+    };
+  }
   const eventConfig = googleMeetTranscriptGeneratedEventConfigSchema.parse(
     input.eventConfig,
   );
-  return preparedOfficialEvent(eventConfig);
+  return preparedOfficialEvent(eventConfig, { eventConnectorId });
 }
 
 async function prepareOfficialStripeEvent(
@@ -3963,7 +4011,7 @@ export const prepareOfficialAutomationReconfiguration$ = command(
       );
     }
     if (automationCreateInputIsGoogleMeet(input)) {
-      return prepareOfficialGoogleMeetEvent(input);
+      return await prepareOfficialGoogleMeetEvent(db, input, signal);
     }
     if (automationCreateInputIsNotion(input)) {
       const enabled = await get(
@@ -4685,11 +4733,15 @@ async function enabledWatchHadConsumer(
     );
   }
   if (supportedGoogleMeetEventType(args.automation.eventType)) {
+    if (args.automation.eventConnectorId === null) {
+      return false;
+    }
     return await hasEnabledGoogleMeetConsumer(
       {
         db: args.db,
         orgId: args.automation.orgId,
         userId: args.automation.ownerUserId,
+        connectorId: args.automation.eventConnectorId,
       },
       signal,
     );
@@ -4757,11 +4809,19 @@ async function ensureEnabledAutomationEventWatch(
       : { kind: "bad-request", message: result.message };
   }
   if (supportedGoogleMeetEventType(args.automation.eventType)) {
+    if (args.automation.eventConnectorId === null) {
+      return {
+        kind: "bad-request",
+        message:
+          "Connect Google Meet before using Google Meet event automations",
+      };
+    }
     const result = await ensureGoogleMeetTranscriptGeneratedSubscriptionForUser(
       {
         db: args.db,
         orgId: args.automation.orgId,
         userId: args.automation.ownerUserId,
+        connectorId: args.automation.eventConnectorId,
       },
       signal,
     );
@@ -5021,6 +5081,7 @@ async function ensureEnabledAutomationEventWatchWithRollback(
 type EnabledAutomationAccountProjection =
   | { readonly status: "gmail-unavailable" }
   | { readonly status: "google-forms-unavailable" }
+  | { readonly status: "google-meet-unavailable" }
   | { readonly status: "notion-unavailable" }
   | { readonly status: "notion-account-changed" }
   | { readonly status: "stripe-unavailable"; readonly message: string }
@@ -5052,16 +5113,82 @@ async function projectGoogleFormsEnabledEventConfig(
   return { ...config, connectorId: eventConnectorId };
 }
 
+type EnabledAutomationAccountProvider =
+  | "gmail"
+  | "google-forms"
+  | "google-meet"
+  | "notion"
+  | "stripe";
+
+function enabledAutomationAccountProvider(
+  automation: AutomationRow,
+): EnabledAutomationAccountProvider | null {
+  if (supportedGmailEventType(automation.eventType)) {
+    return "gmail";
+  }
+  if (supportedGoogleFormsEventType(automation.eventType)) {
+    return "google-forms";
+  }
+  if (supportedGoogleMeetEventType(automation.eventType)) {
+    return "google-meet";
+  }
+  if (supportedNotionEventType(automation.eventType)) {
+    return "notion";
+  }
+  return automation.eventType === "stripe-invoice-paid" ? "stripe" : null;
+}
+
+async function resolveEnabledAutomationConnectorId(
+  db: Db,
+  provider: Exclude<EnabledAutomationAccountProvider, "stripe">,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly workflowId: string;
+  },
+): Promise<string | null> {
+  switch (provider) {
+    case "gmail": {
+      return await resolveGmailAutomationConnectorId(db, args);
+    }
+    case "google-forms": {
+      return await resolveGoogleFormsAutomationConnectorId(db, args);
+    }
+    case "google-meet": {
+      return await resolveGoogleMeetAutomationConnectorId(db, args);
+    }
+    case "notion": {
+      return await resolveNotionAutomationConnectorId(db, args);
+    }
+  }
+}
+
+function unavailableEnabledAutomationProjection(
+  provider: Exclude<EnabledAutomationAccountProvider, "stripe">,
+): EnabledAutomationAccountProjection {
+  switch (provider) {
+    case "gmail": {
+      return { status: "gmail-unavailable" };
+    }
+    case "google-forms": {
+      return { status: "google-forms-unavailable" };
+    }
+    case "google-meet": {
+      return { status: "google-meet-unavailable" };
+    }
+    case "notion": {
+      return { status: "notion-unavailable" };
+    }
+  }
+}
+
 async function lockEnabledAutomationAccountProjection(
   db: Db,
   automation: AutomationRow,
   signal: AbortSignal,
 ): Promise<EnabledAutomationAccountProjection> {
-  const usesGmail = supportedGmailEventType(automation.eventType);
-  const usesGoogleForms = supportedGoogleFormsEventType(automation.eventType);
-  const usesNotion = supportedNotionEventType(automation.eventType);
-  const usesStripe = automation.eventType === "stripe-invoice-paid";
-  if (!usesGmail && !usesGoogleForms && !usesNotion && !usesStripe) {
+  const provider = enabledAutomationAccountProvider(automation);
+  if (provider === null) {
     return { status: "ok", required: false };
   }
   await lockConnectorAccountTarget(db, {
@@ -5069,13 +5196,7 @@ async function lockEnabledAutomationAccountProjection(
     userId: automation.ownerUserId,
     target: {
       kind: "builtin",
-      connectorSlug: usesGmail
-        ? "gmail"
-        : usesGoogleForms
-          ? "google-forms"
-          : usesNotion
-            ? "notion"
-            : "stripe",
+      connectorSlug: provider,
     },
   });
   const connectorArgs = {
@@ -5083,7 +5204,7 @@ async function lockEnabledAutomationAccountProjection(
     userId: automation.ownerUserId,
     workflowId: automation.workflowId,
   };
-  if (usesStripe) {
+  if (provider === "stripe") {
     const readiness = await resolveStripeInvoicePaidAutomationBinding(
       { db, ...connectorArgs },
       signal,
@@ -5104,32 +5225,29 @@ async function lockEnabledAutomationAccountProjection(
       },
     };
   }
-  const eventConnectorId = usesGmail
-    ? await resolveGmailAutomationConnectorId(db, connectorArgs)
-    : usesGoogleForms
-      ? await resolveGoogleFormsAutomationConnectorId(db, connectorArgs)
-      : await resolveNotionAutomationConnectorId(db, connectorArgs);
+  const eventConnectorId = await resolveEnabledAutomationConnectorId(
+    db,
+    provider,
+    connectorArgs,
+  );
   if (eventConnectorId === null) {
-    return {
-      status: usesGmail
-        ? "gmail-unavailable"
-        : usesGoogleForms
-          ? "google-forms-unavailable"
-          : "notion-unavailable",
-    };
+    return unavailableEnabledAutomationProjection(provider);
   }
-  if (usesNotion && automation.eventConnectorId !== eventConnectorId) {
+  if (
+    provider === "notion" &&
+    automation.eventConnectorId !== eventConnectorId
+  ) {
     return { status: "notion-account-changed" };
   }
   let eventConfig: WorkflowAutomationEventConfig | null =
     automation.eventConfig;
-  if (usesNotion) {
+  if (provider === "notion") {
     eventConfig = notionConfigWithConnectorId(
       automation.eventType,
       automation.eventConfig,
       eventConnectorId,
     );
-  } else if (usesGoogleForms) {
+  } else if (provider === "google-forms") {
     eventConfig = await projectGoogleFormsEnabledEventConfig(
       db,
       automation,
@@ -5165,6 +5283,7 @@ async function persistEnabledWorkflowAutomation(
   | { readonly status: "notion-account-changed" }
   | { readonly status: "stripe-unavailable"; readonly message: string }
   | { readonly status: "google-forms-unavailable" }
+  | { readonly status: "google-meet-unavailable" }
   | { readonly status: "ok"; readonly row: AutomationRow | undefined }
 > {
   return await db.transaction(async (tx) => {
@@ -5245,8 +5364,9 @@ async function prepareEnabledAutomationAccountProjection(
 > {
   const usesGmail = supportedGmailEventType(automation.eventType);
   const usesGoogleForms = supportedGoogleFormsEventType(automation.eventType);
+  const usesGoogleMeet = supportedGoogleMeetEventType(automation.eventType);
   const usesNotion = supportedNotionEventType(automation.eventType);
-  if (!usesGmail && !usesGoogleForms && !usesNotion) {
+  if (!usesGmail && !usesGoogleForms && !usesGoogleMeet && !usesNotion) {
     return { kind: "ok", eventConnectorId: automation.eventConnectorId };
   }
   const connectorArgs = {
@@ -5258,7 +5378,9 @@ async function prepareEnabledAutomationAccountProjection(
     ? await resolveGmailAutomationConnectorId(db, connectorArgs)
     : usesGoogleForms
       ? await resolveGoogleFormsAutomationConnectorId(db, connectorArgs)
-      : await resolveNotionAutomationConnectorId(db, connectorArgs);
+      : usesGoogleMeet
+        ? await resolveGoogleMeetAutomationConnectorId(db, connectorArgs)
+        : await resolveNotionAutomationConnectorId(db, connectorArgs);
   signal.throwIfAborted();
   if (eventConnectorId === null) {
     return {
@@ -5267,7 +5389,9 @@ async function prepareEnabledAutomationAccountProjection(
         ? "Connect Gmail before using Gmail event automations"
         : usesGoogleForms
           ? "Connect Google Forms before using Google Forms response automations"
-          : "Connect Notion before using Notion event automations",
+          : usesGoogleMeet
+            ? "Connect Google Meet before using Google Meet event automations"
+            : "Connect Notion before using Notion event automations",
     };
   }
   if (!supportedNotionEventType(automation.eventType)) {
@@ -5399,6 +5523,13 @@ async function persistAndReconcileEnabledWorkflowAutomation(
       kind: "bad-request",
       message:
         "Connect Google Forms before using Google Forms response automations",
+    };
+  }
+  if (enabled.status === "google-meet-unavailable") {
+    signal.throwIfAborted();
+    return {
+      kind: "bad-request",
+      message: "Connect Google Meet before using Google Meet event automations",
     };
   }
   if (!enabled.row) {

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -207,6 +207,7 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
   z.object({
     action: z.literal("set-official-workflow-automation-admission-state"),
     automation_id: z.uuid(),
+    blueprint_key: z.string().min(1).optional(),
     reconciliation_status: z.enum([
       "current",
       "reconciling",


### PR DESCRIPTION
## Summary

- project Google Meet workflow automations onto the exact thread-selected or default connector account during create, enable, copy, official reconciliation, and account lifecycle changes
- reconcile Workspace Events subscriptions per connector account, including staged official consumers, while sharing provider state only among exact consumers and cleaning stale account subscriptions
- fail closed at webhook matching and durable queue admission when the automation account no longer matches the subscription source
- expand integration coverage with two-account selection/default changes, copy, official install/reconfiguration, reconnect, deletion/re-add, legacy repair, admission races, and exact runner source

## Compatibility and scope

- no database migration or public Google Meet event-config change
- no runner protocol change; the existing exact `connectorSourceId` is now revalidated before persistence
- legacy null projections are repaired from current workflow authority and remain unavailable when no current account exists
- preserves the existing one-attempt provider cleanup policy

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts --silent=passed-only` (16 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/official-workflows.test.ts --silent=passed-only` (42 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connector-accounts.test.ts --silent=passed-only` (13 passed)
- `pnpm turbo run lint --filter=api --filter=@okouai/api-contracts`
- `pnpm turbo run check-types --filter=api --filter=@okouai/api-contracts`
- `pnpm knip --workspace api`
- pre-commit full Turbo Knip and `pnpm check-types`

Closes #30595

Parent context: #30585
