### PR TITLE
fix(python): reject ambiguous catalog response framing

### DIFF
--- a/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
+++ b/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
@@ -753,7 +753,9 @@ def _response_headers_bypass_reason(
     if _single_usable_etag(headers) is None:
         return "response_etag"
     parsed_content_length = _parse_content_length(headers)
-    if parsed_content_length.kind not in ("missing", "valid"):
+    if parsed_content_length.kind not in ("missing", "valid") or (
+        parsed_content_length.kind == "valid" and headers.get_all("Transfer-Encoding")
+    ):
         return "response_size"
     return None
 
@@ -850,12 +852,6 @@ def handle_response_headers(flow: http.HTTPFlow) -> bool:
         return True
 
     compressed_content_length = _parse_content_length(flow.response.headers)
-    if compressed_content_length.kind not in ("missing", "valid") or (
-        compressed_content_length.kind == "valid"
-        and flow.response.headers.get_all("Transfer-Encoding")
-    ):
-        _bypass_response(flow, state, "response_size")
-        return True
     state.compressed_content_length = (
         compressed_content_length.value if compressed_content_length.kind == "valid" else None
     )

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_responses.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_responses.py
@@ -105,11 +105,22 @@ async def test_ordinary_owner_rejects_unsolicited_encoded_response(real_flow, en
     catalog_cache.handle_error(retry)
 
 
-async def test_ordinary_identity_miss_without_length_streams_and_caches(real_flow):
-    flow = catalog_flow(real_flow, version="identity-without-length")
+@pytest.mark.parametrize(
+    "transfer_encoding",
+    [None, "chunked"],
+    ids=["close-delimited", "transfer-encoded"],
+)
+async def test_ordinary_identity_miss_without_length_streams_and_caches(
+    real_flow,
+    transfer_encoding: str | None,
+):
+    version = f"identity-without-length-{transfer_encoding or 'none'}"
+    flow = catalog_flow(real_flow, version=version)
     await prepare_miss(flow)
     flow.response = catalog_response()
     del flow.response.headers["Content-Length"]
+    if transfer_encoding is not None:
+        flow.response.headers["Transfer-Encoding"] = transfer_encoding
 
     telemetry = await finish_response(flow)
 
@@ -118,7 +129,7 @@ async def test_ordinary_identity_miss_without_length_streams_and_caches(real_flo
     assert "Content-Encoding" not in flow.response.headers
     assert "Content-Length" not in flow.response.headers
     assert telemetry["model_catalog_cache_status"] == "model_catalog_cold_stored"
-    hit = catalog_flow(real_flow, version="identity-without-length")
+    hit = catalog_flow(real_flow, version=version)
     await catalog_cache.prepare_request(hit, request_end_stream=True)
     assert hit.response is not None
     assert hit.response.content == CATALOG_BODY
@@ -253,6 +264,11 @@ async def test_set_cookie_is_not_replayed_from_cached_brotli_response(real_flow)
             catalog_response(body=b'{"items":[]}'),
             "response_shape",
             id="wrong-shape",
+        ),
+        pytest.param(
+            catalog_response(headers={"Transfer-Encoding": "chunked"}),
+            "response_size",
+            id="ambiguous-framing",
         ),
         pytest.param(
             catalog_response(headers={"Content-Length": str(len(CATALOG_BODY) + 1)}),


### PR DESCRIPTION
## Summary

- reject Codex catalog cache candidates that carry both `Transfer-Encoding` and `Content-Length` through the shared response admission gate
- preserve cache admission for identity responses that use transfer encoding without `Content-Length`
- remove the redundant Brotli-only framing conflict check while retaining compressed-length validation

## Exclusions

- no change to upstream response pass-through behavior or the existing `response_size` telemetry classification
- no API, database, persisted-state, or runner protocol changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_codex_model_catalog_cache_responses.py` (51 passed)
- `uv run --no-sync python -m pytest -q --tb=short tests/` (7,327 passed)
- `git diff --check`

Closes #31006
