### PR TITLE
perf(runner): bound session history sidecar exports

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -874,11 +874,10 @@ async fn run_start_with_home(
         pre_spawn_admission,
         storage_baseline_observer: Default::default(),
         home: home.clone(),
-        workspace_cache: Some(WorkspaceImageCache::shared(
-            paths.clone(),
-            &home,
-            &group_name,
-        )),
+        workspace_cache: Some(
+            WorkspaceImageCache::shared(paths.clone(), &home, &group_name)
+                .with_session_history_sidecar_export_host_cpus(host_cpus),
+        ),
     });
 
     let live_runner_instance_metadata = crate::live_runner_instances::LiveRunnerInstanceMetadata {

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -1367,6 +1367,14 @@ impl WorkspaceImageLease {
 }
 
 impl WorkspaceImagePromotionContext {
+    pub(crate) async fn acquire_session_history_sidecar_export_permit(
+        &self,
+    ) -> RunnerResult<tokio::sync::OwnedSemaphorePermit> {
+        self.cache
+            .acquire_session_history_sidecar_export_permit()
+            .await
+    }
+
     pub(crate) fn run_id(&self) -> RunId {
         self.run_id
     }

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -66,6 +66,9 @@ use std::sync::Arc;
 #[cfg(test)]
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use crate::error::{RunnerError, RunnerResult};
 use crate::paths::{HomePaths, RunnerPaths};
 
 mod entry;
@@ -106,6 +109,7 @@ const WORKSPACE_DRIVE_LAYOUT: &str = "workspace-drive-v1";
 const GIB: u64 = 1024 * 1024 * 1024;
 const MIN_FREE_BYTES_FLOOR: u64 = 50 * GIB;
 const MAX_ENTRY_BYTES_CAP: u64 = 32 * GIB;
+const MAX_SESSION_HISTORY_SIDECAR_EXPORT_CONCURRENCY: usize = 4;
 
 #[cfg(test)]
 const TEST_FS_TOTAL_BYTES: u64 = 2_000 * GIB;
@@ -115,6 +119,7 @@ const TEST_FS_AVAILABLE_BYTES: u64 = 1_000 * GIB;
 #[derive(Clone)]
 pub(crate) struct WorkspaceImageCache {
     inner: Arc<WorkspaceImageCacheInner>,
+    session_history_sidecar_export_permits: Arc<Semaphore>,
     #[cfg(test)]
     prepare_lock_test_gate: Option<WorkspaceImagePrepareLockTestGate>,
 }
@@ -220,6 +225,9 @@ impl WorkspaceImageCache {
                     lock_dir,
                     cache_scope: cache_scope.to_owned(),
                 }),
+                session_history_sidecar_export_permits: Arc::new(Semaphore::new(
+                    MAX_SESSION_HISTORY_SIDECAR_EXPORT_CONCURRENCY,
+                )),
             }
         }
     }
@@ -244,8 +252,43 @@ impl WorkspaceImageCache {
                 held_state_root_scan_notify: tokio::sync::Notify::new(),
                 fail_next_session_history_sidecar_metadata_commit: AtomicBool::new(false),
             }),
+            session_history_sidecar_export_permits: Arc::new(Semaphore::new(
+                MAX_SESSION_HISTORY_SIDECAR_EXPORT_CONCURRENCY,
+            )),
             prepare_lock_test_gate: None,
         }
+    }
+
+    fn with_session_history_sidecar_export_capacity(mut self, capacity: usize) -> Self {
+        self.session_history_sidecar_export_permits = Arc::new(Semaphore::new(capacity.max(1)));
+        self
+    }
+
+    pub(crate) fn with_session_history_sidecar_export_host_cpus(self, host_cpus: usize) -> Self {
+        self.with_session_history_sidecar_export_capacity(
+            (host_cpus / 2).clamp(1, MAX_SESSION_HISTORY_SIDECAR_EXPORT_CONCURRENCY),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_session_history_sidecar_export_capacity_for_test(
+        self,
+        capacity: usize,
+    ) -> Self {
+        self.with_session_history_sidecar_export_capacity(capacity)
+    }
+
+    async fn acquire_session_history_sidecar_export_permit(
+        &self,
+    ) -> RunnerResult<OwnedSemaphorePermit> {
+        Arc::clone(&self.session_history_sidecar_export_permits)
+            .acquire_owned()
+            .await
+            .map_err(|error| {
+                RunnerError::Internal(format!(
+                    "session history sidecar export admission closed unexpectedly: {error}"
+                ))
+            })
     }
 
     pub(crate) fn paths(&self) -> &RunnerPaths {

--- a/crates/runner/src/workspace_promotion.rs
+++ b/crates/runner/src/workspace_promotion.rs
@@ -22,7 +22,7 @@ use crate::workspace_image_cache::{
 };
 use crate::workspace_mount::freeze_workspace_drive;
 
-const SESSION_HISTORY_SIDECAR_EXPORT_TIMEOUT: Duration = Duration::from_secs(10);
+const SESSION_HISTORY_SIDECAR_EXPORT_TIMEOUT: Duration = Duration::from_secs(30);
 const SESSION_HISTORY_SIDECAR_COPY_TIMEOUT: Duration = Duration::from_secs(30);
 const SESSION_HISTORY_SIDECAR_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -254,10 +254,30 @@ async fn export_session_history_sidecar(
         stdin_bytes: None,
         output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
     };
-    let result = match sandbox
-        .exec_with_diagnostic_label(&request, "session-history-sidecar-export")
+    let export_permit = match promotion
+        .acquire_session_history_sidecar_export_permit()
         .await
     {
+        Ok(permit) => permit,
+        Err(e) => {
+            warn!(
+                run_id = %promotion.run_id(),
+                sandbox_id = %promotion.sandbox_id(),
+                profile_name = promotion.profile_name(),
+                reuse_key_fingerprint = %crate::paths::short_digest(promotion.reuse_key()),
+                reuse_key_kind = crate::types::reuse_key_kind(promotion.reuse_key()),
+                reason,
+                error = %e,
+                "workspace image cache session history sidecar export admission failed"
+            );
+            return None;
+        }
+    };
+    let result = sandbox
+        .exec_with_diagnostic_label(&request, "session-history-sidecar-export")
+        .await;
+    drop(export_permit);
+    let result = match result {
         Ok(result) => result,
         Err(e) => {
             warn!(

--- a/crates/runner/src/workspace_promotion/test_support.rs
+++ b/crates/runner/src/workspace_promotion/test_support.rs
@@ -1,5 +1,6 @@
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use sandbox::SandboxId;
+use std::sync::Arc;
 
 use crate::ids::RunId;
 use crate::paths::RunnerPaths;
@@ -16,7 +17,7 @@ const TEST_WORKSPACE_IMAGE: &[u8] = b"workspace image";
 pub(crate) const TEST_WORKSPACE_IMAGE_SIZE_BYTES: u64 = TEST_WORKSPACE_IMAGE.len() as u64;
 
 pub(crate) struct WorkspacePromotionFixture {
-    pub(crate) _dir: tempfile::TempDir,
+    pub(crate) _dir: Arc<tempfile::TempDir>,
     pub(crate) cache: WorkspaceImageCache,
     pub(crate) promotion: WorkspaceImagePromotionContext,
     pub(crate) sandbox_id: SandboxId,
@@ -32,10 +33,35 @@ impl WorkspacePromotionFixture {
         reuse_key: &str,
         restored_session_identity: Option<&RestoredSessionIdentity>,
     ) -> Self {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = Arc::new(tempfile::tempdir().unwrap());
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
         let cache = WorkspaceImageCache::new(paths.clone());
+
+        Self::new_with_cache(dir, cache, reuse_key, restored_session_identity).await
+    }
+
+    pub(crate) async fn new_with_restored_session_identity_and_export_capacity(
+        reuse_key: &str,
+        restored_session_identity: Option<&RestoredSessionIdentity>,
+        export_capacity: usize,
+    ) -> Self {
+        let dir = Arc::new(tempfile::tempdir().unwrap());
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = WorkspaceImageCache::new(paths.clone())
+            .with_session_history_sidecar_export_capacity_for_test(export_capacity);
+
+        Self::new_with_cache(dir, cache, reuse_key, restored_session_identity).await
+    }
+
+    pub(crate) async fn new_with_cache(
+        dir: Arc<tempfile::TempDir>,
+        cache: WorkspaceImageCache,
+        reuse_key: &str,
+        restored_session_identity: Option<&RestoredSessionIdentity>,
+    ) -> Self {
+        let paths = cache.paths().clone();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let workspace_image = cache

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -4,6 +4,7 @@ use super::*;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::sync::Arc;
+use std::task::Poll;
 use std::time::Duration;
 
 use api_contracts::generated::constants::runners::{
@@ -22,7 +23,9 @@ use sandbox::{
     GuestProcessHandle, ProcessExit, Sandbox, SandboxFactory, SandboxId, StartAgentProcessRequest,
     StartProcessRequest,
 };
-use sandbox_mock::{ExecMatcher, MockSandbox, MockSandboxFactory, MockSandboxOverrides};
+use sandbox_mock::{
+    ExecMatcher, MockLifecycleGate, MockSandbox, MockSandboxFactory, MockSandboxOverrides,
+};
 use sha2::{Digest, Sha256};
 use tracing_subscriber::prelude::*;
 use tracing_test_support::{CapturedEvent, CapturedEvents};
@@ -418,6 +421,7 @@ async fn active_workspace_promotion_exports_session_history_sidecar() {
     let exec_calls = sandbox.exec_calls();
     assert_eq!(exec_calls.len(), 3);
     assert!(exec_calls[0].cmd.contains("export-session-history-sidecar"));
+    assert_eq!(exec_calls[0].timeout, Duration::from_secs(30));
     assert_eq!(
         exec_calls[0].env_keys,
         vec![guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV]
@@ -465,6 +469,239 @@ async fn active_workspace_promotion_exports_session_history_sidecar() {
         .await
         .unwrap();
     assert_eq!(tokio::fs::read(sidecar.path).await.unwrap(), history);
+}
+
+#[tokio::test]
+async fn session_history_sidecar_export_admission_queues_before_guest_exec() {
+    let history = br#"{"type":"message","content":"bounded export"}"#;
+    let first_identity = test_restored_session_identity("sess-export-first", history);
+    let second_identity = test_restored_session_identity("sess-export-second", history);
+    let first_fixture =
+        WorkspacePromotionFixture::new_with_restored_session_identity_and_export_capacity(
+            "thread:export-first",
+            Some(&first_identity),
+            1,
+        )
+        .await;
+    let second_fixture = WorkspacePromotionFixture::new_with_cache(
+        Arc::clone(&first_fixture._dir),
+        first_fixture.cache.clone(),
+        "thread:export-second",
+        Some(&second_identity),
+    )
+    .await;
+    let export_metadata = SessionHistorySidecarExportMetadata {
+        representation: SessionHistorySidecarRepresentation::Raw,
+        encoded_size: history.len() as u64,
+    };
+
+    let gate = MockLifecycleGate::new();
+    let first_overrides = Arc::new(MockSandboxOverrides::new());
+    first_overrides.set_exec_lifecycle_gate(gate.clone());
+    let first_sandbox = Arc::new(MockSandbox::with_overrides(
+        first_fixture.sandbox_id.to_string(),
+        first_overrides,
+    ));
+    first_sandbox.push_exec_result(Ok(ExecResult::new(
+        0,
+        serde_json::to_vec(&export_metadata).unwrap(),
+        Vec::new(),
+    )));
+    first_sandbox.push_copy_file_result(Ok(history.to_vec()));
+
+    let second_sandbox = MockSandbox::new(second_fixture.sandbox_id.to_string());
+    second_sandbox.push_exec_result(Ok(ExecResult::new(
+        0,
+        serde_json::to_vec(&export_metadata).unwrap(),
+        Vec::new(),
+    )));
+    second_sandbox.push_copy_file_result(Ok(history.to_vec()));
+
+    let first_promotion = first_fixture.promotion;
+    let first_task_sandbox = Arc::clone(&first_sandbox);
+    let first_task = tokio::spawn(async move {
+        prepare_workspace_image_from_active_sandbox(
+            first_task_sandbox.as_ref(),
+            Some(first_promotion),
+            "test",
+        )
+        .await
+    });
+    gate.wait_entered(1, Duration::from_secs(5)).await.unwrap();
+
+    let second = prepare_workspace_image_from_active_sandbox(
+        &second_sandbox,
+        Some(second_fixture.promotion),
+        "test",
+    );
+    tokio::pin!(second);
+    assert!(matches!(futures_util::poll!(&mut second), Poll::Pending));
+    assert!(second_sandbox.exec_calls().is_empty());
+
+    gate.release_many(10);
+    let first_prepared = first_task
+        .await
+        .unwrap()
+        .expect("first workspace promotion should prepare");
+    let second_prepared = second
+        .await
+        .expect("queued workspace promotion should prepare");
+
+    assert!(
+        second_sandbox.exec_calls()[0]
+            .cmd
+            .contains("export-session-history-sidecar")
+    );
+    first_prepared.abandon("test").await;
+    second_prepared.abandon("test").await;
+}
+
+#[tokio::test]
+async fn session_history_sidecar_export_admission_releases_before_host_copy() {
+    let history = br#"{"type":"message","content":"parallel copy"}"#;
+    let first_identity = test_restored_session_identity("sess-copy-first", history);
+    let second_identity = test_restored_session_identity("sess-copy-second", history);
+    let first_fixture =
+        WorkspacePromotionFixture::new_with_restored_session_identity_and_export_capacity(
+            "thread:copy-first",
+            Some(&first_identity),
+            1,
+        )
+        .await;
+    let second_fixture = WorkspacePromotionFixture::new_with_cache(
+        Arc::clone(&first_fixture._dir),
+        first_fixture.cache.clone(),
+        "thread:copy-second",
+        Some(&second_identity),
+    )
+    .await;
+    let export_metadata = SessionHistorySidecarExportMetadata {
+        representation: SessionHistorySidecarRepresentation::Raw,
+        encoded_size: history.len() as u64,
+    };
+
+    let first_sandbox = Arc::new(PostCopyGateSandbox::new(
+        first_fixture.sandbox_id.to_string(),
+    ));
+    first_sandbox.inner.push_exec_result(Ok(ExecResult::new(
+        0,
+        serde_json::to_vec(&export_metadata).unwrap(),
+        Vec::new(),
+    )));
+    first_sandbox
+        .inner
+        .push_copy_file_result(Ok(history.to_vec()));
+    let second_sandbox = Arc::new(MockSandbox::new(second_fixture.sandbox_id.to_string()));
+    second_sandbox.push_exec_result(Ok(ExecResult::new(
+        0,
+        serde_json::to_vec(&export_metadata).unwrap(),
+        Vec::new(),
+    )));
+    second_sandbox.push_copy_file_result(Ok(history.to_vec()));
+
+    let first_promotion = first_fixture.promotion;
+    let first_task_sandbox = Arc::clone(&first_sandbox);
+    let first_task = tokio::spawn(async move {
+        prepare_workspace_image_from_active_sandbox(
+            first_task_sandbox.as_ref(),
+            Some(first_promotion),
+            "test",
+        )
+        .await
+    });
+    tokio::time::timeout(Duration::from_secs(5), first_sandbox.wait_for_copy())
+        .await
+        .expect("first promotion should reach host copy");
+    assert!(!first_task.is_finished());
+
+    let second_promotion = second_fixture.promotion;
+    let second_task_sandbox = Arc::clone(&second_sandbox);
+    let second_task = tokio::spawn(async move {
+        prepare_workspace_image_from_active_sandbox(
+            second_task_sandbox.as_ref(),
+            Some(second_promotion),
+            "test",
+        )
+        .await
+    });
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while second_sandbox.exec_calls().is_empty() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("second export should enter while first host copy is blocked");
+    assert!(
+        second_sandbox.exec_calls()[0]
+            .cmd
+            .contains("export-session-history-sidecar")
+    );
+
+    first_sandbox.release_copy();
+    let first_prepared = first_task
+        .await
+        .unwrap()
+        .expect("first workspace promotion should prepare");
+    let second_prepared = second_task
+        .await
+        .unwrap()
+        .expect("second workspace promotion should prepare");
+    first_prepared.abandon("test").await;
+    second_prepared.abandon("test").await;
+}
+
+#[tokio::test]
+async fn session_history_sidecar_export_admission_releases_after_panic() {
+    let history = br#"{"type":"message","content":"panic release"}"#;
+    let first_identity = test_restored_session_identity("sess-panic-first", history);
+    let second_identity = test_restored_session_identity("sess-panic-second", history);
+    let first_fixture =
+        WorkspacePromotionFixture::new_with_restored_session_identity_and_export_capacity(
+            "thread:panic-first",
+            Some(&first_identity),
+            1,
+        )
+        .await;
+    let second_fixture = WorkspacePromotionFixture::new_with_cache(
+        Arc::clone(&first_fixture._dir),
+        first_fixture.cache.clone(),
+        "thread:panic-second",
+        Some(&second_identity),
+    )
+    .await;
+
+    let first_prepared = prepare_workspace_image_from_active_sandbox(
+        &PanicExecSandbox::new("panic-export"),
+        Some(first_fixture.promotion),
+        "test",
+    )
+    .await;
+    assert!(first_prepared.is_none());
+
+    let second_sandbox = MockSandbox::new(second_fixture.sandbox_id.to_string());
+    let export_metadata = SessionHistorySidecarExportMetadata {
+        representation: SessionHistorySidecarRepresentation::Raw,
+        encoded_size: history.len() as u64,
+    };
+    second_sandbox.push_exec_result(Ok(ExecResult::new(
+        0,
+        serde_json::to_vec(&export_metadata).unwrap(),
+        Vec::new(),
+    )));
+    second_sandbox.push_copy_file_result(Ok(history.to_vec()));
+
+    let second_prepared = tokio::time::timeout(
+        Duration::from_secs(5),
+        prepare_workspace_image_from_active_sandbox(
+            &second_sandbox,
+            Some(second_fixture.promotion),
+            "test",
+        ),
+    )
+    .await
+    .expect("second promotion should not wait on leaked export admission")
+    .expect("second workspace promotion should prepare");
+    second_prepared.abandon("test").await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- bound concurrent session-history sidecar guest exports with a runner-local, host-CPU-derived semaphore
- hold admission only around the guest export command so independent teardown work remains parallel
- extend the admitted export timeout from 10 seconds to 30 seconds and cover queueing, release-before-copy, and panic release behavior

## Scope

- no API, runner protocol, persisted state, or guest contract changes
- no global serialization of sandbox teardown or workspace promotion
- no new runtime configuration

## Validation

- `cargo fmt --all --check`
- `cargo check -p runner --all-targets`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner workspace_promotion::tests`
- `cargo test -p runner`

Closes #30946
