### PR TITLE
refactor(platform): simplify geist font stack

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -381,9 +381,7 @@ body {
    swap with it. Both families ship in the stylesheet request in index.html;
    their woff2 files only download once an element actually resolves to them. */
 :root[data-typeface="geist"] {
-  --font-family-sans:
-    "Geist", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    sans-serif;
+  --font-family-sans: "Geist", system-ui, sans-serif;
   --font-family-mono:
     "Geist Mono", ui-monospace, "SF Mono", Monaco, Consolas, monospace;
 }


### PR DESCRIPTION
## Summary

- simplify the Geist sans-serif stack to `"Geist", system-ui, sans-serif`
- remove redundant platform-specific fallbacks already covered by `system-ui`
- leave the default Noto Sans stack unchanged

## Verification

- `npx --yes prettier@3.8.1 --check turbo/apps/platform/src/views/css/index.css`
- `git diff --check`
- tests not run (static CSS fallback-list cleanup)
