### PR TITLE
fix(platform): highlight pinned agents for chat threads

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -2093,6 +2093,29 @@ describe("zero sidebar", () => {
     ).toStrictEqual(["Support Agent", "Research Agent"]);
   });
 
+  it("marks the current thread agent as selected in the pinned agent grid", async () => {
+    prepareAgents();
+    context.mocks.data.userPreferences({
+      pinnedAgentIds: [RESEARCH_AGENT_ID],
+    });
+    mockSidebarThreadStory([
+      createThread(RESEARCH_THREAD_ID, "Research kickoff", {
+        agent: { id: RESEARCH_AGENT_ID, avatarUrl: null },
+      }),
+    ]);
+
+    setupSidebarPage({ context, path: `/chats/${RESEARCH_THREAD_ID}` });
+
+    const grid = await screen.findByTestId("pinned-agents-grid");
+    await waitFor(() => {
+      expect(pinnedAgentLink(grid, "Research Agent")).toHaveAttribute(
+        "aria-current",
+        "page",
+      );
+    });
+    expect(pinnedAgentLink(grid, "Zero")).not.toHaveAttribute("aria-current");
+  });
+
   it("pins an agent from the conversation picker and opens that agent chat", async () => {
     mockMobileLayout();
     prepareAgents();

--- a/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
@@ -335,6 +335,7 @@ function PinnedAgentGridCard({
       pathname="/agents/:agentId/chat"
       options={{ pathParams: { agentId: agent.agentId } }}
       data-testid="pinned-agent-card"
+      aria-current={isPrimarySelected ? "page" : undefined}
       draggable={isReorderable}
       onDragStart={(e) => {
         e.dataTransfer.clearData();
@@ -513,8 +514,6 @@ export function PinnedAgentListSection({
   const pathParams = useGet(pathParams$);
   const routeAgentId =
     typeof pathParams?.agentId === "string" ? pathParams.agentId : null;
-  const routeThreadId =
-    typeof pathParams?.threadId === "string" ? pathParams.threadId : null;
   const sidebarAgentId = useLastResolved(currentChatAgentId$) ?? null;
   const pinnedAgentsLoadable = useLastLoadable(pinnedAgents$);
   const displayedPinnedAgentsLoadable = useLastLoadable(displayedPinnedAgents$);
@@ -544,8 +543,7 @@ export function PinnedAgentListSection({
       ? displayedPinnedAgentsLoadable.data
       : pinnedAgents;
 
-  const selectedAgentId =
-    routeAgentId ?? (routeThreadId ? null : sidebarAgentId);
+  const selectedAgentId = routeAgentId ?? sidebarAgentId;
 
   if (layout === "horizontal") {
     const horizontalPinnedAgents =
@@ -712,6 +710,7 @@ export function PinnedAgentListSection({
                   <Link
                     pathname="/agents/:agentId/chat"
                     options={{ pathParams: { agentId: agent.agentId } }}
+                    aria-current={isPrimarySelected ? "page" : undefined}
                     onClick={(e) => {
                       if (e.metaKey || e.ctrlKey || e.shiftKey) {
                         return;


### PR DESCRIPTION
## Summary

- resolve the selected pinned agent from `currentChatAgentId$` for both agent and thread chat routes
- expose the active pinned agent through `aria-current` while reusing the existing selected styling
- add page-level regression coverage for `/chats/:threadId`

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx` (83 passed)

## Related

- #30413 contains an earlier version of this fix on a branch that now conflicts with `main`; this PR reapplies the focused change on the current base.
