### PR TITLE
ci: make e2e finalization non-blocking

### DIFF
--- a/.github/scripts/tests/clerk-test-resource-workflow-test.sh
+++ b/.github/scripts/tests/clerk-test-resource-workflow-test.sh
@@ -243,6 +243,9 @@ if playwright_cleanup
 end
 
 playwright_finalizer = turbo_jobs.fetch("cli-e2e-02-playwright-finalize")
+unless playwright_finalizer["continue-on-error"] == true
+  raise "Playwright finalization must not fail the workflow"
+end
 unless Array(playwright_finalizer["needs"]).include?("cli-e2e-02-playwright")
   raise "Playwright finalizer must wait for every matrix lane"
 end
@@ -268,6 +271,9 @@ unless playwright_finalizer_steps.last == playwright_cleanup
 end
 
 runner_cleanup = turbo_jobs.fetch("cli-e2e-03-runner-cleanup")
+unless runner_cleanup["continue-on-error"] == true
+  raise "runner E2E cleanup must not fail the workflow"
+end
 runner_condition = runner_cleanup.fetch("if")
 unless runner_condition.include?("always()") &&
     !runner_condition.include?("!= 'cancelled'")

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -103,6 +103,15 @@ account_prepare = jobs.fetch("cli-e2e-03-runner-prepare")
 bootstrap = jobs.fetch("cli-e2e-03-runner-bootstrap")
 runner = jobs.fetch("cli-e2e-03-runner")
 account_cleanup = jobs.fetch("cli-e2e-03-runner-cleanup")
+unless playwright_finalizer["continue-on-error"] == true
+  raise "Playwright finalization must not fail the workflow"
+end
+unless account_cleanup["continue-on-error"] == true
+  raise "runner E2E cleanup must not fail the workflow"
+end
+if playwright.key?("continue-on-error") || runner.key?("continue-on-error")
+  raise "actual Playwright and runner E2E jobs must remain blocking"
+end
 expected_api_backend_url = "${{ needs.deploy-api.outputs.preview-url }}"
 assert_canonical_api_backend_url = lambda do |step, name|
   environment = step.fetch("env")
@@ -187,6 +196,8 @@ playwright_run = playwright.fetch("steps").find do |step|
   step["name"] == "Run Playwright E2E tests"
 end
 unless playwright_run&.fetch("shell") == "bash" &&
+    playwright_run["continue-on-error"] ==
+      "${{ vars.CI_CHECK_BROWSER_E2E != '1' }}" &&
     playwright_run.fetch("run").include?('--project="$PLAYWRIGHT_PROJECT"') &&
     playwright_run.dig("env", "PLAYWRIGHT_PROJECT") ==
       "${{ matrix.project }}"
@@ -747,13 +758,17 @@ end
 gate_needs = Array(jobs.fetch("ci-gate-turbo")["needs"])
 %w[
   cli-e2e-02-playwright
-  cli-e2e-02-playwright-finalize
   cli-e2e-03-runner-prepare
   cli-e2e-03-runner-bootstrap
   cli-e2e-03-runner
-  cli-e2e-03-runner-cleanup
 ].each do |job_name|
   raise "CI gate must include #{job_name}" unless gate_needs.include?(job_name)
+end
+%w[
+  cli-e2e-02-playwright-finalize
+  cli-e2e-03-runner-cleanup
+].each do |job_name|
+  raise "CI gate must not wait for #{job_name}" if gate_needs.include?(job_name)
 end
 
 gate_step = jobs.fetch("ci-gate-turbo").fetch("steps").find do |step|
@@ -773,17 +788,23 @@ end
   cli-e2e-03-runner-prepare
   cli-e2e-03-runner-bootstrap
   cli-e2e-03-runner
-  cli-e2e-03-runner-cleanup
 ].each do |job_name|
   expected = "check_result \"#{job_name}\" \"${{ needs.#{job_name}.result }}\" \"$RUNNER_E2E_SKIP_ALLOWED\""
   raise "CI gate must check #{job_name} with RUNNER_E2E_SKIP_ALLOWED" unless gate_script.include?(expected)
 end
 %w[
   cli-e2e-02-playwright
-  cli-e2e-02-playwright-finalize
 ].each do |job_name|
   expected = "check_result \"#{job_name}\" \"${{ needs.#{job_name}.result }}\" \"${{ vars.CI_CHECK_BROWSER_E2E == '1' && 'true' || 'informational' }}\""
   raise "CI gate must check #{job_name} with the browser E2E policy" unless gate_script.include?(expected)
+end
+%w[
+  cli-e2e-02-playwright-finalize
+  cli-e2e-03-runner-cleanup
+].each do |job_name|
+  if gate_script.include?("needs.#{job_name}.result")
+    raise "CI gate must not evaluate #{job_name}"
+  end
 end
 RUBY
 

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1916,6 +1916,7 @@ jobs:
   cli-e2e-02-playwright-finalize:
     runs-on: ubuntu-latest
     timeout-minutes: 8
+    continue-on-error: true
     concurrency:
       group: cli-e2e-02-playwright-finalize-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
@@ -2829,6 +2830,7 @@ jobs:
   cli-e2e-03-runner-cleanup:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    continue-on-error: true
     needs:
       - prepare
       - cli-e2e-03-runner-prepare
@@ -2982,12 +2984,10 @@ jobs:
       - deploy-cli
       - cli-e2e-02-browser
       - cli-e2e-02-playwright
-      - cli-e2e-02-playwright-finalize
       - cli-e2e-01-serial
       - cli-e2e-03-runner-prepare
       - cli-e2e-03-runner-bootstrap
       - cli-e2e-03-runner
-      - cli-e2e-03-runner-cleanup
       - deploy-runner-prepare
       - deploy-runner-start
     # Always run so the gate reports an explicit result (not "skipped").
@@ -3090,12 +3090,10 @@ jobs:
           check_result "deploy-cli" "${{ needs.deploy-cli.result }}" "$CF_APP_SKIP_ALLOWED"
           check_result "cli-e2e-02-browser" "${{ needs.cli-e2e-02-browser.result }}" "${{ vars.CI_CHECK_BROWSER_E2E == '1' && 'true' || 'informational' }}"
           check_result "cli-e2e-02-playwright" "${{ needs.cli-e2e-02-playwright.result }}" "${{ vars.CI_CHECK_BROWSER_E2E == '1' && 'true' || 'informational' }}"
-          check_result "cli-e2e-02-playwright-finalize" "${{ needs.cli-e2e-02-playwright-finalize.result }}" "${{ vars.CI_CHECK_BROWSER_E2E == '1' && 'true' || 'informational' }}"
           check_result "cli-e2e-01-serial" "${{ needs.cli-e2e-01-serial.result }}" "true"
           check_result "cli-e2e-03-runner-prepare" "${{ needs.cli-e2e-03-runner-prepare.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
           check_result "cli-e2e-03-runner-bootstrap" "${{ needs.cli-e2e-03-runner-bootstrap.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
           check_result "cli-e2e-03-runner" "${{ needs.cli-e2e-03-runner.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
-          check_result "cli-e2e-03-runner-cleanup" "${{ needs.cli-e2e-03-runner-cleanup.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
           check_result "deploy-runner-prepare" "${{ needs.deploy-runner-prepare.result }}" "$RUNNER_DEPLOY_SKIP_ALLOWED"
           check_result "deploy-runner-start" "${{ needs.deploy-runner-start.result }}" "$RUNNER_DEPLOY_SKIP_ALLOWED"
 


### PR DESCRIPTION
## Summary

- allow Playwright report finalization and runner Clerk cleanup jobs to fail without failing the Turbo workflow
- remove both auxiliary jobs from `ci-gate-turbo` dependencies and result evaluation while keeping the actual Playwright and runner E2E jobs blocking
- extend workflow contracts to protect the non-blocking finalizer boundary, upstream E2E gate policies, and existing cleanup lifecycle

## Behavior and compatibility

- finalization jobs still run after terminal upstream outcomes with their existing `always()` conditions
- Playwright report handling, cleanup ordering, runner generation/run/retain scopes, concurrency, and timeouts are unchanged
- no E2E test is skipped and no test selection or timeout is changed
- no product API, persisted state, runner protocol, deployment contract, or user-facing behavior changes
- scheduled Clerk cleanup and closed-PR cleanup remain fallback reconciliation paths

## Validation

- `bash .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `bash .github/scripts/tests/clerk-test-resource-workflow-test.sh`
- `bash -n .github/scripts/tests/turbo-playwright-runner-workflow-test.sh .github/scripts/tests/clerk-test-resource-workflow-test.sh`
- `shellcheck .github/scripts/tests/turbo-playwright-runner-workflow-test.sh .github/scripts/tests/clerk-test-resource-workflow-test.sh`
- `.github/scripts/check-workflow-shell-compatibility.sh`
- `actionlint .github/workflows/turbo.yml`
- `cd turbo && pnpm exec prettier --check ../.github/workflows/turbo.yml`
- `scripts/check-file-size.sh .github/workflows/turbo.yml .github/scripts/tests/turbo-playwright-runner-workflow-test.sh .github/scripts/tests/clerk-test-resource-workflow-test.sh`
- `git diff --check`
- `lefthook run pre-commit`

Closes #31103

