### PR TITLE
perf(platform): simplify index resource loading

### DIFF
--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -422,8 +422,8 @@ assert.ok(
   ),
 );
 assert.equal(
-  tagAttributeValues(okouPage.html, "link", "href").includes(
-    "https://static.okou.io",
+  tagAttributeValues(okouPage.html, "link", "href").some(
+    (href) => href === "https://static.okou.io",
   ),
   false,
 );

--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -421,10 +421,11 @@ assert.ok(
     "https://static.okou.io/public/okou-transparent.svg",
   ),
 );
-assert.ok(
-  tagAttributeValues(okouPage.html, "link", "href").some(
-    (href) => href === "https://static.okou.io",
+assert.equal(
+  tagAttributeValues(okouPage.html, "link", "href").includes(
+    "https://static.okou.io",
   ),
+  false,
 );
 assertBootstrapAvatar(okouPage.html);
 assert.equal(clerkCoreScript(okouPage.html), expectedClerkCoreScript);

--- a/.github/scripts/tests/verify-okou-app-runtime-test.sh
+++ b/.github/scripts/tests/verify-okou-app-runtime-test.sh
@@ -11,6 +11,7 @@ curl_log="${test_root}/curl.log"
 sleep_log="${test_root}/sleep.log"
 html_source="${test_root}/index.html"
 old_html_source="${test_root}/old-index.html"
+prioritized_html_source="${test_root}/prioritized-index.html"
 mkdir -p "$assets_directory" "$fake_bin"
 
 fail() {
@@ -31,7 +32,7 @@ cat > "$html_source" <<'HTML'
 <!doctype html>
 <meta name="okou-app-git-commit-sha" content="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
 <meta name="okou-app-version" content="0.812.5">
-<link id="vm0-main-stylesheet" rel="preload" as="style" crossorigin href="https://static.test/okou-app/assets/index-QrSt7890.css" fetchpriority="high">
+<link id="vm0-main-stylesheet" rel="preload" as="style" crossorigin href="https://static.test/okou-app/assets/index-QrSt7890.css">
 <script id="vm0-main-stylesheet-loader"></script>
 <script type="module" crossorigin src="https://static.test/okou-app/assets/app-AbCd1234.js"></script>
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/rolldown-runtime-IjKl9012.js">
@@ -42,7 +43,7 @@ cat > "$old_html_source" <<'HTML'
 <!doctype html>
 <meta name="okou-app-git-commit-sha" content="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb">
 <meta name="okou-app-version" content="0.812.4">
-<link id="vm0-main-stylesheet" rel="preload" as="style" crossorigin href="https://static.test/okou-app/assets/index-Old12345.css" fetchpriority="high">
+<link id="vm0-main-stylesheet" rel="preload" as="style" crossorigin href="https://static.test/okou-app/assets/index-Old12345.css">
 <script id="vm0-main-stylesheet-loader"></script>
 <script type="module" crossorigin src="https://static.test/okou-app/assets/app-Old12345.js"></script>
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/rolldown-runtime-Old12345.js">
@@ -227,6 +228,26 @@ if PATH="${fake_bin}:$PATH" \
 fi
 grep -Fq 'SharedWorker same-origin proxy returned HTTP 200' \
   "${test_root}/worker-failure.log" || fail "worker failure was not identified"
+
+cp "$html_source" "$prioritized_html_source"
+sed -i \
+  's/rel="preload"/rel="preload" fetchpriority="high"/' \
+  "$prioritized_html_source"
+: > "$curl_log"
+: > "$sleep_log"
+if PATH="${fake_bin}:$PATH" \
+  MOCK_CURL_LOG="$curl_log" \
+  MOCK_HTML_SOURCE="$prioritized_html_source" \
+  MOCK_SLEEP_LOG="$sleep_log" \
+  bash "$script" \
+    https://app.test \
+    https://static.test/okou-app/assets \
+    "$assets_directory" > "${test_root}/priority-failure.log" 2>&1; then
+  fail "main stylesheet fetchpriority did not fail HTML verification"
+fi
+grep -Fq 'Expected main stylesheet preload without fetchpriority' \
+  "${test_root}/priority-failure.log" ||
+  fail "main stylesheet fetchpriority failure was not identified"
 
 sed -i '/vendor-EfGh5678/d' "$html_source"
 : > "$curl_log"

--- a/.github/scripts/verify-okou-app-runtime.sh
+++ b/.github/scripts/verify-okou-app-runtime.sh
@@ -193,17 +193,20 @@ if len(parser.main_stylesheets) != 1:
 main_stylesheet = parser.main_stylesheets[0]
 expected_stylesheet_attributes = {
     "as": "style",
-    "fetchpriority": "high",
     "href": expected_stylesheet,
     "rel": "preload",
 }
 observed_stylesheet_attributes = {
     name: main_stylesheet.get(name) for name in expected_stylesheet_attributes
 }
-if observed_stylesheet_attributes != expected_stylesheet_attributes:
+if (
+    observed_stylesheet_attributes != expected_stylesheet_attributes
+    or "fetchpriority" in main_stylesheet
+):
     raise RuntimeError(
-        f"Expected main stylesheet preload {expected_stylesheet_attributes}, "
-        f"got {observed_stylesheet_attributes}"
+        "Expected main stylesheet preload without fetchpriority "
+        f"{expected_stylesheet_attributes}, "
+        f"got {main_stylesheet}"
     )
 if parser.main_stylesheet_loader_count != 1:
     raise RuntimeError(

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -22,8 +22,6 @@
       integrity="sha384-7sRGMm24rKKTHtMbyppyRU6B5l19DDUT9SODgfPRocth+7AB5N8rXNAMwmvR5RQ1"
     />
     <link vite-ignore rel="manifest" href="/manifest.webmanifest" />
-    <link rel="preconnect" href="https://cdn.vm0.io" crossorigin />
-    <link rel="preconnect" href="https://static.vm0.io" crossorigin />
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -294,6 +292,13 @@
         script.onload = startClerk;
       })();
     </script>
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
+      media="print"
+      onload="this.media = 'all'"
+    />
+    <script type="module" src="/src/main.ts"></script>
   </head>
   <body>
     <div id="root"></div>
@@ -375,13 +380,5 @@
         </div>
       </div>
     </div>
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
-      media="print"
-      fetchpriority="low"
-      onload="this.media = 'all'"
-    />
-    <script type="module" src="/src/main.ts" fetchpriority="low"></script>
   </body>
 </html>

--- a/turbo/apps/platform/scripts/app-resource-priority-html.ts
+++ b/turbo/apps/platform/scripts/app-resource-priority-html.ts
@@ -1,6 +1,5 @@
 import type { Plugin } from "vite";
 
-const CRITICAL_STYLE_ID = "app-bootstrap-critical-styles";
 const MAIN_STYLESHEET_ID = "vm0-main-stylesheet";
 const MAIN_STYLESHEET_LOADER_SCRIPT_ID = "vm0-main-stylesheet-loader";
 
@@ -33,30 +32,10 @@ function singleAssetTag(
   return tags[0];
 }
 
-function withFetchPriority(tag: string, priority: "high" | "low"): string {
-  if (/\sfetchpriority=/u.test(tag)) {
-    return tag.replace(
-      /\sfetchpriority="[^"]*"/u,
-      ` fetchpriority="${priority}"`,
-    );
-  }
-
-  const startTagEnd = tag.indexOf(">");
-  if (startTagEnd === -1) {
-    throw new Error(
-      `Generated asset tag is missing its closing bracket: ${tag}`,
-    );
-  }
-  return `${tag.slice(0, startTagEnd)} fetchpriority="${priority}"${tag.slice(startTagEnd)}`;
-}
-
 function mainStylesheetPreload(tag: string): string {
-  return withFetchPriority(
-    tag.replace(
-      /\srel="stylesheet"/u,
-      ` id="${MAIN_STYLESHEET_ID}" rel="preload" as="style"`,
-    ),
-    "high",
+  return tag.replace(
+    /\srel="stylesheet"/u,
+    ` id="${MAIN_STYLESHEET_ID}" rel="preload" as="style"`,
   );
 }
 
@@ -90,93 +69,18 @@ function mainStylesheetLoaderScript(): string {
     </script>`;
 }
 
-function removeTag(htmlSource: string, tag: string): string {
-  const firstIndex = htmlSource.indexOf(tag);
-  const lastIndex = htmlSource.lastIndexOf(tag);
-  if (firstIndex === -1 || firstIndex !== lastIndex) {
-    throw new Error("Generated application resource tag is not unique");
-  }
-  return `${htmlSource.slice(0, firstIndex)}${htmlSource.slice(firstIndex + tag.length)}`;
-}
-
-function prioritizeApplicationResources(htmlSource: string): string {
+function preloadApplicationStylesheet(htmlSource: string): string {
   const linkTagPattern = /<link\b[^>]*>/gu;
-  const scriptTagPattern = /<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/giu;
   const stylesheet = singleAssetTag(
     htmlSource,
     "application stylesheet",
     linkTagPattern,
     /\srel="stylesheet"[^>]*\shref="[^"]*\/assets\/index-[^"/]+\.css"/u,
   );
-  const runtimePreload = singleAssetTag(
-    htmlSource,
-    "runtime module preload",
-    linkTagPattern,
-    /\srel="modulepreload"[^>]*\shref="[^"]*\/assets\/rolldown-runtime-[^"/]+\.js"/u,
-  );
-  const vendorPreload = singleAssetTag(
-    htmlSource,
-    "vendor module preload",
-    linkTagPattern,
-    /\srel="modulepreload"[^>]*\shref="[^"]*\/assets\/vendor-[^"/]+\.js"/u,
-  );
-  const applicationModule = singleAssetTag(
-    htmlSource,
-    "application module",
-    scriptTagPattern,
-    /\stype="module"[^>]*\ssrc="[^"]*\/assets\/index-[^"/]+\.js"/u,
-  );
-
-  let prioritizedHtml = htmlSource;
-  for (const tag of [
+  return htmlSource.replace(
     stylesheet,
-    runtimePreload,
-    vendorPreload,
-    applicationModule,
-  ]) {
-    prioritizedHtml = removeTag(prioritizedHtml, tag);
-  }
-
-  const criticalStyleOpeningTag = `<style id="${CRITICAL_STYLE_ID}">`;
-  const criticalStyleStart = prioritizedHtml.indexOf(criticalStyleOpeningTag);
-  if (criticalStyleStart === -1) {
-    throw new Error(
-      `Expected the critical stylesheet marker #${CRITICAL_STYLE_ID}`,
-    );
-  }
-  const criticalStyleEnd = prioritizedHtml.indexOf(
-    "</style>",
-    criticalStyleStart,
+    `${mainStylesheetPreload(stylesheet)}\n    ${mainStylesheetLoaderScript()}`,
   );
-  if (criticalStyleEnd === -1) {
-    throw new Error("Critical application stylesheet is missing </style>");
-  }
-  const headResources = [
-    mainStylesheetPreload(stylesheet),
-    mainStylesheetLoaderScript(),
-    withFetchPriority(runtimePreload, "low"),
-    withFetchPriority(vendorPreload, "low"),
-  ]
-    .map((tag) => {
-      return `    ${tag}`;
-    })
-    .join("\n");
-  const criticalStyleInsertion = criticalStyleEnd + "</style>".length;
-  prioritizedHtml = `${prioritizedHtml.slice(0, criticalStyleInsertion)}\n${headResources}${prioritizedHtml.slice(criticalStyleInsertion)}`;
-
-  const bodyEnd = prioritizedHtml.lastIndexOf("</body>");
-  if (bodyEnd === -1) {
-    throw new Error("Application HTML is missing </body>");
-  }
-  const lowPriorityApplicationModule = withFetchPriority(
-    applicationModule,
-    "low",
-  );
-  const bodyClosingLineStart = prioritizedHtml.lastIndexOf("\n", bodyEnd) + 1;
-  if (prioritizedHtml.slice(bodyClosingLineStart, bodyEnd).trim()) {
-    return `${prioritizedHtml.slice(0, bodyEnd)}${lowPriorityApplicationModule}${prioritizedHtml.slice(bodyEnd)}`;
-  }
-  return `${prioritizedHtml.slice(0, bodyClosingLineStart)}    ${lowPriorityApplicationModule}\n${prioritizedHtml.slice(bodyClosingLineStart)}`;
 }
 
 export function applicationResourcePriorityHtmlPlugin(): Plugin {
@@ -187,7 +91,7 @@ export function applicationResourcePriorityHtmlPlugin(): Plugin {
     transformIndexHtml: {
       order: "post",
       handler(htmlSource) {
-        return prioritizeApplicationResources(htmlSource);
+        return preloadApplicationStylesheet(htmlSource);
       },
     },
   };

--- a/turbo/apps/platform/scripts/check-build-config.node.ts
+++ b/turbo/apps/platform/scripts/check-build-config.node.ts
@@ -358,9 +358,9 @@ function clerkDiscoveryFixture(): string {
     '<style id="app-bootstrap-critical-styles">body { color: black; }</style>',
     '<script id="vm0-clerk-core-script" src="https://cdn.example.test/clerk.js" defer></script>',
     '<script data-vm0-clerk-bootstrap="">window.__clerkConfigured = true;</script>',
+    '<script type="module" src="/src/main.js"></script>',
     "</head><body>",
     '<div id="app-bootstrap-skeleton"></div>',
-    '<script type="module" src="/src/main.js"></script>',
     "</body></html>",
   ].join("");
 }
@@ -374,7 +374,7 @@ function assertClerkDiscoveryOrder(htmlSource: string): void {
   assert.ok(appModuleIndex > clerkBootstrapIndex);
 }
 
-function assertApplicationResourcePriority(htmlSource: string): void {
+function assertApplicationStylesheetPreload(htmlSource: string): void {
   const criticalStyleIndex = htmlSource.indexOf(
     '<style id="app-bootstrap-critical-styles">',
   );
@@ -382,26 +382,26 @@ function assertApplicationResourcePriority(htmlSource: string): void {
   const stylesheetLoaderIndex = htmlSource.indexOf(
     'id="vm0-main-stylesheet-loader"',
   );
-  const runtimePreloadIndex = htmlSource.indexOf("assets/rolldown-runtime-");
-  const vendorPreloadIndex = htmlSource.indexOf("assets/vendor-");
   const clerkCoreIndex = htmlSource.indexOf('id="vm0-clerk-core-script"');
+  const clerkBootstrapIndex = htmlSource.indexOf('data-vm0-clerk-bootstrap=""');
+  const headEndIndex = htmlSource.indexOf("</head>");
   const skeletonIndex = htmlSource.indexOf('id="app-bootstrap-skeleton"');
   const appModuleIndex = htmlSource.indexOf('<script type="module"');
-  const bodyEndIndex = htmlSource.indexOf("</body>");
 
   assert.ok(criticalStyleIndex !== -1);
-  assert.ok(stylesheetIndex > criticalStyleIndex);
+  assert.ok(clerkCoreIndex > criticalStyleIndex);
+  assert.ok(clerkBootstrapIndex > clerkCoreIndex);
+  assert.ok(appModuleIndex > clerkBootstrapIndex);
+  assert.ok(stylesheetIndex > appModuleIndex);
   assert.ok(stylesheetLoaderIndex > stylesheetIndex);
-  assert.ok(runtimePreloadIndex > stylesheetLoaderIndex);
-  assert.ok(vendorPreloadIndex > runtimePreloadIndex);
-  assert.ok(clerkCoreIndex > vendorPreloadIndex);
-  assert.ok(appModuleIndex > skeletonIndex);
-  assert.ok(bodyEndIndex > appModuleIndex);
+  assert.ok(headEndIndex > stylesheetLoaderIndex);
+  assert.ok(skeletonIndex > headEndIndex);
   assert.match(
     htmlSource,
-    /<link id="vm0-main-stylesheet" rel="preload" as="style"[^>]*fetchpriority="high"[^>]*>/u,
+    /<link id="vm0-main-stylesheet" rel="preload" as="style"[^>]*>/u,
   );
   assert.equal((htmlSource.match(/<link rel="stylesheet"/gu) ?? []).length, 0);
+  assert.doesNotMatch(htmlSource, /\sfetchpriority=/u);
   assert.match(
     htmlSource,
     /window\.__mainStylesheetLoaded = new Promise\(function \(resolve\)/u,
@@ -414,18 +414,6 @@ function assertApplicationResourcePriority(htmlSource: string): void {
   assert.match(
     htmlSource,
     /"error",\s*function \(\) \{\s*resolve\("failed"\);/u,
-  );
-  assert.equal(
-    (
-      htmlSource.match(
-        /<link rel="modulepreload"[^>]*fetchpriority="low"[^>]*>/gu,
-      ) ?? []
-    ).length,
-    2,
-  );
-  assert.match(
-    htmlSource,
-    /<script type="module"[^>]*fetchpriority="low"[^>]*><\/script>/u,
   );
 }
 
@@ -548,7 +536,7 @@ await test("emits the fixed page topology and one external worker", async () => 
     assertClerkDiscoveryOrder(htmlSource);
     assert.equal((htmlSource.match(/<script type="module"/gu) ?? []).length, 1);
     assert.equal((htmlSource.match(/rel="modulepreload"/gu) ?? []).length, 2);
-    assertApplicationResourcePriority(htmlSource);
+    assertApplicationStylesheetPreload(htmlSource);
     assert.ok(
       result.output.some((item) => {
         return item.type === "asset" && item.fileName.endsWith(".json");

--- a/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
@@ -311,16 +311,18 @@ describe("platform Clerk entrypoint", () => {
     expect(clerkCore.nextElementSibling).toBe(bootstrap);
     expect(clerkCore.parentElement).toBe(parsedDocument.head);
     expect(bootstrap.parentElement).toBe(parsedDocument.head);
+    expect(fontStylesheet.parentElement).toBe(parsedDocument.head);
+    expect(mainScript.parentElement).toBe(parsedDocument.head);
     expect(clerkCore.compareDocumentPosition(bootstrap)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
-    expect(bootstrap.compareDocumentPosition(mainScript)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
-    );
-    expect(skeleton.compareDocumentPosition(fontStylesheet)).toBe(
+    expect(bootstrap.compareDocumentPosition(fontStylesheet)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
     expect(fontStylesheet.compareDocumentPosition(mainScript)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(mainScript.compareDocumentPosition(skeleton)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
     expect(html).not.toContain("__VM0_");
@@ -345,11 +347,17 @@ describe("platform Clerk entrypoint", () => {
     expect(fontStylesheet.rel).toBe("stylesheet");
     expect(fontStylesheet.hasAttribute("as")).toBeFalsy();
     expect(fontStylesheet.media).toBe("print");
-    expect(fontStylesheet.getAttribute("fetchpriority")).toBe("low");
+    expect(fontStylesheet.hasAttribute("fetchpriority")).toBeFalsy();
     expect(fontStylesheet.getAttribute("onload")).toBe("this.media = 'all'");
+    expect(mainScript.hasAttribute("fetchpriority")).toBeFalsy();
     expect(
       parsedDocument.querySelector(
         'link[rel="preconnect"][href*="fonts.googleapis.com"], link[rel="preconnect"][href*="fonts.gstatic.com"]',
+      ),
+    ).toBeNull();
+    expect(
+      parsedDocument.querySelector(
+        'link[rel="preconnect"][href="https://cdn.vm0.io"], link[rel="preconnect"][href="https://static.vm0.io"]',
       ),
     ).toBeNull();
     expect(html.indexOf("data-vm0-clerk-bootstrap")).toBeLessThan(


### PR DESCRIPTION
## Summary

- remove the `cdn.vm0.io` and `static.vm0.io` preconnect hints
- keep the Google Fonts stylesheet and app entry module at the end of `<head>` without `fetchpriority`
- limit the post-build HTML transform to converting the generated app stylesheet to `preload as="style"`, then switch it to `stylesheet` after it loads
- preserve Vite's modulepreload and app-module placement without adding resource priorities

## Why the build transform remains

Vite owns the generated, hashed app stylesheet link. Declaring the preload directly in source `index.html` is normalized during the production build and cannot retain both the final hashed asset URL and the preload/onload behavior. The transform is therefore intentionally scoped to that one generated stylesheet.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app run lint:build-config`
- `pnpm --filter @okouai/app exec vitest run src/__tests__/clerk-entrypoint.test.ts`
- `bash .github/scripts/tests/verify-okou-app-runtime-test.sh`
- `bash .github/scripts/tests/deploy-okou-pages-workflow-test.sh`

## Preview verification

- target: `https://pr-30921-app.omby.ai/sign-up`
- PR head: `32ccd786bfeff94fb0ef33f3de9d7d408ab5afbe` (deployed test merge: `b2df79c62fe6c643420fbd6f91b65eef5b368712`)
- `deploy-app`: passed, including the preview gateway and app runtime/SharedWorker smoke test
- generated HTML: one app stylesheet preload with no `fetchpriority`; loader present; app module and Google Fonts remain in `<head>`; modulepreloads have no `fetchpriority`; removed vm0 preconnects remain absent
- browser runtime: the preload switches to `rel="stylesheet"` after load and removes `as`; `/sign-up` renders normally at 412×823
- Lighthouse 13.4.1 mobile cold FCP: 879 ms, 899 ms, 905 ms; median 899 ms (the earlier preview median was 901 ms)
- [median Lighthouse report](https://cdn.okou.io/artifacts/fzp3szfq8h.html)
- [mobile screenshot](https://cdn.okou.io/artifacts/7naejufo92.png)
