### PR TITLE
refactor(rust): centralize cli stderr diagnostic policy

### DIFF
--- a/crates/guest-agent/src/cli/diagnostics.rs
+++ b/crates/guest-agent/src/cli/diagnostics.rs
@@ -3,16 +3,16 @@
 //! This module keeps stderr collection bounded and intentionally leaves final
 //! secret masking to the `execute_cli` caller.
 
+use guest_contracts::cli_stderr_diagnostics::{
+    CLI_STDERR_OMITTED_LONG_LINE, CLI_STDERR_RESULT_MAX_LINE_BYTES, CLI_STDERR_RESULT_MAX_LINES,
+};
 use std::collections::VecDeque;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
-const STDERR_RESULT_MAX_LINES: usize = 200;
-const STDERR_RESULT_MAX_LINE_BYTES: usize = 16 * 1024;
 const STDERR_READ_BUFFER_BYTES: usize = 8 * 1024;
-const STDERR_OMITTED_LONG_LINE: &str = "[stderr line omitted: exceeded diagnostic size limit]";
 
 fn push_stderr_result_line(lines: &mut VecDeque<String>, line: String) {
-    if lines.len() == STDERR_RESULT_MAX_LINES {
+    if lines.len() == CLI_STDERR_RESULT_MAX_LINES {
         lines.pop_front();
     }
     lines.push_back(line);
@@ -20,8 +20,8 @@ fn push_stderr_result_line(lines: &mut VecDeque<String>, line: String) {
 
 fn push_decoded_stderr_result_line(lines: &mut VecDeque<String>, line: &[u8]) {
     let line = String::from_utf8_lossy(line);
-    if line.len() > STDERR_RESULT_MAX_LINE_BYTES {
-        push_stderr_result_line(lines, STDERR_OMITTED_LONG_LINE.to_string());
+    if line.len() > CLI_STDERR_RESULT_MAX_LINE_BYTES {
+        push_stderr_result_line(lines, CLI_STDERR_OMITTED_LONG_LINE.to_string());
     } else {
         push_stderr_result_line(lines, line.into_owned());
     }
@@ -34,13 +34,13 @@ fn finish_stderr_result_line(
     strip_trailing_cr: bool,
 ) {
     if *line_omitted {
-        push_stderr_result_line(lines, STDERR_OMITTED_LONG_LINE.to_string());
+        push_stderr_result_line(lines, CLI_STDERR_OMITTED_LONG_LINE.to_string());
     } else {
         if strip_trailing_cr && line.last() == Some(&b'\r') {
             line.pop();
         }
-        if line.len() > STDERR_RESULT_MAX_LINE_BYTES {
-            push_stderr_result_line(lines, STDERR_OMITTED_LONG_LINE.to_string());
+        if line.len() > CLI_STDERR_RESULT_MAX_LINE_BYTES {
+            push_stderr_result_line(lines, CLI_STDERR_OMITTED_LONG_LINE.to_string());
         } else {
             push_decoded_stderr_result_line(lines, line);
         }
@@ -53,8 +53,8 @@ pub(super) async fn collect_stderr_result_tail<R>(mut stderr: R) -> Vec<String>
 where
     R: AsyncRead + Unpin,
 {
-    let mut lines = VecDeque::with_capacity(STDERR_RESULT_MAX_LINES);
-    let mut line = Vec::with_capacity(STDERR_RESULT_MAX_LINE_BYTES.min(1024));
+    let mut lines = VecDeque::with_capacity(CLI_STDERR_RESULT_MAX_LINES);
+    let mut line = Vec::with_capacity(CLI_STDERR_RESULT_MAX_LINE_BYTES.min(1024));
     let mut line_omitted = false;
     let mut buffer = [0u8; STDERR_READ_BUFFER_BYTES];
 
@@ -75,8 +75,8 @@ where
                 continue;
             }
 
-            if line.len() < STDERR_RESULT_MAX_LINE_BYTES
-                || (byte == b'\r' && line.len() == STDERR_RESULT_MAX_LINE_BYTES)
+            if line.len() < CLI_STDERR_RESULT_MAX_LINE_BYTES
+                || (byte == b'\r' && line.len() == CLI_STDERR_RESULT_MAX_LINE_BYTES)
             {
                 line.push(byte);
             } else {

--- a/crates/guest-agent/tests/cli_stderr_exact_limit_no_newline.rs
+++ b/crates/guest-agent/tests/cli_stderr_exact_limit_no_newline.rs
@@ -6,6 +6,7 @@
 mod common;
 
 use guest_agent::masker::SecretMasker;
+use guest_contracts::cli_stderr_diagnostics::CLI_STDERR_RESULT_MAX_LINE_BYTES;
 use std::time::Duration;
 
 #[tokio::test]
@@ -13,7 +14,7 @@ async fn cli_failure_keeps_exact_limit_stderr_without_newline()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
-    let exact_limit_line = "x".repeat(common::CLI_STDERR_RESULT_MAX_LINE_BYTES);
+    let exact_limit_line = "x".repeat(CLI_STDERR_RESULT_MAX_LINE_BYTES);
 
     unsafe {
         common::setup_env(

--- a/crates/guest-agent/tests/cli_stderr_invalid_utf8_long.rs
+++ b/crates/guest-agent/tests/cli_stderr_invalid_utf8_long.rs
@@ -6,6 +6,7 @@
 mod common;
 
 use guest_agent::masker::SecretMasker;
+use guest_contracts::cli_stderr_diagnostics::CLI_STDERR_OMITTED_LONG_LINE;
 use std::time::Duration;
 
 #[tokio::test]
@@ -29,10 +30,7 @@ async fn cli_failure_omits_invalid_stderr_when_lossy_decode_exceeds_limit()
     .expect("execute_cli should return promptly")?;
 
     assert_eq!(cli_result.exit_code, 1);
-    assert_eq!(
-        cli_result.stderr_lines,
-        vec![common::CLI_STDERR_OMITTED_LONG_LINE]
-    );
+    assert_eq!(cli_result.stderr_lines, vec![CLI_STDERR_OMITTED_LONG_LINE]);
 
     Ok(())
 }

--- a/crates/guest-agent/tests/cli_stderr_logging.rs
+++ b/crates/guest-agent/tests/cli_stderr_logging.rs
@@ -7,6 +7,9 @@ mod common;
 
 use base64::Engine;
 use guest_agent::masker::SecretMasker;
+use guest_contracts::cli_stderr_diagnostics::{
+    CLI_STDERR_OMITTED_LONG_LINE, CLI_STDERR_RESULT_MAX_LINE_BYTES, CLI_STDERR_RESULT_MAX_LINES,
+};
 use std::time::Duration;
 
 #[tokio::test]
@@ -29,7 +32,7 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
         "retained-tail-fragment-three",
     ]
     .join("\n");
-    let mut stderr_payload = (0..(common::CLI_STDERR_RESULT_MAX_LINES + 1))
+    let mut stderr_payload = (0..(CLI_STDERR_RESULT_MAX_LINES + 1))
         .map(|i| match i {
             10 => "tail-boundary-start".to_string(),
             11 => "dropped-tail-fragment-zero".to_string(),
@@ -43,23 +46,20 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
         .join("\n");
     let exact_limit_line = format!(
         "exact-limit-{}",
-        "x".repeat(common::CLI_STDERR_RESULT_MAX_LINE_BYTES - "exact-limit-".len())
+        "x".repeat(CLI_STDERR_RESULT_MAX_LINE_BYTES - "exact-limit-".len())
     );
     let exact_limit_crlf_line = format!(
         "exact-crlf-{}",
-        "x".repeat(common::CLI_STDERR_RESULT_MAX_LINE_BYTES - "exact-crlf-".len())
+        "x".repeat(CLI_STDERR_RESULT_MAX_LINE_BYTES - "exact-crlf-".len())
     );
     let overlong_secret_line = format!(
         "overlong-secret-prefix-{secret}-{}",
-        "x".repeat(common::CLI_STDERR_RESULT_MAX_LINE_BYTES)
+        "x".repeat(CLI_STDERR_RESULT_MAX_LINE_BYTES)
     );
-    assert_eq!(
-        exact_limit_line.len(),
-        common::CLI_STDERR_RESULT_MAX_LINE_BYTES
-    );
+    assert_eq!(exact_limit_line.len(), CLI_STDERR_RESULT_MAX_LINE_BYTES);
     assert_eq!(
         exact_limit_crlf_line.len(),
-        common::CLI_STDERR_RESULT_MAX_LINE_BYTES
+        CLI_STDERR_RESULT_MAX_LINE_BYTES
     );
 
     stderr_payload.push_str(&format!("\n{exact_limit_crlf_line}\r"));
@@ -101,10 +101,7 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
     .expect("execute_cli should return promptly")?;
 
     assert_eq!(cli_result.exit_code, 1);
-    assert_eq!(
-        cli_result.stderr_lines.len(),
-        common::CLI_STDERR_RESULT_MAX_LINES
-    );
+    assert_eq!(cli_result.stderr_lines.len(), CLI_STDERR_RESULT_MAX_LINES);
     let stderr = cli_result.stderr_lines.join("\n");
     assert!(
         !cli_result.stderr_lines.iter().any(|line| line == "line-5"),
@@ -144,7 +141,7 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
         "stderr result should keep lines at the exact size limit, got: {stderr}"
     );
     assert!(
-        stderr.contains(common::CLI_STDERR_OMITTED_LONG_LINE),
+        stderr.contains(CLI_STDERR_OMITTED_LONG_LINE),
         "stderr result should omit overlong lines, got: {stderr}"
     );
     assert!(

--- a/crates/guest-agent/tests/cli_stderr_overlong_lone_cr_no_newline.rs
+++ b/crates/guest-agent/tests/cli_stderr_overlong_lone_cr_no_newline.rs
@@ -6,6 +6,9 @@
 mod common;
 
 use guest_agent::masker::SecretMasker;
+use guest_contracts::cli_stderr_diagnostics::{
+    CLI_STDERR_OMITTED_LONG_LINE, CLI_STDERR_RESULT_MAX_LINE_BYTES,
+};
 use std::time::Duration;
 
 #[tokio::test]
@@ -13,7 +16,7 @@ async fn cli_failure_omits_overlong_stderr_ending_in_lone_cr()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
-    let overlong_line = format!("{}\r", "x".repeat(common::CLI_STDERR_RESULT_MAX_LINE_BYTES));
+    let overlong_line = format!("{}\r", "x".repeat(CLI_STDERR_RESULT_MAX_LINE_BYTES));
 
     unsafe {
         common::setup_env(
@@ -36,10 +39,7 @@ async fn cli_failure_omits_overlong_stderr_ending_in_lone_cr()
     .expect("execute_cli should return promptly")?;
 
     assert_eq!(cli_result.exit_code, 1);
-    assert_eq!(
-        cli_result.stderr_lines,
-        vec![common::CLI_STDERR_OMITTED_LONG_LINE]
-    );
+    assert_eq!(cli_result.stderr_lines, vec![CLI_STDERR_OMITTED_LONG_LINE]);
 
     Ok(())
 }

--- a/crates/guest-agent/tests/cli_stderr_overlong_no_newline.rs
+++ b/crates/guest-agent/tests/cli_stderr_overlong_no_newline.rs
@@ -6,13 +6,16 @@
 mod common;
 
 use guest_agent::masker::SecretMasker;
+use guest_contracts::cli_stderr_diagnostics::{
+    CLI_STDERR_OMITTED_LONG_LINE, CLI_STDERR_RESULT_MAX_LINE_BYTES,
+};
 use std::time::Duration;
 
 #[tokio::test]
 async fn cli_failure_omits_overlong_final_stderr() -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
-    let overlong_line = "x".repeat(common::CLI_STDERR_RESULT_MAX_LINE_BYTES + 1);
+    let overlong_line = "x".repeat(CLI_STDERR_RESULT_MAX_LINE_BYTES + 1);
 
     unsafe {
         common::setup_env(
@@ -35,10 +38,7 @@ async fn cli_failure_omits_overlong_final_stderr() -> Result<(), Box<dyn std::er
     .expect("execute_cli should return promptly")?;
 
     assert_eq!(cli_result.exit_code, 1);
-    assert_eq!(
-        cli_result.stderr_lines,
-        vec![common::CLI_STDERR_OMITTED_LONG_LINE]
-    );
+    assert_eq!(cli_result.stderr_lines, vec![CLI_STDERR_OMITTED_LONG_LINE]);
 
     Ok(())
 }

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -87,17 +87,6 @@ pub const MOCK_POST_RESULT_LIVENESS_EVENT: &str = "vm0_mock_post_result_stale_de
 pub const MOCK_POST_RESULT_RELEASE_ONE_SOCKET: &str = ".vm0-post-result-release-1.sock";
 pub const MOCK_POST_RESULT_RELEASE_TWO_SOCKET: &str = ".vm0-post-result-release-2.sock";
 
-/// Documented maximum number of stderr lines returned in
-/// `guest_agent::cli::CliExecutionResult`.
-pub const CLI_STDERR_RESULT_MAX_LINES: usize = 200;
-
-/// Documented maximum byte length for one returned stderr line after CRLF normalization.
-pub const CLI_STDERR_RESULT_MAX_LINE_BYTES: usize = 16 * 1024;
-
-/// Documented replacement for a stderr line that exceeds the diagnostic limit.
-pub const CLI_STDERR_OMITTED_LONG_LINE: &str =
-    "[stderr line omitted: exceeded diagnostic size limit]";
-
 pub fn unique_temp_path(prefix: &str) -> PathBuf {
     let timestamp_nanos = match SystemTime::now().duration_since(UNIX_EPOCH) {
         Ok(duration) => duration.as_nanos(),

--- a/crates/guest-contracts/src/cli_stderr_diagnostics.rs
+++ b/crates/guest-contracts/src/cli_stderr_diagnostics.rs
@@ -1,0 +1,17 @@
+//! Retained CLI stderr diagnostic policy.
+//!
+//! These values are shared by the guest-agent collector and its integration
+//! fixtures so runtime behavior and boundary payloads stay in lockstep.
+
+/// Maximum number of CLI stderr lines retained in the diagnostic tail.
+pub const CLI_STDERR_RESULT_MAX_LINES: usize = 200;
+
+/// Maximum raw byte length retained for one CLI stderr diagnostic line.
+///
+/// LF is excluded. A preceding CR is stripped before measuring a CRLF-terminated
+/// line, while a lone CR in an EOF-terminated final line counts toward the limit.
+pub const CLI_STDERR_RESULT_MAX_LINE_BYTES: usize = 16 * 1024;
+
+/// Replacement for a CLI stderr line that exceeds the diagnostic byte limit.
+pub const CLI_STDERR_OMITTED_LONG_LINE: &str =
+    "[stderr line omitted: exceeded diagnostic size limit]";

--- a/crates/guest-contracts/src/cli_stderr_diagnostics.rs
+++ b/crates/guest-contracts/src/cli_stderr_diagnostics.rs
@@ -6,10 +6,12 @@
 /// Maximum number of CLI stderr lines retained in the diagnostic tail.
 pub const CLI_STDERR_RESULT_MAX_LINES: usize = 200;
 
-/// Maximum raw byte length retained for one CLI stderr diagnostic line.
+/// Maximum byte length retained for one CLI stderr diagnostic line.
 ///
-/// LF is excluded. A preceding CR is stripped before measuring a CRLF-terminated
-/// line, while a lone CR in an EOF-terminated final line counts toward the limit.
+/// The collector bounds the raw record while reading and rechecks its lossy
+/// UTF-8 decoding. LF is excluded. A preceding CR is stripped from a
+/// CRLF-terminated line, while a lone CR in an EOF-terminated final line counts
+/// toward the limit.
 pub const CLI_STDERR_RESULT_MAX_LINE_BYTES: usize = 16 * 1024;
 
 /// Replacement for a CLI stderr line that exceeds the diagnostic byte limit.

--- a/crates/guest-contracts/src/lib.rs
+++ b/crates/guest-contracts/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod active_input;
 pub mod active_input_receipts;
 pub mod cli_agent_session_id;
+pub mod cli_stderr_diagnostics;
 pub mod codex_session_cleanup;
 pub mod codex_session_path;
 pub mod codex_thread_id;


### PR DESCRIPTION
## Summary

- add a canonical `guest_contracts::cli_stderr_diagnostics` policy module
- make the guest-agent collector and boundary fixtures consume the shared line count, byte limit, and omission marker
- remove the duplicated stderr policy values from integration-test common support

## Behavior and scope

This preserves the existing 200-line tail, 16 KiB per-line limit, omission text, CRLF normalization, EOF-final-line handling, invalid UTF-8 handling, and masking behavior. The 8 KiB read buffer remains a private collector implementation detail.

No dependencies, generated artifacts, APIs, persisted state, runner/guest protocol, feature switches, migrations, or rollout compatibility paths change.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-contracts -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo doc -p guest-contracts -p guest-agent --all-features --no-deps`
- `cargo test -p guest-contracts`
- `cargo test -p guest-agent --test cli_stderr_exact_limit_no_newline --test cli_stderr_overlong_no_newline --test cli_stderr_overlong_lone_cr_no_newline --test cli_stderr_logging --test cli_stderr_invalid_utf8 --test cli_stderr_invalid_utf8_long --test cli_stderr_no_newline`
- repository pre-commit Rust formatting, workspace Clippy, workspace documentation, and file-size hooks

Closes #30954
