### PR TITLE
fix(observability): suppress non-built-in provider noise

### DIFF
--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -666,6 +666,9 @@ pub mod webhooks {
                 /// Optional process failure description.
                 #[serde(default, skip_serializing_if = "Option::is_none")]
                 pub error: Option<String>,
+                /// Optional stable guest-classified execution failure reason.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub failure_reason: Option<String>,
                 /// Highest contiguous agent event sequence delivered before completion.
                 #[serde(default, skip_serializing_if = "Option::is_none")]
                 pub last_event_sequence: Option<u32>,

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -1872,7 +1872,7 @@ mod tests {
             Some(events::CodexFailureDiagnostic {
                 event_type: "turn.completed",
                 message: "Rate limit exceeded.".to_string(),
-                failure_reason: Some(FailureReason::ProviderOverloaded),
+                failure_reason: Some(FailureReason::ProviderRateLimited),
             })
         );
     }

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -285,7 +285,8 @@ fn codex_error_failure_reason(error: Option<&Value>) -> Option<FailureReason> {
 fn codex_error_info_failure_reason(error: &Value) -> Option<FailureReason> {
     match codex_error_info_variant(error)? {
         "contextWindowExceeded" => Some(FailureReason::ContextWindowExceeded),
-        "rateLimitExceeded" | "serverOverloaded" => Some(FailureReason::ProviderOverloaded),
+        "rateLimitExceeded" => Some(FailureReason::ProviderRateLimited),
+        "serverOverloaded" => Some(FailureReason::ProviderOverloaded),
         "responseStreamConnectionFailed" | "responseStreamDisconnected" => {
             Some(FailureReason::ResponseConnectionLost)
         }

--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -269,6 +269,12 @@ fn classify_cli_failure_reason(
     {
         return Some(FailureReason::SafetyPolicyRefusal);
     }
+    if matches!(framework, AgentFramework::Codex)
+        && source == FailureDetailSource::CodexJsonl
+        && failure_patterns::is_codex_rate_limit_retry_exhausted_message(failure_message)
+    {
+        return Some(FailureReason::ProviderRateLimited);
+    }
 
     let normalized = failure_message.to_ascii_lowercase();
     if is_insufficient_credits_error(&normalized) {

--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -1010,6 +1010,68 @@ fn cli_failure_reason_ignores_codex_provider_overloaded_text() {
 }
 
 #[test]
+fn cli_failure_reason_classifies_trusted_codex_rate_limit_retry_exhaustion() {
+    for message in [
+        "exceeded retry limit, last status: 429 Too Many Requests",
+        "Codex failed: exceeded retry limit, last status: 429 Too Many Requests, request id: req_123",
+    ] {
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::Codex,
+            FailureDetailSource::CodexJsonl,
+            message,
+        );
+
+        assert_eq!(
+            reason,
+            Some(FailureReason::ProviderRateLimited),
+            "message: {message}"
+        );
+    }
+}
+
+#[test]
+fn cli_failure_reason_rejects_untrusted_codex_rate_limit_retry_exhaustion() {
+    let signature = "exceeded retry limit, last status: 429 Too Many Requests";
+
+    for (framework, source) in [
+        (AgentFramework::Codex, FailureDetailSource::Stderr),
+        (AgentFramework::ClaudeCode, FailureDetailSource::CodexJsonl),
+    ] {
+        let reason = super::classify_cli_failure_reason(framework, source, signature);
+
+        assert_eq!(reason, None, "framework: {framework:?}, source: {source:?}");
+    }
+}
+
+#[test]
+fn codex_rate_limit_reason_is_attached_without_changing_failure_class() {
+    let diagnostic = FailureDiagnostic::new(
+        FailureClass::CliNonzero,
+        AgentFramework::Codex,
+        PromptMetadata::from_prompt("plain prompt"),
+    )
+    .with_cli_exit_code(1)
+    .with_failure_detail_source(FailureDetailSource::CodexJsonl);
+    let failure_message = selected_failure_message(
+        "exceeded retry limit, last status: 429 Too Many Requests, request id: req_123",
+        FailureDetailSource::CodexJsonl,
+        None,
+    );
+
+    let diagnostic = with_cli_failure_reason(diagnostic, &failure_message);
+
+    assert_eq!(diagnostic.failure_class, FailureClass::CliNonzero);
+    assert_eq!(
+        diagnostic.failure_reason,
+        Some(FailureReason::ProviderRateLimited)
+    );
+    assert_eq!(
+        diagnostic.failure_detail_source,
+        Some(FailureDetailSource::CodexJsonl)
+    );
+}
+
+#[test]
 fn cli_failure_reason_classifies_codex_model_capacity() {
     let reason = classify_cli_failure_reason(
         AgentFramework::Codex,

--- a/crates/guest-agent/src/failure_patterns.rs
+++ b/crates/guest-agent/src/failure_patterns.rs
@@ -8,6 +8,8 @@ const CODEX_MODEL_CAPACITY_MESSAGE: &str =
     "selected model is at capacity. please try a different model.";
 const CODEX_CONTEXT_WINDOW_EXHAUSTED_PREFIX: &str =
     "codex ran out of room in the model's context window.";
+const CODEX_RATE_LIMIT_RETRY_EXHAUSTED_MESSAGE: &str =
+    "exceeded retry limit, last status: 429 too many requests";
 
 pub(crate) fn is_generic_codex_failure_diagnostic(message: &str) -> bool {
     let message = message.trim().to_ascii_lowercase();
@@ -30,6 +32,26 @@ pub(crate) fn is_codex_context_window_exceeded_message(message: &str) -> bool {
         && (message.contains("start a new thread") || message.contains("start a new conversation"))
         && message.contains("clear earlier history")
         && message.contains("before retrying")
+}
+
+pub(crate) fn is_codex_rate_limit_retry_exhausted_message(message: &str) -> bool {
+    let normalized = message.trim().to_ascii_lowercase();
+    let normalized = normalized
+        .strip_prefix("codex failed:")
+        .unwrap_or(&normalized)
+        .trim();
+    let Some(suffix) = normalized.strip_prefix(CODEX_RATE_LIMIT_RETRY_EXHAUSTED_MESSAGE) else {
+        return false;
+    };
+    suffix.is_empty()
+        || suffix
+            .strip_prefix(", request id: ")
+            .is_some_and(|request_id| {
+                !request_id.is_empty()
+                    && request_id
+                        .chars()
+                        .all(|character| !character.is_ascii_whitespace())
+            })
 }
 
 pub(crate) fn has_exact_codex_oauth_connector(value: &Value) -> bool {
@@ -104,5 +126,35 @@ mod tests {
         assert!(!is_codex_context_window_exceeded_message(
             "The prompt mentions the model context window but did not fail."
         ));
+    }
+
+    #[test]
+    fn codex_rate_limit_retry_exhausted_matcher_accepts_known_shapes() {
+        for message in [
+            "exceeded retry limit, last status: 429 Too Many Requests",
+            "exceeded retry limit, last status: 429 Too Many Requests, request id: req_123-abc",
+            " Codex failed: EXCEEDED RETRY LIMIT, LAST STATUS: 429 TOO MANY REQUESTS, REQUEST ID: req_123 ",
+        ] {
+            assert!(
+                is_codex_rate_limit_retry_exhausted_message(message),
+                "message: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn codex_rate_limit_retry_exhausted_matcher_rejects_near_misses() {
+        for message in [
+            "429 Too Many Requests",
+            "exceeded retry limit, last status: 503 Service Unavailable",
+            "exceeded retry limit, last status: 429 Too Many Requests; try later",
+            "exceeded retry limit, last status: 429 Too Many Requests, request id: ",
+            "the log says exceeded retry limit, last status: 429 Too Many Requests",
+        ] {
+            assert!(
+                !is_codex_rate_limit_retry_exhausted_message(message),
+                "message: {message}"
+            );
+        }
     }
 }

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -721,6 +721,8 @@ pub enum FailureReason {
     ContextWindowExceeded,
     /// The provider stopped because an output-token limit was reached.
     OutputTokenLimit,
+    /// The provider rejected the request because of a rate limit.
+    ProviderRateLimited,
     /// The provider reported overload.
     ProviderOverloaded,
     /// The provider stream timed out.
@@ -749,6 +751,7 @@ impl FailureReason {
             Self::TermsAcceptanceRequired => "terms_acceptance_required",
             Self::ContextWindowExceeded => "context_window_exceeded",
             Self::OutputTokenLimit => "output_token_limit",
+            Self::ProviderRateLimited => "provider_rate_limited",
             Self::ProviderOverloaded => "provider_overloaded",
             Self::ProviderStreamTimeout => "provider_stream_timeout",
             Self::ProviderServerError => "provider_server_error",
@@ -1438,6 +1441,28 @@ mod tests {
 
         let json = serde_json::to_value(&diagnostic).unwrap();
         assert_eq!(json["failureReason"], "provider_overloaded");
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn failure_diagnostic_serializes_provider_rate_limited_reason() {
+        assert_eq!(
+            FailureReason::ProviderRateLimited.as_str(),
+            "provider_rate_limited"
+        );
+
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::Codex,
+            PromptMetadata::from_prompt("debug failure"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_reason(FailureReason::ProviderRateLimited);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(json["failureReason"], "provider_rate_limited");
 
         let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
         assert_eq!(round_trip, diagnostic);

--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -943,6 +943,7 @@ async fn complete_claimed_without_sandbox(
             CompleteRequest {
                 run_id: context.run_id,
                 exit_code: failure.exit_code,
+                failure_reason: None,
                 error: Some(failure.error),
                 sandbox_id: None,
                 sandbox_reuse_result: reuse_result,

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -897,6 +897,7 @@ async fn recover_claimed_activation_failure(
             CompleteRequest {
                 run_id,
                 exit_code: execution_failure.exit_code,
+                failure_reason: None,
                 error: Some(execution_failure.error),
                 sandbox_id: None,
                 sandbox_reuse_result: Some(reuse_result),
@@ -2393,6 +2394,7 @@ async fn complete_claimed_failure(
             CompleteRequest {
                 run_id,
                 exit_code: failure.exit_code,
+                failure_reason: None,
                 error: Some(failure.error),
                 sandbox_id: None,
                 sandbox_reuse_result: reuse_result,

--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
+use guest_contracts::diagnostics::FailureReason;
 use sandbox::SandboxId;
 
 use crate::ids::RunId;
@@ -139,6 +140,7 @@ impl BudgetOwnership {
 pub(super) struct CompletionPayload {
     run_id: RunId,
     exit_code: i32,
+    failure_reason: Option<FailureReason>,
     error: Option<String>,
     sandbox_id: SandboxId,
     reuse_result: SandboxReuseResult,
@@ -169,6 +171,7 @@ impl CompletionPayload {
     pub(super) fn new(
         run_id: RunId,
         exit_code: i32,
+        failure_reason: Option<FailureReason>,
         error: Option<String>,
         sandbox_id: SandboxId,
         reuse_result: SandboxReuseResult,
@@ -177,6 +180,7 @@ impl CompletionPayload {
         Self {
             run_id,
             exit_code,
+            failure_reason,
             error,
             sandbox_id,
             reuse_result,
@@ -206,6 +210,7 @@ impl CompletionPayload {
         let Self {
             run_id,
             exit_code,
+            failure_reason,
             error,
             sandbox_id,
             reuse_result,
@@ -219,6 +224,7 @@ impl CompletionPayload {
                 CompleteRequest {
                     run_id,
                     exit_code,
+                    failure_reason,
                     error,
                     sandbox_id: Some(sandbox_id),
                     sandbox_reuse_result: Some(reuse_result),
@@ -318,6 +324,7 @@ mod tests {
     struct CompletionAuthProvider {
         auth_matches: Arc<AtomicBool>,
         active_input_delivery_ids: Arc<std::sync::Mutex<Vec<String>>>,
+        failure_reason: Arc<std::sync::Mutex<Option<FailureReason>>>,
     }
 
     #[async_trait]
@@ -336,6 +343,7 @@ mod tests {
                 Ordering::SeqCst,
             );
             *self.active_input_delivery_ids.lock().unwrap() = request.active_input_delivery_ids;
+            *self.failure_reason.lock().unwrap() = request.failure_reason;
         }
 
         async fn heartbeat(&self, _state: &HeartbeatState) {}
@@ -379,9 +387,11 @@ mod tests {
     async fn completion_payload_forwards_completion_auth() {
         let auth_matches = Arc::new(AtomicBool::new(false));
         let active_input_delivery_ids = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let failure_reason = Arc::new(std::sync::Mutex::new(None));
         let provider = CompletionAuthProvider {
             auth_matches: Arc::clone(&auth_matches),
             active_input_delivery_ids: Arc::clone(&active_input_delivery_ids),
+            failure_reason: Arc::clone(&failure_reason),
         };
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
@@ -389,6 +399,7 @@ mod tests {
         let _ = CompletionPayload::new(
             run_id,
             0,
+            Some(FailureReason::ProviderRateLimited),
             None,
             sandbox_id,
             SandboxReuseResult::PoolMiss,
@@ -405,6 +416,10 @@ mod tests {
         assert_eq!(
             *active_input_delivery_ids.lock().unwrap(),
             vec!["b1e2ad6d-930a-4d51-aa40-7952d54f978b".to_string()]
+        );
+        assert_eq!(
+            *failure_reason.lock().unwrap(),
+            Some(FailureReason::ProviderRateLimited)
         );
     }
 

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -735,10 +735,17 @@ pub(super) async fn run_job(
             cancelled_for_log,
             executor_result.outcome.failure.as_ref(),
         );
+        let failure_reason = executor_result
+            .outcome
+            .failure
+            .as_ref()
+            .and_then(|failure| failure.diagnostic.as_ref())
+            .and_then(|diagnostic| diagnostic.failure_reason);
 
         let completion_payload = CompletionPayload::new(
             run_id,
             executor_result.exit_code,
+            failure_reason,
             executor_result.err.take(),
             sandbox_id,
             reuse_result,

--- a/crates/runner/src/cmd/start/job_terminal_log.rs
+++ b/crates/runner/src/cmd/start/job_terminal_log.rs
@@ -466,9 +466,11 @@ fn is_info_level_job_failure(diagnostic: &FailureDiagnostic) -> bool {
                     | FailureReason::TermsAcceptanceRequired
                     | FailureReason::ContextWindowExceeded
                     | FailureReason::OutputTokenLimit
+                    | FailureReason::ProviderRateLimited
                     | FailureReason::ProviderOverloaded
                     | FailureReason::ProviderStreamTimeout
                     | FailureReason::ProviderServerError
+                    | FailureReason::ResponseConnectionLost
                     | FailureReason::SafetyPolicyRefusal
                     | FailureReason::ReconnectRequired
                     | FailureReason::UsageLimit
@@ -617,9 +619,11 @@ mod tests {
             FailureReason::TermsAcceptanceRequired,
             FailureReason::ContextWindowExceeded,
             FailureReason::OutputTokenLimit,
+            FailureReason::ProviderRateLimited,
             FailureReason::ProviderOverloaded,
             FailureReason::ProviderStreamTimeout,
             FailureReason::ProviderServerError,
+            FailureReason::ResponseConnectionLost,
             FailureReason::SafetyPolicyRefusal,
             FailureReason::ReconnectRequired,
             FailureReason::UsageLimit,
@@ -743,7 +747,7 @@ mod tests {
             (
                 FailureReason::ResponseConnectionLost,
                 "API Error: Connection lost mid-response. The response above may be incomplete.",
-                Level::ERROR,
+                Level::INFO,
             ),
         ] {
             let diagnostic = FailureDiagnostic::new(
@@ -816,9 +820,11 @@ mod tests {
             FailureReason::TermsAcceptanceRequired,
             FailureReason::ContextWindowExceeded,
             FailureReason::OutputTokenLimit,
+            FailureReason::ProviderRateLimited,
             FailureReason::ProviderOverloaded,
             FailureReason::ProviderStreamTimeout,
             FailureReason::ProviderServerError,
+            FailureReason::ResponseConnectionLost,
             FailureReason::SafetyPolicyRefusal,
             FailureReason::ReconnectRequired,
             FailureReason::UsageLimit,

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -2063,6 +2063,7 @@ mod tests {
         CompleteRequest {
             run_id,
             exit_code: 0,
+            failure_reason: None,
             error: None,
             sandbox_id: None,
             sandbox_reuse_result: None,
@@ -4000,6 +4001,7 @@ mod tests {
                 &CompleteRequest {
                     run_id: RunId::nil(),
                     exit_code: 1,
+                    failure_reason: None,
                     error: Some("boom".to_string()),
                     sandbox_id: None,
                     sandbox_reuse_result: None,
@@ -4020,7 +4022,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn api_client_complete_serializes_no_reuse_key() {
+    async fn api_client_complete_serializes_failure_reason_and_no_reuse_key() {
         let server = MockServer::start_async().await;
         let run_id = RunId::nil();
         let mock = server
@@ -4030,7 +4032,9 @@ mod tests {
                     .header("authorization", "Bearer sandbox-token")
                     .json_body(serde_json::json!({
                         "runId": run_id,
-                        "exitCode": 0,
+                        "exitCode": 1,
+                        "error": "rate limited",
+                        "failureReason": "provider_rate_limited",
                         "sandboxReuseResult": "noReuseKey",
                         "workspaceReuseResult": "noReuseKey",
                     }));
@@ -4043,8 +4047,11 @@ mod tests {
             "sandbox-token",
             &CompleteRequest {
                 run_id,
-                exit_code: 0,
-                error: None,
+                exit_code: 1,
+                failure_reason: Some(
+                    guest_contracts::diagnostics::FailureReason::ProviderRateLimited,
+                ),
+                error: Some("rate limited".to_string()),
                 sandbox_id: None,
                 sandbox_reuse_result: Some(SandboxReuseResult::NoReuseKey),
                 workspace_reuse_result: Some(WorkspaceReuseResult::NoReuseKey),

--- a/crates/runner/src/provider/local/tests/support.rs
+++ b/crates/runner/src/provider/local/tests/support.rs
@@ -46,6 +46,7 @@ pub(super) fn complete_request(
     CompleteRequest {
         run_id,
         exit_code,
+        failure_reason: None,
         error: error.map(str::to_owned),
         sandbox_id: None,
         sandbox_reuse_result: None,

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -707,6 +707,7 @@ mod tests {
         CompleteRequest {
             run_id,
             exit_code: 0,
+            failure_reason: None,
             error: None,
             sandbox_id: None,
             sandbox_reuse_result: None,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -3,6 +3,7 @@ use std::net::IpAddr;
 use std::sync::Arc;
 
 use api_contracts::generated::types::runners::runs::CodexRuntimeConfig;
+use guest_contracts::diagnostics::FailureReason;
 use sandbox::SandboxId;
 use serde::{Deserialize, Serialize};
 use unicode_normalization::UnicodeNormalization;
@@ -1643,6 +1644,8 @@ pub struct CompleteRequest {
     pub run_id: RunId,
     pub exit_code: i32,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_reason: Option<FailureReason>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     /// Sandbox the run executed against. `None` when the run failed before
     /// sandbox allocation; otherwise set on every completion regardless of
@@ -2118,6 +2121,7 @@ mod tests {
                 .parse::<RunId>()
                 .unwrap(),
             exit_code: 0,
+            failure_reason: None,
             error: None,
             sandbox_id: None,
             sandbox_reuse_result: None,
@@ -2129,6 +2133,7 @@ mod tests {
         assert!(json.get("exitCode").is_some());
         // optionals omitted when None
         assert!(json.get("error").is_none());
+        assert!(json.get("failureReason").is_none());
         assert!(json.get("sandboxId").is_none());
         assert!(json.get("sandboxReuseResult").is_none());
         assert!(json.get("workspaceReuseResult").is_none());
@@ -2142,6 +2147,7 @@ mod tests {
                 .parse::<RunId>()
                 .unwrap(),
             exit_code: 1,
+            failure_reason: Some(FailureReason::ProviderRateLimited),
             error: Some("timeout".into()),
             sandbox_id: None,
             sandbox_reuse_result: None,
@@ -2150,6 +2156,7 @@ mod tests {
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["error"], "timeout");
+        assert_eq!(json["failureReason"], "provider_rate_limited");
         assert!(json.get("sandboxId").is_none());
         assert!(json.get("sandboxReuseResult").is_none());
         assert!(json.get("workspaceReuseResult").is_none());
@@ -2163,6 +2170,7 @@ mod tests {
                 .parse::<RunId>()
                 .unwrap(),
             exit_code: 0,
+            failure_reason: None,
             error: None,
             sandbox_id: Some(sid),
             sandbox_reuse_result: Some(SandboxReuseResult::Reused),

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -15833,12 +15833,19 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     async function completeFailure(
       modelProvider: ModelProviderType,
       failureReason?: string,
+      persistedModelProvider?: ModelProviderType | null,
     ): Promise<{ readonly runId: string; readonly error: string }> {
       const run = await api.createRun(actor, {
         agentId,
         prompt: `fail ${modelProvider} with ${failureReason ?? "no reason"}`,
         modelProvider,
       });
+      if (persistedModelProvider !== undefined) {
+        await setRunModelProviderFixture({
+          runId: run.runId,
+          modelProvider: persistedModelProvider,
+        });
+      }
       const error = `provider failure for ${run.runId}`;
       await webhooks.requestAgentComplete(
         {
@@ -15903,6 +15910,18 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
       matchingRunFailedCalls(
         context.mocks.axiomLogging.warn,
         unrecognizedReasonFailure.runId,
+      ),
+    ).toHaveLength(1);
+
+    const missingProviderFailure = await completeFailure(
+      "anthropic-api-key",
+      "provider_rate_limited",
+      null,
+    );
+    expect(
+      matchingRunFailedCalls(
+        context.mocks.axiomLogging.warn,
+        missingProviderFailure.runId,
       ),
     ).toHaveLength(1);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -15796,6 +15796,117 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     expect(context.mocks.ably.createTokenRequest).not.toHaveBeenCalled();
   });
 
+  it("suppresses recognized non-built-in provider failures from generic completion logs", async () => {
+    const api = createRunsApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    await seedVm0BuiltInDefaultModelKey();
+    const { actor, agentId } = await entitledRunActor();
+    const upstreamFailureReasons = [
+      "provider_rate_limited",
+      "provider_overloaded",
+      "provider_stream_timeout",
+      "provider_server_error",
+      "response_connection_lost",
+    ] as const;
+    const axiomLevels = [
+      context.mocks.axiomLogging.debug,
+      context.mocks.axiomLogging.info,
+      context.mocks.axiomLogging.warn,
+      context.mocks.axiomLogging.error,
+    ];
+
+    function matchingRunFailedCalls(
+      log: (typeof axiomLevels)[number],
+      runId: string,
+    ) {
+      return log.mock.calls.filter(([message, fields]) => {
+        return (
+          message === "Run failed" &&
+          typeof fields === "object" &&
+          fields !== null &&
+          "runId" in fields &&
+          fields.runId === runId
+        );
+      });
+    }
+
+    async function completeFailure(
+      modelProvider: ModelProviderType,
+      failureReason?: string,
+    ): Promise<{ readonly runId: string; readonly error: string }> {
+      const run = await api.createRun(actor, {
+        agentId,
+        prompt: `fail ${modelProvider} with ${failureReason ?? "no reason"}`,
+        modelProvider,
+      });
+      const error = `provider failure for ${run.runId}`;
+      await webhooks.requestAgentComplete(
+        {
+          runId: run.runId,
+          exitCode: 1,
+          error,
+          ...(failureReason === undefined ? {} : { failureReason }),
+        },
+        {
+          authorization: `Bearer ${api.sandboxTokenForRun(actor, run.runId)}`,
+        },
+        [200],
+      );
+      const failed = await api.readRun(actor, run.runId);
+      expect(failed.status).toBe("failed");
+      expect(failed.error).toBe(error);
+      return { runId: run.runId, error };
+    }
+
+    for (const failureReason of upstreamFailureReasons) {
+      const { runId } = await completeFailure(
+        "anthropic-api-key",
+        failureReason,
+      );
+      for (const level of axiomLevels) {
+        expect(matchingRunFailedCalls(level, runId)).toHaveLength(0);
+      }
+    }
+
+    const builtInFailure = await completeFailure(
+      "built-in",
+      "provider_rate_limited",
+    );
+    const builtInWarnings = matchingRunFailedCalls(
+      context.mocks.axiomLogging.warn,
+      builtInFailure.runId,
+    );
+    expect(builtInWarnings).toHaveLength(1);
+    expect(builtInWarnings[0]?.[1]).toStrictEqual(
+      expect.objectContaining({
+        runId: builtInFailure.runId,
+        exitCode: 1,
+        error: builtInFailure.error,
+        failureReason: "provider_rate_limited",
+        context: "webhook:complete",
+      }),
+    );
+
+    const missingReasonFailure = await completeFailure("anthropic-api-key");
+    expect(
+      matchingRunFailedCalls(
+        context.mocks.axiomLogging.warn,
+        missingReasonFailure.runId,
+      ),
+    ).toHaveLength(1);
+
+    const unrecognizedReasonFailure = await completeFailure(
+      "anthropic-api-key",
+      "provider_future_failure",
+    );
+    expect(
+      matchingRunFailedCalls(
+        context.mocks.axiomLogging.warn,
+        unrecognizedReasonFailure.runId,
+      ),
+    ).toHaveLength(1);
+  });
+
   it("drops queued jobs whose runs reached a terminal state before the claim", async () => {
     const api = createRunsApi(context);
     const webhooks = createWebhookCallbackApi(context);

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -6,6 +6,10 @@ import {
   type RunResult,
   type RunStatus,
 } from "@okouai/api-contracts/contracts/runs";
+import {
+  isBuiltInModelProviderType,
+  modelProviderTypeSchema,
+} from "@okouai/api-contracts/contracts/model-providers";
 import { webhookCompleteContract } from "@okouai/api-contracts/contracts/webhooks";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { agentSessions } from "@okouai/db/schema/agent-session";
@@ -119,6 +123,7 @@ interface RunRecord {
   readonly userId: string;
   readonly chatThreadId: string | null;
   readonly launchSnapshot: (typeof agentRuns.$inferSelect)["launchSnapshot"];
+  readonly modelProvider: string | null;
 }
 
 interface PreparedCompletion {
@@ -147,6 +152,34 @@ type CompletionTransactionResult =
   | { readonly kind: "committed"; readonly commit: CompletionCommit };
 
 const L = logger("webhook:complete");
+
+function isProviderUpstreamFailureReason(
+  failureReason: string | undefined,
+): boolean {
+  switch (failureReason) {
+    case "provider_rate_limited":
+    case "provider_overloaded":
+    case "provider_stream_timeout":
+    case "provider_server_error":
+    case "response_connection_lost": {
+      return true;
+    }
+    default: {
+      return false;
+    }
+  }
+}
+
+function shouldSuppressNonBuiltInProviderFailureLog(
+  run: RunRecord,
+  failureReason: string | undefined,
+): boolean {
+  if (!isProviderUpstreamFailureReason(failureReason)) {
+    return false;
+  }
+  const providerType = modelProviderTypeSchema.safeParse(run.modelProvider);
+  return providerType.success && !isBuiltInModelProviderType(providerType.data);
+}
 
 function checkpointInputForCompletion(
   input: CompleteAgentRunInput,
@@ -218,6 +251,7 @@ async function loadCompletionRun(
       cancellationRecoveryCompleted: agentRuns.cancellationRecoveryCompleted,
       chatThreadId: agentRuns.chatThreadId,
       launchSnapshot: agentRuns.launchSnapshot,
+      modelProvider: agentRuns.modelProvider,
     })
     .from(agentRuns)
     .where(
@@ -285,6 +319,7 @@ async function lockCompletionRun(
       cancellationRecoveryCompleted: agentRuns.cancellationRecoveryCompleted,
       chatThreadId: agentRuns.chatThreadId,
       launchSnapshot: agentRuns.launchSnapshot,
+      modelProvider: agentRuns.modelProvider,
     })
     .from(agentRuns)
     .where(
@@ -816,11 +851,17 @@ export const completeAgentRun$ = command(
           runId: input.body.runId,
           error: commit.transitionError,
         });
-      } else {
+      } else if (
+        !shouldSuppressNonBuiltInProviderFailureLog(
+          commit.run,
+          input.body.failureReason,
+        )
+      ) {
         L.warn("Run failed", {
           runId: input.body.runId,
           exitCode: input.body.exitCode,
           error: commit.transitionError,
+          failureReason: input.body.failureReason,
         });
       }
     } else if (

--- a/turbo/apps/api/src/test-fixtures/agent-runs.ts
+++ b/turbo/apps/api/src/test-fixtures/agent-runs.ts
@@ -576,7 +576,7 @@ export async function setRunModelRuntimeRouteFixture(args: {
  */
 export async function setRunModelProviderFixture(args: {
   readonly runId: string;
-  readonly modelProvider: ModelProviderType;
+  readonly modelProvider: ModelProviderType | null;
 }): Promise<void> {
   const updated = await db()
     .update(agentRuns)

--- a/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
@@ -268,6 +268,41 @@ describe("agent completion active input receipts", () => {
   });
 });
 
+describe("agent completion failure reasons", () => {
+  const baseBody = {
+    runId: "00000000-0000-4000-8000-000000000000",
+    exitCode: 1,
+  };
+
+  it("accepts an optional bounded snake-case failure reason", () => {
+    expect(
+      webhookCompleteContract.complete.body.parse({
+        ...baseBody,
+        failureReason: "provider_rate_limited",
+      }),
+    ).toMatchObject({ failureReason: "provider_rate_limited" });
+    expect(
+      webhookCompleteContract.complete.body.safeParse(baseBody).success,
+    ).toBe(true);
+  });
+
+  it("rejects malformed and overlong failure reasons", () => {
+    for (const failureReason of [
+      "ProviderRateLimited",
+      "provider-rate-limited",
+      "_provider_rate_limited",
+      "a".repeat(65),
+    ]) {
+      expect(
+        webhookCompleteContract.complete.body.safeParse({
+          ...baseBody,
+          failureReason,
+        }).success,
+      ).toBe(false);
+    }
+  });
+});
+
 describe("webhook telemetry contract", () => {
   it("preserves metric payload compatibility across Guest and API rollout", () => {
     const runId = "00000000-0000-4000-8000-000000000000";

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -473,6 +473,12 @@ const webhookCompleteBodySchema = z
     runId: z.string().min(1, "runId is required"),
     exitCode: z.number(),
     error: z.string().optional(),
+    /** Stable guest-classified reason for a failed execution, when available. */
+    failureReason: z
+      .string()
+      .max(64)
+      .regex(/^[a-z][a-z0-9_]*$/)
+      .optional(),
     lastEventSequence: eventSequenceNumberSchema.optional(),
     // Sandbox id the run executed against. Optional because a run that fails
     // before sandbox creation has no sandbox. Persisted to agent_runs.sandbox_id;

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -671,6 +671,9 @@ export const rustTypeBindings = [
           runId: ["Agent run identifier bound to the sandbox token."],
           exitCode: ["Process exit code reported by the caller."],
           error: ["Optional process failure description."],
+          failureReason: [
+            "Optional stable guest-classified execution failure reason.",
+          ],
           lastEventSequence: [
             "Highest contiguous agent event sequence delivered before completion.",
           ],


### PR DESCRIPTION
## Summary

- classify trusted Codex retry-exhausted 429 failures as `provider_rate_limited`
- carry the optional structured failure reason from the guest diagnostic through runner completion
- omit the generic API `Run failed` Axiom log only for recognized provider-upstream failures on recognized non-built-in providers
- retain failure state, exit code, user-facing errors, built-in visibility, and fail-visible behavior for missing or unknown metadata

## Explicit exclusions

- no changes to retry, backoff, admission, provider cooldown, or run-state behavior
- no suppression for built-in providers, unknown provider snapshots, missing reasons, or unrecognized reasons
- no database migration or feature switch

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/api-contracts exec vitest run src/contracts/__tests__/webhooks.test.ts`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t 'suppresses recognized non-built-in provider failures from generic completion logs'`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml --all-targets --all-features`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-contracts diagnostics`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib failure_diagnostics`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib codex_rate_limit`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib failed_turn_completed_classifies_rate_limit_for_diagnostics`
- `CARGO_BUILD_JOBS=1 cargo check --manifest-path crates/Cargo.toml -p runner --bin runner --tests`

Closes #30942
