### PR TITLE
fix(platform): show translation loading for shortcuts

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
@@ -111,6 +111,7 @@ export interface ChatThreadFeedbackSignals {
   readonly close$: Command<void, []>;
   readonly copy$: Command<Promise<void>, [AbortSignal]>;
   readonly translationLanguage$: Computed<Promise<ChatTranslationLanguage>>;
+  readonly translationPromise$: Computed<Promise<void> | null>;
   readonly translationResult$: Computed<ChatThreadTranslationResult | null>;
   readonly setTranslationLanguage$: Command<
     Promise<void>,
@@ -331,6 +332,7 @@ function isSelectionInteractionTarget(target: EventTarget | null): boolean {
 
 function createSelectionState(threadId: string) {
   const internalSelection$ = state<CapturedFeedbackSelection | null>(null);
+  const internalTranslationPromise$ = state<Promise<void> | null>(null);
   const internalTranslationResult$ = state<ChatThreadTranslationResult | null>(
     null,
   );
@@ -355,6 +357,7 @@ function createSelectionState(threadId: string) {
     set(resetToolbarSignal$);
     set(resetTranslationSignal$);
     set(internalSelection$, null);
+    set(internalTranslationPromise$, null);
     set(internalTranslationResult$, null);
   });
   const capture$ = command(({ get, set }) => {
@@ -371,6 +374,7 @@ function createSelectionState(threadId: string) {
       return;
     }
     set(resetTranslationSignal$);
+    set(internalTranslationPromise$, null);
     set(internalTranslationResult$, null);
     set(internalSelection$, selection);
   });
@@ -398,6 +402,7 @@ function createSelectionState(threadId: string) {
   });
   return {
     internalSelection$,
+    internalTranslationPromise$,
     internalTranslationResult$,
     resetToolbarSignal$,
     resetTranslationSignal$,
@@ -411,10 +416,12 @@ function createSelectionState(threadId: string) {
 
 function createTranslationState({
   selection$,
+  promise$,
   result$,
   resetTranslationSignal$,
 }: {
   selection$: State<CapturedFeedbackSelection | null>;
+  promise$: State<Promise<void> | null>;
   result$: State<ChatThreadTranslationResult | null>;
   resetTranslationSignal$: ReturnType<typeof resetSignal>;
 }) {
@@ -429,6 +436,9 @@ function createTranslationState({
   const translationResult$ = computed((get) => {
     return get(result$);
   });
+  const translationPromise$ = computed((get) => {
+    return get(promise$);
+  });
   const setTranslationLanguage$ = command(
     async (
       { set },
@@ -441,7 +451,7 @@ function createTranslationState({
       signal.throwIfAborted();
     },
   );
-  const translate$ = command(
+  const performTranslation$ = command(
     async ({ get, set }, signal: AbortSignal): Promise<void> => {
       const selection = get(selection$);
       if (!selection) {
@@ -469,6 +479,11 @@ function createTranslationState({
       set(result$, { text: response.text, targetLanguage });
     },
   );
+  const translate$ = command(({ set }, signal: AbortSignal): Promise<void> => {
+    const promise = set(performTranslation$, signal);
+    set(promise$, promise);
+    return promise;
+  });
   const copyTranslation$ = command(
     async ({ get }, signal: AbortSignal): Promise<void> => {
       const result = get(result$);
@@ -489,6 +504,7 @@ function createTranslationState({
   );
   return {
     translationLanguage$,
+    translationPromise$,
     translationResult$,
     setTranslationLanguage$,
     translate$,
@@ -755,6 +771,7 @@ export function createChatThreadFeedbackSignals(
   const selection = createSelectionState(threadId);
   const translation = createTranslationState({
     selection$: selection.internalSelection$,
+    promise$: selection.internalTranslationPromise$,
     result$: selection.internalTranslationResult$,
     resetTranslationSignal$: selection.resetTranslationSignal$,
   });
@@ -788,6 +805,7 @@ export function createChatThreadFeedbackSignals(
     close$: selection.close$,
     copy$: selection.copy$,
     translationLanguage$: translation.translationLanguage$,
+    translationPromise$: translation.translationPromise$,
     translationResult$: translation.translationResult$,
     setTranslationLanguage$: translation.setTranslationLanguage$,
     translate$: translation.translate$,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
@@ -816,9 +816,6 @@ describe("chat inline feedback", () => {
         { text: selectedContent, targetLanguage: "fr" },
       ]);
       expect(buttonByText("Translate")).toBeDisabled();
-      expect(
-        buttonByText("Translate").querySelector(".animate-spin"),
-      ).not.toBeNull();
     });
     translationResponse.resolve();
     await expect(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
@@ -734,6 +734,7 @@ describe("chat inline feedback", () => {
     const selectedContent = "Keep the launch checklist short and actionable.";
     const translationRequests: unknown[] = [];
     const preferenceUpdates: unknown[] = [];
+    const translationResponse = context.mocks.deferred<void>();
     let preferences: UserPreferencesResponse = {
       timezone: "UTC",
       locale: "en-US",
@@ -755,8 +756,9 @@ describe("chat inline feedback", () => {
     });
     context.mocks.api(
       chatTranslationContract.translate,
-      ({ body, respond }) => {
+      async ({ body, respond }) => {
         translationRequests.push(body);
+        await translationResponse.promise;
         return respond(200, {
           text:
             body.targetLanguage === "fr"
@@ -813,7 +815,12 @@ describe("chat inline feedback", () => {
       expect(translationRequests).toStrictEqual([
         { text: selectedContent, targetLanguage: "fr" },
       ]);
+      expect(buttonByText("Translate")).toBeDisabled();
+      expect(
+        buttonByText("Translate").querySelector(".animate-spin"),
+      ).not.toBeNull();
     });
+    translationResponse.resolve();
     await expect(
       screen.findByText("Gardez la liste de lancement courte et exploitable."),
     ).resolves.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/okou-page/chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-feedback-selection.tsx
@@ -7,7 +7,7 @@ import {
   MessageCircle,
   X,
 } from "lucide-react";
-import { useGet, useLastResolved, useSet } from "ccstate-react";
+import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 import {
@@ -246,8 +246,8 @@ function TranslationAction({
 }) {
   const { t } = useTranslation();
   const pageSignal = useGet(pageSignal$);
-  const [translationLoadable, translate] = useLoadableSet(feedback.translate$);
-  const translating = translationLoadable.state === "loading";
+  const translate = useSet(feedback.translate$);
+  const translating = useTranslationLoading(feedback);
   return (
     <button
       type="button"
@@ -271,6 +271,12 @@ function TranslationAction({
   );
 }
 
+function useTranslationLoading(feedback: ChatThreadFeedbackSignals): boolean {
+  const translationPromise = useGet(feedback.translationPromise$);
+  const translationLoadable = useLoadable(feedback.translationPromise$);
+  return translationPromise !== null && translationLoadable.state === "loading";
+}
+
 function TranslationResult({
   feedback,
   result,
@@ -286,10 +292,10 @@ function TranslationResult({
   const [languageLoadable, setLanguage] = useLoadableSet(
     feedback.setTranslationLanguage$,
   );
-  const [translationLoadable, translate] = useLoadableSet(feedback.translate$);
+  const translate = useSet(feedback.translate$);
   const language =
     useLastResolved(feedback.translationLanguage$) ?? result.targetLanguage;
-  const translating = translationLoadable.state === "loading";
+  const translating = useTranslationLoading(feedback);
   const updatingLanguage = languageLoadable.state === "loading" || translating;
   const copyTranslation = useSet(feedback.copyTranslation$);
   return (


### PR DESCRIPTION
## Summary

- track chat translation work through a shared in-flight promise
- show the existing loading state for both button and keyboard shortcut triggers
- cover the `T` shortcut with a deferred-response UI regression test

## Testing

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-inline-feedback.test.tsx`

Local browser verification was not run, in line with the repository instructions; PR CI is the verification source.
