### PR TITLE
perf(app): start application before google ads

### DIFF
--- a/turbo/apps/platform/src/__tests__/platform-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/platform-entrypoint.test.ts
@@ -1,10 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { startPlatformEntrypoint } from "../lib/platform-entrypoint.ts";
 import { testContext } from "../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
 const INSTATUS_WIDGET_HOSTNAME = "api.dashboard.instatus.com";
+const GOOGLE_TAG_SCRIPT_URL =
+  "https://www.googletagmanager.com/gtag/js?id=AW-18144854014";
+
+let googleAdsRequestedAfterApplicationStart = false;
 
 function instatusScripts(): HTMLScriptElement[] {
   return Array.from(document.scripts).filter((script) => {
@@ -23,10 +27,29 @@ describe.each(["app.vm0.ai", "app.okou.ai"])(
   "platform entrypoint on %s",
   (hostname) => {
     beforeEach(() => {
+      googleAdsRequestedAfterApplicationStart = false;
       context.mocks.browser.url(`https://${hostname}/`);
       const root = document.createElement("div");
       root.id = "root";
       document.body.replaceChildren(root);
+
+      const addEventListener = vi.spyOn(window, "addEventListener");
+      const appendChild = document.head.appendChild.bind(document.head);
+      vi.spyOn(document.head, "appendChild").mockImplementation(
+        <T extends Node>(node: T): T => {
+          if (
+            node instanceof HTMLScriptElement &&
+            node.src === GOOGLE_TAG_SCRIPT_URL
+          ) {
+            googleAdsRequestedAfterApplicationStart =
+              addEventListener.mock.calls.some(([eventName]) => {
+                return eventName === "pagehide";
+              });
+          }
+          return appendChild(node);
+        },
+      );
+
       startPlatformEntrypoint();
     });
 
@@ -36,6 +59,10 @@ describe.each(["app.vm0.ai", "app.okou.ai"])(
 
     it("does not inject the Instatus widget", () => {
       expect(instatusScripts()).toStrictEqual([]);
+    });
+
+    it("starts the application before requesting Google Ads", () => {
+      expect(googleAdsRequestedAfterApplicationStart).toBeTruthy();
     });
   },
 );

--- a/turbo/apps/platform/src/lib/platform-entrypoint.ts
+++ b/turbo/apps/platform/src/lib/platform-entrypoint.ts
@@ -79,7 +79,6 @@ function startApplication(): void {
 
 export function startPlatformEntrypoint(): void {
   window.__appBootstrapModuleReady = performance.now();
-  initGoogleAds();
   const browserUpgrade = browserUpgradeForUserAgent(navigator.userAgent);
   if (browserUpgrade) {
     const rootElement = document.getElementById("root");
@@ -94,4 +93,5 @@ export function startPlatformEntrypoint(): void {
   } else {
     startApplication();
   }
+  initGoogleAds();
 }


### PR DESCRIPTION
## Summary

- start the Platform application before initializing Google Ads
- preserve the existing production-host gating and unsupported-browser path
- add an entrypoint regression test for the application-before-Ads ordering

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/__tests__/platform-entrypoint.test.ts`
