### PR TITLE
chore(api): retire connector doctor official workflow

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts
@@ -413,8 +413,42 @@ describe.sequential("Official Workflow catalog release boundary", () => {
     });
   });
 
-  it("releases the deployed catalog with stable unique executable identities", async () => {
+  it("retires Connector Doctor while retaining its released identity and Morning Brief behavior", async () => {
     const s3 = installVolumeS3Fixture();
+    const historicalBlueprint: OfficialWorkflowBlueprint = {
+      key: "weekly-check",
+      parameters: [],
+      desiredState: {
+        kind: "schedule",
+        schedule: {
+          type: "cron",
+          cronExpression: "0 9 * * 1",
+        },
+      },
+      runtime: { resultEmail: false },
+    };
+    const released = await syncCatalog(
+      catalog([
+        activeDefinition("connector-doctor", {
+          blueprints: [historicalBlueprint],
+        }),
+      ]),
+    );
+    expect(released.body).toMatchObject({
+      outcome: "accepted",
+      diagnostics: [],
+    });
+    const releasedConnectorDoctor = requireValue(
+      (await readState("connector-doctor")).body.definition,
+      "Expected the released Connector Doctor Definition",
+    );
+    expect(releasedConnectorDoctor).toMatchObject({
+      name: "connector-doctor",
+      lifecycle: "active",
+      blueprints: [{ key: "weekly-check" }],
+      releasedBlueprintKeys: ["weekly-check"],
+    });
+
     const first = await syncDeployedCatalog();
     expect(first.body).toMatchObject({
       outcome: "accepted",
@@ -433,14 +467,14 @@ describe.sequential("Official Workflow catalog release boundary", () => {
     );
     const connectorDoctorDefinition = requireValue(
       connectorDoctorState.body.definition,
-      "Expected the Connector Doctor Definition",
+      "Expected the retired Connector Doctor Definition",
     );
     expect(
       deployedCatalog.payload.definitions.map(({ name, lifecycle }) => {
         return { name, lifecycle };
       }),
     ).toStrictEqual([
-      { name: "connector-doctor", lifecycle: "active" },
+      { name: "connector-doctor", lifecycle: "retired" },
       { name: "morning-brief", lifecycle: "active" },
     ]);
     expect(morningBriefDefinition).toMatchObject({
@@ -463,22 +497,23 @@ describe.sequential("Official Workflow catalog release boundary", () => {
     });
     expect(connectorDoctorDefinition).toMatchObject({
       name: "connector-doctor",
-      lifecycle: "active",
-      blueprints: [
-        {
-          key: "weekly-check",
-          parameters: [],
-          desiredState: {
-            kind: "schedule",
-            schedule: {
-              type: "cron",
-              cronExpression: "0 9 * * 1",
-            },
-          },
-          runtime: { resultEmail: false },
-        },
-      ],
+      lifecycle: "retired",
+      blueprints: [{ key: "weekly-check" }],
+      releasedBlueprintKeys: ["weekly-check"],
+      presentation: { category: "productivity" },
     });
+    expect(connectorDoctorDefinition.revision).toBe(
+      releasedConnectorDoctor.revision,
+    );
+    expect(connectorDoctorDefinition.artifact).toStrictEqual(
+      releasedConnectorDoctor.artifact,
+    );
+    expect(connectorDoctorDefinition.blueprints).toStrictEqual(
+      releasedConnectorDoctor.blueprints,
+    );
+    expect(connectorDoctorDefinition.releasedBlueprintKeys).toStrictEqual(
+      releasedConnectorDoctor.releasedBlueprintKeys,
+    );
     expect(morningBriefState.body.storage).toMatchObject({
       storageName: "official-workflow@morning-brief",
       orgId: SYSTEM_ORG_ID,
@@ -490,11 +525,11 @@ describe.sequential("Official Workflow catalog release boundary", () => {
       storageName: "official-workflow@connector-doctor",
       orgId: SYSTEM_ORG_ID,
       userId: VOLUME_ORG_USER_ID,
-      headVersionId: connectorDoctorDefinition.artifact.storageVersion,
+      headVersionId: releasedConnectorDoctor.artifact.storageVersion,
       versionCount: 1,
     });
     expect(morningBriefState.body.counts).toStrictEqual({
-      releases: 1,
+      releases: 2,
       revisions: 2,
       storages: 2,
       storageVersions: 2,
@@ -502,7 +537,6 @@ describe.sequential("Official Workflow catalog release boundary", () => {
     expect(s3.objects.size).toBe(4);
 
     const morningBriefRevision = morningBriefDefinition.revision;
-    const connectorDoctorRevision = connectorDoctorDefinition.revision;
     const exactMorningBrief = await readState(
       "morning-brief",
       morningBriefRevision,
@@ -537,172 +571,23 @@ describe.sequential("Official Workflow catalog release boundary", () => {
 
     const exactConnectorDoctor = await readState(
       "connector-doctor",
-      connectorDoctorRevision,
+      releasedConnectorDoctor.revision,
     );
     const exactConnectorDoctorRevision = requireValue(
       exactConnectorDoctor.body.revision,
-      "Expected the exact Connector Doctor revision",
+      "Expected the exact historical Connector Doctor revision",
     );
-    const connectorDoctorInstruction =
-      exactConnectorDoctorRevision.definition.workflow.instruction;
-    expect(exactConnectorDoctorRevision.definition.workflow).toMatchObject({
-      displayName: "Connector Doctor",
-      description:
-        "Diagnose connector readiness across your workflows and group exact repair actions.",
-      files: [],
-    });
-    expect(
-      connectorDoctorInstruction.match(
-        /okou doctor connectors --agent "\$OKOU_AGENT_ID" --json/gu,
-      ),
-    ).toHaveLength(1);
-    expect(connectorDoctorInstruction).not.toMatch(
-      /okou doctor connectors --json/gu,
+    expect(exactConnectorDoctorRevision.definition.revision).toBe(
+      releasedConnectorDoctor.revision,
     );
-    expect(connectorDoctorInstruction).toContain(
-      "unique sandbox-local report file with `mktemp`",
+    expect(exactConnectorDoctorRevision.definition.blueprints).toStrictEqual(
+      releasedConnectorDoctor.blueprints,
     );
-    expect(connectorDoctorInstruction).toContain(
-      "redirect its complete standard output directly into that file",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      `report_file="$(mktemp "\${TMPDIR:-/tmp}/connector-doctor.XXXXXX.json")"`,
-    );
-    expect(connectorDoctorInstruction).toContain(
-      `if [ -z "\${OKOU_AGENT_ID:-}" ]; then`,
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "status=failed reason=missing-agent-id",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      'okou doctor connectors --agent "$OKOU_AGENT_ID" --json >"$report_file"',
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "Require a non-empty `OKOU_AGENT_ID` before running the Doctor command",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "do not rerun it, split it into per-workflow diagnoses, or call connector-readiness APIs separately",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "All later commands must be local parsers against that same sandbox file",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "Keep the file sandbox-local; do not upload, attach, or send it",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "use a non-emitting local `jq` check or equivalent local parser",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "all five non-negative integer summary counts",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "every returned workflow's `agent.id` exactly matches the runtime `OKOU_AGENT_ID`",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "A missing runtime Agent identity or any cross-Agent workflow entry makes the diagnosis unavailable",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "A truncated or empty file, invalid JSON, an unsupported schema version, a missing required field",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "any local parsing or projection failure makes the diagnosis unavailable",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "the first data-returning projection must contain only `schemaVersion` and `summary`",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "Never make a tool call that prints, reads, or returns the whole raw file",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "return at most 20 records per tool result",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "Use a count-only projection to determine whether paging is needed",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "advance explicit offsets until every projected record for that branch has been consumed",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "If the Doctor command or local capture fails",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "sole source of diagnostic facts",
-    );
-    expect(connectorDoctorInstruction).toContain("schemaVersion === 1");
-    expect(connectorDoctorInstruction).toContain(
-      "identical `action.kind` and exact `action.url`",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "list every affected workflow with the connector's returned readiness status and reason",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "Never merge entries whose exact URLs differ",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "every connector whose status is `unavailable` and every workflow with a non-null `error`",
-    );
-    expect(connectorDoctorInstruction).toContain("Unknown is never healthy");
-    expect(connectorDoctorInstruction).toContain("summary.checked === 0");
-    expect(connectorDoctorInstruction).toContain(
-      "Describe every valid report as covering effective workflows on the current Agent, including both public and private workflows hosted there",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "Never describe this Agent-scoped result as coverage across visible Agents",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "no effective workflows on the current Agent were available to check",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "not an all-clear over diagnosed workflows",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "summary.attention === 0`, and `summary.unknown === 0",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "aggregate covered effective workflows on the current Agent, including its public and private workflows",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "compact inventory of every checked entry in `workflows`",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "Do not apply a visibility filter to any valid report branch",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "page through a projection of every connector entry with a non-null action",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "separately page through a projection of every connector whose status is `unavailable` and every workflow with a non-null `error`",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "Do not use `tee`, echo the raw output, switch to the human-readable CLI output, or depend on compact JSON whitespace or a higher tool-output limit",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "Do not invoke connector or provider skills, third-party provider APIs",
-    );
-    expect(connectorDoctorInstruction).toContain("okou connector list");
-    expect(connectorDoctorInstruction).toContain("okou connector status");
-    expect(connectorDoctorInstruction).toContain("okou connector check");
-    expect(connectorDoctorInstruction).toContain(
-      "Do not write to or mutate application or provider state",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "application-internal APIs, or application database tables",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "Do not connect, reconnect, authorize, start OAuth flows, request permissions, create callbacks, mutate connectors",
-    );
-    expect(connectorDoctorInstruction).toContain("or follow repair links");
-    expect(connectorDoctorInstruction).toContain(
-      "Do not select or recommend models, and do not recommend workflow or Automation cleanup",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "Return only the Markdown report. The platform delivers it to the shared automation thread",
-    );
-    expect(connectorDoctorInstruction).toContain(
-      "Do not send email or directly send any chat or other message",
+    expect(exactConnectorDoctorRevision.artifact).toStrictEqual(
+      releasedConnectorDoctor.artifact,
     );
 
-    expect(morningBriefRevision).not.toBe(connectorDoctorRevision);
+    expect(morningBriefRevision).not.toBe(releasedConnectorDoctor.revision);
     expect(morningBriefDefinition.blueprints[0]?.fingerprint).not.toBe(
       connectorDoctorDefinition.blueprints[0]?.fingerprint,
     );
@@ -735,7 +620,7 @@ describe.sequential("Official Workflow catalog release boundary", () => {
     );
     const secondConnectorDoctor = requireValue(
       (await readState("connector-doctor")).body.definition,
-      "Expected the unchanged Connector Doctor Definition",
+      "Expected the unchanged retired Connector Doctor Definition",
     );
     expect({
       morningBrief: {

--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -800,6 +800,24 @@ async function syncCatalog(candidate: unknown) {
 }
 
 async function syncDeployedCatalog() {
+  await syncCatalog(
+    catalog([
+      activeDefinition("connector-doctor", [
+        {
+          key: "weekly-check",
+          parameters: [],
+          desiredState: {
+            kind: "schedule",
+            schedule: {
+              type: "cron",
+              cronExpression: "0 9 * * 1",
+            },
+          },
+          runtime: { resultEmail: false },
+        },
+      ]),
+    ]),
+  );
   return await accept(
     setupApp({ context, routes: cronOfficialWorkflowCatalogRoutes })(
       cronOfficialWorkflowCatalogContract,
@@ -1782,7 +1800,7 @@ describe.sequential("Morning Brief preference", () => {
 });
 
 describe.sequential("Official Workflow installations", () => {
-  it("materializes the deployed Official Workflows through generic installation state", async () => {
+  it("materializes active deployed Official Workflows and rejects retired installations", async () => {
     installCatalogStorageFixture();
     const synced = await syncDeployedCatalog();
     expect(synced.body).toMatchObject({ outcome: "accepted", diagnostics: [] });
@@ -1808,10 +1826,6 @@ describe.sequential("Official Workflow installations", () => {
         return { name, displayName };
       }),
     ).toStrictEqual([
-      {
-        name: "connector-doctor",
-        displayName: "Connector Doctor",
-      },
       {
         name: "morning-brief",
         displayName: "Morning Brief",
@@ -1876,83 +1890,17 @@ describe.sequential("Official Workflow installations", () => {
       officialResultEmailEnabled: true,
     });
 
-    const installedConnectorDoctor = await accept(
+    const retiredConnectorDoctor = await accept(
       officialClient().install({
         headers,
         params: { definitionName: "connector-doctor" },
-        body: {
-          agentId,
-          blueprints: [{ blueprintKey: "weekly-check", bindings: [] }],
-        },
+        body: { agentId, blueprints: [] },
       }),
-      [201],
+      [409],
     );
-    expect(installedConnectorDoctor.body.definition).toMatchObject({
-      name: "connector-doctor",
-      lifecycle: "active",
-      blueprints: [{ key: "weekly-check" }],
-    });
-    expect(installedConnectorDoctor.body.workflow).toMatchObject({
-      name: "connector-doctor",
-      displayName: "Connector Doctor",
-      agentId,
-      official: {
-        definitionName: "connector-doctor",
-        installationState: "installed",
-        definitionLifecycle: "active",
-        readOnly: true,
-      },
-    });
-    expect(installedConnectorDoctor.body.workflow.automations).toHaveLength(1);
-    const connectorDoctorAutomation =
-      installedConnectorDoctor.body.workflow.automations[0];
-    expect(connectorDoctorAutomation).toMatchObject({
-      kind: "schedule",
-      enabled: true,
-      chatThreadId: expect.any(String),
-      schedule: {
-        type: "cron",
-        cronExpression: "0 9 * * 1",
-        timezone: "Asia/Shanghai",
-      },
-      official: {
-        blueprintKey: "weekly-check",
-        reconciliationStatus: "current",
-        intendedEnabled: true,
-        parameterBindings: [],
-      },
-    });
-    if (!connectorDoctorAutomation?.chatThreadId) {
-      throw new Error("Expected the Connector Doctor shared automation thread");
-    }
-    expect(connectorDoctorAutomation.chatThreadId).not.toBe(
-      morningBriefAutomation.chatThreadId,
+    expect(retiredConnectorDoctor.body.error.message).toBe(
+      "Official Workflow is retired: connector-doctor",
     );
-    const persistedConnectorDoctor = await accept(
-      installationClient().get({
-        headers,
-        params: { workflowId: installedConnectorDoctor.body.workflow.id },
-      }),
-      [200],
-    );
-    expect(persistedConnectorDoctor.body.workflow.automations).toHaveLength(1);
-    expect(persistedConnectorDoctor.body.workflow.automations).toMatchObject([
-      {
-        id: connectorDoctorAutomation.id,
-        chatThreadId: connectorDoctorAutomation.chatThreadId,
-      },
-    ]);
-    await expect(
-      readWorkflowAutomationAutonomyFixture(
-        context,
-        connectorDoctorAutomation.id,
-      ),
-    ).resolves.toMatchObject({
-      autonomyBudget: 10,
-      enabled: true,
-      officialBlueprintKey: "weekly-check",
-      officialResultEmailEnabled: false,
-    });
   });
 
   it("requires a Preference timezone only when a schedule Blueprint omits one", async () => {

--- a/turbo/apps/api/src/signals/services/official-workflow-catalog-source.ts
+++ b/turbo/apps/api/src/signals/services/official-workflow-catalog-source.ts
@@ -24,57 +24,6 @@ Return only the briefing as concise Markdown. Choose short headings and bullets 
 
 Do not read application database tables or use internal application APIs, signed input or output URLs, or callback endpoints. Do not send email, drafts, chat messages, or provider-side updates. The platform owns any result-email delivery after the run succeeds.`;
 
-const CONNECTOR_DOCTOR_INSTRUCTION = `# Connector Doctor
-
-Produce a concise Markdown connector-readiness report in this Official Workflow's shared automation thread.
-
-## Capture the diagnosis once
-
-In one shell tool call, create a unique sandbox-local report file with \`mktemp\`, then run the aggregate diagnosis exactly once per scheduled or manual run and redirect its complete standard output directly into that file. Use this capture shape so the tool result contains only the path and status:
-
-\`\`\`sh
-if [ -z "\${OKOU_AGENT_ID:-}" ]; then
-  printf 'status=failed reason=missing-agent-id\\n' >&2
-  exit 1
-fi
-report_file="$(mktemp "\${TMPDIR:-/tmp}/connector-doctor.XXXXXX.json")" &&
-if okou doctor connectors --agent "$OKOU_AGENT_ID" --json >"$report_file"; then
-  printf 'report_file=%s status=ok\\n' "$report_file"
-else
-  doctor_status=$?
-  printf 'report_file=%s status=failed exit=%s\\n' "$report_file" "$doctor_status" >&2
-  exit "$doctor_status"
-fi
-\`\`\`
-
-Require a non-empty \`OKOU_AGENT_ID\` before running the Doctor command. Do not use \`tee\`, echo the raw output, switch to the human-readable CLI output, or depend on compact JSON whitespace or a higher tool-output limit. Check the command's exit status and do not rerun it, split it into per-workflow diagnoses, or call connector-readiness APIs separately. The capture call may return only the unique file path and a small success or failure status, never the report body.
-
-All later commands must be local parsers against that same sandbox file. Treat that one captured report as the sole source of diagnostic facts. Do not supplement, verify, or reinterpret it from any other source. Keep the file sandbox-local; do not upload, attach, or send it.
-
-## Validate locally and read the summary first
-
-Before making any health claim, use a non-emitting local \`jq\` check or equivalent local parser against the file. It must parse the entire file successfully, prove that the root is an object with \`schemaVersion === 1\`, and validate the required schema-version-1 fields and types used below: all five non-negative integer summary counts, the \`workflows\` array, workflow and Agent identities, outcomes, connector statuses and reasons, exact action kinds and URLs, and workflow errors. It must also prove that every returned workflow's \`agent.id\` exactly matches the runtime \`OKOU_AGENT_ID\`. A missing runtime Agent identity or any cross-Agent workflow entry makes the diagnosis unavailable. A truncated or empty file, invalid JSON, an unsupported schema version, a missing required field, a type or value mismatch, or any local parsing or projection failure makes the diagnosis unavailable.
-
-After validation, the first data-returning projection must contain only \`schemaVersion\` and \`summary\`. Never make a tool call that prints, reads, or returns the whole raw file; in particular, do not use \`cat\`, \`tee\`, an unfiltered \`jq\` query, or an equivalent whole-file read. Every later data-returning projection must select only the fields required by the chosen report branch and return at most 20 records per tool result. Use a count-only projection to determine whether paging is needed, then advance explicit offsets until every projected record for that branch has been consumed. Local parsers may scan the complete file internally, but the raw document must never cross the tool-return boundary.
-
-If the Doctor command or local capture fails, or any validation condition above fails, return a diagnosis-unavailable report under an **Unknown** heading. State the observed failure without claiming that any connector or workflow is healthy.
-
-## Report valid results
-
-- Describe every valid report as covering effective workflows on the current Agent, including both public and private workflows hosted there. Never describe this Agent-scoped result as coverage across visible Agents.
-- If \`summary.checked === 0\`, report that no effective workflows on the current Agent were available to check. Treat this as a distinct no-workflows result, not an all-clear over diagnosed workflows. The validated summary is sufficient for this branch.
-- Emit a short all-clear only when \`summary.checked > 0\`, \`summary.attention === 0\`, and \`summary.unknown === 0\`. For this branch, page through a projection containing only each checked workflow's returned identity and returned Agent identity. State that the aggregate covered effective workflows on the current Agent, including its public and private workflows, and include a compact inventory of every checked entry in \`workflows\`. Use only workflow and Agent names or IDs present in the JSON.
-- Otherwise, page through a projection of every connector entry with a non-null action, selecting only the workflow identity, connector status and reason, and exact \`action.kind\`, \`action.label\`, and \`action.url\`. Group entries by identical \`action.kind\` and exact \`action.url\`. Include the repair link once for each group, then list every affected workflow with the connector's returned readiness status and reason. Never merge entries whose exact URLs differ, even when their action kinds or connector labels match, because the URL identifies the target Agent.
-- For the same non-all-clear branch, separately page through a projection of every connector whose status is \`unavailable\` and every workflow with a non-null \`error\`. Under **Unknown**, include the returned workflow identity and reason or error message. Unknown is never healthy.
-- Do not apply a visibility filter to any valid report branch. The Agent-scoped aggregate already includes both public and private effective workflows on the current Agent.
-- Keep the report concise and include only facts, counts, statuses, reasons, and repair links present in the returned JSON.
-
-## Safety boundaries
-
-Do not invoke connector or provider skills, third-party provider APIs, \`okou connector list\`, \`okou connector status\`, \`okou connector check\`, application-internal APIs, or application database tables. Do not write to or mutate application or provider state. Do not connect, reconnect, authorize, start OAuth flows, request permissions, create callbacks, mutate connectors, or follow repair links. Do not select or recommend models, and do not recommend workflow or Automation cleanup.
-
-Return only the Markdown report. The platform delivers it to the shared automation thread. Do not send email or directly send any chat or other message.`;
-
 /**
  * The sole deployed source candidate. Every Definition uses the same validated
  * release boundary and immutable shared-artifact publication path.
@@ -111,28 +60,7 @@ export const OFFICIAL_WORKFLOW_SOURCE_CATALOG: OfficialWorkflowSourceCatalog =
       },
       {
         name: "connector-doctor",
-        lifecycle: "active",
-        workflow: {
-          displayName: "Connector Doctor",
-          description:
-            "Diagnose connector readiness across your workflows and group exact repair actions.",
-          instruction: CONNECTOR_DOCTOR_INSTRUCTION,
-          files: [],
-        },
-        blueprints: [
-          {
-            key: "weekly-check",
-            parameters: [],
-            desiredState: {
-              kind: "schedule",
-              schedule: {
-                type: "cron",
-                cronExpression: "0 9 * * 1",
-              },
-            },
-            runtime: { resultEmail: false },
-          },
-        ],
+        lifecycle: "retired",
         presentation: { category: "productivity" },
       },
     ],

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -59,7 +59,6 @@ const OTHER_WORKFLOW_ID = "d0000000-0000-4000-a000-000000000203";
 const CHECKLIST_WORKFLOW_ID = "d0000000-0000-4000-a000-000000000204";
 const COPIED_WORKFLOW_ID = "d0000000-0000-4000-a000-000000000205";
 const MORNING_BRIEF_WORKFLOW_ID = "d0000000-0000-4000-a000-000000000206";
-const CONNECTOR_DOCTOR_WORKFLOW_ID = "d0000000-0000-4000-a000-000000000207";
 const GMAIL_AUTOMATION_ID = "workflow-automation-gmail-new-message";
 const GMAIL_LABEL_AUTOMATION_ID = "workflow-automation-gmail-label-applied";
 const GITHUB_PULL_REQUEST_AUTOMATION_ID =
@@ -723,32 +722,28 @@ function officialSalesResearch(
   };
 }
 
-function namedOfficialWorkflow(
-  definitionName: "morning-brief" | "connector-doctor",
-): WorkflowDetailResponse {
+function morningBriefWorkflow(): WorkflowDetailResponse {
   const base = officialSalesResearch();
   if (!base.official) {
     throw new Error("Expected an Official Workflow fixture");
   }
-  const morningBrief = definitionName === "morning-brief";
-  const displayName = morningBrief ? "Morning Brief" : "Connector Doctor";
   return {
     ...base,
-    id: morningBrief ? MORNING_BRIEF_WORKFLOW_ID : CONNECTOR_DOCTOR_WORKFLOW_ID,
-    name: definitionName,
-    displayName,
+    id: MORNING_BRIEF_WORKFLOW_ID,
+    name: "morning-brief",
+    displayName: "Morning Brief",
     official: {
       ...base.official,
-      definitionName,
+      definitionName: "morning-brief",
     },
     automations: base.automations.map((automation) => {
       return {
         ...automation,
-        id: `workflow-automation-${definitionName}`,
+        id: "workflow-automation-morning-brief",
         official: automation.official
           ? {
               ...automation.official,
-              blueprintKey: morningBrief ? "daily-delivery" : "weekly-check",
+              blueprintKey: "daily-delivery",
             }
           : null,
       };
@@ -1562,17 +1557,12 @@ describe("workflows routes", () => {
   });
 
   it("hides Morning Brief from App workflow lists and counts without hiding other Official Workflows", async () => {
-    mockWorkflowApis([
-      salesResearch(),
-      namedOfficialWorkflow("morning-brief"),
-      namedOfficialWorkflow("connector-doctor"),
-    ]);
+    mockWorkflowApis([officialSalesResearch(), morningBriefWorkflow()]);
 
     detachedSetupPage({ context, path: "/workflows" });
 
     await screen.findByRole("heading", { name: "Workflows" });
     expect(screen.getByText("Sales Research")).toBeInTheDocument();
-    expect(screen.getByText("Connector Doctor")).toBeInTheDocument();
     expect(screen.queryByText("Morning Brief")).not.toBeInTheDocument();
     expect(
       screen.queryByLabelText("Open Morning Brief"),
@@ -1580,7 +1570,7 @@ describe("workflows routes", () => {
   });
 
   it("redirects a cold Morning Brief workflow detail URL to the stable Preferences deep link", async () => {
-    mockWorkflowApis([namedOfficialWorkflow("morning-brief")]);
+    mockWorkflowApis([morningBriefWorkflow()]);
 
     detachedSetupWorkflowDetailPage(
       `/workflows/${MORNING_BRIEF_WORKFLOW_ID}/automations`,


### PR DESCRIPTION
## Summary

- retire `connector-doctor` with the required source-catalog tombstone instead of silently deleting its released name
- remove the active Doctor instruction, workflow payload, weekly blueprint, discovery card, and active installation expectations
- prove retirement retains the exact released revision, artifact, and blueprint history while leaving Morning Brief behavior unchanged

## Verification

- `pnpm format`
- changed-file Prettier, oxlint, and ESLint checks after rebasing onto current `main`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-official-workflow-catalog.test.ts` (14 passed)
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/official-workflows.test.ts` (42 passed)
- `pnpm --filter @okouai/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx` (79 passed)
- `git diff --check`

Closes #30992
