### PR TITLE
fix(api): deploy github app slug cutover

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createProductionApp } from "./production-bootstrap";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed for #30442 post-merge QA on 2026-09-01)
+// (no-op API release marker refreshed for the GitHub App slug cutover on 2026-09-02)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
## Summary

- refresh the API release marker so the renamed GitHub App slug is picked up on the next normal API deployment
- cut the production installation URL from `vm0-zero` to `okou-ai`
- leave repository-scoped preview and test GitHub App configuration unchanged

## External configuration

- updated production `OKOU_GITHUB_APP_SLUG` and `VM0_GITHUB_APP_SLUG` to `okou-ai`
- verified both values still resolve to GitHub App ID `2994368`
- no App ID, permission, callback, secret, or webhook changes

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged TypeScript checks for non-API packages, App, and API
- no local Vitest run because the repository diff is a non-executable release marker; PR CI provides the full checks

