### PR TITLE
fix(api): bind calendar triggers to thread account

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-workflows.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-workflows.ts
@@ -29,6 +29,7 @@ const NOTION_OAUTH_TOKEN_URL = "https://api.notion.com/v1/oauth/token";
 interface GoogleCalendarConnectorOAuthOptions {
   readonly accessToken?: string;
   readonly email?: string;
+  readonly subject?: string;
 }
 
 /**
@@ -66,7 +67,7 @@ export function mockGoogleCalendarConnectorOAuth(
     }),
     http.get(GOOGLE_USERINFO_URL, () => {
       return HttpResponse.json({
-        id: "bdd-calendar-user-id",
+        id: options.subject ?? "bdd-calendar-user-id",
         email: options.email ?? "calendar-user@example.com",
         name: "BDD Calendar User",
       });

--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -544,6 +544,8 @@ function configureOfficialCalendarWatchMock() {
     watchCalls: 0,
     stopCalls: 0,
     watchShouldFail: false,
+    watchAccessTokens: [] as string[],
+    stopAccessTokens: [] as string[],
   };
   mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
   server.use(
@@ -561,6 +563,9 @@ function configureOfficialCalendarWatchMock() {
       "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events/watch",
       async ({ request, params }) => {
         recorder.watchCalls++;
+        recorder.watchAccessTokens.push(
+          request.headers.get("authorization") ?? "",
+        );
         expect(params.calendarId).toBe("primary");
         if (recorder.watchShouldFail) {
           return HttpResponse.json({ error: "watch failed" }, { status: 500 });
@@ -578,10 +583,16 @@ function configureOfficialCalendarWatchMock() {
         });
       },
     ),
-    http.post("https://www.googleapis.com/calendar/v3/channels/stop", () => {
-      recorder.stopCalls++;
-      return new HttpResponse(null, { status: 204 });
-    }),
+    http.post(
+      "https://www.googleapis.com/calendar/v3/channels/stop",
+      ({ request }) => {
+        recorder.stopCalls++;
+        recorder.stopAccessTokens.push(
+          request.headers.get("authorization") ?? "",
+        );
+        return new HttpResponse(null, { status: 204 });
+      },
+    ),
   );
   return recorder;
 }
@@ -5188,6 +5199,9 @@ describe.sequential("Official Workflow installations", () => {
     );
     const setup = await workflowBdd.setupWorkflowOrg();
     const { actor } = setup;
+    if (!actor.orgId) {
+      throw new Error("Expected Calendar transition actor to belong to an org");
+    }
     const { agentId } = await workflowBdd.createAgent(actor);
     onTestFinished(async () => {
       installCatalogStorageFixture();
@@ -5202,10 +5216,61 @@ describe.sequential("Official Workflow installations", () => {
       await bdd.deleteAgent(actor, agentId);
       await cleanupCatalog();
     });
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId: actor.orgId },
+      {
+        [FeatureSwitchKey.ConnectorAccounts]: true,
+      },
+    );
+    const firstAccessToken = `calendar-transition-first-${suffix}`;
+    const secondAccessToken = `calendar-transition-second-${suffix}`;
     mockGoogleCalendarConnectorOAuth({
-      email: `calendar-transition-${suffix}@example.test`,
+      accessToken: firstAccessToken,
+      email: `calendar-transition-first-${suffix}@example.test`,
+      subject: `calendar-transition-first-${suffix}`,
     });
     await workflowBdd.connectConnector(actor, "google-calendar");
+    mockGoogleCalendarConnectorOAuth({
+      accessToken: secondAccessToken,
+      email: `calendar-transition-second-${suffix}@example.test`,
+      subject: `calendar-transition-second-${suffix}`,
+    });
+    const secondOauth = await connectors.startOauth(
+      actor,
+      "google-calendar",
+      "oauth",
+      agentId,
+      { intent: "add", displayName: "Official Calendar Second" },
+    );
+    const secondOauthState = new URL(
+      secondOauth.authorizationUrl,
+    ).searchParams.get("state");
+    if (!secondOauthState) {
+      throw new Error("Expected second Calendar OAuth state");
+    }
+    await connectors.completeOauthCallback("google-calendar", {
+      code: `calendar-transition-second-${suffix}`,
+      state: secondOauthState,
+    });
+    const calendarAccounts = await connectors.listBuiltinConnectorAccounts(
+      actor,
+      "google-calendar",
+    );
+    const secondAccount = calendarAccounts.find((account) => {
+      return (
+        account.externalEmail ===
+        `calendar-transition-second-${suffix}@example.test`
+      );
+    });
+    if (!secondAccount) {
+      throw new Error("Expected second Calendar account");
+    }
+    await connectors.setDefaultBuiltinConnectorAccount(
+      actor,
+      "google-calendar",
+      secondAccount.id,
+    );
     const watch = configureOfficialCalendarWatchMock();
     await setOfficialWorkflowsEnabled(actor, true);
     const headers = authHeaders(actor);
@@ -5283,6 +5348,10 @@ describe.sequential("Official Workflow installations", () => {
       }),
     ]);
     expect(watch.watchCalls).toBe(2);
+    expect(watch.watchAccessTokens).toStrictEqual([
+      `Bearer ${secondAccessToken}`,
+      `Bearer ${secondAccessToken}`,
+    ]);
     expect(watch.stopCalls).toBe(0);
     const identity = await readOfficialWorkflowReconciliationState({
       workflowId,
@@ -5298,6 +5367,53 @@ describe.sequential("Official Workflow installations", () => {
     await expect(
       readAgentRunFamilyCountsFixture(context, agentId),
     ).resolves.toStrictEqual(beforeRuns);
+
+    await syncCatalog(
+      catalog([
+        activeDefinition(definitionName, [
+          {
+            ...structureTransitionCalendarBlueprint(),
+            desiredState: {
+              kind: "event",
+              eventType: "google-calendar-event-updated",
+              eventConfig: {
+                provider: "google-calendar",
+                event: "event_updated",
+                calendarId: "primary",
+              },
+            },
+          },
+        ]),
+      ]),
+    );
+    await expect(
+      runOfficialWorkflowReconciliationWorker(),
+    ).resolves.toStrictEqual(
+      expect.objectContaining({ claimed: 1, completed: 1, installations: 1 }),
+    );
+    const reconfigured = await accept(
+      installationClient().get({ headers, params: { workflowId } }),
+      [200],
+    );
+    expect(reconfigured.body.workflow.automations).toStrictEqual([
+      expect.objectContaining({
+        id: original.id,
+        kind: "event",
+        eventType: "google-calendar-event-updated",
+        enabled: true,
+        official: expect.objectContaining({ reconciliationStatus: "current" }),
+      }),
+    ]);
+    expect(watch.watchCalls).toBe(3);
+    expect(watch.watchAccessTokens).toStrictEqual([
+      `Bearer ${secondAccessToken}`,
+      `Bearer ${secondAccessToken}`,
+      `Bearer ${secondAccessToken}`,
+    ]);
+    expect(watch.stopCalls).toBe(1);
+    expect(watch.stopAccessTokens).toStrictEqual([
+      `Bearer ${secondAccessToken}`,
+    ]);
   });
 
   it("restores a dormant Calendar identity without another enabled consumer", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
@@ -14,6 +14,7 @@ import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import type { ApiTestUser } from "./helpers/api-bdd";
+import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import {
@@ -22,6 +23,7 @@ import {
 } from "./helpers/api-bdd-workflows";
 import { chatEventDisplayText } from "./helpers/chat-event";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
+import { clearWorkflowAutomationEventConnectorAsPreviousApi } from "./helpers/runtime-state";
 import { createRouteMocks } from "./helpers/route-test";
 import { chatThreadRoutes } from "../chat-threads";
 import { workflowAutomationsRoutes } from "../workflow-automations";
@@ -35,6 +37,7 @@ const TEST_APP_ROUTES = Object.freeze([
 const context = testContext();
 const mocks = createRouteMocks(context);
 const wf = createWorkflowsBddApi(context);
+const connectorsApi = createConnectorBddApi(context);
 const runsApi = createRunsApi(context);
 const webhooksApi = createWebhookCallbackApi(context);
 
@@ -208,6 +211,7 @@ function configureGoogleCalendarApiMock(args: {
 
 interface CalendarScenario {
   readonly actor: ApiTestUser & { readonly orgId: string };
+  readonly agentId: string;
   readonly runnerGroup: string;
   readonly workflowId: string;
 }
@@ -231,6 +235,7 @@ async function setupFixture(): Promise<CalendarScenario> {
   context.mocks.s3.send.mockResolvedValue({});
   return {
     actor: { ...actor, orgId: actor.orgId },
+    agentId: agent.agentId,
     runnerGroup,
     workflowId,
   };
@@ -266,6 +271,43 @@ async function connectGoogleCalendar(
     scenario.actor.orgId,
     "org:member",
   );
+}
+
+async function addGoogleCalendarAccount(
+  scenario: CalendarScenario,
+  args: {
+    readonly accessToken: string;
+    readonly email: string;
+    readonly subject: string;
+  },
+): Promise<string> {
+  mockGoogleCalendarConnectorOAuth(args);
+  const start = await connectorsApi.startOauth(
+    scenario.actor,
+    "google-calendar",
+    "oauth",
+    scenario.agentId,
+    { intent: "add", displayName: args.email },
+  );
+  const state = new URL(start.authorizationUrl).searchParams.get("state");
+  if (!state) {
+    throw new Error("Expected Google Calendar OAuth state");
+  }
+  await connectorsApi.completeOauthCallback("google-calendar", {
+    code: "google-calendar-second-code",
+    state,
+  });
+  const accounts = await connectorsApi.listBuiltinConnectorAccounts(
+    scenario.actor,
+    "google-calendar",
+  );
+  const account = accounts.find((candidate) => {
+    return candidate.externalEmail === args.email;
+  });
+  if (!account) {
+    throw new Error("Expected the added Google Calendar account");
+  }
+  return account.id;
 }
 
 async function postGoogleCalendarWebhook(
@@ -485,6 +527,177 @@ describe("POST /api/webhooks/google-calendar", () => {
     });
     const idleAfterDuplicate = await runsApi.pollRunner(runnerGroup);
     expect(idleAfterDuplicate.body.job).toBeNull();
+  });
+
+  it("repairs a legacy projection and dispatches only from the selected Calendar account", async () => {
+    const firstAccessToken = "calendar-first-access-token";
+    const secondAccessToken = "calendar-second-access-token";
+    const channels: (GoogleCalendarWatchChannel & {
+      readonly accessToken: string;
+    })[] = [];
+    const incrementalAccessTokens: string[] = [];
+    mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+    server.use(
+      http.post(
+        "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events/watch",
+        async ({ request }) => {
+          const accessToken =
+            request.headers.get("authorization")?.replace("Bearer ", "") ?? "";
+          const body = (await request.json()) as {
+            readonly id?: string;
+            readonly token?: string;
+          };
+          if (!body.id || !body.token) {
+            throw new Error("Expected Calendar watch channel identity");
+          }
+          const resourceId = `calendar-resource-${accessToken}`;
+          channels.push({
+            channelId: body.id,
+            channelToken: body.token,
+            resourceId,
+            accessToken,
+          });
+          return HttpResponse.json({
+            id: body.id,
+            resourceId,
+            resourceUri:
+              "https://www.googleapis.com/calendar/v3/calendars/primary/events",
+            expiration: String(now() + 7 * 24 * 60 * 60 * 1000),
+          });
+        },
+      ),
+      http.get(
+        "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events",
+        ({ request }) => {
+          const accessToken =
+            request.headers.get("authorization")?.replace("Bearer ", "") ?? "";
+          const syncToken = new URL(request.url).searchParams.get("syncToken");
+          if (!syncToken) {
+            return HttpResponse.json({
+              items: [],
+              nextSyncToken: `baseline-${accessToken}`,
+            });
+          }
+          incrementalAccessTokens.push(accessToken);
+          return HttpResponse.json({
+            items:
+              accessToken === secondAccessToken
+                ? [
+                    {
+                      id: "selected-account-event",
+                      etag: '"selected-account-version"',
+                      status: "confirmed",
+                      summary: "Selected account event",
+                      created: "2026-08-01T09:00:00.000Z",
+                      updated: "2026-08-01T09:00:00.000Z",
+                    },
+                  ]
+                : [],
+            nextSyncToken: `next-${accessToken}`,
+          });
+        },
+      ),
+      http.post("https://www.googleapis.com/calendar/v3/channels/stop", () => {
+        return HttpResponse.json(
+          { error: "retain old channel" },
+          { status: 500 },
+        );
+      }),
+    );
+
+    const scenario = await setupFixture();
+    await updateFeatureSwitchesForUser(context, scenario.actor, {
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
+    mockGoogleCalendarConnectorOAuth({
+      accessToken: firstAccessToken,
+      email: "calendar-first@example.com",
+      subject: "calendar-first-subject",
+    });
+    await wf.connectConnector(scenario.actor, "google-calendar");
+    const secondConnectorId = await addGoogleCalendarAccount(scenario, {
+      accessToken: secondAccessToken,
+      email: "calendar-second@example.com",
+      subject: "calendar-second-subject",
+    });
+
+    const created = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: scenario.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-calendar-event-created",
+        },
+      }),
+      [201],
+    );
+    if (!created.body.chatThreadId) {
+      throw new Error("Expected the Calendar automation thread");
+    }
+    await accept(
+      chatThreadConnectorSelectionsClient().update({
+        headers: authHeaders(),
+        params: { id: created.body.chatThreadId },
+        body: {
+          connectionId: secondConnectorId,
+          target: { kind: "builtin", connectorSlug: "google-calendar" },
+        },
+      }),
+      [200],
+    );
+    await clearWorkflowAutomationEventConnectorAsPreviousApi(
+      context,
+      created.body.id,
+    );
+
+    const firstWatch = channels.find((channel) => {
+      return channel.accessToken === firstAccessToken;
+    });
+    const secondWatch = channels.find((channel) => {
+      return channel.accessToken === secondAccessToken;
+    });
+    if (!firstWatch || !secondWatch) {
+      throw new Error("Expected one watch for each Calendar account");
+    }
+
+    const oldSource = await postGoogleCalendarWebhook(
+      webhookHeaders(firstWatch),
+    );
+    expect(oldSource).toStrictEqual({
+      status: 200,
+      body: {
+        success: true,
+        watchStates: 1,
+        dispatched: 0,
+        duplicates: 0,
+      },
+    });
+    expect(incrementalAccessTokens).toStrictEqual([]);
+
+    const selectedSource = await postGoogleCalendarWebhook(
+      webhookHeaders(secondWatch),
+    );
+    expect(selectedSource).toStrictEqual({
+      status: 200,
+      body: {
+        success: true,
+        watchStates: 1,
+        dispatched: 1,
+        duplicates: 0,
+      },
+    });
+    expect(incrementalAccessTokens).toStrictEqual([secondAccessToken]);
+
+    await runsApi.heartbeatRunner(scenario.runnerGroup);
+    const job = await runsApi.pollRunner(scenario.runnerGroup);
+    if (!job.body.job) {
+      throw new Error("Expected a selected-account Calendar run");
+    }
+    const claim = await runsApi.claimRunnerJob(job.body.job.runId);
+    expect(
+      Object.values(claim.secretConnectorMetadataMap ?? {}),
+    ).toContainEqual(expect.objectContaining({ sourceId: secondConnectorId }));
   });
 
   it("ignores updated and cancelled calendar events", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 
 import { chatThreadConnectorSelectionContract } from "@okouai/api-contracts/contracts/chat-threads";
+import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
 import { workflowAutomationsContract } from "@okouai/api-contracts/contracts/workflows";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
@@ -26,6 +27,7 @@ import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { clearWorkflowAutomationEventConnectorAsPreviousApi } from "./helpers/runtime-state";
 import { createRouteMocks } from "./helpers/route-test";
 import { chatThreadRoutes } from "../chat-threads";
+import { connectorAccountRoutes } from "../connector-accounts";
 import { workflowAutomationsRoutes } from "../workflow-automations";
 import {
   clearGoogleCalendarBeforeRunStartHookForTest,
@@ -1028,6 +1030,105 @@ describe("POST /api/webhooks/google-calendar", () => {
     await expect(
       postGoogleCalendarWebhook(webhookHeaders(oldChannel)),
     ).resolves.toMatchObject({ status: 401 });
+  });
+
+  it("finishes captured Calendar channel cleanup after request cancellation", async () => {
+    const accessToken = "calendar-cleanup-abort-token";
+    const calendar = configureAccountAwareGoogleCalendarApiMock({
+      resourcePrefix: "calendar-cleanup-abort",
+    });
+    const scenario = await setupFixture();
+    await updateFeatureSwitchesForUser(context, scenario.actor, {
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
+
+    mockGoogleCalendarConnectorOAuth({
+      accessToken,
+      email: "calendar-cleanup-abort@example.com",
+      subject: "calendar-cleanup-abort-subject",
+    });
+    await wf.connectConnector(scenario.actor, "google-calendar");
+    const connection = await connectorsApi.readConnectorBySlug(
+      scenario.actor,
+      "google-calendar",
+    );
+    await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: scenario.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-calendar-event-created",
+        },
+      }),
+      [201],
+    );
+    await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: scenario.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-calendar-event-updated",
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_updated",
+            calendarId: "team-calendar@example.com",
+          },
+        },
+      }),
+      [201],
+    );
+    expect(calendar.channels).toHaveLength(2);
+
+    const requestController = new AbortController();
+    const stoppedChannelIds: string[] = [];
+    server.use(
+      http.post(
+        "https://www.googleapis.com/calendar/v3/channels/stop",
+        async ({ request }) => {
+          const body = (await request.json()) as { readonly id?: string };
+          if (!body.id) {
+            throw new Error("Expected a Calendar channel id");
+          }
+          stoppedChannelIds.push(body.id);
+          if (stoppedChannelIds.length === 1) {
+            const error = new Error("request cancelled during channel cleanup");
+            error.name = "AbortError";
+            requestController.abort(error);
+          }
+          return new HttpResponse(null, { status: 204 });
+        },
+      ),
+    );
+    const accountClient = setupApp({
+      context,
+      routes: connectorAccountRoutes,
+      signal: requestController.signal,
+    })(connectorAccountsContract);
+
+    await expect(
+      accountClient.delete({
+        headers: authHeaders(),
+        params: { connectionId: connection.id },
+        body: {
+          target: { kind: "builtin", connectorSlug: "google-calendar" },
+        },
+      }),
+    ).rejects.toThrow("Unknown response status 500");
+    expect(new Set(stoppedChannelIds)).toStrictEqual(
+      new Set(
+        calendar.channels.map((channel) => {
+          return channel.channelId;
+        }),
+      ),
+    );
+    await expect(
+      connectorsApi.listBuiltinConnectorAccounts(
+        scenario.actor,
+        "google-calendar",
+      ),
+    ).resolves.toStrictEqual([]);
   });
 
   it("ignores updated and cancelled calendar events", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
@@ -4,7 +4,7 @@ import { chatThreadConnectorSelectionContract } from "@okouai/api-contracts/cont
 import { workflowAutomationsContract } from "@okouai/api-contracts/contracts/workflows";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
-import { expect } from "vitest";
+import { expect, onTestFinished } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
@@ -27,7 +27,11 @@ import { clearWorkflowAutomationEventConnectorAsPreviousApi } from "./helpers/ru
 import { createRouteMocks } from "./helpers/route-test";
 import { chatThreadRoutes } from "../chat-threads";
 import { workflowAutomationsRoutes } from "../workflow-automations";
-import { webhooksGoogleCalendarRoutes } from "../webhooks-google-calendar";
+import {
+  clearGoogleCalendarBeforeRunStartHookForTest,
+  setGoogleCalendarBeforeRunStartHookForTest,
+  webhooksGoogleCalendarRoutes,
+} from "../webhooks-google-calendar";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...webhooksGoogleCalendarRoutes,
@@ -203,6 +207,96 @@ function configureGoogleCalendarApiMock(args: {
           items: args.incrementalItems ?? [],
           nextSyncToken: args.incrementalNextSyncToken ?? "calendar-sync-next",
         });
+      },
+    ),
+  );
+  return recorder;
+}
+
+interface AccountAwareGoogleCalendarRecorder {
+  readonly channels: (GoogleCalendarWatchChannel & {
+    readonly accessToken: string;
+  })[];
+  readonly baselineAccessTokens: string[];
+  readonly incrementalAccessTokens: string[];
+  readonly stoppedAccessTokens: string[];
+}
+
+function googleCalendarRequestAccessToken(request: Request): string {
+  return request.headers.get("authorization")?.replace("Bearer ", "") ?? "";
+}
+
+function configureAccountAwareGoogleCalendarApiMock(args: {
+  readonly resourcePrefix: string;
+  readonly incrementalItems?: (
+    accessToken: string,
+  ) => readonly Record<string, unknown>[];
+  readonly stopStatus?: 204 | 500;
+}): AccountAwareGoogleCalendarRecorder {
+  const recorder: AccountAwareGoogleCalendarRecorder = {
+    channels: [],
+    baselineAccessTokens: [],
+    incrementalAccessTokens: [],
+    stoppedAccessTokens: [],
+  };
+  mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+  server.use(
+    http.post(
+      "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events/watch",
+      async ({ request, params }) => {
+        const accessToken = googleCalendarRequestAccessToken(request);
+        const body = (await request.json()) as {
+          readonly id?: string;
+          readonly token?: string;
+        };
+        if (!body.id || !body.token || typeof params.calendarId !== "string") {
+          throw new Error(
+            "Expected Calendar watch target and channel identity",
+          );
+        }
+        const resourceId = `${args.resourcePrefix}-${recorder.channels.length + 1}`;
+        recorder.channels.push({
+          channelId: body.id,
+          channelToken: body.token,
+          resourceId,
+          accessToken,
+        });
+        return HttpResponse.json({
+          id: body.id,
+          resourceId,
+          resourceUri: `https://www.googleapis.com/calendar/v3/calendars/${params.calendarId}/events`,
+          expiration: String(now() + 7 * 24 * 60 * 60 * 1000),
+        });
+      },
+    ),
+    http.get(
+      "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events",
+      ({ request }) => {
+        const accessToken = googleCalendarRequestAccessToken(request);
+        const syncToken = new URL(request.url).searchParams.get("syncToken");
+        if (!syncToken) {
+          recorder.baselineAccessTokens.push(accessToken);
+          return HttpResponse.json({
+            items: [],
+            nextSyncToken: `${args.resourcePrefix}-baseline-${accessToken}`,
+          });
+        }
+        recorder.incrementalAccessTokens.push(accessToken);
+        return HttpResponse.json({
+          items: args.incrementalItems?.(accessToken) ?? [],
+          nextSyncToken: `${args.resourcePrefix}-next-${accessToken}`,
+        });
+      },
+    ),
+    http.post(
+      "https://www.googleapis.com/calendar/v3/channels/stop",
+      ({ request }) => {
+        recorder.stoppedAccessTokens.push(
+          googleCalendarRequestAccessToken(request),
+        );
+        return args.stopStatus === 500
+          ? HttpResponse.json({ error: "retain channel" }, { status: 500 })
+          : new HttpResponse(null, { status: 204 });
       },
     ),
   );
@@ -532,78 +626,24 @@ describe("POST /api/webhooks/google-calendar", () => {
   it("repairs a legacy projection and dispatches only from the selected Calendar account", async () => {
     const firstAccessToken = "calendar-first-access-token";
     const secondAccessToken = "calendar-second-access-token";
-    const channels: (GoogleCalendarWatchChannel & {
-      readonly accessToken: string;
-    })[] = [];
-    const incrementalAccessTokens: string[] = [];
-    mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
-    server.use(
-      http.post(
-        "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events/watch",
-        async ({ request }) => {
-          const accessToken =
-            request.headers.get("authorization")?.replace("Bearer ", "") ?? "";
-          const body = (await request.json()) as {
-            readonly id?: string;
-            readonly token?: string;
-          };
-          if (!body.id || !body.token) {
-            throw new Error("Expected Calendar watch channel identity");
-          }
-          const resourceId = `calendar-resource-${accessToken}`;
-          channels.push({
-            channelId: body.id,
-            channelToken: body.token,
-            resourceId,
-            accessToken,
-          });
-          return HttpResponse.json({
-            id: body.id,
-            resourceId,
-            resourceUri:
-              "https://www.googleapis.com/calendar/v3/calendars/primary/events",
-            expiration: String(now() + 7 * 24 * 60 * 60 * 1000),
-          });
-        },
-      ),
-      http.get(
-        "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events",
-        ({ request }) => {
-          const accessToken =
-            request.headers.get("authorization")?.replace("Bearer ", "") ?? "";
-          const syncToken = new URL(request.url).searchParams.get("syncToken");
-          if (!syncToken) {
-            return HttpResponse.json({
-              items: [],
-              nextSyncToken: `baseline-${accessToken}`,
-            });
-          }
-          incrementalAccessTokens.push(accessToken);
-          return HttpResponse.json({
-            items:
-              accessToken === secondAccessToken
-                ? [
-                    {
-                      id: "selected-account-event",
-                      etag: '"selected-account-version"',
-                      status: "confirmed",
-                      summary: "Selected account event",
-                      created: "2026-08-01T09:00:00.000Z",
-                      updated: "2026-08-01T09:00:00.000Z",
-                    },
-                  ]
-                : [],
-            nextSyncToken: `next-${accessToken}`,
-          });
-        },
-      ),
-      http.post("https://www.googleapis.com/calendar/v3/channels/stop", () => {
-        return HttpResponse.json(
-          { error: "retain old channel" },
-          { status: 500 },
-        );
-      }),
-    );
+    const calendar = configureAccountAwareGoogleCalendarApiMock({
+      resourcePrefix: "calendar-selected",
+      stopStatus: 500,
+      incrementalItems: (accessToken) => {
+        return accessToken === secondAccessToken
+          ? [
+              {
+                id: "selected-account-event",
+                etag: '"selected-account-version"',
+                status: "confirmed",
+                summary: "Selected account event",
+                created: "2026-08-01T09:00:00.000Z",
+                updated: "2026-08-01T09:00:00.000Z",
+              },
+            ]
+          : [];
+      },
+    });
 
     const scenario = await setupFixture();
     await updateFeatureSwitchesForUser(context, scenario.actor, {
@@ -632,13 +672,14 @@ describe("POST /api/webhooks/google-calendar", () => {
       }),
       [201],
     );
-    if (!created.body.chatThreadId) {
+    const chatThreadId = created.body.chatThreadId;
+    if (!chatThreadId) {
       throw new Error("Expected the Calendar automation thread");
     }
     await accept(
       chatThreadConnectorSelectionsClient().update({
         headers: authHeaders(),
-        params: { id: created.body.chatThreadId },
+        params: { id: chatThreadId },
         body: {
           connectionId: secondConnectorId,
           target: { kind: "builtin", connectorSlug: "google-calendar" },
@@ -651,10 +692,10 @@ describe("POST /api/webhooks/google-calendar", () => {
       created.body.id,
     );
 
-    const firstWatch = channels.find((channel) => {
+    const firstWatch = calendar.channels.find((channel) => {
       return channel.accessToken === firstAccessToken;
     });
-    const secondWatch = channels.find((channel) => {
+    const secondWatch = calendar.channels.find((channel) => {
       return channel.accessToken === secondAccessToken;
     });
     if (!firstWatch || !secondWatch) {
@@ -673,7 +714,7 @@ describe("POST /api/webhooks/google-calendar", () => {
         duplicates: 0,
       },
     });
-    expect(incrementalAccessTokens).toStrictEqual([]);
+    expect(calendar.incrementalAccessTokens).toStrictEqual([]);
 
     const selectedSource = await postGoogleCalendarWebhook(
       webhookHeaders(secondWatch),
@@ -687,7 +728,7 @@ describe("POST /api/webhooks/google-calendar", () => {
         duplicates: 0,
       },
     });
-    expect(incrementalAccessTokens).toStrictEqual([secondAccessToken]);
+    expect(calendar.incrementalAccessTokens).toStrictEqual([secondAccessToken]);
 
     await runsApi.heartbeatRunner(scenario.runnerGroup);
     const job = await runsApi.pollRunner(scenario.runnerGroup);
@@ -698,6 +739,295 @@ describe("POST /api/webhooks/google-calendar", () => {
     expect(
       Object.values(claim.secretConnectorMetadataMap ?? {}),
     ).toContainEqual(expect.objectContaining({ sourceId: secondConnectorId }));
+  });
+
+  it("supersedes an old Calendar source when account selection changes at queue admission", async () => {
+    const firstAccessToken = "calendar-admission-first-token";
+    const secondAccessToken = "calendar-admission-second-token";
+    const calendar = configureAccountAwareGoogleCalendarApiMock({
+      resourcePrefix: "calendar-admission",
+      stopStatus: 500,
+      incrementalItems: () => {
+        return [
+          {
+            id: "calendar-admission-event",
+            etag: '"calendar-admission-version"',
+            status: "confirmed",
+            summary: "Admission race",
+            created: "2026-08-01T10:00:00.000Z",
+            updated: "2026-08-01T10:00:00.000Z",
+          },
+        ];
+      },
+    });
+
+    const scenario = await setupFixture();
+    await updateFeatureSwitchesForUser(context, scenario.actor, {
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
+    mockGoogleCalendarConnectorOAuth({
+      accessToken: firstAccessToken,
+      email: "calendar-admission-first@example.com",
+      subject: "calendar-admission-first-subject",
+    });
+    await wf.connectConnector(scenario.actor, "google-calendar");
+    const secondConnectorId = await addGoogleCalendarAccount(scenario, {
+      accessToken: secondAccessToken,
+      email: "calendar-admission-second@example.com",
+      subject: "calendar-admission-second-subject",
+    });
+    const created = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: scenario.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-calendar-event-created",
+        },
+      }),
+      [201],
+    );
+    const admissionChatThreadId = created.body.chatThreadId;
+    if (!admissionChatThreadId) {
+      throw new Error("Expected the Calendar automation thread");
+    }
+    const firstWatch = calendar.channels.find((channel) => {
+      return channel.accessToken === firstAccessToken;
+    });
+    if (!firstWatch) {
+      throw new Error("Expected the initial Calendar watch");
+    }
+
+    onTestFinished(() => {
+      clearGoogleCalendarBeforeRunStartHookForTest();
+    });
+    setGoogleCalendarBeforeRunStartHookForTest(async () => {
+      clearGoogleCalendarBeforeRunStartHookForTest();
+      await accept(
+        chatThreadConnectorSelectionsClient().update({
+          headers: authHeaders(),
+          params: { id: admissionChatThreadId },
+          body: {
+            connectionId: secondConnectorId,
+            target: { kind: "builtin", connectorSlug: "google-calendar" },
+          },
+        }),
+        [200],
+      );
+    });
+
+    const response = await postGoogleCalendarWebhook(
+      webhookHeaders(firstWatch),
+    );
+
+    expect(response).toStrictEqual({
+      status: 200,
+      body: {
+        success: true,
+        watchStates: 1,
+        dispatched: 0,
+        duplicates: 0,
+      },
+    });
+    expect(calendar.incrementalAccessTokens).toStrictEqual([firstAccessToken]);
+    expect(
+      calendar.channels.some((channel) => {
+        return channel.accessToken === secondAccessToken;
+      }),
+    ).toBeTruthy();
+    await runsApi.heartbeatRunner(scenario.runnerGroup);
+    const idle = await runsApi.pollRunner(scenario.runnerGroup);
+    expect(idle.body.job).toBeNull();
+  });
+
+  it("reconciles Calendar watches across default deletion and first-account re-add", async () => {
+    const firstAccessToken = "calendar-lifecycle-first-token";
+    const secondAccessToken = "calendar-lifecycle-second-token";
+    const thirdAccessToken = "calendar-lifecycle-third-token";
+    const calendar = configureAccountAwareGoogleCalendarApiMock({
+      resourcePrefix: "calendar-lifecycle",
+    });
+
+    const scenario = await setupFixture();
+    await updateFeatureSwitchesForUser(context, scenario.actor, {
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
+    mockGoogleCalendarConnectorOAuth({
+      accessToken: firstAccessToken,
+      email: "calendar-lifecycle-first@example.com",
+      subject: "calendar-lifecycle-first-subject",
+    });
+    await wf.connectConnector(scenario.actor, "google-calendar");
+    const initialAccounts = await connectorsApi.listBuiltinConnectorAccounts(
+      scenario.actor,
+      "google-calendar",
+    );
+    const firstAccount = initialAccounts[0];
+    if (!firstAccount) {
+      throw new Error("Expected the first Calendar account");
+    }
+    const secondConnectorId = await addGoogleCalendarAccount(scenario, {
+      accessToken: secondAccessToken,
+      email: "calendar-lifecycle-second@example.com",
+      subject: "calendar-lifecycle-second-subject",
+    });
+    await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: scenario.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-calendar-event-created",
+        },
+      }),
+      [201],
+    );
+    const firstWatch = calendar.channels[0];
+    if (!firstWatch) {
+      throw new Error("Expected the first Calendar watch");
+    }
+
+    await connectorsApi.setDefaultBuiltinConnectorAccount(
+      scenario.actor,
+      "google-calendar",
+      secondConnectorId,
+    );
+    await connectorsApi.deleteBuiltinConnectorAccount(
+      scenario.actor,
+      "google-calendar",
+      secondConnectorId,
+    );
+    const accountsAfterDefaultDeletion =
+      await connectorsApi.listBuiltinConnectorAccounts(
+        scenario.actor,
+        "google-calendar",
+      );
+    expect(accountsAfterDefaultDeletion).toMatchObject([
+      { id: firstAccount.id, isDefault: true },
+    ]);
+    await connectorsApi.deleteBuiltinConnectorAccount(
+      scenario.actor,
+      "google-calendar",
+      firstAccount.id,
+    );
+
+    mockGoogleCalendarConnectorOAuth({
+      accessToken: thirdAccessToken,
+      email: "calendar-lifecycle-third@example.com",
+      subject: "calendar-lifecycle-third-subject",
+    });
+    await wf.connectConnector(scenario.actor, "google-calendar");
+
+    expect(
+      calendar.channels.map((channel) => {
+        return channel.accessToken;
+      }),
+    ).toStrictEqual([
+      firstAccessToken,
+      secondAccessToken,
+      firstAccessToken,
+      thirdAccessToken,
+    ]);
+    expect(calendar.baselineAccessTokens).toStrictEqual([
+      firstAccessToken,
+      secondAccessToken,
+      firstAccessToken,
+      thirdAccessToken,
+    ]);
+    expect(calendar.stoppedAccessTokens).toStrictEqual([
+      firstAccessToken,
+      secondAccessToken,
+      firstAccessToken,
+    ]);
+    await expect(
+      postGoogleCalendarWebhook(webhookHeaders(firstWatch)),
+    ).resolves.toMatchObject({ status: 401 });
+  });
+
+  it("replaces Calendar principal state and stops the captured old channel", async () => {
+    const firstAccessToken = "calendar-principal-first-token";
+    const refreshedAccessToken = "calendar-principal-refreshed-token";
+    const replacementAccessToken = "calendar-principal-replacement-token";
+    const calendar = configureAccountAwareGoogleCalendarApiMock({
+      resourcePrefix: "calendar-principal",
+    });
+    const scenario = await setupFixture();
+
+    mockGoogleCalendarConnectorOAuth({
+      accessToken: firstAccessToken,
+      email: "calendar-principal-first@example.com",
+      subject: "calendar-principal-first-subject",
+    });
+    await wf.connectConnector(scenario.actor, "google-calendar");
+    const initialConnection = await connectorsApi.readConnectorBySlug(
+      scenario.actor,
+      "google-calendar",
+    );
+    await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: scenario.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-calendar-event-created",
+        },
+      }),
+      [201],
+    );
+    const oldChannel = calendar.channels[0];
+    if (!oldChannel) {
+      throw new Error("Expected the initial Calendar channel");
+    }
+
+    mockGoogleCalendarConnectorOAuth({
+      accessToken: refreshedAccessToken,
+      email: "calendar-principal-renamed@example.com",
+      subject: "calendar-principal-first-subject",
+    });
+    const reconnect = await connectorsApi.startOauth(
+      scenario.actor,
+      "google-calendar",
+      "oauth",
+      scenario.agentId,
+      { intent: "reconnect", connectionId: initialConnection.id },
+    );
+    const reconnectState = new URL(reconnect.authorizationUrl).searchParams.get(
+      "state",
+    );
+    if (!reconnectState) {
+      throw new Error("Expected Calendar reconnect OAuth state");
+    }
+    await connectorsApi.completeOauthCallback("google-calendar", {
+      code: "google-calendar-same-principal-code",
+      state: reconnectState,
+    });
+    expect(calendar.channels).toHaveLength(1);
+    expect(calendar.stoppedAccessTokens).toStrictEqual([]);
+
+    mockGoogleCalendarConnectorOAuth({
+      accessToken: replacementAccessToken,
+      email: "calendar-principal-replacement@example.com",
+      subject: "calendar-principal-replacement-subject",
+    });
+    await wf.connectConnector(scenario.actor, "google-calendar");
+
+    const replacementConnection = await connectorsApi.readConnectorBySlug(
+      scenario.actor,
+      "google-calendar",
+    );
+    expect(replacementConnection).toMatchObject({
+      id: initialConnection.id,
+      externalId: "calendar-principal-replacement-subject",
+    });
+    expect(
+      calendar.channels.map((channel) => {
+        return channel.accessToken;
+      }),
+    ).toStrictEqual([firstAccessToken, replacementAccessToken]);
+    expect(calendar.stoppedAccessTokens).toStrictEqual([refreshedAccessToken]);
+    await expect(
+      postGoogleCalendarWebhook(webhookHeaders(oldChannel)),
+    ).resolves.toMatchObject({ status: 401 });
   });
 
   it("ignores updated and cancelled calendar events", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
@@ -3401,6 +3401,59 @@ describe("okou workflow automations", () => {
     });
   });
 
+  it("repairs a missing exact Calendar watch in the renewal pass", async () => {
+    mockEnv("CRON_SECRET", CRON_SECRET);
+    const scenario = await setupFixture();
+    await connectGoogleCalendar(scenario);
+    const initialWatch = configureGoogleCalendarWatchMock();
+    configureGoogleCalendarStopMock();
+    await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: scenario.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-calendar-event-created",
+        },
+      }),
+      [201],
+    );
+    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
+      scenario.actor,
+      "google-calendar",
+    );
+
+    server.use(
+      http.post(
+        "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events/watch",
+        () => {
+          return HttpResponse.json(
+            { error: "registration unavailable" },
+            { status: 500 },
+          );
+        },
+      ),
+    );
+    await connectGoogleCalendar(scenario);
+    expect(initialWatch.watchCalls).toBe(1);
+
+    const repairedWatch = configureGoogleCalendarWatchMock();
+    const reconciled = await accept(
+      renewGoogleCalendarWatchesClient().renew({
+        headers: { authorization: `Bearer ${CRON_SECRET}` },
+      }),
+      [200],
+    );
+
+    expect(reconciled.body).toStrictEqual({
+      success: true,
+      renewed: 0,
+      failed: 0,
+    });
+    expect(repairedWatch.watchCalls).toBe(1);
+    expect(repairedWatch.baselineCalls).toBe(1);
+  });
+
   it("retains a replaced Calendar channel until its stop succeeds", async () => {
     mockEnv("CRON_SECRET", CRON_SECRET);
     const startedAt = Date.parse("2026-08-05T08:00:00.000Z");

--- a/turbo/apps/api/src/signals/routes/__tests__/workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflows.test.ts
@@ -46,6 +46,7 @@ import {
   mockGoogleFormsConnectorOAuth,
   mockStripeConnectorOAuth,
 } from "./helpers/api-bdd-connectors";
+import { mockGoogleCalendarConnectorOAuth } from "./helpers/api-bdd-workflows";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createFixtureTracker, createRouteMocks } from "./helpers/route-test";
@@ -419,6 +420,49 @@ async function connectGmailAccount(
   });
   if (!account) {
     throw new Error(`Expected Gmail account ${args.email}`);
+  }
+  return account;
+}
+
+async function connectGoogleCalendarAccount(
+  actor: ApiTestUser,
+  agentId: string,
+  args: {
+    readonly accessToken: string;
+    readonly email: string;
+    readonly subject: string;
+    readonly account?: { readonly intent: "add"; readonly displayName: string };
+  },
+) {
+  mockGoogleCalendarConnectorOAuth({
+    accessToken: args.accessToken,
+    email: args.email,
+    subject: args.subject,
+  });
+  const start = await connectorApi.startOauth(
+    actor,
+    "google-calendar",
+    "oauth",
+    agentId,
+    args.account,
+  );
+  const state = new URL(start.authorizationUrl).searchParams.get("state");
+  if (!state) {
+    throw new Error("Expected Google Calendar OAuth state");
+  }
+  await connectorApi.completeOauthCallback("google-calendar", {
+    code: `google-calendar-copy-${randomUUID()}`,
+    state,
+  });
+  const accounts = await connectorApi.listBuiltinConnectorAccounts(
+    actor,
+    "google-calendar",
+  );
+  const account = accounts.find((candidate) => {
+    return candidate.externalEmail === args.email;
+  });
+  if (!account) {
+    throw new Error(`Expected Google Calendar account ${args.email}`);
   }
   return account;
 }
@@ -2052,6 +2096,130 @@ describe("workflows", () => {
       "Bearer gmail-copy-first-token",
       "Bearer gmail-copy-second-token",
       "Bearer gmail-copy-first-token",
+    ]);
+  });
+
+  it("rebinds copied Calendar automations to the target thread default account", async () => {
+    const actor = user();
+    if (!actor.orgId) {
+      throw new Error(
+        "Expected Calendar workflow copy actor to belong to an org",
+      );
+    }
+    await api.grantProEntitlement(actor, { tier: "team" });
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId: actor.orgId },
+      { [FeatureSwitchKey.ConnectorAccounts]: true },
+    );
+    const sourceAgent = await createAgent(actor, {
+      displayName: "Calendar Copy Source Agent",
+      visibility: "private",
+    });
+    const targetAgent = await createAgent(actor, {
+      displayName: "Calendar Copy Target Agent",
+      visibility: "private",
+    });
+    const workflow = await createWorkflow(actor, {
+      agentId: sourceAgent.agentId,
+      name: `calendar-copy-${randomUUID().slice(0, 8)}`,
+      instruction: "# Calendar copy source",
+    });
+
+    const watchedTokens: string[] = [];
+    server.use(
+      http.get(
+        "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events",
+        () => {
+          return HttpResponse.json({
+            items: [],
+            nextSyncToken: `calendar-copy-sync-${watchedTokens.length}`,
+          });
+        },
+      ),
+      http.post(
+        "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events/watch",
+        async ({ request }) => {
+          const authorization = request.headers.get("authorization");
+          if (!authorization) {
+            throw new Error("Expected Calendar watch authorization");
+          }
+          watchedTokens.push(authorization);
+          const body = (await request.json()) as { readonly id?: string };
+          if (!body.id) {
+            throw new Error("Expected Calendar watch channel id");
+          }
+          return HttpResponse.json({
+            id: body.id,
+            resourceId: `calendar-copy-resource-${watchedTokens.length}`,
+            resourceUri:
+              "https://www.googleapis.com/calendar/v3/calendars/primary/events",
+            expiration: "4102444800000",
+          });
+        },
+      ),
+      http.post("https://www.googleapis.com/calendar/v3/channels/stop", () => {
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await connectGoogleCalendarAccount(actor, sourceAgent.agentId, {
+      accessToken: "calendar-copy-first-token",
+      email: `calendar-copy-first-${randomUUID()}@example.test`,
+      subject: `calendar-copy-first-${randomUUID()}`,
+    });
+    const secondAccount = await connectGoogleCalendarAccount(
+      actor,
+      sourceAgent.agentId,
+      {
+        accessToken: "calendar-copy-second-token",
+        email: `calendar-copy-second-${randomUUID()}@example.test`,
+        subject: `calendar-copy-second-${randomUUID()}`,
+        account: { intent: "add", displayName: "Calendar Copy Second" },
+      },
+    );
+    const automation = await accept(
+      automationsClient().create({
+        headers: authHeaders(actor),
+        params: { workflowId: workflow.body.id },
+        body: {
+          kind: "event",
+          eventType: "google-calendar-event-created",
+        },
+      }),
+      [201],
+    );
+    if (automation.body.kind !== "event" || !automation.body.chatThreadId) {
+      throw new Error("Expected Calendar automation thread");
+    }
+    await accept(
+      chatThreadConnectorSelectionsClient().update({
+        headers: authHeaders(actor),
+        params: { id: automation.body.chatThreadId },
+        body: {
+          connectionId: secondAccount.id,
+          target: { kind: "builtin", connectorSlug: "google-calendar" },
+        },
+      }),
+      [200],
+    );
+    expect(watchedTokens).toStrictEqual([
+      "Bearer calendar-copy-first-token",
+      "Bearer calendar-copy-second-token",
+    ]);
+
+    await accept(
+      detailClient().copy({
+        headers: authHeaders(actor),
+        params: { workflowId: workflow.body.id },
+        body: { toAgentId: targetAgent.agentId },
+      }),
+      [201],
+    );
+    expect(watchedTokens).toStrictEqual([
+      "Bearer calendar-copy-first-token",
+      "Bearer calendar-copy-second-token",
+      "Bearer calendar-copy-first-token",
     ]);
   });
 

--- a/turbo/apps/api/src/signals/routes/chat-threads-connector-selections.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-connector-selections.ts
@@ -17,6 +17,7 @@ import {
 } from "../services/chat-thread-connector-selection.service";
 import { userFeatureSwitchContext } from "../services/feature-switches.service";
 import { reconcileGmailWatchesForUser } from "../services/gmail-automation-event.service";
+import { reconcileGoogleCalendarWatchesForUser } from "../services/google-calendar-automation-event.service";
 import { reconcileGoogleFormsWatchesForUser } from "../services/google-forms-automation-event.service";
 import { reconcileGoogleMeetSubscriptionsForUser } from "../services/google-meet-automation-event.service";
 import type { RouteEntry } from "../route-entry";
@@ -87,6 +88,7 @@ const updateSelectionInner$ = command(
     if (
       body.data.target.kind === "builtin" &&
       (body.data.target.connectorSlug === "gmail" ||
+        body.data.target.connectorSlug === "google-calendar" ||
         body.data.target.connectorSlug === "google-forms" ||
         body.data.target.connectorSlug === "google-meet")
     ) {
@@ -96,15 +98,20 @@ const updateSelectionInner$ = command(
               { db: writeDb, orgId: auth.orgId, userId: auth.userId },
               signal,
             )
-          : body.data.target.connectorSlug === "google-forms"
-            ? reconcileGoogleFormsWatchesForUser(
+          : body.data.target.connectorSlug === "google-calendar"
+            ? reconcileGoogleCalendarWatchesForUser(
                 { db: writeDb, orgId: auth.orgId, userId: auth.userId },
                 signal,
               )
-            : reconcileGoogleMeetSubscriptionsForUser(
-                { db: writeDb, orgId: auth.orgId, userId: auth.userId },
-                signal,
-              ),
+            : body.data.target.connectorSlug === "google-forms"
+              ? reconcileGoogleFormsWatchesForUser(
+                  { db: writeDb, orgId: auth.orgId, userId: auth.userId },
+                  signal,
+                )
+              : reconcileGoogleMeetSubscriptionsForUser(
+                  { db: writeDb, orgId: auth.orgId, userId: auth.userId },
+                  signal,
+                ),
         signal,
       );
     }
@@ -148,6 +155,7 @@ const clearSelectionInner$ = command(
     if (
       body.data.kind === "builtin" &&
       (body.data.connectorSlug === "gmail" ||
+        body.data.connectorSlug === "google-calendar" ||
         body.data.connectorSlug === "google-forms" ||
         body.data.connectorSlug === "google-meet")
     ) {
@@ -157,15 +165,20 @@ const clearSelectionInner$ = command(
               { db: writeDb, orgId: auth.orgId, userId: auth.userId },
               signal,
             )
-          : body.data.connectorSlug === "google-forms"
-            ? reconcileGoogleFormsWatchesForUser(
+          : body.data.connectorSlug === "google-calendar"
+            ? reconcileGoogleCalendarWatchesForUser(
                 { db: writeDb, orgId: auth.orgId, userId: auth.userId },
                 signal,
               )
-            : reconcileGoogleMeetSubscriptionsForUser(
-                { db: writeDb, orgId: auth.orgId, userId: auth.userId },
-                signal,
-              ),
+            : body.data.connectorSlug === "google-forms"
+              ? reconcileGoogleFormsWatchesForUser(
+                  { db: writeDb, orgId: auth.orgId, userId: auth.userId },
+                  signal,
+                )
+              : reconcileGoogleMeetSubscriptionsForUser(
+                  { db: writeDb, orgId: auth.orgId, userId: auth.userId },
+                  signal,
+                ),
         signal,
       );
     }

--- a/turbo/apps/api/src/signals/routes/connector-accounts.ts
+++ b/turbo/apps/api/src/signals/routes/connector-accounts.ts
@@ -33,6 +33,7 @@ import {
 } from "../services/custom-connector.service";
 import { userFeatureSwitchContext } from "../services/feature-switches.service";
 import { reconcileGmailWatchesForUser } from "../services/gmail-automation-event.service";
+import { reconcileGoogleCalendarWatchesForUser } from "../services/google-calendar-automation-event.service";
 import { reconcileGoogleFormsWatchesForUser } from "../services/google-forms-automation-event.service";
 import { reconcileGoogleMeetSubscriptionsForUser } from "../services/google-meet-automation-event.service";
 
@@ -244,6 +245,7 @@ const setDefaultInner$ = command(
     if (
       body.data.target.kind === "builtin" &&
       (body.data.target.connectorSlug === "gmail" ||
+        body.data.target.connectorSlug === "google-calendar" ||
         body.data.target.connectorSlug === "google-forms" ||
         body.data.target.connectorSlug === "google-meet")
     ) {
@@ -253,15 +255,20 @@ const setDefaultInner$ = command(
               { db: writeDb, orgId: auth.orgId, userId: auth.userId },
               signal,
             )
-          : body.data.target.connectorSlug === "google-forms"
-            ? reconcileGoogleFormsWatchesForUser(
+          : body.data.target.connectorSlug === "google-calendar"
+            ? reconcileGoogleCalendarWatchesForUser(
                 { db: writeDb, orgId: auth.orgId, userId: auth.userId },
                 signal,
               )
-            : reconcileGoogleMeetSubscriptionsForUser(
-                { db: writeDb, orgId: auth.orgId, userId: auth.userId },
-                signal,
-              ),
+            : body.data.target.connectorSlug === "google-forms"
+              ? reconcileGoogleFormsWatchesForUser(
+                  { db: writeDb, orgId: auth.orgId, userId: auth.userId },
+                  signal,
+                )
+              : reconcileGoogleMeetSubscriptionsForUser(
+                  { db: writeDb, orgId: auth.orgId, userId: auth.userId },
+                  signal,
+                ),
         signal,
       );
     }

--- a/turbo/apps/api/src/signals/routes/webhooks-google-calendar.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-google-calendar.ts
@@ -4,7 +4,21 @@ import { webhookGoogleCalendarContract } from "@okouai/api-contracts/contracts/w
 import type { RouteEntry } from "../route-entry";
 import { request$ } from "../context/hono";
 import { now } from "../../lib/time";
-import { dispatchGoogleCalendarWebhook$ } from "../services/google-calendar-automation-event.service";
+import {
+  clearGoogleCalendarBeforeRunStartHookForTest as clearBeforeRunStartHook,
+  dispatchGoogleCalendarWebhook$,
+  setGoogleCalendarBeforeRunStartHookForTest as setBeforeRunStartHook,
+} from "../services/google-calendar-automation-event.service";
+
+export function setGoogleCalendarBeforeRunStartHookForTest(
+  hook: Parameters<typeof setBeforeRunStartHook>[0],
+): void {
+  setBeforeRunStartHook(hook);
+}
+
+export function clearGoogleCalendarBeforeRunStartHookForTest(): void {
+  clearBeforeRunStartHook();
+}
 
 function jsonError(message: string, status: 400 | 401 | 429 | 503): Response {
   return Response.json({ error: message }, { status });

--- a/turbo/apps/api/src/signals/routes/workflows.ts
+++ b/turbo/apps/api/src/signals/routes/workflows.ts
@@ -77,6 +77,7 @@ import {
 } from "../services/autonomy-budget.service";
 import { bestEffort, onRejection, settle } from "../utils";
 import { reconcileGmailWatchesForUser } from "../services/gmail-automation-event.service";
+import { reconcileGoogleCalendarWatchesForUser } from "../services/google-calendar-automation-event.service";
 import { lockConnectorAccountTarget } from "../services/auth-state-lock.service";
 import { reprojectWorkflowAutomationsForOwner } from "../services/workflow-automation-account-projection.service";
 import { reconcileGoogleFormsWatchesForUser } from "../services/google-forms-automation-event.service";
@@ -1049,6 +1050,7 @@ async function copyWorkflowUserAutomations(
   args: CopyWorkflowAutomationRowsArgs,
 ): Promise<{
   readonly hasGmailAutomations: boolean;
+  readonly hasGoogleCalendarAutomations: boolean;
   readonly hasGoogleFormsAutomations: boolean;
   readonly hasGoogleMeetAutomations: boolean;
   readonly hasStripeAutomations: boolean;
@@ -1068,6 +1070,7 @@ async function copyWorkflowUserAutomations(
   if (rows.length === 0) {
     return {
       hasGmailAutomations: false,
+      hasGoogleCalendarAutomations: false,
       hasGoogleFormsAutomations: false,
       hasGoogleMeetAutomations: false,
       hasStripeAutomations: false,
@@ -1077,6 +1080,13 @@ async function copyWorkflowUserAutomations(
     return (
       automation.eventType === "gmail-new-message" ||
       automation.eventType === "gmail-label-applied"
+    );
+  });
+  const hasGoogleCalendarAutomations = rows.some((automation) => {
+    return (
+      automation.eventType === "google-calendar-event-created" ||
+      automation.eventType === "google-calendar-event-updated" ||
+      automation.eventType === "google-calendar-event-cancelled"
     );
   });
   const hasGoogleFormsAutomations = rows.some((automation) => {
@@ -1090,6 +1100,7 @@ async function copyWorkflowUserAutomations(
   });
   const accountTargets = [
     ...(hasGmailAutomations ? (["gmail"] as const) : []),
+    ...(hasGoogleCalendarAutomations ? (["google-calendar"] as const) : []),
     ...(hasGoogleFormsAutomations ? (["google-forms"] as const) : []),
     ...(hasGoogleMeetAutomations ? (["google-meet"] as const) : []),
     ...(hasStripeAutomations ? (["stripe"] as const) : []),
@@ -1115,6 +1126,7 @@ async function copyWorkflowUserAutomations(
   }
   return {
     hasGmailAutomations,
+    hasGoogleCalendarAutomations,
     hasGoogleFormsAutomations,
     hasGoogleMeetAutomations,
     hasStripeAutomations,
@@ -1128,6 +1140,7 @@ async function copyWorkflowRuntimeConfiguration(
   | {
       readonly workflow: { readonly id: string };
       readonly hasGmailAutomations: boolean;
+      readonly hasGoogleCalendarAutomations: boolean;
       readonly hasGoogleFormsAutomations: boolean;
       readonly hasGoogleMeetAutomations: boolean;
       readonly hasStripeAutomations: boolean;
@@ -1166,6 +1179,7 @@ type CopyWorkflowDatabaseResult =
       readonly kind: "ok";
       readonly inserted: { readonly id: string };
       readonly hasGmailAutomations: boolean;
+      readonly hasGoogleCalendarAutomations: boolean;
       readonly hasGoogleFormsAutomations: boolean;
       readonly hasGoogleMeetAutomations: boolean;
       readonly hasStripeAutomations: boolean;
@@ -1233,6 +1247,9 @@ async function copyWorkflowDatabaseRows(
     }
     const accountTargets = [
       ...(inserted.hasGmailAutomations ? (["gmail"] as const) : []),
+      ...(inserted.hasGoogleCalendarAutomations
+        ? (["google-calendar"] as const)
+        : []),
       ...(inserted.hasGoogleFormsAutomations
         ? (["google-forms"] as const)
         : []),
@@ -1259,6 +1276,7 @@ async function copyWorkflowDatabaseRows(
       kind: "ok",
       inserted: inserted.workflow,
       hasGmailAutomations: inserted.hasGmailAutomations,
+      hasGoogleCalendarAutomations: inserted.hasGoogleCalendarAutomations,
       hasGoogleFormsAutomations: inserted.hasGoogleFormsAutomations,
       hasGoogleMeetAutomations: inserted.hasGoogleMeetAutomations,
       hasStripeAutomations: inserted.hasStripeAutomations,
@@ -1299,6 +1317,12 @@ async function reconcileCopiedWorkflowAutomationWatches(
   const owner = { db: args.db, orgId: args.orgId, userId: args.userId };
   if (args.copied.hasGmailAutomations) {
     await bestEffort(reconcileGmailWatchesForUser(owner, signal), signal);
+  }
+  if (args.copied.hasGoogleCalendarAutomations) {
+    await bestEffort(
+      reconcileGoogleCalendarWatchesForUser(owner, signal),
+      signal,
+    );
   }
   if (args.copied.hasGoogleFormsAutomations) {
     await bestEffort(reconcileGoogleFormsWatchesForUser(owner, signal), signal);

--- a/turbo/apps/api/src/signals/services/automation-event-watch-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/automation-event-watch-lifecycle.service.ts
@@ -44,6 +44,7 @@ type AutomationEventWatchTarget =
       readonly provider: "google_calendar";
       readonly orgId: string;
       readonly userId: string;
+      readonly connectorId: string | null;
       readonly calendarId: string;
     }
   | {
@@ -136,6 +137,7 @@ function automationEventWatchTarget(
     provider: "google_calendar",
     orgId: automation.orgId,
     userId: automation.ownerUserId,
+    connectorId: automation.eventConnectorId ?? null,
     calendarId,
   };
 }
@@ -150,7 +152,7 @@ function targetKey(target: AutomationEventWatchTarget): string {
   if (target.provider === "google_meet") {
     return `google_meet:${target.orgId}:${target.userId}:${target.connectorId}`;
   }
-  return `google_calendar:${target.orgId}:${target.userId}:${target.calendarId}`;
+  return `google_calendar:${target.orgId}:${target.userId}:${target.connectorId ?? "unavailable"}:${target.calendarId}`;
 }
 
 export async function reconcileAutomationEventWatches(
@@ -211,6 +213,9 @@ export async function reconcileAutomationEventWatches(
         db: args.db,
         orgId: target.orgId,
         userId: target.userId,
+        ...(target.connectorId === null
+          ? {}
+          : { connectorId: target.connectorId }),
         calendarId: target.calendarId,
       },
       signal,
@@ -310,17 +315,25 @@ async function ensureNonFormsTarget(
       signal,
     );
   } else {
-    result = await ensureGoogleCalendarWatchForUser(
-      {
-        db,
-        orgId: target.orgId,
-        userId: target.userId,
-        calendarId: target.calendarId,
-        forceRefresh: false,
-        allowStagedOfficialTarget,
-      },
-      signal,
-    );
+    result =
+      target.connectorId === null
+        ? {
+            kind: "bad_request",
+            message:
+              "Connect Google Calendar before using Google Calendar event automations",
+          }
+        : await ensureGoogleCalendarWatchForUser(
+            {
+              db,
+              orgId: target.orgId,
+              userId: target.userId,
+              connectorId: target.connectorId,
+              calendarId: target.calendarId,
+              forceRefresh: false,
+              allowStagedOfficialTarget,
+            },
+            signal,
+          );
   }
   signal.throwIfAborted();
   return result.kind === "ok"

--- a/turbo/apps/api/src/signals/services/connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-data.service.ts
@@ -85,7 +85,12 @@ import {
   stopPreparedGmailWatch,
   type PendingGmailWatchStop,
 } from "./gmail-automation-event.service";
-import { cleanupGoogleCalendarWatchesForConnector } from "./google-calendar-automation-event.service";
+import {
+  prepareGoogleCalendarWatchStopForConnector,
+  reconcileGoogleCalendarWatchesForUser,
+  stopPreparedGoogleCalendarWatches,
+  type PendingGoogleCalendarWatchStop,
+} from "./google-calendar-automation-event.service";
 import {
   prepareGoogleFormsWatchStopForConnector,
   reconcileGoogleFormsWatchesForUser,
@@ -969,18 +974,6 @@ async function revokePendingConnectorToken(
   );
 }
 
-async function cleanupConnectorWatchesForDisconnect(
-  db: Db,
-  connectorSlug: string,
-  connectorId: string,
-  signal: AbortSignal,
-): Promise<void> {
-  const args = { db, connectorId };
-  if (connectorSlug === "google-calendar") {
-    await bestEffort(cleanupGoogleCalendarWatchesForConnector(args, signal));
-  }
-}
-
 async function reconcileAccountBoundAutomationWatches(
   db: Db,
   args: {
@@ -993,6 +986,11 @@ async function reconcileAccountBoundAutomationWatches(
   if (args.connectorSlug === "gmail") {
     await bestEffort(
       reconcileGmailWatchesForUser({ db, ...args }, signal),
+      signal,
+    );
+  } else if (args.connectorSlug === "google-calendar") {
+    await bestEffort(
+      reconcileGoogleCalendarWatchesForUser({ db, ...args }, signal),
       signal,
     );
   } else if (args.connectorSlug === "google-forms") {
@@ -1115,6 +1113,7 @@ interface DeleteConnectorLocalStateArgs {
 
 interface PendingConnectorAutomationCleanup {
   readonly pendingGmailWatchStop: PendingGmailWatchStop | null;
+  readonly pendingGoogleCalendarWatchStop: PendingGoogleCalendarWatchStop | null;
   readonly pendingGoogleFormsWatchStop: PendingGoogleFormsWatchStop | null;
   readonly pendingGoogleMeetSubscriptionDelete: PendingGoogleMeetSubscriptionDelete | null;
 }
@@ -1135,6 +1134,10 @@ async function prepareConnectorAutomationCleanup(
     args.connectorSlug === "gmail"
       ? await prepareGmailWatchStopForConnector(cleanupArgs, signal)
       : null;
+  const pendingGoogleCalendarWatchStop =
+    args.connectorSlug === "google-calendar"
+      ? await prepareGoogleCalendarWatchStopForConnector(cleanupArgs, signal)
+      : null;
   const pendingGoogleFormsWatchStop =
     args.connectorSlug === "google-forms"
       ? await prepareGoogleFormsWatchStopForConnector(cleanupArgs, signal)
@@ -1148,6 +1151,7 @@ async function prepareConnectorAutomationCleanup(
       : null;
   return {
     pendingGmailWatchStop,
+    pendingGoogleCalendarWatchStop,
     pendingGoogleFormsWatchStop,
     pendingGoogleMeetSubscriptionDelete,
   };
@@ -1173,6 +1177,7 @@ async function deleteConnectorAccountLocalState(
       kind: account.kind,
       pendingTokenRevoke: null,
       pendingGmailWatchStop: null,
+      pendingGoogleCalendarWatchStop: null,
       pendingGoogleMeetSubscriptionDelete: null,
       pendingGoogleFormsWatchStop: null,
     };
@@ -1192,6 +1197,7 @@ async function deleteConnectorAccountLocalState(
       kind: deletion.kind,
       pendingTokenRevoke: null,
       pendingGmailWatchStop: null,
+      pendingGoogleCalendarWatchStop: null,
       pendingGoogleMeetSubscriptionDelete: null,
       pendingGoogleFormsWatchStop: null,
     };
@@ -1232,16 +1238,6 @@ async function deleteConnectorAccountLocalState(
     existing.id,
     signal,
   );
-  if (args.connectorSlug !== "gmail" && args.connectorSlug !== "google-forms") {
-    await cleanupConnectorWatchesForDisconnect(
-      tx,
-      args.connectorSlug,
-      existing.id,
-      signal,
-    );
-  }
-  signal.throwIfAborted();
-
   await deleteConnectorCredentialStorageConnection(
     tx,
     { connectorId: existing.id },
@@ -1278,6 +1274,10 @@ async function stopPendingConnectorAutomationCleanup(
       capturedAbort ??= stopped.error;
     }
   }
+  capturedAbort ??= await stopPendingGoogleCalendarAutomationCleanup(
+    pending.pendingGoogleCalendarWatchStop,
+    signal,
+  );
   if (pending.pendingGoogleMeetSubscriptionDelete !== null) {
     const deleted = await settleIncludingAbort(
       bestEffort(
@@ -1316,6 +1316,22 @@ async function stopPendingConnectorAutomationCleanup(
     }
   }
   return capturedAbort;
+}
+
+async function stopPendingGoogleCalendarAutomationCleanup(
+  pending: PendingGoogleCalendarWatchStop | null,
+  signal: AbortSignal,
+): Promise<unknown> {
+  if (pending === null) {
+    return null;
+  }
+  const stopped = await settleIncludingAbort(
+    bestEffort(stopPreparedGoogleCalendarWatches(pending, signal), signal),
+  );
+  if (signal.aborted) {
+    return signal.reason;
+  }
+  return stopped.ok ? null : stopped.error;
 }
 
 export const deleteConnectorLocalState$ = command(
@@ -1380,6 +1396,15 @@ export const deleteConnectorLocalState$ = command(
     if (args.connectorSlug === "gmail") {
       await bestEffort(
         reconcileGmailWatchesForUser(
+          { db: writeDb, orgId: args.orgId, userId: args.userId },
+          signal,
+        ),
+        signal,
+      );
+    }
+    if (args.connectorSlug === "google-calendar") {
+      await bestEffort(
+        reconcileGoogleCalendarWatchesForUser(
           { db: writeDb, orgId: args.orgId, userId: args.userId },
           signal,
         ),
@@ -2345,6 +2370,71 @@ async function reprojectConnectedWorkflowAutomations(
   );
 }
 
+async function prepareGoogleCalendarPrincipalReplacementWatchStop(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly connectorSlug: string;
+    readonly existing: StoredConnectorRow | null;
+    readonly nextPrincipalId: string;
+  },
+  signal: AbortSignal,
+): Promise<PendingGoogleCalendarWatchStop | null> {
+  if (
+    args.existing === null ||
+    args.connectorSlug !== "google-calendar" ||
+    args.existing.externalId === args.nextPrincipalId
+  ) {
+    return null;
+  }
+  return await prepareGoogleCalendarWatchStopForConnector(
+    {
+      db,
+      orgId: args.orgId,
+      userId: args.userId,
+      connectorId: args.existing.id,
+    },
+    signal,
+  );
+}
+
+async function prepareConnectorTokenConnectionCleanup(
+  args: CommitConnectorTokenConnectionArgs,
+  existing: StoredConnectorRow | null,
+  signal: AbortSignal,
+): Promise<{
+  readonly pendingTokenRevoke: PendingConnectorTokenRevoke | null;
+  readonly pendingGoogleCalendarWatchStop: PendingGoogleCalendarWatchStop | null;
+}> {
+  const pendingTokenRevoke =
+    await loadPendingConnectorTokenRevokeForTokenConnect(
+      args.db,
+      {
+        orgId: args.orgId,
+        userId: args.userId,
+        connectorSlug: args.runtimeMethod.connectorSlug,
+        snapshot: args.snapshot,
+        featureSwitchContext: args.featureSwitchContext,
+        existing,
+      },
+      signal,
+    );
+  const pendingGoogleCalendarWatchStop =
+    await prepareGoogleCalendarPrincipalReplacementWatchStop(
+      args.db,
+      {
+        orgId: args.orgId,
+        userId: args.userId,
+        connectorSlug: args.runtimeMethod.connectorSlug,
+        existing,
+        nextPrincipalId: args.userInfo.id,
+      },
+      signal,
+    );
+  return { pendingTokenRevoke, pendingGoogleCalendarWatchStop };
+}
+
 async function commitConnectorTokenConnection(
   args: CommitConnectorTokenConnectionArgs,
   signal: AbortSignal,
@@ -2354,6 +2444,7 @@ async function commitConnectorTokenConnection(
       readonly connectorRow: StoredConnectorRow;
       readonly created: boolean;
       readonly pendingTokenRevoke: PendingConnectorTokenRevoke | null;
+      readonly pendingGoogleCalendarWatchStop: PendingGoogleCalendarWatchStop | null;
     }
   | ConnectorConnectionMutationFailure
   | { readonly status: "identityMismatch" }
@@ -2392,17 +2483,10 @@ async function commitConnectorTokenConnection(
   ) {
     return { status: "identityMismatch" };
   }
-  const pendingTokenRevoke =
-    await loadPendingConnectorTokenRevokeForTokenConnect(
-      args.db,
-      {
-        orgId: args.orgId,
-        userId: args.userId,
-        connectorSlug: args.runtimeMethod.connectorSlug,
-        snapshot: args.snapshot,
-        featureSwitchContext: args.featureSwitchContext,
-        existing: existingConnector,
-      },
+  const { pendingTokenRevoke, pendingGoogleCalendarWatchStop } =
+    await prepareConnectorTokenConnectionCleanup(
+      args,
+      existingConnector,
       signal,
     );
 
@@ -2467,6 +2551,7 @@ async function commitConnectorTokenConnection(
     connectorRow,
     created: existingConnector === null,
     pendingTokenRevoke,
+    pendingGoogleCalendarWatchStop,
   };
 }
 
@@ -2564,6 +2649,13 @@ export const upsertConnectorTokenConnection$ = command(
     if (connectionResult.status !== "connected") {
       return connectionResult;
     }
+
+    const automationCleanupAbort =
+      await stopPendingGoogleCalendarAutomationCleanup(
+        connectionResult.pendingGoogleCalendarWatchStop,
+        signal,
+      );
+    postCommitAbort ??= automationCleanupAbort;
 
     await finalizeConnectorStateChangeAfterCommit(
       {

--- a/turbo/apps/api/src/signals/services/connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-data.service.ts
@@ -2371,7 +2371,7 @@ async function reprojectConnectedWorkflowAutomations(
 }
 
 async function prepareGoogleCalendarPrincipalReplacementWatchStop(
-  db: Db,
+  db: Tx,
   args: {
     readonly orgId: string;
     readonly userId: string;

--- a/turbo/apps/api/src/signals/services/connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-data.service.ts
@@ -1326,7 +1326,7 @@ async function stopPendingGoogleCalendarAutomationCleanup(
     return null;
   }
   const stopped = await settleIncludingAbort(
-    bestEffort(stopPreparedGoogleCalendarWatches(pending, signal), signal),
+    bestEffort(stopPreparedGoogleCalendarWatches(pending), signal),
   );
   if (signal.aborted) {
     return signal.reason;

--- a/turbo/apps/api/src/signals/services/google-calendar-automation-account.service.ts
+++ b/turbo/apps/api/src/signals/services/google-calendar-automation-account.service.ts
@@ -1,0 +1,68 @@
+import { workflowAutomations } from "@okouai/db/schema/workflow";
+import { and, eq, inArray } from "drizzle-orm";
+
+import type { Db, ReadonlyDb } from "../external/db";
+import { resolveWorkflowAutomationConnectorId } from "./workflow-automation-account.service";
+
+export const GOOGLE_CALENDAR_EVENT_TYPES = [
+  "google-calendar-event-created",
+  "google-calendar-event-updated",
+  "google-calendar-event-cancelled",
+] as const;
+
+export async function resolveGoogleCalendarAutomationConnectorId(
+  db: ReadonlyDb,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly workflowId: string;
+  },
+): Promise<string | null> {
+  return await resolveWorkflowAutomationConnectorId(db, {
+    ...args,
+    connectorSlug: "google-calendar",
+  });
+}
+
+export async function reprojectGoogleCalendarAutomationsForOwner(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+  },
+): Promise<void> {
+  const automations = await db
+    .select({
+      id: workflowAutomations.id,
+      workflowId: workflowAutomations.workflowId,
+      eventConnectorId: workflowAutomations.eventConnectorId,
+    })
+    .from(workflowAutomations)
+    .where(
+      and(
+        eq(workflowAutomations.orgId, args.orgId),
+        eq(workflowAutomations.ownerUserId, args.userId),
+        eq(workflowAutomations.kind, "event"),
+        inArray(workflowAutomations.eventType, [
+          ...GOOGLE_CALENDAR_EVENT_TYPES,
+        ]),
+      ),
+    );
+
+  for (const automation of automations) {
+    const eventConnectorId = await resolveGoogleCalendarAutomationConnectorId(
+      db,
+      {
+        ...args,
+        workflowId: automation.workflowId,
+      },
+    );
+    if (automation.eventConnectorId === eventConnectorId) {
+      continue;
+    }
+    await db
+      .update(workflowAutomations)
+      .set({ eventConnectorId })
+      .where(eq(workflowAutomations.id, automation.id));
+  }
+}

--- a/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
@@ -1,6 +1,6 @@
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { command } from "ccstate";
-import { and, eq, inArray, or, sql } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, isNull, or, sql } from "drizzle-orm";
 import { z } from "zod";
 import {
   googleCalendarEventCancelledEventConfigSchema,
@@ -22,9 +22,10 @@ import { logger } from "../../lib/log";
 import { testOverride } from "../../lib/singleton";
 import { webUrl } from "../../lib/web-url";
 import { writeDb$, type Db } from "../external/db";
-import { onRejection, tapError } from "../utils";
+import { onRejection, settle, tapError } from "../utils";
 import { nowDate } from "../../lib/time";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
+import { lockConnectorAccountTarget } from "./auth-state-lock.service";
 import { workflowAutomationColumns } from "./autonomy-budget-schema.service";
 import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
 import {
@@ -39,9 +40,14 @@ import {
 } from "./automation-event-source-timing.service";
 import { runWorkflowAutomationNow$ } from "./workflow-automation-run.service";
 import type { AutomationRow } from "./workflow-automation-launch.service";
+import type { WorkflowQueueAdmissionTransaction } from "./workflow-chat-event-queue.service";
 import type { WorkflowAutomationContext } from "./workflow-automation-context.service";
 import { workflowAutomationCanFire } from "./workflow-automation-access.service";
 import { ensureWorkflowUserAutomationThread } from "./workflow-user-automation-thread.service";
+import {
+  GOOGLE_CALENDAR_EVENT_TYPES,
+  reprojectGoogleCalendarAutomationsForOwner,
+} from "./google-calendar-automation-account.service";
 
 const log = logger("api:google-calendar-automation-event");
 
@@ -54,12 +60,6 @@ const WATCH_LIFECYCLE_TIMEOUT_MS = 30 * 1000;
 const CALENDAR_EVENTS_PAGE_SIZE = 2500;
 const DEFAULT_CALENDAR_ID = "primary";
 const ATTENDEE_PROMPT_LIMIT = 20;
-const GOOGLE_CALENDAR_EVENT_TYPES = [
-  "google-calendar-event-created",
-  "google-calendar-event-updated",
-  "google-calendar-event-cancelled",
-] as const;
-
 interface GoogleCalendarAccess {
   readonly connectorId: string;
   readonly emailAddress: string | null;
@@ -178,6 +178,11 @@ interface GoogleCalendarChannelIdentity {
   readonly resourceId: string;
 }
 
+export interface PendingGoogleCalendarWatchStop {
+  readonly accessToken: string;
+  readonly channels: readonly GoogleCalendarChannelIdentity[];
+}
+
 interface PreparedGoogleCalendarWatch {
   readonly stateId: string;
   readonly channelId: string;
@@ -222,7 +227,7 @@ type GoogleCalendarRunStarter = (args: {
   // are otherwise indistinguishable.
   readonly eventChangeKey: string;
   readonly timing: AutomationEventRunTiming;
-}) => Promise<"ok" | "error">;
+}) => Promise<"ok" | "error" | "superseded">;
 
 interface GoogleCalendarWorkflowRunStartTestInput {
   readonly automationId: string;
@@ -242,6 +247,15 @@ const googleCalendarRunStarterOverride = testOverride<
 >(() => {
   return undefined;
 });
+
+class GoogleCalendarAutomationSourceChangedError extends Error {
+  constructor() {
+    super(
+      "Google Calendar automation source changed before durable queue admission",
+    );
+    this.name = "GoogleCalendarAutomationSourceChangedError";
+  }
+}
 
 type GoogleCalendarDispatchStateResult =
   | {
@@ -279,7 +293,8 @@ async function resolveGoogleCalendarAccess(
     readonly db: Db;
     readonly orgId: string;
     readonly userId: string;
-    readonly connectorId?: string;
+    readonly connectorId: string;
+    readonly refreshExpiredToken?: boolean;
   },
   signal: AbortSignal,
 ): Promise<GoogleCalendarAccessResult> {
@@ -292,9 +307,7 @@ async function resolveGoogleCalendarAccess(
     orgId: args.orgId,
     userId: args.userId,
     connectorSlug: "google-calendar",
-    ...(args.connectorId === undefined
-      ? {}
-      : { connectorId: args.connectorId }),
+    connectorId: args.connectorId,
   });
   signal.throwIfAborted();
   if (loaded.kind === "missing") {
@@ -337,7 +350,10 @@ async function resolveGoogleCalendarAccess(
         "Reconnect Google Calendar before using Google Calendar event automations",
     };
   }
-  if (!tokenNeedsRefresh(connection.tokenExpiresAt, currentTime)) {
+  if (
+    !tokenNeedsRefresh(connection.tokenExpiresAt, currentTime) ||
+    args.refreshExpiredToken === false
+  ) {
     return {
       kind: "ok",
       access: {
@@ -1014,7 +1030,10 @@ async function loadCalendarWatchState(
 }
 
 function watchNeedsRefresh(
-  state: GoogleCalendarWatchStateRow,
+  state: Pick<
+    GoogleCalendarWatchStateRow,
+    "needsRewatch" | "syncToken" | "watchExpirationAt"
+  >,
   currentTime: Date,
 ): boolean {
   return (
@@ -1049,6 +1068,7 @@ export async function hasEnabledGoogleCalendarConsumer(
     readonly db: Db;
     readonly orgId: string;
     readonly userId: string;
+    readonly connectorId: string;
     readonly calendarId: string;
   },
   signal: AbortSignal,
@@ -1063,6 +1083,7 @@ export async function hasEnabledGoogleCalendarConsumer(
       and(
         eq(workflowAutomations.orgId, args.orgId),
         eq(workflowAutomations.ownerUserId, args.userId),
+        eq(workflowAutomations.eventConnectorId, args.connectorId),
         eq(workflowAutomations.enabled, true),
         eq(workflowAutomations.kind, "event"),
         inArray(workflowAutomations.eventType, [
@@ -1489,6 +1510,7 @@ async function finalizePreparedCalendarWatch(args: {
         db: tx,
         orgId: current.orgId,
         userId: current.userId,
+        connectorId: current.connectorId,
         calendarId: current.calendarId,
       },
       lifecycleSignal,
@@ -1619,6 +1641,7 @@ export async function ensureGoogleCalendarWatchForUser(
     readonly db: Db;
     readonly orgId: string;
     readonly userId: string;
+    readonly connectorId: string;
     readonly calendarId?: string;
     readonly forceRefresh?: boolean;
     readonly allowStagedOfficialTarget?: boolean;
@@ -1645,6 +1668,7 @@ export async function ensureGoogleCalendarWatchForUser(
         db: tx,
         orgId: args.orgId,
         userId: args.userId,
+        connectorId: args.connectorId,
         calendarId,
       },
       signal,
@@ -1883,6 +1907,7 @@ async function decideGoogleCalendarWatchReconciliation(
         db: args.db,
         orgId: state.orgId,
         userId: state.userId,
+        connectorId: state.connectorId,
         calendarId: state.calendarId,
       },
       signal,
@@ -2001,10 +2026,17 @@ export async function reconcileGoogleCalendarWatchesForUser(
     readonly db: Db;
     readonly orgId: string;
     readonly userId: string;
+    readonly connectorId?: string;
     readonly calendarId?: string;
+    readonly renewBefore?: Date;
   },
   signal: AbortSignal,
 ): Promise<boolean> {
+  let succeeded = await repairAndEnsureGoogleCalendarWatchesForOwner(
+    args,
+    signal,
+  );
+
   const states = await args.db
     .select({
       connectorId: googleCalendarWatchStates.connectorId,
@@ -2015,19 +2047,22 @@ export async function reconcileGoogleCalendarWatchesForUser(
       and(
         eq(googleCalendarWatchStates.orgId, args.orgId),
         eq(googleCalendarWatchStates.userId, args.userId),
+        ...(args.connectorId === undefined
+          ? []
+          : [eq(googleCalendarWatchStates.connectorId, args.connectorId)]),
         ...(args.calendarId === undefined
           ? []
           : [eq(googleCalendarWatchStates.calendarId, args.calendarId)]),
       ),
     );
   signal.throwIfAborted();
-  let succeeded = true;
   for (const state of states) {
     const result = await reconcileGoogleCalendarWatchState(
       {
         db: args.db,
         connectorId: state.connectorId,
         calendarId: state.calendarId,
+        renewBefore: args.renewBefore,
       },
       signal,
     );
@@ -2036,27 +2071,214 @@ export async function reconcileGoogleCalendarWatchesForUser(
   return succeeded;
 }
 
-export async function cleanupGoogleCalendarWatchesForConnector(
+async function repairAndEnsureGoogleCalendarWatchesForOwner(
   args: {
     readonly db: Db;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly connectorId?: string;
+    readonly calendarId?: string;
+    readonly ensureRefreshRequired?: boolean;
+  },
+  signal: AbortSignal,
+): Promise<boolean> {
+  await repairGoogleCalendarAutomationProjections(args.db, args);
+  signal.throwIfAborted();
+  const targets = await loadEnabledGoogleCalendarTargets(args.db, args);
+  const existingStates = await args.db
+    .select({
+      connectorId: googleCalendarWatchStates.connectorId,
+      calendarId: googleCalendarWatchStates.calendarId,
+      needsRewatch: googleCalendarWatchStates.needsRewatch,
+      syncToken: googleCalendarWatchStates.syncToken,
+      watchExpirationAt: googleCalendarWatchStates.watchExpirationAt,
+    })
+    .from(googleCalendarWatchStates)
+    .where(
+      and(
+        eq(googleCalendarWatchStates.orgId, args.orgId),
+        eq(googleCalendarWatchStates.userId, args.userId),
+        ...(args.connectorId === undefined
+          ? []
+          : [eq(googleCalendarWatchStates.connectorId, args.connectorId)]),
+        ...(args.calendarId === undefined
+          ? []
+          : [eq(googleCalendarWatchStates.calendarId, args.calendarId)]),
+      ),
+    );
+  signal.throwIfAborted();
+  const existingByKey = new Map(
+    existingStates.map((state) => {
+      return [`${state.connectorId}\n${state.calendarId}`, state] as const;
+    }),
+  );
+  let succeeded = true;
+  for (const target of targets) {
+    const existing = existingByKey.get(
+      `${target.connectorId}\n${target.calendarId}`,
+    );
+    if (
+      existing &&
+      (args.ensureRefreshRequired === false ||
+        !watchNeedsRefresh(existing, nowDate()))
+    ) {
+      continue;
+    }
+    const ensured = await ensureGoogleCalendarWatchForUser(
+      {
+        db: args.db,
+        orgId: args.orgId,
+        userId: args.userId,
+        connectorId: target.connectorId,
+        calendarId: target.calendarId,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    succeeded &&= ensured.kind === "ok";
+  }
+  return succeeded;
+}
+
+async function repairGoogleCalendarAutomationProjections(
+  db: Db,
+  args: { readonly orgId: string; readonly userId: string },
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    await lockConnectorAccountTarget(tx, {
+      ...args,
+      target: { kind: "builtin", connectorSlug: "google-calendar" },
+    });
+    await reprojectGoogleCalendarAutomationsForOwner(tx, args);
+  });
+}
+
+async function loadEnabledGoogleCalendarTargets(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly connectorId?: string;
+    readonly calendarId?: string;
+  },
+): Promise<
+  readonly { readonly connectorId: string; readonly calendarId: string }[]
+> {
+  const consumers = await db
+    .select({
+      connectorId: workflowAutomations.eventConnectorId,
+      eventType: workflowAutomations.eventType,
+      eventConfig: workflowAutomations.eventConfig,
+    })
+    .from(workflowAutomations)
+    .where(
+      and(
+        eq(workflowAutomations.orgId, args.orgId),
+        eq(workflowAutomations.ownerUserId, args.userId),
+        eq(workflowAutomations.enabled, true),
+        eq(workflowAutomations.kind, "event"),
+        isNotNull(workflowAutomations.eventConnectorId),
+        inArray(workflowAutomations.eventType, [
+          ...GOOGLE_CALENDAR_EVENT_TYPES,
+        ]),
+      ),
+    );
+  const targets = new Map<
+    string,
+    { readonly connectorId: string; readonly calendarId: string }
+  >();
+  for (const consumer of consumers) {
+    if (consumer.connectorId === null) {
+      continue;
+    }
+    const config = parseGoogleCalendarEventAutomationConfig({
+      eventType: consumer.eventType,
+      eventConfig: consumer.eventConfig,
+    });
+    if (
+      !config ||
+      (args.connectorId !== undefined &&
+        consumer.connectorId !== args.connectorId) ||
+      (args.calendarId && config.calendarId !== args.calendarId)
+    ) {
+      continue;
+    }
+    const target = {
+      connectorId: consumer.connectorId,
+      calendarId: config.calendarId,
+    };
+    targets.set(`${target.connectorId}\n${target.calendarId}`, target);
+  }
+  return [...targets.values()];
+}
+
+export async function prepareGoogleCalendarWatchStopForConnector(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly userId: string;
     readonly connectorId: string;
   },
   signal: AbortSignal,
-): Promise<void> {
+): Promise<PendingGoogleCalendarWatchStop | null> {
   const states = await args.db
-    .select({ calendarId: googleCalendarWatchStates.calendarId })
+    .select()
     .from(googleCalendarWatchStates)
-    .where(eq(googleCalendarWatchStates.connectorId, args.connectorId));
+    .where(
+      and(
+        eq(googleCalendarWatchStates.orgId, args.orgId),
+        eq(googleCalendarWatchStates.userId, args.userId),
+        eq(googleCalendarWatchStates.connectorId, args.connectorId),
+      ),
+    );
   signal.throwIfAborted();
+  const channels = new Map<string, GoogleCalendarChannelIdentity>();
   for (const state of states) {
-    await reconcileGoogleCalendarWatchState(
-      {
-        db: args.db,
-        connectorId: args.connectorId,
-        calendarId: state.calendarId,
-        forceStop: true,
-      },
-      signal,
+    if (state.resourceId !== "") {
+      const channel = {
+        channelId: state.channelId,
+        channelToken: state.channelToken,
+        resourceId: state.resourceId,
+      };
+      channels.set(`${channel.channelId}\n${channel.resourceId}`, channel);
+    }
+    const previous = previousCalendarChannel(state);
+    if (previous) {
+      channels.set(`${previous.channelId}\n${previous.resourceId}`, previous);
+    }
+  }
+  if (channels.size === 0) {
+    return null;
+  }
+  const access = await resolveGoogleCalendarAccess(
+    { ...args, refreshExpiredToken: false },
+    signal,
+  );
+  signal.throwIfAborted();
+  return access.kind === "ok"
+    ? {
+        accessToken: access.access.accessToken,
+        channels: [...channels.values()],
+      }
+    : null;
+}
+
+export async function stopPreparedGoogleCalendarWatches(
+  pending: PendingGoogleCalendarWatchStop,
+  signal: AbortSignal,
+): Promise<void> {
+  let failed = false;
+  for (const channel of pending.channels) {
+    const stopped = await stopCalendarChannelWithLifecycleOwnership({
+      accessToken: pending.accessToken,
+      channel,
+    });
+    signal.throwIfAborted();
+    failed ||= !stopped;
+  }
+  if (failed) {
+    throw new Error(
+      "Failed to stop one or more Google Calendar watch channels",
     );
   }
 }
@@ -2242,6 +2464,7 @@ async function loadGoogleCalendarEventAutomations(
       and(
         eq(workflowAutomations.orgId, args.state.orgId),
         eq(workflowAutomations.ownerUserId, args.state.userId),
+        eq(workflowAutomations.eventConnectorId, args.state.connectorId),
         eq(workflowAutomations.enabled, true),
         eq(workflowAutomations.kind, "event"),
         inArray(workflowAutomations.eventType, [
@@ -2344,6 +2567,142 @@ function googleCalendarTriggerContext(args: {
   };
 }
 
+async function persistCurrentGoogleCalendarAutomationSource(
+  tx: WorkflowQueueAdmissionTransaction,
+  args: {
+    readonly automationId: string;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly connectorSourceId: string;
+    readonly watchStateId: string;
+    readonly calendarId: string;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  await lockConnectorAccountTarget(tx, {
+    orgId: args.orgId,
+    userId: args.userId,
+    target: { kind: "builtin", connectorSlug: "google-calendar" },
+  });
+  const [currentState] = await tx
+    .select({ id: googleCalendarWatchStates.id })
+    .from(googleCalendarWatchStates)
+    .where(
+      and(
+        eq(googleCalendarWatchStates.id, args.watchStateId),
+        eq(googleCalendarWatchStates.orgId, args.orgId),
+        eq(googleCalendarWatchStates.userId, args.userId),
+        eq(googleCalendarWatchStates.connectorId, args.connectorSourceId),
+        eq(googleCalendarWatchStates.calendarId, args.calendarId),
+      ),
+    )
+    .for("key share")
+    .limit(1);
+  const [current] = await tx
+    .select({
+      id: workflowAutomations.id,
+      eventType: workflowAutomations.eventType,
+      eventConfig: workflowAutomations.eventConfig,
+    })
+    .from(workflowAutomations)
+    .where(
+      and(
+        eq(workflowAutomations.id, args.automationId),
+        eq(workflowAutomations.orgId, args.orgId),
+        eq(workflowAutomations.ownerUserId, args.userId),
+        eq(workflowAutomations.enabled, true),
+        eq(workflowAutomations.kind, "event"),
+        eq(workflowAutomations.eventConnectorId, args.connectorSourceId),
+        inArray(workflowAutomations.eventType, [
+          ...GOOGLE_CALENDAR_EVENT_TYPES,
+        ]),
+      ),
+    )
+    .for("update")
+    .limit(1);
+  signal.throwIfAborted();
+  if (
+    !currentState ||
+    !current ||
+    parseGoogleCalendarEventAutomationConfig(current)?.calendarId !==
+      args.calendarId
+  ) {
+    throw new GoogleCalendarAutomationSourceChangedError();
+  }
+}
+
+const startGoogleCalendarAutomationRun$ = command(
+  async (
+    { set },
+    args: {
+      readonly automation: GoogleCalendarEventAutomationRow;
+      readonly state: GoogleCalendarWatchStateRow;
+      readonly event: CalendarEventContext;
+      readonly eventChangeKey: string;
+      readonly timing: AutomationEventRunTiming;
+      readonly apiStartTime: number;
+    },
+    signal: AbortSignal,
+  ): Promise<"ok" | "error" | "superseded"> => {
+    const runInput = await args.timing.measure(
+      "api_dispatch_pre_create_zero_automation_event_build_run_input",
+      () => {
+        const context = googleCalendarTriggerContext({
+          workflowName: args.automation.workflowName,
+          automationId: args.automation.automation.id,
+          event: args.event,
+          eventChangeKey: args.eventChangeKey,
+        });
+        return { context };
+      },
+    );
+    signal.throwIfAborted();
+    const started = await settle(
+      set(
+        runWorkflowAutomationNow$,
+        {
+          due: {
+            automation: args.automation.automation,
+            agentId: args.automation.agentId,
+            chatThreadId: args.automation.chatThreadId,
+          },
+          automationContext: runInput.context,
+          connectorSourceId: args.state.connectorId,
+          apiStartTime: args.apiStartTime,
+          triggerSource: "automation-event",
+          persistSourceTransition: async (tx) => {
+            await persistCurrentGoogleCalendarAutomationSource(
+              tx,
+              {
+                automationId: args.automation.automation.id,
+                orgId: args.automation.automation.orgId,
+                userId: args.automation.automation.ownerUserId,
+                connectorSourceId: args.state.connectorId,
+                watchStateId: args.state.id,
+                calendarId: args.state.calendarId,
+              },
+              signal,
+            );
+          },
+          dispatchFailedCallbacks: dispatchFailedRunCallbacks,
+          timing: args.timing.collectorForRunStart(),
+        },
+        signal,
+      ),
+      signal,
+    );
+    if (!started.ok) {
+      if (started.error instanceof GoogleCalendarAutomationSourceChangedError) {
+        return "superseded";
+      }
+      throw started.error;
+    }
+    return started.value.kind === "ok" || started.value.kind === "enqueued"
+      ? "ok"
+      : "error";
+  },
+);
+
 async function insertGoogleCalendarProcessedEvent(
   args: {
     readonly db: Db;
@@ -2407,6 +2766,13 @@ async function dispatchGoogleCalendarAutomationEvent(
     timing: args.timing,
   });
   signal.throwIfAborted();
+  if (result === "superseded") {
+    await args.db
+      .delete(googleCalendarProcessedEvents)
+      .where(eq(googleCalendarProcessedEvents.id, processedId));
+    signal.throwIfAborted();
+    return "duplicate";
+  }
   if (result !== "ok") {
     await args.db
       .delete(googleCalendarProcessedEvents)
@@ -2589,20 +2955,7 @@ async function dispatchGoogleCalendarWatchState(
   },
   signal: AbortSignal,
 ): Promise<GoogleCalendarDispatchStateResult> {
-  const hasConsumer = await args.sourceTiming.measure(
-    "api_dispatch_pre_create_zero_automation_event_load_automations",
-    async () => {
-      return await hasEnabledGoogleCalendarConsumer(
-        {
-          db: args.db,
-          orgId: args.state.orgId,
-          userId: args.state.userId,
-          calendarId: args.state.calendarId,
-        },
-        signal,
-      );
-    },
-  );
+  const hasConsumer = await hasCurrentGoogleCalendarWatchConsumer(args, signal);
   if (!hasConsumer) {
     log.debug("Workflow watch dispatch skipped", {
       provider: "google_calendar",
@@ -2708,6 +3061,49 @@ async function dispatchGoogleCalendarWatchState(
   );
 }
 
+async function hasCurrentGoogleCalendarWatchConsumer(
+  args: {
+    readonly db: Db;
+    readonly state: GoogleCalendarWatchStateRow;
+    readonly sourceTiming: AutomationEventSourceTiming;
+  },
+  signal: AbortSignal,
+): Promise<boolean> {
+  const hasConsumer = await args.sourceTiming.measure(
+    "api_dispatch_pre_create_zero_automation_event_load_automations",
+    async () => {
+      return await hasEnabledGoogleCalendarConsumer(
+        {
+          db: args.db,
+          orgId: args.state.orgId,
+          userId: args.state.userId,
+          connectorId: args.state.connectorId,
+          calendarId: args.state.calendarId,
+        },
+        signal,
+      );
+    },
+  );
+  if (hasConsumer) {
+    return true;
+  }
+  await repairGoogleCalendarAutomationProjections(args.db, {
+    orgId: args.state.orgId,
+    userId: args.state.userId,
+  });
+  signal.throwIfAborted();
+  return await hasEnabledGoogleCalendarConsumer(
+    {
+      db: args.db,
+      orgId: args.state.orgId,
+      userId: args.state.userId,
+      connectorId: args.state.connectorId,
+      calendarId: args.state.calendarId,
+    },
+    signal,
+  );
+}
+
 export const dispatchGoogleCalendarWebhook$ = command(
   async (
     { set },
@@ -2760,39 +3156,18 @@ export const dispatchGoogleCalendarWebhook$ = command(
           });
         }
       : async ({ automation, state, event, eventChangeKey, timing }) => {
-          const runInput = await timing.measure(
-            "api_dispatch_pre_create_zero_automation_event_build_run_input",
-            () => {
-              const context = googleCalendarTriggerContext({
-                workflowName: automation.workflowName,
-                automationId: automation.automation.id,
-                event,
-                eventChangeKey,
-              });
-              return { context };
-            },
-          );
-          const result = await set(
-            runWorkflowAutomationNow$,
+          return await set(
+            startGoogleCalendarAutomationRun$,
             {
-              due: {
-                automation: automation.automation,
-                agentId: automation.agentId,
-                chatThreadId: automation.chatThreadId,
-              },
-              automationContext: runInput.context,
-              connectorSourceId: state.connectorId,
+              automation,
+              state,
+              event,
+              eventChangeKey,
+              timing,
               apiStartTime: args.apiStartTime,
-              triggerSource: "automation-event",
-              dispatchFailedCallbacks: dispatchFailedRunCallbacks,
-              timing: timing.collectorForRunStart(),
             },
             signal,
           );
-          signal.throwIfAborted();
-          return result.kind === "ok" || result.kind === "enqueued"
-            ? "ok"
-            : "error";
         };
 
     const result = await dispatchGoogleCalendarWatchState(
@@ -2825,6 +3200,41 @@ export const renewGoogleCalendarWatches$ = command(
     const renewBefore = new Date(
       currentTime.getTime() + WATCH_RENEWAL_WINDOW_MS,
     );
+    const automationOwners = await db
+      .selectDistinct({
+        orgId: workflowAutomations.orgId,
+        userId: workflowAutomations.ownerUserId,
+      })
+      .from(workflowAutomations)
+      .where(
+        and(
+          eq(workflowAutomations.enabled, true),
+          eq(workflowAutomations.kind, "event"),
+          isNull(workflowAutomations.eventConnectorId),
+          inArray(workflowAutomations.eventType, [
+            ...GOOGLE_CALENDAR_EVENT_TYPES,
+          ]),
+        ),
+      );
+    signal.throwIfAborted();
+
+    let failed = 0;
+    for (const owner of automationOwners) {
+      const prepared = await repairAndEnsureGoogleCalendarWatchesForOwner(
+        { db, ...owner, ensureRefreshRequired: false },
+        signal,
+      );
+      signal.throwIfAborted();
+      if (!prepared) {
+        failed += 1;
+        log.warn("Google Calendar watch repair failed", {
+          provider: "google_calendar",
+          action: "repair",
+          result: "provider_error",
+        });
+      }
+    }
+
     const states = await db
       .select({
         connectorId: googleCalendarWatchStates.connectorId,
@@ -2834,7 +3244,6 @@ export const renewGoogleCalendarWatches$ = command(
     signal.throwIfAborted();
 
     let renewed = 0;
-    let failed = 0;
     for (const state of states) {
       const result = await reconcileGoogleCalendarWatchState(
         {

--- a/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
@@ -2212,6 +2212,78 @@ async function loadEnabledGoogleCalendarTargets(
   return [...targets.values()];
 }
 
+async function loadMissingGoogleCalendarWatchTargets(db: Db): Promise<
+  readonly {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly connectorId: string;
+    readonly calendarId: string;
+  }[]
+> {
+  const consumers = await db
+    .select({
+      orgId: workflowAutomations.orgId,
+      userId: workflowAutomations.ownerUserId,
+      connectorId: workflowAutomations.eventConnectorId,
+      eventType: workflowAutomations.eventType,
+      eventConfig: workflowAutomations.eventConfig,
+    })
+    .from(workflowAutomations)
+    .where(
+      and(
+        eq(workflowAutomations.enabled, true),
+        eq(workflowAutomations.kind, "event"),
+        isNotNull(workflowAutomations.eventConnectorId),
+        inArray(workflowAutomations.eventType, [
+          ...GOOGLE_CALENDAR_EVENT_TYPES,
+        ]),
+      ),
+    );
+  const states = await db
+    .select({
+      connectorId: googleCalendarWatchStates.connectorId,
+      calendarId: googleCalendarWatchStates.calendarId,
+    })
+    .from(googleCalendarWatchStates);
+  const existingKeys = new Set(
+    states.map((state) => {
+      return `${state.connectorId}\n${state.calendarId}`;
+    }),
+  );
+  const missing = new Map<
+    string,
+    {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly connectorId: string;
+      readonly calendarId: string;
+    }
+  >();
+  for (const consumer of consumers) {
+    if (consumer.connectorId === null) {
+      continue;
+    }
+    const config = parseGoogleCalendarEventAutomationConfig({
+      eventType: consumer.eventType,
+      eventConfig: consumer.eventConfig,
+    });
+    if (!config) {
+      continue;
+    }
+    const watchKey = `${consumer.connectorId}\n${config.calendarId}`;
+    if (existingKeys.has(watchKey)) {
+      continue;
+    }
+    missing.set(watchKey, {
+      orgId: consumer.orgId,
+      userId: consumer.userId,
+      connectorId: consumer.connectorId,
+      calendarId: config.calendarId,
+    });
+  }
+  return [...missing.values()];
+}
+
 export async function prepareGoogleCalendarWatchStopForConnector(
   args: {
     readonly db: Db;
@@ -3230,6 +3302,24 @@ export const renewGoogleCalendarWatches$ = command(
         log.warn("Google Calendar watch repair failed", {
           provider: "google_calendar",
           action: "repair",
+          result: "provider_error",
+        });
+      }
+    }
+
+    const missingTargets = await loadMissingGoogleCalendarWatchTargets(db);
+    signal.throwIfAborted();
+    for (const target of missingTargets) {
+      const ensured = await ensureGoogleCalendarWatchForUser(
+        { db, ...target },
+        signal,
+      );
+      signal.throwIfAborted();
+      if (ensured.kind !== "ok") {
+        failed += 1;
+        log.warn("Google Calendar watch repair failed", {
+          provider: "google_calendar",
+          action: "ensure_missing",
           result: "provider_error",
         });
       }

--- a/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
@@ -2409,7 +2409,6 @@ export async function prepareGoogleCalendarWatchStopForConnector(
 
 export async function stopPreparedGoogleCalendarWatches(
   pending: PendingGoogleCalendarWatchStop,
-  signal: AbortSignal,
 ): Promise<void> {
   let failed = false;
   for (const channel of pending.channels) {
@@ -2417,7 +2416,6 @@ export async function stopPreparedGoogleCalendarWatches(
       accessToken: pending.accessToken,
       channel,
     });
-    signal.throwIfAborted();
     failed ||= !stopped;
   }
   if (failed) {

--- a/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
@@ -18,6 +18,7 @@ import {
   workflows,
 } from "@okouai/db/schema/workflow";
 import { apiBackendUrl } from "../../lib/api-backend-url";
+import type { Tx } from "../../lib/db-types";
 import { logger } from "../../lib/log";
 import { testOverride } from "../../lib/singleton";
 import { webUrl } from "../../lib/web-url";
@@ -1666,9 +1667,23 @@ export async function ensureGoogleCalendarWatchForUser(
   }
 
   const prepared = await args.db.transaction(async (tx) => {
+    // Principal replacement owns the account lock before it snapshots and
+    // removes watches, so every new watch target must follow the same order.
+    await lockConnectorAccountTarget(tx, {
+      orgId: args.orgId,
+      userId: args.userId,
+      target: { kind: "builtin", connectorSlug: "google-calendar" },
+    });
+    const lockedAccessResult = await resolveGoogleCalendarAccess(
+      { ...args, db: tx, refreshExpiredToken: false },
+      signal,
+    );
+    if (lockedAccessResult.kind !== "ok") {
+      return lockedAccessResult;
+    }
     await lockGoogleCalendarLifecycle(
       tx,
-      accessResult.access.connectorId,
+      lockedAccessResult.access.connectorId,
       calendarId,
     );
     signal.throwIfAborted();
@@ -1690,7 +1705,7 @@ export async function ensureGoogleCalendarWatchForUser(
     const existing = await loadCalendarWatchState(
       {
         db: tx,
-        connectorId: accessResult.access.connectorId,
+        connectorId: lockedAccessResult.access.connectorId,
         calendarId,
       },
       signal,
@@ -1704,12 +1719,12 @@ export async function ensureGoogleCalendarWatchForUser(
       return { kind: "unchanged" } as const;
     }
 
-    return await prepareCalendarWatch(
+    const watch = await prepareCalendarWatch(
       {
         db: tx,
         orgId: args.orgId,
         userId: args.userId,
-        access: accessResult.access,
+        access: lockedAccessResult.access,
         calendarId,
         previousState: existing,
         resetBaseline:
@@ -1719,6 +1734,9 @@ export async function ensureGoogleCalendarWatchForUser(
       },
       signal,
     );
+    return watch.kind === "prepared"
+      ? { ...watch, access: lockedAccessResult.access }
+      : watch;
   });
   if (prepared.kind === "unchanged") {
     return { kind: "ok" };
@@ -1729,7 +1747,7 @@ export async function ensureGoogleCalendarWatchForUser(
 
   const registered = await activatePreparedCalendarWatch({
     db: args.db,
-    access: accessResult.access,
+    access: prepared.access,
     calendarId,
     prepared: prepared.prepared,
     allowStagedOfficialTarget: args.allowStagedOfficialTarget,
@@ -1896,6 +1914,24 @@ async function decideGoogleCalendarWatchReconciliation(
   },
   signal: AbortSignal,
 ): Promise<GoogleCalendarWatchReconcileDecision> {
+  const observedState = await loadCalendarWatchState(
+    {
+      db: args.db,
+      connectorId: args.connectorId,
+      calendarId: args.calendarId,
+    },
+    signal,
+  );
+  if (!observedState) {
+    return { kind: "unchanged" };
+  }
+  // Keep the account -> lifecycle lock order consistent with connector
+  // replacement and deletion cleanup.
+  await lockConnectorAccountTarget(args.db, {
+    orgId: observedState.orgId,
+    userId: observedState.userId,
+    target: { kind: "builtin", connectorSlug: "google-calendar" },
+  });
   await lockGoogleCalendarLifecycle(args.db, args.connectorId, args.calendarId);
   signal.throwIfAborted();
   const state = await loadCalendarWatchState(
@@ -2296,13 +2332,39 @@ async function loadMissingGoogleCalendarWatchTargets(db: Db): Promise<
 
 export async function prepareGoogleCalendarWatchStopForConnector(
   args: {
-    readonly db: Db;
+    readonly db: Tx;
     readonly orgId: string;
     readonly userId: string;
     readonly connectorId: string;
   },
   signal: AbortSignal,
 ): Promise<PendingGoogleCalendarWatchStop | null> {
+  // Hold both ownership levels until the caller's deletion/replacement
+  // transaction commits, then stop the exact captured channels post-commit.
+  await lockConnectorAccountTarget(args.db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    target: { kind: "builtin", connectorSlug: "google-calendar" },
+  });
+  const targets = await args.db
+    .select({ calendarId: googleCalendarWatchStates.calendarId })
+    .from(googleCalendarWatchStates)
+    .where(
+      and(
+        eq(googleCalendarWatchStates.orgId, args.orgId),
+        eq(googleCalendarWatchStates.userId, args.userId),
+        eq(googleCalendarWatchStates.connectorId, args.connectorId),
+      ),
+    )
+    .orderBy(googleCalendarWatchStates.calendarId);
+  for (const target of targets) {
+    await lockGoogleCalendarLifecycle(
+      args.db,
+      args.connectorId,
+      target.calendarId,
+    );
+  }
+  signal.throwIfAborted();
   const states = await args.db
     .select()
     .from(googleCalendarWatchStates)

--- a/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
@@ -238,15 +238,25 @@ interface GoogleCalendarWorkflowRunStartTestInput {
   readonly summary: string | null;
 }
 
-type GoogleCalendarRunStarterTestOverride = (
+type GoogleCalendarBeforeRunStartTestHook = (
   args: GoogleCalendarWorkflowRunStartTestInput,
-) => Promise<"ok" | "error">;
+) => Promise<void>;
 
-const googleCalendarRunStarterOverride = testOverride<
-  GoogleCalendarRunStarterTestOverride | undefined
+const googleCalendarBeforeRunStartHook = testOverride<
+  GoogleCalendarBeforeRunStartTestHook | undefined
 >(() => {
   return undefined;
 });
+
+export function setGoogleCalendarBeforeRunStartHookForTest(
+  hook: GoogleCalendarBeforeRunStartTestHook,
+): void {
+  googleCalendarBeforeRunStartHook.set(hook);
+}
+
+export function clearGoogleCalendarBeforeRunStartHookForTest(): void {
+  googleCalendarBeforeRunStartHook.clear();
+}
 
 class GoogleCalendarAutomationSourceChangedError extends Error {
   constructor() {
@@ -2818,7 +2828,9 @@ async function dispatchGoogleCalendarAutomationEvent(
     readonly startRun: GoogleCalendarRunStarter;
   },
   signal: AbortSignal,
-): Promise<"dispatched" | "duplicate" | { readonly kind: "run_error" }> {
+): Promise<
+  "dispatched" | "duplicate" | "superseded" | { readonly kind: "run_error" }
+> {
   const processedId = await args.timing.measure(
     "api_dispatch_pre_create_zero_automation_event_record_processed_event",
     async () => {
@@ -2843,7 +2855,7 @@ async function dispatchGoogleCalendarAutomationEvent(
       .delete(googleCalendarProcessedEvents)
       .where(eq(googleCalendarProcessedEvents.id, processedId));
     signal.throwIfAborted();
-    return "duplicate";
+    return "superseded";
   }
   if (result !== "ok") {
     await args.db
@@ -3215,32 +3227,38 @@ export const dispatchGoogleCalendarWebhook$ = command(
       return { kind: "unauthorized" };
     }
 
-    const runStarterOverride = googleCalendarRunStarterOverride.get();
-    const startRun: GoogleCalendarRunStarter = runStarterOverride
-      ? async ({ automation, state, event }) => {
-          return await runStarterOverride({
-            automationId: automation.automation.id,
-            workflowName: automation.workflowName,
-            changeType: event.changeType,
-            calendarId: state.calendarId,
-            eventId: event.eventId,
-            summary: event.summary,
-          });
-        }
-      : async ({ automation, state, event, eventChangeKey, timing }) => {
-          return await set(
-            startGoogleCalendarAutomationRun$,
-            {
-              automation,
-              state,
-              event,
-              eventChangeKey,
-              timing,
-              apiStartTime: args.apiStartTime,
-            },
-            signal,
-          );
-        };
+    const startRun: GoogleCalendarRunStarter = async ({
+      automation,
+      state,
+      event,
+      eventChangeKey,
+      timing,
+    }) => {
+      const beforeRunStart = googleCalendarBeforeRunStartHook.get();
+      if (beforeRunStart) {
+        await beforeRunStart({
+          automationId: automation.automation.id,
+          workflowName: automation.workflowName,
+          changeType: event.changeType,
+          calendarId: state.calendarId,
+          eventId: event.eventId,
+          summary: event.summary,
+        });
+        signal.throwIfAborted();
+      }
+      return await set(
+        startGoogleCalendarAutomationRun$,
+        {
+          automation,
+          state,
+          event,
+          eventChangeKey,
+          timing,
+          apiStartTime: args.apiStartTime,
+        },
+        signal,
+      );
+    };
 
     const result = await dispatchGoogleCalendarWatchState(
       {

--- a/turbo/apps/api/src/signals/services/official-workflow-reconciliation.service.ts
+++ b/turbo/apps/api/src/signals/services/official-workflow-reconciliation.service.ts
@@ -157,12 +157,19 @@ function eventWatchFailureMessage(result: {
 
 function accountConnectorSlug(
   eventType: string | null,
-): "gmail" | "google-forms" | "notion" | "stripe" | null {
+): "gmail" | "google-calendar" | "google-forms" | "notion" | "stripe" | null {
   if (
     eventType === "gmail-new-message" ||
     eventType === "gmail-label-applied"
   ) {
     return "gmail";
+  }
+  if (
+    eventType === "google-calendar-event-created" ||
+    eventType === "google-calendar-event-updated" ||
+    eventType === "google-calendar-event-cancelled"
+  ) {
+    return "google-calendar";
   }
   if (
     eventType === "notion-child-page-created" ||
@@ -193,6 +200,7 @@ async function lockOfficialAutomationAccountProjection(
       readonly kind: "locked";
       readonly connectorSlug:
         | "gmail"
+        | "google-calendar"
         | "google-forms"
         | "notion"
         | "stripe"
@@ -204,9 +212,18 @@ async function lockOfficialAutomationAccountProjection(
   const currentConnectorSlug = accountConnectorSlug(args.currentEventType);
   const nextConnectorSlug = accountConnectorSlug(args.nextEventType);
   const connectorSlugs = [currentConnectorSlug, nextConnectorSlug]
-    .filter((slug): slug is "gmail" | "google-forms" | "notion" | "stripe" => {
-      return slug !== null;
-    })
+    .filter(
+      (
+        slug,
+      ): slug is
+        | "gmail"
+        | "google-calendar"
+        | "google-forms"
+        | "notion"
+        | "stripe" => {
+        return slug !== null;
+      },
+    )
     .filter((slug, index, values) => {
       return values.indexOf(slug) === index;
     })

--- a/turbo/apps/api/src/signals/services/workflow-automation-account-projection.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation-account-projection.service.ts
@@ -2,6 +2,7 @@ import type { ConnectorAccountTarget } from "@okouai/api-contracts/contracts/con
 
 import type { Db } from "../external/db";
 import { reprojectGmailAutomationsForOwner } from "./gmail-automation-account.service";
+import { reprojectGoogleCalendarAutomationsForOwner } from "./google-calendar-automation-account.service";
 import { reprojectGoogleFormsAutomationsForOwner } from "./google-forms-automation-account.service";
 import { reprojectGoogleMeetAutomationsForOwner } from "./google-meet-automation-account.service";
 import { reprojectNotionAutomationsForOwner } from "./notion-automation-account.service";
@@ -21,6 +22,11 @@ export async function reprojectWorkflowAutomationsForOwner(
   }
   if (args.target.connectorSlug === "gmail") {
     await reprojectGmailAutomationsForOwner(db, args);
+    signal.throwIfAborted();
+    return;
+  }
+  if (args.target.connectorSlug === "google-calendar") {
+    await reprojectGoogleCalendarAutomationsForOwner(db, args);
     signal.throwIfAborted();
     return;
   }

--- a/turbo/apps/api/src/signals/services/workflow-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation.service.ts
@@ -5535,6 +5535,37 @@ function enabledAutomationWithAccountProjection(
   };
 }
 
+async function finalizeAndPublishEnabledWorkflowAutomation(
+  db: Db,
+  args: {
+    readonly previousAutomation: AutomationRow;
+    readonly enabledAutomation: AutomationRow;
+    readonly memberUserId: string;
+  },
+  signal: AbortSignal,
+): Promise<AutomationResult> {
+  const row = await finalizeEnabledOfficialAutomation(
+    db,
+    args.previousAutomation,
+    args.enabledAutomation,
+    signal,
+  );
+  const chatThreadId = await loadWorkflowUserAutomationThreadId(db, {
+    orgId: row.orgId,
+    userId: row.ownerUserId,
+    workflowId: row.workflowId,
+  });
+  signal.throwIfAborted();
+  await publishThreadBoundWorkflowAutomationChanged(
+    args.memberUserId,
+    chatThreadId,
+  );
+  signal.throwIfAborted();
+  const summary = await rowToSummary(db, row, { chatThreadId });
+  signal.throwIfAborted();
+  return { kind: "ok", summary };
+}
+
 async function persistAndReconcileEnabledWorkflowAutomation(
   db: Db,
   args: {
@@ -5649,26 +5680,15 @@ async function persistAndReconcileEnabledWorkflowAutomation(
   if (watchFailure) {
     return watchFailure;
   }
-  const row = await finalizeEnabledOfficialAutomation(
+  return await finalizeAndPublishEnabledWorkflowAutomation(
     db,
-    args.automation,
-    enabled.row,
+    {
+      previousAutomation: args.automation,
+      enabledAutomation: enabled.row,
+      memberUserId: args.memberUserId,
+    },
     signal,
   );
-  const chatThreadId = await loadWorkflowUserAutomationThreadId(db, {
-    orgId: row.orgId,
-    userId: row.ownerUserId,
-    workflowId: row.workflowId,
-  });
-  signal.throwIfAborted();
-  await publishThreadBoundWorkflowAutomationChanged(
-    args.memberUserId,
-    chatThreadId,
-  );
-  signal.throwIfAborted();
-  const summary = await rowToSummary(db, row, { chatThreadId });
-  signal.throwIfAborted();
-  return { kind: "ok", summary };
 }
 
 function validateEventAutomationEnableReadiness(

--- a/turbo/apps/api/src/signals/services/workflow-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation.service.ts
@@ -109,6 +109,7 @@ import {
   ensureGoogleCalendarWatchForUser,
   hasEnabledGoogleCalendarConsumer,
 } from "./google-calendar-automation-event.service";
+import { resolveGoogleCalendarAutomationConnectorId } from "./google-calendar-automation-account.service";
 import {
   ensureGoogleFormsWatchForUser,
   hasEnabledGoogleFormsConsumer,
@@ -1681,13 +1682,15 @@ async function insertEventAutomation(
   return await db.transaction(async (tx) => {
     const connectorSlug = automationCreateInputIsGmail(args.input)
       ? "gmail"
-      : automationCreateInputIsNotion(args.input)
-        ? "notion"
-        : automationCreateInputIsGoogleForms(args.input)
-          ? "google-forms"
-          : automationCreateInputIsGoogleMeet(args.input)
-            ? "google-meet"
-            : null;
+      : automationCreateInputIsGoogleCalendar(args.input)
+        ? "google-calendar"
+        : automationCreateInputIsNotion(args.input)
+          ? "notion"
+          : automationCreateInputIsGoogleForms(args.input)
+            ? "google-forms"
+            : automationCreateInputIsGoogleMeet(args.input)
+              ? "google-meet"
+              : null;
     if (connectorSlug !== null) {
       await lockConnectorAccountTarget(tx, {
         orgId: args.input.orgId,
@@ -1702,13 +1705,15 @@ async function insertEventAutomation(
     };
     const eventConnectorId = automationCreateInputIsGmail(args.input)
       ? await resolveGmailAutomationConnectorId(tx, connectorArgs)
-      : automationCreateInputIsNotion(args.input)
-        ? await resolveNotionAutomationConnectorId(tx, connectorArgs)
-        : automationCreateInputIsGoogleForms(args.input)
-          ? await resolveGoogleFormsAutomationConnectorId(tx, connectorArgs)
-          : automationCreateInputIsGoogleMeet(args.input)
-            ? await resolveGoogleMeetAutomationConnectorId(tx, connectorArgs)
-            : null;
+      : automationCreateInputIsGoogleCalendar(args.input)
+        ? await resolveGoogleCalendarAutomationConnectorId(tx, connectorArgs)
+        : automationCreateInputIsNotion(args.input)
+          ? await resolveNotionAutomationConnectorId(tx, connectorArgs)
+          : automationCreateInputIsGoogleForms(args.input)
+            ? await resolveGoogleFormsAutomationConnectorId(tx, connectorArgs)
+            : automationCreateInputIsGoogleMeet(args.input)
+              ? await resolveGoogleMeetAutomationConnectorId(tx, connectorArgs)
+              : null;
     if (
       args.expectedEventConnectorId !== undefined &&
       eventConnectorId !== args.expectedEventConnectorId
@@ -2244,6 +2249,22 @@ async function createGoogleCalendarEventAutomationForWorkflow(
   },
   signal: AbortSignal,
 ): Promise<AutomationResult> {
+  const eventConnectorId = await resolveGoogleCalendarAutomationConnectorId(
+    args.context.db,
+    {
+      orgId: args.input.orgId,
+      userId: args.input.member.userId,
+      workflowId: args.context.workflowId,
+    },
+  );
+  signal.throwIfAborted();
+  if (eventConnectorId === null) {
+    return {
+      kind: "bad-request",
+      message:
+        "Connect Google Calendar before adding a Google Calendar event automation",
+    };
+  }
   const preparedConfig = parseGoogleCalendarEventConfig(
     args.input.eventType,
     args.input.eventConfig,
@@ -2254,6 +2275,7 @@ async function createGoogleCalendarEventAutomationForWorkflow(
           db: args.context.db,
           orgId: args.input.orgId,
           userId: args.input.member.userId,
+          connectorId: eventConnectorId,
           calendarId: preparedConfig.calendarId,
         },
         signal,
@@ -2267,7 +2289,15 @@ async function createGoogleCalendarEventAutomationForWorkflow(
     workflowTitle: args.context.workflowTitle,
     automationId: args.context.automationId,
     currentTime: nowDate(),
+    expectedEventConnectorId: eventConnectorId,
   });
+  if (summary === null) {
+    return {
+      kind: "bad-request",
+      message:
+        "Google Calendar account selection changed; retry adding the automation",
+    };
+  }
   if (!args.input.enabled) {
     signal.throwIfAborted();
     return { kind: "ok", summary };
@@ -2280,6 +2310,7 @@ async function createGoogleCalendarEventAutomationForWorkflow(
         db: args.context.db,
         orgId: args.input.orgId,
         userId: args.input.member.userId,
+        connectorId: eventConnectorId,
         calendarId: preparedConfig.calendarId,
         forceRefresh: !hadConsumer,
       },
@@ -2305,7 +2336,7 @@ async function createGoogleCalendarEventAutomationForWorkflow(
             ownerUserId: args.input.member.userId,
             eventType: args.input.eventType,
             eventConfig: preparedConfig,
-            eventConnectorId: null,
+            eventConnectorId,
           },
         ],
       },
@@ -3797,6 +3828,33 @@ async function prepareOfficialGmailEvent(
     : prepared;
 }
 
+async function prepareOfficialGoogleCalendarEvent(
+  db: Db,
+  input: CreateGoogleCalendarEventAutomationInput,
+  signal: AbortSignal,
+): Promise<OfficialAutomationEventPreparationResult> {
+  const eventConnectorId = await resolveGoogleCalendarAutomationConnectorId(
+    db,
+    {
+      orgId: input.orgId,
+      userId: input.member.userId,
+      workflowId: input.workflowId,
+    },
+  );
+  signal.throwIfAborted();
+  if (eventConnectorId === null) {
+    return {
+      kind: "bad-request",
+      message:
+        "Connect Google Calendar before adding a Google Calendar event automation",
+    };
+  }
+  return preparedOfficialEvent(
+    parseGoogleCalendarEventConfig(input.eventType, input.eventConfig),
+    { eventConnectorId },
+  );
+}
+
 async function prepareOfficialGithubEvent(
   db: Db,
   input: CreateGithubEventAutomationInput,
@@ -3988,9 +4046,7 @@ export const prepareOfficialAutomationReconfiguration$ = command(
       return await prepareOfficialGithubEvent(db, input, signal);
     }
     if (automationCreateInputIsGoogleCalendar(input)) {
-      return preparedOfficialEvent(
-        parseGoogleCalendarEventConfig(input.eventType, input.eventConfig),
-      );
+      return await prepareOfficialGoogleCalendarEvent(db, input, signal);
     }
     if (automationCreateInputIsGoogleForms(input)) {
       const enabled = await get(
@@ -4764,6 +4820,9 @@ async function enabledWatchHadConsumer(
   if (!supportedGoogleCalendarEventType(args.automation.eventType)) {
     return false;
   }
+  if (args.automation.eventConnectorId === null) {
+    return false;
+  }
   const config = parseGoogleCalendarEventConfig(
     args.automation.eventType,
     args.automation.eventConfig,
@@ -4773,6 +4832,7 @@ async function enabledWatchHadConsumer(
       db: args.db,
       orgId: args.automation.orgId,
       userId: args.automation.ownerUserId,
+      connectorId: args.automation.eventConnectorId,
       calendarId: config.calendarId,
     },
     signal,
@@ -4851,6 +4911,13 @@ async function ensureEnabledAutomationEventWatch(
   if (!supportedGoogleCalendarEventType(args.automation.eventType)) {
     return null;
   }
+  if (args.automation.eventConnectorId === null) {
+    return {
+      kind: "bad-request",
+      message:
+        "Connect Google Calendar before using Google Calendar event automations",
+    };
+  }
   const config = parseGoogleCalendarEventConfig(
     args.automation.eventType,
     args.automation.eventConfig,
@@ -4860,6 +4927,7 @@ async function ensureEnabledAutomationEventWatch(
       db: args.db,
       orgId: args.automation.orgId,
       userId: args.automation.ownerUserId,
+      connectorId: args.automation.eventConnectorId,
       calendarId: config.calendarId,
       forceRefresh: !args.hadConsumer,
     },
@@ -5080,6 +5148,7 @@ async function ensureEnabledAutomationEventWatchWithRollback(
 
 type EnabledAutomationAccountProjection =
   | { readonly status: "gmail-unavailable" }
+  | { readonly status: "google-calendar-unavailable" }
   | { readonly status: "google-forms-unavailable" }
   | { readonly status: "google-meet-unavailable" }
   | { readonly status: "notion-unavailable" }
@@ -5115,6 +5184,7 @@ async function projectGoogleFormsEnabledEventConfig(
 
 type EnabledAutomationAccountProvider =
   | "gmail"
+  | "google-calendar"
   | "google-forms"
   | "google-meet"
   | "notion"
@@ -5125,6 +5195,9 @@ function enabledAutomationAccountProvider(
 ): EnabledAutomationAccountProvider | null {
   if (supportedGmailEventType(automation.eventType)) {
     return "gmail";
+  }
+  if (supportedGoogleCalendarEventType(automation.eventType)) {
+    return "google-calendar";
   }
   if (supportedGoogleFormsEventType(automation.eventType)) {
     return "google-forms";
@@ -5151,6 +5224,9 @@ async function resolveEnabledAutomationConnectorId(
     case "gmail": {
       return await resolveGmailAutomationConnectorId(db, args);
     }
+    case "google-calendar": {
+      return await resolveGoogleCalendarAutomationConnectorId(db, args);
+    }
     case "google-forms": {
       return await resolveGoogleFormsAutomationConnectorId(db, args);
     }
@@ -5170,6 +5246,9 @@ function unavailableEnabledAutomationProjection(
     case "gmail": {
       return { status: "gmail-unavailable" };
     }
+    case "google-calendar": {
+      return { status: "google-calendar-unavailable" };
+    }
     case "google-forms": {
       return { status: "google-forms-unavailable" };
     }
@@ -5178,6 +5257,28 @@ function unavailableEnabledAutomationProjection(
     }
     case "notion": {
       return { status: "notion-unavailable" };
+    }
+  }
+}
+
+function enabledAutomationUnavailableMessage(
+  provider: Exclude<EnabledAutomationAccountProvider, "stripe">,
+): string {
+  switch (provider) {
+    case "gmail": {
+      return "Connect Gmail before using Gmail event automations";
+    }
+    case "google-calendar": {
+      return "Connect Google Calendar before using Google Calendar event automations";
+    }
+    case "google-forms": {
+      return "Connect Google Forms before using Google Forms response automations";
+    }
+    case "google-meet": {
+      return "Connect Google Meet before using Google Meet event automations";
+    }
+    case "notion": {
+      return "Connect Notion before using Notion event automations";
     }
   }
 }
@@ -5279,6 +5380,7 @@ async function persistEnabledWorkflowAutomation(
   | { readonly status: "team-required" }
   | { readonly status: "conflict" }
   | { readonly status: "gmail-unavailable" }
+  | { readonly status: "google-calendar-unavailable" }
   | { readonly status: "notion-unavailable" }
   | { readonly status: "notion-account-changed" }
   | { readonly status: "stripe-unavailable"; readonly message: string }
@@ -5362,11 +5464,8 @@ async function prepareEnabledAutomationAccountProjection(
   | { readonly kind: "ok"; readonly eventConnectorId: string | null }
   | AutomationActionFailure
 > {
-  const usesGmail = supportedGmailEventType(automation.eventType);
-  const usesGoogleForms = supportedGoogleFormsEventType(automation.eventType);
-  const usesGoogleMeet = supportedGoogleMeetEventType(automation.eventType);
-  const usesNotion = supportedNotionEventType(automation.eventType);
-  if (!usesGmail && !usesGoogleForms && !usesGoogleMeet && !usesNotion) {
+  const provider = enabledAutomationAccountProvider(automation);
+  if (provider === null || provider === "stripe") {
     return { kind: "ok", eventConnectorId: automation.eventConnectorId };
   }
   const connectorArgs = {
@@ -5374,28 +5473,23 @@ async function prepareEnabledAutomationAccountProjection(
     userId: automation.ownerUserId,
     workflowId: automation.workflowId,
   };
-  const eventConnectorId = usesGmail
-    ? await resolveGmailAutomationConnectorId(db, connectorArgs)
-    : usesGoogleForms
-      ? await resolveGoogleFormsAutomationConnectorId(db, connectorArgs)
-      : usesGoogleMeet
-        ? await resolveGoogleMeetAutomationConnectorId(db, connectorArgs)
-        : await resolveNotionAutomationConnectorId(db, connectorArgs);
+  const eventConnectorId = await resolveEnabledAutomationConnectorId(
+    db,
+    provider,
+    connectorArgs,
+  );
   signal.throwIfAborted();
   if (eventConnectorId === null) {
     return {
       kind: "bad-request",
-      message: usesGmail
-        ? "Connect Gmail before using Gmail event automations"
-        : usesGoogleForms
-          ? "Connect Google Forms before using Google Forms response automations"
-          : usesGoogleMeet
-            ? "Connect Google Meet before using Google Meet event automations"
-            : "Connect Notion before using Notion event automations",
+      message: enabledAutomationUnavailableMessage(provider),
     };
   }
-  if (!supportedNotionEventType(automation.eventType)) {
+  if (provider !== "notion") {
     return { kind: "ok", eventConnectorId };
+  }
+  if (!supportedNotionEventType(automation.eventType)) {
+    throw new Error("Notion automation account projection is incomplete");
   }
   const eventType = automation.eventType;
   const validation = await validateNotionEventConfigForConnector(
@@ -5496,6 +5590,14 @@ async function persistAndReconcileEnabledWorkflowAutomation(
     return {
       kind: "bad-request",
       message: "Connect Gmail before using Gmail event automations",
+    };
+  }
+  if (enabled.status === "google-calendar-unavailable") {
+    signal.throwIfAborted();
+    return {
+      kind: "bad-request",
+      message:
+        "Connect Google Calendar before using Google Calendar event automations",
     };
   }
   if (enabled.status === "notion-unavailable") {


### PR DESCRIPTION
## Summary

- persist the exact thread-selected or default Google Calendar connector in the existing automation account projection
- reconcile Calendar watches by exact connector and calendar across selection, default, connection, copy, official workflow, enable, disable, deletion, and scheduled repair lifecycles
- reject delayed or concurrent source changes during webhook matching and durable queue admission, while preserving exact connector credentials for the run
- move account deletion and principal-replacement channel cleanup after the local transaction using captured channel identities
- serialize watch creation and renewal with connector cleanup in account-to-lifecycle lock order so cleanup captures a stable channel set
- finish every captured Calendar channel stop after request cancellation while preserving the cancellation result
- keep the strict Calendar event config and database schema unchanged for mixed-version compatibility

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/workflow-automations.test.ts --maxWorkers=1 --silent=passed-only` (79 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-google-calendar.test.ts src/signals/routes/__tests__/workflows.test.ts --maxWorkers=1 --silent=passed-only` (42 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/official-workflows.test.ts src/signals/routes/__tests__/connector-accounts.test.ts --maxWorkers=1 --silent=passed-only` (54 tests)
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- pre-commit repository formatting, full Knip, full Turbo type checking, and file-size checks

Closes #30594

Parent context: #30585
