### PR TITLE
test(guest-download): cover empty artifact preparation failure

### DIFF
--- a/crates/guest-download/tests/integration/binary_logging/empty_artifact.rs
+++ b/crates/guest-download/tests/integration/binary_logging/empty_artifact.rs
@@ -75,6 +75,12 @@ fn binary_empty_artifact_preparation_failure_preserves_prior_work() {
     assert_does_not_contain_any("sandbox ops log", &ops_log, &forbidden);
 
     let ops = fixture.ops_entries().unwrap();
+    assert!(
+        ops.iter().any(|entry| {
+            entry["action_type"] == "guest_download_target_prepare" && entry["success"] == true
+        }),
+        "staged instruction target should be prepared before the artifact failure: {ops:?}"
+    );
     let mut empty_artifact_ops = ops
         .iter()
         .filter(|entry| entry["action_type"] == "artifact_empty_prepare");

--- a/crates/guest-download/tests/integration/binary_logging/empty_artifact.rs
+++ b/crates/guest-download/tests/integration/binary_logging/empty_artifact.rs
@@ -1,0 +1,103 @@
+use super::BinaryLoggingFixture;
+use crate::support::assert_does_not_contain_any;
+use serde_json::json;
+
+#[test]
+fn binary_empty_artifact_preparation_failure_preserves_prior_work() {
+    let fixture = BinaryLoggingFixture::new("empty-artifact-prepare-failure").unwrap();
+    let staged_source = fixture
+        .dir
+        .path()
+        .join("runtime")
+        .join("storage-instructions")
+        .join("0");
+    let staged_parent = staged_source.parent().unwrap().to_path_buf();
+    let staged_archive = fixture.dir.path().join("staged-secret-token.tar.gz");
+    let prepared_empty_artifact = fixture.dir.path().join("prepared-empty-artifact");
+    let blocker = fixture.dir.path().join("artifact-blocker");
+    let blocked_empty_artifact = blocker.join("blocked-empty-artifact");
+    std::fs::write(&blocker, "not a directory").unwrap();
+
+    let staged_archive_url = format!("file://{}", staged_archive.display());
+    let earlier_archive_url = "https://storage.invalid/empty?token=earlier-secret-token";
+    let blocked_archive_url = "https://storage.invalid/empty?token=blocked-secret-token";
+    let manifest = json!({
+        "storageMounts": [
+            {
+                "mountPath": fixture.dir.path().join(".codex"),
+                "extractPath": staged_source,
+                "archiveUrl": staged_archive_url,
+                "instructionsTargetFilename": "AGENTS.md"
+            },
+            {
+                "mountPath": prepared_empty_artifact,
+                "archiveUrl": earlier_archive_url,
+                "empty": true,
+                "name": "prepared-empty",
+                "versionId": "prepared-empty-v1",
+                "writeback": true
+            },
+            {
+                "mountPath": blocked_empty_artifact,
+                "archiveUrl": blocked_archive_url,
+                "empty": true,
+                "name": "blocked-empty",
+                "versionId": "blocked-empty-v1",
+                "writeback": true
+            }
+        ]
+    });
+
+    let output = fixture
+        .run_manifest_stdin(&serde_json::to_vec(&manifest).unwrap())
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(!staged_source.exists());
+    assert!(!staged_parent.exists());
+    assert!(prepared_empty_artifact.is_dir());
+    assert!(!blocked_empty_artifact.exists());
+    assert!(!staged_archive.exists());
+
+    let system_log = fixture.read_system_log().unwrap();
+    let ops_log = fixture.read_ops_log().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let forbidden = [
+        staged_archive_url.as_str(),
+        earlier_archive_url,
+        blocked_archive_url,
+        "staged-secret-token",
+        "earlier-secret-token",
+        "blocked-secret-token",
+    ];
+    assert_does_not_contain_any("stderr", &stderr, &forbidden);
+    assert_does_not_contain_any("system log", &system_log, &forbidden);
+    assert_does_not_contain_any("sandbox ops log", &ops_log, &forbidden);
+
+    let ops = fixture.ops_entries().unwrap();
+    let mut empty_artifact_ops = ops
+        .iter()
+        .filter(|entry| entry["action_type"] == "artifact_empty_prepare");
+    let prepared = empty_artifact_ops.next().unwrap();
+    assert_eq!(prepared["success"], true);
+    assert!(prepared.get("error").is_none());
+
+    let failed = empty_artifact_ops.next().unwrap();
+    assert_eq!(failed["success"], false);
+    let error = failed["error"].as_str().unwrap();
+    assert!(error.contains("artifact 2"), "unexpected error: {error}");
+    assert!(
+        error.contains("vasStorageName=blocked-empty"),
+        "unexpected error: {error}"
+    );
+    assert!(
+        error.contains("vasVersionId=blocked-empty-v1"),
+        "unexpected error: {error}"
+    );
+    assert!(empty_artifact_ops.next().is_none());
+    assert!(
+        !ops.iter()
+            .any(|entry| entry["action_type"] == "guest_download_archive_scheduler"),
+        "archive scheduler should not run: {ops:?}"
+    );
+}

--- a/crates/guest-download/tests/integration/binary_logging/empty_artifact.rs
+++ b/crates/guest-download/tests/integration/binary_logging/empty_artifact.rs
@@ -17,6 +17,7 @@ fn binary_empty_artifact_preparation_failure_preserves_prior_work() {
     let blocker = fixture.dir.path().join("artifact-blocker");
     let blocked_empty_artifact = blocker.join("blocked-empty-artifact");
     std::fs::write(&blocker, "not a directory").unwrap();
+    assert!(!staged_archive.exists());
 
     let staged_archive_url = format!("file://{}", staged_archive.display());
     let earlier_archive_url = "https://storage.invalid/empty?token=earlier-secret-token";
@@ -57,7 +58,6 @@ fn binary_empty_artifact_preparation_failure_preserves_prior_work() {
     assert!(!staged_parent.exists());
     assert!(prepared_empty_artifact.is_dir());
     assert!(!blocked_empty_artifact.exists());
-    assert!(!staged_archive.exists());
 
     let system_log = fixture.read_system_log().unwrap();
     let ops_log = fixture.read_ops_log().unwrap();
@@ -75,10 +75,20 @@ fn binary_empty_artifact_preparation_failure_preserves_prior_work() {
     assert_does_not_contain_any("sandbox ops log", &ops_log, &forbidden);
 
     let ops = fixture.ops_entries().unwrap();
-    assert!(
-        ops.iter().any(|entry| {
+    let target_prepare_index = ops
+        .iter()
+        .position(|entry| {
             entry["action_type"] == "guest_download_target_prepare" && entry["success"] == true
-        }),
+        })
+        .expect("missing successful guest_download_target_prepare operation");
+    let failed_artifact_index = ops
+        .iter()
+        .position(|entry| {
+            entry["action_type"] == "artifact_empty_prepare" && entry["success"] == false
+        })
+        .expect("missing failed artifact_empty_prepare operation");
+    assert!(
+        target_prepare_index < failed_artifact_index,
         "staged instruction target should be prepared before the artifact failure: {ops:?}"
     );
     let mut empty_artifact_ops = ops

--- a/crates/guest-download/tests/integration/binary_logging/mod.rs
+++ b/crates/guest-download/tests/integration/binary_logging/mod.rs
@@ -8,6 +8,7 @@ use std::process::{Command, Output};
 use tempfile::TempDir;
 
 mod attribution;
+mod empty_artifact;
 mod manifest_input;
 mod redaction;
 mod runtime_paths;


### PR DESCRIPTION
## Summary

- cover the explicit empty-artifact directory preparation failure through the real `guest-download --manifest-stdin` entry path
- verify staged instruction cleanup, non-transactional preservation, failed-artifact attribution, scheduler bypass, and archive URL redaction

## Scope

- test-only change; production behavior and manifest contracts are unchanged

## Validation

- `cargo fmt --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-download --test integration binary_empty_artifact_preparation_failure`
- `cargo test --manifest-path crates/Cargo.toml -p guest-download --all-targets --all-features`
- `cargo clippy -p guest-download --all-targets --all-features`
- `cargo doc -p guest-download --all-features --no-deps`
- pre-commit workspace Rust formatting, Clippy, Rustdoc, file-size, and commit-message hooks

Closes #31001
