### PR TITLE
refactor(api): empty the branded compatibility table

### DIFF
--- a/docs/okou-cli-cutover.md
+++ b/docs/okou-cli-cutover.md
@@ -60,10 +60,10 @@ Keep `OKOU_TOKEN`, `OKOU_AGENT_ID`, the canonical `OKOU_*` names,
 identifiers, the Slack `/zero model` interaction, and the separate Desktop
 identity. These are not executable CLI producers.
 
-`/api/okou/**` is not a preserved identity. It is a compatibility surface being
-drained under #26701: it is down to 53 rows in `MIGRATED_BRANDED_PATHS`, and
-after #28984 no contract declares a branded path, so those rows are the only
-thing still registering one.
+`/api/okou/**` is not a preserved identity. It was a compatibility surface
+drained under #26701, and #31088 emptied `MIGRATED_BRANDED_PATHS`, its last
+holder. After #28984 no contract declares a branded path either, so nothing
+registers one and every request to `/api/okou/**` or `/api/zero/**` is a 404.
 
 The run-token scope pair was the one exception, retired separately once the
 issuing side had drained; see `docs/okou-protocol-migration.md`.

--- a/turbo/apps/api/src/__tests__/api-namespace-compatibility.test.ts
+++ b/turbo/apps/api/src/__tests__/api-namespace-compatibility.test.ts
@@ -16,43 +16,22 @@ const LEGACY_PREFIX = "/api/zero";
 
 // The legacy `/api/zero/**` paths this service still owes a caller, keyed by
 // the canonical `/api/okou/**` path the same handler answers. #30667 deleted
-// `LEGACY_ZERO_PATHS`, so none of them is derived any more: each is named
+// `LEGACY_ZERO_PATHS`, so none of them is derived any more: each was named
 // directly by a `MIGRATED_BRANDED_PATHS` row. Restated here rather than
 // imported from `route-entry.ts`, so narrowing that table fails this file
 // instead of quietly agreeing with itself.
 //
-// #30668 took the list from six paths to two, because for four of them the
-// producer that held the branded URL moved rather than a caller draining: the
-// Slack app console now posts the three webhooks to `/api/webhooks/slack/*`,
-// with `Slackbot 1.0` observed delivering to each, and `routes/slack-oauth.ts`
-// emits the neutral `redirect_uri` since #30551.
+// The list is empty. #30668 took it from six paths to two once the Slack app
+// console and `routes/slack-oauth.ts` began holding neutral URLs, #30812 took
+// the Teams callback, and #31088 took the Slack install link — the last one,
+// and the one no deploy could drain, because its branded form was handed to
+// people rather than computed per request. Nothing on this service answers a
+// branded path now.
 //
-// #30812 then took the Teams callback, leaving one. #30667 had unified
-// `callbackRedirectUri` onto the canonical path, and a `redirect_uri` is
-// computed per request rather than handed to a person, so that deploy bounded
-// the branded form to authorizations already in flight — minutes, long past by
-// the time the row went.
-//
-// The one that remains has no producer left to move and no deploy that can
-// drain it either: the Slack install link was handed to people rather than
-// computed per request, and its `zero` form was still answering browser and
-// crawler requests ten hours after the deploy that was supposed to have drained
-// it.
-const SERVED_LEGACY_PATHS: Readonly<Record<string, string>> = {
-  "/api/okou/slack/oauth/install": "/api/zero/slack/oauth/install",
-};
-
-// A row #28701 removed from `LEGACY_ZERO_PATHS` whose path did not retire with
-// it: `MIGRATED_BRANDED_PATHS` names both branded forms of the neutral
-// `/api/org` contract, so the removed row recorded that the path was owed
-// rather than being what served it. Pinned here because it is why removing
-// twenty-five rows changed nothing a caller can observe, and why #30667 could
-// remove the remaining six the same way.
-const MIGRATED_BRANDED_SUBJECT = {
-  neutral: "/api/org",
-  canonical: "/api/okou/org",
-  legacy: "/api/zero/org",
-} as const;
+// The cases driven from this list stay: they are what a slice re-adding a
+// compatibility path has to satisfy, and restating the path here is how it
+// does that.
+const SERVED_LEGACY_PATHS: Readonly<Record<string, string>> = {};
 
 function routeKey(entry: RouteEntry): string {
   return `${entry.route.method} ${entry.route.path}`;
@@ -206,18 +185,12 @@ describe("API namespace compatibility", () => {
     ).toStrictEqual([]);
   });
 
-  // The issue that narrowed the table proposed `/api/zero/org` as the retired
-  // subject, from a request-log window where its traffic had stopped. It is not
-  // retired, and this pins why: the row removed from the compatibility table is
-  // not what served the path.
-  it("keeps a removed row's path served by the migrated branded table", () => {
-    for (const path of Object.values(MIGRATED_BRANDED_SUBJECT)) {
-      expect(
-        registrationsFor(path).length,
-        `Expected ${path} to stay served`,
-      ).toBeGreaterThan(0);
-    }
-  });
+  // A case pinning `/api/org` used to sit here. #28701 removed that path's
+  // `LEGACY_ZERO_PATHS` row while a `MIGRATED_BRANDED_PATHS` row kept both
+  // branded forms served, which is why removing twenty-five rows changed
+  // nothing a caller could observe — the removed row recorded that the path was
+  // owed rather than being what served it. #31088 removed the row that served
+  // it too, so the path has no branded form left and the case has no subject.
 
   it("keeps neutral health, webhook, and product-scoped Desktop routes single", () => {
     const neutralPaths = [
@@ -290,63 +263,13 @@ describe("API namespace compatibility", () => {
     expect(missingCompatibilityPaths(ROUTES)).toStrictEqual([]);
   });
 
-  // The regression #28278 hit ~354 times: a contract moves off `/api/okou/**`
-  // to a neutral path, both branded registrations disappear, and every
-  // mechanism assertion in this file still passes. This pins that the literal
-  // list is what fails, so such a migration cannot go green and then 404 in
-  // production. Removing the path from the list is the way out, and it has to
-  // be deliberate.
-  //
-  // #28600 moved the last branded contract, so the subject is now a route that
-  // has already migrated, moved a second time to a path no
-  // `MIGRATED_BRANDED_PATHS` row names. That is the same failure: a slice edits
-  // the contract and forgets the rows the branded paths depend on. #30668 took
-  // the Slack events row this used to drive and repointed it at the Slack
-  // install link, whose branded forms that PR measured still in use.
-  it("reports the branded registrations a neutral contract migration would drop", () => {
-    const canonical = "/api/okou/slack/oauth/install";
-    const legacy = "/api/zero/slack/oauth/install";
-    const declared = "/api/slack/oauth/install";
-    const neutral = "/api/slack/install";
-    expect(
-      SERVED_LEGACY_PATHS[canonical],
-      `${canonical} must stay in the served-legacy list for this guard to mean anything`,
-    ).toBe(legacy);
-    expect(
-      ROUTES.filter((entry) => {
-        return entry.route.path === declared;
-      }),
-      `Expected a contract declaring ${declared} for this guard to move something`,
-    ).not.toHaveLength(0);
-
-    const migratedRoutes = ROUTES.map((entry): RouteEntry => {
-      if (entry.route.path !== declared) {
-        return entry;
-      }
-      return {
-        route: { ...entry.route, path: neutral },
-        handler: entry.handler,
-      };
-    });
-    const migratedRegistrations = withApiNamespaceAliases(migratedRoutes);
-
-    // The mechanism stays internally consistent, which is exactly why it cannot
-    // be the thing that catches this.
-    expect(
-      migratedRegistrations.map((entry) => {
-        return entry.route.path;
-      }),
-    ).toContain(neutral);
-    expect(apiNamespaceAliasPaths(neutral)).toStrictEqual([neutral]);
-    expect(() => {
-      assertUniqueRouteRegistrations(migratedRegistrations);
-    }).not.toThrow();
-
-    // The literal list is what notices.
-    expect(missingCompatibilityPaths(migratedRoutes)).toStrictEqual(
-      [canonical, legacy].sort(),
-    );
-  });
+  // The regression #28278 hit ~354 times used to be pinned here: a contract
+  // moves off `/api/okou/**` to a neutral path, both branded registrations
+  // disappear, and every mechanism assertion in this file still passes, so the
+  // literal list above is what has to fail. It needs a listed path to move, and
+  // #31088 emptied the list, so the case has no subject. The synthetic twin in
+  // `migrated-branded-paths.test.ts` keeps that guard on the mechanism itself,
+  // where it does not depend on a shipped row.
 
   // A row whose canonical path nothing answers is a row no caller can use. Read
   // from the served composition rather than from `ROUTES`: once a #28278 slice

--- a/turbo/apps/api/src/__tests__/api-namespace-legacy-paths.test.ts
+++ b/turbo/apps/api/src/__tests__/api-namespace-legacy-paths.test.ts
@@ -9,25 +9,17 @@ import { testContext } from "./test-context";
 const c = initContract();
 const REQUEST_ORIGIN = "http://api.test";
 
-// `/api/slack/oauth/install` is a `MIGRATED_BRANDED_PATHS` key in
-// `route-entry.ts`, so a contract declaring it is registered on both branded
-// forms as well. The `__test` paths are named by no table, so they stand in for
-// the branded contract paths #28701 stopped deriving a legacy form for and
-// #30667 made unconditional.
+// The `__test` paths are named by no table, so they stand in for the branded
+// contract paths #28701 stopped deriving a legacy form for and #30667 made
+// unconditional.
 //
-// #30668 moved this subject off `/api/webhooks/slack/events`, whose row it
-// retired once the Slack app console stopped posting to the branded forms. The
-// install row is the opposite case and the reason it is the subject now: its
-// branded URL was handed to people rather than emitted per request, so no
-// deploy can drain it and the row outlives the ones a console held.
+// A third contract used to sit alongside them, declaring a
+// `MIGRATED_BRANDED_PATHS` key so that a row's branded forms were driven
+// through the app factory too. #30668 made that subject
+// `/api/slack/oauth/install`, whose branded URL was handed to people rather
+// than emitted per request; #31088 removed that row along with the rest of the
+// table, so no key is left for such a contract to declare.
 const namespaceContract = c.router({
-  migrated: {
-    method: "GET",
-    path: "/api/slack/oauth/install",
-    responses: {
-      200: z.object({ served: z.literal(true) }),
-    },
-  },
   unlisted: {
     method: "GET",
     path: "/api/okou/__test/namespace-alias",
@@ -50,7 +42,6 @@ const served$ = computed(() => {
 });
 
 const TEST_ROUTES: readonly RouteEntry[] = [
-  { route: namespaceContract.migrated, handler: served$ },
   { route: namespaceContract.unlisted, handler: served$ },
   { route: namespaceContract.unlistedById, handler: served$ },
 ];
@@ -65,25 +56,6 @@ describe("legacy API namespace paths", () => {
   function createTestApp() {
     return createAppWithRoutes({ signal: context.signal, routes: TEST_ROUTES });
   }
-
-  it("serves a migrated route's declared path and both branded paths", async () => {
-    const app = createTestApp();
-
-    const legacy = await app.request(
-      `${REQUEST_ORIGIN}/api/zero/slack/oauth/install`,
-    );
-    const canonical = await app.request(
-      `${REQUEST_ORIGIN}/api/okou/slack/oauth/install`,
-    );
-    const declared = await app.request(
-      `${REQUEST_ORIGIN}/api/slack/oauth/install`,
-    );
-
-    expect([legacy.status, canonical.status, declared.status]).toStrictEqual([
-      200, 200, 200,
-    ]);
-    await expect(legacy.json()).resolves.toStrictEqual({ served: true });
-  });
 
   // Before #28701 this path was served by the blanket expansion and reported
   // once per app instance. #28701 narrowed it to a table of six, and #30667

--- a/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
+++ b/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
@@ -1,11 +1,10 @@
+import { brandedApiNamespace } from "@okouai/api-contracts/contracts/api-namespaces";
 import { initContract } from "@okouai/api-contracts/contracts/trpc-contract";
 import { computed } from "ccstate";
 import { z } from "zod";
 
 import { createAppWithRoutes } from "../app-factory-core";
 import { ROUTES } from "../signals/route";
-import { orgReadRoutes } from "../signals/routes/org-read";
-import { slackOauthRoutes } from "../signals/routes/slack-oauth";
 import {
   assertUniqueRouteRegistrations,
   type RouteEntry,
@@ -96,59 +95,19 @@ const BRANDED_PATHS_OWED = [
   "/api/zero/synthetic/thing",
 ] as const;
 
-// Every route a #28278 slice has moved off `/api/okou/**`, keyed by the
-// neutral path its contract declares now and holding the two branded paths
-// released callers still reach it at. Restated here rather than read back
-// from `MIGRATED_BRANDED_PATHS` or derived from `apiNamespaceAliasPaths`: the
-// table is what a migration edits, and the function returns a neutral path
-// unchanged, so an expectation taken from either asserts nothing. Each slice
-// appends its own rows.
-const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
-  // #28422
-  "/api/logs/:id": ["/api/okou/logs/:id", "/api/zero/logs/:id"],
-  // #28464: the Slack, Teams, and Feishu connect and OAuth-start routes. The
-  // paths a provider console holds are not in this slice and stay branded;
-  // they are covered by `provider-console-paths.test.ts`. #30812 removed
-  // `slack/oauth/connect` and #30807 removed `slack/channels`, leaving the one
-  // OAuth-start path a marketing landing page published.
-  "/api/slack/oauth/install": [
-    "/api/okou/slack/oauth/install",
-    "/api/zero/slack/oauth/install",
-  ],
-  // #28465. Keys hold their path parameters verbatim, because the table is
-  // matched against `entry.route.path` rather than an expanded request path.
-  "/api/desktop/updates/:channel/:platform/:arch/dmg": [
-    "/api/okou/desktop/updates/:channel/:platform/:arch/dmg",
-    "/api/zero/desktop/updates/:channel/:platform/:arch/dmg",
-  ],
-  "/api/desktop/updates/:channel/:platform/:arch/release": [
-    "/api/okou/desktop/updates/:channel/:platform/:arch/release",
-    "/api/zero/desktop/updates/:channel/:platform/:arch/release",
-  ],
-  // #28462: feature switches, model policies, org model providers and their
-  // device-auth sessions, the org profile and membership routes, and the usage
-  // reads. #30804 removed `feature-switches` and #30807 removed
-  // `model-policies`, leaving the org profile.
-  "/api/org": ["/api/okou/org", "/api/zero/org"],
-  // #28461. #30807 removed the four per-agent rows.
-  "/api/workflows": ["/api/okou/workflows", "/api/zero/workflows"],
-  // #28544: the two Feishu routes that left `FINAL_PROVIDER_CONSOLE_PATHS`.
-  // #28709 removed the OAuth callback, and #31068 removed the events row as an
-  // owner decision rather than on evidence: both production installations still
-  // hold the branded URL in their own Feishu app console, so removing it stops
-  // their deliveries, and the owner accepted that after notifying both holders.
-  // #28565: the connector-account reads and writes and the managed SocialKit
-  // request, the two contracts that were added while #28278 was in flight and
-  // so appeared in no slice's inventory.
-  // #28600 added the Slack OAuth callback and the three inbound Slack webhooks,
-  // the last contracts to leave the brand namespace, and #30668 removed all
-  // four once their producers moved: the Slack app console now holds the
-  // neutral webhook URLs, and `routes/slack-oauth.ts` emits the neutral
-  // callback as its `redirect_uri`.
-  // #30807 then removed forty-four rows as a class: no source in `turbo/`
-  // emits a branded literal outside tests, and the Computer Use family that an
-  // installed Desktop build does hardcode had already been settled by #30804.
-};
+// Every route a #28278 slice has moved off `/api/okou/**` and still answers on
+// a branded path, keyed by the neutral path its contract declares now.
+// Restated here rather than read back from `MIGRATED_BRANDED_PATHS` or derived
+// from `apiNamespaceAliasPaths`: the table is what a migration edits, and the
+// function returns a neutral path unchanged, so an expectation taken from
+// either asserts nothing.
+//
+// The inventory is empty. #31088 removed the last six rows — `/api/org`,
+// `/api/workflows`, `/api/logs/:id`, the two `desktop/updates` rows and
+// `/api/slack/oauth/install` — so no route answers on a branded path any more.
+// A slice that adds a row back has to restate it here, which is what the two
+// cases over the production route table below are for.
+const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {};
 
 function missingBrandedPaths(
   routes: readonly RouteEntry[],
@@ -168,7 +127,10 @@ function missingBrandedPaths(
 // leaves a neutral path alone, which is why a contract that moves to its
 // neutral path loses both branded registrations. This file covers the table
 // that gives them back: what it registers, what it must not touch, and the
-// migration mistake it exists to make loud.
+// migration mistake it exists to make loud. The synthetic cases drive that
+// mechanism directly and stay meaningful with the shipped table empty; the
+// cases over the real route table are what a slice adding a row back has to
+// satisfy.
 describe("branded paths for migrated neutral routes", () => {
   const context = testContext();
 
@@ -261,43 +223,30 @@ describe("branded paths for migrated neutral routes", () => {
   });
 
   // The synthetic cases above cover the mechanism; this runs the real route
-  // table through the composition production registers, so a moved contract
-  // that lost its rows fails here rather than 404ing a released caller.
-  it("serves every migrated route at its neutral path and both branded paths", () => {
+  // table through the composition production registers. While the inventory
+  // held rows, it asserted each one was served on its neutral path and on both
+  // branded forms, so a moved contract that lost its rows failed here rather
+  // than 404ing a released caller. The inventory is empty now, so the property
+  // it pins is the whole-table one the rows were exceptions to: the
+  // composition registers a branded path for nothing.
+  //
+  // Read off the composition rather than off the table, so it also fails if a
+  // contract starts declaring a branded path again.
+  it("registers no branded path for any route in the production table", () => {
+    expect(Object.keys(MIGRATED_ROUTE_PATHS)).toStrictEqual([]);
+
     const registered = withMigratedBrandedPaths(
       withApiNamespaceAliases(ROUTES),
     );
 
-    for (const [neutral, brandedPaths] of Object.entries(
-      MIGRATED_ROUTE_PATHS,
-    )) {
-      const declared = ROUTES.filter((entry) => {
-        return entry.route.path === neutral;
-      });
-      expect(
-        declared.length,
-        `Expected a contract declaring ${neutral}`,
-      ).toBeGreaterThan(0);
-
-      for (const source of declared) {
-        for (const path of [neutral, ...brandedPaths]) {
-          const key = `${source.route.method} ${path}`;
-          const matches = registered.filter((entry) => {
-            return (
-              entry.route.method === source.route.method &&
-              entry.route.path === path
-            );
-          });
-          expect(matches, `Missing registration for ${key}`).toHaveLength(1);
-          const match = matches[0];
-          if (!match) {
-            throw new Error(`Missing registration for ${key}`);
-          }
-          expect(match.handler).toBe(source.handler);
-          expect(match.route).toStrictEqual({ ...source.route, path });
-        }
-      }
-    }
+    expect(
+      registeredPaths(registered)
+        .filter((path) => {
+          return brandedApiNamespace(path) !== undefined;
+        })
+        .sort(),
+    ).toStrictEqual([]);
+    expect(registered).toHaveLength(ROUTES.length);
   });
 
   // Hono keeps both registrations for a duplicated path and answers with the
@@ -316,132 +265,39 @@ describe("branded paths for migrated neutral routes", () => {
     }).not.toThrow();
   });
 
-  // A count, restated here as a literal, over the inventory above. The
-  // per-family cases prove that every row the inventory lists is served on both
-  // branded forms; this proves the inventory itself is complete, so a later
-  // change that removes a still-needed row fails a test instead of passing
-  // because nothing enumerated it.
+  // A count, restated here as a literal, over the inventory above. While the
+  // inventory held rows it proved the inventory itself was complete, so a
+  // change that dropped a still-needed row failed a test instead of passing
+  // because nothing enumerated it. That is the guard every removal from #28709
+  // onward kept as the table went from 314 rows to six, and #31088 kept when it
+  // took the last six.
   //
-  // That is the guard #28709 left behind when it took the table from 314 rows
-  // to 184, #28711 kept when it took the 42 drained rows that left 142, #28917
-  // kept when it took 53 more and left 89, #28974 kept when it took
-  // `uploads/prepare` and left 88, #28916 kept when it took the 26 cut-over
-  // rows that left 62, #30668 kept when it took the four Slack rows whose
-  // producer moved and left 58, #30804 kept when it took the four Computer Use
-  // host rows and `feature-switches` and left 53, #30812 kept when it took
-  // the Teams OAuth callback and the Slack connect start and left 51, #30807
-  // kept when it took forty-four rows as a class and left 7, and #31068 kept
-  // when it took the Feishu events row and left 6. None of them left a case
-  // asserting the removed rows now 404: `docs/fallback.md` section 1 rules that
-  // class out, and the route table already proves the registration is gone.
-  // What needs a test is the opposite direction — a row disappearing without
-  // the request-log evidence #26701 requires — which is what this count and the
-  // per-family cases catch.
-  //
-  // `MIGRATED_ROUTE_PATHS` carries every row. It used to be two short, because
-  // the maps and weather cases owned `/api/maps/geocode` and
-  // `/api/weather/current`; #28917 drained both families out of the table, so
-  // those cases and the offset they needed are gone and the size below is the
-  // whole table. Raise the number only with that evidence; an unexplained edit
-  // here is the failure this is for.
+  // At zero it still carries that direction: the count is what a slice adding a
+  // row back has to raise deliberately, with the evidence #26701's gate wants.
+  // None of those removals left a case asserting the removed rows now 404 —
+  // `docs/fallback.md` section 1 rules that class out, and the case above
+  // already proves the composition registers no branded path.
   it("holds the branded rows this suite has evidence for and no others", () => {
-    const MIGRATED_BRANDED_ROW_COUNT = 6;
+    const MIGRATED_BRANDED_ROW_COUNT = 0;
 
     expect(Object.keys(MIGRATED_ROUTE_PATHS)).toHaveLength(
       MIGRATED_BRANDED_ROW_COUNT,
     );
   });
 
-  // The #28464 twin of the two assertions above, driven through the app factory
-  // production uses rather than over the route table. The one path left is an
-  // install link already sitting in a Slack message, a bookmark or a search
-  // index, which is the holder no deploy bounds. The status is whatever the
-  // handler returns without credentials or provider configuration; the point is
-  // that all three forms reach the same handler instead of falling through to
-  // 404. #30812 dropped `slack/oauth/connect` from the list, because no page
-  // publishes a connect link for anyone to be holding, and #30807 dropped
-  // `slack/channels`, the one a released web build derived from a contract.
-  it("serves the migrated IM connect paths through the production app factory", async () => {
-    context.mocks.clerk.authenticateRequest.mockResolvedValue({
-      isAuthenticated: false,
-    });
-
-    const families = [
-      { routes: slackOauthRoutes, suffix: "slack/oauth/install" },
-    ];
-
-    for (const { routes, suffix } of families) {
-      const app = createAppWithRoutes({ signal: context.signal, routes });
-
-      async function statusFor(path: string): Promise<number> {
-        const response = await app.request(`${REQUEST_ORIGIN}${path}`, {
-          method: "GET",
-        });
-        return response.status;
-      }
-
-      const neutral = await statusFor(`/api/${suffix}`);
-      const okou = await statusFor(`/api/okou/${suffix}`);
-      const zero = await statusFor(`/api/zero/${suffix}`);
-
-      expect({ suffix, neutral, okou, zero }).toStrictEqual({
-        suffix,
-        neutral,
-        okou: neutral,
-        zero: neutral,
-      });
-      expect(neutral).not.toBe(404);
-    }
-  });
-
-  // The #28462 twin, driven through the same production app factory. An
-  // installed desktop build hardcodes `/api/okou/org` rather than deriving it
-  // from a contract, and a `CLI_PKG_URL`-pinned CLI was still reading
-  // `/api/zero/org` when #30804 measured the table, so this is the row a
-  // dropped registration would strand longest. That slice also covered
-  // `feature-switches`, whose row #30804 retired, which is why only `org` is
-  // exercised here now. Requests are unauthenticated, so the status is whatever
-  // the auth layer returns — the point is that all three forms reach the same
-  // handler instead of falling through to 404.
-  it("serves the migrated org paths through the production app factory", async () => {
-    context.mocks.clerk.authenticateRequest.mockResolvedValue({
-      isAuthenticated: false,
-    });
-
-    const families = [{ routes: orgReadRoutes, suffix: "org" }];
-
-    for (const { routes, suffix } of families) {
-      const app = createAppWithRoutes({ signal: context.signal, routes });
-
-      async function statusFor(path: string): Promise<number> {
-        const response = await app.request(`${REQUEST_ORIGIN}${path}`, {
-          method: "GET",
-        });
-        return response.status;
-      }
-
-      const neutral = await statusFor(`/api/${suffix}`);
-      const okou = await statusFor(`/api/okou/${suffix}`);
-      const zero = await statusFor(`/api/zero/${suffix}`);
-
-      expect({ suffix, neutral, okou, zero }).toStrictEqual({
-        suffix,
-        neutral,
-        okou: neutral,
-        zero: neutral,
-      });
-      expect(neutral).not.toBe(404);
-    }
-  });
-
-  // #28545's twin used to sit here, the one slice whose branded forms a
-  // provider console held rather than a released client. #28917 removed the
-  // slice's bot row once the Azure Bot messaging endpoint had been repointed at
-  // the neutral path, and #30812 removed the callback once #30667 had unified
-  // `callbackRedirectUri` onto the canonical path — a `redirect_uri` is
-  // computed per request, so the deploy bounded the branded form to
-  // authorizations already in flight. The slice has no rows left, so there is
-  // nothing for this case to drive.
+  // Two app-factory twins used to sit here, one per family with a row left:
+  // #28464's Slack install link and #28462's `/api/org`. Each drove all three
+  // forms through the app factory production uses and asserted they answered
+  // identically rather than falling through to 404. #31088 removed both rows,
+  // so neither has a subject, and replacing them with the opposite assertion is
+  // the tombstone `docs/fallback.md` section 1 rules out — the case above
+  // already proves the composition registers no branded path.
+  //
+  // #28545's twin, the one slice whose branded forms a provider console held
+  // rather than a released client, had already gone the same way: #28917
+  // removed the bot row once the Azure Bot messaging endpoint was repointed at
+  // the neutral path, and #30812 the callback once #30667 unified
+  // `callbackRedirectUri` onto the canonical path.
 
   // The synthetic routes are not in the production `MIGRATED_BRANDED_PATHS`, so
   // this app registers only what the two contracts declare and what the

--- a/turbo/apps/api/src/signals/route-entry.ts
+++ b/turbo/apps/api/src/signals/route-entry.ts
@@ -66,12 +66,17 @@ function servesNamespaceAliasPath(
  * Teams app configuration still held, and dropped both the derivation and the
  * reporting behind it.
  *
- * #30667 then removed the table itself. Each of its six paths is named directly
- * by a `MIGRATED_BRANDED_PATHS` row below, so none of them lost a registration,
- * and nothing in this repository produces a `/api/zero/**` URL any more — the
- * last producer was `callbackRedirectUri` in `routes/teams-oauth.ts`, unified
- * onto the canonical path in the same commit. A `/api/zero/**` path is now
- * served only where that table names it.
+ * #30667 then removed the table itself. Each of its six paths was named
+ * directly by a `MIGRATED_BRANDED_PATHS` row below, so none of them lost a
+ * registration, and nothing in this repository produces a `/api/zero/**` URL
+ * any more — the last producer was `callbackRedirectUri` in
+ * `routes/teams-oauth.ts`, unified onto the canonical path in the same commit.
+ *
+ * #31088 then emptied `MIGRATED_BRANDED_PATHS`, so this expansion is the only
+ * thing that can produce a branded registration. Every contract declares a
+ * neutral path, `apiNamespaceAliasPaths` returns a neutral path unchanged, and
+ * the legacy form is never derived, so neither branded namespace is registered
+ * for anything.
  */
 export function withApiNamespaceAliases(
   routes: readonly RouteEntry[],
@@ -91,453 +96,36 @@ export function withApiNamespaceAliases(
  * The branded paths a migrated route still answers on, keyed by the neutral
  * canonical path its contract now declares.
  *
- * This is the only table left that registers a branded path, and since #30667
- * the only thing that registers a `/api/zero/**` path at all. It names branded
- * registrations for a contract that declares a neutral path, including the
- * `/api/okou/**` form the expansion above cannot derive.
- * `apiNamespaceAliasPaths` returns a neutral path unchanged, so once #28278
- * moves a contract off `/api/okou/**` the expansion produces no branded path
- * for it and neither branded path is registered any more — published CLI builds
- * still calling the branded path would get a 404 with nothing able to say
- * otherwise.
+ * The table is empty. It was the only thing that registered a branded path,
+ * and since #30667 the only thing that registered a `/api/zero/**` path at
+ * all, so with no row left neither `/api/okou/**` nor `/api/zero/**` is served
+ * for any path. #31090 removes this constant and `withMigratedBrandedPaths`
+ * with it; the mechanism is kept here only so that #31088's behavioural change
+ * and that structural one stay separately attributable.
  *
- * A migrated route generally owes both branded forms, so a value is a list
- * rather than a single path.
+ * A row was compatibility debt under #26701's removal gate, retired only on
+ * request-log evidence that its holder was gone or on an owner decision
+ * recorded against the row. #28709 first applied that gate and took the table
+ * from 314 rows to 184; #28711, #28974, #28917, #28916, #30668, #30804,
+ * #30812, #30807 and #31068 then took it to six, and #31088 took those six.
+ * The reading rules each of those removals left behind are on their issues,
+ * and the rows themselves are in this file's history.
  *
- * Each #28278 slice adds the rows for the paths it moves, so a move and the
- * compatibility it owes land in one commit.
- *
- * Every row is compatibility debt under #26701's removal gate: a row is removed
- * only under its evidence rules.
- * `vm0-request-log-prod` retained 6.3 days when #28701 read it, which is long
- * enough to name a caller that is still there and not long enough to prove a
- * silent row has no caller that returns.
- *
- * The surfaces a row holds open, and the window each one bounds: an open web or
- * app page keeps the bundle it loaded for about two days, and an execution
- * context pins its commit-addressed CLI package at creation, so a run queued
- * before this deploy can still start the older CLI and hold it for the two-hour
- * `JOB_TIMEOUT` drain. An installed CLI or desktop build has no window at all,
- * which is why removal is gated on #26701's request-log evidence rather than on
- * a date.
- *
- * #28709 applied that gate to the whole table for the first time and took it
- * from 314 rows to 184. Each removed row had no request on either branded form
- * across the 6.3 days `vm0-request-log-prod` retained, measured per row rather
- * than from a truncated top-N summary — the log holds about 6,300 distinct
- * branded path templates, most of them scanner noise, so a ranked query that
- * stops short buries exactly the low-traffic rows this gate is deciding. The
- * check matched each row's branded forms as patterns rather than as literals,
- * because a CORS preflight is logged under its request path rather than the
- * route template it never matched.
- *
- * Two classes of row survived that check and are why the table is 184 rather
- * than 135. Forty-six rows took measured traffic on a branded form inside the
- * window, all of it from released App and CLI builds, so they are still serving
- * a caller. Three rows took none and stay anyway, because for them silence is
- * the expected reading rather than evidence: the two `desktop/updates` rows are
- * a one-shot download an installed macOS build asks for when its owner clicks
- * it, and the Feishu events row is delivered to by an app console we cannot
- * edit. None of those holders drains on a deploy, so a quiet week measures how
- * often the surface is used, not whether it is still owed.
- *
- * #28711 then took forty-two of those forty-six traffic-bearing rows, leaving
- * 142. Their branded forms had gone quiet for longer than any window that can
- * hold their callers. Two facts about that evidence are worth keeping, because
- * the next removal will meet them again:
- *
- * - `x_client_version` does not separate CLI builds. The commit-addressed
- *   packages either side of a #28278 slice share one semver, so the same
- *   version reports both branded and neutral requests. Only the pinning window
- *   bounds the CLI tail; the version field proves nothing about migration.
- * - A row's caller mix decides which window applies, so it has to be measured
- *   per row rather than assumed per slice. #28711 was scoped as CLI-only work
- *   and twelve of its rows turned out to have a web-app caller too, which is
- *   the ~2 day bundle window rather than the two-hour one. Group the log by
- *   `x_client_type` before reading a silence as a drain.
- *
- * #28917 then took fifty-three of the 142, leaving 89. Every one of them was
- * silent on both branded forms across the whole retained window — 2026-08-20
- * 06:34Z to 2026-08-24 08:28Z, 4.1 days, all 685 distinct branded templates
- * pulled without truncation and matched with `:param` rewritten to `[^/]+`.
- * Three whole slices drained: #28417 (maps), #28357 (weather) and #28418
- * (browser, finance, SEO) no longer have a row here.
- *
- * Silence alone is weak for the rarer rows, so it was corroborated rather than
- * trusted: for thirty-five of the fifty-three the neutral path carried traffic
- * inside the same window while both branded forms stayed at zero, and no
- * shipped CLI, desktop or platform build emits a branded literal for any of
- * them. The desktop build's entire hardcoded surface is `auth/me`,
- * `computer-use/{heartbeat,host/*,hosts/start}`, `desktop/{updates,
- * migration-policy}`, `feature-switches` and `org`, and #28917 kept every one
- * of those rows; #30804 later retired the Computer Use host rows and
- * `feature-switches` from it.
- *
- * Three rows the #28917 inventory listed were held back, and each names a way
- * a zero-count reading fails:
- *
- * - `integrations/teams/oauth/callback`. `callbackRedirectUri` in
- *   `routes/teams-oauth.ts` still emitted its `zero` form for the VM0 brand
- *   then, so the row was an active producer target that no window could drain
- *   and no count could retire. #30667 unified that producer onto the canonical
- *   path; see the comment on the row itself.
- * - `computer-use/hosts/start` and `computer-use/host/stop`. Both are
- *   hardcoded in every Desktop build up to 0.38.53, and those builds were
- *   still sending branded `heartbeat` and `host/commands/next` inside this
- *   window. Start and stop fire once per session, so at the measured rate the
- *   branded count they should produce over four days is under one request.
- *   Zero is not a drain; it is the absence of statistical power.
- *
- * The general rule those three leave behind: a zero count retires a row only
- * when the row's caller both has a bounded window and would have been expected
- * to appear in the window at all. Check the call rate before reading a silence.
- *
- * #28916 then took twenty-six more. Its set is disjoint from #28917's: those
- * rows were silent, these were not. Each of these carried branded traffic early
- * in the same window and went to exactly zero once its producer cut over, with
- * the neutral path taking the same calls from the same callers on the same day.
- * Across the twenty-six the crossover is direct — branded 10/2415/27/0/0
- * against neutral 0/3425/6605/13822/3810 on 08-20 through 08-24. An observed
- * cutover is stronger than a silence, because it names the build that stopped
- * emitting the branded form rather than only the absence of a request. Two more
- * facts about reading this log:
- *
- * - `x_client_type` is absent on some released callers, so it cannot be the
- *   only field a caller is classified by. The desktop Computer Use host sends
- *   no client headers at all and appears as `user_agent: node`; classifying by
- *   `x_client_type` alone read it as an anonymous caller and put two rows of
- *   that family on this removal's list. Group by `user_agent` as well, and hold
- *   a row whose caller is an installed build under the exclusion above.
- * - A conditional endpoint is quiet for reasons that have nothing to do with a
- *   drain. `computer-use/host/commands/:commandId/complete` is called only when
- *   a write command finishes, so its silence measures how often that happened,
- *   not whether the caller of `host/commands/next` — which this table held at
- *   the time, and #30804 has since removed — is still there. Read a row against
- *   the traffic of the loop it belongs to, not only against its own. This is
- *   #28917's call-rate rule reached from the other direction.
- *
- * A production traffic sweep does not see this repository's own CI. E2E runs
- * against preview deployments, so a row called only by a workflow step or an
- * `e2e/` helper reads as zero-traffic in `vm0-request-log-prod` and looks
- * drained when it is not — the next E2E run after its removal is what finds
- * out. Six rows were held open by CI alone until #29169 moved those callers to
- * neutral paths. Before removing a row, grep `e2e/`, `.github/scripts/` and
- * `.github/workflows/` for both of its branded forms; treat a hit as a caller
- * to repoint in the same commit, not as evidence the row is still owed. That
- * grep returns nothing today, and this note is here so it stays that way.
- *
- * #30668 then took the four Slack rows whose producer moved, leaving 58. Every
- * removal before it waited for a caller to drain; these four retired because
- * the thing emitting the branded URL was repointed, which is a stronger reading
- * than either a silence or an observed cutover — the branded form has no
- * producer left rather than no recent caller. The Slack app console holds the
- * three webhook URLs and `routes/slack-oauth.ts` emits the callback's
- * `redirect_uri`; the rows they serve carry the detail.
- *
- * That distinction is the rule worth keeping, because the same sweep proposed
- * two more rows and neither survived it. A producer that emits a URL per
- * request is bounded by its own deploy; a producer that hands a URL to a person
- * is not, because the link outlives every deploy in a message, a bookmark or a
- * search index. `slack/oauth/install` and `slack/oauth/connect` are the second
- * kind, and `slack/oauth/install` proves it: its `zero` form was still taking
- * browser and crawler requests ten hours after the deploy that was supposed to
- * have drained it. Ask which of the two a producer is before reading a deploy
- * as a drain.
- *
- * #30804 then took the four Computer Use host rows and `feature-switches`,
- * leaving 53. Those five held the last branded traffic an installed Okou
- * Desktop build produced, and the reading that retired them is neither a
- * silence nor a repointed producer: every branded request in the window came
- * from a machine that was already running a current build on the neutral paths
- * on either side of it. Two addresses emitted all eighteen, one at
- * `x_client_version` 0.38.2 over thirty-four seconds on 08-30 and one at
- * 0.34.0 for a single `feature-switches` read on 09-01, and both addresses
- * report 0.40.4 by the end of the window. An old build launched briefly beside
- * a current one is not a caller with a window to wait out, which is why this
- * removal is an owner decision — recorded on #30804 — rather than a drain.
- *
- * What that leaves for the next sweep to reuse: read `x_client_version`
- * per address over the whole window, not only on the branded requests. A
- * version far below the current one looks like a stranded install until the
- * same address is seen on the current version an hour later. The host
- * inventory does not settle it either — the two `computer_use_hosts` rows below
- * 0.38.100 that were active in the same week sent no request in this window at
- * all, and the versions that did send one have no row.
- *
- * #30812 then took `integrations/teams/oauth/callback` and
- * `slack/oauth/connect`, leaving 51, and refines that rule in the direction the
- * two of them expose. Which kind a producer is turns out to be a property of
- * the link rather than of the function: `buildSlackConnectUrl` is the same
- * shape as `buildSlackInstallUrl` and hands the same kind of URL to the same
- * kind of person, and the difference between them is only that two marketing
- * landing pages publish an install `href` and nothing publishes a connect one.
- * So the second kind is retired by finding where the link was published rather
- * than by waiting, and the evidence that settles it is a differential in one
- * window: the crawler population that found `/api/zero/slack/oauth/install`
- * twenty times found no form of `slack/oauth/connect` at all. The Teams
- * callback is the first kind and drained on its deploy, `chat_teams_context`
- * holding zero rows over the whole life of the integration.
- *
- * The retained window is now 4.4 days, 2026-08-27 22:19Z to 2026-09-01 08:48Z.
- * It has not grown since #28917 measured 4.1, so the header's caution about
- * what a silence can carry has not loosened.
- *
- * #30807 then took forty-four rows at once and left 7. It is the first removal
- * argued as a class rather than row by row, and it rests on two facts that hold
- * for the whole set. No live source emits a branded path: a sweep of `turbo/`
- * outside tests, this file and `api-namespaces.ts` finds no `/api/okou/**` or
- * `/api/zero/**` string literal, and `packages/api-contracts` declares no
- * branded contract path at all after #28984, so every caller in every shipped
- * build derives the neutral path from a contract. The exception is a build that
- * hardcodes the path instead of deriving it, and there is exactly one: the
- * installed macOS Desktop app. Its entire branded surface at `6c2036fa`, the
- * commit before #28487 moved it, is `auth/me`, `org`, `feature-switches`, the
- * stable `desktop/updates` DMG and the five `computer-use` host endpoints.
- * `org` and the two `desktop/updates` rows are kept; `feature-switches` and
- * four of the host endpoints went in #30804; and the fifth,
- * `host/commands/:commandId/complete`, is the one row here that needed #30804's
- * reading rather than this one. The other two holders recover on their own:
- * `apps/platform/public/sw.js` registers only `install`, `push` and
- * `notificationclick`, has no `fetch` handler and never touches the Cache API,
- * so no service worker can pin an old bundle and a stale tab recovers on
- * reload; and the CLI resolves from `CLI_PKG_URL`, which the API deploy
- * rewrites, so it swaps with the API.
- *
- * Measured over the same window with `user_agent` containing `curl` excluded —
- * that field held nothing but this migration's own probes — the log carries
- * seventeen distinct branded templates in total, fourteen of which took a
- * request that is not `curl`, pulled without truncation and matched with
- * `:param` rewritten to `[^/]+`. Not one of them matches any of the forty-four.
- * Thirty-eight of the removed rows also had live neutral traffic in the same
- * window against zero branded, which is the crossover reading #28916 relied on.
- * The other six — `computer-use/audit-events`, `slack/channels` and the four
- * `integrations/slack` rows that are not the status read — were silent on the
- * neutral path too, so they retire on the producer sweep rather than on a
- * count, which is the distinction #30668 recorded and #30812 sharpened.
- *
- * The web surface also has a gate that can be checked rather than waited out,
- * which is the same move #30812 made for the published link. Read the floor
- * instead of the clock: `lib/web-client-compatibility.json` holds it at
- * `0.812.3`, and #28974 recorded the App crossover at `0.780.0` — every build
- * up to `0.779.x` called a branded form and every build from `0.780.0` called
- * the neutral one. The floor already answers every build that could emit a
- * branded path with `426`, so the old-web-client gate in `docs/fallback.md`
- * section 7 has passed rather than merely being assumed from the ~2 day bundle
- * window.
- *
- * The Computer Use family left the table entirely here, and only one of its
- * three remaining rows was a close call. `audit-events` has no caller in this
- * repository at all, and `hosts` is the platform host list rather than the
- * desktop host loop — 17,255 neutral requests from 396 addresses against zero
- * branded — so the attribution the earlier comment gave them was wrong and
- * neither needed a desktop argument. `host/commands/:commandId/complete` did.
- * It is hardcoded in the Desktop build, and #28916 and #28917 both held it back
- * because a conditional endpoint's silence measures a call rate: 239 neutral
- * completions against 156,191 neutral `host/commands/next` puts the branded
- * count the old build's four polls should produce at 0.006 requests, so zero
- * proves nothing. #30804 is what settles it. The single address that sent any
- * branded Computer Use request in the window, 80.251.209.110, ran 0.38.106
- * through 0.40.4 on the neutral paths continuously across it and sent its own
- * neutral completions at 0.38.126 and 0.38.128, so the 0.38.2 build is one
- * launched briefly beside a current one rather than a stranded install. #30804
- * also removed both halves of the loop this row completes, so that build can no
- * longer be handed a command to complete: the reader has outlived its producer,
- * which is `docs/fallback.md` section 5.
- *
- * #31068 then took the Feishu events row, leaving 6, and it is the one removal
- * here that no evidence supports. #30817 held the row back for a reason that
- * still holds: both production installations pasted the branded URL into their
- * own Feishu app console, which we cannot edit, so their silence measures how
- * quiet they are rather than whether the console moved. `feishuCallbackUrl`
- * only began handing out the neutral path in `bc505642` (#28341, 2026-08-20),
- * and both installations were created before it — 2026-07-27 and 2026-08-04,
- * each with a `callback_verified_at` minutes later against the branded path and
- * no re-verification since. Removing this row therefore stops delivery to both,
- * and it fails silently: the bot goes quiet with no error surfaced to either
- * holder. The owner made that call on 2026-09-02, notifying both holders
- * directly, because recovery is one copy of the neutral URL from
- * `app.okou.ai/settings/feishu` back into the Feishu console. This is an owner
- * decision recorded on #31068, not a drain — do not cite it as one.
+ * Two of the last six are worth naming here, because the reasoning that had
+ * held them was wrong rather than merely spent. #28715 kept the two
+ * `desktop/updates` rows on the belief that a hard-stopped Zero Desktop
+ * reaches the Okou DMG through the branded form. It does not: `Download Okou`
+ * resolves through the neutral `/api/desktop/updates/stable/darwin/arm64/dmg`,
+ * and across 2026-09-01 07:00Z to 2026-09-02 07:30Z all 1,445 update requests
+ * from 144 addresses were on that neutral path while both branded forms took
+ * none — including from the 107 to 108 Zero installs that have been polling
+ * `desktop/migration-policy`, `feature-switches` and `auth/me` since the policy
+ * went `hard` on 2026-08-31T02:26Z. Those rows were gated on nothing, and
+ * #26364 governs the Zero install base rather than this surface.
  */
 type MigratedBrandedPathTable = Readonly<Record<string, readonly string[]>>;
 
-const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
-  // #28422: all that is left of the logs, artifact catalog, push subscription
-  // and run rows the slice moved. #28917 removed the per-artifact catalog read
-  // and every run row but the agent telemetry read; #28916 then removed the
-  // catalog collection, push subscriptions and that agent telemetry read on
-  // cutover evidence; and #30807 removed `realtime/token`, whose neutral path
-  // took 40,923 requests from 484 addresses in the same window its branded
-  // forms took none. `/api/zero/logs/:id` was not in that removal: it took two
-  // requests inside the window from a caller reporting no client type.
-  "/api/logs/:id": ["/api/okou/logs/:id", "/api/zero/logs/:id"],
-  // #28464: the Slack, Teams, and Feishu connect and OAuth-start routes, of
-  // which #28709 kept only the Slack rows and #30807 then removed
-  // `slack/channels`, a contract-derived read whose branded forms took nothing
-  // while its neutral path served the platform bundle. The paths a provider
-  // console holds were not in this slice; they moved in #28600, and #30668
-  // retired every one of those rows.
-  //
-  // What is left has a holder that no client version bounds:
-  // `buildSlackInstallUrl` in `services/slack-data.service.ts` hands a link to a
-  // user, and that link lives in a Slack message, a bookmark or a search index
-  // for as long as its holder keeps it. The producer emits the neutral path
-  // today, which bounds the links minted from now on and nothing about the ones
-  // already out there. `/api/okou/slack/oauth/install` is also the measured
-  // traffic the legacy-path table #30667 deleted listed, which only this row
-  // can serve.
-  //
-  // #30668 measured that holder directly rather than reasoning about it.
-  // `/api/zero/slack/oauth/install` took 24 requests across the retained
-  // window on `api.vm0.ai`, the last at 2026-09-01 01:05:54Z — ten hours after
-  // the #30551 deploy that was supposed to have drained it — from search
-  // crawlers, the `vm0-seo-health` monitor and browser user agents on distinct
-  // addresses, every one answered 307. The branded install URL is published
-  // somewhere a crawler can reach, so it has no drain window at all, and the
-  // #30807 window measured 21 more non-`curl` requests on that form.
-  //
-  // #30812 removed `slack/oauth/connect`, the sibling row, and the two are why
-  // "a producer hands a URL to a person" is a property of the link rather than
-  // of the function that builds it. `buildSlackConnectUrl` is the same shape as
-  // `buildSlackInstallUrl` and emits the same neutral path, but no page
-  // publishes a connect link: the two hardcoded `href`s that kept the branded
-  // install form alive are on the marketing landing pages, both
-  // `/api/slack/oauth/install`, and neither has a connect equivalent. The
-  // measurement is the differential rather than the silence — over the same
-  // 4.4-day window and the same crawler population that found
-  // `/api/zero/slack/oauth/install` twenty times, all three forms of
-  // `slack/oauth/connect` took zero requests, the neutral one included. A
-  // published branded link would have been found the same way.
-  //
-  // Removal follows the #26701 evidence gate like every other row, not either
-  // clock.
-  "/api/slack/oauth/install": [
-    "/api/okou/slack/oauth/install",
-    "/api/zero/slack/oauth/install",
-  ],
-  // #28465: the stable desktop release page and DMG download.
-  //
-  // These two rows hold open a longer window than any other row in this table.
-  // Their callers are installed macOS applications, not a web bundle or a
-  // commit-addressed CLI artifact: the final Zero bridge release documented in
-  // `apps/desktop/README.md` opens the `okou` DMG path from a constant compiled
-  // into the shipped build, and `isTrustedZeroMigrationDownloadUrl` in that
-  // build refuses any other path — so a user who never updates keeps asking for
-  // the branded form indefinitely. The platform download button held the same
-  // path until this slice moved it, and released tabs keep it for the ~2 day
-  // old-web-client window. The `zero` form was reachable through the blanket
-  // expansion until the contract moved, so both are owed.
-  //
-  // An installed desktop build has no drain window at all, so these rows must
-  // not be removed on the #26701 evidence rules alone: retiring the branded
-  // forms needs the Desktop-side drain gate tracked by #26364. That is why
-  // #28715 held them back, and why #30807's class argument does not reach them
-  // either — the recovery it relies on is a page reload, and an installed
-  // application has no equivalent. #30804's reading does not reach them either:
-  // a download is a one-shot the owner starts by clicking, so this row's
-  // silence says nothing about whether an old install is still out there.
-  //
-  // Each key holds its path parameters verbatim, because the lookup below
-  // matches `entry.route.path` exactly rather than an expanded request path.
-  "/api/desktop/updates/:channel/:platform/:arch/dmg": [
-    "/api/okou/desktop/updates/:channel/:platform/:arch/dmg",
-    "/api/zero/desktop/updates/:channel/:platform/:arch/dmg",
-  ],
-  "/api/desktop/updates/:channel/:platform/:arch/release": [
-    "/api/okou/desktop/updates/:channel/:platform/:arch/release",
-    "/api/zero/desktop/updates/:channel/:platform/:arch/release",
-  ],
-  // #28462: feature switches, model policies, org-level model providers and
-  // their device-auth sessions, the org profile and membership routes, and the
-  // usage reads, of which only the org profile is still owed. #28917 removed
-  // the three `model-providers/codex/device-auth/sessions` rows, the three
-  // `org/invite` rows, and `usage/members`; #28916 removed the
-  // `model-providers` collection, `org/logo`, `org/members` and `usage/record`,
-  // all four platform-held and cut over on 08-21; and #30807 removed
-  // `model-policies`, which no installed build hardcodes and whose neutral path
-  // took 2,100 requests from 297 addresses against zero branded.
-  //
-  // #30804 removed `feature-switches` and kept `org`, which is the whole point
-  // of measuring the first surface per row rather than per slice. The desktop
-  // build hardcodes both, and in the 2026-08-27 22:19Z to 2026-09-01 08:26Z
-  // window both took branded requests from it — three on `feature-switches`,
-  // four on `org` — but only `org` has a second producer. A `CLI_PKG_URL`-pinned
-  // CLI at 9.279.3 read `/api/zero/org` on 08-31 03:58, 08-31 08:52 and 09-01
-  // 02:10, each answered 200, so that row still serves a caller with a live
-  // pinning window. The `feature-switches` requests came from the two desktop
-  // addresses alone — 0.38.2 at 08-30 09:17:31 and 0.34.0 at 09-01 03:11:31 —
-  // and both addresses were running 0.40.4 on the neutral path by the end of the
-  // window, so what the row was holding open was a briefly launched old build
-  // rather than an install still on its way to updating.
-  //
-  // The CI bootstrap steps in `.github/workflows/turbo.yml` used to call
-  // `/api/okou/model-providers` on purpose, to exercise the compatibility these
-  // rows guarantee; #28916 repointed them at the neutral path along with the
-  // row itself, so no check depends on a row this table may retire. A row
-  // retires under #26701's evidence rules like every other row in this file.
-  "/api/org": ["/api/okou/org", "/api/zero/org"],
-  // #28461: the agent reads and writes and the workflow and
-  // workflow-automation management routes, of which only the workflow
-  // collection is still owed. #28711 removed `agents/:id/instructions`,
-  // `workflow-automations`, `workflows/:workflowId`,
-  // `workflows/:workflowId/automations` and `workflows/:workflowId/run` on
-  // drained-traffic evidence; #28917 removed `workflow-automations/:id/enable`
-  // and `workflow-automations/:id/disable`; #28916 removed the `agents`
-  // collection and `workflow-automations/:id` on cutover evidence; and #30807
-  // removed the four per-agent rows, whose neutral paths took traffic from the
-  // platform bundle and the CLI throughout its window while both branded forms
-  // stayed at zero.
-  //
-  // `/api/zero/workflows` took four requests inside that window from a caller
-  // reporting no client type, so this row is not in that removal. Every caller
-  // in this repository derives its URL from the contract; released builds are
-  // what still hold the branded form, and two surfaces do.
-  //
-  // A published CLI package embeds the contract path it was built from and
-  // stays pinned by an execution context's `CLI_PKG_URL` — `okou workflow` and
-  // `okou workflow automation` are the commands behind this path. That artifact
-  // drains over the maximum queue lifetime plus the maximum claimed execution
-  // and finalization lifetime, with execution bounded by the runner's 2h
-  // `JOB_TIMEOUT`, as `docs/deployment-compatibility.md` describes for
-  // commit-addressed CLI artifacts.
-  //
-  // A browser tab holding already-loaded platform code keeps calling the `okou`
-  // path it was built against until it navigates or reloads: the ~2 day
-  // old-web-client window in `docs/fallback.md` section 7, and the longer of
-  // the two. The `zero` form was reachable through the blanket expansion until
-  // the contract moved. Both forms are owed, and both retire under #26701's
-  // evidence rules rather than on either clock.
-  "/api/workflows": ["/api/okou/workflows", "/api/zero/workflows"],
-  // #28600 added the last branded contract paths — the Slack OAuth callback and
-  // the three inbound Slack webhooks — and #30668 removed all four. They are
-  // the first rows in this table to retire because their producer moved rather
-  // than because a caller drained, and each producer is now the neutral path:
-  //
-  // - The Slack app console `A0AD6KS3D32` holds one URL per endpoint, so
-  //   repointing Event Subscriptions, Interactivity and the `/okou` command at
-  //   `api.okou.ai/api/webhooks/slack/*` left the branded forms with no holder
-  //   at all. Slack returned `Verified` for the events URL, and the log shows
-  //   the delivery arriving at the new one rather than only the old one going
-  //   quiet: every neutral webhook path took requests from `user_agent:
-  //   Slackbot 1.0`, Slack's own infrastructure, on 2026-08-31 — `events` from
-  //   08:56:33Z and still every few minutes, `commands` at 09:02:28Z,
-  //   `interactive` at 08:58:28Z. `/api/zero/slack/events` took its last of 53
-  //   requests at 08:54:51Z. None of the three needs a silence argument: the
-  //   holder was observed posting somewhere else.
-  // - `callbackRedirectUri` in `routes/slack-oauth.ts` emits the callback as
-  //   the `redirect_uri` sent to Slack, and #30551 deployed it emitting
-  //   `/api/integrations/slack/oauth/callback` at 2026-08-31 15:01Z. The
-  //   registered redirect URL was added to the console first, so no
-  //   authorization was ever sent a URI the console did not hold. Unlike a
-  //   handed-out link, a `redirect_uri` is computed per request, so the deploy
-  //   bounds the branded form to authorizations already in flight; both branded
-  //   forms took no request in the retained window.
-  //
-  // All that is left of the Slack surface in this table is the published
-  // install link above. #30807 removed the messaging and file rows and
-  // `slack/channels`, every caller of which derives its URL from the contract,
-  // and #30812 removed the connect link nothing publishes.
-};
+const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {};
 
 /**
  * Registers the branded paths named in `MIGRATED_BRANDED_PATHS`, so a contract

--- a/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
@@ -136,60 +136,22 @@ describe("desktop update routes", () => {
     });
   });
 
-  it("redirects the release page route to the current stable desktop release", async () => {
-    mockDesktopUpdateManifest(
-      stableManifest("0.2.1", {
-        "0.2.1": darwinArm64Release(
-          "0.2.1",
-          "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.2.1/Zero-darwin-arm64-0.2.1.zip",
-        ),
-      }),
-    );
-
-    const response = await appRequest(
-      "http://api.test/api/zero/desktop/updates/stable/darwin/arm64/release",
-    );
-
-    expect(response.status).toBe(302);
-    expect(response.headers.get("Location")).toBe(
-      "https://github.com/vm0-ai/vm0/releases/tag/desktop-v0.2.1",
-    );
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
-  });
-
-  it("redirects the dmg route to the current stable desktop dmg asset", async () => {
-    mockDesktopUpdateManifest(
-      stableManifest("0.12.0", {
-        "0.12.0": darwinArm64Release(
-          "0.12.0",
-          "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.12.0/Zero-darwin-arm64-0.12.0.zip",
-        ),
-      }),
-    );
-
-    const response = await appRequest(
-      "http://api.test/api/zero/desktop/updates/stable/darwin/arm64/dmg",
-    );
-
-    expect(response.status).toBe(302);
-    expect(response.headers.get("Location")).toBe(
-      "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.12.0/Zero-darwin-arm64-0.12.0.dmg",
-    );
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
-  });
-
-  // #28465 moved these two routes off `/api/okou/**`. Installed desktop builds
-  // poll the branded form from a constant compiled into the shipped binary and
-  // a released platform tab holds it until it reloads, so both branded forms
-  // have to keep resolving through `MIGRATED_BRANDED_PATHS`.
+  // #28465 moved these two routes off `/api/okou/**` to the neutral path, and
+  // #31088 removed the `MIGRATED_BRANDED_PATHS` rows that kept the branded
+  // forms answering, so the neutral path is the only one either route serves.
   //
-  // The update line each path serves is asserted alongside the path, because a
-  // path move alone would have changed it: the line is derived from the request
-  // namespace, so the neutral path has to inherit the Okou line the `okou` form
-  // served rather than fall through to Zero. Every expectation is written out
-  // rather than taken from `apiNamespaceAliasPaths`, which returns a neutral
-  // path unchanged and so would assert nothing.
-  it("serves the moved desktop routes on the neutral and both branded paths", async () => {
+  // The update line is asserted alongside the path, because the move alone
+  // would have changed it: the line is derived from the request namespace, and
+  // the neutral path has to inherit the Okou line the `okou` form served rather
+  // than fall through to Zero. Both manifests are mocked, so a fall-through
+  // would resolve to a Zero artifact and fail here rather than 404. Every
+  // expectation is written out rather than taken from `apiNamespaceAliasPaths`,
+  // which returns a neutral path unchanged and so would assert nothing.
+  //
+  // Two plainer redirect cases and an `/api/okou` cutover case used to sit
+  // beside this one. #31088 left them without a path of their own to drive, and
+  // what they asserted is covered here.
+  it("serves the moved desktop routes on the neutral path", async () => {
     mockDesktopUpdateManifest(
       stableManifest("0.12.0", {
         "0.12.0": darwinArm64Release(
@@ -212,53 +174,25 @@ describe("desktop update routes", () => {
       OKOU_DESKTOP_UPDATE_MANIFEST_URL,
     );
 
-    const expectations = [
-      {
-        prefix: "/api",
-        release:
-          "https://github.com/vm0-ai/vm0/releases/tag/okou-desktop-v1.2.3",
-        dmg: "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v1.2.3/Okou-darwin-arm64-1.2.3.dmg",
-      },
-      {
-        prefix: "/api/okou",
-        release:
-          "https://github.com/vm0-ai/vm0/releases/tag/okou-desktop-v1.2.3",
-        dmg: "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v1.2.3/Okou-darwin-arm64-1.2.3.dmg",
-      },
-      {
-        prefix: "/api/zero",
-        release: "https://github.com/vm0-ai/vm0/releases/tag/desktop-v0.12.0",
-        dmg: "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.12.0/Zero-darwin-arm64-0.12.0.dmg",
-      },
-    ] as const;
+    const releaseResponse = await appRequest(
+      "http://api.test/api/desktop/updates/stable/darwin/arm64/release",
+    );
 
-    for (const { prefix, release, dmg } of expectations) {
-      const releaseResponse = await appRequest(
-        `http://api.test${prefix}/desktop/updates/stable/darwin/arm64/release`,
-      );
+    expect(releaseResponse.status).toBe(302);
+    expect(releaseResponse.headers.get("Location")).toBe(
+      "https://github.com/vm0-ai/vm0/releases/tag/okou-desktop-v1.2.3",
+    );
+    expect(releaseResponse.headers.get("Cache-Control")).toBe("no-store");
 
-      expect({ prefix, status: releaseResponse.status }).toStrictEqual({
-        prefix,
-        status: 302,
-      });
-      expect({
-        prefix,
-        location: releaseResponse.headers.get("Location"),
-      }).toStrictEqual({ prefix, location: release });
+    const dmgResponse = await appRequest(
+      "http://api.test/api/desktop/updates/stable/darwin/arm64/dmg",
+    );
 
-      const dmgResponse = await appRequest(
-        `http://api.test${prefix}/desktop/updates/stable/darwin/arm64/dmg`,
-      );
-
-      expect({ prefix, status: dmgResponse.status }).toStrictEqual({
-        prefix,
-        status: 302,
-      });
-      expect({
-        prefix,
-        location: dmgResponse.headers.get("Location"),
-      }).toStrictEqual({ prefix, location: dmg });
-    }
+    expect(dmgResponse.status).toBe(302);
+    expect(dmgResponse.headers.get("Location")).toBe(
+      "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v1.2.3/Okou-darwin-arm64-1.2.3.dmg",
+    );
+    expect(dmgResponse.headers.get("Cache-Control")).toBe("no-store");
   });
 
   it("serves the current stable macOS arm64 update from the manifest", async () => {
@@ -415,36 +349,6 @@ describe("desktop update routes", () => {
     );
   });
 
-  it("serves branded Okou routes from the final identity line after cutover", async () => {
-    const zipUrl =
-      "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v1.2.3/Okou-darwin-arm64-1.2.3.zip";
-    mockDesktopUpdateManifest(
-      {
-        ...stableManifest("1.2.3", {
-          "1.2.3": darwinArm64Release("1.2.3", zipUrl, "Okou"),
-        }),
-        product: "okou",
-      },
-      OKOU_DESKTOP_UPDATE_MANIFEST_URL,
-    );
-
-    const brandedReleaseResponse = await appRequest(
-      "http://api.test/api/okou/desktop/updates/stable/darwin/arm64/release",
-    );
-    expect(brandedReleaseResponse.status).toBe(302);
-    expect(brandedReleaseResponse.headers.get("Location")).toBe(
-      "https://github.com/vm0-ai/vm0/releases/tag/okou-desktop-v1.2.3",
-    );
-
-    const brandedDmgResponse = await appRequest(
-      "http://api.test/api/okou/desktop/updates/stable/darwin/arm64/dmg",
-    );
-    expect(brandedDmgResponse.status).toBe(302);
-    expect(brandedDmgResponse.headers.get("Location")).toBe(
-      "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v1.2.3/Okou-darwin-arm64-1.2.3.dmg",
-    );
-  });
-
   it("returns not found for the retired pre-adoption Okou update line", async () => {
     for (const path of [
       "/api/desktop/updates/okou/stable/darwin/arm64/release",
@@ -534,7 +438,7 @@ describe("desktop update routes", () => {
     );
 
     const response = await appRequest(
-      "http://api.test/api/zero/desktop/updates/stable/darwin/x64/dmg",
+      "http://api.test/api/desktop/updates/stable/darwin/x64/dmg",
     );
 
     expect(response.status).toBe(400);
@@ -598,15 +502,19 @@ describe("desktop update routes", () => {
 
   it("returns not found when no dmg release is available", async () => {
     const zipUrl =
-      "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.11.2/Zero-darwin-arm64-0.11.2.zip";
+      "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v0.11.2/Okou-darwin-arm64-0.11.2.zip";
     mockDesktopUpdateManifest(
-      stableManifest("0.11.2", {
-        "0.11.2": darwinArm64Release("0.11.2", zipUrl),
-      }),
+      {
+        ...stableManifest("0.11.2", {
+          "0.11.2": darwinArm64Release("0.11.2", zipUrl, "Okou"),
+        }),
+        product: "okou",
+      },
+      OKOU_DESKTOP_UPDATE_MANIFEST_URL,
     );
 
     const response = await appRequest(
-      "http://api.test/api/zero/desktop/updates/stable/darwin/arm64/dmg",
+      "http://api.test/api/desktop/updates/stable/darwin/arm64/dmg",
     );
 
     expect(response.status).toBe(404);

--- a/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
@@ -141,12 +141,12 @@ describe("desktop update routes", () => {
   // forms answering, so the neutral path is the only one either route serves.
   //
   // The update line is asserted alongside the path, because the move alone
-  // would have changed it: the line is derived from the request namespace, and
-  // the neutral path has to inherit the Okou line the `okou` form served rather
-  // than fall through to Zero. Both manifests are mocked, so a fall-through
-  // would resolve to a Zero artifact and fail here rather than 404. Every
-  // expectation is written out rather than taken from `apiNamespaceAliasPaths`,
-  // which returns a neutral path unchanged and so would assert nothing.
+  // would have changed it: the neutral path has to serve the Okou line the
+  // `okou` form served rather than the Zero line. Both manifests are mocked, so
+  // reading the wrong one resolves to a Zero artifact and fails here rather
+  // than 404ing. Every expectation is written out rather than taken from
+  // `apiNamespaceAliasPaths`, which returns a neutral path unchanged and so
+  // would assert nothing.
   //
   // Two plainer redirect cases and an `/api/okou` cutover case used to sit
   // beside this one. #31088 left them without a path of their own to drive, and

--- a/turbo/apps/api/src/signals/routes/__tests__/provider-console-paths.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/provider-console-paths.test.ts
@@ -41,8 +41,9 @@ interface ResponseSnapshot {
 // once the Slack app console was repointed at `/api/webhooks/slack/*` and
 // `routes/slack-oauth.ts` began emitting the neutral `redirect_uri`. The Feishu
 // OAuth callback was narrowed the same way by #28709 and the Teams OAuth
-// callback by #30812, which leaves nothing in this file holding a branded form.
-// What each block still pins is that the console flow reaches its handler.
+// callback by #30812, which left nothing in this file holding a branded form.
+// #31088 then emptied the table outright, so no path anywhere has one. What
+// each block still pins is that the console flow reaches its handler.
 
 async function snapshot(response: Response): Promise<ResponseSnapshot> {
   return {
@@ -217,8 +218,9 @@ describe("provider console paths", () => {
   // `MIGRATED_BRANDED_PATHS` row; #28709 removed that row, because the only
   // thing holding the branded form was an already-loaded platform tab
   // forwarding a code, a window that closed well before the retained request
-  // log begins. The case stays because the callback is still reached from a
-  // Feishu console flow, narrowed to the path that serves it.
+  // log begins, and #31088 emptied the table itself. The case stays because the
+  // callback is still reached from a Feishu console flow, narrowed to the path
+  // that serves it.
   describe("GET /api/integrations/feishu/oauth/callback", () => {
     it("rejects a callback without connect state", async () => {
       const snapshots = await snapshotEachPath(

--- a/turbo/apps/api/src/signals/routes/__tests__/slack-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/slack-oauth.test.ts
@@ -115,9 +115,9 @@ describe("Slack OAuth API routes", () => {
     });
   });
 
-  describe("GET /api/zero/slack/oauth/install", () => {
+  describe("GET /api/slack/oauth/install", () => {
     it("redirects to Slack OAuth with bot scopes and callback URI", async () => {
-      const response = await appRequest("/api/zero/slack/oauth/install");
+      const response = await appRequest("/api/slack/oauth/install");
 
       expect(response.status).toBe(307);
       const location = response.headers.get("location");
@@ -149,7 +149,7 @@ describe("Slack OAuth API routes", () => {
     });
 
     it("serializes the Okou brand in install state", async () => {
-      const response = await appRequest("/api/zero/slack/oauth/install", {
+      const response = await appRequest("/api/slack/oauth/install", {
         origin: "https://okou.ai",
       });
 
@@ -176,7 +176,7 @@ describe("Slack OAuth API routes", () => {
     it("includes platform state and truncates prompt by codepoint", async () => {
       const prompt = "\u{1F600}".repeat(600);
       const response = await appRequest(
-        `/api/zero/slack/oauth/install?orgId=org_1&userId=user_1&reinstall=1&prompt=${encodeURIComponent(prompt)}`,
+        `/api/slack/oauth/install?orgId=org_1&userId=user_1&reinstall=1&prompt=${encodeURIComponent(prompt)}`,
       );
 
       const redirectUrl = new URL(response.headers.get("location")!);
@@ -197,7 +197,7 @@ describe("Slack OAuth API routes", () => {
 
     it("includes the pending prompt in install state when provided", async () => {
       const response = await appRequest(
-        `/api/zero/slack/oauth/install?orgId=org_1&userId=user_1&prompt=${encodeURIComponent("summarize my inbox")}`,
+        `/api/slack/oauth/install?orgId=org_1&userId=user_1&prompt=${encodeURIComponent("summarize my inbox")}`,
       );
 
       expect(response.status).toBe(307);
@@ -219,7 +219,7 @@ describe("Slack OAuth API routes", () => {
       const prompt = "x".repeat(1200);
 
       const response = await appRequest(
-        `/api/zero/slack/oauth/install?prompt=${encodeURIComponent(prompt)}`,
+        `/api/slack/oauth/install?prompt=${encodeURIComponent(prompt)}`,
       );
 
       expect(response.status).toBe(307);
@@ -232,7 +232,7 @@ describe("Slack OAuth API routes", () => {
 
     it("omits prompt from install state when absent", async () => {
       const response = await appRequest(
-        "/api/zero/slack/oauth/install?orgId=org_1&userId=user_1",
+        "/api/slack/oauth/install?orgId=org_1&userId=user_1",
       );
 
       expect(response.status).toBe(307);
@@ -244,7 +244,7 @@ describe("Slack OAuth API routes", () => {
     });
 
     it("uses the web rewrite origin for Slack callback URLs", async () => {
-      const response = await appRequest("/api/zero/slack/oauth/install", {
+      const response = await appRequest("/api/slack/oauth/install", {
         origin: API_ORIGIN,
         headers: { "x-vm0-web-origin": WEB_ORIGIN },
       });
@@ -257,7 +257,7 @@ describe("Slack OAuth API routes", () => {
     });
 
     it("accepts the exact okou.ai web origin on direct API requests", async () => {
-      const response = await appRequest("/api/zero/slack/oauth/install", {
+      const response = await appRequest("/api/slack/oauth/install", {
         origin: API_ORIGIN,
         headers: { "x-vm0-web-origin": "https://okou.ai" },
       });
@@ -272,30 +272,30 @@ describe("Slack OAuth API routes", () => {
 
     it("redirects direct API host install requests to the canonical web route", async () => {
       const response = await appRequest(
-        "/api/zero/slack/oauth/install?orgId=org_1&userId=user_1",
+        "/api/slack/oauth/install?orgId=org_1&userId=user_1",
         { origin: API_ORIGIN },
       );
 
       expect(response.status).toBe(307);
       expect(response.headers.get("location")).toBe(
-        `${WEB_ORIGIN}/api/zero/slack/oauth/install?orgId=org_1&userId=user_1`,
+        `${WEB_ORIGIN}/api/slack/oauth/install?orgId=org_1&userId=user_1`,
       );
     });
 
     it("ignores untrusted web origin headers on direct API host install requests", async () => {
-      const response = await appRequest("/api/zero/slack/oauth/install", {
+      const response = await appRequest("/api/slack/oauth/install", {
         origin: API_ORIGIN,
         headers: { "x-vm0-web-origin": "https://evil.example" },
       });
 
       expect(response.status).toBe(307);
       expect(response.headers.get("location")).toBe(
-        `${WEB_ORIGIN}/api/zero/slack/oauth/install`,
+        `${WEB_ORIGIN}/api/slack/oauth/install`,
       );
     });
 
     it("trusts okou.ai subdomains as web origins", async () => {
-      const response = await appRequest("/api/zero/slack/oauth/install", {
+      const response = await appRequest("/api/slack/oauth/install", {
         origin: API_ORIGIN,
         headers: { "x-vm0-web-origin": "https://console.okou.ai" },
       });
@@ -309,21 +309,21 @@ describe("Slack OAuth API routes", () => {
     });
 
     it("does not trust lookalike okou.ai web origins", async () => {
-      const response = await appRequest("/api/zero/slack/oauth/install", {
+      const response = await appRequest("/api/slack/oauth/install", {
         origin: API_ORIGIN,
         headers: { "x-vm0-web-origin": "https://okou.ai.evil.example" },
       });
 
       expect(response.status).toBe(307);
       expect(response.headers.get("location")).toBe(
-        `${WEB_ORIGIN}/api/zero/slack/oauth/install`,
+        `${WEB_ORIGIN}/api/slack/oauth/install`,
       );
     });
 
     it("returns 503 when Slack client ID is not configured", async () => {
       mockEnv("SLACK_OAUTH_CLIENT_ID", "");
 
-      const response = await appRequest("/api/zero/slack/oauth/install");
+      const response = await appRequest("/api/slack/oauth/install");
 
       expect(response.status).toBe(503);
       await expect(response.json()).resolves.toStrictEqual({
@@ -733,7 +733,7 @@ describe("Slack OAuth API routes", () => {
       mockEnv("OKOU_WEB_URL", previewApiOrigin);
       mockEnv("APP_URL", previewAppOrigin);
 
-      const start = await appRequest("/api/zero/slack/oauth/install", {
+      const start = await appRequest("/api/slack/oauth/install", {
         origin: previewApiOrigin,
       });
       expect(start.status).toBe(307);

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
@@ -61,7 +61,8 @@ const trackTeamsFixture = createFixtureTracker<TeamsConnectFixture>(
 // The final Microsoft console path from #28278. #28917 retired this route's
 // `MIGRATED_BRANDED_PATHS` row — the Azure Bot messaging endpoint was already
 // repointed here before #28545 landed — so the branded forms this file used to
-// replay are no longer registered.
+// replay are no longer registered. #31088 emptied that table, so no route has
+// a branded form to replay any more.
 const TEAMS_BOT_PATH = "http://api.test/api/webhooks/teams/bot";
 const BOT_APP_ID = "00000000-0000-0000-0000-000000000001";
 const BOT_APP_PASSWORD = "teams-test-password";

--- a/turbo/apps/api/src/signals/routes/desktop-updates.ts
+++ b/turbo/apps/api/src/signals/routes/desktop-updates.ts
@@ -64,10 +64,16 @@ const getDesktopMigrationPolicy$ = command(({ set }) => {
  * path, which makes the neutral path the successor of the `okou` form rather
  * than a new one: the platform download button and the Zero migration bridge
  * both point at it and both expect an Okou artifact. So neutral resolves to the
- * Okou line, and only the `/api/zero/**` compatibility alias still resolves to
- * the Zero line, which is what its callers reached before the move. Keying the
- * default on `zero` rather than on `okou` is what keeps every caller on the
- * product it had.
+ * Okou line, and the `/api/zero/**` compatibility alias resolved to the Zero
+ * line, which is what its callers reached before the move. Keying the default
+ * on `zero` rather than on `okou` is what kept every caller on the product it
+ * had.
+ *
+ * #31088 removed the `MIGRATED_BRANDED_PATHS` rows that registered that alias,
+ * and nothing else registers a branded path, so no request can arrive on one
+ * and every caller resolves to the Okou line. The `zero` branch has no
+ * reachable input left and is kept here only so that #31088 stays a change to
+ * what is registered; retiring it is a separate change.
  */
 function desktopUpdateLineFromRequestUrl(
   requestUrl: string,

--- a/turbo/apps/api/src/signals/routes/desktop-updates.ts
+++ b/turbo/apps/api/src/signals/routes/desktop-updates.ts
@@ -1,4 +1,3 @@
-import { brandedApiNamespace } from "@okouai/api-contracts/contracts/api-namespaces";
 import {
   DESKTOP_UPDATE_LINE_LEGACY_OKOU,
   DESKTOP_UPDATE_LINE_OKOU,
@@ -10,7 +9,7 @@ import {
 import { command } from "ccstate";
 
 import { notFound } from "../../lib/error";
-import { request$, setResHeader$ } from "../context/hono";
+import { setResHeader$ } from "../context/hono";
 import { pathParamsOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
 import {
@@ -57,36 +56,29 @@ const getDesktopMigrationPolicy$ = command(({ set }) => {
 });
 
 /**
- * The update line the release-page and DMG routes serve, taken from the
- * namespace the request arrived on.
+ * The update line the unqualified release-page and DMG routes serve.
  *
  * #28465 moved the contract from `/api/okou/desktop/updates/**` to the neutral
  * path, which makes the neutral path the successor of the `okou` form rather
  * than a new one: the platform download button and the Zero migration bridge
- * both point at it and both expect an Okou artifact. So neutral resolves to the
- * Okou line, and the `/api/zero/**` compatibility alias resolved to the Zero
- * line, which is what its callers reached before the move. Keying the default
- * on `zero` rather than on `okou` is what kept every caller on the product it
- * had.
+ * both point at it and both expect an Okou artifact.
  *
- * #31088 removed the `MIGRATED_BRANDED_PATHS` rows that registered that alias,
- * and nothing else registers a branded path, so no request can arrive on one
- * and every caller resolves to the Okou line. The `zero` branch has no
- * reachable input left and is kept here only so that #31088 stays a change to
- * what is registered; retiring it is a separate change.
+ * These two routes used to read the line off the request namespace, so the
+ * `/api/zero/**` compatibility alias kept resolving to the Zero line its
+ * callers reached before the move. #31088 removed the
+ * `MIGRATED_BRANDED_PATHS` rows that registered that alias and nothing else
+ * registers a branded path, so no request can arrive on one and the Zero
+ * branch had no reachable input left. The Zero line is still reachable through
+ * `productFeed`, `productReleasePage` and `productDmgDownload`, which name it
+ * in the path.
  */
-function desktopUpdateLineFromRequestUrl(
-  requestUrl: string,
-): DesktopUpdateLine {
-  return brandedApiNamespace(new URL(requestUrl).pathname) === "zero"
-    ? DESKTOP_UPDATE_LINE_ZERO
-    : DESKTOP_UPDATE_LINE_OKOU;
-}
+const UNQUALIFIED_DESKTOP_UPDATE_LINE: DesktopUpdateLine =
+  DESKTOP_UPDATE_LINE_OKOU;
 
 const getDesktopReleasePage$ = command(async ({ get }, signal: AbortSignal) => {
   const url = await loadDesktopReleasePageUrl(
     {
-      line: desktopUpdateLineFromRequestUrl(get(request$).url),
+      line: UNQUALIFIED_DESKTOP_UPDATE_LINE,
       ...get(releasePageParams$),
     },
     signal,
@@ -126,7 +118,7 @@ const getDesktopUpdateFeed$ = command(async ({ get }, signal: AbortSignal) => {
 const getDesktopDmgDownload$ = command(async ({ get }, signal: AbortSignal) => {
   const url = await loadDesktopDmgDownloadUrl(
     {
-      line: desktopUpdateLineFromRequestUrl(get(request$).url),
+      line: UNQUALIFIED_DESKTOP_UPDATE_LINE,
       ...get(dmgDownloadParams$),
     },
     signal,

--- a/turbo/apps/api/src/signals/services/feishu-config.ts
+++ b/turbo/apps/api/src/signals/services/feishu-config.ts
@@ -91,8 +91,9 @@ export function feishuCallbackUrl(
  * reached only when `callbackTarget` is absent. The Feishu console holds
  * `feishuOAuthAppCallbackUrl()` instead, so nothing outside this service pins
  * this path; #28544 moved it off the legacy `/api/zero/**` namespace it had
- * kept, to the neutral path its contract now declares. Both branded forms stay
- * routable through `MIGRATED_BRANDED_PATHS`.
+ * kept, to the neutral path its contract now declares. #28709 retired the
+ * `MIGRATED_BRANDED_PATHS` row that kept both branded forms routable, and
+ * #31088 emptied that table, so the neutral path is the only one served.
  */
 export function feishuOAuthCallbackUrl(): string {
   return new URL(

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -202,13 +202,17 @@ working for those builds:
   bridge falls back to `soft` on any request failure, so deleting or breaking
   the endpoint would silently release users the hard stop is holding.
 - **The Okou DMG route must keep resolving.** `Download Okou` opens
-  `https://api.vm0.ai/api/desktop/updates/stable/darwin/arm64/dmg`. #28278 moved
-  that route off the brand namespace, and builds published before the move open
-  `https://api.vm0.ai/api/okou/desktop/updates/stable/darwin/arm64/dmg` and
-  reject any other path, so the API keeps serving both branded forms through
-  `MIGRATED_BRANDED_PATHS` in `apps/api/src/signals/route-entry.ts`. An installed
-  build never drains on its own; retiring those forms needs the Desktop drain
-  gate tracked by #26364.
+  `https://api.vm0.ai/api/desktop/updates/stable/darwin/arm64/dmg`, the neutral
+  path #28278 moved that route to. The API served the branded forms alongside it
+  through `MIGRATED_BRANDED_PATHS` in `apps/api/src/signals/route-entry.ts`, on
+  the reading that a build published before the move opens
+  `https://api.vm0.ai/api/okou/desktop/updates/stable/darwin/arm64/dmg` instead.
+  Measurement did not support it: across 2026-09-01 07:00Z to 2026-09-02 07:30Z
+  every one of the 1,445 update requests, from 144 addresses, was on the neutral
+  path and neither branded form took any, including from the Zero installs that
+  have been polling this API since the policy went `hard`. #31088 removed those
+  rows, so the neutral path above is the one that has to keep resolving.
+  #26364 tracks the Zero install base itself.
 
 This does not submit or publish the app to the Mac App Store. The App Store
 Connect API key is only used as notarytool authentication for Apple's


### PR DESCRIPTION
Closes #31088. Part of #26701.

## What changed

`MIGRATED_BRANDED_PATHS` in `turbo/apps/api/src/signals/route-entry.ts` is now empty. It was the only thing registering a branded path, and `apiNamespaceAliasPaths` returns a neutral path unchanged, so after this no request to `/api/okou/**` or `/api/zero/**` is served — every one of them is a 404. Every neutral contract path is untouched.

The constant and `withMigratedBrandedPaths` stay in place. #31090 removes the mechanism; keeping the behavioural change separate from the structural one keeps a regression attributable.

The six rows removed, with the evidence on the issue:

- `/api/org` and `/api/workflows` — both holders are gone. The CLI moved from `9.279.3` to `9.304–9.305`, and the two internal Okou Desktop installs at `0.7.0` and `0.38.85` have not appeared since #30804; the oldest active build is `0.38.126`.
- `/api/logs/:id` — one request on 2026-08-30 17:59, nothing since.
- The two `desktop/updates` rows — zero branded traffic. This corrects the reasoning #28715 recorded: `Download Okou` resolves through the *neutral* path, not the branded one. All 1,445 update requests in the 2026-09-01 07:00Z → 2026-09-02 07:30Z window, from 144 addresses, were neutral. Since the migration policy went `hard` on 2026-08-31T02:26Z, 107–108 Zero installs have been polling `desktop/migration-policy`, `feature-switches` and `auth/me`, every one of them neutral and not one branded. These rows were gated on nothing; #26364 governs the Zero install base, not this surface.
- `/api/slack/oauth/install` — two requests from search-index snapshots and forwarded links, no producer left. The landing-page `href`s moved to the neutral path in `vm0-marketing#523`. An owner decision on 2026-09-02.

## Tests

`migrated-branded-paths.test.ts` keeps its synthetic mechanism cases, which drive `withMigratedBrandedPaths` through an explicit table and stay meaningful with the shipped one empty. The restated inventory is empty and the count literal is `0`. The cases that asserted a specific row served both branded forms have no subject left, so:

- the sweep over the production route table now asserts the composition registers no branded path for anything, read off the composition rather than off the table;
- the two app-factory twins (`slack/oauth/install`, `/api/org`) are gone, with a comment recording what they covered.

No case asserts that a removed path 404s — `docs/fallback.md` section 1 rules that class out, and the registration-level assertion already proves the path is gone.

`api-namespace-compatibility.test.ts` and `api-namespace-legacy-paths.test.ts` lose the subjects that depended on a shipped row the same way. The list-driven cases stay: restating a path there is what a slice re-adding compatibility has to do.

`desktop-updates.test.ts` and `slack-oauth.test.ts` drove their cases through branded paths. They are repointed at the neutral path, and the desktop line assertions keep both manifests mocked so a fall-through to the Zero line fails rather than 404s.

## Comments

Eight locations were listed on the issue. Six carried a comment that explained why a row existed or treated the table as live, and are updated: `route-entry.ts` (both docblocks), `signals/services/feishu-config.ts`, `routes/__tests__/desktop-updates.test.ts`, `routes/__tests__/teams-bot.test.ts`, `routes/__tests__/provider-console-paths.test.ts` (both), `__tests__/api-namespace-legacy-paths.test.ts`. The other two — `routes/__tests__/computer-use.bdd.test.ts:1698` and `routes/__tests__/helpers/api-bdd-computer-use.ts:560` — carry no such comment on current `main`; #30804 and #30807 removed the Computer Use rows and the comments with them.

Three more that the issue did not list said the same thing and are updated too:

- `turbo/apps/desktop/README.md` carried the #28715 reasoning verbatim, that a pre-move build opens the branded DMG path and rejects any other. That is the claim this issue corrects, so leaving it would have kept the wrong reason in the one place a reader looks for it.
- `docs/okou-cli-cutover.md` gave a row count for the table.
- `signals/routes/desktop-updates.ts` explains why the neutral path resolves to the Okou line and the `zero` alias to the Zero line.

## One reader retired with its producer

`desktopUpdateLineFromRequestUrl` in `signals/routes/desktop-updates.ts` derived the update line from the request namespace, which is how the `/api/zero/**` alias resolved to the Zero line. With no branded registration left, no request can arrive on one, so that branch had no reachable input — `docs/fallback.md` section 5, a reader outliving its producer. The two unqualified routes now read the Okou line directly. The Zero line stays reachable through `productFeed`, `productReleasePage` and `productDmgDownload`, which name it in the path, and the `RELEASES.json` feed, which has always pinned it.

`MIGRATED_BRANDED_PATHS` and `withMigratedBrandedPaths` are the one reader deliberately left behind, because #31090 removes them and the issue asks for the behavioural and structural changes to stay separately attributable.

## Verification

`vitest --project api` over the touched files passes: `migrated-branded-paths`, `api-namespace-compatibility`, `api-namespace-legacy-paths`, `desktop-updates`, `slack-oauth`, `provider-console-paths`, `app-factory`, `teams-bot`, `feishu-integration`. `teams-bot` and `feishu-integration` have runner-claim failures in this sandbox that reproduce identically on `main` at the same commit, so they are environmental and not from this change. `prettier --check` and `eslint` are clean on every changed file. Type-checking is left to CI; this sandbox has 3 GB of RAM and `tsc` runs out of heap.

A grep of `e2e/`, `.github/scripts/` and `.github/workflows/` for either branded form returns nothing, so no CI caller is held open by a removed row.