### PR TITLE
docs(platform): explain the queue drawer bootstrap settle point

### DIFF
--- a/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
+++ b/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
@@ -21,8 +21,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   click,
-  detachedSetupPage,
   queryAllByRoleFast,
+  setupPageAndWaitForContent,
 } from "../../../__tests__/page-helper.ts";
 import {
   testContext,
@@ -230,7 +230,10 @@ async function openDrawer(
   sharedWorkerTestTransport: "direct" | "message-port" = "direct",
 ): Promise<void> {
   mockQueuedThread();
-  detachedSetupPage({
+  // Settle the app bootstrap on its own observable signal before polling for
+  // the queue button, so the button's `waitFor` budget covers only the queue
+  // marker rendering instead of the whole page startup.
+  await setupPageAndWaitForContent({
     context,
     path: `/chats/${THREAD_ID}`,
     featureSwitches: {


### PR DESCRIPTION
> **Superseded in substance by #30967.** The code change this PR was opened for landed independently on `main` at 03:48 UTC as the second commit of #30967 (`fix: resolve ci failures on pr #30967`), which made the byte-identical `detachedSetupPage` → `await setupPageAndWaitForContent` swap in `openDrawer`. That collision is what turned this PR's merge-queue entry `UNMERGEABLE`. This PR is now reduced to the three-line rationale comment; close it instead if you would rather not spend a queue cycle on documentation.

## What remains here

```diff
   mockQueuedThread();
+  // Settle the app bootstrap on its own observable signal before polling for
+  // the queue button, so the button's `waitFor` budget covers only the queue
+  // marker rendering instead of the whole page startup.
   await setupPageAndWaitForContent({
```

+3 / -0, one file. The comment records why `openDrawer` must not go back to a bare `detachedSetupPage`, which is the part of the fix that is invisible in the code itself.

## Original diagnosis, retained as the record

`queue-drawer.test.tsx > refreshes the concurrency limit through the shared worker when billing changes in realtime` failed three times in ~25 minutes on `test-app (7)`, all in `merge_group`:

- [run 33586766441](https://github.com/vm0-ai/vm0/actions/runs/33586766441) (`ea7b779c5`, riding #30968) — [job](https://github.com/vm0-ai/vm0/actions/runs/33586766441/job/100112487334)
- [run 33587513369](https://github.com/vm0-ai/vm0/actions/runs/33587513369) (`375c5e1c7`, riding #30965) — [job](https://github.com/vm0-ai/vm0/actions/runs/33587513369/job/100114685432)
- [run 33588280627](https://github.com/vm0-ai/vm0/actions/runs/33588280627) (`32bdb8376`, riding #30972) — [job](https://github.com/vm0-ai/vm0/actions/runs/33588280627/job/100116910304)

```
Error: Could not find button: queue...
 ❯ getButtonByText src/views/queue-page/__tests__/queue-drawer.test.tsx:210:11
 ❯ src/views/queue-page/__tests__/queue-drawer.test.tsx:242:12
```

All three DOM dumps show the full-screen skeleton still mounted, with the nav rail already rendered underneath — a partially-bootstrapped app, not a render failure.

### Not change-owned, not environmental

The three occurrences rode unrelated queued PRs with no file overlap: #30968 (chat feedback), #30965 (strapi feature-switch removal), #30972 (connector accounts). None touches the queue page, the shared worker, billing, or concurrency.

| phase | 33586766441 | 33587513369 | 33588280627 | green 33586765758 |
|---|---|---|---|---|
| transform | 25.47s | 25.58s | 26.50s | 25.83s |
| setup | 35.28s | 35.62s | 36.27s | 34.09s |
| import | 69.86s | 69.90s | 71.22s | 67.03s |
| environment | 9.13s | 9.23s | — | 7.95s |
| tests | 392.39s | 402.42s | 402.84s | 352.88s |

Green run 33586765758 is a push to `main` (`f013dbf1`) that started at essentially the same moment and passed all 20 files on the same shard. All three failures ran at normal speed.

### Root cause

`openDrawer` entered through the fire-and-forget `detachedSetupPage` and then polled for the button with a bare `waitFor`. `turbo/apps/platform` sets no testing-library `configure()`, so that `waitFor` ran on the default **1000 ms** `asyncUtilTimeout` and had to absorb the entire page bootstrap *plus* the queue marker render.

Instrumenting that `waitFor` on an idle 2-core box shows every test in the file spending **476–1085 ms of the 1000 ms budget** just reaching the button:

```
1085ms  654ms  587ms  581ms  566ms  508ms  585ms  488ms  547ms  476ms  553ms  489ms
```

Zero to ~50% headroom before any CI variance — a latent flake in all twelve tests, which is why three hits landed inside 25 minutes. `setupPageAndWaitForContent` arms a `MutationObserver` *before* bootstrap starts and resolves when `[data-testid="app-skeleton"]` is removed or goes `aria-hidden="true"`. The button `waitFor` then covers only the queue marker: **10–63 ms**.

### Validation performed before #30967 landed

Reproduced deterministically on a 2-core box under 4 `node` busy loops, before/after on the same host and load:

| | result |
|---|---|
| `origin/main` at `960d7c45d`, 3 runs | **3/3 failed**, always `Could not find button: queue...` |
| this branch, 5 runs | **5/5 passed**, `Tests 12 passed (12)` |

After merging current `main`: 12/12 passed, eslint clean, prettier clean, `git diff --check` clean.

### Relationship to the `chat-thread-idb` occurrence

There is a common bootstrap gate. [Run 33579922723](https://github.com/vm0-ai/vm0/actions/runs/33579922723) on `test-app (4)` failed with the same skeleton-still-mounted symptom in `chat-thread-idb.test.tsx`; both tests were racing the whole app bootstrap inside one default 1000 ms budget. #30936 fixed that sibling with this same helper at 02:18 UTC but touched only its own file, leaving `queue-drawer.test.tsx` exposed until #30967 caught it 90 minutes later.
