### PR TITLE
fix(api): repair model-annotated legacy snapshots

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-event-snapshot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-event-snapshot.test.ts
@@ -57,6 +57,7 @@ const R2_GC_SHARD_GROUP_COUNT = 16 ** 2;
 const RETIRED_MORNING_BRIEF_CUTOVER_ERROR = "legacy_morning_brief_cutover";
 const RETIRED_MORNING_BRIEF_CUTOVER_MESSAGE =
   "This legacy Morning Brief was stopped during the Official Workflow cutover.";
+const HISTORICAL_MORNING_BRIEF_SELECTED_MODEL = "claude-sonnet-5";
 
 function sanitizedLegacyControlRevokeLine(row: ChatEventRow): string {
   const invalidFields = [
@@ -207,6 +208,65 @@ function sanitizedLegacyContextlessMorningBriefClaimLines(
     throw new Error("Expected an exact historical contextless claim pair");
   }
   chatEventFromRow(root);
+  chatEventFromRow(claim);
+  const encode = (row: ChatEventRow): string => {
+    return `${JSON.stringify({
+      id: row.id,
+      chatThreadId: row.chatThreadId,
+      runId: row.runId,
+      revokesEventId: row.revokesEventId,
+      eventType: "input.prompt",
+      payload: row.payload,
+      contextType: "morning_brief",
+      contextId: null,
+      runEventSequenceNumber: null,
+      runEventId: null,
+      seqId: row.seqId,
+      createdAt: row.createdAt,
+    })}\n`;
+  };
+  return { root: encode(root), claim: encode(claim) };
+}
+
+function sanitizedLegacyContextlessMorningBriefModelClaimLines(
+  root: ChatEventRow,
+  claim: ChatEventRow,
+): { readonly root: string; readonly claim: string } {
+  const projectedRoot = chatEventFromRow(root);
+  if (
+    !isSanitizedContextlessMorningBriefRoot(root) ||
+    projectedRoot.eventType !== "input.prompt" ||
+    projectedRoot.userMessage.parts.some((part) => {
+      return part.type === "model";
+    }) ||
+    claim.id === root.id ||
+    claim.chatThreadId !== root.chatThreadId ||
+    claim.eventType !== "input.prompt" ||
+    claim.runId === null ||
+    claim.revokesEventId !== root.id ||
+    claim.contextType !== "morning_brief" ||
+    claim.contextId !== null ||
+    claim.runEventSequenceNumber !== null ||
+    claim.runEventId !== null ||
+    claim.seqId <= root.seqId ||
+    claim.createdAt <= root.createdAt ||
+    !isDeepStrictEqual(claim.payload, {
+      userMessage: {
+        version: 1,
+        parts: [
+          ...projectedRoot.userMessage.parts,
+          {
+            type: "model",
+            selectedModel: HISTORICAL_MORNING_BRIEF_SELECTED_MODEL,
+          },
+        ],
+      },
+    })
+  ) {
+    throw new Error(
+      "Expected an exact historical contextless model-annotated claim pair",
+    );
+  }
   chatEventFromRow(claim);
   const encode = (row: ChatEventRow): string => {
     return `${JSON.stringify({
@@ -567,7 +627,7 @@ describe("chat event snapshot read endpoints", () => {
     const agent = await bdd.createAgent(owner, {
       displayName: "Morning Brief archive repair agent",
     });
-    const markers = Array.from({ length: 6 }, (_, index) => {
+    const markers = Array.from({ length: 7 }, (_, index) => {
       return `morning-brief-history-${(index + 1).toString()}-${randomUUID()}`;
     });
     let threadId: string | undefined;
@@ -599,12 +659,13 @@ describe("chat event snapshot read endpoints", () => {
     const promptRows = originalRows.filter((row) => {
       return row.eventType === "input.prompt";
     });
-    expect(promptRows).toHaveLength(6);
+    expect(promptRows).toHaveLength(7);
 
     const runIds = markers.map(() => {
       return randomUUID();
     });
     const contextlessClaimRunId = randomUUID();
+    const contextlessModelClaimRunId = randomUUID();
     const historicalDocuments: readonly UserMessageDocument[] = [
       {
         version: 1,
@@ -677,6 +738,15 @@ describe("chat event snapshot read endpoints", () => {
           },
         ],
       },
+      {
+        version: 1,
+        parts: [
+          {
+            type: "text",
+            text: "Preserve the authoritative Run model annotation.",
+          },
+        ],
+      },
     ];
     const promptIndexById = new Map(
       promptRows.map((row, index) => {
@@ -712,6 +782,10 @@ describe("chat event snapshot read endpoints", () => {
       rejectionRows[5],
       revocationFixtureMessage,
     );
+    const contextlessModelClaimRow = requiredRevokingRow(
+      rejectionRows[6],
+      revocationFixtureMessage,
+    );
     const contextlessRootRow = requiredPromptRow(
       originalRows.find((row) => {
         return row.id === contextlessClaimRow.revokesEventId;
@@ -729,6 +803,12 @@ describe("chat event snapshot read endpoints", () => {
         return row.id === contextlessRetirementRow.revokesEventId;
       }),
       "Expected the historical contextless retirement root prompt",
+    );
+    const contextlessModelClaimRootRow = requiredPromptRow(
+      originalRows.find((row) => {
+        return row.id === contextlessModelClaimRow.revokesEventId;
+      }),
+      "Expected the historical contextless model-annotated root prompt",
     );
     const contextlessRetirementCompanionRow = requiredValue(
       originalRows.find((row) => {
@@ -757,6 +837,14 @@ describe("chat event snapshot read endpoints", () => {
         : historicalDocuments[contextlessRetirementRootPromptIndex],
       "Expected the contextless retirement document",
     );
+    const contextlessModelClaimRootPromptIndex = requiredValue(
+      promptIndexById.get(contextlessModelClaimRootRow.id),
+      "Expected the contextless model-annotated claim prompt index",
+    );
+    const contextlessModelClaimDocument = requiredValue(
+      historicalDocuments[contextlessModelClaimRootPromptIndex],
+      "Expected the contextless model-annotated claim document",
+    );
     const expectedRows = originalRows.map((row): ChatEventRow => {
       if (row.id === contextlessClaimRow.id) {
         return chatEventRowSchema.parse({
@@ -766,6 +854,29 @@ describe("chat event snapshot read endpoints", () => {
           contextType: "web",
           contextId: null,
           payload: { userMessage: contextlessDocument },
+          runEventSequenceNumber: null,
+          runEventId: null,
+        });
+      }
+      if (row.id === contextlessModelClaimRow.id) {
+        return chatEventRowSchema.parse({
+          ...row,
+          eventType: "input.prompt",
+          runId: contextlessModelClaimRunId,
+          contextType: "web",
+          contextId: null,
+          payload: {
+            userMessage: {
+              version: 1,
+              parts: [
+                ...contextlessModelClaimDocument.parts,
+                {
+                  type: "model",
+                  selectedModel: HISTORICAL_MORNING_BRIEF_SELECTED_MODEL,
+                },
+              ],
+            },
+          },
           runEventSequenceNumber: null,
           runEventId: null,
         });
@@ -837,7 +948,8 @@ describe("chat event snapshot read endpoints", () => {
           runId:
             row.id === contextlessRootRow.id ||
             row.id === chainedRootRow.id ||
-            row.id === contextlessRetirementRootRow.id
+            row.id === contextlessRetirementRootRow.id ||
+            row.id === contextlessModelClaimRootRow.id
               ? null
               : runId,
           contextType: "web",
@@ -884,7 +996,9 @@ describe("chat event snapshot read endpoints", () => {
         row.id === contextlessRootRow.id ||
         row.id === contextlessClaimRow.id ||
         row.id === contextlessRetirementRootRow.id ||
-        row.id === contextlessRetirementRow.id
+        row.id === contextlessRetirementRow.id ||
+        row.id === contextlessModelClaimRootRow.id ||
+        row.id === contextlessModelClaimRow.id
       ) {
         return chatEventRowSchema.parse({
           ...row,
@@ -994,6 +1108,18 @@ describe("chat event snapshot read endpoints", () => {
     const staleContextlessRetirementCompanion = staleRows.find((row) => {
       return row.id === contextlessRetirementCompanionRow.id;
     });
+    const staleContextlessModelClaimRoot = requiredValue(
+      staleRows.find((row) => {
+        return row.id === contextlessModelClaimRootRow.id;
+      }),
+      "Expected a byte-exact contextless model-annotated claim root",
+    );
+    const staleContextlessModelClaim = requiredValue(
+      staleRows.find((row) => {
+        return row.id === contextlessModelClaimRow.id;
+      }),
+      "Expected a byte-exact contextless model-annotated claim",
+    );
     if (
       staleDirectControlRevoke === undefined ||
       staleContextlessRoot === undefined ||
@@ -1026,6 +1152,11 @@ describe("chat event snapshot read endpoints", () => {
         staleContextlessRetirement,
         staleContextlessRetirementCompanion,
       );
+    const byteExactContextlessModelClaimLines =
+      sanitizedLegacyContextlessMorningBriefModelClaimLines(
+        staleContextlessModelClaimRoot,
+        staleContextlessModelClaim,
+      );
     const staleArchive = Buffer.from(
       staleRows
         .map((row) => {
@@ -1046,6 +1177,12 @@ describe("chat event snapshot read endpoints", () => {
           }
           if (row.id === contextlessRetirementCompanionRow.id) {
             return byteExactContextlessRetirementLines.companion;
+          }
+          if (row.id === contextlessModelClaimRootRow.id) {
+            return byteExactContextlessModelClaimLines.root;
+          }
+          if (row.id === contextlessModelClaimRow.id) {
+            return byteExactContextlessModelClaimLines.claim;
           }
           return row.id === chainedControlRevokeRow.id
             ? byteExactChainedRevokeLine
@@ -1070,6 +1207,13 @@ describe("chat event snapshot read endpoints", () => {
       staleArchive.includes(
         Buffer.from(
           `${byteExactContextlessRetirementLines.root}${byteExactContextlessRetirementLines.retirement}${byteExactContextlessRetirementLines.companion}`,
+        ),
+      ),
+    ).toBeTruthy();
+    expect(
+      staleArchive.includes(
+        Buffer.from(
+          `${byteExactContextlessModelClaimLines.root}${byteExactContextlessModelClaimLines.claim}`,
         ),
       ),
     ).toBeTruthy();
@@ -1197,6 +1341,43 @@ describe("chat event snapshot read endpoints", () => {
     });
     expect(
       repairedRows.find((row) => {
+        return row.id === contextlessModelClaimRootRow.id;
+      }),
+    ).toMatchObject({
+      eventType: "input.prompt",
+      runId: null,
+      revokesEventId: null,
+      contextType: "web",
+      contextId: null,
+      payload: { userMessage: contextlessModelClaimDocument },
+    });
+    expect(
+      repairedRows.find((row) => {
+        return row.id === contextlessModelClaimRow.id;
+      }),
+    ).toMatchObject({
+      eventType: "input.prompt",
+      runId: contextlessModelClaimRunId,
+      revokesEventId: contextlessModelClaimRootRow.id,
+      contextType: "web",
+      contextId: null,
+      payload: {
+        userMessage: {
+          version: 1,
+          parts: [
+            ...contextlessModelClaimDocument.parts,
+            {
+              type: "model",
+              selectedModel: HISTORICAL_MORNING_BRIEF_SELECTED_MODEL,
+            },
+          ],
+        },
+      },
+      runEventSequenceNumber: null,
+      runEventId: null,
+    });
+    expect(
+      repairedRows.find((row) => {
         return row.id === contextlessRetirementRootRow.id;
       }),
     ).toMatchObject({
@@ -1249,7 +1430,7 @@ describe("chat event snapshot read endpoints", () => {
     const expectedPromptRows = expectedRows.filter((row) => {
       return row.eventType === "input.prompt";
     });
-    expect(expectedPromptRows).toHaveLength(7);
+    expect(expectedPromptRows).toHaveLength(9);
     expect(
       projectedPrompts.map((event) => {
         return {
@@ -1549,6 +1730,21 @@ describe("chat event snapshot read endpoints", () => {
       runEventSequenceNumber: null,
       runEventId: null,
     });
+    const contextlessModelClaim = chatEventRowSchema.parse({
+      ...contextlessClaim,
+      payload: {
+        userMessage: {
+          version: 1,
+          parts: [
+            ...contextlessDocument.parts,
+            {
+              type: "model",
+              selectedModel: HISTORICAL_MORNING_BRIEF_SELECTED_MODEL,
+            },
+          ],
+        },
+      },
+    });
     const contextlessRetirement = chatEventRowSchema.parse({
       ...rejectedRow,
       runId: null,
@@ -1587,6 +1783,10 @@ describe("chat event snapshot read endpoints", () => {
       contextlessRoot,
       contextlessRetirement,
       contextlessRetirementCompanion,
+    );
+    sanitizedLegacyContextlessMorningBriefModelClaimLines(
+      contextlessRoot,
+      contextlessModelClaim,
     );
     const contextlessRows = (
       root: ChatEventRow,
@@ -1690,6 +1890,123 @@ describe("chat event snapshot read endpoints", () => {
             })
           : row;
       }),
+    );
+    const missingModelClaimPredecessorBody = encodeRows(
+      contextlessRows(
+        contextlessRoot,
+        chatEventRowSchema.parse({
+          ...contextlessModelClaim,
+          revokesEventId: randomUUID(),
+        }),
+      ),
+    );
+    const mismatchedModelClaimPayloadBody = encodeRows(
+      contextlessRows(
+        contextlessRoot,
+        chatEventRowSchema.parse({
+          ...contextlessModelClaim,
+          payload: {
+            userMessage: {
+              version: 1,
+              parts: [
+                {
+                  type: "text",
+                  text: "Sanitized mismatched model-annotated prompt.",
+                },
+                {
+                  type: "model",
+                  selectedModel: HISTORICAL_MORNING_BRIEF_SELECTED_MODEL,
+                },
+              ],
+            },
+          },
+        }),
+      ),
+    );
+    const reorderedModelClaimBody = encodeRows(
+      contextlessRows(
+        contextlessRoot,
+        chatEventRowSchema.parse({
+          ...contextlessModelClaim,
+          createdAt: contextlessRoot.createdAt,
+        }),
+      ),
+    );
+    const crossThreadModelClaimBody = encodeRows(
+      contextlessRows(
+        contextlessRoot,
+        chatEventRowSchema.parse({
+          ...contextlessModelClaim,
+          chatThreadId: randomUUID(),
+        }),
+      ),
+    );
+    const malformedModelClaimBody = encodeRows(
+      contextlessRows(
+        contextlessRoot,
+        chatEventRowSchema.parse({
+          ...contextlessModelClaim,
+          payload: {
+            userMessage: {
+              version: 1,
+              parts: [
+                {
+                  type: "model",
+                  selectedModel: HISTORICAL_MORNING_BRIEF_SELECTED_MODEL,
+                },
+                ...contextlessDocument.parts,
+              ],
+            },
+          },
+        }),
+      ),
+    );
+    const ambiguousModelClaimBody = encodeRows(
+      contextlessRows(
+        contextlessRoot,
+        contextlessModelClaim,
+        chatEventRowSchema.parse({
+          ...semanticRootRow,
+          revokesEventId: contextlessRoot.id,
+        }),
+      ),
+    );
+    const duplicateModelClaimIdBody = encodeRows(
+      originalRows.map((row) => {
+        if (row.id === contextlessRoot.id) {
+          return contextlessRoot;
+        }
+        if (row.id === contextlessModelClaim.id) {
+          return contextlessModelClaim;
+        }
+        return row.id === semanticRootRow.id
+          ? chatEventRowSchema.parse({
+              ...semanticRootRow,
+              id: contextlessRoot.id,
+            })
+          : row;
+      }),
+    );
+    const futureModelClaimBody = encodeRows(
+      contextlessRows(
+        contextlessRoot,
+        chatEventRowSchema.parse({
+          ...contextlessModelClaim,
+          payload: {
+            userMessage: {
+              version: 1,
+              parts: [
+                ...contextlessDocument.parts,
+                {
+                  type: "model",
+                  selectedModel: HISTORICAL_MORNING_BRIEF_SELECTED_MODEL,
+                  serviceTier: "priority",
+                },
+              ],
+            },
+          },
+        }),
+      ),
     );
     const missingRetirementPredecessorBody = encodeRows(
       contextlessRetirementRows(
@@ -1956,6 +2273,54 @@ describe("chat event snapshot read endpoints", () => {
       {
         failureClass: "projection",
         object: gzipSync(duplicateContextlessIdBody),
+        projectionSubstage: "retired_context",
+        projectionVariant: "missing_context_id",
+      },
+      {
+        failureClass: "projection",
+        object: gzipSync(missingModelClaimPredecessorBody),
+        projectionSubstage: "retired_context",
+        projectionVariant: "missing_context_id",
+      },
+      {
+        failureClass: "projection",
+        object: gzipSync(mismatchedModelClaimPayloadBody),
+        projectionSubstage: "retired_context",
+        projectionVariant: "missing_context_id",
+      },
+      {
+        failureClass: "projection",
+        object: gzipSync(reorderedModelClaimBody),
+        projectionSubstage: "retired_context",
+        projectionVariant: "missing_context_id",
+      },
+      {
+        failureClass: "projection",
+        object: gzipSync(crossThreadModelClaimBody),
+        projectionSubstage: "retired_context",
+        projectionVariant: "missing_context_id",
+      },
+      {
+        failureClass: "projection",
+        object: gzipSync(malformedModelClaimBody),
+        projectionSubstage: "retired_context",
+        projectionVariant: "missing_context_id",
+      },
+      {
+        failureClass: "projection",
+        object: gzipSync(ambiguousModelClaimBody),
+        projectionSubstage: "retired_context",
+        projectionVariant: "missing_context_id",
+      },
+      {
+        failureClass: "projection",
+        object: gzipSync(duplicateModelClaimIdBody),
+        projectionSubstage: "retired_context",
+        projectionVariant: "missing_context_id",
+      },
+      {
+        failureClass: "projection",
+        object: gzipSync(futureModelClaimBody),
         projectionSubstage: "retired_context",
         projectionVariant: "missing_context_id",
       },

--- a/turbo/apps/api/src/signals/services/chat-event-snapshot-body.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-snapshot-body.service.ts
@@ -143,6 +143,42 @@ function isExactContextlessMorningBriefRoot(row: ChatEventRow): boolean {
   );
 }
 
+function hasExactContextlessMorningBriefModelClaimPayload(
+  row: ChatEventRow,
+  root: ChatEventRow,
+): boolean {
+  const rootUserMessage = root.payload?.userMessage;
+  const claimUserMessage = row.payload?.userMessage;
+  if (
+    !isRecord(rootUserMessage) ||
+    !Array.isArray(rootUserMessage.parts) ||
+    !isRecord(claimUserMessage) ||
+    !Array.isArray(claimUserMessage.parts) ||
+    rootUserMessage.parts.some((part) => {
+      return isRecord(part) && part.type === "model";
+    }) ||
+    claimUserMessage.parts.length !== rootUserMessage.parts.length + 1
+  ) {
+    return false;
+  }
+  const modelPart = claimUserMessage.parts.at(-1);
+  // The #25467 queue-claim writer copied every original part, then appended
+  // exactly one server-owned Run model annotation. The archived Morning Brief
+  // fixture predates service-tier annotations, so every wider shape stays
+  // fail-closed.
+  return (
+    isRecord(modelPart) &&
+    Object.keys(modelPart).length === 2 &&
+    modelPart.type === "model" &&
+    typeof modelPart.selectedModel === "string" &&
+    modelPart.selectedModel.length > 0 &&
+    isDeepStrictEqual(
+      claimUserMessage.parts.slice(0, -1),
+      rootUserMessage.parts,
+    )
+  );
+}
+
 function isExactContextlessMorningBriefClaim(
   row: ChatEventRow,
   root: ChatEventRow,
@@ -160,7 +196,8 @@ function isExactContextlessMorningBriefClaim(
     root.seqId < row.seqId &&
     root.createdAt < row.createdAt &&
     hasExactContextlessMorningBriefPromptPayload(row) &&
-    isDeepStrictEqual(row.payload, root.payload)
+    (isDeepStrictEqual(row.payload, root.payload) ||
+      hasExactContextlessMorningBriefModelClaimPayload(row, root))
   );
 }
 
@@ -446,13 +483,14 @@ function repairMorningBriefRow(
     return { row, removedDocumentParts: 0 };
   }
   // Before Morning Brief context rows existed, queue claim wrote an ordered,
-  // run-owned replacement prompt. The Phase A drain fallback also wrote an
-  // ordered run-less rejection plus its adjacent error companion. Both writers
-  // revoked a run-less root and copied its exact document. Migration 0836 later
-  // classified the affected inputs while intentionally preserving their null
-  // context IDs. Accept only those complete archive-local relationships; never
-  // derive or synthesize an ID. This persisted-state compatibility is limited
-  // to immutable legacy V7 Snapshots. Remove it after all surviving V7 heads
+  // run-owned replacement prompt. One revision copied the document byte-for-
+  // byte; #25467 copied its original parts and appended the authoritative Run
+  // model annotation. The Phase A drain fallback also wrote an ordered run-less
+  // rejection plus its adjacent error companion. Migration 0836 classified the
+  // affected inputs while intentionally preserving their null context IDs.
+  // Accept only those complete archive-local relationships; never derive or
+  // synthesize an ID. This persisted-state compatibility is limited to
+  // immutable legacy V7 Snapshots. Remove it after all surviving V7 heads
   // converge to r1 and the retired writer rollback window closes; removal is
   // tracked by #30369 and #28905.
   if (row.contextId === null && !contextlessRepairIds.has(row.id)) {


### PR DESCRIPTION
## Summary

- repair immutable V7 Morning Brief Snapshot rows only when one unique contextless, runless `input.prompt` root is revoked by one unique same-thread, run-owned `input.prompt` claim whose payload is the root's original parts plus exactly one final two-field Run model annotation
- retain every predecessor repair path byte-exactly, rewrite only the retired Snapshot projection to current `web` / null context, and continue validating every repaired row against the current Chat Event contract before exact-pointer CAS publication
- add a sanitized positive route regression plus missing, duplicate, reordered, cross-thread, malformed, payload-mismatched, ambiguous, and future negative cases that prove source bytes and the pointer remain unchanged on rejection

## Diagnosis

The bounded production structure rules out the Phase A retirement writer: the archive contains only prompts, messages, followups, and completed runs, with no rejection/error pair. Repository history identifies the remaining relationship:

- migration 0836 (`9e8fc83b090bf6aa4bb874be9c279e78295d8182`) classified historical queued roots and run-owned claims as `morning_brief` while intentionally preserving null context IDs
- the queue-claim writer introduced by #25467 (`64f785f5b8a3a9bd6b802b079299bcde6b7d1100`) copied the root document after removing any prior model part and appended the selected Run model as the final annotation
- the sanitized historical Morning Brief fixture at `f71e821906627a3e7198eb8a395d2e2825b0e748` confirms the archived claim used exactly `{ type: "model", selectedModel }`, before service-tier annotations

The matcher therefore requires the complete existing identity, thread, Run, revocation, sequence/time, and null Run-event relationship, plus an exact prefix match and one exact final two-key model part. It rejects roots that already contain a model part and rejects all wider annotations, including `serviceTier`.

No archived production row, payload, message text, attachment, source Snapshot object, or user content was read or logged.

## Fallbacks

- `chat-event-snapshot-body.service.ts` — `hasExactContextlessMorningBriefModelClaimPayload` extends the existing persisted-state V7 Snapshot compatibility matcher for the proven pre-service-tier queue-claim writer. Surface: immutable archived Snapshot projection in the API reader. Window: surviving legacy V7 heads only. Removal condition: every surviving V7 head has converged to current-r1 and the retired writer rollback window has closed; tracked by #30369 and #28905. No context ID or payload is synthesized.

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/chat-event-snapshot-body.service.ts apps/api/src/signals/routes/__tests__/chat-event-snapshot.test.ts`
- `pnpm --filter api run lint`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-event-snapshot.test.ts --reporter=verbose` (8 passed)
- `git diff --check`

Closes #30911
