### PR TITLE
fix(platform): reset connector credential forms on open

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
@@ -15,6 +15,7 @@ import {
   connectConnectorOAuthAuthCode$,
   connectorCurrentConnectionStatus,
   getConnectorStatusDirectConnectMethod,
+  resetManualGrantForm$,
 } from "../okou-page/settings/connectors.ts";
 import {
   customConnectorAuthorizedAgentsById$,
@@ -236,6 +237,7 @@ function createCatalogConnectorActivation(
     const directConnectMethod =
       getConnectorStatusDirectConnectMethod(connector);
     if (!directConnectMethod) {
+      set(resetManualGrantForm$, connector.slug);
       set(activeChatConnectorActionState$, {
         ...descriptor,
         catalogItem: connector,

--- a/turbo/apps/platform/src/signals/connectors-page/directed-authorize-slug.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-authorize-slug.ts
@@ -13,6 +13,7 @@ import {
   agentConnectorAuthorizations,
   reloadAgentConnectorAuthorizations$,
 } from "../okou-page/agent-connector-authorizations.ts";
+import { resetManualGrantForm$ } from "../okou-page/settings/connectors.ts";
 
 /**
  * Connector slug extracted from `/connectors/:connectorSlug/authorize` route params.
@@ -74,6 +75,9 @@ export const directedAuthorizeConnectModalKey$ = computed((get) => {
 });
 export const setDirectedAuthorizeConnectModalKey$ = command(
   ({ set }, key: DirectedAuthorizeConnectModalKey | null) => {
+    if (key) {
+      set(resetManualGrantForm$, key.connectorSlug);
+    }
     set(internalDirectedAuthorizeConnectModalKey$, key);
   },
 );

--- a/turbo/apps/platform/src/signals/connectors-page/directed-connect-slug.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-connect-slug.ts
@@ -9,6 +9,7 @@ import {
 } from "@okouai/api-contracts/contracts/custom-connectors";
 import { pathParams$, searchParams$ } from "../route.ts";
 import { agents$ } from "../agent.ts";
+import { resetManualGrantForm$ } from "../okou-page/settings/connectors.ts";
 
 /**
  * Connector slug extracted from `/connectors/:connectorSlug/connect` route params.
@@ -90,11 +91,17 @@ export const directedConnectCustomDialogKey$ = computed((get) => {
 });
 export const setManualGrantDialogKey$ = command(
   ({ set }, key: DirectedConnectManualGrantDialogKey | null) => {
+    if (key) {
+      set(resetManualGrantForm$, key.connectorSlug);
+    }
     set(internalManualGrantDialogKey$, key);
   },
 );
 export const setDirectedConnectModalKey$ = command(
   ({ set }, key: DirectedConnectModalKey | null) => {
+    if (key) {
+      set(resetManualGrantForm$, key.connectorSlug);
+    }
     set(internalDirectedConnectModalKey$, key);
   },
 );

--- a/turbo/apps/platform/src/signals/okou-page/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/connectors.ts
@@ -29,6 +29,7 @@ import {
   createComposerConnectorAccountSignals,
   type ComposerConnectorAccountSignals,
 } from "./composer-connector-accounts.ts";
+import { resetManualGrantForm$ } from "./settings/connectors.ts";
 
 export interface ComposerConnectorAuthorizationState {
   readonly agentId: string;
@@ -338,6 +339,9 @@ function createConnectorUiSignals(): Pick<
   });
   const updateConnectorUiState$ = command(
     ({ set }, patch: Partial<ComposerConnectorUiState>): void => {
+      if (patch.selectedConnectorSlug) {
+        set(resetManualGrantForm$, patch.selectedConnectorSlug);
+      }
       set(internalUiState$, (current) => {
         return { ...current, ...patch };
       });

--- a/turbo/apps/platform/src/signals/okou-page/settings/connector-account-dialogs.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connector-account-dialogs.ts
@@ -14,6 +14,7 @@ import {
   readConnectorAccount$,
   settingsConnectorAccounts,
 } from "./connector-accounts.ts";
+import { resetManualGrantForm$ } from "./connectors.ts";
 
 export type ConnectorAccountConnectMode =
   | { readonly kind: "add" }
@@ -167,6 +168,7 @@ export const openBuiltinAccountConnectDialog$ = command(
     connector: PlatformConnectorCatalogStatusItem,
     mode: ConnectorAccountConnectMode,
   ) => {
+    set(resetManualGrantForm$, connector.slug);
     set(internalBuiltinAccountManager$, null);
     set(settingsConnectorAccounts.clearTarget$);
     set(internalBuiltinAccountConnectDialog$, { connector, mode });

--- a/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
@@ -630,6 +630,9 @@ export const selectedConnectorSlug$ = computed((get) => {
 });
 export const setSelectedConnectorSlug$ = command(
   ({ get, set }, connectorSlug: ConnectorSlug | null) => {
+    if (connectorSlug) {
+      set(resetManualGrantForm$, connectorSlug);
+    }
     set(internalSelectedConnectorSlug$, connectorSlug);
     const deviceAuthCurrent = get(internalConnectorOAuthDeviceAuthState$);
     if (connectorSlug !== deviceAuthCurrent.connectorSlug) {
@@ -787,7 +790,7 @@ export const setManualGrantFormValue$ = command(
   },
 );
 
-export const clearManualGrantForm$ = command(
+export const resetManualGrantForm$ = command(
   ({ get, set }, connectorSlug: ConnectorSlug) => {
     const current = get(manualGrantFormValues$);
     const updated = { ...current };

--- a/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
@@ -886,6 +886,7 @@ export const customConnectorEditConfirmation$ = computed((get) => {
   return get(internalEditConfirmation$);
 });
 export const openCustomConnectorCreateDialog$ = command(({ set }) => {
+  set(internalCreateForm$, CREATE_FORM_DEFAULTS);
   set(internalEditConfirmation$, null);
   set(internalDialog$, { kind: "create" });
 });
@@ -1092,10 +1093,6 @@ export const removeCustomConnectorAuthMethod$ = command(
     });
   },
 );
-export const resetCustomConnectorCreateForm$ = command(({ set }) => {
-  set(internalCreateForm$, CREATE_FORM_DEFAULTS);
-});
-
 // ---------------------------------------------------------------------------
 // Connect form state
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -66,7 +66,10 @@ import { detachedNavigateTo$ } from "../../../signals/route.ts";
 import { ROUTES } from "../../../signals/route-paths.ts";
 import { createDeferredPromise, resetSignal } from "../../../signals/utils.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { submitManualGrant$ } from "../../../signals/okou-page/settings/connectors.ts";
+import {
+  manualGrantFormValuesFor$,
+  submitManualGrant$,
+} from "../../../signals/okou-page/settings/connectors.ts";
 import { customConnectorCreateForm$ } from "../../../signals/okou-page/settings/custom-connectors.ts";
 
 const context = testContext();
@@ -4414,6 +4417,62 @@ describe("connectors page", () => {
     });
   });
 
+  it("resets manual grant values when the connection dialog opens", async () => {
+    mockConnectors([]);
+    mockPublicConnectorStatus([
+      publicStatusItem({
+        connectorSlug: "axiom",
+        label: "Public Axiom",
+        authMethods: [
+          {
+            id: "api-token",
+            label: "Public API Token",
+            description: null,
+            grantKind: "manual",
+            manualFields: [
+              {
+                id: "apiToken",
+                label: "Public API token",
+                required: true,
+                placeholder: "public-xaat",
+                inputType: "password",
+              },
+            ],
+            startOptions: [],
+          },
+        ],
+      }),
+    ]);
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    const connectButton = await screen.findByLabelText("Connect Public Axiom");
+    click(connectButton);
+    const firstDialog = await screen.findByRole("dialog", {
+      name: "Public Axiom",
+    });
+    await fill(
+      within(firstDialog).getByPlaceholderText("public-xaat"),
+      "stale-manual-token",
+    );
+    click(within(firstDialog).getByLabelText("Close"));
+
+    await waitFor(() => {
+      expect(firstDialog).not.toBeInTheDocument();
+    });
+    expect(context.store.get(manualGrantFormValuesFor$)("axiom")).toStrictEqual(
+      { apiToken: "stale-manual-token" },
+    );
+
+    click(connectButton);
+    const reopenedDialog = await screen.findByRole("dialog", {
+      name: "Public Axiom",
+    });
+    expect(
+      within(reopenedDialog).getByPlaceholderText("public-xaat"),
+    ).toHaveValue("");
+  });
+
   it("connects manual-grant connectors without permission dialogs", async () => {
     mockConnectors([]);
     mockPublicConnectorStatus([
@@ -4516,6 +4575,9 @@ describe("connectors page", () => {
     expect(
       screen.queryByText("You've successfully connected with Public Axiom!"),
     ).not.toBeInTheDocument();
+    expect(context.store.get(manualGrantFormValuesFor$)("axiom")).toStrictEqual(
+      { apiToken: "xaat-test" },
+    );
 
     await fill(screen.getByPlaceholderText("Find connectors"), "stripe");
     click(await screen.findByLabelText("Connect Public Stripe"));
@@ -5460,6 +5522,44 @@ describe("connectors page", () => {
     });
     click(buttonByText("Add authentication", createDialog));
     expect(queryMenuItemByText("No authentication")).not.toBeInTheDocument();
+  });
+
+  it("initializes the custom connector create form on every open", async () => {
+    mockCustomConnectorStory();
+
+    detachedSetupPage({ context, path: "/connectors?tab=custom" });
+
+    click(await screen.findByText("New connector"));
+    const firstDialog = await screen.findByRole("dialog", {
+      name: "New custom connector",
+    });
+    click(buttonByText("Add authentication", firstDialog));
+    click(menuItemByText("OAuth 2.0"));
+    await fill(
+      within(firstDialog).getByLabelText("Client secret"),
+      "stale-client-secret",
+    );
+    click(buttonByText("Cancel", firstDialog));
+
+    await waitFor(() => {
+      expect(firstDialog).not.toBeInTheDocument();
+    });
+    expect(
+      context.store.get(customConnectorCreateForm$).oauthClientSecret,
+    ).toBe("stale-client-secret");
+
+    click(screen.getByText("New connector"));
+    const reopenedDialog = await screen.findByRole("dialog", {
+      name: "New custom connector",
+    });
+    expect(
+      context.store.get(customConnectorCreateForm$).authMethodTypes,
+    ).toStrictEqual([]);
+    click(buttonByText("Add authentication", reopenedDialog));
+    click(menuItemByText("OAuth 2.0"));
+    expect(within(reopenedDialog).getByLabelText("Client secret")).toHaveValue(
+      "",
+    );
   });
 
   it.each([
@@ -6735,6 +6835,9 @@ describe("connectors page", () => {
       expect(screen.getByText("Acme API")).toBeInTheDocument();
     });
     expect(createdBodies).toHaveLength(1);
+    expect(
+      context.store.get(customConnectorCreateForm$).oauthClientSecret,
+    ).toBe("connector-oauth-client-secret");
     expect(createdBodies[0]).toMatchObject({
       displayName: "Acme API",
       storageVersion: 1,

--- a/turbo/apps/platform/src/views/okou-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/add-connection-dialog.tsx
@@ -49,7 +49,6 @@ import {
   runConnectorConnectSuccess$,
   submitManualGrant$,
   setManualGrantFormValue$,
-  clearManualGrantForm$,
   manualGrantFormValuesFor$,
   connectorCurrentConnectionStatus,
   connectorExpiryCountdownText,
@@ -293,7 +292,6 @@ function ManualGrantForm({
 }) {
   const { t } = useTranslation();
   const setFormValue = useSet(setManualGrantFormValue$);
-  const clearForm = useSet(clearManualGrantForm$);
   const pageSignal = useGet(pageSignal$);
   const manualGrantFormValuesFor = useGet(manualGrantFormValuesFor$);
   const fieldValues = manualGrantFormValuesFor(connectorSlug);
@@ -323,7 +321,6 @@ function ManualGrantForm({
       if (!connected) {
         return;
       }
-      clearForm(connectorSlug);
       await onSuccess(connected.connectionId);
     },
   );

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-create-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-create-dialog.tsx
@@ -45,7 +45,6 @@ import {
   customConnectorEditConfirmation$,
   openCustomConnectorEditConfirmationDialog$,
   removeCustomConnectorAuthMethod$,
-  resetCustomConnectorCreateForm$,
   setCustomConnectorCreateField$,
   setCustomConnectorCreateKind$,
   type CustomConnectorAuthMethodType,
@@ -1310,7 +1309,6 @@ export function CustomConnectorCreateDialog({
     closeCustomConnectorEditConfirmationDialog$,
   );
   const closeDialog = useSet(closeCustomConnectorDialog$);
-  const resetForm = useSet(resetCustomConnectorCreateForm$);
   const [createLoadable, createConnector] = useLoadableSet(
     createCustomConnector$,
   );
@@ -1329,7 +1327,6 @@ export function CustomConnectorCreateDialog({
   const advancedApiDefinition = connectorHasAdvancedApiDefinition(connector);
 
   const close = () => {
-    resetForm();
     closeDialog();
   };
 

--- a/turbo/apps/platform/src/views/okou-page/directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/directed-connect-page.tsx
@@ -33,7 +33,6 @@ import {
   submitManualGrant$,
   manualGrantFormSubmitting$,
   setManualGrantFormValue$,
-  clearManualGrantForm$,
   manualGrantFormValuesFor$,
   setManualGrantFormSubmitting$,
   getOnlyManualConnectorStatusAuthMethod,
@@ -227,7 +226,6 @@ function ManualGrantForm({
   const { t } = useTranslation();
   const submit = useSet(submitManualGrant$);
   const setFormValue = useSet(setManualGrantFormValue$);
-  const clearForm = useSet(clearManualGrantForm$);
   const pageSignal = useGet(pageSignal$);
   const manualGrantFormValuesFor = useGet(manualGrantFormValuesFor$);
   const fieldValues = manualGrantFormValuesFor(connectorSlug);
@@ -269,7 +267,6 @@ function ManualGrantForm({
               return;
             }
             await onSuccess();
-            clearForm(connectorSlug);
           })(),
         ),
         () => {

--- a/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
+++ b/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
@@ -21,8 +21,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   click,
-  detachedSetupPage,
   queryAllByRoleFast,
+  setupPageAndWaitForContent,
 } from "../../../__tests__/page-helper.ts";
 import {
   testContext,
@@ -230,7 +230,7 @@ async function openDrawer(
   sharedWorkerTestTransport: "direct" | "message-port" = "direct",
 ): Promise<void> {
   mockQueuedThread();
-  detachedSetupPage({
+  await setupPageAndWaitForContent({
     context,
     path: `/chats/${THREAD_ID}`,
     featureSwitches: {


### PR DESCRIPTION
## Summary

- reset manual connector grant values at every modal-open entry point instead of after a successful submission
- initialize the custom connector create form when opening it and stop clearing it when the dialog closes
- cover retained state after submit or close and empty state on the next fresh open

## Testing

- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/connectors-page.test.tsx --maxWorkers=1 -t "resets manual grant values when the connection dialog opens|initializes the custom connector create form on every open|connects manual-grant connectors without permission dialogs|configures OAuth app credentials at creation and authorizes on connect"` (4 passed)
