### PR TITLE
refactor: remove expired official metadata rollout fallbacks

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-workflows.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-workflows.ts
@@ -43,6 +43,7 @@ function summary(workflow: WorkflowDetailResponse): WorkflowSummary {
     createdAt: workflow.createdAt,
     canManage: workflow.canManage,
     canPublish: workflow.canPublish,
+    official: workflow.official,
   };
 }
 
@@ -54,6 +55,7 @@ function automationSummaryBase(automation: ChatThreadWorkflowAutomation) {
     chatThreadId: automation.chatThreadId,
     nextRunAt: automation.nextRunAt,
     lastRunAt: automation.lastRunAt,
+    official: null,
   };
 }
 
@@ -124,6 +126,7 @@ export const apiWorkflowsHandlers = [
       ownerUserId: "test-user-123",
       canManage: true,
       canPublish: true,
+      official: null,
       createdByUserId: "test-user-123",
       updatedByUserId: "test-user-123",
       createdAt: now,
@@ -446,6 +449,7 @@ type WorkflowAutomationCreateBase = {
   readonly chatThreadId: string;
   readonly nextRunAt: string | null;
   readonly lastRunAt: string | null;
+  readonly official: null;
 };
 
 function createNotionChildPageAutomationSummary(
@@ -723,6 +727,7 @@ function workflowAutomationCreateHandlers() {
         chatThreadId: "00000000-0000-4000-a000-000000000301",
         nextRunAt: null,
         lastRunAt: null,
+        official: null,
       };
       const automation = createWorkflowAutomationSummaryForRequest(base, body);
       workflow.automations = [...workflow.automations, automation];

--- a/turbo/apps/platform/src/mocks/handlers/workflow-automations-store.ts
+++ b/turbo/apps/platform/src/mocks/handlers/workflow-automations-store.ts
@@ -47,6 +47,7 @@ type MockWorkflowAutomationBase = {
   readonly nextRunAt: string | null;
   readonly lastRunAt: string | null;
   readonly ownerUserId: string;
+  readonly official: null;
   readonly workflow: ChatThreadWorkflowAutomation["workflow"];
 };
 
@@ -240,6 +241,7 @@ export function createMockWorkflowAutomation(
     nextRunAt: null,
     lastRunAt: null,
     ownerUserId: "test-user-123",
+    official: null,
     workflow,
   };
   if (overrides?.kind === "event") {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-test-helpers.ts
@@ -773,5 +773,6 @@ export function workflowSummary({
     createdAt: "2026-06-01T00:00:00.000Z",
     canManage: true,
     canPublish: false,
+    official: null,
   };
 }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
@@ -1225,6 +1225,7 @@ describe("chat inline feedback", () => {
           createdAt: "2026-07-17T00:00:00.000Z",
           canManage: true,
           canPublish: false,
+          official: null,
         },
       ]);
     });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -465,6 +465,7 @@ describe("chat lifecycle", () => {
       chatThreadId: AUTOMATION_THREAD_ID,
       nextRunAt: null,
       lastRunAt: null,
+      official: null,
       workflow: {
         id: "a0000001-0000-4000-a000-000000000006",
         agentId: AGENT_ID,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -3644,6 +3644,7 @@ describe("zero sidebar", () => {
       createdAt: "2026-03-10T00:05:00.000Z",
       canManage: true,
       canPublish: true,
+      official: null,
       createdByUserId: "test-user-123",
       updatedByUserId: "test-user-123",
       updatedAt: "2026-03-10T00:05:00.000Z",

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -165,6 +165,7 @@ function createWorkflowSummary({
     createdAt: "2026-06-20T12:00:00.000Z",
     canManage: true,
     canPublish: true,
+    official: null,
   };
 }
 

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -238,6 +238,7 @@ function weekdayWorkflowAutomation(): WorkflowScheduleAutomationSummary {
     chatThreadId: "thread_weekday_brief",
     nextRunAt: "2026-06-19T01:00:00.000Z",
     lastRunAt: "2026-06-18T01:00:00.000Z",
+    official: null,
   };
 }
 
@@ -261,6 +262,7 @@ function gmailWorkflowAutomation(): WorkflowGmailNewMessageAutomationSummary {
     chatThreadId: "thread_gmail_new_message",
     nextRunAt: null,
     lastRunAt: null,
+    official: null,
   };
 }
 
@@ -282,6 +284,7 @@ function gmailLabelWorkflowAutomation(): WorkflowGmailLabelAppliedAutomationSumm
     chatThreadId: "thread_gmail_label_applied",
     nextRunAt: null,
     lastRunAt: null,
+    official: null,
   };
 }
 
@@ -305,6 +308,7 @@ function githubPullRequestWorkflowAutomation(): WorkflowGithubPullRequestAutomat
     chatThreadId: "thread_github_pull_request",
     nextRunAt: null,
     lastRunAt: null,
+    official: null,
   };
 }
 
@@ -325,6 +329,7 @@ function googleCalendarWorkflowAutomation(): WorkflowGoogleCalendarEventCreatedA
     chatThreadId: "thread_google_calendar_event_created",
     nextRunAt: null,
     lastRunAt: null,
+    official: null,
   };
 }
 
@@ -345,6 +350,7 @@ function googleCalendarUpdatedWorkflowAutomation(): WorkflowGoogleCalendarEventU
     chatThreadId: "thread_google_calendar_event_updated",
     nextRunAt: null,
     lastRunAt: null,
+    official: null,
   };
 }
 
@@ -365,6 +371,7 @@ function googleCalendarCancelledWorkflowAutomation(): WorkflowGoogleCalendarEven
     chatThreadId: "thread_google_calendar_event_cancelled",
     nextRunAt: null,
     lastRunAt: null,
+    official: null,
   };
 }
 
@@ -385,6 +392,7 @@ function googleMeetTranscriptGeneratedWorkflowAutomation(): WorkflowGoogleMeetTr
     chatThreadId: "thread_google_meet_transcript_generated",
     nextRunAt: null,
     lastRunAt: null,
+    official: null,
   };
 }
 
@@ -412,6 +420,7 @@ function googleFormsResponseSubmittedWorkflowAutomation(
     chatThreadId: "thread_google_forms_response_submitted",
     nextRunAt: null,
     lastRunAt: null,
+    official: null,
     ...(warning ? { warning } : {}),
   };
 }
@@ -438,6 +447,7 @@ function notionChildPageWorkflowAutomation(): WorkflowNotionChildPageCreatedAuto
     chatThreadId: "thread_notion_child_page",
     nextRunAt: null,
     lastRunAt: null,
+    official: null,
   };
 }
 
@@ -463,6 +473,7 @@ function notionDatabaseItemWorkflowAutomation(): WorkflowNotionDatabaseItemCreat
     chatThreadId: "thread_notion_database_item",
     nextRunAt: null,
     lastRunAt: null,
+    official: null,
   };
 }
 
@@ -491,6 +502,7 @@ function notionPageContentUpdatedWorkflowAutomation(): WorkflowNotionPageContent
     chatThreadId: "thread_notion_page_content_updated",
     nextRunAt: null,
     lastRunAt: null,
+    official: null,
   };
 }
 
@@ -511,6 +523,7 @@ function webhookWorkflowAutomation(): WorkflowWebhookAutomationSummary {
     chatThreadId: "thread_webhook",
     nextRunAt: null,
     lastRunAt: null,
+    official: null,
     webhookUrl:
       "https://api.vm0.test/api/webhooks/workflow-automations/whk_test",
     secretLastFour: "abcd",
@@ -539,6 +552,7 @@ function stripeInvoicePaidWorkflowAutomation(
     chatThreadId: "thread_stripe_invoice_paid",
     nextRunAt: null,
     lastRunAt: null,
+    official: null,
     health: {
       lastMatchingEventReceivedAt: null,
       lastDeliveryStatus: null,
@@ -588,6 +602,7 @@ function salesResearch(): WorkflowDetailResponse {
     ownerUserId: CURRENT_USER_ID,
     canManage: true,
     canPublish: false,
+    official: null,
     createdByUserId: CURRENT_USER_ID,
     updatedByUserId: UPDATED_USER_ID,
     createdAt: "2026-06-17T13:52:00.000Z",
@@ -736,7 +751,7 @@ function namedOfficialWorkflow(
               ...automation.official,
               blueprintKey: morningBrief ? "daily-delivery" : "weekly-check",
             }
-          : undefined,
+          : null,
       };
     }),
   };
@@ -755,6 +770,7 @@ function opsPlaybook(): WorkflowDetailResponse {
     ownerUserId: CURRENT_USER_ID,
     canManage: true,
     canPublish: true,
+    official: null,
     createdByUserId: CURRENT_USER_ID,
     updatedByUserId: CURRENT_USER_ID,
     createdAt: "2026-06-15T12:00:00.000Z",
@@ -779,6 +795,7 @@ function launchChecklistWorkflow(): WorkflowDetailResponse {
     ownerUserId: CURRENT_USER_ID,
     canManage: true,
     canPublish: true,
+    official: null,
     createdByUserId: CURRENT_USER_ID,
     updatedByUserId: CURRENT_USER_ID,
     createdAt: "2026-06-18T12:00:00.000Z",
@@ -803,6 +820,7 @@ function otherAgentWorkflow(): WorkflowDetailResponse {
     ownerUserId: CURRENT_USER_ID,
     canManage: true,
     canPublish: false,
+    official: null,
     createdByUserId: CURRENT_USER_ID,
     updatedByUserId: CURRENT_USER_ID,
     createdAt: "2026-06-16T12:00:00.000Z",
@@ -845,7 +863,7 @@ function summary(workflow: WorkflowDetailResponse): WorkflowSummary {
     createdAt: workflow.createdAt,
     canManage: workflow.canManage,
     canPublish: workflow.canPublish,
-    ...(workflow.official === undefined ? {} : { official: workflow.official }),
+    official: workflow.official,
   };
 }
 

--- a/turbo/packages/api-contracts/src/contracts/__tests__/workflows.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/workflows.test.ts
@@ -386,6 +386,7 @@ describe("Stripe invoice-paid workflow automation contract", () => {
       chatThreadId: null,
       nextRunAt: null,
       lastRunAt: null,
+      official: null,
       kind: "event",
       eventType: "stripe-invoice-paid",
       eventConfig,

--- a/turbo/packages/api-contracts/src/contracts/workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/workflows.ts
@@ -779,9 +779,6 @@ const workflowAutomationSummaryBaseSchema = z.object({
   chatThreadId: z.string().nullable(),
   nextRunAt: z.string().datetime().nullable(),
   lastRunAt: z.string().datetime().nullable(),
-  // Retained new App -> old API fallback from P1. Remove the optional parser
-  // in #29991 only after production proves pre-P1 APIs are no longer serving
-  // or retained for rollback.
   official: z
     .object({
       blueprintKey: officialWorkflowBlueprintKeySchema,
@@ -796,8 +793,7 @@ const workflowAutomationSummaryBaseSchema = z.object({
       parameterBindings: z.array(officialWorkflowParameterBindingSchema),
     })
     .strict()
-    .nullable()
-    .optional(),
+    .nullable(),
 });
 
 export const workflowScheduleAutomationSummarySchema =
@@ -1517,9 +1513,6 @@ export const workflowSummarySchema = z.object({
   createdAt: z.string().datetime(),
   canManage: z.boolean(),
   canPublish: z.boolean(),
-  // Retained new App -> old API fallback from P1. Remove the optional parser
-  // in #29991 only after production proves pre-P1 APIs are no longer serving
-  // or retained for rollback.
   official: z
     .object({
       definitionName: workflowNameSchema,
@@ -1528,8 +1521,7 @@ export const workflowSummarySchema = z.object({
       readOnly: z.literal(true),
     })
     .strict()
-    .nullable()
-    .optional(),
+    .nullable(),
   shadowedBy: z
     .object({
       id: z.string().uuid(),


### PR DESCRIPTION
Removes the two expired P1 `new App -> old API` fallbacks on the workflow and automation summary responses. Partially addresses #29991; the issue stays open for the third candidate (see below).

## Cohort — P1 `official` metadata

**Old boundary:** #29660 (P1) added `official` to the workflow summary and automation summary responses. During rollout a newly promoted App could still reach a pre-P1 API that omitted the key, so the contract kept it `.optional()`.

**New boundary:** `official` is required on `workflowSummarySchema` and `workflowAutomationSummaryBaseSchema`. It stays `.nullable()`, because a workflow or automation that is not an Official installation legitimately has no Official metadata.

Removed:
- `.optional()` and the rollout comment on `official` in `workflowSummarySchema`
- `.optional()` and the rollout comment on `official` in `workflowAutomationSummaryBaseSchema`
- the `...(workflow.official === undefined ? {} : { official: workflow.official })` conditional spread in the workflows-page test summary helper, which existed only because the field could be absent

**Window:** the consumer is a new App calling an older API, so the governing gate is `docs/fallback.md` section 7 — the old API is no longer serving and no longer retained as a rollback target.

**Rollout evidence (observed):**
- #29660 merged `2026-08-27T01:29:41Z` (`a22b7d6bca`).
- First `api/production` deployment containing it: `be006a7c27`, `2026-08-27T01:43:49Z`, confirmed with `git merge-base --is-ancestor` walking the deployment list forward from oldest.
- **70 `api/production` deployments** have carried it; 69 further promotions since the first.
- Elapsed: **144.3 hours** (6.0 days).

**Source evidence that the current API always sets the field:**
- `workflowSummary` in `turbo/apps/api/src/signals/services/workflow-data.service.ts` sets `official` to `null` or an object on its only return path. It is the sole builder of this shape — `canPublish`, a required sibling field, appears in exactly one place in `turbo/apps/api/src`, inside that function — and every caller (`routes/workflows.ts` x3, `workflow-detail.service.ts`, `workflow-automation.service.ts`, `workflow-data.service.ts`) goes through it. The one spread that post-processes it, in `workflow-detail.service.ts`, only overrides `displayName` and `description`.
- `rowSummaryBase` in `turbo/apps/api/src/signals/services/workflow-automation.service.ts` likewise always sets `official`, and is spread into all 16 automation summary variants.

**No client-side change was needed.** Every consumer already uses a truthy check or optional chaining — `automation.official ? ...`, `workflow.official?.…` in `official-workflow-configuration.tsx`, `workflow-detail-page.tsx`, and `cli/src/commands/doctor/connectors.ts` — which treat an absent key and `null` identically. Removing `.optional()` therefore tightens the parser without changing any rendered behavior, and turns a future regression (an API that stops emitting the key) into a loud parse failure instead of an Official Workflow silently rendering as an ordinary editable one.

**Client floor:** deliberately not relied on. PR #30366 recorded that App builds well below the `0.812.1` floor were still transmitting hours after it was raised. It is not needed here anyway: tightening a shared **response** schema only affects clients that ship the new bundle, and an older App bundle carries its own older, permissive parser.

**MaskDB:** not applicable. No schema, column, or persisted payload changes.

## Deliberately left in place

`officialWorkflowInstallationResponseSchema.definition` stays optional. Re-verified on this base: the install, get-installation, and reconfigure routes in `turbo/apps/api/src/signals/routes/official-workflows.ts` (lines 158, 186, 257) build `body: { workflow: detail, ...(definition ? { definition } : {}) }`, and `getOfficialWorkflowInstallationDefinition` returns `null` whenever the accepted catalog has no entry for that definition name — the state the App surfaces as `definitionLifecycle: "unavailable"`. That omission is **live runtime behavior**, not an expired rollout fallback, so requiring the field would need a deliberate route behavior change that is out of scope for compatibility cleanup. Recorded on #29991, which stays open for it.

## Test fixture updates

No fallback-specific test existed for either field, so nothing was deleted, and nothing was inverted into a negative assertion. The changes are the fixtures that predate the tightened contract and now set `official: null` explicitly:

- `mocks/handlers/api-workflows.ts` — the shared `summary` and `automationSummaryBase` builders, the `create` handler literal, and `WorkflowAutomationCreateBase`
- `mocks/handlers/workflow-automations-store.ts` — `MockWorkflowAutomationBase` and its base literal
- `views/okou-page/__tests__/chat-composer-test-helpers.ts` — the shared `workflowSummary` factory, which covers 19 sites in `chat-composer-editor-and-suggestions.test.tsx`
- `views/workflows-page/__tests__/workflows-page.test.tsx` — 14 automation factories, 4 workflow factories, one `: undefined` to `: null`, and the conditional spread collapse
- one fixture each in `sidebar.test.tsx`, `chat-inline-feedback.test.tsx`, `chat-workflows-and-goals.test.tsx`, `team-navigation.test.tsx`
- `api-contracts/src/contracts/__tests__/workflows.test.ts` — the Stripe invoice-paid persisted summary fixture

## Checks (run against the combined diff)

- `pnpm format` — no changes
- `pnpm -F @okouai/api-contracts lint`, `pnpm -F @okouai/app lint` — no new warnings
- `pnpm -F @okouai/api-contracts check-types`, `pnpm -F @okouai/app check-types`, `pnpm -F api check-types`, `pnpm -F cli check-types`
- `pnpm knip` — no new findings
- `pnpm -F @okouai/api-contracts exec vitest run` — 677 passing across 36 files
- `pnpm -F @okouai/app exec vitest run` on `workflows-page` (81), `team-navigation` + `chat-workflows-and-goals` + `chat-inline-feedback` (91), `sidebar` + `chat-composer-editor-and-suggestions` (102) — 274 passing

No local Postgres was available in this environment, so the `api` route suites are left to the PR pipeline; `pnpm -F api check-types` passes. No full local Vitest run and no local dev server, per repository policy.
