### PR TITLE
fix(api): report no-auth connector accounts as connected

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
@@ -1078,6 +1078,121 @@ describe("connector account lifecycle routes", () => {
     {
       label: "HTTP",
       body: {
+        displayName: "No-auth account HTTP",
+        prefixTemplates: ["https://no-auth-api.example.com/"],
+        fields: [],
+        headerInjections: [],
+        queryInjections: [],
+        authMode: "none" as const,
+      } satisfies CreateCustomConnectorBody,
+    },
+    {
+      label: "MCP",
+      body: {
+        kind: "mcp" as const,
+        displayName: "No-auth account MCP",
+        endpoint: "https://no-auth-mcp.example.com/",
+        transport: "streamable-http" as const,
+        fields: [],
+        headerInjections: [],
+        queryInjections: [],
+        authMode: "none" as const,
+      } satisfies CreateCustomConnectorBody,
+    },
+  ])(
+    "projects current no-auth custom $label accounts as connected",
+    async ({ body }) => {
+      const fixture = await seedFixture();
+      mocks.clerk.session(fixture.userId, fixture.orgId);
+      await accept(
+        featureClient().update({
+          headers: authHeaders(),
+          body: {
+            switches: {
+              [FeatureSwitchKey.ConnectorAccounts]: true,
+              [FeatureSwitchKey.CustomConnectorMcp]: true,
+              [FeatureSwitchKey.CustomConnectorNoAuth]: true,
+            },
+          },
+        }),
+        [200],
+      );
+      const definition = await accept(
+        customConnectorClient().create({ headers: authHeaders(), body }),
+        [201],
+      );
+      const connected = await accept(
+        customConnectorValuesClient().set({
+          headers: authHeaders(),
+          params: { id: definition.body.id },
+          body: { values: [], account: { intent: "add" } },
+        }),
+        [200],
+      );
+      const accountId = connected.body.connectedAccountId;
+      if (!accountId) {
+        throw new Error("Expected a connected no-auth custom account");
+      }
+
+      const accounts = await accept(
+        accountClient().connections({
+          headers: authHeaders(),
+          query: {
+            kind: "custom",
+            customConnectorId: definition.body.id,
+            limit: 100,
+          },
+        }),
+        [200],
+      );
+      expect(accounts.body.connections).toMatchObject([
+        {
+          id: accountId,
+          authMethod: "none",
+          isDefault: true,
+          connectionStatus: "connected",
+          reconnectReason: null,
+        },
+      ]);
+
+      const exact = await accept(
+        accountClient().connection({
+          headers: authHeaders(),
+          params: { connectionId: accountId },
+          query: {
+            kind: "custom",
+            customConnectorId: definition.body.id,
+          },
+        }),
+        [200],
+      );
+      expect(exact.body).toMatchObject({
+        id: accountId,
+        authMethod: "none",
+        connectionStatus: "connected",
+        reconnectReason: null,
+      });
+
+      const summaries = await accept(
+        accountClient().summaries({ headers: authHeaders() }),
+        [200],
+      );
+      expect(summaries.body.summaries).toContainEqual({
+        target: {
+          kind: "custom",
+          customConnectorId: definition.body.id,
+        },
+        accountCount: 1,
+        attentionCount: 0,
+        defaultConnection: exact.body,
+      });
+    },
+  );
+
+  it.each([
+    {
+      label: "HTTP",
+      body: {
         displayName: "Account HTTP",
         prefixTemplates: ["https://api.example.com/"],
         fields: [

--- a/turbo/apps/api/src/signals/services/connector-account-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-lifecycle.service.ts
@@ -11,7 +11,10 @@ import {
   connectorReconnectReasonSchema,
   type ConnectorReconnectReason,
 } from "@okouai/api-contracts/contracts/connector-schemas";
-import { isIntegrationManagedCustomConnectorProviderAdapter } from "@okouai/api-contracts/contracts/custom-connectors";
+import {
+  isIntegrationManagedCustomConnectorProviderAdapter,
+  type CustomConnectorAuthMode,
+} from "@okouai/api-contracts/contracts/custom-connectors";
 import { connectors } from "@okouai/db/schema/connector";
 import { chatThreadConnectorSelections } from "@okouai/db/schema/chat-thread-connector-selection";
 import { orgCustomConnectors } from "@okouai/db/schema/org-custom-connector";
@@ -142,6 +145,21 @@ function parseReconnectReason(
 
 function parseOauthScopes(value: string | null): string[] | null {
   return value === null ? null : oauthScopesSchema.parse(JSON.parse(value));
+}
+
+function customConnectorHasRequiredCredentialMaterial(
+  authMode: CustomConnectorAuthMode,
+  hasAccessToken: boolean,
+): boolean {
+  switch (authMode) {
+    case "none":
+    case "manual": {
+      return true;
+    }
+    case "oauth": {
+      return hasAccessToken;
+    }
+  }
 }
 
 function encodeCursor(row: ConnectorAccountRow): string {
@@ -446,10 +464,15 @@ function customConnection(
     now,
     isRefreshable: row.refreshTokenId !== null,
   });
-  const hasRequiredToken =
-    row.definitionAuthMode === "manual" || row.accessTokenId !== null;
+  const hasRequiredCredentialMaterial =
+    customConnectorHasRequiredCredentialMaterial(
+      row.definitionAuthMode,
+      row.accessTokenId !== null,
+    );
   const connectionStatus =
-    contractCurrent && credentialStatus === "available" && hasRequiredToken
+    contractCurrent &&
+    credentialStatus === "available" &&
+    hasRequiredCredentialMaterial
       ? "connected"
       : "reconnect-required";
   return {
@@ -554,14 +577,17 @@ function projectSummaryGroup(
     now,
     isRefreshable: row.hasRefreshToken,
   });
-  const hasRequiredToken =
-    row.definitionAuthMode === "manual" || row.hasAccessToken;
+  const hasRequiredCredentialMaterial =
+    customConnectorHasRequiredCredentialMaterial(
+      row.definitionAuthMode,
+      row.hasAccessToken,
+    );
   return {
     target: { kind: "custom", customConnectorId: row.customConnectorId },
     needsAttention:
       !contractCurrent ||
       credentialStatus === "reconnect-required" ||
-      !hasRequiredToken,
+      !hasRequiredCredentialMaterial,
   };
 }
 


### PR DESCRIPTION
## Summary

- report current no-auth custom connector accounts as connected without requiring an OAuth access token
- share one exhaustive auth-mode credential-material rule between account detail and summary projection
- cover HTTP and MCP no-auth account list, exact detail, and summary behavior through API route integration tests

## Compatibility

- no API shape, database schema, persisted-state, frontend, feature-switch, or user-workflow changes
- OAuth accounts still require an access token; manual, stale-contract, expiry, and explicit reconnect behavior remains unchanged

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connector-accounts.test.ts --maxWorkers=1 --silent=passed-only` (15 passed)
- `pnpm knip`
- pre-commit full Turbo type checks (14 tasks passed)

Closes #30951
