### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/turbo/apps/cli/src/commands/doctor/__tests__/connectors.test.ts
+++ b/turbo/apps/cli/src/commands/doctor/__tests__/connectors.test.ts
@@ -437,9 +437,8 @@ describe("okou doctor connectors command", () => {
       },
       connectors: [],
       error: {
-        code: "OFFICIAL_WORKFLOW_UNSUPPORTED",
-        message:
-          "Connector readiness is unavailable for this Official Workflow during rollout.",
+        code: "CONFLICT",
+        message: "The workflow could not be checked in its current state.",
         status: 409,
       },
     });

--- a/turbo/apps/cli/src/commands/doctor/connectors.ts
+++ b/turbo/apps/cli/src/commands/doctor/connectors.ts
@@ -161,21 +161,7 @@ function workflowIdentity(
   };
 }
 
-function apiRequestError(
-  error: ApiRequestError,
-  workflow: WorkflowSummary,
-): ConnectorDoctorError {
-  // A commit-addressed CLI can reach an API version from before #30491.
-  // Remove this branch after #30491 is deployed and those API rollback targets
-  // are retired; cleanup is tracked by the parent Connector Doctor EPIC #30469.
-  if (workflow.official && error.status === 409) {
-    return {
-      code: "OFFICIAL_WORKFLOW_UNSUPPORTED",
-      message:
-        "Connector readiness is unavailable for this Official Workflow during rollout.",
-      status: 409,
-    };
-  }
+function apiRequestError(error: ApiRequestError): ConnectorDoctorError {
   switch (error.status) {
     case 400: {
       return {
@@ -232,15 +218,12 @@ function apiRequestError(
   }
 }
 
-function sanitizedRequestError(
-  error: unknown,
-  workflow: WorkflowSummary,
-): ConnectorDoctorError {
+function sanitizedRequestError(error: unknown): ConnectorDoctorError {
   if (error instanceof ApiRequestError) {
     if (error.status === 401 || error.code === "UNAUTHORIZED") {
       throw error;
     }
-    return apiRequestError(error, workflow);
+    return apiRequestError(error);
   }
   if (
     (error instanceof Error || error instanceof DOMException) &&
@@ -294,7 +277,7 @@ async function diagnoseWorkflow(
       ...workflowIdentity(workflow),
       outcome: "unknown",
       connectors: [],
-      error: sanitizedRequestError(error, workflow),
+      error: sanitizedRequestError(error),
     };
   }
   const connectors = response.connectors.map((entry) => {


### PR DESCRIPTION
Removes the Connector Doctor rollout branch that absorbed pre-#30491 API responses for Official Workflows.

## Cohort — Connector Doctor `OFFICIAL_WORKFLOW_UNSUPPORTED` 409 branch

**Old boundary:** before #30491, `POST /api/workflows/:workflowId/connector-readiness` answered `409` for an Official Workflow because readiness was not supported there. A commit-addressed CLI can outlive an API deploy, so `apiRequestError` special-cased `workflow.official && error.status === 409` and reported a dedicated `OFFICIAL_WORKFLOW_UNSUPPORTED` error with rollout-specific copy.

**New boundary:** the CLI no longer special-cases that combination. The pre-existing generic `case 409` still maps to `CONFLICT`, so an unexpected conflict degrades gracefully rather than throwing.

Removed:
- the `workflow.official && error.status === 409` branch and its rollout comment
- the now-unused `workflow: WorkflowSummary` parameter on `apiRequestError` and on `sanitizedRequestError`, plus both call-site arguments
- the `OFFICIAL_WORKFLOW_UNSUPPORTED` assertion in the doctor test, replaced with the generic `CONFLICT` result the same mocked `409` now produces

**Window:** the fallback lives in the CLI and guards against an older API, so the governing gate is the pre-#30491 API leaving service — canonical window 1 — plus the comment's requirement that its rollback targets be retired.

**Rollout evidence (observed):**
- #30513 (`feat(api): support official workflow connector readiness`) merged `2026-08-31T09:33:48Z` (`ee0b374445`) and closed #30491.
- First `api/production` deployment containing it: `b8cb505f2d`, `2026-08-31T11:48:49Z`, confirmed with `git merge-base --is-ancestor` walking the deployment list forward from oldest.
- **21 further `api/production` deployments** have been promoted since.
- Elapsed: **33.2 hours**.

**Source evidence that the current API cannot produce this 409:** `connectorReadinessInner$` in `turbo/apps/api/src/signals/routes/workflows.ts` returns `forbidden` when the `WorkflowConnectorReadiness` switch is off, `workflowNotFound` for a missing workflow, `providerUnavailable` when an Official revision cannot be read, `connectorReadinessTimeout` / `providerUnavailable` / `payloadTooLarge` from the detection result, and `200` otherwise. The `conflict(...)` calls in that file all belong to sibling handlers (workflow update, rename, delete), not to readiness. No path in the readiness handler yields `409`.

**Contract left intact:** `409` stays declared on `workflowsDetailContract.connectorReadiness`. Removing it would turn any future conflict into an unexpected-status failure, and the CLI's generic `CONFLICT` case already handles it. Only the expired Official-specific branch is gone.

**Axiom:** no useful route-level signal. The discriminator is a status/`official` pairing on a route whose 409 producer has already been removed from the API, and `vm0-request-log-prod` cannot join a response status to the workflow's Official flag. Recorded as a deliberate non-use rather than a zero-count claim; the deployment chain and the handler source above carry this cohort.

**MaskDB:** not applicable. No schema, column, or persisted payload changes.

## Explicitly deferred

- **`userPreferencesResponseSchema.translationLanguage` (#30862).** Added `2026-09-01`, hours before this run; its rollback targets are still current.
- **`chatThreadSnapshotProjection.selectedVideoModel` (#26765) and `selectedImageModel` (#27688).** Their stated gate includes cached IndexedDB rows resyncing, which is persisted browser data rather than a drained deploy window. Yesterday's client census also showed sub-floor App builds still active.
- **#29991 remaining Official Workflow fallbacks** (`definition`, and the P1 `workflow.official` / `automation.official` optionals). A dedicated one-shot workflow owns these.
- **Queued-launch-context brand reads** for Telegram, AgentPhone, and Feishu. Re-checked this run: MaskDB's projection still does not expose `public_brand` on `chat_telegram_context`, `chat_agentphone_context`, or `chat_feishu_context`, and `feishu_chat_ingress` is still absent. Seventh consecutive run blocked on this.
- **AgentPhone brandless connect**, **#28571**, **#29908**, **#26519**, **#27786**, **#28275**, **#28914**, **#30468** — unchanged product or evidence gates.

## Checks (run once against the combined diff)

- `pnpm format`
- `pnpm -F @okouai/cli lint` (no new warnings), `pnpm -F @okouai/cli check-types`
- `pnpm knip` (no new unused files, exports, or dependencies)
- `pnpm -F @okouai/cli exec vitest run src/commands/doctor/__tests__/connectors.test.ts` — 12 passing

Full coverage is left to the PR pipeline; no full local Vitest run and no local dev server.
