### PR TITLE
fix(desktop): treat CGEvent timestamps as nanoseconds in the click track

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/ClickMapping.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/ClickMapping.swift
@@ -75,7 +75,7 @@ extension CaptureGeometry {
 /// Kept free of CoreGraphics types so the projection below can be exercised
 /// without a capture device or an event tap.
 public struct CapturedClick: Equatable, Sendable {
-    public let ticks: UInt64
+    public let timestampNanoseconds: UInt64
     public let screenX: Double
     public let screenY: Double
     public let button: String
@@ -83,14 +83,14 @@ public struct CapturedClick: Equatable, Sendable {
     public let modifiers: [String]
 
     public init(
-        ticks: UInt64,
+        timestampNanoseconds: UInt64,
         screenX: Double,
         screenY: Double,
         button: String,
         clickCount: Int,
         modifiers: [String]
     ) {
-        self.ticks = ticks
+        self.timestampNanoseconds = timestampNanoseconds
         self.screenX = screenX
         self.screenY = screenY
         self.button = button
@@ -130,7 +130,11 @@ public func projectClicks(
     var droppedOutOfFrame = 0
 
     for click in clicks {
-        guard let offsetMs = timeline.offsetMilliseconds(atTicks: click.ticks) else {
+        guard
+            let offsetMs = timeline.offsetMilliseconds(
+                atNanoseconds: click.timestampNanoseconds
+            )
+        else {
             continue
         }
         guard
@@ -159,33 +163,28 @@ public func projectClicks(
 
 /// Converts `CGEvent` timestamps onto the recording's timeline.
 ///
-/// `CGEvent.timestamp` is mach absolute time in raw tick units, which are not
-/// nanoseconds on every machine; the timebase ratio has to be applied or every
-/// click lands at the wrong moment in the video.
+/// `CGEvent.timestamp` is nanoseconds since startup, the same clock the first
+/// video frame's presentation timestamp is anchored on, so placing a click is a
+/// plain subtraction.
+///
+/// An earlier version declared it "mach absolute time in raw tick units" and
+/// applied the mach timebase ratio on top, which multiplied every offset by
+/// `numer/denom`. That ratio is 1/1 on Intel, so the mistake was invisible
+/// there and only corrupted Apple silicon captures, by ~41.7x.
 public struct ClickTimeline: Equatable, Sendable {
-    public let startTicks: UInt64
-    public let timebaseNumerator: UInt32
-    public let timebaseDenominator: UInt32
+    public let startNanoseconds: UInt64
 
-    public init(
-        startTicks: UInt64,
-        timebaseNumerator: UInt32,
-        timebaseDenominator: UInt32
-    ) {
-        self.startTicks = startTicks
-        self.timebaseNumerator = timebaseNumerator
-        self.timebaseDenominator = max(1, timebaseDenominator)
+    public init(startNanoseconds: UInt64) {
+        self.startNanoseconds = startNanoseconds
     }
 
     /// Milliseconds from the start of the recording, or `nil` for an event that
     /// predates it.
-    public func offsetMilliseconds(atTicks ticks: UInt64) -> Int? {
-        guard ticks >= startTicks else {
+    public func offsetMilliseconds(atNanoseconds nanoseconds: UInt64) -> Int? {
+        guard nanoseconds >= startNanoseconds else {
             return nil
         }
-        let elapsedTicks = Double(ticks - startTicks)
-        let nanoseconds =
-            elapsedTicks * Double(timebaseNumerator) / Double(timebaseDenominator)
-        return Int((nanoseconds / 1_000_000).rounded())
+        let elapsed = Double(nanoseconds - startNanoseconds)
+        return Int((elapsed / 1_000_000).rounded())
     }
 }

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/ClickTrackRecorder.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/ClickTrackRecorder.swift
@@ -124,7 +124,7 @@ final class ClickTrackRecorder: @unchecked Sendable {
         }
         let location = event.location
         let click = CapturedClick(
-            ticks: event.timestamp,
+            timestampNanoseconds: event.timestamp,
             screenX: Double(location.x),
             screenY: Double(location.y),
             button: button,

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
@@ -345,7 +345,6 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
     private let sampleQueue = DispatchQueue(label: "ai.okou.recorder.samples")
 
     private let clickTracker = ClickTrackRecorder()
-    private var timebase = mach_timebase_info_data_t()
 
     private var state: RecorderSessionState = .ready
     /// Set when the stream ended without `stop` being called. The session stays
@@ -379,23 +378,22 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         self.outputSize = outputSize
         self.audioPlan = audioPlan
         super.init()
-        mach_timebase_info(&timebase)
     }
 
-    /// Converts a host-clock presentation timestamp back into the raw mach tick
-    /// units `CGEvent.timestamp` reports, so clicks and frames share one origin.
+    /// The host-clock presentation timestamp in nanoseconds, the unit
+    /// `CGEvent.timestamp` reports, so clicks and frames share one origin.
     ///
     /// Returns `nil` rather than a zero anchor when the timestamp cannot be
     /// converted: anchoring at tick 0 would place every click at its offset from
     /// system boot instead of from the recording, which is a confidently wrong
     /// answer. The caller leaves the timeline unset and the track comes out
     /// empty.
-    private func hostTicks(from time: CMTime) -> UInt64? {
+    private func hostNanoseconds(from time: CMTime) -> UInt64? {
         let nanoseconds = CMTimeGetSeconds(time) * 1_000_000_000
-        guard nanoseconds > 0, timebase.numer > 0 else {
+        guard nanoseconds > 0 else {
             return nil
         }
-        return UInt64(nanoseconds * Double(timebase.denom) / Double(timebase.numer))
+        return UInt64(nanoseconds)
     }
 
     var describedGeometry: [String: Any] {
@@ -856,12 +854,8 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
             sessionStartedAt = timestamp
             // Anchor clicks on the very same frame the video starts on rather
             // than on when `start` was called, so the two timelines cannot drift.
-            if let startTicks = hostTicks(from: timestamp) {
-                clickTimeline = ClickTimeline(
-                    startTicks: startTicks,
-                    timebaseNumerator: timebase.numer,
-                    timebaseDenominator: timebase.denom
-                )
+            if let startNanoseconds = hostNanoseconds(from: timestamp) {
+                clickTimeline = ClickTimeline(startNanoseconds: startNanoseconds)
             }
         }
         latestSampleAt = timestamp

--- a/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/ClickMappingTests.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/ClickMappingTests.swift
@@ -101,51 +101,40 @@ struct ClickMappingTests {
 }
 
 struct ClickTimelineTests {
-    /// Apple silicon reports 125/3 nanoseconds per tick rather than 1/1, so a
-    /// timeline that ignores the ratio is wrong by ~40x on those machines.
-    private let appleSilicon = ClickTimeline(
-        startTicks: 1_000,
-        timebaseNumerator: 125,
-        timebaseDenominator: 3
-    )
+    /// A recording that started a little over two days into an uptime, the
+    /// magnitudes a real capture actually produces.
+    private let timeline = ClickTimeline(startNanoseconds: 196_584_887_536_968)
 
+    /// `CGEvent.timestamp` is nanoseconds since startup, not raw mach ticks.
+    /// Applying the mach timebase ratio on top of it scaled every offset by
+    /// `numer/denom`, which is 1/1 on Intel and 125/3 on Apple silicon — so the
+    /// mistake only ever corrupted Apple silicon captures, and by enough that a
+    /// 21 second recording reported click offsets spanning 12 minutes.
     @Test
-    func convertsTicksToMillisecondsUsingTheTimebaseRatio() {
-        // 24_000 ticks * 125/3 = 1_000_000ns = 1ms
-        #expect(appleSilicon.offsetMilliseconds(atTicks: 25_000) == 1)
+    func placesAnEventOnTheRecordingTimeline() {
+        #expect(
+            timeline.offsetMilliseconds(
+                atNanoseconds: 196_584_890_536_968
+            ) == 3_000
+        )
     }
 
     @Test
     func reportsZeroAtTheStartOfTheRecording() {
-        #expect(appleSilicon.offsetMilliseconds(atTicks: 1_000) == 0)
+        #expect(
+            timeline.offsetMilliseconds(
+                atNanoseconds: 196_584_887_536_968
+            ) == 0
+        )
     }
 
     @Test
     func dropsEventsThatPredateTheRecording() {
-        #expect(appleSilicon.offsetMilliseconds(atTicks: 999) == nil)
-    }
-
-    @Test
-    func handlesTheOneToOneTimebase() {
-        let intel = ClickTimeline(
-            startTicks: 0,
-            timebaseNumerator: 1,
-            timebaseDenominator: 1
+        #expect(
+            timeline.offsetMilliseconds(
+                atNanoseconds: 196_584_887_536_967
+            ) == nil
         )
-
-        #expect(intel.offsetMilliseconds(atTicks: 2_000_000) == 2)
-    }
-
-    @Test
-    func neverDividesByAZeroDenominator() {
-        let degenerate = ClickTimeline(
-            startTicks: 0,
-            timebaseNumerator: 1,
-            timebaseDenominator: 0
-        )
-
-        #expect(degenerate.timebaseDenominator == 1)
-        #expect(degenerate.offsetMilliseconds(atTicks: 1_000_000) == 1)
     }
 }
 
@@ -158,15 +147,15 @@ struct ClickProjectionTests {
         scale: 2
     )
     private let outputSize = OutputSize(width: 1920, height: 960)
-    private let timeline = ClickTimeline(
-        startTicks: 24_000,
-        timebaseNumerator: 1,
-        timebaseDenominator: 1
-    )
+    private let timeline = ClickTimeline(startNanoseconds: 24_000)
 
-    private func click(ticks: UInt64, x: Double, y: Double) -> CapturedClick {
+    private func click(
+        atNanoseconds nanoseconds: UInt64,
+        x: Double,
+        y: Double
+    ) -> CapturedClick {
         return CapturedClick(
-            ticks: ticks,
+            timestampNanoseconds: nanoseconds,
             screenX: x,
             screenY: y,
             button: "left",
@@ -178,7 +167,7 @@ struct ClickProjectionTests {
     @Test
     func projectsAClickThatLandedInsideTheRecording() {
         let projection = projectClicks(
-            [click(ticks: 2_024_000, x: 500, y: 250)],
+            [click(atNanoseconds: 2_024_000, x: 500, y: 250)],
             timeline: timeline,
             geometry: display,
             outputSize: outputSize
@@ -201,7 +190,7 @@ struct ClickProjectionTests {
     @Test
     func dropsClicksFromBeforeTheFirstFrameWithoutCountingThemOutOfFrame() {
         let projection = projectClicks(
-            [click(ticks: 1_000, x: 500, y: 250)],
+            [click(atNanoseconds: 1_000, x: 500, y: 250)],
             timeline: timeline,
             geometry: display,
             outputSize: outputSize
@@ -214,7 +203,7 @@ struct ClickProjectionTests {
     @Test
     func countsClicksThatLandedOutsideTheCapturedRegion() {
         let projection = projectClicks(
-            [click(ticks: 2_024_000, x: 1_500, y: 250)],
+            [click(atNanoseconds: 2_024_000, x: 1_500, y: 250)],
             timeline: timeline,
             geometry: display,
             outputSize: outputSize
@@ -228,9 +217,9 @@ struct ClickProjectionTests {
     func separatesTheTwoDropReasonsInOneRecording() {
         let projection = projectClicks(
             [
-                click(ticks: 1_000, x: 500, y: 250),
-                click(ticks: 2_024_000, x: 1_500, y: 250),
-                click(ticks: 3_024_000, x: 500, y: 250),
+                click(atNanoseconds: 1_000, x: 500, y: 250),
+                click(atNanoseconds: 2_024_000, x: 1_500, y: 250),
+                click(atNanoseconds: 3_024_000, x: 500, y: 250),
             ],
             timeline: timeline,
             geometry: display,


### PR DESCRIPTION
Root cause behind #31140's second defect. That PR only stopped `okou video camera` from silently succeeding on a broken sidecar; this fixes the sidecar.

## The bug

`ClickTimeline` documented `CGEvent.timestamp` as "mach absolute time in raw tick units" and applied the mach timebase ratio to it, while `startTicks` came from a `CMTime` converted the *other* way through `hostTicks`. The two values were never in the same unit, so every click offset came out scaled by `numer/denom`.

That ratio is **1/1 on Intel and 125/3 on Apple silicon**, which is why this shipped — it is invisible on Intel and inflates every Apple silicon capture by ~41.7x.

Concretely, a 21.06 s recording emitted click offsets spanning 749,295 "ms" (about 12 minutes), so every consumer that filters events to the recording window drops all of them.

## Evidence

Dividing the emitted `tMs` by 125/3 and anchoring the first click at 3.05 s reproduces every event's real position. The right-hand column is measured independently, from frame-difference peaks in the video itself:

| click | emitted `tMs` | ÷ (125/3) | measured from frames | error |
|---|---|---|---|---|
| 1 open the `+` menu | 8191037307 | 3.050 s | 3.2 s | −150 ms |
| 2 pick Plan mode | 8191131072 | 5.300 s | 5.4 s | −100 ms |
| 3 open the access menu | 8191197715 | 6.900 s | 6.9 s | 0 ms |
| 4 dismiss the menu | 8191370636 | 11.050 s | 11.0 s | +50 ms |
| 5 stop recording | 8191786602 | 21.033 s | file ends 21.058 s | — |

The residuals sit inside the ±100 ms precision of the frame anchors, and a scale error of even 0.5 % would put click 5 off by ~90 ms. The absolute magnitude also checks out: it implies ~2.3 days of uptime at capture time.

## The fix

Anchor the timeline in nanoseconds on both sides and drop the timebase from the click path entirely, so there is no two-unit arithmetic left to get wrong:

- `ClickTimeline` now holds `startNanoseconds` and does a plain subtraction.
- `hostTicks(from:)` becomes `hostNanoseconds(from:)`.
- `CapturedClick.ticks` becomes `timestampNanoseconds`.
- The now-unused `mach_timebase_info_data_t` field is removed.

## Why the tests did not catch it

`ClickTimelineTests` pinned the arithmetic (`// 24_000 ticks * 125/3 = 1_000_000ns = 1ms`) but not the assumption underneath it — what unit `CGEvent.timestamp` actually reports. The arithmetic was self-consistently wrong. The tests now use the magnitudes a real capture produces, and carry the reason in a comment so the assumption is visible rather than implied.

## Acceptance

`pnpm -F @okouai/desktop test:native` covers the pure logic on `macos-latest` in CI. What CI cannot check is the runtime unit itself, since that needs a real capture with a real event tap. Worth confirming on-device before release: record a short clip, click at a couple of moments you can identify in the picture, and check the sidecar's `tMs` against them. If it is ever wrong the other way, #31140 now makes `okou video camera` fail loudly instead of silently transcoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)