### PR TITLE
refactor(api): drop the feishu events compatibility row

### DIFF
--- a/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
+++ b/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
@@ -133,14 +133,10 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   // #28461. #30807 removed the four per-agent rows.
   "/api/workflows": ["/api/okou/workflows", "/api/zero/workflows"],
   // #28544: the two Feishu routes that left `FINAL_PROVIDER_CONSOLE_PATHS`.
-  // Both branded forms used to be the declared paths, so this row is the only
-  // thing registering them now — it is what keeps the two production Feishu
-  // installations delivering to the URL each of them holds in its own Feishu
-  // app console.
-  "/api/webhooks/feishu/events/:installationId": [
-    "/api/okou/feishu/events/:installationId",
-    "/api/zero/feishu/events/:installationId",
-  ],
+  // #28709 removed the OAuth callback, and #31068 removed the events row as an
+  // owner decision rather than on evidence: both production installations still
+  // hold the branded URL in their own Feishu app console, so removing it stops
+  // their deliveries, and the owner accepted that after notifying both holders.
   // #28565: the connector-account reads and writes and the managed SocialKit
   // request, the two contracts that were added while #28278 was in flight and
   // so appeared in no slice's inventory.
@@ -333,11 +329,11 @@ describe("branded paths for migrated neutral routes", () => {
   // rows that left 62, #30668 kept when it took the four Slack rows whose
   // producer moved and left 58, #30804 kept when it took the four Computer Use
   // host rows and `feature-switches` and left 53, #30812 kept when it took
-  // the Teams OAuth callback and the Slack connect start and left 51, and
-  // #30807 kept when it took forty-four rows as a class and left 7. None of
-  // them left a case asserting the removed rows now 404: `docs/fallback.md`
-  // section 1 rules that class out, and the route table already proves the
-  // registration is gone.
+  // the Teams OAuth callback and the Slack connect start and left 51, #30807
+  // kept when it took forty-four rows as a class and left 7, and #31068 kept
+  // when it took the Feishu events row and left 6. None of them left a case
+  // asserting the removed rows now 404: `docs/fallback.md` section 1 rules that
+  // class out, and the route table already proves the registration is gone.
   // What needs a test is the opposite direction — a row disappearing without
   // the request-log evidence #26701 requires — which is what this count and the
   // per-family cases catch.
@@ -349,7 +345,7 @@ describe("branded paths for migrated neutral routes", () => {
   // whole table. Raise the number only with that evidence; an unexplained edit
   // here is the failure this is for.
   it("holds the branded rows this suite has evidence for and no others", () => {
-    const MIGRATED_BRANDED_ROW_COUNT = 7;
+    const MIGRATED_BRANDED_ROW_COUNT = 6;
 
     expect(Object.keys(MIGRATED_ROUTE_PATHS)).toHaveLength(
       MIGRATED_BRANDED_ROW_COUNT,

--- a/turbo/apps/api/src/signals/route-entry.ts
+++ b/turbo/apps/api/src/signals/route-entry.ts
@@ -343,6 +343,21 @@ export function withApiNamespaceAliases(
  * also removed both halves of the loop this row completes, so that build can no
  * longer be handed a command to complete: the reader has outlived its producer,
  * which is `docs/fallback.md` section 5.
+ *
+ * #31068 then took the Feishu events row, leaving 6, and it is the one removal
+ * here that no evidence supports. #30817 held the row back for a reason that
+ * still holds: both production installations pasted the branded URL into their
+ * own Feishu app console, which we cannot edit, so their silence measures how
+ * quiet they are rather than whether the console moved. `feishuCallbackUrl`
+ * only began handing out the neutral path in `bc505642` (#28341, 2026-08-20),
+ * and both installations were created before it — 2026-07-27 and 2026-08-04,
+ * each with a `callback_verified_at` minutes later against the branded path and
+ * no re-verification since. Removing this row therefore stops delivery to both,
+ * and it fails silently: the bot goes quiet with no error surfaced to either
+ * holder. The owner made that call on 2026-09-02, notifying both holders
+ * directly, because recovery is one copy of the neutral URL from
+ * `app.okou.ai/settings/feishu` back into the Feishu console. This is an owner
+ * decision recorded on #31068, not a drain — do not cite it as one.
  */
 type MigratedBrandedPathTable = Readonly<Record<string, readonly string[]>>;
 
@@ -493,39 +508,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   // the contract moved. Both forms are owed, and both retire under #26701's
   // evidence rules rather than on either clock.
   "/api/workflows": ["/api/okou/workflows", "/api/zero/workflows"],
-  // #28544: the Feishu routes that were classified as console-held without a
-  // Feishu console actually holding them — the console registers the
-  // frontend-forwarding OAuth target from `feishuOAuthAppCallbackUrl()` rather
-  // than the API callback, and #28338 already moved the events URL shown to
-  // operators.
-  //
-  // The events row is the load-bearing one, and the reason it outlived the
-  // #28709 sweep with no traffic behind it. Each Feishu installation registered
-  // its event subscription URL in its own Feishu app console, which we cannot
-  // edit, so an installation created before #28338 still posts to the branded
-  // form it was given. That holder has no drain window at all — it changes when
-  // its operator edits their own console — so a week without a delivery says
-  // the installation was quiet, not that its console moved. It is also why
-  // #30807's class argument does not reach this row: the producer is a console
-  // we cannot edit rather than a build we ship, and unlike the published Slack
-  // install link #30812 retired, there is nowhere to go and look.
-  //
-  // The slice's other row, the OAuth callback, covered a time-boxed surface
-  // instead: `feishu-oauth-callback-page.ts` forwards the code it received from
-  // the Feishu console's `app.vm0.ai` target to whichever path the contract
-  // declared when that bundle was built, so an already-loaded platform tab kept
-  // posting the branded form for the ~2 day old-web-client window in
-  // `docs/fallback.md` section 7, and the `oauthRedirectUri()` branch behind it
-  // is reached only when `callbackTarget` is absent, which neither frontend
-  // entry point does. That window closed long before the retained log began, so
-  // #28709 removed it.
-  //
-  // The key holds its path parameter verbatim, because the lookup below matches
-  // `entry.route.path` exactly rather than an expanded request path.
-  "/api/webhooks/feishu/events/:installationId": [
-    "/api/okou/feishu/events/:installationId",
-    "/api/zero/feishu/events/:installationId",
-  ],
   // #28600 added the last branded contract paths — the Slack OAuth callback and
   // the three inbound Slack webhooks — and #30668 removed all four. They are
   // the first rows in this table to retire because their producer moved rather

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -2876,36 +2876,34 @@ describe("Feishu integration", () => {
     );
   });
 
-  it("emits the final path and still serves the branded ones", async () => {
+  it("emits the final path and serves it", async () => {
     const fixture = await setupFeishuRunFixture();
     // #28278 step 3 switched this producer: the URL the connect service hands
     // the operator now carries the final path on the unchanged callback origin.
     // Installation ids are UUIDs, so percent-encoding leaves the id verbatim.
+    // #31068 retired this route's `MIGRATED_BRANDED_PATHS` row, so the branded
+    // forms this case used to replay alongside it are no longer registered.
     expect(fixture.callbackUrl).toBe(
       `${FEISHU_CALLBACK_ORIGIN}/api/webhooks/feishu/events/${fixture.installationId}`,
     );
     const event = v2Event(fixture.appId, "unknown.event", {});
-    const eventPaths = [
-      `/api/okou/feishu/events/${fixture.installationId}`,
-      `/api/zero/feishu/events/${fixture.installationId}`,
+    const url = new URL(
       `/api/webhooks/feishu/events/${fixture.installationId}`,
-    ];
+      fixture.callbackUrl,
+    ).toString();
 
-    for (const path of eventPaths) {
-      const url = new URL(path, fixture.callbackUrl).toString();
-      const accepted = await postEvent(url, event, { encrypted: true });
-      expect(accepted.status).toBe(200);
-      await expect(accepted.text()).resolves.toBe("OK");
+    const accepted = await postEvent(url, event, { encrypted: true });
+    expect(accepted.status).toBe(200);
+    await expect(accepted.text()).resolves.toBe("OK");
 
-      const rejected = await postEvent(url, event, {
-        encrypted: true,
-        validSignature: false,
-      });
-      expect(rejected.status).toBe(401);
-      await expect(rejected.json()).resolves.toStrictEqual({
-        error: "Invalid Feishu signature",
-      });
-    }
+    const rejected = await postEvent(url, event, {
+      encrypted: true,
+      validSignature: false,
+    });
+    expect(rejected.status).toBe(401);
+    await expect(rejected.json()).resolves.toStrictEqual({
+      error: "Invalid Feishu signature",
+    });
   });
 
   it("retries a durably admitted Feishu event after dispatch fails", async () => {

--- a/turbo/apps/api/src/signals/services/feishu-config.ts
+++ b/turbo/apps/api/src/signals/services/feishu-config.ts
@@ -70,10 +70,11 @@ export async function loadFeishuInstallationConfig(
 
 /**
  * The event subscription URL an operator registers in their own Feishu Open
- * Platform app. #28278 step 3 switches this producer to the final path; the
- * branded paths stay routable, so installations that already hold the old URL
- * keep delivering events. The hostname carries the installation's product
- * brand while the path and installation ID remain provider-compatible.
+ * Platform app. #28278 step 3 switched this producer to the final path, and
+ * #31068 retired the branded row behind it, so an installation still holding
+ * the old URL in its own Feishu console stops delivering until its operator
+ * copies this one back. The hostname carries the installation's product brand
+ * while the path and installation ID remain provider-compatible.
  */
 export function feishuCallbackUrl(
   installationId: string,


### PR DESCRIPTION
Closes #31068. Part of #26701.

Removes the `/api/webhooks/feishu/events/:installationId` row from
`MIGRATED_BRANDED_PATHS`, so `/api/okou/feishu/events/:installationId` and
`/api/zero/feishu/events/:installationId` are no longer registered.

## This is an owner decision, not a drain

#30817 held this row back and its reasoning still holds: both production
installations hold the branded URL, so zero traffic is not drain evidence.
`feishuCallbackUrl` only moved to the neutral path in `bc505642` (#28341,
2026-08-20); the two installations were created 2026-07-27 and 2026-08-04, each
`callback_verified_at` minutes after creation against the branded path and never
re-verified. Each Feishu app console still points at the path it was given, and
this row is the only thing answering it.

**Removing it breaks both webhooks, and the failure is silent on the Feishu
side** — the bot simply stops responding, with no error surfaced to the holder.
The owner accepted that on 2026-09-02 and is notifying both holders directly
(one an `@okou.ai` colleague, one a personal contact). Recovery is one copy of
the neutral URL from `app.okou.ai/settings/feishu` back into the Feishu console.

## Changes

- `signals/route-entry.ts`: row and its `#28544` slice comment removed. The
  slice comment existed only to justify this row, and its argument is the one
  being retired. A header paragraph records the removal as an owner decision so
  nobody later reads it as a drain precedent.
- `__tests__/migrated-branded-paths.test.ts`: the restated row and the comment
  above it removed — that comment asserted the row "is what keeps the two
  production Feishu installations delivering to the URL each of them holds in
  its own Feishu app console", which is the retired justification.
  `MIGRATED_BRANDED_ROW_COUNT` goes 7 → 6, matching `main`.
- `routes/__tests__/feishu-integration.test.ts`: `emits the final path and still
  serves the branded ones` replayed the two branded paths through the app
  factory and would now fail. It keeps its positive coverage on the neutral path
  and drops the branded replay. No 404 assertion was added in its place:
  `docs/fallback.md` section 1 bans tombstone tests, which is the same call
  #28917 made for the Teams bot endpoint.
- `services/feishu-config.ts`: the `feishuCallbackUrl` doc comment stated "the
  branded paths stay routable, so installations that already hold the old URL
  keep delivering events", which this change makes false.

## Left in place

The two `desktop/updates` rows. They are how a Zero Desktop blocked by the
`hard` migration policy reaches Okou through the Download Okou button; the
caller is an installed macOS build with no refresh equivalent. They retire with
#26364.

Note on scope: `main` currently carries 7 rows, so 6 remain after this — the
`logs/:id`, `slack/oauth/install`, `org` and `workflows` rows are still there
alongside the two `desktop/updates` rows.

## Verification

The table holds `main`'s rows minus this one, the mirror in
`migrated-branded-paths.test.ts` was edited with it (the suite fails if they
diverge), and the count literal matches. The neutral path keeps its full
integration coverage. Per repo guidance, local vitest was not run; CI is the
gate.
