### PR TITLE
fix(python): stop starred tails changing fixed first arguments

### DIFF
--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/ast_helpers.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/ast_helpers.py
@@ -80,10 +80,11 @@ def _deduplicate_static_argument_outcomes(
 
 
 def _static_iterable_first_outcomes(node: ast.AST) -> tuple[list[ast.AST | None], bool]:
-    """Return ordered first-node/empty outcomes and whether any expansion is unknown.
+    """Return ordered first-node/empty outcomes and whether a first outcome is unknown.
 
     ``None`` represents a statically empty expansion. The unknown flag remains separate because
-    the linter conservatively treats any dynamic nested expansion as a possible empty call prefix.
+    the linter conservatively treats a dynamic expansion before a fixed first node as a possible
+    empty call prefix.
     """
     if isinstance(node, ast.NamedExpr):
         return _static_iterable_first_outcomes(node.value)
@@ -109,6 +110,8 @@ def _static_iterable_first_outcomes(node: ast.AST) -> tuple[list[ast.AST | None]
     outcomes: list[ast.AST | None] = [None]
     has_unknown_expansion = False
     for element in node.elts:
+        if not any(outcome is None for outcome in outcomes):
+            break
         if isinstance(element, ast.Starred):
             element_outcomes, element_has_unknown_expansion = _static_iterable_first_outcomes(
                 element.value
@@ -116,16 +119,15 @@ def _static_iterable_first_outcomes(node: ast.AST) -> tuple[list[ast.AST | None]
         else:
             element_outcomes = [element]
             element_has_unknown_expansion = False
-        if any(outcome is None for outcome in outcomes):
-            next_outcomes: list[ast.AST | None] = []
-            for outcome in outcomes:
-                if outcome is None:
-                    next_outcomes.extend(element_outcomes)
-                else:
-                    next_outcomes.append(outcome)
-            if element_has_unknown_expansion:
-                next_outcomes.extend(outcomes)
-            outcomes = _deduplicate_static_argument_outcomes(next_outcomes)
+        next_outcomes: list[ast.AST | None] = []
+        for outcome in outcomes:
+            if outcome is None:
+                next_outcomes.extend(element_outcomes)
+            else:
+                next_outcomes.append(outcome)
+        if element_has_unknown_expansion:
+            next_outcomes.extend(outcomes)
+        outcomes = _deduplicate_static_argument_outcomes(next_outcomes)
         has_unknown_expansion = has_unknown_expansion or element_has_unknown_expansion
     return outcomes, has_unknown_expansion
 

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/fixed_first_starred_tail.base.py.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/fixed_first_starred_tail.base.py.txt
@@ -1,0 +1,2 @@
+args = ()
+value = flow.metadata.get(*["external_key", *args], "sandbox_run_id")

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -260,6 +260,15 @@ def test_registered_flow_metadata_guard_flags_literals_after_dynamic_star_args(t
     )
 
 
+def test_registered_flow_metadata_guard_ignores_literals_after_fixed_starred_prefix(tmp_path):
+    source_path = tmp_path / "fixed_first_starred_tail.py"
+    _write_python_source(source_path, "fixed_first_starred_tail.base.py.txt")
+
+    violations = flow_metadata_key_linter.metadata_key_violations(source_path)
+
+    assert violations == []
+
+
 def test_registered_flow_metadata_guard_flags_composed_iterables(tmp_path):
     source_path = tmp_path / "composed_iterables.py"
     _write_python_source(source_path, "composed_iterables.base.py.txt")


### PR DESCRIPTION
## Summary

- stop nested list and tuple analysis once every possible first argument is fixed
- keep conservative first-argument handling for dynamic leading expansions
- cover the fixed-prefix case through the public flow-metadata linter API

## Exclusions

- no metadata registry, addon runtime, API, schema, or deployment behavior changes

## Validation

- `uv run --no-sync python -m pytest tests/test_flow_metadata_key_contract.py`
- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `./scripts/check-flow-metadata-keys.py`
- `uv run --no-sync python -m pytest tests/`

Closes #31056
