### PR TITLE
refactor(runner): make firecracker process identity canonical

### DIFF
--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -85,14 +85,15 @@ enum Warning {
         pid: u32,
         sandbox_id: String,
         base_dir: PathBuf,
-        identity: Option<process::FirecrackerProcessIdentity>,
+        generation: Option<process::ProcfsProcessGeneration>,
     },
     /// A firecracker process whose ppid chain doesn't lead to any runner.
     OrphanFirecracker {
         pid: u32,
         sandbox_id: String,
+        base_dir: Option<PathBuf>,
         ppid: Option<u32>,
-        identity: Option<process::FirecrackerProcessIdentity>,
+        generation: Option<process::ProcfsProcessGeneration>,
     },
     /// A mitmdump process on an unclaimed port whose ppid chain is orphaned.
     OrphanMitmdump {
@@ -271,12 +272,18 @@ impl Warning {
                 pid,
                 sandbox_id,
                 base_dir,
-                identity,
+                generation,
             } => {
                 // Resolved if fresh discovery no longer contains the same
                 // Firecracker observation or sandbox_id is now known (either
                 // tracked as active or parked as idle).
-                if !fresh_contains_firecracker(fresh, *pid, identity.as_ref()) {
+                if !fresh_contains_firecracker(
+                    fresh,
+                    *pid,
+                    sandbox_id,
+                    Some(base_dir),
+                    generation.as_ref(),
+                ) {
                     return false;
                 }
                 match read_status(base_dir).await {
@@ -292,12 +299,23 @@ impl Warning {
                 }
             }
             Self::StaleMitmproxy { port } => fresh.mitmdumps.iter().any(|mitm| mitm.port == *port),
-            Self::OrphanFirecracker { pid, identity, .. } => {
+            Self::OrphanFirecracker {
+                pid,
+                sandbox_id,
+                base_dir,
+                generation,
+                ..
+            } => {
                 // Resolved if fresh discovery no longer contains the same
                 // Firecracker observation or a runner registry entry appeared
                 // after the initial scan and now owns the process.
-                fresh_contains_firecracker(fresh, *pid, identity.as_ref())
-                    && process::is_orphan(*pid, runner_pids).await
+                fresh_contains_firecracker(
+                    fresh,
+                    *pid,
+                    sandbox_id,
+                    base_dir.as_deref(),
+                    generation.as_ref(),
+                ) && process::is_orphan(*pid, runner_pids).await
             }
             Self::OrphanMitmdump { pid, .. } => {
                 // Resolved if the process exited or a runner registry entry
@@ -342,14 +360,15 @@ fn pid_exists(pid: u32) -> bool {
 fn fresh_contains_firecracker(
     fresh: &process::DiscoveredProcesses,
     pid: u32,
-    identity: Option<&process::FirecrackerProcessIdentity>,
+    sandbox_id: &str,
+    base_dir: Option<&Path>,
+    generation: Option<&process::ProcfsProcessGeneration>,
 ) -> bool {
     fresh.firecrackers.iter().any(|firecracker| {
         firecracker.pid == pid
-            && match identity {
-                Some(identity) => firecracker.identity.as_ref() == Some(identity),
-                None => firecracker.identity.is_none(),
-            }
+            && firecracker.sandbox_id == sandbox_id
+            && firecracker.base_dir.as_deref() == base_dir
+            && firecracker.generation.as_ref() == generation
     })
 }
 
@@ -1147,7 +1166,7 @@ fn correlate_jobs(
                 pid: fc.pid,
                 sandbox_id: fc.sandbox_id.clone(),
                 base_dir: base_dir.to_path_buf(),
-                identity: fc.identity.clone(),
+                generation: fc.generation,
             });
             jobs.push(JobReport {
                 status: JobStatus::NotInStatus {
@@ -1226,8 +1245,9 @@ async fn detect_orphan_firecrackers(
             warnings.push(Warning::OrphanFirecracker {
                 pid: fc.pid,
                 sandbox_id: fc.sandbox_id.clone(),
+                base_dir: fc.base_dir.clone(),
                 ppid: fc.ppid,
-                identity: fc.identity.clone(),
+                generation: fc.generation,
             });
         }
     }
@@ -1770,19 +1790,14 @@ printf '%s\n' \
     }
 
     fn fc_info(pid: u32, sandbox_id: &str, base_dir: &Path) -> process::FirecrackerProcessInfo {
-        let sandbox_id = sandbox_id.to_string();
-        let base_dir = base_dir.to_path_buf();
         process::FirecrackerProcessInfo {
             pid,
             ppid: None,
-            sandbox_id: sandbox_id.clone(),
-            base_dir: Some(base_dir.clone()),
-            identity: Some(process::FirecrackerProcessIdentity {
-                pid,
+            sandbox_id: sandbox_id.to_string(),
+            base_dir: Some(base_dir.to_path_buf()),
+            generation: Some(process::ProcfsProcessGeneration {
                 pgid: pid,
                 starttime: u64::from(pid),
-                sandbox_id,
-                base_dir: Some(base_dir),
             }),
         }
     }
@@ -1987,17 +2002,17 @@ printf '%s\n' \
             fc_info(401, "sandbox-idle", Path::new("/data/r1")), // idle, OK
             fc_info(402, "sandbox-orphan", Path::new("/data/r1")), // orphan, warn
         ];
-        let expected_identity = fc[2].identity.clone();
+        let expected_generation = fc[2].generation;
         let (jobs, warnings) = correlate_jobs(&status, Path::new("/data/r1"), &fc);
         assert_eq!(jobs.len(), 2, "one active job + one orphan surface");
         assert_eq!(warnings.len(), 1);
         let msg = warnings[0].to_string();
         assert!(msg.contains("sandbox-orphan"), "{msg}");
         assert!(msg.contains("not in status.json"), "{msg}");
-        let Warning::FirecrackerNotInStatus { identity, .. } = &warnings[0] else {
+        let Warning::FirecrackerNotInStatus { generation, .. } = &warnings[0] else {
             panic!("orphan Firecracker must produce FirecrackerNotInStatus");
         };
-        assert_eq!(identity, &expected_identity);
+        assert_eq!(generation, &expected_generation);
 
         // The orphan row must carry the sandbox_id in `NotInStatus`, not
         // misfiled into a `run_id` variant. Type-checking this here locks
@@ -2021,7 +2036,7 @@ printf '%s\n' \
             ppid: None,
             sandbox_id: "sbox-abc".into(),
             base_dir: Some(PathBuf::from("/data/r2")),
-            identity: None,
+            generation: None,
         }];
         let (jobs, warnings) = correlate_jobs(&status, Path::new("/data/r1"), &fc);
         assert_eq!(jobs.len(), 1);
@@ -2465,7 +2480,7 @@ printf '%s\n' \
             pid: 101,
             sandbox_id: "S1".into(),
             base_dir: base_dir.clone(),
-            identity: fresh.firecrackers[0].identity.clone(),
+            generation: fresh.firecrackers[0].generation,
         };
         assert!(
             !warning.persists(None, &fresh, &[], None).await,
@@ -2500,7 +2515,7 @@ printf '%s\n' \
             pid: 101,
             sandbox_id: "S1".into(),
             base_dir: base_dir.clone(),
-            identity: fresh.firecrackers[0].identity.clone(),
+            generation: fresh.firecrackers[0].generation,
         };
         assert!(!warning.persists(None, &fresh, &[], None).await);
     }
@@ -2525,7 +2540,7 @@ printf '%s\n' \
             pid: 101,
             sandbox_id: "S-ghost".into(),
             base_dir: base_dir.clone(),
-            identity: fresh.firecrackers[0].identity.clone(),
+            generation: fresh.firecrackers[0].generation,
         };
         assert!(warning.persists(None, &fresh, &[], None).await);
     }
@@ -2539,7 +2554,7 @@ printf '%s\n' \
             pid: firecracker.pid,
             sandbox_id: "S-anything".into(),
             base_dir,
-            identity: firecracker.identity,
+            generation: firecracker.generation,
         };
         assert!(!warning.persists(None, &empty_fresh(), &[], None).await);
     }
@@ -2553,16 +2568,47 @@ printf '%s\n' \
             pid: original.pid,
             sandbox_id: original.sandbox_id.clone(),
             base_dir: base_dir.clone(),
-            identity: original.identity,
+            generation: original.generation,
         };
         let mut replacement = fc_info(101, "S-ghost", &base_dir);
-        replacement.identity.as_mut().unwrap().starttime += 1;
+        replacement.generation.as_mut().unwrap().starttime += 1;
         let fresh = process::DiscoveredProcesses {
             firecrackers: vec![replacement],
             mitmdumps: vec![],
             dnsmasqs: vec![],
         };
 
+        assert!(!warning.persists(None, &fresh, &[], None).await);
+    }
+
+    #[tokio::test]
+    async fn firecracker_not_in_status_clears_when_workspace_facts_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_dir = dir.path().to_path_buf();
+        let original = fc_info(101, "S-ghost", &base_dir);
+        let warning = Warning::FirecrackerNotInStatus {
+            pid: original.pid,
+            sandbox_id: original.sandbox_id.clone(),
+            base_dir: base_dir.clone(),
+            generation: original.generation,
+        };
+
+        let mut changed_sandbox = original.clone();
+        changed_sandbox.sandbox_id = "S-replacement".into();
+        let fresh = process::DiscoveredProcesses {
+            firecrackers: vec![changed_sandbox],
+            mitmdumps: vec![],
+            dnsmasqs: vec![],
+        };
+        assert!(!warning.persists(None, &fresh, &[], None).await);
+
+        let mut changed_base_dir = original;
+        changed_base_dir.base_dir = Some(base_dir.join("replacement"));
+        let fresh = process::DiscoveredProcesses {
+            firecrackers: vec![changed_base_dir],
+            mitmdumps: vec![],
+            dnsmasqs: vec![],
+        };
         assert!(!warning.persists(None, &fresh, &[], None).await);
     }
 
@@ -2721,7 +2767,7 @@ printf '%s\n' \
     async fn orphan_firecracker_recheck_requires_same_identified_observation() {
         let child = sleeping_child();
         let firecracker = fc_info(child.0.id(), "sandbox-orphan", Path::new("/data/r1"));
-        let expected_identity = firecracker.identity.clone();
+        let expected_generation = firecracker.generation;
         let fresh = process::DiscoveredProcesses {
             firecrackers: vec![firecracker.clone()],
             mitmdumps: vec![],
@@ -2730,10 +2776,10 @@ printf '%s\n' \
         let warnings = detect_orphan_firecrackers(&[firecracker], &[], None).await;
         assert_eq!(warnings.len(), 1);
         let warning = &warnings[0];
-        let Warning::OrphanFirecracker { identity, .. } = warning else {
+        let Warning::OrphanFirecracker { generation, .. } = warning else {
             panic!("orphan Firecracker must produce OrphanFirecracker");
         };
-        assert_eq!(identity, &expected_identity);
+        assert_eq!(generation, &expected_generation);
         assert!(warning.persists(None, &fresh, &[], None).await);
         assert!(
             !warning
@@ -2742,7 +2788,7 @@ printf '%s\n' \
         );
 
         let mut replacement = fresh.firecrackers[0].clone();
-        replacement.identity.as_mut().unwrap().pgid += 1;
+        replacement.generation.as_mut().unwrap().pgid += 1;
         let replacement_fresh = process::DiscoveredProcesses {
             firecrackers: vec![replacement],
             mitmdumps: vec![],
@@ -2762,7 +2808,7 @@ printf '%s\n' \
             ppid: Some(std::process::id()),
             sandbox_id: sandbox_id.clone(),
             base_dir: None,
-            identity: None,
+            generation: None,
         };
         let fresh = process::DiscoveredProcesses {
             firecrackers: vec![firecracker.clone()],
@@ -2779,12 +2825,9 @@ printf '%s\n' \
             ppid: Some(std::process::id()),
             sandbox_id: sandbox_id.clone(),
             base_dir: None,
-            identity: Some(process::FirecrackerProcessIdentity {
-                pid,
+            generation: Some(process::ProcfsProcessGeneration {
                 pgid: pid,
                 starttime: u64::from(pid),
-                sandbox_id,
-                base_dir: None,
             }),
         };
         let replacement_fresh = process::DiscoveredProcesses {
@@ -2898,7 +2941,7 @@ printf '%s\n' \
             pid: 17,
             sandbox_id: "sbox-gone".into(),
             base_dir: PathBuf::from("/data/r1"),
-            identity: None,
+            generation: None,
         };
         assert_eq!(
             w.to_string(),
@@ -2914,8 +2957,9 @@ printf '%s\n' \
         let w = Warning::OrphanFirecracker {
             pid: 42,
             sandbox_id: "xyz".into(),
+            base_dir: None,
             ppid: Some(10),
-            identity: None,
+            generation: None,
         };
         assert_eq!(
             w.to_string(),
@@ -2925,8 +2969,9 @@ printf '%s\n' \
         let w = Warning::OrphanFirecracker {
             pid: 42,
             sandbox_id: "xyz".into(),
+            base_dir: None,
             ppid: None,
-            identity: None,
+            generation: None,
         };
         assert_eq!(
             w.to_string(),

--- a/crates/runner/src/cmd/gc/workspaces/tests.rs
+++ b/crates/runner/src/cmd/gc/workspaces/tests.rs
@@ -43,7 +43,7 @@ fn firecracker_with_base_dir(
         ppid: Some(1),
         sandbox_id: sandbox_id.to_string(),
         base_dir: Some(base_dir.to_path_buf()),
-        identity: None,
+        generation: None,
     }
 }
 
@@ -53,7 +53,7 @@ fn incomplete_firecracker(pid: u32) -> crate::process::FirecrackerProcessInfo {
         ppid: Some(1),
         sandbox_id: format!("pid-{pid}"),
         base_dir: None,
-        identity: None,
+        generation: None,
     }
 }
 

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -503,7 +503,6 @@ mod tests {
     fn make_target_at_base(pid: u32, sandbox_id: &str, base_dir: &Path) -> KillTarget {
         let mut target = make_target(pid, sandbox_id);
         target.base_dir = Some(base_dir.to_path_buf());
-        target.identity.as_mut().unwrap().base_dir = Some(base_dir.to_path_buf());
         target
     }
 

--- a/crates/runner/src/cmd/kill/orphan.rs
+++ b/crates/runner/src/cmd/kill/orphan.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 use tracing::info;
 
 use crate::process::{
-    self, DiscoveredProcesses, FirecrackerProcessIdentity, ProcessDiscovery, ProcessStat,
-    ProcessStatRead,
+    self, DiscoveredProcesses, ProcessDiscovery, ProcessStat, ProcessStatRead,
+    ProcfsProcessGeneration,
 };
 
 use super::target::KillTarget;
@@ -37,8 +37,8 @@ where
     Discover: FnOnce() -> DiscoverFuture,
     DiscoverFuture: std::future::Future<Output = ProcessDiscovery>,
 {
-    let identity = match validate_orphan_target(target).await {
-        OrphanTargetValidation::Valid { identity } => identity,
+    let generation = match validate_orphan_target(target).await {
+        OrphanTargetValidation::Valid { generation } => generation,
         OrphanTargetValidation::AlreadyGone => {
             return already_gone_orphan_outcome_with_discovery(target, discover).await;
         }
@@ -47,14 +47,16 @@ where
         }
     };
 
-    match signal_process_group(target.pid, identity.pgid) {
-        ProcessGroupSignalResult::Signaled => match wait_for_orphan_exit(&identity).await {
-            Ok(()) => Outcome::Killed(target.clone()),
-            Err(failure) => Outcome::TerminationUnconfirmed {
-                target: target.clone(),
-                failure,
-            },
-        },
+    match signal_process_group(target.pid, generation.pgid) {
+        ProcessGroupSignalResult::Signaled => {
+            match wait_for_orphan_exit(target.pid, &generation).await {
+                Ok(()) => Outcome::Killed(target.clone()),
+                Err(failure) => Outcome::TerminationUnconfirmed {
+                    target: target.clone(),
+                    failure,
+                },
+            }
+        }
         ProcessGroupSignalResult::AlreadyGone => {
             already_gone_orphan_outcome_with_discovery(target, discover).await
         }
@@ -123,12 +125,7 @@ fn should_cleanup_disappeared_initial_orphan(
 }
 
 fn target_has_workspace_identity(target: &KillTarget) -> bool {
-    match (&target.base_dir, &target.identity) {
-        (Some(base_dir), Some(identity)) => {
-            identity.sandbox_id == target.sandbox_id && identity.base_dir.as_ref() == Some(base_dir)
-        }
-        _ => false,
-    }
+    target.base_dir.is_some() && target.generation.is_some()
 }
 
 fn discovered_has_same_or_unidentified_firecracker(
@@ -141,15 +138,13 @@ fn discovered_has_same_or_unidentified_firecracker(
 }
 
 enum OrphanTargetValidation {
-    Valid {
-        identity: FirecrackerProcessIdentity,
-    },
+    Valid { generation: ProcfsProcessGeneration },
     AlreadyGone,
     Changed,
 }
 
 async fn validate_orphan_target(target: &KillTarget) -> OrphanTargetValidation {
-    let Some(identity) = &target.identity else {
+    let Some(generation) = &target.generation else {
         tracing::warn!(
             pid = target.pid,
             sandbox_id = %target.sandbox_id,
@@ -157,15 +152,6 @@ async fn validate_orphan_target(target: &KillTarget) -> OrphanTargetValidation {
         );
         return OrphanTargetValidation::Changed;
     };
-
-    if identity.pid != target.pid {
-        tracing::warn!(
-            pid = target.pid,
-            identity_pid = identity.pid,
-            "refusing orphan kill with inconsistent process identity"
-        );
-        return OrphanTargetValidation::Changed;
-    }
 
     let stat = match process::read_process_stat_checked(target.pid).await {
         ProcessStatRead::Found(stat) => stat,
@@ -192,12 +178,12 @@ async fn validate_orphan_target(target: &KillTarget) -> OrphanTargetValidation {
             return OrphanTargetValidation::Changed;
         }
     };
-    if identity.procfs_generation() != stat.procfs_generation() {
+    if generation != &stat.procfs_generation() {
         tracing::warn!(
             pid = target.pid,
-            expected_pgid = identity.pgid,
+            expected_pgid = generation.pgid,
             current_pgid = stat.pgid,
-            expected_starttime = identity.starttime,
+            expected_starttime = generation.starttime,
             current_starttime = stat.starttime,
             "refusing orphan kill after process identity changed"
         );
@@ -217,7 +203,7 @@ async fn validate_orphan_target(target: &KillTarget) -> OrphanTargetValidation {
             pid = target.pid,
             "failed to read cmdline before orphan kill"
         );
-        return classify_orphan_validation_after_unreadable_pid_fact(target.pid, identity).await;
+        return classify_orphan_validation_after_unreadable_pid_fact(target.pid, generation).await;
     };
     if !process::is_firecracker_cmdline(&cmdline) {
         tracing::warn!(
@@ -230,13 +216,13 @@ async fn validate_orphan_target(target: &KillTarget) -> OrphanTargetValidation {
     let cwd_info = process::read_cwd(target.pid)
         .await
         .and_then(|cwd| process::parse_workspace_cwd(&cwd));
-    if !orphan_identity_matches_facts(identity, &stat, true, cwd_info.as_ref()) {
+    if !orphan_target_matches_facts(target, generation, &stat, true, cwd_info.as_ref()) {
         tracing::warn!(
             pid = target.pid,
             sandbox_id = %target.sandbox_id,
             "refusing orphan kill after workspace identity changed"
         );
-        return classify_orphan_validation_after_unreadable_pid_fact(target.pid, identity).await;
+        return classify_orphan_validation_after_unreadable_pid_fact(target.pid, generation).await;
     }
 
     let final_stat = match process::read_process_stat_checked(target.pid).await {
@@ -264,12 +250,12 @@ async fn validate_orphan_target(target: &KillTarget) -> OrphanTargetValidation {
             return OrphanTargetValidation::Changed;
         }
     };
-    if identity.procfs_generation() != final_stat.procfs_generation() {
+    if generation != &final_stat.procfs_generation() {
         tracing::warn!(
             pid = target.pid,
-            expected_pgid = identity.pgid,
+            expected_pgid = generation.pgid,
             current_pgid = final_stat.pgid,
-            expected_starttime = identity.starttime,
+            expected_starttime = generation.starttime,
             current_starttime = final_stat.starttime,
             "refusing orphan kill after process identity changed during validation"
         );
@@ -285,24 +271,21 @@ async fn validate_orphan_target(target: &KillTarget) -> OrphanTargetValidation {
     }
 
     OrphanTargetValidation::Valid {
-        identity: identity.clone(),
+        generation: *generation,
     }
 }
 
 async fn classify_orphan_validation_after_unreadable_pid_fact(
     pid: u32,
-    identity: &FirecrackerProcessIdentity,
+    generation: &ProcfsProcessGeneration,
 ) -> OrphanTargetValidation {
     match process::read_process_stat_checked(pid).await {
         ProcessStatRead::Found(stat)
-            if identity.procfs_generation() == stat.procfs_generation()
-                && !process::process_stat_is_live(&stat) =>
+            if generation == &stat.procfs_generation() && !process::process_stat_is_live(&stat) =>
         {
             OrphanTargetValidation::AlreadyGone
         }
-        ProcessStatRead::Found(stat)
-            if identity.procfs_generation() == stat.procfs_generation() =>
-        {
+        ProcessStatRead::Found(stat) if generation == &stat.procfs_generation() => {
             OrphanTargetValidation::Changed
         }
         ProcessStatRead::Found(_) => OrphanTargetValidation::Changed,
@@ -314,12 +297,12 @@ async fn classify_orphan_validation_after_unreadable_pid_fact(
 }
 
 async fn initial_process_confirmed_terminated(target: &KillTarget) -> bool {
-    let Some(identity) = &target.identity else {
+    let Some(generation) = &target.generation else {
         return false;
     };
     matches!(
         classify_orphan_exit_observation(
-            identity,
+            generation,
             process::read_process_stat_checked(target.pid).await,
         ),
         OrphanExitObservation::Terminated
@@ -374,17 +357,15 @@ impl std::fmt::Display for OrphanExitFailure {
 }
 
 fn classify_orphan_exit_observation(
-    identity: &FirecrackerProcessIdentity,
+    generation: &ProcfsProcessGeneration,
     read: ProcessStatRead,
 ) -> OrphanExitObservation {
     match read {
-        ProcessStatRead::Found(stat)
-            if identity.procfs_generation() != stat.procfs_generation() =>
-        {
+        ProcessStatRead::Found(stat) if generation != &stat.procfs_generation() => {
             OrphanExitObservation::IdentityChanged {
-                expected_pgid: identity.pgid,
+                expected_pgid: generation.pgid,
                 observed_pgid: stat.pgid,
-                expected_starttime: identity.starttime,
+                expected_starttime: generation.starttime,
                 observed_starttime: stat.starttime,
             }
         }
@@ -402,10 +383,12 @@ fn classify_orphan_exit_observation(
 }
 
 async fn wait_for_orphan_exit(
-    identity: &FirecrackerProcessIdentity,
+    pid: u32,
+    generation: &ProcfsProcessGeneration,
 ) -> Result<(), OrphanExitFailure> {
     wait_for_orphan_exit_with(
-        identity,
+        pid,
+        generation,
         ORPHAN_EXIT_TIMEOUT,
         ORPHAN_EXIT_POLL_INTERVAL,
         process::read_process_stat_checked,
@@ -414,7 +397,8 @@ async fn wait_for_orphan_exit(
 }
 
 async fn wait_for_orphan_exit_with<ReadStat, ReadStatFuture>(
-    identity: &FirecrackerProcessIdentity,
+    pid: u32,
+    generation: &ProcfsProcessGeneration,
     timeout: Duration,
     poll_interval: Duration,
     mut read_stat: ReadStat,
@@ -425,27 +409,24 @@ where
 {
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
-        let failure =
-            match classify_orphan_exit_observation(identity, read_stat(identity.pid).await) {
-                OrphanExitObservation::Terminated => return Ok(()),
-                OrphanExitObservation::IdentityChanged {
+        let failure = match classify_orphan_exit_observation(generation, read_stat(pid).await) {
+            OrphanExitObservation::Terminated => return Ok(()),
+            OrphanExitObservation::IdentityChanged {
+                expected_pgid,
+                observed_pgid,
+                expected_starttime,
+                observed_starttime,
+            } => {
+                return Err(OrphanExitFailure::IdentityChanged {
                     expected_pgid,
                     observed_pgid,
                     expected_starttime,
                     observed_starttime,
-                } => {
-                    return Err(OrphanExitFailure::IdentityChanged {
-                        expected_pgid,
-                        observed_pgid,
-                        expected_starttime,
-                        observed_starttime,
-                    });
-                }
-                OrphanExitObservation::Live => OrphanExitFailure::TimedOut,
-                OrphanExitObservation::Unverifiable(error) => {
-                    OrphanExitFailure::Unverifiable(error)
-                }
-            };
+                });
+            }
+            OrphanExitObservation::Live => OrphanExitFailure::TimedOut,
+            OrphanExitObservation::Unverifiable(error) => OrphanExitFailure::Unverifiable(error),
+        };
 
         let now = tokio::time::Instant::now();
         if now >= deadline {
@@ -455,24 +436,22 @@ where
     }
 }
 
-fn orphan_identity_matches_facts(
-    identity: &FirecrackerProcessIdentity,
+fn orphan_target_matches_facts(
+    target: &KillTarget,
+    generation: &ProcfsProcessGeneration,
     stat: &ProcessStat,
     is_firecracker_cmdline: bool,
     cwd_info: Option<&(String, PathBuf)>,
 ) -> bool {
-    identity.procfs_generation() == stat.procfs_generation()
+    generation == &stat.procfs_generation()
         && is_firecracker_cmdline
-        && workspace_identity_matches(identity, cwd_info)
+        && workspace_identity_matches(target, cwd_info)
 }
 
-fn workspace_identity_matches(
-    identity: &FirecrackerProcessIdentity,
-    cwd_info: Option<&(String, PathBuf)>,
-) -> bool {
-    match (&identity.base_dir, cwd_info) {
+fn workspace_identity_matches(target: &KillTarget, cwd_info: Option<&(String, PathBuf)>) -> bool {
+    match (&target.base_dir, cwd_info) {
         (Some(expected_base_dir), Some((sandbox_id, base_dir))) => {
-            sandbox_id == &identity.sandbox_id && base_dir == expected_base_dir
+            sandbox_id == &target.sandbox_id && base_dir == expected_base_dir
         }
         _ => false,
     }
@@ -540,16 +519,16 @@ mod tests {
     const ORPHAN_KILL_CHILD_ENV: &str = "OKOU_RUNNER_ORPHAN_KILL_TEST_CHILD";
     const ORPHAN_KILL_READY_LINE: &str = "vm0 orphan kill test ready";
 
-    fn process_stat(identity: &FirecrackerProcessIdentity) -> ProcessStat {
-        process_stat_with_state(identity, 'S')
+    fn process_stat(generation: &ProcfsProcessGeneration) -> ProcessStat {
+        process_stat_with_state(generation, 'S')
     }
 
-    fn process_stat_with_state(identity: &FirecrackerProcessIdentity, state: char) -> ProcessStat {
+    fn process_stat_with_state(generation: &ProcfsProcessGeneration, state: char) -> ProcessStat {
         ProcessStat {
             state,
             ppid: 7,
-            pgid: identity.pgid,
-            starttime: identity.starttime,
+            pgid: generation.pgid,
+            starttime: generation.starttime,
         }
     }
 
@@ -571,12 +550,9 @@ mod tests {
             run_id: None,
             sandbox_id: "sbox-missing".into(),
             base_dir: Some(PathBuf::from("/data/r1")),
-            identity: Some(FirecrackerProcessIdentity {
-                pid: u32::MAX,
+            generation: Some(ProcfsProcessGeneration {
                 pgid: 1234,
                 starttime: 123456,
-                sandbox_id: "sbox-missing".into(),
-                base_dir: Some(PathBuf::from("/data/r1")),
             }),
         }
     }
@@ -623,7 +599,7 @@ mod tests {
     #[test]
     fn disappeared_initial_without_workspace_identity_rejects_cleanup() {
         let mut initial = make_target(200, "sbox-123");
-        initial.identity.as_mut().unwrap().base_dir = None;
+        initial.base_dir = None;
         let discovered = discovered_with_firecrackers(vec![]);
 
         assert!(!should_cleanup_disappeared_initial_orphan(
@@ -655,7 +631,7 @@ mod tests {
             ppid: None,
             sandbox_id: "pid-201".into(),
             base_dir: None,
-            identity: None,
+            generation: None,
         }]);
 
         assert!(!should_cleanup_disappeared_initial_orphan(
@@ -667,14 +643,15 @@ mod tests {
     }
 
     #[test]
-    fn orphan_identity_facts_match() {
+    fn orphan_target_facts_match() {
         let target = make_target(200, "sbox-123");
-        let identity = target.identity.as_ref().unwrap();
-        let stat = process_stat(identity);
+        let generation = target.generation.as_ref().unwrap();
+        let stat = process_stat(generation);
         let cwd_info = ("sbox-123".to_string(), PathBuf::from("/data/r1"));
 
-        assert!(orphan_identity_matches_facts(
-            identity,
+        assert!(orphan_target_matches_facts(
+            &target,
+            generation,
             &stat,
             true,
             Some(&cwd_info)
@@ -682,19 +659,20 @@ mod tests {
     }
 
     #[test]
-    fn orphan_identity_rejects_changed_starttime() {
+    fn orphan_target_rejects_changed_starttime() {
         let target = make_target(200, "sbox-123");
-        let identity = target.identity.as_ref().unwrap();
+        let generation = target.generation.as_ref().unwrap();
         let stat = ProcessStat {
             state: 'S',
             ppid: 7,
-            pgid: identity.pgid,
-            starttime: identity.starttime + 1,
+            pgid: generation.pgid,
+            starttime: generation.starttime + 1,
         };
         let cwd_info = ("sbox-123".to_string(), PathBuf::from("/data/r1"));
 
-        assert!(!orphan_identity_matches_facts(
-            identity,
+        assert!(!orphan_target_matches_facts(
+            &target,
+            generation,
             &stat,
             true,
             Some(&cwd_info)
@@ -702,19 +680,20 @@ mod tests {
     }
 
     #[test]
-    fn orphan_identity_rejects_changed_pgid() {
+    fn orphan_target_rejects_changed_pgid() {
         let target = make_target(200, "sbox-123");
-        let identity = target.identity.as_ref().unwrap();
+        let generation = target.generation.as_ref().unwrap();
         let stat = ProcessStat {
             state: 'S',
             ppid: 7,
-            pgid: identity.pgid + 1,
-            starttime: identity.starttime,
+            pgid: generation.pgid + 1,
+            starttime: generation.starttime,
         };
         let cwd_info = ("sbox-123".to_string(), PathBuf::from("/data/r1"));
 
-        assert!(!orphan_identity_matches_facts(
-            identity,
+        assert!(!orphan_target_matches_facts(
+            &target,
+            generation,
             &stat,
             true,
             Some(&cwd_info)
@@ -722,53 +701,45 @@ mod tests {
     }
 
     #[test]
-    fn firecracker_identity_projects_to_procfs_generation() {
+    fn target_generation_matches_process_stat_generation() {
         let target = make_target(200, "sbox-123");
-        let identity = target.identity.as_ref().unwrap();
-        let matching = process_stat(identity);
+        let generation = target.generation.as_ref().unwrap();
+        let matching = process_stat(generation);
         let changed_starttime = ProcessStat {
             state: 'S',
             ppid: 7,
-            pgid: identity.pgid,
-            starttime: identity.starttime + 1,
+            pgid: generation.pgid,
+            starttime: generation.starttime + 1,
         };
         let changed_pgid = ProcessStat {
             state: 'S',
             ppid: 7,
-            pgid: identity.pgid + 1,
-            starttime: identity.starttime,
+            pgid: generation.pgid + 1,
+            starttime: generation.starttime,
         };
         let changed_ppid = ProcessStat {
             state: 'S',
             ppid: 9,
-            pgid: identity.pgid,
-            starttime: identity.starttime,
+            pgid: generation.pgid,
+            starttime: generation.starttime,
         };
 
-        assert_eq!(identity.procfs_generation(), matching.procfs_generation());
-        assert_eq!(
-            identity.procfs_generation(),
-            changed_ppid.procfs_generation()
-        );
-        assert_ne!(
-            identity.procfs_generation(),
-            changed_starttime.procfs_generation()
-        );
-        assert_ne!(
-            identity.procfs_generation(),
-            changed_pgid.procfs_generation()
-        );
+        assert_eq!(*generation, matching.procfs_generation());
+        assert_eq!(*generation, changed_ppid.procfs_generation());
+        assert_ne!(*generation, changed_starttime.procfs_generation());
+        assert_ne!(*generation, changed_pgid.procfs_generation());
     }
 
     #[test]
-    fn orphan_identity_rejects_non_firecracker_cmdline() {
+    fn orphan_target_rejects_non_firecracker_cmdline() {
         let target = make_target(200, "sbox-123");
-        let identity = target.identity.as_ref().unwrap();
-        let stat = process_stat(identity);
+        let generation = target.generation.as_ref().unwrap();
+        let stat = process_stat(generation);
         let cwd_info = ("sbox-123".to_string(), PathBuf::from("/data/r1"));
 
-        assert!(!orphan_identity_matches_facts(
-            identity,
+        assert!(!orphan_target_matches_facts(
+            &target,
+            generation,
             &stat,
             false,
             Some(&cwd_info)
@@ -776,14 +747,15 @@ mod tests {
     }
 
     #[test]
-    fn orphan_identity_rejects_changed_workspace() {
+    fn orphan_target_rejects_changed_workspace() {
         let target = make_target(200, "sbox-123");
-        let identity = target.identity.as_ref().unwrap();
-        let stat = process_stat(identity);
+        let generation = target.generation.as_ref().unwrap();
+        let stat = process_stat(generation);
         let cwd_info = ("sbox-other".to_string(), PathBuf::from("/data/r1"));
 
-        assert!(!orphan_identity_matches_facts(
-            identity,
+        assert!(!orphan_target_matches_facts(
+            &target,
+            generation,
             &stat,
             true,
             Some(&cwd_info)
@@ -791,69 +763,70 @@ mod tests {
     }
 
     #[test]
-    fn orphan_identity_rejects_missing_workspace_identity() {
+    fn orphan_target_rejects_missing_workspace_identity() {
         let mut target = make_target(200, "sbox-123");
         target.base_dir = None;
-        target.identity.as_mut().unwrap().base_dir = None;
-        let identity = target.identity.as_ref().unwrap();
-        let stat = process_stat(identity);
+        let generation = target.generation.as_ref().unwrap();
+        let stat = process_stat(generation);
 
-        assert!(!orphan_identity_matches_facts(identity, &stat, true, None));
+        assert!(!orphan_target_matches_facts(
+            &target, generation, &stat, true, None
+        ));
     }
 
     #[test]
     fn zombie_process_stat_is_already_exited() {
         let target = make_target(200, "sbox-123");
-        let identity = target.identity.as_ref().unwrap();
+        let generation = target.generation.as_ref().unwrap();
         let zombie = ProcessStat {
             state: 'Z',
             ppid: 7,
-            pgid: identity.pgid,
-            starttime: identity.starttime,
+            pgid: generation.pgid,
+            starttime: generation.starttime,
         };
 
-        assert_eq!(identity.procfs_generation(), zombie.procfs_generation());
+        assert_eq!(*generation, zombie.procfs_generation());
         assert!(!process::process_stat_is_live(&zombie));
     }
 
     #[test]
     fn dead_process_stat_is_already_exited() {
         let target = make_target(200, "sbox-123");
-        let identity = target.identity.as_ref().unwrap();
+        let generation = target.generation.as_ref().unwrap();
         let dead = ProcessStat {
             state: 'X',
             ppid: 7,
-            pgid: identity.pgid,
-            starttime: identity.starttime,
+            pgid: generation.pgid,
+            starttime: generation.starttime,
         };
 
-        assert_eq!(identity.procfs_generation(), dead.procfs_generation());
+        assert_eq!(*generation, dead.procfs_generation());
         assert!(!process::process_stat_is_live(&dead));
     }
 
     #[test]
     fn orphan_exit_observation_distinguishes_live_and_terminal_states() {
         let target = make_target(200, "sbox-123");
-        let identity = target.identity.as_ref().unwrap();
+        let generation = target.generation.as_ref().unwrap();
 
         assert_eq!(
             classify_orphan_exit_observation(
-                identity,
-                ProcessStatRead::Found(process_stat(identity)),
+                generation,
+                ProcessStatRead::Found(process_stat(generation)),
             ),
             OrphanExitObservation::Live
         );
         for state in ['Z', 'X', 'x'] {
             assert_eq!(
                 classify_orphan_exit_observation(
-                    identity,
-                    ProcessStatRead::Found(process_stat_with_state(identity, state)),
+                    generation,
+                    ProcessStatRead::Found(process_stat_with_state(generation, state)),
                 ),
                 OrphanExitObservation::Terminated
             );
         }
         assert_eq!(
-            classify_orphan_exit_observation(identity, ProcessStatRead::Missing),
+            classify_orphan_exit_observation(generation, ProcessStatRead::Missing),
             OrphanExitObservation::Terminated
         );
     }
@@ -861,20 +834,20 @@ mod tests {
     #[test]
     fn orphan_exit_observation_rejects_identity_changes() {
         let target = make_target(200, "sbox-123");
-        let identity = target.identity.as_ref().unwrap();
+        let generation = target.generation.as_ref().unwrap();
         let changed = ProcessStat {
-            pgid: identity.pgid + 1,
-            starttime: identity.starttime + 1,
-            ..process_stat(identity)
+            pgid: generation.pgid + 1,
+            starttime: generation.starttime + 1,
+            ..process_stat(generation)
         };
 
         assert_eq!(
-            classify_orphan_exit_observation(identity, ProcessStatRead::Found(changed)),
+            classify_orphan_exit_observation(generation, ProcessStatRead::Found(changed)),
             OrphanExitObservation::IdentityChanged {
-                expected_pgid: identity.pgid,
-                observed_pgid: identity.pgid + 1,
-                expected_starttime: identity.starttime,
-                observed_starttime: identity.starttime + 1,
+                expected_pgid: generation.pgid,
+                observed_pgid: generation.pgid + 1,
+                expected_starttime: generation.starttime,
+                observed_starttime: generation.starttime + 1,
             }
         );
     }
@@ -882,11 +855,11 @@ mod tests {
     #[test]
     fn orphan_exit_observation_rejects_unverifiable_reads() {
         let target = make_target(200, "sbox-123");
-        let identity = target.identity.as_ref().unwrap();
+        let generation = target.generation.as_ref().unwrap();
 
         assert!(matches!(
             classify_orphan_exit_observation(
-                identity,
+                generation,
                 ProcessStatRead::Unreadable(std::io::Error::from(
                     std::io::ErrorKind::PermissionDenied,
                 )),
@@ -894,7 +867,7 @@ mod tests {
             OrphanExitObservation::Unverifiable(_)
         ));
         assert_eq!(
-            classify_orphan_exit_observation(identity, ProcessStatRead::Invalid),
+            classify_orphan_exit_observation(generation, ProcessStatRead::Invalid),
             OrphanExitObservation::Unverifiable("process stat is invalid".into())
         );
     }
@@ -902,14 +875,15 @@ mod tests {
     #[tokio::test]
     async fn orphan_exit_wait_observes_delayed_termination() {
         let target = make_target(200, "sbox-123");
-        let identity = target.identity.as_ref().unwrap();
+        let generation = target.generation.as_ref().unwrap();
         let mut reads = VecDeque::from([
-            ProcessStatRead::Found(process_stat(identity)),
-            ProcessStatRead::Found(process_stat_with_state(identity, 'Z')),
+            ProcessStatRead::Found(process_stat(generation)),
+            ProcessStatRead::Found(process_stat_with_state(generation, 'Z')),
         ]);
 
         let result = wait_for_orphan_exit_with(
-            identity,
+            target.pid,
+            generation,
             Duration::from_secs(1),
             Duration::ZERO,
             move |_| std::future::ready(reads.pop_front().unwrap()),
@@ -922,11 +896,15 @@ mod tests {
     #[tokio::test]
     async fn orphan_exit_wait_times_out_while_identity_is_live() {
         let target = make_target(200, "sbox-123");
-        let identity = target.identity.as_ref().unwrap();
+        let generation = target.generation.as_ref().unwrap();
 
-        let result = wait_for_orphan_exit_with(identity, Duration::ZERO, Duration::ZERO, |_| {
-            std::future::ready(ProcessStatRead::Found(process_stat(identity)))
-        })
+        let result = wait_for_orphan_exit_with(
+            target.pid,
+            generation,
+            Duration::ZERO,
+            Duration::ZERO,
+            |_| std::future::ready(ProcessStatRead::Found(process_stat(generation))),
+        )
         .await;
 
         assert_eq!(result, Err(OrphanExitFailure::TimedOut));
@@ -935,18 +913,21 @@ mod tests {
     #[tokio::test]
     async fn orphan_exit_wait_fails_when_identity_changes() {
         let target = make_target(200, "sbox-123");
-        let identity = target.identity.as_ref().unwrap();
+        let generation = target.generation.as_ref().unwrap();
         let changed = ProcessStat {
-            pgid: identity.pgid + 1,
-            starttime: identity.starttime + 1,
-            ..process_stat(identity)
+            pgid: generation.pgid + 1,
+            starttime: generation.starttime + 1,
+            ..process_stat(generation)
         };
 
-        let result =
-            wait_for_orphan_exit_with(identity, Duration::from_secs(1), Duration::ZERO, |_| {
-                std::future::ready(ProcessStatRead::Found(changed.clone()))
-            })
-            .await;
+        let result = wait_for_orphan_exit_with(
+            target.pid,
+            generation,
+            Duration::from_secs(1),
+            Duration::ZERO,
+            |_| std::future::ready(ProcessStatRead::Found(changed.clone())),
+        )
+        .await;
 
         let Err(failure) = result else {
             panic!("changed process identity should fail the exit wait");
@@ -954,10 +935,10 @@ mod tests {
         assert_eq!(
             failure,
             OrphanExitFailure::IdentityChanged {
-                expected_pgid: identity.pgid,
-                observed_pgid: identity.pgid + 1,
-                expected_starttime: identity.starttime,
-                observed_starttime: identity.starttime + 1,
+                expected_pgid: generation.pgid,
+                observed_pgid: generation.pgid + 1,
+                expected_starttime: generation.starttime,
+                observed_starttime: generation.starttime + 1,
             }
         );
         assert_eq!(
@@ -970,11 +951,12 @@ mod tests {
     #[tokio::test]
     async fn orphan_exit_wait_recovers_from_transient_unverifiable_read() {
         let target = make_target(200, "sbox-123");
-        let identity = target.identity.as_ref().unwrap();
+        let generation = target.generation.as_ref().unwrap();
         let mut reads = VecDeque::from([ProcessStatRead::Invalid, ProcessStatRead::Missing]);
 
         let result = wait_for_orphan_exit_with(
-            identity,
+            target.pid,
+            generation,
             Duration::from_secs(1),
             Duration::ZERO,
             move |_| std::future::ready(reads.pop_front().unwrap()),
@@ -987,11 +969,15 @@ mod tests {
     #[tokio::test]
     async fn orphan_exit_wait_fails_when_observation_remains_unverifiable() {
         let target = make_target(200, "sbox-123");
-        let identity = target.identity.as_ref().unwrap();
+        let generation = target.generation.as_ref().unwrap();
 
-        let result = wait_for_orphan_exit_with(identity, Duration::ZERO, Duration::ZERO, |_| {
-            std::future::ready(ProcessStatRead::Invalid)
-        })
+        let result = wait_for_orphan_exit_with(
+            target.pid,
+            generation,
+            Duration::ZERO,
+            Duration::ZERO,
+            |_| std::future::ready(ProcessStatRead::Invalid),
+        )
         .await;
 
         let Err(failure) = result else {
@@ -1076,19 +1062,13 @@ mod tests {
         else {
             panic!("spawned group member stat should be readable");
         };
-        let leader_identity = FirecrackerProcessIdentity {
-            pid: leader_pid,
+        let leader_generation = ProcfsProcessGeneration {
             pgid: leader_stat.pgid,
             starttime: leader_stat.starttime,
-            sandbox_id: sandbox_id.into(),
-            base_dir: Some(base_dir.path().to_path_buf()),
         };
-        let member_identity = FirecrackerProcessIdentity {
-            pid: member_pid,
+        let member_generation = ProcfsProcessGeneration {
             pgid: member_stat.pgid,
             starttime: member_stat.starttime,
-            sandbox_id: sandbox_id.into(),
-            base_dir: Some(base_dir.path().to_path_buf()),
         };
         let target = KillTarget {
             pid: leader_pid,
@@ -1096,7 +1076,7 @@ mod tests {
             run_id: None,
             sandbox_id: sandbox_id.into(),
             base_dir: Some(base_dir.path().to_path_buf()),
-            identity: Some(leader_identity.clone()),
+            generation: Some(leader_generation),
         };
 
         let fixture_error = if leader_pid == member_pid {
@@ -1127,8 +1107,8 @@ mod tests {
         let observations = if fixture_error.is_none() {
             let outcome = terminate(&target).await;
             let (leader_exit, member_exit) = tokio::join!(
-                wait_for_orphan_exit(&leader_identity),
-                wait_for_orphan_exit(&member_identity),
+                wait_for_orphan_exit(leader_pid, &leader_generation),
+                wait_for_orphan_exit(member_pid, &member_generation),
             );
             Some((outcome, leader_exit, member_exit))
         } else {

--- a/crates/runner/src/cmd/kill/target.rs
+++ b/crates/runner/src/cmd/kill/target.rs
@@ -4,9 +4,7 @@ use sandbox::SandboxControlTarget;
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
-use crate::process::{
-    self, DiscoveredProcesses, FirecrackerProcessIdentity, FirecrackerProcessInfo,
-};
+use crate::process::{self, DiscoveredProcesses, FirecrackerProcessInfo, ProcfsProcessGeneration};
 use crate::run_resolution;
 
 use super::KillArgs;
@@ -42,7 +40,7 @@ pub(super) struct KillTarget {
     pub(super) run_id: Option<String>,
     pub(super) sandbox_id: String,
     pub(super) base_dir: Option<PathBuf>,
-    pub(super) identity: Option<FirecrackerProcessIdentity>,
+    pub(super) generation: Option<ProcfsProcessGeneration>,
 }
 
 impl From<&FirecrackerProcessInfo> for KillTarget {
@@ -53,7 +51,7 @@ impl From<&FirecrackerProcessInfo> for KillTarget {
             run_id: None,
             sandbox_id: process.sandbox_id.clone(),
             base_dir: process.base_dir.clone(),
-            identity: process.identity.clone(),
+            generation: process.generation,
         }
     }
 }
@@ -258,10 +256,13 @@ fn ensure_same_target_after_confirmation(
 }
 
 fn same_firecracker_identity(initial: &KillTarget, current: &KillTarget) -> bool {
-    match (&initial.identity, &current.identity) {
-        (Some(initial), Some(current)) => initial == current,
-        _ => false,
-    }
+    initial.pid == current.pid
+        && initial.sandbox_id == current.sandbox_id
+        && initial.base_dir == current.base_dir
+        && matches!(
+            (initial.generation, current.generation),
+            (Some(initial), Some(current)) if initial == current
+        )
 }
 
 /// Resolve a `--run` prefix to a single Firecracker process.
@@ -505,11 +506,35 @@ mod tests {
         };
         let initial = make_target(200, "sbox-123");
         let mut current = make_target(200, "sbox-123");
-        current.identity.as_mut().unwrap().starttime += 1;
+        current.generation.as_mut().unwrap().starttime += 1;
 
         let error = ensure_same_target_after_confirmation(&args, &initial, &current).unwrap_err();
 
         assert!(error.contains("changed identity"), "{error}");
+    }
+
+    #[test]
+    fn sandbox_reresolution_requires_same_canonical_process_facts() {
+        let args = KillArgs {
+            run: None,
+            sandbox: Some("sbox".into()),
+            force: true,
+        };
+        let initial = make_target(200, "sbox-123");
+
+        let mut changed_pid = initial.clone();
+        changed_pid.pid += 1;
+        assert!(
+            ensure_same_target_after_confirmation(&args, &initial, &changed_pid).is_err(),
+            "changed PID must not retain sandbox process identity"
+        );
+
+        let mut changed_base_dir = initial.clone();
+        changed_base_dir.base_dir = Some(PathBuf::from("/data/r2"));
+        assert!(
+            ensure_same_target_after_confirmation(&args, &initial, &changed_base_dir).is_err(),
+            "changed workspace base must not retain sandbox process identity"
+        );
     }
 
     #[test]
@@ -575,7 +600,7 @@ mod tests {
     fn same_sandbox_fallback_rejects_changed_process_identity() {
         let expected = make_target(200, "sbox-123");
         let mut changed = make_target(200, "sbox-123");
-        changed.identity.as_mut().unwrap().starttime += 1;
+        changed.generation.as_mut().unwrap().starttime += 1;
         let discovered = discovered_with_firecrackers(vec![make_fc_from_target(&changed)]);
 
         let error = resolve_same_sandbox_process(&expected, &discovered).unwrap_err();

--- a/crates/runner/src/cmd/kill/test_support.rs
+++ b/crates/runner/src/cmd/kill/test_support.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::process::{DiscoveredProcesses, FirecrackerProcessIdentity, FirecrackerProcessInfo};
+use crate::process::{DiscoveredProcesses, FirecrackerProcessInfo, ProcfsProcessGeneration};
 
 use super::target::KillTarget;
 
@@ -10,7 +10,7 @@ pub(super) fn make_fc(pid: u32, sandbox_id: &str) -> FirecrackerProcessInfo {
         ppid: None,
         sandbox_id: sandbox_id.into(),
         base_dir: Some(PathBuf::from("/data/r1")),
-        identity: None,
+        generation: None,
     }
 }
 
@@ -21,12 +21,9 @@ pub(super) fn make_target(pid: u32, sandbox_id: &str) -> KillTarget {
         run_id: None,
         sandbox_id: sandbox_id.into(),
         base_dir: Some(PathBuf::from("/data/r1")),
-        identity: Some(FirecrackerProcessIdentity {
-            pid,
+        generation: Some(ProcfsProcessGeneration {
             pgid: pid + 1000,
             starttime: 123456,
-            sandbox_id: sandbox_id.into(),
-            base_dir: Some(PathBuf::from("/data/r1")),
         }),
     }
 }
@@ -37,7 +34,7 @@ pub(super) fn make_fc_from_target(target: &KillTarget) -> FirecrackerProcessInfo
         ppid: target.ppid,
         sandbox_id: target.sandbox_id.clone(),
         base_dir: target.base_dir.clone(),
-        identity: target.identity.clone(),
+        generation: target.generation,
     }
 }
 

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -686,7 +686,7 @@ mod tests {
             ppid: Some(1),
             sandbox_id: live_sandbox_id.to_string(),
             base_dir: None,
-            identity: None,
+            generation: None,
         };
 
         fixture
@@ -730,7 +730,7 @@ mod tests {
             ppid: Some(1),
             sandbox_id: "pid-1234".to_string(),
             base_dir: None,
-            identity: None,
+            generation: None,
         };
         let discovery = OrphanReapProcessDiscovery {
             firecrackers: Arc::new(vec![unresolved_firecracker]),
@@ -892,7 +892,7 @@ mod tests {
             ppid: Some(1),
             sandbox_id: "pid-1234".to_string(),
             base_dir: None,
-            identity: None,
+            generation: None,
         };
         fixture
             .reap_current_orphans_with_firecrackers(
@@ -943,7 +943,7 @@ mod tests {
             ppid: Some(1),
             sandbox_id: sandbox_id.to_string(),
             base_dir: None,
-            identity: None,
+            generation: None,
         };
         fixture
             .reap_current_orphans_with_firecrackers(
@@ -1002,7 +1002,7 @@ mod tests {
             ppid: Some(1),
             sandbox_id: sandbox_id.to_string(),
             base_dir: None,
-            identity: None,
+            generation: None,
         };
         fixture
             .reap_current_orphans_with_firecrackers(
@@ -1049,7 +1049,7 @@ mod tests {
             ppid: Some(1),
             sandbox_id: sandbox_id.to_string(),
             base_dir: None,
-            identity: None,
+            generation: None,
         };
 
         fixture

--- a/crates/runner/src/process.rs
+++ b/crates/runner/src/process.rs
@@ -22,7 +22,7 @@ pub(crate) use self::procfs::{
     read_process_stat_checked_blocking, read_process_stat_checked_from,
 };
 pub use self::types::{
-    DiscoveredProcesses, DnsmasqProcessInfo, FirecrackerProcessIdentity, FirecrackerProcessInfo,
-    MitmproxyProcessInfo, ProcessStat,
+    DiscoveredProcesses, DnsmasqProcessInfo, FirecrackerProcessInfo, MitmproxyProcessInfo,
+    ProcessStat, ProcfsProcessGeneration,
 };
 pub(crate) use self::types::{ProcessDiscovery, process_stat_is_live};

--- a/crates/runner/src/process/discovery.rs
+++ b/crates/runner/src/process/discovery.rs
@@ -2,8 +2,8 @@ use std::path::{Path, PathBuf};
 
 use super::procfs::{read_cmdline, read_cwd, read_ppid, read_process_stat, scan_proc_cmdlines};
 use super::types::{
-    DiscoveredProcesses, DnsmasqProcessInfo, FirecrackerProcessIdentity, FirecrackerProcessInfo,
-    MitmproxyProcessInfo, ProcessDiscovery, ProcessStat, process_stat_is_live,
+    DiscoveredProcesses, DnsmasqProcessInfo, FirecrackerProcessInfo, MitmproxyProcessInfo,
+    ProcessDiscovery, ProcessStat, process_stat_is_live,
 };
 
 /// Check if an argv belongs to a firecracker process.
@@ -91,41 +91,25 @@ impl FirecrackerCandidateResolution {
                 process_stat,
                 sandbox_id,
                 base_dir,
-            } => {
-                let identity = Some(FirecrackerProcessIdentity {
-                    pid,
-                    pgid: process_stat.pgid,
-                    starttime: process_stat.starttime,
-                    sandbox_id: sandbox_id.clone(),
-                    base_dir: Some(base_dir.clone()),
-                });
-                Some(FirecrackerProcessInfo {
-                    pid,
-                    ppid,
-                    sandbox_id,
-                    base_dir: Some(base_dir),
-                    identity,
-                })
-            }
+            } => Some(FirecrackerProcessInfo {
+                pid,
+                ppid,
+                sandbox_id,
+                base_dir: Some(base_dir),
+                generation: Some(process_stat.procfs_generation()),
+            }),
             Self::StableUnknownWorkspace {
                 pid,
                 ppid,
                 process_stat,
             } => {
                 let sandbox_id = fallback_sandbox_id(pid);
-                let identity = Some(FirecrackerProcessIdentity {
-                    pid,
-                    pgid: process_stat.pgid,
-                    starttime: process_stat.starttime,
-                    sandbox_id: sandbox_id.clone(),
-                    base_dir: None,
-                });
                 Some(FirecrackerProcessInfo {
                     pid,
                     ppid,
                     sandbox_id,
                     base_dir: None,
-                    identity,
+                    generation: Some(process_stat.procfs_generation()),
                 })
             }
             Self::UnidentifiedLive { pid, ppid } => {
@@ -182,7 +166,7 @@ fn unidentified_firecracker_process(pid: u32, ppid: Option<u32>) -> FirecrackerP
         ppid,
         sandbox_id: fallback_sandbox_id(pid),
         base_dir: None,
-        identity: None,
+        generation: None,
     }
 }
 
@@ -375,7 +359,7 @@ mod tests {
             ppid: Some(1),
             sandbox_id: "sandbox-a".to_string(),
             base_dir: None,
-            identity: None,
+            generation: None,
         }];
 
         assert!(firecracker_process_exists_for_sandbox_id(
@@ -553,16 +537,7 @@ mod tests {
         assert_eq!(info.ppid, Some(7));
         assert_eq!(info.sandbox_id, "sandbox-a");
         assert_eq!(info.base_dir, Some(base_dir.clone()));
-        assert_eq!(
-            info.identity,
-            Some(FirecrackerProcessIdentity {
-                pid: 42,
-                pgid: process_stat.pgid,
-                starttime: process_stat.starttime,
-                sandbox_id: "sandbox-a".to_string(),
-                base_dir: Some(base_dir),
-            })
-        );
+        assert_eq!(info.generation, Some(process_stat.procfs_generation()));
     }
 
     #[test]
@@ -585,16 +560,7 @@ mod tests {
         assert_eq!(info.ppid, Some(7));
         assert_eq!(info.sandbox_id, "pid-42");
         assert_eq!(info.base_dir, None);
-        assert_eq!(
-            info.identity,
-            Some(FirecrackerProcessIdentity {
-                pid: 42,
-                pgid: process_stat.pgid,
-                starttime: process_stat.starttime,
-                sandbox_id: "pid-42".to_string(),
-                base_dir: None,
-            })
-        );
+        assert_eq!(info.generation, Some(process_stat.procfs_generation()));
         assert!(info.workspace_identity_incomplete());
     }
 
@@ -620,7 +586,7 @@ mod tests {
         assert_eq!(info.ppid, Some(7));
         assert_eq!(info.sandbox_id, "pid-42");
         assert_eq!(info.base_dir, None);
-        assert_eq!(info.identity, None);
+        assert_eq!(info.generation, None);
         assert!(info.workspace_identity_incomplete());
     }
 

--- a/crates/runner/src/process/types.rs
+++ b/crates/runner/src/process/types.rs
@@ -13,10 +13,10 @@ pub struct ProcessStat {
 }
 
 /// Stable generation of a process observed through procfs.
-#[derive(Debug, Eq, PartialEq)]
-pub(crate) struct ProcfsProcessGeneration {
-    pgid: u32,
-    starttime: u64,
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ProcfsProcessGeneration {
+    pub pgid: u32,
+    pub starttime: u64,
 }
 
 impl ProcessStat {
@@ -37,25 +37,6 @@ pub(crate) fn process_stat_is_live(stat: &ProcessStat) -> bool {
     !matches!(stat.state, 'Z' | 'X' | 'x')
 }
 
-/// Firecracker process identity captured during discovery.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct FirecrackerProcessIdentity {
-    pub pid: u32,
-    pub pgid: u32,
-    pub starttime: u64,
-    pub sandbox_id: String,
-    pub base_dir: Option<PathBuf>,
-}
-
-impl FirecrackerProcessIdentity {
-    pub(crate) fn procfs_generation(&self) -> ProcfsProcessGeneration {
-        ProcfsProcessGeneration {
-            pgid: self.pgid,
-            starttime: self.starttime,
-        }
-    }
-}
-
 /// Info extracted from a firecracker process cmdline.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FirecrackerProcessInfo {
@@ -66,7 +47,7 @@ pub struct FirecrackerProcessInfo {
     /// sandbox reuse this is stable across successive run_ids.
     pub sandbox_id: String,
     pub base_dir: Option<PathBuf>,
-    pub identity: Option<FirecrackerProcessIdentity>,
+    pub generation: Option<ProcfsProcessGeneration>,
 }
 
 impl FirecrackerProcessInfo {


### PR DESCRIPTION
## Summary

- make the top-level Firecracker process fields the canonical PID and workspace observations
- replace the duplicated process identity aggregate with an optional procfs generation (`pgid` and `starttime`)
- keep doctor and kill revalidation tied to both canonical workspace facts and the procfs generation while preserving existing fail-closed cleanup checks

## Scope

- runner-internal process discovery, doctor, kill, GC, and orphan-reaping code only
- no API, wire protocol, persisted-state, migration, or deployment-boundary changes

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner` (3393 passed, 24 ignored; additional test target 1 passed)
- focused runner tests for process discovery, doctor, kill, workspace GC, and orphan reaping
- repository pre-commit hooks, including Rust workspace formatting, Clippy, documentation, file-size, and commit-message checks

Closes #31000
