### PR TITLE
feat(pi): add a feature-gated canonical memory mount

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -34,6 +34,7 @@ import {
 import { isChatRunTerminalEventType } from "@okouai/api-contracts/contracts/chat-events";
 import {
   ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES,
+  CANONICAL_CODEX_MEMORY_MOUNT_PATH,
   CANCELLATION_RECOVERY_STALE_AFTER_MS,
   DEFAULT_PROFILE,
   PI_MEMORY_ROOT,
@@ -145,6 +146,7 @@ import {
 import { createRouteMocks } from "./helpers/route-test";
 import { formatUserPresentationTemplateId } from "@okouai/core/presentation-template-selection";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
+import { commitMemoryVersion } from "./helpers/memory";
 import { overwriteModelProviderSecretForTests } from "./helpers/model-provider-state";
 import {
   readCustomConnectorCredentialStorageParent,
@@ -5259,6 +5261,182 @@ describe("CHAT-02: model-first provider policies", () => {
     await cancelChatRun(actor, enabled.runId, enabledClaim.sandboxHeaders);
   }, 90_000);
 
+  it("pins recall-enabled Pi memory through API completion and Sandbox handoff", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    const orgId = requireOrgId(actor);
+    const initialMemory = await commitMemoryVersion(context, actor, [
+      {
+        path: "MEMORY.md",
+        content: "Pi memory version pinned before the API-first completion.",
+      },
+    ]);
+    const usagePricingResolution = await createTerraUsagePricingResolution();
+    await configureBuiltInPiModel(actor, "gpt-5.6-terra");
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId },
+      {
+        [FeatureSwitchKey.PiLoop]: true,
+        [FeatureSwitchKey.PiMemoryRecall]: true,
+      },
+    );
+    mockPiResourceArchiveDownloads();
+    const checkpointObjects = mockPiCheckpointObjectStore();
+    let modelCalls = 0;
+    server.use(
+      http.post("https://api.openai.com/v1/responses", () => {
+        modelCalls += 1;
+        return new HttpResponse(
+          modelCalls === 1
+            ? piResponsesTextSse("API-first memory checkpoint", modelCalls)
+            : piResponsesToolSse({
+                callId: "call_pi_memory_handoff",
+                name: "read",
+                arguments: { path: "/home/user/workspace/AGENTS.md" },
+                sequence: modelCalls,
+              }),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+
+    const first = await sendChatRun(
+      actor,
+      {
+        agentId,
+        prompt: "complete through the Pi API-first slot",
+        model: "gpt-5.6-terra",
+      },
+      "vm0",
+      usagePricingResolution,
+    );
+    await waitForRunStatus(actor, first.runId, "completed", 10_000);
+    await flushWaitUntilForTest();
+    expect(modelCalls).toBe(1);
+
+    const newerMemory = await commitMemoryVersion(context, actor, [
+      {
+        path: "MEMORY.md",
+        content: "A newer HEAD must not replace the session-pinned version.",
+      },
+    ]);
+    expect(newerMemory.versionId).not.toBe(initialMemory.versionId);
+
+    const second = await sendChatRun(
+      actor,
+      {
+        agentId,
+        threadId: first.threadId,
+        prompt: "handoff with the pinned Pi memory mount",
+        model: "gpt-5.6-terra",
+      },
+      "vm0",
+      usagePricingResolution,
+    );
+    const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${second.runId}/manifest.json`;
+    await expect
+      .poll(() => {
+        return checkpointObjects.has(manifestKey);
+      })
+      .toBe(true);
+    expect(modelCalls).toBe(2);
+    const manifestBytes = checkpointObjects.get(manifestKey);
+    if (!manifestBytes) {
+      throw new Error("Expected the Pi memory ownership-transfer manifest");
+    }
+    expect(
+      piApiFirstTurnManifestSchema.parse(
+        JSON.parse(manifestBytes.toString("utf8")),
+      ),
+    ).toMatchObject({
+      outcome: "ownership-transfer",
+      mode: "pending-tool-continuation",
+    });
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId },
+      { [FeatureSwitchKey.PiMemoryRecall]: false },
+    );
+    const claimed = await claimChatRun(runnerGroup, second.runId);
+    expect(claimed.claim.cliAgentType).toBe("pi");
+    expect(claimed.claim.featureFlags).toMatchObject({
+      [FeatureSwitchKey.PiMemoryRecall]: true,
+    });
+    expect(claimed.claim.appendSystemPrompt).not.toMatch(/auto.?memory/iu);
+    const storageManifest = expectCanonicalStorageManifest(
+      claimed.claim.storageManifest,
+    );
+    if (!storageManifest) {
+      throw new Error("Expected recall-enabled Pi Storage mounts");
+    }
+    const memorySlotMounts = storageManifest.storageMounts.filter((mount) => {
+      return mount.name === "memory" || mount.mountPath === PI_MEMORY_ROOT;
+    });
+    expect(memorySlotMounts).toHaveLength(1);
+    expect(memorySlotMounts[0]).toMatchObject({
+      name: "memory",
+      versionId: initialMemory.versionId,
+      mountPath: PI_MEMORY_ROOT,
+      missingRootPolicy: "preserveParentVersion",
+      writeback: true,
+      archiveUrl: expect.any(String),
+    });
+    expect(memorySlotMounts[0]).not.toHaveProperty("generatedBy");
+    expect(storageManifest.storageMounts).not.toContainEqual(
+      expect.objectContaining({
+        mountPath: CANONICAL_CODEX_MEMORY_MOUNT_PATH,
+      }),
+    );
+
+    await cancelChatRun(actor, second.runId, claimed.sandboxHeaders);
+  }, 90_000);
+
+  it("keeps an empty recall-enabled Pi memory mount valid", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    const orgId = requireOrgId(actor);
+    await configureBuiltInPiModel(actor, "gpt-5.6-terra");
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId },
+      {
+        [FeatureSwitchKey.PiLoop]: true,
+        [FeatureSwitchKey.PiMemoryRecall]: true,
+      },
+    );
+    mockPiResourceArchiveDownloads(true);
+    mockPiCheckpointObjectStore();
+    await api.heartbeatRunner(runnerGroup);
+
+    const run = await sendChatRun(actor, {
+      agentId,
+      prompt: "launch Pi with an absent memory Storage",
+      model: "gpt-5.6-terra",
+    });
+    const claimed = await claimChatRun(runnerGroup, run.runId);
+    const storageManifest = expectCanonicalStorageManifest(
+      claimed.claim.storageManifest,
+    );
+    if (!storageManifest) {
+      throw new Error("Expected empty recall-enabled Pi Storage mounts");
+    }
+    const memorySlotMounts = storageManifest.storageMounts.filter((mount) => {
+      return mount.name === "memory" || mount.mountPath === PI_MEMORY_ROOT;
+    });
+    expect(memorySlotMounts).toHaveLength(1);
+    expect(memorySlotMounts[0]).toMatchObject({
+      name: "memory",
+      versionId: expect.any(String),
+      mountPath: PI_MEMORY_ROOT,
+      missingRootPolicy: "preserveParentVersion",
+      writeback: true,
+      empty: true,
+    });
+    expect(memorySlotMounts[0]).not.toHaveProperty("archiveUrl");
+    expect(memorySlotMounts[0]).not.toHaveProperty("generatedBy");
+
+    await cancelChatRun(actor, run.runId, claimed.sandboxHeaders);
+  }, 90_000);
+
   it("keeps captured Codex admission after PiLoop turns on", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     const orgId = requireOrgId(actor);
@@ -5334,6 +5512,18 @@ describe("CHAT-02: model-first provider policies", () => {
     const disabledClaim = await claimChatRun(runnerGroup, disabled.runId);
     expect(disabledClaim.claim.cliAgentType).toBe("codex");
     expect(disabledClaim.claim.piLaunchConfig).toBeUndefined();
+    expect(
+      expectCanonicalStorageManifest(
+        disabledClaim.claim.storageManifest,
+      )?.storageMounts.filter((mount) => {
+        return mount.name === "memory";
+      }),
+    ).toStrictEqual([
+      expect.objectContaining({
+        mountPath: CANONICAL_CODEX_MEMORY_MOUNT_PATH,
+        missingRootPolicy: "preserveParentVersion",
+      }),
+    ]);
     await expect(
       readRunLaunchSnapshotFixture(context, disabled.runId),
     ).resolves.toMatchObject({

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -1502,7 +1502,10 @@ describe("RUN-01/RUN-02: session continuation, memory policies, and volume pinni
     expect(
       expectCanonicalStorageManifest(customClaim.storageManifest)
         ?.storageMounts.filter((mount) => {
-          return mount.name === "custom-memory";
+          return (
+            mount.name === "memory" ||
+            mount.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH
+          );
         })
         .map((mount) => {
           return {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -575,6 +575,7 @@ interface ResolvedAgentExecution {
   readonly volumeVersions?: Record<string, string>;
   readonly additionalVolumes?: readonly AdditionalVolume[];
   readonly persistedStorageMounts?: readonly PersistedStorageMount[];
+  readonly previousRunStorageMounts?: readonly PersistedStorageMount[];
   readonly agentSessionId?: string;
   readonly continuedFromAgentSessionId?: string;
   readonly resumeSession?: StoredExecutionContext["resumeSession"];
@@ -1509,26 +1510,36 @@ function frameworkApiKeyEnv(framework: SupportedFramework): string {
   return framework === "codex" ? "OPENAI_API_KEY" : "ANTHROPIC_API_KEY";
 }
 
-function autoMemoryMountPath(framework: SupportedFramework): string {
+function autoMemoryMountPath(
+  framework: SupportedFramework,
+  piSandbox: PiModelConfig | undefined,
+): string {
+  if (piSandbox !== undefined) {
+    return PI_MEMORY_ROOT;
+  }
   return framework === "codex"
     ? CANONICAL_CODEX_MEMORY_MOUNT_PATH
     : CANONICAL_CLAUDE_MEMORY_MOUNT_PATH;
 }
 
-function autoMemoryArtifact(framework: SupportedFramework): ContextArtifact {
+function autoMemoryArtifact(
+  framework: SupportedFramework,
+  piSandbox: PiModelConfig | undefined,
+): ContextArtifact {
   return withAutoMemoryMissingRootPolicy({
     name: AUTO_MEMORY_ARTIFACT_NAME,
-    mountPath: autoMemoryMountPath(framework),
+    mountPath: autoMemoryMountPath(framework, piSandbox),
   });
 }
 
 function isCanonicalAutoMemoryArtifact(
   artifact: ContextArtifact,
   framework: SupportedFramework,
+  piSandbox: PiModelConfig | undefined,
 ): boolean {
   return (
     artifact.name === AUTO_MEMORY_ARTIFACT_NAME &&
-    artifact.mountPath === autoMemoryMountPath(framework)
+    artifact.mountPath === autoMemoryMountPath(framework, piSandbox)
   );
 }
 
@@ -1544,9 +1555,10 @@ function withAutoMemoryMissingRootPolicy(
 function withCanonicalAutoMemoryMissingRootPolicy(
   artifacts: readonly ContextArtifact[],
   framework: SupportedFramework,
+  piSandbox: PiModelConfig | undefined,
 ): readonly ContextArtifact[] {
   return artifacts.map((artifact) => {
-    return isCanonicalAutoMemoryArtifact(artifact, framework)
+    return isCanonicalAutoMemoryArtifact(artifact, framework, piSandbox)
       ? withAutoMemoryMissingRootPolicy(artifact)
       : artifact;
   });
@@ -1555,22 +1567,24 @@ function withCanonicalAutoMemoryMissingRootPolicy(
 function claimsAutoMemorySlot(
   artifact: ContextArtifact,
   framework: SupportedFramework,
+  piSandbox: PiModelConfig | undefined,
 ): boolean {
   return (
     artifact.name === AUTO_MEMORY_ARTIFACT_NAME ||
-    artifact.mountPath === autoMemoryMountPath(framework)
+    artifact.mountPath === autoMemoryMountPath(framework, piSandbox)
   );
 }
 
 function withoutSupersededAutoMemoryArtifacts(
   artifacts: readonly ContextArtifact[],
   framework: SupportedFramework,
+  piSandbox: PiModelConfig | undefined,
   slotOwnerIndex: number,
 ): readonly ContextArtifact[] {
   return artifacts.filter((artifact, index) => {
     return (
       index >= slotOwnerIndex ||
-      !isCanonicalAutoMemoryArtifact(artifact, framework)
+      !isCanonicalAutoMemoryArtifact(artifact, framework, piSandbox)
     );
   });
 }
@@ -1593,9 +1607,56 @@ function composeArtifacts(
   });
 }
 
+function withPinnedPiContinuationMemory(
+  artifacts: readonly ContextArtifact[],
+  previousRunStorageMounts: readonly PersistedStorageMount[] | undefined,
+): readonly ContextArtifact[] {
+  const previousMemoryMount = previousRunStorageMounts?.find((mount) => {
+    return (
+      mount.name === AUTO_MEMORY_ARTIFACT_NAME &&
+      mount.mountPath === PI_MEMORY_ROOT &&
+      mount.version !== undefined
+    );
+  });
+  if (!previousMemoryMount?.version) {
+    return artifacts;
+  }
+  const pinnedMemoryArtifact = withAutoMemoryMissingRootPolicy({
+    name: AUTO_MEMORY_ARTIFACT_NAME,
+    version: previousMemoryMount.version,
+    mountPath: PI_MEMORY_ROOT,
+  });
+  let slotOwnerIndex: number | undefined;
+  for (let index = artifacts.length - 1; index >= 0; index -= 1) {
+    const artifact = artifacts[index];
+    if (
+      artifact &&
+      (artifact.name === AUTO_MEMORY_ARTIFACT_NAME ||
+        artifact.mountPath === PI_MEMORY_ROOT)
+    ) {
+      slotOwnerIndex = index;
+      break;
+    }
+  }
+  if (slotOwnerIndex === undefined) {
+    return [...artifacts, pinnedMemoryArtifact];
+  }
+  const slotOwner = artifacts[slotOwnerIndex]!;
+  if (
+    slotOwner.name !== AUTO_MEMORY_ARTIFACT_NAME ||
+    slotOwner.mountPath !== PI_MEMORY_ROOT
+  ) {
+    return artifacts;
+  }
+  return artifacts.map((artifact, index) => {
+    return index === slotOwnerIndex ? pinnedMemoryArtifact : artifact;
+  });
+}
+
 function artifactsForRun(args: {
   readonly resolved: ResolvedAgentExecution;
   readonly framework: SupportedFramework;
+  readonly piSandbox: PiModelConfig | undefined;
   readonly includeAutoMemory: boolean;
   readonly bodyArtifacts: readonly ContextArtifact[] | undefined;
 }): RunArtifacts {
@@ -1603,9 +1664,16 @@ function artifactsForRun(args: {
   const composeContextArtifacts = isContinuation
     ? []
     : composeArtifacts(args.resolved.content);
-  const baseArtifacts = isContinuation
+  const unpinnedBaseArtifacts = isContinuation
     ? args.resolved.artifacts
     : [...composeContextArtifacts, ...args.resolved.artifacts];
+  const baseArtifacts =
+    isContinuation && args.piSandbox !== undefined && args.includeAutoMemory
+      ? withPinnedPiContinuationMemory(
+          unpinnedBaseArtifacts,
+          args.resolved.previousRunStorageMounts,
+        )
+      : unpinnedBaseArtifacts;
   const bodyArtifacts = args.bodyArtifacts ?? [];
   const artifacts = [...baseArtifacts, ...bodyArtifacts];
   if (!args.includeAutoMemory) {
@@ -1622,23 +1690,32 @@ function artifactsForRun(args: {
   let autoMemorySlotArtifactIndex: number | undefined;
   for (let index = artifacts.length - 1; index >= 0; index -= 1) {
     const artifact = artifacts[index];
-    if (artifact && claimsAutoMemorySlot(artifact, args.framework)) {
+    if (
+      artifact &&
+      claimsAutoMemorySlot(artifact, args.framework, args.piSandbox)
+    ) {
       autoMemorySlotArtifactIndex = index;
       break;
     }
   }
   if (autoMemorySlotArtifactIndex === undefined) {
     return {
-      artifacts: [...artifacts, autoMemoryArtifact(args.framework)],
+      artifacts: [
+        ...artifacts,
+        autoMemoryArtifact(args.framework, args.piSandbox),
+      ],
     };
   }
 
   const slotOwner = artifacts[autoMemorySlotArtifactIndex]!;
-  if (!isCanonicalAutoMemoryArtifact(slotOwner, args.framework)) {
+  if (
+    !isCanonicalAutoMemoryArtifact(slotOwner, args.framework, args.piSandbox)
+  ) {
     return {
       artifacts: withoutSupersededAutoMemoryArtifacts(
         artifacts,
         args.framework,
+        args.piSandbox,
         autoMemorySlotArtifactIndex,
       ),
     };
@@ -1648,6 +1725,7 @@ function artifactsForRun(args: {
     artifacts: withCanonicalAutoMemoryMissingRootPolicy(
       artifacts,
       args.framework,
+      args.piSandbox,
     ),
   };
 }
@@ -5866,6 +5944,7 @@ function resolveBySessionId(
               previousRun: {
                 id: agentRuns.id,
                 vars: agentRuns.vars,
+                storageMounts: agentRuns.storageMounts,
                 modelProvider: agentRuns.modelProvider,
                 modelRuntimeProvider: agentRuns.modelRuntimeProvider,
                 modelRuntimeModel: agentRuns.modelRuntimeModel,
@@ -5923,6 +6002,8 @@ function resolveBySessionId(
         orgId: snapshot.agent.orgId,
         content: options.executionPlan.content,
         ...resolvedSessionStorage(snapshot.session),
+        previousRunStorageMounts:
+          snapshot.previousRun?.storageMounts ?? undefined,
         vars:
           (snapshot.previousRun?.vars as Record<string, string> | null) ??
           undefined,
@@ -9238,7 +9319,13 @@ function prepareRunOutputMetadata(args: {
   const artifacts = artifactsForRun({
     resolved: args.resolved,
     framework: args.framework,
-    includeAutoMemory: args.piSandbox === undefined,
+    piSandbox: args.piSandbox,
+    includeAutoMemory:
+      args.piSandbox === undefined ||
+      isFeatureEnabled(
+        FeatureSwitchKey.PiMemoryRecall,
+        args.featureSwitchContext,
+      ),
     bodyArtifacts: args.body.artifacts,
   }).artifacts;
   return {

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -139,6 +139,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PiLoop]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.PiMemoryRecall]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       true,
     );
@@ -159,6 +160,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PiLoop]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.PiMemoryRecall]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       false,
     );

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -58,6 +58,7 @@ export enum FeatureSwitchKey {
   CustomConnectorMcp = "customConnectorMcp",
   SharedThreadSharing = "sharedThreadSharing",
   PiLoop = "piLoop",
+  PiMemoryRecall = "piMemoryRecall",
   PresentationTemplates = "presentationTemplates",
   IntroVideo = "introVideo",
   ChatTranslation = "chatTranslation",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -276,6 +276,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.PiMemoryRecall]: {
+    maintainer: "lancy@vm0.ai",
+    description:
+      "Mount the canonical user memory Storage for Pi runs without enabling memory generation.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.PresentationTemplates]: {
     maintainer: "bingjie@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- register an independent, staff-scoped `piMemoryRecall` switch that remains globally disabled
- resolve the canonical memory mount from the actual runtime owner and pin Pi continuations to the persisted Storage version
- preserve native Codex/Claude paths, reserved-slot de-duplication, and `preserveParentVersion` semantics without adding prompt injection or generation
- cover recall-off, recall-on, empty Storage, API-first handoff, continuation pinning, native runtime, and legacy/custom-slot behavior

## Testing

- `pnpm --dir turbo exec prettier --check apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts apps/api/src/signals/services/agent-run-create.service.ts packages/core/src/__tests__/feature-switch.test.ts packages/core/src/feature-switch-key.ts packages/core/src/feature-switch.ts`
- `pnpm -F @okouai/core lint`
- `pnpm -F @okouai/core check-types`
- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts --silent=passed-only`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t "pins recall-enabled Pi memory through API completion and Sandbox handoff|keeps an empty recall-enabled Pi memory mount valid|publishes OpenRouter Responses blocks and hands fast Sandbox tool turns to H2|keeps captured Codex admission after PiLoop turns on" --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-reads.bdd.test.ts -t "restores volumes, memory, and conversation state when continuing sessions" --silent=passed-only`

Closes #31073
Parent: #31067
