### PR TITLE
test(api): settle queued-claim template usage before asserting

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -15843,6 +15843,11 @@ describe("CHAT-02: shared user message queue", () => {
 
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
+    // The terminal callback acknowledges before it drains the queue, and it
+    // reports the template usage only after the auto-sent run is already
+    // visible. Settle that background work so the assertions below observe the
+    // finished dispatch instead of a half-built one.
+    await flushWaitUntilForTest();
 
     const messages = await waitForThreadMessages(
       actor,


### PR DESCRIPTION
## Problem

`Turbo` run [33577047745](https://github.com/vm0-ai/vm0/actions/runs/33577047745) (push to `main`, head `4e77d3344`) failed in [`test-api (5)`](https://github.com/vm0-ai/vm0/actions/runs/33577047745/job/100083272348):

```
AssertionError: expected [] to strictly equal [ ObjectContaining{…} ]
 ❯ src/signals/routes/__tests__/chat-events.bdd.test.ts:15883:35
```

`CHAT-02: shared user message queue > projects inline templates into queued web launch material` observed an empty template-usage buffer, not a wrong event. Shard result was `Tests 1 failed | 751 passed (752)`.

Shared-Postgres saturation does not explain it: the failing shard's `tests` phase was 170.43s, inside the range of two recent green `test-api (5)` runs on `main` (276.74s and 145.84s).

## First causal nondeterminism

The queued-claim template usage is reported from background work, and the test had no settle point before reading the buffer.

1. `completeChatRunOk` acknowledges the terminal chat callback and hands the heavy work to `waitUntil(processTerminalChatCallback(...))` (`internal-chat-run-callback.service.ts:5182`).
2. Inside that background task, `autoSendQueuedMessageForThread` runs, in order: `createAutoSentQueuedRun` (creates the run and the run-linked replacement message), `appendAutoSentQueuedRunMarkerIfQueued`, `publishAutoSentQueuedRunSignals`, and only then `logTemplateUsage({ dispatchPath: "queued-claim", ... })` (`internal-chat-run-callback.service.ts:4206`).
3. The test synchronized on `waitForThreadMessages(...)`, which resolves as soon as the replacement message carries a `runId` — a state written in step (2)'s *first* stage. Everything after that, including the marker append and two Ably publishes, still had to run before the telemetry call.
4. `expect(templateUsageEvents()).toStrictEqual([...])` then read `context.mocks.axiom.ingest` once, synchronously. `ingestToAxiom` records the mock call synchronously, so the buffer was empty simply because `logTemplateUsage` had not been reached yet.

The outcome was intermittent because the window is the DB write plus two realtime publishes between the observable message and the telemetry call. Under load that window widens past the test's read.

**Reproduced deterministically.** Injecting a 300 ms delay immediately before `logTemplateUsage` on the queued-claim path reproduced the exact CI assertion output (`expected [] to strictly equal [ ObjectContaining{…} ]` at line 15883). With the fix applied and the same delay still injected, the test passed. The injected delay was reverted; it is not part of this PR.

## Not causal

- `test-api (7)` `cancelled` and `ci-gate-turbo` are fail-fast/aggregate noise.
- `deploy-api` failed on a GitHub API socket hang up — unrelated external infrastructure.
- No teardown `AbortError` or `PromiseRejectionHandledWarning` was involved; `clearAllDetached()` in `afterEach` already drains prior tests' background work, so this is scoped to the test's own dispatch.
- The other three `template_used` tests in this file are unaffected: `normal-send` (`chat-events.command.ts:3630`) and `active-input` (`active-input-delivery.service.ts:401`) both emit inside the awaited request handler, before the response.

## Fix

Await `flushWaitUntilForTest()` right after the anchor run completes, at the terminal-callback domain boundary. This is the sanctioned barrier for API `waitUntil()` work and is already the established idiom in this exact file.

No retry, sleep, timeout increase, skipped test, weakened assertion, or manual detached cleanup. The business assertion is untouched: the test still proves that exactly one template-usage event with `dispatchPath: "queued-claim"` is reported, and that building the input while the message stays queued reports nothing.

## Validation

- Target test run 5×, passed every time.
- Full `chat-events.bdd.test.ts`: `Tests 146 passed (146)`.
- `pnpm prettier --check` on the changed file: clean.
- `pnpm -F api lint`: exit 0 (only pre-existing warnings).
- `pnpm -F api check-types`: exit 0.
- `git diff --check`: clean.

Live browser validation is not applicable — this is an API-level Vitest test with no UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
