### PR TITLE
refactor(platform): move queue data into shared worker

### DIFF
--- a/turbo/apps/platform/src/shared-database/computed-key.ts
+++ b/turbo/apps/platform/src/shared-database/computed-key.ts
@@ -1,5 +1,9 @@
 import { DESKTOP_PRODUCTS } from "@okouai/api-contracts/contracts/client-headers";
 import { computerUseHostStatusSchema } from "@okouai/api-contracts/contracts/computer-use";
+import {
+  queueResponseSchema,
+  type QueueResponse,
+} from "@okouai/api-contracts/contracts/runs";
 import { z } from "zod";
 
 import {
@@ -10,6 +14,7 @@ import {
 export const computedKeySchema = z.enum([
   "chat-thread-indicators",
   "computer-use-hosts",
+  "queue-data",
 ]);
 
 export type ComputedKey = z.infer<typeof computedKeySchema>;
@@ -30,6 +35,7 @@ export type ListedComputerUseHost = z.infer<typeof listedComputerUseHostSchema>;
 interface ComputedValueMap {
   readonly "chat-thread-indicators": ChatThreadIndicators;
   readonly "computer-use-hosts": ListedComputerUseHost[];
+  readonly "queue-data": QueueResponse;
 }
 
 export type ComputedValue<TKey extends ComputedKey> = ComputedValueMap[TKey];
@@ -45,5 +51,8 @@ export function parseComputedValue(
   if (computedKey === "chat-thread-indicators") {
     return chatThreadIndicatorsSchema.parse(value);
   }
-  return listedComputerUseHostSchema.array().parse(value);
+  if (computedKey === "computer-use-hosts") {
+    return listedComputerUseHostSchema.array().parse(value);
+  }
+  return queueResponseSchema.parse(value);
 }

--- a/turbo/apps/platform/src/shared-database/test-bridge.ts
+++ b/turbo/apps/platform/src/shared-database/test-bridge.ts
@@ -170,7 +170,9 @@ class DirectSharedDatabaseBridge implements SharedDatabaseBridge {
         ? "chat-thread-indicators"
         : message.name === "computerUseHostsChanged"
           ? "computer-use-hosts"
-          : null;
+          : message.name === "billing:changed"
+            ? "queue-data"
+            : null;
     if (!computedKey) {
       return;
     }

--- a/turbo/apps/platform/src/shared-database/worker-signals.ts
+++ b/turbo/apps/platform/src/shared-database/worker-signals.ts
@@ -10,6 +10,10 @@ import {
   reloadComputerUseHosts$,
 } from "../signals/external/computer-use-hosts.ts";
 import {
+  queueData$,
+  reloadQueueData$,
+} from "../signals/queue-page/queue-signals.ts";
+import {
   setAblyLoop$,
   setAblyPayloadLoop$,
   setupRealtime$,
@@ -288,7 +292,11 @@ const reloadWorkerComputed$ = command(
       set(reloadChatIndicators$);
       return;
     }
-    set(reloadComputerUseHosts$);
+    if (computedKey === "computer-use-hosts") {
+      set(reloadComputerUseHosts$);
+      return;
+    }
+    set(reloadQueueData$);
   },
 );
 
@@ -327,14 +335,25 @@ export const reloadWorkerComputerUseHostsFromRealtime$ = command(
   },
 );
 
+export const reloadWorkerQueueDataFromRealtime$ = command(
+  ({ set }, signal: AbortSignal): boolean => {
+    signal.throwIfAborted();
+    set(reloadWorkerComputed$, "queue-data");
+    set(reloadComputedForConnections$, "queue-data");
+    return false;
+  },
+);
+
 export const recoverCredentialStoreAfterRealtimeReconnect$ = command(
   ({ set }, signal: AbortSignal): void => {
     signal.throwIfAborted();
     set(broadcastSharedDatabaseReconnect$);
     set(reloadWorkerComputed$, "chat-thread-indicators");
     set(reloadWorkerComputed$, "computer-use-hosts");
+    set(reloadWorkerComputed$, "queue-data");
     set(reloadComputedForConnections$, "chat-thread-indicators");
     set(reloadComputedForConnections$, "computer-use-hosts");
+    set(reloadComputedForConnections$, "queue-data");
   },
 );
 
@@ -406,6 +425,19 @@ const runCredentialStoreDaemons$ = command(
             scope: "user",
             topic: "computerUseHostsChanged",
             loopCommand$: reloadWorkerComputerUseHostsFromRealtime$,
+            options: {
+              runOnForegroundCatchUp: false,
+              runOnSubscribe: true,
+            },
+          },
+          signal,
+        ),
+        set(
+          setAblyLoop$,
+          {
+            scope: "user",
+            topic: "billing:changed",
+            loopCommand$: reloadWorkerQueueDataFromRealtime$,
             options: {
               runOnForegroundCatchUp: false,
               runOnSubscribe: true,
@@ -528,7 +560,9 @@ export const getComputedStoreMessage$ = command(
     const value =
       message.computedKey === "chat-thread-indicators"
         ? await get(workerChatThreadIndicators$)
-        : await get(computerUseHosts$);
+        : message.computedKey === "computer-use-hosts"
+          ? await get(computerUseHosts$)
+          : await get(queueData$);
     signal.throwIfAborted();
     return value;
   },

--- a/turbo/apps/platform/src/signals/okou-page/billing.ts
+++ b/turbo/apps/platform/src/signals/okou-page/billing.ts
@@ -31,7 +31,6 @@ import { toast } from "@okouai/ui/components/ui/sonner";
 import { apiClient$ } from "../api-client.ts";
 import { replaceSearchParams$, searchParams$ } from "../route.ts";
 import { reloadUsageRecords$ } from "./settings/personal-usage-record.ts";
-import { reloadQueueData$ } from "../queue-page/queue-signals.ts";
 import { setAblyLoop$, subscribeRealtimeReadyCatchUp$ } from "../realtime.ts";
 import { foregroundReady$ } from "../foreground-catch-up.ts";
 import { isOrgAdmin$ } from "../org.ts";
@@ -718,7 +717,6 @@ export const handleBillingRedirect$ = command(
 const reloadBillingStatusFromRemoteChange$ = command(
   async ({ set }, signal: AbortSignal) => {
     set(reloadBillingStatus$);
-    set(reloadQueueData$);
     set(reloadUsagePackManagement$);
     set(reloadUsageRecords$);
     set(refreshOrgMembers$);

--- a/turbo/apps/platform/src/signals/shared-database.ts
+++ b/turbo/apps/platform/src/signals/shared-database.ts
@@ -1,4 +1,5 @@
 import { command, computed, state, type Command } from "ccstate";
+import type { QueueResponse } from "@okouai/api-contracts/contracts/runs";
 import type {
   ChatThreadIndicators,
   ChatEventDataKey,
@@ -39,13 +40,25 @@ const reloadComputerUseHostsFromWorker$ = command(({ set }): void => {
   });
 });
 
+const internalReloadQueueDataFromWorker$ = state(0);
+
+const reloadQueueDataFromWorker$ = command(({ set }): void => {
+  set(internalReloadQueueDataFromWorker$, (value) => {
+    return value + 1;
+  });
+});
+
 export const reloadComputedFromWorker$ = command(
   ({ set }, computedKey: ComputedKey): void => {
     if (computedKey === "chat-thread-indicators") {
       set(reloadChatIndicatorsLocally$);
       return;
     }
-    set(reloadComputerUseHostsFromWorker$);
+    if (computedKey === "computer-use-hosts") {
+      set(reloadComputerUseHostsFromWorker$);
+      return;
+    }
+    set(reloadQueueDataFromWorker$);
   },
 );
 
@@ -64,6 +77,13 @@ export const computerUseHostsFromWorker$ = computed(
     return await get(installedSharedDatabaseBridge$).getComputed(
       "computer-use-hosts",
     );
+  },
+);
+
+export const queueDataFromWorker$ = computed(
+  async (get): Promise<QueueResponse> => {
+    get(internalReloadQueueDataFromWorker$);
+    return await get(installedSharedDatabaseBridge$).getComputed("queue-data");
   },
 );
 

--- a/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
+++ b/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
@@ -225,7 +225,10 @@ function getButtonByLabel(label: string): HTMLElement {
   return button;
 }
 
-async function openDrawer(memberUsageEnabled = false): Promise<void> {
+async function openDrawer(
+  memberUsageEnabled = false,
+  sharedWorkerTestTransport: "direct" | "message-port" = "direct",
+): Promise<void> {
   mockQueuedThread();
   detachedSetupPage({
     context,
@@ -233,6 +236,7 @@ async function openDrawer(memberUsageEnabled = false): Promise<void> {
     featureSwitches: {
       [FeatureSwitchKey.ConcurrencyMemberUsage]: memberUsageEnabled,
     },
+    sharedWorkerTestTransport,
   });
   const queueButton = await waitFor(() => {
     return getButtonByText("queue...");
@@ -364,7 +368,7 @@ describe("queue drawer", () => {
     expect(screen.getByText("Buy $42/month")).toBeInTheDocument();
   });
 
-  it("refreshes the concurrency limit when billing changes in realtime", async () => {
+  it("refreshes the concurrency limit through the shared worker when billing changes in realtime", async () => {
     let concurrencyLimit = 5;
     mockConcurrencyCapability(true);
     context.mocks.api(runsQueueContract.getQueue, ({ respond }) => {
@@ -382,7 +386,7 @@ describe("queue drawer", () => {
       );
     });
 
-    await openDrawer();
+    await openDrawer(false, "message-port");
 
     await waitFor(() => {
       expect(screen.getByText(/3 of 5 slots/)).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
@@ -26,7 +26,7 @@ import {
   setConcurrencyQuantity$,
   setQueueDrawerOpen$,
 } from "../../signals/queue-page/queue-drawer-state.ts";
-import { queueData$ } from "../../signals/queue-page/queue-signals.ts";
+import { queueDataFromWorker$ } from "../../signals/shared-database.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import {
   billingStatusAsync$,
@@ -727,7 +727,7 @@ function ConcurrencyPurchaseCardMount({
 
 function QueueDrawerContent() {
   const { t } = useTranslation();
-  const dataLoadable = useLastLoadable(queueData$);
+  const dataLoadable = useLastLoadable(queueDataFromWorker$);
   const data = dataLoadable.state === "hasData" ? dataLoadable.data : null;
   const pageSignal = useGet(pageSignal$);
   const isAdminLoadable = useLastLoadable(isOrgAdmin$);


### PR DESCRIPTION
## Summary

- add queue data to the typed SharedWorker computed bridge
- move billing realtime invalidation and reconnect recovery for queue data into the credential worker
- render the queue drawer from the App mirror and cover realtime refresh through the MessagePort worker path

## Testing

- pnpm -F @okouai/app lint
- pnpm -F @okouai/app check-types
- pnpm knip --workspace @okouai/app
- pnpm -F @okouai/app exec vitest run src/views/queue-page/__tests__/queue-drawer.test.tsx
- pnpm -F @okouai/app build (with local placeholder Clerk publishable keys)