### PR TITLE
refactor(db): remove legacy provider alias lookup

### DIFF
--- a/turbo/packages/db/scripts/previous-release-built-in-provider-identity-test-fixture.ts
+++ b/turbo/packages/db/scripts/previous-release-built-in-provider-identity-test-fixture.ts
@@ -1,14 +1,24 @@
 import { randomUUID } from "node:crypto";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 
-import { modelProviders } from "../schema/model-provider";
+import { modelProviders } from "../src/schema/model-provider";
 
+const PREVIOUS_RELEASE_BUILT_IN_PROVIDER_IDENTITY_TYPES = [
+  "vm0",
+  "built-in",
+] as const;
 const ORG_NO_SECRET_PROVIDER_USER_ID = "__org__";
 
 type ModelProviderRow = typeof modelProviders.$inferSelect;
 
-export async function upsertBuiltInNoSecretModelProviderIdentity(
+/**
+ * Frozen #29938 application behavior from
+ * aad55f424b8a4b72c2b06e25335e06de53e10c7a for the historical 1013-1015
+ * deployment compatibility proof. Production code must not import this test
+ * fixture.
+ */
+export async function upsertPreviousReleaseBuiltInNoSecretModelProviderIdentity(
   db: NodePgDatabase<Record<string, never>>,
   args: {
     readonly orgId: string;
@@ -24,19 +34,28 @@ export async function upsertBuiltInNoSecretModelProviderIdentity(
     );
     signal.throwIfAborted();
 
-    const [existingProvider] = await tx
+    const existingProviders = await tx
       .select()
       .from(modelProviders)
       .where(
         and(
           eq(modelProviders.orgId, args.orgId),
           eq(modelProviders.userId, ORG_NO_SECRET_PROVIDER_USER_ID),
-          eq(modelProviders.type, "built-in"),
+          inArray(modelProviders.type, [
+            ...PREVIOUS_RELEASE_BUILT_IN_PROVIDER_IDENTITY_TYPES,
+          ]),
         ),
       )
       .for("update");
     signal.throwIfAborted();
 
+    if (existingProviders.length > 1) {
+      throw new Error(
+        "Conflicting built-in model provider alias rows; refusing to merge or delete either row",
+      );
+    }
+
+    const existingProvider = existingProviders[0];
     if (existingProvider) {
       const [provider] = await tx
         .update(modelProviders)

--- a/turbo/packages/db/scripts/test-built-in-provider-discriminator-migration.ts
+++ b/turbo/packages/db/scripts/test-built-in-provider-discriminator-migration.ts
@@ -2,11 +2,11 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { modelProviderWriteTypeSchema } from "@okouai/api-contracts/contracts/model-providers";
-import { upsertBuiltInNoSecretModelProviderIdentity } from "@okouai/db/operations/model-provider-built-in-identity";
 import { drizzle } from "drizzle-orm/node-postgres";
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import { Client } from "pg";
 import { applyMigrationsFromDirectoryUpToTag } from "./migration-consistency-helpers";
+import { upsertPreviousReleaseBuiltInNoSecretModelProviderIdentity } from "./previous-release-built-in-provider-identity-test-fixture";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const MIGRATIONS_DIR = path.join(dirname, "../src/migrations");
@@ -20,7 +20,7 @@ interface ProviderRowSnapshot {
   readonly type: string | null;
 }
 
-interface NewAppNoSecretProviderRow {
+interface PreviousReleaseAppNoSecretProviderRow {
   readonly id: string;
   readonly selectedModel: string | null;
   readonly type: string;
@@ -119,7 +119,7 @@ function expectedCanonicalRows(
   });
 }
 
-async function executeNewAppNoSecretProviderWrite(
+async function executePreviousReleaseAppNoSecretProviderWrite(
   db: NodePgDatabase<Record<string, never>>,
   args: {
     readonly orgId: string;
@@ -129,20 +129,21 @@ async function executeNewAppNoSecretProviderWrite(
   },
 ): Promise<{
   readonly created: boolean;
-  readonly provider: NewAppNoSecretProviderRow;
+  readonly provider: PreviousReleaseAppNoSecretProviderRow;
 }> {
   const canonicalType = modelProviderWriteTypeSchema.parse(args.requestType);
   assert.equal(canonicalType, "built-in");
-  const result = await upsertBuiltInNoSecretModelProviderIdentity(
-    db,
-    {
-      orgId: args.orgId,
-      selectedModel: args.selectedModel,
-      updatedAt: new Date("2026-08-27T00:00:00.000Z"),
-      proposedId: args.proposedId,
-    },
-    new AbortController().signal,
-  );
+  const result =
+    await upsertPreviousReleaseBuiltInNoSecretModelProviderIdentity(
+      db,
+      {
+        orgId: args.orgId,
+        selectedModel: args.selectedModel,
+        updatedAt: new Date("2026-08-27T00:00:00.000Z"),
+        proposedId: args.proposedId,
+      },
+      new AbortController().signal,
+    );
   return {
     created: result.created,
     provider: {
@@ -289,7 +290,7 @@ async function validateBridgeAndBackfill(baseUrl: string): Promise<void> {
       await client.query("SET lock_timeout = '100ms'");
       try {
         await assert.rejects(
-          executeNewAppNoSecretProviderWrite(db, {
+          executePreviousReleaseAppNoSecretProviderWrite(db, {
             orgId: "provider-migration-org-prebridge-upsert",
             proposedId: ids.preBridgeLockProbeProvider,
             requestType: "built-in",
@@ -327,12 +328,13 @@ async function validateBridgeAndBackfill(baseUrl: string): Promise<void> {
       },
     ]);
 
-    const preBridgeUpsert = await executeNewAppNoSecretProviderWrite(db, {
-      orgId: "provider-migration-org-prebridge-upsert",
-      proposedId: ids.preBridgeProposedProvider,
-      requestType: "built-in",
-      selectedModel: "gpt-5.6-terra",
-    });
+    const preBridgeUpsert =
+      await executePreviousReleaseAppNoSecretProviderWrite(db, {
+        orgId: "provider-migration-org-prebridge-upsert",
+        proposedId: ids.preBridgeProposedProvider,
+        requestType: "built-in",
+        selectedModel: "gpt-5.6-terra",
+      });
     assert.deepEqual(preBridgeUpsert, {
       created: false,
       provider: {
@@ -341,15 +343,13 @@ async function validateBridgeAndBackfill(baseUrl: string): Promise<void> {
         type: "built-in",
       },
     });
-    const repeatedPreBridgeUpsert = await executeNewAppNoSecretProviderWrite(
-      db,
-      {
+    const repeatedPreBridgeUpsert =
+      await executePreviousReleaseAppNoSecretProviderWrite(db, {
         orgId: "provider-migration-org-prebridge-upsert",
         proposedId: ids.preBridgeSecondProposedProvider,
         requestType: "built-in",
         selectedModel: "gpt-5.6-luna",
-      },
-    );
+      });
     assert.deepEqual(repeatedPreBridgeUpsert, {
       created: false,
       provider: {
@@ -358,15 +358,13 @@ async function validateBridgeAndBackfill(baseUrl: string): Promise<void> {
         type: "built-in",
       },
     });
-    const createdPreBridgeUpsert = await executeNewAppNoSecretProviderWrite(
-      db,
-      {
+    const createdPreBridgeUpsert =
+      await executePreviousReleaseAppNoSecretProviderWrite(db, {
         orgId: "provider-migration-org-prebridge-new",
         proposedId: ids.preBridgeNewProvider,
         requestType: "built-in",
         selectedModel: "gpt-5.6-luna",
-      },
-    );
+      });
     assert.deepEqual(createdPreBridgeUpsert, {
       created: true,
       provider: {
@@ -434,12 +432,13 @@ async function validateBridgeAndBackfill(baseUrl: string): Promise<void> {
       assert.deepEqual(afterRows, expectedCanonicalRows(beforeRows));
     }
 
-    const postBridgeUpsert = await executeNewAppNoSecretProviderWrite(db, {
-      orgId: "provider-migration-org-prebridge-upsert",
-      proposedId: ids.postBridgeProposedProvider,
-      requestType: "built-in",
-      selectedModel: "gpt-5.6-sol",
-    });
+    const postBridgeUpsert =
+      await executePreviousReleaseAppNoSecretProviderWrite(db, {
+        orgId: "provider-migration-org-prebridge-upsert",
+        proposedId: ids.postBridgeProposedProvider,
+        requestType: "built-in",
+        selectedModel: "gpt-5.6-sol",
+      });
     assert.deepEqual(postBridgeUpsert, {
       created: false,
       provider: {
@@ -475,16 +474,16 @@ async function validateBridgeAndBackfill(baseUrl: string): Promise<void> {
     }
 
     console.log(
-      "   ✅ new-app/before-bridge built-in SQL is accepted by the expanded schema",
+      "   ✅ previous-release app/before-bridge built-in SQL is accepted by the expanded schema",
     );
     console.log(
-      "   ✅ canonical and repeated app upserts keep one pre-bridge row, its original id, and accurate created state",
+      "   ✅ previous-release canonical and repeated upserts keep one pre-bridge row, its original id, and accurate created state",
     );
     console.log(
-      "   ✅ canonical app writes take the built-in provider-state advisory lock",
+      "   ✅ previous-release app writes take the built-in provider-state advisory lock",
     );
     console.log(
-      "   ✅ the same new-app SQL remains one-row/id-preserving with the database bridge installed",
+      "   ✅ the same previous-release app SQL remains one-row/id-preserving with the database bridge installed",
     );
     console.log(
       "   ✅ 5,001-row input crosses the 5,000-row bounded backfill boundary",
@@ -536,7 +535,7 @@ async function validateCollisionAndDriftFailures(
     `);
 
     await assert.rejects(
-      executeNewAppNoSecretProviderWrite(db, {
+      executePreviousReleaseAppNoSecretProviderWrite(db, {
         orgId: "provider-collision-org",
         proposedId: "00000000-0000-4000-8000-000000299143",
         requestType: "built-in",
@@ -600,7 +599,7 @@ async function validateCollisionAndDriftFailures(
     );
 
     console.log(
-      "   ✅ app and migration alias-pair collisions abort without merging, deleting, or changing either row",
+      "   ✅ previous-release app and migration alias-pair collisions abort without changing either row",
     );
     console.log(
       "   ✅ provider-identity unique-index drift aborts before any backfill\n",
@@ -615,7 +614,7 @@ export async function validateBuiltInProviderDiscriminatorMigration(
   baseUrl: string,
 ): Promise<void> {
   console.log(
-    "=== Phase 1.31: Validate built-in provider writer/backfill boundary ===\n",
+    "=== Phase 1.31: Validate historical built-in provider writer/backfill boundary ===\n",
   );
   await validateBridgeAndBackfill(baseUrl);
   await validateCollisionAndDriftFailures(baseUrl);

--- a/turbo/packages/db/scripts/test-built-in-provider-discriminator-permanent.ts
+++ b/turbo/packages/db/scripts/test-built-in-provider-discriminator-permanent.ts
@@ -1,5 +1,16 @@
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { upsertBuiltInNoSecretModelProviderIdentity } from "@okouai/db/operations/model-provider-built-in-identity";
+import { drizzle } from "drizzle-orm/node-postgres";
 import { Client } from "pg";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const ACTIVE_PROVIDER_IDENTITY_HELPER = path.join(
+  dirname,
+  "../src/operations/model-provider-built-in-identity.ts",
+);
 
 function databaseErrorField(
   error: unknown,
@@ -12,6 +23,29 @@ function databaseErrorField(
   return typeof value === "string" ? value : undefined;
 }
 
+function databaseErrorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+  const code = Reflect.get(error, "code");
+  if (typeof code === "string") {
+    return code;
+  }
+  return databaseErrorCode(Reflect.get(error, "cause"));
+}
+
+async function assertActiveProviderIdentityHelperIsCanonicalOnly(): Promise<void> {
+  const source = await fs.readFile(ACTIVE_PROVIDER_IDENTITY_HELPER, "utf8");
+  const canonicalTypeFilters = source.match(
+    /eq\(modelProviders\.type, "built-in"\)/gu,
+  );
+  assert.equal(canonicalTypeFilters?.length, 1);
+  assert.doesNotMatch(source, /["'`]vm0["'`]/u);
+  assert.doesNotMatch(source, /\binArray\s*\(/u);
+  assert.doesNotMatch(source, /\bexistingProviders\b/u);
+  assert.doesNotMatch(source, /alias(?:-pair| rows?)/iu);
+}
+
 export async function validatePermanentBuiltInProviderDiscriminatorState(
   dbUrl: string,
 ): Promise<void> {
@@ -20,6 +54,7 @@ export async function validatePermanentBuiltInProviderDiscriminatorState(
   );
   const client = new Client({ connectionString: dbUrl });
   await client.connect();
+  const db = drizzle(client);
 
   const ids = {
     run: "00000000-0000-4000-8000-000000299101",
@@ -31,11 +66,18 @@ export async function validatePermanentBuiltInProviderDiscriminatorState(
     proposedProvider: "00000000-0000-4000-8000-000000299107",
     historicalProvider: "00000000-0000-4000-8000-000000299108",
     invalidPolicy: "00000000-0000-4000-8000-000000299109",
+    helperProvider: "00000000-0000-4000-8000-000000310840",
+    helperLockProbeProvider: "00000000-0000-4000-8000-000000310841",
+    helperUpdateProvider: "00000000-0000-4000-8000-000000310842",
+    helperRepeatedProvider: "00000000-0000-4000-8000-000000310843",
   } as const;
   const orgId = "org-provider-discriminator-permanent-30671";
+  const helperOrgId = "org-provider-identity-permanent-31084";
   const userId = "user-provider-discriminator-permanent-30671";
 
   try {
+    await assertActiveProviderIdentityHelperIsCanonicalOnly();
+
     const residuals = await client.query<{ count: number }>(`
       SELECT (
         (SELECT count(*) FROM "agent_runs" WHERE "model_provider" = 'vm0') +
@@ -239,6 +281,109 @@ export async function validatePermanentBuiltInProviderDiscriminatorState(
     `);
     assert.deepEqual(indexState.rows, [{ count: 1 }]);
 
+    const created = await upsertBuiltInNoSecretModelProviderIdentity(
+      db,
+      {
+        orgId: helperOrgId,
+        selectedModel: "gpt-5.6-sol",
+        updatedAt: new Date("2026-09-02T00:00:00.000Z"),
+        proposedId: ids.helperProvider,
+      },
+      new AbortController().signal,
+    );
+    assert.equal(created.created, true);
+    assert.equal(created.provider.id, ids.helperProvider);
+    assert.equal(created.provider.type, "built-in");
+    assert.equal(created.provider.selectedModel, "gpt-5.6-sol");
+
+    const lockClient = new Client({ connectionString: dbUrl });
+    await lockClient.connect();
+    try {
+      await lockClient.query("BEGIN");
+      await lockClient.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [
+        `model_provider_state:${helperOrgId}:__org__:built-in`,
+      ]);
+      await client.query("SET lock_timeout = '100ms'");
+      try {
+        await assert.rejects(
+          upsertBuiltInNoSecretModelProviderIdentity(
+            db,
+            {
+              orgId: helperOrgId,
+              selectedModel: "gpt-5.6-terra",
+              updatedAt: new Date("2026-09-02T00:01:00.000Z"),
+              proposedId: ids.helperLockProbeProvider,
+            },
+            new AbortController().signal,
+          ),
+          (error: unknown) => {
+            return databaseErrorCode(error) === "55P03";
+          },
+        );
+      } finally {
+        await client.query("RESET lock_timeout");
+        await lockClient.query("ROLLBACK");
+      }
+    } finally {
+      await lockClient.end();
+    }
+
+    const afterLockProbe = await client.query<{
+      count: number;
+      id: string;
+      selectedModel: string;
+      type: string;
+    }>(
+      `
+        SELECT
+          count(*) OVER ()::integer AS "count",
+          "id"::text AS "id",
+          "selected_model" AS "selectedModel",
+          "type"
+        FROM "model_providers"
+        WHERE "org_id" = $1 AND "user_id" = '__org__'
+      `,
+      [helperOrgId],
+    );
+    assert.deepEqual(afterLockProbe.rows, [
+      {
+        count: 1,
+        id: ids.helperProvider,
+        selectedModel: "gpt-5.6-sol",
+        type: "built-in",
+      },
+    ]);
+
+    const updated = await upsertBuiltInNoSecretModelProviderIdentity(
+      db,
+      {
+        orgId: helperOrgId,
+        selectedModel: "gpt-5.6-terra",
+        updatedAt: new Date("2026-09-02T00:02:00.000Z"),
+        proposedId: ids.helperUpdateProvider,
+      },
+      new AbortController().signal,
+    );
+    assert.equal(updated.created, false);
+    assert.equal(updated.provider.id, ids.helperProvider);
+    assert.equal(updated.provider.type, "built-in");
+    assert.equal(updated.provider.selectedModel, "gpt-5.6-terra");
+
+    const repeated = await upsertBuiltInNoSecretModelProviderIdentity(
+      db,
+      {
+        orgId: helperOrgId,
+        selectedModel: "gpt-5.6-luna",
+        updatedAt: new Date("2026-09-02T00:03:00.000Z"),
+        proposedId: ids.helperRepeatedProvider,
+      },
+      new AbortController().signal,
+    );
+    assert.equal(repeated.created, false);
+    assert.equal(repeated.provider.id, ids.helperProvider);
+    assert.equal(repeated.provider.type, "built-in");
+    assert.equal(repeated.provider.selectedModel, "gpt-5.6-luna");
+
     console.log(
       "   ✅ permanent data and catalog state contain no exact vm0 discriminator or rollback bridge",
     );
@@ -247,6 +392,9 @@ export async function validatePermanentBuiltInProviderDiscriminatorState(
     );
     console.log(
       "   ✅ exact-value contraction preserves other historical provider spellings\n",
+    );
+    console.log(
+      "   ✅ active helper is canonical-only and preserves creation, locking, update, repeated-upsert, and row identity semantics\n",
     );
   } finally {
     await client.query(`DELETE FROM "org_model_policies" WHERE "org_id" = $1`, [
@@ -257,6 +405,9 @@ export async function validatePermanentBuiltInProviderDiscriminatorState(
     ]);
     await client.query(`DELETE FROM "model_providers" WHERE "org_id" = $1`, [
       orgId,
+    ]);
+    await client.query(`DELETE FROM "model_providers" WHERE "org_id" = $1`, [
+      helperOrgId,
     ]);
     await client.query(`DELETE FROM "agent_sessions" WHERE "id" = $1`, [
       ids.session,

--- a/turbo/packages/db/scripts/test-built-in-provider-discriminator-permanent.ts
+++ b/turbo/packages/db/scripts/test-built-in-provider-discriminator-permanent.ts
@@ -1,16 +1,7 @@
 import assert from "node:assert/strict";
-import fs from "node:fs/promises";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { upsertBuiltInNoSecretModelProviderIdentity } from "@okouai/db/operations/model-provider-built-in-identity";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Client } from "pg";
-
-const dirname = path.dirname(fileURLToPath(import.meta.url));
-const ACTIVE_PROVIDER_IDENTITY_HELPER = path.join(
-  dirname,
-  "../src/operations/model-provider-built-in-identity.ts",
-);
 
 function databaseErrorField(
   error: unknown,
@@ -32,18 +23,6 @@ function databaseErrorCode(error: unknown): string | undefined {
     return code;
   }
   return databaseErrorCode(Reflect.get(error, "cause"));
-}
-
-async function assertActiveProviderIdentityHelperIsCanonicalOnly(): Promise<void> {
-  const source = await fs.readFile(ACTIVE_PROVIDER_IDENTITY_HELPER, "utf8");
-  const canonicalTypeFilters = source.match(
-    /eq\(modelProviders\.type, "built-in"\)/gu,
-  );
-  assert.equal(canonicalTypeFilters?.length, 1);
-  assert.doesNotMatch(source, /["'`]vm0["'`]/u);
-  assert.doesNotMatch(source, /\binArray\s*\(/u);
-  assert.doesNotMatch(source, /\bexistingProviders\b/u);
-  assert.doesNotMatch(source, /alias(?:-pair| rows?)/iu);
 }
 
 export async function validatePermanentBuiltInProviderDiscriminatorState(
@@ -76,8 +55,6 @@ export async function validatePermanentBuiltInProviderDiscriminatorState(
   const userId = "user-provider-discriminator-permanent-30671";
 
   try {
-    await assertActiveProviderIdentityHelperIsCanonicalOnly();
-
     const residuals = await client.query<{ count: number }>(`
       SELECT (
         (SELECT count(*) FROM "agent_runs" WHERE "model_provider" = 'vm0') +
@@ -394,7 +371,7 @@ export async function validatePermanentBuiltInProviderDiscriminatorState(
       "   ✅ exact-value contraction preserves other historical provider spellings\n",
     );
     console.log(
-      "   ✅ active helper is canonical-only and preserves creation, locking, update, repeated-upsert, and row identity semantics\n",
+      "   ✅ active helper preserves canonical creation, locking, update, repeated-upsert, and row identity semantics\n",
     );
   } finally {
     await client.query(`DELETE FROM "org_model_policies" WHERE "org_id" = $1`, [


### PR DESCRIPTION
## Summary

- make the active built-in provider identity helper query only the canonical `built-in` discriminator while preserving its existing lock, update, insert, conflict-target, abort, and return behavior
- freeze the previous-release dual-value writer from `aad55f424b8a4b72c2b06e25335e06de53e10c7a` in an explicitly historical test fixture so the 1013-1015 deployment proof no longer imports production code
- extend the permanent validator with current-schema create, update, repeated-upsert, identity, selected-model, and lock coverage

## Validation

- `pnpm exec prettier --check packages/db/src/operations/model-provider-built-in-identity.ts packages/db/scripts/previous-release-built-in-provider-identity-test-fixture.ts packages/db/scripts/test-built-in-provider-discriminator-migration.ts packages/db/scripts/test-built-in-provider-discriminator-permanent.ts`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- historical 1013-1015 Provider discriminator migration validator
- migration 1038 Provider discriminator contract validator
- permanent current-schema Provider discriminator validator
- `pnpm --filter @okouai/db exec vitest run scripts/legacy-database-identity-inventory.test.ts` (22 passed; manifest remains 17 total / 0 migrate / 17 retain)
- `DATABASE_URL=<local-current-schema-db> pnpm --filter api exec vitest run src/signals/routes/__tests__/misc-routes.bdd.test.ts` (6 passed)

## Scope

- active Provider discriminator scan returns zero exact-lowercase `vm0` readers or writers outside historical fixtures and negative tests
- no shipped migrations, snapshots, journal, Provider API contracts, routing, catalogs, secrets, IDs, selected-model behavior, workflows, Actions, Browser state, MaskDB, or production resources changed

Refs #31084
