### PR TITLE
fix(desktop): offer every space in the window picker and let it be dismissed

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/RecordableWindowPolicy.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/RecordableWindowPolicy.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Decides which of the system's windows the picker may offer.
+///
+/// The recorder reads every Space rather than only the active one, so a
+/// full-screen editor or browser is offerable too. That wider read also carries
+/// the system's own surfaces — menu bar extras, the Dock, notification banners —
+/// which are never what someone means to record. They sit above the normal
+/// window layer, and that is what separates them here.
+public enum RecordableWindowPolicy {
+    /// The layer ordinary application windows live on. Everything the system
+    /// floats above them — status items, the Dock, banners — is numbered higher.
+    public static let applicationWindowLayer = 0
+
+    /// Whether a window belongs in the picker.
+    ///
+    /// An untitled window is refused as well: the picker labels each choice with
+    /// its title, and a nameless tile is worse than one fewer choice.
+    public static func isRecordable(title: String?, windowLayer: Int) -> Bool {
+        guard let title, !title.isEmpty else {
+            return false
+        }
+        return windowLayer == applicationWindowLayer
+    }
+}

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
@@ -99,9 +99,13 @@ private func shareableContent(timeout: TimeInterval = 10) throws -> SCShareableC
     }
     let semaphore = DispatchSemaphore(value: 0)
     let box = ResultBox<SCShareableContent>()
+    // `onScreenWindowsOnly` is off because "on screen" means the active Space.
+    // With it on, a full-screen editor or browser living on its own Space was
+    // missing from the picker, and picking it later could not be resolved
+    // either. `recordableWindows` drops the system chrome the wider list adds.
     SCShareableContent.getExcludingDesktopWindows(
         true,
-        onScreenWindowsOnly: true
+        onScreenWindowsOnly: false
     ) { content, error in
         box.set(value: content, error: error)
         semaphore.signal()
@@ -195,6 +199,19 @@ private func handleRequestPermission() -> [String: Any] {
     return ["granted": CGRequestScreenCaptureAccess()]
 }
 
+/// The windows a person could plausibly mean to record.
+///
+/// `recorder.sources` and `recorder.windowPreviews` both go through this so the
+/// two lists line up by window id. `RecordableWindowPolicy` owns the rule.
+private func recordableWindows(_ content: SCShareableContent) -> [SCWindow] {
+    return content.windows.filter { window in
+        return RecordableWindowPolicy.isRecordable(
+            title: window.title,
+            windowLayer: window.windowLayer
+        )
+    }
+}
+
 private func handleSources() throws -> [String: Any] {
     let content = try shareableContent()
     var sources: [[String: Any]] = []
@@ -207,8 +224,8 @@ private func handleSources() throws -> [String: Any] {
         ])
     }
 
-    for window in content.windows {
-        guard let title = window.title, !title.isEmpty else {
+    for window in recordableWindows(content) {
+        guard let title = window.title else {
             continue
         }
         var source: [String: Any] = [
@@ -295,12 +312,9 @@ private func handleWindowPreviews() throws -> [String: Any] {
     let content = try shareableContent()
     let deadline = Date().addingTimeInterval(windowPreviewBudget)
     var previews: [[String: Any]] = []
-    for window in content.windows {
+    for window in recordableWindows(content) {
         guard previews.count < windowPreviewLimit, Date() < deadline else {
             break
-        }
-        guard let title = window.title, !title.isEmpty else {
-            continue
         }
         guard let dataUrl = windowPreview(window) else {
             continue

--- a/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/RecordableWindowPolicyTests.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/RecordableWindowPolicyTests.swift
@@ -1,0 +1,45 @@
+import Testing
+
+@testable import ScreenRecorderCore
+
+struct RecordableWindowPolicyTests {
+    @Test
+    func offersAnOrdinaryApplicationWindow() {
+        #expect(
+            RecordableWindowPolicy.isRecordable(
+                title: "Quarterly plan",
+                windowLayer: RecordableWindowPolicy.applicationWindowLayer
+            )
+        )
+    }
+
+    @Test
+    func refusesTheSystemSurfacesThatFloatAboveWindows() {
+        // Reading every Space brings menu bar extras and the Dock along with the
+        // real windows. One Mac listed a dozen of them, titled after their
+        // owning process, ahead of any document.
+        #expect(
+            !RecordableWindowPolicy.isRecordable(title: "Menubar", windowLayer: 25)
+        )
+        #expect(
+            !RecordableWindowPolicy.isRecordable(title: "StatusIndicator", windowLayer: 25)
+        )
+        #expect(!RecordableWindowPolicy.isRecordable(title: "Dock", windowLayer: 20))
+    }
+
+    @Test
+    func refusesAWindowThePickerCouldNotLabel() {
+        #expect(
+            !RecordableWindowPolicy.isRecordable(
+                title: nil,
+                windowLayer: RecordableWindowPolicy.applicationWindowLayer
+            )
+        )
+        #expect(
+            !RecordableWindowPolicy.isRecordable(
+                title: "",
+                windowLayer: RecordableWindowPolicy.applicationWindowLayer
+            )
+        )
+    }
+}

--- a/turbo/apps/desktop/src/renderer/recorder/recorder-bar.test.tsx
+++ b/turbo/apps/desktop/src/renderer/recorder/recorder-bar.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DesktopRecorderApi } from "../../desktop-bridge";
+import type { DesktopRecorderWindowChoice } from "../../desktop-recorder-types";
+
+interface RecorderStub {
+  readonly api: DesktopRecorderApi;
+  readonly completeWindowSelection: ReturnType<typeof vi.fn>;
+  /** Answers the pending `selectWindow`, the way the picker window does. */
+  readonly pick: (choice: DesktopRecorderWindowChoice) => void;
+}
+
+function installRecorder(): RecorderStub {
+  const completeWindowSelection = vi.fn(async () => {
+    return await Promise.resolve();
+  });
+  let answer: ((choice: DesktopRecorderWindowChoice | null) => void) | null =
+    null;
+  const api = {
+    getCapabilities: async () => {
+      return await Promise.resolve({ supportsMicrophone: true });
+    },
+    selectWindow: async () => {
+      return await new Promise<DesktopRecorderWindowChoice | null>(
+        (resolve) => {
+          answer = resolve;
+        },
+      );
+    },
+    completeWindowSelection,
+    beginAreaSelection: async () => {
+      return await Promise.resolve();
+    },
+    startCapture: async () => {
+      return await Promise.resolve();
+    },
+    cancel: async () => {
+      return await Promise.resolve();
+    },
+  } as unknown as DesktopRecorderApi;
+  vi.stubGlobal("vm0DesktopRecorder", api);
+  return {
+    api,
+    completeWindowSelection,
+    pick: (choice) => {
+      answer?.(choice);
+    },
+  };
+}
+
+/**
+ * The bar reads the bridge once when its module loads, so the stub has to be in
+ * place before the import rather than before the render.
+ */
+async function renderBar(): Promise<void> {
+  const { RecorderBar } = await import("./recorder-bar");
+  render(<RecorderBar />);
+  await waitFor(() => {
+    expect(screen.getByText("Display")).toBeTruthy();
+  });
+}
+
+function clickSource(label: string): void {
+  const button = screen
+    .getByText(label)
+    .closest("button") as HTMLButtonElement | null;
+  if (!button) {
+    throw new Error(`Expected a source button labelled ${label}`);
+  }
+  button.click();
+}
+
+describe("RecorderBar", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("names the window mode after the mode, not the window it landed on", async () => {
+    const recorder = installRecorder();
+    await renderBar();
+
+    clickSource("Window");
+    recorder.pick({ sourceId: "window:9", title: "Menubar" });
+
+    // A window called "Menubar" used to rename the button, so the row read
+    // Display / Menubar / Area and looked like three capture modes.
+    await waitFor(() => {
+      expect(screen.getByText("Menubar")).toBeTruthy();
+    });
+    expect(screen.getByText("Window")).toBeTruthy();
+    const button = screen.getByText("Window").closest("button");
+    expect(button?.getAttribute("title")).toBe("Menubar");
+    expect(button?.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("abandons an open window pick when the display is chosen instead", async () => {
+    const recorder = installRecorder();
+    await renderBar();
+
+    clickSource("Window");
+    clickSource("Display");
+
+    // Leaving the pick pending kept the picker floating over everything and
+    // surfaced Electron's "reply was never sent" once the bar went away.
+    await waitFor(() => {
+      expect(recorder.completeWindowSelection).toHaveBeenCalledWith(null);
+    });
+    expect(
+      screen
+        .getByText("Display")
+        .closest("button")
+        ?.getAttribute("aria-pressed"),
+    ).toBe("true");
+  });
+
+  it("abandons an open window pick when an area is chosen instead", async () => {
+    const recorder = installRecorder();
+    await renderBar();
+
+    clickSource("Window");
+    clickSource("Area");
+
+    await waitFor(() => {
+      expect(recorder.completeWindowSelection).toHaveBeenCalledWith(null);
+    });
+  });
+});

--- a/turbo/apps/desktop/src/renderer/recorder/recorder-bar.tsx
+++ b/turbo/apps/desktop/src/renderer/recorder/recorder-bar.tsx
@@ -75,10 +75,23 @@ export function RecorderBar(): React.ReactElement {
       });
   }, []);
 
+  /**
+   * Abandons an open window pick.
+   *
+   * `selectWindow` stays pending until something answers it. Leaving it open
+   * while the user moves on left the picker floating over every other choice,
+   * and tearing the bar down with the call still in flight surfaced Electron's
+   * "reply was never sent" as a recording error.
+   */
+  const abandonWindowChoice = useCallback(() => {
+    void recorder?.completeWindowSelection(null);
+  }, []);
+
   const chooseArea = useCallback(() => {
     if (!recorder) {
       return;
     }
+    abandonWindowChoice();
     setError(null);
     // An area capture is started by the overlay that draws it, so the audio
     // choices travel with the request rather than waiting for Start here.
@@ -91,7 +104,7 @@ export function RecorderBar(): React.ReactElement {
             : "Could not select a region",
         );
       });
-  }, [microphone, systemAudio]);
+  }, [abandonWindowChoice, microphone, systemAudio]);
 
   const start = useCallback(() => {
     if (!recorder) {
@@ -137,6 +150,7 @@ export function RecorderBar(): React.ReactElement {
           className="recorder-bar__source"
           aria-pressed={choice.kind === "display"}
           onClick={() => {
+            abandonWindowChoice();
             setChoice({ kind: "display" });
           }}
         >
@@ -148,12 +162,17 @@ export function RecorderBar(): React.ReactElement {
           type="button"
           className="recorder-bar__source"
           aria-pressed={choice.kind === "window"}
+          title={choice.kind === "window" ? choice.title : undefined}
           onClick={chooseWindow}
         >
           <AppWindow size={22} />
-          <span className="recorder-bar__source-label">
-            {choice.kind === "window" ? choice.title : "Window"}
-          </span>
+          {/* The mode keeps its own name. Naming the button after the chosen
+              window made a pick titled "Menubar" read as a third capture mode
+              beside Display and Area; the target belongs under it. */}
+          <span className="recorder-bar__source-label">Window</span>
+          {choice.kind === "window" ? (
+            <span className="recorder-bar__source-target">{choice.title}</span>
+          ) : null}
         </button>
 
         <button

--- a/turbo/apps/desktop/src/renderer/recorder/recorder.css
+++ b/turbo/apps/desktop/src/renderer/recorder/recorder.css
@@ -93,8 +93,10 @@ select {
   gap: 5px;
   box-sizing: border-box;
   width: 88px;
-  height: 64px;
-  padding: 0 6px;
+  /* Grows for the caption naming the chosen window; the row stretches all
+     three together so they stay one control group. */
+  min-height: 64px;
+  padding: 4px 6px;
   border: 1px solid transparent;
   border-radius: 12px;
   background: transparent;
@@ -117,6 +119,18 @@ select {
   display: block;
   max-width: 100%;
   overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+/* The window the pick landed on, subordinate to the mode name above it. */
+.recorder-bar__source-target {
+  display: block;
+  max-width: 100%;
+  margin-top: -2px;
+  overflow: hidden;
+  color: rgb(245 245 247 / 55%);
+  font-size: 10px;
   white-space: nowrap;
   text-overflow: ellipsis;
 }


### PR DESCRIPTION
Three defects found while recording with the bar, all in the window picker added by #30966.

## 1. The picker only listed the active Space

`SCShareableContent.getExcludingDesktopWindows` was called with `onScreenWindowsOnly: true`. On macOS "on screen" means the current Space, so a full-screen editor or browser on its own Space never appeared — and could not be recorded at all, since the same read resolves the capture target later. Reported with ChatGPT and VS Code missing while both were open in their own Spaces.

Now read with `onScreenWindowsOnly: false`.

## 2. The wider read listed the system's own chrome

Reading every Space also returns menu bar extras, the Dock, and notification banners. They were shown as ordinary choices titled after their owning process — the picker offered `Menubar`, `Menubar`, `StatusIndicator` ahead of any document.

New `RecordableWindowPolicy` keeps only windows on the ordinary application layer, which is where real windows live and where none of that chrome does. `recorder.sources` and `recorder.windowPreviews` both go through it, so the two lists still line up by window id.

## 3. Leaving Window mode left the pick pending

`selectWindow` resolves only when something answers it. Clicking `Display` or `Area` answered nothing, so:

- the picker stayed floating on top of everything, and
- tearing the bar down with the call still in flight surfaced Electron's `Error invoking remote method 'desktop-recorder:select-window': reply was never sent` as a recording error — visible for a moment before the recording started normally.

Both paths now abandon the open pick first.

## 4. The mode button was renamed after the chosen window

`Window` was replaced by the chosen window's title, so picking a window called `Menubar` produced a button reading `Menubar` sitting between `Display` and `Area` — it read as a third capture mode. The button keeps its own name; the target is shown underneath and in the tooltip.

## Testing

- `pnpm -F @okouai/desktop check-types` — clean
- `pnpm -F @okouai/desktop lint` — clean
- `pnpm -F @okouai/desktop exec vitest run` — 477 passed, 2 failed in `bootstrap-degraded.test.ts`; both fail identically on unmodified `main` (`3d08aa1`) in this container and are unrelated to this change (auto-update mocks)

New coverage:

- `RecordableWindowPolicyTests` covers the layer rule — an ordinary window is offered, menu bar extras and the Dock are refused, and an untitled window the picker could not label is refused.
- `recorder-bar.test.tsx` covers the two renderer regressions. Each case was confirmed to fail against the pre-fix bar: the mode button renamed itself after a window titled `Menubar`, and choosing `Display` or `Area` never called `completeWindowSelection`, which is what left the picker floating and produced the "reply was never sent" error.

The Swift helper cannot be compiled in a Linux container. The `Desktop` workflow builds and tests it on `macos-latest` for this PR, which is where `RecordableWindowPolicy`, the changed `main.swift`, and the new Swift tests get exercised.

`onScreenWindowsOnly: false` itself has no unit test — it is a single ScreenCaptureKit call flag with no seam to assert on. The filtering it makes necessary is what `RecordableWindowPolicy` covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
