### PR TITLE
refactor(api): quiesce model usage observation storage

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -141,10 +141,6 @@ import {
   setRunAutonomyBudgetFixture,
   steerRunTimeBudgetFixture,
 } from "./helpers/runtime-state";
-import {
-  deleteModelStatsObservations,
-  readModelStatsObservations,
-} from "./helpers/model-stats-state";
 import { createRouteMocks } from "./helpers/route-test";
 import { formatUserPresentationTemplateId } from "@okouai/core/presentation-template-selection";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
@@ -229,8 +225,6 @@ const CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET = "okou web upload-file -f <path>";
 const RUN_TIME_BUDGET_STEER_AT_MS = 115 * 60 * 1000;
 const PI_API_FIRST_TURN_USAGE_NAMESPACE =
   "26e1c547-485d-4438-bf6d-4b77959da0cb";
-const PI_API_FIRST_TURN_OBSERVATION_NAMESPACE =
-  "670e6ebc-79c3-4f44-b322-e26d1be7cf2e";
 const TERRA_USAGE_PRICING = [
   "tokens.input",
   "tokens.output",
@@ -552,22 +546,6 @@ async function expectTerraApiFirstTurnUsage(
     cacheRead: 3,
     cacheWrite: 2,
   });
-  if (firstAssistant?.role !== "assistant") {
-    throw new Error("Expected the Terra first turn to persist an assistant");
-  }
-  const responseSourceId =
-    firstAssistant.responseId ??
-    createHash("sha256").update(sessionBytes).digest("hex");
-  const observationIdempotencyKey = uuidv5(
-    JSON.stringify([runId, responseSourceId]),
-    PI_API_FIRST_TURN_OBSERVATION_NAMESPACE,
-  );
-  onTestFinished(async () => {
-    await deleteModelStatsObservations(context, [observationIdempotencyKey]);
-  });
-  await expect(
-    readModelStatsObservations(context, [observationIdempotencyKey]),
-  ).resolves.toStrictEqual([]);
   await expectTerraApiUsage(runId, "", {
     input: 5,
     output: 3,
@@ -5670,6 +5648,9 @@ describe("CHAT-02: model-first provider policies", () => {
     onTestFinished(async () => {
       await deletePiApiFirstTurnUsageEventsFixture(idempotencyKeys);
     });
+    // No production API can preseed first-turn billing identities before the
+    // provider responds. This run-owned fixture creates the otherwise
+    // unreachable retry state while the public chat API remains under test.
     await insertPiApiFirstTurnUsageEventsFixture({
       runId: run.runId,
       orgId,
@@ -5744,18 +5725,24 @@ describe("CHAT-02: model-first provider policies", () => {
       usagePricingResolution,
     );
     await providerEntered.promise;
-    const [expectedEvent] = terraApiFirstTurnUsageEvents(
+    const usageEvents = terraApiFirstTurnUsageEvents(
       run.runId,
       "resp_pi_api_0",
     );
+    const [expectedEvent] = usageEvents;
     if (!expectedEvent) {
       throw new Error("Expected a Terra billing identity fixture");
     }
     onTestFinished(async () => {
-      await deletePiApiFirstTurnUsageEventsFixture([
-        expectedEvent.idempotencyKey,
-      ]);
+      await deletePiApiFirstTurnUsageEventsFixture(
+        usageEvents.map((event) => {
+          return event.idempotencyKey;
+        }),
+      );
     });
+    // No production API can preseed a conflicting first-turn billing identity
+    // before the provider responds. This run-owned fixture creates that
+    // otherwise unreachable state while the public chat API remains under test.
     await insertPiApiFirstTurnUsageEventsFixture({
       runId: run.runId,
       orgId,
@@ -5772,6 +5759,8 @@ describe("CHAT-02: model-first provider policies", () => {
       status: "failed",
       error: expect.stringContaining("[PI_API_MODEL_FAILED]"),
     });
+    // Public usage summaries omit unprocessed rows. Inspect this run's unique
+    // rows only to prove the failed transaction added no partial billing data.
     await expect(readRunUsageEventsFixture(run.runId)).resolves.toStrictEqual([
       expect.objectContaining({
         category: expectedEvent.category,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -52,6 +52,7 @@ import {
 } from "@okouai/api-contracts/contracts/model-provider-gateways";
 import { modelProvidersMainContract } from "@okouai/api-contracts/contracts/model-provider-routes";
 import { describe, expect, it, onTestFinished } from "vitest";
+import { v5 as uuidv5 } from "uuid";
 import { z } from "zod";
 import { createApp } from "../../../app-factory";
 import { env, mockEnv, mockOptionalEnv } from "../../../lib/env";
@@ -140,6 +141,10 @@ import {
   setRunAutonomyBudgetFixture,
   steerRunTimeBudgetFixture,
 } from "./helpers/runtime-state";
+import {
+  deleteModelStatsObservations,
+  readModelStatsObservations,
+} from "./helpers/model-stats-state";
 import { createRouteMocks } from "./helpers/route-test";
 import { formatUserPresentationTemplateId } from "@okouai/core/presentation-template-selection";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
@@ -160,6 +165,7 @@ import {
   acquireBddVm0ApiKey,
   completeRunWithoutCallbacksFixture,
   deleteAgentRunFixture,
+  deletePiApiFirstTurnUsageEventsFixture,
   holdAgentRunRowLockFixture,
   holdChatEventQueueItemFixture,
   holdChatThreadRowLockFixture,
@@ -168,6 +174,7 @@ import {
   holdThreadSessionBindingClearFixture,
   holdThreadSessionConversationChangesFixture,
   holdThreadSessionConversationClearFixture,
+  insertPiApiFirstTurnUsageEventsFixture,
   readCanonicalChatEventStorageFixture,
   readRunUsageEventsFixture,
   releaseBddVm0ApiKey,
@@ -220,6 +227,10 @@ const runStateStore = createStore();
 const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
 const CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET = "okou web upload-file -f <path>";
 const RUN_TIME_BUDGET_STEER_AT_MS = 115 * 60 * 1000;
+const PI_API_FIRST_TURN_USAGE_NAMESPACE =
+  "26e1c547-485d-4438-bf6d-4b77959da0cb";
+const PI_API_FIRST_TURN_OBSERVATION_NAMESPACE =
+  "670e6ebc-79c3-4f44-b322-e26d1be7cf2e";
 const TERRA_USAGE_PRICING = [
   "tokens.input",
   "tokens.output",
@@ -541,11 +552,51 @@ async function expectTerraApiFirstTurnUsage(
     cacheRead: 3,
     cacheWrite: 2,
   });
+  if (firstAssistant?.role !== "assistant") {
+    throw new Error("Expected the Terra first turn to persist an assistant");
+  }
+  const responseSourceId =
+    firstAssistant.responseId ??
+    createHash("sha256").update(sessionBytes).digest("hex");
+  const observationIdempotencyKey = uuidv5(
+    JSON.stringify([runId, responseSourceId]),
+    PI_API_FIRST_TURN_OBSERVATION_NAMESPACE,
+  );
+  onTestFinished(async () => {
+    await deleteModelStatsObservations(context, [observationIdempotencyKey]);
+  });
+  await expect(
+    readModelStatsObservations(context, [observationIdempotencyKey]),
+  ).resolves.toStrictEqual([]);
   await expectTerraApiUsage(runId, "", {
     input: 5,
     output: 3,
     cacheRead: 3,
     cacheCreation: 2,
+  });
+}
+
+function terraApiFirstTurnUsageEvents(
+  runId: string,
+  responseSourceId: string,
+): readonly {
+  readonly idempotencyKey: string;
+  readonly category: string;
+  readonly quantity: number;
+}[] {
+  return [
+    { category: "tokens.input", quantity: 5 },
+    { category: "tokens.output", quantity: 3 },
+    { category: "tokens.cache_read", quantity: 3 },
+    { category: "tokens.cache_creation", quantity: 2 },
+  ].map((entry) => {
+    return {
+      ...entry,
+      idempotencyKey: uuidv5(
+        JSON.stringify([runId, responseSourceId, entry.category]),
+        PI_API_FIRST_TURN_USAGE_NAMESPACE,
+      ),
+    };
   });
 }
 
@@ -5554,6 +5605,180 @@ describe("CHAT-02: model-first provider policies", () => {
     },
     90_000,
   );
+
+  it("keeps Terra first-turn billing idempotent for matching usage identities", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    const orgId = requireOrgId(actor);
+    const usagePricingResolution = await createTerraUsagePricingResolution();
+    await configureBuiltInPiModel(actor, "gpt-5.6-terra");
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId },
+      { [FeatureSwitchKey.PiLoop]: true },
+    );
+    mockPiResourceArchiveDownloads();
+    mockPiCheckpointObjectStore();
+
+    const providerEntered = createDeferredPromise<void>(context.signal);
+    const releaseProvider = createDeferredPromise<void>(context.signal);
+    onTestFinished(() => {
+      if (!releaseProvider.settled()) {
+        releaseProvider.resolve(undefined);
+      }
+    });
+    let modelCalls = 0;
+    server.use(
+      http.post("https://api.openai.com/v1/responses", async () => {
+        modelCalls += 1;
+        if (!providerEntered.settled()) {
+          providerEntered.resolve(undefined);
+        }
+        await releaseProvider.promise;
+        return new HttpResponse(
+          piResponsesTextSse("idempotent Terra billing", 0, {
+            input_tokens: 10,
+            output_tokens: 3,
+            total_tokens: 13,
+            input_tokens_details: {
+              cached_tokens: 3,
+              cache_write_tokens: 2,
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+
+    const run = await sendChatRun(
+      actor,
+      {
+        agentId,
+        prompt: "reuse matching Terra billing identities",
+        model: "gpt-5.6-terra",
+      },
+      "vm0",
+      usagePricingResolution,
+    );
+    await providerEntered.promise;
+    const usageEvents = terraApiFirstTurnUsageEvents(
+      run.runId,
+      "resp_pi_api_0",
+    );
+    const idempotencyKeys = usageEvents.map((event) => {
+      return event.idempotencyKey;
+    });
+    onTestFinished(async () => {
+      await deletePiApiFirstTurnUsageEventsFixture(idempotencyKeys);
+    });
+    await insertPiApiFirstTurnUsageEventsFixture({
+      runId: run.runId,
+      orgId,
+      userId: actor.userId,
+      events: usageEvents,
+    });
+
+    releaseProvider.resolve(undefined);
+    await waitForRunStatus(actor, run.runId, "completed");
+    await flushWaitUntilForTest();
+
+    expect(modelCalls).toBe(1);
+    await expectTerraApiUsage(run.runId, "", {
+      input: 5,
+      output: 3,
+      cacheRead: 3,
+      cacheCreation: 2,
+    });
+  }, 90_000);
+
+  it("fails Terra first-turn billing on a conflicting usage identity", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    const orgId = requireOrgId(actor);
+    const usagePricingResolution = await createTerraUsagePricingResolution();
+    await configureBuiltInPiModel(actor, "gpt-5.6-terra");
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId },
+      { [FeatureSwitchKey.PiLoop]: true },
+    );
+    mockPiResourceArchiveDownloads();
+    mockPiCheckpointObjectStore();
+
+    const providerEntered = createDeferredPromise<void>(context.signal);
+    const releaseProvider = createDeferredPromise<void>(context.signal);
+    onTestFinished(() => {
+      if (!releaseProvider.settled()) {
+        releaseProvider.resolve(undefined);
+      }
+    });
+    let modelCalls = 0;
+    server.use(
+      http.post("https://api.openai.com/v1/responses", async () => {
+        modelCalls += 1;
+        if (!providerEntered.settled()) {
+          providerEntered.resolve(undefined);
+        }
+        await releaseProvider.promise;
+        return new HttpResponse(
+          piResponsesTextSse("conflicting Terra billing", 0, {
+            input_tokens: 10,
+            output_tokens: 3,
+            total_tokens: 13,
+            input_tokens_details: {
+              cached_tokens: 3,
+              cache_write_tokens: 2,
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+
+    const run = await sendChatRun(
+      actor,
+      {
+        agentId,
+        prompt: "reject a conflicting Terra billing identity",
+        model: "gpt-5.6-terra",
+      },
+      "vm0",
+      usagePricingResolution,
+    );
+    await providerEntered.promise;
+    const [expectedEvent] = terraApiFirstTurnUsageEvents(
+      run.runId,
+      "resp_pi_api_0",
+    );
+    if (!expectedEvent) {
+      throw new Error("Expected a Terra billing identity fixture");
+    }
+    onTestFinished(async () => {
+      await deletePiApiFirstTurnUsageEventsFixture([
+        expectedEvent.idempotencyKey,
+      ]);
+    });
+    await insertPiApiFirstTurnUsageEventsFixture({
+      runId: run.runId,
+      orgId,
+      userId: actor.userId,
+      events: [{ ...expectedEvent, quantity: expectedEvent.quantity + 1 }],
+    });
+
+    releaseProvider.resolve(undefined);
+    await waitForRunStatus(actor, run.runId, "failed");
+    await flushWaitUntilForTest();
+
+    expect(modelCalls).toBe(1);
+    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+      status: "failed",
+      error: expect.stringContaining("[PI_API_MODEL_FAILED]"),
+    });
+    await expect(readRunUsageEventsFixture(run.runId)).resolves.toStrictEqual([
+      expect.objectContaining({
+        category: expectedEvent.category,
+        quantity: expectedEvent.quantity + 1,
+      }),
+    ]);
+  }, 90_000);
 
   it("resumes pre-migration OpenRouter Chat JSONL through API-first Responses", async () => {
     const { actor, agentId } = await entitledChatActor();

--- a/turbo/apps/api/src/signals/routes/__tests__/runner-model-usage-observations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runner-model-usage-observations.test.ts
@@ -73,41 +73,39 @@ describe("POST /api/runners/model-usage-observations", () => {
       body: { success: true },
     });
 
+    // Raw observation rows have no production read API. Inspect these unique
+    // keys only to prove the still-live compatibility endpoint discards its
+    // accepted batches instead of feeding future rankings.
     await expect(
       readModelStatsObservations(context, idempotencyKeys),
     ).resolves.toStrictEqual([]);
   });
 
-  it("preserves request validation without storing invalid observations", async () => {
+  it("preserves request validation for invalid observations", async () => {
     const idempotencyKey = randomUUID();
-    onTestFinished(async () => {
-      await deleteModelStatsObservations(context, [idempotencyKey]);
-    });
-
-    await accept(
-      client().report({
-        headers: officialRunnerHeaders(),
-        body: {
-          events: [
-            {
-              ...observation(
-                idempotencyKey,
-                DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
-              ),
-              inputTokens: 0,
-              outputTokens: 0,
-              cacheReadInputTokens: 0,
-              cacheCreationInputTokens: 0,
-            },
-          ],
-        },
-      }),
-      [400],
-    );
 
     await expect(
-      readModelStatsObservations(context, [idempotencyKey]),
-    ).resolves.toStrictEqual([]);
+      accept(
+        client().report({
+          headers: officialRunnerHeaders(),
+          body: {
+            events: [
+              {
+                ...observation(
+                  idempotencyKey,
+                  DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+                ),
+                inputTokens: 0,
+                outputTokens: 0,
+                cacheReadInputTokens: 0,
+                cacheCreationInputTokens: 0,
+              },
+            ],
+          },
+        }),
+        [400],
+      ),
+    ).resolves.toMatchObject({ status: 400 });
   });
 
   it("accepts only official runner authentication", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/runner-model-usage-observations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runner-model-usage-observations.test.ts
@@ -44,7 +44,7 @@ function observation(idempotencyKey: string, model: string) {
 }
 
 describe("POST /api/runners/model-usage-observations", () => {
-  it("persists supported observations idempotently and excludes unsupported models", async () => {
+  it("accepts valid observations without storing them", async () => {
     const supportedKey = randomUUID();
     const unsupportedKey = randomUUID();
     const idempotencyKeys = [supportedKey, unsupportedKey];
@@ -75,12 +75,39 @@ describe("POST /api/runners/model-usage-observations", () => {
 
     await expect(
       readModelStatsObservations(context, idempotencyKeys),
-    ).resolves.toStrictEqual([
-      {
-        idempotencyKey: supportedKey,
-        aggregatedAt: null,
-      },
-    ]);
+    ).resolves.toStrictEqual([]);
+  });
+
+  it("preserves request validation without storing invalid observations", async () => {
+    const idempotencyKey = randomUUID();
+    onTestFinished(async () => {
+      await deleteModelStatsObservations(context, [idempotencyKey]);
+    });
+
+    await accept(
+      client().report({
+        headers: officialRunnerHeaders(),
+        body: {
+          events: [
+            {
+              ...observation(
+                idempotencyKey,
+                DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+              ),
+              inputTokens: 0,
+              outputTokens: 0,
+              cacheReadInputTokens: 0,
+              cacheCreationInputTokens: 0,
+            },
+          ],
+        },
+      }),
+      [400],
+    );
+
+    await expect(
+      readModelStatsObservations(context, [idempotencyKey]),
+    ).resolves.toStrictEqual([]);
   });
 
   it("accepts only official runner authentication", async () => {

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -2679,9 +2679,10 @@ const modelUsageObservationsInner$ = command(
       return body.response;
     }
 
-    // Old runners can submit retained observation batches while their fleet
-    // drains. Remove this old-runner -> new-backend sink with #30974 only
-    // after #30973 is deployed everywhere and its live traffic gate passes.
+    // Old runner -> new backend compatibility: retained batches can arrive for
+    // the two-hour run lifetime plus the five-minute flush interval, including
+    // old-image resumption. Remove this sink with #30974 only after #30973 is
+    // deployed everywhere and live traffic stays at zero for that window.
 
     return {
       status: 200 as const,

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -35,7 +35,6 @@ import { agentSessions } from "@okouai/db/schema/agent-session";
 import { agents } from "@okouai/db/schema/agent";
 import { blobs } from "@okouai/db/schema/blob";
 import { runnerJobQueue } from "@okouai/db/schema/runner-job-queue";
-import { modelUsageObservation } from "@okouai/db/schema/model-usage-observation";
 import {
   runnerState,
   type RunnerHeldSandboxState as PersistedRunnerHeldSandboxState,
@@ -56,10 +55,6 @@ import {
   type SQL,
 } from "drizzle-orm";
 import { z } from "zod";
-import {
-  isSupportedRunModel,
-  normalizeRunModelId,
-} from "@okouai/api-contracts/contracts/model-providers";
 
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -2684,34 +2679,9 @@ const modelUsageObservationsInner$ = command(
       return body.response;
     }
 
-    const observedAt = nowDate();
-    const observationValues = body.data.events.flatMap((event) => {
-      const canonicalModel = normalizeRunModelId(event.model);
-      if (!isSupportedRunModel(canonicalModel)) {
-        return [];
-      }
-      return [
-        {
-          model: canonicalModel,
-          inputTokens: event.inputTokens,
-          outputTokens: event.outputTokens,
-          cacheReadInputTokens: event.cacheReadInputTokens,
-          cacheCreationInputTokens: event.cacheCreationInputTokens,
-          observedAt,
-          idempotencyKey: event.idempotencyKey,
-        },
-      ];
-    });
-
-    if (observationValues.length > 0) {
-      await set(writeDb$)
-        .insert(modelUsageObservation)
-        .values(observationValues)
-        .onConflictDoNothing({
-          target: [modelUsageObservation.idempotencyKey],
-        });
-    }
-    signal.throwIfAborted();
+    // Old runners can submit retained observation batches while their fleet
+    // drains. Remove this old-runner -> new-backend sink with #30974 only
+    // after #30973 is deployed everywhere and its live traffic gate passes.
 
     return {
       status: 200 as const,

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn-usage.service.ts
@@ -2,18 +2,15 @@ import { createHash } from "node:crypto";
 
 import { MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS } from "@okouai/api-contracts/contracts/model-price-tiers";
 import type { PiModelConfig } from "@okouai/api-contracts/contracts/runners";
-import { modelUsageObservation } from "@okouai/db/schema/model-usage-observation";
 import { usageEvent } from "@okouai/db/schema/usage-event";
 import type { PiApiFirstTurnResult } from "@okouai/pi-agent-runtime/api";
-import { and, eq, inArray } from "drizzle-orm";
+import { inArray } from "drizzle-orm";
 import { v5 as uuidv5 } from "uuid";
 
 import type { Db } from "../external/db";
 
 const PI_API_FIRST_TURN_USAGE_NAMESPACE =
   "26e1c547-485d-4438-bf6d-4b77959da0cb";
-const PI_API_FIRST_TURN_OBSERVATION_NAMESPACE =
-  "670e6ebc-79c3-4f44-b322-e26d1be7cf2e";
 const TERRA_MODEL = "gpt-5.6-terra";
 
 function terraLongContextMinimumInputTokens(): number {
@@ -120,24 +117,11 @@ function isFastPiApiFirstTurn(args: RecordPiApiFirstTurnUsageArgs): boolean {
   return args.requestedServiceTier === "priority";
 }
 
-function sameObservation(
-  row: typeof modelUsageObservation.$inferSelect,
-  expected: typeof modelUsageObservation.$inferInsert,
-): boolean {
-  return (
-    row.model === expected.model &&
-    row.inputTokens === expected.inputTokens &&
-    row.outputTokens === expected.outputTokens &&
-    row.cacheReadInputTokens === expected.cacheReadInputTokens &&
-    row.cacheCreationInputTokens === expected.cacheCreationInputTokens
-  );
-}
-
 /**
- * Persist API-owned Terra usage before any lifecycle commit. The response
- * identity owns both billing and public model observation rows, so retries and
- * late cancellation observers converge on the same immutable records. Sandbox
- * provider calls keep their independent MITM-owned delivery identities.
+ * Persist API-owned Terra billing usage before any lifecycle commit. The
+ * response identity keeps retries and late cancellation observers converged on
+ * the same immutable ledger rows. Sandbox provider calls keep their independent
+ * MITM-owned delivery identities.
  */
 export async function recordPiApiFirstTurnUsage(
   db: Db,
@@ -167,95 +151,57 @@ export async function recordPiApiFirstTurnUsage(
       quantity: entry.quantity,
     } as const;
   });
-  const usage = args.turn.assistantMessage.usage;
-  const observationRow = {
-    idempotencyKey: idempotencyKey(PI_API_FIRST_TURN_OBSERVATION_NAMESPACE, [
-      args.runId,
-      responseSourceId,
-    ]),
-    model: TERRA_MODEL,
-    inputTokens: usageQuantity(usage.input, "input"),
-    outputTokens: usageQuantity(usage.output, "output"),
-    cacheReadInputTokens: usageQuantity(usage.cacheRead, "cache-read"),
-    cacheCreationInputTokens: usageQuantity(usage.cacheWrite, "cache-creation"),
-  } as const;
-
+  if (usageRows.length === 0) {
+    return;
+  }
   await db.transaction(async (tx) => {
-    if (usageRows.length > 0) {
-      await tx
-        .insert(usageEvent)
-        .values(usageRows)
-        .onConflictDoNothing({ target: [usageEvent.idempotencyKey] });
-      const storedUsageRows = await tx
-        .select({
-          idempotencyKey: usageEvent.idempotencyKey,
-          runId: usageEvent.runId,
-          orgId: usageEvent.orgId,
-          userId: usageEvent.userId,
-          kind: usageEvent.kind,
-          provider: usageEvent.provider,
-          category: usageEvent.category,
-          quantity: usageEvent.quantity,
-        })
-        .from(usageEvent)
-        .where(
-          inArray(
-            usageEvent.idempotencyKey,
-            usageRows.map((row) => {
-              return row.idempotencyKey;
-            }),
-          ),
-        );
-      const expectedByKey = new Map(
-        usageRows.map((row) => {
-          return [row.idempotencyKey, row] as const;
-        }),
-      );
-      for (const row of storedUsageRows) {
-        const expected = expectedByKey.get(row.idempotencyKey);
-        if (
-          !expected ||
-          row.runId !== expected.runId ||
-          row.orgId !== expected.orgId ||
-          row.userId !== expected.userId ||
-          row.kind !== expected.kind ||
-          row.provider !== expected.provider ||
-          row.category !== expected.category ||
-          row.quantity !== expected.quantity
-        ) {
-          throw new Error("Pi API first-turn usage identity collision");
-        }
-        expectedByKey.delete(row.idempotencyKey);
-      }
-      if (expectedByKey.size > 0) {
-        throw new Error("Pi API first-turn usage persistence is incomplete");
-      }
-    }
-
     await tx
-      .insert(modelUsageObservation)
-      .values(observationRow)
-      .onConflictDoNothing({
-        target: [modelUsageObservation.idempotencyKey],
-      });
-    const [storedObservation] = await tx
-      .select()
-      .from(modelUsageObservation)
+      .insert(usageEvent)
+      .values(usageRows)
+      .onConflictDoNothing({ target: [usageEvent.idempotencyKey] });
+    const storedUsageRows = await tx
+      .select({
+        idempotencyKey: usageEvent.idempotencyKey,
+        runId: usageEvent.runId,
+        orgId: usageEvent.orgId,
+        userId: usageEvent.userId,
+        kind: usageEvent.kind,
+        provider: usageEvent.provider,
+        category: usageEvent.category,
+        quantity: usageEvent.quantity,
+      })
+      .from(usageEvent)
       .where(
-        and(
-          eq(
-            modelUsageObservation.idempotencyKey,
-            observationRow.idempotencyKey,
-          ),
-          eq(modelUsageObservation.model, TERRA_MODEL),
+        inArray(
+          usageEvent.idempotencyKey,
+          usageRows.map((row) => {
+            return row.idempotencyKey;
+          }),
         ),
-      )
-      .limit(1);
-    if (
-      !storedObservation ||
-      !sameObservation(storedObservation, observationRow)
-    ) {
-      throw new Error("Pi API first-turn observation identity collision");
+      );
+    const expectedByKey = new Map(
+      usageRows.map((row) => {
+        return [row.idempotencyKey, row] as const;
+      }),
+    );
+    for (const row of storedUsageRows) {
+      const expected = expectedByKey.get(row.idempotencyKey);
+      if (
+        !expected ||
+        row.runId !== expected.runId ||
+        row.orgId !== expected.orgId ||
+        row.userId !== expected.userId ||
+        row.kind !== expected.kind ||
+        row.provider !== expected.provider ||
+        row.category !== expected.category ||
+        row.quantity !== expected.quantity
+      ) {
+        throw new Error("Pi API first-turn usage identity collision");
+      }
+      expectedByKey.delete(row.idempotencyKey);
+    }
+    if (expectedByKey.size > 0) {
+      throw new Error("Pi API first-turn usage persistence is incomplete");
     }
   });
 }

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -3069,6 +3069,10 @@ export async function readRunUsageEventsFixture(runId: string): Promise<
     .orderBy(usageEvent.category);
 }
 
+/**
+ * Seed immutable first-turn billing identities that production APIs cannot
+ * create before the model response, for route-level retry and collision tests.
+ */
 export async function insertPiApiFirstTurnUsageEventsFixture(args: {
   readonly runId: string;
   readonly orgId: string;

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -3069,6 +3069,42 @@ export async function readRunUsageEventsFixture(runId: string): Promise<
     .orderBy(usageEvent.category);
 }
 
+export async function insertPiApiFirstTurnUsageEventsFixture(args: {
+  readonly runId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly events: readonly {
+    readonly idempotencyKey: string;
+    readonly category: string;
+    readonly quantity: number;
+  }[];
+}): Promise<void> {
+  await db()
+    .insert(usageEvent)
+    .values(
+      args.events.map((event) => {
+        return {
+          runId: args.runId,
+          idempotencyKey: event.idempotencyKey,
+          orgId: args.orgId,
+          userId: args.userId,
+          kind: "model",
+          provider: "gpt-5.6-terra",
+          category: event.category,
+          quantity: event.quantity,
+        };
+      }),
+    );
+}
+
+export async function deletePiApiFirstTurnUsageEventsFixture(
+  idempotencyKeys: readonly string[],
+): Promise<void> {
+  await db()
+    .delete(usageEvent)
+    .where(inArray(usageEvent.idempotencyKey, [...idempotencyKeys]));
+}
+
 /**
  * Exercise the production predicates shared by artifact catalog/realtime,
  * thread/Google Drive, and Feishu/AgentPhone/Teams/Telegram dispatch readers.


### PR DESCRIPTION
## Summary

- stop persisting runner-reported model usage observations while preserving official-runner authentication, payload validation, and the successful compatibility response
- stop writing Terra API first-turn observations while preserving billing usage rows and their immutable idempotency checks
- add integration coverage for no-storage behavior, billing retry convergence, and identity collisions

## Exclusions

- keep the runner observation endpoint and request contract until the runner fleet drain is complete
- leave observation schema, aggregation, and remaining read paths to the other child issues under the delivery parent

## Testing

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/runner-model-usage-observations.test.ts`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t 'runs the Pi API first turn once for gpt-5.6-terra|keeps Terra first-turn billing idempotent|fails Terra first-turn billing'`

## Fallbacks

- `turbo/apps/api/src/signals/routes/runners.ts:modelUsageObservationsInner$` remains an old-runner-to-new-backend compatibility sink: valid official-runner batches still receive success but are not stored. Remove it with #30974 only after #30973 is deployed everywhere and the live traffic gate passes for the maximum run lifetime plus the five-minute flush interval, including the old-image resumption window.

Closes #30970

Parent: #30964
