### PR TITLE
test(runner): cover gc coordinator phase ordering

### DIFF
--- a/crates/runner/src/cmd/gc/mod.rs
+++ b/crates/runner/src/cmd/gc/mod.rs
@@ -23,7 +23,7 @@ mod workspaces;
 mod test_support;
 
 use debootstrap::gc_debootstrap;
-use image_refs::protected_image_refs_for_gc;
+use image_refs::{ProtectedImageRefs, protected_image_refs_for_gc};
 use images::gc_nested_images_with_protected_refs;
 use job_logs::gc_job_logs;
 use nbd::gc_nbd_orphans;
@@ -31,7 +31,7 @@ use orphaned_locks::gc_orphaned_locks;
 use report::{GcReport, log_gc_phase_summary, log_gc_summary};
 use storage::gc_storage_cache;
 use version_service_locks::gc_orphaned_version_service_locks;
-use versions::{analyze_version_gc, gc_versions_with_analysis};
+use versions::{VersionGcAnalysis, analyze_version_gc, gc_versions_with_analysis};
 use workspaces::gc_workspace_orphans;
 
 /// Artifacts younger than this are unconditionally kept, regardless of lock
@@ -58,28 +58,187 @@ pub struct GcArgs {
     protect_version: Option<String>,
 }
 
+trait GcOperations {
+    async fn analyze_versions(
+        &mut self,
+        home: &HomePaths,
+        protect_version: Option<&str>,
+        keep_latest: Option<usize>,
+    ) -> RunnerResult<VersionGcAnalysis>;
+
+    async fn protected_image_refs(
+        &mut self,
+        home: &HomePaths,
+        version_analysis: &VersionGcAnalysis,
+    ) -> ProtectedImageRefs;
+
+    async fn gc_images(
+        &mut self,
+        home: &HomePaths,
+        keep_latest: Option<usize>,
+        dry_run: bool,
+        protected_image_refs: &ProtectedImageRefs,
+    ) -> RunnerResult<GcReport>;
+
+    async fn gc_nbd_orphans(&mut self, dry_run: bool) -> RunnerResult<GcReport>;
+
+    async fn gc_workspace_orphans(
+        &mut self,
+        home: &HomePaths,
+        dry_run: bool,
+    ) -> RunnerResult<GcReport>;
+
+    async fn gc_orphaned_locks(
+        &mut self,
+        home: &HomePaths,
+        dry_run: bool,
+    ) -> RunnerResult<GcReport>;
+
+    async fn gc_job_logs(&mut self, home: &HomePaths, dry_run: bool) -> RunnerResult<GcReport>;
+
+    async fn gc_versions(
+        &mut self,
+        home: &HomePaths,
+        dry_run: bool,
+        version_analysis: VersionGcAnalysis,
+    ) -> RunnerResult<GcReport>;
+
+    async fn gc_orphaned_version_service_locks(
+        &mut self,
+        home: &HomePaths,
+        dry_run: bool,
+    ) -> RunnerResult<GcReport>;
+
+    async fn gc_debootstrap(
+        &mut self,
+        home: &HomePaths,
+        keep_latest: Option<usize>,
+        dry_run: bool,
+    ) -> RunnerResult<GcReport>;
+
+    async fn gc_storage_cache(&mut self, home: &HomePaths, dry_run: bool)
+    -> RunnerResult<GcReport>;
+}
+
+struct RealGcOperations;
+
+impl GcOperations for RealGcOperations {
+    async fn analyze_versions(
+        &mut self,
+        home: &HomePaths,
+        protect_version: Option<&str>,
+        keep_latest: Option<usize>,
+    ) -> RunnerResult<VersionGcAnalysis> {
+        analyze_version_gc(home, protect_version, keep_latest).await
+    }
+
+    async fn protected_image_refs(
+        &mut self,
+        home: &HomePaths,
+        version_analysis: &VersionGcAnalysis,
+    ) -> ProtectedImageRefs {
+        protected_image_refs_for_gc(home, version_analysis).await
+    }
+
+    async fn gc_images(
+        &mut self,
+        home: &HomePaths,
+        keep_latest: Option<usize>,
+        dry_run: bool,
+        protected_image_refs: &ProtectedImageRefs,
+    ) -> RunnerResult<GcReport> {
+        gc_nested_images_with_protected_refs(home, keep_latest, dry_run, protected_image_refs).await
+    }
+
+    async fn gc_nbd_orphans(&mut self, dry_run: bool) -> RunnerResult<GcReport> {
+        gc_nbd_orphans(dry_run).await
+    }
+
+    async fn gc_workspace_orphans(
+        &mut self,
+        home: &HomePaths,
+        dry_run: bool,
+    ) -> RunnerResult<GcReport> {
+        Ok(GcReport::from(gc_workspace_orphans(home, dry_run).await?))
+    }
+
+    async fn gc_orphaned_locks(
+        &mut self,
+        home: &HomePaths,
+        dry_run: bool,
+    ) -> RunnerResult<GcReport> {
+        gc_orphaned_locks(home, dry_run).await
+    }
+
+    async fn gc_job_logs(&mut self, home: &HomePaths, dry_run: bool) -> RunnerResult<GcReport> {
+        gc_job_logs(home, dry_run).await
+    }
+
+    async fn gc_versions(
+        &mut self,
+        home: &HomePaths,
+        dry_run: bool,
+        version_analysis: VersionGcAnalysis,
+    ) -> RunnerResult<GcReport> {
+        gc_versions_with_analysis(home, dry_run, version_analysis).await
+    }
+
+    async fn gc_orphaned_version_service_locks(
+        &mut self,
+        home: &HomePaths,
+        dry_run: bool,
+    ) -> RunnerResult<GcReport> {
+        gc_orphaned_version_service_locks(home, dry_run).await
+    }
+
+    async fn gc_debootstrap(
+        &mut self,
+        home: &HomePaths,
+        keep_latest: Option<usize>,
+        dry_run: bool,
+    ) -> RunnerResult<GcReport> {
+        gc_debootstrap(home, keep_latest, dry_run).await
+    }
+
+    async fn gc_storage_cache(
+        &mut self,
+        home: &HomePaths,
+        dry_run: bool,
+    ) -> RunnerResult<GcReport> {
+        gc_storage_cache(home, dry_run).await
+    }
+}
+
 pub async fn run_gc(args: GcArgs) -> RunnerResult<()> {
     let home = HomePaths::new()?;
+    let mut operations = RealGcOperations;
+    run_gc_with_operations(&args, &home, &mut operations).await
+}
+
+async fn run_gc_with_operations(
+    args: &GcArgs,
+    home: &HomePaths,
+    operations: &mut impl GcOperations,
+) -> RunnerResult<()> {
     // Retained version and service configs protect their image pairs before
     // version cleanup consumes the same retention analysis.
-    let version_analysis =
-        analyze_version_gc(&home, args.protect_version.as_deref(), args.keep_latest).await?;
-    let protected_image_refs = protected_image_refs_for_gc(&home, &version_analysis).await;
+    let version_analysis = operations
+        .analyze_versions(home, args.protect_version.as_deref(), args.keep_latest)
+        .await?;
+    let protected_image_refs = operations
+        .protected_image_refs(home, &version_analysis)
+        .await;
 
     let mut report = GcReport::default();
-    let images_report = gc_nested_images_with_protected_refs(
-        &home,
-        args.keep_latest,
-        args.dry_run,
-        &protected_image_refs,
-    )
-    .await?;
+    let images_report = operations
+        .gc_images(home, args.keep_latest, args.dry_run, &protected_image_refs)
+        .await?;
     record_gc_phase(&mut report, "images", images_report, args.dry_run);
 
-    let nbd_report = gc_nbd_orphans(args.dry_run).await?;
+    let nbd_report = operations.gc_nbd_orphans(args.dry_run).await?;
     record_gc_phase(&mut report, "nbd orphans", nbd_report, args.dry_run);
 
-    let workspace_report = GcReport::from(gc_workspace_orphans(&home, args.dry_run).await?);
+    let workspace_report = operations.gc_workspace_orphans(home, args.dry_run).await?;
     record_gc_phase(
         &mut report,
         "workspace orphans",
@@ -88,17 +247,21 @@ pub async fn run_gc(args: GcArgs) -> RunnerResult<()> {
     );
 
     // General lock GC preserves service locks needed by version cleanup.
-    let lock_report = gc_orphaned_locks(&home, args.dry_run).await?;
+    let lock_report = operations.gc_orphaned_locks(home, args.dry_run).await?;
     record_gc_phase(&mut report, "orphaned locks", lock_report, args.dry_run);
 
-    let job_log_report = gc_job_logs(&home, args.dry_run).await?;
+    let job_log_report = operations.gc_job_logs(home, args.dry_run).await?;
     record_gc_phase(&mut report, "job logs", job_log_report, args.dry_run);
 
-    let version_report = gc_versions_with_analysis(&home, args.dry_run, version_analysis).await?;
+    let version_report = operations
+        .gc_versions(home, args.dry_run, version_analysis)
+        .await?;
     record_gc_phase(&mut report, "versions", version_report, args.dry_run);
 
     // Version service locks become orphaned only after version cleanup.
-    let version_lock_report = gc_orphaned_version_service_locks(&home, args.dry_run).await?;
+    let version_lock_report = operations
+        .gc_orphaned_version_service_locks(home, args.dry_run)
+        .await?;
     record_gc_phase(
         &mut report,
         "version service locks",
@@ -106,7 +269,9 @@ pub async fn run_gc(args: GcArgs) -> RunnerResult<()> {
         args.dry_run,
     );
 
-    let debootstrap_report = gc_debootstrap(&home, args.keep_latest, args.dry_run).await?;
+    let debootstrap_report = operations
+        .gc_debootstrap(home, args.keep_latest, args.dry_run)
+        .await?;
     record_gc_phase(
         &mut report,
         "debootstrap cache",
@@ -114,7 +279,7 @@ pub async fn run_gc(args: GcArgs) -> RunnerResult<()> {
         args.dry_run,
     );
 
-    let storage_report = gc_storage_cache(&home, args.dry_run).await?;
+    let storage_report = operations.gc_storage_cache(home, args.dry_run).await?;
     record_gc_phase(&mut report, "storage cache", storage_report, args.dry_run);
 
     log_gc_summary(&report, args.dry_run);
@@ -140,6 +305,190 @@ mod tests {
     struct GcCli {
         #[command(flatten)]
         args: GcArgs,
+    }
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum SafetyGcPhase {
+        AnalyzeVersions,
+        ProtectedImageRefs,
+        Images,
+        OrphanedLocks,
+        Versions,
+        OrphanedVersionServiceLocks,
+    }
+
+    struct FakeGcOperations {
+        events: Vec<SafetyGcPhase>,
+        expected_analysis: VersionGcAnalysis,
+    }
+
+    impl FakeGcOperations {
+        fn new() -> Self {
+            Self {
+                events: Vec::new(),
+                expected_analysis: versions::empty_complete_version_gc_analysis(),
+            }
+        }
+    }
+
+    impl GcOperations for FakeGcOperations {
+        async fn analyze_versions(
+            &mut self,
+            _home: &HomePaths,
+            _protect_version: Option<&str>,
+            _keep_latest: Option<usize>,
+        ) -> RunnerResult<VersionGcAnalysis> {
+            self.events.push(SafetyGcPhase::AnalyzeVersions);
+            Ok(self.expected_analysis.clone())
+        }
+
+        async fn protected_image_refs(
+            &mut self,
+            _home: &HomePaths,
+            version_analysis: &VersionGcAnalysis,
+        ) -> ProtectedImageRefs {
+            self.events.push(SafetyGcPhase::ProtectedImageRefs);
+            assert_eq!(version_analysis, &self.expected_analysis);
+            ProtectedImageRefs::incomplete()
+        }
+
+        async fn gc_images(
+            &mut self,
+            _home: &HomePaths,
+            _keep_latest: Option<usize>,
+            _dry_run: bool,
+            protected_image_refs: &ProtectedImageRefs,
+        ) -> RunnerResult<GcReport> {
+            self.events.push(SafetyGcPhase::Images);
+            assert!(!protected_image_refs.is_complete());
+            Ok(GcReport::default())
+        }
+
+        async fn gc_nbd_orphans(&mut self, _dry_run: bool) -> RunnerResult<GcReport> {
+            Ok(GcReport::default())
+        }
+
+        async fn gc_workspace_orphans(
+            &mut self,
+            _home: &HomePaths,
+            _dry_run: bool,
+        ) -> RunnerResult<GcReport> {
+            Ok(GcReport::default())
+        }
+
+        async fn gc_orphaned_locks(
+            &mut self,
+            _home: &HomePaths,
+            _dry_run: bool,
+        ) -> RunnerResult<GcReport> {
+            self.events.push(SafetyGcPhase::OrphanedLocks);
+            Ok(GcReport::default())
+        }
+
+        async fn gc_job_logs(
+            &mut self,
+            _home: &HomePaths,
+            _dry_run: bool,
+        ) -> RunnerResult<GcReport> {
+            Ok(GcReport::default())
+        }
+
+        async fn gc_versions(
+            &mut self,
+            _home: &HomePaths,
+            _dry_run: bool,
+            version_analysis: VersionGcAnalysis,
+        ) -> RunnerResult<GcReport> {
+            self.events.push(SafetyGcPhase::Versions);
+            assert_eq!(version_analysis, self.expected_analysis);
+            Ok(GcReport::default())
+        }
+
+        async fn gc_orphaned_version_service_locks(
+            &mut self,
+            _home: &HomePaths,
+            _dry_run: bool,
+        ) -> RunnerResult<GcReport> {
+            self.events.push(SafetyGcPhase::OrphanedVersionServiceLocks);
+            Ok(GcReport::default())
+        }
+
+        async fn gc_debootstrap(
+            &mut self,
+            _home: &HomePaths,
+            _keep_latest: Option<usize>,
+            _dry_run: bool,
+        ) -> RunnerResult<GcReport> {
+            Ok(GcReport::default())
+        }
+
+        async fn gc_storage_cache(
+            &mut self,
+            _home: &HomePaths,
+            _dry_run: bool,
+        ) -> RunnerResult<GcReport> {
+            Ok(GcReport::default())
+        }
+    }
+
+    #[tokio::test]
+    async fn gc_coordinator_preserves_safety_critical_phase_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let args = GcArgs {
+            dry_run: true,
+            keep_latest: Some(2),
+            protect_version: Some("v1.2.3".to_string()),
+        };
+        let mut operations = FakeGcOperations::new();
+
+        run_gc_with_operations(&args, &home, &mut operations)
+            .await
+            .unwrap();
+
+        let image_chain: Vec<_> = operations
+            .events
+            .iter()
+            .copied()
+            .filter(|phase| {
+                matches!(
+                    phase,
+                    SafetyGcPhase::AnalyzeVersions
+                        | SafetyGcPhase::ProtectedImageRefs
+                        | SafetyGcPhase::Images
+                )
+            })
+            .collect();
+        assert_eq!(
+            image_chain,
+            [
+                SafetyGcPhase::AnalyzeVersions,
+                SafetyGcPhase::ProtectedImageRefs,
+                SafetyGcPhase::Images,
+            ]
+        );
+
+        let version_lock_chain: Vec<_> = operations
+            .events
+            .iter()
+            .copied()
+            .filter(|phase| {
+                matches!(
+                    phase,
+                    SafetyGcPhase::OrphanedLocks
+                        | SafetyGcPhase::Versions
+                        | SafetyGcPhase::OrphanedVersionServiceLocks
+                )
+            })
+            .collect();
+        assert_eq!(
+            version_lock_chain,
+            [
+                SafetyGcPhase::OrphanedLocks,
+                SafetyGcPhase::Versions,
+                SafetyGcPhase::OrphanedVersionServiceLocks,
+            ]
+        );
     }
 
     #[test]

--- a/crates/runner/src/cmd/gc/versions.rs
+++ b/crates/runner/src/cmd/gc/versions.rs
@@ -213,6 +213,15 @@ impl VersionGcAnalysis {
     }
 }
 
+#[cfg(test)]
+pub(super) fn empty_complete_version_gc_analysis() -> VersionGcAnalysis {
+    VersionGcAnalysis {
+        entries: Vec::new(),
+        binary_scan_complete: true,
+        config_scan_complete: true,
+    }
+}
+
 pub(super) async fn analyze_version_gc(
     home: &HomePaths,
     protect: Option<&str>,


### PR DESCRIPTION
## Summary

- route the runner GC sequence through a private generic operations seam while preserving the public command behavior
- keep every production operation as a direct delegation to the existing GC domain implementation
- add a host-free coordinator regression test for both safety-critical ordering chains and the version-analysis/protected-reference handoffs

## Explicit exclusions

- no changes to GC retention or deletion behavior
- no public API, configuration, dependency, database, persisted-state, or protocol changes
- no ordering contract for unrelated GC phases or for interleaving between the two independent safety chains

## Validation

- `cargo fmt --manifest-path crates/runner/Cargo.toml --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner gc_coordinator_preserves_safety_critical_phase_order`
- `cargo test --manifest-path crates/Cargo.toml -p runner` (3408 passed, 24 ignored; guest inventory 1 passed)
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- repository pre-commit hooks (Rust format, Clippy, docs, file size, commitlint)

Closes #31136
