### PR TITLE
feat(runner): isolate firecracker guests in weighted cgroups

### DIFF
--- a/.github/scripts/runner-behavior-host-cpu-fairness.sh
+++ b/.github/scripts/runner-behavior-host-cpu-fairness.sh
@@ -34,6 +34,14 @@ REMOTE="${METAL_USER}@${HOST}"
 EXECUTION_KEY="${JOB_REF}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 REMOTE_BIN="/tmp/vm0-host-cpu-fairness-${EXECUTION_KEY}"
 
+cleanup_remote_binary() {
+  ssh "$REMOTE" bash -s -- "$REMOTE_BIN" 2>/dev/null <<'REMOTE_CLEANUP' || true
+set -euo pipefail
+rm -f -- "$1"
+REMOTE_CLEANUP
+}
+trap cleanup_remote_binary EXIT
+
 scp "$TEST_BIN" "${REMOTE}:${REMOTE_BIN}"
 
 ssh "$REMOTE" bash -s -- \

--- a/.github/scripts/runner-behavior-host-cpu-fairness.sh
+++ b/.github/scripts/runner-behavior-host-cpu-fairness.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${METAL_USER:?METAL_USER is required}"
+: "${HOST:?HOST is required}"
+: "${JOB_REF:?JOB_REF is required}"
+: "${DEFAULT_ROOTFS_HASH:?DEFAULT_ROOTFS_HASH is required}"
+: "${TEST_BIN:?TEST_BIN is required}"
+: "${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+: "${GITHUB_RUN_ATTEMPT:?GITHUB_RUN_ATTEMPT is required}"
+
+case "$JOB_REF" in
+  ''|*[!a-zA-Z0-9._-]*)
+    echo "JOB_REF contains unsupported characters" >&2
+    exit 2
+    ;;
+esac
+case "$GITHUB_RUN_ID:$GITHUB_RUN_ATTEMPT" in
+  *[!0-9:]*|:*|*:)
+    echo "GITHUB_RUN_ID and GITHUB_RUN_ATTEMPT must be numeric" >&2
+    exit 2
+    ;;
+esac
+if [ ! -x "$TEST_BIN" ]; then
+  echo "host CPU fairness test binary is not executable: $TEST_BIN" >&2
+  exit 2
+fi
+if [[ ! "$DEFAULT_ROOTFS_HASH" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "DEFAULT_ROOTFS_HASH must be a lowercase SHA-256 hash" >&2
+  exit 2
+fi
+
+REMOTE="${METAL_USER}@${HOST}"
+EXECUTION_KEY="${JOB_REF}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+REMOTE_BIN="/tmp/vm0-host-cpu-fairness-${EXECUTION_KEY}"
+
+scp "$TEST_BIN" "${REMOTE}:${REMOTE_BIN}"
+
+ssh "$REMOTE" bash -s -- \
+  "$REMOTE_BIN" "$DEFAULT_ROOTFS_HASH" "$EXECUTION_KEY" <<'REMOTE_SCRIPT'
+set -euo pipefail
+
+TEST_BIN=$1
+ROOTFS_HASH=$2
+EXECUTION_KEY=$3
+BASE_DIR="/var/lib/vm0-runner/host-cpu-fairness/${EXECUTION_KEY}"
+BASELINE_UNIT="vm0-host-cpu-baseline-${EXECUTION_KEY}"
+MANAGED_UNIT="vm0-host-cpu-managed-${EXECUTION_KEY}"
+
+case "$EXECUTION_KEY" in
+  ''|*[!a-zA-Z0-9._-]*)
+    echo "unsafe execution key" >&2
+    exit 2
+    ;;
+esac
+
+cleanup() {
+  sudo systemctl stop "${BASELINE_UNIT}.service" 2>/dev/null || true
+  sudo systemctl stop "${MANAGED_UNIT}.service" 2>/dev/null || true
+  sudo rm -f -- "$TEST_BIN"
+  sudo rm -rf -- "$BASE_DIR"
+}
+trap cleanup EXIT
+
+SYSTEMD_VERSION=$(systemd --version | awk 'NR == 1 { print $2 }')
+case "$SYSTEMD_VERSION" in
+  ''|*[!0-9]*)
+    echo "cannot parse systemd version: $SYSTEMD_VERSION" >&2
+    exit 1
+    ;;
+esac
+if [ "$SYSTEMD_VERSION" -lt 254 ]; then
+  echo "systemd 254+ is required, found $SYSTEMD_VERSION" >&2
+  exit 1
+fi
+
+FIRECRACKER_DIR=$(find /var/lib/vm0-runner/firecracker \
+  -mindepth 1 -maxdepth 1 -type d | sort -V | tail -1)
+FIRECRACKER="${FIRECRACKER_DIR}/firecracker"
+KERNEL=$(find "$FIRECRACKER_DIR" -maxdepth 1 -type f -name 'vmlinux-*' | sort | tail -1)
+ROOTFS="/var/lib/vm0-runner/images/${ROOTFS_HASH}/rootfs.ext4"
+for fixture in "$TEST_BIN" "$FIRECRACKER" "$KERNEL" "$ROOTFS"; do
+  if [ ! -f "$fixture" ]; then
+    echo "required host CPU fairness fixture is missing: $fixture" >&2
+    exit 1
+  fi
+done
+
+sudo modprobe nbd nbds_max=4096
+sudo mkdir -p "$BASE_DIR/baseline" "$BASE_DIR/managed"
+
+run_test() {
+  local mode=$1
+  local unit=$2
+  local base_dir=$3
+  local max_ratio=${4:-}
+  local args=(
+    --wait
+    --collect
+    --pipe
+    "--unit=${unit}"
+    --property=Type=exec
+    --property=Delegate=cpu
+    --property=DelegateSubgroup=control
+    --property=AllowedCPUs=0-3
+    --property=TimeoutStopSec=60
+    "--setenv=VM0_HOST_CPU_TEST_MODE=${mode}"
+    "--setenv=VM0_HOST_CPU_TEST_FIRECRACKER=${FIRECRACKER}"
+    "--setenv=VM0_HOST_CPU_TEST_KERNEL=${KERNEL}"
+    "--setenv=VM0_HOST_CPU_TEST_ROOTFS=${ROOTFS}"
+    "--setenv=VM0_HOST_CPU_TEST_BASE_DIR=${base_dir}"
+  )
+  if [ -n "$max_ratio" ]; then
+    args+=("--setenv=VM0_HOST_CPU_TEST_MAX_NORMALIZED_RATIO=${max_ratio}")
+  fi
+  sudo systemd-run "${args[@]}" \
+    "$TEST_BIN" --ignored --test-threads=1 --nocapture
+}
+
+echo "=== Unmanaged host CPU baseline ==="
+BASELINE_OUTPUT=$(run_test baseline "$BASELINE_UNIT" "$BASE_DIR/baseline")
+printf '%s\n' "$BASELINE_OUTPUT"
+BASELINE_RATIO=$(printf '%s\n' "$BASELINE_OUTPUT" \
+  | sed -n 's/^HOST_CPU_NORMALIZED_RATIO=//p' | tail -1)
+if ! awk -v value="$BASELINE_RATIO" 'BEGIN { exit !(value + 0 > 0) }'; then
+  echo "baseline did not publish a valid normalized ratio: $BASELINE_RATIO" >&2
+  exit 1
+fi
+MAX_RATIO=$(awk -v baseline="$BASELINE_RATIO" \
+  'BEGIN { value = baseline * 1.25; if (value < 1.75) value = 1.75; printf "%.6f", value }')
+echo "Baseline normalized ratio: $BASELINE_RATIO; managed tolerance: $MAX_RATIO"
+
+echo "=== Managed weighted host CPU proof ==="
+run_test managed "$MANAGED_UNIT" "$BASE_DIR/managed" "$MAX_RATIO"
+REMOTE_SCRIPT

--- a/.github/scripts/runner-behavior-host-cpu-fairness.sh
+++ b/.github/scripts/runner-behavior-host-cpu-fairness.sh
@@ -128,9 +128,12 @@ run_test() {
 echo "=== Unmanaged host CPU baseline ==="
 BASELINE_OUTPUT=$(run_test baseline "$BASELINE_UNIT" "$BASE_DIR/baseline")
 printf '%s\n' "$BASELINE_OUTPUT"
+# libtest writes the first nocapture record after its `test ...` prefix, so
+# extract the marker suffix while retaining strict numeric validation below.
 BASELINE_RATIO=$(printf '%s\n' "$BASELINE_OUTPUT" \
-  | sed -n 's/^HOST_CPU_NORMALIZED_RATIO=//p' | tail -1)
-if ! awk -v value="$BASELINE_RATIO" 'BEGIN { exit !(value + 0 > 0) }'; then
+  | sed -n 's/.*HOST_CPU_NORMALIZED_RATIO=//p' | tail -1)
+if ! awk -v value="$BASELINE_RATIO" \
+  'BEGIN { exit !(value ~ /^[0-9]+([.][0-9]+)?$/ && value + 0 > 0) }'; then
   echo "baseline did not publish a valid normalized ratio: $BASELINE_RATIO" >&2
   exit 1
 fi

--- a/.github/scripts/tests/crates-detect-workflow-test.sh
+++ b/.github/scripts/tests/crates-detect-workflow-test.sh
@@ -16,6 +16,8 @@ crates_json=$(yq -o=json '.' "$CRATES_WORKFLOW")
 jq -e '
   .jobs.detect as $detect |
   .jobs.check as $check |
+  .jobs["host-cpu-fairness-test"] as $host_cpu |
+  .jobs["ci-gate-crates"] as $gate |
   {
     "any-changed": "${{ steps.detect.outputs.any-changed }}",
     "ci-changed": "${{ steps.detect.outputs.ci-changed }}",
@@ -26,6 +28,7 @@ jq -e '
     "ably-subscriber-changed": "${{ steps.detect.outputs.ably-subscriber-changed }}",
     "api-contracts-changed": "${{ steps.detect.outputs.api-contracts-changed }}",
     "runner-changed": "${{ steps.detect.outputs.runner-changed }}",
+    "sandbox-fc-changed": "${{ steps.detect.outputs.sandbox-fc-changed }}",
     "nbd-cow-changed": "${{ steps.detect.outputs.nbd-cow-changed }}",
     "vsock-test-changed": "${{ steps.detect.outputs.vsock-test-changed }}",
     "crates-runner-consumer-needed": "${{ steps.runner-tests.outputs.crates-runner-consumer-needed }}",
@@ -57,6 +60,28 @@ jq -e '
   any($check.steps[]?;
     .name == "Configure Git safe directory" and
     .run == "git config --global --add safe.directory \"$GITHUB_WORKSPACE\""
+  ) and
+  ($host_cpu.needs | sort) == ([
+    "detect",
+    "runner-build",
+    "runner-behavior-lane-a",
+    "runner-behavior-lane-b",
+    "runner-behavior-lane-c",
+    "runner-behavior-lane-d"
+  ] | sort) and
+  $host_cpu.env.TARGET_TRIPLE == "${{ needs.runner-build.outputs.target }}" and
+  any($host_cpu.steps[]?;
+    .name == "Cross-compile host CPU fairness test" and
+    (.run | contains("--test host_cpu_fairness"))
+  ) and
+  any($host_cpu.steps[]?;
+    .name == "Verify weighted host CPU service with real Firecracker Guests" and
+    .run == ".github/scripts/runner-behavior-host-cpu-fairness.sh"
+  ) and
+  ($gate.needs | index("host-cpu-fairness-test")) != null and
+  any($gate.steps[]?;
+    .name == "Validate CI results" and
+    (.run | contains("needs.host-cpu-fairness-test.result"))
   )
 ' <<<"$crates_json" >/dev/null || fail "Crates workflow contract changed"
 

--- a/.github/scripts/tests/rust-ci-memory-workflow-test.sh
+++ b/.github/scripts/tests/rust-ci-memory-workflow-test.sh
@@ -19,7 +19,7 @@ action_json=$(yq -o=json '.' "$ACTION")
 
 jq -e '
   . as $workflow |
-  ["check", "coverage", "runner-firewall-contract-test", "nbd-cow-test"] |
+  ["check", "coverage", "runner-firewall-contract-test", "host-cpu-fairness-test", "nbd-cow-test"] |
   all(.[];
     . as $job |
     ($workflow.jobs[$job].steps[-1] |

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -69,6 +69,7 @@ jobs:
       ably-subscriber-changed: ${{ steps.detect.outputs.ably-subscriber-changed }}
       api-contracts-changed: ${{ steps.detect.outputs.api-contracts-changed }}
       runner-changed: ${{ steps.detect.outputs.runner-changed }}
+      sandbox-fc-changed: ${{ steps.detect.outputs.sandbox-fc-changed }}
       nbd-cow-changed: ${{ steps.detect.outputs.nbd-cow-changed }}
       vsock-test-changed: ${{ steps.detect.outputs.vsock-test-changed }}
       crates-runner-consumer-needed: ${{ steps.runner-tests.outputs.crates-runner-consumer-needed }}
@@ -111,6 +112,7 @@ jobs:
           check_crate ably-subscriber
           check_crate api-contracts
           check_crate runner
+          check_crate sandbox-fc
           check_crate nbd-cow
           check_crate vsock-test
           check_crate xtask
@@ -652,6 +654,7 @@ jobs:
       bin-dir: ${{ steps.manifest.outputs.bin-dir }}
       default-rootfs-hash: ${{ steps.manifest.outputs.selected-rootfs-hash }}
       default-snapshot-hash: ${{ steps.manifest.outputs.selected-snapshot-hash }}
+      target: ${{ steps.selected-host.outputs.target }}
     steps:
       - uses: actions/checkout@v7.0.1
 
@@ -913,6 +916,73 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
         run: .github/scripts/runner-behavior-balloon-pressure.sh
 
+  host-cpu-fairness-test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260825
+    needs:
+      - detect
+      - runner-build
+      - runner-behavior-lane-a
+      - runner-behavior-lane-b
+      - runner-behavior-lane-c
+      - runner-behavior-lane-d
+    if: |
+      !cancelled() &&
+      needs.runner-build.result == 'success' &&
+      needs.runner-behavior-lane-a.result == 'success' &&
+      needs.runner-behavior-lane-b.result == 'success' &&
+      needs.runner-behavior-lane-c.result == 'success' &&
+      needs.runner-behavior-lane-d.result == 'success' && (
+        needs.detect.outputs.sandbox-fc-changed == 'true' ||
+        needs.detect.outputs.ci-changed == 'true'
+      )
+    timeout-minutes: 15
+    env:
+      TARGET_TRIPLE: ${{ needs.runner-build.outputs.target }}
+      METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+      HOST: ${{ needs.runner-build.outputs.host }}
+      JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
+      DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates -> target
+          shared-key: ${{ needs.runner-build.outputs.target }}-host-cpu-fairness
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Cross-compile host CPU fairness test
+        run: |
+          cd crates
+          cargo test --no-run --release --target "$TARGET_TRIPLE" \
+            -p sandbox-fc --test host_cpu_fairness
+          TEST_BIN=$(find "target/$TARGET_TRIPLE/release/deps" \
+            -name 'host_cpu_fairness-*' -executable -type f | head -1)
+          if [ -z "$TEST_BIN" ]; then
+            echo "::error::host CPU fairness test binary not found"
+            exit 1
+          fi
+          echo "TEST_BIN=crates/$TEST_BIN" >> "$GITHUB_ENV"
+
+      - name: Setup SSH via Cloudflare Tunnel
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-user: ${{ env.METAL_USER }}
+          ssh-hosts: ${{ env.HOST }}
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
+      - name: Verify weighted host CPU service with real Firecracker Guests
+        run: .github/scripts/runner-behavior-host-cpu-fairness.sh
+
+      - name: Report peak memory
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/report-memory-peak
+
   ci-gate-crates:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -931,6 +1001,7 @@ jobs:
       - runner-behavior-lane-b
       - runner-behavior-lane-c
       - runner-behavior-lane-d
+      - host-cpu-fairness-test
       - nbd-cow-test
     # Always run so the gate reports an explicit result (not "skipped").
     if: always()
@@ -981,6 +1052,7 @@ jobs:
           check_result "runner-behavior-lane-b" "${{ needs.runner-behavior-lane-b.result }}" "true"
           check_result "runner-behavior-lane-c" "${{ needs.runner-behavior-lane-c.result }}" "true"
           check_result "runner-behavior-lane-d" "${{ needs.runner-behavior-lane-d.result }}" "true"
+          check_result "host-cpu-fairness-test" "${{ needs.host-cpu-fairness-test.result }}" "true"
           check_result "nbd-cow-test" "${{ needs.nbd-cow-test.result }}" "true"
 
           echo "::endgroup::"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -945,9 +945,9 @@ jobs:
       JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
       DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         with:
           workspaces: crates -> target
           shared-key: ${{ needs.runner-build.outputs.target }}-host-cpu-fairness

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -179,6 +179,7 @@ pub async fn run_benchmark(
         .create_runtime(sandbox::RuntimeConfig {
             proxy_port: Some(mitm.port()),
             dns_port: None, // benchmark does not use custom DNS proxy
+            host_cpu_placement: None,
         })
         .await
     {

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -39,6 +39,7 @@ use systemctl::{
 };
 use unit_config::read_unit_config_path_bounded;
 use unit_file::{
+    RUNNER_SERVICE_CONTROL_SUBGROUP_DIRECTIVE, RUNNER_SERVICE_CPU_DELEGATION_DIRECTIVE,
     RUNNER_SERVICE_NOFILE_LIMIT_DIRECTIVE, cleanup_unit_staging_files, generate_unit_file,
     remove_unit_file_if_exists, resolve_config_path, validate_current_exe_path, validate_env_vars,
     validate_systemd_path, write_unit_file,
@@ -189,6 +190,13 @@ fn systemd_run_limit_nofile_property_arg() -> String {
     format!("--property={RUNNER_SERVICE_NOFILE_LIMIT_DIRECTIVE}")
 }
 
+fn systemd_run_cpu_delegation_property_args() -> [String; 2] {
+    [
+        format!("--property={RUNNER_SERVICE_CPU_DELEGATION_DIRECTIVE}"),
+        format!("--property={RUNNER_SERVICE_CONTROL_SUBGROUP_DIRECTIVE}"),
+    ]
+}
+
 type ServiceFuture<'a, T> = Pin<Box<dyn Future<Output = RunnerResult<T>> + 'a>>;
 
 async fn restore_service_state_after_reload_failure(
@@ -316,6 +324,7 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
     let desc_arg = format!("--description=VM0 Runner ({})", unit.unit_name());
     let syslog_arg = format!("--property=SyslogIdentifier={}", unit.unit_name());
     let nofile_arg = systemd_run_limit_nofile_property_arg();
+    let [delegate_arg, delegate_subgroup_arg] = systemd_run_cpu_delegation_property_args();
     with_service_activation_image_artifacts(
         &unit,
         &config_path,
@@ -333,6 +342,8 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
                 "--property=KillSignal=SIGTERM",
                 "--property=TimeoutStopSec=300",
                 &*nofile_arg,
+                &*delegate_arg,
+                &*delegate_subgroup_arg,
                 &*syslog_arg,
             ]);
             for entry in &args.env {
@@ -1469,6 +1480,17 @@ profiles:
         assert_eq!(
             systemd_run_limit_nofile_property_arg(),
             "--property=LimitNOFILE=524288:524288"
+        );
+    }
+
+    #[test]
+    fn systemd_run_delegates_cpu_with_control_subgroup() {
+        assert_eq!(
+            systemd_run_cpu_delegation_property_args(),
+            [
+                "--property=Delegate=cpu".to_string(),
+                "--property=DelegateSubgroup=control".to_string(),
+            ]
         );
     }
 

--- a/crates/runner/src/cmd/service/unit_file.rs
+++ b/crates/runner/src/cmd/service/unit_file.rs
@@ -13,6 +13,8 @@ use super::target::RunnerServiceUnit;
 const UNIT_STAGING_MARKER: &str = ".tmp@";
 const UNIT_STAGING_MAX_ATTEMPTS: u64 = 32;
 pub(super) const RUNNER_SERVICE_NOFILE_LIMIT_DIRECTIVE: &str = "LimitNOFILE=524288:524288";
+pub(super) const RUNNER_SERVICE_CPU_DELEGATION_DIRECTIVE: &str = "Delegate=cpu";
+pub(super) const RUNNER_SERVICE_CONTROL_SUBGROUP_DIRECTIVE: &str = "DelegateSubgroup=control";
 #[cfg(unix)]
 const UNIT_FILE_MODE: u32 = 0o600;
 static UNIT_STAGING_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -92,6 +94,8 @@ RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=300
 {RUNNER_SERVICE_NOFILE_LIMIT_DIRECTIVE}
+{RUNNER_SERVICE_CPU_DELEGATION_DIRECTIVE}
+{RUNNER_SERVICE_CONTROL_SUBGROUP_DIRECTIVE}
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier={unit_name}
@@ -461,6 +465,8 @@ mod tests {
         assert!(content.contains("Restart=on-failure"));
         assert!(content.contains("TimeoutStopSec=300"));
         assert!(content.contains("LimitNOFILE=524288:524288"));
+        assert!(content.contains("Delegate=cpu"));
+        assert!(content.contains("DelegateSubgroup=control"));
         assert!(content.contains("[Install]"));
         assert!(content.contains("WantedBy=multi-user.target"));
         assert!(!content.contains("Environment="));

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -586,6 +586,9 @@ async fn run_start_with_home(
         concurrency_factor,
         max_concurrent,
     ));
+    let host_cpu_placement = host_cpu_placement_config(&budget, args.local)?;
+    let control_cpu_weight = host_cpu_placement.control_weight();
+    let guests_cpu_weight = host_cpu_placement.guests_weight();
     info!(
         host_cpus,
         host_memory_mb,
@@ -595,6 +598,9 @@ async fn run_start_with_home(
         max_concurrent,
         host_cpu_admission_reservation = budget.host_cpu_admission_reservation(),
         guest_cpu_admission_capacity = budget.guest_cpu_admission_capacity(),
+        control_cpu_weight,
+        guests_cpu_weight,
+        host_cpu_placement_mode = ?host_cpu_placement.mode(),
         vcpu_admission_limit = budget.vcpu_admission_limit(),
         effective_vcpu = budget.effective_vcpu(),
         effective_memory_mb = budget.effective_memory_mb(),
@@ -742,6 +748,7 @@ async fn run_start_with_home(
             .create_runtime(sandbox::RuntimeConfig {
                 proxy_port: Some(mitm.port()),
                 dns_port: Some(dns_port),
+                host_cpu_placement: Some(host_cpu_placement),
             })
             .await
             .map_err(|e| RunnerError::Internal(format!("sandbox runtime: {e}")))?;
@@ -972,6 +979,23 @@ async fn run_start_with_home(
         tracing::warn!(error = %e, "failed to remove live runner instance record");
     }
     run_result
+}
+
+fn host_cpu_placement_config(
+    budget: &ResourceBudget,
+    local: bool,
+) -> RunnerResult<sandbox::HostCpuPlacementConfig> {
+    let (control_weight, guests_weight) = budget.host_cpu_cgroup_weights();
+    sandbox::HostCpuPlacementConfig::new(
+        control_weight,
+        guests_weight,
+        if local {
+            sandbox::HostCpuPlacementMode::PreferManaged
+        } else {
+            sandbox::HostCpuPlacementMode::Required
+        },
+    )
+    .map_err(|message| RunnerError::Internal(format!("host CPU placement policy: {message}")))
 }
 
 fn validate_server_config_for_start(

--- a/crates/runner/src/cmd/start/tests/budget.rs
+++ b/crates/runner/src/cmd/start/tests/budget.rs
@@ -6,6 +6,22 @@ use super::support::{
     wait_budget_count, wait_cancel_token, wait_discover_entered,
     wait_status_idle_reuse_keys_and_active_runs,
 };
+
+#[test]
+fn host_cpu_placement_policy_uses_worker_mode_and_budget_ratio() {
+    let budget = ResourceBudget::new(4, 32_768, 2.0, 8);
+
+    let production = host_cpu_placement_config(&budget, false).unwrap();
+    assert_eq!(production.control_weight(), 200);
+    assert_eq!(production.guests_weight(), 9_800);
+    assert_eq!(production.mode(), sandbox::HostCpuPlacementMode::Required);
+
+    let local = host_cpu_placement_config(&budget, true).unwrap();
+    assert_eq!(local.control_weight(), 200);
+    assert_eq!(local.guests_weight(), 9_800);
+    assert_eq!(local.mode(), sandbox::HostCpuPlacementMode::PreferManaged);
+}
+
 // -----------------------------------------------------------------------
 // Test 11: Budget full → job skipped (not claimed) → budget freed → next job succeeds
 //

--- a/crates/runner/src/resource_budget.rs
+++ b/crates/runner/src/resource_budget.rs
@@ -331,6 +331,23 @@ impl ResourceBudget {
         self.cpu_capacity.guest_capacity
     }
 
+    /// Normalize the fixed host reservation and Guest capacity to cgroup v2 weights.
+    ///
+    /// `R(P) + C(P) = P`, so this maps the reviewed admission headroom ratio
+    /// directly onto the kernel's full `1..=10000` weight range. The mapping
+    /// intentionally excludes `concurrency_factor`: overcommit changes how many
+    /// declared vCPUs may run, not the host-control share while they are runnable.
+    pub fn host_cpu_cgroup_weights(&self) -> (u32, u32) {
+        const TOTAL_WEIGHT: u32 = 10_000;
+
+        let total_capacity = self.cpu_capacity.host_reservation + self.cpu_capacity.guest_capacity;
+        let control_weight = (self.cpu_capacity.host_reservation / total_capacity
+            * f64::from(TOTAL_WEIGHT))
+        .round() as u32;
+        let control_weight = control_weight.clamp(1, TOTAL_WEIGHT - 1);
+        (control_weight, TOTAL_WEIGHT - control_weight)
+    }
+
     /// Returns the fractional declared-vCPU admission limit after overcommit.
     pub fn vcpu_admission_limit(&self) -> f64 {
         self.cpu_capacity.admission_limit
@@ -451,6 +468,18 @@ mod tests {
                 assert!(budget.try_reserve_inner(2, 1));
             }
             assert!(!budget.try_reserve_inner(2, 1));
+        }
+    }
+
+    #[test]
+    fn host_cpu_cgroup_weights_preserve_reservation_ratio() {
+        let cases = [(1, (600, 9400)), (4, (200, 9800)), (64, (36, 9964))];
+
+        for (host_cpus, expected) in cases {
+            let first = ResourceBudget::new(host_cpus, 1, 1.0, 0);
+            let overcommitted = ResourceBudget::new(host_cpus, 1, 2.0, 0);
+            assert_eq!(first.host_cpu_cgroup_weights(), expected);
+            assert_eq!(overcommitted.host_cpu_cgroup_weights(), expected);
         }
     }
 

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -5,6 +5,7 @@ mod invariant;
 mod leak_cleaner;
 
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Instant;
 
 use async_trait::async_trait;
@@ -24,6 +25,7 @@ use crate::factory::create_transaction::{
     rollback_create_transaction,
 };
 use crate::factory::leak_cleaner::LeakCleaner;
+use crate::host_cpu_cgroup::HostCpuCgroupManager;
 use crate::network::{NetnsPoolConfig, NetnsPoolHandle};
 use crate::paths::{FactoryPaths, RuntimePaths, SandboxPaths, SockPaths};
 use crate::prerequisites;
@@ -42,6 +44,7 @@ pub(crate) struct FirecrackerFactory {
     resources: Option<StartedFactoryResources>,
     /// Best-effort release authority for sandboxes destroyed after shutdown.
     shutdown_netns_pool: Option<NetnsPoolHandle>,
+    host_cpu_cgroup: Option<Arc<HostCpuCgroupManager>>,
 }
 
 struct StartedFactoryResources {
@@ -68,6 +71,7 @@ impl FirecrackerFactory {
         config: FirecrackerConfig,
         netns_pool: Option<NetnsPoolHandle>,
         device_pool: nbd_cow::pool::DevicePoolHandle,
+        host_cpu_cgroup: Option<Arc<HostCpuCgroupManager>>,
     ) -> Result<Self, SandboxError> {
         let t = std::time::Instant::now();
         let mode = match config.snapshot.as_ref() {
@@ -169,6 +173,7 @@ impl FirecrackerFactory {
                 leak_cleaner,
             }),
             shutdown_netns_pool: None,
+            host_cpu_cgroup,
         })
     }
 
@@ -367,6 +372,7 @@ impl FirecrackerFactory {
             cow_device,
             device_rate_limits,
             leak_tx,
+            host_cpu_cgroup: self.host_cpu_cgroup.clone(),
         });
         Ok(Box::new(sandbox))
     }
@@ -627,6 +633,7 @@ mod tests {
             cleanup_group: FactoryCleanupGroup::new(),
             resources: None,
             shutdown_netns_pool: None,
+            host_cpu_cgroup: None,
         }
     }
 
@@ -666,6 +673,7 @@ mod tests {
                 leak_cleaner,
             }),
             shutdown_netns_pool: None,
+            host_cpu_cgroup: None,
         }
     }
 

--- a/crates/sandbox-fc/src/firecracker_process.rs
+++ b/crates/sandbox-fc/src/firecracker_process.rs
@@ -1,6 +1,7 @@
 //! Applies the shared process contract for Firecracker children.
 
 use std::io;
+use std::os::fd::AsRawFd;
 use std::path::Path;
 use std::process::Stdio;
 
@@ -9,7 +10,11 @@ use tokio::process::{Child, Command};
 /// Firecracker's jailer defaults both open-file limits to this value.
 const FIRECRACKER_NOFILE_LIMIT: libc::rlim_t = 2048;
 
-pub(crate) fn spawn_firecracker(mut command: Command, current_dir: &Path) -> io::Result<Child> {
+pub(crate) fn spawn_firecracker(
+    mut command: Command,
+    current_dir: &Path,
+    placement_file: Option<std::fs::File>,
+) -> io::Result<Child> {
     command
         .current_dir(current_dir)
         .stdin(Stdio::null())
@@ -18,10 +23,13 @@ pub(crate) fn spawn_firecracker(mut command: Command, current_dir: &Path) -> io:
         .process_group(0)
         .kill_on_drop(true);
 
-    // SAFETY: `setrlimit` is async-signal-safe and receives a valid pointer to
-    // child-local stack storage. The hook does not access shared process state.
+    // SAFETY: `write` and `setrlimit` are async-signal-safe. The placement file
+    // remains owned by the closure until exec and is opened close-on-exec.
     unsafe {
-        command.pre_exec(|| {
+        command.pre_exec(move || {
+            if let Some(file) = placement_file.as_ref() {
+                write_self_to_cgroup(file.as_raw_fd())?;
+            }
             let limit = libc::rlimit {
                 rlim_cur: FIRECRACKER_NOFILE_LIMIT,
                 rlim_max: FIRECRACKER_NOFILE_LIMIT,
@@ -37,6 +45,24 @@ pub(crate) fn spawn_firecracker(mut command: Command, current_dir: &Path) -> io:
     command.spawn()
 }
 
+fn write_self_to_cgroup(fd: std::os::fd::RawFd) -> io::Result<()> {
+    loop {
+        // SAFETY: `fd` is open for writing and the one-byte buffer remains valid.
+        let written = unsafe { libc::write(fd, b"0".as_ptr().cast(), 1) };
+        if written == 1 {
+            return Ok(());
+        }
+        if written < 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(error);
+        }
+        return Err(io::Error::from_raw_os_error(libc::EIO));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -46,7 +72,7 @@ mod tests {
         let mut command = Command::new("/bin/sh");
         command.args(["-c", "ulimit -Sn; ulimit -Hn"]);
 
-        let output = spawn_firecracker(command, Path::new("/"))
+        let output = spawn_firecracker(command, Path::new("/"), None)
             .unwrap()
             .wait_with_output()
             .await
@@ -58,5 +84,37 @@ mod tests {
             String::from_utf8_lossy(&output.stderr)
         );
         assert_eq!(String::from_utf8(output.stdout).unwrap(), "2048\n2048\n");
+    }
+
+    #[tokio::test]
+    async fn spawned_child_is_placed_before_exec() {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let placement_path = temp.path().join("cgroup.procs");
+        let placement_file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .custom_flags(libc::O_CLOEXEC)
+            .open(&placement_path)
+            .unwrap();
+        let placement_fd = placement_file.as_raw_fd().to_string();
+        let mut command = Command::new("/bin/sh");
+        command.args([
+            "-c",
+            "test ! -e /proc/self/fd/\"$1\"",
+            "host-cpu-placement",
+            &placement_fd,
+        ]);
+
+        let status = spawn_firecracker(command, Path::new("/"), Some(placement_file))
+            .unwrap()
+            .wait()
+            .await
+            .unwrap();
+
+        assert!(status.success());
+        assert_eq!(std::fs::read_to_string(placement_path).unwrap(), "0");
     }
 }

--- a/crates/sandbox-fc/src/host_cpu_cgroup.rs
+++ b/crates/sandbox-fc/src/host_cpu_cgroup.rs
@@ -38,7 +38,7 @@ pub(crate) struct HostCpuCgroupManager {
 }
 
 pub(crate) struct GuestCpuCgroupLease {
-    leaf_path: PathBuf,
+    leaf_path: Option<PathBuf>,
     placement_file: Option<File>,
 }
 
@@ -93,14 +93,27 @@ impl HostCpuCgroupManager {
                 )));
             }
         };
-        let control_path = parse_control_membership(&membership)?;
-        let relative_control = control_path.strip_prefix("/").map_err(|_| {
+        let membership_path = parse_unified_membership(&membership)?;
+        let relative_membership = membership_path.strip_prefix("/").map_err(|_| {
             InitializationError::Invalid(format!(
                 "unified membership is not absolute: {}",
-                control_path.display()
+                membership_path.display()
             ))
         })?;
-        let control_path = cgroup_mount.join(relative_control);
+        let current_path = cgroup_mount.join(relative_membership);
+        if membership_path.file_name().and_then(|name| name.to_str()) != Some(CONTROL_GROUP) {
+            if read_delegate_marker(&current_path)?.is_some() {
+                return Err(InitializationError::Invalid(format!(
+                    "delegated cgroup does not use the required {CONTROL_GROUP} subgroup: {}",
+                    membership_path.display()
+                )));
+            }
+            return Err(InitializationError::Unavailable(format!(
+                "current cgroup is not the systemd {CONTROL_GROUP} subgroup: {}",
+                membership_path.display()
+            )));
+        }
+        let control_path = current_path;
         let root_path = control_path.parent().ok_or_else(|| {
             InitializationError::Invalid("control subgroup has no delegated parent".into())
         })?;
@@ -157,7 +170,7 @@ impl HostCpuCgroupManager {
         })?;
         match configure_guest_leaf(&leaf_path, vcpu) {
             Ok(placement_file) => Ok(GuestCpuCgroupLease {
-                leaf_path,
+                leaf_path: Some(leaf_path),
                 placement_file: Some(placement_file),
             }),
             Err(error) => {
@@ -189,13 +202,16 @@ impl GuestCpuCgroupLease {
 
     pub(crate) fn release(mut self) -> io::Result<()> {
         drop(self.placement_file.take());
-        fs::remove_dir(&self.leaf_path)
+        match self.leaf_path.take() {
+            Some(leaf_path) => fs::remove_dir(leaf_path),
+            None => Ok(()),
+        }
     }
 
     #[cfg(test)]
     pub(crate) fn from_test_file(leaf_path: PathBuf, placement_file: File) -> Self {
         Self {
-            leaf_path,
+            leaf_path: Some(leaf_path),
             placement_file: Some(placement_file),
         }
     }
@@ -204,11 +220,12 @@ impl GuestCpuCgroupLease {
 impl Drop for GuestCpuCgroupLease {
     fn drop(&mut self) {
         drop(self.placement_file.take());
-        if let Err(error) = fs::remove_dir(&self.leaf_path)
+        if let Some(leaf_path) = self.leaf_path.take()
+            && let Err(error) = fs::remove_dir(&leaf_path)
             && error.kind() != io::ErrorKind::NotFound
         {
             warn!(
-                path = %self.leaf_path.display(),
+                path = %leaf_path.display(),
                 %error,
                 "failed to remove Guest CPU cgroup during drop"
             );
@@ -216,7 +233,7 @@ impl Drop for GuestCpuCgroupLease {
     }
 }
 
-fn parse_control_membership(membership: &str) -> Result<PathBuf, InitializationError> {
+fn parse_unified_membership(membership: &str) -> Result<PathBuf, InitializationError> {
     let mut unified = membership.lines().filter_map(|line| {
         let mut fields = line.splitn(3, ':');
         match (fields.next(), fields.next(), fields.next()) {
@@ -235,12 +252,6 @@ fn parse_control_membership(membership: &str) -> Result<PathBuf, InitializationE
         ));
     }
     let path = PathBuf::from(path);
-    if path.file_name().and_then(|name| name.to_str()) != Some(CONTROL_GROUP) {
-        return Err(InitializationError::Unavailable(format!(
-            "current cgroup is not the systemd {CONTROL_GROUP} subgroup: {}",
-            path.display()
-        )));
-    }
     if !path.is_absolute()
         || path
             .components()
@@ -320,6 +331,16 @@ fn require_plain_directory(path: &Path, label: &str) -> Result<(), Initializatio
 }
 
 fn require_delegate_xattr(path: &Path) -> Result<(), InitializationError> {
+    if read_delegate_marker(path)?.is_none() {
+        return Err(InitializationError::Invalid(format!(
+            "delegated service root {} lacks systemd user.delegate marker",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn read_delegate_marker(path: &Path) -> Result<Option<()>, InitializationError> {
     let path_c = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
         InitializationError::Invalid(format!("delegated root contains NUL: {}", path.display()))
     })?;
@@ -335,10 +356,17 @@ fn require_delegate_xattr(path: &Path) -> Result<(), InitializationError> {
         )
     };
     if size < 0 {
+        let error = io::Error::last_os_error();
+        if matches!(
+            error.raw_os_error(),
+            Some(code)
+                if code == libc::ENOENT || code == libc::ENODATA || code == libc::ENOTSUP
+        ) {
+            return Ok(None);
+        }
         return Err(InitializationError::Invalid(format!(
-            "delegated service root {} lacks systemd user.delegate marker: {}",
+            "read systemd user.delegate marker from {}: {error}",
             path.display(),
-            io::Error::last_os_error()
         )));
     }
     let size = usize::try_from(size)
@@ -349,7 +377,7 @@ fn require_delegate_xattr(path: &Path) -> Result<(), InitializationError> {
             path.display()
         )));
     }
-    Ok(())
+    Ok(Some(()))
 }
 
 fn require_controller(path: &Path, controller: &str) -> Result<(), InitializationError> {
@@ -605,6 +633,23 @@ mod tests {
             HostCpuCgroupManager::initialize_with_paths(preferred, &proc, temp.path())
                 .unwrap()
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn prefer_managed_rejects_delegation_without_control_subgroup() {
+        let (_temp, proc, mount) = fake_delegated_tree();
+        fs::write(&proc, "0::/system.slice/vm0-runner.service\n").unwrap();
+        let config =
+            HostCpuPlacementConfig::new(100, 9900, HostCpuPlacementMode::PreferManaged).unwrap();
+
+        assert!(HostCpuCgroupManager::initialize_with_paths(config, &proc, &mount).is_err());
+        assert_eq!(
+            fs::read_to_string(
+                mount.join("system.slice/vm0-runner.service/cgroup.subtree_control")
+            )
+            .unwrap(),
+            ""
         );
     }
 

--- a/crates/sandbox-fc/src/host_cpu_cgroup.rs
+++ b/crates/sandbox-fc/src/host_cpu_cgroup.rs
@@ -1,0 +1,678 @@
+//! Weighted host cgroup v2 placement for normal Firecracker processes.
+
+use std::ffi::CString;
+use std::fs::{self, File, OpenOptions};
+use std::io;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+use sandbox::{
+    HostCpuPlacementConfig, HostCpuPlacementMode, SandboxError, SandboxId,
+    SandboxInitializationPhase,
+};
+use tracing::{info, warn};
+
+const PROC_SELF_CGROUP: &str = "/proc/self/cgroup";
+const CGROUP_V2_MOUNT: &str = "/sys/fs/cgroup";
+const CONTROL_GROUP: &str = "control";
+const GUESTS_GROUP: &str = "guests";
+const CGROUP_CONTROLLERS: &str = "cgroup.controllers";
+const CGROUP_SUBTREE_CONTROL: &str = "cgroup.subtree_control";
+const CGROUP_PROCS: &str = "cgroup.procs";
+const CPU_WEIGHT: &str = "cpu.weight";
+const DELEGATE_XATTR: &[u8] = b"user.delegate\0";
+
+#[derive(Debug, thiserror::Error)]
+enum InitializationError {
+    #[error("host CPU cgroup delegation unavailable: {0}")]
+    Unavailable(String),
+    #[error("invalid host CPU cgroup delegation: {0}")]
+    Invalid(String),
+}
+
+#[derive(Debug)]
+pub(crate) struct HostCpuCgroupManager {
+    guests_path: PathBuf,
+}
+
+pub(crate) struct GuestCpuCgroupLease {
+    leaf_path: PathBuf,
+    placement_file: Option<File>,
+}
+
+impl HostCpuCgroupManager {
+    pub(crate) fn initialize(
+        config: HostCpuPlacementConfig,
+    ) -> Result<Option<Arc<Self>>, SandboxError> {
+        Self::initialize_with_paths(
+            config,
+            Path::new(PROC_SELF_CGROUP),
+            Path::new(CGROUP_V2_MOUNT),
+        )
+    }
+
+    fn initialize_with_paths(
+        config: HostCpuPlacementConfig,
+        proc_self_cgroup: &Path,
+        cgroup_mount: &Path,
+    ) -> Result<Option<Arc<Self>>, SandboxError> {
+        match Self::initialize_at(config, proc_self_cgroup, cgroup_mount) {
+            Ok(manager) => Ok(Some(Arc::new(manager))),
+            Err(InitializationError::Unavailable(message))
+                if config.mode() == HostCpuPlacementMode::PreferManaged =>
+            {
+                warn!(%message, "host CPU placement unavailable; continuing unmanaged in local mode");
+                Ok(None)
+            }
+            Err(error) => Err(SandboxError::Initialization {
+                phase: SandboxInitializationPhase::Runtime,
+                message: error.to_string(),
+            }),
+        }
+    }
+
+    fn initialize_at(
+        config: HostCpuPlacementConfig,
+        proc_self_cgroup: &Path,
+        cgroup_mount: &Path,
+    ) -> Result<Self, InitializationError> {
+        let membership = match fs::read_to_string(proc_self_cgroup) {
+            Ok(membership) => membership,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                return Err(InitializationError::Unavailable(format!(
+                    "{} does not exist",
+                    proc_self_cgroup.display()
+                )));
+            }
+            Err(error) => {
+                return Err(InitializationError::Invalid(format!(
+                    "read {}: {error}",
+                    proc_self_cgroup.display()
+                )));
+            }
+        };
+        let control_path = parse_control_membership(&membership)?;
+        let relative_control = control_path.strip_prefix("/").map_err(|_| {
+            InitializationError::Invalid(format!(
+                "unified membership is not absolute: {}",
+                control_path.display()
+            ))
+        })?;
+        let control_path = cgroup_mount.join(relative_control);
+        let root_path = control_path.parent().ok_or_else(|| {
+            InitializationError::Invalid("control subgroup has no delegated parent".into())
+        })?;
+
+        validate_preflight(root_path, &control_path)?;
+        enable_cpu_controller(root_path)?;
+
+        let guests_path = root_path.join(GUESTS_GROUP);
+        match fs::create_dir(&guests_path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                require_plain_directory(&guests_path, "guests subgroup")?;
+            }
+            Err(error) => {
+                return Err(InitializationError::Invalid(format!(
+                    "create guests subgroup {}: {error}",
+                    guests_path.display()
+                )));
+            }
+        }
+
+        require_empty_membership(&guests_path.join(CGROUP_PROCS), "guests subgroup")?;
+        write_weight(&control_path, config.control_weight())?;
+        write_weight(&guests_path, config.guests_weight())?;
+        enable_cpu_controller(&guests_path)?;
+        reconcile_guest_leaves(&guests_path)?;
+
+        info!(
+            root = %root_path.display(),
+            control_cpu_weight = config.control_weight(),
+            guests_cpu_weight = config.guests_weight(),
+            mode = ?config.mode(),
+            "host CPU placement initialized"
+        );
+        Ok(Self { guests_path })
+    }
+
+    pub(crate) fn acquire(
+        &self,
+        sandbox_id: SandboxId,
+        vcpu: u32,
+    ) -> Result<GuestCpuCgroupLease, SandboxError> {
+        if !(HostCpuPlacementConfig::MIN_WEIGHT..=HostCpuPlacementConfig::MAX_WEIGHT)
+            .contains(&vcpu)
+        {
+            return Err(SandboxError::Start {
+                message: format!("declared vCPU {vcpu} is outside the cgroup CPU weight range"),
+            });
+        }
+
+        let leaf_path = self.guests_path.join(sandbox_id.to_string());
+        fs::create_dir(&leaf_path).map_err(|error| SandboxError::Start {
+            message: format!("create Guest CPU cgroup {}: {error}", leaf_path.display()),
+        })?;
+        match configure_guest_leaf(&leaf_path, vcpu) {
+            Ok(placement_file) => Ok(GuestCpuCgroupLease {
+                leaf_path,
+                placement_file: Some(placement_file),
+            }),
+            Err(error) => {
+                if let Err(cleanup_error) = fs::remove_dir(&leaf_path) {
+                    warn!(
+                        path = %leaf_path.display(),
+                        %cleanup_error,
+                        "failed to roll back empty Guest CPU cgroup"
+                    );
+                }
+                Err(SandboxError::Start {
+                    message: format!(
+                        "configure Guest CPU cgroup {}: {error}",
+                        leaf_path.display()
+                    ),
+                })
+            }
+        }
+    }
+}
+
+impl GuestCpuCgroupLease {
+    pub(crate) fn clone_placement_file(&self) -> io::Result<File> {
+        self.placement_file
+            .as_ref()
+            .ok_or_else(|| io::Error::other("Guest CPU cgroup lease already released"))?
+            .try_clone()
+    }
+
+    pub(crate) fn release(mut self) -> io::Result<()> {
+        drop(self.placement_file.take());
+        fs::remove_dir(&self.leaf_path)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_test_file(leaf_path: PathBuf, placement_file: File) -> Self {
+        Self {
+            leaf_path,
+            placement_file: Some(placement_file),
+        }
+    }
+}
+
+impl Drop for GuestCpuCgroupLease {
+    fn drop(&mut self) {
+        drop(self.placement_file.take());
+        if let Err(error) = fs::remove_dir(&self.leaf_path)
+            && error.kind() != io::ErrorKind::NotFound
+        {
+            warn!(
+                path = %self.leaf_path.display(),
+                %error,
+                "failed to remove Guest CPU cgroup during drop"
+            );
+        }
+    }
+}
+
+fn parse_control_membership(membership: &str) -> Result<PathBuf, InitializationError> {
+    let mut unified = membership.lines().filter_map(|line| {
+        let mut fields = line.splitn(3, ':');
+        match (fields.next(), fields.next(), fields.next()) {
+            (Some("0"), Some(""), Some(path)) => Some(path),
+            _ => None,
+        }
+    });
+    let Some(path) = unified.next() else {
+        return Err(InitializationError::Unavailable(
+            "no unified cgroup v2 membership entry".into(),
+        ));
+    };
+    if unified.next().is_some() {
+        return Err(InitializationError::Invalid(
+            "multiple unified cgroup v2 membership entries".into(),
+        ));
+    }
+    let path = PathBuf::from(path);
+    if path.file_name().and_then(|name| name.to_str()) != Some(CONTROL_GROUP) {
+        return Err(InitializationError::Unavailable(format!(
+            "current cgroup is not the systemd {CONTROL_GROUP} subgroup: {}",
+            path.display()
+        )));
+    }
+    if !path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::RootDir | Component::Normal(_)))
+    {
+        return Err(InitializationError::Invalid(format!(
+            "unified membership contains an unsafe path: {}",
+            path.display()
+        )));
+    }
+    Ok(path)
+}
+
+fn validate_preflight(root_path: &Path, control_path: &Path) -> Result<(), InitializationError> {
+    require_plain_directory(root_path, "delegated service root")?;
+    require_plain_directory(control_path, "control subgroup")?;
+    require_delegate_xattr(root_path)?;
+    require_controller(&root_path.join(CGROUP_CONTROLLERS), "cpu")?;
+    require_empty_membership(&root_path.join(CGROUP_PROCS), "delegated service root")?;
+
+    let subtree_control = root_path.join(CGROUP_SUBTREE_CONTROL);
+    OpenOptions::new()
+        .write(true)
+        .open(&subtree_control)
+        .map_err(|error| {
+            InitializationError::Invalid(format!(
+                "required cgroup file is not writable {}: {error}",
+                subtree_control.display()
+            ))
+        })?;
+
+    for entry in fs::read_dir(root_path).map_err(|error| {
+        InitializationError::Invalid(format!(
+            "read delegated service root {}: {error}",
+            root_path.display()
+        ))
+    })? {
+        let entry = entry.map_err(|error| {
+            InitializationError::Invalid(format!("read delegated service root entry: {error}"))
+        })?;
+        let file_type = entry.file_type().map_err(|error| {
+            InitializationError::Invalid(format!(
+                "inspect delegated service root entry {}: {error}",
+                entry.path().display()
+            ))
+        })?;
+        if file_type.is_symlink() {
+            return Err(InitializationError::Invalid(format!(
+                "symlink in delegated service root: {}",
+                entry.path().display()
+            )));
+        }
+        if file_type.is_dir()
+            && entry.file_name() != CONTROL_GROUP
+            && entry.file_name() != GUESTS_GROUP
+        {
+            return Err(InitializationError::Invalid(format!(
+                "unexpected subgroup in delegated service root: {}",
+                entry.path().display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn require_plain_directory(path: &Path, label: &str) -> Result<(), InitializationError> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        InitializationError::Invalid(format!("inspect {label} {}: {error}", path.display()))
+    })?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(InitializationError::Invalid(format!(
+            "{label} is not a plain directory: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn require_delegate_xattr(path: &Path) -> Result<(), InitializationError> {
+    let path_c = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+        InitializationError::Invalid(format!("delegated root contains NUL: {}", path.display()))
+    })?;
+    // SAFETY: both pointers are valid NUL-terminated strings and the value
+    // buffer is valid for the supplied length.
+    let mut value = [0_u8; 8];
+    let size = unsafe {
+        libc::getxattr(
+            path_c.as_ptr(),
+            DELEGATE_XATTR.as_ptr().cast(),
+            value.as_mut_ptr().cast(),
+            value.len(),
+        )
+    };
+    if size < 0 {
+        return Err(InitializationError::Invalid(format!(
+            "delegated service root {} lacks systemd user.delegate marker: {}",
+            path.display(),
+            io::Error::last_os_error()
+        )));
+    }
+    let size = usize::try_from(size)
+        .map_err(|_| InitializationError::Invalid("invalid user.delegate marker length".into()))?;
+    if value.get(..size) != Some(b"1") {
+        return Err(InitializationError::Invalid(format!(
+            "delegated service root {} has invalid user.delegate marker",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn require_controller(path: &Path, controller: &str) -> Result<(), InitializationError> {
+    let value = fs::read_to_string(path).map_err(|error| {
+        InitializationError::Invalid(format!("read {}: {error}", path.display()))
+    })?;
+    if !contains_controller(&value, controller) {
+        return Err(InitializationError::Invalid(format!(
+            "{} does not expose {controller}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn contains_controller(value: &str, controller: &str) -> bool {
+    value
+        .split_ascii_whitespace()
+        .any(|token| token.trim_start_matches(['+', '-']) == controller)
+}
+
+fn require_empty_membership(path: &Path, label: &str) -> Result<(), InitializationError> {
+    let membership = fs::read_to_string(path).map_err(|error| {
+        InitializationError::Invalid(format!(
+            "read {label} membership {}: {error}",
+            path.display()
+        ))
+    })?;
+    if !membership.trim().is_empty() {
+        return Err(InitializationError::Invalid(format!(
+            "{label} has processes in {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn enable_cpu_controller(path: &Path) -> Result<(), InitializationError> {
+    let subtree_control = path.join(CGROUP_SUBTREE_CONTROL);
+    fs::write(&subtree_control, "+cpu").map_err(|error| {
+        InitializationError::Invalid(format!(
+            "enable cpu in {}: {error}",
+            subtree_control.display()
+        ))
+    })?;
+    require_controller(&subtree_control, "cpu")
+}
+
+fn write_weight(path: &Path, weight: u32) -> Result<(), InitializationError> {
+    let weight_path = path.join(CPU_WEIGHT);
+    fs::write(&weight_path, weight.to_string()).map_err(|error| {
+        InitializationError::Invalid(format!("write {}: {error}", weight_path.display()))
+    })?;
+    let actual = fs::read_to_string(&weight_path).map_err(|error| {
+        InitializationError::Invalid(format!("read {}: {error}", weight_path.display()))
+    })?;
+    if actual.trim() != weight.to_string() {
+        return Err(InitializationError::Invalid(format!(
+            "{} did not retain weight {weight}: {actual:?}",
+            weight_path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn reconcile_guest_leaves(guests_path: &Path) -> Result<(), InitializationError> {
+    for entry in fs::read_dir(guests_path).map_err(|error| {
+        InitializationError::Invalid(format!(
+            "read guests subgroup {}: {error}",
+            guests_path.display()
+        ))
+    })? {
+        let entry = entry.map_err(|error| {
+            InitializationError::Invalid(format!("read guests subgroup entry: {error}"))
+        })?;
+        let file_type = entry.file_type().map_err(|error| {
+            InitializationError::Invalid(format!(
+                "inspect guests subgroup entry {}: {error}",
+                entry.path().display()
+            ))
+        })?;
+        if file_type.is_symlink() {
+            return Err(InitializationError::Invalid(format!(
+                "symlink in guests subgroup: {}",
+                entry.path().display()
+            )));
+        }
+        if !file_type.is_dir() {
+            continue;
+        }
+
+        let name = entry.file_name().into_string().map_err(|_| {
+            InitializationError::Invalid(format!(
+                "non-UTF-8 Guest subgroup: {}",
+                entry.path().display()
+            ))
+        })?;
+        let sandbox_id = name.parse::<SandboxId>().map_err(|_| {
+            InitializationError::Invalid(format!("unexpected Guest subgroup name: {name}"))
+        })?;
+        if sandbox_id.to_string() != name {
+            return Err(InitializationError::Invalid(format!(
+                "non-canonical Guest subgroup name: {name}"
+            )));
+        }
+        require_empty_membership(&entry.path().join(CGROUP_PROCS), "stale Guest subgroup")?;
+        for child in fs::read_dir(entry.path()).map_err(|error| {
+            InitializationError::Invalid(format!(
+                "read stale Guest subgroup {}: {error}",
+                entry.path().display()
+            ))
+        })? {
+            let child = child.map_err(|error| {
+                InitializationError::Invalid(format!("read stale Guest subgroup entry: {error}"))
+            })?;
+            if child
+                .file_type()
+                .map_err(|error| {
+                    InitializationError::Invalid(format!(
+                        "inspect stale Guest subgroup entry {}: {error}",
+                        child.path().display()
+                    ))
+                })?
+                .is_dir()
+            {
+                return Err(InitializationError::Invalid(format!(
+                    "nested subgroup under stale Guest {}: {}",
+                    name,
+                    child.path().display()
+                )));
+            }
+        }
+        fs::remove_dir(entry.path()).map_err(|error| {
+            InitializationError::Invalid(format!(
+                "remove empty stale Guest subgroup {}: {error}",
+                entry.path().display()
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+fn configure_guest_leaf(leaf_path: &Path, vcpu: u32) -> io::Result<File> {
+    let weight_path = leaf_path.join(CPU_WEIGHT);
+    fs::write(&weight_path, vcpu.to_string())?;
+    let actual = fs::read_to_string(&weight_path)?;
+    if actual.trim() != vcpu.to_string() {
+        return Err(io::Error::other(format!(
+            "{} did not retain weight {vcpu}: {actual:?}",
+            weight_path.display()
+        )));
+    }
+    OpenOptions::new()
+        .write(true)
+        .custom_flags(libc::O_CLOEXEC)
+        .open(leaf_path.join(CGROUP_PROCS))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+
+    fn set_delegate_xattr(path: &Path) {
+        let path = CString::new(path.as_os_str().as_bytes()).unwrap();
+        // SAFETY: pointers and lengths refer to valid process memory.
+        let result = unsafe {
+            libc::setxattr(
+                path.as_ptr(),
+                DELEGATE_XATTR.as_ptr().cast(),
+                b"1".as_ptr().cast(),
+                1,
+                0,
+            )
+        };
+        assert_eq!(result, 0, "setxattr: {}", io::Error::last_os_error());
+    }
+
+    fn fake_delegated_tree() -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let temp = tempfile::tempdir().unwrap();
+        let mount = temp.path().join("cgroup");
+        let root = mount.join("system.slice/vm0-runner.service");
+        let control = root.join(CONTROL_GROUP);
+        let guests = root.join(GUESTS_GROUP);
+        fs::create_dir_all(&control).unwrap();
+        fs::create_dir(&guests).unwrap();
+        set_delegate_xattr(&root);
+        fs::write(root.join(CGROUP_CONTROLLERS), "cpu memory\n").unwrap();
+        fs::write(root.join(CGROUP_SUBTREE_CONTROL), "").unwrap();
+        fs::write(root.join(CGROUP_PROCS), "").unwrap();
+        fs::write(control.join(CPU_WEIGHT), "100\n").unwrap();
+        fs::write(guests.join(CPU_WEIGHT), "100\n").unwrap();
+        fs::write(guests.join(CGROUP_SUBTREE_CONTROL), "").unwrap();
+        fs::write(guests.join(CGROUP_PROCS), "").unwrap();
+        let proc = temp.path().join("self.cgroup");
+        fs::write(&proc, "0::/system.slice/vm0-runner.service/control\n").unwrap();
+        (temp, proc, mount)
+    }
+
+    #[test]
+    fn initializes_existing_delegated_hierarchy_and_weights() {
+        let (_temp, proc, mount) = fake_delegated_tree();
+        let config =
+            HostCpuPlacementConfig::new(200, 9800, HostCpuPlacementMode::Required).unwrap();
+
+        let manager = HostCpuCgroupManager::initialize_at(config, &proc, &mount).unwrap();
+
+        let root = manager.guests_path.parent().unwrap();
+        assert_eq!(
+            fs::read_to_string(root.join(CGROUP_SUBTREE_CONTROL)).unwrap(),
+            "+cpu"
+        );
+        assert_eq!(
+            fs::read_to_string(root.join(CONTROL_GROUP).join(CPU_WEIGHT)).unwrap(),
+            "200"
+        );
+        assert_eq!(
+            fs::read_to_string(root.join(GUESTS_GROUP).join(CPU_WEIGHT)).unwrap(),
+            "9800"
+        );
+        assert_eq!(
+            fs::read_to_string(root.join(GUESTS_GROUP).join(CGROUP_SUBTREE_CONTROL)).unwrap(),
+            "+cpu"
+        );
+    }
+
+    #[test]
+    fn missing_control_membership_is_unavailable() {
+        let temp = tempfile::tempdir().unwrap();
+        let proc = temp.path().join("self.cgroup");
+        fs::write(&proc, "0::/user.slice/session.scope\n").unwrap();
+        let config =
+            HostCpuPlacementConfig::new(100, 9900, HostCpuPlacementMode::Required).unwrap();
+
+        let error = HostCpuCgroupManager::initialize_at(config, &proc, temp.path()).unwrap_err();
+
+        assert!(matches!(error, InitializationError::Unavailable(_)));
+    }
+
+    #[test]
+    fn placement_mode_only_allows_unavailable_local_fallback() {
+        let temp = tempfile::tempdir().unwrap();
+        let proc = temp.path().join("self.cgroup");
+        fs::write(&proc, "0::/user.slice/session.scope\n").unwrap();
+
+        let required =
+            HostCpuPlacementConfig::new(100, 9900, HostCpuPlacementMode::Required).unwrap();
+        assert!(HostCpuCgroupManager::initialize_with_paths(required, &proc, temp.path()).is_err());
+
+        let preferred =
+            HostCpuPlacementConfig::new(100, 9900, HostCpuPlacementMode::PreferManaged).unwrap();
+        assert!(
+            HostCpuCgroupManager::initialize_with_paths(preferred, &proc, temp.path())
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn prefer_managed_fails_after_hierarchy_mutation_begins() {
+        let (_temp, proc, mount) = fake_delegated_tree();
+        let root = mount.join("system.slice/vm0-runner.service");
+        let control_weight = root.join(CONTROL_GROUP).join(CPU_WEIGHT);
+        fs::remove_file(&control_weight).unwrap();
+        fs::create_dir(&control_weight).unwrap();
+        let config =
+            HostCpuPlacementConfig::new(100, 9900, HostCpuPlacementMode::PreferManaged).unwrap();
+
+        assert!(HostCpuCgroupManager::initialize_with_paths(config, &proc, &mount).is_err());
+        assert_eq!(
+            fs::read_to_string(root.join(CGROUP_SUBTREE_CONTROL)).unwrap(),
+            "+cpu"
+        );
+    }
+
+    #[test]
+    fn rejects_populated_canonical_guest_leaf_without_removing_it() {
+        let (_temp, proc, mount) = fake_delegated_tree();
+        let guests = mount.join("system.slice/vm0-runner.service/guests");
+        let stale = guests.join(SandboxId::new_v4().to_string());
+        fs::create_dir(&stale).unwrap();
+        fs::write(stale.join(CGROUP_PROCS), "123\n").unwrap();
+        let config =
+            HostCpuPlacementConfig::new(100, 9900, HostCpuPlacementMode::Required).unwrap();
+
+        assert!(matches!(
+            HostCpuCgroupManager::initialize_at(config, &proc, &mount),
+            Err(InitializationError::Invalid(_))
+        ));
+        assert!(stale.exists());
+    }
+
+    #[test]
+    fn rejects_populated_or_unknown_delegated_state() {
+        let (_temp, proc, mount) = fake_delegated_tree();
+        let root = mount.join("system.slice/vm0-runner.service");
+        fs::write(root.join(CGROUP_PROCS), "123\n").unwrap();
+        let config =
+            HostCpuPlacementConfig::new(100, 9900, HostCpuPlacementMode::Required).unwrap();
+        assert!(matches!(
+            HostCpuCgroupManager::initialize_at(config, &proc, &mount),
+            Err(InitializationError::Invalid(_))
+        ));
+
+        fs::write(root.join(CGROUP_PROCS), "").unwrap();
+        fs::create_dir(root.join("unknown")).unwrap();
+        assert!(matches!(
+            HostCpuCgroupManager::initialize_at(config, &proc, &mount),
+            Err(InitializationError::Invalid(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_symlinked_guest_entry() {
+        let (_temp, proc, mount) = fake_delegated_tree();
+        let guests = mount.join("system.slice/vm0-runner.service/guests");
+        symlink("/tmp", guests.join("unsafe")).unwrap();
+        let config =
+            HostCpuPlacementConfig::new(100, 9900, HostCpuPlacementMode::Required).unwrap();
+
+        assert!(matches!(
+            HostCpuCgroupManager::initialize_at(config, &proc, &mount),
+            Err(InitializationError::Invalid(_))
+        ));
+    }
+}

--- a/crates/sandbox-fc/src/host_cpu_cgroup.rs
+++ b/crates/sandbox-fc/src/host_cpu_cgroup.rs
@@ -102,7 +102,14 @@ impl HostCpuCgroupManager {
         })?;
         let current_path = cgroup_mount.join(relative_membership);
         if membership_path.file_name().and_then(|name| name.to_str()) != Some(CONTROL_GROUP) {
-            if read_delegate_marker(&current_path)?.is_some() {
+            let parent_path = current_path.parent();
+            let delegation_present = read_delegate_marker(&current_path)?.is_some()
+                || parent_path
+                    .map(read_delegate_marker)
+                    .transpose()?
+                    .flatten()
+                    .is_some();
+            if delegation_present {
                 return Err(InitializationError::Invalid(format!(
                     "delegated cgroup does not use the required {CONTROL_GROUP} subgroup: {}",
                     membership_path.display()
@@ -649,6 +656,22 @@ mod tests {
                 mount.join("system.slice/vm0-runner.service/cgroup.subtree_control")
             )
             .unwrap(),
+            ""
+        );
+    }
+
+    #[test]
+    fn prefer_managed_rejects_wrong_delegated_subgroup() {
+        let (_temp, proc, mount) = fake_delegated_tree();
+        let root = mount.join("system.slice/vm0-runner.service");
+        fs::create_dir(root.join("worker")).unwrap();
+        fs::write(&proc, "0::/system.slice/vm0-runner.service/worker\n").unwrap();
+        let config =
+            HostCpuPlacementConfig::new(100, 9900, HostCpuPlacementMode::PreferManaged).unwrap();
+
+        assert!(HostCpuCgroupManager::initialize_with_paths(config, &proc, &mount).is_err());
+        assert_eq!(
+            fs::read_to_string(root.join(CGROUP_SUBTREE_CONTROL)).unwrap(),
             ""
         );
     }

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -39,6 +39,7 @@ mod guest_dns_failure_diagnostics;
 mod guest_dns_probe;
 mod guest_dns_readiness;
 mod guest_operations;
+mod host_cpu_cgroup;
 mod leaked_resources;
 mod network;
 mod park_coordinator;

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use tracing::{info, warn};
 
@@ -11,6 +13,7 @@ use nbd_cow::pool::{DevicePoolConfig, DevicePoolHandle};
 use crate::config::{FirecrackerConfig, SnapshotConfig};
 use crate::duration::duration_ms;
 use crate::factory::FirecrackerFactory;
+use crate::host_cpu_cgroup::HostCpuCgroupManager;
 use crate::network::{NetnsPoolConfig, NetnsPoolHandle};
 use crate::paths::{RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths};
 use crate::runtime_dirs::checked_runtime_sock_dir;
@@ -24,6 +27,7 @@ pub struct FirecrackerRuntime {
     device_pool: DevicePoolHandle,
     proxy_port: Option<u16>,
     dns_port: Option<u16>,
+    host_cpu_cgroup: Option<Arc<HostCpuCgroupManager>>,
 }
 
 impl FirecrackerRuntime {
@@ -33,6 +37,10 @@ impl FirecrackerRuntime {
     /// All factories created via [`SandboxRuntime::create_factory`] share these
     /// resources.
     pub async fn new(config: sandbox::RuntimeConfig) -> Result<Self, SandboxError> {
+        let host_cpu_cgroup = match config.host_cpu_placement {
+            Some(placement) => HostCpuCgroupManager::initialize(placement)?,
+            None => None,
+        };
         let t = std::time::Instant::now();
         let netns_config = NetnsPoolConfig {
             proxy_port: config.proxy_port,
@@ -66,6 +74,7 @@ impl FirecrackerRuntime {
             device_pool,
             proxy_port: config.proxy_port,
             dns_port: config.dns_port,
+            host_cpu_cgroup,
         })
     }
 
@@ -118,6 +127,7 @@ impl SandboxRuntime for FirecrackerRuntime {
             fc_config,
             Some(self.netns_pool.clone()),
             self.device_pool.clone(),
+            self.host_cpu_cgroup.clone(),
         )
         .await?;
         Ok(Box::new(factory))

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -55,6 +55,7 @@ use crate::guest_dns_failure_diagnostics::{
 };
 use crate::guest_dns_readiness::wait_for_guest_dns_readiness;
 use crate::guest_operations::{GuestOperationStartError, GuestOperationStartGate};
+use crate::host_cpu_cgroup::{GuestCpuCgroupLease, HostCpuCgroupManager};
 use crate::leaked_resources::LeakedResources;
 use crate::network::{NetnsInfo, NetnsLease};
 use crate::park_coordinator::{
@@ -472,6 +473,7 @@ struct ProcessMonitorContext {
     state_tx: watch::Sender<SandboxState>,
     guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
     runtime_cancel: CancellationToken,
+    guest_cpu_cgroup: Option<GuestCpuCgroupLease>,
 }
 
 enum ProcessMonitorExit {
@@ -548,6 +550,8 @@ pub struct FirecrackerSandbox {
     park_outcome: Option<SandboxParkOutcome>,
     /// Host-side normal-operation fence held while this sandbox is parked.
     park_fence: Option<NormalOperationFence>,
+    /// Optional managed host CPU placement for the Firecracker process.
+    host_cpu_cgroup: Option<Arc<HostCpuCgroupManager>>,
 }
 
 pub(crate) struct FirecrackerSandboxInit {
@@ -559,6 +563,7 @@ pub(crate) struct FirecrackerSandboxInit {
     pub(crate) cow_device: PooledNbdCowDevice,
     pub(crate) device_rate_limits: Option<FirecrackerDeviceRateLimits>,
     pub(crate) leak_tx: Option<tokio::sync::mpsc::UnboundedSender<LeakedResources>>,
+    pub(crate) host_cpu_cgroup: Option<Arc<HostCpuCgroupManager>>,
 }
 
 pub(crate) struct SandboxNetwork {
@@ -635,6 +640,7 @@ impl FirecrackerSandbox {
             cow_device,
             device_rate_limits,
             leak_tx,
+            host_cpu_cgroup,
         } = init;
         let id = config.id.to_string();
         Self {
@@ -659,6 +665,7 @@ impl FirecrackerSandbox {
             is_parked: false,
             park_outcome: None,
             park_fence: None,
+            host_cpu_cgroup,
         }
     }
 
@@ -1109,25 +1116,37 @@ impl FirecrackerSandbox {
         runtime_cancel: CancellationToken,
         boot_mode: &str,
     ) -> sandbox::Result<ApiClient> {
-        let child = spawn_firecracker(command, self.sandbox_paths.workspace()).map_err(|e| {
-            SandboxError::Start {
+        let guest_cpu_cgroup = self
+            .host_cpu_cgroup
+            .as_ref()
+            .map(|manager| manager.acquire(self.config.id, self.config.resources.cpu_count))
+            .transpose()?;
+        let placement_file = guest_cpu_cgroup
+            .as_ref()
+            .map(GuestCpuCgroupLease::clone_placement_file)
+            .transpose()
+            .map_err(|e| SandboxError::Start {
+                message: format!("clone Guest CPU cgroup placement descriptor: {e}"),
+            })?;
+        let child = spawn_firecracker(command, self.sandbox_paths.workspace(), placement_file)
+            .map_err(|e| SandboxError::Start {
                 message: format!(
                     "spawn firecracker: {e} (boot_mode={boot_mode}, api_sock={})",
                     api_sock.display()
                 ),
-            }
-        })?;
+            })?;
 
         self.process_group_pid = child.id();
-        self.runtime.set_process(monitor_process(
-            &self.id,
-            child,
-            Arc::clone(&self.state),
-            Arc::clone(&self.state_publish_lock),
-            self.state_tx.clone(),
-            Arc::clone(&self.guest),
+        let context = ProcessMonitorContext {
+            state: Arc::clone(&self.state),
+            state_publish_lock: Arc::clone(&self.state_publish_lock),
+            state_tx: self.state_tx.clone(),
+            guest: Arc::clone(&self.guest),
             runtime_cancel,
-        ));
+            guest_cpu_cgroup,
+        };
+        self.runtime
+            .set_process(monitor_process_with_context(&self.id, child, context));
 
         let client = ApiClient::new(api_sock).map_err(|e| SandboxError::Start {
             message: format!(
@@ -1595,23 +1614,33 @@ impl Drop for FirecrackerSandbox {
 /// The process monitor owns the `Child`, so process exit is classified from
 /// `wait()` rather than from stdout/stderr pipe EOF. Stdout and stderr readers
 /// are only log forwarders.
+#[cfg(test)]
 fn monitor_process(
     id: &str,
-    mut child: tokio::process::Child,
+    child: tokio::process::Child,
     state: Arc<AtomicU8>,
     state_publish_lock: Arc<Mutex<()>>,
     state_tx: watch::Sender<SandboxState>,
     guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
     runtime_cancel: CancellationToken,
 ) -> ProcessMonitorHandle {
-    let readers = ProcessLogReaders::from_child(id, &mut child);
     let context = ProcessMonitorContext {
         state,
         state_publish_lock,
         state_tx,
         guest,
         runtime_cancel,
+        guest_cpu_cgroup: None,
     };
+    monitor_process_with_context(id, child, context)
+}
+
+fn monitor_process_with_context(
+    id: &str,
+    mut child: tokio::process::Child,
+    context: ProcessMonitorContext,
+) -> ProcessMonitorHandle {
+    let readers = ProcessLogReaders::from_child(id, &mut child);
     monitor_process_with_log_readers(id, child, context, readers)
 }
 
@@ -1628,10 +1657,11 @@ fn monitor_process_with_log_readers(
 fn monitor_process_with_log_readers_and_exit_notifier(
     id: &str,
     mut child: tokio::process::Child,
-    context: ProcessMonitorContext,
+    mut context: ProcessMonitorContext,
     readers: ProcessLogReaders,
     exit_notifier: ChildExitNotifier,
 ) -> ProcessMonitorHandle {
+    let guest_cpu_cgroup = context.guest_cpu_cgroup.take();
     if let Some(reason) = exit_notifier.unavailable_reason() {
         warn!(
             id = %id,
@@ -1656,6 +1686,11 @@ fn monitor_process_with_log_readers_and_exit_notifier(
 
         if let Err(error) = &status {
             warn!(id = %id, %error, "process monitor failed to wait for child");
+        }
+        if let Some(guest_cpu_cgroup) = guest_cpu_cgroup
+            && let Err(error) = guest_cpu_cgroup.release()
+        {
+            warn!(id = %id, %error, "failed to release Guest CPU cgroup after process reap");
         }
         context.runtime_cancel.cancel();
 

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -186,6 +186,7 @@ fn test_sandbox_with_state(state: SandboxState) -> FirecrackerSandbox {
         is_parked: false,
         park_outcome: None,
         park_fence: None,
+        host_cpu_cgroup: None,
     }
 }
 
@@ -3661,6 +3662,37 @@ async fn process_monitor_reports_unexpected_exit() {
 }
 
 #[tokio::test]
+async fn process_monitor_releases_guest_cpu_cgroup_after_reap() {
+    let temp = tempfile::tempdir().unwrap();
+    let leaf = temp.path().join("guest");
+    std::fs::create_dir(&leaf).unwrap();
+    let placement_file = std::fs::File::create(temp.path().join("placement")).unwrap();
+    let lease = GuestCpuCgroupLease::from_test_file(leaf.clone(), placement_file);
+    let state = Arc::new(AtomicU8::new(SandboxState::Created as u8));
+    let state_publish_lock = Arc::new(Mutex::new(()));
+    let (state_tx, _state_rx) = watch::channel(SandboxState::Created);
+    let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+    let mut child = monitored_cat_process();
+    let stdin = child.stdin.take();
+    let context = ProcessMonitorContext {
+        state,
+        state_publish_lock,
+        state_tx,
+        guest,
+        runtime_cancel: CancellationToken::new(),
+        guest_cpu_cgroup: Some(lease),
+    };
+
+    let handle = monitor_process_with_context("test-sandbox", child, context);
+    assert!(leaf.exists());
+
+    drop(stdin);
+    handle.wait().await;
+
+    assert!(!leaf.exists());
+}
+
+#[tokio::test]
 async fn process_monitor_cancels_control_server_after_exit() {
     let dir = tempfile::tempdir().unwrap();
     let sock_path = dir.path().join("control.sock");
@@ -3749,6 +3781,7 @@ async fn process_monitor_aborts_stuck_log_reader_after_exit() {
         state_tx,
         guest,
         runtime_cancel: CancellationToken::new(),
+        guest_cpu_cgroup: None,
     };
     let handle = monitor_process_with_log_readers("test-sandbox", child, context, readers);
 
@@ -3788,6 +3821,7 @@ async fn process_monitor_wait_cancel_keeps_log_reader_cleanup_owned() {
         state_tx,
         guest,
         runtime_cancel: CancellationToken::new(),
+        guest_cpu_cgroup: None,
     };
     let handle = monitor_process_with_log_readers("test-sandbox", child, context, readers);
 
@@ -4062,6 +4096,7 @@ async fn stdout_eof_does_not_mark_running_process_crashed() {
         state_tx: state_tx.clone(),
         guest,
         runtime_cancel: CancellationToken::new(),
+        guest_cpu_cgroup: None,
     };
 
     let handle = monitor_process_with_log_readers("test-sandbox", child, context, readers);
@@ -4156,6 +4191,7 @@ async fn process_monitor_fallback_does_not_kill_group_after_parent_reap() {
         state_tx,
         guest,
         runtime_cancel: CancellationToken::new(),
+        guest_cpu_cgroup: None,
     };
 
     let handle = monitor_process_with_log_readers_and_exit_notifier(

--- a/crates/sandbox-fc/src/snapshot/attempt/process.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt/process.rs
@@ -93,7 +93,7 @@ impl SnapshotProcess {
             spawn.binary_path,
             spawn.api_sock,
         );
-        let mut child = spawn_firecracker(command, spawn.current_dir)?;
+        let mut child = spawn_firecracker(command, spawn.current_dir, None)?;
 
         // Stream stdout/stderr lines to tracing (same pattern as sandbox.rs).
         // Stderr is also retained in a bounded ring buffer so that an early

--- a/crates/sandbox-fc/tests/host_cpu_fairness.rs
+++ b/crates/sandbox-fc/tests/host_cpu_fairness.rs
@@ -1,0 +1,481 @@
+#![cfg(target_os = "linux")]
+
+//! Root-required real-Firecracker proof for weighted host CPU placement.
+
+use std::error::Error;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Duration;
+
+use futures_util::future::join_all;
+use sandbox::{
+    EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, FactoryConfig, HostCpuPlacementConfig,
+    HostCpuPlacementMode, ResourceLimits, RuntimeConfig, Sandbox, SandboxConfig, SandboxRuntime,
+};
+use sandbox_fc::FirecrackerRuntime;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+const CONTROL_WEIGHT: u32 = 200;
+const GUESTS_WEIGHT: u32 = 9_800;
+const SAMPLE_WARMUP: Duration = Duration::from_secs(1);
+const SAMPLE_WINDOW: Duration = Duration::from_secs(5);
+const SATURATED_SAMPLES: usize = 3;
+const SATURATED_SAMPLES_U64: u64 = 3;
+const TEST_VCPUS: [u32; 4] = [1, 1, 4, 4];
+const CPU_LOAD_COMMAND: &str = "sh -c 'for i in $(seq 1 $(nproc)); do timeout 8 sh -c \
+    \"while :; do :; done\" & done; wait || true'";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TestMode {
+    Baseline,
+    Managed,
+}
+
+impl TestMode {
+    fn from_env() -> TestResult<Self> {
+        match required_env("VM0_HOST_CPU_TEST_MODE")?.as_str() {
+            "baseline" => Ok(Self::Baseline),
+            "managed" => Ok(Self::Managed),
+            value => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("VM0_HOST_CPU_TEST_MODE must be baseline or managed, got {value:?}"),
+            )
+            .into()),
+        }
+    }
+}
+
+struct RunningSandbox {
+    vcpu: u32,
+    sandbox: Box<dyn Sandbox>,
+}
+
+struct Measurement {
+    usage: Vec<u64>,
+    control_ticks: u64,
+    control_max_gap_micros: u64,
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires root, Firecracker fixtures, NBD, and delegated cgroup v2"]
+async fn real_firecracker_guests_receive_weighted_host_cpu_service() -> TestResult<()> {
+    if !nix::unistd::getuid().is_root() {
+        return Err(io::Error::new(io::ErrorKind::PermissionDenied, "test requires root").into());
+    }
+    let mode = TestMode::from_env()?;
+    let firecracker = required_path("VM0_HOST_CPU_TEST_FIRECRACKER")?;
+    let kernel = required_path("VM0_HOST_CPU_TEST_KERNEL")?;
+    let rootfs = required_path("VM0_HOST_CPU_TEST_ROOTFS")?;
+    let base_dir = PathBuf::from(required_env("VM0_HOST_CPU_TEST_BASE_DIR")?);
+    fs::create_dir_all(&base_dir)?;
+
+    let host_cpu_placement = match mode {
+        TestMode::Baseline => None,
+        TestMode::Managed => Some(
+            HostCpuPlacementConfig::new(
+                CONTROL_WEIGHT,
+                GUESTS_WEIGHT,
+                HostCpuPlacementMode::Required,
+            )
+            .map_err(io::Error::other)?,
+        ),
+    };
+    let mut runtime = FirecrackerRuntime::new(RuntimeConfig {
+        proxy_port: None,
+        dns_port: None,
+        host_cpu_placement,
+    })
+    .await?;
+    let mut factory = runtime
+        .create_factory(FactoryConfig {
+            profile: "vm0/host-cpu-metal".into(),
+            binary_path: firecracker,
+            kernel_path: kernel,
+            rootfs_path: rootfs,
+            base_dir,
+            snapshot: None,
+        })
+        .await?;
+
+    let mut sandboxes = Vec::with_capacity(TEST_VCPUS.len());
+    for vcpu in TEST_VCPUS {
+        let mut sandbox = factory
+            .create(SandboxConfig {
+                id: sandbox::SandboxId::new_v4(),
+                resources: ResourceLimits {
+                    cpu_count: vcpu,
+                    memory_mb: 512,
+                },
+                device_rate_limits: None,
+                workspace_drive: None,
+            })
+            .await?;
+        sandbox.start().await?;
+        sandboxes.push(RunningSandbox { vcpu, sandbox });
+    }
+
+    let cgroup_root = delegated_root()?;
+    if mode == TestMode::Managed {
+        verify_managed_hierarchy(&cgroup_root, &sandboxes)?;
+    }
+
+    let mut saturated_usage = vec![0_u64; sandboxes.len()];
+    let mut saturated_control_ticks = 0_u64;
+    let mut saturated_control_max_gap_micros = 0_u64;
+    for sample in 0..SATURATED_SAMPLES {
+        let measurement =
+            run_load_and_measure(mode, &cgroup_root, &sandboxes, &[0, 1, 2, 3]).await?;
+        assert_eq!(measurement.usage.len(), saturated_usage.len());
+        for (index, (total, usage)) in saturated_usage
+            .iter_mut()
+            .zip(measurement.usage.iter().copied())
+            .enumerate()
+        {
+            assert!(
+                usage > 0,
+                "sandbox {index} made no CPU progress in sample {sample}"
+            );
+            *total = total.saturating_add(usage);
+        }
+        saturated_control_ticks = saturated_control_ticks.saturating_add(measurement.control_ticks);
+        saturated_control_max_gap_micros =
+            saturated_control_max_gap_micros.max(measurement.control_max_gap_micros);
+    }
+    assert!(
+        saturated_control_ticks > 100,
+        "Runner control ticker made insufficient progress: {}",
+        saturated_control_ticks
+    );
+    assert!(
+        saturated_control_max_gap_micros < 1_000_000,
+        "Runner control ticker was not scheduled for {} microseconds",
+        saturated_control_max_gap_micros
+    );
+
+    let normalized = saturated_usage
+        .iter()
+        .zip(&sandboxes)
+        .map(|(usage, sandbox)| *usage as f64 / f64::from(sandbox.vcpu))
+        .collect::<Vec<_>>();
+    let normalized_ratio = ratio(&normalized)?;
+    println!("HOST_CPU_NORMALIZED_RATIO={normalized_ratio:.6}");
+    println!("HOST_CPU_CONTROL_TICKS={saturated_control_ticks}");
+    println!("HOST_CPU_CONTROL_MAX_GAP_MICROS={saturated_control_max_gap_micros}");
+
+    if mode == TestMode::Managed {
+        let max_ratio = required_env("VM0_HOST_CPU_TEST_MAX_NORMALIZED_RATIO")?
+            .parse::<f64>()
+            .map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("parse VM0_HOST_CPU_TEST_MAX_NORMALIZED_RATIO: {error}"),
+                )
+            })?;
+        assert!(
+            normalized_ratio <= max_ratio,
+            "normalized Guest CPU progress ratio {normalized_ratio:.3} exceeds baseline-derived {max_ratio:.3}: {normalized:?}"
+        );
+
+        let selected = 2;
+        let borrowing = run_load_and_measure(mode, &cgroup_root, &sandboxes, &[selected]).await?;
+        let saturated_selected = saturated_usage
+            .get(selected)
+            .copied()
+            .ok_or_else(|| io::Error::other("selected saturated sandbox is missing"))?
+            / SATURATED_SAMPLES_U64;
+        let borrowing_selected = borrowing
+            .usage
+            .get(selected)
+            .copied()
+            .ok_or_else(|| io::Error::other("selected borrowing sandbox is missing"))?;
+        assert!(
+            borrowing_selected as f64 >= saturated_selected as f64 * 1.4,
+            "remaining Guest did not borrow idle CPU: saturated={saturated_selected}, borrowing={borrowing_selected}"
+        );
+    }
+
+    while let Some(running) = sandboxes.pop() {
+        factory.destroy(running.sandbox).await;
+    }
+    if mode == TestMode::Managed {
+        verify_no_guest_leaves(&cgroup_root)?;
+    }
+    factory.shutdown().await;
+    runtime.shutdown().await;
+    Ok(())
+}
+
+async fn run_load_and_measure(
+    mode: TestMode,
+    cgroup_root: &Path,
+    sandboxes: &[RunningSandbox],
+    active: &[usize],
+) -> TestResult<Measurement> {
+    let active_sandboxes = active
+        .iter()
+        .map(|index| {
+            sandboxes
+                .get(*index)
+                .map(|running| &*running.sandbox)
+                .ok_or_else(|| io::Error::other(format!("active sandbox {index} is missing")))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let load = async {
+        let results = join_all(active_sandboxes.into_iter().map(burn_cpu)).await;
+        for result in results {
+            let result = result?;
+            assert!(
+                matches!(result.termination, ExecTermination::Exited { exit_code: 0 }),
+                "CPU load failed: {:?}: {}",
+                result.termination,
+                String::from_utf8_lossy(&result.stderr)
+            );
+        }
+        TestResult::Ok(())
+    };
+    let sample = async {
+        tokio::time::sleep(SAMPLE_WARMUP).await;
+        let before = read_usage(mode, cgroup_root, sandboxes)?;
+        let stop = Arc::new(AtomicBool::new(false));
+        let ticks = Arc::new(AtomicU64::new(0));
+        let max_gap_micros = Arc::new(AtomicU64::new(0));
+        let ticker_stop = Arc::clone(&stop);
+        let ticker_ticks = Arc::clone(&ticks);
+        let ticker_max_gap_micros = Arc::clone(&max_gap_micros);
+        let ticker = tokio::task::spawn_blocking(move || {
+            let mut previous = std::time::Instant::now();
+            while !ticker_stop.load(Ordering::Relaxed) {
+                let now = std::time::Instant::now();
+                let gap_micros =
+                    u64::try_from(now.duration_since(previous).as_micros()).unwrap_or(u64::MAX);
+                ticker_max_gap_micros.fetch_max(gap_micros, Ordering::Relaxed);
+                previous = now;
+                ticker_ticks.fetch_add(1, Ordering::Relaxed);
+                std::hint::spin_loop();
+            }
+        });
+        tokio::time::sleep(SAMPLE_WINDOW).await;
+        let after = read_usage(mode, cgroup_root, sandboxes)?;
+        stop.store(true, Ordering::Relaxed);
+        ticker.await?;
+        let usage = after
+            .iter()
+            .zip(before)
+            .map(|(after, before)| after.saturating_sub(before))
+            .collect();
+        TestResult::Ok(Measurement {
+            usage,
+            control_ticks: ticks.load(Ordering::Relaxed),
+            control_max_gap_micros: max_gap_micros.load(Ordering::Relaxed),
+        })
+    };
+    let (load_result, measurement) = tokio::join!(load, sample);
+    load_result?;
+    measurement
+}
+
+async fn burn_cpu(sandbox: &dyn Sandbox) -> sandbox::Result<sandbox::ExecResult> {
+    sandbox
+        .exec_with_diagnostic_label(
+            &ExecRequest {
+                cmd: CPU_LOAD_COMMAND,
+                timeout: Duration::from_secs(15),
+                env: &[],
+                sudo: false,
+                expected_exit_codes: &[],
+                stdin_bytes: None,
+                output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
+            },
+            "host-cpu-metal-load",
+        )
+        .await
+}
+
+fn read_usage(
+    mode: TestMode,
+    cgroup_root: &Path,
+    sandboxes: &[RunningSandbox],
+) -> TestResult<Vec<u64>> {
+    sandboxes
+        .iter()
+        .map(|sandbox| match mode {
+            TestMode::Baseline => process_cpu_ticks(sandbox_pid(sandbox)?),
+            TestMode::Managed => {
+                cgroup_usage_usec(&cgroup_root.join("guests").join(sandbox.sandbox.id()))
+            }
+        })
+        .collect()
+}
+
+fn process_cpu_ticks(pid: u32) -> TestResult<u64> {
+    let task_dir = PathBuf::from(format!("/proc/{pid}/task"));
+    let mut total = 0_u64;
+    for task in fs::read_dir(task_dir)? {
+        let stat = fs::read_to_string(task?.path().join("stat"))?;
+        let close = stat.rfind(')').ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "process stat lacks command terminator",
+            )
+        })?;
+        let fields = stat
+            .get(close + 2..)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "process stat is truncated"))?
+            .split_ascii_whitespace()
+            .collect::<Vec<_>>();
+        let user = parse_stat_field(&fields, 11)?;
+        let system = parse_stat_field(&fields, 12)?;
+        total = total.saturating_add(user).saturating_add(system);
+    }
+    Ok(total)
+}
+
+fn parse_stat_field(fields: &[&str], index: usize) -> TestResult<u64> {
+    fields
+        .get(index)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "process stat field missing"))?
+        .parse::<u64>()
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error).into())
+}
+
+fn cgroup_usage_usec(path: &Path) -> TestResult<u64> {
+    for line in fs::read_to_string(path.join("cpu.stat"))?.lines() {
+        if let Some(value) = line.strip_prefix("usage_usec ") {
+            return value
+                .parse::<u64>()
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error).into());
+        }
+    }
+    Err(io::Error::new(io::ErrorKind::InvalidData, "cpu.stat lacks usage_usec").into())
+}
+
+fn verify_managed_hierarchy(root: &Path, sandboxes: &[RunningSandbox]) -> TestResult<()> {
+    assert!(
+        fs::read_to_string(root.join("cgroup.subtree_control"))?
+            .split_ascii_whitespace()
+            .any(|controller| controller == "cpu")
+    );
+    assert!(
+        fs::read_to_string(root.join("guests/cgroup.subtree_control"))?
+            .split_ascii_whitespace()
+            .any(|controller| controller == "cpu")
+    );
+    assert_eq!(read_u32(root.join("control/cpu.weight"))?, CONTROL_WEIGHT);
+    assert_eq!(read_u32(root.join("guests/cpu.weight"))?, GUESTS_WEIGHT);
+    assert!(
+        fs::read_to_string(root.join("cgroup.procs"))?
+            .trim()
+            .is_empty()
+    );
+    for sandbox in sandboxes {
+        let leaf = root.join("guests").join(sandbox.sandbox.id());
+        assert_eq!(read_u32(leaf.join("cpu.weight"))?, sandbox.vcpu);
+        let expected_membership = format!(
+            "{}/guests/{}",
+            current_unified_membership()?.trim_end_matches("/control"),
+            sandbox.sandbox.id()
+        );
+        let pid = sandbox_pid(sandbox)?;
+        for task in fs::read_dir(format!("/proc/{pid}/task"))? {
+            let membership = fs::read_to_string(task?.path().join("cgroup"))?;
+            assert_eq!(unified_membership(&membership)?, expected_membership);
+        }
+    }
+    Ok(())
+}
+
+fn verify_no_guest_leaves(root: &Path) -> TestResult<()> {
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(root.join("guests"))? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            entries.push(entry.file_name());
+        }
+    }
+    assert!(entries.is_empty(), "stale Guest CPU cgroups: {entries:?}");
+    Ok(())
+}
+
+fn delegated_root() -> TestResult<PathBuf> {
+    let membership = current_unified_membership()?;
+    let control = Path::new("/sys/fs/cgroup").join(membership.trim_start_matches('/'));
+    control.parent().map(Path::to_path_buf).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidData, "control cgroup has no parent").into()
+    })
+}
+
+fn current_unified_membership() -> TestResult<String> {
+    unified_membership(&fs::read_to_string("/proc/self/cgroup")?)
+}
+
+fn unified_membership(raw: &str) -> TestResult<String> {
+    let mut matches = raw.lines().filter_map(|line| line.strip_prefix("0::"));
+    let value = matches.next().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "unified cgroup membership missing",
+        )
+    })?;
+    if matches.next().is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "multiple unified cgroup memberships",
+        )
+        .into());
+    }
+    Ok(value.to_owned())
+}
+
+fn sandbox_pid(sandbox: &RunningSandbox) -> TestResult<u32> {
+    sandbox.sandbox.host_process_pid().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::NotFound, "Firecracker host PID unavailable").into()
+    })
+}
+
+fn ratio(values: &[f64]) -> TestResult<f64> {
+    let min = values.iter().copied().reduce(f64::min).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "no normalized CPU measurements",
+        )
+    })?;
+    let max = values.iter().copied().reduce(f64::max).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "no normalized CPU measurements",
+        )
+    })?;
+    if min <= 0.0 {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "zero CPU progress").into());
+    }
+    Ok(max / min)
+}
+
+fn read_u32(path: PathBuf) -> TestResult<u32> {
+    fs::read_to_string(path)?
+        .trim()
+        .parse::<u32>()
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error).into())
+}
+
+fn required_path(name: &str) -> TestResult<PathBuf> {
+    let path = PathBuf::from(required_env(name)?);
+    if !path.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("{name} is not a file: {}", path.display()),
+        )
+        .into());
+    }
+    Ok(path)
+}
+
+fn required_env(name: &str) -> TestResult<String> {
+    std::env::var(name).map_err(|error| {
+        io::Error::new(io::ErrorKind::InvalidInput, format!("{name}: {error}")).into()
+    })
+}

--- a/crates/sandbox-fc/tests/host_cpu_fairness.rs
+++ b/crates/sandbox-fc/tests/host_cpu_fairness.rs
@@ -23,8 +23,7 @@ const CONTROL_WEIGHT: u32 = 200;
 const GUESTS_WEIGHT: u32 = 9_800;
 const SAMPLE_WARMUP: Duration = Duration::from_secs(1);
 const SAMPLE_WINDOW: Duration = Duration::from_secs(5);
-const SATURATED_SAMPLES: usize = 3;
-const SATURATED_SAMPLES_U64: u64 = 3;
+const SATURATED_SAMPLES: u64 = 3;
 const TEST_VCPUS: [u32; 4] = [1, 1, 4, 4];
 const CPU_LOAD_COMMAND: &str = "sh -c 'for i in $(seq 1 $(nproc)); do timeout 8 sh -c \
     \"while :; do :; done\" & done; wait || true'";
@@ -186,7 +185,7 @@ async fn real_firecracker_guests_receive_weighted_host_cpu_service() -> TestResu
             .get(selected)
             .copied()
             .ok_or_else(|| io::Error::other("selected saturated sandbox is missing"))?
-            / SATURATED_SAMPLES_U64;
+            / SATURATED_SAMPLES;
         let borrowing_selected = borrowing
             .usage
             .get(selected)

--- a/crates/sandbox-mock/src/tests/factory_runtime.rs
+++ b/crates/sandbox-mock/src/tests/factory_runtime.rs
@@ -115,6 +115,7 @@ async fn runtime_provider_creates_runtime() {
         .create_runtime(RuntimeConfig {
             proxy_port: None,
             dns_port: None,
+            host_cpu_placement: None,
         })
         .await
         .unwrap();

--- a/crates/sandbox/src/config.rs
+++ b/crates/sandbox/src/config.rs
@@ -185,6 +185,73 @@ pub struct FactoryConfig {
     pub snapshot: Option<SnapshotRef>,
 }
 
+/// Whether a sandbox runtime must establish managed host CPU placement.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HostCpuPlacementMode {
+    /// Runtime initialization fails when the delegated host CPU boundary is unavailable.
+    Required,
+    /// Runtime initialization may continue unmanaged only when delegation is unavailable.
+    PreferManaged,
+}
+
+/// Runner-wide policy for weighted host CPU placement.
+///
+/// The concrete sandbox provider discovers and owns its host resource boundary;
+/// callers only choose the sibling weights and whether delegation is required.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HostCpuPlacementConfig {
+    control_weight: u32,
+    guests_weight: u32,
+    mode: HostCpuPlacementMode,
+}
+
+impl HostCpuPlacementConfig {
+    /// Smallest CPU weight accepted by cgroup v2.
+    pub const MIN_WEIGHT: u32 = 1;
+    /// Largest CPU weight accepted by cgroup v2.
+    pub const MAX_WEIGHT: u32 = 10_000;
+
+    /// Build a validated placement policy.
+    pub fn new(
+        control_weight: u32,
+        guests_weight: u32,
+        mode: HostCpuPlacementMode,
+    ) -> Result<Self, String> {
+        for (name, weight) in [
+            ("control_weight", control_weight),
+            ("guests_weight", guests_weight),
+        ] {
+            if !(Self::MIN_WEIGHT..=Self::MAX_WEIGHT).contains(&weight) {
+                return Err(format!(
+                    "{name} must be between {} and {}",
+                    Self::MIN_WEIGHT,
+                    Self::MAX_WEIGHT
+                ));
+            }
+        }
+        Ok(Self {
+            control_weight,
+            guests_weight,
+            mode,
+        })
+    }
+
+    /// Weight assigned to Runner control work.
+    pub fn control_weight(self) -> u32 {
+        self.control_weight
+    }
+
+    /// Aggregate weight assigned to all Firecracker Guests.
+    pub fn guests_weight(self) -> u32 {
+        self.guests_weight
+    }
+
+    /// Startup behavior when host cgroup delegation is unavailable.
+    pub fn mode(self) -> HostCpuPlacementMode {
+        self.mode
+    }
+}
+
 /// Runtime-wide configuration used to initialize shared backend resources.
 ///
 /// These values are discovered before a runtime is created and apply to every
@@ -195,6 +262,11 @@ pub struct RuntimeConfig {
     pub proxy_port: Option<u16>,
     /// DNS proxy port for DNS query interception. Shared across all factories.
     pub dns_port: Option<u16>,
+    /// Optional host CPU placement policy for normal sandboxes.
+    ///
+    /// `None` is reserved for direct developer utilities that do not enter the
+    /// Runner worker admission loop.
+    pub host_cpu_placement: Option<HostCpuPlacementConfig>,
 }
 
 #[cfg(test)]
@@ -223,5 +295,23 @@ mod tests {
         let id = SandboxId::new_v4();
         let parsed: SandboxId = id.to_string().parse().unwrap();
         assert_eq!(parsed, id);
+    }
+
+    #[test]
+    fn host_cpu_placement_config_validates_kernel_weight_range() {
+        let config = HostCpuPlacementConfig::new(
+            HostCpuPlacementConfig::MIN_WEIGHT,
+            HostCpuPlacementConfig::MAX_WEIGHT,
+            HostCpuPlacementMode::Required,
+        )
+        .unwrap();
+        assert_eq!(config.control_weight(), 1);
+        assert_eq!(config.guests_weight(), 10_000);
+        assert_eq!(config.mode(), HostCpuPlacementMode::Required);
+
+        assert!(HostCpuPlacementConfig::new(0, 1, HostCpuPlacementMode::Required).is_err());
+        assert!(
+            HostCpuPlacementConfig::new(1, 10_001, HostCpuPlacementMode::PreferManaged).is_err()
+        );
     }
 }

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -27,9 +27,9 @@ mod snapshot;
 mod types;
 
 pub use config::{
-    BlockRateLimits, DeviceRateLimits, FactoryConfig, NetworkRateLimits, ResourceLimits,
-    RuntimeConfig, SandboxConfig, SandboxId, SnapshotRef, WorkspaceDriveConfig,
-    WorkspaceDriveSeedImage,
+    BlockRateLimits, DeviceRateLimits, FactoryConfig, HostCpuPlacementConfig, HostCpuPlacementMode,
+    NetworkRateLimits, ResourceLimits, RuntimeConfig, SandboxConfig, SandboxId, SnapshotRef,
+    WorkspaceDriveConfig, WorkspaceDriveSeedImage,
 };
 pub use control::{
     RemoteExecResult, RemoteKillResult, SandboxControl, SandboxControlError, SandboxControlTarget,


### PR DESCRIPTION
## Summary

- delegate the CPU controller to persistent and transient Runner services and derive the `control:guests` weights from the existing host CPU reservation policy
- initialize and validate the delegated cgroup v2 hierarchy in `sandbox-fc`, place every normal Firecracker process in a declared-vCPU-weighted leaf before exec, and retain the leaf through process reap
- add focused policy, hierarchy, pre-exec, and monitor tests plus a baseline-calibrated real-Firecracker metal CI proof

## Compatibility and scope

- production workers fail before job admission when the required delegation contract is unavailable or invalid; `runner start --local` may use the explicit unmanaged fallback only when no supported contract is present
- snapshot construction and direct benchmark runtimes remain outside managed placement
- no API, queue, profile, persistence, schema, or UI behavior changes

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p sandbox -p sandbox-fc -p runner --all-targets -- -D warnings`
- `cd crates && cargo doc -p sandbox -p sandbox-fc -p runner --no-deps`
- `cd crates && cargo test -p sandbox -p sandbox-fc -p runner`
- `lefthook run pre-commit`
- `bash -n .github/scripts/runner-behavior-host-cpu-fairness.sh`
- real-Firecracker managed proof on `local-1`: final `200:9800` weights, normalized progress ratio `1.045256`, maximum control scheduling gap `96,024 µs`, with borrowing, thread membership, and cleanup checks passing

Closes #30902

Parent context: #30896
