### PR TITLE
feat(ui): gate the geist typeface behind a feature switch

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -299,7 +299,7 @@
     </script>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap"
       media="print"
       onload="this.media = 'all'"
     />

--- a/turbo/apps/platform/src/signals/okou-page/flatten-annotated-image.ts
+++ b/turbo/apps/platform/src/signals/okou-page/flatten-annotated-image.ts
@@ -30,6 +30,18 @@ const NOTE_PADDING_UNITS = 6;
 const ARROW_HEAD_UNITS = 18;
 const CORNER_RADIUS_UNITS = 4;
 
+/**
+ * Resolved to a concrete stack rather than passed as `var(...)`: canvas takes a
+ * plain CSS font shorthand and does not resolve custom properties. Reading the
+ * token keeps flattened annotations on whatever typeface the app is currently
+ * rendering.
+ */
+function annotationFontFamily(): string {
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue("--font-family-sans")
+    .trim();
+}
+
 interface Scale {
   readonly width: number;
   readonly height: number;
@@ -175,7 +187,7 @@ function drawPin(
   context.stroke();
 
   context.fillStyle = "#FFFFFF";
-  context.font = `700 ${px(scale, PIN_FONT_UNITS)}px "Noto Sans", system-ui, sans-serif`;
+  context.font = `700 ${px(scale, PIN_FONT_UNITS)}px ${annotationFontFamily()}`;
   context.textAlign = "center";
   context.textBaseline = "middle";
   context.fillText(String(ordinal), x, y);
@@ -228,7 +240,7 @@ function drawNote(
   const fontSize = px(scale, NOTE_FONT_UNITS);
   const lineHeight = px(scale, NOTE_LINE_UNITS);
   const padding = px(scale, NOTE_PADDING_UNITS);
-  context.font = `600 ${fontSize}px "Noto Sans", system-ui, sans-serif`;
+  context.font = `600 ${fontSize}px ${annotationFontFamily()}`;
   context.textAlign = "left";
   context.textBaseline = "top";
 
@@ -356,7 +368,7 @@ function drawMark(
   const x = toX(mark.at.x);
   const y = toY(mark.at.y);
   const fontSize = px(scale, TEXT_FONT_UNITS);
-  context.font = `700 ${fontSize}px "Noto Sans", system-ui, sans-serif`;
+  context.font = `700 ${fontSize}px ${annotationFontFamily()}`;
   context.textAlign = "left";
   context.textBaseline = "top";
   context.lineJoin = "round";

--- a/turbo/apps/platform/src/signals/theme.ts
+++ b/turbo/apps/platform/src/signals/theme.ts
@@ -168,6 +168,21 @@ export function applyColorThemeDocumentAttributes(
 }
 
 /**
+ * Keep the Geist typeface attribute on the document while a themed app shell is
+ * mounted. Document scope matches the color themes above: portaled dialogs,
+ * popovers, and toasts read the same font tokens as the app shell.
+ */
+export function applyTypefaceDocumentAttribute(enabled: boolean) {
+  const root = document.documentElement;
+
+  if (enabled) {
+    root.dataset.typeface = "geist";
+  } else {
+    delete root.dataset.typeface;
+  }
+}
+
+/**
  * Initialize theme from localStorage or system preference.
  */
 export const initTheme$ = command(({ get, set }) => {

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -376,6 +376,18 @@ body {
   }
 }
 
+/* Geist rollout, gated by the geistTypeface switch. The app shell sets the
+   attribute on the document root so portaled dialogs, popovers, and toasts
+   swap with it. Both families ship in the stylesheet request in index.html;
+   their woff2 files only download once an element actually resolves to them. */
+:root[data-typeface="geist"] {
+  --font-family-sans:
+    "Geist", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    sans-serif;
+  --font-family-mono:
+    "Geist Mono", ui-monospace, "SF Mono", Monaco, Consolas, monospace;
+}
+
 /* Palette colors are kept as the exact source values. Each named theme pairs
    one anchor with one companion; the same pair drives the picker swatch and
    the low-concentration workspace ambience below. */

--- a/turbo/apps/platform/src/views/okou-page/__tests__/typeface-feature-switch.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/typeface-feature-switch.test.tsx
@@ -1,0 +1,69 @@
+import { screen, waitFor } from "@testing-library/react";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { describe, expect, it } from "vitest";
+
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+
+function prepareDefaultAgent(): void {
+  context.mocks.data.agents([
+    {
+      agentId: AGENT_ID,
+      ownerId: "test-user-123",
+      displayName: "Zero",
+      description: null,
+      sound: null,
+      avatarUrl: null,
+      visibility: "public",
+    },
+  ]);
+}
+
+describe("geist typeface feature switch", () => {
+  it("keeps the default typeface in the app shell when the switch is off", async () => {
+    prepareDefaultAgent();
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    await screen.findByRole("textbox", { name: "Message" });
+
+    expect(document.documentElement.dataset.typeface).toBeUndefined();
+  });
+
+  it("switches the app shell to geist when the switch is on", async () => {
+    prepareDefaultAgent();
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: { [FeatureSwitchKey.GeistTypeface]: true },
+    });
+
+    await screen.findByRole("textbox", { name: "Message" });
+
+    await waitFor(() => {
+      expect(document.documentElement.dataset.typeface).toBe("geist");
+    });
+  });
+
+  it("switches the minimal shell to geist so directed pages match the app", async () => {
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/permissions?connectorSlug=slack&permission=admin.analytics%3Aread&action=approve`,
+      featureSwitches: { [FeatureSwitchKey.GeistTypeface]: true },
+    });
+
+    await screen.findByText("Unknown permission action: approve");
+
+    await waitFor(() => {
+      expect(document.documentElement.dataset.typeface).toBe("geist");
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/okou-page/directed-shared.tsx
+++ b/turbo/apps/platform/src/views/okou-page/directed-shared.tsx
@@ -15,6 +15,7 @@ import { AccountDropdown } from "./sidebar-account";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
   applyColorThemeDocumentAttributes,
+  applyTypefaceDocumentAttribute,
   colorTheme$,
 } from "../../signals/theme.ts";
 
@@ -23,8 +24,11 @@ export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
   const dialogOpen = useGet(settingsDialogOpen$);
   const closeSettingsModal = useSet(closeSettingsModal$);
   const colorTheme = useGet(colorTheme$);
+  const features = useGet(featureSwitch$);
   const gradientColorThemesEnabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.GradientColorThemes] ?? false;
+    features[FeatureSwitchKey.GradientColorThemes] ?? false;
+  const geistTypefaceEnabled =
+    features[FeatureSwitchKey.GeistTypeface] ?? false;
 
   return (
     <div
@@ -32,6 +36,9 @@ export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
         applyColorThemeDocumentAttributes(
           element !== null && gradientColorThemesEnabled,
           colorTheme,
+        );
+        applyTypefaceDocumentAttribute(
+          element !== null && geistTypefaceEnabled,
         );
       }}
       className="zero-app zero-viewport-shell flex w-full bg-background"

--- a/turbo/apps/platform/src/views/okou-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-layout.tsx
@@ -51,6 +51,7 @@ import { lightboxUrl$ } from "../../signals/okou-page/attachment-chips.ts";
 import { AttachmentLightbox } from "./attachment-chips.tsx";
 import {
   applyColorThemeDocumentAttributes,
+  applyTypefaceDocumentAttribute,
   colorTheme$,
 } from "../../signals/theme.ts";
 
@@ -370,8 +371,11 @@ function MobileSidebarMount() {
 
 function SidebarLayoutInner({ children }: { children: ReactNode }) {
   const colorTheme = useGet(colorTheme$);
+  const features = useGet(featureSwitch$);
   const gradientColorThemesEnabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.GradientColorThemes] ?? false;
+    features[FeatureSwitchKey.GradientColorThemes] ?? false;
+  const geistTypefaceEnabled =
+    features[FeatureSwitchKey.GeistTypeface] ?? false;
   const isDesktop = useMediaQuery(SIDEBAR_DESKTOP_MEDIA_QUERY);
 
   return (
@@ -380,6 +384,9 @@ function SidebarLayoutInner({ children }: { children: ReactNode }) {
         applyColorThemeDocumentAttributes(
           element !== null && gradientColorThemesEnabled,
           colorTheme,
+        );
+        applyTypefaceDocumentAttribute(
+          element !== null && geistTypefaceEnabled,
         );
       }}
       className="zero-app zero-viewport-shell flex w-full bg-background"

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -65,4 +65,5 @@ export enum FeatureSwitchKey {
   GradientColorThemes = "gradientColorThemes",
   DesktopScreenRecording = "desktopScreenRecording",
   IosPwaStartupImages = "iosPwaStartupImages",
+  GeistTypeface = "geistTypeface",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -356,6 +356,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     // Ming only for the first pass; widen once the system mapping settles.
     enabledEmailHashes: ["54757055"], // fnv1a("ming@vm0.ai")
   },
+  [FeatureSwitchKey.GeistTypeface]: {
+    maintainer: "ming@vm0.ai",
+    description:
+      "Set the interface typeface to Geist and Geist Mono instead of Noto Sans and JetBrains Mono.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.SharedThreadSharing]: {
     maintainer: "ethan@vm0.ai",
     description:

--- a/turbo/packages/ui/src/components/ui/sonner.tsx
+++ b/turbo/packages/ui/src/components/ui/sonner.tsx
@@ -76,8 +76,7 @@ function Toaster({ onReady, ...props }: ToasterProps) {
               "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
           },
           style: {
-            fontFamily:
-              '"Noto Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+            fontFamily: "var(--font-family-sans)",
           },
         }}
         {...rest}


### PR DESCRIPTION
## What

Adds **Geist / Geist Mono** to the app as an opt-in typeface behind the new `geistTypeface` feature switch. Noto Sans / JetBrains Mono remain the default for everyone.

## How it works

`packages/core` registers `geistTypeface` (`enabled: false`, `enabledOrgIdHashes: STAFF_ORG_ID_HASHES`). The app shell reads it and sets `data-typeface="geist"` on the document root; a `:root[data-typeface="geist"]` rule in `index.css` retargets `--font-family-sans` / `--font-family-mono`. Nothing else in the app needs to know which font is active — every consumer already goes through those two tokens.

This mirrors the existing `gradientColorThemes` precedent exactly, including the document-root scope, so portaled dialogs, popovers, and toasts swap along with the shell instead of being stranded on the default.

Both shells are wired: `sidebar-layout.tsx` (main app) and `directed-shared.tsx` (shared-thread view).

## Changes

| File | Change |
| --- | --- |
| `packages/core/src/feature-switch-key.ts` | New `GeistTypeface` key |
| `packages/core/src/feature-switch.ts` | Registry entry, off by default, staff orgs only |
| `apps/platform/src/signals/theme.ts` | `applyTypefaceDocumentAttribute`, sibling to `applyColorThemeDocumentAttributes` |
| `apps/platform/src/views/okou-page/sidebar-layout.tsx` | Wire the switch in the app shell |
| `apps/platform/src/views/okou-page/directed-shared.tsx` | Wire the switch in the shared-thread shell |
| `apps/platform/src/views/css/index.css` | `:root[data-typeface="geist"]` token override |
| `apps/platform/index.html` | Google Fonts request now also carries Geist + Geist Mono |
| `packages/ui/src/components/ui/sonner.tsx` | Toast `fontFamily` reads `var(--font-family-sans)` instead of a hardcoded stack |
| `apps/platform/src/signals/okou-page/flatten-annotated-image.ts` | Canvas annotations resolve the token instead of hardcoding the family |

## Cost of shipping both families

The stylesheet is one request either way, and `@font-face` files are lazy — the browser only downloads a woff2 once an element actually resolves to it. So the inactive pair costs a few KB of extra CSS text and **zero** font downloads. That is cheaper and much simpler than injecting a second stylesheet at runtime. When the switch graduates, drop Noto Sans / JetBrains Mono from the URL and delete the default branch.

The two hardcoded call sites were changed rather than duplicated: a toast or a flattened annotation stuck on Noto Sans while the rest of the UI is Geist is a visible seam.

## Verification

- `check-types`, `lint`, and `knip` pass locally for `@okouai/app`, `@okouai/ui`, and `@okouai/core`
- `@okouai/core` suite (206 tests) and the platform `clerk-entrypoint` + `lab-page` suites pass
- Prior to gating, the unconditional version of this change was walked through end-to-end on the PR preview: real signup, app chrome, dark mode, and the JA locale all rendered Geist correctly, and Geist Mono was confirmed downloading and painting

## Two pre-existing findings, not addressed here

1. **Chat markdown code ignores `--font-family-mono`.** `apps/platform/src/views/css/vendor/uiw-react-markdown-preview-5.2.0.css` hardcodes its own `ui-monospace, SFMono-Regular, …` stack and out-specifies the base `code, pre` rule. So chat code blocks were never on JetBrains Mono and will not become Geist Mono. Bare `code` / `pre` elsewhere do follow the token.
2. **`packages/ui/tailwind.config.ts` `fontFamily` is inert.** The app is on Tailwind v4; that v3-style config does not drive the `font-sans` / `font-mono` utilities, which resolve to Tailwind's own defaults. Left untouched here.

Both are worth separate issues if we want mono to actually change where users mostly see code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
