### PR TITLE
perf(platform): keep auth skeleton until auth is ready

### DIFF
--- a/turbo/apps/platform/src/signals/auth-v2-page-setup.ts
+++ b/turbo/apps/platform/src/signals/auth-v2-page-setup.ts
@@ -110,18 +110,16 @@ function setupAuthV2Page(mode: AuthV2PageMode) {
           }),
       platformContext.authBrand.brandName,
     );
-    await set(hideAppSkeleton$, signal);
-    signal.throwIfAborted();
     await set(continuationSignals.initialize$, signal);
     signal.throwIfAborted();
-    if (get(continuationSignals.state$).status !== "inactive") {
-      return;
+    if (get(continuationSignals.state$).status === "inactive") {
+      if (signInSignals) {
+        await set(signInSignals.initialize$, signal);
+      } else if (signUpSignals) {
+        await set(signUpSignals.initialize$, signal);
+      }
     }
-    if (signInSignals) {
-      await set(signInSignals.initialize$, signal);
-    } else if (signUpSignals) {
-      await set(signUpSignals.initialize$, signal);
-    }
+    await set(hideAppSkeleton$, signal);
   });
 }
 

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -338,10 +338,16 @@ async function editRestoredIdentifier(): Promise<void> {
 }
 
 describe("auth v2 sign-in flow", () => {
-  it("shows the loading state until the low-level Clerk resource is ready", async () => {
+  it("keeps the bootstrap skeleton until the low-level Clerk resource is ready", async () => {
     const clerkLoad = createDeferredPromise<void>(context.signal);
     mockedClerk.load.mockImplementation(() => {
       return clerkLoad.promise;
+    });
+    const bootstrapSkeleton = document.createElement("div");
+    bootstrapSkeleton.id = "app-bootstrap-skeleton";
+    document.body.append(bootstrapSkeleton);
+    context.signal.addEventListener("abort", () => {
+      bootstrapSkeleton.remove();
     });
 
     setupSignInPage({ status: "needs_identifier" });
@@ -352,6 +358,7 @@ describe("auth v2 sign-in flow", () => {
       "Checking what your account needs next.",
     );
     expect(roleElement("link", "Sign up")).toBeUndefined();
+    expect(bootstrapSkeleton).not.toHaveAttribute("aria-hidden");
 
     await act(async () => {
       clerkLoad.resolve(undefined);
@@ -361,6 +368,9 @@ describe("auth v2 sign-in flow", () => {
     await expect(
       screen.findByLabelText("Email address"),
     ).resolves.toBeVisible();
+    await waitFor(() => {
+      expect(bootstrapSkeleton).toHaveAttribute("aria-hidden", "true");
+    });
   });
 
   it("starts a fresh identifier request with an empty draft", async () => {


### PR DESCRIPTION
## Summary

- keep the app bootstrap skeleton visible while Auth v2 continuation and sign-in/sign-up state initialize
- preserve continuation-route behavior while moving the skeleton fade to the final auth readiness boundary
- cover delayed Clerk initialization so the loading surface cannot disappear before the sign-in form is ready

## Verification

- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx`
- `pnpm -F @okouai/app exec vitest run src/signals/auth-v2-page-setup.test.ts`

The full local Vitest suite was not run; the PR pipeline will run the repository checks.
