### PR TITLE
perf(api): scope custom connector runtime sync catalog loads

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9590,7 +9590,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
-  it("uses exact runtime projections and authoritative fallback for builtin sync", async () => {
+  it("uses exact runtime projections and authoritative fallback for mixed sync", async () => {
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
     mockEnv(
@@ -9614,6 +9614,63 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     );
     await api.enableAgentConnectors(actor, agentId, ["lark"]);
 
+    const permissionedCustom = await connectors.createCustomConnector(
+      actor,
+      manualHttpCustomConnectorCreateBody({
+        slug: `_runtime-projection-permissioned-${randomUUID().slice(0, 8)}`,
+        displayName: "Runtime Projection Permissioned",
+        prefixTemplates: [
+          "https://runtime-projection-permissioned.example.test/api/",
+        ],
+        permissionBundleRef: "builtin:slack@1",
+      }),
+    );
+    const plainCustom = await connectors.createCustomConnector(
+      actor,
+      manualHttpCustomConnectorCreateBody({
+        slug: `_runtime-projection-plain-${randomUUID().slice(0, 8)}`,
+        displayName: "Runtime Projection Plain",
+        prefixTemplates: ["https://runtime-projection-plain.example.test/api/"],
+      }),
+    );
+    onTestFinished(async () => {
+      await installApiTestConnectorCatalog();
+      await connectors.deleteCustomConnector(
+        actor,
+        permissionedCustom.id,
+        [204, 404],
+      );
+      await connectors.deleteCustomConnector(actor, plainCustom.id, [204, 404]);
+    });
+    await connectors.setCustomConnectorSecret(
+      actor,
+      permissionedCustom.id,
+      "permissioned-runtime-token",
+    );
+    await connectors.setCustomConnectorSecret(
+      actor,
+      plainCustom.id,
+      "plain-runtime-token",
+    );
+    const customGrants = [
+      {
+        customConnectorId: permissionedCustom.id,
+        permissionNames: ["chat:write"],
+      },
+      { customConnectorId: plainCustom.id, permissionNames: [] },
+    ];
+    const customGrantResponse =
+      await connectors.requestUpdateAgentCustomConnectorGrants(
+        actor,
+        agentId,
+        customGrants,
+        [200],
+      );
+    if (customGrantResponse.status !== 200) {
+      throw new Error("Expected custom connector grants to succeed");
+    }
+    expect(customGrantResponse.body.grants).toStrictEqual(customGrants);
+
     const run = await api.createRun(actor, {
       agentId,
       prompt: "refresh lark through exact runtime projections",
@@ -9628,35 +9685,107 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       throw new Error("Expected the lark runtime target");
     }
     expect(larkTarget.sourceId).toBe(connected.id);
+    const permissionedTarget = customConnectorRuntimeRegistration(
+      claim,
+      permissionedCustom.id,
+    );
+    const plainTarget = customConnectorRuntimeRegistration(
+      claim,
+      plainCustom.id,
+    );
+    const mixedTargets = [larkTarget, permissionedTarget, plainTarget];
 
     await installApiTestConnectorCatalog({
       catalogVersion: `api-test-runtime-sync-projection-${randomUUID()}`,
       runtimeProjection: true,
     });
-    await corruptApiTestConnectorCatalogRuntimeProjectionDigest("slack");
+    await corruptApiTestConnectorCatalogRuntimeProjectionDigest("figma");
     await corruptApiTestConnectorCatalogActiveSnapshotPayload();
 
-    const [projectedRuntime] = await api.syncConnectorRuntime(run.runId, {
-      targets: [larkTarget],
-    });
-    expect(projectedRuntime).toMatchObject({
+    const [projectedBuiltin, projectedPermissioned, projectedPlain] =
+      await api.syncConnectorRuntime(run.runId, {
+        targets: mixedTargets,
+      });
+    expect(projectedBuiltin).toMatchObject({
       target: { kind: "builtin", connectorSlug: "lark" },
       state: "available",
+    });
+    const permissionedRuntime = availableCustomConnectorRuntime(
+      projectedPermissioned,
+    );
+    expect(permissionedRuntime).toMatchObject({
+      target: {
+        kind: "custom",
+        customConnectorId: permissionedCustom.id,
+      },
+      firewall: { sourceId: permissionedTarget.sourceId },
+      baseUrlVars: {},
+    });
+    expect(
+      permissionedRuntime.firewall.firewall.apis[0]?.permissions,
+    ).toStrictEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "chat:write" })]),
+    );
+    expect(permissionedRuntime.networkPolicy.allow).toContain("chat:write");
+    expect(permissionedRuntime.networkPolicy.deny.length).toBeGreaterThan(0);
+    expect(permissionedRuntime.networkPolicy.unknownPolicy).toBe("deny");
+    const plainRuntime = availableCustomConnectorRuntime(projectedPlain);
+    expect(plainRuntime).toMatchObject({
+      target: { kind: "custom", customConnectorId: plainCustom.id },
+      firewall: { sourceId: plainTarget.sourceId },
+      baseUrlVars: {},
+    });
+    expect(plainRuntime.firewall.firewall.apis[0]?.permissions).toStrictEqual(
+      [],
+    );
+    const [projectedPlainOnly] = await api.syncConnectorRuntime(run.runId, {
+      targets: [plainTarget],
+    });
+    expect(availableCustomConnectorRuntime(projectedPlainOnly)).toMatchObject({
+      target: { kind: "custom", customConnectorId: plainCustom.id },
+      firewall: { sourceId: plainTarget.sourceId },
+      baseUrlVars: {},
     });
 
     await installApiTestConnectorCatalog({
       catalogVersion: `api-test-runtime-sync-fallback-${randomUUID()}`,
       runtimeProjection: true,
     });
-    await corruptApiTestConnectorCatalogRuntimeProjectionDigest("lark");
+    await corruptApiTestConnectorCatalogRuntimeProjectionDigest("slack");
 
-    const [fallbackRuntime] = await api.syncConnectorRuntime(run.runId, {
-      targets: [larkTarget],
+    const fallbackRuntimes = await api.syncConnectorRuntime(run.runId, {
+      targets: mixedTargets,
     });
-    expect(fallbackRuntime).toMatchObject({
-      target: { kind: "builtin", connectorSlug: "lark" },
-      state: "available",
-    });
+    expect(fallbackRuntimes).toMatchObject([
+      {
+        target: { kind: "builtin", connectorSlug: "lark" },
+        state: "available",
+      },
+      {
+        target: {
+          kind: "custom",
+          customConnectorId: permissionedCustom.id,
+        },
+        state: "available",
+        firewall: { sourceId: permissionedTarget.sourceId },
+        baseUrlVars: {},
+      },
+      {
+        target: { kind: "custom", customConnectorId: plainCustom.id },
+        state: "available",
+        firewall: { sourceId: plainTarget.sourceId },
+        baseUrlVars: {},
+      },
+    ]);
+    const fallbackPermissioned = availableCustomConnectorRuntime(
+      fallbackRuntimes[1],
+    );
+    expect(fallbackPermissioned.networkPolicy).toStrictEqual(
+      permissionedRuntime.networkPolicy,
+    );
+    expect(
+      fallbackPermissioned.firewall.firewall.apis[0]?.permissions,
+    ).toStrictEqual(permissionedRuntime.firewall.firewall.apis[0]?.permissions);
 
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);

--- a/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
@@ -18,10 +18,8 @@ import {
   loadEffectiveCustomConnectorPermissionBundle,
   type CustomConnectorRuntimeDataRows,
 } from "./agent-run-create.service";
-import {
-  loadConnectorRuntimeSelection,
-  loadConnectorRuntimeSnapshot,
-} from "./connector-catalog-runtime.service";
+import { loadConnectorRuntimeSelection } from "./connector-catalog-runtime.service";
+import { loadCustomConnectorPermissionBundleDependencySlugs } from "./custom-connector-permission-bundle.service";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { resolveActiveNetworkPolicyRefreshes } from "./user-permission-grants.service";
 import { loadCustomConnectorRuntimeData } from "./custom-connector.service";
@@ -90,6 +88,18 @@ async function loadCustomSnapshot(args: {
       const customConnectorIds = args.registrations.map((registration) => {
         return registration.customConnectorId;
       });
+      const metadataConnectorSlugs =
+        await loadCustomConnectorPermissionBundleDependencySlugs(tx, {
+          orgId: args.scope.orgId,
+          customConnectorIds,
+        });
+      const connectorCatalogSelection = await loadConnectorRuntimeSelection(
+        tx,
+        {
+          requestedConnectorSlugs: [],
+          metadataConnectorSlugs,
+        },
+      );
       const accountResolutions = await resolveConnectorAccounts(tx, {
         orgId: args.scope.orgId,
         userId: args.scope.userId,
@@ -124,7 +134,6 @@ async function loadCustomSnapshot(args: {
           );
         }
       }
-      const connectorCatalogSnapshot = await loadConnectorRuntimeSnapshot(tx);
       const featureSwitchContext = await loadUserFeatureSwitchContext(
         tx,
         args.scope.orgId,
@@ -169,7 +178,7 @@ async function loadCustomSnapshot(args: {
         });
       }
       return {
-        connectorCatalogSnapshot,
+        connectorCatalogSelection,
         featureSwitchContext,
         customTargets,
         accountResolutions,
@@ -221,7 +230,7 @@ async function resolveCustomTarget(args: {
   const row = custom.row;
   const permissionBundle = await loadEffectiveCustomConnectorPermissionBundle({
     row,
-    snapshot: args.snapshot.connectorCatalogSnapshot,
+    snapshot: args.snapshot.connectorCatalogSelection,
   });
   if (permissionBundle === undefined) {
     return customUnresolvedResult(target, "permission-bundle-unavailable");
@@ -234,7 +243,7 @@ async function resolveCustomTarget(args: {
   const context = await buildCustomConnectorRuntimeContext({
     rows: [row],
     featureSwitchContext: args.snapshot.featureSwitchContext,
-    connectorCatalogSnapshot: args.snapshot.connectorCatalogSnapshot,
+    connectorCatalogSnapshot: args.snapshot.connectorCatalogSelection,
     grants: [
       custom.grant ?? {
         customConnectorId: target.customConnectorId,


### PR DESCRIPTION
## Summary

- load only custom permission-bundle metadata dependencies during connector runtime sync
- preserve exact account, grant, feature, and authoritative full-catalog fallback semantics
- cover mixed built-in/custom projection, metadata-free custom sync, and custom fallback through route integration

## Problem

Custom connector runtime sync always loaded the complete accepted connector catalog inside its repeatable-read transaction. On a process-cold API instance, that avoidable work can push the handler beyond the runner's three-second request deadline.

## Implementation

The custom runtime path now resolves the requested custom connectors' permission-bundle dependency slugs and loads a scoped catalog selection. It continues to use the existing projection validation and authoritative complete-catalog fallback behavior, so stale or corrupt projections preserve current correctness semantics.

This does not change runner timeouts, retry behavior, request/response contracts, or persisted data.

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/connector-runtime-sync.service.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (188 tests passed)
- `pnpm knip --workspace api`
- pre-commit full Knip, type-check, file-size, and commit-message checks

Closes #30994
