### PR TITLE
fix(platform): prevent desktop viewport pinch zoom

### DIFF
--- a/turbo/apps/platform/src/lib/viewport-pinch.ts
+++ b/turbo/apps/platform/src/lib/viewport-pinch.ts
@@ -1,0 +1,31 @@
+const ZOOMABLE_IMAGE_CANVAS_SELECTOR = "[data-zoomable-image-canvas='true']";
+
+function isZoomableImageCanvasEvent(event: Event): boolean {
+  return (
+    event.target instanceof Element &&
+    event.target.closest(ZOOMABLE_IMAGE_CANVAS_SELECTOR) !== null
+  );
+}
+
+function preventViewportPinch(event: Event): void {
+  if (!isZoomableImageCanvasEvent(event)) {
+    event.preventDefault();
+  }
+}
+
+function preventViewportWheelZoom(event: WheelEvent): void {
+  if (event.ctrlKey) {
+    preventViewportPinch(event);
+  }
+}
+
+export function setupViewportPinchPrevention(signal: AbortSignal): void {
+  const options: AddEventListenerOptions = {
+    capture: true,
+    passive: false,
+    signal,
+  };
+  document.addEventListener("wheel", preventViewportWheelZoom, options);
+  document.addEventListener("gesturestart", preventViewportPinch, options);
+  document.addEventListener("gesturechange", preventViewportPinch, options);
+}

--- a/turbo/apps/platform/src/views/main.tsx
+++ b/turbo/apps/platform/src/views/main.tsx
@@ -16,6 +16,7 @@ import {
   isStandalonePwa,
   setupKeyboardDismissGesture,
 } from "../lib/keyboard-dismiss-gesture.ts";
+import { setupViewportPinchPrevention } from "../lib/viewport-pinch.ts";
 import { IN_VITEST } from "../env.ts";
 import "./css/index.css";
 
@@ -52,6 +53,7 @@ export const setupRouter = (
   render: (children: React.ReactNode) => void,
 ) => {
   const signal = store.get(rootSignal$);
+  setupViewportPinchPrevention(signal);
   if (isStandalonePwa()) {
     const cleanupKeyboardDismissGesture = setupKeyboardDismissGesture();
     signal.addEventListener("abort", cleanupKeyboardDismissGesture, {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/attachment-chips.test.tsx
@@ -521,6 +521,42 @@ describe("zero attachment chips", () => {
     });
   });
 
+  it("prevents viewport pinch outside the image preview canvas", async () => {
+    await setupUploadedImagePreview();
+
+    const composer = screen.getByPlaceholderText(PLACEHOLDER);
+    const wheelPinchEvent = zoomWheelEvent(composer, {
+      clientX: 0,
+      clientY: 0,
+      ctrlKey: true,
+      deltaY: -20,
+    });
+    fireEvent(composer, wheelPinchEvent);
+    expect(wheelPinchEvent.defaultPrevented).toBeTruthy();
+
+    const scrollEvent = createEvent.wheel(composer, { deltaY: 20 });
+    fireEvent(composer, scrollEvent);
+    expect(scrollEvent.defaultPrevented).toBeFalsy();
+
+    for (const eventName of ["gesturestart", "gesturechange"]) {
+      const safariPinchEvent = new Event(eventName, {
+        bubbles: true,
+        cancelable: true,
+      });
+      fireEvent(composer, safariPinchEvent);
+      expect(safariPinchEvent.defaultPrevented).toBeTruthy();
+    }
+
+    click(screen.getByLabelText("Open image preview for photo.png"));
+    const zoomStage = await screen.findByTestId("artifact-dialog-image-stage");
+    const previewPinchEvent = new Event("gesturestart", {
+      bubbles: true,
+      cancelable: true,
+    });
+    fireEvent(zoomStage, previewPinchEvent);
+    expect(previewPinchEvent.defaultPrevented).toBeFalsy();
+  });
+
   it("zooms an uploaded image preview and resets its canvas when reopened", async () => {
     await setupUploadedImagePreview();
 


### PR DESCRIPTION
## Summary

- prevent desktop viewport zoom from trackpad pinch and Control-modified wheel input
- cancel Safari gesture events while preserving ordinary wheel scrolling
- exempt the shared zoomable image canvas so product preview zoom keeps its existing trackpad, Command, and touch behavior
- bind the global listeners to the platform root lifecycle

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/attachment-chips.test.tsx` (51 passed)
