### PR TITLE
fix(cli): render the camera cut at the frame rate the recording declares

### DIFF
--- a/turbo/apps/cli/src/commands/video/__tests__/camera.test.ts
+++ b/turbo/apps/cli/src/commands/video/__tests__/camera.test.ts
@@ -12,6 +12,11 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cameraCommand } from "../camera";
 
+/** What the fake ffprobe says about the video stream, adjustable per test. */
+const probedStream = vi.hoisted(() => {
+  return { avg_frame_rate: "30/1", r_frame_rate: "30/1" };
+});
+
 vi.mock("child_process", async () => {
   const { readFileSync, writeFileSync } =
     await vi.importActual<typeof import("node:fs")>("node:fs");
@@ -19,14 +24,7 @@ vi.mock("child_process", async () => {
     execFileSync: vi.fn((command: string, args: readonly string[]) => {
       if (command === "ffprobe") {
         return JSON.stringify({
-          streams: [
-            {
-              width: 1920,
-              height: 1080,
-              avg_frame_rate: "30/1",
-              r_frame_rate: "30/1",
-            },
-          ],
+          streams: [{ width: 1920, height: 1080, ...probedStream }],
           format: { duration: "10.000000" },
         });
       }
@@ -66,6 +64,8 @@ describe("okou video camera command", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    probedStream.avg_frame_rate = "30/1";
+    probedStream.r_frame_rate = "30/1";
     rmSync(directory, { recursive: true, force: true });
   });
 
@@ -177,6 +177,55 @@ describe("okou video camera command", () => {
         "-c:v",
         "libx264",
       ]),
+    );
+  });
+
+  it("renders at the frame rate the recording declares, not the probed average", async () => {
+    // A screen capture only stores a frame when the picture changes, so
+    // ffprobe averages a mostly still recording to well under one frame per
+    // second. That figure is valid as far as ffprobe is concerned, and it
+    // used to become the output frame rate.
+    probedStream.avg_frame_rate = "150/241";
+    probedStream.r_frame_rate = "1/2";
+    const videoPath = join(directory, "recording.mp4");
+    const eventsPath = join(directory, "recording.clicks.json");
+    const outputPath = join(directory, "draft.mp4");
+    writeFileSync(videoPath, Buffer.from("source-video"));
+    writeFileSync(
+      eventsPath,
+      JSON.stringify({
+        version: 1,
+        recording: {
+          durationMs: 10_000,
+          video: { width: 1920, height: 1080, frameRate: 30 },
+        },
+        clicks: [{ tMs: 2_000, normalized: { x: 0.12, y: 0.22 } }],
+        pointerEvents: [
+          { tMs: 1_700, kind: "move", normalized: { x: 0.1, y: 0.2 } },
+          { tMs: 2_000, kind: "click", normalized: { x: 0.12, y: 0.22 } },
+        ],
+      }),
+    );
+
+    await cameraCommand.parseAsync(
+      ["--file", videoPath, "--events", eventsPath, "--output", outputPath],
+      { from: "user" },
+    );
+
+    const result = JSON.parse(stdout()) as {
+      planPath: string;
+      frameRate: number;
+    };
+    expect(result.frameRate).toBe(30);
+    const plan = JSON.parse(readFileSync(result.planPath, "utf8")) as {
+      source: { frameRate: number };
+    };
+    expect(plan.source.frameRate).toBe(30);
+    const ffmpegCall = vi.mocked(execFileSync).mock.calls.find((call) => {
+      return call[0] === "ffmpeg";
+    });
+    expect(ffmpegCall?.[1]).toEqual(
+      expect.arrayContaining(["-vf", expect.stringMatching(/^fps=30,/u)]),
     );
   });
 

--- a/turbo/apps/cli/src/commands/video/camera.ts
+++ b/turbo/apps/cli/src/commands/video/camera.ts
@@ -34,8 +34,6 @@ const ffprobeSchema = z.object({
       z.object({
         width: z.number().int().positive(),
         height: z.number().int().positive(),
-        avg_frame_rate: z.string(),
-        r_frame_rate: z.string(),
       }),
     )
     .min(1),
@@ -55,28 +53,20 @@ function parseJsonFile(path: string): unknown {
   return JSON.parse(readFileSync(path, "utf8")) as unknown;
 }
 
-function frameRate(value: string): number | null {
-  const [numeratorText, denominatorText] = value.split("/");
-  const numerator = Number(numeratorText);
-  const denominator = Number(denominatorText);
-  if (
-    !Number.isFinite(numerator) ||
-    !Number.isFinite(denominator) ||
-    denominator === 0
-  ) {
-    return null;
-  }
-  const result = numerator / denominator;
-  return result > 0 ? result : null;
-}
-
 /**
- * `ffprobe` genuinely omits `format.duration` for some containers and reports
- * an unusable frame rate for variable-rate captures, so those two fields fall
- * back to the values the recording sidecar or plan declares. Width and height
- * always come from the probe, because a mismatch there means the wrong file.
+ * `ffprobe` genuinely omits `format.duration` for some containers, so the
+ * duration falls back to the value the recording sidecar or plan declares.
+ * Width and height always come from the probe, because a mismatch there means
+ * the wrong file.
+ *
+ * The frame rate is never probed. A screen capture only stores a frame when
+ * the picture changes, so for a recording with long still stretches `ffprobe`
+ * reports an average of well under one frame per second. That number looks
+ * valid, and rendering at it turned the cut into a slideshow and left the
+ * camera motion with almost no frames to move on. The recording declares the
+ * rate it was captured at, and that is the rate the cut plays back at.
  */
-function probeVideo(path: string, fallback: VideoSource): VideoSource {
+function probeVideo(path: string, declared: VideoSource): VideoSource {
   const raw = execFileSync(
     "ffprobe",
     [
@@ -85,7 +75,7 @@ function probeVideo(path: string, fallback: VideoSource): VideoSource {
       "-select_streams",
       "v:0",
       "-show_entries",
-      "stream=width,height,avg_frame_rate,r_frame_rate:format=duration",
+      "stream=width,height:format=duration",
       "-of",
       "json",
       path,
@@ -98,19 +88,14 @@ function probeVideo(path: string, fallback: VideoSource): VideoSource {
     throw new Error("Source file has no video stream");
   }
   const durationSeconds = Number(result.format.duration);
-  const detectedFrameRate =
-    frameRate(video.avg_frame_rate) ?? frameRate(video.r_frame_rate);
   return {
     durationMs:
       Number.isFinite(durationSeconds) && durationSeconds > 0
         ? Math.round(durationSeconds * 1_000)
-        : fallback.durationMs,
+        : declared.durationMs,
     width: video.width,
     height: video.height,
-    frameRate:
-      detectedFrameRate && detectedFrameRate <= 240
-        ? detectedFrameRate
-        : fallback.frameRate,
+    frameRate: declared.frameRate,
   };
 }
 
@@ -138,9 +123,6 @@ function assertPlanMatchesVideo(plan: CameraPlan, source: VideoSource): void {
   }
   if (Math.abs(plan.source.durationMs - source.durationMs) > 1_000) {
     throw new Error("Camera plan does not match the source video duration");
-  }
-  if (Math.abs(plan.source.frameRate - source.frameRate) > 0.01) {
-    throw new Error("Camera plan does not match the source video frame rate");
   }
 }
 


### PR DESCRIPTION
## Summary

`okou video camera` took its output frame rate from ffprobe's `avg_frame_rate` (then `r_frame_rate`) and only fell back to the sidecar's `frameRate` when the probed value was missing or above 240. That guard never fires for the file it was meant to catch.

A desktop screen capture only stores a frame when the picture changes, so a window or area recording of a mostly still screen is a sparse variable-rate MP4. ffprobe averages it to a valid-looking rate well under one frame per second. Reproduced with an 8 s file holding 5 frames:

| ffprobe field | value |
|---|---|
| `avg_frame_rate` | `150/241` (≈0.62 fps) |
| `r_frame_rate` | `1/2` (0.5 fps) |

Both pass the `> 0 && <= 240` check, so the cut was rendered with `fps=0.62` and the camera motion was sampled on that same sparse grid: a slideshow with jumping zooms. Click timing was not affected (the pipeline aligns by time), only playback quality.

## Change

- The frame rate is never probed anymore. The recording sidecar and the camera plan both declare the capture rate, and the cut always plays back at that rate. ffprobe still supplies width, height, and duration.
- `assertPlanMatchesVideo` no longer compares the plan's frame rate with the probed one, since that would now compare the plan to itself.
- Regression test: with the fake ffprobe reporting `150/241` / `1/2`, the plan, the JSON result, and the ffmpeg `-vf` chain all stay at 30 fps. On the previous code this test fails with `expected 0.6224066390041494 to be 30`.

## Test plan

- [x] `pnpm -F @okouai/cli exec vitest run src/commands/video/__tests__/camera.test.ts` (4 passed; new test verified failing on the old code)
- [x] `pnpm -F @okouai/cli lint`, `tsc --noEmit`, `pnpm knip --workspace apps/cli`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
