### PR TITLE
fix(platform): update chat sidebar navigation

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -416,13 +416,11 @@
         "agents": "Agenten",
         "artifacts": "Artefakte",
         "connectors": "Integrationen",
-        "newChat": "Neuer Chat",
         "settings": "Einstellungen",
         "workflows": "Workflows",
         "works": "Einsatzorte von {{agentName}}"
       },
       "rail": {
-        "new": "Neu",
         "workflows": "Workflows",
         "works": "Kanäle"
       },

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -416,13 +416,11 @@
         "agents": "Agents",
         "artifacts": "Artifacts",
         "connectors": "Connectors",
-        "newChat": "New chat",
         "settings": "Settings",
         "workflows": "Workflows",
         "works": "Where {{agentName}} works"
       },
       "rail": {
-        "new": "New",
         "workflows": "Workflows",
         "works": "Channels"
       },

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -430,13 +430,11 @@
         "agents": "Agentes",
         "artifacts": "Artefactos",
         "connectors": "Conectores",
-        "newChat": "Nuevo chat",
         "settings": "Configuración",
         "workflows": "Flujos de trabajo",
         "works": "Dónde trabaja {{agentName}}"
       },
       "rail": {
-        "new": "Nuevo",
         "workflows": "Flujos de trabajo",
         "works": "Integraciones"
       },

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -430,13 +430,11 @@
         "agents": "Agents",
         "artifacts": "Artéfacts",
         "connectors": "Connecteurs",
-        "newChat": "Nouveau chat",
         "settings": "Paramètres",
         "workflows": "Workflows",
         "works": "Où {{agentName}} travaille"
       },
       "rail": {
-        "new": "Nouveau",
         "workflows": "Workflows",
         "works": "Travail"
       },

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -416,13 +416,11 @@
         "agents": "एजेंटों",
         "artifacts": "आर्टिफ़ैक्ट्स",
         "connectors": "कनेक्टर्स",
-        "newChat": "नई चैट",
         "settings": "सेटिंग्स",
         "workflows": "वर्कफ़्लो",
         "works": "जहां {{agentName}} काम करता है"
       },
       "rail": {
-        "new": "नया",
         "workflows": "वर्कफ़्लो",
         "works": "काम करता है"
       },

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -416,13 +416,11 @@
         "agents": "Agen",
         "artifacts": "Artifact",
         "connectors": "Konektor",
-        "newChat": "Chat baru",
         "settings": "Pengaturan",
         "workflows": "Alur kerja",
         "works": "Tempat {{agentName}} bekerja"
       },
       "rail": {
-        "new": "Baru",
         "workflows": "Alur kerja",
         "works": "Bekerja"
       },

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -430,13 +430,11 @@
         "agents": "Agenti",
         "artifacts": "Artefatti",
         "connectors": "Connettori",
-        "newChat": "Nuova chat",
         "settings": "Impostazioni",
         "workflows": "Flussi di lavoro",
         "works": "Dove lavora {{agentName}}"
       },
       "rail": {
-        "new": "Nuovo",
         "workflows": "Flussi di lavoro",
         "works": "Integrazioni"
       },

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -416,13 +416,11 @@
         "agents": "エージェント",
         "artifacts": "アーティファクト",
         "connectors": "コネクター",
-        "newChat": "新しいチャット",
         "settings": "設定",
         "workflows": "ワークフロー",
         "works": "{{agentName}}の連携先"
       },
       "rail": {
-        "new": "新しい",
         "workflows": "ワークフロー",
         "works": "連携先"
       },

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -416,13 +416,11 @@
         "agents": "에이전트",
         "artifacts": "아티팩트",
         "connectors": "커넥터",
-        "newChat": "새 채팅",
         "settings": "설정",
         "workflows": "워크플로",
         "works": "{{agentName}}가(이) 작업하는 곳"
       },
       "rail": {
-        "new": "새로 만들기",
         "workflows": "워크플로",
         "works": "작업"
       },

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -430,13 +430,11 @@
         "agents": "Agentes",
         "artifacts": "Artefatos",
         "connectors": "Conectores",
-        "newChat": "Novo chat",
         "settings": "Configurações",
         "workflows": "Fluxos de trabalho",
         "works": "Onde {{agentName}} trabalha"
       },
       "rail": {
-        "new": "Novo",
         "workflows": "Fluxos de trabalho",
         "works": "Trabalha"
       },

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-start-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-start-cards.test.tsx
@@ -801,16 +801,16 @@ describe("chat start cards", () => {
     await waitFor(() => {
       expect(downloads.downloads).toHaveLength(1);
     });
-    const newChatLink = queryAllByRoleFast("link").find((link) => {
+    const newChatButton = queryAllByRoleFast("button").find((button) => {
       return (
-        link.getAttribute("aria-label") === "New chat" &&
-        link.getAttribute("href") === "/"
+        button.getAttribute("aria-label") === "New chat" &&
+        button.querySelector(".lucide-square-pen") !== null
       );
     });
-    if (!newChatLink) {
-      throw new Error("Expected the new chat navigation link");
+    if (!newChatButton) {
+      throw new Error("Expected the new chat navigation button");
     }
-    click(newChatLink);
+    click(newChatButton);
     await waitFor(() => {
       expect(
         screen.queryByRole("dialog", { name: "Create an intro video" }),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -3318,7 +3318,7 @@ describe("zero sidebar", () => {
     expect(within(nav).queryByText("Automations")).not.toBeInTheDocument();
   });
 
-  it("renders the three-column navigation", async () => {
+  it("renders the three-column chat navigation and actions", async () => {
     prepareDefaultAgent();
 
     setupSidebarPage({
@@ -3331,6 +3331,11 @@ describe("zero sidebar", () => {
     });
 
     // Labeled icon rail carries text captions for its nav destinations.
+    const chatLink = within(rail).getByLabelText("Chat");
+    expect(within(rail).getByText("Chat")).toBeInTheDocument();
+    expect(
+      chatLink.querySelector(".lucide-message-circle"),
+    ).toBeInTheDocument();
     expect(within(rail).getByText("Agents")).toBeInTheDocument();
     expect(within(rail).getByText("Connectors")).toBeInTheDocument();
 
@@ -3339,11 +3344,13 @@ describe("zero sidebar", () => {
     expect(within(list).getByText("Chat")).toBeInTheDocument();
     const searchButton = within(list).getByLabelText("Search workspace");
     const newChatButton = within(list).getByLabelText("New chat");
+    const chatThreadsTitle = within(list).getByText("Chats with Zero");
     expect(searchButton).toHaveAttribute(
       "aria-keyshortcuts",
       "Meta+K Control+K",
     );
-    expect(newChatButton).toBeInTheDocument();
+    expect(chatThreadsTitle.parentElement).toContainElement(newChatButton);
+    expect(newChatButton.querySelector(".lucide-plus")).toBeInTheDocument();
     expect(
       within(list).getByTestId("pinned-agents-horizontal"),
     ).toBeInTheDocument();
@@ -3381,7 +3388,7 @@ describe("zero sidebar", () => {
     expect(upgradeSlot).toHaveClass("empty:hidden");
   });
 
-  it("keeps the new-chat rail responsive across consecutive clicks", async () => {
+  it("keeps the chat rail responsive across consecutive clicks", async () => {
     prepareDefaultAgent();
     mockSidebarThreadStory([
       createThread(EXISTING_THREAD_ID, "Existing conversation"),
@@ -3399,14 +3406,14 @@ describe("zero sidebar", () => {
         "Existing conversation",
       ),
     ).toBeInTheDocument();
-    const newChatLink = within(rail).getByLabelText("New chat");
-    click(newChatLink);
+    const chatLink = within(rail).getByLabelText("Chat");
+    click(chatLink);
 
     await waitFor(() => {
       expect(pathname()).toBe(`/agents/${AGENT_ID}/chat`);
     });
     click(
-      within(screen.getByTestId("labeled-nav-rail")).getByLabelText("New chat"),
+      within(screen.getByTestId("labeled-nav-rail")).getByLabelText("Chat"),
     );
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -3343,14 +3343,29 @@ describe("zero sidebar", () => {
     const list = screen.getByTestId("chat-list-column");
     expect(within(list).getByText("Chat")).toBeInTheDocument();
     const searchButton = within(list).getByLabelText("Search workspace");
-    const newChatButton = within(list).getByLabelText("New chat");
     const chatThreadsTitle = within(list).getByText("Chats with Zero");
+    if (!searchButton.parentElement || !chatThreadsTitle.parentElement) {
+      throw new Error("Chat action headers not found");
+    }
+    const headerNewChatButton = within(
+      searchButton.parentElement,
+    ).getByLabelText("New chat");
+    const threadNewChatButton = within(
+      chatThreadsTitle.parentElement,
+    ).getByLabelText("New chat");
     expect(searchButton).toHaveAttribute(
       "aria-keyshortcuts",
       "Meta+K Control+K",
     );
-    expect(chatThreadsTitle.parentElement).toContainElement(newChatButton);
-    expect(newChatButton.querySelector(".lucide-plus")).toBeInTheDocument();
+    expect(
+      headerNewChatButton.querySelector(".lucide-square-pen"),
+    ).toBeInTheDocument();
+    expect(chatThreadsTitle.parentElement).toContainElement(
+      threadNewChatButton,
+    );
+    expect(
+      threadNewChatButton.querySelector(".lucide-plus"),
+    ).toBeInTheDocument();
     expect(
       within(list).getByTestId("pinned-agents-horizontal"),
     ).toBeInTheDocument();
@@ -3388,25 +3403,44 @@ describe("zero sidebar", () => {
     expect(upgradeSlot).toHaveClass("empty:hidden");
   });
 
-  it("keeps the chat rail responsive across consecutive clicks", async () => {
-    prepareDefaultAgent();
+  it("routes new chat to the current agent and chat rail to the default agent", async () => {
+    prepareAgents();
     mockSidebarThreadStory([
-      createThread(EXISTING_THREAD_ID, "Existing conversation"),
+      createThread(RESEARCH_THREAD_ID, "Research conversation", {
+        agent: { id: RESEARCH_AGENT_ID, avatarUrl: null },
+      }),
     ]);
 
     setupSidebarPage({
       context,
-      path: `/chats/${EXISTING_THREAD_ID}`,
+      path: `/chats/${RESEARCH_THREAD_ID}`,
     });
 
     const rail = await screen.findByTestId("labeled-nav-rail");
     await screen.findByPlaceholderText(PLACEHOLDER);
     expect(
       within(screen.getByTestId("chat-list-column")).getByText(
-        "Existing conversation",
+        "Research conversation",
       ),
     ).toBeInTheDocument();
+    await screen.findByText("Chats with Research Agent");
+
+    const list = screen.getByTestId("chat-list-column");
+    const searchButton = within(list).getByLabelText("Search workspace");
+    if (!searchButton.parentElement) {
+      throw new Error("Chat header not found");
+    }
+    const newChatButton = within(searchButton.parentElement).getByLabelText(
+      "New chat",
+    );
+    click(newChatButton);
+
+    await waitFor(() => {
+      expect(pathname()).toBe(`/agents/${RESEARCH_AGENT_ID}/chat`);
+    });
+
     const chatLink = within(rail).getByLabelText("Chat");
+    expect(chatLink).toHaveAttribute("href", `/agents/${AGENT_ID}/chat`);
     click(chatLink);
 
     await waitFor(() => {
@@ -4149,7 +4183,13 @@ describe("zero sidebar", () => {
     });
 
     const list = await screen.findByTestId("chat-list-column");
-    const newChatButton = within(list).getByLabelText("New chat");
+    const chatThreadsTitle = await within(list).findByText("Chats with Zero");
+    if (!chatThreadsTitle.parentElement) {
+      throw new Error("Chat threads header not found");
+    }
+    const newChatButton = within(chatThreadsTitle.parentElement).getByLabelText(
+      "New chat",
+    );
     await waitFor(() => {
       expect(newChatButton).toBeEnabled();
     });
@@ -4209,7 +4249,13 @@ describe("zero sidebar", () => {
     context.store.set(setChatPageImageModelSelection$, "fal-ai/flux-pro/v1.1");
 
     const list = await screen.findByTestId("chat-list-column");
-    const newChatButton = within(list).getByLabelText("New chat");
+    const chatThreadsTitle = await within(list).findByText("Chats with Zero");
+    if (!chatThreadsTitle.parentElement) {
+      throw new Error("Chat threads header not found");
+    }
+    const newChatButton = within(chatThreadsTitle.parentElement).getByLabelText(
+      "New chat",
+    );
     await waitFor(() => {
       expect(newChatButton).toBeEnabled();
     });

--- a/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
@@ -904,7 +904,12 @@ function ChatThreadsListMenu({
 }
 
 function ChatThreadsTitle({ showMarkAllRead }: { showMarkAllRead: boolean }) {
+  const { t } = useTranslation();
   const { titleLabel } = useChatThreadsTitleLabels();
+  const newChatAction = useNewChatMenuAction();
+  const newChatLabel = t(($) => {
+    return $.chat.newChat;
+  });
   const setCollapsed = useSet(setSessionListCollapsed$);
   const collapsed = useGet(sessionListCollapsed$);
 
@@ -925,6 +930,30 @@ function ChatThreadsTitle({ showMarkAllRead }: { showMarkAllRead: boolean }) {
         </span>
       </span>
       <div className="flex items-center gap-0.5">
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  newChatAction.onSelect("main");
+                }}
+                disabled={newChatAction.disabled}
+                variant="quiet"
+                size="icon-sm"
+                iconSize="md"
+                className="relative z-10 shrink-0"
+                aria-label={newChatLabel}
+              >
+                <Plus size={18} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p className="text-xs">{newChatLabel}</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
         <ChatThreadsListMenu showMarkAllRead={showMarkAllRead} />
       </div>
     </div>

--- a/turbo/apps/platform/src/views/okou-page/sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar.tsx
@@ -6,6 +6,7 @@ import {
   Package,
   Route,
   Users,
+  Edit,
   MessageCircle,
   ChevronRight,
   PanelLeftClose,
@@ -32,8 +33,8 @@ import {
   type SidebarNavId,
 } from "../../signals/okou-page/nav.ts";
 import { activeRoute$ } from "../../signals/active-route.ts";
-import type { RouteKey } from "../../signals/route-paths.ts";
-import { defaultAgentName$ } from "../../signals/agent.ts";
+import { ROUTES, type RouteKey } from "../../signals/route-paths.ts";
+import { defaultAgentId$, defaultAgentName$ } from "../../signals/agent.ts";
 import { assistantName$ } from "../../signals/branding.ts";
 import {
   manageSectionCollapsed$,
@@ -58,6 +59,7 @@ import {
 import { ThreeColumnSearchDialog } from "./sidebar-dialogs.tsx";
 import { SidebarUpgradeCard } from "./sidebar-upgrade.tsx";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
+import { currentChatAgentId$ } from "../../signals/agent-chat.ts";
 
 type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
 
@@ -443,6 +445,7 @@ function ExpandedFooter() {
 function LabeledRailLink({
   id,
   navPath,
+  navOptions,
   label,
   icon: Icon,
   iconImg,
@@ -452,6 +455,7 @@ function LabeledRailLink({
 }: {
   id: SidebarNavId;
   navPath: string;
+  navOptions?: Parameters<typeof Link>[0]["options"];
   label: string;
   icon: NavIcon;
   iconImg?: string | undefined;
@@ -485,6 +489,7 @@ function LabeledRailLink({
   return (
     <Link
       pathname={navPath as Parameters<typeof Link>[0]["pathname"]}
+      options={navOptions}
       onClick={(e) => {
         if (e.metaKey || e.ctrlKey || e.shiftKey) {
           return;
@@ -586,14 +591,17 @@ function ThreeColumnChatListToggle({
 function LabeledNavRail() {
   const chatListHidden = useGet(sidebarOff$);
   const activeId = useGet(activeRoute$);
+  const defaultAgentId = useLastResolved(defaultAgentId$) ?? null;
   const slackScopeMismatch = useLastResolved(slackOrgScopeMismatch$) ?? false;
-  const onSelect = useNavSelect();
+  const onNavSelect = useNavSelect();
+  const navigate = useSet(detachedNavigateTo$);
   const { manageNav, footerNav } = useResolvedNavItems();
   const { t } = useTranslation();
   const navItems: {
     id: SidebarNavId;
     activeKeys: readonly RouteKey[];
     pathname: string;
+    options?: Parameters<typeof Link>[0]["options"];
     label: string;
     icon: NavIcon;
     iconImg?: string | undefined;
@@ -601,7 +609,10 @@ function LabeledNavRail() {
     {
       id: "chat",
       activeKeys: ["home", "agentChat", "agentIdeas", "chat"],
-      pathname: "/",
+      pathname: defaultAgentId ? ROUTES.agentChat : ROUTES.home,
+      options: defaultAgentId
+        ? { pathParams: { agentId: defaultAgentId } }
+        : undefined,
       label: t(($) => {
         return $.appShell.sidebar.chat;
       }),
@@ -610,6 +621,18 @@ function LabeledNavRail() {
     ...manageNav,
     ...footerNav,
   ];
+  const onSelect = (id: SidebarNavId) => {
+    if (id === "chat") {
+      if (!defaultAgentId) {
+        return;
+      }
+      navigate(ROUTES.agentChat, {
+        pathParams: { agentId: defaultAgentId },
+      });
+      return;
+    }
+    onNavSelect(id);
+  };
   return (
     <aside
       data-testid="labeled-nav-rail"
@@ -640,6 +663,7 @@ function LabeledNavRail() {
               key={item.id}
               id={item.id}
               navPath={item.pathname}
+              navOptions={item.options}
               label={item.label}
               icon={item.icon}
               iconImg={item.iconImg}
@@ -694,12 +718,25 @@ function ThreeColumnSearchDialogContainer() {
 }
 
 function ChatListColumn() {
+  const currentChatAgentId = useLastResolved(currentChatAgentId$) ?? null;
+  const navigate = useSet(detachedNavigateTo$);
   const openThreeColumnSearch = useSet(openThreeColumnSearchDialog$);
   const { t } = useTranslation();
   const searchLabel = t(($) => {
     return $.appShell.sidebar.searchWorkspace;
   });
   const searchShortcutLabel = getShortcutLabel("mod+k");
+  const newChatLabel = t(($) => {
+    return $.chat.newChat;
+  });
+  const onNewChat = () => {
+    if (!currentChatAgentId) {
+      return;
+    }
+    navigate(ROUTES.agentChat, {
+      pathParams: { agentId: currentChatAgentId },
+    });
+  };
   return (
     <aside
       data-testid="chat-list-column"
@@ -733,6 +770,24 @@ function ChatListColumn() {
                 {searchLabel}
                 <span aria-hidden="true">{` · ${searchShortcutLabel}`}</span>
               </p>
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                onClick={onNewChat}
+                disabled={!currentChatAgentId}
+                aria-label={newChatLabel}
+                variant="quiet"
+                size="icon-sm"
+                iconSize="md"
+              >
+                <Edit size={18} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p className="text-xs">{newChatLabel}</p>
             </TooltipContent>
           </Tooltip>
           <ThreeColumnChatListToggle hidden={false} tooltipSide="bottom" />

--- a/turbo/apps/platform/src/views/okou-page/sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar.tsx
@@ -6,7 +6,7 @@ import {
   Package,
   Route,
   Users,
-  Edit,
+  MessageCircle,
   ChevronRight,
   PanelLeftClose,
   Plug,
@@ -57,13 +57,6 @@ import {
 } from "./sidebar-pinned.tsx";
 import { ThreeColumnSearchDialog } from "./sidebar-dialogs.tsx";
 import { SidebarUpgradeCard } from "./sidebar-upgrade.tsx";
-import { rootSignal$ } from "../../signals/root-signal.ts";
-import { detach, Reason } from "../../signals/utils.ts";
-import { currentChatAgentId$ } from "../../signals/agent-chat.ts";
-import {
-  createNewChatThread$,
-  newChatThreadDisabled$,
-} from "../../signals/chat-page/optimistic-chat-thread-page.ts";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 
 type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
@@ -471,7 +464,7 @@ function LabeledRailLink({
     switch (id) {
       case "chat": {
         return t(($) => {
-          return $.appShell.sidebar.rail.new;
+          return $.appShell.sidebar.chat;
         });
       }
       case "workflows": {
@@ -610,9 +603,9 @@ function LabeledNavRail() {
       activeKeys: ["home", "agentChat", "agentIdeas", "chat"],
       pathname: "/",
       label: t(($) => {
-        return $.appShell.sidebar.navigation.newChat;
+        return $.appShell.sidebar.chat;
       }),
-      icon: Edit as NavIcon,
+      icon: MessageCircle as NavIcon,
     },
     ...manageNav,
     ...footerNav,
@@ -701,28 +694,12 @@ function ThreeColumnSearchDialogContainer() {
 }
 
 function ChatListColumn() {
-  const currentChatAgentId = useLastResolved(currentChatAgentId$) ?? null;
-  const createNewChat = useSet(createNewChatThread$);
-  const newChatDisabled = useGet(newChatThreadDisabled$);
-  const rootSignal = useGet(rootSignal$);
   const openThreeColumnSearch = useSet(openThreeColumnSearchDialog$);
   const { t } = useTranslation();
   const searchLabel = t(($) => {
     return $.appShell.sidebar.searchWorkspace;
   });
   const searchShortcutLabel = getShortcutLabel("mod+k");
-  const newChatLabel = t(($) => {
-    return $.appShell.sidebar.navigation.newChat;
-  });
-  const onNewChat = () => {
-    if (!currentChatAgentId) {
-      return;
-    }
-    detach(
-      createNewChat(currentChatAgentId, "main", rootSignal),
-      Reason.DomCallback,
-    );
-  };
   return (
     <aside
       data-testid="chat-list-column"
@@ -756,24 +733,6 @@ function ChatListColumn() {
                 {searchLabel}
                 <span aria-hidden="true">{` · ${searchShortcutLabel}`}</span>
               </p>
-            </TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                onClick={onNewChat}
-                disabled={!currentChatAgentId || newChatDisabled}
-                aria-label={newChatLabel}
-                variant="quiet"
-                size="icon-sm"
-                iconSize="md"
-              >
-                <Edit size={18} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              <p className="text-xs">{newChatLabel}</p>
             </TooltipContent>
           </Tooltip>
           <ThreeColumnChatListToggle hidden={false} tooltipSide="bottom" />


### PR DESCRIPTION
## Summary

- replace the labeled rail edit icon and `New` caption with a chat icon and `Chat`
- keep the toolbar `New chat` action and route it to the current agent chat landing page
- keep the plus action beside `Chats with …` for creating a new conversation with the current agent
- route the labeled rail `Chat` action directly to the workspace default agent chat page
- remove superseded sidebar translation keys across all supported locales

## Verification

- `cd turbo && pnpm format`
- `cd turbo && pnpm turbo run lint --concurrency=1 --log-order grouped`
- `cd turbo && pnpm knip`
- `cd turbo && pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `cd turbo && pnpm --filter @okouai/app run check-types`
- `cd turbo && pnpm --filter api run check-types`
- `cd turbo && DATABASE_URL='postgresql://postgres@localhost:5432/vm0_test' pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx` (82 tests passed)
- `cd turbo && DATABASE_URL='postgresql://postgres@localhost:5432/vm0_test' pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-start-cards.test.tsx` (16 tests passed)
- exact-head GitHub Actions checks passed

## Visual verification

Runtime UI head browser-tested: `faf4e91105e7092e8efdc0aa3e81234a8d0aa8f2`

Final head: `927d65e6e8f61e5a5b5f46e99736659735799817` (test-only selector update after browser verification; runtime code unchanged)

- App: https://pr-31099-app.omby.ai
- API: https://pr-31099-api.vm6.ai
- Desktop viewport: 1280 × 900, Headless Chrome 151
- Fresh test organization; onboarding bypassed after sign-in because onboarding is out of scope; no feature switches enabled
- PASS: rail shows a chat icon and `Chat`; toolbar edit-icon `New chat` remains; a plus-icon `New chat` sits beside `Chats with …`
- PASS: from a non-default `Routing QA` agent, toolbar `New chat` navigated to that current agent chat route without creating a thread
- PASS: rail `Chat` exposed the default-agent href and navigated back to the default `Okou` chat route
- PASS: title plus created a new default-agent conversation (`POST /api/chat-threads` 201) and opened its thread route
- Screenshots: [current-agent chat](https://cdn.okou.io/artifacts/fqdsx0p25f.png), [default-agent chat after rail click](https://cdn.okou.io/artifacts/865bx0bmrk.png)
