### PR TITLE
docs(python): clarify anthropic sse callback gating

### DIFF
--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -105,6 +105,13 @@ def create_anthropic_messages_sse_usage_extractor(
     have been fed, callers must invoke ``scanner.finish()`` to flush a trailing
     event without a blank-line terminator.
 
+    ``include_usage`` controls both usage extraction and delivery of the
+    callbacks described below. When it is ``False``, usage parsing is disabled
+    and ``on_parse_error``, ``on_lifecycle_event``, and ``on_accounting_event``
+    are not called, even when provided. ``failure_observer`` is independent of
+    this option and continues to receive failure evidence for events it
+    requests.
+
     When a captured event cannot be parsed or exceeds an extractor bound,
     ``on_parse_error(event_type, error)`` receives the resolved event identity
     and parser diagnostic only for ``message_start`` and ``message_delta``.


### PR DESCRIPTION
## Summary

Clarify the public `create_anthropic_messages_sse_usage_extractor()` docstring so callers know that
`include_usage=False` disables usage parsing and delivery of `on_parse_error`, `on_lifecycle_event`,
and `on_accounting_event`, while `failure_observer` remains independent.

The existing event-specific callback semantics and caller-owned HTTP decoding boundary remain
documented.

## Scope

- Updated the factory docstring in `crates/runner/mitm-addon/src/usage/anthropic_messages.py`.
- No runtime behavior, tests, exported types, or API signatures changed.

## Validation

From `crates/runner/mitm-addon`:

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (7333 passed)
- `git diff --check`

Closes #31134
