### PR TITLE
fix(platform): inject prod clerk key into local env template

### DIFF
--- a/turbo/apps/platform/.env.local.tpl
+++ b/turbo/apps/platform/.env.local.tpl
@@ -1,7 +1,7 @@
 # App Environment Configuration
 # Use 1Password CLI to inject secrets: ./scripts/sync-env.sh
 VITE_CLERK_PUBLISHABLE_KEY_PREVIEW=op://Development/clerk/CLERK_PUBLISHABLE_KEY
-VITE_CLERK_PUBLISHABLE_KEY_PROD=
+VITE_CLERK_PUBLISHABLE_KEY_PROD=op://Development/clerk/CLERK_PUBLISHABLE_KEY_PROD
 VITE_API_URL=http://localhost:3000
 PUBLIC_ARTIFACTS_BASE_URL=https://cdn.vm7.io
 


### PR DESCRIPTION
## Problem

`pnpm dev` cannot start the platform app locally:

```
@okouai/app:dev: error when starting dev server:
@okouai/app:dev: Error: Missing VITE_CLERK_PUBLISHABLE_KEY_PROD environment variable
```

`clerkCoreHtmlPlugin` (`turbo/apps/platform/scripts/clerk-html.ts`) asserts both
publishable keys in `configResolved`, which Vite runs for `serve` as well as
`build`. `turbo/apps/platform/.env.local.tpl` left `VITE_CLERK_PUBLISHABLE_KEY_PROD`
empty, so `sync-env.sh` produced an empty value and the dev server aborted before
listening. Because the platform task fails, the whole `turbo dev` run exits and the
web/API/proxy tasks go down with it.

CI is unaffected: `.github/workflows/turbo.yml` supplies the value from
`vars.CLERK_PUBLISHABLE_KEY_PROD`, so only local development was broken.

## Change

Point the template at the 1Password entry that already holds the value, matching how
`VITE_CLERK_PUBLISHABLE_KEY_PREVIEW` is sourced. Clerk publishable keys are public by
design (they ship inlined in every built artifact), so this adds no secret exposure.

## Test plan

- [x] `scripts/sync-env.sh` populates the key
- [x] `pnpm dev` starts; `dev:status` reports Web / App / API / Onboard all running
- [x] `curl -k https://api.vm7.ai:8443/health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)