### PR TITLE
perf(api): attribute goal queue load phases

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -98,6 +98,8 @@ const GOAL_DRAIN_SUCCESS_TIMING_ACTION_TYPES = [
   ...GOAL_SCHEDULER_TIMING_ACTION_TYPES,
   "api_dispatch_pre_create_zero_goal_drain_event_queue_age",
   "api_dispatch_pre_create_zero_goal_drain_load_event",
+  "api_dispatch_pre_create_zero_goal_drain_load_event_lock_thread",
+  "api_dispatch_pre_create_zero_goal_drain_load_event_select_candidate",
   "api_dispatch_pre_create_zero_goal_drain_load_target",
   "api_dispatch_pre_create_zero_goal_drain_resolve_model_context",
   "api_dispatch_pre_create_zero_goal_drain_model_context_load_initial_feature_switches",

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -149,6 +149,8 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_pre_create_zero_goal_drain_scheduler_goal_handoff"
   | "api_dispatch_pre_create_zero_goal_drain_event_queue_age"
   | "api_dispatch_pre_create_zero_goal_drain_load_event"
+  | "api_dispatch_pre_create_zero_goal_drain_load_event_lock_thread"
+  | "api_dispatch_pre_create_zero_goal_drain_load_event_select_candidate"
   | "api_dispatch_pre_create_zero_goal_drain_load_target"
   | "api_dispatch_pre_create_zero_goal_drain_revoke_invalid_event"
   | "api_dispatch_pre_create_zero_goal_drain_resolve_model_context"

--- a/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
@@ -27,6 +27,10 @@ import {
   canonicalChatEventGoalId,
   canonicalChatEventUserMessage,
 } from "./canonical-chat-event-read.service";
+import type {
+  ApiDispatchTimingCollector,
+  ApiDispatchTimingDimensions,
+} from "./api-dispatch-timing.service";
 
 const goalInputRevoker = alias(chatEvents, "goal_input_revoker");
 
@@ -126,56 +130,75 @@ export async function admitGoalQueueEvent(
 /** Load the next runnable goal trigger. */
 export async function loadNextGoalQueueEvent(
   db: Db,
-  chatThreadId: string,
-  queueItemCreatedBefore?: Date,
+  args: {
+    readonly chatThreadId: string;
+    readonly queueItemCreatedBefore: Date | undefined;
+    readonly timing: ApiDispatchTimingCollector;
+    readonly timingDimensions: ApiDispatchTimingDimensions;
+  },
 ): Promise<PendingGoalQueueEvent | null> {
   return await db.transaction(async (tx) => {
-    if (!(await lockChatQueueThread(tx, chatThreadId))) {
+    const threadExists = await args.timing.measure(
+      "api_dispatch_pre_create_zero_goal_drain_load_event_lock_thread",
+      "nested",
+      async () => {
+        return await lockChatQueueThread(tx, args.chatThreadId);
+      },
+      args.timingDimensions,
+    );
+    if (!threadExists) {
       return null;
     }
 
-    const [event] = await tx
-      .select({
-        id: chatEvents.id,
-        chatThreadId: chatEvents.chatThreadId,
-        userId: chatThreads.userId,
-        orgId: agents.orgId,
-        goalId: canonicalChatEventGoalId(),
-        createdAt: chatEvents.createdAt,
-      })
-      .from(chatEvents)
-      .innerJoin(chatThreads, eq(chatThreads.id, chatEvents.chatThreadId))
-      .innerJoin(agents, eq(agents.id, chatThreads.agentId))
-      .where(
-        and(
-          eq(chatEvents.chatThreadId, chatThreadId),
-          pendingChatQueueEventCondition(tx),
-          chatEventTypeIn(["input.goal"]),
-          queueItemCreatedBefore
-            ? lt(chatEvents.createdAt, queueItemCreatedBefore)
-            : undefined,
-          notExists(
-            tx
-              .select({ id: chatEvents.id })
-              .from(chatEvents)
-              .where(
-                and(
-                  eq(chatEvents.chatThreadId, chatThreadId),
-                  pendingChatQueueEventCondition(tx),
-                  chatEventTypeIn(["input.prompt", "input.automation"]),
-                  queueItemCreatedBefore
-                    ? lt(chatEvents.createdAt, queueItemCreatedBefore)
-                    : undefined,
-                ),
+    const [event] = await args.timing.measure(
+      "api_dispatch_pre_create_zero_goal_drain_load_event_select_candidate",
+      "nested",
+      async () => {
+        return await tx
+          .select({
+            id: chatEvents.id,
+            chatThreadId: chatEvents.chatThreadId,
+            userId: chatThreads.userId,
+            orgId: agents.orgId,
+            goalId: canonicalChatEventGoalId(),
+            createdAt: chatEvents.createdAt,
+          })
+          .from(chatEvents)
+          .innerJoin(chatThreads, eq(chatThreads.id, chatEvents.chatThreadId))
+          .innerJoin(agents, eq(agents.id, chatThreads.agentId))
+          .where(
+            and(
+              eq(chatEvents.chatThreadId, args.chatThreadId),
+              pendingChatQueueEventCondition(tx),
+              chatEventTypeIn(["input.goal"]),
+              args.queueItemCreatedBefore
+                ? lt(chatEvents.createdAt, args.queueItemCreatedBefore)
+                : undefined,
+              notExists(
+                tx
+                  .select({ id: chatEvents.id })
+                  .from(chatEvents)
+                  .where(
+                    and(
+                      eq(chatEvents.chatThreadId, args.chatThreadId),
+                      pendingChatQueueEventCondition(tx),
+                      chatEventTypeIn(["input.prompt", "input.automation"]),
+                      args.queueItemCreatedBefore
+                        ? lt(chatEvents.createdAt, args.queueItemCreatedBefore)
+                        : undefined,
+                    ),
+                  ),
               ),
-          ),
-          chatThreadAdmissionAllowedCondition(tx, {
-            threadId: chatThreadId,
-          }),
-        ),
-      )
-      .orderBy(asc(chatEvents.createdAt), asc(chatEvents.id))
-      .limit(1);
+              chatThreadAdmissionAllowedCondition(tx, {
+                threadId: args.chatThreadId,
+              }),
+            ),
+          )
+          .orderBy(asc(chatEvents.createdAt), asc(chatEvents.id))
+          .limit(1);
+      },
+      args.timingDimensions,
+    );
     if (!event) {
       return null;
     }

--- a/turbo/apps/api/src/signals/services/goal-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/goal-queue-drain.service.ts
@@ -565,11 +565,12 @@ export const drainGoalQueueForThread$ = command(
         "api_dispatch_pre_create_zero_goal_drain_load_event",
         "nested",
         async () => {
-          return await loadNextGoalQueueEvent(
-            db,
-            args.chatThreadId,
-            args.queueItemCreatedBefore,
-          );
+          return await loadNextGoalQueueEvent(db, {
+            chatThreadId: args.chatThreadId,
+            queueItemCreatedBefore: args.queueItemCreatedBefore,
+            timing,
+            timingDimensions: phaseDimensions,
+          });
         },
         phaseDimensions,
       );


### PR DESCRIPTION
## Summary

- add fixed child timing for the goal queue thread-lock query
- add fixed child timing for the combined goal candidate-selection query
- reuse the existing run-owned collector and bounded goal-drain dimensions
- extend real callback/API integration coverage for both child actions

## Behavior preserved

This is attribution only. It does not change the SQL predicates, query ordering, transaction boundary, lock scope, queue priority, FIFO, cutoff, admission blockers, retry behavior, final queue-first verification, claim/CAS, public API, persisted state, queue payload, or Runner protocol.

The existing `api_dispatch_pre_create_zero_goal_drain_load_event` action remains the parent. Transaction lifecycle and local framework overhead remain its offline residual, and drains that create no run continue to publish no run-owned timing.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts` (54 passed)
- `pnpm knip --workspace api`
- pre-commit full Knip and Turbo type checks (14 tasks passed)
- `git diff --check`

Closes #31066

Parent context: #24203
