### PR TITLE
fix(runner): classify peer certificate serial warning as info

### DIFF
--- a/crates/runner/src/proxy/stderr.rs
+++ b/crates/runner/src/proxy/stderr.rs
@@ -59,9 +59,11 @@ fn log_addon_process_event(event: AddonProcessEvent) {
 }
 
 fn is_non_positive_peer_certificate_serial_deprecation(line: &str) -> bool {
-    line.strip_suffix(NON_POSITIVE_PEER_CERTIFICATE_SERIAL_DEPRECATION)
-        .and_then(|source| source.strip_suffix(": "))
-        .is_some_and(|source| !source.is_empty())
+    !line.starts_with(ADDON_PROCESS_EVENT_PREFIX)
+        && line
+            .strip_suffix(NON_POSITIVE_PEER_CERTIFICATE_SERIAL_DEPRECATION)
+            .and_then(|source| source.strip_suffix(": "))
+            .is_some_and(|source| !source.is_empty())
 }
 
 pub(super) fn log_mitmdump_stderr_line(line: &str) {
@@ -221,6 +223,19 @@ mod tests {
         assert_eq!(event.level, Level::WARN);
         assert_event_field(&event, "message", &format!("stderr: {line}"));
         assert!(!event.fields.contains_key("type"));
+    }
+
+    #[test]
+    fn malformed_envelope_with_certificate_deprecation_remains_warning() {
+        let line = format!(
+            "{ADDON_PROCESS_EVENT_PREFIX}OpenSSL/crypto.py:984: \
+             {NON_POSITIVE_PEER_CERTIFICATE_SERIAL_DEPRECATION}"
+        );
+
+        let event = capture_mitmdump_stderr_log(&line);
+
+        assert_eq!(event.level, Level::WARN);
+        assert_event_field(&event, "message", &format!("stderr: {line}"));
     }
 
     #[test]

--- a/crates/runner/src/proxy/stderr.rs
+++ b/crates/runner/src/proxy/stderr.rs
@@ -60,7 +60,8 @@ fn log_addon_process_event(event: AddonProcessEvent) {
 
 fn is_non_positive_peer_certificate_serial_deprecation(line: &str) -> bool {
     line.strip_suffix(NON_POSITIVE_PEER_CERTIFICATE_SERIAL_DEPRECATION)
-        .is_some_and(|source| source.ends_with(": "))
+        .and_then(|source| source.strip_suffix(": "))
+        .is_some_and(|source| !source.is_empty())
 }
 
 pub(super) fn log_mitmdump_stderr_line(line: &str) {
@@ -267,6 +268,16 @@ mod tests {
             assert_eq!(event.level, Level::WARN);
             assert_event_field(&event, "message", &format!("stderr: {line}"));
         }
+    }
+
+    #[test]
+    fn certificate_deprecation_without_source_remains_warning() {
+        let line = format!(": {NON_POSITIVE_PEER_CERTIFICATE_SERIAL_DEPRECATION}");
+
+        let event = capture_mitmdump_stderr_log(&line);
+
+        assert_eq!(event.level, Level::WARN);
+        assert_event_field(&event, "message", &format!("stderr: {line}"));
     }
 
     #[test]

--- a/crates/runner/src/proxy/stderr.rs
+++ b/crates/runner/src/proxy/stderr.rs
@@ -1,11 +1,16 @@
 //! Addon process-event parsing and mitmdump stderr re-emission.
 
 use serde_json::{Map, Value};
-use tracing::{error, warn};
+use tracing::{error, info, warn};
 
 const ADDON_PROCESS_EVENT_PREFIX: &str = "VM0_ADDON_EVENT ";
 const ADDON_PROCESS_EVENT_VERSION: u8 = 1;
 const MAX_ADDON_PROCESS_EVENT_BYTES: usize = 4096;
+const NON_POSITIVE_PEER_CERTIFICATE_SERIAL_DEPRECATION: &str = concat!(
+    "CryptographyDeprecationWarning: Parsed a serial number which wasn't positive ",
+    "(i.e., it was negative or zero), which is disallowed by RFC 5280. Loading this ",
+    "certificate will cause an exception in a future release of cryptography."
+);
 
 #[derive(Debug, PartialEq, Eq)]
 enum AddonProcessEventLevel {
@@ -53,9 +58,24 @@ fn log_addon_process_event(event: AddonProcessEvent) {
     }
 }
 
+fn is_non_positive_peer_certificate_serial_deprecation(line: &str) -> bool {
+    line.strip_suffix(NON_POSITIVE_PEER_CERTIFICATE_SERIAL_DEPRECATION)
+        .is_some_and(|source| source.ends_with(": "))
+}
+
 pub(super) fn log_mitmdump_stderr_line(line: &str) {
     if let Some(event) = parse_addon_process_event(line) {
         log_addon_process_event(event);
+        return;
+    }
+
+    if is_non_positive_peer_certificate_serial_deprecation(line) {
+        info!(
+            target: "mitmdump",
+            reason = "non_positive_peer_certificate_serial_deprecation",
+            mitmdump_stderr = %line,
+            "mitmdump peer certificate serial deprecation"
+        );
         return;
     }
 
@@ -200,5 +220,62 @@ mod tests {
         assert_eq!(event.level, Level::WARN);
         assert_event_field(&event, "message", &format!("stderr: {line}"));
         assert!(!event.fields.contains_key("type"));
+    }
+
+    #[test]
+    fn non_positive_peer_certificate_serial_deprecation_reemits_structured_info() {
+        for source in ["OpenSSL/crypto.py:1231", "OpenSSL/crypto.py:984"] {
+            let line = format!("{source}: {NON_POSITIVE_PEER_CERTIFICATE_SERIAL_DEPRECATION}");
+
+            let event = capture_mitmdump_stderr_log(&line);
+
+            assert_eq!(event.level, Level::INFO);
+            assert_event_field(
+                &event,
+                "message",
+                "mitmdump peer certificate serial deprecation",
+            );
+            assert_event_field(
+                &event,
+                "reason",
+                "non_positive_peer_certificate_serial_deprecation",
+            );
+            assert_event_field(&event, "mitmdump_stderr", &line);
+        }
+    }
+
+    #[test]
+    fn related_certificate_stderr_remains_warning() {
+        let lines = [
+            NON_POSITIVE_PEER_CERTIFICATE_SERIAL_DEPRECATION.replacen(
+                "CryptographyDeprecationWarning",
+                "UserWarning",
+                1,
+            ),
+            NON_POSITIVE_PEER_CERTIFICATE_SERIAL_DEPRECATION
+                .strip_suffix('.')
+                .unwrap()
+                .to_owned(),
+            "ValueError: Failed to parse peer certificate serial number".to_owned(),
+        ];
+
+        for warning in lines {
+            let line = format!("OpenSSL/crypto.py:984: {warning}");
+
+            let event = capture_mitmdump_stderr_log(&line);
+
+            assert_eq!(event.level, Level::WARN);
+            assert_event_field(&event, "message", &format!("stderr: {line}"));
+        }
+    }
+
+    #[test]
+    fn ordinary_mitmdump_stderr_remains_warning() {
+        let line = "ordinary mitmdump warning";
+
+        let event = capture_mitmdump_stderr_log(line);
+
+        assert_eq!(event.level, Level::WARN);
+        assert_event_field(&event, "message", "stderr: ordinary mitmdump warning");
     }
 }


### PR DESCRIPTION
## Summary

- classify the exact known non-positive peer-certificate serial deprecation at the runner's mitmdump stderr boundary
- require a non-empty warning source and the expected separator before applying the classification
- reject the addon-event namespace from this classifier so malformed envelopes retain generic `warn` handling
- retain the complete original line and a stable reason in local `info` logs, below Axiom's `WARN+` ingestion threshold
- preserve generic `warn` behavior for changed text, near matches, exceptions, tracebacks, ordinary stderr, and malformed addon envelopes
- preserve structured addon `warn` and `error` events unchanged

## Scope

This is a runner-only log-severity change. It does not modify the Axiom filter, mitmdump launch configuration, TLS or certificate behavior, the pinned mitmproxy dependency, schemas, persisted data, APIs, queues, or protocols.

Mixed runner versions remain compatible: older runners continue to emit the line at `warn`, while newer runners retain it locally at `info`.

## Validation

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo test -p runner proxy::stderr` — 11 passed
- `cargo test -p runner` — 3,398 passed, 24 ignored
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `git diff --check`
- pre-commit workspace Cargo formatting, Clippy, documentation, file-size, and commit-message checks

## Remaining verification

Post-deployment Axiom verification requires the new runner version to roll out. The unchanged Axiom integration test covers local sibling-layer retention and `INFO` exclusion from ingestion.

Closes #30950
