### PR TITLE
test(platform): settle chat bootstrap before asserting the composer

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-thread-idb.test.tsx
@@ -13,7 +13,10 @@ import {
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { browserContract } from "@okouai/api-contracts/contracts/browser";
 
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  setupPageAndWaitForContent,
+} from "../../../__tests__/page-helper.ts";
 import {
   testContext,
   chatEventRowsResponse,
@@ -285,7 +288,11 @@ describe("okou chat thread IndexedDB fallback", () => {
       return respond(200, { events: [], hasMore: false });
     });
 
-    detachedSetupPage({
+    // Wait for bootstrap to hand the viewport over to page content before
+    // asserting on the composer. The app skeleton retiring is the real settle
+    // point, so the assertions below do not have to fit page bootstrap into a
+    // single Testing Library polling budget.
+    await setupPageAndWaitForContent({
       context,
       path: `/chats/${OTHER_THREAD_ID}`,
       user: { id: idbUserId(), fullName: "Test User" },


### PR DESCRIPTION
## Problem

`test-app (4)` failed on `main` in the `Turbo` run
https://github.com/vm0-ai/vm0/actions/runs/33579922723 (push to `main`, head
`009aaf863dd60add63739d886c7b78cf95f760c9`, failing job
https://github.com/vm0-ai/vm0/actions/runs/33579922723/job/100091892926):

```
FAIL src/views/okou-page/__tests__/chat-thread-idb.test.tsx
  > okou chat thread IndexedDB fallback
  > keeps a notification-opened thread pending until foreground metadata catch-up
AssertionError: promise rejected "TestingLibraryElementError: Unable to fin…" instead of resolving
Caused by: Unable to find an element with the placeholder text of:
  Ask me to automate workflows, manage tasks...
```

The captured DOM is decisive: the composer was missing because the app had not
finished bootstrapping. The full-screen skeleton was still opaque when
`findByPlaceholderText` gave up, with the nav rail already rendered underneath:

```html
<div aria-label="Loading" aria-live="polite"
     class="fixed inset-0 z-50 flex items-center justify-center bg-background opacity-100"
     data-testid="app-skeleton" role="status">
```

## Root cause

The test called `detachedSetupPage(...)` and then immediately asserted on the
composer placeholder. `detachedSetupPage` is fire-and-forget, and
`turbo/apps/platform` never calls testing-library `configure()`, so that
`findBy*` runs with the default **1000 ms** `asyncUtilTimeout`. The entire page
bootstrap therefore had to complete inside one polling budget. Every other test
in this file already places an explicit barrier (`await someDeferred.promise`)
between setup and its first `findBy*`; this one had none.

That budget was already almost fully consumed on a healthy host, which makes
this a latent flake rather than a one-off:

| run | this test | file |
|---|---|---|
| failing 33579922723 | **1080 ms (failed at the 1000 ms `findBy` cap)** | 11542 ms |
| green 33579375761 | 1665 ms | 7029 ms |
| green 33576071416 | 1820 ms | 7879 ms |

## Trigger, not the defect

The shard was uniformly slower, including phases that do no database or network
work at all, which points at runner host contention rather than a shared-
database bottleneck:

| phase | failing (33579922723) | green (33579375761) | green (33576071416) | ratio vs green |
|---|---|---|---|---|
| transform | 29.32s | 20.14s | 20.55s | ~1.44x |
| setup | 43.54s | 28.93s | 29.97s | ~1.48x |
| import | 71.58s | 48.48s | 49.64s | ~1.46x |
| environment | 10.53s | 6.85s | 6.99s | ~1.52x |
| tests | 274.49s | 165.38s | 171.44s | ~1.63x |

A ~1.5x slower host did not create a defect, it exposed one. The fragility is
test-side.

`test-app (3)` was `cancelled` by fail-fast and `ci-gate-turbo` is the aggregate
gate; neither is a separate issue.

## Fix

Use the existing `setupPageAndWaitForContent` helper instead of
`detachedSetupPage`. It installs a `MutationObserver` **before** bootstrap starts
and resolves when the app skeleton is removed or goes `aria-hidden="true"` —
a real product settle point owned by the test's `AbortSignal`, with no polling
deadline. Ten other page tests already use this helper.

No timeout was raised, and no sleep, retry, skip, or weakened assertion was
added. The business contract is unchanged: the test still proves that a
notification-opened thread stays pending (no "Chat thread not found", no new
snapshot request, the previous thread container still mounted) until the tab
returns to the foreground and metadata catch-up completes.

## Validation

- `chat-thread-idb.test.tsx`, 5 clean runs: 7/7 passing each time; the target
  test steady at 973-1085 ms, ~20% of the 5000 ms per-test budget.
- Reproduced the CI failure locally by running the file under CPU contention
  (6 busy loops on 2 cores): before the fix the target test failed 2/2 with the
  exact `Unable to find an element with the placeholder text` error; after the
  fix it passes at that load.
- A/B under moderate contention (3 busy loops), 3 runs each: before
  2657/3014/2730 ms, after 2401/2530/2765 ms — no added cost.
- Neighbouring regression files `chat-thread-metadata-readiness.test.tsx` and
  `app-skeleton.test.tsx`: 14/14 passing.
- `prettier --check`, `eslint`, `pnpm -F @okouai/app check-types`, and
  `git diff --check`: clean.

This is a happy-dom component test, so live browser validation is not
applicable.
