### PR TITLE
fix(runner): report authoritative provider failure reasons

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1308,6 +1308,7 @@ dependencies = [
 name = "guest-contracts"
 version = "0.12.20"
 dependencies = [
+ "api-contracts",
  "base64 0.23.1",
  "chrono",
  "libc",

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -1872,7 +1872,7 @@ mod tests {
             Some(events::CodexFailureDiagnostic {
                 event_type: "turn.completed",
                 message: "Rate limit exceeded.".to_string(),
-                failure_reason: Some(FailureReason::ProviderOverloaded),
+                failure_reason: Some(FailureReason::ProviderRateLimited),
             })
         );
     }

--- a/crates/guest-agent/src/complete.rs
+++ b/crates/guest-agent/src/complete.rs
@@ -24,6 +24,7 @@ use crate::http::HttpClient;
 use crate::run_context::GuestRuntime;
 use api_contracts::generated::types::webhooks::agent::complete;
 use guest_common::{log_info, log_warn};
+use guest_contracts::diagnostics::FailureReason;
 use serde::Serialize;
 use std::time::Instant;
 
@@ -34,6 +35,8 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 struct CompletePayload<'a> {
     run_id: &'a str,
     exit_code: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    failure_reason: Option<complete::RequestFailureReason>,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -74,6 +77,7 @@ fn as_optional_slice(values: &[String]) -> Option<&[String]> {
 pub async fn report_checkpoint_for_run(
     runtime: &GuestRuntime,
     exit_code: i32,
+    failure_reason: Option<FailureReason>,
     error: Option<&str>,
     last_event_sequence: Option<u32>,
     active_input_delivery_ids: &[String],
@@ -85,6 +89,7 @@ pub async fn report_checkpoint_for_run(
         payload_for_runtime(
             runtime,
             exit_code,
+            failure_reason,
             error,
             last_event_sequence,
             active_input_delivery_ids,
@@ -151,6 +156,7 @@ pub async fn report_user_cancellation_for_run(
 fn payload_for_runtime<'a>(
     runtime: &'a GuestRuntime,
     exit_code: i32,
+    failure_reason: Option<FailureReason>,
     error: Option<&'a str>,
     last_event_sequence: Option<u32>,
     active_input_delivery_ids: &'a [String],
@@ -160,6 +166,7 @@ fn payload_for_runtime<'a>(
     CompletePayload {
         run_id: &config.run_id,
         exit_code,
+        failure_reason: failure_reason.map(Into::into),
         error,
         last_event_sequence,
         sandbox_id: as_optional(&config.sandbox_id),
@@ -182,6 +189,7 @@ fn checkpointless_payload_for_run<'a>(
     CompletePayload {
         run_id,
         exit_code,
+        failure_reason: None,
         error: None,
         last_event_sequence,
         sandbox_id: as_optional(sandbox_id),
@@ -211,6 +219,7 @@ mod tests {
         let payload = CompletePayload {
             run_id: "run-123",
             exit_code: 0,
+            failure_reason: None,
             error: None,
             last_event_sequence: None,
             sandbox_id: None,
@@ -228,6 +237,7 @@ mod tests {
         let payload = CompletePayload {
             run_id: "run-123",
             exit_code: 0,
+            failure_reason: None,
             error: None,
             last_event_sequence: None,
             sandbox_id: Some("abc"),
@@ -242,6 +252,25 @@ mod tests {
         assert!(json.contains(r#""workspaceReuseResult":"sandboxReused""#));
     }
 
+    #[test]
+    fn payload_uses_the_generated_failure_reason_contract() {
+        let payload = CompletePayload {
+            run_id: "run-123",
+            exit_code: 1,
+            failure_reason: Some(FailureReason::ProviderRateLimited.into()),
+            error: Some("rate limited"),
+            last_event_sequence: None,
+            sandbox_id: None,
+            sandbox_reuse_result: None,
+            workspace_reuse_result: None,
+            active_input_delivery_ids: None,
+            checkpoint: None,
+        };
+
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["failureReason"], "provider_rate_limited");
+    }
+
     /// Completion metadata fields must be skipped independently so one absent
     /// runner value does not silently drop another useful value.
     #[test]
@@ -249,6 +278,7 @@ mod tests {
         let payload = CompletePayload {
             run_id: "run-123",
             exit_code: 0,
+            failure_reason: None,
             error: None,
             last_event_sequence: None,
             sandbox_id: None,
@@ -267,6 +297,7 @@ mod tests {
         let payload = CompletePayload {
             run_id: "run-123",
             exit_code: 0,
+            failure_reason: None,
             error: None,
             last_event_sequence: None,
             sandbox_id: Some("sid"),
@@ -292,6 +323,7 @@ mod tests {
         let payload = CompletePayload {
             run_id: "run-123",
             exit_code: 0,
+            failure_reason: None,
             error: None,
             last_event_sequence: Some(7),
             sandbox_id: None,

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -7,8 +7,8 @@ use crate::constants;
 use crate::env::{Framework, GuestConfig};
 use crate::error::AgentError;
 use crate::failure_patterns::{
-    has_exact_codex_oauth_connector, is_codex_context_window_exceeded_message,
-    is_codex_model_capacity_message,
+    has_exact_codex_oauth_connector, is_codex_chatgpt_account_unsupported_model_message,
+    is_codex_context_window_exceeded_message, is_codex_model_capacity_message,
 };
 use crate::http::{HttpAttemptObserver, HttpClient};
 use crate::masker::SecretMasker;
@@ -279,13 +279,20 @@ fn codex_error_failure_reason(error: Option<&Value>) -> Option<FailureReason> {
     {
         return Some(FailureReason::ContextWindowExceeded);
     }
+    if codex_error_message(Some(error))
+        .as_deref()
+        .is_some_and(is_codex_chatgpt_account_unsupported_model_message)
+    {
+        return Some(FailureReason::UnsupportedModel);
+    }
     None
 }
 
 fn codex_error_info_failure_reason(error: &Value) -> Option<FailureReason> {
     match codex_error_info_variant(error)? {
         "contextWindowExceeded" => Some(FailureReason::ContextWindowExceeded),
-        "rateLimitExceeded" | "serverOverloaded" => Some(FailureReason::ProviderOverloaded),
+        "rateLimitExceeded" => Some(FailureReason::ProviderRateLimited),
+        "serverOverloaded" => Some(FailureReason::ProviderOverloaded),
         "responseStreamConnectionFailed" | "responseStreamDisconnected" => {
             Some(FailureReason::ResponseConnectionLost)
         }
@@ -764,6 +771,46 @@ mod tests {
                 event_type: "error",
                 message: "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.".to_string(),
                 failure_reason: Some(FailureReason::ContextWindowExceeded),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_error_event_unsupported_model_yields_failure_reason() {
+        let message =
+            "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.";
+        let event = serde_json::json!({
+            "type": "error",
+            "message": message,
+            "error": {"message": message}
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "error",
+                message: message.to_string(),
+                failure_reason: Some(FailureReason::UnsupportedModel),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_error_event_unsupported_model_near_miss_remains_unclassified() {
+        let message =
+            "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account";
+        let event = serde_json::json!({
+            "type": "error",
+            "message": message,
+            "error": {"message": message}
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "error",
+                message: message.to_string(),
+                failure_reason: None,
             })
         );
     }

--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -269,6 +269,18 @@ fn classify_cli_failure_reason(
     {
         return Some(FailureReason::SafetyPolicyRefusal);
     }
+    if matches!(framework, AgentFramework::Codex)
+        && source == FailureDetailSource::CodexJsonl
+        && failure_patterns::is_codex_rate_limit_retry_exhausted_message(failure_message)
+    {
+        return Some(FailureReason::ProviderRateLimited);
+    }
+    if matches!(framework, AgentFramework::Codex)
+        && source == FailureDetailSource::Stderr
+        && is_codex_chatgpt_account_unsupported_model_run_error(failure_message)
+    {
+        return Some(FailureReason::UnsupportedModel);
+    }
 
     let normalized = failure_message.to_ascii_lowercase();
     if is_insufficient_credits_error(&normalized) {
@@ -548,6 +560,26 @@ fn is_codex_oauth_reconnect_required_run_error(error_message: &str) -> bool {
             .as_ref()
             .is_some_and(is_codex_oauth_reconnect_required_value)
         {
+            return true;
+        }
+        search_start = end_index;
+    }
+    false
+}
+
+fn is_codex_chatgpt_account_unsupported_model_run_error(error_message: &str) -> bool {
+    let mut search_start = 0;
+    while let Some((value, end_index)) = parse_next_json_object(error_message, search_start) {
+        if value.as_ref().is_some_and(|value| {
+            value.get("type").and_then(Value::as_str) == Some("error")
+                && value.get("status").and_then(Value::as_u64) == Some(400)
+                && value.get("error").is_some_and(|error| {
+                    error.get("type").and_then(Value::as_str) == Some("invalid_request_error")
+                        && error.get("message").and_then(Value::as_str).is_some_and(
+                            failure_patterns::is_codex_chatgpt_account_unsupported_model_message,
+                        )
+                })
+        }) {
             return true;
         }
         search_start = end_index;

--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -1010,6 +1010,141 @@ fn cli_failure_reason_ignores_codex_provider_overloaded_text() {
 }
 
 #[test]
+fn cli_failure_reason_classifies_trusted_codex_rate_limit_retry_exhaustion() {
+    for message in [
+        "exceeded retry limit, last status: 429 Too Many Requests",
+        "Codex failed: exceeded retry limit, last status: 429 Too Many Requests, request id: req_123",
+    ] {
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::Codex,
+            FailureDetailSource::CodexJsonl,
+            message,
+        );
+
+        assert_eq!(
+            reason,
+            Some(FailureReason::ProviderRateLimited),
+            "message: {message}"
+        );
+    }
+}
+
+#[test]
+fn cli_failure_reason_rejects_untrusted_codex_rate_limit_retry_exhaustion() {
+    let signature = "exceeded retry limit, last status: 429 Too Many Requests";
+
+    for (framework, source) in [
+        (AgentFramework::Codex, FailureDetailSource::Stderr),
+        (AgentFramework::ClaudeCode, FailureDetailSource::CodexJsonl),
+    ] {
+        let reason = super::classify_cli_failure_reason(framework, source, signature);
+
+        assert_eq!(reason, None, "framework: {framework:?}, source: {source:?}");
+    }
+}
+
+#[test]
+fn codex_rate_limit_reason_is_attached_without_changing_failure_class() {
+    let diagnostic = FailureDiagnostic::new(
+        FailureClass::CliNonzero,
+        AgentFramework::Codex,
+        PromptMetadata::from_prompt("plain prompt"),
+    )
+    .with_cli_exit_code(1)
+    .with_failure_detail_source(FailureDetailSource::CodexJsonl);
+    let failure_message = selected_failure_message(
+        "exceeded retry limit, last status: 429 Too Many Requests, request id: req_123",
+        FailureDetailSource::CodexJsonl,
+        None,
+    );
+
+    let diagnostic = with_cli_failure_reason(diagnostic, &failure_message);
+
+    assert_eq!(diagnostic.failure_class, FailureClass::CliNonzero);
+    assert_eq!(
+        diagnostic.failure_reason,
+        Some(FailureReason::ProviderRateLimited)
+    );
+    assert_eq!(
+        diagnostic.failure_detail_source,
+        Some(FailureDetailSource::CodexJsonl)
+    );
+}
+
+#[test]
+fn cli_failure_reason_classifies_exact_codex_unsupported_model_envelope() {
+    let message = r#"Codex failed: {"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}}"#;
+
+    assert_eq!(
+        super::classify_cli_failure_reason(
+            AgentFramework::Codex,
+            FailureDetailSource::Stderr,
+            message,
+        ),
+        Some(FailureReason::UnsupportedModel)
+    );
+}
+
+#[test]
+fn cli_failure_reason_rejects_untrusted_or_near_miss_unsupported_model_envelopes() {
+    const EXACT_MESSAGE: &str =
+        "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.";
+    let cases = [
+        (
+            AgentFramework::ClaudeCode,
+            FailureDetailSource::Stderr,
+            format!(
+                r#"{{"type":"error","status":400,"error":{{"type":"invalid_request_error","message":"{EXACT_MESSAGE}"}}}}"#
+            ),
+        ),
+        (
+            AgentFramework::Codex,
+            FailureDetailSource::CodexJsonl,
+            format!(
+                r#"{{"type":"error","status":400,"error":{{"type":"invalid_request_error","message":"{EXACT_MESSAGE}"}}}}"#
+            ),
+        ),
+        (
+            AgentFramework::Codex,
+            FailureDetailSource::Stderr,
+            format!(
+                r#"{{"type":"error","status":401,"error":{{"type":"invalid_request_error","message":"{EXACT_MESSAGE}"}}}}"#
+            ),
+        ),
+        (
+            AgentFramework::Codex,
+            FailureDetailSource::Stderr,
+            format!(
+                r#"{{"type":"error","status":400,"error":{{"type":"unsupported_model","message":"{EXACT_MESSAGE}"}}}}"#
+            ),
+        ),
+        (
+            AgentFramework::Codex,
+            FailureDetailSource::Stderr,
+            r#"{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account"}}"#.to_string(),
+        ),
+        (
+            AgentFramework::Codex,
+            FailureDetailSource::Stderr,
+            EXACT_MESSAGE.to_string(),
+        ),
+        (
+            AgentFramework::Codex,
+            FailureDetailSource::Stderr,
+            "{malformed".to_string(),
+        ),
+    ];
+
+    for (framework, source, message) in cases {
+        assert_eq!(
+            super::classify_cli_failure_reason(framework, source, &message),
+            None,
+            "framework: {framework:?}, source: {source:?}, message: {message}"
+        );
+    }
+}
+
+#[test]
 fn cli_failure_reason_classifies_codex_model_capacity() {
     let reason = classify_cli_failure_reason(
         AgentFramework::Codex,

--- a/crates/guest-agent/src/failure_patterns.rs
+++ b/crates/guest-agent/src/failure_patterns.rs
@@ -8,6 +8,10 @@ const CODEX_MODEL_CAPACITY_MESSAGE: &str =
     "selected model is at capacity. please try a different model.";
 const CODEX_CONTEXT_WINDOW_EXHAUSTED_PREFIX: &str =
     "codex ran out of room in the model's context window.";
+const CODEX_RATE_LIMIT_RETRY_EXHAUSTED_MESSAGE: &str =
+    "exceeded retry limit, last status: 429 too many requests";
+const CODEX_UNSUPPORTED_MODEL_MESSAGE_SUFFIX: &str =
+    "' model is not supported when using Codex with a ChatGPT account.";
 
 pub(crate) fn is_generic_codex_failure_diagnostic(message: &str) -> bool {
     let message = message.trim().to_ascii_lowercase();
@@ -30,6 +34,36 @@ pub(crate) fn is_codex_context_window_exceeded_message(message: &str) -> bool {
         && (message.contains("start a new thread") || message.contains("start a new conversation"))
         && message.contains("clear earlier history")
         && message.contains("before retrying")
+}
+
+pub(crate) fn is_codex_rate_limit_retry_exhausted_message(message: &str) -> bool {
+    let normalized = message.trim().to_ascii_lowercase();
+    let normalized = normalized
+        .strip_prefix("codex failed:")
+        .unwrap_or(&normalized)
+        .trim();
+    let Some(suffix) = normalized.strip_prefix(CODEX_RATE_LIMIT_RETRY_EXHAUSTED_MESSAGE) else {
+        return false;
+    };
+    suffix.is_empty()
+        || suffix
+            .strip_prefix(", request id: ")
+            .is_some_and(|request_id| {
+                !request_id.is_empty()
+                    && request_id
+                        .chars()
+                        .all(|character| !character.is_ascii_whitespace())
+            })
+}
+
+pub(crate) fn is_codex_chatgpt_account_unsupported_model_message(message: &str) -> bool {
+    let Some(model) = message
+        .strip_prefix("The '")
+        .and_then(|message| message.strip_suffix(CODEX_UNSUPPORTED_MODEL_MESSAGE_SUFFIX))
+    else {
+        return false;
+    };
+    !model.is_empty() && !model.contains('\'')
 }
 
 pub(crate) fn has_exact_codex_oauth_connector(value: &Value) -> bool {
@@ -104,5 +138,55 @@ mod tests {
         assert!(!is_codex_context_window_exceeded_message(
             "The prompt mentions the model context window but did not fail."
         ));
+    }
+
+    #[test]
+    fn codex_rate_limit_retry_exhausted_matcher_accepts_known_shapes() {
+        for message in [
+            "exceeded retry limit, last status: 429 Too Many Requests",
+            "exceeded retry limit, last status: 429 Too Many Requests, request id: req_123-abc",
+            " Codex failed: EXCEEDED RETRY LIMIT, LAST STATUS: 429 TOO MANY REQUESTS, REQUEST ID: req_123 ",
+        ] {
+            assert!(
+                is_codex_rate_limit_retry_exhausted_message(message),
+                "message: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn codex_rate_limit_retry_exhausted_matcher_rejects_near_misses() {
+        for message in [
+            "429 Too Many Requests",
+            "exceeded retry limit, last status: 503 Service Unavailable",
+            "exceeded retry limit, last status: 429 Too Many Requests; try later",
+            "exceeded retry limit, last status: 429 Too Many Requests, request id: ",
+            "the log says exceeded retry limit, last status: 429 Too Many Requests",
+        ] {
+            assert!(
+                !is_codex_rate_limit_retry_exhausted_message(message),
+                "message: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn codex_unsupported_model_matcher_requires_the_exact_message() {
+        assert!(is_codex_chatgpt_account_unsupported_model_message(
+            "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."
+        ));
+
+        for message in [
+            "The '' model is not supported when using Codex with a ChatGPT account.",
+            "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account",
+            "the 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+            "The 'gpt-5.6-sol' model is not supported with this account.",
+            "The 'gpt'5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+        ] {
+            assert!(
+                !is_codex_chatgpt_account_unsupported_model_message(message),
+                "message: {message}"
+            );
+        }
     }
 }

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -857,6 +857,7 @@ async fn complete_execution(
                     runtime,
                     0,
                     None,
+                    None,
                     state.last_event_sequence,
                     state.active_input_delivery_ids,
                     checkpoint,
@@ -927,6 +928,10 @@ async fn complete_execution(
                         match complete::report_checkpoint_for_run(
                             runtime,
                             exit_code,
+                            state
+                                .failure_diagnostic
+                                .as_ref()
+                                .and_then(|diagnostic| diagnostic.failure_reason),
                             state.failure_message,
                             state.last_event_sequence,
                             state.active_input_delivery_ids,
@@ -2029,7 +2034,7 @@ mod tests {
             when.method(POST)
                 .path("/api/webhooks/agent/complete")
                 .json_body_includes(
-                    r#"{"exitCode":1,"error":"You've hit your usage limit.","checkpoint":{"cliAgentSessionId":"recovery-session-from-main"}}"#,
+                    r#"{"exitCode":1,"failureReason":"usage_limit","error":"You've hit your usage limit.","checkpoint":{"cliAgentSessionId":"recovery-session-from-main"}}"#,
                 );
             then.status(completion_status)
                 .header("Content-Type", "application/json")
@@ -2055,6 +2060,7 @@ mod tests {
             PromptMetadata::from_prompt("plain prompt"),
         )
         .with_cli_exit_code(1)
+        .with_failure_reason(FailureReason::UsageLimit)
         .with_session_history_status(SessionHistoryStatus::Present);
         let exit_code = complete_execution(
             1,

--- a/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
+++ b/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
@@ -220,8 +220,16 @@ async fn unchanged_artifact_checkpoint_records_content_hash_timing()
     let checkpoint =
         guest_agent::checkpoint::prepare_checkpoint_for_runtime(&runtime, &session_metadata)
             .await?;
-    guest_agent::complete::report_checkpoint_for_run(&runtime, 0, None, None, &[], checkpoint)
-        .await?;
+    guest_agent::complete::report_checkpoint_for_run(
+        &runtime,
+        0,
+        None,
+        None,
+        None,
+        &[],
+        checkpoint,
+    )
+    .await?;
 
     history_prepare.assert_calls_async(1).await;
     storage_prepare.assert_calls_async(0).await;

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -262,6 +262,7 @@ fn recovery_checkpoint_resolves_history_from_codex_sessions_root() -> TestResult
             1,
             None,
             None,
+            None,
             &[],
             checkpoint,
         )

--- a/crates/guest-agent/tests/integration_cases/checkpoint/success.rs
+++ b/crates/guest-agent/tests/integration_cases/checkpoint/success.rs
@@ -95,6 +95,7 @@ async fn pi_checkpoint_reports_full_combined_completion_payload() {
         &runtime,
         0,
         None,
+        None,
         Some(42),
         &active_input_delivery_ids,
         checkpoint,

--- a/crates/guest-agent/tests/integration_cases/checkpoint/support.rs
+++ b/crates/guest-agent/tests/integration_cases/checkpoint/support.rs
@@ -55,6 +55,7 @@ pub(super) async fn report_prepared_checkpoint(
         exit_code,
         None,
         None,
+        None,
         &[],
         checkpoint,
     )

--- a/crates/guest-contracts/Cargo.toml
+++ b/crates/guest-contracts/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 description = "Shared contracts between runner and guest binaries"
 
 [dependencies]
+api-contracts.workspace = true
 base64.workspace = true
 chrono = { workspace = true, features = ["alloc"] }
 libc.workspace = true

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -721,6 +721,8 @@ pub enum FailureReason {
     ContextWindowExceeded,
     /// The provider stopped because an output-token limit was reached.
     OutputTokenLimit,
+    /// The provider rejected the request because of a rate limit.
+    ProviderRateLimited,
     /// The provider reported overload.
     ProviderOverloaded,
     /// The provider stream timed out.
@@ -733,6 +735,8 @@ pub enum FailureReason {
     SafetyPolicyRefusal,
     /// The CLI requires reconnecting or re-authentication.
     ReconnectRequired,
+    /// The selected model is unsupported for the authenticated provider account.
+    UnsupportedModel,
     /// The provider reported a usage limit.
     UsageLimit,
 }
@@ -749,13 +753,40 @@ impl FailureReason {
             Self::TermsAcceptanceRequired => "terms_acceptance_required",
             Self::ContextWindowExceeded => "context_window_exceeded",
             Self::OutputTokenLimit => "output_token_limit",
+            Self::ProviderRateLimited => "provider_rate_limited",
             Self::ProviderOverloaded => "provider_overloaded",
             Self::ProviderStreamTimeout => "provider_stream_timeout",
             Self::ProviderServerError => "provider_server_error",
             Self::ResponseConnectionLost => "response_connection_lost",
             Self::SafetyPolicyRefusal => "safety_policy_refusal",
             Self::ReconnectRequired => "reconnect_required",
+            Self::UnsupportedModel => "unsupported_model",
             Self::UsageLimit => "usage_limit",
+        }
+    }
+}
+
+impl From<FailureReason>
+    for api_contracts::generated::types::webhooks::agent::complete::RequestFailureReason
+{
+    fn from(reason: FailureReason) -> Self {
+        match reason {
+            FailureReason::SessionHistoryLimit => Self::SessionHistoryLimit,
+            FailureReason::InsufficientCredits => Self::InsufficientCredits,
+            FailureReason::InvalidApiKey => Self::InvalidApiKey,
+            FailureReason::InvalidCredentials => Self::InvalidCredentials,
+            FailureReason::TermsAcceptanceRequired => Self::TermsAcceptanceRequired,
+            FailureReason::ContextWindowExceeded => Self::ContextWindowExceeded,
+            FailureReason::OutputTokenLimit => Self::OutputTokenLimit,
+            FailureReason::ProviderRateLimited => Self::ProviderRateLimited,
+            FailureReason::ProviderOverloaded => Self::ProviderOverloaded,
+            FailureReason::ProviderStreamTimeout => Self::ProviderStreamTimeout,
+            FailureReason::ProviderServerError => Self::ProviderServerError,
+            FailureReason::ResponseConnectionLost => Self::ResponseConnectionLost,
+            FailureReason::SafetyPolicyRefusal => Self::SafetyPolicyRefusal,
+            FailureReason::ReconnectRequired => Self::ReconnectRequired,
+            FailureReason::UnsupportedModel => Self::UnsupportedModel,
+            FailureReason::UsageLimit => Self::UsageLimit,
         }
     }
 }
@@ -1419,6 +1450,47 @@ mod tests {
 
         let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
         assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn failure_reason_maps_exhaustively_to_the_public_completion_contract() {
+        for (reason, expected) in [
+            (FailureReason::SessionHistoryLimit, "session_history_limit"),
+            (FailureReason::InsufficientCredits, "insufficient_credits"),
+            (FailureReason::InvalidApiKey, "invalid_api_key"),
+            (FailureReason::InvalidCredentials, "invalid_credentials"),
+            (
+                FailureReason::TermsAcceptanceRequired,
+                "terms_acceptance_required",
+            ),
+            (
+                FailureReason::ContextWindowExceeded,
+                "context_window_exceeded",
+            ),
+            (FailureReason::OutputTokenLimit, "output_token_limit"),
+            (FailureReason::ProviderRateLimited, "provider_rate_limited"),
+            (FailureReason::ProviderOverloaded, "provider_overloaded"),
+            (
+                FailureReason::ProviderStreamTimeout,
+                "provider_stream_timeout",
+            ),
+            (FailureReason::ProviderServerError, "provider_server_error"),
+            (
+                FailureReason::ResponseConnectionLost,
+                "response_connection_lost",
+            ),
+            (FailureReason::SafetyPolicyRefusal, "safety_policy_refusal"),
+            (FailureReason::ReconnectRequired, "reconnect_required"),
+            (FailureReason::UnsupportedModel, "unsupported_model"),
+            (FailureReason::UsageLimit, "usage_limit"),
+        ] {
+            let public_reason: api_contracts::generated::types::webhooks::agent::complete::RequestFailureReason =
+                reason.into();
+
+            assert_eq!(reason.as_str(), expected);
+            assert_eq!(serde_json::to_value(reason).unwrap(), expected);
+            assert_eq!(serde_json::to_value(public_reason).unwrap(), expected);
+        }
     }
 
     #[test]

--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -918,6 +918,7 @@ async fn complete_claimed_without_sandbox(
             CompleteRequest {
                 run_id: context.run_id,
                 exit_code: failure.exit_code,
+                failure_reason: None,
                 error: Some(failure.error),
                 sandbox_id: None,
                 sandbox_reuse_result: reuse_result,

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -986,6 +986,7 @@ async fn recover_claimed_activation_failure(
             CompleteRequest {
                 run_id,
                 exit_code: execution_failure.exit_code,
+                failure_reason: None,
                 error: Some(execution_failure.error),
                 sandbox_id: None,
                 sandbox_reuse_result: Some(reuse_result),
@@ -2462,6 +2463,7 @@ async fn complete_claimed_failure(
             CompleteRequest {
                 run_id,
                 exit_code: failure.exit_code,
+                failure_reason: None,
                 error: Some(failure.error),
                 sandbox_id: None,
                 sandbox_reuse_result: reuse_result,

--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::{Duration, Instant};
 
+use api_contracts::generated::types::webhooks::agent::complete::RequestFailureReason;
 use chrono::{DateTime, Utc};
 use sandbox::SandboxId;
 
@@ -139,6 +140,7 @@ impl BudgetOwnership {
 pub(super) struct CompletionPayload {
     run_id: RunId,
     exit_code: i32,
+    failure_reason: Option<RequestFailureReason>,
     error: Option<String>,
     sandbox_id: SandboxId,
     reuse_result: SandboxReuseResult,
@@ -169,6 +171,7 @@ impl CompletionPayload {
     pub(super) fn new(
         run_id: RunId,
         exit_code: i32,
+        failure_reason: Option<RequestFailureReason>,
         error: Option<String>,
         sandbox_id: SandboxId,
         reuse_result: SandboxReuseResult,
@@ -177,6 +180,7 @@ impl CompletionPayload {
         Self {
             run_id,
             exit_code,
+            failure_reason,
             error,
             sandbox_id,
             reuse_result,
@@ -206,6 +210,7 @@ impl CompletionPayload {
         let Self {
             run_id,
             exit_code,
+            failure_reason,
             error,
             sandbox_id,
             reuse_result,
@@ -219,6 +224,7 @@ impl CompletionPayload {
                 CompleteRequest {
                     run_id,
                     exit_code,
+                    failure_reason,
                     error,
                     sandbox_id: Some(sandbox_id),
                     sandbox_reuse_result: Some(reuse_result),
@@ -318,6 +324,7 @@ mod tests {
     struct CompletionAuthProvider {
         auth_matches: Arc<AtomicBool>,
         active_input_delivery_ids: Arc<std::sync::Mutex<Vec<String>>>,
+        failure_reason: Arc<std::sync::Mutex<Option<RequestFailureReason>>>,
     }
 
     #[async_trait]
@@ -335,6 +342,7 @@ mod tests {
                 completion_auth.matches_sandbox_token_for_test(request.run_id, "completion-token"),
                 Ordering::SeqCst,
             );
+            *self.failure_reason.lock().unwrap() = request.failure_reason;
             *self.active_input_delivery_ids.lock().unwrap() = request.active_input_delivery_ids;
         }
 
@@ -379,9 +387,11 @@ mod tests {
     async fn completion_payload_forwards_completion_auth() {
         let auth_matches = Arc::new(AtomicBool::new(false));
         let active_input_delivery_ids = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let failure_reason = Arc::new(std::sync::Mutex::new(None));
         let provider = CompletionAuthProvider {
             auth_matches: Arc::clone(&auth_matches),
             active_input_delivery_ids: Arc::clone(&active_input_delivery_ids),
+            failure_reason: Arc::clone(&failure_reason),
         };
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
@@ -389,6 +399,7 @@ mod tests {
         let _ = CompletionPayload::new(
             run_id,
             0,
+            Some(RequestFailureReason::ProviderRateLimited),
             None,
             sandbox_id,
             SandboxReuseResult::PoolMiss,
@@ -405,6 +416,10 @@ mod tests {
         assert_eq!(
             *active_input_delivery_ids.lock().unwrap(),
             vec!["b1e2ad6d-930a-4d51-aa40-7952d54f978b".to_string()]
+        );
+        assert_eq!(
+            *failure_reason.lock().unwrap(),
+            Some(RequestFailureReason::ProviderRateLimited)
         );
     }
 

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -735,10 +735,22 @@ pub(super) async fn run_job(
             cancelled_for_log,
             executor_result.outcome.failure.as_ref(),
         );
+        let failure_reason = if executor_result.exit_code == 0 || cancelled_for_log {
+            None
+        } else {
+            executor_result
+                .outcome
+                .failure
+                .as_ref()
+                .and_then(|failure| failure.diagnostic.as_ref())
+                .and_then(|diagnostic| diagnostic.failure_reason)
+                .map(Into::into)
+        };
 
         let completion_payload = CompletionPayload::new(
             run_id,
             executor_result.exit_code,
+            failure_reason,
             executor_result.err.take(),
             sandbox_id,
             reuse_result,

--- a/crates/runner/src/cmd/start/job_terminal_log.rs
+++ b/crates/runner/src/cmd/start/job_terminal_log.rs
@@ -466,11 +466,14 @@ fn is_info_level_job_failure(diagnostic: &FailureDiagnostic) -> bool {
                     | FailureReason::TermsAcceptanceRequired
                     | FailureReason::ContextWindowExceeded
                     | FailureReason::OutputTokenLimit
+                    | FailureReason::ProviderRateLimited
                     | FailureReason::ProviderOverloaded
                     | FailureReason::ProviderStreamTimeout
                     | FailureReason::ProviderServerError
+                    | FailureReason::ResponseConnectionLost
                     | FailureReason::SafetyPolicyRefusal
                     | FailureReason::ReconnectRequired
+                    | FailureReason::UnsupportedModel
                     | FailureReason::UsageLimit
             )
         ),
@@ -617,11 +620,14 @@ mod tests {
             FailureReason::TermsAcceptanceRequired,
             FailureReason::ContextWindowExceeded,
             FailureReason::OutputTokenLimit,
+            FailureReason::ProviderRateLimited,
             FailureReason::ProviderOverloaded,
             FailureReason::ProviderStreamTimeout,
             FailureReason::ProviderServerError,
+            FailureReason::ResponseConnectionLost,
             FailureReason::SafetyPolicyRefusal,
             FailureReason::ReconnectRequired,
+            FailureReason::UnsupportedModel,
             FailureReason::UsageLimit,
         ] {
             let diagnostic = job_failure_diagnostic(Some(reason));
@@ -743,7 +749,7 @@ mod tests {
             (
                 FailureReason::ResponseConnectionLost,
                 "API Error: Connection lost mid-response. The response above may be incomplete.",
-                Level::ERROR,
+                Level::INFO,
             ),
         ] {
             let diagnostic = FailureDiagnostic::new(
@@ -816,11 +822,14 @@ mod tests {
             FailureReason::TermsAcceptanceRequired,
             FailureReason::ContextWindowExceeded,
             FailureReason::OutputTokenLimit,
+            FailureReason::ProviderRateLimited,
             FailureReason::ProviderOverloaded,
             FailureReason::ProviderStreamTimeout,
             FailureReason::ProviderServerError,
+            FailureReason::ResponseConnectionLost,
             FailureReason::SafetyPolicyRefusal,
             FailureReason::ReconnectRequired,
+            FailureReason::UnsupportedModel,
             FailureReason::UsageLimit,
         ] {
             let diagnostic = FailureDiagnostic::new(

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -2483,6 +2483,7 @@ mod tests {
         CompleteRequest {
             run_id,
             exit_code: 0,
+            failure_reason: None,
             error: None,
             sandbox_id: None,
             sandbox_reuse_result: None,
@@ -5050,6 +5051,7 @@ mod tests {
                 &CompleteRequest {
                     run_id: RunId::nil(),
                     exit_code: 1,
+                    failure_reason: None,
                     error: Some("boom".to_string()),
                     sandbox_id: None,
                     sandbox_reuse_result: None,
@@ -5094,6 +5096,7 @@ mod tests {
             &CompleteRequest {
                 run_id,
                 exit_code: 0,
+                failure_reason: None,
                 error: None,
                 sandbox_id: None,
                 sandbox_reuse_result: Some(SandboxReuseResult::NoReuseKey),

--- a/crates/runner/src/provider/local/tests/support.rs
+++ b/crates/runner/src/provider/local/tests/support.rs
@@ -46,6 +46,7 @@ pub(super) fn complete_request(
     CompleteRequest {
         run_id,
         exit_code,
+        failure_reason: None,
         error: error.map(str::to_owned),
         sandbox_id: None,
         sandbox_reuse_result: None,

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -707,6 +707,7 @@ mod tests {
         CompleteRequest {
             run_id,
             exit_code: 0,
+            failure_reason: None,
             error: None,
             sandbox_id: None,
             sandbox_reuse_result: None,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -3,6 +3,7 @@ use std::net::IpAddr;
 use std::sync::Arc;
 
 use api_contracts::generated::types::runners::runs::CodexRuntimeConfig;
+use api_contracts::generated::types::webhooks::agent::complete::RequestFailureReason;
 use sandbox::SandboxId;
 use serde::{Deserialize, Serialize};
 use unicode_normalization::UnicodeNormalization;
@@ -1643,6 +1644,8 @@ pub struct CompleteRequest {
     pub run_id: RunId,
     pub exit_code: i32,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_reason: Option<RequestFailureReason>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     /// Sandbox the run executed against. `None` when the run failed before
     /// sandbox allocation; otherwise set on every completion regardless of
@@ -2118,6 +2121,7 @@ mod tests {
                 .parse::<RunId>()
                 .unwrap(),
             exit_code: 0,
+            failure_reason: None,
             error: None,
             sandbox_id: None,
             sandbox_reuse_result: None,
@@ -2129,6 +2133,7 @@ mod tests {
         assert!(json.get("exitCode").is_some());
         // optionals omitted when None
         assert!(json.get("error").is_none());
+        assert!(json.get("failureReason").is_none());
         assert!(json.get("sandboxId").is_none());
         assert!(json.get("sandboxReuseResult").is_none());
         assert!(json.get("workspaceReuseResult").is_none());
@@ -2142,6 +2147,7 @@ mod tests {
                 .parse::<RunId>()
                 .unwrap(),
             exit_code: 1,
+            failure_reason: Some(RequestFailureReason::ProviderRateLimited),
             error: Some("timeout".into()),
             sandbox_id: None,
             sandbox_reuse_result: None,
@@ -2150,6 +2156,7 @@ mod tests {
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["error"], "timeout");
+        assert_eq!(json["failureReason"], "provider_rate_limited");
         assert!(json.get("sandboxId").is_none());
         assert!(json.get("sandboxReuseResult").is_none());
         assert!(json.get("workspaceReuseResult").is_none());
@@ -2163,6 +2170,7 @@ mod tests {
                 .parse::<RunId>()
                 .unwrap(),
             exit_code: 0,
+            failure_reason: None,
             error: None,
             sandbox_id: Some(sid),
             sandbox_reuse_result: Some(SandboxReuseResult::Reused),

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -293,6 +293,18 @@ export async function readRunFailureReasonFixture(
   return response.failure_reason ?? null;
 }
 
+export async function setRunModelProviderStateFixture(
+  context: TestContext,
+  runId: string,
+  modelProvider: string | null,
+): Promise<void> {
+  await postAction(context, {
+    action: "set-run-model-provider",
+    run_id: runId,
+    model_provider: modelProvider,
+  });
+}
+
 /**
  * Launch snapshots are intentionally writer-only in Stage 2, so persistence
  * cannot be observed through a production API. Keep this test-only exception

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -21,6 +21,7 @@ import {
 } from "@okouai/api-contracts/contracts/runners";
 import type { CreateCustomConnectorBody } from "@okouai/api-contracts/contracts/custom-connectors";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
+import type { RunFailureReason } from "@okouai/api-contracts/contracts/run-failure-reasons";
 import { testCustomConnectorSkillVersionAssociationContract } from "@okouai/api-contracts/contracts/test-custom-connector-skill-version-association";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { SEED_SKILLS } from "@okouai/core/seed-skills";
@@ -149,6 +150,7 @@ import {
   seedVm0BuiltInDefaultModelKey as seedVm0BuiltInDefaultModelKeyState,
   seedVm0BuiltInModelKey as seedVm0BuiltInModelKeyState,
   setCustomConnectorAuthTemplateFixture,
+  setRunModelProviderStateFixture,
   setRunnerJobConnectorRuntimeTargets,
   setRunnerJobContextProfileAsPreviousApi,
 } from "./helpers/runtime-state";
@@ -18268,6 +18270,221 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
 });
 
 describe("RUN-03: sandbox completion reports against missing checkpoints and settled runs", () => {
+  it("suppresses only reviewed non-built-in failures from generic completion logs", async () => {
+    const api = createRunsApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    await seedVm0BuiltInDefaultModelKey();
+    const { actor, agentId } = await entitledRunActor();
+    const suppressedReasons = [
+      "insufficient_credits",
+      "invalid_api_key",
+      "invalid_credentials",
+      "terms_acceptance_required",
+      "context_window_exceeded",
+      "output_token_limit",
+      "provider_rate_limited",
+      "provider_overloaded",
+      "provider_stream_timeout",
+      "provider_server_error",
+      "response_connection_lost",
+      "safety_policy_refusal",
+      "reconnect_required",
+      "usage_limit",
+    ] as const satisfies readonly RunFailureReason[];
+    const axiomLevels = [
+      context.mocks.axiomLogging.debug,
+      context.mocks.axiomLogging.info,
+      context.mocks.axiomLogging.warn,
+      context.mocks.axiomLogging.error,
+    ];
+
+    function matchingLogCalls(
+      log: (typeof axiomLevels)[number],
+      message: string,
+      runId: string,
+    ) {
+      return log.mock.calls.filter(([candidateMessage, fields]) => {
+        return (
+          candidateMessage === message &&
+          typeof fields === "object" &&
+          fields !== null &&
+          "runId" in fields &&
+          fields.runId === runId
+        );
+      });
+    }
+
+    async function completeFailure(args: {
+      readonly failureReason?: RunFailureReason;
+      readonly modelProvider?: ModelProviderType;
+      readonly persistedModelProvider?: string | null;
+    }): Promise<{ readonly runId: string; readonly error: string }> {
+      const modelProvider = args.modelProvider ?? "anthropic-api-key";
+      const run = await api.createRun(actor, {
+        agentId,
+        prompt: `fail ${modelProvider} with ${args.failureReason ?? "no reason"}`,
+        modelProvider,
+      });
+      if (args.persistedModelProvider !== undefined) {
+        await setRunModelProviderStateFixture(
+          context,
+          run.runId,
+          args.persistedModelProvider,
+        );
+      }
+      const error = `provider failure for ${run.runId}`;
+      await webhooks.requestAgentComplete(
+        {
+          runId: run.runId,
+          exitCode: 1,
+          error,
+          ...(args.failureReason === undefined
+            ? {}
+            : { failureReason: args.failureReason }),
+        },
+        {
+          authorization: `Bearer ${api.sandboxTokenForRun(actor, run.runId)}`,
+        },
+        [200],
+      );
+      await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+        status: "failed",
+        error,
+      });
+      await expect(
+        readRunFailureReasonFixture(context, run.runId),
+      ).resolves.toBe(args.failureReason ?? null);
+      return { runId: run.runId, error };
+    }
+
+    for (const failureReason of suppressedReasons) {
+      const { runId } = await completeFailure({ failureReason });
+      for (const level of axiomLevels) {
+        expect(matchingLogCalls(level, "Run failed", runId)).toHaveLength(0);
+      }
+    }
+
+    const visibleControls = [
+      await completeFailure({
+        modelProvider: "built-in",
+        failureReason: "provider_rate_limited",
+      }),
+      await completeFailure({
+        failureReason: "provider_rate_limited",
+        persistedModelProvider: null,
+      }),
+      await completeFailure({
+        failureReason: "provider_rate_limited",
+        persistedModelProvider: "legacy-unknown-provider",
+      }),
+      await completeFailure({}),
+      await completeFailure({ failureReason: "session_history_limit" }),
+      await completeFailure({ failureReason: "unsupported_model" }),
+    ];
+    for (const control of visibleControls) {
+      const warnings = matchingLogCalls(
+        context.mocks.axiomLogging.warn,
+        "Run failed",
+        control.runId,
+      );
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]?.[1]).toStrictEqual(
+        expect.objectContaining({
+          runId: control.runId,
+          exitCode: 1,
+          error: control.error,
+          context: "webhook:complete",
+        }),
+      );
+    }
+
+    const missingCheckpoint = await api.createRun(actor, {
+      agentId,
+      prompt: "keep the missing-checkpoint warning visible",
+      modelProvider: "anthropic-api-key",
+    });
+    await webhooks.requestAgentComplete(
+      {
+        runId: missingCheckpoint.runId,
+        exitCode: 0,
+        failureReason: "provider_overloaded",
+      },
+      {
+        authorization: `Bearer ${api.sandboxTokenForRun(
+          actor,
+          missingCheckpoint.runId,
+        )}`,
+      },
+      [200],
+    );
+    expect(
+      matchingLogCalls(
+        context.mocks.axiomLogging.warn,
+        "Run failed because checkpoint was not found",
+        missingCheckpoint.runId,
+      ),
+    ).toHaveLength(1);
+    expect(
+      matchingLogCalls(
+        context.mocks.axiomLogging.warn,
+        "Run failed",
+        missingCheckpoint.runId,
+      ),
+    ).toHaveLength(0);
+
+    const suppressibleFirst = await completeFailure({
+      failureReason: "provider_overloaded",
+    });
+    await webhooks.requestAgentComplete(
+      {
+        runId: suppressibleFirst.runId,
+        exitCode: 1,
+        error: "late unsupported-model report",
+        failureReason: "unsupported_model",
+      },
+      {
+        authorization: `Bearer ${api.sandboxTokenForRun(
+          actor,
+          suppressibleFirst.runId,
+        )}`,
+      },
+      [200],
+    );
+    expect(
+      matchingLogCalls(
+        context.mocks.axiomLogging.warn,
+        "Run failed",
+        suppressibleFirst.runId,
+      ),
+    ).toHaveLength(0);
+
+    const visibleFirst = await completeFailure({
+      failureReason: "unsupported_model",
+    });
+    await webhooks.requestAgentComplete(
+      {
+        runId: visibleFirst.runId,
+        exitCode: 1,
+        error: "late overload report",
+        failureReason: "provider_overloaded",
+      },
+      {
+        authorization: `Bearer ${api.sandboxTokenForRun(
+          actor,
+          visibleFirst.runId,
+        )}`,
+      },
+      [200],
+    );
+    expect(
+      matchingLogCalls(
+        context.mocks.axiomLogging.warn,
+        "Run failed",
+        visibleFirst.runId,
+      ),
+    ).toHaveLength(1);
+  });
+
   it.each(["claude-code", "codex"] as const)(
     "atomically completes a run with a %s checkpoint",
     async (cliAgentType) => {

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -2562,6 +2562,18 @@ const specializedRuntimeFixtureAction$ = command(
         },
       };
     }
+    if (body.action === "set-run-model-provider") {
+      const [run] = await db
+        .update(agentRuns)
+        .set({ modelProvider: body.model_provider })
+        .where(eq(agentRuns.id, body.run_id))
+        .returning({ id: agentRuns.id });
+      signal.throwIfAborted();
+      if (!run) {
+        throw new Error("Expected the model-provider run fixture");
+      }
+      return { status: 200 as const, body: { ok: true as const } };
+    }
     return null;
   },
 );

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -6,6 +6,10 @@ import {
   type RunResult,
   type RunStatus,
 } from "@okouai/api-contracts/contracts/runs";
+import {
+  isBuiltInModelProviderType,
+  modelProviderTypeSchema,
+} from "@okouai/api-contracts/contracts/model-providers";
 import type { RunFailureReason } from "@okouai/api-contracts/contracts/run-failure-reasons";
 import { webhookCompleteContract } from "@okouai/api-contracts/contracts/webhooks";
 import { agentRuns } from "@okouai/db/schema/agent-run";
@@ -126,6 +130,7 @@ interface RunRecord {
   readonly chatThreadId: string | null;
   readonly triggerSource: string | null;
   readonly launchSnapshot: (typeof agentRuns.$inferSelect)["launchSnapshot"];
+  readonly modelProvider: string | null;
 }
 
 interface PreparedCompletion {
@@ -142,6 +147,7 @@ interface CompletionCommit {
   readonly responseStatus: TerminalStatus;
   readonly transitionError?: string;
   readonly transitionFailureKind?: PreparedCompletion["failureKind"];
+  readonly transitionFailureReason?: RunFailureReason;
   readonly finalization: FinalizeActiveInputDeliveryResult;
   readonly piMemoryStage1Admission?: PiMemoryStage1Admission;
 }
@@ -156,6 +162,45 @@ type CompletionTransactionResult =
   | { readonly kind: "committed"; readonly commit: CompletionCommit };
 
 const L = logger("webhook:complete");
+
+function isSuppressibleNonBuiltInFailureReason(
+  failureReason: RunFailureReason | undefined,
+): boolean {
+  switch (failureReason) {
+    case "insufficient_credits":
+    case "invalid_api_key":
+    case "invalid_credentials":
+    case "terms_acceptance_required":
+    case "context_window_exceeded":
+    case "output_token_limit":
+    case "provider_rate_limited":
+    case "provider_overloaded":
+    case "provider_stream_timeout":
+    case "provider_server_error":
+    case "response_connection_lost":
+    case "safety_policy_refusal":
+    case "reconnect_required":
+    case "usage_limit": {
+      return true;
+    }
+    case "session_history_limit":
+    case "unsupported_model":
+    case undefined: {
+      return false;
+    }
+  }
+}
+
+function shouldSuppressNonBuiltInProviderFailureLog(
+  run: RunRecord,
+  failureReason: RunFailureReason | undefined,
+): boolean {
+  if (!isSuppressibleNonBuiltInFailureReason(failureReason)) {
+    return false;
+  }
+  const providerType = modelProviderTypeSchema.safeParse(run.modelProvider);
+  return providerType.success && !isBuiltInModelProviderType(providerType.data);
+}
 
 function checkpointInputForCompletion(
   input: CompleteAgentRunInput,
@@ -228,6 +273,7 @@ async function loadCompletionRun(
       chatThreadId: agentRuns.chatThreadId,
       triggerSource: agentRuns.triggerSource,
       launchSnapshot: agentRuns.launchSnapshot,
+      modelProvider: agentRuns.modelProvider,
     })
     .from(agentRuns)
     .where(
@@ -297,6 +343,7 @@ async function lockCompletionRun(
       chatThreadId: agentRuns.chatThreadId,
       triggerSource: agentRuns.triggerSource,
       launchSnapshot: agentRuns.launchSnapshot,
+      modelProvider: agentRuns.modelProvider,
     })
     .from(agentRuns)
     .where(
@@ -453,6 +500,7 @@ async function completeActiveAgentRunTransition(
       responseStatus: prepared.status,
       transitionError: prepared.error,
       transitionFailureKind: prepared.failureKind,
+      transitionFailureReason: prepared.failureReason,
       finalization,
       piMemoryStage1Admission,
     },
@@ -893,11 +941,17 @@ export const completeAgentRun$ = command(
           runId: input.body.runId,
           error: commit.transitionError,
         });
-      } else {
+      } else if (
+        !shouldSuppressNonBuiltInProviderFailureLog(
+          commit.run,
+          commit.transitionFailureReason,
+        )
+      ) {
         L.warn("Run failed", {
           runId: input.body.runId,
           exitCode: input.body.exitCode,
           error: commit.transitionError,
+          failureReason: commit.transitionFailureReason,
         });
       }
     } else if (

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -75,6 +75,11 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     run_id: z.uuid(),
   }),
   z.object({
+    action: z.literal("set-run-model-provider"),
+    run_id: z.uuid(),
+    model_provider: z.string().nullable(),
+  }),
+  z.object({
     action: z.literal("save-run-summary"),
     run_id: z.uuid(),
     trigger_source: z.string(),


### PR DESCRIPTION
## Summary

- add source-aware `provider_rate_limited` and `unsupported_model` guest diagnostics while keeping overload distinct
- propagate the optional authoritative failure reason through both guest checkpoint completion and runner fallback completion
- use typed failure reasons plus validated non-built-in provider ownership to suppress only the reviewed generic API failure logs
- align runner terminal severity for reviewed expected upstream outcomes

## Compatibility and rollout

- completion payloads remain backward compatible because `failureReason` is optional
- success, cancellation, early runner failures, and unclassified failures continue to omit the field
- raw error text, exit code, checkpoint data, event watermark, sandbox/workspace metadata, and active-input receipts are unchanged
- do not merge or promote this writer until the API reader from #31097 is confirmed deployed to production

## Excluded

- Chat Event schema/version transport (#31079)
- product recovery and API display formatting (#31080)
- retry, backoff, admission, terminal-state, provider cooldown, timeout, and resource policies

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml --workspace --no-deps --all-features`
- `cargo check --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --all-targets`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --quiet`
- `cargo test --manifest-path crates/Cargo.toml -p runner --quiet`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F @okouai/api-contracts exec vitest run`
- `pnpm knip`

Closes #31078

Parent: #31048
