### PR TITLE
fix(runner): cap pre-spawn admission to available cpus

### DIFF
--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -19,7 +19,7 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true, features = ["serde", "now"] }
 clap = { workspace = true, features = ["derive", "env"] }
-nix = { workspace = true, features = ["user", "signal", "fs", "process", "inotify"] }
+nix = { workspace = true, features = ["user", "signal", "fs", "process", "inotify", "sched"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_path_to_error = { workspace = true }

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -601,10 +601,18 @@ async fn run_start_with_home(
         profiles = runner_config.profiles.len(),
         "resource budget initialized"
     );
-    match pre_spawn_capacity {
+    match &pre_spawn_capacity {
         host::PreSpawnCpuCapacity::ExactPhysical(_) => {
             info!(
-                capacity_source = "physical_topology",
+                capacity_source = pre_spawn_capacity.source(),
+                pre_spawn_vcpu_tokens = pre_spawn_admission.total_tokens(),
+                host_logical_cpus = host_cpus,
+                "pre-spawn admission initialized"
+            );
+        }
+        host::PreSpawnCpuCapacity::RestrictedPhysical(_) => {
+            info!(
+                capacity_source = pre_spawn_capacity.source(),
                 pre_spawn_vcpu_tokens = pre_spawn_admission.total_tokens(),
                 host_logical_cpus = host_cpus,
                 "pre-spawn admission initialized"
@@ -612,7 +620,7 @@ async fn run_start_with_home(
         }
         host::PreSpawnCpuCapacity::ConservativeLogical(_) => {
             warn!(
-                capacity_source = "logical_cpu_fallback",
+                capacity_source = pre_spawn_capacity.source(),
                 reason = "topology directories are absent for all online CPUs",
                 pre_spawn_vcpu_tokens = pre_spawn_admission.total_tokens(),
                 host_logical_cpus = host_cpus,

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -602,15 +602,8 @@ async fn run_start_with_home(
         "resource budget initialized"
     );
     match &pre_spawn_capacity {
-        host::PreSpawnCpuCapacity::ExactPhysical(_) => {
-            info!(
-                capacity_source = pre_spawn_capacity.source(),
-                pre_spawn_vcpu_tokens = pre_spawn_admission.total_tokens(),
-                host_logical_cpus = host_cpus,
-                "pre-spawn admission initialized"
-            );
-        }
-        host::PreSpawnCpuCapacity::RestrictedPhysical(_) => {
+        host::PreSpawnCpuCapacity::ExactPhysical(_)
+        | host::PreSpawnCpuCapacity::RestrictedPhysical(_) => {
             info!(
                 capacity_source = pre_spawn_capacity.source(),
                 pre_spawn_vcpu_tokens = pre_spawn_admission.total_tokens(),
@@ -621,7 +614,7 @@ async fn run_start_with_home(
         host::PreSpawnCpuCapacity::ConservativeLogical(_) => {
             warn!(
                 capacity_source = pre_spawn_capacity.source(),
-                reason = "topology directories are absent for all online CPUs",
+                reason = "topology directories are absent for all effective CPUs",
                 pre_spawn_vcpu_tokens = pre_spawn_admission.total_tokens(),
                 host_logical_cpus = host_cpus,
                 "pre-spawn admission initialized"

--- a/crates/runner/src/host.rs
+++ b/crates/runner/src/host.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeSet;
 use std::path::Path;
 
+use nix::sched::{CpuSet, sched_getaffinity};
+use nix::unistd::Pid;
+
 use crate::error::{RunnerError, RunnerResult};
 
 const CPU_SYSFS_ROOT: &str = "/sys/devices/system/cpu";
@@ -8,13 +11,24 @@ const CPU_SYSFS_ROOT: &str = "/sys/devices/system/cpu";
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum PreSpawnCpuCapacity {
     ExactPhysical(u32),
+    RestrictedPhysical(u32),
     ConservativeLogical(u32),
 }
 
 impl PreSpawnCpuCapacity {
     pub(crate) fn tokens(&self) -> u32 {
         match self {
-            Self::ExactPhysical(tokens) | Self::ConservativeLogical(tokens) => *tokens,
+            Self::ExactPhysical(tokens)
+            | Self::RestrictedPhysical(tokens)
+            | Self::ConservativeLogical(tokens) => *tokens,
+        }
+    }
+
+    pub(crate) fn source(&self) -> &'static str {
+        match self {
+            Self::ExactPhysical(_) => "physical_topology",
+            Self::RestrictedPhysical(_) => "restricted_physical_topology",
+            Self::ConservativeLogical(_) => "logical_cpu_fallback",
         }
     }
 }
@@ -29,20 +43,64 @@ pub fn cpu_count() -> RunnerResult<usize> {
 pub(crate) fn pre_spawn_cpu_capacity(
     logical_cpu_count: usize,
 ) -> RunnerResult<PreSpawnCpuCapacity> {
-    pre_spawn_cpu_capacity_at(Path::new(CPU_SYSFS_ROOT), logical_cpu_count)
+    let affinity_cpus = cpu_affinity()?;
+    pre_spawn_cpu_capacity_at(Path::new(CPU_SYSFS_ROOT), logical_cpu_count, &affinity_cpus)
         .map_err(|error| RunnerError::Internal(format!("detect physical CPU topology: {error}")))
+}
+
+fn cpu_affinity() -> RunnerResult<BTreeSet<usize>> {
+    let cpu_set = sched_getaffinity(Pid::from_raw(0))
+        .map_err(|error| RunnerError::Internal(format!("detect CPU affinity: {error}")))?;
+    let mut cpus = BTreeSet::new();
+    for cpu in 0..CpuSet::count() {
+        if cpu_set.is_set(cpu).map_err(|error| {
+            RunnerError::Internal(format!("inspect CPU {cpu} in process affinity: {error}"))
+        })? {
+            cpus.insert(cpu);
+        }
+    }
+    if cpus.is_empty() {
+        return Err(RunnerError::Internal(
+            "process CPU affinity contains no CPUs".into(),
+        ));
+    }
+    Ok(cpus)
 }
 
 fn pre_spawn_cpu_capacity_at(
     cpu_root: &Path,
     logical_cpu_count: usize,
+    affinity_cpus: &BTreeSet<usize>,
 ) -> Result<PreSpawnCpuCapacity, String> {
-    match physical_core_count(cpu_root)? {
-        Some(physical_cores) => u32::try_from(physical_cores)
-            .map(PreSpawnCpuCapacity::ExactPhysical)
-            .map_err(|_| {
-                format!("physical CPU count {physical_cores} exceeds supported pre-spawn capacity")
-            }),
+    if logical_cpu_count == 0 {
+        return Err("available logical CPU count is zero".into());
+    }
+
+    let online_path = cpu_root.join("online");
+    let online = std::fs::read_to_string(&online_path)
+        .map_err(|error| format!("read {}: {error}", online_path.display()))?;
+    let online_cpus = parse_cpu_list(&online)?;
+    let effective_cpus = online_cpus
+        .intersection(affinity_cpus)
+        .copied()
+        .collect::<BTreeSet<_>>();
+    if effective_cpus.is_empty() {
+        return Err("online CPUs and process affinity do not overlap".into());
+    }
+    let affinity_restricted = effective_cpus != online_cpus;
+
+    match physical_core_count(cpu_root, &effective_cpus)? {
+        Some(physical_cores) => {
+            let capacity = physical_cores.min(logical_cpu_count);
+            let capacity = u32::try_from(capacity).map_err(|_| {
+                format!("physical CPU count {capacity} exceeds supported pre-spawn capacity")
+            })?;
+            if affinity_restricted || physical_cores > logical_cpu_count {
+                Ok(PreSpawnCpuCapacity::RestrictedPhysical(capacity))
+            } else {
+                Ok(PreSpawnCpuCapacity::ExactPhysical(capacity))
+            }
+        }
         None => {
             let conservative_logical = (logical_cpu_count / 2).max(1);
             u32::try_from(conservative_logical)
@@ -56,14 +114,13 @@ fn pre_spawn_cpu_capacity_at(
     }
 }
 
-fn physical_core_count(cpu_root: &Path) -> Result<Option<usize>, String> {
-    let online_path = cpu_root.join("online");
-    let online = std::fs::read_to_string(&online_path)
-        .map_err(|error| format!("read {}: {error}", online_path.display()))?;
-    let cpus = parse_cpu_list(&online)?;
+fn physical_core_count(
+    cpu_root: &Path,
+    effective_cpus: &BTreeSet<usize>,
+) -> Result<Option<usize>, String> {
     let mut missing_topology = BTreeSet::new();
 
-    for cpu in &cpus {
+    for cpu in effective_cpus {
         let topology = cpu_root.join(format!("cpu{cpu}/topology"));
         match std::fs::symlink_metadata(&topology) {
             Ok(_) => {}
@@ -74,18 +131,18 @@ fn physical_core_count(cpu_root: &Path) -> Result<Option<usize>, String> {
         }
     }
 
-    if missing_topology == cpus {
+    if &missing_topology == effective_cpus {
         return Ok(None);
     }
     if !missing_topology.is_empty() {
         return Err(format!(
-            "physical CPU topology is missing for online CPUs {missing_topology:?}"
+            "physical CPU topology is missing for effective CPUs {missing_topology:?}"
         ));
     }
 
     let mut cores = BTreeSet::new();
 
-    for cpu in cpus {
+    for cpu in effective_cpus {
         let topology = cpu_root.join(format!("cpu{cpu}/topology"));
         let package_id = read_topology_id(&topology.join("physical_package_id"))?;
         let core_id = read_topology_id(&topology.join("core_id"))?;
@@ -93,7 +150,7 @@ fn physical_core_count(cpu_root: &Path) -> Result<Option<usize>, String> {
     }
 
     if cores.is_empty() {
-        return Err("online CPU topology contains no physical cores".into());
+        return Err("effective CPU topology contains no physical cores".into());
     }
     Ok(Some(cores.len()))
 }
@@ -166,6 +223,10 @@ pub fn memory_mb() -> RunnerResult<usize> {
 mod tests {
     use super::*;
 
+    fn cpu_set(cpus: impl IntoIterator<Item = usize>) -> BTreeSet<usize> {
+        cpus.into_iter().collect()
+    }
+
     fn write_topology(root: &Path, cpu: usize, package_id: i64, core_id: i64) {
         let topology = root.join(format!("cpu{cpu}/topology"));
         std::fs::create_dir_all(&topology).unwrap();
@@ -176,6 +237,11 @@ mod tests {
     #[test]
     fn cpu_count_is_positive() {
         assert!(cpu_count().unwrap() > 0);
+    }
+
+    #[test]
+    fn cpu_affinity_is_nonempty() {
+        assert!(!cpu_affinity().unwrap().is_empty());
     }
 
     #[test]
@@ -205,8 +271,64 @@ mod tests {
         write_topology(dir.path(), 5, 1, 0);
 
         assert_eq!(
-            pre_spawn_cpu_capacity_at(dir.path(), 6).unwrap(),
+            pre_spawn_cpu_capacity_at(dir.path(), 6, &cpu_set(0..6)).unwrap(),
             PreSpawnCpuCapacity::ExactPhysical(3)
+        );
+    }
+
+    #[test]
+    fn pre_spawn_cpu_capacity_restricts_topology_to_affinity() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("online"), "0-5").unwrap();
+        for cpu in 0..6 {
+            write_topology(dir.path(), cpu, 0, cpu as i64);
+        }
+
+        assert_eq!(
+            pre_spawn_cpu_capacity_at(dir.path(), 3, &BTreeSet::from([1, 3, 5])).unwrap(),
+            PreSpawnCpuCapacity::RestrictedPhysical(3)
+        );
+    }
+
+    #[test]
+    fn pre_spawn_cpu_capacity_deduplicates_affinity_smt_siblings() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("online"), "0-3").unwrap();
+        write_topology(dir.path(), 0, 0, 0);
+        write_topology(dir.path(), 1, 0, 0);
+        write_topology(dir.path(), 2, 0, 1);
+        write_topology(dir.path(), 3, 0, 1);
+
+        assert_eq!(
+            pre_spawn_cpu_capacity_at(dir.path(), 2, &BTreeSet::from([0, 1])).unwrap(),
+            PreSpawnCpuCapacity::RestrictedPhysical(1)
+        );
+    }
+
+    #[test]
+    fn pre_spawn_cpu_capacity_is_capped_by_available_parallelism() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("online"), "0-3").unwrap();
+        for cpu in 0..4 {
+            write_topology(dir.path(), cpu, 0, cpu as i64);
+        }
+
+        assert_eq!(
+            pre_spawn_cpu_capacity_at(dir.path(), 2, &cpu_set(0..4)).unwrap(),
+            PreSpawnCpuCapacity::RestrictedPhysical(2)
+        );
+    }
+
+    #[test]
+    fn pre_spawn_cpu_capacity_ignores_topology_outside_affinity() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("online"), "0-2").unwrap();
+        write_topology(dir.path(), 0, 0, 0);
+        write_topology(dir.path(), 1, 0, 1);
+
+        assert_eq!(
+            pre_spawn_cpu_capacity_at(dir.path(), 2, &BTreeSet::from([0, 1])).unwrap(),
+            PreSpawnCpuCapacity::RestrictedPhysical(2)
         );
     }
 
@@ -216,7 +338,7 @@ mod tests {
         std::fs::write(dir.path().join("online"), "0-15").unwrap();
 
         assert_eq!(
-            pre_spawn_cpu_capacity_at(dir.path(), 16).unwrap(),
+            pre_spawn_cpu_capacity_at(dir.path(), 16, &cpu_set(0..16)).unwrap(),
             PreSpawnCpuCapacity::ConservativeLogical(8)
         );
     }
@@ -227,7 +349,7 @@ mod tests {
         std::fs::write(dir.path().join("online"), "0").unwrap();
 
         assert_eq!(
-            pre_spawn_cpu_capacity_at(dir.path(), 1).unwrap(),
+            pre_spawn_cpu_capacity_at(dir.path(), 1, &BTreeSet::from([0])).unwrap(),
             PreSpawnCpuCapacity::ConservativeLogical(1)
         );
     }
@@ -239,8 +361,8 @@ mod tests {
         write_topology(dir.path(), 0, 0, 0);
 
         assert_eq!(
-            physical_core_count(dir.path()).unwrap_err(),
-            "physical CPU topology is missing for online CPUs {1}"
+            pre_spawn_cpu_capacity_at(dir.path(), 2, &BTreeSet::from([0, 1])).unwrap_err(),
+            "physical CPU topology is missing for effective CPUs {1}"
         );
     }
 
@@ -251,7 +373,10 @@ mod tests {
         write_topology(dir.path(), 0, 0, 0);
         write_topology(dir.path(), 2, 0, 2);
 
-        assert_eq!(physical_core_count(dir.path()).unwrap(), Some(2));
+        assert_eq!(
+            physical_core_count(dir.path(), &BTreeSet::from([0, 2])).unwrap(),
+            Some(2)
+        );
     }
 
     #[test]
@@ -262,25 +387,57 @@ mod tests {
         std::fs::create_dir_all(&topology).unwrap();
         std::fs::write(topology.join("physical_package_id"), "0").unwrap();
 
-        let error = physical_core_count(dir.path()).unwrap_err();
+        let effective_cpus = BTreeSet::from([0]);
+        let error = physical_core_count(dir.path(), &effective_cpus).unwrap_err();
         assert!(error.contains("read"), "unexpected error: {error}");
         assert!(error.contains("core_id"), "unexpected error: {error}");
 
         std::fs::write(topology.join("core_id"), "invalid").unwrap();
 
-        let error = physical_core_count(dir.path()).unwrap_err();
+        let error = physical_core_count(dir.path(), &effective_cpus).unwrap_err();
         assert!(error.contains("parse"), "unexpected error: {error}");
         assert!(error.contains("core_id"), "unexpected error: {error}");
     }
 
     #[test]
-    fn physical_core_count_rejects_missing_or_empty_online_list() {
+    fn pre_spawn_cpu_capacity_rejects_missing_or_empty_online_list() {
         let missing = tempfile::tempdir().unwrap();
-        assert!(physical_core_count(missing.path()).is_err());
+        assert!(pre_spawn_cpu_capacity_at(missing.path(), 1, &BTreeSet::from([0])).is_err());
 
         let empty = tempfile::tempdir().unwrap();
         std::fs::write(empty.path().join("online"), "\n").unwrap();
-        assert!(physical_core_count(empty.path()).is_err());
+        assert!(pre_spawn_cpu_capacity_at(empty.path(), 1, &BTreeSet::from([0])).is_err());
+    }
+
+    #[test]
+    fn pre_spawn_cpu_capacity_rejects_empty_effective_capacity() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("online"), "0-1").unwrap();
+
+        assert_eq!(
+            pre_spawn_cpu_capacity_at(dir.path(), 1, &BTreeSet::from([2])).unwrap_err(),
+            "online CPUs and process affinity do not overlap"
+        );
+        assert_eq!(
+            pre_spawn_cpu_capacity_at(dir.path(), 0, &BTreeSet::from([0])).unwrap_err(),
+            "available logical CPU count is zero"
+        );
+    }
+
+    #[test]
+    fn pre_spawn_cpu_capacity_sources_are_stable() {
+        assert_eq!(
+            PreSpawnCpuCapacity::ExactPhysical(1).source(),
+            "physical_topology"
+        );
+        assert_eq!(
+            PreSpawnCpuCapacity::RestrictedPhysical(1).source(),
+            "restricted_physical_topology"
+        );
+        assert_eq!(
+            PreSpawnCpuCapacity::ConservativeLogical(1).source(),
+            "logical_cpu_fallback"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- restrict physical-core topology accounting to CPUs in the Runner process affinity mask
- cap the resulting pre-spawn admission capacity by `available_parallelism()` so CPU quota remains authoritative
- expose restricted capacity with a distinct startup source and cover affinity, SMT, quota, fallback, and malformed-topology behavior

## Scope

This changes only the Runner startup calculation for the process-local pre-spawn admission gate. It does not change permit weights or lifetime, exact-reuse behavior, the whole-run resource budget, Firecracker placement, APIs, queues, persistence, or guest protocols.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner host::tests -- --nocapture`
- `cargo test -p runner --all-targets --all-features`
- `cargo build -p runner`
- repository pre-commit and commit-message hooks

Closes #31041
