### PR TITLE
fix(platform): align model recovery card with the app card and button language

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1944,11 +1944,10 @@
       "providerIncompatibleAction": "Starten Sie eine neue Sitzung",
       "providerIncompatiblePrefix": "Diese Sitzung wurde bei einem anderen Modellanbieter gestartet und kann nicht mit dem aktuellen fortgesetzt werden.",
       "recovery": {
-        "capacityDescription": "Dieses Modell ist vorübergehend ausgelastet. Versuchen Sie es in einigen Minuten erneut oder wechseln Sie jetzt das Modell.",
-        "capacityTitle": "{{framework}}-Modell ist ausgelastet",
+        "capacityDescription": "Versuchen Sie es gleich erneut oder wechseln Sie das Modell.",
+        "capacityTitle": "Dieses Modell ist gerade ausgelastet",
         "claudeCode": "Claude Code",
         "codex": "Codex",
-        "continue": "Fortfahren",
         "resetAndTryAgain": "Zurücksetzen und erneut versuchen",
         "resetsAt": "Wird um {{time}} zurückgesetzt",
         "selectModel": "Modell wechseln",

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1948,6 +1948,7 @@
         "capacityTitle": "Dieses Modell ist gerade ausgelastet",
         "claudeCode": "Claude Code",
         "codex": "Codex",
+        "continue": "Fortfahren",
         "resetAndTryAgain": "Zurücksetzen und erneut versuchen",
         "resetsAt": "Wird um {{time}} zurückgesetzt",
         "selectModel": "Modell wechseln",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1944,11 +1944,10 @@
       "providerIncompatibleAction": "Start a new session",
       "providerIncompatiblePrefix": "This session was started with a different model provider and can't be continued with the current one.",
       "recovery": {
-        "capacityDescription": "This model is temporarily at capacity. Try again in a few minutes, or switch models now.",
-        "capacityTitle": "{{framework}} model is busy",
+        "capacityDescription": "Try again shortly, or switch models.",
+        "capacityTitle": "This model is busy right now",
         "claudeCode": "Claude Code",
         "codex": "Codex",
-        "continue": "Continue",
         "resetAndTryAgain": "Reset and try again",
         "resetsAt": "Resets {{time}}",
         "selectModel": "Switch model",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1948,6 +1948,7 @@
         "capacityTitle": "This model is busy right now",
         "claudeCode": "Claude Code",
         "codex": "Codex",
+        "continue": "Continue",
         "resetAndTryAgain": "Reset and try again",
         "resetsAt": "Resets {{time}}",
         "selectModel": "Switch model",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1975,11 +1975,10 @@
       "providerIncompatibleAction": "Empieza una nueva sesión",
       "providerIncompatiblePrefix": "Esta sesión se inició con un modelo diferente y no se puede continuar con el actual.",
       "recovery": {
-        "capacityDescription": "Este modelo está temporalmente al límite de capacidad. Inténtalo de nuevo en unos minutos o cambia de modelo ahora.",
-        "capacityTitle": "El modelo de {{framework}} está ocupado",
+        "capacityDescription": "Inténtalo de nuevo en unos minutos o cambia de modelo.",
+        "capacityTitle": "Este modelo está ocupado ahora mismo",
         "claudeCode": "Claude Code",
         "codex": "Codex",
-        "continue": "Continuar",
         "resetAndTryAgain": "Restablecer e intentar de nuevo",
         "resetsAt": "Se restablece {{time}}",
         "selectModel": "Cambiar de modelo",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1979,6 +1979,7 @@
         "capacityTitle": "Este modelo está ocupado ahora mismo",
         "claudeCode": "Claude Code",
         "codex": "Codex",
+        "continue": "Continuar",
         "resetAndTryAgain": "Restablecer e intentar de nuevo",
         "resetsAt": "Se restablece {{time}}",
         "selectModel": "Cambiar de modelo",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1975,11 +1975,10 @@
       "providerIncompatibleAction": "Commencer une nouvelle session",
       "providerIncompatiblePrefix": "Cette session a été commencée avec un fournisseur de modèle différent et ne peut pas être continuée avec le fournisseur actuel.",
       "recovery": {
-        "capacityDescription": "Ce modèle est temporairement saturé. Réessayez dans quelques minutes ou changez de modèle maintenant.",
-        "capacityTitle": "Le modèle {{framework}} est occupé",
+        "capacityDescription": "Réessayez dans quelques instants ou changez de modèle.",
+        "capacityTitle": "Ce modèle est saturé pour le moment",
         "claudeCode": "Claude Code",
         "codex": "Codex",
-        "continue": "Continuer",
         "resetAndTryAgain": "Réinitialiser et réessayer",
         "resetsAt": "Réinitialisation à {{time}}",
         "selectModel": "Changer de modèle",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1979,6 +1979,7 @@
         "capacityTitle": "Ce modèle est saturé pour le moment",
         "claudeCode": "Claude Code",
         "codex": "Codex",
+        "continue": "Continuer",
         "resetAndTryAgain": "Réinitialiser et réessayer",
         "resetsAt": "Réinitialisation à {{time}}",
         "selectModel": "Changer de modèle",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1944,11 +1944,10 @@
       "providerIncompatibleAction": "नया सत्र प्रारंभ करें",
       "providerIncompatiblePrefix": "यह सत्र एक अलग मॉडल प्रोवाइडर के साथ शुरू किया गया था और इसे वर्तमान के साथ जारी नहीं रखा जा सकता है।",
       "recovery": {
-        "capacityDescription": "यह मॉडल अस्थायी रूप से व्यस्त है। कुछ मिनट बाद फिर कोशिश करें, या अभी मॉडल बदलें।",
-        "capacityTitle": "{{framework}} मॉडल व्यस्त है",
+        "capacityDescription": "थोड़ी देर बाद फिर कोशिश करें, या मॉडल बदलें।",
+        "capacityTitle": "यह मॉडल अभी व्यस्त है",
         "claudeCode": "Claude Code",
         "codex": "Codex",
-        "continue": "जारी रखें",
         "resetAndTryAgain": "रीसेट करके फिर कोशिश करें",
         "resetsAt": "{{time}} पर रीसेट होगा",
         "selectModel": "मॉडल बदलें",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1948,6 +1948,7 @@
         "capacityTitle": "यह मॉडल अभी व्यस्त है",
         "claudeCode": "Claude Code",
         "codex": "Codex",
+        "continue": "जारी रखें",
         "resetAndTryAgain": "रीसेट करके फिर कोशिश करें",
         "resetsAt": "{{time}} पर रीसेट होगा",
         "selectModel": "मॉडल बदलें",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1941,11 +1941,10 @@
       "providerIncompatibleAction": "Mulai sesi baru",
       "providerIncompatiblePrefix": "Sesi ini dimulai dengan provider model yang berbeda dan tidak bisa dilanjutkan dengan yang saat ini.",
       "recovery": {
-        "capacityDescription": "Model ini sementara mencapai kapasitas. Coba lagi dalam beberapa menit, atau ganti model sekarang.",
-        "capacityTitle": "Model {{framework}} sedang sibuk",
+        "capacityDescription": "Coba lagi sebentar lagi, atau ganti model.",
+        "capacityTitle": "Model ini sedang sibuk",
         "claudeCode": "Claude Code",
         "codex": "Codex",
-        "continue": "Lanjutkan",
         "resetAndTryAgain": "Atur ulang dan coba lagi",
         "resetsAt": "Direset pada {{time}}",
         "selectModel": "Ganti model",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1945,6 +1945,7 @@
         "capacityTitle": "Model ini sedang sibuk",
         "claudeCode": "Claude Code",
         "codex": "Codex",
+        "continue": "Lanjutkan",
         "resetAndTryAgain": "Atur ulang dan coba lagi",
         "resetsAt": "Direset pada {{time}}",
         "selectModel": "Ganti model",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1975,11 +1975,10 @@
       "providerIncompatibleAction": "Inizia una nuova sessione",
       "providerIncompatiblePrefix": "Questa sessione è stata avviata con un provider di modelli diverso e non può continuare con quello attuale.",
       "recovery": {
-        "capacityDescription": "Questo modello è temporaneamente al limite della capacità. Riprova tra qualche minuto oppure cambia modello ora.",
-        "capacityTitle": "Il modello {{framework}} è occupato",
+        "capacityDescription": "Riprova tra poco oppure cambia modello.",
+        "capacityTitle": "Questo modello è occupato in questo momento",
         "claudeCode": "Claude Code",
         "codex": "Codex",
-        "continue": "Continua",
         "resetAndTryAgain": "Reimposta e riprova",
         "resetsAt": "Ripristino alle {{time}}",
         "selectModel": "Cambia modello",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1979,6 +1979,7 @@
         "capacityTitle": "Questo modello è occupato in questo momento",
         "claudeCode": "Claude Code",
         "codex": "Codex",
+        "continue": "Continua",
         "resetAndTryAgain": "Reimposta e riprova",
         "resetsAt": "Ripristino alle {{time}}",
         "selectModel": "Cambia modello",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1945,6 +1945,7 @@
         "capacityTitle": "このモデルは現在混雑しています",
         "claudeCode": "Claude Code",
         "codex": "Codex",
+        "continue": "続ける",
         "resetAndTryAgain": "リセットして再試行",
         "resetsAt": "{{time}} にリセット",
         "selectModel": "モデルを切り替える",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1941,11 +1941,10 @@
       "providerIncompatibleAction": "新しいセッションを開始する",
       "providerIncompatiblePrefix": "このセッションは別のモデル プロバイダーで開始されたため、現在のモデル プロバイダーでは続行できません。",
       "recovery": {
-        "capacityDescription": "このモデルは一時的に混雑しています。数分後にもう一度試すか、今すぐ別のモデルに切り替えてください。",
-        "capacityTitle": "{{framework}} モデルは混雑しています",
+        "capacityDescription": "少ししてからもう一度試すか、別のモデルに切り替えてください。",
+        "capacityTitle": "このモデルは現在混雑しています",
         "claudeCode": "Claude Code",
         "codex": "Codex",
-        "continue": "続ける",
         "resetAndTryAgain": "リセットして再試行",
         "resetsAt": "{{time}} にリセット",
         "selectModel": "モデルを切り替える",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1941,11 +1941,10 @@
       "providerIncompatibleAction": "새 세션 시작",
       "providerIncompatiblePrefix": "이 세션은 다른 모델 공급자로 시작되어 현재 공급자로 계속할 수 없습니다.",
       "recovery": {
-        "capacityDescription": "이 모델은 일시적으로 사용량이 많습니다. 몇 분 후 다시 시도하거나 지금 다른 모델로 전환하세요.",
-        "capacityTitle": "{{framework}} 모델이 혼잡합니다",
+        "capacityDescription": "잠시 후 다시 시도하거나 다른 모델로 전환하세요.",
+        "capacityTitle": "이 모델은 지금 혼잡합니다",
         "claudeCode": "Claude Code",
         "codex": "Codex",
-        "continue": "계속",
         "resetAndTryAgain": "재설정하고 다시 시도",
         "resetsAt": "{{time}}에 재설정",
         "selectModel": "모델 전환",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1945,6 +1945,7 @@
         "capacityTitle": "이 모델은 지금 혼잡합니다",
         "claudeCode": "Claude Code",
         "codex": "Codex",
+        "continue": "계속",
         "resetAndTryAgain": "재설정하고 다시 시도",
         "resetsAt": "{{time}}에 재설정",
         "selectModel": "모델 전환",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1979,6 +1979,7 @@
         "capacityTitle": "Este modelo está ocupado no momento",
         "claudeCode": "Claude Code",
         "codex": "Codex",
+        "continue": "Continuar",
         "resetAndTryAgain": "Redefinir e tentar novamente",
         "resetsAt": "Redefine {{time}}",
         "selectModel": "Trocar modelo",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1975,11 +1975,10 @@
       "providerIncompatibleAction": "Iniciar uma nova sessão",
       "providerIncompatiblePrefix": "Esta sessão foi iniciada com um provedor de modelo diferente e não pode continuar com o atual.",
       "recovery": {
-        "capacityDescription": "Este modelo está temporariamente sem capacidade. Tente novamente em alguns minutos ou troque de modelo agora.",
-        "capacityTitle": "O modelo {{framework}} está ocupado",
+        "capacityDescription": "Tente novamente em instantes ou troque de modelo.",
+        "capacityTitle": "Este modelo está ocupado no momento",
         "claudeCode": "Claude Code",
         "codex": "Codex",
-        "continue": "Continuar",
         "resetAndTryAgain": "Redefinir e tentar novamente",
         "resetsAt": "Redefine {{time}}",
         "selectModel": "Trocar modelo",

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -730,22 +730,24 @@ body {
    the transcript carried two radii, four border tokens and three fills.
 
    `zero-chat-frame` is the same recipe without the fill, for the frames that
-   own their background (a video stage is black, not white). */
-.zero-app .zero-chat-card,
-.zero-app .zero-chat-frame {
-  border: 0.7px solid hsl(var(--gray-400));
-  border-radius: var(--zero-chat-card-radius);
-  box-shadow: var(--zero-chat-card-shadow);
-}
-.zero-app .zero-chat-card {
-  background-color: hsl(var(--card));
-}
-/* These rules are unlayered, so they outrank Tailwind's `utilities` layer: a
-   `hover:border-*` utility on the same element would never apply. Clickable
-   chat cards opt into their hover border here instead, mirroring
-   `.zero-card.cursor-pointer:hover` below. */
-.zero-app .zero-chat-card-interactive:hover {
-  border-color: hsl(var(--gray-500));
+   own their background (a video stage is black, not white).
+
+   These live in `@layer components` on purpose. Unlayered rules outrank every
+   Tailwind utility regardless of specificity, which would silently kill any
+   `border-*`, `bg-*`, or `hover:*` a caller composes onto the same element —
+   the selected and hover states of the browser session card, for instance.
+   Inside `components`, the utilities layer still wins, so this stays a base
+   that callers can override. */
+@layer components {
+  .zero-app .zero-chat-card,
+  .zero-app .zero-chat-frame {
+    border: 0.7px solid hsl(var(--gray-400));
+    border-radius: var(--zero-chat-card-radius);
+    box-shadow: var(--zero-chat-card-shadow);
+  }
+  .zero-app .zero-chat-card {
+    background-color: hsl(var(--card));
+  }
 }
 
 /* White card: shared border, radius (all white cards except chat bubbles) */

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -544,6 +544,9 @@ body {
   --zero-composer-radius: 1.5rem;
   --zero-card-shadow:
     0 2px 12px hsl(220 12% 50% / 0.04), 0 0 0 0.5px hsl(220 12% 50% / 0.02);
+  /* A card inside a message is not elevated off the page the way a page-level
+     card is, so it gets contact rather than lift: a 2px blur instead of 12px. */
+  --zero-chat-card-shadow: 0 1px 2px hsl(220 12% 50% / 0.04);
   /* Static focus veil for the composer. Fading this layer through opacity lets
      the browser composite it without interpolating the wide blur every frame. */
   --zero-composer-focus-veil: 0 10px 48px -8px hsl(220 14% 50% / 0.08);
@@ -559,6 +562,7 @@ body {
   --zero-card-shadow:
     0 2px 12px hsl(var(--state-layer) / 0.035),
     0 0 0 0.5px hsl(var(--state-layer) / 0.018);
+  --zero-chat-card-shadow: 0 1px 2px hsl(var(--state-layer) / 0.035);
   --zero-composer-focus-veil: 0 10px 48px -8px hsl(var(--state-layer) / 0.07);
 }
 
@@ -731,7 +735,7 @@ body {
 .zero-app .zero-chat-frame {
   border: 0.7px solid hsl(var(--gray-400));
   border-radius: var(--zero-chat-card-radius);
-  box-shadow: var(--zero-card-shadow);
+  box-shadow: var(--zero-chat-card-shadow);
 }
 .zero-app .zero-chat-card {
   background-color: hsl(var(--card));

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -740,6 +740,13 @@ body {
 .zero-app .zero-chat-card {
   background-color: hsl(var(--card));
 }
+/* These rules are unlayered, so they outrank Tailwind's `utilities` layer: a
+   `hover:border-*` utility on the same element would never apply. Clickable
+   chat cards opt into their hover border here instead, mirroring
+   `.zero-card.cursor-pointer:hover` below. */
+.zero-app .zero-chat-card-interactive:hover {
+  border-color: hsl(var(--foreground) / 0.2);
+}
 
 /* White card: shared border, radius (all white cards except chat bubbles) */
 .zero-app .zero-card {

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -745,7 +745,7 @@ body {
    chat cards opt into their hover border here instead, mirroring
    `.zero-card.cursor-pointer:hover` below. */
 .zero-app .zero-chat-card-interactive:hover {
-  border-color: hsl(var(--foreground) / 0.2);
+  border-color: hsl(var(--gray-500));
 }
 
 /* White card: shared border, radius (all white cards except chat bubbles) */

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -537,6 +537,9 @@ body {
 /* Zero app: inherits global cool gray tokens; only card-specific tokens defined here */
 .zero-app {
   --zero-card-radius: 1.25rem;
+  /* Cards rendered inside a chat message sit one level in from the page, so
+     they take one step down the radius scale. */
+  --zero-chat-card-radius: 0.75rem;
   /* The composer is the largest surface on the page and leads the radius scale. */
   --zero-composer-radius: 1.5rem;
   --zero-card-shadow:
@@ -716,6 +719,22 @@ body {
     var(--color-state-hover)
   );
   border-color: hsl(var(--gray-400));
+}
+
+/* Cards inside the chat transcript: notice cards, action cards, artifact and
+   media frames. One surface, one hairline, one shadow, one radius — before this
+   the transcript carried two radii, four border tokens and three fills.
+
+   `zero-chat-frame` is the same recipe without the fill, for the frames that
+   own their background (a video stage is black, not white). */
+.zero-app .zero-chat-card,
+.zero-app .zero-chat-frame {
+  border: 0.7px solid hsl(var(--gray-400));
+  border-radius: var(--zero-chat-card-radius);
+  box-shadow: var(--zero-card-shadow);
+}
+.zero-app .zero-chat-card {
+  background-color: hsl(var(--card));
 }
 
 /* White card: shared border, radius (all white cards except chat bubbles) */

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-results.test.tsx
@@ -1722,14 +1722,14 @@ describe("chat lifecycle", () => {
       name: "Codex model capacity",
       threadId: "e7000000-0000-4000-a000-000000000030",
       error: "Selected model is at capacity. Please try a different model.",
-      title: "Codex model is busy",
+      title: "This model is busy right now",
     },
     {
       name: "Claude Code model capacity",
       threadId: "e7000000-0000-4000-a000-000000000031",
       error:
         "Claude Sonnet 4.6 is overloaded. Please wait a few minutes and try again, or switch to another model.",
-      title: "Claude Code model is busy",
+      title: "This model is busy right now",
     },
   ])(
     "recognizes the latest $name error",
@@ -2137,7 +2137,7 @@ describe("chat lifecycle", () => {
     ).toBeInTheDocument();
 
     fireEvent.keyDown(document, { key: "Escape" });
-    click(buttonByText("Continue", card));
+    click(buttonByText("Try again", card));
     await waitFor(() => {
       expect(retriedPrompt).toBe("continue");
       expect(retriedUserMessage).toMatchObject({
@@ -2234,7 +2234,12 @@ describe("chat lifecycle", () => {
     ).not.toBeInTheDocument();
     expect(sentPrompt).toBeUndefined();
 
-    click(within(card).getByRole("combobox", { name: "GPT 5.6 Sol" }));
+    // The failed model is excluded from the menu, so the trigger must not
+    // present it as the current choice.
+    expect(
+      within(card).queryByRole("combobox", { name: "GPT 5.6 Sol" }),
+    ).not.toBeInTheDocument();
+    click(within(card).getByRole("combobox", { name: "Switch model" }));
     await expect(
       screen.findByRole("option", { name: /GPT 5\.6 Luna/u }),
     ).resolves.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-results.test.tsx
@@ -2234,11 +2234,8 @@ describe("chat lifecycle", () => {
     ).not.toBeInTheDocument();
     expect(sentPrompt).toBeUndefined();
 
-    // The failed model is excluded from the menu, so the trigger must not
-    // present it as the current choice.
-    expect(
-      within(card).queryByRole("combobox", { name: "GPT 5.6 Sol" }),
-    ).not.toBeInTheDocument();
+    // The failed model is excluded from the menu, so the trigger offers the
+    // placeholder rather than a choice the user cannot make.
     click(within(card).getByRole("combobox", { name: "Switch model" }));
     await expect(
       screen.findByRole("option", { name: /GPT 5\.6 Luna/u }),

--- a/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
@@ -465,7 +465,7 @@ function ArtifactDialogCard({
       className={`flex w-full flex-1 flex-col overflow-hidden ${
         fillHeight
           ? "h-full min-h-0 bg-transparent"
-          : "min-h-[420px] rounded-xl border border-border/70 bg-background shadow-sm"
+          : "zero-chat-card min-h-[420px]"
       }`}
       data-testid="artifact-dialog-card"
     >
@@ -849,7 +849,7 @@ function ArtifactDialogVideoBody({
   return (
     <ArtifactDialogStage centered>
       <div
-        className="w-full overflow-hidden rounded-xl border border-border/70 bg-black shadow-sm"
+        className="zero-chat-frame w-full overflow-hidden bg-black"
         data-testid="artifact-dialog-video-stage"
       >
         {resourceUrl !== null && (
@@ -885,7 +885,7 @@ function ArtifactDialogAudioBody({
 
   return (
     <ArtifactDialogStage centered>
-      <div className="flex w-full max-w-[520px] flex-col items-center gap-4 rounded-xl border border-border/70 bg-background p-6 shadow-sm">
+      <div className="zero-chat-card flex w-full max-w-[520px] flex-col items-center gap-4 p-6">
         <span className="flex h-14 w-14 items-center justify-center rounded-2xl border border-border/70 bg-muted/50 text-muted-foreground">
           <FileMusic size={28} />
         </span>
@@ -932,7 +932,7 @@ function ArtifactDialogDocumentFrameBody({
   return (
     <ArtifactDialogStage scrollable={false}>
       <div
-        className="flex h-full min-h-0 w-full flex-1 overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm"
+        className="zero-chat-card flex h-full min-h-0 w-full flex-1 overflow-hidden"
         data-testid="artifact-dialog-document-frame"
       >
         {src !== null && (
@@ -957,7 +957,7 @@ function ArtifactDialogGenericFileBody({ filename }: { filename: string }) {
   const { t } = useTranslation();
   return (
     <ArtifactDialogStage centered>
-      <div className="flex w-full max-w-md flex-col items-center justify-center gap-3 rounded-xl border border-border/70 bg-background p-6 text-center text-muted-foreground shadow-sm">
+      <div className="zero-chat-card flex w-full max-w-md flex-col items-center justify-center gap-3 p-6 text-center text-muted-foreground">
         <p className="text-sm">
           {t(($) => {
             return $.artifacts.preview.noInline;

--- a/turbo/apps/platform/src/views/okou-page/banking-action-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/banking-action-card.tsx
@@ -343,7 +343,7 @@ function BankingActionCardLoading() {
   return (
     <div
       data-testid="banking-action-card-loading"
-      className="flex min-h-[88px] w-full items-center justify-center rounded-lg border border-border/70 bg-background/85 p-3 shadow-sm"
+      className="zero-chat-card flex min-h-[88px] w-full items-center justify-center p-3"
     >
       <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
     </div>
@@ -356,7 +356,7 @@ function BankingActionCardError({ signals }: { signals: BankingSignals }) {
   return (
     <div
       data-testid="banking-action-card-error"
-      className="flex min-h-[88px] w-full items-center gap-3 rounded-lg border border-border/70 bg-background/85 p-3 shadow-sm"
+      className="zero-chat-card flex min-h-[88px] w-full items-center gap-3 p-3"
     >
       <AlertCircle className="h-5 w-5 shrink-0 text-destructive" />
       <div className="min-w-0 flex-1 text-sm text-muted-foreground">
@@ -388,7 +388,7 @@ function LoadedBankingActionCard({
     <div
       data-testid="banking-action-card"
       className={cn(
-        "w-full rounded-lg border border-border/70 bg-background/85 p-3 text-left shadow-sm",
+        "zero-chat-card w-full p-3 text-left",
         compact &&
           "flex min-h-[88px] flex-col gap-3 sm:flex-row sm:items-center sm:justify-between",
       )}

--- a/turbo/apps/platform/src/views/okou-page/browser-session-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/browser-session-card.tsx
@@ -21,7 +21,7 @@ interface BrowserSessionCardProps {
 const BROWSER_SESSION_CARD_SHELL_CLASS =
   "inline-flex w-[min(100%,400px)] align-top";
 const BROWSER_SESSION_CARD_CLASS =
-  "flex w-full flex-col overflow-hidden rounded-lg border border-foreground/10 bg-background text-left text-foreground transition-all duration-200";
+  "zero-chat-card flex w-full flex-col overflow-hidden text-left text-foreground transition-all duration-200";
 const BROWSER_SESSION_CARD_HOVER_CLASS =
   "hover:scale-[1.015] hover:border-foreground/20";
 

--- a/turbo/apps/platform/src/views/okou-page/browser-session-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/browser-session-card.tsx
@@ -23,7 +23,7 @@ const BROWSER_SESSION_CARD_SHELL_CLASS =
 const BROWSER_SESSION_CARD_CLASS =
   "zero-chat-card flex w-full flex-col overflow-hidden text-left text-foreground transition-all duration-200";
 const BROWSER_SESSION_CARD_HOVER_CLASS =
-  "hover:scale-[1.015] hover:border-foreground/20";
+  "zero-chat-card-interactive hover:scale-[1.015]";
 
 function BrowserSessionCardShell({
   children,

--- a/turbo/apps/platform/src/views/okou-page/browser-session-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/browser-session-card.tsx
@@ -23,7 +23,7 @@ const BROWSER_SESSION_CARD_SHELL_CLASS =
 const BROWSER_SESSION_CARD_CLASS =
   "zero-chat-card flex w-full flex-col overflow-hidden text-left text-foreground transition-all duration-200";
 const BROWSER_SESSION_CARD_HOVER_CLASS =
-  "zero-chat-card-interactive hover:scale-[1.015]";
+  "hover:scale-[1.015] hover:border-gray-500";
 
 function BrowserSessionCardShell({
   children,

--- a/turbo/apps/platform/src/views/okou-page/chat-body-cards.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-body-cards.tsx
@@ -416,7 +416,7 @@ function UnavailableActionCard() {
   return (
     <div
       data-testid="unavailable-action-card"
-      className="flex min-h-[88px] w-full items-center gap-3 rounded-lg border border-border/70 bg-background/85 p-3 text-left shadow-sm"
+      className="zero-chat-card flex min-h-[88px] w-full items-center gap-3 p-3 text-left"
     >
       <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40 text-muted-foreground">
         <AlertCircle size={22} />
@@ -565,7 +565,7 @@ function ComputerUseAuthorizationCard({
   return (
     <div
       data-testid="computer-use-authorization-card"
-      className="flex min-h-[88px] w-full flex-col gap-3 rounded-lg border border-border/70 bg-background/85 p-3 text-left shadow-sm sm:flex-row sm:items-center sm:justify-between"
+      className="zero-chat-card flex min-h-[88px] w-full flex-col gap-3 p-3 text-left sm:flex-row sm:items-center sm:justify-between"
     >
       <div className="flex min-w-0 items-center gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40">
@@ -611,7 +611,7 @@ function PlanUpgradeCard({ signals }: { signals: PlanUpgradeSignals }) {
   return (
     <div
       data-testid="plan-upgrade-card"
-      className="flex min-h-[88px] w-full flex-col gap-3 rounded-lg border border-border/70 bg-background/85 p-3 text-left shadow-sm sm:flex-row sm:items-center sm:justify-between"
+      className="zero-chat-card flex min-h-[88px] w-full flex-col gap-3 p-3 text-left sm:flex-row sm:items-center sm:justify-between"
     >
       <div className="flex min-w-0 items-center gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40">
@@ -1225,7 +1225,7 @@ function PermissionActionCardContent({
   return (
     <div
       data-testid="permission-action-card"
-      className="flex min-h-[88px] w-full flex-col gap-3 rounded-lg border border-border/70 bg-background/85 p-3 text-left shadow-sm sm:flex-row sm:items-center sm:justify-between"
+      className="zero-chat-card flex min-h-[88px] w-full flex-col gap-3 p-3 text-left sm:flex-row sm:items-center sm:justify-between"
     >
       <div className="flex min-w-0 items-center gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40">

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -5426,7 +5426,13 @@ function AssistantErrorFallback({ error }: { error: string }) {
 
   if (error.trim().toLowerCase() === "run cancelled") {
     return (
-      <div className="zero-chat-card inline-flex items-center gap-2 px-3 py-1.5 text-[0.9375rem] text-muted-foreground">
+      <div
+        className="inline-flex items-center gap-2 bg-muted/50 px-3 py-1.5 text-[0.9375rem] text-muted-foreground"
+        style={{
+          border: "0.7px solid hsl(var(--border))",
+          borderRadius: "12px",
+        }}
+      >
         <Hand size={14} className="shrink-0" />
         <span>
           {t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -5311,9 +5311,14 @@ function AssistantRecoveryActions({
           }}
         >
           <AssistantRecoveryActionSpinner loading={retrying} />
-          {t(($) => {
-            return $.chat.errors.recovery.tryAgain;
-          })}
+          {/* A timed-out run is resumed, not retried, and its copy says so. */}
+          {recovery.kind === "execution-timeout"
+            ? t(($) => {
+                return $.chat.errors.recovery.continue;
+              })
+            : t(($) => {
+                return $.chat.errors.recovery.tryAgain;
+              })}
         </Button>
       )}
     </div>

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -5247,6 +5247,13 @@ function AssistantRecoveryActions({
   const hasResetAction = recovery.actions.resetAndTryAgain !== null;
   const hasRetryAction = recovery.actions.tryAgain !== null;
   const hasModelSelectionAction = recovery.kind !== "execution-timeout";
+  // `excludedModel` drops the failed model from the menu, so showing it as the
+  // trigger label would offer a choice the user cannot make. Fall back to the
+  // "Switch model" placeholder until they pick something else.
+  const pickerValue =
+    modelSelection && modelSelection.selectedModel === recovery.failedModel
+      ? null
+      : modelSelection;
   const handleModelSelection = (
     selection: ModelProviderSelection | null,
   ): void => {
@@ -5262,6 +5269,8 @@ function AssistantRecoveryActions({
         <Button
           type="button"
           size="sm"
+          variant="outline"
+          className="zero-btn-morandi"
           disabled={retrying || resetting}
           onClick={() => {
             detach(resetAndRetry(pageSignal), Reason.DomCallback);
@@ -5275,7 +5284,7 @@ function AssistantRecoveryActions({
       )}
       {hasModelSelectionAction && (
         <ModelProviderPicker
-          value={modelSelection}
+          value={pickerValue}
           onChange={handleModelSelection}
           placeholder={t(($) => {
             return $.chat.errors.recovery.selectModel;
@@ -5292,7 +5301,10 @@ function AssistantRecoveryActions({
         <Button
           type="button"
           size="sm"
-          variant={hasResetAction ? "outline" : "default"}
+          variant="outline"
+          // Filled neutral leads; the plain outline reads as the secondary
+          // action when reset is also offered.
+          className={hasResetAction ? undefined : "zero-btn-morandi"}
           disabled={retrying || resetting}
           onClick={() => {
             detach(retry(pageSignal), Reason.DomCallback);
@@ -5300,7 +5312,7 @@ function AssistantRecoveryActions({
         >
           <AssistantRecoveryActionSpinner loading={retrying} />
           {t(($) => {
-            return $.chat.errors.recovery.continue;
+            return $.chat.errors.recovery.tryAgain;
           })}
         </Button>
       )}
@@ -5328,6 +5340,11 @@ function AssistantErrorRecoveryCard({
         return $.chat.errors.recovery.unavailableTitle;
       });
     }
+    if (recovery.kind === "model-capacity") {
+      return t(($) => {
+        return $.chat.errors.recovery.capacityTitle;
+      });
+    }
     const framework =
       recovery.framework === "codex"
         ? t(($) => {
@@ -5336,19 +5353,12 @@ function AssistantErrorRecoveryCard({
         : t(($) => {
             return $.chat.errors.recovery.claudeCode;
           });
-    return recovery.kind === "usage-limit"
-      ? t(
-          ($) => {
-            return $.chat.errors.recovery.usageTitle;
-          },
-          { framework },
-        )
-      : t(
-          ($) => {
-            return $.chat.errors.recovery.capacityTitle;
-          },
-          { framework },
-        );
+    return t(
+      ($) => {
+        return $.chat.errors.recovery.usageTitle;
+      },
+      { framework },
+    );
   })();
   const description =
     recovery.kind === "execution-timeout"
@@ -5371,19 +5381,23 @@ function AssistantErrorRecoveryCard({
     <div
       role="status"
       data-testid="assistant-error-recovery"
-      className="rounded-xl border border-border/80 bg-muted/35 p-4 text-foreground"
+      className="zero-card p-4 text-foreground"
     >
-      <div className="flex items-start gap-3">
-        <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-amber-500/10 text-amber-600 dark:text-amber-400">
-          {recovery.kind === "usage-limit" ||
-          recovery.kind === "execution-timeout" ? (
-            <Clock size={17} />
-          ) : (
-            <AlertCircle size={17} />
-          )}
-        </div>
+      <div className="flex items-start gap-2.5">
+        {recovery.kind === "usage-limit" ||
+        recovery.kind === "execution-timeout" ? (
+          <Clock
+            size={16}
+            className="mt-[3px] shrink-0 text-amber-600 dark:text-amber-400"
+          />
+        ) : (
+          <AlertCircle
+            size={16}
+            className="mt-[3px] shrink-0 text-amber-600 dark:text-amber-400"
+          />
+        )}
         <div className="min-w-0 flex-1">
-          <div className="font-medium leading-6">{title}</div>
+          <div className="text-[0.9375rem] font-medium leading-6">{title}</div>
           <p className="mt-0.5 text-sm leading-5 text-muted-foreground">
             {description}
           </p>

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -5166,7 +5166,7 @@ function InsufficientCreditsCard() {
   };
 
   return (
-    <div className="rounded-lg border border-border/60 bg-muted/30 px-3 py-3 max-w-md">
+    <div className="zero-chat-card max-w-md px-3 py-3">
       <p className="text-[0.9375rem] font-medium text-foreground">{headline}</p>
       <p className="mt-1 text-sm text-muted-foreground">{helper}</p>
       {!canShowBillingAction ? null : shouldStartProCheckout ? (
@@ -5264,7 +5264,7 @@ function AssistantRecoveryActions({
   };
 
   return (
-    <div className="mt-3 flex flex-wrap items-center gap-2">
+    <div className="flex shrink-0 flex-wrap items-center gap-2">
       {hasResetAction && (
         <Button
           type="button"
@@ -5289,7 +5289,7 @@ function AssistantRecoveryActions({
           placeholder={t(($) => {
             return $.chat.errors.recovery.selectModel;
           })}
-          triggerClassName="h-8 w-auto min-w-[9rem] bg-background text-sm"
+          triggerClassName="h-8 w-auto bg-background text-sm"
           compactTrigger
           resolveDefaultSelection={false}
           {...(recovery.failedModel
@@ -5386,35 +5386,31 @@ function AssistantErrorRecoveryCard({
     <div
       role="status"
       data-testid="assistant-error-recovery"
-      className="zero-card p-4 text-foreground"
+      className="zero-chat-card flex flex-wrap items-center gap-x-3 gap-y-2 px-3.5 py-2.5 text-foreground"
     >
-      <div className="flex items-start gap-2.5">
+      <div className="flex min-w-0 flex-[1_1_16rem] items-center gap-2.5">
         {recovery.kind === "usage-limit" ||
         recovery.kind === "execution-timeout" ? (
-          <Clock
-            size={16}
-            className="mt-[3px] shrink-0 text-amber-600 dark:text-amber-400"
-          />
+          <Clock size={16} className="shrink-0 text-primary-950" />
         ) : (
-          <AlertCircle
-            size={16}
-            className="mt-[3px] shrink-0 text-amber-600 dark:text-amber-400"
-          />
+          <Coffee size={16} className="shrink-0 text-primary-950" />
         )}
-        <div className="min-w-0 flex-1">
-          <div className="text-[0.9375rem] font-medium leading-6">{title}</div>
-          <p className="mt-0.5 text-sm leading-5 text-muted-foreground">
-            {description}
-          </p>
-          {resetText && (
-            <div className="mt-2 inline-flex items-center gap-1.5 text-sm font-medium text-foreground">
-              <Clock size={14} className="text-muted-foreground" />
-              {resetText}
-            </div>
-          )}
-          <AssistantRecoveryActions recovery={recovery} thread={thread} />
-        </div>
+        <span className="shrink-0 text-[0.9375rem] font-medium leading-6">
+          {title}
+        </span>
+        {/* The row is the point on desktop; on a phone a half-truncated
+            sentence is worse than none, and the title already carries it. */}
+        <span className="hidden min-w-0 flex-1 truncate text-sm text-muted-foreground sm:block">
+          {description}
+        </span>
+        {resetText && (
+          <span className="hidden shrink-0 items-center gap-1.5 text-sm font-medium text-foreground sm:inline-flex">
+            <Clock size={14} className="text-muted-foreground" />
+            {resetText}
+          </span>
+        )}
       </div>
+      <AssistantRecoveryActions recovery={recovery} thread={thread} />
     </div>
   );
 }
@@ -5430,13 +5426,7 @@ function AssistantErrorFallback({ error }: { error: string }) {
 
   if (error.trim().toLowerCase() === "run cancelled") {
     return (
-      <div
-        className="inline-flex items-center gap-2 bg-muted/50 px-3 py-1.5 text-[0.9375rem] text-muted-foreground"
-        style={{
-          border: "0.7px solid hsl(var(--border))",
-          borderRadius: "12px",
-        }}
-      >
+      <div className="zero-chat-card inline-flex items-center gap-2 px-3 py-1.5 text-[0.9375rem] text-muted-foreground">
         <Hand size={14} className="shrink-0" />
         <span>
           {t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx
@@ -46,7 +46,7 @@ function ConnectorAccountActionCardLoading() {
   return (
     <div
       data-testid="connector-account-action-card-loading"
-      className="flex min-h-[104px] w-full items-center justify-center rounded-lg border border-border/70 bg-background/85 p-3 shadow-sm"
+      className="zero-chat-card flex min-h-[104px] w-full items-center justify-center p-3"
     >
       <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
     </div>
@@ -63,7 +63,7 @@ function ConnectorAccountActionCardError({
   return (
     <div
       data-testid="connector-account-action-card-error"
-      className="flex min-h-[104px] w-full items-center gap-3 rounded-lg border border-border/70 bg-background/85 p-3 shadow-sm"
+      className="zero-chat-card flex min-h-[104px] w-full items-center gap-3 p-3"
     >
       <AlertCircle className="h-5 w-5 shrink-0 text-destructive" />
       <div className="min-w-0 flex-1 text-sm text-muted-foreground">
@@ -98,7 +98,7 @@ function UnavailableConnectorAccountActionCard() {
   return (
     <div
       data-testid="connector-account-action-card-unavailable"
-      className="flex min-h-[104px] w-full items-center gap-3 rounded-lg border border-border/70 bg-background/85 p-3 shadow-sm"
+      className="zero-chat-card flex min-h-[104px] w-full items-center gap-3 p-3"
     >
       <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40 text-muted-foreground">
         <AlertCircle size={22} />
@@ -173,7 +173,7 @@ function ReadyConnectorAccountActionCard({
   return (
     <div
       data-testid="connector-account-action-card"
-      className="w-full rounded-lg border border-border/70 bg-background/85 p-3 text-left shadow-sm"
+      className="zero-chat-card w-full p-3 text-left"
     >
       <div className="flex items-start gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40 text-muted-foreground">


### PR DESCRIPTION
Ethan flagged the "Codex model is busy" box in production; Ming reviewed the mockups and picked the direction, then asked for the whole transcript to be brought onto one card style. Design exploration: https://okou-model-busy-recovery-card.okou.app

## One card recipe for the transcript

Cards rendered inside a chat message carried **two radii, four border tokens, three fills and three shadow treatments**:

| Card | Radius | Border | Fill | Shadow |
|---|---|---|---|---|
| Action / connector cards ×11 | 8px | `border/70` | `background/85` | `shadow-sm` |
| Out-of-credits notice | 8px | `border/60` | `muted/30` | none |
| Model-busy notice | 12px | `border/80` | `muted/35` | none |
| Browser session card | 8px | `foreground/10` | `background` | none |
| Artifact / media frames ×5 | 12px | `border/70` | `background` | `shadow-sm` |

This adds `.zero-chat-card` — 12px (`--zero-chat-card-radius`), one 0.7px gray-400 hairline, `--zero-chat-card-shadow`, the card surface — and applies it to all 20 call sites. `.zero-chat-frame` is the same recipe without the fill, for frames that own their background (the video stage is black).

`--zero-chat-card-shadow` is `0 1px 2px`, not the page-level `--zero-card-shadow` (`0 2px 12px`): a card inside a message is not elevated off the page the way a page-level card is. `--zero-card-radius` and `--zero-card-shadow` are untouched, so page cards are unaffected.

The run-cancelled pill keeps its own styling — it is an inline status chip, not a card.

## Model-busy card

- Single-row layout: glyph, headline and reason on one line with the actions on the right, wrapping to a stack below `sm`.
- The description is `hidden sm:block` — on a phone a half-truncated sentence is worse than none, and the headline already carries it.
- `Coffee` glyph in `primary-950` replaces the amber `AlertCircle`. Nothing is broken; the run just needs another go, so the card should not use a warning colour.
- `Continue` → `Try again` on the neutral `zero-btn-morandi` page primary, replacing the brand-orange `default` variant. Brand primary stays inside dialogs. The `execution-timeout` branch keeps `Continue`, because a timed-out run is resumed rather than retried and its copy says "Continue to keep working".
- `capacityTitle` drops its `{{framework}}` interpolation in all 10 locales. `failedModel` is only populated on the `model-unavailable` branch, so that slot always resolved to the framework name — printed directly above a picker listing model names. Naming the failed model needs the run's model recorded on the chat event, which is a separate change.
- The picker loses `min-w-[9rem]`, which parked the chevron ~40px from its label.

## Picker fix

When `excludedModel` removes the failed model from the menu, the trigger no longer displays that model as the current selection; it falls back to the `Switch model` placeholder so the label and the menu agree. Covered by an updated assertion in `chat-run-results.test.tsx`.

## Verification

- `pnpm -F @okouai/app check-types` — pass
- `pnpm -F @okouai/app lint` (includes `lint:i18n`) — pass
- `pnpm knip --workspace apps/platform` — pass
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-run-results.test.tsx` — 41/41 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
