### PR TITLE
perf(runner): expand fresh delivery scan to 64

### DIFF
--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -75,7 +75,7 @@ const BACKGROUND_FILL_ACTIVE_LIMIT: usize = CONCURRENCY;
 const BACKGROUND_FILL_QUEUE_CAPACITY: usize = 32;
 /// Maximum number of completed telemetry tasks reaped between scheduler polls.
 const BACKGROUND_FILL_REPORT_REAP_BATCH: usize = 32;
-const FRESH_DELIVERY_SCAN_LIMIT: usize = 32;
+const FRESH_DELIVERY_SCAN_LIMIT: usize = 64;
 const FRESH_DELIVERY_PER_RUN_LIMIT: usize = 4;
 const FRESH_DELIVERY_RUNNER_LIMIT: usize = 8;
 
@@ -4837,7 +4837,7 @@ mod tests {
 
     #[tokio::test]
     async fn fresh_delivery_reaches_later_misses_after_warm_prefix() {
-        const WARM_PREFIX_COUNT: usize = 16;
+        const WARM_PREFIX_COUNT: usize = 48;
 
         fn scan_fixture_plan(base_url: &str, body_size: u64) -> StoragePlan {
             let storages = (0..WARM_PREFIX_COUNT + 5)


### PR DESCRIPTION
## Summary

- expand the finite fresh archive delivery scan from 32 to 64 cache-identity groups so misses after
  moderately long warm prefixes can overlap fresh sandbox creation
- preserve the existing four-per-run, eight-runner-wide, 8 MiB, single-request, writer ownership,
  publication, staging, cancellation, and sequential guest fallback limits
- extend production-path coverage from sixteen to forty-eight real warm cache groups before later
  HTTP misses, while the existing saturation fixture continues to prove the first group beyond the
  compiled cap is untouched

## Controlled local-1 decision

An optimized aarch64 temporary same-build harness ran on `local-1.aws.vm3.ai`. It alternated 32,
64, and 128 for 20 warm-up rounds plus 150 recorded all-warm samples per arm. The harness used real
temporary cache/lock state and the existing external HTTP test boundary, then was removed before
commit.

| Scan | p50 | p90 | p95 | p99 | p90/p95/p99 delta vs 32 |
| --- | ---: | ---: | ---: | ---: | ---: |
| 32 | 21.473 ms | 22.093 ms | 22.204 ms | 25.018 ms | baseline |
| 64 | 25.615 ms | 26.258 ms | 26.537 ms | 27.702 ms | +4.165 / +4.333 / +2.684 ms |
| 128 | 33.809 ms | 34.686 ms | 35.008 ms | 36.040 ms | +12.593 / +12.804 / +11.022 ms |

The challenged guard rejects an arm when all-warm p90 or p95 grows by more than 10 ms. Scan 128
was therefore rejected. Scan 64 passed and admitted four later misses after a 48-group warm prefix;
scan 32 admitted none. Scan 64 did not reach misses after a 96-group prefix, so this PR claims only
partial finite coverage, not elimination of the production long-prefix tail.

The harness passed with zero failures. File descriptors remained 10 before/after; maximum RSS was
14,628 KiB; `/usr/bin/time -v` reported zero major faults, zero swaps, and exit status 0. The remote
benchmark executable and all benchmark-only source were removed.

## Behavior and compatibility

- affects only fresh cold/workspace archive preparation; reused live sandboxes are unchanged
- adds at most 32 positional local group decisions relative to the previous cap while admitted
  requests and retained bodies remain bounded by the unchanged resource limits
- changes no API, database, queue payload, manifest, cache format, guest protocol, configuration,
  feature switch, or telemetry contract
- old and new Runner binaries can drain together because the number is internal compiled behavior
- realized `api_to_spawn` benefit remains a fixed API/Runner post-deploy validation question; the
  local gate measured candidate overhead and admission reach, not complete sandbox overlap

## Local runner validation

- local-mode aarch64 deployment completed successfully
- a valid `vm0/default` shell smoke completed with exit code 0
- normal Runner mode was restored; the systemd service is active and its `ExecStart` contains no
  `--local`
- the final normal-mode `service wait-running` command could not observe a live-runner record
  because the development API tunnel was not running; this does not affect the storage-path
  benchmark or leave the service in local mode

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo check --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p runner fresh_delivery -- --nocapture` (24 passed)
- `cargo test --manifest-path crates/Cargo.toml -p runner --quiet` (3,397 passed, 24 ignored; guest inventory passed)
- `cargo build --manifest-path crates/Cargo.toml -p runner`
- `lefthook run pre-commit`
- commit hooks, including commitlint
- `git diff --check`

Closes #31104

Parent context: #24203
