### PR TITLE
test(api): split the stale official admission scenario

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -1491,6 +1491,65 @@ async function installOfficialWorkflowLifecycleScenario() {
   };
 }
 
+async function installStaleAdmissionScenario() {
+  installCatalogStorageFixture();
+  const suffix = randomUUID().replaceAll("-", "").slice(0, 10);
+  const definitionName = `api-test-stale-${suffix}`;
+  await syncCatalog(
+    catalog([activeDefinition(definitionName, [loopBlueprint()])]),
+  );
+  const { actor } = await workflowBdd.setupWorkflowOrg();
+  if (!actor.orgId) {
+    throw new Error("Expected organization-scoped actor");
+  }
+  const { agentId } = await workflowBdd.createAgent(actor);
+  const headers = authHeaders(actor);
+  await setOfficialWorkflowsEnabled(actor, true);
+  const installed = await accept(
+    officialClient().install({
+      headers,
+      params: { definitionName },
+      body: {
+        agentId,
+        blueprints: [
+          {
+            blueprintKey: "pulse",
+            bindings: [{ key: "interval-seconds", value: 60 }],
+          },
+        ],
+      },
+    }),
+    [201],
+  );
+  onTestFinished(async () => {
+    installCatalogStorageFixture();
+    const createdRuns = await runs.listAgentRuns(actor, {
+      agent: agentId,
+      limit: 100,
+    });
+    for (const run of createdRuns.runs) {
+      await runs.requestCancelRun(actor, run.id, [200, 400]);
+    }
+    await flushWaitUntilForTest();
+    await bdd.deleteAgent(actor, agentId);
+    await cleanupCatalog();
+  });
+  const automation = installed.body.workflow.automations[0];
+  if (!automation?.official) {
+    throw new Error("Expected Official Automation state");
+  }
+  return {
+    actor,
+    agentId,
+    automation,
+    definitionName,
+    headers,
+    installed,
+    originalFingerprint: automation.official.appliedFingerprint,
+    suffix,
+  };
+}
+
 beforeEach(async () => {
   mockEnv("CRON_SECRET", CRON_SECRET);
   mockEnv(
@@ -7145,115 +7204,16 @@ describe.sequential("Official Workflow Run admission", () => {
     ).resolves.toStrictEqual({ items: [], claim: beforeCleanup.claim });
   });
 
-  it("repairs stale admission state and creates no Run for unresolved or unverifiable state", async () => {
-    installCatalogStorageFixture();
-    const suffix = randomUUID().replaceAll("-", "").slice(0, 10);
-    const definitionName = `api-test-stale-${suffix}`;
-    await syncCatalog(
-      catalog([activeDefinition(definitionName, [loopBlueprint()])]),
-    );
-    const setup = await workflowBdd.setupWorkflowOrg();
-    const { actor } = setup;
-    if (!actor.orgId) {
-      throw new Error("Expected organization-scoped actor");
-    }
-    const { agentId } = await workflowBdd.createAgent(actor);
-    const ordinaryWorkflowId = await workflowBdd.createWorkflow(actor, {
-      agentId,
-      name: `api-test-stale-ordinary-${suffix}`,
-    });
-    const headers = authHeaders(actor);
-    await setOfficialWorkflowsEnabled(actor, true);
-    const installed = await accept(
-      officialClient().install({
-        headers,
-        params: { definitionName },
-        body: {
-          agentId,
-          blueprints: [
-            {
-              blueprintKey: "pulse",
-              bindings: [{ key: "interval-seconds", value: 60 }],
-            },
-          ],
-        },
-      }),
-      [201],
-    );
-    const ordinaryAutomation = await accept(
-      automationClient().create({
-        headers,
-        params: { workflowId: ordinaryWorkflowId },
-        body: { schedule: { type: "loop", intervalSeconds: 3600 } },
-      }),
-      [201],
-    );
-    onTestFinished(async () => {
-      installCatalogStorageFixture();
-      const createdRuns = await runs.listAgentRuns(actor, {
-        agent: agentId,
-        limit: 100,
-      });
-      for (const run of createdRuns.runs) {
-        await runs.requestCancelRun(actor, run.id, [200, 400]);
-      }
-      await flushWaitUntilForTest();
-      await bdd.deleteAgent(actor, agentId);
-      await cleanupCatalog();
-    });
+  it("repairs stale reconciling, needs_reconfiguration, and failed admission state", async () => {
+    const { agentId, automation, headers } =
+      await installStaleAdmissionScenario();
     const runnerGroup = runs.configureRunnerGroup();
     runs.acceptStorageDownloads();
     runs.acceptTelemetryIngest();
-    const automation = installed.body.workflow.automations[0];
-    if (!automation?.official) {
-      throw new Error("Expected Official Automation state");
-    }
-    const originalFingerprint = automation.official.appliedFingerprint;
     const beforeRunFamily = await readAgentRunFamilyCountsFixture(
       context,
       agentId,
     );
-
-    const crossTableMismatches = [
-      {
-        automationId: automation.id,
-        mismatchedWorkflowId: ordinaryWorkflowId,
-        restoredWorkflowId: installed.body.workflow.id,
-      },
-      {
-        automationId: ordinaryAutomation.body.id,
-        mismatchedWorkflowId: installed.body.workflow.id,
-        restoredWorkflowId: ordinaryWorkflowId,
-      },
-    ];
-
-    for (const mismatch of crossTableMismatches) {
-      await retargetWorkflowAutomationFixture(
-        context,
-        mismatch.automationId,
-        mismatch.mismatchedWorkflowId,
-      );
-      await assertOfficialWorkflowAutomationFinalAdmissionRejectedFixture(
-        context,
-        mismatch.automationId,
-        installed.body.workflow.id,
-      );
-      await accept(
-        automationClient().run({
-          headers,
-          params: { id: mismatch.automationId },
-        }),
-        [409],
-      );
-      await expect(
-        readAgentRunFamilyCountsFixture(context, agentId),
-      ).resolves.toStrictEqual(beforeRunFamily);
-      await retargetWorkflowAutomationFixture(
-        context,
-        mismatch.automationId,
-        mismatch.restoredWorkflowId,
-      );
-    }
 
     for (const status of [
       "reconciling",
@@ -7281,6 +7241,32 @@ describe.sequential("Official Workflow Run admission", () => {
         `Repaired ${status} admission`,
       );
     }
+
+    await expect(
+      readAgentRunFamilyCountsFixture(context, agentId),
+    ).resolves.toStrictEqual({
+      run_count: beforeRunFamily.run_count + 3,
+      callback_count: beforeRunFamily.callback_count + 6,
+      runner_job_count: beforeRunFamily.runner_job_count,
+      launch_queue_count: beforeRunFamily.launch_queue_count,
+    });
+  });
+
+  it("repairs a stale applied fingerprint and reconciles a changed release at admission", async () => {
+    const {
+      agentId,
+      automation,
+      definitionName,
+      headers,
+      originalFingerprint,
+    } = await installStaleAdmissionScenario();
+    const runnerGroup = runs.configureRunnerGroup();
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    const beforeRunFamily = await readAgentRunFamilyCountsFixture(
+      context,
+      agentId,
+    );
 
     await setOfficialWorkflowAutomationAdmissionStateFixture(
       context,
@@ -7342,19 +7328,87 @@ describe.sequential("Official Workflow Run admission", () => {
       readWorkflowAutomationAutonomyFixture(context, automation.id),
     ).resolves.toMatchObject({ autonomyBudget: 5, enabled: true });
 
-    await syncCatalog(
-      catalog([activeDefinition(definitionName, [unresolvedLoopBlueprint()])]),
-    );
-    const beforeUnresolved = await readAgentRunFamilyCountsFixture(
-      context,
-      agentId,
-    );
-    expect(beforeUnresolved).toStrictEqual({
-      run_count: beforeRunFamily.run_count + 5,
-      callback_count: beforeRunFamily.callback_count + 10,
+    await expect(
+      readAgentRunFamilyCountsFixture(context, agentId),
+    ).resolves.toStrictEqual({
+      run_count: beforeRunFamily.run_count + 2,
+      callback_count: beforeRunFamily.callback_count + 4,
       runner_job_count: beforeRunFamily.runner_job_count,
       launch_queue_count: beforeRunFamily.launch_queue_count,
     });
+  });
+
+  it("creates no Run for cross-table mismatched, unresolved, or unavailable admission", async () => {
+    const {
+      actor,
+      agentId,
+      automation,
+      definitionName,
+      headers,
+      installed,
+      suffix,
+    } = await installStaleAdmissionScenario();
+    const ordinaryWorkflowId = await workflowBdd.createWorkflow(actor, {
+      agentId,
+      name: `api-test-stale-ordinary-${suffix}`,
+    });
+    const ordinaryAutomation = await accept(
+      automationClient().create({
+        headers,
+        params: { workflowId: ordinaryWorkflowId },
+        body: { schedule: { type: "loop", intervalSeconds: 3600 } },
+      }),
+      [201],
+    );
+    const beforeRunFamily = await readAgentRunFamilyCountsFixture(
+      context,
+      agentId,
+    );
+
+    const crossTableMismatches = [
+      {
+        automationId: automation.id,
+        mismatchedWorkflowId: ordinaryWorkflowId,
+        restoredWorkflowId: installed.body.workflow.id,
+      },
+      {
+        automationId: ordinaryAutomation.body.id,
+        mismatchedWorkflowId: installed.body.workflow.id,
+        restoredWorkflowId: ordinaryWorkflowId,
+      },
+    ];
+
+    for (const mismatch of crossTableMismatches) {
+      await retargetWorkflowAutomationFixture(
+        context,
+        mismatch.automationId,
+        mismatch.mismatchedWorkflowId,
+      );
+      await assertOfficialWorkflowAutomationFinalAdmissionRejectedFixture(
+        context,
+        mismatch.automationId,
+        installed.body.workflow.id,
+      );
+      await accept(
+        automationClient().run({
+          headers,
+          params: { id: mismatch.automationId },
+        }),
+        [409],
+      );
+      await expect(
+        readAgentRunFamilyCountsFixture(context, agentId),
+      ).resolves.toStrictEqual(beforeRunFamily);
+      await retargetWorkflowAutomationFixture(
+        context,
+        mismatch.automationId,
+        mismatch.restoredWorkflowId,
+      );
+    }
+
+    await syncCatalog(
+      catalog([activeDefinition(definitionName, [unresolvedLoopBlueprint()])]),
+    );
     await accept(
       automationClient().run({
         headers,
@@ -7364,7 +7418,7 @@ describe.sequential("Official Workflow Run admission", () => {
     );
     await expect(
       readAgentRunFamilyCountsFixture(context, agentId),
-    ).resolves.toStrictEqual(beforeUnresolved);
+    ).resolves.toStrictEqual(beforeRunFamily);
     const unresolved = await accept(
       installationClient().get({
         headers,
@@ -7381,10 +7435,6 @@ describe.sequential("Official Workflow Run admission", () => {
     });
 
     await cleanupCatalog();
-    const beforeUnavailable = await readAgentRunFamilyCountsFixture(
-      context,
-      agentId,
-    );
     await accept(
       workflowClient().run({
         headers,
@@ -7394,7 +7444,7 @@ describe.sequential("Official Workflow Run admission", () => {
     );
     await expect(
       readAgentRunFamilyCountsFixture(context, agentId),
-    ).resolves.toStrictEqual(beforeUnavailable);
+    ).resolves.toStrictEqual(beforeRunFamily);
   });
 
   it("creates no Run-family rows for unresolved explicit, schedule, once, or webhook admission", async () => {


### PR DESCRIPTION
## Summary

`Official Workflow Run admission > repairs stale admission state and creates no Run for unresolved or unverifiable state` timed out at 5000ms twice within three minutes on `test-api (4)`:

- https://github.com/vm0-ai/vm0/actions/runs/33589731186 (push to `main`, `7f3d97cc`)
- https://github.com/vm0-ai/vm0/actions/runs/33589880032 (merge_group, `6a449374`)

The trigger was a saturated shared Postgres. Phase breakdown against two green `test-api (4)` runs shows every non-test phase running *faster* than green while `tests` inflated to about 2.1-2.3x:

| phase | failure 33589880032 | failure 33589731186 | green 33589304480 | green 33589195492 |
|---|---|---|---|---|
| transform | 15.41s | 14.09s | 20.97s | 21.63s |
| setup | 32.76s | 27.73s | 50.85s | 48.19s |
| import | 73.46s | 65.75s | 114.58s | 111.58s |
| **tests** | **137.13s** | **147.04s** | 64.53s | 65.70s |

The saturation is environmental, but it only broke one test out of 415 because that test had no margin left. In green run 33589304480 it was the **slowest test in the whole shard at 1996ms** — 40% of the default 5000ms budget and 42% ahead of the next slowest (1407ms). At 2.3x it lands at ~4.6s and is the first and only casualty.

Raising `testTimeout` is not the fix. This test does far more serial work than any sibling: five complete Run lifecycles (three stale admission statuses, a stale applied fingerprint, and an admission-time release reconciliation, each with a runner claim, agent events, completion webhook, and `flushWaitUntilForTest`) plus the cross-table mismatch, unresolved, and unavailable rejection paths — all in one `it`.

## Change

Split the single scenario into three focused ones that share a new `installStaleAdmissionScenario()` helper, following the precedent of #30196:

- `repairs stale reconciling, needs_reconfiguration, and failed admission state` (3 Runs)
- `repairs a stale applied fingerprint and reconciles a changed release at admission` (2 Runs)
- `creates no Run for cross-table mismatched, unresolved, or unavailable admission` (0 Runs)

Every assertion is preserved. The cumulative `readAgentRunFamilyCountsFixture` check that pinned exactly 5 Runs / 10 callbacks and zero `runner_job` / `launch_queue` leakage is kept as a per-scenario delta (+3/+6 and +2/+4), and the rejection scenarios still assert that no Run-family row is created at all. No retries, sleeps, timeout changes, skips, or weakened assertions.

## Measured effect

Identical local `--project=api --shard=4/8` workload, same machine:

| | slowest test in shard | rank | shard duration |
|---|---|---|---|
| before | 1708ms (this test) | #1 | 126.5s |
| after | 867ms (largest split scenario) | #12 | 123.9s |

Peak per-test wall clock drops ~2x and the test stops being an outlier; total shard time is unchanged. Scaled to the green CI measurement, 1996ms becomes roughly 1010ms — about 20% of the budget instead of 40%, so the 2.1-2.3x saturation that failed this test now leaves it around 2.3s.

## Validation

- `pnpm exec vitest run src/signals/routes/__tests__/official-workflows.test.ts` — 5 consecutive passes, 44/44 each; split scenarios stable at 567-635ms, 443-483ms, 343-370ms (baseline for the merged test on the same machine: 1143-1273ms)
- `pnpm vitest run --project=api --shard=4/8 --maxWorkers=2` — 28 files, 417 tests passed
- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/official-workflows.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types` (deps, gateways, core, bootstrap, tests projects)
- `pnpm knip --workspace api`
- `git diff --check`

API tests were run against a UTC Postgres. This is a Node-level API integration test, so no browser or preview validation applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
