### PR TITLE
fix(platform): replace feishu review guide icon

### DIFF
--- a/turbo/apps/platform/src/lib/__tests__/static-assets.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/static-assets.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../../views/okou-page/platform-assets.ts";
 import {
   platformFeishuAppCreatedCredentialsImg,
+  platformFeishuAppIconImg,
   platformFeishuAvailabilitySettingsAllMembersImg,
   platformFeishuCreateEnterpriseCustomAppImg,
   platformFeishuEncryptionStrategyImg,
@@ -65,6 +66,7 @@ const SETTINGS_ICON_KEYS = [
 
 const FEISHU_GUIDE_IMAGES = Object.freeze({
   platformFeishuAppCreatedCredentialsImg,
+  platformFeishuAppIconImg,
   platformFeishuAvailabilitySettingsAllMembersImg,
   platformFeishuCreateEnterpriseCustomAppImg,
   platformFeishuEncryptionStrategyImg,
@@ -158,7 +160,7 @@ describe("static asset object keys", () => {
     expect(renamedKeys).toStrictEqual([]);
   });
 
-  it("keeps all 32 published string-literal keys under zero-page", () => {
+  it("keeps all 33 published string-literal keys under zero-page", () => {
     const objectKeys = Object.entries(sources).flatMap(([file, source]) => {
       if (file.endsWith("/static-assets.test.ts")) {
         return [];
@@ -170,6 +172,6 @@ describe("static asset object keys", () => {
     const pageKeys = objectKeys.filter((key) => {
       return key.startsWith("views/zero-page/");
     });
-    expect(pageKeys).toHaveLength(32);
+    expect(pageKeys).toHaveLength(33);
   });
 });

--- a/turbo/apps/platform/src/lib/static-assets.ts
+++ b/turbo/apps/platform/src/lib/static-assets.ts
@@ -20,6 +20,9 @@ export const platformVm0LogoImg = platformStaticAssetUrl(
 export const platformVm0LogoDarkImg = platformStaticAssetUrl(
   "assets/vm0-logo-dark-f3de8c7713f8.svg",
 );
+export const platformFeishuAppIconImg = platformStaticAssetUrl(
+  "views/zero-page/assets/feishu/app-icon-okou-fefdc683bf5c.png",
+);
 export const platformFeishuCreateEnterpriseCustomAppImg =
   platformStaticAssetUrl(
     "views/zero-page/assets/feishu/create-enterprise-custom-app-bfcbb0ba2ffb.png",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/works-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/works-page.test.tsx
@@ -1051,9 +1051,23 @@ describe("works page", () => {
     expect(createGuideImage).toHaveAttribute("width", "1234");
     expect(createGuideImage).toHaveAttribute("height", "998");
     expect(queryRole("button", "Show creating a Feishu app guide")).toBeNull();
+    const iconDownloadLink = screen
+      .getByText("Download the optional VM0 icon")
+      .closest("a");
+    expect(iconDownloadLink).toHaveAttribute(
+      "href",
+      "https://static.vm0.io/platform/views/zero-page/assets/feishu/app-icon-okou-fefdc683bf5c.png",
+    );
+    expect(iconDownloadLink).toHaveAttribute(
+      "download",
+      "vm0-feishu-app-icon.png",
+    );
     expect(
-      screen.getByText("Download the optional VM0 icon").closest("a"),
-    ).toHaveAttribute("download", "vm0-feishu-app-icon.png");
+      screen.getByRole("img", { name: "Optional VM0 app icon" }),
+    ).toHaveAttribute(
+      "src",
+      "https://static.vm0.io/platform/views/zero-page/assets/feishu/app-icon-okou-fefdc683bf5c.png",
+    );
 
     click(screen.getByText("Next"));
 

--- a/turbo/apps/platform/src/views/okou-page/feishu-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/feishu-card.tsx
@@ -43,6 +43,7 @@ import { useTranslation } from "react-i18next";
 import { i18n } from "../../i18n/index.ts";
 import {
   platformFeishuAppCreatedCredentialsImg,
+  platformFeishuAppIconImg,
   platformFeishuAvailabilitySettingsAllMembersImg,
   platformFeishuCreateEnterpriseCustomAppImg,
   platformFeishuEncryptionStrategyImg,
@@ -59,6 +60,7 @@ import {
   defaultAgentName$,
   sortedAgents$,
 } from "../../signals/agent.ts";
+import { downloadAttachment$ } from "../../signals/attachment-download.ts";
 import { brandName$ } from "../../signals/branding.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { ROUTES } from "../../signals/route-paths.ts";
@@ -468,7 +470,10 @@ function canSubmitFeishuSetup(
 
 function FeishuCreateStep() {
   const brandName = useGet(brandName$);
+  const downloadAttachment = useSet(downloadAttachment$);
+  const signal = useGet(pageSignal$);
   const { t } = useTranslation();
+  const iconFilename = `${brandName.toLowerCase()}-feishu-app-icon.png`;
 
   return (
     <div className="space-y-4">
@@ -524,8 +529,19 @@ function FeishuCreateStep() {
           </div>
           <p className="mt-1 text-sm text-muted-foreground">
             <a
-              href="/icons/icon-512.png"
-              download={`${brandName.toLowerCase()}-feishu-app-icon.png`}
+              href={platformFeishuAppIconImg}
+              download={iconFilename}
+              onClick={(event) => {
+                event.preventDefault();
+                detach(
+                  downloadAttachment(
+                    { filename: iconFilename, url: platformFeishuAppIconImg },
+                    signal,
+                  ),
+                  Reason.DomCallback,
+                  "Feishu app icon download",
+                );
+              }}
               className="font-medium text-foreground underline underline-offset-4"
             >
               {t(
@@ -542,7 +558,7 @@ function FeishuCreateStep() {
           </p>
         </div>
         <img
-          src="/icons/icon-512.png"
+          src={platformFeishuAppIconImg}
           alt={t(
             ($) => {
               return $.connectors.providerSettings.feishu.create.iconAlt;


### PR DESCRIPTION
## Summary
- replace the Feishu review guide preview and downloadable app icon with the uploaded Okou avatar
- reference the image through a content-hashed platform static asset URL
- preserve real PNG downloads for the cross-origin CDN asset by reusing the existing attachment download flow
- cover the frozen object key plus the guide download and preview URLs

## Dependency
- vm0-ai/static-files#173 is merged
- verified both CDN endpoints return the uploaded PNG with the expected SHA-256 before enabling pr-auto

## Verification
- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged shared, platform, and API type checks
- `pnpm --filter @okouai/app exec vitest run src/lib/__tests__/static-assets.test.ts` (48 passed)
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/works-page.test.tsx` (25 passed)
- `git diff --check`
- confirmed `static.okou.io` allows CORS from `https://app.okou.ai`

Browser verification was not run because the repository instructions prohibit starting a local dev server unless explicitly requested; the PR pipeline remains authoritative.