### PR TITLE
fix(guest-agent): preserve checkpoint upload failure details

### DIFF
--- a/crates/guest-agent/src/artifact/mod.rs
+++ b/crates/guest-agent/src/artifact/mod.rs
@@ -445,7 +445,9 @@ async fn upload_archive_bundle(
         .await
     {
         record_sandbox_op("artifact_s3_upload", s3_start.elapsed(), false, None);
-        return Err(e);
+        return Err(AgentError::Checkpoint(format!(
+            "artifact archive upload failed: {e}"
+        )));
     }
 
     log_info!(LOG_TAG, "Uploading manifest to S3...");
@@ -458,7 +460,9 @@ async fn upload_archive_bundle(
         .await
     {
         record_sandbox_op("artifact_s3_upload", s3_start.elapsed(), false, None);
-        return Err(e);
+        return Err(AgentError::Checkpoint(format!(
+            "artifact manifest upload failed: {e}"
+        )));
     }
     record_sandbox_op("artifact_s3_upload", s3_start.elapsed(), true, None);
     Ok(())
@@ -1012,7 +1016,7 @@ mod tests {
         let archive_upload = server.mock(|when, then| {
             when.method(PUT)
                 .path("/test/failed-artifact-archive-upload");
-            then.status(403);
+            then.status(500);
         });
         let manifest_upload = server.mock(|when, then| {
             when.method(PUT)
@@ -1040,12 +1044,15 @@ mod tests {
         )
         .await;
 
-        let Err(AgentError::Http(message)) = result else {
-            panic!("expected archive upload HTTP error");
+        let Err(AgentError::Checkpoint(message)) = result else {
+            panic!("expected archive upload checkpoint error");
         };
-        assert_eq!(message, "PUT presigned: HTTP 403 Forbidden");
+        assert_eq!(
+            message,
+            "artifact archive upload failed: http: PUT presigned failed after 3 attempts; last failure: HTTP 500"
+        );
         prepare.assert_calls(1);
-        archive_upload.assert_calls(1);
+        archive_upload.assert_calls(3);
         manifest_upload.assert_calls(0);
         commit.assert_calls(0);
         assert_eq!(
@@ -1136,10 +1143,13 @@ mod tests {
         )
         .await;
 
-        let Err(AgentError::Http(message)) = result else {
-            panic!("expected manifest upload HTTP error");
+        let Err(AgentError::Checkpoint(message)) = result else {
+            panic!("expected manifest upload checkpoint error");
         };
-        assert_eq!(message, "PUT presigned: HTTP 403 Forbidden");
+        assert_eq!(
+            message,
+            "artifact manifest upload failed: http: PUT presigned: HTTP 403 Forbidden"
+        );
         prepare.assert_calls(1);
         archive_upload.assert_calls(1);
         manifest_upload.assert_calls(1);

--- a/crates/guest-agent/src/checkpoint/session_history.rs
+++ b/crates/guest-agent/src/checkpoint/session_history.rs
@@ -539,7 +539,9 @@ async fn upload_session_history(
             false,
             None,
         );
-        return Err(e);
+        return Err(AgentError::Checkpoint(format!(
+            "session history upload failed: {e}"
+        )));
     }
     record_sandbox_op(
         "session_history_s3_upload",

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -81,6 +81,70 @@ pub(crate) enum HttpAttemptFailureKind {
     Transport,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RetryableFailure {
+    HttpStatus(u16),
+    Timeout { connect_observed: bool },
+    Connect,
+    Transport,
+}
+
+impl RetryableFailure {
+    fn from_status(status: reqwest::StatusCode) -> Self {
+        Self::HttpStatus(status.as_u16())
+    }
+
+    fn from_transport(error: &reqwest::Error) -> Self {
+        let timeout_observed = error.is_timeout();
+        let connect_observed = error.is_connect();
+        if timeout_observed {
+            Self::Timeout { connect_observed }
+        } else if connect_observed {
+            Self::Connect
+        } else {
+            Self::Transport
+        }
+    }
+
+    fn attempt_outcome(self) -> HttpAttemptOutcome {
+        match self {
+            Self::HttpStatus(status) => HttpAttemptOutcome::Failure {
+                kind: HttpAttemptFailureKind::HttpStatus,
+                http_status: Some(status),
+                timeout_observed: None,
+                connect_observed: None,
+            },
+            Self::Timeout { connect_observed } => HttpAttemptOutcome::Failure {
+                kind: HttpAttemptFailureKind::Timeout,
+                http_status: None,
+                timeout_observed: Some(true),
+                connect_observed: Some(connect_observed),
+            },
+            Self::Connect => HttpAttemptOutcome::Failure {
+                kind: HttpAttemptFailureKind::Connect,
+                http_status: None,
+                timeout_observed: Some(false),
+                connect_observed: Some(true),
+            },
+            Self::Transport => HttpAttemptOutcome::Failure {
+                kind: HttpAttemptFailureKind::Transport,
+                http_status: None,
+                timeout_observed: Some(false),
+                connect_observed: Some(false),
+            },
+        }
+    }
+
+    fn terminal_cause(self) -> String {
+        match self {
+            Self::HttpStatus(status) => format!("HTTP {status}"),
+            Self::Timeout { .. } => "timeout".to_string(),
+            Self::Connect => "connect".to_string(),
+            Self::Transport => "transport".to_string(),
+        }
+    }
+}
+
 /// Synchronous observer for selected control and event request paths.
 pub(crate) trait HttpAttemptObserver: Send + Sync {
     fn attempt_started(&self, attempt: HttpAttemptStarted) -> Result<(), AgentError>;
@@ -405,11 +469,17 @@ impl RetryRequest {
     }
 }
 
-async fn send_with_retry<BuildRequest, BuildRequestFuture, BuildClientError, ClientErrorFuture>(
+async fn send_with_retry<
+    BuildRequest,
+    BuildRequestFuture,
+    BuildClientError,
+    ClientErrorFuture,
+    BuildFinalError,
+>(
     label: &str,
     max_attempts: u32,
     retry_delay: Duration,
-    final_error: String,
+    build_final_error: BuildFinalError,
     mut build_request: BuildRequest,
     mut build_client_error: BuildClientError,
     observer: Option<&dyn HttpAttemptObserver>,
@@ -419,7 +489,9 @@ where
     BuildRequestFuture: Future<Output = Result<RetryRequest, AgentError>>,
     BuildClientError: FnMut(Response, u32, u32) -> ClientErrorFuture,
     ClientErrorFuture: Future<Output = AgentError>,
+    BuildFinalError: FnOnce(Option<RetryableFailure>) -> AgentError,
 {
+    let mut last_retryable_failure = None;
     for attempt in 1..=max_attempts {
         let request = build_request().await?;
         let active_attempt =
@@ -445,45 +517,22 @@ where
             }
             Ok(resp) => {
                 let status = resp.status();
-                observe_attempt_finished(
-                    observer,
-                    active_attempt,
-                    HttpAttemptOutcome::Failure {
-                        kind: HttpAttemptFailureKind::HttpStatus,
-                        http_status: Some(status.as_u16()),
-                        timeout_observed: None,
-                        connect_observed: None,
-                    },
-                )?;
+                let failure = RetryableFailure::from_status(status);
+                observe_attempt_finished(observer, active_attempt, failure.attempt_outcome())?;
                 // 4xx errors are deterministic except for rate limits.
                 if status.is_client_error() && status.as_u16() != HTTP_TOO_MANY_REQUESTS {
                     return Err(build_client_error(resp, attempt, max_attempts).await);
                 }
+                last_retryable_failure = Some(failure);
                 log_warn!(
                     LOG_TAG,
                     "HTTP {label} failed (attempt {attempt}/{max_attempts}): HTTP {status}",
                 );
             }
             Err(error) => {
-                let timeout_observed = error.is_timeout();
-                let connect_observed = error.is_connect();
-                let failure_kind = if timeout_observed {
-                    HttpAttemptFailureKind::Timeout
-                } else if connect_observed {
-                    HttpAttemptFailureKind::Connect
-                } else {
-                    HttpAttemptFailureKind::Transport
-                };
-                observe_attempt_finished(
-                    observer,
-                    active_attempt,
-                    HttpAttemptOutcome::Failure {
-                        kind: failure_kind,
-                        http_status: None,
-                        timeout_observed: Some(timeout_observed),
-                        connect_observed: Some(connect_observed),
-                    },
-                )?;
+                let failure = RetryableFailure::from_transport(&error);
+                observe_attempt_finished(observer, active_attempt, failure.attempt_outcome())?;
+                last_retryable_failure = Some(failure);
                 let error = format_reqwest_error(error);
                 log_warn!(
                     LOG_TAG,
@@ -497,7 +546,21 @@ where
         }
     }
 
-    Err(AgentError::Http(final_error))
+    Err(build_final_error(last_retryable_failure))
+}
+
+fn presigned_retry_exhausted_error(
+    max_attempts: u32,
+    last_failure: Option<RetryableFailure>,
+) -> AgentError {
+    let message = match last_failure {
+        Some(failure) => format!(
+            "PUT presigned failed after {max_attempts} attempts; last failure: {}",
+            failure.terminal_cause()
+        ),
+        None => format!("PUT presigned failed after {max_attempts} attempts"),
+    };
+    AgentError::Http(message)
 }
 
 fn observe_attempt_finished(
@@ -674,7 +737,10 @@ impl HttpClient {
             "POST",
             max_attempts,
             self.retry_delay,
-            format!("POST failed after {max_attempts} attempts to {url}"),
+            {
+                let final_error = format!("POST failed after {max_attempts} attempts to {url}");
+                move |_| AgentError::Http(final_error)
+            },
             || {
                 let request_id = Uuid::new_v4().to_string();
                 let mut req = client
@@ -775,7 +841,7 @@ impl HttpClient {
             "PUT presigned",
             max_attempts,
             self.retry_delay,
-            format!("PUT presigned failed after {max_attempts} attempts"),
+            move |last_failure| presigned_retry_exhausted_error(max_attempts, last_failure),
             move || {
                 let data = data.clone();
                 std::future::ready(Ok(RetryRequest::unobserved(
@@ -923,7 +989,7 @@ impl HttpClient {
             "PUT presigned",
             max_attempts,
             self.retry_delay,
-            format!("PUT presigned failed after {max_attempts} attempts"),
+            move |last_failure| presigned_retry_exhausted_error(max_attempts, last_failure),
             move || {
                 let source_file = Arc::clone(&source_file);
                 async move {

--- a/crates/guest-agent/tests/integration_cases/checkpoint/success.rs
+++ b/crates/guest-agent/tests/integration_cases/checkpoint/success.rs
@@ -268,6 +268,58 @@ async fn checkpoint_rejects_prepare_response_without_upload_url() {
 }
 
 #[tokio::test]
+async fn checkpoint_reports_session_history_upload_stage_and_final_status() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let mut runtime = runtime_from_process_env().unwrap();
+    runtime.config.framework = guest_agent::env::Framework::Codex;
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let session_id = "aeaeaeae-aeae-4eae-8eae-aeaeaeaeaeae";
+    let (history_dir, history_path, history) = write_prunable_codex_history(session_id).unwrap();
+    std::fs::write(&history_path, &history).unwrap();
+    use_test_codex_home(&mut runtime, history_dir.path());
+
+    let upload_path = "/test/failed-session-history-upload";
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "presignedUrl": server.url(upload_path),
+                "existing": false,
+                "encoding": "identity",
+            }));
+    });
+    let upload_mock = server.mock(|when, then| {
+        when.method(PUT).path(upload_path);
+        then.status(502);
+    });
+    let complete_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/complete");
+        then.status(200)
+            .json_body(json!({"success": true, "status": "completed"}));
+    });
+
+    let error = guest_agent::checkpoint::prepare_checkpoint_for_runtime(
+        &runtime,
+        &checkpoint_session_metadata(&runtime),
+    )
+    .await
+    .err()
+    .expect("failed history upload should fail checkpoint preparation");
+
+    assert_eq!(
+        error.to_string(),
+        "checkpoint: session history upload failed: http: PUT presigned failed after 3 attempts; last failure: HTTP 502"
+    );
+    prepare_mock.assert_calls_async(1).await;
+    upload_mock.assert_calls_async(3).await;
+    complete_mock.assert_calls_async(0).await;
+}
+
+#[tokio::test]
 async fn success_checkpoint_discards_oversized_claude_history_without_compact_boundary() {
     let api = SharedApiMock::new().await;
     let server = api.server();

--- a/crates/guest-agent/tests/integration_cases/presigned_upload.rs
+++ b/crates/guest-agent/tests/integration_cases/presigned_upload.rs
@@ -153,11 +153,15 @@ async fn put_presigned_429_retries() {
 
     // 429 is retriable — should exhaust all retries.
     mock.assert_calls_async(3).await;
-    assert!(result.is_err());
+    let error = result.unwrap_err().to_string();
+    assert_eq!(
+        error,
+        "http: PUT presigned failed after 3 attempts; last failure: HTTP 429"
+    );
 }
 
 #[tokio::test]
-async fn put_presigned_transport_error_does_not_log_presigned_url() {
+async fn put_presigned_connect_error_does_not_log_presigned_url() {
     let _api = SharedApiMock::new().await;
 
     let tmp = tempfile::tempdir().unwrap();
@@ -175,7 +179,11 @@ async fn put_presigned_transport_error_does_not_log_presigned_url() {
         )
         .await;
 
-    assert!(result.is_err());
+    let error = result.unwrap_err().to_string();
+    assert_eq!(
+        error,
+        "http: PUT presigned failed after 3 attempts; last failure: connect"
+    );
     let system_log = std::fs::read_to_string(&system_log_path).unwrap();
     assert!(
         system_log.contains("HTTP PUT presigned failed (attempt 1/3)"),
@@ -192,6 +200,18 @@ async fn put_presigned_transport_error_does_not_log_presigned_url() {
     assert!(
         !system_log.contains(signature),
         "system log leaked presigned signature: {system_log}"
+    );
+    assert!(
+        !error.contains(&url),
+        "returned error leaked full presigned URL: {error}"
+    );
+    assert!(
+        !error.contains("X-Amz-Signature"),
+        "returned error leaked presigned query key: {error}"
+    );
+    assert!(
+        !error.contains(signature),
+        "returned error leaked presigned signature: {error}"
     );
 }
 
@@ -317,7 +337,11 @@ async fn put_presigned_file_retry_fails_if_source_shrinks() {
         .await;
 
     assert!(mutation_done.load(Ordering::SeqCst));
-    assert!(result.is_err());
+    let error = result.unwrap_err().to_string();
+    assert_eq!(
+        error,
+        "http: PUT presigned failed after 3 attempts; last failure: transport"
+    );
     let calls = mock.calls_async().await;
     assert_eq!(calls, 1);
 }
@@ -453,6 +477,33 @@ async fn put_presigned_file_4xx_no_retry() {
     assert!(result.is_err());
 }
 
+#[tokio::test]
+async fn put_presigned_file_retry_exhausted_includes_final_status() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("exhausted.bin");
+    std::fs::write(&file_path, b"exhausted file data").unwrap();
+
+    let mock = server.mock(|when, then| {
+        when.method(PUT).path("/test/put-file-exhaust");
+        then.status(503);
+    });
+
+    let url = api.url("/test/put-file-exhaust");
+    let result = http_client!()
+        .put_presigned_file(&url, &file_path, "application/gzip")
+        .await;
+
+    mock.assert_calls_async(3).await;
+    let error = result.unwrap_err().to_string();
+    assert_eq!(
+        error,
+        "http: PUT presigned failed after 3 attempts; last failure: HTTP 503"
+    );
+}
+
 // =========================================================================
 // Edge cases
 // =========================================================================
@@ -474,5 +525,9 @@ async fn put_presigned_retry_exhausted() {
         .await;
 
     mock.assert_calls_async(3).await;
-    assert!(result.is_err());
+    let error = result.unwrap_err().to_string();
+    assert_eq!(
+        error,
+        "http: PUT presigned failed after 3 attempts; last failure: HTTP 500"
+    );
 }


### PR DESCRIPTION
## Summary

- preserve the final bounded failure classification when a presigned PUT exhausts its retry budget
- identify whether checkpoint persistence failed while uploading session history, the artifact archive, or the artifact manifest
- cover retryable HTTP statuses, connect and transport failures, stage propagation, and presigned URL secrecy

## Behavior

Checkpoint uploads remain mandatory and run-fatal. Retry counts, delays, upload timeouts, 4xx handling, and CLI exit semantics are unchanged. The durable terminal error now includes only a fixed upload stage and a bounded final cause (`HTTP <status>`, `timeout`, `connect`, or `transport`). It never includes the presigned URL, query parameters, object key, artifact name, or response body.

This PR does not change checkpoint storage, API contracts, database state, UI behavior, presigned URL lifetime, or retry policy.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p guest-agent --no-deps`
- `cargo test -p guest-agent`
- `cargo test -p guest-agent --test integration presigned_upload`
- `cargo test -p guest-agent --test integration checkpoint_reports_session_history_upload_stage_and_final_status`
- `cargo test -p guest-agent --test event_delivery_transport_classification`
- `cargo test -p guest-agent snapshot_archive_upload_failure_skips_manifest_and_commit`
- `cargo test -p guest-agent snapshot_manifest_upload_failure_skips_commit`
- `cargo test -p guest-agent complete_execution_writes_checkpoint_failure_diagnostic`

Closes #30947
