### PR TITLE
refactor(pi): make ownership transfer v3-only

### DIFF
--- a/crates/guest-agent/src/cli/pi_rpc.rs
+++ b/crates/guest-agent/src/cli/pi_rpc.rs
@@ -29,20 +29,19 @@
 //!
 //! ## API-first startup boundary
 //!
-//! Legacy manifest V1/V2 handoffs emit this private control before official RPC
-//! output:
+//! Manifest V3 handoffs emit this private control before official RPC output:
 //!
 //! ```json
 //! {
 //!   "type": "vm0_pi_api_first_turn_boundary",
-//!   "schemaVersion": 1,
-//!   "sandboxEventSequenceStart": 4
+//!   "schemaVersion": 2,
+//!   "sandboxEventSequenceStart": 4,
+//!   "ownershipTransferMode": "pending-tool-continuation"
 //! }
 //! ```
 //!
-//! The host maps both legacy manifest versions to implicit
-//! `pending-tool-continuation`. Manifest V3 instead emits boundary schema V2
-//! with one explicit `ownershipTransferMode`: `sandbox-first`,
+//! Boundary schema V2 carries one explicit `ownershipTransferMode`:
+//! `sandbox-first`,
 //! `pending-tool-continuation`, or `settled-session-continuation`. The private
 //! boundary schema is independent of the public manifest schema. Rust accepts a
 //! boundary only when its type and schema version are exact, all fields are
@@ -251,15 +250,6 @@ pub(super) enum PiRpcOwnershipTransferMode {
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct PiApiFirstTurnBoundaryControlV1 {
-    #[serde(rename = "type")]
-    record_type: String,
-    schema_version: u32,
-    sandbox_event_sequence_start: u64,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct PiApiFirstTurnBoundaryControlV2 {
     #[serde(rename = "type")]
     record_type: String,
@@ -371,22 +361,6 @@ fn validated_boundary_sequence(sequence: u64) -> Result<u32, AgentError> {
 
 fn parse_boundary_control(record: &Value) -> Result<PiRpcStartup, AgentError> {
     match record.get("schemaVersion").and_then(Value::as_u64) {
-        Some(1) => {
-            let control: PiApiFirstTurnBoundaryControlV1 =
-                serde_json::from_value(record.clone())
-                    .map_err(|_| PiRpcStartupBoundary::malformed_record_error())?;
-            if control.record_type != PI_API_FIRST_TURN_BOUNDARY_CONTROL_TYPE
-                || control.schema_version != 1
-            {
-                return Err(PiRpcStartupBoundary::malformed_record_error());
-            }
-            Ok(PiRpcStartup {
-                sandbox_event_sequence_start: validated_boundary_sequence(
-                    control.sandbox_event_sequence_start,
-                )?,
-                ownership_transfer_mode: PiRpcOwnershipTransferMode::PendingToolContinuation,
-            })
-        }
         Some(2) => {
             let control: PiApiFirstTurnBoundaryControlV2 =
                 serde_json::from_value(record.clone())
@@ -1003,19 +977,15 @@ mod tests {
     }
 
     #[test]
-    fn boundary_v1_maps_to_pending_tool_continuation() {
-        let startup = parse_boundary_control(&json!({
+    fn boundary_v1_is_rejected() {
+        let error = parse_boundary_control(&json!({
             "type": PI_API_FIRST_TURN_BOUNDARY_CONTROL_TYPE,
             "schemaVersion": 1,
             "sandboxEventSequenceStart": 4,
         }))
-        .expect("legacy boundary should remain readable");
+        .expect_err("legacy boundary should fail closed");
 
-        assert_eq!(startup.sandbox_event_sequence_start, 4);
-        assert_eq!(
-            startup.ownership_transfer_mode,
-            PiRpcOwnershipTransferMode::PendingToolContinuation
-        );
+        assert!(error.to_string().contains("PI_HANDOFF_BOUNDARY_INVALID"));
     }
 
     #[test]

--- a/crates/guest-agent/tests/pi_cli_handoff_boundary.rs
+++ b/crates/guest-agent/tests/pi_cli_handoff_boundary.rs
@@ -25,18 +25,18 @@ async fn guest_fails_closed_for_invalid_missing_conflicting_and_late_pi_boundari
             expected_code: "PI_HANDOFF_BOUNDARY_MISSING",
         },
         BoundaryCase {
-            name: "malformed",
-            script: r#"printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1}'"#,
+            name: "legacy-schema",
+            script: r#"printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":4}'"#,
             expected_code: "PI_HANDOFF_BOUNDARY_INVALID",
         },
         BoundaryCase {
             name: "zero",
-            script: r#"printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":0}'"#,
+            script: r#"printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":2,"sandboxEventSequenceStart":0,"ownershipTransferMode":"pending-tool-continuation"}'"#,
             expected_code: "PI_HANDOFF_BOUNDARY_INVALID",
         },
         BoundaryCase {
             name: "overflowing",
-            script: r#"printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":2147483648}'"#,
+            script: r#"printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":2,"sandboxEventSequenceStart":2147483648,"ownershipTransferMode":"pending-tool-continuation"}'"#,
             expected_code: "PI_HANDOFF_BOUNDARY_INVALID",
         },
         BoundaryCase {
@@ -57,22 +57,22 @@ async fn guest_fails_closed_for_invalid_missing_conflicting_and_late_pi_boundari
         BoundaryCase {
             name: "conflicting",
             script: r#"
-printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":4}'
-printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":5}'
+printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":2,"sandboxEventSequenceStart":4,"ownershipTransferMode":"pending-tool-continuation"}'
+printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":2,"sandboxEventSequenceStart":5,"ownershipTransferMode":"pending-tool-continuation"}'
 "#,
             expected_code: "PI_HANDOFF_BOUNDARY_CONFLICT",
         },
         BoundaryCase {
             name: "late",
             script: r#"
-printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":4}'
+printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":2,"sandboxEventSequenceStart":4,"ownershipTransferMode":"pending-tool-continuation"}'
 IFS= read -r state_command
 case "$state_command" in
   *'"type":"get_state"'*) ;;
   *) exit 21 ;;
 esac
 printf '%s\n' "{\"id\":\"${OKOU_RUN_ID}:pi:get-state\",\"type\":\"response\",\"command\":\"get_state\",\"success\":true,\"data\":{\"sessionId\":\"11111111-1111-4111-8111-111111111111\",\"sessionFile\":\"/home/user/.pi/agent/sessions/--home-user-workspace--/session.jsonl\"}}"
-printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":4}'
+printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":2,"sandboxEventSequenceStart":4,"ownershipTransferMode":"pending-tool-continuation"}'
 "#,
             expected_code: "PI_HANDOFF_BOUNDARY_LATE",
         },

--- a/crates/guest-agent/tests/pi_cli_malformed_tool_event.rs
+++ b/crates/guest-agent/tests/pi_cli_malformed_tool_event.rs
@@ -21,7 +21,7 @@ async fn missing_pi_tool_result_error_status_terminates_projection()
         &npx,
         r#"#!/bin/sh
 set -eu
-printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":1}'
+printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":2,"sandboxEventSequenceStart":1,"ownershipTransferMode":"pending-tool-continuation"}'
 IFS= read -r state_command
 case "$state_command" in
   *'"type":"get_state"'*) ;;

--- a/crates/guest-agent/tests/pi_cli_run_id_env.rs
+++ b/crates/guest-agent/tests/pi_cli_run_id_env.rs
@@ -62,7 +62,7 @@ test -n "${OKOU_PI_LAUNCH_PAYLOAD_FILE:-}"
 test -n "${PI_FINAL_ASSISTANT_EVENT_PATH:-}"
 printf '%s' "$OKOU_RUN_ID" > "$RUN_ID_CAPTURE_PATH"
 printf '%s' "$OKOU_PI_LAUNCH_PAYLOAD_FILE" > "$PI_PAYLOAD_CAPTURE_PATH"
-printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":4}'
+printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":2,"sandboxEventSequenceStart":4,"ownershipTransferMode":"pending-tool-continuation"}'
 IFS= read -r state_command
 case "$state_command" in
   *'"type":"get_state"'*) ;;

--- a/crates/guest-agent/tests/pi_cli_settlement_errors.rs
+++ b/crates/guest-agent/tests/pi_cli_settlement_errors.rs
@@ -40,7 +40,7 @@ async fn run_settlement_case(
         &npx,
         r#"#!/bin/sh
 set -eu
-printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":1}'
+printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":2,"sandboxEventSequenceStart":1,"ownershipTransferMode":"pending-tool-continuation"}'
 IFS= read -r state_command
 case "$state_command" in
   *'"type":"get_state"'*) ;;

--- a/crates/guest-agent/tests/pi_cli_stalled_stdin_cancellation.rs
+++ b/crates/guest-agent/tests/pi_cli_stalled_stdin_cancellation.rs
@@ -31,7 +31,7 @@ async fn pi_cancellation_reaps_child_with_stalled_steer_write()
         r#"#!/bin/sh
 set -eu
 printf '%s\n' "$$" > "$PI_CHILD_PID_PATH"
-printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":1}'
+printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":2,"sandboxEventSequenceStart":1,"ownershipTransferMode":"pending-tool-continuation"}'
 IFS= read -r state_command
 case "$state_command" in
   *'"type":"get_state"'*) ;;

--- a/crates/guest-agent/tests/pi_initial_prompt_stdin_reap_sigkill.rs
+++ b/crates/guest-agent/tests/pi_initial_prompt_stdin_reap_sigkill.rs
@@ -20,7 +20,7 @@ async fn pi_initial_prompt_stdin_failure_reap_escalates_to_sigkill()
         r#"#!/bin/sh
 set -eu
 trap '' TERM
-printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":1}'
+printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":2,"sandboxEventSequenceStart":1,"ownershipTransferMode":"pending-tool-continuation"}'
 IFS= read -r state_command
 case "$state_command" in
   *'"type":"get_state"'*) ;;

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -37,7 +37,7 @@ import {
   CANCELLATION_RECOVERY_STALE_AFTER_MS,
   DEFAULT_PROFILE,
   PI_MEMORY_ROOT,
-  piApiFirstTurnManifestV3Schema,
+  piApiFirstTurnManifestSchema,
 } from "@okouai/api-contracts/contracts/runners";
 import { mailContract } from "@okouai/api-contracts/contracts/mail";
 import {
@@ -135,6 +135,7 @@ import {
   readThreadSessionConversation,
   seedVm0BuiltInModelKey as seedVm0BuiltInModelKeyState,
   setRunAutonomyBudgetFixture,
+  setRunnerJobPiOwnershipTransferAsPreviousApi,
   steerRunTimeBudgetFixture,
 } from "./helpers/runtime-state";
 import { createRouteMocks } from "./helpers/route-test";
@@ -6422,7 +6423,7 @@ describe("CHAT-02: model-first provider policies", () => {
     await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
       status: "running",
     });
-    const manifest = piApiFirstTurnManifestV3Schema.parse(
+    const manifest = piApiFirstTurnManifestSchema.parse(
       JSON.parse(checkpointObjects.get(manifestKey)?.toString("utf8") ?? "{}"),
     );
     expect(manifest).toMatchObject({
@@ -6539,7 +6540,7 @@ describe("CHAT-02: model-first provider policies", () => {
     await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
       status: "running",
     });
-    const manifest = piApiFirstTurnManifestV3Schema.parse(
+    const manifest = piApiFirstTurnManifestSchema.parse(
       JSON.parse(checkpointObjects.get(manifestKey)?.toString("utf8") ?? "{}"),
     );
     expect(manifest).toMatchObject({
@@ -6722,7 +6723,7 @@ describe("CHAT-02: model-first provider policies", () => {
         return checkpointObjects.get(manifestKey);
       })
       .toBeInstanceOf(Buffer);
-    const manifest = piApiFirstTurnManifestV3Schema.parse(
+    const manifest = piApiFirstTurnManifestSchema.parse(
       JSON.parse(checkpointObjects.get(manifestKey)?.toString("utf8") ?? "{}"),
     );
     expect(manifest).toMatchObject({
@@ -7192,7 +7193,7 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(checkpointObjects.get(fallbackManifestKey)).toBeInstanceOf(Buffer);
     expect(modelCalls).toBe(0);
 
-    const fallbackManifest = piApiFirstTurnManifestV3Schema.parse(
+    const fallbackManifest = piApiFirstTurnManifestSchema.parse(
       JSON.parse(
         checkpointObjects.get(fallbackManifestKey)?.toString("utf8") ?? "{}",
       ),
@@ -7229,11 +7230,16 @@ describe("CHAT-02: model-first provider policies", () => {
       prompt: fallbackPrompt,
       piLaunchConfig: {
         apiFirstTurn: {
-          ownershipTransfer: { schemaVersion: 1 },
           sandboxEventSequenceStart: 1,
         },
       },
     });
+    const fallbackFirstTurnConfig =
+      fallbackClaim.claim.piLaunchConfig?.apiFirstTurn;
+    if (!fallbackFirstTurnConfig) {
+      throw new Error("Expected Pi API first-turn launch config");
+    }
+    expect(fallbackFirstTurnConfig).not.toHaveProperty("ownershipTransfer");
     const postProviderPrompt = "must fail after one provider request";
     const postProvider = await sendChatRun(actor, {
       agentId,
@@ -7515,7 +7521,7 @@ describe("CHAT-02: model-first provider policies", () => {
     if (!manifestBytes) {
       throw new Error("Expected compaction ownership-transfer manifest");
     }
-    const manifest = piApiFirstTurnManifestV3Schema.parse(
+    const manifest = piApiFirstTurnManifestSchema.parse(
       JSON.parse(manifestBytes.toString("utf8")),
     );
     expect(manifest).toMatchObject({
@@ -7737,7 +7743,7 @@ describe("CHAT-02: model-first provider policies", () => {
     if (!manifestBytes) {
       throw new Error("Expected pending-tool ownership-transfer manifest");
     }
-    const manifest = piApiFirstTurnManifestV3Schema.parse(
+    const manifest = piApiFirstTurnManifestSchema.parse(
       JSON.parse(manifestBytes.toString("utf8")),
     );
     expect(manifest).toMatchObject({
@@ -7770,6 +7776,7 @@ describe("CHAT-02: model-first provider policies", () => {
       { content: "before parallel tools", sequenceNumber: 0 },
       { content: "after parallel tools", sequenceNumber: 3 },
     ]);
+    await setRunnerJobPiOwnershipTransferAsPreviousApi(context, run.runId);
     const claimed = await claimChatRun(runnerGroup, run.runId);
     expect(claimed.claim.cliAgentType).toBe("pi");
     expect(claimed.claim.piSessionId).toBe(run.threadId);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -654,6 +654,16 @@ export async function setRunnerJobContextProfileAsPreviousApi(
   });
 }
 
+export async function setRunnerJobPiOwnershipTransferAsPreviousApi(
+  context: TestContext,
+  runId: string,
+): Promise<void> {
+  await postAction(context, {
+    action: "set-runner-job-pi-ownership-transfer-as-previous-api",
+    run_id: runId,
+  });
+}
+
 export async function removeRunCanonicalStorageState(
   context: TestContext,
   runId: string,

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -1715,6 +1715,11 @@ type PreviousApiRunnerJobContextProfileAction = Extract<
   { action: "set-runner-job-context-profile-as-previous-api" }
 >;
 
+type PreviousApiRunnerJobPiOwnershipTransferAction = Extract<
+  TestRuntimeStateActionBody,
+  { action: "set-runner-job-pi-ownership-transfer-as-previous-api" }
+>;
+
 type PreviousApiWorkflowAutomationEventConnectorAction = Extract<
   TestRuntimeStateActionBody,
   { action: "clear-workflow-automation-event-connector-as-previous-api" }
@@ -1790,6 +1795,32 @@ async function setRunnerJobContextProfileAsPreviousApi(
   return { status: 200 as const, body: { ok: true as const } };
 }
 
+async function setRunnerJobPiOwnershipTransferAsPreviousApi(
+  db: Db,
+  body: PreviousApiRunnerJobPiOwnershipTransferAction,
+  signal: AbortSignal,
+) {
+  // The previous API persisted this exact marker in every Pi launch slot.
+  // Current claims must retain marker-bearing queued contexts during rollout.
+  const [updated] = await db
+    .update(runnerJobQueue)
+    .set({
+      executionContext: sql`jsonb_set(
+        ${runnerJobQueue.executionContext},
+        '{piLaunchConfig,apiFirstTurn,ownershipTransfer}',
+        '{"schemaVersion":1}'::jsonb,
+        true
+      )`,
+    })
+    .where(eq(runnerJobQueue.runId, body.run_id))
+    .returning({ runId: runnerJobQueue.runId });
+  signal.throwIfAborted();
+  if (!updated) {
+    throw new Error("Expected a Pi runner job for previous API marker update");
+  }
+  return { status: 200 as const, body: { ok: true as const } };
+}
+
 async function clearWorkflowAutomationEventConnectorAsPreviousApi(
   db: Db,
   body: PreviousApiWorkflowAutomationEventConnectorAction,
@@ -1816,6 +1847,7 @@ type CompatibilityFixtureAction =
   | PreviousApiComputerAccessAction
   | PreviousApiBrowserTabSnapshotAction
   | PreviousApiRunnerJobContextProfileAction
+  | PreviousApiRunnerJobPiOwnershipTransferAction
   | PreviousApiWorkflowAutomationEventConnectorAction
   | ConnectorPermissionBaselineMutationAction;
 
@@ -2076,6 +2108,7 @@ function isCompatibilityFixtureAction(
     "set-computer-use-host-as-previous-api",
     "set-browser-tab-snapshot-as-previous-api",
     "set-runner-job-context-profile-as-previous-api",
+    "set-runner-job-pi-ownership-transfer-as-previous-api",
     "clear-workflow-automation-event-connector-as-previous-api",
     "mutate-runner-job-connector-permission-baseline",
   ].includes(body.action);
@@ -2107,6 +2140,13 @@ async function compatibilityFixtureActionResponse(
     }
     case "set-runner-job-context-profile-as-previous-api": {
       return await setRunnerJobContextProfileAsPreviousApi(db, body, signal);
+    }
+    case "set-runner-job-pi-ownership-transfer-as-previous-api": {
+      return await setRunnerJobPiOwnershipTransferAsPreviousApi(
+        db,
+        body,
+        signal,
+      );
     }
     case "clear-workflow-automation-event-connector-as-previous-api": {
       return await clearWorkflowAutomationEventConnectorAsPreviousApi(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -7011,7 +7011,6 @@ function preparePiLaunchResources(args: {
             schemaVersion: 2,
             apiFirstTurn: {
               schemaVersion: 1,
-              ownershipTransfer: { schemaVersion: 1 },
               resourceSnapshotDigest: piResourceSnapshotDigest(
                 piResourceDiscoveryMounts(args.storageMounts),
               ),

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
@@ -608,7 +608,6 @@ interface PreparedApiFirstTurn {
   readonly sessionId: string;
   readonly startedAt: number;
   readonly turn: PiApiFirstTurnResult;
-  readonly ownershipTransferCapability: ApiFirstTurnLaunchConfig["ownershipTransfer"];
 }
 
 type ApiFirstTurnExecutionContext =
@@ -620,7 +619,6 @@ interface ApiFirstTurnCommitIdentity {
   readonly baseSessionId: string;
   readonly baseSessionSha256: string | null;
   readonly deadlineAt: number;
-  readonly ownershipTransferSchemaVersion: 1 | null;
   readonly resourceSnapshotDigest: string;
   readonly sandboxEventSequenceStart: number;
   readonly sessionId: string;
@@ -634,8 +632,6 @@ function apiFirstTurnCommitIdentity(
     baseSessionId: launchConfig.baseSession.sessionId,
     baseSessionSha256: launchConfig.baseSession.sha256,
     deadlineAt: launchConfig.deadlineAt,
-    ownershipTransferSchemaVersion:
-      launchConfig.ownershipTransfer?.schemaVersion ?? null,
     resourceSnapshotDigest: launchConfig.resourceSnapshotDigest,
     sandboxEventSequenceStart: launchConfig.sandboxEventSequenceStart,
     sessionId,
@@ -650,8 +646,6 @@ function sameApiFirstTurnCommitIdentity(
     left.baseSessionId === right.baseSessionId &&
     left.baseSessionSha256 === right.baseSessionSha256 &&
     left.deadlineAt === right.deadlineAt &&
-    left.ownershipTransferSchemaVersion ===
-      right.ownershipTransferSchemaVersion &&
     left.resourceSnapshotDigest === right.resourceSnapshotDigest &&
     left.sandboxEventSequenceStart === right.sandboxEventSequenceStart &&
     left.sessionId === right.sessionId
@@ -920,13 +914,7 @@ async function executeApiModelTurn(
             "Pi API first turn lost eligibility before provider ownership",
           );
           if (state.activeDeliveryId) {
-            if (args.commitIdentity.ownershipTransferSchemaVersion === 1) {
-              throw new PiApiFirstTurnActiveInputBeforeProviderError();
-            }
-            throw piApiFirstTurnError(
-              "PI_API_FIRST_TURN_NOT_COMMITTABLE",
-              "Pi API first turn cannot claim provider ownership with active input",
-            );
+            throw new PiApiFirstTurnActiveInputBeforeProviderError();
           }
           modelSignal.throwIfAborted();
           markProviderRequestMayHaveStarted();
@@ -1040,7 +1028,6 @@ function validateApiFirstTurnH1(
 }
 
 function ownershipTransferManifest(args: {
-  readonly capability: ApiFirstTurnLaunchConfig["ownershipTransfer"];
   readonly mode: PiApiFirstTurnOwnershipTransferMode;
   readonly baseSession: PiApiFirstTurnManifest["baseSession"];
   readonly session: {
@@ -1050,25 +1037,10 @@ function ownershipTransferManifest(args: {
   };
   readonly sandboxEventSequenceStart: number;
 }): PiApiFirstTurnManifest {
-  if (args.capability?.schemaVersion === 1) {
-    return {
-      schemaVersion: 3,
-      outcome: "ownership-transfer",
-      mode: args.mode,
-      baseSession: args.baseSession,
-      session: args.session,
-      sandboxEventSequenceStart: args.sandboxEventSequenceStart,
-    };
-  }
-  if (args.mode !== "pending-tool-continuation") {
-    throw piApiFirstTurnError(
-      "PI_LAUNCH_CONFIG_INVALID",
-      "Pi ownership transfer is not supported by the selected Sandbox",
-    );
-  }
   return {
-    schemaVersion: 2,
-    outcome: "handoff",
+    schemaVersion: 3,
+    outcome: "ownership-transfer",
+    mode: args.mode,
     baseSession: args.baseSession,
     session: args.session,
     sandboxEventSequenceStart: args.sandboxEventSequenceStart,
@@ -1086,15 +1058,10 @@ function eligibleSandboxFallbackReason(
   args: {
     readonly failure: PiApiFirstTurnError;
     readonly ownership: PiApiFirstTurnOwnership;
-    readonly launchConfig: ApiFirstTurnLaunchConfig;
   },
   signal: AbortSignal,
 ): PiSandboxFallbackReason | null {
-  if (
-    signal.aborted ||
-    args.ownership.stage !== "pre-provider" ||
-    args.launchConfig.ownershipTransfer?.schemaVersion !== 1
-  ) {
+  if (signal.aborted || args.ownership.stage !== "pre-provider") {
     return null;
   }
   switch (args.failure.code) {
@@ -1159,8 +1126,7 @@ function materializeApiFirstTurnH0(args: {
 
 /**
  * Intentional runtime ownership fallback for a real preparation failure. This
- * is not old-Sandbox tolerance: the immutable launch capability proves the V3
- * reader. Keep it while API preparation happens after durable activation;
+ * remains necessary while API preparation happens after durable activation;
  * parent issue #30564 owns that lifecycle boundary.
  */
 const publishSandboxFallback$ = command(async function publishSandboxFallback(
@@ -1172,12 +1138,6 @@ const publishSandboxFallback$ = command(async function publishSandboxFallback(
   const { executionContext, launchConfig, sessionId } =
     validateApiFirstTurnLaunch(args);
   const commitIdentity = apiFirstTurnCommitIdentity(args);
-  if (launchConfig.ownershipTransfer?.schemaVersion !== 1) {
-    throw piApiFirstTurnError(
-      "PI_LAUNCH_CONFIG_INVALID",
-      "Pi sandbox fallback requires ownership-transfer capability proof",
-    );
-  }
   signal.throwIfAborted();
   const loadedSession = await set(
     loadResumeSessionJsonl$,
@@ -1246,7 +1206,6 @@ const publishSandboxFallback$ = command(async function publishSandboxFallback(
       );
     }
     const manifest = ownershipTransferManifest({
-      capability: launchConfig.ownershipTransfer,
       mode: "sandbox-first",
       baseSession: launchConfig.baseSession,
       session: {
@@ -1335,7 +1294,6 @@ const prepareApiFirstTurn$ = command(async function prepareApiFirstTurn(
     sessionId,
     startedAt,
     turn,
-    ownershipTransferCapability: launchConfig.ownershipTransfer,
   };
 });
 
@@ -1436,15 +1394,6 @@ const commitApiFirstTurn$ = command(async function commitApiFirstTurn(
       "Pi API first turn lost commit eligibility after the provider request",
     );
     const hasActiveInput = state.activeDeliveryId !== null;
-    if (
-      hasActiveInput &&
-      prepared.commitIdentity.ownershipTransferSchemaVersion !== 1
-    ) {
-      throw piApiFirstTurnError(
-        "PI_API_FIRST_TURN_NOT_COMMITTABLE",
-        "Pi API first turn cannot preserve active input without ownership-transfer capability",
-      );
-    }
     const transferMode: PiApiFirstTurnOwnershipTransferMode | null = prepared
       .turn.handoffRequired
       ? "pending-tool-continuation"
@@ -1490,7 +1439,6 @@ const commitApiFirstTurn$ = command(async function commitApiFirstTurn(
     await set(publishEvents$, { auth: prepared.auth, events }, signal);
     if (transferMode) {
       const manifest = ownershipTransferManifest({
-        capability: prepared.ownershipTransferCapability,
         mode: transferMode,
         baseSession: prepared.baseSession,
         session: {
@@ -1719,8 +1667,6 @@ export const runPiApiFirstTurn$ = command(
           {
             failure,
             ownership,
-            launchConfig:
-              activation.executionContext.piLaunchConfig.apiFirstTurn,
           },
           signal,
         );

--- a/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
@@ -498,7 +498,6 @@ async function startOwnershipTransferHost(args: {
             sha256: args.baseSessionSha256,
           },
           sandboxEventSequenceStart: 1,
-          ownershipTransfer: { schemaVersion: 1 },
         },
       },
     }),

--- a/turbo/apps/cli/src/lib/pi-agent-loop.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.ts
@@ -109,10 +109,9 @@ export async function piSandboxAgentConfigFromEnv(
  * Resolve the API-first handoff and run the official sandbox-owned Pi RPC host.
  *
  * The handoff resolver validates the immutable manifest, authoritative session,
- * and ownership mode. Manifest V1/V2 handoffs retain their schema V1
- * private control and pending-tool startup. Manifest V3 emits a schema V2
- * control carrying the explicit ownership mode. This host writes that control
- * before entering `runPiOfficialRpcMode`.
+ * and ownership mode. The V3 manifest emits a schema V2 private control
+ * carrying the explicit ownership mode. This host writes that control before
+ * entering `runPiOfficialRpcMode`.
  *
  * The guest-agent consumes that control record before admitting any official
  * Pi RPC record, so the control is not an agent event, Chat event, transcript

--- a/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.test.ts
+++ b/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.test.ts
@@ -67,18 +67,35 @@ const EMPTY_SESSION_JSONL = MemoryPiSession.create({
   cwd: "/home/user/workspace",
   id: SESSION_ID,
 }).toJsonl();
-type PiApiFirstTurnManifestV1 = Extract<
+type PendingToolManifest = Extract<
   PiApiFirstTurnManifest,
-  { readonly schemaVersion: 1 }
+  { readonly mode: "pending-tool-continuation" }
 >;
 
 function manifest(
   jsonl: string,
-  overrides: Partial<PiApiFirstTurnManifestV1> = {},
-): PiApiFirstTurnManifestV1 {
+  overrides: Partial<PendingToolManifest> = {},
+): PendingToolManifest {
   const bytes = Buffer.from(jsonl);
   return {
-    schemaVersion: 1,
+    schemaVersion: 3,
+    outcome: "ownership-transfer",
+    mode: "pending-tool-continuation",
+    baseSession: { sessionId: SESSION_ID, sha256: H0_HASH },
+    session: {
+      sessionId: SESSION_ID,
+      sha256: createHash("sha256").update(bytes).digest("hex"),
+      rawSize: bytes.length,
+    },
+    sandboxEventSequenceStart: 4,
+    ...overrides,
+  };
+}
+
+function legacyManifest(jsonl: string, schemaVersion: 1 | 2): object {
+  const bytes = Buffer.from(jsonl);
+  return {
+    schemaVersion,
     outcome: "handoff",
     baseSession: { sessionId: SESSION_ID, sha256: H0_HASH },
     session: {
@@ -86,18 +103,7 @@ function manifest(
       sha256: createHash("sha256").update(bytes).digest("hex"),
       rawSize: bytes.length,
     },
-    ...overrides,
-  };
-}
-
-function manifestV2(
-  jsonl: string,
-  sandboxEventSequenceStart: number,
-): PiApiFirstTurnManifest {
-  return {
-    ...manifest(jsonl),
-    schemaVersion: 2,
-    sandboxEventSequenceStart,
+    ...(schemaVersion === 2 ? { sandboxEventSequenceStart: 4 } : {}),
   };
 }
 
@@ -125,7 +131,6 @@ function manifestV3(
 function config(
   deadlineAt: number,
   sandboxEventSequenceStart = 1,
-  ownershipTransfer = false,
   baseSessionSha256: string | null = H0_HASH,
 ): PiApiFirstTurnConfig {
   return {
@@ -136,9 +141,6 @@ function config(
     deadlineAt,
     baseSession: { sessionId: SESSION_ID, sha256: baseSessionSha256 },
     sandboxEventSequenceStart,
-    ...(ownershipTransfer
-      ? { ownershipTransfer: { schemaVersion: 1 as const } }
-      : {}),
   };
 }
 
@@ -202,38 +204,34 @@ describe("Pi API first-turn handoff loader", () => {
     );
     expect(await readFile(restored.sessionFile, "utf8")).toBe(jsonl);
     expect(restored.boundaryControl).toStrictEqual({
-      schemaVersion: 1,
-      sandboxEventSequenceStart: 1,
+      schemaVersion: 2,
+      sandboxEventSequenceStart: 4,
+      ownershipTransferMode: "pending-tool-continuation",
     });
     expect(restored.ownershipTransferMode).toBe("pending-tool-continuation");
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
-  it("restores H1 with the authoritative future manifest boundary", async () => {
-    const sessionDir = await mkdtemp(join(tmpdir(), "pi-handoff-loader-"));
-    temporaryDirectories.push(sessionDir);
-    const jsonl = HANDOFF_SESSION_JSONL;
-    const sandboxEventSequenceStart = 4;
-    const fetchMock = vi.fn(async (input: Parameters<typeof fetch>[0]) => {
-      return String(input).endsWith("manifest.json")
-        ? Response.json(manifestV2(jsonl, sandboxEventSequenceStart))
-        : new Response(jsonl);
-    });
+  it.each([1, 2] as const)(
+    "rejects retired manifest V%s before downloading a session",
+    async (schemaVersion) => {
+      const fetchMock = vi.fn(async () => {
+        return Response.json(
+          legacyManifest(HANDOFF_SESSION_JSONL, schemaVersion),
+        );
+      });
 
-    const restored = await resolvePiApiFirstTurnHandoff({
-      config: config(5_000),
-      sessionDir,
-      sessionId: SESSION_ID,
-      runtime: fixedRuntime(fetchMock as typeof fetch),
-    });
-
-    expect(restored.boundaryControl).toStrictEqual({
-      schemaVersion: 1,
-      sandboxEventSequenceStart,
-    });
-    expect(restored.ownershipTransferMode).toBe("pending-tool-continuation");
-    expect(await readFile(restored.sessionFile, "utf8")).toBe(jsonl);
-  });
+      await expect(
+        resolvePiApiFirstTurnHandoff({
+          config: config(5_000),
+          sessionDir: "/unused",
+          sessionId: SESSION_ID,
+          runtime: fixedRuntime(fetchMock as typeof fetch),
+        }),
+      ).rejects.toMatchObject({ code: "PI_HANDOFF_MANIFEST_INVALID" });
+      expect(fetchMock).toHaveBeenCalledOnce();
+    },
+  );
 
   it.each([
     {
@@ -269,7 +267,7 @@ describe("Pi API first-turn handoff loader", () => {
     });
 
     const restored = await resolvePiApiFirstTurnHandoff({
-      config: config(5_000, 1, true, fixture.baseSessionSha256),
+      config: config(5_000, 1, fixture.baseSessionSha256),
       sessionDir,
       sessionId: SESSION_ID,
       runtime: fixedRuntime(fetchMock as typeof fetch),
@@ -282,24 +280,6 @@ describe("Pi API first-turn handoff loader", () => {
     });
     expect(restored.ownershipTransferMode).toBe(fixture.mode);
     expect(await readFile(restored.sessionFile, "utf8")).toBe(fixture.jsonl);
-  });
-
-  it("rejects V3 before downloading a session when the launch lacks capability proof", async () => {
-    const fetchMock = vi.fn(async () => {
-      return Response.json(
-        manifestV3(SETTLED_SESSION_JSONL, "settled-session-continuation", 4),
-      );
-    });
-
-    await expect(
-      resolvePiApiFirstTurnHandoff({
-        config: config(5_000),
-        sessionDir: "/unused",
-        sessionId: SESSION_ID,
-        runtime: fixedRuntime(fetchMock as typeof fetch),
-      }),
-    ).rejects.toMatchObject({ code: "PI_HANDOFF_MANIFEST_UNSUPPORTED" });
-    expect(fetchMock).toHaveBeenCalledOnce();
   });
 
   it.each([
@@ -334,7 +314,7 @@ describe("Pi API first-turn handoff loader", () => {
 
     await expect(
       resolvePiApiFirstTurnHandoff({
-        config: config(5_000, 1, true, fixture.baseSessionSha256),
+        config: config(5_000, 1, fixture.baseSessionSha256),
         sessionDir: "/unused",
         sessionId: SESSION_ID,
         runtime: fixedRuntime(fetchMock as typeof fetch),
@@ -361,7 +341,7 @@ describe("Pi API first-turn handoff loader", () => {
 
     await expect(
       resolvePiApiFirstTurnHandoff({
-        config: config(5_000, 1, true, settledHash),
+        config: config(5_000, 1, settledHash),
         sessionDir: "/unused",
         sessionId: SESSION_ID,
         runtime: fixedRuntime(fetchMock as typeof fetch),
@@ -369,38 +349,27 @@ describe("Pi API first-turn handoff loader", () => {
     ).rejects.toMatchObject({ code: "PI_HANDOFF_H1_INVALID" });
   });
 
-  it("fails closed for a v1 manifest with a dynamic launch boundary", async () => {
-    const pointer = manifest(HANDOFF_SESSION_JSONL);
-    const fetchMock = vi.fn(async () => {
-      return Response.json(pointer);
-    });
-
-    await expect(
-      resolvePiApiFirstTurnHandoff({
-        config: config(5_000, 4),
-        sessionDir: "/unused",
-        sessionId: SESSION_ID,
-        runtime: fixedRuntime(fetchMock as typeof fetch),
-      }),
-    ).rejects.toMatchObject({ code: "PI_HANDOFF_SEQUENCE_MISMATCH" });
-    expect(fetchMock).toHaveBeenCalledOnce();
-  });
-
   it.each([
     {
-      name: "missing future boundary",
+      name: "missing boundary",
       pointer: {
         ...manifest(HANDOFF_SESSION_JSONL),
-        schemaVersion: 2,
+        sandboxEventSequenceStart: undefined,
       },
     },
     {
-      name: "zero future boundary",
-      pointer: manifestV2(HANDOFF_SESSION_JSONL, 0),
+      name: "zero boundary",
+      pointer: {
+        ...manifest(HANDOFF_SESSION_JSONL),
+        sandboxEventSequenceStart: 0,
+      },
     },
     {
-      name: "overflowing future boundary",
-      pointer: manifestV2(HANDOFF_SESSION_JSONL, MAX_EVENT_SEQUENCE_NUMBER + 1),
+      name: "overflowing boundary",
+      pointer: {
+        ...manifest(HANDOFF_SESSION_JSONL),
+        sandboxEventSequenceStart: MAX_EVENT_SEQUENCE_NUMBER + 1,
+      },
     },
   ])("rejects a $name as an invalid manifest", async ({ pointer }) => {
     const fetchMock = vi.fn(async () => {

--- a/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.ts
+++ b/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.ts
@@ -27,9 +27,7 @@ type PiApiFirstTurnHandoffErrorCode =
   | "PI_HANDOFF_H1_TOO_LARGE"
   | "PI_HANDOFF_H1_WRITE_FAILED"
   | "PI_HANDOFF_MANIFEST_INVALID"
-  | "PI_HANDOFF_MANIFEST_UNSUPPORTED"
   | "PI_HANDOFF_MANIFEST_TIMEOUT"
-  | "PI_HANDOFF_SEQUENCE_MISMATCH"
   | "PI_HANDOFF_SESSION_MISMATCH";
 
 class PiApiFirstTurnHandoffError extends Error {
@@ -46,16 +44,11 @@ class PiApiFirstTurnHandoffError extends Error {
   }
 }
 
-export type PiApiFirstTurnBoundaryControl =
-  | {
-      readonly schemaVersion: 1;
-      readonly sandboxEventSequenceStart: number;
-    }
-  | {
-      readonly schemaVersion: 2;
-      readonly sandboxEventSequenceStart: number;
-      readonly ownershipTransferMode: PiApiFirstTurnOwnershipTransferMode;
-    };
+export interface PiApiFirstTurnBoundaryControl {
+  readonly schemaVersion: 2;
+  readonly sandboxEventSequenceStart: number;
+  readonly ownershipTransferMode: PiApiFirstTurnOwnershipTransferMode;
+}
 
 interface PiApiFirstTurnHandoff {
   readonly sessionFile: string;
@@ -250,50 +243,6 @@ function validateManifestIdentity(args: {
   }
 }
 
-function validatedBoundaryControl(args: {
-  readonly config: PiApiFirstTurnConfig;
-  readonly manifest: PiApiFirstTurnManifest;
-}): PiApiFirstTurnBoundaryControl {
-  if (args.manifest.schemaVersion === 3) {
-    if (args.config.ownershipTransfer?.schemaVersion !== 1) {
-      throw new PiApiFirstTurnHandoffError(
-        "PI_HANDOFF_MANIFEST_UNSUPPORTED",
-        "Pi ownership-transfer manifest was not enabled for this Sandbox",
-      );
-    }
-    return {
-      schemaVersion: 2,
-      sandboxEventSequenceStart: args.manifest.sandboxEventSequenceStart,
-      ownershipTransferMode: args.manifest.mode,
-    };
-  }
-  // API-written manifests and commit-addressed CLIs overlap across queued runs
-  // and the two-hour runner drain. Remove v1 after #29618 is live on every Pi
-  // runner, pre-v2 work has drained, and no retained rollback API emits v1;
-  // tracked by #29612.
-  if (args.manifest.schemaVersion === 2) {
-    return {
-      schemaVersion: 1,
-      sandboxEventSequenceStart: args.manifest.sandboxEventSequenceStart,
-    };
-  }
-  if (args.config.sandboxEventSequenceStart !== 1) {
-    throw new PiApiFirstTurnHandoffError(
-      "PI_HANDOFF_SEQUENCE_MISMATCH",
-      "Pi API first-turn manifest boundary does not match the launch",
-    );
-  }
-  return { schemaVersion: 1, sandboxEventSequenceStart: 1 };
-}
-
-function ownershipTransferMode(
-  manifest: PiApiFirstTurnManifest,
-): PiApiFirstTurnOwnershipTransferMode {
-  return manifest.schemaVersion === 3
-    ? manifest.mode
-    : "pending-tool-continuation";
-}
-
 function validateSessionMode(args: {
   readonly inspection: PiSessionInspection;
   readonly manifest: PiApiFirstTurnManifest;
@@ -448,21 +397,21 @@ export async function resolvePiApiFirstTurnHandoff(args: {
 }): Promise<PiApiFirstTurnHandoff> {
   const runtime = args.runtime ?? defaultRuntime;
   const manifest = await pollManifest(args.config, runtime);
-  const boundaryControl = validatedBoundaryControl({
-    config: args.config,
-    manifest,
-  });
-  const mode = ownershipTransferMode(manifest);
+  const boundaryControl: PiApiFirstTurnBoundaryControl = {
+    schemaVersion: 2,
+    sandboxEventSequenceStart: manifest.sandboxEventSequenceStart,
+    ownershipTransferMode: manifest.mode,
+  };
   return {
     boundaryControl,
-    ownershipTransferMode: mode,
+    ownershipTransferMode: manifest.mode,
     sessionFile: await restoreSession({
       config: args.config,
       manifest,
       runtime,
       sessionDir: args.sessionDir,
       sessionId: args.sessionId,
-      mode,
+      mode: manifest.mode,
     }),
   };
 }

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -412,43 +412,24 @@ describe("Pi sandbox execution contract", () => {
     ).toBe(false);
   });
 
-  it("accepts manifest v1 as the implicit start-at-1 contract", () => {
-    const manifest = piApiFirstTurnManifestSchema.parse({
+  it.each([
+    {
       schemaVersion: 1,
       outcome: "handoff",
       baseSession: { sessionId: piSessionId, sha256: null },
       session: handoffSession,
-    });
-
-    expect(manifest.schemaVersion).toBe(1);
-    expect(manifest).not.toHaveProperty("sandboxEventSequenceStart");
-    expect(
-      piApiFirstTurnManifestSchema.safeParse({
-        ...manifest,
-        sandboxEventSequenceStart: 1,
-      }).success,
-    ).toBe(false);
-  });
-
-  it("accepts an authoritative future manifest boundary after launch", () => {
-    const sandboxEventSequenceStart = 4;
-    const manifest = piApiFirstTurnManifestSchema.parse({
+    },
+    {
       schemaVersion: 2,
       outcome: "handoff",
       baseSession: { sessionId: piSessionId, sha256: null },
       session: handoffSession,
-      sandboxEventSequenceStart,
-    });
-    const config = piApiFirstTurnConfigSchema.parse(
-      piStoredContext.piLaunchConfig.apiFirstTurn,
+      sandboxEventSequenceStart: 4,
+    },
+  ])("rejects retired manifest schema $schemaVersion", (manifest) => {
+    expect(piApiFirstTurnManifestSchema.safeParse(manifest).success).toBe(
+      false,
     );
-
-    expect(manifest).toMatchObject({
-      schemaVersion: 2,
-      sandboxEventSequenceStart,
-    });
-    expect(config.sandboxEventSequenceStart).toBe(1);
-    expect(config).not.toHaveProperty("ownershipTransfer");
   });
 
   it.each([
@@ -473,12 +454,16 @@ describe("Pi sandbox execution contract", () => {
     });
   });
 
-  it("keeps V3 capability additive and fail-closed", () => {
+  it("keeps the ignored stored-context marker exact and optional", () => {
+    const canonical = piApiFirstTurnConfigSchema.parse(
+      piStoredContext.piLaunchConfig.apiFirstTurn,
+    );
     const configured = piApiFirstTurnConfigSchema.parse({
       ...piStoredContext.piLaunchConfig.apiFirstTurn,
       ownershipTransfer: { schemaVersion: 1 },
     });
 
+    expect(canonical).not.toHaveProperty("ownershipTransfer");
     expect(configured.ownershipTransfer).toStrictEqual({ schemaVersion: 1 });
     expect(
       piApiFirstTurnConfigSchema.safeParse({
@@ -530,15 +515,6 @@ describe("Pi sandbox execution contract", () => {
     (sandboxEventSequenceStart) => {
       expect(
         piApiFirstTurnManifestSchema.safeParse({
-          schemaVersion: 2,
-          outcome: "handoff",
-          baseSession: { sessionId: piSessionId, sha256: null },
-          session: handoffSession,
-          sandboxEventSequenceStart,
-        }).success,
-      ).toBe(false);
-      expect(
-        piApiFirstTurnManifestSchema.safeParse({
           schemaVersion: 3,
           outcome: "ownership-transfer",
           mode: "settled-session-continuation",
@@ -556,11 +532,12 @@ describe("Pi sandbox execution contract", () => {
     },
   );
 
-  it("rejects a future manifest without its dynamic boundary", () => {
+  it("rejects a V3 manifest without its dynamic boundary", () => {
     expect(
       piApiFirstTurnManifestSchema.safeParse({
-        schemaVersion: 2,
-        outcome: "handoff",
+        schemaVersion: 3,
+        outcome: "ownership-transfer",
+        mode: "pending-tool-continuation",
         baseSession: { sessionId: piSessionId, sha256: null },
         session: handoffSession,
       }).success,

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -806,27 +806,6 @@ const piApiFirstTurnSessionSchema = z
 
 const piSandboxEventSequenceStartSchema = eventSequenceNumberSchema.min(1);
 
-export const piApiFirstTurnManifestV1Schema = z
-  .object({
-    schemaVersion: z.literal(1),
-    outcome: z.literal("handoff"),
-    baseSession: piSessionCheckpointSchema,
-    session: piApiFirstTurnSessionSchema,
-  })
-  .strict()
-  .readonly();
-
-export const piApiFirstTurnManifestV2Schema = z
-  .object({
-    schemaVersion: z.literal(2),
-    outcome: z.literal("handoff"),
-    baseSession: piSessionCheckpointSchema,
-    session: piApiFirstTurnSessionSchema,
-    sandboxEventSequenceStart: piSandboxEventSequenceStartSchema,
-  })
-  .strict()
-  .readonly();
-
 const piApiFirstTurnOwnershipTransferManifestShape = {
   schemaVersion: z.literal(3),
   outcome: z.literal("ownership-transfer"),
@@ -841,7 +820,7 @@ export const piApiFirstTurnOwnershipTransferModeSchema = z.enum([
   "settled-session-continuation",
 ]);
 
-export const piApiFirstTurnManifestV3Schema = z.discriminatedUnion("mode", [
+export const piApiFirstTurnManifestSchema = z.discriminatedUnion("mode", [
   z
     .object({
       ...piApiFirstTurnOwnershipTransferManifestShape,
@@ -865,12 +844,6 @@ export const piApiFirstTurnManifestV3Schema = z.discriminatedUnion("mode", [
     .readonly(),
 ]);
 
-export const piApiFirstTurnManifestSchema = z.union([
-  piApiFirstTurnManifestV1Schema,
-  piApiFirstTurnManifestV2Schema,
-  piApiFirstTurnManifestV3Schema,
-]);
-
 const piApiFirstTurnOwnershipTransferCapabilitySchema = z
   .object({
     schemaVersion: z.literal(1),
@@ -879,10 +852,9 @@ const piApiFirstTurnOwnershipTransferCapabilitySchema = z
   .readonly();
 
 /**
- * Optional consumer capability for the ownership-transfer manifest. The API
- * keeps this absent while it writes legacy V1/V2 pending-tool handoffs. A
- * future writer may publish manifest V3 only after the selected Sandbox has
- * proven support and this marker is present in its immutable launch slot.
+ * Ignored compatibility field for stored contexts written before #31020.
+ * Keep accepting this exact shape until parent #31007 records the
+ * marker-omitting deployment and its queued/claimed context window drains.
  */
 const piApiFirstTurnOwnershipTransferSchema =
   piApiFirstTurnOwnershipTransferCapabilitySchema.optional();

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -291,6 +291,10 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     profile: z.string(),
   }),
   z.object({
+    action: z.literal("set-runner-job-pi-ownership-transfer-as-previous-api"),
+    run_id: z.uuid(),
+  }),
+  z.object({
     action: z.literal(
       "clear-workflow-automation-event-connector-as-previous-api",
     ),


### PR DESCRIPTION
## Summary

- make the Pi first-turn manifest strictly V3 and the private guest boundary strictly V2
- stop producing or using the `ownershipTransfer` marker while retaining exact stored-context parsing until the parent cleanup gate
- cover rejection of legacy manifests and prove that a predecessor marker context still claims successfully

## Deployment compatibility

- this is intentionally forward-only: rollback to a pre-V3 API/CLI is unsupported, as agreed in #31007
- generated Rust marker bindings and Runner validation remain until the deployment and drain gate for the parent issue

## Test plan

- `pnpm format`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F @okouai/api-contracts test`
- `pnpm -F @okouai/cli lint`
- `pnpm -F @okouai/cli check-types`
- `pnpm -F @okouai/cli build`
- `pnpm -F @okouai/cli exec vitest run src/lib/pi-agent-loop.test.ts src/lib/pi-api-first-turn-handoff.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t 'hands a Terra resource failure|publishes ordered mixed blocks'`
- `pnpm knip`
- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets -- -D warnings`
- `cargo doc -p guest-agent --no-deps`
- `cargo test -p guest-agent`
- repository pre-commit hooks

Closes #31020

Parent: #31007
