### PR TITLE
fix(platform): keep chat translation menu open while scrolling

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
@@ -324,7 +324,7 @@ function shouldDismissSelectionForInteractionTarget(
 
 function isSelectionInteractionTarget(target: EventTarget | null): boolean {
   return (
-    target instanceof HTMLElement &&
+    target instanceof Element &&
     target.closest(SELECTION_INTERACTION_SELECTOR) !== null
   );
 }
@@ -739,7 +739,10 @@ function createListenersRef({
       );
       doc.addEventListener(
         "scroll",
-        () => {
+        (event) => {
+          if (isSelectionInteractionTarget(event.target)) {
+            return;
+          }
           set(dismissOnScroll$);
         },
         { capture: true, passive: true, signal },

--- a/turbo/apps/platform/src/signals/chat-page/chat-translation.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-translation.ts
@@ -3,9 +3,11 @@ import {
   chatTranslationContract,
   type ChatTranslationResponse,
 } from "@okouai/api-contracts/contracts/chat-translation";
-import type {
-  ChatTranslationLanguage,
-  UserLocale,
+import {
+  CHAT_TRANSLATION_LANGUAGE_BY_USER_LOCALE,
+  userLocaleSchema,
+  type ChatTranslationLanguage,
+  type UserLocale,
 } from "@okouai/api-contracts/contracts/user-preferences";
 
 import { accept } from "../../lib/accept.ts";
@@ -19,6 +21,11 @@ import {
 function languageFromLocale(
   locale: UserLocale | string | null | undefined,
 ): ChatTranslationLanguage {
+  const userLocale = userLocaleSchema.safeParse(locale);
+  if (userLocale.success) {
+    return CHAT_TRANSLATION_LANGUAGE_BY_USER_LOCALE[userLocale.data];
+  }
+
   if (locale?.startsWith("zh-TW") || locale?.startsWith("zh-HK")) {
     return "zh-TW";
   }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
@@ -824,6 +824,19 @@ describe("chat inline feedback", () => {
     await user.click(
       screen.getByRole("combobox", { name: "Translation language" }),
     );
+    const languageListbox = await screen.findByRole("listbox");
+    const languageMenu = languageListbox.closest(
+      "[data-chat-selection-interaction]",
+    );
+    if (!(languageMenu instanceof HTMLElement)) {
+      throw new Error("Translation language menu is not available");
+    }
+    fireEvent.scroll(languageMenu);
+    expect(
+      screen.getByText("Gardez la liste de lancement courte et exploitable."),
+    ).toBeInTheDocument();
+    expect(languageListbox).toBeInTheDocument();
+
     await user.click(await screen.findByRole("option", { name: "简体中文" }));
     await waitFor(() => {
       expect(preferenceUpdates).toContainEqual({

--- a/turbo/apps/platform/src/views/okou-page/chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-feedback-selection.tsx
@@ -226,10 +226,19 @@ function TranslationLanguageSelect({
       >
         <SelectValue />
       </SelectTrigger>
-      <SelectContent data-chat-selection-interaction className="max-h-64">
+      {/* Seven 32px rows plus their gaps, list padding, and popup borders. */}
+      <SelectContent
+        data-chat-selection-interaction
+        hideScrollButtons
+        className="max-h-[258px] overscroll-contain"
+      >
         {items.map((item) => {
           return (
-            <SelectItem key={item.value} value={item.value}>
+            <SelectItem
+              key={item.value}
+              value={item.value}
+              className="h-8 whitespace-nowrap"
+            >
               {item.label}
             </SelectItem>
           );

--- a/turbo/packages/api-contracts/src/contracts/user-preferences.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/user-preferences.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  CHAT_TRANSLATION_LANGUAGE_BY_USER_LOCALE,
   SUPPORTED_USER_LOCALES,
+  chatTranslationLanguageSchema,
   updateUserPreferencesRequestSchema,
   userLocaleSchema,
   userPreferencesResponseSchema,
@@ -144,5 +146,18 @@ describe("user preferences contract", () => {
     expect(preferences.supportedLocales).toStrictEqual([
       ...SUPPORTED_USER_LOCALES,
     ]);
+  });
+
+  it("supports chat translation for every current user locale", () => {
+    expect(Object.keys(CHAT_TRANSLATION_LANGUAGE_BY_USER_LOCALE)).toStrictEqual(
+      [...SUPPORTED_USER_LOCALES],
+    );
+    expect(
+      Object.values(CHAT_TRANSLATION_LANGUAGE_BY_USER_LOCALE).every(
+        (language) => {
+          return chatTranslationLanguageSchema.safeParse(language).success;
+        },
+      ),
+    ).toBe(true);
   });
 });

--- a/turbo/packages/api-contracts/src/contracts/user-preferences.ts
+++ b/turbo/packages/api-contracts/src/contracts/user-preferences.ts
@@ -60,6 +60,19 @@ export type ChatTranslationLanguage = z.infer<
   typeof chatTranslationLanguageSchema
 >;
 
+export const CHAT_TRANSLATION_LANGUAGE_BY_USER_LOCALE = {
+  "en-US": "en",
+  "pt-BR": "pt-BR",
+  "ja-JP": "ja",
+  "ko-KR": "ko",
+  "id-ID": "id",
+  "de-DE": "de",
+  "es-ES": "es",
+  "it-IT": "it",
+  "fr-FR": "fr",
+  "hi-IN": "hi",
+} as const satisfies Record<UserLocale, ChatTranslationLanguage>;
+
 export const userPreferencesResponseSchema = z.object({
   timezone: z.string().nullable(),
   locale: userLocaleSchema.nullable(),


### PR DESCRIPTION
## Summary

- require every supported i18n locale to map to a valid chat translation target
- size the language selector to seven complete rows and scroll overflow without clipped items
- keep the translation popover open while its language selector scrolls and contain overscroll

## Testing

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/api-contracts exec vitest run src/contracts/user-preferences.test.ts`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-inline-feedback.test.tsx`