### PR TITLE
fix(api): self-heal renamed calendar primary watches

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
@@ -676,8 +676,13 @@ describe("okou workflow automations", () => {
 
   async function connectGoogleCalendar(
     scenario: AutomationScenario,
+    options: {
+      readonly accessToken?: string;
+      readonly email?: string;
+      readonly subject?: string;
+    } = { email: GOOGLE_CALENDAR_EMAIL },
   ): Promise<string> {
-    mockGoogleCalendarConnectorOAuth({ email: GOOGLE_CALENDAR_EMAIL });
+    mockGoogleCalendarConnectorOAuth(options);
     await wf.connectConnector(scenario.actor, "google-calendar");
     const connector = await connectorsApi.readConnectorBySlug(
       scenario.actor,
@@ -2703,6 +2708,11 @@ describe("okou workflow automations", () => {
         body: {
           kind: "event",
           eventType: "google-calendar-event-created",
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_created",
+            calendarId: GOOGLE_CALENDAR_EMAIL,
+          },
         },
       }),
       [201],
@@ -3462,7 +3472,7 @@ describe("okou workflow automations", () => {
     await connectGoogleCalendar(scenario);
     const watch = configureGoogleCalendarWatchMock();
     const stop = configureGoogleCalendarStopMock([500, 204]);
-    await accept(
+    const created = await accept(
       automationsClient().create({
         headers: authHeaders(),
         params: { workflowId: scenario.workflowId },
@@ -3517,6 +3527,319 @@ describe("okou workflow automations", () => {
       { id: watch.channelIds[0], resourceId: "calendar-resource-1" },
       { id: watch.channelIds[0], resourceId: "calendar-resource-1" },
     ]);
+
+    await accept(
+      automationsClient().disable({
+        headers: authHeaders(),
+        params: { id: created.body.id },
+      }),
+      [200],
+    );
+    expect(stop.calls).toBe(3);
+  });
+
+  it("self-heals a renamed primary Calendar target without crossing accounts", async () => {
+    mockEnv("CRON_SECRET", CRON_SECRET);
+    mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+    const legacyCalendarId = "legacy-primary@example.com";
+    const firstAccessToken = "renamed-primary-first-token";
+    const secondAccessToken = "renamed-primary-second-token";
+    const watchCalls = new Map<string, number>();
+    const actions: string[] = [];
+    server.use(
+      http.get(
+        "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events",
+        ({ request, params }) => {
+          const calendarId = params.calendarId;
+          const authorization = request.headers.get("authorization");
+          if (typeof calendarId !== "string" || authorization === null) {
+            throw new Error("Expected a Calendar target and access token");
+          }
+          const accessToken = authorization.replace("Bearer ", "");
+          actions.push(`${accessToken}:events:${calendarId}`);
+          return HttpResponse.json({
+            items: [],
+            nextSyncToken: `${accessToken}-${calendarId}-sync`,
+          });
+        },
+      ),
+      http.get(
+        "https://www.googleapis.com/calendar/v3/calendars/:calendarId",
+        ({ request, params }) => {
+          const calendarId = params.calendarId;
+          const authorization = request.headers.get("authorization");
+          if (typeof calendarId !== "string" || authorization === null) {
+            throw new Error("Expected a Calendar target and access token");
+          }
+          const accessToken = authorization.replace("Bearer ", "");
+          actions.push(`${accessToken}:resolve:${calendarId}`);
+          return HttpResponse.json({
+            id:
+              accessToken === firstAccessToken
+                ? "renamed-primary-resource"
+                : `${calendarId}-resource`,
+          });
+        },
+      ),
+      http.post(
+        "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events/watch",
+        async ({ request, params }) => {
+          const calendarId = params.calendarId;
+          const authorization = request.headers.get("authorization");
+          if (typeof calendarId !== "string" || authorization === null) {
+            throw new Error("Expected a Calendar target and access token");
+          }
+          const accessToken = authorization.replace("Bearer ", "");
+          const call = (watchCalls.get(accessToken) ?? 0) + 1;
+          watchCalls.set(accessToken, call);
+          actions.push(`${accessToken}:watch:${calendarId}:${call}`);
+          if (
+            accessToken === firstAccessToken &&
+            calendarId === legacyCalendarId &&
+            call === 2
+          ) {
+            return HttpResponse.json(
+              { error: { status: "NOT_FOUND" } },
+              { status: 404 },
+            );
+          }
+          const body = (await request.json()) as {
+            readonly id: string;
+          };
+          return HttpResponse.json({
+            id: body.id,
+            resourceId: `${accessToken}-resource-${call}`,
+            resourceUri: `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events`,
+            expiration: String(now() + 60 * 60 * 1000),
+          });
+        },
+      ),
+      http.post(
+        "https://www.googleapis.com/calendar/v3/channels/stop",
+        ({ request }) => {
+          const authorization = request.headers.get("authorization");
+          if (authorization === null) {
+            throw new Error("Expected a Calendar access token");
+          }
+          const accessToken = authorization.replace("Bearer ", "");
+          actions.push(`${accessToken}:stop`);
+          return new HttpResponse(null, { status: 204 });
+        },
+      ),
+    );
+
+    const first = await setupFixture();
+    await connectGoogleCalendar(first, {
+      accessToken: firstAccessToken,
+      email: "first-owner@example.com",
+      subject: "renamed-primary-first-subject",
+    });
+    const firstAutomation = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: first.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-calendar-event-created",
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_created",
+            calendarId: legacyCalendarId,
+          },
+        },
+      }),
+      [201],
+    );
+
+    const second = await setupFixture();
+    await connectGoogleCalendar(second, {
+      accessToken: secondAccessToken,
+      email: "second-owner@example.com",
+      subject: "renamed-primary-second-subject",
+    });
+    const secondAutomation = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: second.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-calendar-event-created",
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_created",
+            calendarId: legacyCalendarId,
+          },
+        },
+      }),
+      [201],
+    );
+
+    const renewed = await accept(
+      renewGoogleCalendarWatchesClient().renew({
+        headers: { authorization: `Bearer ${CRON_SECRET}` },
+      }),
+      [200],
+    );
+    expect(renewed.body).toStrictEqual({
+      success: true,
+      renewed: 2,
+      failed: 0,
+    });
+
+    mocks.clerk.session(
+      first.fixture.userId,
+      first.fixture.orgId,
+      "org:member",
+    );
+    await expect(
+      wf.readAutomation(firstAutomation.body.id),
+    ).resolves.toMatchObject({ eventConfig: { calendarId: "primary" } });
+    mocks.clerk.session(
+      second.fixture.userId,
+      second.fixture.orgId,
+      "org:member",
+    );
+    await expect(
+      wf.readAutomation(secondAutomation.body.id),
+    ).resolves.toMatchObject({
+      eventConfig: { calendarId: legacyCalendarId },
+    });
+
+    const primaryWatchIndex = actions.indexOf(
+      `${firstAccessToken}:watch:primary:3`,
+    );
+    const legacyStopIndex = actions.indexOf(`${firstAccessToken}:stop`);
+    expect(primaryWatchIndex).toBeGreaterThan(-1);
+    expect(legacyStopIndex).toBeGreaterThan(primaryWatchIndex);
+    expect(
+      actions.filter((action) => {
+        return action.startsWith(`${secondAccessToken}:resolve:`);
+      }),
+    ).toStrictEqual([]);
+
+    await accept(
+      automationsClient().disable({
+        headers: authHeaders(),
+        params: { id: secondAutomation.body.id },
+      }),
+      [200],
+    );
+    mocks.clerk.session(
+      first.fixture.userId,
+      first.fixture.orgId,
+      "org:member",
+    );
+    await accept(
+      automationsClient().disable({
+        headers: authHeaders(),
+        params: { id: firstAutomation.body.id },
+      }),
+      [200],
+    );
+  });
+
+  it("does not remap a shared Calendar when provider resources differ", async () => {
+    mockEnv("CRON_SECRET", CRON_SECRET);
+    mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+    const sharedCalendarId = "shared-calendar@example.com";
+    const accessToken = "shared-calendar-token";
+    let watchCalls = 0;
+    let primaryWatchCalls = 0;
+    let stopCalls = 0;
+    server.use(
+      http.get(
+        "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events",
+        () => {
+          return HttpResponse.json({ items: [], nextSyncToken: "shared-sync" });
+        },
+      ),
+      http.get(
+        "https://www.googleapis.com/calendar/v3/calendars/:calendarId",
+        ({ params }) => {
+          return HttpResponse.json({
+            id:
+              params.calendarId === "primary"
+                ? "owner-primary-resource"
+                : "shared-resource",
+          });
+        },
+      ),
+      http.post(
+        "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events/watch",
+        async ({ request, params }) => {
+          if (params.calendarId === "primary") {
+            primaryWatchCalls += 1;
+          }
+          watchCalls += 1;
+          if (watchCalls === 2) {
+            return HttpResponse.json(
+              { error: { status: "NOT_FOUND" } },
+              { status: 404 },
+            );
+          }
+          const body = (await request.json()) as { readonly id: string };
+          return HttpResponse.json({
+            id: body.id,
+            resourceId: "shared-channel-resource",
+            resourceUri: `https://www.googleapis.com/calendar/v3/calendars/${String(params.calendarId)}/events`,
+            expiration: String(now() + 60 * 60 * 1000),
+          });
+        },
+      ),
+      http.post("https://www.googleapis.com/calendar/v3/channels/stop", () => {
+        stopCalls += 1;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    const scenario = await setupFixture();
+    await connectGoogleCalendar(scenario, {
+      accessToken,
+      email: "shared-owner@example.com",
+      subject: "shared-calendar-subject",
+    });
+    const automation = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: scenario.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-calendar-event-created",
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_created",
+            calendarId: sharedCalendarId,
+          },
+        },
+      }),
+      [201],
+    );
+
+    const renewed = await accept(
+      renewGoogleCalendarWatchesClient().renew({
+        headers: { authorization: `Bearer ${CRON_SECRET}` },
+      }),
+      [200],
+    );
+    expect(renewed.body).toStrictEqual({
+      success: true,
+      renewed: 0,
+      failed: 1,
+    });
+    await expect(wf.readAutomation(automation.body.id)).resolves.toMatchObject({
+      eventConfig: { calendarId: sharedCalendarId },
+    });
+    expect(primaryWatchCalls).toBe(0);
+    expect(stopCalls).toBe(0);
+
+    await accept(
+      automationsClient().disable({
+        headers: authHeaders(),
+        params: { id: automation.body.id },
+      }),
+      [200],
+    );
+    expect(stopCalls).toBe(1);
   });
 
   it("leaves a Gmail automation disabled when watch setup fails", async () => {

--- a/turbo/apps/api/src/signals/services/connector-account-state.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-state.service.ts
@@ -3,7 +3,7 @@ import { googleCalendarWatchStates } from "@okouai/db/schema/google-calendar-eve
 import { googleFormsWatchStates } from "@okouai/db/schema/google-forms-event";
 import { googleWorkspaceEventSubscriptionStates } from "@okouai/db/schema/google-workspace-event";
 import { mailDrafts } from "@okouai/db/schema/mail-draft";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import type { Tx } from "../../lib/db-types";
 import { nowDate } from "../../lib/time";
@@ -32,6 +32,18 @@ export async function reconcileConnectorAccountState(
         .set({ emailAddress: args.nextEmail, updatedAt: nowDate() })
         .where(eq(gmailWatchStates.connectorId, args.connectorId));
       signal.throwIfAborted();
+      if (args.previousEmail !== null) {
+        await db
+          .update(googleCalendarWatchStates)
+          .set({ needsRewatch: true, updatedAt: nowDate() })
+          .where(
+            and(
+              eq(googleCalendarWatchStates.connectorId, args.connectorId),
+              eq(googleCalendarWatchStates.calendarId, args.previousEmail),
+            ),
+          );
+        signal.throwIfAborted();
+      }
     }
     return;
   }

--- a/turbo/apps/api/src/signals/services/google-calendar-automation-account.service.ts
+++ b/turbo/apps/api/src/signals/services/google-calendar-automation-account.service.ts
@@ -1,6 +1,13 @@
+import {
+  googleCalendarEventCancelledEventConfigSchema,
+  googleCalendarEventCreatedEventConfigSchema,
+  googleCalendarEventUpdatedEventConfigSchema,
+  type GoogleCalendarAutomationEventConfig,
+} from "@okouai/api-contracts/contracts/workflows";
 import { workflowAutomations } from "@okouai/db/schema/workflow";
 import { and, eq, inArray } from "drizzle-orm";
 
+import { nowDate } from "../../lib/time";
 import type { Db, ReadonlyDb } from "../external/db";
 import { resolveWorkflowAutomationConnectorId } from "./workflow-automation-account.service";
 
@@ -9,6 +16,85 @@ export const GOOGLE_CALENDAR_EVENT_TYPES = [
   "google-calendar-event-updated",
   "google-calendar-event-cancelled",
 ] as const;
+
+export const GOOGLE_CALENDAR_PRIMARY_ID = "primary";
+
+function parseGoogleCalendarAutomationConfig(
+  eventType: string | null,
+  eventConfig: unknown,
+): GoogleCalendarAutomationEventConfig | null {
+  if (eventType === "google-calendar-event-created") {
+    const parsed =
+      googleCalendarEventCreatedEventConfigSchema.safeParse(eventConfig);
+    return parsed.success ? parsed.data : null;
+  }
+  if (eventType === "google-calendar-event-updated") {
+    const parsed =
+      googleCalendarEventUpdatedEventConfigSchema.safeParse(eventConfig);
+    return parsed.success ? parsed.data : null;
+  }
+  if (eventType === "google-calendar-event-cancelled") {
+    const parsed =
+      googleCalendarEventCancelledEventConfigSchema.safeParse(eventConfig);
+    return parsed.success ? parsed.data : null;
+  }
+  return null;
+}
+
+export async function migrateGoogleCalendarAutomationTargets(
+  db: Db,
+  args: {
+    readonly connectorId: string;
+    readonly fromCalendarId: string;
+    readonly toCalendarId: string;
+  },
+  signal: AbortSignal,
+): Promise<number> {
+  const automations = await db
+    .select({
+      id: workflowAutomations.id,
+      eventType: workflowAutomations.eventType,
+      eventConfig: workflowAutomations.eventConfig,
+    })
+    .from(workflowAutomations)
+    .where(
+      and(
+        eq(workflowAutomations.eventConnectorId, args.connectorId),
+        eq(workflowAutomations.kind, "event"),
+        inArray(workflowAutomations.eventType, [
+          ...GOOGLE_CALENDAR_EVENT_TYPES,
+        ]),
+      ),
+    );
+  signal.throwIfAborted();
+
+  const currentTime = nowDate();
+  let migrated = 0;
+  for (const automation of automations) {
+    const config = parseGoogleCalendarAutomationConfig(
+      automation.eventType,
+      automation.eventConfig,
+    );
+    if (config === null || config.calendarId !== args.fromCalendarId) {
+      continue;
+    }
+    await db
+      .update(workflowAutomations)
+      .set({
+        eventConfig: { ...config, calendarId: args.toCalendarId },
+        updatedAt: currentTime,
+      })
+      .where(
+        and(
+          eq(workflowAutomations.id, automation.id),
+          eq(workflowAutomations.eventConnectorId, args.connectorId),
+        ),
+      );
+    signal.throwIfAborted();
+    migrated += 1;
+  }
+  return migrated;
+}
 
 export async function resolveGoogleCalendarAutomationConnectorId(
   db: ReadonlyDb,

--- a/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
@@ -46,7 +46,9 @@ import type { WorkflowAutomationContext } from "./workflow-automation-context.se
 import { workflowAutomationCanFire } from "./workflow-automation-access.service";
 import { ensureWorkflowUserAutomationThread } from "./workflow-user-automation-thread.service";
 import {
+  GOOGLE_CALENDAR_PRIMARY_ID,
   GOOGLE_CALENDAR_EVENT_TYPES,
+  migrateGoogleCalendarAutomationTargets,
   reprojectGoogleCalendarAutomationsForOwner,
 } from "./google-calendar-automation-account.service";
 
@@ -59,7 +61,6 @@ const WATCH_RENEWAL_WINDOW_MS = 24 * 60 * 60 * 1000;
 const WATCH_TTL_SECONDS = 7 * 24 * 60 * 60;
 const WATCH_LIFECYCLE_TIMEOUT_MS = 30 * 1000;
 const CALENDAR_EVENTS_PAGE_SIZE = 2500;
-const DEFAULT_CALENDAR_ID = "primary";
 const ATTENDEE_PROMPT_LIMIT = 20;
 interface GoogleCalendarAccess {
   readonly connectorId: string;
@@ -71,9 +72,19 @@ type GoogleCalendarAccessResult =
   | { readonly kind: "ok"; readonly access: GoogleCalendarAccess }
   | { readonly kind: "bad_request"; readonly message: string };
 
+interface GoogleCalendarProviderFailure {
+  readonly stage: "watch_registration";
+  readonly status: number;
+  readonly reason: string;
+}
+
 type EnsureGoogleCalendarWatchResult =
   | { readonly kind: "ok" }
-  | { readonly kind: "bad_request"; readonly message: string };
+  | {
+      readonly kind: "bad_request";
+      readonly message: string;
+      readonly providerFailure?: GoogleCalendarProviderFailure;
+    };
 
 type GoogleCalendarWatchReconcileResult =
   | { readonly kind: "unchanged" }
@@ -102,6 +113,8 @@ const calendarWatchResponseSchema = z.object({
   resourceUri: z.string(),
   expiration: z.union([z.string(), z.number()]).optional(),
 });
+
+const calendarResourceSchema = z.object({ id: z.string() });
 
 const calendarEventDateTimeSchema = z
   .object({
@@ -299,6 +312,40 @@ function tokenNeedsRefresh(
   );
 }
 
+export async function normalizeGoogleCalendarIdForConnector(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly connectorId: string;
+    readonly calendarId: string;
+  },
+  signal: AbortSignal,
+): Promise<string> {
+  if (args.calendarId === GOOGLE_CALENDAR_PRIMARY_ID) {
+    return args.calendarId;
+  }
+  const snapshot = await loadConnectorRuntimeSnapshot(db);
+  signal.throwIfAborted();
+  const loaded = await loadConnectorCredentialConnection({
+    db,
+    snapshot,
+    orgId: args.orgId,
+    userId: args.userId,
+    connectorSlug: "google-calendar",
+    connectorId: args.connectorId,
+  });
+  signal.throwIfAborted();
+  if (loaded.kind === "missing" || loaded.kind === "unavailable") {
+    return args.calendarId;
+  }
+  const emailAddress = loaded.connection.externalEmail;
+  return emailAddress !== null &&
+    emailAddress.toLowerCase() === args.calendarId.toLowerCase()
+    ? GOOGLE_CALENDAR_PRIMARY_ID
+    : args.calendarId;
+}
+
 async function resolveGoogleCalendarAccess(
   args: {
     readonly db: Db;
@@ -421,6 +468,58 @@ function googleCalendarWebhookUrl(): string {
   return new URL("/api/webhooks/google-calendar", baseUrl).toString();
 }
 
+function googleCalendarProviderReason(status: number): string {
+  if (status === 0) {
+    return "request_failed";
+  }
+  if (status === 400) {
+    return "invalid_request";
+  }
+  if (status === 401) {
+    return "unauthorized";
+  }
+  if (status === 403) {
+    return "forbidden";
+  }
+  if (status === 404) {
+    return "not_found";
+  }
+  if (status === 409) {
+    return "conflict";
+  }
+  if (status === 429) {
+    return "rate_limited";
+  }
+  if (status >= 500) {
+    return "provider_unavailable";
+  }
+  return "provider_error";
+}
+
+function calendarWatchProviderFailure(
+  status: number,
+): GoogleCalendarProviderFailure {
+  return {
+    stage: "watch_registration",
+    status,
+    reason: googleCalendarProviderReason(status),
+  };
+}
+
+function logCalendarWatchProviderFailure(
+  action: "ensure" | "renew",
+  failure: GoogleCalendarProviderFailure,
+): void {
+  log.warn("Workflow watch lifecycle reconciliation failed", {
+    provider: "google_calendar",
+    action,
+    result: "provider_error",
+    stage: failure.stage,
+    status: failure.status,
+    reason: failure.reason,
+  });
+}
+
 async function googleCalendarFetchJson<T>(
   schema: z.ZodType<T>,
   accessToken: string,
@@ -540,6 +639,36 @@ async function watchCalendarEvents(
   );
 }
 
+async function calendarTargetsResolveToSameResource(
+  args: {
+    readonly accessToken: string;
+    readonly firstCalendarId: string;
+    readonly secondCalendarId: string;
+  },
+  signal: AbortSignal,
+): Promise<boolean> {
+  const first = await googleCalendarFetchJson(
+    calendarResourceSchema,
+    args.accessToken,
+    calendarApiUrl(`/calendars/${encodeURIComponent(args.firstCalendarId)}`),
+    { method: "GET" },
+    signal,
+  );
+  signal.throwIfAborted();
+  if (first.kind !== "ok") {
+    return false;
+  }
+  const second = await googleCalendarFetchJson(
+    calendarResourceSchema,
+    args.accessToken,
+    calendarApiUrl(`/calendars/${encodeURIComponent(args.secondCalendarId)}`),
+    { method: "GET" },
+    signal,
+  );
+  signal.throwIfAborted();
+  return second.kind === "ok" && first.value.id === second.value.id;
+}
+
 async function stopCalendarChannel(
   args: {
     readonly accessToken: string;
@@ -564,6 +693,9 @@ async function stopCalendarChannel(
   );
   signal.throwIfAborted();
   if (result.kind !== "ok") {
+    if (result.status === 404) {
+      return true;
+    }
     log.warn("Failed to stop Google Calendar watch channel", {
       provider: "google_calendar",
       action: "stop",
@@ -1575,7 +1707,11 @@ async function activatePreparedCalendarWatch(args: {
   readonly allowStagedOfficialTarget?: boolean;
 }): Promise<
   | { readonly kind: "ok"; readonly state: GoogleCalendarWatchStateRow }
-  | { readonly kind: "bad_request"; readonly message: string }
+  | {
+      readonly kind: "bad_request";
+      readonly message: string;
+      readonly providerFailure?: GoogleCalendarProviderFailure;
+    }
 > {
   const lifecycleSignal = AbortSignal.timeout(WATCH_LIFECYCLE_TIMEOUT_MS);
   const watch = await tapError(
@@ -1595,6 +1731,9 @@ async function activatePreparedCalendarWatch(args: {
       kind: "bad_request",
       message:
         "Failed to register Google Calendar watch for event automation setup",
+      providerFailure: calendarWatchProviderFailure(
+        watch?.kind === "error" ? watch.status : 0,
+      ),
     };
   }
 
@@ -1659,7 +1798,7 @@ export async function ensureGoogleCalendarWatchForUser(
   },
   signal: AbortSignal,
 ): Promise<EnsureGoogleCalendarWatchResult> {
-  const calendarId = args.calendarId ?? DEFAULT_CALENDAR_ID;
+  const calendarId = args.calendarId ?? GOOGLE_CALENDAR_PRIMARY_ID;
   const accessResult = await resolveGoogleCalendarAccess(args, signal);
   signal.throwIfAborted();
   if (accessResult.kind !== "ok") {
@@ -1758,10 +1897,197 @@ export async function ensureGoogleCalendarWatchForUser(
       action: "ensure",
       result: "ok",
     });
+  } else if (registered.providerFailure) {
+    logCalendarWatchProviderFailure("ensure", registered.providerFailure);
   }
   return registered.kind === "ok"
     ? { kind: "ok" }
-    : { kind: "bad_request", message: registered.message };
+    : {
+        kind: "bad_request",
+        message: registered.message,
+        ...(registered.providerFailure
+          ? { providerFailure: registered.providerFailure }
+          : {}),
+      };
+}
+
+interface LegacyPrimaryCalendarMigrationArgs {
+  readonly db: Db;
+  readonly access: GoogleCalendarAccess;
+  readonly legacyCalendarId: string;
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+async function persistLegacyPrimaryCalendarMigration(
+  args: LegacyPrimaryCalendarMigrationArgs,
+  signal: AbortSignal,
+): Promise<GoogleCalendarWatchStateRow | null> {
+  return await args.db.transaction(async (tx) => {
+    await lockConnectorAccountTarget(tx, {
+      orgId: args.orgId,
+      userId: args.userId,
+      target: { kind: "builtin", connectorSlug: "google-calendar" },
+    });
+    await lockGoogleCalendarLifecycle(
+      tx,
+      args.access.connectorId,
+      args.legacyCalendarId,
+    );
+    await lockGoogleCalendarLifecycle(
+      tx,
+      args.access.connectorId,
+      GOOGLE_CALENDAR_PRIMARY_ID,
+    );
+    signal.throwIfAborted();
+
+    const legacyState = await loadCalendarWatchState(
+      {
+        db: tx,
+        connectorId: args.access.connectorId,
+        calendarId: args.legacyCalendarId,
+      },
+      signal,
+    );
+    const primaryState = await loadCalendarWatchState(
+      {
+        db: tx,
+        connectorId: args.access.connectorId,
+        calendarId: GOOGLE_CALENDAR_PRIMARY_ID,
+      },
+      signal,
+    );
+    if (
+      !legacyState ||
+      !primaryState ||
+      legacyState.resourceId.length === 0 ||
+      primaryState.resourceId.length === 0 ||
+      previousCalendarChannel(primaryState)
+    ) {
+      return null;
+    }
+    const hasLegacyConsumer = await hasEnabledGoogleCalendarConsumer(
+      {
+        db: tx,
+        orgId: args.orgId,
+        userId: args.userId,
+        connectorId: args.access.connectorId,
+        calendarId: args.legacyCalendarId,
+      },
+      signal,
+    );
+    if (!hasLegacyConsumer) {
+      return null;
+    }
+
+    const migrated = await migrateGoogleCalendarAutomationTargets(
+      tx,
+      {
+        connectorId: args.access.connectorId,
+        fromCalendarId: args.legacyCalendarId,
+        toCalendarId: GOOGLE_CALENDAR_PRIMARY_ID,
+      },
+      signal,
+    );
+    if (migrated === 0) {
+      return null;
+    }
+    const currentTime = nowDate();
+    const [updated] = await tx
+      .update(googleCalendarWatchStates)
+      .set({
+        previousChannelId: legacyState.channelId,
+        previousChannelToken: legacyState.channelToken,
+        previousResourceId: legacyState.resourceId,
+        updatedAt: currentTime,
+      })
+      .where(
+        and(
+          eq(googleCalendarWatchStates.id, primaryState.id),
+          isNull(googleCalendarWatchStates.previousChannelId),
+          isNull(googleCalendarWatchStates.previousChannelToken),
+          isNull(googleCalendarWatchStates.previousResourceId),
+        ),
+      )
+      .returning();
+    if (!updated) {
+      throw new Error("Failed to stage legacy Google Calendar watch cleanup");
+    }
+    await tx
+      .delete(googleCalendarWatchStates)
+      .where(eq(googleCalendarWatchStates.id, legacyState.id));
+    signal.throwIfAborted();
+    return updated;
+  });
+}
+
+async function migrateLegacyPrimaryCalendarWatch(
+  args: LegacyPrimaryCalendarMigrationArgs,
+  signal: AbortSignal,
+): Promise<boolean> {
+  const sameResource = await calendarTargetsResolveToSameResource(
+    {
+      accessToken: args.access.accessToken,
+      firstCalendarId: args.legacyCalendarId,
+      secondCalendarId: GOOGLE_CALENDAR_PRIMARY_ID,
+    },
+    signal,
+  );
+  if (!sameResource) {
+    return false;
+  }
+
+  const ensured = await ensureGoogleCalendarWatchForUser(
+    {
+      db: args.db,
+      orgId: args.orgId,
+      userId: args.userId,
+      connectorId: args.access.connectorId,
+      calendarId: GOOGLE_CALENDAR_PRIMARY_ID,
+      allowStagedOfficialTarget: true,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+  if (ensured.kind !== "ok") {
+    return false;
+  }
+
+  const migratedState = await persistLegacyPrimaryCalendarMigration(
+    args,
+    signal,
+  );
+
+  if (!migratedState) {
+    await reconcileGoogleCalendarWatchState(
+      {
+        db: args.db,
+        connectorId: args.access.connectorId,
+        calendarId: GOOGLE_CALENDAR_PRIMARY_ID,
+      },
+      signal,
+    );
+    return false;
+  }
+
+  const previous = previousCalendarChannel(migratedState);
+  if (previous) {
+    const stopped = await stopCalendarChannelWithLifecycleOwnership({
+      accessToken: args.access.accessToken,
+      channel: previous,
+    });
+    if (stopped) {
+      await clearPreviousCalendarChannel({
+        db: args.db,
+        access: args.access,
+        calendarId: GOOGLE_CALENDAR_PRIMARY_ID,
+        stateId: migratedState.id,
+        currentChannelId: migratedState.channelId,
+        previousChannelId: previous.channelId,
+      });
+    }
+  }
+  return true;
 }
 
 type GoogleCalendarWatchReconcileDecision =
@@ -1770,6 +2096,7 @@ type GoogleCalendarWatchReconcileDecision =
       readonly kind: "prepared";
       readonly access: GoogleCalendarAccess;
       readonly prepared: PreparedGoogleCalendarWatch;
+      readonly state: GoogleCalendarWatchStateRow;
     };
 
 function calendarWatchRenewalDue(args: {
@@ -1869,6 +2196,7 @@ async function prepareCalendarWatchRenewal(
     kind: "prepared",
     access: args.access,
     prepared: prepared.prepared,
+    state: args.state,
   };
 }
 
@@ -2052,11 +2380,42 @@ async function reconcileGoogleCalendarWatchState(
     prepared: decision.prepared,
   });
   if (registered.kind !== "ok") {
-    log.warn("Workflow watch lifecycle reconciliation failed", {
-      provider: "google_calendar",
-      action: "renew",
-      result: "provider_error",
-    });
+    if (
+      registered.providerFailure?.status === 404 &&
+      args.calendarId !== GOOGLE_CALENDAR_PRIMARY_ID
+    ) {
+      const migrated = await migrateLegacyPrimaryCalendarWatch(
+        {
+          db: args.db,
+          access: decision.access,
+          legacyCalendarId: args.calendarId,
+          orgId: decision.state.orgId,
+          userId: decision.state.userId,
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+      if (migrated) {
+        log.debug("Workflow watch lifecycle reconciled", {
+          provider: "google_calendar",
+          action: "migrate_primary",
+          result: "ok",
+          stage: registered.providerFailure.stage,
+          status: registered.providerFailure.status,
+          reason: registered.providerFailure.reason,
+        });
+        return { kind: "renewed" };
+      }
+    }
+    if (registered.providerFailure) {
+      logCalendarWatchProviderFailure("renew", registered.providerFailure);
+    } else {
+      log.warn("Workflow watch lifecycle reconciliation failed", {
+        provider: "google_calendar",
+        action: "renew",
+        result: "provider_error",
+      });
+    }
     return { kind: "failed" };
   }
   log.debug("Workflow watch lifecycle reconciled", {

--- a/turbo/apps/api/src/signals/services/workflow-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation.service.ts
@@ -100,6 +100,7 @@ import {
 import {
   ensureGoogleCalendarWatchForUser,
   hasEnabledGoogleCalendarConsumer,
+  normalizeGoogleCalendarIdForConnector,
 } from "./google-calendar-automation-event.service";
 import { resolveGoogleCalendarAutomationConnectorId } from "./google-calendar-automation-account.service";
 import {
@@ -2211,10 +2212,22 @@ async function createGoogleCalendarEventAutomationForWorkflow(
         "Connect Google Calendar before adding a Google Calendar event automation",
     };
   }
-  const preparedConfig = parseGoogleCalendarEventConfig(
+  const parsedConfig = parseGoogleCalendarEventConfig(
     args.input.eventType,
     args.input.eventConfig,
   );
+  const calendarId = await normalizeGoogleCalendarIdForConnector(
+    args.context.db,
+    {
+      orgId: args.input.orgId,
+      userId: args.input.member.userId,
+      connectorId: eventConnectorId,
+      calendarId: parsedConfig.calendarId,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+  const preparedConfig = { ...parsedConfig, calendarId };
   const hadConsumer = args.input.enabled
     ? await hasEnabledGoogleCalendarConsumer(
         {
@@ -3639,8 +3652,23 @@ async function prepareOfficialGoogleCalendarEvent(
         "Connect Google Calendar before adding a Google Calendar event automation",
     };
   }
+  const parsedConfig = parseGoogleCalendarEventConfig(
+    input.eventType,
+    input.eventConfig,
+  );
+  const calendarId = await normalizeGoogleCalendarIdForConnector(
+    db,
+    {
+      orgId: input.orgId,
+      userId: input.member.userId,
+      connectorId: eventConnectorId,
+      calendarId: parsedConfig.calendarId,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
   return preparedOfficialEvent(
-    parseGoogleCalendarEventConfig(input.eventType, input.eventConfig),
+    { ...parsedConfig, calendarId },
     { eventConnectorId },
   );
 }
@@ -5123,6 +5151,26 @@ async function lockEnabledAutomationAccountProjection(
       automation.eventConfig,
       eventConnectorId,
     );
+  } else if (provider === "google-calendar") {
+    if (!supportedGoogleCalendarEventType(automation.eventType)) {
+      throw new Error("Expected a Google Calendar event automation");
+    }
+    const parsedConfig = parseGoogleCalendarEventConfig(
+      automation.eventType,
+      automation.eventConfig,
+    );
+    const calendarId = await normalizeGoogleCalendarIdForConnector(
+      db,
+      {
+        orgId: automation.orgId,
+        userId: automation.ownerUserId,
+        connectorId: eventConnectorId,
+        calendarId: parsedConfig.calendarId,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    eventConfig = { ...parsedConfig, calendarId };
   } else if (provider === "google-forms") {
     eventConfig = await projectGoogleFormsEnabledEventConfig(
       db,


### PR DESCRIPTION
## Summary

- normalize the selected Google Calendar account's own email target to Google's stable `primary` selector during creation, official reconfiguration, and re-enablement
- recover legacy email-based watches after a registration `404` only when the same connector token proves that the legacy target and `primary` resolve to the same canonical calendar resource
- register and baseline the replacement watch before atomically migrating exact-connector automation configs and watch state, then retire the legacy channel without a webhook recognition gap
- keep shared and secondary calendars fail-closed, mark legacy watch state for reconciliation after a same-principal email change, and retain structured provider stage/status/reason diagnostics

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- targeted Calendar lifecycle integration coverage: 3 passed (primary self-heal, exact-account isolation, shared-calendar fail-closed)

Closes #31096
