### PR TITLE
fix(python): enforce inline firewall api lists

### DIFF
--- a/crates/runner/mitm-addon/src/registry_firewalls.py
+++ b/crates/runner/mitm-addon/src/registry_firewalls.py
@@ -316,14 +316,14 @@ def resolve_firewall_entries(
     path. A supplied snapshot pins builtin resolution for this call so a single
     registry pass cannot mix catalog versions.
 
-    Inline firewalls are deep-copied and receive per-entry `None` builtin cache
-    keys. Builtin catalog API IDs are discarded during expansion, so builtin
-    APIs receive generated run-scoped IDs. Inline APIs preserve an existing
-    non-empty string ID; absent, empty, or non-string IDs are generated.
-    Generated IDs use `<runId>:<index>`, where the zero-based index advances over
-    dictionary API entries in resolved firewall order, including entries whose
-    IDs are preserved. Callers must validate `sandbox["runId"]` as a non-empty string
-    before calling.
+    Inline firewalls are deep-copied, must contain a list-valued `apis` field,
+    and receive per-entry `None` builtin cache keys. Builtin catalog API IDs are
+    discarded during expansion, so builtin APIs receive generated run-scoped
+    IDs. Inline APIs preserve an existing non-empty string ID; absent, empty, or
+    non-string IDs are generated. Generated IDs use `<runId>:<index>`, where the
+    zero-based index advances over dictionary API entries in resolved firewall
+    order, including entries whose IDs are preserved. Callers must validate
+    `sandbox["runId"]` as a non-empty string before calling.
 
     When `sandbox["firewalls"]` is present, `connectorRuntimeTargets` defaults to
     an empty list when absent. When supplied, it must be a list of object targets.
@@ -408,6 +408,9 @@ def resolve_firewall_entries(
                     "inline firewall entry firewall must be an object"
                 )
             resolved_firewall = copy.deepcopy(firewall)
+            raw_apis = resolved_firewall.get("apis")
+            if not isinstance(raw_apis, list):
+                raise FirewallEntryResolutionError("inline firewall apis must be a list")
             connector_runtime_metadata.clear_connector_runtime_kind(resolved_firewall)
             _apply_source_id(resolved_firewall, _source_id(entry))
             custom_connector_id = _custom_connector_id(entry)
@@ -417,9 +420,6 @@ def resolve_firewall_entries(
                     connector_runtime_metadata.mark_connector_runtime_kind(
                         resolved_firewall, "custom"
                     )
-                raw_apis = resolved_firewall.get("apis")
-                if not isinstance(raw_apis, list):
-                    raise FirewallEntryResolutionError("inline firewall apis must be a list")
                 for api in raw_apis:
                     if isinstance(api, dict):
                         api["customConnectorId"] = custom_connector_id

--- a/crates/runner/mitm-addon/tests/test_registry_inline_firewalls.py
+++ b/crates/runner/mitm-addon/tests/test_registry_inline_firewalls.py
@@ -115,6 +115,31 @@ class TestRegistryInlineFirewalls:
             "run-inline:1",
         ]
 
+    def test_missing_inline_apis_rejects_only_affected_sandbox(self, tmp_path, mitm_ctx):
+        path = tmp_path / "registry.json"
+        malformed_sandbox = inline_sandbox("run-malformed")
+        del malformed_sandbox["firewalls"][0]["firewall"]["apis"]
+        write_multi_sandbox_registry(
+            path,
+            {
+                "10.200.0.1": malformed_sandbox,
+                "10.200.0.2": inline_sandbox("run-valid"),
+            },
+        )
+
+        with mitm_ctx():
+            state = registry.load_registry_state(str(path))
+            valid_context = registry.get_sandbox_context("10.200.0.2", str(path))
+
+        assert not isinstance(state, registry.RegistryUnavailable)
+        assert set(state.sandboxes) == {"10.200.0.2"}
+        invalid_sandbox = state.invalid_sandboxes["10.200.0.1"]
+        assert invalid_sandbox.reason == "invalid_firewalls"
+        assert invalid_sandbox.message == "inline firewall apis must be a list"
+        assert valid_context is not None
+        _, compiled_firewalls, _ = valid_context
+        assert compiled_firewalls is not None
+
     def test_malformed_custom_connector_apis_reject_only_affected_sandbox(self, tmp_path, mitm_ctx):
         path = tmp_path / "registry.json"
         malformed_sandbox = inline_sandbox("run-malformed")

--- a/crates/runner/mitm-addon/tests/test_request_handler_registry_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_registry_admission.py
@@ -452,6 +452,58 @@ async def test_invalid_registered_sandbox_firewalls_shape_blocks_before_auth_inj
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_registry_sandbox"
 
 
+async def test_invalid_inline_apis_blocks_before_auth_injection(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+):
+    sandbox_info = _single_firewall_sandbox(
+        tmp_path,
+        api_entry={
+            "base": "https://api.github.com",
+            "auth": {"headers": {"Authorization": "Bearer secret"}},
+            "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+        },
+        network_policy={
+            "allow": ["full-access"],
+            "deny": [],
+            "ask": [],
+            "unknownPolicy": "allow",
+        },
+    )
+    firewalls = sandbox_info["firewalls"]
+    assert isinstance(firewalls, list)
+    firewall_entry = firewalls[0]
+    assert isinstance(firewall_entry, dict)
+    firewall = firewall_entry["firewall"]
+    assert isinstance(firewall, dict)
+    firewall["apis"] = None
+    reg_path = _write_registry(tmp_path, client_ip="10.200.0.5", sandbox_info=sandbox_info)
+    flow = real_flow(with_response=False, client_ip="10.200.0.5", host="api.github.com")
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 503
+    assert json.loads(flow.response.content) == {
+        "error": "invalid_registry_sandbox",
+        "message": "inline firewall apis must be a list",
+        "reason": "invalid_firewalls",
+    }
+    auth_fetch.assert_not_called()
+    assert flow.request.headers.get("Authorization") is None
+    assert metadata_keys.SANDBOX_RUN_ID not in flow.metadata
+    assert metadata_keys.FIREWALL_BASE not in flow.metadata
+    assert metadata_keys.FIREWALL_AUTH_CACHE_KEY not in flow.metadata
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_registry_sandbox"
+
+
 async def test_registered_sandbox_null_firewalls_passes_through_without_auth_injection(
     tmp_path,
     real_flow,


### PR DESCRIPTION
## Summary

- require list-valued `apis` for every inline firewall resolved from the proxy registry
- classify only the malformed sandbox as `invalid_firewalls` while valid peers remain available
- verify malformed ordinary inline entries receive the existing local 503 before auth injection

Supported TypeScript and Rust producers already guarantee this shape. This aligns the Python registry boundary for unsupported malformed registry JSON; it is not based on a confirmed production exploit.

## Scope

- keeps direct `matching.compile_firewalls()` tolerance unchanged
- preserves absent or null top-level `firewalls`, valid inline firewalls, and nested matcher semantics
- does not change TypeScript or Rust contracts, persisted formats, APIs, protocols, migrations, or rollout sequencing

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_registry_inline_firewalls.py tests/test_request_handler_registry_admission.py tests/test_compiled_firewall_malformed_policies.py` (65 passed)
- `uv run --no-sync python -m pytest tests/` (7,333 passed)

Closes #31003
