### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -201,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -211,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
@@ -3160,9 +3160,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "socket2"


### PR DESCRIPTION
## Summary

- Update `aws-lc-rs` from 1.18.0 to 1.18.1.
- Update `aws-lc-sys` from 0.44.0 to 0.45.0.
- Update `smallvec` from 1.15.2 to 1.16.0.

## Dependencies not updated

- `generic-array` remains at 0.14.7 because `crypto-common` 0.1.7 requires exactly `generic-array = 0.14.7`.

## Manual version bumps

- None. This PR only updates `crates/Cargo.lock`.

## Test status

- `cargo test --workspace --exclude runner --no-fail-fast`: all executed targets passed except `sandbox-fc`'s `workspace_drive_image::tests::prepare_workspace_drive_image_without_seed_truncates_and_formats_fresh_image` (823/824 `sandbox-fc` tests passed). The test requires `mkfs.ext4`, which is unavailable in the current environment; an unchanged-lock baseline reproduced the same failure.
- `cargo check -p runner --tests`: passed. Runner test execution was not attempted in this constrained environment; all runner test targets compiled successfully.
