### PR TITLE
fix(cli): render camera moves with zoompan instead of resizing crop

### DIFF
--- a/turbo/apps/cli/src/commands/video/__tests__/camera.test.ts
+++ b/turbo/apps/cli/src/commands/video/__tests__/camera.test.ts
@@ -2,7 +2,10 @@
  * Integration tests for the click-driven camera command.
  *
  * Only ffmpeg and ffprobe are mocked. The command parses real sidecars, writes
- * real camera plans and command files, and exercises Commander end to end.
+ * real camera plans, and exercises Commander end to end. The mock records the
+ * generated `-vf` filter so the render geometry can be asserted; ffmpeg itself
+ * never runs here, so these tests cannot catch a filter that real ffmpeg
+ * rejects.
  */
 
 import { execFileSync } from "child_process";
@@ -13,7 +16,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cameraCommand } from "../camera";
 
 vi.mock("child_process", async () => {
-  const { readFileSync, writeFileSync } =
+  const { writeFileSync } =
     await vi.importActual<typeof import("node:fs")>("node:fs");
   return {
     execFileSync: vi.fn((command: string, args: readonly string[]) => {
@@ -33,10 +36,9 @@ vi.mock("child_process", async () => {
       if (command === "ffmpeg") {
         const filterIndex = args.indexOf("-vf");
         const filter = filterIndex >= 0 ? args[filterIndex + 1] : undefined;
-        const commandsPath = filter?.match(/sendcmd=f='([^']+)'/)?.[1];
         const outputPath = args.at(-1);
-        if (commandsPath && outputPath) {
-          writeFileSync(outputPath, readFileSync(commandsPath));
+        if (filter && outputPath) {
+          writeFileSync(outputPath, filter);
         }
       }
       return Buffer.from("");
@@ -162,16 +164,22 @@ describe("okou video camera command", () => {
       }),
     );
 
-    const generatedCommands = readFileSync(outputPath, "utf8");
-    expect(generatedCommands).toContain("crop@camera w 1920.000000");
-    expect(generatedCommands).toContain("crop@camera w 960.000000");
+    // libavfilter cannot resize a filter output link at runtime, so the render
+    // must keep a fixed output size and move a sampling window instead of
+    // animating `crop`.
+    const renderedFilter = readFileSync(outputPath, "utf8");
+    expect(renderedFilter).toContain("zoompan=");
+    expect(renderedFilter).toContain(":d=1:s=1920x1080");
+    expect(renderedFilter).not.toContain("sendcmd");
+    expect(renderedFilter).not.toContain("crop@camera");
+    expect(renderedFilter).toContain("2.000000");
     const ffmpegCall = vi.mocked(execFileSync).mock.calls.find((call) => {
       return call[0] === "ffmpeg";
     });
     expect(ffmpegCall?.[1]).toEqual(
       expect.arrayContaining([
         "-vf",
-        expect.stringContaining("sendcmd="),
+        expect.stringContaining("zoompan="),
         "-map",
         "0:a?",
         "-c:v",
@@ -243,6 +251,36 @@ describe("okou video camera command", () => {
     ]);
   });
 
+  it("rejects a sidecar whose timestamps are not recording-relative", async () => {
+    const videoPath = join(directory, "recording.mp4");
+    const eventsPath = join(directory, "recording.clicks.json");
+    const outputPath = join(directory, "draft.mp4");
+    writeFileSync(videoPath, Buffer.from("source-video"));
+    writeFileSync(
+      eventsPath,
+      JSON.stringify({
+        version: 1,
+        recording: {
+          durationMs: 10_000,
+          video: { width: 1920, height: 1080, frameRate: 30 },
+        },
+        // A desktop recorder emitted these from a monotonic system clock rather
+        // than from the recording start, so none of them land in the video.
+        clicks: [
+          { tMs: 8_191_037_307, normalized: { x: 0.45, y: 0.48 } },
+          { tMs: 8_191_786_602, normalized: { x: 0.52, y: 0.96 } },
+        ],
+      }),
+    );
+
+    await expect(
+      cameraCommand.parseAsync(
+        ["--file", videoPath, "--events", eventsPath, "--output", outputPath],
+        { from: "user" },
+      ),
+    ).rejects.toThrow(/not relative to the recording start/u);
+  });
+
   it("renders an AI-edited camera plan without regenerating it", async () => {
     const videoPath = join(directory, "recording.mp4");
     const planPath = join(directory, "edited.camera-plan.json");
@@ -285,9 +323,9 @@ describe("okou video camera command", () => {
 
     const result = JSON.parse(stdout()) as { planPath: string };
     expect(result.planPath).toBe(planPath);
-    expect(readFileSync(outputPath, "utf8")).toContain(
-      "crop@camera w 1280.000000",
-    );
+    const renderedFilter = readFileSync(outputPath, "utf8");
+    expect(renderedFilter).toContain("zoompan=");
+    expect(renderedFilter).toContain("1.500000");
     const unchangedPlan = JSON.parse(readFileSync(planPath, "utf8")) as {
       ranges: { scale: number }[];
     };

--- a/turbo/apps/cli/src/commands/video/camera-plan.ts
+++ b/turbo/apps/cli/src/commands/video/camera-plan.ts
@@ -424,9 +424,24 @@ export function createCameraPlan(
     throw new Error("Pointer events do not match the source video duration");
   }
 
-  const samples = samplesFromTrack(track).filter((sample) => {
+  const allSamples = samplesFromTrack(track);
+  const samples = allSamples.filter((sample) => {
     return sample.tMs <= source.durationMs;
   });
+  // A recording with no pointer events legitimately produces no camera moves.
+  // Events that all sit outside the recording mean the sidecar's tMs values are
+  // not relative to the recording start, which previously produced an empty
+  // plan and a silent plain transcode that looked like a successful render.
+  if (allSamples.length > 0 && samples.length === 0) {
+    const first = allSamples[0];
+    const last = allSamples.at(-1);
+    throw new Error(
+      `Pointer event timestamps are not relative to the recording start: ` +
+        `events span ${String(first?.tMs)}ms-${String(last?.tMs)}ms but the ` +
+        `recording is ${String(source.durationMs)}ms long. No camera moves ` +
+        `can be derived from this sidecar`,
+    );
+  }
   const ranges = cameraWindows(samples, source.durationMs).map(
     (window, rangeIndex) => {
       return {
@@ -601,13 +616,145 @@ export function createCameraFrameStates(
   return frames;
 }
 
-export function createFfmpegCameraCommands(plan: CameraPlan): string {
-  const commands = createCameraFrameStates(plan).map((frame) => {
-    return `${commandNumber(frame.timeMs / 1_000)} crop@camera w ${commandNumber(
-      frame.cropWidth,
-    )}, crop@camera h ${commandNumber(frame.cropHeight)}, crop@camera x ${commandNumber(
-      frame.cropX,
-    )}, crop@camera y ${commandNumber(frame.cropY)};`;
-  });
-  return `${commands.join("\n")}\n`;
+interface CameraSegment {
+  readonly startMs: number;
+  readonly from: CameraTransform;
+  readonly to: CameraTransform;
+}
+
+/**
+ * The camera is a chain of spring settles: it only changes course when the
+ * active focus changes, and coasts on a closed-form spring in between. Walking
+ * frames the same way `createCameraFrameStates` does keeps the two in step,
+ * but recording just the course changes turns the whole animation into a short
+ * piecewise expression instead of one command per frame.
+ */
+function cameraSegments(plan: CameraPlan): readonly CameraSegment[] {
+  const frameCount = Math.max(
+    1,
+    Math.ceil((plan.source.durationMs / 1_000) * plan.source.frameRate),
+  );
+  const initial: CameraTransform = {
+    scale: 1,
+    translationX: 0,
+    translationY: 0,
+  };
+  let activeTarget = targetAt(plan, 0);
+  let transitionStartMs = 0;
+  let transitionFrom = initial;
+  const segments: CameraSegment[] = [
+    { startMs: 0, from: initial, to: activeTarget },
+  ];
+
+  for (let frameIndex = 0; frameIndex < frameCount; frameIndex += 1) {
+    const timeMs = (frameIndex * 1_000) / plan.source.frameRate;
+    const target = targetAt(plan, timeMs);
+    if (target.key !== activeTarget.key) {
+      const current = interpolate(
+        transitionFrom,
+        activeTarget,
+        springProgress(timeMs - transitionStartMs),
+      );
+      transitionFrom = current;
+      transitionStartMs = timeMs;
+      activeTarget = target;
+      segments.push({ startMs: timeMs, from: current, to: target });
+    }
+  }
+  return segments;
+}
+
+const SPRING_DECAY = SPRING_DAMPING / (2 * SPRING_MASS);
+const SPRING_FREQUENCY = Math.sqrt(
+  Math.max(0, SPRING_STIFFNESS / SPRING_MASS - SPRING_DECAY * SPRING_DECAY),
+);
+
+/** `springProgress` written in ffmpeg expression syntax, over `timeExpression` seconds. */
+function springExpression(
+  startSeconds: number,
+  timeExpression: string,
+): string {
+  const elapsed = `(${timeExpression}-${commandNumber(startSeconds)})`;
+  const response =
+    `(1-exp(${commandNumber(-SPRING_DECAY)}*${elapsed})*` +
+    `(cos(${commandNumber(SPRING_FREQUENCY)}*${elapsed})+` +
+    `${commandNumber(SPRING_DECAY / SPRING_FREQUENCY)}*` +
+    `sin(${commandNumber(SPRING_FREQUENCY)}*${elapsed})))`;
+  return `if(gt(${response},${commandNumber(1 - SPRING_PRECISION)}),1,max(0,${response}))`;
+}
+
+/**
+ * Sum of one term per segment. The windows are half-open so exactly one term is
+ * ever non-zero, which keeps the expression flat instead of deeply nested.
+ */
+function piecewiseExpression(
+  segments: readonly CameraSegment[],
+  select: (transform: CameraTransform) => number,
+  timeExpression: string,
+  endSeconds: number,
+): string {
+  return segments
+    .map((segment, index) => {
+      const startSeconds = segment.startMs / 1_000;
+      const next = segments[index + 1];
+      const stopSeconds = next ? next.startMs / 1_000 : endSeconds;
+      const from = select(segment.from);
+      const to = select(segment.to);
+      const value =
+        from === to
+          ? commandNumber(from)
+          : `(${commandNumber(from)}+${commandNumber(to - from)}*` +
+            `(${springExpression(startSeconds, timeExpression)}))`;
+      return (
+        `(gte(${timeExpression},${commandNumber(startSeconds)})*` +
+        `lt(${timeExpression},${commandNumber(stopSeconds)}))*${value}`
+      );
+    })
+    .join("+");
+}
+
+/**
+ * Renders the camera move as a single `zoompan` filter.
+ *
+ * The previous renderer drove `crop` through `sendcmd`, changing the crop
+ * width and height every frame. libavfilter cannot resize a filter's output
+ * link at runtime, so ffmpeg segfaults as soon as a plan contains an actual
+ * zoom; only a pure pan survived. `zoompan` samples a moving window into a
+ * fixed output size, so the link geometry never changes.
+ */
+export function createFfmpegCameraFilter(plan: CameraPlan): string {
+  const segments = cameraSegments(plan);
+  const endSeconds = plan.source.durationMs / 1_000 + 1;
+  const time = `(on/${plan.source.frameRate.toString()})`;
+  const zoom = piecewiseExpression(
+    segments,
+    (transform) => {
+      return transform.scale;
+    },
+    time,
+    endSeconds,
+  );
+  const translationX = piecewiseExpression(
+    segments,
+    (transform) => {
+      return transform.translationX;
+    },
+    time,
+    endSeconds,
+  );
+  const translationY = piecewiseExpression(
+    segments,
+    (transform) => {
+      return transform.translationY;
+    },
+    time,
+    endSeconds,
+  );
+  return (
+    `zoompan=z='max(1,${zoom})'` +
+    `:x='max(0,min(iw-iw/zoom,(0-(${translationX}))/zoom))'` +
+    `:y='max(0,min(ih-ih/zoom,(0-(${translationY}))/zoom))'` +
+    `:d=1:s=${plan.source.width.toString()}x${plan.source.height.toString()}` +
+    `:fps=${plan.source.frameRate.toString()}`
+  );
 }

--- a/turbo/apps/cli/src/commands/video/camera.ts
+++ b/turbo/apps/cli/src/commands/video/camera.ts
@@ -2,13 +2,10 @@ import { execFileSync } from "child_process";
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
-  rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import { dirname, join, parse, resolve } from "node:path";
 import { performance } from "node:perf_hooks";
 import { Command } from "commander";
@@ -17,7 +14,7 @@ import { withErrorHandler } from "../../lib/command/with-error-handler";
 import {
   cameraPlanSchema,
   createCameraPlan,
-  createFfmpegCameraCommands,
+  createFfmpegCameraFilter,
   inputTrackClickTimes,
   inputTrackSchema,
   inputTrackVideoSource,
@@ -158,52 +155,43 @@ function renderVideo(
   plan: CameraPlan,
   force: boolean,
 ): void {
-  const temporaryDirectory = mkdtempSync(join(tmpdir(), "okou-camera-"));
-  try {
-    const commandsPath = join(temporaryDirectory, "camera.commands");
-    writeFileSync(commandsPath, createFfmpegCameraCommands(plan));
-    const filter = [
-      `fps=${plan.source.frameRate.toString()}`,
-      `sendcmd=f='${commandsPath}'`,
-      `crop@camera=w=${plan.source.width.toString()}:h=${plan.source.height.toString()}:x=0:y=0:exact=1`,
-      `scale=${plan.source.width.toString()}:${plan.source.height.toString()}:flags=lanczos`,
-      "setsar=1",
-    ].join(",");
-    execFileSync(
-      "ffmpeg",
-      [
-        force ? "-y" : "-n",
-        "-v",
-        "error",
-        "-i",
-        inputPath,
-        "-vf",
-        filter,
-        "-map",
-        "0:v:0",
-        "-map",
-        "0:a?",
-        "-c:v",
-        "libx264",
-        "-preset",
-        "fast",
-        "-crf",
-        "18",
-        "-pix_fmt",
-        "yuv420p",
-        "-c:a",
-        "aac",
-        "-b:a",
-        "192k",
-        "-movflags",
-        "+faststart",
-        outputPath,
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] },
-    );
-  } finally {
-    rmSync(temporaryDirectory, { recursive: true, force: true });
-  }
+  const filter = [
+    `fps=${plan.source.frameRate.toString()}`,
+    createFfmpegCameraFilter(plan),
+    "setsar=1",
+  ].join(",");
+  execFileSync(
+    "ffmpeg",
+    [
+      force ? "-y" : "-n",
+      "-v",
+      "error",
+      "-i",
+      inputPath,
+      "-vf",
+      filter,
+      "-map",
+      "0:v:0",
+      "-map",
+      "0:a?",
+      "-c:v",
+      "libx264",
+      "-preset",
+      "fast",
+      "-crf",
+      "18",
+      "-pix_fmt",
+      "yuv420p",
+      "-c:a",
+      "aac",
+      "-b:a",
+      "192k",
+      "-movflags",
+      "+faststart",
+      outputPath,
+    ],
+    { stdio: ["ignore", "ignore", "pipe"] },
+  );
 }
 
 function extractReviewFrame(


### PR DESCRIPTION
## What was broken

`okou video camera` cannot produce a zoom today. Two independent defects, and they mask each other.

### 1. The renderer segfaults ffmpeg (this PR fixes it)

`createFfmpegCameraCommands` drove `crop@camera` through `sendcmd`, rewriting the crop **width and height** every frame. libavfilter cannot resize a filter's output link at runtime, so ffmpeg dies with SIGSEGV as soon as a plan contains a real zoom. The CLI runs ffmpeg with `-v error`, so the process is killed before printing anything and the user only sees a bare `✗ Command failed`.

Isolated on ffmpeg 6.1.1 using the command file the current code generates:

| sendcmd animates | result |
|---|---|
| `w` `h` `x` `y` (zoom) | **SIGSEGV (139)** |
| same, values rounded to integers | SIGSEGV |
| same, values rounded to even integers | SIGSEGV |
| same, `exact=1` removed | SIGSEGV |
| same, no downstream `scale` at all | SIGSEGV |
| `x` `y` only, `w`/`h` fixed (pan) | OK |
| `zoompan` (control) | OK |

So the crash is in `crop` itself, not in anything downstream.

### 2. The sidecar's `tMs` is not recording-relative (root cause is in the desktop recorder, not here)

On a real desktop capture the clicks land far outside the recording, every sample is filtered out, and the command reports **success** with `ranges: []` after a plain transcode. Nothing tells the caller that no camera move was produced.

The root cause is upstream in `ScreenRecorderHelper`: `ClickTrackRecorder.handle` stores `CGEvent.timestamp` as `ticks`, while `ClickTimeline.startTicks` is derived from a `CMTime` through `hostTicks`. The two are not in the same unit, so `offsetMilliseconds` inflates every offset by exactly the mach timebase ratio.

Measured on a 21.06 s capture, dividing the emitted `tMs` by `numer/denom = 125/3` and anchoring the first click at 3.05 s reproduces every event's real position, verified independently against frame-difference peaks in the video:

| click | emitted `tMs` | ÷ (125/3) | measured from frames | error |
|---|---|---|---|---|
| 1 (open + menu) | 8191037307 | 3.050 s | 3.2 s | −150 ms |
| 2 (pick Plan mode) | 8191131072 | 5.300 s | 5.4 s | −100 ms |
| 3 (open access menu) | 8191197715 | 6.900 s | 6.9 s | 0 ms |
| 4 (dismiss menu) | 8191370636 | 11.050 s | 11.0 s | +50 ms |
| 5 (stop recording) | 8191786602 | 21.033 s | video ends 21.058 s | — |

The residuals are within the ±100 ms precision of the frame-difference anchors, and a scale error of even 0.5 % would put click 5 off by ~90 ms. On an Intel Mac the timebase is 1/1, so the bug is invisible there.

**This PR does not change the recorder** — the Swift fix belongs to whoever owns `turbo/apps/desktop/native`. It only stops the CLI from silently succeeding on such a sidecar.

## What changed

- **`camera-plan.ts`** — replaced `createFfmpegCameraCommands` with `createFfmpegCameraFilter`, which renders through `zoompan`. `zoompan` samples a moving window into a fixed output size, so the link geometry never changes.

  The spring animation is unchanged. The camera only changes course when the active focus changes and coasts on a closed-form spring in between, so recording just those course changes replaces the per-frame command file with a short piecewise expression — **5 segments and 5.9 KB** for a 21 s recording that previously emitted **620 command lines**. Segment boundaries are found by walking frames exactly the way `createCameraFrameStates` still does, so the two stay in step.

- **`camera-plan.ts`** — `createCameraPlan` now throws when a track has pointer events but none fall inside the recording, reporting the observed span and the recording duration. A recording with genuinely no clicks still yields zero ranges and a plain transcode, as before.

- **`camera.ts`** — `renderVideo` passes the filter directly; no temp directory or command file.

## Verification

Rendering the same plan two ways — through the old per-frame crop rectangles (applied outside ffmpeg, since ffmpeg crashes on them) and through the new `zoompan` filter — gives the same picture: **45 dB PSNR on held frames**. The lower whole-clip average is a timebase artifact of the reference, which resamples to 30 fps while the plan runs at the source's 29.442 fps.

## Testing gap this exposes

`__tests__/camera.test.ts` mocks `execFileSync`, so ffmpeg never runs and the suite happily asserted a filter that crashes real ffmpeg. The tests now assert the invariant that actually matters — a fixed output size and no animated `crop` — and the mock records the generated filter. A real-ffmpeg render would belong in `cli-e2e`; I did not add one here to keep the change focused, and it is worth doing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)