### PR TITLE
fix(desktop): surface a failed movie writer instead of delivering its first fragment

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/ClickMapping.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/ClickMapping.swift
@@ -81,6 +81,12 @@ public struct CapturedClick: Equatable, Sendable {
     public let button: String
     public let clickCount: Int
     public let modifiers: [String]
+    /// Where the captured region stood when this click happened, for a source
+    /// that moves during the recording. A window capture follows the window
+    /// wherever it is dragged, so a click after the drag must be projected
+    /// through the window's position at that moment, not the one it had when
+    /// the capture was prepared. `nil` means the recording's geometry applies.
+    public let geometry: CaptureGeometry?
 
     public init(
         ticks: UInt64,
@@ -88,7 +94,8 @@ public struct CapturedClick: Equatable, Sendable {
         screenY: Double,
         button: String,
         clickCount: Int,
-        modifiers: [String]
+        modifiers: [String],
+        geometry: CaptureGeometry? = nil
     ) {
         self.ticks = ticks
         self.screenX = screenX
@@ -96,6 +103,7 @@ public struct CapturedClick: Equatable, Sendable {
         self.button = button
         self.clickCount = clickCount
         self.modifiers = modifiers
+        self.geometry = geometry
     }
 }
 
@@ -134,7 +142,7 @@ public func projectClicks(
             continue
         }
         guard
-            let point = geometry.mapClick(
+            let point = (click.geometry ?? geometry).mapClick(
                 screenX: click.screenX,
                 screenY: click.screenY,
                 outputSize: outputSize

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/SampleTimingPolicy.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/SampleTimingPolicy.swift
@@ -11,16 +11,26 @@ import Foundation
 /// anchor as duplicates, and any sample whose adjusted time fails to advance.
 /// Both are dropped here rather than handed to the writer.
 public enum SampleTimingPolicy {
+    /// Slack allowed when comparing against the previous sample's end, so
+    /// floating-point drift between neighbouring buffers is not read as overlap.
+    public static let overlapTolerance = 0.000_001
+
     /// The media time to write `captureSeconds` at, or `nil` to drop it.
     ///
     /// - `captureSeconds`: the sample's time relative to the anchor frame.
     /// - `pauses`: the recording's pause spans.
     /// - `lastWrittenSeconds`: the media time of the last sample written to
     ///   the same track, or `nil` when the track has none yet.
+    /// - `lastWrittenEndSeconds`: where that sample ended, for tracks whose
+    ///   samples have extent. Audio buffers carry 20 ms of sound each, and the
+    ///   writer refuses one that starts before the previous one has finished:
+    ///   a window capture's audio jumps like that when the window's app starts
+    ///   making sound. Video frames pass their own start here.
     public static func mediaTime(
         captureSeconds: Double,
         pauses: PauseTimeline,
-        lastWrittenSeconds: Double?
+        lastWrittenSeconds: Double?,
+        lastWrittenEndSeconds: Double? = nil
     ) -> Double? {
         guard captureSeconds >= 0 else {
             return nil
@@ -29,6 +39,9 @@ public enum SampleTimingPolicy {
             return nil
         }
         if let lastWrittenSeconds, mediaSeconds <= lastWrittenSeconds {
+            return nil
+        }
+        if let lastWrittenEndSeconds, mediaSeconds + overlapTolerance < lastWrittenEndSeconds {
             return nil
         }
         return mediaSeconds

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/SampleTimingPolicy.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/SampleTimingPolicy.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Decides where a captured sample lands on the movie's timeline, or that it
+/// must not be written at all.
+///
+/// The writer refuses a sample whose time is not later than the previous one
+/// on the same track, and once it has refused one it refuses everything after
+/// it for the rest of the recording. Two things in the capture produce such
+/// samples: audio buffers that arrive stamped earlier than the video frame the
+/// session was anchored on, which the pause arithmetic would fold onto the
+/// anchor as duplicates, and any sample whose adjusted time fails to advance.
+/// Both are dropped here rather than handed to the writer.
+public enum SampleTimingPolicy {
+    /// The media time to write `captureSeconds` at, or `nil` to drop it.
+    ///
+    /// - `captureSeconds`: the sample's time relative to the anchor frame.
+    /// - `pauses`: the recording's pause spans.
+    /// - `lastWrittenSeconds`: the media time of the last sample written to
+    ///   the same track, or `nil` when the track has none yet.
+    public static func mediaTime(
+        captureSeconds: Double,
+        pauses: PauseTimeline,
+        lastWrittenSeconds: Double?
+    ) -> Double? {
+        guard captureSeconds >= 0 else {
+            return nil
+        }
+        guard let mediaSeconds = pauses.mediaTime(forCaptureTime: captureSeconds) else {
+            return nil
+        }
+        if let lastWrittenSeconds, mediaSeconds <= lastWrittenSeconds {
+            return nil
+        }
+        return mediaSeconds
+    }
+}

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/ClickTrackRecorder.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/ClickTrackRecorder.swift
@@ -50,6 +50,10 @@ final class ClickTrackRecorder: @unchecked Sendable {
     private var tap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
     private var warnings: [String] = []
+    /// Where the captured region stands right now, for a source that moves.
+    /// Asked at each click, so the click is projected through the geometry of
+    /// its own moment rather than the recording's first. Set before `start`.
+    var geometryProvider: (() -> CaptureGeometry?)?
 
     /// Starts observing clicks. Never throws: losing the click track must not
     /// cost the user their video, so a refused tap is reported as a warning on
@@ -129,7 +133,8 @@ final class ClickTrackRecorder: @unchecked Sendable {
             screenY: Double(location.y),
             button: button,
             clickCount: Int(event.getIntegerValueField(.mouseEventClickState)),
-            modifiers: modifierNames(for: event.flags)
+            modifiers: modifierNames(for: event.flags),
+            geometry: geometryProvider?()
         )
         lock.lock()
         clicks.append(click)

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
@@ -517,9 +517,14 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         try? FileManager.default.removeItem(at: url)
 
         let assetWriter = try AVAssetWriter(outputURL: url, fileType: .mp4)
-        // Fragmented output keeps the file playable if this process dies mid
-        // capture; an unfinalized plain MP4 would be unreadable.
-        assetWriter.movieFragmentInterval = CMTime(seconds: 2, preferredTimescale: 600)
+        // Written as one movie, finalized at stop, rather than in two-second
+        // fragments. Fragments were meant to keep the file playable if this
+        // process died mid-capture, but nothing recovers such a file, and
+        // closing a fragment failed whenever the video track had no frame in
+        // it: a window capture only produces a frame when the window changes,
+        // so a still window left every fragment after the first empty, and the
+        // writer failed at the boundary. Every recording of a still window
+        // ended a few seconds in.
 
         let video = AVAssetWriterInput(
             mediaType: .video,

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
@@ -86,7 +86,17 @@ private func resolveDisplay(
 
 // MARK: - Source discovery
 
-private func shareableContent(timeout: TimeInterval = 10) throws -> SCShareableContent {
+/// Reads what ScreenCaptureKit can share.
+///
+/// `onScreenWindowsOnly` is off by default because "on screen" means the active
+/// Space: a full-screen editor or browser on its own Space would otherwise be
+/// missing from the picker and unresolvable as a capture target. Callers that
+/// only need displays pass `true`, because the wide read walks every window on
+/// every Space and is the slowest part of starting a recording.
+private func shareableContent(
+    timeout: TimeInterval = 10,
+    onScreenWindowsOnly: Bool = false
+) throws -> SCShareableContent {
     // Asking ScreenCaptureKit without the grant makes the system put its own
     // prompt on screen, every single time. Once the answer is already no, say
     // so instead: the app can then offer Settings rather than the user being
@@ -99,13 +109,9 @@ private func shareableContent(timeout: TimeInterval = 10) throws -> SCShareableC
     }
     let semaphore = DispatchSemaphore(value: 0)
     let box = ResultBox<SCShareableContent>()
-    // `onScreenWindowsOnly` is off because "on screen" means the active Space.
-    // With it on, a full-screen editor or browser living on its own Space was
-    // missing from the picker, and picking it later could not be resolved
-    // either. `recordableWindows` drops the system chrome the wider list adds.
     SCShareableContent.getExcludingDesktopWindows(
         true,
-        onScreenWindowsOnly: false
+        onScreenWindowsOnly: onScreenWindowsOnly
     ) { content, error in
         box.set(value: content, error: error)
         semaphore.signal()
@@ -351,7 +357,7 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
     /// Set when the stream ended without `stop` being called. The session stays
     /// finalizable so the partial recording and its click track are still
     /// written; only the reported status changes.
-    private var externalStop: (reason: StreamStopReason, message: String)?
+    private var externalStop: (reason: StreamStopReason, code: String, message: String)?
     private var stream: SCStream?
     private var writer: AVAssetWriter?
     private var videoInput: AVAssetWriterInput?
@@ -620,12 +626,18 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         systemAudio?.markAsFinished()
         microphone?.markAsFinished()
 
+        var writerFailure: String?
         if let assetWriter {
             let semaphore = DispatchSemaphore(value: 0)
             assetWriter.finishWriting {
                 semaphore.signal()
             }
             _ = semaphore.wait(timeout: .now() + 30)
+            if assetWriter.status == .failed {
+                writerFailure =
+                    assetWriter.error?.localizedDescription
+                    ?? "The screen recording could not be written"
+            }
         }
 
         guard let url else {
@@ -651,7 +663,7 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
             startedAtUnixMs: startedAt
         )
 
-        return [
+        var result: [String: Any] = [
             "videoPath": url.path,
             "clickTrackPath": clickTrackPath,
             "durationMs": Int(duration * 1000),
@@ -659,6 +671,19 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
             "width": outputSize.width,
             "height": outputSize.height,
         ]
+        // The file is handed back either way — it holds whatever was written
+        // before the failure — but the caller must not deliver it as a finished
+        // recording. Reported here as well as through `recorder.state`, because
+        // a stop that races the poll would otherwise ship it.
+        lock.lock()
+        let failure = externalStop.flatMap { $0.reason == .failed ? $0 : nil }
+        lock.unlock()
+        if let writerFailure {
+            result["failure"] = ["code": "capture_failed", "message": writerFailure]
+        } else if let failure {
+            result["failure"] = ["code": failure.code, "message": failure.message]
+        }
+        return result
     }
 
     private func writeClickTrack(
@@ -712,7 +737,7 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         ]
         if let externalStop, externalStop.reason == .failed {
             described["error"] = [
-                "code": "source_lost",
+                "code": externalStop.code,
                 "message": externalStop.message,
             ]
         }
@@ -796,10 +821,14 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
     /// frames that were captured before the stream ended, and discarding them
     /// would throw away the recording the user just made. `stop` finalizes as
     /// usual, and the reported status tells the caller to run it.
-    private func noteExternalStop(reason: StreamStopReason, message: String) {
+    private func noteExternalStop(
+        reason: StreamStopReason,
+        code: String = "source_lost",
+        message: String
+    ) {
         lock.lock()
         if externalStop == nil {
-            externalStop = (reason, message)
+            externalStop = (reason, code, message)
         }
         let captureStream = stream
         stream = nil
@@ -864,15 +893,25 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
                 )
             }
         }
-        latestSampleAt = timestamp
         let input = writerInputLocked(for: type)
         let start = sessionStartedAt
         let timeline = pauseTimeline
         lock.unlock()
 
+        // A writer that has failed answers `isReadyForMoreMediaData` with false
+        // for the rest of its life. Treating that like ordinary back-pressure
+        // dropped every later frame in silence while the clock kept running,
+        // and `stop` then delivered a recording holding its first fragment.
+        if assetWriter.status == .failed {
+            noteWriterFailure(assetWriter)
+            return
+        }
         guard let input, input.isReadyForMoreMediaData, let start else {
             return
         }
+        lock.lock()
+        latestSampleAt = timestamp
+        lock.unlock()
         // Frames keep arriving while paused; they are dropped, and everything
         // after a pause is shifted back so the movie has no frozen stretch.
         let captureSeconds = CMTimeGetSeconds(CMTimeSubtract(timestamp, start))
@@ -891,7 +930,24 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         else {
             return
         }
-        input.append(retimed)
+        if !input.append(retimed), assetWriter.status == .failed {
+            noteWriterFailure(assetWriter)
+        }
+    }
+
+    /// Ends the capture because the file can no longer be written to.
+    ///
+    /// Reported as `capture_failed` rather than `source_lost`: the source is
+    /// still there, it is the output that broke. What was written before the
+    /// failure is kept for `stop` to finalize, the same as any other external
+    /// end.
+    private func noteWriterFailure(_ assetWriter: AVAssetWriter) {
+        noteExternalStop(
+            reason: .failed,
+            code: "capture_failed",
+            message: assetWriter.error?.localizedDescription
+                ?? "The screen recording could not be written"
+        )
     }
 }
 
@@ -948,7 +1004,10 @@ private func handlePrepare(_ request: [String: Any]) throws -> [String: Any] {
         microphone: microphone,
         microphoneSupported: microphoneSupported()
     )
-    let content = try shareableContent()
+    // Only a window capture has to find its target among every Space's
+    // windows; a display or area capture is aimed at a display and pays for
+    // the wide read with nothing but a slower start.
+    let content = try shareableContent(onScreenWindowsOnly: sourceKind != "window")
 
     let filter: SCContentFilter
     let geometry: CaptureGeometry

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
@@ -431,6 +431,10 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
     /// writer input, so a sample that would not advance its track is refused
     /// before the writer refuses it and fails.
     private var lastWrittenSeconds: [ObjectIdentifier: Double] = [:]
+    /// Where the last sample written to each track ended: its start plus its
+    /// duration for audio, its start for video, which has no extent the
+    /// writer enforces.
+    private var lastWrittenEndSeconds: [ObjectIdentifier: Double] = [:]
     /// The format description each track was started with, keyed by writer
     /// input. A sample whose format differs from it is the leading way a
     /// window capture can turn into a sample the writer refuses.
@@ -1011,6 +1015,7 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         let start = sessionStartedAt
         let timeline = pauseTimeline
         let lastWritten = input.map { lastWrittenSeconds[ObjectIdentifier($0)] } ?? nil
+        let lastWrittenEnd = input.map { lastWrittenEndSeconds[ObjectIdentifier($0)] } ?? nil
         lock.unlock()
 
         // A writer that has failed answers `isReadyForMoreMediaData` with false
@@ -1034,7 +1039,8 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
             let mediaSeconds = SampleTimingPolicy.mediaTime(
                 captureSeconds: captureSeconds,
                 pauses: timeline,
-                lastWrittenSeconds: lastWritten
+                lastWrittenSeconds: lastWritten,
+                lastWrittenEndSeconds: lastWrittenEnd
             )
         else {
             return
@@ -1054,9 +1060,12 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
             return
         }
         if input.append(retimed) {
+            let duration = CMSampleBufferGetDuration(sampleBuffer)
+            let extent = type == .screen || !duration.isValid ? 0 : max(0, duration.seconds)
             lock.lock()
             latestSampleAt = timestamp
             lastWrittenSeconds[ObjectIdentifier(input)] = mediaSeconds
+            lastWrittenEndSeconds[ObjectIdentifier(input)] = mediaSeconds + extent
             if firstFormat[ObjectIdentifier(input)] == nil,
                 let format = CMSampleBufferGetFormatDescription(sampleBuffer)
             {
@@ -1094,7 +1103,15 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
                 : "no duration"
         )
         if let mediaSeconds {
-            parts.append(String(format: "at %.2fs", mediaSeconds))
+            parts.append(String(format: "at %.3fs", mediaSeconds))
+        }
+        lock.lock()
+        let previousEnd = writerInputLocked(for: type).flatMap {
+            lastWrittenEndSeconds[ObjectIdentifier($0)]
+        }
+        lock.unlock()
+        if let previousEnd {
+            parts.append(String(format: "previous sample ended at %.3fs", previousEnd))
         }
         return parts.joined(separator: ", ")
     }

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
@@ -86,6 +86,44 @@ private func resolveDisplay(
 
 // MARK: - Source discovery
 
+/// One screen read, kept briefly so the picker and the capture that follows it
+/// do not each pay for their own.
+private final class ShareableContentCache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var content: SCShareableContent?
+    private var coversEverySpace = false
+    private var readAt = Date.distantPast
+
+    /// How long one read stays good for. Opening the picker reads the screen
+    /// twice in a row and preparing the capture reads it a third time; a
+    /// window that closes inside this span still fails cleanly as
+    /// `source_lost`, the same as one that closes a moment later.
+    private let lifetime: TimeInterval = 20
+
+    func reuse(onScreenWindowsOnly: Bool) -> SCShareableContent? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let content, Date().timeIntervalSince(readAt) < lifetime else {
+            return nil
+        }
+        // A read of every Space answers a request for the current one too.
+        guard coversEverySpace || onScreenWindowsOnly else {
+            return nil
+        }
+        return content
+    }
+
+    func store(_ content: SCShareableContent, coversEverySpace: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.content = content
+        self.coversEverySpace = coversEverySpace
+        readAt = Date()
+    }
+}
+
+private let shareableContentCache = ShareableContentCache()
+
 /// Reads what ScreenCaptureKit can share.
 ///
 /// `onScreenWindowsOnly` is off by default because "on screen" means the active
@@ -106,6 +144,9 @@ private func shareableContent(
             code: "permission_denied",
             message: "Okou needs Screen Recording permission in System Settings"
         )
+    }
+    if let cached = shareableContentCache.reuse(onScreenWindowsOnly: onScreenWindowsOnly) {
+        return cached
     }
     let semaphore = DispatchSemaphore(value: 0)
     let box = ResultBox<SCShareableContent>()
@@ -136,6 +177,7 @@ private func shareableContent(
             message: "Screen recording permission is not granted"
         )
     }
+    shareableContentCache.store(content, coversEverySpace: !onScreenWindowsOnly)
     return content
 }
 

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
@@ -380,6 +380,25 @@ private func handleWindowPreviews() throws -> [String: Any] {
 /// cannot drift.
 private let captureFrameRate: CMTimeScale = 30
 
+/// The writer's failure as a message worth reading.
+///
+/// AVFoundation wraps most writer failures as `-11800`, "The operation could
+/// not be completed", and keeps the status that actually says what happened
+/// one level down as the underlying error. Both are spelled out so the tray
+/// shows something that can be looked up rather than only the wrapper.
+private func writerFailureMessage(_ assetWriter: AVAssetWriter) -> String {
+    guard let error = assetWriter.error as NSError? else {
+        return "The screen recording could not be written"
+    }
+    var parts = ["\(error.domain) \(error.code)"]
+    var underlying = error.userInfo[NSUnderlyingErrorKey] as? NSError
+    while let next = underlying {
+        parts.append("\(next.domain) \(next.code)")
+        underlying = next.userInfo[NSUnderlyingErrorKey] as? NSError
+    }
+    return "\(error.localizedDescription) (\(parts.joined(separator: " / ")))"
+}
+
 // MARK: - Capture session
 
 private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput, @unchecked Sendable {
@@ -680,9 +699,7 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
             }
             _ = semaphore.wait(timeout: .now() + 30)
             if assetWriter.status == .failed {
-                writerFailure =
-                    assetWriter.error?.localizedDescription
-                    ?? "The screen recording could not be written"
+                writerFailure = writerFailureMessage(assetWriter)
             }
         }
 
@@ -861,6 +878,38 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         return max(0, captureSeconds - pauseTimeline.pausedSecondsBefore(captureSeconds))
     }
 
+    /// Why the first frame cannot go on the video track, or `nil` when it can.
+    private func frameSizeMismatch(_ sampleBuffer: CMSampleBuffer) -> String? {
+        guard let image = CMSampleBufferGetImageBuffer(sampleBuffer) else {
+            return "The screen capture delivered a frame with no image"
+        }
+        let width = CVPixelBufferGetWidth(image)
+        let height = CVPixelBufferGetHeight(image)
+        guard width == outputSize.width, height == outputSize.height else {
+            return
+                "The screen capture delivered \(width)×\(height) frames "
+                + "but the recording was prepared for \(outputSize.width)×\(outputSize.height)"
+        }
+        return nil
+    }
+
+    /// Whether a screen sample is a finished picture rather than a status
+    /// marker. A sample without the attachment at all is treated as complete:
+    /// that is how a frame arrives from a filter the system does not annotate.
+    private func isCompleteFrame(_ sampleBuffer: CMSampleBuffer) -> Bool {
+        guard
+            let attachments = CMSampleBufferGetSampleAttachmentsArray(
+                sampleBuffer,
+                createIfNecessary: false
+            ) as? [[SCStreamFrameInfo: Any]],
+            let rawStatus = attachments.first?[.status] as? Int,
+            let status = SCFrameStatus(rawValue: rawStatus)
+        else {
+            return true
+        }
+        return status == .complete
+    }
+
     /// Records that the stream ended on its own.
     ///
     /// Deliberately does not move to a terminal state: the writer still holds
@@ -913,6 +962,13 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         else {
             return
         }
+        // ScreenCaptureKit also delivers frames that carry no new picture —
+        // idle, blank, and the bookkeeping frames around start and stop. They
+        // are not images the encoder can take, and handing one to the writer
+        // is a way to fail it. Only a complete frame goes on.
+        if type == .screen, !isCompleteFrame(sampleBuffer) {
+            return
+        }
         let timestamp = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
 
         lock.lock()
@@ -925,6 +981,14 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
                 // Anchor the timeline on the first video frame so audio that
                 // arrives first cannot start the session before the picture.
                 lock.unlock()
+                return
+            }
+            // A frame of the wrong size fails the writer with nothing but
+            // "the operation could not be completed". Refusing it here names
+            // both sizes instead, before the session is anchored on it.
+            if let mismatch = frameSizeMismatch(sampleBuffer) {
+                lock.unlock()
+                noteExternalStop(reason: .failed, code: "capture_failed", message: mismatch)
                 return
             }
             assetWriter.startSession(atSourceTime: timestamp)
@@ -1005,8 +1069,7 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         noteExternalStop(
             reason: .failed,
             code: "capture_failed",
-            message: assetWriter.error?.localizedDescription
-                ?? "The screen recording could not be written"
+            message: writerFailureMessage(assetWriter)
         )
     }
 }
@@ -1138,6 +1201,12 @@ private func handlePrepare(_ request: [String: Any]) throws -> [String: Any] {
     let configuration = SCStreamConfiguration()
     configuration.width = outputSize.width
     configuration.height = outputSize.height
+    // The video track is built for exactly `outputSize`, and the writer fails
+    // on the first frame of any other size. A whole display is always scaled
+    // into the configured size, but a window or a cropped region is delivered
+    // at its own pixel size unless the stream is told to scale it, which is
+    // why display captures worked while window and area captures did not.
+    configuration.scalesToFit = sourceKind != "display"
     configuration.minimumFrameInterval = CMTime(value: 1, timescale: captureFrameRate)
     configuration.showsCursor = true
     configuration.queueDepth = 6

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
@@ -431,6 +431,10 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
     /// writer input, so a sample that would not advance its track is refused
     /// before the writer refuses it and fails.
     private var lastWrittenSeconds: [ObjectIdentifier: Double] = [:]
+    /// The format description each track was started with, keyed by writer
+    /// input. A sample whose format differs from it is the leading way a
+    /// window capture can turn into a sample the writer refuses.
+    private var firstFormat: [ObjectIdentifier: CMFormatDescription] = [:]
     private var clickTimeline: ClickTimeline?
     private var pauseTimeline = PauseTimeline()
     private var startedAtUnixMs = 0
@@ -1014,7 +1018,7 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         // dropped every later frame in silence while the clock kept running,
         // and `stop` then delivered a recording holding its first fragment.
         if assetWriter.status == .failed {
-            noteWriterFailure(assetWriter)
+            noteWriterFailure(assetWriter, sample: sampleBuffer, type: type, at: nil)
             return
         }
         guard let input, input.isReadyForMoreMediaData, let start else {
@@ -1053,9 +1057,65 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
             lock.lock()
             latestSampleAt = timestamp
             lastWrittenSeconds[ObjectIdentifier(input)] = mediaSeconds
+            if firstFormat[ObjectIdentifier(input)] == nil,
+                let format = CMSampleBufferGetFormatDescription(sampleBuffer)
+            {
+                firstFormat[ObjectIdentifier(input)] = format
+            }
             lock.unlock()
         } else if assetWriter.status == .failed {
-            noteWriterFailure(assetWriter)
+            noteWriterFailure(assetWriter, sample: sampleBuffer, type: type, at: mediaSeconds)
+        }
+    }
+
+    /// Describes a sample the way the failure message needs it: which track,
+    /// what format, and whether that format is the one the track began with.
+    private func describeSample(
+        _ sampleBuffer: CMSampleBuffer,
+        type: SCStreamOutputType,
+        at mediaSeconds: Double?
+    ) -> String {
+        var parts: [String] = [type == .screen ? "screen" : "audio"]
+        if let format = CMSampleBufferGetFormatDescription(sampleBuffer) {
+            parts.append(describeFormat(format))
+            lock.lock()
+            let first = writerInputLocked(for: type).flatMap { firstFormat[ObjectIdentifier($0)] }
+            lock.unlock()
+            if let first, !CMFormatDescriptionEqual(first, format) {
+                parts.append("format changed from \(describeFormat(first))")
+            }
+        } else {
+            parts.append("no format description")
+        }
+        let duration = CMSampleBufferGetDuration(sampleBuffer)
+        parts.append(
+            duration.isValid && duration.seconds > 0
+                ? String(format: "duration %.1fms", duration.seconds * 1000)
+                : "no duration"
+        )
+        if let mediaSeconds {
+            parts.append(String(format: "at %.2fs", mediaSeconds))
+        }
+        return parts.joined(separator: ", ")
+    }
+
+    private func describeFormat(_ format: CMFormatDescription) -> String {
+        let subtype = CMFormatDescriptionGetMediaSubType(format)
+        let code = String(
+            [24, 16, 8, 0].map { Character(UnicodeScalar(UInt8((subtype >> $0) & 0xff))) }
+        )
+        switch CMFormatDescriptionGetMediaType(format) {
+        case kCMMediaType_Video:
+            let size = CMVideoFormatDescriptionGetDimensions(format)
+            return "\(size.width)×\(size.height) \(code)"
+        case kCMMediaType_Audio:
+            guard let asbd = CMAudioFormatDescriptionGetStreamBasicDescription(format)?.pointee
+            else {
+                return code
+            }
+            return "\(Int(asbd.mSampleRate)) Hz \(asbd.mChannelsPerFrame) ch \(code)"
+        default:
+            return code
         }
     }
 
@@ -1065,11 +1125,17 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
     /// still there, it is the output that broke. What was written before the
     /// failure is kept for `stop` to finalize, the same as any other external
     /// end.
-    private func noteWriterFailure(_ assetWriter: AVAssetWriter) {
+    private func noteWriterFailure(
+        _ assetWriter: AVAssetWriter,
+        sample: CMSampleBuffer,
+        type: SCStreamOutputType,
+        at mediaSeconds: Double?
+    ) {
         noteExternalStop(
             reason: .failed,
             code: "capture_failed",
             message: writerFailureMessage(assetWriter)
+                + " while writing \(describeSample(sample, type: type, at: mediaSeconds))"
         )
     }
 }

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
@@ -1081,7 +1081,7 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
             lock.lock()
             let first = writerInputLocked(for: type).flatMap { firstFormat[ObjectIdentifier($0)] }
             lock.unlock()
-            if let first, !CMFormatDescriptionEqual(first, format) {
+            if let first, !CMFormatDescriptionEqual(first, otherFormatDescription: format) {
                 parts.append("format changed from \(describeFormat(first))")
             }
         } else {

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
@@ -366,6 +366,10 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
     private var outputURL: URL?
     private var sessionStartedAt: CMTime?
     private var latestSampleAt: CMTime?
+    /// Media time of the last sample written to each track, keyed by the
+    /// writer input, so a sample that would not advance its track is refused
+    /// before the writer refuses it and fails.
+    private var lastWrittenSeconds: [ObjectIdentifier: Double] = [:]
     private var clickTimeline: ClickTimeline?
     private var pauseTimeline = PauseTimeline()
     private var startedAtUnixMs = 0
@@ -896,6 +900,7 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         let input = writerInputLocked(for: type)
         let start = sessionStartedAt
         let timeline = pauseTimeline
+        let lastWritten = input.map { lastWrittenSeconds[ObjectIdentifier($0)] } ?? nil
         lock.unlock()
 
         // A writer that has failed answers `isReadyForMoreMediaData` with false
@@ -909,28 +914,41 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         guard let input, input.isReadyForMoreMediaData, let start else {
             return
         }
-        lock.lock()
-        latestSampleAt = timestamp
-        lock.unlock()
         // Frames keep arriving while paused; they are dropped, and everything
-        // after a pause is shifted back so the movie has no frozen stretch.
+        // after a pause is shifted back so the movie has no frozen stretch. A
+        // sample stamped before the anchor frame, or one that would not move
+        // its track forward, is dropped too: the writer would refuse it and
+        // then refuse everything after it. `SampleTimingPolicy` owns the rule.
         let captureSeconds = CMTimeGetSeconds(CMTimeSubtract(timestamp, start))
-        guard let mediaSeconds = timeline.mediaTime(forCaptureTime: captureSeconds)
+        guard
+            let mediaSeconds = SampleTimingPolicy.mediaTime(
+                captureSeconds: captureSeconds,
+                pauses: timeline,
+                lastWrittenSeconds: lastWritten
+            )
         else {
             return
         }
+        // Retimed in the sample's own timebase, not a coarser one: rounding
+        // 48 kHz audio onto a 600 Hz grid could move neighbouring buffers onto
+        // each other.
         guard
             let retimed = retimedSampleBuffer(
                 sampleBuffer,
                 to: CMTimeAdd(
                     start,
-                    CMTime(seconds: mediaSeconds, preferredTimescale: 600)
+                    CMTime(seconds: mediaSeconds, preferredTimescale: timestamp.timescale)
                 )
             )
         else {
             return
         }
-        if !input.append(retimed), assetWriter.status == .failed {
+        if input.append(retimed) {
+            lock.lock()
+            latestSampleAt = timestamp
+            lastWrittenSeconds[ObjectIdentifier(input)] = mediaSeconds
+            lock.unlock()
+        } else if assetWriter.status == .failed {
             noteWriterFailure(assetWriter)
         }
     }

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
@@ -435,6 +435,8 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
     /// duration for audio, its start for video, which has no extent the
     /// writer enforces.
     private var lastWrittenEndSeconds: [ObjectIdentifier: Double] = [:]
+    /// The duration the last sample on each track was written with.
+    private var lastWrittenDurationSeconds: [ObjectIdentifier: Double] = [:]
     /// The format description each track was started with, keyed by writer
     /// input. A sample whose format differs from it is the leading way a
     /// window capture can turn into a sample the writer refuses.
@@ -855,13 +857,14 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         return systemAudioInput
     }
 
-    /// Rewrites a sample's presentation time without touching its payload.
+    /// Rewrites a sample's timing without touching its payload.
     private func retimedSampleBuffer(
         _ sampleBuffer: CMSampleBuffer,
-        to presentationTime: CMTime
+        to presentationTime: CMTime,
+        duration: CMTime
     ) -> CMSampleBuffer? {
         var timing = CMSampleTimingInfo(
-            duration: CMSampleBufferGetDuration(sampleBuffer),
+            duration: duration,
             presentationTimeStamp: presentationTime,
             decodeTimeStamp: .invalid
         )
@@ -1045,6 +1048,18 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         else {
             return
         }
+        // A screen frame arrives without a duration; the writer infers one from
+        // the frame that follows. A whole-display capture always has a next
+        // frame within a frame interval, but a window capture only produces a
+        // frame when the window changes, so the last frame before a fragment
+        // boundary can have no successor by the time the fragment must be
+        // closed — and the fragment cannot be written. The frame is given the
+        // capture interval as its duration instead.
+        let sourceDuration = CMSampleBufferGetDuration(sampleBuffer)
+        let duration =
+            type == .screen && !(sourceDuration.isValid && sourceDuration.seconds > 0)
+            ? CMTime(value: 1, timescale: captureFrameRate)
+            : sourceDuration
         // Retimed in the sample's own timebase, not a coarser one: rounding
         // 48 kHz audio onto a 600 Hz grid could move neighbouring buffers onto
         // each other.
@@ -1054,18 +1069,20 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
                 to: CMTimeAdd(
                     start,
                     CMTime(seconds: mediaSeconds, preferredTimescale: timestamp.timescale)
-                )
+                ),
+                duration: duration
             )
         else {
             return
         }
         if input.append(retimed) {
-            let duration = CMSampleBufferGetDuration(sampleBuffer)
             let extent = type == .screen || !duration.isValid ? 0 : max(0, duration.seconds)
             lock.lock()
             latestSampleAt = timestamp
             lastWrittenSeconds[ObjectIdentifier(input)] = mediaSeconds
             lastWrittenEndSeconds[ObjectIdentifier(input)] = mediaSeconds + extent
+            lastWrittenDurationSeconds[ObjectIdentifier(input)] =
+                duration.isValid ? duration.seconds : 0
             if firstFormat[ObjectIdentifier(input)] == nil,
                 let format = CMSampleBufferGetFormatDescription(sampleBuffer)
             {
@@ -1112,6 +1129,27 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         lock.unlock()
         if let previousEnd {
             parts.append(String(format: "previous sample ended at %.3fs", previousEnd))
+        }
+        // An append that fails right after a fragment boundary is usually the
+        // first to notice a fragment that could not be closed, and what closes
+        // a fragment is the other track's last sample.
+        if type != .screen {
+            lock.lock()
+            let video = videoInput.map { ObjectIdentifier($0) }
+            let lastFrame = video.flatMap { lastWrittenSeconds[$0] }
+            let lastFrameDuration = video.flatMap { lastWrittenDurationSeconds[$0] }
+            lock.unlock()
+            if let lastFrame {
+                parts.append(
+                    String(
+                        format: "video track last frame at %.3fs lasting %.1fms",
+                        lastFrame,
+                        (lastFrameDuration ?? 0) * 1000
+                    )
+                )
+            } else {
+                parts.append("video track has no frames yet")
+            }
         }
         return parts.joined(separator: ", ")
     }

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
@@ -444,6 +444,13 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
     private var clickTimeline: ClickTimeline?
     private var pauseTimeline = PauseTimeline()
     private var startedAtUnixMs = 0
+    /// The window being recorded, when the capture follows one. Its bounds are
+    /// re-read while recording so a click is projected through where the
+    /// window is at that moment, not where it was when the capture was
+    /// prepared; a window capture follows the window wherever it is dragged.
+    private let windowID: CGWindowID?
+    private var currentGeometry: CaptureGeometry
+    private var windowBoundsTimer: DispatchSourceTimer?
 
     init(
         id: String,
@@ -451,16 +458,71 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         configuration: SCStreamConfiguration,
         geometry: CaptureGeometry,
         outputSize: OutputSize,
-        audioPlan: AudioTrackPlan
+        audioPlan: AudioTrackPlan,
+        windowID: CGWindowID? = nil
     ) {
         self.id = id
         self.filter = filter
         self.configuration = configuration
         self.geometry = geometry
+        self.currentGeometry = geometry
         self.outputSize = outputSize
         self.audioPlan = audioPlan
+        self.windowID = windowID
         super.init()
         mach_timebase_info(&timebase)
+    }
+
+    private func currentGeometryNow() -> CaptureGeometry {
+        lock.lock()
+        defer { lock.unlock() }
+        return currentGeometry
+    }
+
+    /// Follows the recorded window's bounds while recording. Four times a
+    /// second is well inside how fast a window can be dragged and clicked.
+    private func startWindowBoundsTracking() {
+        guard let windowID else {
+            return
+        }
+        let timer = DispatchSource.makeTimerSource(queue: sampleQueue)
+        timer.schedule(deadline: .now(), repeating: .milliseconds(250))
+        timer.setEventHandler { [weak self] in
+            self?.refreshWindowBounds(windowID)
+        }
+        timer.resume()
+        lock.lock()
+        windowBoundsTimer = timer
+        lock.unlock()
+    }
+
+    private func stopWindowBoundsTracking() {
+        lock.lock()
+        let timer = windowBoundsTimer
+        windowBoundsTimer = nil
+        lock.unlock()
+        timer?.cancel()
+    }
+
+    private func refreshWindowBounds(_ windowID: CGWindowID) {
+        guard
+            let list = CGWindowListCopyWindowInfo(.optionIncludingWindow, windowID)
+                as? [[String: Any]],
+            let info = list.first,
+            let boundsDictionary = info[kCGWindowBounds as String] as? NSDictionary,
+            let bounds = CGRect(dictionaryRepresentation: boundsDictionary as CFDictionary)
+        else {
+            return
+        }
+        lock.lock()
+        currentGeometry = CaptureGeometry(
+            originX: bounds.origin.x,
+            originY: bounds.origin.y,
+            widthPoints: bounds.width,
+            heightPoints: bounds.height,
+            scale: geometry.scale
+        )
+        lock.unlock()
     }
 
     /// Converts a host-clock presentation timestamp back into the raw mach tick
@@ -612,16 +674,34 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         lock.lock()
         startedAtUnixMs = Int(Date().timeIntervalSince1970 * 1000)
         lock.unlock()
+        clickTracker.geometryProvider = { [weak self] in
+            self?.currentGeometryNow()
+        }
         clickTracker.start()
+        startWindowBoundsTracking()
+    }
+
+    /// Where the capture stands right now on the recording's clock.
+    ///
+    /// Read from the host clock, which is the clock ScreenCaptureKit stamps
+    /// frames with, rather than from the last written sample: nothing is
+    /// written while paused, so that sample's time froze at the moment of the
+    /// pause and made every pause span empty. The movie then kept a frozen
+    /// stretch the length of the pause, clicks made during it were kept, and
+    /// every click after it sat that much later than the picture.
+    private func captureSecondsNowLocked() -> Double? {
+        guard let start = sessionStartedAt else {
+            return nil
+        }
+        let now = CMClockGetTime(CMClockGetHostTimeClock())
+        return max(0, CMTimeGetSeconds(CMTimeSubtract(now, start)))
     }
 
     func pause() throws {
         try transition(.pause)
         lock.lock()
-        if let start = sessionStartedAt, let latest = latestSampleAt {
-            pauseTimeline.pause(
-                at: max(0, CMTimeGetSeconds(CMTimeSubtract(latest, start)))
-            )
+        if let seconds = captureSecondsNowLocked() {
+            pauseTimeline.pause(at: seconds)
         }
         lock.unlock()
     }
@@ -629,10 +709,8 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
     func resume() throws {
         try transition(.resume)
         lock.lock()
-        if let start = sessionStartedAt, let latest = latestSampleAt {
-            pauseTimeline.resume(
-                at: max(0, CMTimeGetSeconds(CMTimeSubtract(latest, start)))
-            )
+        if let seconds = captureSecondsNowLocked() {
+            pauseTimeline.resume(at: seconds)
         }
         lock.unlock()
     }
@@ -642,6 +720,7 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
     func discard() throws {
         try transition(.discard)
         clickTracker.stop()
+        stopWindowBoundsTracking()
 
         lock.lock()
         let captureStream = stream
@@ -673,6 +752,7 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
     func stop() throws -> [String: Any] {
         try transition(.stop)
         clickTracker.stop()
+        stopWindowBoundsTracking()
 
         lock.lock()
         let captureStream = stream
@@ -947,6 +1027,7 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         captureStream?.stopCapture { _ in }
         // The tap outlives the stream unless it is torn down here.
         clickTracker.stop()
+        stopWindowBoundsTracking()
     }
 
     // MARK: SCStreamDelegate
@@ -1262,6 +1343,7 @@ private func handlePrepare(_ request: [String: Any]) throws -> [String: Any] {
     let geometry: CaptureGeometry
 
     var croppedArea: AreaRect?
+    var windowID: CGWindowID?
 
     if sourceKind == "display" {
         let display = try resolveDisplay(content, sourceId: sourceId)
@@ -1309,6 +1391,7 @@ private func handlePrepare(_ request: [String: Any]) throws -> [String: Any] {
             )
         }
         filter = SCContentFilter(desktopIndependentWindow: window)
+        windowID = rawID
         geometry = CaptureGeometry(
             originX: window.frame.origin.x,
             originY: window.frame.origin.y,
@@ -1360,7 +1443,8 @@ private func handlePrepare(_ request: [String: Any]) throws -> [String: Any] {
         configuration: configuration,
         geometry: geometry,
         outputSize: outputSize,
-        audioPlan: audioPlan
+        audioPlan: audioPlan,
+        windowID: windowID
     )
     sessionStore.insert(session)
 

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
@@ -1366,7 +1366,23 @@ private func responseObject(for request: [String: Any]) -> [String: Any] {
     return response
 }
 
+/// Connects this process to the window server before any request is served.
+///
+/// CoreGraphics makes that connection lazily, on whichever thread first asks
+/// for it, and on current macOS it asserts (`CGS_REQUIRE_INIT`) rather than
+/// connecting when that first ask comes from a background thread. Every
+/// request here is served on one, so the picker's window enumeration and
+/// previews could abort the whole helper mid-session. The connection is made
+/// here, on the main thread, the way a non-AppKit process is expected to. The
+/// activation policy keeps the helper out of the Dock and off the app switcher.
+private func connectToWindowServer() {
+    let application = NSApplication.shared
+    application.setActivationPolicy(.prohibited)
+    _ = CGMainDisplayID()
+}
+
 private func runStdioSession() {
+    connectToWindowServer()
     let mainRunLoop = CFRunLoopGetCurrent()
     DispatchQueue.global(qos: .userInitiated).async {
         while let line = readLine(strippingNewline: true) {

--- a/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/ClickMappingTests.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/ClickMappingTests.swift
@@ -212,6 +212,44 @@ struct ClickProjectionTests {
     }
 
     @Test
+    func projectsAClickThroughTheGeometryOfItsOwnMoment() {
+        // The window was dragged 100 points right and down before this click.
+        // Projected through the recording's original geometry the click would
+        // land at (0.6, 0.7) — the wrong place in a video that followed the
+        // window; through the geometry captured with it, it lands where the
+        // user actually clicked.
+        let moved = CaptureGeometry(
+            originX: 100,
+            originY: 100,
+            widthPoints: 1000,
+            heightPoints: 500,
+            scale: 2
+        )
+        let projection = projectClicks(
+            [
+                CapturedClick(
+                    ticks: 2_024_000,
+                    screenX: 600,
+                    screenY: 350,
+                    button: "left",
+                    clickCount: 1,
+                    modifiers: [],
+                    geometry: moved
+                )
+            ],
+            timeline: timeline,
+            geometry: display,
+            outputSize: outputSize
+        )
+
+        #expect(projection.droppedOutOfFrame == 0)
+        #expect(projection.clicks.first?.point.normalizedX == 0.5)
+        #expect(projection.clicks.first?.point.normalizedY == 0.5)
+        #expect(projection.clicks.first?.point.frameX == 960)
+        #expect(projection.clicks.first?.point.frameY == 480)
+    }
+
+    @Test
     func countsClicksThatLandedOutsideTheCapturedRegion() {
         let projection = projectClicks(
             [click(ticks: 2_024_000, x: 1_500, y: 250)],

--- a/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/SampleTimingPolicyTests.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/SampleTimingPolicyTests.swift
@@ -1,0 +1,82 @@
+import Testing
+
+@testable import ScreenRecorderCore
+
+struct SampleTimingPolicyTests {
+    @Test
+    func writesTheFirstSampleOfATrackAtTheAnchor() {
+        #expect(
+            SampleTimingPolicy.mediaTime(
+                captureSeconds: 0,
+                pauses: PauseTimeline(),
+                lastWrittenSeconds: nil
+            ) == 0
+        )
+    }
+
+    @Test
+    func dropsSamplesStampedBeforeTheAnchorFrame() {
+        // Audio can arrive stamped earlier than the video frame the session
+        // was anchored on. Folding those onto the anchor gave the audio track
+        // several samples at the same instant, which the writer refused — and
+        // then refused everything after them.
+        #expect(
+            SampleTimingPolicy.mediaTime(
+                captureSeconds: -0.02,
+                pauses: PauseTimeline(),
+                lastWrittenSeconds: nil
+            ) == nil
+        )
+    }
+
+    @Test
+    func refusesASampleThatDoesNotAdvanceItsTrack() {
+        #expect(
+            SampleTimingPolicy.mediaTime(
+                captureSeconds: 1.0,
+                pauses: PauseTimeline(),
+                lastWrittenSeconds: 1.0
+            ) == nil
+        )
+        #expect(
+            SampleTimingPolicy.mediaTime(
+                captureSeconds: 0.9,
+                pauses: PauseTimeline(),
+                lastWrittenSeconds: 1.0
+            ) == nil
+        )
+    }
+
+    @Test
+    func admitsASampleLaterThanTheLastWritten() {
+        #expect(
+            SampleTimingPolicy.mediaTime(
+                captureSeconds: 1.05,
+                pauses: PauseTimeline(),
+                lastWrittenSeconds: 1.0
+            ) == 1.05
+        )
+    }
+
+    @Test
+    func stillTakesThePausedStretchBackOut() {
+        var pauses = PauseTimeline()
+        pauses.pause(at: 2)
+        pauses.resume(at: 5)
+
+        #expect(
+            SampleTimingPolicy.mediaTime(
+                captureSeconds: 3,
+                pauses: pauses,
+                lastWrittenSeconds: 2
+            ) == nil
+        )
+        #expect(
+            SampleTimingPolicy.mediaTime(
+                captureSeconds: 6,
+                pauses: pauses,
+                lastWrittenSeconds: 2
+            ) == 3
+        )
+    }
+}

--- a/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/SampleTimingPolicyTests.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/SampleTimingPolicyTests.swift
@@ -59,6 +59,49 @@ struct SampleTimingPolicyTests {
     }
 
     @Test
+    func refusesAnAudioBufferThatOverlapsThePreviousOne() {
+        // The previous buffer ran from 6.04s to 6.06s. A buffer that starts at
+        // 6.05s overlaps it, which the writer refuses; one that starts exactly
+        // where it ended, or later, is fine.
+        #expect(
+            SampleTimingPolicy.mediaTime(
+                captureSeconds: 6.05,
+                pauses: PauseTimeline(),
+                lastWrittenSeconds: 6.04,
+                lastWrittenEndSeconds: 6.06
+            ) == nil
+        )
+        #expect(
+            SampleTimingPolicy.mediaTime(
+                captureSeconds: 6.06,
+                pauses: PauseTimeline(),
+                lastWrittenSeconds: 6.04,
+                lastWrittenEndSeconds: 6.06
+            ) == 6.06
+        )
+        #expect(
+            SampleTimingPolicy.mediaTime(
+                captureSeconds: 6.5,
+                pauses: PauseTimeline(),
+                lastWrittenSeconds: 6.04,
+                lastWrittenEndSeconds: 6.06
+            ) == 6.5
+        )
+    }
+
+    @Test
+    func toleratesFloatingPointDriftAtTheBoundary() {
+        #expect(
+            SampleTimingPolicy.mediaTime(
+                captureSeconds: 6.06 - 0.000_000_1,
+                pauses: PauseTimeline(),
+                lastWrittenSeconds: 6.04,
+                lastWrittenEndSeconds: 6.06
+            ) != nil
+        )
+    }
+
+    @Test
     func stillTakesThePausedStretchBackOut() {
         var pauses = PauseTimeline()
         pauses.pause(at: 2)

--- a/turbo/apps/desktop/src/desktop-auth-session.test.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.test.ts
@@ -427,6 +427,60 @@ describe("DesktopAuthSession", () => {
     ]);
   });
 
+  it("mints a fresh token and retries a request when the bearer and the cookies are both rejected", async () => {
+    // The recorder uploads the video, then its click track. The token is
+    // short-lived, so after a long upload the second request can arrive with
+    // an expired bearer; its cookies do not answer for the API either. The
+    // request has to recover on its own rather than fail the delivery.
+    const { session, runAuthWindow } = createSession();
+    const observedAuthorization: (string | null)[] = [];
+    session.completeSignIn("expired");
+    runAuthWindow.mockImplementation(async () => {
+      session.completeSignIn("fresh");
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+        const headers = new Headers(init?.headers);
+        observedAuthorization.push(headers.get("authorization"));
+        return headers.get("authorization") === "Bearer fresh"
+          ? jsonResponse({ id: "upload-1" })
+          : new Response(null, { status: 401 });
+      }),
+    );
+
+    const response = await session.fetchWithSessionAuth(
+      new URL("https://api.vm0.ai/api/uploads/prepare"),
+      { method: "POST", body: "{}" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(observedAuthorization).toStrictEqual([
+      "Bearer expired",
+      null,
+      "Bearer fresh",
+    ]);
+    expect(runAuthWindow).toHaveBeenCalledOnce();
+    expect(session.getCachedToken()).toBe("fresh");
+  });
+
+  it("hands back the 401 when a refresh yields no token", async () => {
+    const { session, runAuthWindow } = createSession();
+    session.completeSignIn("expired");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 401 })),
+    );
+
+    const response = await session.fetchWithSessionAuth(
+      new URL("https://api.vm0.ai/api/uploads/prepare"),
+    );
+
+    expect(response.status).toBe(401);
+    expect(runAuthWindow).toHaveBeenCalledOnce();
+    expect(session.getCachedToken()).toBeNull();
+  });
+
   it("derives signed-in state with a null organization on 404", async () => {
     const { session } = createSession();
     vi.stubGlobal(

--- a/turbo/apps/desktop/src/desktop-auth-session.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.ts
@@ -147,6 +147,24 @@ export class DesktopAuthSession {
     }
 
     this.token = null;
+    const withCookies = await fetch(requestUrl, {
+      ...init,
+      headers: await this.headersFor(requestUrl, init?.headers),
+    });
+    if (withCookies.status !== 401) {
+      return withCookies;
+    }
+
+    // The token is short-lived, and a call made minutes after the last one —
+    // the click track uploaded after a long video — arrives with an expired
+    // bearer and cookies that no longer answer either. Delivering a recording
+    // must not depend on the token still being the one minted at sign-in:
+    // mint a fresh one and try once more. A refresh that yields nothing means
+    // the sign-in itself is gone, and the 401 stands.
+    const refreshed = await this.getToken({ forceRefresh: true });
+    if (!refreshed) {
+      return withCookies;
+    }
     return await fetch(requestUrl, {
       ...init,
       headers: await this.headersFor(requestUrl, init?.headers),
@@ -165,8 +183,12 @@ export class DesktopAuthSession {
       return signedOutDesktopAuthState();
     }
 
+    // With a cached token, a rejected request already refreshes and retries
+    // inside fetchWithSessionAuth; a second hidden refresh here would only
+    // open the window again for the same answer.
+    const hadToken = this.token !== null;
     const state = await this.fetchAuthState();
-    if (state.status !== "signed_out") {
+    if (state.status !== "signed_out" || hadToken) {
       return state;
     }
 

--- a/turbo/apps/desktop/src/desktop-recorder-controller.test.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-controller.test.ts
@@ -326,15 +326,19 @@ describe("DesktopRecorderController", () => {
     await controller.start();
 
     await expect(controller.stop()).rejects.toThrow("helper timed out");
+    // The reason is recorded for the tray as well as thrown: the window that
+    // asked is often gone by the time the answer arrives.
     expect(controller.getState()).toMatchObject({
       status: "recording",
       sessionId: "session-1",
+      error: { code: "capture_failed", message: "helper timed out" },
     });
 
     await expect(controller.stop()).resolves.toEqual(RECORDING);
     expect(controller.getState()).toMatchObject({
       status: "idle",
       lastRecording: RECORDING,
+      error: null,
     });
   });
 

--- a/turbo/apps/desktop/src/desktop-recorder-controller.test.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-controller.test.ts
@@ -406,6 +406,68 @@ describe("DesktopRecorderController", () => {
     });
   });
 
+  it("keeps a recording whose writer broke and does not deliver it", async () => {
+    // The helper hands the file back with the failure it hit: what was
+    // written before the writer died is still worth a deliberate retry, but
+    // shipping it as the finished recording put a two-second movie in front
+    // of the user with nothing saying why.
+    const broken: DesktopRecorderRecording = {
+      ...RECORDING,
+      failure: {
+        code: "capture_failed",
+        message: "Cannot append sample buffer",
+      },
+    };
+    const { controller, deliver, openReview } = createController(
+      createBackendFake({ stop: vi.fn(async () => broken) }),
+    );
+    await enableAndPrepare(controller);
+    await controller.start();
+
+    await controller.stop();
+
+    const state = controller.getState();
+    expect(state.status).toBe("idle");
+    expect(state.error).toEqual({
+      code: "capture_failed",
+      message: "Cannot append sample buffer",
+    });
+    expect(state.lastRecording).toEqual(broken);
+    expect(deliver).not.toHaveBeenCalled();
+    expect(openReview).not.toHaveBeenCalled();
+
+    await controller.retryDelivery();
+    expect(deliver).toHaveBeenCalledWith(broken);
+  });
+
+  it("reports a writer failure noticed by the poll before the user stops", async () => {
+    const broken: DesktopRecorderRecording = {
+      ...RECORDING,
+      failure: { code: "capture_failed", message: "Disk full" },
+    };
+    const { controller, deliver } = createController(
+      createBackendFake({
+        getStatus: vi.fn(
+          async (): Promise<DesktopRecorderNativeStatus> => ({
+            status: "failed",
+            elapsedMs: 900,
+            error: { code: "capture_failed", message: "Disk full" },
+          }),
+        ),
+        stop: vi.fn(async () => broken),
+      }),
+    );
+    await enableAndPrepare(controller);
+    await controller.start();
+
+    await controller.refreshRecordingStatus();
+
+    expect(controller.getState().status).toBe("idle");
+    expect(controller.getState().error?.message).toBe("Disk full");
+    expect(controller.getState().lastRecording).toEqual(broken);
+    expect(deliver).not.toHaveBeenCalled();
+  });
+
   it("can deliver a salvaged recording on request", async () => {
     const backend = createBackendFake({
       getStatus: vi.fn(

--- a/turbo/apps/desktop/src/desktop-recorder-controller.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-controller.ts
@@ -223,13 +223,24 @@ export class DesktopRecorderController {
     this.setStatus("finalizing");
     // A rejected stop leaves the session in the caller's hands: go back to
     // `recording` so the stop can be retried, rather than stranding the machine
-    // in `finalizing` where neither stop nor prepare is accepted again.
-    const recording = await this.restoreStatusOnFailure(
-      resumeStatus,
-      async () => {
-        return await backend.stop(sessionId);
-      },
-    );
+    // in `finalizing` where neither stop nor prepare is accepted again. The
+    // reason is recorded as well as rethrown: the window that asked is often
+    // gone by the time the answer arrives, and a rejection nobody receives
+    // left the controls vanished with nothing anywhere saying why.
+    let recording: DesktopRecorderRecording;
+    try {
+      recording = await backend.stop(sessionId);
+    } catch (error) {
+      if (this.featureEnabled) {
+        this.error = {
+          code: "capture_failed",
+          message: error instanceof Error ? error.message : String(error),
+        };
+        this.setStatus(resumeStatus);
+        this.onChange();
+      }
+      throw error;
+    }
     if (!this.featureEnabled) {
       return recording;
     }

--- a/turbo/apps/desktop/src/desktop-recorder-controller.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-controller.ts
@@ -235,6 +235,14 @@ export class DesktopRecorderController {
     }
     this.lastRecording = recording;
     this.sessionId = null;
+    // A capture whose writer broke still hands back the file it managed to
+    // write, but shipping it as the finished recording is how a two-second
+    // movie reached the editor. Keep it, say why, and leave delivery to a
+    // deliberate retry.
+    if (recording.failure) {
+      this.failSession(recording.failure);
+      return recording;
+    }
     await this.runDelivery(recording);
     return recording;
   }
@@ -351,8 +359,9 @@ export class DesktopRecorderController {
     this.lastRecording = recording;
     this.sessionId = null;
     this.elapsedMs = 0;
-    if (failure) {
-      this.failSession(failure);
+    const reason = failure ?? recording.failure;
+    if (reason) {
+      this.failSession(reason);
       return;
     }
     await this.runDelivery(recording);

--- a/turbo/apps/desktop/src/desktop-recorder-native.test.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-native.test.ts
@@ -17,6 +17,8 @@ interface HelperBehavior {
   readonly prelude?: string;
   readonly silent?: boolean;
   readonly exit?: boolean;
+  /** Answers only after this long, the way a finalize of a long movie does. */
+  readonly delayMs?: number;
 }
 
 const SOURCES: HelperBehavior = {
@@ -109,6 +111,15 @@ function handleLine(line) {
   if (behavior.prelude) process.stdout.write(behavior.prelude);
   if (behavior.exit) process.exit(1);
   if (behavior.silent) return;
+  if (behavior.delayMs) {
+    const delayed = { ...behavior, delayMs: 0 };
+    setTimeout(() => respond(request, delayed), behavior.delayMs);
+    return;
+  }
+  respond(request, behavior);
+}
+
+function respond(request, behavior) {
   if (behavior.error) {
     process.stdout.write(
       JSON.stringify({ id: request.id, status: "failed", error: behavior.error }) + "\\n"
@@ -143,8 +154,13 @@ process.stdin.resume();
 function createBackend(
   helperPath: string,
   requestTimeoutMs = 5_000,
+  stopTimeoutMs?: number,
 ): RecorderNativeBackend {
-  const backend = createRecorderNativeBackend({ helperPath, requestTimeoutMs });
+  const backend = createRecorderNativeBackend({
+    helperPath,
+    requestTimeoutMs,
+    ...(stopTimeoutMs === undefined ? {} : { stopTimeoutMs }),
+  });
   openBackends.push(backend);
   return backend;
 }
@@ -425,6 +441,56 @@ describe("createRecorderNativeBackend", () => {
     expect(await rejection(backend.getStatus("session-1"))).toMatchObject({
       code: "capture_failed",
       message: "Screen recorder helper returned an invalid status",
+    });
+  });
+
+  it("gives stop its own budget so a long finalize is not abandoned", async () => {
+    // The helper drains the stream and finalizes the movie inside `stop`,
+    // which for a long recording runs well past the ordinary request budget.
+    // Timing it out at that budget put the controller back to "recording"
+    // while the helper had already stopped, and the session was lost.
+    const { helperPath } = await createHelper({
+      "recorder.state": {
+        delayMs: 800,
+        result: { status: "recording", elapsedMs: 1 },
+      },
+      "recorder.stop": { ...STOP, delayMs: 800 },
+    });
+    const backend = createBackend(helperPath, 300, 3_000);
+
+    expect(await rejection(backend.getStatus("session-1"))).toMatchObject({
+      message: "Screen recorder helper timed out running recorder.state",
+    });
+    await expect(backend.stop("session-1")).resolves.toMatchObject({
+      videoPath: "/tmp/screen-recording.mp4",
+    });
+  });
+
+  it("carries the writer failure the helper reports on a stopped recording", async () => {
+    const { helperPath } = await createHelper({
+      "recorder.stop": {
+        result: {
+          ...STOP.result,
+          failure: {
+            code: "capture_failed",
+            message: "Cannot append sample buffer",
+          },
+        },
+      },
+    });
+    const backend = createBackend(helperPath);
+
+    await expect(backend.stop("session-1")).resolves.toEqual({
+      videoPath: "/tmp/screen-recording.mp4",
+      clickTrackPath: "/tmp/screen-recording.clicks.json",
+      durationMs: 4200,
+      sizeBytes: 8192,
+      width: 1920,
+      height: 1080,
+      failure: {
+        code: "capture_failed",
+        message: "Cannot append sample buffer",
+      },
     });
   });
 

--- a/turbo/apps/desktop/src/desktop-recorder-native.test.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-native.test.ts
@@ -17,6 +17,8 @@ interface HelperBehavior {
   readonly prelude?: string;
   readonly silent?: boolean;
   readonly exit?: boolean;
+  /** Written to stderr first, the way a crashing helper leaves its report. */
+  readonly stderr?: string;
   /** Answers only after this long, the way a finalize of a long movie does. */
   readonly delayMs?: number;
 }
@@ -109,6 +111,7 @@ function handleLine(line) {
     return;
   }
   if (behavior.prelude) process.stdout.write(behavior.prelude);
+  if (behavior.stderr) process.stderr.write(behavior.stderr);
   if (behavior.exit) process.exit(1);
   if (behavior.silent) return;
   if (behavior.delayMs) {
@@ -525,7 +528,25 @@ describe("createRecorderNativeBackend", () => {
       await rejection(backend.start("session-1", "/tmp/screen-recording.mp4")),
     ).toMatchObject({
       code: "helper_unavailable",
-      message: "Screen recorder helper exited",
+      message: "Screen recorder helper exited with code 1",
+    });
+  });
+
+  it("carries what the helper wrote to stderr when it dies mid-request", async () => {
+    // A helper that crashes leaves its report on stderr. Unread, an exit
+    // during a stop was indistinguishable from one that was closed on purpose.
+    const { helperPath } = await createHelper({
+      "recorder.stop": {
+        stderr: "Fatal error: Index out of range\n",
+        exit: true,
+      },
+    });
+    const backend = createBackend(helperPath);
+
+    expect(await rejection(backend.stop("session-1"))).toMatchObject({
+      code: "helper_unavailable",
+      message:
+        "Screen recorder helper exited with code 1: Fatal error: Index out of range",
     });
   });
 

--- a/turbo/apps/desktop/src/desktop-recorder-native.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-native.ts
@@ -16,6 +16,14 @@ import type {
 
 const HELPER_NAME = "screen-recorder-helper";
 const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
+/**
+ * `recorder.stop` waits on the helper draining the capture stream and then
+ * finalizing the movie, which for a long recording takes well past the
+ * ordinary request budget. Timing it out at the ordinary budget abandoned the
+ * finalize while it was still running, and left the controller believing the
+ * capture was still open.
+ */
+const DEFAULT_STOP_TIMEOUT_MS = 60_000;
 
 class DesktopRecorderHelperError extends Error {
   constructor(
@@ -151,6 +159,7 @@ class RecorderHelperClient {
   request(
     kind: string,
     payload: Record<string, unknown> = {},
+    timeoutMs: number = this.requestTimeoutMs,
   ): Promise<Record<string, unknown>> {
     if (this.closed) {
       return Promise.reject(
@@ -172,7 +181,7 @@ class RecorderHelperClient {
             ),
           );
         }
-      }, this.requestTimeoutMs);
+      }, timeoutMs);
       this.pending.set(id, {
         resolve: (value) => {
           clearTimeout(timer);
@@ -331,6 +340,7 @@ function toSources(
 function toRecording(
   result: Record<string, unknown>,
 ): DesktopRecorderRecording {
+  const failure = isRecord(result.failure) ? result.failure : null;
   return {
     videoPath: requiredString(result, "videoPath"),
     clickTrackPath: requiredString(result, "clickTrackPath"),
@@ -338,6 +348,17 @@ function toRecording(
     sizeBytes: requiredNumber(result, "sizeBytes"),
     width: requiredNumber(result, "width"),
     height: requiredNumber(result, "height"),
+    ...(failure
+      ? {
+          failure: {
+            code: errorCode(failure.code),
+            message:
+              typeof failure.message === "string"
+                ? failure.message
+                : "Screen recording failed",
+          },
+        }
+      : {}),
   };
 }
 
@@ -379,12 +400,14 @@ export function createRecorderNativeBackend(
   options: {
     readonly helperPath?: string;
     readonly requestTimeoutMs?: number;
+    readonly stopTimeoutMs?: number;
   } = {},
 ): RecorderNativeBackend {
   const client = new RecorderHelperClient(
     options.helperPath ?? resolveNativeHelperPath(HELPER_NAME),
     options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
   );
+  const stopTimeoutMs = options.stopTimeoutMs ?? DEFAULT_STOP_TIMEOUT_MS;
 
   return {
     dispose: () => {
@@ -461,7 +484,9 @@ export function createRecorderNativeBackend(
       await client.request("recorder.discard", { sessionId });
     },
     stop: async (sessionId: string) =>
-      toRecording(await client.request("recorder.stop", { sessionId })),
+      toRecording(
+        await client.request("recorder.stop", { sessionId }, stopTimeoutMs),
+      ),
     getStatus: async (sessionId: string) =>
       toNativeStatus(await client.request("recorder.state", { sessionId })),
   };

--- a/turbo/apps/desktop/src/desktop-recorder-native.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-native.ts
@@ -144,9 +144,13 @@ interface PendingRequest {
  * process owns an in-flight `SCStream` and `AVAssetWriter`, so killing it would
  * destroy the recording the user is making. A slow command fails on its own.
  */
+/** How much of the helper's stderr is kept for the message of an abrupt exit. */
+const STDERR_TAIL_LIMIT = 2_000;
+
 class RecorderHelperClient {
   private child: ChildProcessWithoutNullStreams | null = null;
   private stdoutBuffer = "";
+  private stderrTail = "";
   private requestCounter = 0;
   private closed = false;
   private readonly pending = new Map<string, PendingRequest>();
@@ -236,6 +240,14 @@ class RecorderHelperClient {
       this.stdoutBuffer += chunk;
       this.drainStdout();
     });
+    // The helper's own diagnostics — and the crash report when it dies — come
+    // out here. Left unread they went nowhere, so a helper that exited
+    // mid-capture was indistinguishable from one that was closed on purpose.
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      console.warn("[screen-recorder-helper]", chunk.trimEnd());
+      this.stderrTail = (this.stderrTail + chunk).slice(-STDERR_TAIL_LIMIT);
+    });
     child.on("error", (error) => {
       if (this.child === child) {
         this.child = null;
@@ -247,15 +259,20 @@ class RecorderHelperClient {
         ),
       );
     });
-    child.on("close", () => {
+    child.on("close", (code, signal) => {
       if (this.child !== child) {
         return;
       }
       this.child = null;
+      const how =
+        signal !== null
+          ? `with signal ${signal}`
+          : `with code ${String(code ?? "unknown")}`;
+      const tail = this.stderrTail.trim();
       this.rejectAll(
         new DesktopRecorderHelperError(
           "helper_unavailable",
-          "Screen recorder helper exited",
+          `Screen recorder helper exited ${how}${tail ? `: ${tail}` : ""}`,
         ),
       );
     });

--- a/turbo/apps/desktop/src/desktop-recorder-types.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-types.ts
@@ -134,6 +134,12 @@ export interface DesktopRecorderRecording {
   readonly sizeBytes: number;
   readonly width: number;
   readonly height: number;
+  /**
+   * Set when the capture broke before it was stopped. The file still holds
+   * whatever was written up to that point, so it is kept for a deliberate
+   * retry, but it must not be delivered as though the recording finished.
+   */
+  readonly failure?: DesktopRecorderError;
 }
 
 export interface DesktopRecorderState {

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -855,7 +855,14 @@ function installDesktopRecorder(): void {
       resume: () => screenRecorder.resume(),
       discard: () => screenRecorder.discard(),
       stop: async () => {
-        await screenRecorder.stop();
+        try {
+          await screenRecorder.stop();
+        } catch (error) {
+          // The window that asked may already be gone; the terminal running
+          // the app is the one place this is guaranteed to be seen.
+          console.error("Desktop screen recording stop failed", error);
+          throw error;
+        }
       },
       cancel: () => {
         getRecorderWindows().hideBar();

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -221,6 +221,44 @@ const quitConfirmation = new DesktopQuitConfirmationController({
     app.quit();
   },
 });
+/**
+ * Whether a finished recording could be handed back to Okou.
+ *
+ * Answering means two round trips to the API, and it used to be asked only
+ * when Start was pressed, ahead of everything else on that path: on a slow
+ * link that alone was a second or more of "Starting…". The question is asked
+ * when the bar opens instead, and Start reuses that answer while the bar is
+ * up. A bar left open for a long time asks again.
+ */
+let deliverabilityCheck: {
+  readonly at: number;
+  readonly result: Promise<boolean>;
+} | null = null;
+const DELIVERABILITY_CHECK_LIFETIME_MS = 5 * 60 * 1000;
+
+function checkDeliverability(): Promise<boolean> {
+  const now = Date.now();
+  if (
+    deliverabilityCheck &&
+    now - deliverabilityCheck.at < DELIVERABILITY_CHECK_LIFETIME_MS
+  ) {
+    return deliverabilityCheck.result;
+  }
+  const result = getAuthSession()
+    .getAuthState()
+    .then((auth) => {
+      return auth.status === "signed_in" && auth.organization !== null;
+    });
+  // A failed check must not be served to the next Start; it asks afresh.
+  result.catch(() => {
+    if (deliverabilityCheck?.result === result) {
+      deliverabilityCheck = null;
+    }
+  });
+  deliverabilityCheck = { at: now, result };
+  return result;
+}
+
 const screenRecorder = new DesktopRecorderController({
   createBackend: () => createRecorderNativeBackend(),
   createOutputPath: () =>
@@ -229,10 +267,7 @@ const screenRecorder = new DesktopRecorderController({
       "recordings",
       `screen-recording-${Date.now().toString()}.mp4`,
     ),
-  canDeliver: async () => {
-    const auth = await getAuthSession().getAuthState();
-    return auth.status === "signed_in" && auth.organization !== null;
-  },
+  canDeliver: () => checkDeliverability(),
   deliver: async (recording) => {
     const auth = await getAuthSession().getAuthState();
     if (auth.status !== "signed_in") {
@@ -783,12 +818,26 @@ async function startRecorderCapture(
   captured: DesktopRecorderArea | null,
 ): Promise<void> {
   const windows = getRecorderWindows();
-  await screenRecorder.ensureScreenRecordingPermission();
-  await screenRecorder.prepare(request);
-  await screenRecorder.start();
+  // Each phase is timed and logged: "Starting…" was reported as taking
+  // seconds, and where those seconds go is the only way to know what to cut.
+  const startedAt = Date.now();
+  const phases: string[] = [];
+  const timed = async (name: string, run: () => Promise<void>) => {
+    const phaseStartedAt = Date.now();
+    await run();
+    phases.push(`${name} ${String(Date.now() - phaseStartedAt)}ms`);
+  };
+  await timed("permission", () =>
+    screenRecorder.ensureScreenRecordingPermission(),
+  );
+  await timed("prepare", () => screenRecorder.prepare(request));
+  await timed("start", () => screenRecorder.start());
   // The bar has done its job; leaving it up would put it in the capture.
   windows.hideBar();
   windows.showController(captured);
+  console.info(
+    `Desktop screen recording started in ${String(Date.now() - startedAt)}ms (${phases.join(", ")})`,
+  );
 }
 
 function installDesktopRecorder(): void {
@@ -1000,6 +1049,8 @@ function installTray(): void {
     getRecorderState: () => screenRecorder.getState(),
     startScreenRecording: async () => {
       getRecorderWindows().showBar();
+      // Asked now so Start does not have to wait for the answer.
+      checkDeliverability().catch(() => {});
     },
     stopScreenRecording: async () => {
       await screenRecorder.stop();

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -55,6 +55,7 @@ import { DesktopRecorderWindows } from "./desktop-recorder-windows";
 import { STOP_SCREEN_RECORDING_ACCELERATOR } from "./desktop-recorder-types";
 import type {
   DesktopRecorderArea,
+  DesktopRecorderError,
   DesktopRecorderAudioChoice,
   DesktopRecorderPrepareRequest,
 } from "./desktop-recorder-types";
@@ -335,10 +336,21 @@ function refreshDesktopTray(): void {
  * time, and it exists because the recording controls live in the menu bar
  * rather than in an overlay that the capture would record.
  */
+let lastLoggedRecorderError: DesktopRecorderError | null = null;
+
 function notifyScreenRecorderChanged(): void {
   refreshDesktopTray();
 
-  const status = screenRecorder.getState().status;
+  const state = screenRecorder.getState();
+  // The tray truncates the message to a menu line; the terminal gets it whole.
+  if (state.error && state.error !== lastLoggedRecorderError) {
+    console.error(
+      `Desktop screen recording ${state.error.code}: ${state.error.message}`,
+    );
+  }
+  lastLoggedRecorderError = state.error;
+
+  const status = state.status;
   // Paused still holds the capture open, so the poll, the stop shortcut and the
   // on-screen controls all stay alive for it.
   const isCapturing = status === "recording" || status === "paused";

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -308,11 +308,14 @@ function notifyScreenRecorderChanged(): void {
   // on-screen controls all stay alive for it.
   const isCapturing = status === "recording" || status === "paused";
 
-  // The controller belongs to a live capture and nothing else. Deciding that
-  // here rather than at each call site is what dismisses it when a recording
-  // ends from the tray, the shortcut, the system indicator, or a failure — and
-  // what takes it off screen the moment a finish starts uploading.
-  if (!isCapturing) {
+  // The controller stays up through the finish as well as the capture: it
+  // vanishing the instant Stop was pressed, seconds before the finalize and
+  // upload were done, read as the recorder having quit. It is dismissed once
+  // the session is over, whether that came from the tray, the shortcut, the
+  // system indicator, a failure, or a successful delivery.
+  const showsController =
+    isCapturing || status === "finalizing" || status === "delivering";
+  if (!showsController) {
     recorderWindows?.hideController();
   }
 

--- a/turbo/apps/desktop/src/renderer/recorder/recording-controller.test.tsx
+++ b/turbo/apps/desktop/src/renderer/recorder/recording-controller.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DesktopRecorderApi } from "../../desktop-bridge";
+import type {
+  DesktopRecorderState,
+  DesktopRecorderStatus,
+} from "../../desktop-recorder-types";
+
+function stateWith(status: DesktopRecorderStatus): DesktopRecorderState {
+  return {
+    available: true,
+    status,
+    sessionId: "session-1",
+    elapsedMs: 83_000,
+    error: null,
+    lastRecording: null,
+  };
+}
+
+/** Installs a bridge whose reported status the test can move. */
+function installRecorder(initial: DesktopRecorderStatus): {
+  readonly setStatus: (status: DesktopRecorderStatus) => void;
+} {
+  let status = initial;
+  const api = {
+    getState: async () => {
+      return await Promise.resolve(stateWith(status));
+    },
+    pause: async () => {
+      return await Promise.resolve();
+    },
+    resume: async () => {
+      return await Promise.resolve();
+    },
+    stop: async () => {
+      return await Promise.resolve();
+    },
+    discard: async () => {
+      return await Promise.resolve();
+    },
+  } as unknown as DesktopRecorderApi;
+  vi.stubGlobal("vm0DesktopRecorder", api);
+  return {
+    setStatus: (next) => {
+      status = next;
+    },
+  };
+}
+
+/** The controller reads the bridge when its module loads, so stub first. */
+async function renderController(): Promise<void> {
+  const { RecordingController } = await import("./recording-controller");
+  render(<RecordingController />);
+}
+
+function button(label: string): HTMLButtonElement {
+  return screen.getByLabelText(label) as HTMLButtonElement;
+}
+
+describe("RecordingController", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("shows the clock and live controls while recording", async () => {
+    installRecorder("recording");
+    await renderController();
+
+    await waitFor(() => {
+      expect(screen.getByText("01:23")).toBeTruthy();
+    });
+    expect(button("Pause").disabled).toBe(false);
+    expect(button("Finish recording").disabled).toBe(false);
+  });
+
+  it("stays up through the finish and says what it is doing", async () => {
+    // Vanishing the instant Stop was pressed, seconds before the movie was
+    // finalized and uploaded, read as the recorder having quit.
+    const recorder = installRecorder("recording");
+    await renderController();
+    await waitFor(() => {
+      expect(screen.getByText("01:23")).toBeTruthy();
+    });
+
+    recorder.setStatus("finalizing");
+    await waitFor(() => {
+      expect(screen.getByText("Finishing…")).toBeTruthy();
+    });
+    expect(button("Pause").disabled).toBe(true);
+    expect(button("Finish recording").disabled).toBe(true);
+    expect(button("Delete recording").disabled).toBe(true);
+
+    recorder.setStatus("delivering");
+    await waitFor(() => {
+      expect(screen.getByText("Uploading…")).toBeTruthy();
+    });
+  });
+});

--- a/turbo/apps/desktop/src/renderer/recorder/recording-controller.tsx
+++ b/turbo/apps/desktop/src/renderer/recorder/recording-controller.tsx
@@ -16,11 +16,18 @@ function formatElapsed(elapsedMs: number): string {
  * Lives in its own window placed outside the captured region, so for an area
  * capture it is never part of the video.
  */
+type FinishPhase = "finalizing" | "delivering" | null;
+
+function finishLabel(phase: FinishPhase): string {
+  return phase === "delivering" ? "Uploading…" : "Finishing…";
+}
+
 export function RecordingController(): React.ReactElement {
   // Narrowed once here so the handlers below need no assertions.
   const bridge = recorder;
   const [paused, setPaused] = useState(false);
   const [elapsedMs, setElapsedMs] = useState(0);
+  const [finishing, setFinishing] = useState<FinishPhase>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -34,6 +41,13 @@ export function RecordingController(): React.ReactElement {
         .then((state) => {
           setPaused(state.status === "paused");
           setElapsedMs(state.elapsedMs);
+          // The window outlives the capture so the finish has somewhere to be
+          // seen; the controls it carried are meaningless by then.
+          setFinishing(
+            state.status === "finalizing" || state.status === "delivering"
+              ? state.status
+              : null,
+          );
         })
         .catch((pollError: unknown) => {
           setError(
@@ -63,24 +77,26 @@ export function RecordingController(): React.ReactElement {
       });
   }
 
+  const controlsDisabled = busy || finishing !== null || !bridge;
+
   return (
     <div className="recording-controller">
       <span className="recording-controller__clock">
         <span
           className={
-            paused
+            paused || finishing
               ? "recording-controller__dot recording-controller__dot--paused"
               : "recording-controller__dot"
           }
         />
-        {formatElapsed(elapsedMs)}
+        {finishing ? finishLabel(finishing) : formatElapsed(elapsedMs)}
       </span>
 
       <button
         type="button"
         className="recording-controller__button"
         aria-label={paused ? "Resume" : "Pause"}
-        disabled={busy || !bridge}
+        disabled={controlsDisabled}
         onClick={() => {
           if (bridge) {
             run(
@@ -97,7 +113,7 @@ export function RecordingController(): React.ReactElement {
         type="button"
         className="recording-controller__button recording-controller__button--stop"
         aria-label="Finish recording"
-        disabled={busy || !bridge}
+        disabled={controlsDisabled}
         onClick={() => {
           if (bridge) {
             run(() => bridge.stop(), "Could not finish the recording");
@@ -111,7 +127,7 @@ export function RecordingController(): React.ReactElement {
         type="button"
         className="recording-controller__button recording-controller__button--discard"
         aria-label="Delete recording"
-        disabled={busy || !bridge}
+        disabled={controlsDisabled}
         onClick={() => {
           if (bridge) {
             run(() => bridge.discard(), "Could not delete the recording");


### PR DESCRIPTION
## What went wrong

A twelve-minute desktop recording came back as a two-second movie. Its click track spanned the full twelve minutes and the container's own metadata claimed nineteen seconds, so the capture stream was alive the whole time and only the frames stopped landing.

The `AVAssetWriter` failed early and nothing in the helper noticed:

- A failed writer answers `isReadyForMoreMediaData` with `false` for the rest of its life. The sample handler's guard treated that as ordinary back-pressure and silently dropped every later frame, while `latestSampleAt` — and therefore the on-screen clock and `durationMs` in the click track — kept advancing.
- `stop` finalized the failed writer, never looked at `assetWriter.status` or `.error`, read the file size, and handed the file to delivery as a finished recording.

Nothing in the helper referenced `.failed` on the writer at any point. Running the branch on macOS then turned up the reasons the writer was failing in the first place, and several separate defects on the same path; they are all in this PR.

## Changes

**Surfacing a failed writer (`main.swift`, `desktop-recorder-native.ts`, `desktop-recorder-controller.ts`)**

- The sample handler checks `assetWriter.status` before the readiness guard and after any rejected `append`. A failed writer ends the capture through the same external-stop path a lost source uses, reported as `capture_failed` (the source is still there; the output broke). `externalStop` now carries the code it should be reported with instead of hard-coding `source_lost`.
- `stop` checks the writer after `finishWriting` and returns the file together with a `failure` field when the writer broke or the capture had already ended in failure. The file is still handed back — it holds whatever was written — but the caller must not deliver it as finished. Reported on `stop` as well as through `recorder.state` because a stop that races the one-second poll would otherwise ship it.
- `latestSampleAt` only advances for frames that reach the append path, so the clock no longer runs on dropped frames.
- The tray showed only AVFoundation's wrapper, "The operation could not be completed". The message now spells out the domain and code of every underlying error, and names the sample the writer refused: track, format, duration, media time, and where the previous sample ended.
- `recorder.stop` gets its own sixty-second budget. The helper can block up to forty seconds inside `stop` (ten draining the stream, thirty finalizing), but every request shared the fifteen-second budget, so a long recording's finalize was abandoned mid-flight; `restoreStatusOnFailure` then put the controller back to `recording` against a helper that had already moved to `stopped`, and every later command was refused as `invalid_state`.
- `toRecording` carries the `failure` field through, and `stop` plus the poll-driven salvage path honor it: the salvaged file is kept as `lastRecording`, the error is shown, and delivery waits for a deliberate retry.

**Why the writer was failing (`main.swift`, `SampleTimingPolicy.swift`)**

- **Samples the writer refuses.** The writer refuses a sample that does not advance its track, and once it has refused one it refuses everything after it. Audio buffers stamped before the anchor video frame were folded onto the anchor as duplicates, and an audio buffer could start before the previous one had finished. `SampleTimingPolicy` decides where a sample lands or that it must be dropped, and is unit-tested.
- **Fragments that could not be closed.** The movie was written as fragmented MP4 (`movieFragmentInterval` of two seconds). Closing a fragment failed whenever the video track had no frame in it, and a window capture only produces a frame when the window changes, so a still window left every fragment after the first empty. The movie is now written as one movie, finalized at stop; screen frames also get the capture interval as their duration rather than relying on a successor frame.
- **Frames of the wrong size.** The video track is built for exactly the prepared output size. A whole display is always scaled into the configured size, but a window or a cropped region is delivered at its own pixel size unless the stream is told to scale it, so the writer failed on the first frame. Window and area streams now set `scalesToFit`, and the first frame is measured against the track before the session is anchored on it; a mismatch ends the capture with a message naming both sizes.
- **Frames with no picture.** ScreenCaptureKit's idle, blank and bookkeeping frames carry nothing the encoder can take; only frames whose `SCFrameStatus` is `complete` reach the writer.

**Clicks stay aligned with the picture (`ClickMapping.swift`, `ClickTrackRecorder.swift`, `main.swift`)**

- A pause was measured from the last written sample, whose time froze at the moment of the pause, so every pause span came out empty: the movie kept a frozen stretch and every click after a pause sat that much later than the picture. Pause and resume are read from the host clock instead.
- A window capture follows the window wherever it is dragged, but clicks were projected through the geometry the capture was prepared with. Each click now carries the geometry of its own moment; the recorded window's bounds are re-read four times a second while recording.

**Start and finish read as working (`main.ts`, `recording-controller.tsx`, `main.swift`)**

- Pressing Stop made the floating controls vanish at once, seconds before the finalize and upload finished, which read as the recorder having quit. The controller now stays up through `finalizing` and `delivering`, shows which it is doing with its controls disabled, and is dismissed when the session ends. Covered by `recording-controller.test.tsx`.
- Starting took seconds. Opening the picker reads the screen twice and preparing the capture a third time, and a window capture needs the read that walks every Space — which #31065 made wider. One read is now kept for twenty seconds and reused, `prepare` for a display or area capture asks for on-screen windows only, and the delivery check is answered when the bar opens rather than on Start. A window that closes inside the cache's span still fails cleanly as `source_lost`. Each start phase is timed and logged.
- A refused stop left no trace: the controls vanished, no browser opened, and the tray showed nothing. The rejection went to the controller window that had just been closed, `restoreStatusOnFailure` put the status back without recording why, and the helper's stderr was never read. A refused stop is now recorded in state for the tray, the helper's stderr is kept and carried on an abrupt exit, and the main process logs the rejection.
- The helper connected to the window server lazily from whichever thread asked first. On current macOS that asserts (`CGS_REQUIRE_INIT`) rather than connecting when the first ask comes from a background thread, and every request is served on one, so the picker's window enumeration could abort the helper mid-session. The connection is made on the main thread at startup.

**Delivering a long recording (`desktop-auth-session.ts`)**

- The recorder uploads the video, then its click track. The token is short-lived, so after a long upload the second request arrived with an expired bearer, and its cookies no longer answered for the API either — the delivery failed at the last step. A request rejected on both now mints a fresh token and retries once; a refresh that yields nothing means the sign-in itself is gone and the 401 stands. `getAuthState` no longer opens a second hidden sign-in window for the same answer.

**Protocol compatibility.** `failure` is additive. A new client against an old helper sees no field and behaves as before; an old client against a new helper ignores the field. The desktop app ships helper and client together in any case.

## Not changed, noted for follow-up

- The helper's stdio loop handles requests serially, so `recorder.state` polls queue behind a long `stop` and time out at fifteen seconds while it runs. Harmless today — the controller is in `finalizing` and skips the poll — but worth a concurrent reader if `stop` ever runs longer.
- The reported elapsed clock is still derived from the last appended sample, so a still window recorded with audio off stops advancing it at the last visual change. Reusing the host clock, or padding the last frame at stop, is a trade-off between a reported duration longer than the encoded movie and a frozen clock.
- The window-bounds timer runs on the sample-delivery queue.
- Window captures hard-code `scale: 2` in `CaptureGeometry` rather than the display's backing scale, so click mapping is off by two on a non-Retina display.

## Testing

- `pnpm -F @okouai/desktop check-types`, `lint` — clean
- `pnpm -F @okouai/desktop exec vitest run` — 481 passed, 2 failed in `bootstrap-degraded.test.ts`; both fail identically on unmodified `main` in this container (auto-update mocks) and are unrelated
- `desktop-recorder-controller.test.ts`: a stop result carrying `failure` is kept, not delivered, and delivered on explicit retry — verified to fail against the pre-fix controller (1 failed / 21 passed). A poll-noticed failure whose stop result also carries `failure` is reported; this one passes on the old controller too, since the poll path already honored its own argument, and is kept as a guard.
- `desktop-recorder-native.test.ts`: `stop` outlives the ordinary request budget while `state` still times out at it; the helper's `failure` field is carried through `toRecording`; a helper that dies mid-request carries its stderr.
- `SampleTimingPolicyTests.swift`, `ClickMappingTests.swift`: the timing rule and the moved-window click projection.
- `recording-controller.test.tsx`: the controls stay up through `finalizing` and `delivering`, disabled, naming the phase.

The Swift helper cannot be compiled here. The `Desktop` workflow builds and tests it on `macos-latest` for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
