### PR TITLE
feat: gate morning brief behind an independent switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -1271,6 +1271,20 @@ async function setOfficialWorkflowsEnabled(
   );
 }
 
+async function setMorningBriefEnabled(
+  actor: ApiTestUser,
+  enabled: boolean,
+): Promise<void> {
+  if (!actor.orgId) {
+    throw new Error("Expected organization-scoped actor");
+  }
+  await updateFeatureSwitchesForUser(
+    context,
+    { orgId: actor.orgId, userId: actor.userId },
+    { [FeatureSwitchKey.MorningBrief]: enabled },
+  );
+}
+
 async function connectGoogleMeetForOfficialWorkflow(
   actor: ApiTestUser,
 ): Promise<void> {
@@ -1601,6 +1615,7 @@ describe.sequential("Morning Brief preference", () => {
     });
     const headers = authHeaders(actor);
     await setOfficialWorkflowsEnabled(actor, false);
+    await setMorningBriefEnabled(actor, true);
 
     const initial = await accept(
       morningBriefPreferenceClient().get({ headers }),
@@ -1730,10 +1745,44 @@ describe.sequential("Morning Brief preference", () => {
       },
     ]);
     expect(after.body.workflow.id).toBe(identities.workflowId);
+
+    await setMorningBriefEnabled(actor, false);
+    const deniedRead = await accept(
+      morningBriefPreferenceClient().get({ headers }),
+      [403],
+    );
+    expect(deniedRead.body.error.code).toBe("FORBIDDEN");
+    const deniedUpdate = await accept(
+      morningBriefPreferenceClient().update({
+        headers,
+        body: { enabled: false },
+      }),
+      [403],
+    );
+    expect(deniedUpdate.body.error.code).toBe("FORBIDDEN");
+
+    const afterRolloutOff = await accept(
+      installationClient().get({
+        headers,
+        params: { workflowId: morningBrief.id },
+      }),
+      [200],
+    );
+    expect(afterRolloutOff.body.workflow).toMatchObject({
+      id: identities.workflowId,
+      automations: [
+        {
+          id: identities.automationId,
+          chatThreadId: identities.chatThreadId,
+          enabled: true,
+        },
+      ],
+    });
   });
 
   it("returns typed missing-timezone and missing-default-Agent states without mutation", async () => {
     const missingTimezone = await workflowBdd.setupWorkflowOrg();
+    await setMorningBriefEnabled(missingTimezone.actor, true);
     const timezoneHeaders = authHeaders(missingTimezone.actor);
     const unavailableTimezone = await accept(
       morningBriefPreferenceClient().get({ headers: timezoneHeaders }),
@@ -1756,6 +1805,7 @@ describe.sequential("Morning Brief preference", () => {
 
     const missingAgent = bdd.user();
     await bdd.updateUserTimezone(missingAgent, "Asia/Shanghai");
+    await setMorningBriefEnabled(missingAgent, true);
     const agentHeaders = authHeaders(missingAgent);
     const unavailableAgent = await accept(
       morningBriefPreferenceClient().get({ headers: agentHeaders }),
@@ -1829,6 +1879,22 @@ describe.sequential("Morning Brief preference", () => {
         );
       }),
     );
+
+    const hiddenRead = await accept(
+      morningBriefPreferenceClient().get({ headers }),
+      [403],
+    );
+    expect(hiddenRead.body.error.code).toBe("FORBIDDEN");
+    const hiddenUpdate = await accept(
+      morningBriefPreferenceClient().update({
+        headers,
+        body: { enabled: false },
+      }),
+      [403],
+    );
+    expect(hiddenUpdate.body.error.code).toBe("FORBIDDEN");
+
+    await setMorningBriefEnabled(actor, true);
 
     const read = await accept(
       morningBriefPreferenceClient().get({ headers }),

--- a/turbo/apps/api/src/signals/routes/morning-brief-preference.ts
+++ b/turbo/apps/api/src/signals/routes/morning-brief-preference.ts
@@ -1,11 +1,14 @@
 import { morningBriefPreferenceContract } from "@okouai/api-contracts/contracts/morning-brief-preference";
-import { command } from "ccstate";
+import { isFeatureEnabled } from "@okouai/core/feature-switch";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { command, computed } from "ccstate";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { publicBrand$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import {
   morningBriefPreference$,
   updateMorningBriefPreference$,
@@ -17,6 +20,25 @@ const morningBriefPreferenceReadAuth = {
   missingOrganizationStatus: 401,
   requiredCapability: "agent:read",
 } as const;
+
+function forbidden(message: string) {
+  return {
+    status: 403 as const,
+    body: { error: { message, code: "FORBIDDEN" as const } },
+  };
+}
+
+const morningBriefEnabled$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  const overrides = await get(
+    userFeatureSwitchOverrides(auth.orgId, auth.userId),
+  );
+  return isFeatureEnabled(FeatureSwitchKey.MorningBrief, {
+    orgId: auth.orgId,
+    userId: auth.userId,
+    overrides,
+  });
+});
 
 const morningBriefPreferenceWriteAuth = {
   requireOrganization: true,
@@ -41,6 +63,10 @@ function failureResponse(failure: MorningBriefPreferenceFailure) {
 const getMorningBriefPreferenceInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
+    if (!(await get(morningBriefEnabled$))) {
+      return forbidden("Morning Brief is not enabled");
+    }
+    signal.throwIfAborted();
     const result = await set(
       morningBriefPreference$,
       {
@@ -60,6 +86,10 @@ const updateBody$ = bodyResultOf(morningBriefPreferenceContract.update);
 const updateMorningBriefPreferenceInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
+    if (!(await get(morningBriefEnabled$))) {
+      return forbidden("Morning Brief is not enabled");
+    }
+    signal.throwIfAborted();
     const body = await get(updateBody$);
     signal.throwIfAborted();
     if (!body.ok) {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/preference-settings.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/preference-settings.test.tsx
@@ -105,6 +105,64 @@ describe("unified preference settings", () => {
     expect(new URLSearchParams(search()).get("settings")).toBe("debug");
   });
 
+  it.each([
+    {
+      morningBrief: false,
+      officialWorkflows: false,
+      visible: false,
+    },
+    {
+      morningBrief: true,
+      officialWorkflows: false,
+      visible: true,
+    },
+    {
+      morningBrief: false,
+      officialWorkflows: true,
+      visible: false,
+    },
+    {
+      morningBrief: true,
+      officialWorkflows: true,
+      visible: true,
+    },
+  ])(
+    "gates Morning Brief loading with morningBrief=$morningBrief independently from officialWorkflows=$officialWorkflows",
+    async ({ morningBrief, officialWorkflows, visible }) => {
+      let preferenceReads = 0;
+      context.mocks.api(morningBriefPreferenceContract.get, ({ respond }) => {
+        preferenceReads += 1;
+        return respond(200, {
+          enabled: false,
+          nextRunAt: null,
+          timezone: "Asia/Shanghai",
+          unavailableReason: null,
+        });
+      });
+
+      detachedSetupPage({
+        context,
+        path: "/agents?settings=preference",
+        featureSwitches: {
+          [FeatureSwitchKey.MorningBrief]: morningBrief,
+          [FeatureSwitchKey.OfficialWorkflows]: officialWorkflows,
+        },
+      });
+
+      const dialog = await screen.findByRole("dialog", { name: "Settings" });
+      await waitFor(() => {
+        expect({
+          cardVisible:
+            within(dialog).queryByTestId("morning-brief-preference") !== null,
+          preferenceLoaded: preferenceReads > 0,
+        }).toStrictEqual({
+          cardVisible: visible,
+          preferenceLoaded: visible,
+        });
+      });
+    },
+  );
+
   it("preserves the legacy Morning Brief focus and displays its authoritative next email", async () => {
     const scrollIntoView = mockScrollIntoView();
     const nextRunAt = "2030-01-02T23:30:00.000Z";
@@ -120,6 +178,10 @@ describe("unified preference settings", () => {
     detachedSetupPage({
       context,
       path: "/settings?tab=timezone&focus=morning-brief",
+      featureSwitches: {
+        [FeatureSwitchKey.MorningBrief]: true,
+        [FeatureSwitchKey.OfficialWorkflows]: false,
+      },
     });
 
     const dialog = await screen.findByRole("dialog", { name: "Settings" });
@@ -191,6 +253,10 @@ describe("unified preference settings", () => {
     detachedSetupPage({
       context,
       path: "/agents?settings=preference",
+      featureSwitches: {
+        [FeatureSwitchKey.MorningBrief]: true,
+        [FeatureSwitchKey.OfficialWorkflows]: false,
+      },
     });
     const toggle = await screen.findByRole("switch", {
       name: "Morning Brief",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
@@ -1195,7 +1195,10 @@ describe("zero sidebar account menu", () => {
         fullName: "Alex Rivera",
         email: "alex.rivera@example.test",
       },
-      featureSwitches: { [FeatureSwitchKey.OkouDebug]: true },
+      featureSwitches: {
+        [FeatureSwitchKey.OkouDebug]: true,
+        [FeatureSwitchKey.MorningBrief]: true,
+      },
     });
 
     const menu = await openAccountMenu();

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/preference-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/preference-section.tsx
@@ -4,7 +4,9 @@ import { useTranslation } from "react-i18next";
 import { Sun, Moon, Monitor, Keyboard, Loader2, Palette } from "lucide-react";
 import { cn } from "@okouai/ui";
 import type { SendMode } from "@okouai/api-contracts/contracts/user-preferences";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
+import { featureSwitch$ } from "../../../../../signals/external/feature-switch.ts";
 import { pageSignal$ } from "../../../../../signals/page-signal.ts";
 import {
   themePreference$,
@@ -196,6 +198,7 @@ function EnterBlock() {
 
 export function PreferenceSection() {
   const { t } = useTranslation();
+  const featureSwitches = useGet(featureSwitch$);
 
   return (
     <div className="flex flex-col gap-8">
@@ -244,7 +247,9 @@ export function PreferenceSection() {
           })}
         />
         <TimezoneSettings />
-        <MorningBriefSettings />
+        {featureSwitches[FeatureSwitchKey.MorningBrief] ? (
+          <MorningBriefSettings />
+        ) : null}
       </section>
     </div>
   );

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -1567,6 +1567,10 @@ describe("workflows routes", () => {
 
     detachedSetupWorkflowDetailPage(
       `/workflows/${MORNING_BRIEF_WORKFLOW_ID}/automations`,
+      {
+        [FeatureSwitchKey.MorningBrief]: true,
+        [FeatureSwitchKey.OfficialWorkflows]: false,
+      },
     );
 
     await waitFor(() => {
@@ -1578,12 +1582,27 @@ describe("workflows routes", () => {
     expect(screen.queryByText("Instructions")).not.toBeInTheDocument();
   });
 
-  it("hides Official discovery when the feature switch is disabled", async () => {
-    mockWorkflowApis([officialSalesResearch()]);
-    detachedSetupPage({ context, path: "/workflows" });
-    await screen.findByRole("heading", { name: "Workflows" });
-    expect(screen.queryByText("Browse Official")).not.toBeInTheDocument();
-  });
+  it.each([
+    { morningBrief: false, officialWorkflows: false, visible: false },
+    { morningBrief: true, officialWorkflows: false, visible: false },
+    { morningBrief: false, officialWorkflows: true, visible: true },
+    { morningBrief: true, officialWorkflows: true, visible: true },
+  ])(
+    "gates Browse Official with officialWorkflows=$officialWorkflows independently from morningBrief=$morningBrief",
+    async ({ morningBrief, officialWorkflows, visible }) => {
+      mockWorkflowApis([officialSalesResearch()]);
+      detachedSetupPage({
+        context,
+        path: "/workflows",
+        featureSwitches: {
+          [FeatureSwitchKey.MorningBrief]: morningBrief,
+          [FeatureSwitchKey.OfficialWorkflows]: officialWorkflows,
+        },
+      });
+      await screen.findByRole("heading", { name: "Workflows" });
+      expect(screen.queryByText("Browse Official") !== null).toBe(visible);
+    },
+  );
 
   it("keeps active catalog browse and retired direct detail truthful", async () => {
     const active = officialCatalogDetail("active");

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -96,6 +96,33 @@ describe("isFeatureEnabled", () => {
     ).toBe(true);
   });
 
+  it("should keep Morning Brief default-off with an independent staff rollout and user override", () => {
+    const staffOrgId = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
+    expect(isFeatureEnabled(FeatureSwitchKey.MorningBrief, {})).toBe(false);
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.MorningBrief, {
+        orgId: staffOrgId,
+      }),
+    ).toBe(true);
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.MorningBrief, {
+        orgId: staffOrgId,
+        overrides: { [FeatureSwitchKey.MorningBrief]: false },
+      }),
+    ).toBe(false);
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.MorningBrief, {
+        orgId: "org_nonexistent",
+        overrides: { [FeatureSwitchKey.MorningBrief]: true },
+      }),
+    ).toBe(true);
+    expect(getFeatureSwitchMetadata()[FeatureSwitchKey.MorningBrief]).toEqual({
+      maintainer: "lancy@vm0.ai",
+      description:
+        "Enable the first-class Morning Brief experience in Preferences.",
+    });
+  });
+
   it("should return true when orgId matches even if userId does not", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.Lab, {
@@ -152,6 +179,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.IntroVideo]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.MorningBrief]).toBe(true);
 
     const otherOrgStates = getAllFeatureStates({
       orgId: "org_nonexistent",
@@ -172,6 +200,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.IntroVideo]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.MorningBrief]).toBe(false);
   });
 
   it("should enable intro video for Bingjie only", () => {

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -98,6 +98,7 @@ describe("isFeatureEnabled", () => {
 
   it("should keep Morning Brief default-off with an independent staff rollout and user override", () => {
     const staffOrgId = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
+    expect(FeatureSwitchKey.MorningBrief).toBe("morningBrief");
     expect(isFeatureEnabled(FeatureSwitchKey.MorningBrief, {})).toBe(false);
     expect(
       isFeatureEnabled(FeatureSwitchKey.MorningBrief, {

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -39,6 +39,7 @@ export enum FeatureSwitchKey {
   GoogleFormsWorkflowAutomations = "googleFormsWorkflowAutomations",
   StripeInvoicePaidWorkflowAutomations = "stripeInvoicePaidWorkflowAutomations",
   OfficialWorkflows = "officialWorkflows",
+  MorningBrief = "morningBrief",
   TestOauthConnector = "_testOauthConnector",
   FreshdeskConnector = "freshdeskConnector",
   StabilityAiConnector = "stabilityAiConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -222,6 +222,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.MorningBrief]: {
+    maintainer: "lancy@vm0.ai",
+    description:
+      "Enable the first-class Morning Brief experience in Preferences.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.TestOauthConnector]: {
     maintainer: "liangyou@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- Restore the default-off `morningBrief` switch with an initial staff-organization rollout, and independently gate the unified Preferences card plus its narrow read/write APIs.
- Preserve `officialWorkflows` as the sole gate for Browse Official and generic catalog installation; neither switch implies the other.
- Keep Morning Brief on the existing `daily-delivery` Official Workflow install, reconciliation, runtime, and email path. Disabling rollout access fails closed without mutating an installed automation.

## Testing

- Prettier check for all changed files
- Turbo lint: 13/13 tasks passed (API: 0 errors; existing warnings only)
- TypeScript: 12/12 non-API/non-Platform packages, Platform, and API passed
- Knip passed (configuration hints only)
- Core feature-switch test: 29 passed
- Unified Preferences test: 14 passed, including all four switch combinations and functional toggle behavior with Official Workflows off
- Workflows routing tests: 5 targeted cases passed, including all four Browse Official switch combinations
- Sidebar Settings target: 1 passed
- Morning Brief API tests: 3 passed, covering fail-closed GET/mutation, independent installation, and non-mutation after rollout disable

Closes #31087
