### PR TITLE
refactor(rust): share runner-to-guest artifact payload contract

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -133,12 +133,11 @@ fn optional_positive_duration_secs(
 // the run payload. If the value is unset or empty, there are no artifacts.
 // ---------------------------------------------------------------------------
 
-/// One artifact mount described by the runner-provided artifact JSON array.
+/// Checkpoint state materialized from one runner-provided artifact entry.
 ///
-/// The wire value is encoded as camelCase JSON, so this struct expects
-/// `mountPath`, `storageId`, and `versionId` keys at the guest-agent boundary.
-#[derive(Clone, Debug, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+/// [`guest_contracts::env::RunArtifact`] owns the wire representation parsed
+/// before this guest-agent type is constructed.
+#[derive(Clone, Debug)]
 pub struct ArtifactEnv {
     /// VAS storage name for the mounted artifact. This is also the artifact
     /// name reported in checkpoint snapshot payloads.
@@ -153,8 +152,34 @@ pub struct ArtifactEnv {
     pub version_id: String,
     /// Optional internal checkpoint policy. Absence means strict failure on a
     /// missing or unreadable artifact root.
-    #[serde(default)]
     pub missing_root_policy: Option<ArtifactEntryMissingRootPolicy>,
+}
+
+impl From<guest_contracts::env::RunArtifact> for ArtifactEnv {
+    fn from(artifact: guest_contracts::env::RunArtifact) -> Self {
+        Self {
+            name: artifact.name,
+            mount_path: artifact.mount_path,
+            storage_id: artifact.storage_id,
+            version_id: artifact.version_id,
+            missing_root_policy: artifact
+                .missing_root_policy
+                .map(artifact_env_missing_root_policy),
+        }
+    }
+}
+
+fn artifact_env_missing_root_policy(
+    policy: guest_contracts::env::RunArtifactMissingRootPolicy,
+) -> ArtifactEntryMissingRootPolicy {
+    match policy {
+        guest_contracts::env::RunArtifactMissingRootPolicy::Fail => {
+            ArtifactEntryMissingRootPolicy::Fail
+        }
+        guest_contracts::env::RunArtifactMissingRootPolicy::PreserveParentVersion => {
+            ArtifactEntryMissingRootPolicy::PreserveParentVersion
+        }
+    }
 }
 
 /// Raw runner bootstrap values used to build an owned guest-agent run config.
@@ -612,7 +637,8 @@ fn parse_artifacts_value(raw: &str) -> Result<Vec<ArtifactEnv>, serde_json::Erro
     if raw.is_empty() {
         return Ok(Vec::new());
     }
-    serde_json::from_str::<Vec<ArtifactEnv>>(raw)
+    serde_json::from_str::<Vec<guest_contracts::env::RunArtifact>>(raw)
+        .map(|artifacts| artifacts.into_iter().map(ArtifactEnv::from).collect())
 }
 
 fn parse_feature_flags_value(raw: &str) -> Result<HashMap<String, bool>, serde_json::Error> {

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -173,6 +173,36 @@ pub const RUN_PAYLOAD_FILENAME: &str = "payload.json";
 /// are no artifact mounts.
 pub const ARTIFACTS_ENV: &str = "VM0_ARTIFACTS";
 
+/// One artifact mount in the runner-to-guest run payload.
+///
+/// The complete artifact list is serialized as a JSON array inside
+/// [`RunPayload::artifacts`].
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunArtifact {
+    /// VAS storage name reported in artifact checkpoint snapshots.
+    pub name: String,
+    /// Absolute guest path containing the mounted artifact.
+    pub mount_path: String,
+    /// VAS storage identifier used to recompute the artifact content hash.
+    pub storage_id: String,
+    /// VAS version identifier mounted at startup.
+    pub version_id: String,
+    /// Behavior when the artifact root is absent during checkpointing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub missing_root_policy: Option<RunArtifactMissingRootPolicy>,
+}
+
+/// Runner-to-guest policy for an artifact root missing during checkpointing.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RunArtifactMissingRootPolicy {
+    /// Treat the missing artifact root as a checkpoint error.
+    Fail,
+    /// Preserve the artifact version mounted at startup.
+    PreserveParentVersion,
+}
+
 /// Logical run-payload field name for the JSON map of feature flag names to
 /// enabled states.
 ///
@@ -553,6 +583,68 @@ pub fn sanitize_env_key_for_diagnostic(key: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn run_artifacts_round_trip_with_and_without_missing_root_policy() {
+        let artifacts = vec![
+            RunArtifact {
+                name: "plain".to_string(),
+                mount_path: "/plain".to_string(),
+                storage_id: "storage-plain".to_string(),
+                version_id: "version-plain".to_string(),
+                missing_root_policy: None,
+            },
+            RunArtifact {
+                name: "memory".to_string(),
+                mount_path: "/memory".to_string(),
+                storage_id: "storage-memory".to_string(),
+                version_id: "version-memory".to_string(),
+                missing_root_policy: Some(RunArtifactMissingRootPolicy::PreserveParentVersion),
+            },
+        ];
+
+        let json = serde_json::to_value(&artifacts).unwrap();
+
+        assert_eq!(
+            json,
+            serde_json::json!([
+                {
+                    "name": "plain",
+                    "mountPath": "/plain",
+                    "storageId": "storage-plain",
+                    "versionId": "version-plain"
+                },
+                {
+                    "name": "memory",
+                    "mountPath": "/memory",
+                    "storageId": "storage-memory",
+                    "versionId": "version-memory",
+                    "missingRootPolicy": "preserveParentVersion"
+                }
+            ])
+        );
+        assert_eq!(
+            serde_json::from_value::<Vec<RunArtifact>>(json).unwrap(),
+            artifacts
+        );
+    }
+
+    #[test]
+    fn run_artifact_requires_all_string_fields() {
+        let artifact = serde_json::json!({
+            "name": "artifact",
+            "mountPath": "/artifact",
+            "storageId": "storage",
+            "versionId": "version"
+        });
+
+        for field in ["name", "mountPath", "storageId", "versionId"] {
+            let mut missing = artifact.clone();
+            missing.as_object_mut().unwrap().remove(field);
+
+            assert!(serde_json::from_value::<RunArtifact>(missing).is_err());
+        }
+    }
 
     #[test]
     fn contract_names_match_wire_values() {

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 
 use api_contracts::generated::constants::model_provider_env::placeholders as model_provider_placeholders;
-use api_contracts::generated::types::runners::runs::{
-    CodexRuntimeConfig, PiLaunchConfig, PiModelConfig,
+use api_contracts::generated::types::runners::{
+    runs::{CodexRuntimeConfig, PiLaunchConfig, PiModelConfig},
+    storage::ArtifactEntryMissingRootPolicy,
 };
 use guest_contracts::cli_agent_session_id::is_valid_cli_agent_session_id;
 use guest_contracts::codex_thread_id::canonical_codex_thread_id;
@@ -753,27 +754,35 @@ fn serialize_artifacts_payload(context: &ExecutionContext) -> RunnerResult<Strin
         return Ok(String::new());
     }
 
-    let payload: Vec<serde_json::Value> = manifest
+    let payload: Vec<guest_contracts::env::RunArtifact> = manifest
         .artifacts
         .iter()
-        .map(|a| {
-            let mut entry = serde_json::json!({
-                "name": a.vas_storage_name,
-                "mountPath": a.mount_path,
-                "storageId": a.vas_storage_id,
-                "versionId": a.vas_version_id,
-            });
-            if let Some(policy) = a.missing_root_policy
-                && let Some(object) = entry.as_object_mut()
-            {
-                object.insert("missingRootPolicy".to_string(), serde_json::json!(policy));
-            }
-            entry
+        .map(|artifact| guest_contracts::env::RunArtifact {
+            name: artifact.vas_storage_name.clone(),
+            mount_path: artifact.mount_path.clone(),
+            storage_id: artifact.vas_storage_id.clone(),
+            version_id: artifact.vas_version_id.clone(),
+            missing_root_policy: artifact
+                .missing_root_policy
+                .map(run_artifact_missing_root_policy),
         })
         .collect();
 
     serde_json::to_string(&payload)
         .map_err(|e| RunnerError::Internal(format!("serialize artifact payload: {e}")))
+}
+
+fn run_artifact_missing_root_policy(
+    policy: ArtifactEntryMissingRootPolicy,
+) -> guest_contracts::env::RunArtifactMissingRootPolicy {
+    match policy {
+        ArtifactEntryMissingRootPolicy::Fail => {
+            guest_contracts::env::RunArtifactMissingRootPolicy::Fail
+        }
+        ArtifactEntryMissingRootPolicy::PreserveParentVersion => {
+            guest_contracts::env::RunArtifactMissingRootPolicy::PreserveParentVersion
+        }
+    }
 }
 
 fn serialize_feature_flags_payload(context: &ExecutionContext) -> RunnerResult<String> {

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -4,6 +4,7 @@ use api_contracts::generated::constants::model_provider_env::placeholders as mod
 use api_contracts::generated::types::runners::{
     runs::CodexRuntimeConfig, storage::ArtifactEntryMissingRootPolicy,
 };
+use guest_contracts::env::{RunArtifact, RunArtifactMissingRootPolicy};
 use sandbox::SandboxId;
 use sandbox_mock::MockSandbox;
 use serde_json::json;
@@ -909,13 +910,13 @@ fn build_env_json_with_single_artifact() {
     assert!(!env.contains_key("VM0_ARTIFACTS"));
     let payload = build_run_payload_for_run(&ctx).unwrap();
     let raw = &payload.artifacts;
-    let parsed: Vec<serde_json::Value> = serde_json::from_str(raw).unwrap();
+    let parsed: Vec<RunArtifact> = serde_json::from_str(raw).unwrap();
     assert_eq!(parsed.len(), 1);
-    assert_eq!(parsed[0]["name"], "my-vol");
-    assert_eq!(parsed[0]["mountPath"], "/artifacts");
-    assert_eq!(parsed[0]["storageId"], "sid-1");
-    assert_eq!(parsed[0]["versionId"], "v1");
-    assert!(parsed[0].get("missingRootPolicy").is_none());
+    assert_eq!(parsed[0].name, "my-vol");
+    assert_eq!(parsed[0].mount_path, "/artifacts");
+    assert_eq!(parsed[0].storage_id, "sid-1");
+    assert_eq!(parsed[0].version_id, "v1");
+    assert_eq!(parsed[0].missing_root_policy, None);
     // Legacy singleton env vars must no longer be emitted.
     assert!(!env.contains_key("VM0_ARTIFACT_DRIVER"));
     assert!(!env.contains_key("VM0_ARTIFACT_MOUNT_PATH"));
@@ -943,11 +944,14 @@ fn build_env_json_with_artifact_missing_root_policy() {
     assert!(!env.contains_key("VM0_ARTIFACTS"));
     let payload = build_run_payload_for_run(&ctx).unwrap();
     let raw = &payload.artifacts;
-    let parsed: Vec<serde_json::Value> = serde_json::from_str(raw).unwrap();
+    let parsed: Vec<RunArtifact> = serde_json::from_str(raw).unwrap();
 
     assert_eq!(parsed.len(), 1);
-    assert_eq!(parsed[0]["name"], "memory");
-    assert_eq!(parsed[0]["missingRootPolicy"], "preserveParentVersion");
+    assert_eq!(parsed[0].name, "memory");
+    assert_eq!(
+        parsed[0].missing_root_policy,
+        Some(RunArtifactMissingRootPolicy::PreserveParentVersion)
+    );
 }
 
 #[test]
@@ -977,14 +981,14 @@ fn build_env_json_with_two_artifacts() {
     assert!(!env.contains_key("VM0_ARTIFACTS"));
     let payload = build_run_payload_for_run(&ctx).unwrap();
     let raw = &payload.artifacts;
-    let parsed: Vec<serde_json::Value> = serde_json::from_str(raw).unwrap();
+    let parsed: Vec<RunArtifact> = serde_json::from_str(raw).unwrap();
     assert_eq!(parsed.len(), 2);
-    assert_eq!(parsed[0]["name"], "art-a");
-    assert_eq!(parsed[0]["mountPath"], "/workspace");
-    assert_eq!(parsed[0]["storageId"], "sid-a");
-    assert_eq!(parsed[1]["name"], "art-b");
-    assert_eq!(parsed[1]["mountPath"], "/data");
-    assert_eq!(parsed[1]["storageId"], "sid-b");
+    assert_eq!(parsed[0].name, "art-a");
+    assert_eq!(parsed[0].mount_path, "/workspace");
+    assert_eq!(parsed[0].storage_id, "sid-a");
+    assert_eq!(parsed[1].name, "art-b");
+    assert_eq!(parsed[1].mount_path, "/data");
+    assert_eq!(parsed[1].storage_id, "sid-b");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add shared runner-to-guest artifact entry and missing-root-policy wire types in `guest-contracts`
- map runner storage-manifest values into the shared contract and map guest payload values into checkpoint-owned state
- compile-link runner serialization tests to the shared DTO and cover its exact serde behavior

## Compatibility and exclusions

- preserve `RunPayload.artifacts` as a nested JSON string and retain the empty-string convention
- preserve camelCase keys, strict required fields, accepted policy values, optional-policy omission, and unknown extra-field tolerance
- do not change environment keys, storage/download manifests, generated API contracts, or checkpoint webhook models

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner`
- repository pre-commit and commit-message hooks

Closes #31142
