### PR TITLE
fix(python): reject invalid utf-8 catalog versions

### DIFF
--- a/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
+++ b/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
@@ -328,6 +328,8 @@ def _catalog_url(original_url: str) -> str | None:
             raw_query,
             keep_blank_values=True,
             strict_parsing=True,
+            encoding="utf-8",
+            errors="strict",
             max_num_fields=MAX_CATALOG_QUERY_FIELDS,
         )
     except ValueError:
@@ -335,13 +337,15 @@ def _catalog_url(original_url: str) -> str | None:
     if len(query) != MAX_CATALOG_QUERY_FIELDS or query[0][0] != _CLIENT_VERSION_QUERY_NAME:
         return None
     client_version = query[0][1]
-    if (
-        not client_version
-        or len(client_version.encode()) > _MAX_CLIENT_VERSION_BYTES
-        or any(
-            ord(character) < _ASCII_CONTROL_BOUNDARY or ord(character) == _ASCII_DELETE
-            for character in client_version
-        )
+    if not client_version:
+        return None
+    try:
+        encoded_client_version = client_version.encode()
+    except UnicodeEncodeError:
+        return None
+    if len(encoded_client_version) > _MAX_CLIENT_VERSION_BYTES or any(
+        ord(character) < _ASCII_CONTROL_BOUNDARY or ord(character) == _ASCII_DELETE
+        for character in client_version
     ):
         return None
     encoded_version = urllib.parse.quote(client_version, safe="")

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
@@ -206,6 +206,46 @@ async def test_fully_percent_encoded_maximum_catalog_query_reuses_canonical_cach
 
 
 @pytest.mark.parametrize(
+    "raw_query",
+    [
+        pytest.param("client_version=%FF", id="invalid-value-ff"),
+        pytest.param("client_version=%FE", id="invalid-value-fe"),
+        pytest.param("client_version=bad\udcff", id="surrogate-value"),
+        pytest.param("%FF=0.145.0", id="invalid-name"),
+    ],
+)
+async def test_invalid_utf8_catalog_query_never_reuses_or_populates_cache(
+    real_flow,
+    raw_query: str,
+):
+    valid_flow = catalog_flow(real_flow, version="\ufffd")
+    await install_catalog(valid_flow)
+    catalog_cache.release_flow_state(valid_flow)
+
+    invalid_flow = catalog_flow(real_flow)
+    _set_catalog_query(invalid_flow, raw_query)
+
+    await catalog_cache.prepare_request(invalid_flow, request_end_stream=True)
+
+    assert invalid_flow.response is None
+    telemetry: dict[str, object] = {}
+    catalog_cache.add_network_log_fields(invalid_flow, telemetry)
+    assert telemetry == {
+        "model_catalog_cache_status": "model_catalog_bypass",
+        "model_catalog_cache_bypass_reason": "request_url",
+    }
+
+    invalid_flow.response = catalog_response(body=b'{"models":[{"slug":"invalid"}]}')
+    assert await finish_response(invalid_flow) == telemetry
+
+    valid_hit = catalog_flow(real_flow, version="\ufffd")
+    await catalog_cache.prepare_request(valid_hit, request_end_stream=True)
+
+    assert valid_hit.response is not None
+    assert valid_hit.response.content == CATALOG_BODY
+
+
+@pytest.mark.parametrize(
     ("raw_query", "character_bounded"),
     [
         pytest.param(
@@ -270,6 +310,8 @@ async def test_high_cardinality_catalog_query_bypasses_before_percent_decoding(r
         raw_query,
         keep_blank_values=True,
         strict_parsing=True,
+        encoding="utf-8",
+        errors="strict",
         max_num_fields=catalog_cache.MAX_CATALOG_QUERY_FIELDS,
     )
     assert flow.response is None


### PR DESCRIPTION
## Summary

- decode catalog query names and values with strict UTF-8 semantics before cache-key construction
- bypass cache admission for invalid percent-decoded bytes and raw surrogate version values
- verify malformed queries cannot reuse or populate the valid U+FFFD cache partition

## Exclusions

- no API, database, persisted-state, queue-payload, or migration changes
- no change to ordinary upstream forwarding for cache-bypassed requests

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_codex_model_catalog_cache_hooks.py -q` (33 passed)
- `uv run --no-sync python -m pytest tests/` (7329 passed)

Closes #30957
