### PR TITLE
fix(api): suppress repeated auth unavailability warnings

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -1312,7 +1312,9 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
       refreshToken: "refresh-1",
       expiresIn: -60,
     });
+    let failedRefreshCalls = 0;
     fw.mockTestOauthTokenRefresh(() => {
+      failedRefreshCalls += 1;
       return HttpResponse.json({ error: "invalid_grant" }, { status: 400 });
     });
 
@@ -1328,6 +1330,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
       })),
     };
 
+    context.mocks.axiomLogging.warn.mockClear();
     const failed = await fw.requestFirewallAuth(headers, body, [502]);
     if (failed.status !== 502) {
       throw new Error("Expected invalid_grant to fail with 502");
@@ -1348,6 +1351,22 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     expect(failedConnector.reconnectReason).toBe(
       "authorization_expired_or_revoked",
     );
+
+    const repeated = await fw.requestFirewallAuth(headers, body, [502]);
+    if (repeated.status !== 502) {
+      throw new Error("Expected repeated invalid_grant to fail with 502");
+    }
+    expect(repeated.body.error.failureReason).toBe("reconnect_required");
+    expect(failedRefreshCalls).toBe(2);
+    const refreshWarnings = context.mocks.axiomLogging.warn.mock.calls.filter(
+      ([message]) => {
+        return (
+          typeof message === "string" &&
+          message.includes("test-oauth token refresh failed")
+        );
+      },
+    );
+    expect(refreshWarnings).toHaveLength(1);
 
     fw.mockTestOauthTokenRefresh(() => {
       return fw.oauthTokenResponse({
@@ -1403,6 +1422,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
       })),
     };
 
+    context.mocks.axiomLogging.warn.mockClear();
     const failed = await fw.requestFirewallAuth(headers, body, [502]);
     if (failed.status !== 502) {
       throw new Error("Expected invalid_rapt to fail with 502");
@@ -1674,6 +1694,25 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
       throw new Error("Expected the flagged connector to keep failing");
     }
     expect(flagged.body.error.failureReason).toBe("reconnect_required");
+    const missingInputWarnings =
+      context.mocks.axiomLogging.warn.mock.calls.filter(([message]) => {
+        return (
+          message === "test-oauth token refresh failed: required input missing"
+        );
+      });
+    expect(missingInputWarnings).toHaveLength(1);
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+      "test-oauth token refresh failed: required input missing",
+      expect.objectContaining({
+        accessSourceKey: "test-oauth",
+        failureReason: "reconnect_required",
+        missingInputNames: ["refreshToken"],
+      }),
+    );
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("Failed to refresh test-oauth token"),
+      expect.anything(),
+    );
 
     // The reconnect flag is visible through the public connector read.
     const connectorsApi = createConnectorBddApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
@@ -412,6 +412,7 @@ function gmailPushBody(args: {
 
 async function postGmailWebhook(
   rawBody: string,
+  googleIdToken = signedGoogleIdToken(),
 ): Promise<{ readonly status: number; readonly body: unknown }> {
   const response = await createApp({
     signal: context.signal,
@@ -419,7 +420,7 @@ async function postGmailWebhook(
   }).request("/api/webhooks/gmail", {
     method: "POST",
     headers: {
-      authorization: `Bearer ${signedGoogleIdToken()}`,
+      authorization: `Bearer ${googleIdToken}`,
       "Content-Type": "application/json",
     },
     body: rawBody,
@@ -1090,6 +1091,99 @@ describe("POST /api/webhooks/gmail", () => {
         return new HttpResponse(null, { status: 204 });
       }),
     );
+    await accept(
+      automationsClient().delete({
+        headers: authHeaders(actor),
+        params: { id: created.body.id },
+      }),
+      [204],
+    );
+  });
+
+  it("silently acknowledges events after Gmail access becomes unavailable", async () => {
+    const startedAt = now();
+    const gmailEmail = uniqueGmailEmail();
+    configureGmailEnv();
+    configureGmailWatchMock();
+    const { actor, workflowId } = await setupFixture();
+    await connectGmail(actor, gmailEmail);
+    const created = await accept(
+      automationsClient().create({
+        headers: authHeaders(actor),
+        params: { workflowId },
+        body: {
+          kind: "event",
+          eventType: "gmail-new-message",
+          eventConfig: { provider: "gmail", event: "new_message" },
+        },
+      }),
+      [201],
+    );
+
+    let refreshCalls = 0;
+    server.use(
+      http.post("https://oauth2.googleapis.com/token", () => {
+        refreshCalls += 1;
+        return HttpResponse.json({ error: "invalid_grant" }, { status: 400 });
+      }),
+    );
+    const googleIdToken = signedGoogleIdToken();
+    mockNow(startedAt + 2 * 60 * 60 * 1000);
+    context.mocks.axiomLogging.warn.mockClear();
+
+    for (const messageId of [
+      "pubsub-gmail-access-unavailable-first",
+      "pubsub-gmail-access-unavailable-repeat",
+    ]) {
+      const response = await postGmailWebhook(
+        gmailPushBody({
+          emailAddress: gmailEmail,
+          historyId: 101,
+          messageId,
+        }),
+        googleIdToken,
+      );
+      expectResponseStatus(response, 200);
+      expect(response.body).toStrictEqual({
+        success: true,
+        watchStates: 1,
+        dispatched: 0,
+        duplicates: 0,
+      });
+    }
+
+    expect(refreshCalls).toBe(1);
+    expect(
+      context.mocks.axiomLogging.warn.mock.calls.filter(([message]) => {
+        return message === "Connector credential refresh failed";
+      }),
+    ).toHaveLength(1);
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalledWith(
+      "Gmail event skipped because connector access is unavailable",
+      expect.anything(),
+    );
+    await accept(
+      automationsClient().disable({
+        headers: authHeaders(actor),
+        params: { id: created.body.id },
+      }),
+      [200],
+    );
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalledWith(
+      "Workflow watch lifecycle reconciliation failed",
+      expect.objectContaining({
+        provider: "gmail",
+        result: "access_unavailable",
+      }),
+    );
+
+    mockNow(startedAt);
+    server.use(
+      http.post("https://gmail.googleapis.com/gmail/v1/users/me/stop", () => {
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+    await connectGmail(actor, gmailEmail);
     await accept(
       automationsClient().delete({
         headers: authHeaders(actor),

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
@@ -11,7 +11,7 @@ import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { createApp } from "../../../app-factory";
 import { mockEnv } from "../../../lib/env";
-import { now } from "../../../lib/time";
+import { mockNow, now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import type { ApiTestUser } from "./helpers/api-bdd";
@@ -490,6 +490,94 @@ describe("POST /api/webhooks/google-calendar", () => {
         return new HttpResponse(null, { status: 204 });
       }),
     );
+    await accept(
+      automationsClient().delete({
+        headers: authHeaders(),
+        params: { id: created.body.id },
+      }),
+      [204],
+    );
+  });
+
+  it("silently acknowledges events after Calendar access becomes unavailable", async () => {
+    const startedAt = Date.parse("2026-09-02T00:00:00.000Z");
+    mockNow(startedAt);
+    const recorder = configureGoogleCalendarApiMock({});
+    const scenario = await setupFixture();
+    await connectGoogleCalendar(scenario);
+    const created = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: scenario.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-calendar-event-created",
+        },
+      }),
+      [201],
+    );
+    const watch = recorder.channels[0];
+    if (!watch) {
+      throw new Error("Expected a registered Google Calendar watch channel");
+    }
+
+    let refreshCalls = 0;
+    server.use(
+      http.post("https://oauth2.googleapis.com/token", () => {
+        refreshCalls += 1;
+        return HttpResponse.json({ error: "invalid_grant" }, { status: 400 });
+      }),
+    );
+    mockNow(startedAt + 2 * 60 * 60 * 1000);
+    context.mocks.axiomLogging.warn.mockClear();
+
+    for (const messageNumber of ["2", "3"]) {
+      const response = await postGoogleCalendarWebhook(
+        webhookHeaders(watch, { "x-goog-message-number": messageNumber }),
+      );
+      expect(response).toStrictEqual({
+        status: 200,
+        body: {
+          success: true,
+          watchStates: 1,
+          dispatched: 0,
+          duplicates: 0,
+        },
+      });
+    }
+
+    expect(refreshCalls).toBe(1);
+    expect(
+      context.mocks.axiomLogging.warn.mock.calls.filter(([message]) => {
+        return message === "Connector credential refresh failed";
+      }),
+    ).toHaveLength(1);
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalledWith(
+      "Google Calendar event skipped because connector access is unavailable",
+      expect.anything(),
+    );
+    await accept(
+      automationsClient().disable({
+        headers: authHeaders(),
+        params: { id: created.body.id },
+      }),
+      [200],
+    );
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalledWith(
+      "Workflow watch lifecycle reconciliation failed",
+      expect.objectContaining({
+        provider: "google_calendar",
+        result: "access_unavailable",
+      }),
+    );
+
+    mockNow(startedAt);
+    server.use(
+      http.post("https://www.googleapis.com/calendar/v3/channels/stop", () => {
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+    await connectGoogleCalendar(scenario);
     await accept(
       automationsClient().delete({
         headers: authHeaders(),

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-forms.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-forms.test.ts
@@ -11,7 +11,7 @@ import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { createApp } from "../../../app-factory";
 import { mockOptionalEnv } from "../../../lib/env";
-import { now } from "../../../lib/time";
+import { mockNow, now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import {
@@ -282,7 +282,10 @@ function formsPushBody(messageId: string, watchId: string): string {
   });
 }
 
-async function postWebhook(rawBody: string): Promise<{
+async function postWebhook(
+  rawBody: string,
+  googleIdToken = signedGoogleIdToken(),
+): Promise<{
   readonly status: number;
   readonly body: unknown;
 }> {
@@ -292,7 +295,7 @@ async function postWebhook(rawBody: string): Promise<{
   }).request("/api/webhooks/google-forms", {
     method: "POST",
     headers: {
-      authorization: `Bearer ${signedGoogleIdToken()}`,
+      authorization: `Bearer ${googleIdToken}`,
       "Content-Type": "application/json",
     },
     body: rawBody,
@@ -369,7 +372,7 @@ async function setupGoogleFormsAutomation() {
   }
   expect(created.body.eventConfig.connectorId).toBe(connector.id);
   expect(created.body).not.toHaveProperty("warning");
-  return { automationId: created.body.id, chatThreadId, formsApi };
+  return { actor, automationId: created.body.id, chatThreadId, formsApi };
 }
 
 describe("Google Forms Pub/Sub webhook", () => {
@@ -460,6 +463,72 @@ describe("Google Forms Pub/Sub webhook", () => {
     });
     expect(formsApi.responseFilters).toHaveLength(2);
     await flushWaitUntilForTest();
+  });
+
+  it("silently acknowledges events after Forms access becomes unavailable", async () => {
+    const startedAt = now();
+    const { actor, automationId, formsApi } =
+      await setupGoogleFormsAutomation();
+    const watchId = formsApi.watchIds[0];
+    if (!watchId) {
+      throw new Error("Expected a Google Forms watch id");
+    }
+
+    let refreshCalls = 0;
+    server.use(
+      http.post("https://oauth2.googleapis.com/token", () => {
+        refreshCalls += 1;
+        return HttpResponse.json({ error: "invalid_grant" }, { status: 400 });
+      }),
+    );
+    const googleIdToken = signedGoogleIdToken();
+    mockNow(startedAt + 2 * 60 * 60 * 1000);
+    context.mocks.axiomLogging.warn.mockClear();
+
+    for (const messageId of [
+      "pubsub-forms-access-unavailable-first",
+      "pubsub-forms-access-unavailable-repeat",
+    ]) {
+      const response = await postWebhook(
+        formsPushBody(messageId, watchId),
+        googleIdToken,
+      );
+      expect(response).toStrictEqual({
+        status: 200,
+        body: {
+          success: true,
+          watchStates: 1,
+          dispatched: 0,
+          duplicates: 0,
+        },
+      });
+    }
+
+    expect(refreshCalls).toBe(1);
+    expect(
+      context.mocks.axiomLogging.warn.mock.calls.filter(([message]) => {
+        return message === "Connector credential refresh failed";
+      }),
+    ).toHaveLength(1);
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalledWith(
+      "Google Forms event skipped because connector access is unavailable",
+      expect.anything(),
+    );
+
+    mockNow(startedAt);
+    mockGoogleFormsConnectorOAuth();
+    await workflows.connectConnector(actor, "google-forms");
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped workflow actor");
+    }
+    mocks.clerk.session(actor.userId, actor.orgId, "org:member");
+    await accept(
+      automationsClient().delete({
+        headers: authHeaders(),
+        params: { id: automationId },
+      }),
+      [204],
+    );
   });
 
   it("ignores an unknown watch id", async () => {

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -2443,7 +2443,25 @@ async function markRefreshFailure(
 async function markRefreshTokenMissing(
   args: RefreshAccessTokenArgs,
   context: RefreshTokenContext,
+  missingInputNames: readonly string[],
+  shouldLogWarning: boolean,
 ): Promise<RefreshAccessTokenResult> {
+  if (shouldLogWarning) {
+    L.warn(
+      `${args.accessSourceKey} token refresh failed: required input missing`,
+      {
+        accessSourceKey: args.accessSourceKey,
+        orgId: args.orgId,
+        userId: args.userId,
+        ...(args.sourceType === "model-provider" && args.sourceId
+          ? { modelProviderAccountId: args.sourceId }
+          : {}),
+        errorCode: null,
+        failureReason: "reconnect_required",
+        missingInputNames,
+      },
+    );
+  }
   await markRefreshFailure(args, context, null, "reconnect_required", null);
   return refreshTokenMissingResult();
 }
@@ -2453,20 +2471,23 @@ async function markAndReturnRefreshFailure(
   context: RefreshTokenContext,
   error: unknown,
   signal: AbortSignal,
+  shouldLogWarning: boolean,
 ): Promise<RefreshAccessTokenResult> {
   const message = error instanceof Error ? error.message : "Unknown error";
   const { errorCode, failureReason } = classifyRefreshFailure(error, signal);
-  L.warn(`${args.accessSourceKey} token refresh failed: ${message}`, {
-    accessSourceKey: args.accessSourceKey,
-    orgId: args.orgId,
-    userId: args.userId,
-    ...(args.sourceType === "model-provider" && args.sourceId
-      ? { modelProviderAccountId: args.sourceId }
-      : {}),
-    errorCode,
-    failureReason,
-    ...oauthRefreshFailureLogFields(error),
-  });
+  if (shouldLogWarning) {
+    L.warn(`${args.accessSourceKey} token refresh failed: ${message}`, {
+      accessSourceKey: args.accessSourceKey,
+      orgId: args.orgId,
+      userId: args.userId,
+      ...(args.sourceType === "model-provider" && args.sourceId
+        ? { modelProviderAccountId: args.sourceId }
+        : {}),
+      errorCode,
+      failureReason,
+      ...oauthRefreshFailureLogFields(error),
+    });
+  }
   await markRefreshFailure(
     args,
     context,
@@ -2584,12 +2605,6 @@ function currentPreparedRefreshState(args: {
   readonly state: RefreshState | null;
 }): RefreshState | null {
   if (!args.state) {
-    L.warn(`${args.refreshArgs.accessSourceKey} token refresh source missing`, {
-      accessSourceKey: args.refreshArgs.accessSourceKey,
-      orgId: args.refreshArgs.orgId,
-      userId: args.refreshArgs.userId,
-      sourceType: args.refreshArgs.sourceType,
-    });
     return null;
   }
   return preparedRefreshSourceMatchesState(
@@ -2763,16 +2778,35 @@ async function refreshLockedAccessToken(args: {
       `No ${args.refreshArgs.accessSourceKey} refresh inputs available, skipping`,
       { missingInputNames },
     );
-    return markRefreshTokenMissing(args.refreshArgs, args.prepared.context);
+    return markRefreshTokenMissing(
+      args.refreshArgs,
+      args.prepared.context,
+      missingInputNames,
+      !lockedState.needsReconnect,
+    );
   }
+
+  return refreshPreparedLockedAccessToken({
+    refreshArgs: args.refreshArgs,
+    prepared: args.prepared,
+    lockedState,
+  });
+}
+
+async function refreshPreparedLockedAccessToken(args: {
+  readonly refreshArgs: RefreshAccessTokenArgs;
+  readonly prepared: PreparedRefreshTokenContext;
+  readonly lockedState: RefreshState;
+}): Promise<RefreshAccessTokenResult> {
+  const { refreshArgs, prepared, lockedState } = args;
 
   const refreshSignal = firewallAuthRefreshTimeoutSignal();
   const refreshResult = await settle(
     refreshPreparedAccessToken(
       {
-        prepared: args.prepared,
+        prepared,
         inputs: refreshInputsFromLockedState({
-          accessSourceKey: args.refreshArgs.accessSourceKey,
+          accessSourceKey: refreshArgs.accessSourceKey,
           state: lockedState,
         }),
       },
@@ -2781,28 +2815,31 @@ async function refreshLockedAccessToken(args: {
   );
   if (!refreshResult.ok) {
     return markAndReturnRefreshFailure(
-      args.refreshArgs,
-      args.prepared.context,
+      refreshArgs,
+      prepared.context,
       refreshResult.error,
       refreshSignal,
+      !lockedState.needsReconnect,
     );
   }
 
   const outputValidation = validateRefreshResultOutputs({
-    accessSourceKey: args.refreshArgs.accessSourceKey,
-    context: args.prepared.context,
+    accessSourceKey: refreshArgs.accessSourceKey,
+    context: prepared.context,
     result: refreshResult.value,
   });
   if (!outputValidation.ok) {
-    L.warn(outputValidation.message, {
-      accessSourceKey: args.refreshArgs.accessSourceKey,
-      orgId: args.refreshArgs.orgId,
-      userId: args.refreshArgs.userId,
-      sourceType: args.refreshArgs.sourceType,
-    });
+    if (!lockedState.needsReconnect) {
+      L.warn(outputValidation.message, {
+        accessSourceKey: refreshArgs.accessSourceKey,
+        orgId: refreshArgs.orgId,
+        userId: refreshArgs.userId,
+        sourceType: refreshArgs.sourceType,
+      });
+    }
     await markRefreshFailure(
-      args.refreshArgs,
-      args.prepared.context,
+      refreshArgs,
+      prepared.context,
       null,
       "upstream_provider",
       null,
@@ -2811,25 +2848,23 @@ async function refreshLockedAccessToken(args: {
   }
 
   const returnedSecretValues = await markRefreshSuccess(
-    args.refreshArgs,
-    args.prepared,
-    args.prepared.context,
+    refreshArgs,
+    prepared,
+    prepared.context,
     outputValidation.outputs,
     refreshResult.value,
   );
   const refreshedSecrets = runtimeSecretsFromRefreshResult({
-    accessSourceKey: args.refreshArgs.accessSourceKey,
-    context: args.prepared.context,
+    accessSourceKey: refreshArgs.accessSourceKey,
+    context: prepared.context,
     returnedSecretValues,
   });
   Object.assign(
-    args.refreshArgs.connectorSecrets,
+    refreshArgs.connectorSecrets,
     returnedSecretValues,
     refreshedSecrets,
   );
-  L.debug(
-    `${args.refreshArgs.accessSourceKey} access token refreshed successfully`,
-  );
+  L.debug(`${refreshArgs.accessSourceKey} access token refreshed successfully`);
   return {
     ok: true,
     status: "refreshed",
@@ -4408,17 +4443,6 @@ async function refreshSelectedTokens(
         featureSwitchContext: context.featureSwitchContext,
       });
       if (!refreshResult.ok) {
-        if (refreshResult.reason !== "refresh-failed") {
-          L.warn(
-            `[${context.auth.runId}] Failed to refresh ${accessSourceKey} token`,
-            {
-              sourceType: metadata.sourceType,
-              sourceUserId: metadata.sourceUserId,
-              metadataKey: metadata.metadataKey,
-              reason: refreshResult.reason,
-            },
-          );
-        }
         if (refreshResult.reason === "source-missing") {
           return {
             accessSourceKey,
@@ -4497,9 +4521,6 @@ async function syncSkippedTokens(
     sourceMissing,
   } of currentTokens) {
     if (sourceMissing) {
-      L.warn(
-        `[${context.auth.runId}] Skipped access source ${accessSourceKey}: source missing`,
-      );
       for (const envVar of context.envVarsByAccessSource.get(accessSourceKey) ??
         []) {
         delete context.secrets[envVar];
@@ -4511,9 +4532,6 @@ async function syncSkippedTokens(
       continue;
     }
     if (failureReason) {
-      L.warn(
-        `[${context.auth.runId}] Skipped access source ${accessSourceKey}: reconnect still required`,
-      );
       for (const envVar of context.envVarsByAccessSource.get(accessSourceKey) ??
         []) {
         delete context.secrets[envVar];

--- a/turbo/apps/api/src/signals/services/gmail-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/gmail-automation-event.service.ts
@@ -1015,11 +1015,6 @@ async function reconcileActiveGmailStates(
     signal,
   );
   if (!access) {
-    log.warn("Workflow watch lifecycle reconciliation failed", {
-      provider: "gmail",
-      action: "renew",
-      result: "access_unavailable",
-    });
     return { kind: "failed" };
   }
   const watch = await watchGmailMailbox(
@@ -1102,11 +1097,6 @@ async function stopInactiveGmailStates(
   );
   if (!access) {
     await markGmailStatesForRetry(args.db, args.states);
-    log.warn("Workflow watch lifecycle reconciliation failed", {
-      provider: "gmail",
-      action: "stop",
-      result: "access_unavailable",
-    });
     return { kind: "failed" };
   }
 
@@ -2661,10 +2651,6 @@ async function dispatchGmailWatchState(
   );
   signal.throwIfAborted();
   if (access.kind !== "ok") {
-    log.warn("Gmail event skipped because connector access is unavailable", {
-      watchStateId: args.state.id,
-      message: access.message,
-    });
     return { kind: "ok", dispatched: 0, duplicates: 0 };
   }
 

--- a/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
@@ -1982,11 +1982,6 @@ async function decideGoogleCalendarWatchReconciliation(
     if (!hasConsumer) {
       await markCalendarWatchNeedsRewatch(args.db, state.id);
     }
-    log.warn("Workflow watch lifecycle reconciliation failed", {
-      provider: "google_calendar",
-      action: hasConsumer ? "renew" : "stop",
-      result: "access_unavailable",
-    });
     return { kind: "failed" };
   }
 
@@ -3125,13 +3120,6 @@ async function dispatchGoogleCalendarWatchState(
   );
   signal.throwIfAborted();
   if (access.kind !== "ok") {
-    log.warn(
-      "Google Calendar event skipped because connector access is unavailable",
-      {
-        watchStateId: args.state.id,
-        message: access.message,
-      },
-    );
     return { kind: "ok", dispatched: 0, duplicates: 0 };
   }
   const baselineInput = {

--- a/turbo/apps/api/src/signals/services/google-forms-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-forms-automation-event.service.ts
@@ -1871,13 +1871,6 @@ async function dispatchGoogleFormsAutomation(
   );
   signal.throwIfAborted();
   if (access.kind !== "ok") {
-    log.warn(
-      "Google Forms event skipped because connector access is unavailable",
-      {
-        automationId: args.automation.automation.id,
-        message: access.message,
-      },
-    );
     return { kind: "ok", dispatched: 0, duplicates: 0 };
   }
   const listed = await args.sourceTiming.measure(


### PR DESCRIPTION
## Summary

- emit refresh warnings only when an auth source first transitions into `needsReconnect`
- keep retries and recovery active while suppressing repeated firewall-auth warnings
- silently acknowledge Gmail, Google Calendar, and Google Forms automation events when connector access is already unavailable
- remove duplicate lifecycle reconciliation warnings for known unavailable connector access

## Scope

- no API contract, schema, UI, queue, or runner behavior changes
- provider failures from a previously usable source and internal invariant failures remain warnings

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts src/signals/routes/__tests__/webhooks-gmail.test.ts src/signals/routes/__tests__/webhooks-google-calendar.test.ts src/signals/routes/__tests__/webhooks-google-forms.test.ts` (97 tests)
- pre-commit hooks: repository formatter, full Knip, and repository type checks

Closes #31114
