### PR TITLE
fix(platform): count share selections by message group

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-sharing.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-sharing.ts
@@ -27,9 +27,25 @@ export interface ChatThreadSharingSignals {
   readonly close$: Command<Promise<void>, [AbortSignal]>;
   readonly toggle$: Command<
     ToggleSharedThreadSelectionResult,
-    [readonly ShareableChatEvent[]]
+    [string, readonly ShareableChatEvent[]]
   >;
   readonly create$: Command<Promise<void>, [AbortSignal]>;
+}
+
+// A visual message group is the only thing the reader can tick, so it is also
+// the unit the selection stores and counts. A single assistant run group can
+// hold a dozen output messages; counting those instead made one click jump the
+// counter from "3 selected" to "13 selected".
+interface SelectedGroup {
+  readonly events: readonly ShareableChatEvent[];
+  readonly bytes: number;
+}
+
+function groupBytes(events: readonly ShareableChatEvent[]): number {
+  const encoder = new TextEncoder();
+  return events.reduce((total, event) => {
+    return total + encoder.encode(event.text).byteLength;
+  }, 0);
 }
 
 export function createChatThreadSharingSignals(
@@ -40,11 +56,13 @@ export function createChatThreadSharingSignals(
   >,
 ): ChatThreadSharingSignals {
   const internalPhase$ = state<SharedThreadSelectionPhase>("idle");
-  const internalSelectedBytes$ = state<ReadonlyMap<string, number>>(new Map());
+  const internalSelectedGroups$ = state<ReadonlyMap<string, SelectedGroup>>(
+    new Map(),
+  );
   const internalCreatedSharedThreadId$ = state<string | null>(null);
 
   const start$ = command(({ set }, signal: AbortSignal) => {
-    set(internalSelectedBytes$, new Map());
+    set(internalSelectedGroups$, new Map());
     set(internalCreatedSharedThreadId$, null);
     set(internalPhase$, "selecting");
     return set(
@@ -55,7 +73,7 @@ export function createChatThreadSharingSignals(
   });
 
   const close$ = command(({ set }, signal: AbortSignal) => {
-    set(internalSelectedBytes$, new Map());
+    set(internalSelectedGroups$, new Map());
     set(internalCreatedSharedThreadId$, null);
     set(internalPhase$, "idle");
     return set(
@@ -68,41 +86,52 @@ export function createChatThreadSharingSignals(
   const toggle$ = command(
     (
       { get, set },
+      groupKey: string,
       events: readonly ShareableChatEvent[],
     ): ToggleSharedThreadSelectionResult => {
-      const selected = get(internalSelectedBytes$);
+      const selected = get(internalSelectedGroups$);
+      const stored = selected.get(groupKey);
+      // A group that grew while it was selected reads as partially selected,
+      // so ticking it again covers the new messages instead of clearing it.
+      const storedEventIds = new Set(
+        stored?.events.map((event) => {
+          return event.id;
+        }),
+      );
       const allSelected = events.every((event) => {
-        return selected.has(event.id);
+        return storedEventIds.has(event.id);
       });
-      if (allSelected) {
+      if (stored !== undefined && allSelected) {
         const next = new Map(selected);
-        for (const event of events) {
-          next.delete(event.id);
-        }
-        set(internalSelectedBytes$, next);
+        next.delete(groupKey);
+        set(internalSelectedGroups$, next);
         return "deselected";
       }
 
-      const next = new Map(selected);
-      for (const event of events) {
-        if (!next.has(event.id)) {
-          next.set(event.id, new TextEncoder().encode(event.text).byteLength);
-        }
-      }
-      const selectedBytes = [...next.values()].reduce((total, value) => {
-        return total + value;
+      const next = new Map(selected).set(groupKey, {
+        events,
+        bytes: groupBytes(events),
+      });
+      const selectedBytes = [...next.values()].reduce((total, group) => {
+        return total + group.bytes;
       }, 0);
       if (selectedBytes > SHARED_THREAD_SELECTION_TEXT_LIMIT_BYTES) {
         return "too-large";
       }
-      set(internalSelectedBytes$, next);
+      set(internalSelectedGroups$, next);
       return "selected";
     },
   );
 
   const create$ = command(
     async ({ get, set }, signal: AbortSignal): Promise<void> => {
-      const eventIds = [...get(internalSelectedBytes$).keys()];
+      const eventIds = [...get(internalSelectedGroups$).values()].flatMap(
+        (group) => {
+          return group.events.map((event) => {
+            return event.id;
+          });
+        },
+      );
       const client = get(apiClient$)(sharedThreadsContract);
       const result = await accept(
         client.create({
@@ -126,10 +155,16 @@ export function createChatThreadSharingSignals(
       return get(internalPhase$);
     }),
     selectedEventIds$: computed((get) => {
-      return new Set(get(internalSelectedBytes$).keys());
+      const ids = new Set<string>();
+      for (const group of get(internalSelectedGroups$).values()) {
+        for (const event of group.events) {
+          ids.add(event.id);
+        }
+      }
+      return ids;
     }),
     selectedCount$: computed((get) => {
-      return get(internalSelectedBytes$).size;
+      return get(internalSelectedGroups$).size;
     }),
     createdSharedThreadId$: computed((get) => {
       return get(internalCreatedSharedThreadId$);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-thread-sharing.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-thread-sharing.test.tsx
@@ -15,6 +15,11 @@ const context = testContext();
 const THREAD_ID = "b0000000-0000-4000-a000-000000000701";
 const USER_EVENT_ID = "10000000-0000-4000-8000-000000000701";
 const ASSISTANT_EVENT_ID = "20000000-0000-4000-8000-000000000701";
+const ASSISTANT_EVENT_IDS = [
+  "20000000-0000-4000-8000-000000000801",
+  "20000000-0000-4000-8000-000000000802",
+  "20000000-0000-4000-8000-000000000803",
+] as const;
 const RUN_ID = "d0000000-0000-4000-a000-000000000701";
 const SHARED_THREAD_ID = "30000000-0000-4000-8000-000000000701";
 
@@ -161,6 +166,72 @@ describe("chat thread sharing", () => {
       screen.findByText("Shareable prompt"),
     ).resolves.toBeInTheDocument();
     expect(buttonsByText("Share messages")).toHaveLength(0);
+  });
+
+  it("counts a multi-message group as one selection", async () => {
+    const user = userEvent.setup({ delay: null });
+    let submittedEventIds: readonly string[] = [];
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      threadTitle: "Multi answer conversation",
+      chatEvents: [
+        {
+          id: USER_EVENT_ID,
+          role: "user",
+          content: "Shareable prompt",
+          runId: RUN_ID,
+          createdAt: "2026-08-06T10:00:00Z",
+        },
+        ...ASSISTANT_EVENT_IDS.map((id, index) => {
+          return {
+            id,
+            role: "assistant" as const,
+            content: `Shareable answer ${String(index + 1)}`,
+            runId: RUN_ID,
+            createdAt: `2026-08-06T10:00:0${String(index + 1)}Z`,
+          };
+        }),
+      ],
+      activeRunIds: [RUN_ID],
+    });
+    context.mocks.api(sharedThreadsContract.create, ({ body, respond }) => {
+      submittedEventIds = body.eventIds;
+      return respond(201, { id: SHARED_THREAD_ID });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.SharedThreadSharing]: true,
+      },
+    });
+
+    await screen.findByText("Shareable answer 3");
+    await user.click(buttonByText("Share messages"));
+
+    const answerGroup = screen
+      .getByText("Shareable answer 3")
+      .closest("[data-chat-share-selectable-group]");
+    const checkbox =
+      answerGroup?.querySelector<HTMLElement>('[role="checkbox"]');
+    if (!checkbox) {
+      throw new Error("Expected the assistant group selection checkbox");
+    }
+
+    await user.click(checkbox);
+
+    // One tick over a group holding three answers is one selection, not three.
+    await waitFor(() => {
+      expect(screen.getAllByText("1 selected").length).toBeGreaterThan(0);
+    });
+    expect(checkedCheckboxes()).toHaveLength(1);
+
+    await user.click(buttonByText("Share"));
+    await screen.findByRole("textbox", { name: "Shared conversation link" });
+    expect([...submittedEventIds].sort()).toStrictEqual(
+      [...ASSISTANT_EVENT_IDS].sort(),
+    );
   });
 
   it("keeps an oversized visual message group unselected", async () => {

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -5693,7 +5693,7 @@ function SelectablePagedGroupRow({
     if (phase !== "selecting") {
       return;
     }
-    const result = toggle(events);
+    const result = toggle(group.beginEventId, events);
     if (result === "too-large") {
       toast.error(
         t(($) => {


### PR DESCRIPTION
## Problem

In the share panel, the right-hand checkboxes are rendered one per **visual message group**
(`SelectablePagedGroupRow`), and ticking one toggles every shareable event inside that group.
The counter, however, reported the number of selected **events**:

```ts
// signals/chat-page/chat-thread-sharing.ts
selectedCount$: computed((get) => {
  return get(internalSelectedBytes$).size; // ← event ids, not groups
}),
```

An assistant run group holds one `output.message` per turn, so a long run puts a dozen messages
behind a single checkbox. On a thread offering only four checkboxes, ticking the fourth jumped the
counter from `3 selected` straight to `13 selected` — the unit displayed did not match the unit the
reader can actually tick.

The existing test never caught it because its fixture gives each group exactly one message, so both
units coincide.

## Change

Key the selection by group (`beginEventId`) instead of by event, so the stored unit, the counter,
and the checkbox are all the same thing.

- `selectedCount$` is now the number of selected groups.
- The 1.5 MB budget still sums the text of every selected message.
- `create$` still submits every event id behind the selected groups; the API orders them by
  `seqId` server-side, so client ordering is irrelevant.
- Re-ticking a group that grew while selected still covers the new messages rather than clearing it.

## Test plan

- [x] New case `counts a multi-message group as one selection`: an active run with three answers in
      one group; one tick reports `1 selected` and shares all three event ids
- [x] Verified the new test fails when the counter goes back to counting events
- [x] `pnpm -F @okouai/app exec vitest run` — 165 files, 2212 tests passed
- [x] `pnpm format`, `pnpm turbo run lint`, `pnpm check-types`, `pnpm knip` (output identical to the
      clean-tree baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)