### PR TITLE
perf(python): scan proxy connect headers incrementally

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -529,22 +529,31 @@ def _abort_stream(stream: _ConnectedStream) -> None:
 async def _read_proxy_connect_status(sock: socket.socket) -> tuple[int, bool]:
     loop = asyncio.get_running_loop()
     buffer = bytearray()
+    header_terminator = b"\r\n\r\n"
+    search_start = 0
     total_header_bytes = 0
     while True:
-        header_end = buffer.find(b"\r\n\r\n")
+        header_end = buffer.find(header_terminator, search_start)
         if header_end < 0:
             remaining_bytes = _MAX_FIREWALL_AUTH_RESPONSE_HEADER_BYTES - total_header_bytes
             if len(buffer) > remaining_bytes:
                 raise ValueError("Firewall auth HTTP proxy response headers too large")
+            previous_buffer_end = len(buffer)
             chunk = await loop.sock_recv(sock, remaining_bytes + 1 - len(buffer))
             if not chunk:
                 raise asyncio.IncompleteReadError(bytes(buffer), None)
             buffer.extend(chunk)
+            # A terminator crossing this read can start only in the last three old bytes.
+            search_start = max(
+                0,
+                previous_buffer_end - len(header_terminator) + 1,
+            )
             continue
 
-        header_end += len(b"\r\n\r\n")
+        header_end += len(header_terminator)
         header_block = bytes(buffer[:header_end])
         del buffer[:header_end]
+        search_start = 0
         total_header_bytes += len(header_block)
         if total_header_bytes > _MAX_FIREWALL_AUTH_RESPONSE_HEADER_BYTES:
             raise ValueError("Firewall auth HTTP proxy response headers too large")

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
@@ -129,24 +129,6 @@ class _LifecycleSocketFactory:
         return created
 
 
-class _FindTrackingBytearray(bytearray):
-    def __init__(
-        self,
-        find_calls: list[tuple[int, int]],
-        search_misses: asyncio.Queue[None],
-    ) -> None:
-        super().__init__()
-        self._find_calls = find_calls
-        self._search_misses = search_misses
-
-    def find(self, sub: bytes, start: int = 0, end: int | None = None) -> int:
-        self._find_calls.append((len(self), start))
-        result = super().find(sub, start) if end is None else super().find(sub, start, end)
-        if result < 0:
-            self._search_misses.put_nowait(None)
-        return result
-
-
 @dataclass(frozen=True)
 class _OrderedResolver:
     expected_host: str
@@ -2120,8 +2102,13 @@ class TestFirewallAuthAsyncTransport:
         search_misses: asyncio.Queue[None] = asyncio.Queue()
         find_calls: list[tuple[int, int]] = []
 
-        def tracking_buffer() -> _FindTrackingBytearray:
-            return _FindTrackingBytearray(find_calls, search_misses)
+        class FindTrackingBytearray(bytearray):
+            def find(self, sub: bytes, start: int = 0, end: int | None = None) -> int:
+                find_calls.append((len(self), start))
+                result = super().find(sub, start) if end is None else super().find(sub, start, end)
+                if result < 0:
+                    search_misses.put_nowait(None)
+                return result
 
         async def handle_proxy(
             reader: asyncio.StreamReader,
@@ -2140,7 +2127,7 @@ class TestFirewallAuthAsyncTransport:
                     os.environ,
                     _https_proxy_environment(f"http://127.0.0.1:{proxy_port}"),
                 ),
-                patch.object(auth_client, "bytearray", tracking_buffer, create=True),
+                patch.object(auth_client, "bytearray", FindTrackingBytearray, create=True),
                 patch.object(platform_api, "VERCEL_BYPASS", ""),
                 mitm_ctx(api_url="https://platform.example"),
                 pytest.raises(

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
@@ -129,6 +129,24 @@ class _LifecycleSocketFactory:
         return created
 
 
+class _FindTrackingBytearray(bytearray):
+    def __init__(
+        self,
+        find_calls: list[tuple[int, int]],
+        search_misses: asyncio.Queue[None],
+    ) -> None:
+        super().__init__()
+        self._find_calls = find_calls
+        self._search_misses = search_misses
+
+    def find(self, sub: bytes, start: int = 0, end: int | None = None) -> int:
+        self._find_calls.append((len(self), start))
+        result = super().find(sub, start) if end is None else super().find(sub, start, end)
+        if result < 0:
+            self._search_misses.put_nowait(None)
+        return result
+
+
 @dataclass(frozen=True)
 class _OrderedResolver:
     expected_host: str
@@ -2087,6 +2105,55 @@ class TestFirewallAuthAsyncTransport:
         assert proxy_requests[0].method == "CONNECT"
         assert proxy_requests[0].target == "platform.example"
         assert response_body.decode() not in str(exc_info.value)
+
+    async def test_https_proxy_connect_scans_fragmented_headers_incrementally(
+        self,
+        mitm_ctx,
+    ):
+        header_terminator = b"\r\n\r\n"
+        response = (
+            b"HTTP/1.1 100 Continue\r\nX-Info: ready\r\n\r\n"
+            b"HTTP/1.1 407 Proxy Authentication Required\r\nX-Fill: "
+            + b"x" * 4096
+            + header_terminator
+        )
+        search_misses: asyncio.Queue[None] = asyncio.Queue()
+        find_calls: list[tuple[int, int]] = []
+
+        def tracking_buffer() -> _FindTrackingBytearray:
+            return _FindTrackingBytearray(find_calls, search_misses)
+
+        async def handle_proxy(
+            reader: asyncio.StreamReader,
+            writer: asyncio.StreamWriter,
+        ) -> None:
+            await _read_raw_http_request(reader)
+            for offset in range(len(response)):
+                await search_misses.get()
+                writer.write(response[offset : offset + 1])
+                await writer.drain()
+            await _close_test_writer(writer)
+
+        async with _run_test_server(handle_proxy) as proxy_port:
+            with (
+                patch.dict(
+                    os.environ,
+                    _https_proxy_environment(f"http://127.0.0.1:{proxy_port}"),
+                ),
+                patch.object(auth_client, "bytearray", tracking_buffer, create=True),
+                patch.object(platform_api, "VERCEL_BYPASS", ""),
+                mitm_ctx(api_url="https://platform.example"),
+                pytest.raises(
+                    OSError,
+                    match=r"^Firewall auth HTTP proxy CONNECT failed with status 407$",
+                ),
+            ):
+                await auth_client.fetch_firewall_headers(firewall_auth_request())
+
+        search_windows = [buffer_length - start for buffer_length, start in find_calls]
+        assert len(find_calls) == len(response) + 2
+        assert max(search_windows) <= len(header_terminator)
+        assert sum(search_windows) <= len(response) * len(header_terminator)
 
     async def test_https_proxy_connect_bounds_response_headers_and_closes_socket(
         self,


### PR DESCRIPTION
## Summary

- advance proxy CONNECT header delimiter searches past bytes already ruled out
- retain the three-byte overlap needed for delimiters split across socket reads
- add a deterministic one-byte-fragment integration regression covering informational responses and linear search work

## Scope

- preserves the cumulative 64 KiB header cap, status handling, pre-TLS trailing-data rejection, cancellation, deadline translation, and socket cleanup
- does not change APIs, persisted data, configuration, runner protocols, or user-facing behavior

## Testing

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_firewall_auth_client.py` (99 passed)
- `uv run --no-sync python -m pytest tests/` (7334 passed)

Closes #31052
