### PR TITLE
refactor: remove connector catalog count feature switch

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -718,9 +718,6 @@ describe("connectors page", () => {
     detachedSetupPage({
       context,
       path: "/connectors",
-      featureSwitches: {
-        [FeatureSwitchKey.ConnectorCatalogCount]: true,
-      },
     });
 
     await expect(
@@ -760,7 +757,6 @@ describe("connectors page", () => {
     detachedSetupPage({
       context,
       path: "/connectors",
-      featureSwitches: { [FeatureSwitchKey.ConnectorCatalogCount]: true },
     });
 
     await expect(
@@ -793,9 +789,6 @@ describe("connectors page", () => {
     detachedSetupPage({
       context,
       path: "/connectors",
-      featureSwitches: {
-        [FeatureSwitchKey.ConnectorCatalogCount]: true,
-      },
     });
 
     await expect(
@@ -813,35 +806,6 @@ describe("connectors page", () => {
     await expect(
       screen.findByText("Connect 1,234 services for your agents to use."),
     ).resolves.toBeInTheDocument();
-  });
-
-  it("keeps the existing catalog description when the count switch is disabled", async () => {
-    mockConnectors([]);
-    mockPublicConnectorStatus([
-      publicStatusItem({
-        connectorSlug: "github",
-        label: "GitHub",
-        authMethods: [],
-      }),
-      publicStatusItem({
-        connectorSlug: "slack",
-        label: "Slack",
-        authMethods: [],
-      }),
-    ]);
-
-    detachedSetupPage({
-      context,
-      path: "/connectors",
-      featureSwitches: { [FeatureSwitchKey.ConnectorCatalogCount]: false },
-    });
-
-    await expect(
-      screen.findByText("Connect third-party services for your agents to use."),
-    ).resolves.toBeInTheDocument();
-    expect(
-      screen.queryByText("Connect 2 services for your agents to use."),
-    ).not.toBeInTheDocument();
   });
 
   it("shows only the update dialog when the client requires an upgrade", async () => {

--- a/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
@@ -903,14 +903,13 @@ interface SettingsConnectorCardProps {
 }
 
 interface ConnectorCatalogHeaderProps {
-  readonly connectorCatalogCountEnabled: boolean;
   readonly connectorCatalogCount: number | null;
 }
 
 function ConnectorCatalogHeader(props: ConnectorCatalogHeaderProps) {
   const { t } = useTranslation();
   const description =
-    props.connectorCatalogCountEnabled && props.connectorCatalogCount !== null
+    props.connectorCatalogCount !== null
       ? t(
           ($) => {
             return $.connectors.catalog.descriptionWithCount;
@@ -1030,8 +1029,6 @@ export function ConnectorsPage() {
     filteredConnectorCatalogItems$,
   );
   const catalogStatusLoadable = useLastLoadable(connectorCatalogDiscovery$);
-  const connectorCatalogCountEnabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.ConnectorCatalogCount] ?? false;
   const connectorAccountsEnabled =
     useGet(featureSwitch$)[FeatureSwitchKey.ConnectorAccounts] ?? false;
   const accountSummariesLoadable = useLoadable(
@@ -1270,10 +1267,7 @@ export function ConnectorsPage() {
       ref={scrollContainerRef}
       className="flex flex-1 flex-col min-h-0 overflow-auto [scrollbar-gutter:stable]"
     >
-      <ConnectorCatalogHeader
-        connectorCatalogCountEnabled={connectorCatalogCountEnabled}
-        connectorCatalogCount={connectorCatalogCount}
-      />
+      <ConnectorCatalogHeader connectorCatalogCount={connectorCatalogCount} />
 
       <main className="flex-1 px-4 sm:px-6 pt-3 pb-16">
         <div className="relative mx-auto w-full max-w-[900px]">

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -130,7 +130,6 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.CustomConnectorMcp]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.StrapiIntegration]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ConcurrencyMemberUsage]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.ConnectorCatalogCount]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PersonalModelProviderAccounts]).toBe(
       true,
     );
@@ -156,7 +155,6 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.CustomConnectorMcp]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.StrapiIntegration]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ConcurrencyMemberUsage]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ConnectorCatalogCount]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PersonalModelProviderAccounts]).toBe(
       false,
     );

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -51,7 +51,6 @@ export enum FeatureSwitchKey {
   ComputerUseDesktopPlugins = "computerUseDesktopPlugins",
   ChatErrorRecovery = "chatErrorRecovery",
   ResponsiveFollowupCards = "responsiveFollowupCards",
-  ConnectorCatalogCount = "connectorCatalogCount",
   SidebarSubscriptionUsage = "sidebarSubscriptionUsage",
   PersonalModelProviderAccounts = "personalModelProviderAccounts",
   ConnectorAccounts = "connectorAccounts",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -362,12 +362,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     // Ming only for the first pass; widen once the system mapping settles.
     enabledEmailHashes: ["54757055"], // fnv1a("ming@vm0.ai")
   },
-  [FeatureSwitchKey.ConnectorCatalogCount]: {
-    maintainer: "ethan@vm0.ai",
-    description: "Show the exact effective connector catalog size.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.SharedThreadSharing]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- permanently show the exact effective connector catalog size after discovery data loads
- keep the count-free description only while the catalog total is loading
- remove the `connectorCatalogCount` feature-switch key, registry entry, overrides, and disabled-state test

## Terminal state

- State: `fully-rolled-out`
- Basis: Ethan explicitly requested "全量+清理这个开关" on 2026-09-02.

## Archaeology and behavior comparison

- `78ab60d7622cf6174b4c1b206bf22cc0d9f6b190` (#26083) introduced the switch and gated count UI. Its parent always showed the generic count-free description.
- `fbc46db2de3468aab2eae6b86455db58e0ee457a` (#26362) removed the pending animation and kept a static count presentation.
- `3bbc265321226c3d1ce3b4df75558569c8b04162` (#28226) replaced the estimate with the exact `totalConnectorCount` reported for the effective catalog.
- `e8d0c2acb679ccd23b218a694aaf1a6893f97791` (#28904) extracted the current header component without changing the switch semantics.
- This PR preserves the current switch-on behavior, retains the count-free loading fallback, and removes the post-load switch-off branch.

## Cleanup scope

- removed `FeatureSwitchKey.ConnectorCatalogCount` and its registry configuration
- removed the platform feature-state read and header boolean prop
- removed staff/non-staff registry assertions for the deleted key
- removed the disabled-state UI test
- converted the positive catalog-count and loading tests to exercise the permanent behavior directly, without feature overrides

## Search and Knip

- Exact follow-up searches for `FeatureSwitchKey.ConnectorCatalogCount`, `"connectorCatalogCount"`, `connectorCatalogCountEnabled`, and the enum declaration return no source matches.
- `descriptionWithCount`, `effectiveConnectorCatalogCount`, `totalConnectorCount`, and the count product copy remain because they implement the permanent path.
- Historical changelog references and unrelated catalog-count timing metrics remain intentionally.
- Knip baseline: clean for `apps/platform` and `packages/core`.
- Knip after cleanup and latest-main rebase: clean for the same workspaces.

## Verification

- Prettier on all changed files
- `git diff --check`
- Platform targeted test: 123/123 passed
- Core feature-switch test: 27/27 passed
- Platform and Core workspace type-checks passed
- Platform and Core workspace lint passed before the latest-main rebase; changed-file oxlint, type-aware oxlint, and ESLint passed again after the rebase
- Full repository Vitest was intentionally not run; remaining repository-wide checks are delegated to the PR pipeline per repository policy.
