### PR TITLE
fix(platform): close member balances with settings session

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/settings/personal-usage-record.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/personal-usage-record.ts
@@ -7,7 +7,7 @@ import {
 import { usageMembersContract } from "@okouai/api-contracts/contracts/usage";
 import { accept } from "../../../lib/accept.ts";
 import { apiClient$ } from "../../api-client.ts";
-import { onRejection } from "../../utils.ts";
+import { onRejection, resetSignal } from "../../utils.ts";
 
 export type CreditBalanceTab = "mine" | "team";
 
@@ -16,6 +16,7 @@ const usagePackMembersDialogOpenState$ = state(false);
 const usagePackMemberAdditionsExpandedMemberIdState$ = state<string | null>(
   null,
 );
+const resetUsagePackMembersDialogSignal$ = resetSignal();
 
 export const creditBalanceTab$ = computed((get) => {
   return get(creditBalanceTabState$);
@@ -35,14 +36,40 @@ export const usagePackMemberAdditionsExpandedMemberId$ = computed((get) => {
   return get(usagePackMemberAdditionsExpandedMemberIdState$);
 });
 
-export const setUsagePackMembersDialogOpen$ = command(
-  ({ set }, open: boolean) => {
-    if (open) {
-      set(usagePackMemberAdditionsExpandedMemberIdState$, null);
-    }
-    set(usagePackMembersDialogOpenState$, open);
+const resetUsagePackMembersDialogState$ = command(({ set }) => {
+  set(usagePackMembersDialogOpenState$, false);
+  set(usagePackMemberAdditionsExpandedMemberIdState$, null);
+});
+
+export const openUsagePackMembersDialog$ = command(
+  ({ set }, settingsDialogSignal: AbortSignal) => {
+    settingsDialogSignal.throwIfAborted();
+    const signal = set(
+      resetUsagePackMembersDialogSignal$,
+      settingsDialogSignal,
+    );
+    signal.addEventListener(
+      "abort",
+      () => {
+        set(resetUsagePackMembersDialogState$);
+      },
+      { once: true },
+    );
+    set(usagePackMemberAdditionsExpandedMemberIdState$, null);
+    set(usagePackMembersDialogOpenState$, true);
   },
 );
+
+export const closeUsagePackMembersDialog$ = command(({ set }) => {
+  set(usagePackMembersDialogOpenState$, false);
+});
+
+export const completeUsagePackMembersDialogClose$ = command(({ get, set }) => {
+  if (get(usagePackMembersDialogOpenState$)) {
+    return;
+  }
+  set(resetUsagePackMembersDialogSignal$);
+});
 
 export const toggleUsagePackMemberAdditions$ = command(
   ({ get, set }, memberId: string) => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/personal-usage-tab.test.tsx
@@ -278,6 +278,18 @@ async function openUsageSettings(
   });
 }
 
+async function openSettingsFromAccountMenu(): Promise<HTMLElement> {
+  const accountName = await screen.findByText("Test User");
+  const accountButton = accountName.closest("button");
+  if (!accountButton) {
+    throw new Error("Account menu trigger not found");
+  }
+  click(accountButton);
+  const menu = await screen.findByRole("menu");
+  click(within(menu).getByText("Settings"));
+  return screen.findByRole("dialog", { name: "Settings" });
+}
+
 describe("personal usage settings", () => {
   it("shows the member's usage pack credit breakdown", async () => {
     const user = userEvent.setup();
@@ -545,7 +557,7 @@ describe("personal usage settings", () => {
     ).toHaveTextContent("20,400 credits · 2% off");
   });
 
-  it("shows every member's usage pack balance to an admin", async () => {
+  it("shows every member's usage pack balance and closes it with the settings session", async () => {
     const user = userEvent.setup();
     mockPersonalUsageStory(usageRows(), "pro", false, "admin");
     context.mocks.data.orgMembers({
@@ -623,6 +635,7 @@ describe("personal usage settings", () => {
       within(card).getByTestId("usage-pack-credit-grants-section"),
     ).toBeInTheDocument();
 
+    const settingsDialog = screen.getByRole("dialog", { name: "Settings" });
     await user.click(buttonByAriaLabel("View member balances", card));
     const memberDialog = await screen.findByRole("dialog", {
       name: "Member usage pack credits",
@@ -716,6 +729,30 @@ describe("personal usage settings", () => {
     const orgCredits = await screen.findByTestId("credit-balance-info");
     expect(within(orgCredits).getByText("Org credits")).toBeInTheDocument();
     expect(within(orgCredits).getByText("12,500")).toBeInTheDocument();
+
+    click(within(settingsDialog).getByLabelText("Close"));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Settings" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("dialog", {
+          name: "Member usage pack credits",
+        }),
+      ).not.toBeInTheDocument();
+    });
+
+    const reopenedSettingsDialog = await openSettingsFromAccountMenu();
+    click(within(reopenedSettingsDialog).getByText("Credit balance"));
+    const reopenedCard = await screen.findByTestId("usage-pack-credit-card");
+    await waitFor(() => {
+      expect(
+        buttonByAriaLabel("View member balances", reopenedCard),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("dialog", { name: "Member usage pack credits" }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows an illustrated empty state when the range has no usage", async () => {

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/credit-balance-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/credit-balance-section.tsx
@@ -32,6 +32,7 @@ import { orgMembers$ } from "../../../../../signals/external/org-members.ts";
 import { usagePackCreditsAsync$ } from "../../../../../signals/okou-page/billing.ts";
 import {
   openSettingsUsagePackConfiguration$,
+  settingsDialogSignal$,
   setSettingsActiveSection$,
 } from "../../../../../signals/okou-page/settings/settings-dialog.ts";
 import {
@@ -39,7 +40,9 @@ import {
   setBillingSubPage$,
 } from "../../../../../signals/okou-page/settings/workspace-settings-state.ts";
 import {
-  setUsagePackMembersDialogOpen$,
+  closeUsagePackMembersDialog$,
+  completeUsagePackMembersDialogClose$,
+  openUsagePackMembersDialog$,
   toggleUsagePackMemberAdditions$,
   usagePackMemberAdditionsExpandedMemberId$,
   usagePackMembersDialogOpen$,
@@ -443,13 +446,32 @@ function UsagePackMemberBalancesDialog({
 }) {
   const { t } = useTranslation();
   const membersLoadable = useLoadable(orgMembers$);
+  const settingsDialogSignal = useGet(settingsDialogSignal$);
   const open = useGet(usagePackMembersDialogOpen$);
-  const setOpen = useSet(setUsagePackMembersDialogOpen$);
-  if (membersLoadable.state !== "hasData" || membersLoadable.data.length <= 1) {
+  const openDialog = useSet(openUsagePackMembersDialog$);
+  const closeDialog = useSet(closeUsagePackMembersDialog$);
+  const completeClose = useSet(completeUsagePackMembersDialogClose$);
+  if (
+    !settingsDialogSignal ||
+    membersLoadable.state !== "hasData" ||
+    membersLoadable.data.length <= 1
+  ) {
     return null;
   }
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          closeDialog();
+        }
+      }}
+      onOpenChangeComplete={(nextOpen) => {
+        if (!nextOpen) {
+          completeClose();
+        }
+      }}
+    >
       <TooltipProvider delayDuration={100}>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -462,7 +484,7 @@ function UsagePackMemberBalancesDialog({
                 return $.billing.usage.usagePack.viewMembers;
               })}
               onClick={() => {
-                setOpen(true);
+                openDialog(settingsDialogSignal);
               }}
             >
               <Users size={15} />


### PR DESCRIPTION
## Summary

- bind the usage-pack member balances dialog to the active Settings session
- reset the dialog and expanded-member state when that session aborts
- cover closing Settings with the child dialog open and reopening Credit balance

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/personal-usage-tab.test.tsx`
