### PR TITLE
docs(runner): document the run cancellation protocol

### DIFF
--- a/crates/runner/src/run_cancellation.rs
+++ b/crates/runner/src/run_cancellation.rs
@@ -48,7 +48,7 @@
 //! [`job discovery`](https://github.com/vm0-ai/vm0/blob/main/crates/runner/src/cmd/start/job_discovery.rs#L976-L1004),
 //! [`sandbox finalization`](https://github.com/vm0-ai/vm0/blob/main/crates/runner/src/cmd/start/sandbox_finalization.rs#L697-L732),
 //! and the focused
-//! [`cancellation tests`](https://github.com/vm0-ai/vm0/blob/main/crates/runner/src/run_cancellation.rs#L276-L349).
+//! [`cancellation tests`](https://github.com/vm0-ai/vm0/blob/main/crates/runner/src/run_cancellation.rs#L395-L494).
 //! The job-discovery-specific ownership lifecycle is described in
 //! [issue #30953](https://github.com/vm0-ai/vm0/issues/30953).
 

--- a/crates/runner/src/run_cancellation.rs
+++ b/crates/runner/src/run_cancellation.rs
@@ -1,3 +1,57 @@
+//! Per-run cancellation state shared by provider, lifecycle, admission, and
+//! execution paths.
+//!
+//! [`RunCancellationRegistry`] owns one [`RunCancellationHandle`] for each
+//! registered run. The [`RunCancellationRegistration`] returned by
+//! [`RunCancellationRegistry::register`] is the lifecycle owner for that
+//! registry entry: it must stay owned until the run has been cleaned up, and
+//! callers must explicitly call [`RunCancellationRegistration::unregister`].
+//! Dropping the registration does not remove the entry.
+//!
+//! ## Cancellation protocol
+//!
+//! A registration is unique by run ID. A duplicate registration is rejected
+//! so that provider and local cancellation continue to target the active
+//! handle. [`RunCancellationRegistry::begin_hard_stop`] marks the hard-stop
+//! barrier and returns a snapshot of registrations that existed at that
+//! point. The caller dispatches hard cancellation to that snapshot. A
+//! registration created after the barrier is inserted and then returned with
+//! hard cancellation already requested.
+//!
+//! Each handle exposes an aggregate cancellation token and two independent
+//! class-specific tokens through [`RunCancellationSignals`]. Either a
+//! cooperative-user request or a hard request cancels the aggregate token;
+//! only the matching class-specific token is cancelled. Request methods return
+//! whether their cancellation class changed from not requested to requested.
+//! The signals are monotonic, so a hard cancellation remains observable after
+//! a cooperative request and a cooperative request does not imply hard
+//! cancellation.
+//!
+//! ## Ownership transfer protocol
+//!
+//! The handle's transfer gate serializes cancellation requests with ownership
+//! transitions for a sandbox. A caller transferring or publishing ownership
+//! should acquire [`RunCancellationHandle::transfer_guard`], inspect the
+//! applicable cancellation signal while holding it, perform the ownership
+//! transition, and release the guard only after the transition is complete.
+//! The gate is not itself a cancellation signal.
+//!
+//! A caller must not await the transfer gate while holding another shared lock
+//! whose release is needed by cancellation or finalization. It should use
+//! [`RunCancellationHandle::try_transfer_guard`] while holding that lock and,
+//! when the attempt fails, release the other lock before awaiting the gate.
+//! The idle-pool publication path in
+//! [`sandbox_finalization`](https://github.com/vm0-ai/vm0/blob/main/crates/runner/src/cmd/start/sandbox_finalization.rs#L809-L829)
+//! follows this ordering. The broader lifecycle is exercised by
+//! [`signals`](https://github.com/vm0-ai/vm0/blob/main/crates/runner/src/cmd/start/signals.rs#L213-L247),
+//! [`provider cancellation`](https://github.com/vm0-ai/vm0/blob/main/crates/runner/src/provider/api_ably_supervisor.rs#L850-L884),
+//! [`job discovery`](https://github.com/vm0-ai/vm0/blob/main/crates/runner/src/cmd/start/job_discovery.rs#L976-L1004),
+//! [`sandbox finalization`](https://github.com/vm0-ai/vm0/blob/main/crates/runner/src/cmd/start/sandbox_finalization.rs#L697-L732),
+//! and the focused
+//! [`cancellation tests`](https://github.com/vm0-ai/vm0/blob/main/crates/runner/src/run_cancellation.rs#L276-L349).
+//! The job-discovery-specific ownership lifecycle is described in
+//! [issue #30953](https://github.com/vm0-ai/vm0/issues/30953).
+
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -7,6 +61,14 @@ use tokio_util::sync::CancellationToken;
 use crate::ids::RunId;
 
 #[derive(Clone, Debug, Default)]
+/// Registry of cancellation handles for active runs.
+///
+/// The registry permits at most one registration for each run ID. Keep the
+/// [`RunCancellationRegistration`] returned by [`Self::register`] owned until
+/// the corresponding run has completed cleanup; the registry does not remove
+/// an entry when that value is dropped. Cancellation callers receive cloned
+/// handles, so the registration remains the authority for removing the active
+/// mapping.
 pub(crate) struct RunCancellationRegistry {
     inner: Arc<Mutex<RunCancellationRegistryState>>,
 }
@@ -18,10 +80,20 @@ struct RunCancellationRegistryState {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Registration failed because the run ID already has an active entry.
 pub(crate) struct DuplicateRunCancellationRegistration;
 
 #[derive(Debug)]
 #[must_use = "the registration must remain owned until its run is cleaned up"]
+/// Lifecycle owner for one entry in a [`RunCancellationRegistry`].
+///
+/// Keep this value alive from registration through provider claim, activation,
+/// execution, and the final cleanup path so provider or lifecycle cancellation
+/// can continue to find the run. Registration teardown is explicit: dropping
+/// this value does not unregister it, so callers must invoke
+/// [`Self::unregister`]. The boolean result distinguishes removal of the
+/// current entry from a stale registration that has already been replaced or
+/// removed.
 pub(crate) struct RunCancellationRegistration {
     registry: RunCancellationRegistry,
     run_id: RunId,
@@ -29,11 +101,24 @@ pub(crate) struct RunCancellationRegistration {
 }
 
 #[derive(Clone, Debug)]
+/// Cloneable cancellation state for one run.
+///
+/// Clones share the aggregate token, the cooperative-user token, the hard
+/// token, and the transfer gate. Use the class-specific signals when behavior
+/// differs between cooperative recovery and destructive hard cancellation.
+/// Cancellation requests and sandbox ownership transitions are serialized by
+/// the transfer gate.
 pub(crate) struct RunCancellationHandle {
     inner: Arc<RunCancellationInner>,
 }
 
 #[derive(Clone, Debug)]
+/// Cancellation tokens consumed by execution and recovery paths.
+///
+/// [`Self::any`] is cancelled by either cancellation class. [`Self::cooperative_user`]
+/// is cancelled only by a cooperative-user request, and [`Self::hard`] is
+/// cancelled only by a hard request. The class-specific tokens are independent
+/// monotonic signals rather than interchangeable aliases.
 pub(crate) struct RunCancellationSignals {
     any: CancellationToken,
     cooperative_user: CancellationToken,
@@ -49,10 +134,17 @@ struct RunCancellationInner {
 }
 
 impl RunCancellationRegistry {
+    /// Create an empty registry with no hard-stop barrier set.
     pub(crate) fn new() -> Self {
         Self::default()
     }
 
+    /// Register one run and return the registration that owns its entry.
+    ///
+    /// Registration is unique by `run_id`; a duplicate returns
+    /// [`DuplicateRunCancellationRegistration`] and leaves the existing
+    /// handle untouched. If [`Self::begin_hard_stop`] has already run, the new
+    /// entry is inserted and then hard-cancelled before this method returns.
     pub(crate) async fn register(
         &self,
         run_id: RunId,
@@ -76,10 +168,19 @@ impl RunCancellationRegistry {
         })
     }
 
+    /// Clone the current handle for `run_id`, if it is registered.
+    ///
+    /// The returned handle does not own registry membership. The corresponding
+    /// [`RunCancellationRegistration`] must remain owned until the run's
+    /// cleanup path calls [`RunCancellationRegistration::unregister`].
     pub(crate) async fn handle(&self, run_id: RunId) -> Option<RunCancellationHandle> {
         self.inner.lock().await.registrations.get(&run_id).cloned()
     }
 
+    /// Clone handles for the registered run IDs in `run_ids`.
+    ///
+    /// Missing IDs are omitted. The returned map is a snapshot of handles and
+    /// does not change registry membership.
     pub(crate) async fn handles_for(
         &self,
         run_ids: &[RunId],
@@ -98,10 +199,12 @@ impl RunCancellationRegistry {
     }
 
     #[cfg(test)]
+    /// Test whether a run ID currently has a registry entry.
     pub(crate) async fn contains(&self, run_id: RunId) -> bool {
         self.inner.lock().await.registrations.contains_key(&run_id)
     }
 
+    /// Return the run IDs in `run_ids` that are not currently registered.
     pub(crate) async fn missing_run_ids(&self, run_ids: &[RunId]) -> Vec<RunId> {
         let state = self.inner.lock().await;
         run_ids
@@ -111,6 +214,14 @@ impl RunCancellationRegistry {
             .collect()
     }
 
+    /// Enter the hard-stop barrier and snapshot the registrations before it.
+    ///
+    /// This method marks the registry as hard-stopping and returns cloned
+    /// handles for entries that existed under the registry lock. It does not
+    /// cancel those handles itself; the caller dispatches hard cancellation to
+    /// the returned snapshot. A concurrent registration is ordered either
+    /// before this barrier and appears in the snapshot, or after it and is
+    /// returned by [`Self::register`] already hard-cancelled.
     pub(crate) async fn begin_hard_stop(&self) -> Vec<(RunId, RunCancellationHandle)> {
         let mut state = self.inner.lock().await;
         state.hard_stopping = true;
@@ -123,23 +234,37 @@ impl RunCancellationRegistry {
 }
 
 impl RunCancellationRegistration {
+    /// Clone the handle associated with this registration.
     pub(crate) fn handle(&self) -> RunCancellationHandle {
         self.handle.clone()
     }
 
+    /// Clone the aggregate token, which observes either cancellation class.
     pub(crate) fn token(&self) -> CancellationToken {
         self.handle.token()
     }
 
     #[cfg(test)]
+    /// Test whether either cancellation class has been requested.
     pub(crate) fn is_cancelled(&self) -> bool {
         self.handle.is_cancelled()
     }
 
+    /// Request hard cancellation for this registration's run.
+    ///
+    /// Returns `true` only when hard cancellation was not already requested.
+    /// The request also cancels the aggregate token and is serialized with
+    /// ownership transitions by the transfer gate.
     pub(crate) async fn request_hard_cancellation(&self) -> bool {
         self.handle.request_hard_cancellation().await
     }
 
+    /// Remove this registration when it is still the current entry.
+    ///
+    /// Returns `true` when this call removed the mapping for the registration's
+    /// run ID. Returns `false` for a stale registration or an entry already
+    /// removed by an earlier call. A stale registration cannot remove a
+    /// replacement registration for the same run ID.
     pub(crate) async fn unregister(&self) -> bool {
         let mut state = self.registry.inner.lock().await;
         let is_current = state
@@ -154,6 +279,7 @@ impl RunCancellationRegistration {
 }
 
 impl RunCancellationHandle {
+    /// Create an uncancelled handle with a fresh transfer gate.
     pub(crate) fn new() -> Self {
         Self {
             inner: Arc::new(RunCancellationInner {
@@ -165,18 +291,22 @@ impl RunCancellationHandle {
         }
     }
 
+    /// Clone the aggregate token, cancelled by either cancellation class.
     pub(crate) fn token(&self) -> CancellationToken {
         self.inner.token.clone()
     }
 
+    /// Return whether cooperative or hard cancellation has been requested.
     pub(crate) fn is_cancelled(&self) -> bool {
         self.inner.token.is_cancelled()
     }
 
+    /// Return whether hard cancellation has been requested.
     pub(crate) fn is_hard_cancelled(&self) -> bool {
         self.inner.hard_token.is_cancelled()
     }
 
+    /// Snapshot the aggregate, cooperative-user, and hard cancellation tokens.
     pub(crate) fn signals(&self) -> RunCancellationSignals {
         RunCancellationSignals {
             any: self.inner.token.clone(),
@@ -185,6 +315,11 @@ impl RunCancellationHandle {
         }
     }
 
+    /// Request cooperative-user cancellation.
+    ///
+    /// The cooperative-user and aggregate tokens are cancelled while holding
+    /// the transfer gate. Returns `true` only for the first request of this
+    /// cancellation class; a hard request is tracked independently.
     pub(crate) async fn request_cooperative_user_cancellation(&self) -> bool {
         let _transfer_guard = self.inner.transfer_gate.lock().await;
         let was_requested = self.inner.cooperative_user_token.is_cancelled();
@@ -193,6 +328,11 @@ impl RunCancellationHandle {
         !was_requested
     }
 
+    /// Request hard cancellation.
+    ///
+    /// The hard and aggregate tokens are cancelled while holding the transfer
+    /// gate. Returns `true` only for the first request of the hard cancellation
+    /// class; a cooperative-user request is tracked independently.
     pub(crate) async fn request_hard_cancellation(&self) -> bool {
         let _transfer_guard = self.inner.transfer_gate.lock().await;
         let was_requested = self.inner.hard_token.is_cancelled();
@@ -201,10 +341,21 @@ impl RunCancellationHandle {
         !was_requested
     }
 
+    /// Wait for and hold the transfer gate across an ownership transition.
+    ///
+    /// The caller must inspect the relevant cancellation signal while holding
+    /// the returned guard, perform the transfer or cleanup decision, and drop
+    /// the guard after that decision. Do not await this method while holding a
+    /// different shared lock that cancellation or finalization needs.
     pub(crate) async fn transfer_guard(&self) -> OwnedMutexGuard<()> {
         self.inner.transfer_gate.clone().lock_owned().await
     }
 
+    /// Try to hold the transfer gate without waiting.
+    ///
+    /// Use this when another shared lock is currently held. If this returns
+    /// `None`, release that lock before awaiting [`Self::transfer_guard`] so a
+    /// cancellation or finalization path cannot be blocked by lock ordering.
     pub(crate) fn try_transfer_guard(&self) -> Option<OwnedMutexGuard<()>> {
         self.inner.transfer_gate.clone().try_lock_owned().ok()
     }
@@ -215,19 +366,23 @@ impl RunCancellationHandle {
 }
 
 impl RunCancellationSignals {
+    /// Clone the aggregate token, cancelled by either cancellation class.
     pub(crate) fn any(&self) -> CancellationToken {
         self.any.clone()
     }
 
+    /// Clone the token cancelled by a cooperative-user request.
     pub(crate) fn cooperative_user(&self) -> CancellationToken {
         self.cooperative_user.clone()
     }
 
+    /// Clone the token cancelled by a hard request.
     pub(crate) fn hard(&self) -> CancellationToken {
         self.hard.clone()
     }
 
     #[cfg(test)]
+    /// Build test signals that share one aggregate and hard token.
     pub(crate) fn hard_only(cancel: CancellationToken) -> Self {
         Self {
             any: cancel.clone(),


### PR DESCRIPTION
## Summary

- Document the run cancellation registry, registration lifetime, duplicate-registration handling, and hard-stop barrier.
- Document aggregate, cooperative, and hard cancellation token semantics, including class-specific boolean results.
- Document the transfer gate protocol and link representative lifecycle, provider, admission, finalization, and test call sites plus #30953.
- Keep runtime behavior unchanged; this PR only updates `crates/runner/src/run_cancellation.rs` documentation.

Closes #30997

## Validation

- `cargo fmt --all --manifest-path crates/Cargo.toml -- --check` — passed
- `cargo doc --workspace --all-features --no-deps --manifest-path crates/Cargo.toml` — passed
- `cargo clippy --all-targets --all-features --manifest-path crates/Cargo.toml` — passed
- Runner binary test target type-check with `cargo check -p runner --bin runner --tests` under serialized, no-debug-info settings — passed
- `cargo test -p runner --lib` — not applicable; `runner` has no library target
- Focused runner cancellation tests could not complete locally; the large test binary was killed with exit 137 during linking in the 3.8 GiB, no-swap container.
