### PR TITLE
perf(nbd-cow): send read replies with vectored writes

### DIFF
--- a/crates/nbd-cow/src/server.rs
+++ b/crates/nbd-cow/src/server.rs
@@ -4,6 +4,9 @@
 //! decodes NBD requests, applies them through [`crate::cow_io::CowIo`], and writes
 //! NBD replies back to the kernel.
 
+use std::io::IoSlice;
+#[cfg(test)]
+use std::num::NonZeroUsize;
 use std::os::unix::io::{FromRawFd, IntoRawFd, OwnedFd};
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -114,19 +117,64 @@ impl DispatchReadObserver {
     }
 }
 
+#[derive(Clone, Copy)]
+struct DispatchWriteLimit {
+    #[cfg(test)]
+    max_bytes: Option<NonZeroUsize>,
+}
+
+impl DispatchWriteLimit {
+    fn none() -> Self {
+        Self {
+            #[cfg(test)]
+            max_bytes: None,
+        }
+    }
+
+    #[cfg(test)]
+    fn new(max_bytes: NonZeroUsize) -> Self {
+        Self {
+            max_bytes: Some(max_bytes),
+        }
+    }
+
+    #[cfg(test)]
+    fn apply<'a>(&self, buffers: &'a [IoSlice<'_>]) -> Vec<IoSlice<'a>> {
+        let mut remaining = self.max_bytes.map_or(usize::MAX, NonZeroUsize::get);
+        let mut limited = Vec::with_capacity(buffers.len());
+        for buffer in buffers {
+            if remaining == 0 {
+                break;
+            }
+            let len = buffer.len().min(remaining);
+            limited.push(IoSlice::new(&buffer[..len]));
+            remaining -= len;
+        }
+        limited
+    }
+}
+
 /// Run the NBD dispatch loop on a Unix stream.
 ///
 /// Reads NBD requests from the socket, dispatches to the COW layer,
 /// and sends replies back. Handles graceful shutdown via the cancellation token.
 pub async fn dispatch(socket_fd: OwnedFd, cow: CowIo, shutdown: CancellationToken) -> Result<()> {
-    dispatch_with_read_observer(socket_fd, cow, shutdown, DispatchReadObserver::none()).await
+    dispatch_with_observers(
+        socket_fd,
+        cow,
+        shutdown,
+        DispatchReadObserver::none(),
+        DispatchWriteLimit::none(),
+    )
+    .await
 }
 
-async fn dispatch_with_read_observer(
+async fn dispatch_with_observers(
     socket_fd: OwnedFd,
     cow: CowIo,
     shutdown: CancellationToken,
     read_observer: DispatchReadObserver,
+    write_limit: DispatchWriteLimit,
 ) -> Result<()> {
     let raw_fd = socket_fd.into_raw_fd();
     let std_stream = unsafe { std::os::unix::net::UnixStream::from_raw_fd(raw_fd) };
@@ -163,7 +211,15 @@ async fn dispatch_with_read_observer(
 
         let outcome = match request.command {
             Command::Read => {
-                handle_read(&request, &cow, &mut writer, &mut payload_buf, &shutdown).await?
+                handle_read(
+                    &request,
+                    &cow,
+                    &mut writer,
+                    &mut payload_buf,
+                    &shutdown,
+                    write_limit,
+                )
+                .await?
             }
             Command::Write => {
                 handle_write(
@@ -266,12 +322,50 @@ async fn write_all_or_shutdown(
     Ok(IoOutcome::Complete)
 }
 
+async fn write_all_vectored_or_shutdown(
+    writer: &mut tokio::net::unix::OwnedWriteHalf,
+    header: &[u8],
+    payload: &[u8],
+    shutdown: &CancellationToken,
+    write_limit: DispatchWriteLimit,
+) -> Result<IoOutcome> {
+    let mut write_slices = [IoSlice::new(header), IoSlice::new(payload)];
+    let mut remaining = write_slices.as_mut_slice();
+    #[cfg(not(test))]
+    let _ = write_limit;
+    while !remaining.is_empty() {
+        #[cfg(test)]
+        let limited = write_limit.apply(remaining);
+        #[cfg(test)]
+        let buffers = limited.as_slice();
+        #[cfg(not(test))]
+        let buffers: &[IoSlice<'_>] = remaining;
+        let count = tokio::select! {
+            biased;
+            () = shutdown.cancelled() => {
+                return Ok(IoOutcome::Shutdown);
+            }
+            result = writer.write_vectored(buffers) => result?,
+        };
+        if count == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "failed to write whole buffer",
+            )
+            .into());
+        }
+        IoSlice::advance_slices(&mut remaining, count);
+    }
+    Ok(IoOutcome::Complete)
+}
+
 async fn handle_read(
     request: &NbdRequest,
     cow: &CowIo,
     writer: &mut tokio::net::unix::OwnedWriteHalf,
     payload_buf: &mut Vec<u8>,
     shutdown: &CancellationToken,
+    write_limit: DispatchWriteLimit,
 ) -> Result<HandlerOutcome> {
     if request.length > MAX_REQUEST_LENGTH {
         return send_error_reply(writer, request.handle, libc::EIO as u32, shutdown)
@@ -281,12 +375,12 @@ async fn handle_read(
     let len = request.length as usize;
     if len <= MAX_REUSABLE_PAYLOAD_LENGTH {
         resize_reusable_payload(payload_buf, len);
-        let result = read_and_reply(request, cow, writer, payload_buf, shutdown).await;
+        let result = read_and_reply(request, cow, writer, payload_buf, shutdown, write_limit).await;
         reset_reusable_payload_if_oversized(payload_buf);
         result
     } else {
         let mut data = vec![0u8; len];
-        read_and_reply(request, cow, writer, &mut data, shutdown).await
+        read_and_reply(request, cow, writer, &mut data, shutdown, write_limit).await
     }
 }
 
@@ -311,6 +405,7 @@ async fn read_and_reply(
     writer: &mut tokio::net::unix::OwnedWriteHalf,
     data: &mut Vec<u8>,
     shutdown: &CancellationToken,
+    write_limit: DispatchWriteLimit,
 ) -> Result<HandlerOutcome> {
     let read_buffer = std::mem::take(data);
     match cow.read(request.offset, read_buffer).await {
@@ -331,12 +426,15 @@ async fn read_and_reply(
 
     let reply = success_reply(request.handle);
     let reply_buf = protocol::serialize_reply(&reply);
-    if let IoOutcome::Shutdown = write_all_or_shutdown(writer, &reply_buf, shutdown).await? {
-        return Ok(HandlerOutcome::Shutdown);
+    if data.is_empty() {
+        write_all_or_shutdown(writer, &reply_buf, shutdown)
+            .await
+            .map(handler_outcome)
+    } else {
+        write_all_vectored_or_shutdown(writer, &reply_buf, data.as_slice(), shutdown, write_limit)
+            .await
+            .map(handler_outcome)
     }
-    write_all_or_shutdown(writer, data.as_slice(), shutdown)
-        .await
-        .map(handler_outcome)
 }
 
 async fn handle_write(

--- a/crates/nbd-cow/src/server/tests.rs
+++ b/crates/nbd-cow/src/server/tests.rs
@@ -64,11 +64,12 @@ async fn setup_observed_dispatch(
 
     let shutdown_clone = shutdown.clone();
     let task = tokio::spawn(async move {
-        dispatch_with_read_observer(
+        dispatch_with_observers(
             server_fd,
             cow,
             shutdown_clone,
             DispatchReadObserver::new(event_sender),
+            DispatchWriteLimit::none(),
         )
         .await
     });
@@ -289,6 +290,108 @@ async fn dispatch_large_then_small_requests_keep_stream_aligned() {
     };
     must(
         writer.write_all(&serialize_request(&disc)).await,
+        "write disconnect request",
+    );
+    wait_for_dispatch(task).await;
+}
+
+#[tokio::test]
+async fn dispatch_forced_partial_vectored_reads_keep_stream_aligned() {
+    let base_data: Vec<u8> = (0..3 * crate::BLOCK_SIZE)
+        .map(|index| (index % 251) as u8)
+        .collect();
+    let (_base, _cow_file, cow) = create_test_cow(&base_data);
+    let cow = CowIo::new(cow);
+
+    let shutdown = CancellationToken::new();
+    let (mut reader, mut writer, server_fd) = setup_dispatch_socket();
+    let shutdown_clone = shutdown.clone();
+    let write_limit = NonZeroUsize::new(7).expect("write limit must be non-zero");
+    let task = tokio::spawn(async move {
+        dispatch_with_observers(
+            server_fd,
+            cow,
+            shutdown_clone,
+            DispatchReadObserver::none(),
+            DispatchWriteLimit::new(write_limit),
+        )
+        .await
+    });
+
+    let small_read = NbdRequest {
+        command: Command::Read,
+        handle: 10,
+        offset: 17,
+        length: 23,
+    };
+    let large_read = NbdRequest {
+        command: Command::Read,
+        handle: 11,
+        offset: 512,
+        length: (2 * crate::BLOCK_SIZE + 5) as u32,
+    };
+    let zero_read = NbdRequest {
+        command: Command::Read,
+        handle: 12,
+        offset: 0,
+        length: 0,
+    };
+    let trailing_read = NbdRequest {
+        command: Command::Read,
+        handle: 13,
+        offset: (3 * crate::BLOCK_SIZE - 31) as u64,
+        length: 31,
+    };
+
+    for request in [&small_read, &large_read, &zero_read, &trailing_read] {
+        must(
+            writer.write_all(&serialize_request(request)).await,
+            "write read request",
+        );
+    }
+
+    let small_reply = read_reply(&mut reader).await;
+    assert_eq!(small_reply.error, 0);
+    assert_eq!(small_reply.handle, small_read.handle);
+    let small_payload = read_payload(&mut reader, small_read.length as usize).await;
+    assert_eq!(
+        small_payload,
+        base_data
+            [small_read.offset as usize..small_read.offset as usize + small_read.length as usize]
+    );
+
+    let large_reply = read_reply(&mut reader).await;
+    assert_eq!(large_reply.error, 0);
+    assert_eq!(large_reply.handle, large_read.handle);
+    let large_payload = read_payload(&mut reader, large_read.length as usize).await;
+    assert_eq!(
+        large_payload,
+        base_data
+            [large_read.offset as usize..large_read.offset as usize + large_read.length as usize]
+    );
+
+    let zero_reply = read_reply(&mut reader).await;
+    assert_eq!(zero_reply.error, 0);
+    assert_eq!(zero_reply.handle, zero_read.handle);
+
+    let trailing_reply = read_reply(&mut reader).await;
+    assert_eq!(trailing_reply.error, 0);
+    assert_eq!(trailing_reply.handle, trailing_read.handle);
+    let trailing_payload = read_payload(&mut reader, trailing_read.length as usize).await;
+    assert_eq!(
+        trailing_payload,
+        base_data[trailing_read.offset as usize
+            ..trailing_read.offset as usize + trailing_read.length as usize]
+    );
+
+    let disconnect = NbdRequest {
+        command: Command::Disconnect,
+        handle: 14,
+        offset: 0,
+        length: 0,
+    };
+    must(
+        writer.write_all(&serialize_request(&disconnect)).await,
         "write disconnect request",
     );
     wait_for_dispatch(task).await;


### PR DESCRIPTION
## Summary

- send successful non-empty NBD Read headers and payloads through one cancellation-aware vectored-write loop
- preserve the existing single-buffer path for zero-length Reads and all header-only replies
- cover header, slice-boundary, and payload partial progress deterministically through the full dispatch path and a real Unix socketpair

## Scope

- no NBD wire-format, COW-format, persistence, connection-count, buffering, or public API changes
- no new dependencies or payload concatenation/allocation on the production Read response path
- biased shutdown selection, `WriteZero`, and socket error propagation remain explicit on every pending vectored submission

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p nbd-cow --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p nbd-cow --all-features --no-deps`
- `cargo test -p nbd-cow --all-features`
- repository pre-commit hook, including workspace-wide Rust formatting, documentation, Clippy, and file-size checks

The built-in benchmark target compiles and its 41 tests pass through the all-features validation. Representative `rand4k-read` and `mixed-70r30w` measurements were not run because this container is not root and lacks `fio` and `dmsetup`; this PR makes no unmeasured IOPS or latency claim.

Closes #30963
