### PR TITLE
feat(platform): preview docx and pptx files

### DIFF
--- a/turbo/apps/platform/src/lib/platform-host.ts
+++ b/turbo/apps/platform/src/lib/platform-host.ts
@@ -33,6 +33,8 @@ const OKOU_ROOT_DOMAINS = [
   OKOU_PAGES_DOMAIN,
 ] as const;
 const PREVIEW_API_DOMAIN = "vm6.ai";
+const OFFICE_DOCUMENT_VIEWER_BASE_URL =
+  "https://view.officeapps.live.com/op/embed.aspx";
 const PRODUCTION_HOSTED_SITE_DOMAINS = ["sites.vm0.io", "okou.app"] as const;
 const PREVIEW_HOSTED_SITE_DOMAINS = ["sites.vm7.io"] as const;
 const PLATFORM_SERVICE_LABELS = ["platform", "app", "www", "api"] as const;
@@ -231,6 +233,10 @@ export function resolvePublicArtifactsBaseUrl():
   | "https://cdn.vm0.io"
   | "https://cdn.vm7.io" {
   return resolvePlatformRuntimeConfig().publicArtifactsBaseUrl;
+}
+
+export function resolveOfficeDocumentViewerBaseUrl(): string {
+  return OFFICE_DOCUMENT_VIEWER_BASE_URL;
 }
 
 export function resolveHostedSiteDomains(): readonly (

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -115,6 +115,10 @@ export const composerImageAnnotationEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.ComposerImageAnnotation] ?? false;
 });
 
+export const officeDocumentPreviewEnabled$ = computed((get): boolean => {
+  return get(featureSwitch$)[FeatureSwitchKey.OfficeDocumentPreview] ?? false;
+});
+
 export const codexFastModeEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.CodexFastMode] ?? false;
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/thread-sidebar.test.tsx
@@ -1,10 +1,4 @@
-import {
-  act,
-  fireEvent,
-  screen,
-  waitFor,
-  within,
-} from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   artifactCatalogContract,
@@ -56,8 +50,6 @@ import {
   normalizeMockChatEvents,
   type MockChatEventInput,
 } from "./chat-event-test-helpers.ts";
-import { canonicalUserMessageFileUrl } from "../../../signals/chat-page/user-message-files.ts";
-import { openFileLightbox$ } from "../../../signals/okou-page/attachment-chips.ts";
 
 const context = testContext();
 warmMermaidParser();
@@ -144,6 +136,40 @@ function threadArtifactFile(
     googleDriveSync: { status: "not_synced" },
     ...overrides,
   };
+}
+
+function officeUserFileMessages(
+  fileId: string,
+  filename: string,
+): MockChatEventInput[] {
+  return [
+    {
+      id: `msg-${fileId}`,
+      role: "user",
+      content: "Review this Office document",
+      fileParts: [
+        {
+          type: "file",
+          fileId,
+          filenameSnapshot: filename,
+          contentType:
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        },
+      ],
+      runId: "run-sidebar",
+      seqId: 1,
+      createdAt: "2026-03-10T00:00:01Z",
+    },
+    {
+      id: `msg-${fileId}-completed`,
+      role: "assistant",
+      content: null,
+      runId: "run-sidebar",
+      runLifecycleEvent: "completed",
+      seqId: 2,
+      createdAt: "2026-03-10T00:00:02Z",
+    },
+  ];
 }
 
 function googleDriveConnector(
@@ -553,7 +579,6 @@ describe("thread-owned utility sidebar", () => {
   it("uses the public office attachment url instead of its presigned resource url", async () => {
     const filename = "private-manuscript.docx";
     const fileId = "office-with-distinct-public-url";
-    const url = canonicalUserMessageFileUrl(fileId);
     const resourceUrl = `https://r2.example.com/artifacts/${filename}?sig=test`;
     const shareUrl = `https://cdn.vm7.io/artifacts/test/run-sidebar/${filename}`;
     context.mocks.api(webFilesContract.fileUrl, ({ query, respond }) => {
@@ -564,12 +589,10 @@ describe("thread-owned utility sidebar", () => {
       featureSwitches: {
         [FeatureSwitchKey.OfficeDocumentPreview]: true,
       },
+      messages: officeUserFileMessages(fileId, filename),
     });
-    await screen.findByText("Build the launch plan");
 
-    act(() => {
-      context.store.set(openFileLightbox$, { url, filename });
-    });
+    click(await screen.findByLabelText(`Preview ${filename}`));
 
     const dialog = await screen.findByTestId("attachment-lightbox");
     const dialogFrame = await within(dialog).findByTitle(`${filename} preview`);
@@ -656,7 +679,6 @@ describe("thread-owned utility sidebar", () => {
   it("does not send a presigned office attachment url to the viewer when the api omits its public url", async () => {
     const filename = "legacy-api-document.docx";
     const fileId = "office-without-public-url";
-    const url = canonicalUserMessageFileUrl(fileId);
     const resourceUrl = `https://r2.example.com/artifacts/${filename}?sig=test`;
     context.mocks.api(webFilesContract.fileUrl, ({ query, respond }) => {
       expect(query.file_id).toBe(fileId);
@@ -666,12 +688,10 @@ describe("thread-owned utility sidebar", () => {
       featureSwitches: {
         [FeatureSwitchKey.OfficeDocumentPreview]: true,
       },
+      messages: officeUserFileMessages(fileId, filename),
     });
-    await screen.findByText("Build the launch plan");
 
-    act(() => {
-      context.store.set(openFileLightbox$, { url, filename });
-    });
+    click(await screen.findByLabelText(`Preview ${filename}`));
 
     const dialog = await screen.findByTestId("attachment-lightbox");
     await expect(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/thread-sidebar.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   artifactCatalogContract,
@@ -28,6 +34,8 @@ import {
   connectorsMainContract,
 } from "@okouai/api-contracts/contracts/connectors";
 import { mailContract } from "@okouai/api-contracts/contracts/mail";
+import { webFilesContract } from "@okouai/api-contracts/contracts/web-files";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -48,6 +56,8 @@ import {
   normalizeMockChatEvents,
   type MockChatEventInput,
 } from "./chat-event-test-helpers.ts";
+import { canonicalUserMessageFileUrl } from "../../../signals/chat-page/user-message-files.ts";
+import { openFileLightbox$ } from "../../../signals/okou-page/attachment-chips.ts";
 
 const context = testContext();
 warmMermaidParser();
@@ -218,6 +228,7 @@ function setupArtifactCatalog(
 
 function setupChatThread({
   artifactFiles = [],
+  featureSwitches = {},
   messages = [
     {
       id: "msg-sidebar-user",
@@ -246,6 +257,7 @@ function setupChatThread({
   ],
 }: {
   artifactFiles?: ChatThreadArtifactFile[];
+  featureSwitches?: Partial<Record<FeatureSwitchKey, boolean>>;
   messages?: MockChatEventInput[];
 } = {}) {
   let servedMessages = [...messages];
@@ -312,6 +324,7 @@ function setupChatThread({
 
   detachedSetupPage({
     context,
+    featureSwitches,
     path: THREAD_PATH,
   });
 
@@ -493,6 +506,9 @@ describe("thread-owned utility sidebar", () => {
           createdAt: "2026-03-10T00:00:02Z",
         },
       ],
+      featureSwitches: {
+        [FeatureSwitchKey.OfficeDocumentPreview]: true,
+      },
     });
 
     const card = await screen.findByLabelText(`Preview ${filename}`);
@@ -532,6 +548,144 @@ describe("thread-owned utility sidebar", () => {
       throw new Error("Office split-view iframe is missing its source URL");
     }
     expect(new URL(sidebarFrameUrl).searchParams.get("src")).toBe(url);
+  });
+
+  it("uses the public office attachment url instead of its presigned resource url", async () => {
+    const filename = "private-manuscript.docx";
+    const fileId = "office-with-distinct-public-url";
+    const url = canonicalUserMessageFileUrl(fileId);
+    const resourceUrl = `https://r2.example.com/artifacts/${filename}?sig=test`;
+    const shareUrl = `https://cdn.vm7.io/artifacts/test/run-sidebar/${filename}`;
+    context.mocks.api(webFilesContract.fileUrl, ({ query, respond }) => {
+      expect(query.file_id).toBe(fileId);
+      return respond(200, { url: resourceUrl, publicUrl: shareUrl });
+    });
+    setupChatThread({
+      featureSwitches: {
+        [FeatureSwitchKey.OfficeDocumentPreview]: true,
+      },
+    });
+    await screen.findByText("Build the launch plan");
+
+    act(() => {
+      context.store.set(openFileLightbox$, { url, filename });
+    });
+
+    const dialog = await screen.findByTestId("attachment-lightbox");
+    const dialogFrame = await within(dialog).findByTitle(`${filename} preview`);
+    const dialogFrameUrl = dialogFrame.getAttribute("src");
+    expect(dialogFrameUrl).not.toBeNull();
+    if (dialogFrameUrl === null) {
+      throw new Error("Office preview iframe is missing its source URL");
+    }
+    expect(new URL(dialogFrameUrl).searchParams.get("src")).toBe(shareUrl);
+    expect(new URL(dialogFrameUrl).searchParams.get("src")).not.toBe(
+      resourceUrl,
+    );
+
+    click(within(dialog).getByLabelText("Open in split view"));
+
+    const sidebar = await screen.findByTestId("artifact-sidebar");
+    const sidebarFrame = await within(sidebar).findByTitle(
+      `${filename} preview`,
+    );
+    const sidebarFrameUrl = sidebarFrame.getAttribute("src");
+    expect(sidebarFrameUrl).not.toBeNull();
+    if (sidebarFrameUrl === null) {
+      throw new Error("Office split-view iframe is missing its source URL");
+    }
+    expect(new URL(sidebarFrameUrl).searchParams.get("src")).toBe(shareUrl);
+    expect(new URL(sidebarFrameUrl).searchParams.get("src")).not.toBe(
+      resourceUrl,
+    );
+  });
+
+  it("keeps office files on the generic preview when the feature switch is disabled", async () => {
+    const filename = "revised-manuscript.docx";
+    const url = `https://cdn.vm7.io/artifacts/test/run-sidebar/${filename}`;
+    setupChatThread({
+      artifactFiles: [
+        threadArtifactFile(url, {
+          id: "artifact-office-disabled",
+          filename,
+          contentType:
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        }),
+      ],
+      featureSwitches: {
+        [FeatureSwitchKey.OfficeDocumentPreview]: false,
+      },
+      messages: [
+        {
+          id: "msg-office-disabled",
+          role: "assistant",
+          content: `[${filename}](${url})`,
+          runId: "run-sidebar",
+          seqId: 1,
+          createdAt: "2026-03-10T00:00:01Z",
+        },
+        {
+          id: "msg-office-disabled-completed",
+          role: "assistant",
+          content: null,
+          runId: "run-sidebar",
+          runLifecycleEvent: "completed",
+          seqId: 2,
+          createdAt: "2026-03-10T00:00:02Z",
+        },
+      ],
+    });
+
+    click(await screen.findByLabelText(`Preview ${filename}`));
+
+    const dialog = await screen.findByTestId("attachment-lightbox");
+    expect(
+      within(dialog).getByText("No inline preview available for this file."),
+    ).toBeInTheDocument();
+    expect(within(dialog).queryByTitle(`${filename} preview`)).toBeNull();
+
+    click(within(dialog).getByLabelText("Open in split view"));
+
+    const sidebar = await screen.findByTestId("artifact-sidebar");
+    expect(
+      within(sidebar).getByText("No inline preview available for this file."),
+    ).toBeInTheDocument();
+    expect(within(sidebar).queryByTitle(`${filename} preview`)).toBeNull();
+  });
+
+  it("does not send a presigned office attachment url to the viewer when the api omits its public url", async () => {
+    const filename = "legacy-api-document.docx";
+    const fileId = "office-without-public-url";
+    const url = canonicalUserMessageFileUrl(fileId);
+    const resourceUrl = `https://r2.example.com/artifacts/${filename}?sig=test`;
+    context.mocks.api(webFilesContract.fileUrl, ({ query, respond }) => {
+      expect(query.file_id).toBe(fileId);
+      return respond(200, { url: resourceUrl });
+    });
+    setupChatThread({
+      featureSwitches: {
+        [FeatureSwitchKey.OfficeDocumentPreview]: true,
+      },
+    });
+    await screen.findByText("Build the launch plan");
+
+    act(() => {
+      context.store.set(openFileLightbox$, { url, filename });
+    });
+
+    const dialog = await screen.findByTestId("attachment-lightbox");
+    await expect(
+      within(dialog).findByText("Preview unavailable."),
+    ).resolves.toBeInTheDocument();
+    expect(within(dialog).queryByTitle(`${filename} preview`)).toBeNull();
+
+    click(within(dialog).getByLabelText("Open in split view"));
+
+    const sidebar = await screen.findByTestId("artifact-sidebar");
+    await expect(
+      within(sidebar).findByText("Preview unavailable."),
+    ).resolves.toBeInTheDocument();
+    expect(within(sidebar).queryByTitle(`${filename} preview`)).toBeNull();
   });
 
   it("previews a public catalog document through the resolved resource url", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/thread-sidebar.test.tsx
@@ -452,21 +452,31 @@ describe("thread-owned utility sidebar", () => {
     expect(requestedThreadIds).toContain(THREAD_ID);
   });
 
-  it("opens an assistant generic file card in the preview dialog", async () => {
-    const filename = "revised-manuscript.docx";
+  it.each([
+    {
+      contentType:
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      filename: "revised-manuscript.docx",
+    },
+    {
+      contentType:
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      filename: "quarterly-review.pptx",
+    },
+  ])("previews $filename in the dialog and split view", async (fixture) => {
+    const { contentType, filename } = fixture;
     const url = `https://cdn.vm7.io/artifacts/test/run-sidebar/${filename}`;
     setupChatThread({
       artifactFiles: [
         threadArtifactFile(url, {
-          id: "artifact-revised-manuscript",
+          id: `artifact-${filename}`,
           filename,
-          contentType:
-            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          contentType,
         }),
       ],
       messages: [
         {
-          id: "msg-revised-manuscript",
+          id: `msg-${filename}`,
           role: "assistant",
           content: `[${filename}](${url})`,
           runId: "run-sidebar",
@@ -474,7 +484,7 @@ describe("thread-owned utility sidebar", () => {
           createdAt: "2026-03-10T00:00:01Z",
         },
         {
-          id: "msg-revised-manuscript-completed",
+          id: `msg-${filename}-completed`,
           role: "assistant",
           content: null,
           runId: "run-sidebar",
@@ -492,10 +502,18 @@ describe("thread-owned utility sidebar", () => {
     click(card);
 
     const dialog = await screen.findByTestId("attachment-lightbox");
-    expect(
-      within(dialog).getByText("No inline preview available for this file."),
-    ).toBeInTheDocument();
-    expect(within(dialog).getAllByText(filename).length).toBeGreaterThan(0);
+    const dialogFrame = await within(dialog).findByTitle(`${filename} preview`);
+    const dialogFrameUrl = dialogFrame.getAttribute("src");
+    expect(dialogFrameUrl).not.toBeNull();
+    if (dialogFrameUrl === null) {
+      throw new Error("Office preview iframe is missing its source URL");
+    }
+    const parsedDialogFrameUrl = new URL(dialogFrameUrl);
+    expect(parsedDialogFrameUrl.origin).toBe(
+      "https://view.officeapps.live.com",
+    );
+    expect(parsedDialogFrameUrl.pathname).toBe("/op/embed.aspx");
+    expect(parsedDialogFrameUrl.searchParams.get("src")).toBe(url);
 
     click(within(dialog).getByLabelText("Open in split view"));
 
@@ -505,7 +523,15 @@ describe("thread-owned utility sidebar", () => {
       ).not.toBeInTheDocument();
     });
     const sidebar = await screen.findByTestId("artifact-sidebar");
-    expect(within(sidebar).getAllByText(filename).length).toBeGreaterThan(0);
+    const sidebarFrame = await within(sidebar).findByTitle(
+      `${filename} preview`,
+    );
+    const sidebarFrameUrl = sidebarFrame.getAttribute("src");
+    expect(sidebarFrameUrl).not.toBeNull();
+    if (sidebarFrameUrl === null) {
+      throw new Error("Office split-view iframe is missing its source URL");
+    }
+    expect(new URL(sidebarFrameUrl).searchParams.get("src")).toBe(url);
   });
 
   it("previews a public catalog document through the resolved resource url", async () => {

--- a/turbo/apps/platform/src/views/okou-page/artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/artifact-sidebar.tsx
@@ -71,6 +71,10 @@ import {
 } from "./artifact-image-navigation.ts";
 import { AutoFocusedArtifactIframe } from "./auto-focused-artifact-iframe.tsx";
 import { PresentationArtifactViewport } from "./presentation-artifact-viewport.tsx";
+import {
+  isOfficeDocumentPreview,
+  OfficeDocumentPreview,
+} from "./office-document-preview.tsx";
 
 // ---------------------------------------------------------------------------
 // ArtifactSidebar — thread-owned pane for rendering kind-specific artifact
@@ -906,6 +910,15 @@ function ArtifactBody({
       />
     );
   }
+  if (isOfficeDocumentPreview(filename)) {
+    return (
+      <ArtifactOfficeDocumentBody
+        filename={filename}
+        fullscreen={fullscreen}
+        url={url}
+      />
+    );
+  }
   return <ArtifactGenericBody filename={filename} />;
 }
 
@@ -1487,6 +1500,30 @@ function ArtifactIframeBody({
           )}
           className="h-full min-h-0 w-full border-0 bg-background"
           data-testid={`artifact-sidebar-body-${kind}`}
+        />
+      </div>
+    </ArtifactStageShell>
+  );
+}
+
+function ArtifactOfficeDocumentBody({
+  filename,
+  fullscreen,
+  url,
+}: {
+  filename: string;
+  fullscreen: boolean;
+  url: string;
+}) {
+  return (
+    <ArtifactStageShell scrollable={false}>
+      <div className="flex h-full min-h-0 w-full flex-1 overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm">
+        <OfficeDocumentPreview
+          filename={filename}
+          focusKey={`${url}:${fullscreen ? "fullscreen" : "sidebar"}`}
+          focusOnMount={fullscreen}
+          testId="artifact-sidebar-body-office"
+          url={url}
         />
       </div>
     </ArtifactStageShell>

--- a/turbo/apps/platform/src/views/okou-page/artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/artifact-sidebar.tsx
@@ -75,6 +75,7 @@ import {
   isOfficeDocumentPreview,
   OfficeDocumentPreview,
 } from "./office-document-preview.tsx";
+import { officeDocumentPreviewEnabled$ } from "../../signals/external/feature-switch.ts";
 
 // ---------------------------------------------------------------------------
 // ArtifactSidebar — thread-owned pane for rendering kind-specific artifact
@@ -850,6 +851,7 @@ function ArtifactBody({
   text$?: TextPreviewComputed;
 }) {
   const { t } = useTranslation();
+  const officeDocumentPreviewEnabled = useGet(officeDocumentPreviewEnabled$);
   if (kind === "markdown") {
     return markdownTree$ ? (
       <ArtifactMarkdownBody tree$={markdownTree$} />
@@ -910,7 +912,7 @@ function ArtifactBody({
       />
     );
   }
-  if (isOfficeDocumentPreview(filename)) {
+  if (officeDocumentPreviewEnabled && isOfficeDocumentPreview(filename)) {
     return (
       <ArtifactOfficeDocumentBody
         filename={filename}

--- a/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
@@ -96,6 +96,10 @@ import {
 import { AutoFocusedArtifactIframe } from "./auto-focused-artifact-iframe.tsx";
 import { PresentationArtifactViewport } from "./presentation-artifact-viewport.tsx";
 import { IconTooltipButton } from "../components/icon-tooltip.tsx";
+import {
+  isOfficeDocumentPreview,
+  OfficeDocumentPreview,
+} from "./office-document-preview.tsx";
 
 type TextPreviewLoadState = {
   readonly status: "loading" | "loaded" | "error";
@@ -969,6 +973,28 @@ function ArtifactDialogGenericFileBody({ filename }: { filename: string }) {
   );
 }
 
+function ArtifactDialogOfficeDocumentBody({
+  filename,
+  preview,
+}: {
+  filename: string;
+  preview: Extract<AttachmentLightboxState, { kind: "file" }>;
+}) {
+  return (
+    <ArtifactDialogStage scrollable={false}>
+      <div className="flex h-full min-h-0 w-full flex-1 overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm">
+        <OfficeDocumentPreview
+          filename={filename}
+          focusKey={`${preview.url}:dialog`}
+          focusOnMount={false}
+          testId="artifact-dialog-body-office"
+          url={preview.url}
+        />
+      </div>
+    </ArtifactDialogStage>
+  );
+}
+
 function ArtifactDialogBody({
   artifact,
   imageNavigation,
@@ -999,6 +1025,14 @@ function ArtifactDialogBody({
   }
 
   if (preview.kind === "file") {
+    if (isOfficeDocumentPreview(filename)) {
+      return (
+        <ArtifactDialogOfficeDocumentBody
+          filename={filename}
+          preview={preview}
+        />
+      );
+    }
     return <ArtifactDialogGenericFileBody filename={filename} />;
   }
 

--- a/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
@@ -52,6 +52,7 @@ import {
   navigateImageLightbox$,
   openAudioLightbox$,
   openDocumentLightbox$,
+  openFileLightbox$,
   openImageLightbox$,
   toggleLightboxDialogFullscreen$,
   type AttachmentArtifactMetadata,
@@ -1579,11 +1580,19 @@ export function FileAttachmentChip({
 }) {
   const { t } = useTranslation();
   const downloadAttachment = useSet(downloadAttachment$);
+  const openFileLightbox = useSet(openFileLightbox$);
   const pageSignal = useGet(pageSignal$);
+  const officeDocumentPreviewEnabled = useGet(officeDocumentPreviewEnabled$);
+  const previewOfficeDocument =
+    officeDocumentPreviewEnabled && isOfficeDocumentPreview(filename);
   return (
     <button
       type="button"
       onClick={() => {
+        if (previewOfficeDocument) {
+          openFileLightbox({ filename, url });
+          return;
+        }
         detach(
           downloadAttachment({ filename, url }, pageSignal),
           Reason.DomCallback,
@@ -1591,12 +1600,21 @@ export function FileAttachmentChip({
         );
       }}
       title={filename}
-      aria-label={t(
-        ($) => {
-          return $.artifacts.attachments.download;
-        },
-        { filename },
-      )}
+      aria-label={
+        previewOfficeDocument
+          ? t(
+              ($) => {
+                return $.chat.attachments.previewFile;
+              },
+              { filename },
+            )
+          : t(
+              ($) => {
+                return $.artifacts.attachments.download;
+              },
+              { filename },
+            )
+      }
       className={`${FILE_CHIP_CLASSES} hover:bg-state-hover`}
     >
       <FileChipBody

--- a/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
@@ -70,7 +70,10 @@ import {
   DEFAULT_ANNOTATION_INK,
   openAnnotationEditor$,
 } from "../../signals/okou-page/image-annotation.ts";
-import { composerImageAnnotationEnabled$ } from "../../signals/external/feature-switch.ts";
+import {
+  composerImageAnnotationEnabled$,
+  officeDocumentPreviewEnabled$,
+} from "../../signals/external/feature-switch.ts";
 import { useResolvedAttachmentUrl } from "./attachment-resource.ts";
 import {
   ArtifactActionSeparator,
@@ -1005,6 +1008,7 @@ function ArtifactDialogBody({
   preview: AttachmentLightboxState;
 }) {
   const filename = artifactDialogFilename(preview);
+  const officeDocumentPreviewEnabled = useGet(officeDocumentPreviewEnabled$);
 
   if (preview.kind === "image") {
     return (
@@ -1025,7 +1029,7 @@ function ArtifactDialogBody({
   }
 
   if (preview.kind === "file") {
-    if (isOfficeDocumentPreview(filename)) {
+    if (officeDocumentPreviewEnabled && isOfficeDocumentPreview(filename)) {
       return (
         <ArtifactDialogOfficeDocumentBody
           filename={filename}

--- a/turbo/apps/platform/src/views/okou-page/attachment-resource.ts
+++ b/turbo/apps/platform/src/views/okou-page/attachment-resource.ts
@@ -1,6 +1,14 @@
 import { useGet, useLastResolved } from "ccstate-react";
-import { pageAttachmentResourceUrlResolver$ } from "../../signals/attachment-resource-url.ts";
+import {
+  pageAttachmentResourceUrlResolver$,
+  type AttachmentUrls,
+} from "../../signals/attachment-resource-url.ts";
 import { publicAttachmentUrl } from "./attachment-url";
+
+export function useAttachmentUrls(url: string): AttachmentUrls | undefined {
+  const resolveResourceUrl = useGet(pageAttachmentResourceUrlResolver$);
+  return useLastResolved(resolveResourceUrl(publicAttachmentUrl(url)));
+}
 
 /**
  * Resolves the URL a browser element can actually load, or null while that is
@@ -11,11 +19,7 @@ import { publicAttachmentUrl } from "./attachment-url";
  * not need to know which form it holds.
  */
 export function useResolvedAttachmentUrl(url: string): string | null {
-  const resolveResourceUrl = useGet(pageAttachmentResourceUrlResolver$);
-  return (
-    useLastResolved(resolveResourceUrl(publicAttachmentUrl(url)))
-      ?.resourceUrl ?? null
-  );
+  return useAttachmentUrls(url)?.resourceUrl ?? null;
 }
 
 /**
@@ -25,9 +29,5 @@ export function useResolvedAttachmentUrl(url: string): string | null {
  * the object it just authorized.
  */
 export function useAttachmentShareUrl(url: string): string | null {
-  const resolveResourceUrl = useGet(pageAttachmentResourceUrlResolver$);
-  return (
-    useLastResolved(resolveResourceUrl(publicAttachmentUrl(url)))?.shareUrl ??
-    null
-  );
+  return useAttachmentUrls(url)?.shareUrl ?? null;
 }

--- a/turbo/apps/platform/src/views/okou-page/office-document-preview.tsx
+++ b/turbo/apps/platform/src/views/okou-page/office-document-preview.tsx
@@ -1,0 +1,74 @@
+import { Loader2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { resolveOfficeDocumentViewerBaseUrl } from "../../lib/platform-host.ts";
+import { AutoFocusedArtifactIframe } from "./auto-focused-artifact-iframe.tsx";
+import { useAttachmentUrls } from "./attachment-resource.ts";
+
+export function isOfficeDocumentPreview(filename: string): boolean {
+  const normalizedFilename = filename.toLowerCase();
+  return (
+    normalizedFilename.endsWith(".docx") || normalizedFilename.endsWith(".pptx")
+  );
+}
+
+function officeDocumentViewerUrl(sourceUrl: string): string {
+  const viewerUrl = new URL(resolveOfficeDocumentViewerBaseUrl());
+  viewerUrl.searchParams.set("src", sourceUrl);
+  return viewerUrl.toString();
+}
+
+export function OfficeDocumentPreview({
+  filename,
+  focusKey,
+  focusOnMount,
+  testId,
+  url,
+}: {
+  filename: string;
+  focusKey: string;
+  focusOnMount: boolean;
+  testId: string;
+  url: string;
+}) {
+  const { t } = useTranslation();
+  const attachmentUrls = useAttachmentUrls(url);
+
+  if (attachmentUrls === undefined) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        <Loader2 size={20} className="animate-spin" />
+      </div>
+    );
+  }
+
+  if (attachmentUrls.shareUrl === null) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+        {t(($) => {
+          return $.artifacts.preview.genericUnavailable;
+        })}
+      </div>
+    );
+  }
+
+  // The Office viewer fetches the document server-side, so it needs the
+  // durable public URL rather than the browser-scoped presigned resource URL.
+  return (
+    <AutoFocusedArtifactIframe
+      focusKey={focusKey}
+      focusOnMount={focusOnMount}
+      src={officeDocumentViewerUrl(attachmentUrls.shareUrl)}
+      title={t(
+        ($) => {
+          return $.artifacts.preview.dialogLabel;
+        },
+        { filename },
+      )}
+      referrerPolicy="no-referrer"
+      scrolling="yes"
+      allowFullScreen
+      className="block h-full min-h-0 w-full border-0 bg-background"
+      data-testid={testId}
+    />
+  );
+}

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -68,6 +68,7 @@ export enum FeatureSwitchKey {
   ChatConversationLocator = "chatConversationLocator",
   ChatTranslation = "chatTranslation",
   ComposerImageAnnotation = "composerImageAnnotation",
+  OfficeDocumentPreview = "officeDocumentPreview",
   GradientColorThemes = "gradientColorThemes",
   DesktopScreenRecording = "desktopScreenRecording",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -354,6 +354,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.OfficeDocumentPreview]: {
+    maintainer: "yuma@vm0.ai",
+    description:
+      "Preview DOCX and PPTX attachments with the Microsoft Office viewer.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.GradientColorThemes]: {
     maintainer: "ming@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- preview `.docx` and `.pptx` attachments in the standard file dialog and Inbox split view
- load the Office viewer only after the user opens a supported document, using the stable public attachment URL and no referrer
- keep the existing generic-file fallback for unsupported file types

## Testing

- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/thread-sidebar.test.tsx`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter @okouai/app run check-types`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter @okouai/app run lint`
- `pnpm knip`
