### PR TITLE
docs(rust): include codex cleanup helper protocol

### DIFF
--- a/crates/guest-agent/src/lib.rs
+++ b/crates/guest-agent/src/lib.rs
@@ -12,8 +12,8 @@
 //!
 //! # Runner-only helper protocol
 //!
-//! The `guest-agent` executable has three runner-only helper commands. The
-//! handwritten dispatcher in `src/main.rs` handles these commands before the
+//! The `guest-agent` executable has the following runner-only helper commands.
+//! The handwritten dispatcher in `src/main.rs` handles these commands before the
 //! normal asynchronous guest-agent runtime starts. They are an internal
 //! protocol between the guest binary and `runner`, not general-purpose user
 //! CLI commands.
@@ -171,6 +171,44 @@
 //! `crates/runner/src/idle_reuse_preparation.rs::IdleReusePreparation::new`,
 //! sends the linked request through `exec_request`, and validates the linked
 //! report in `validate_result`.
+//!
+//! ## `cleanup-codex-session`
+//!
+//! ### Invocation
+//!
+//! ```text
+//! guest-agent cleanup-codex-session <session-id> <fallback-relative-path>
+//! ```
+//!
+//! Exactly two UTF-8 positional arguments are required: a canonical Codex
+//! session ID and its matching canonical logical rollout path relative to the
+//! fixed Codex home. The helper consumes no protocol stdin. Input validation is
+//! owned by [`CodexSessionCleanupRequest`](guest_contracts::codex_session_cleanup::CodexSessionCleanupRequest),
+//! including the canonical session-ID and fallback-path rules and the
+//! [`CODEX_SESSION_CLEANUP_MAX_PATH_BYTES`](guest_contracts::codex_session_cleanup::CODEX_SESSION_CLEANUP_MAX_PATH_BYTES)
+//! path limit. The fixed role owns the
+//! [`CODEX_SESSION_CLEANUP_SCAN_BUDGET`](guest_contracts::codex_session_cleanup::CODEX_SESSION_CLEANUP_SCAN_BUDGET)
+//! and
+//! [`CODEX_SESSION_CLEANUP_OUTPUT_LIMIT_BYTES`](guest_contracts::codex_session_cleanup::CODEX_SESSION_CLEANUP_OUTPUT_LIMIT_BYTES)
+//! limits; callers cannot override them.
+//!
+//! The helper performs bounded cleanup in the retained Codex sessions tree.
+//! On success, stdout is either empty or exactly one LF-terminated canonical
+//! logical path. Empty stdout means that the runner uses the fallback logical
+//! path; a returned path identifies the canonical existing path selected by
+//! cleanup. Stderr is reserved for non-protocol diagnostics. Input validation,
+//! scan, ambiguity, deletion, output, or helper failures return a nonzero exit
+//! status, and the runner does not write replacement history after such a
+//! failure.
+//!
+//! The fixed-role launcher is
+//! `crates/vsock-guest/src/agent_command.rs::spawn_codex_session_cleanup_with_pipes`.
+//! The runner invokes the operation only for an actually reused sandbox from
+//! `crates/runner/src/executor/session_restore/codex.rs::cleanup_existing_codex_session`
+//! before writing replacement history, and independently validates the output in
+//! `parse_codex_cleanup_output`
+//! before using a returned path as the restore destination. Keep these source
+//! references in sync with the shared contract when changing this protocol.
 
 pub mod active_input;
 mod active_input_receipts;


### PR DESCRIPTION
## Summary

- Add the production `cleanup-codex-session` command to the canonical `guest-agent` helper protocol documentation.
- Document its exact arguments, shared validation contract, fixed role-owned budgets, result streams, and vsock/runner boundaries.
- Preserve runtime behavior and existing tests.

## Scope

This is a documentation-only change in `crates/guest-agent/src/lib.rs`. It does not modify the dispatcher, helper implementation, protocol serialization, runner behavior, tests, persisted data, or deployment configuration.

Closes #31038

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo doc -p guest-agent --all-features --no-deps`
- `git diff --check`
