### PR TITLE
test(app): restore timeout margin in template picker composer tests

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
@@ -411,6 +411,38 @@ async function selectAvatarRecommendationFilters(
   await user.keyboard("{Escape}");
 }
 
+// Serves the deck the detail preview renders into its slide shadow roots. The
+// inline stylesheet gives every slide a fixed size so the preview scales it the
+// same way it scales a real deck.
+function mockStyledPresentationDeck(
+  template: (typeof PRESENTATION_TEMPLATE_PICKER_ITEMS)[number],
+): void {
+  context.mocks.http.get("*/__vm0-dev-artifact-fetch", () => {
+    return new Response(
+      `<!doctype html><html><head><style>:root { --bg: white; --ink: black; } section { width: 1600px; height: 900px; background: var(--bg); color: var(--ink); }</style></head><body>${template.previewImages
+        .map((_, index) => {
+          return `<section data-vm0-slide data-slide-id="slide-${index + 1}"><h1>Slide ${index + 1}</h1></section>`;
+        })
+        .join("")}</body></html>`,
+      { headers: { "Content-Type": "text/html" } },
+    );
+  });
+}
+
+// Opens the picker and the template's detail preview from its card. Returns the
+// dialog, which stays mounted across the picker/detail transition.
+async function openPresentationDetailPreview(
+  template: (typeof PRESENTATION_TEMPLATE_PICKER_ITEMS)[number],
+): Promise<HTMLElement> {
+  click(
+    await waitFor(() => {
+      return screen.getByLabelText("Template");
+    }),
+  );
+  click(screen.getByLabelText(`Preview ${template.title} at current slide`));
+  return screen.getByRole("dialog");
+}
+
 beforeEach(() => {
   context.mocks.data.onboardingStatus({ defaultAgentId: AGENT_ID });
   context.mocks.api(billingStatusContract.get, ({ respond }) => {
@@ -2423,38 +2455,6 @@ describe("chat composer templates", () => {
     click(reopenedTemplateButton);
     expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:template-detail-1");
   });
-
-  // Serves the deck the detail preview renders into its slide shadow roots. The
-  // inline stylesheet gives every slide a fixed size so the preview scales it
-  // the same way it scales a real deck.
-  function mockStyledPresentationDeck(
-    template: (typeof PRESENTATION_TEMPLATE_PICKER_ITEMS)[number],
-  ): void {
-    context.mocks.http.get("*/__vm0-dev-artifact-fetch", () => {
-      return new Response(
-        `<!doctype html><html><head><style>:root { --bg: white; --ink: black; } section { width: 1600px; height: 900px; background: var(--bg); color: var(--ink); }</style></head><body>${template.previewImages
-          .map((_, index) => {
-            return `<section data-vm0-slide data-slide-id="slide-${index + 1}"><h1>Slide ${index + 1}</h1></section>`;
-          })
-          .join("")}</body></html>`,
-        { headers: { "Content-Type": "text/html" } },
-      );
-    });
-  }
-
-  // Opens the picker and the template's detail preview from its card. Returns
-  // the dialog, which stays mounted across the picker/detail transition.
-  async function openPresentationDetailPreview(
-    template: (typeof PRESENTATION_TEMPLATE_PICKER_ITEMS)[number],
-  ): Promise<HTMLElement> {
-    click(
-      await waitFor(() => {
-        return screen.getByLabelText("Template");
-      }),
-    );
-    click(screen.getByLabelText(`Preview ${template.title} at current slide`));
-    return screen.getByRole("dialog");
-  }
 
   // This test used to also cover the theme lifecycle, which put two independent
   // contracts plus page bootstrap into one 5000ms budget and left ~1.1s of

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
@@ -438,6 +438,44 @@ beforeEach(() => {
 });
 
 describe("chat composer templates", () => {
+  // Whichever test renders the chat page first pays a one-time cost for
+  // evaluating the chat-page module graph and for React's first render of it
+  // (~900ms in CI). That cost lands inside the first test's 5000ms budget, so
+  // this file opens with its cheapest page-rendering assertion. Keep it first:
+  // putting a long interaction sequence here stacks the one-time cost on top of
+  // the sequence and leaves the test without margin on a contended runner.
+  it("places the template control immediately after the legacy attach button by default", async () => {
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    const composer = composerElementFrom(
+      await screen.findByPlaceholderText(PLACEHOLDER),
+    );
+
+    await waitFor(() => {
+      const controls = Array.from(
+        composer.querySelectorAll(
+          [
+            'button[aria-label="Attach"]',
+            'button[aria-label="Template"]',
+            'button[aria-label="Connectors"]',
+          ].join(","),
+        ),
+      ).map((button) => {
+        return button.getAttribute("aria-label");
+      });
+
+      expect(controls).toStrictEqual(["Attach", "Template", "Connectors"]);
+      expect(
+        composer.querySelector('button[aria-label="Upload"]'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it("inserts multiple inline templates and sends a template-only message", async () => {
     const user = userEvent.setup({ delay: null });
     const first = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;
@@ -775,38 +813,6 @@ describe("chat composer templates", () => {
     await waitFor(() => {
       expect(highResolutionImage).toHaveAttribute("data-loaded", "true");
       expect(lowResolutionImage).not.toHaveAttribute("data-replaced");
-    });
-  });
-
-  it("places the template control immediately after the legacy attach button by default", async () => {
-    mockChatLifecycle(context, { threadId: THREAD_ID });
-
-    detachedSetupPage({
-      context,
-      path: `/chats/${THREAD_ID}`,
-    });
-
-    const composer = composerElementFrom(
-      await screen.findByPlaceholderText(PLACEHOLDER),
-    );
-
-    await waitFor(() => {
-      const controls = Array.from(
-        composer.querySelectorAll(
-          [
-            'button[aria-label="Attach"]',
-            'button[aria-label="Template"]',
-            'button[aria-label="Connectors"]',
-          ].join(","),
-        ),
-      ).map((button) => {
-        return button.getAttribute("aria-label");
-      });
-
-      expect(controls).toStrictEqual(["Attach", "Template", "Connectors"]);
-      expect(
-        composer.querySelector('button[aria-label="Upload"]'),
-      ).not.toBeInTheDocument();
     });
   });
 
@@ -2418,8 +2424,12 @@ describe("chat composer templates", () => {
     expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:template-detail-1");
   });
 
-  it("navigates presentation template detail previews from the main preview", async () => {
-    const template = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;
+  // Serves the deck the detail preview renders into its slide shadow roots. The
+  // inline stylesheet gives every slide a fixed size so the preview scales it
+  // the same way it scales a real deck.
+  function mockStyledPresentationDeck(
+    template: (typeof PRESENTATION_TEMPLATE_PICKER_ITEMS)[number],
+  ): void {
     context.mocks.http.get("*/__vm0-dev-artifact-fetch", () => {
       return new Response(
         `<!doctype html><html><head><style>:root { --bg: white; --ink: black; } section { width: 1600px; height: 900px; background: var(--bg); color: var(--ink); }</style></head><body>${template.previewImages
@@ -2430,6 +2440,30 @@ describe("chat composer templates", () => {
         { headers: { "Content-Type": "text/html" } },
       );
     });
+  }
+
+  // Opens the picker and the template's detail preview from its card. Returns
+  // the dialog, which stays mounted across the picker/detail transition.
+  async function openPresentationDetailPreview(
+    template: (typeof PRESENTATION_TEMPLATE_PICKER_ITEMS)[number],
+  ): Promise<HTMLElement> {
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Template");
+      }),
+    );
+    click(screen.getByLabelText(`Preview ${template.title} at current slide`));
+    return screen.getByRole("dialog");
+  }
+
+  // This test used to also cover the theme lifecycle, which put two independent
+  // contracts plus page bootstrap into one 5000ms budget and left ~1.1s of
+  // margin on a healthy CI runner. The theme lifecycle now has its own test.
+  // Navigation keeps the render assertions that share its warm preview state,
+  // so neither test re-pays for loading a cold detail preview.
+  it("navigates presentation template detail previews from the main preview", async () => {
+    const template = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;
+    mockStyledPresentationDeck(template);
     mockChatLifecycle(context, { threadId: THREAD_ID });
 
     detachedSetupPage({
@@ -2437,14 +2471,7 @@ describe("chat composer templates", () => {
       path: `/chats/${THREAD_ID}`,
     });
 
-    click(
-      await waitFor(() => {
-        return screen.getByLabelText("Template");
-      }),
-    );
-    click(screen.getByLabelText(`Preview ${template.title} at current slide`));
-
-    const templateDialog = screen.getByRole("dialog");
+    const templateDialog = await openPresentationDetailPreview(template);
     expect(
       within(templateDialog).getByRole("heading", {
         name: `Template / ${template.title}`,
@@ -2538,51 +2565,6 @@ describe("chat composer templates", () => {
       "true",
     );
 
-    click(screen.getByLabelText("Select style Candy party"));
-    expect(screen.getByLabelText("Select style Candy party")).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
-    expect(
-      within(templateDialog)
-        .getByLabelText("Preview slide 1")
-        .querySelector("iframe"),
-    ).toBeNull();
-    const prismSlidePreviewButton =
-      within(templateDialog).getByLabelText("Preview slide 1");
-    expect(
-      prismSlidePreviewButton.querySelector(
-        `[aria-label="${template.title} slide 1 preview"]`,
-      )?.shadowRoot,
-    ).toBe(carnivalShadowRoot);
-    expect(carnivalShadowPreviewRoot?.style.getPropertyValue("--accent")).toBe(
-      "#7257E6",
-    );
-    expect(prismSlidePreviewButton.querySelectorAll("span")).toHaveLength(1);
-
-    const templateButton = queryAllByRoleFast("button", templateDialog).find(
-      (candidate) => {
-        return (
-          candidate.textContent?.replace(/\s+/g, " ").trim() === "Template"
-        );
-      },
-    );
-    if (!templateButton) {
-      throw new Error("Template button not found");
-    }
-    click(templateButton);
-    click(screen.getByLabelText(`Preview ${template.title} at current slide`));
-
-    await waitFor(() => {
-      expect(
-        within(templateDialog).getByLabelText("Preview slide 1"),
-      ).toHaveAttribute("aria-pressed", "true");
-    });
-    expect(screen.getByLabelText("Select style Funfair")).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
-
     fireEvent.keyDown(
       screen.getByLabelText(`${template.title} slide preview`),
       {
@@ -2657,6 +2639,81 @@ describe("chat composer templates", () => {
         "true",
       );
     });
+  });
+
+  it("restores the default presentation detail theme when the preview reopens", async () => {
+    const template = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;
+    mockStyledPresentationDeck(template);
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    const templateDialog = await openPresentationDetailPreview(template);
+    const firstSlidePreviewButton =
+      within(templateDialog).getByLabelText("Preview slide 1");
+    await waitFor(() => {
+      expect(
+        firstSlidePreviewButton.querySelector(
+          `[aria-label="${template.title} slide 1 preview"]`,
+        )?.shadowRoot,
+      ).not.toBeNull();
+    });
+    const carnivalShadowRoot = firstSlidePreviewButton.querySelector(
+      `[aria-label="${template.title} slide 1 preview"]`,
+    )?.shadowRoot;
+    const carnivalShadowPreviewRoot =
+      carnivalShadowRoot?.querySelector<HTMLElement>(
+        ".vm0-shadow-preview-root",
+      ) ?? null;
+    expect(carnivalShadowPreviewRoot?.style.getPropertyValue("--accent")).toBe(
+      "#FF7A1A",
+    );
+
+    click(screen.getByLabelText("Select style Candy party"));
+    expect(screen.getByLabelText("Select style Candy party")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    const prismSlidePreviewButton =
+      within(templateDialog).getByLabelText("Preview slide 1");
+    expect(prismSlidePreviewButton.querySelector("iframe")).toBeNull();
+    // Switching the theme restyles the existing shadow root instead of
+    // remounting the preview, so the accent changes in place.
+    expect(
+      prismSlidePreviewButton.querySelector(
+        `[aria-label="${template.title} slide 1 preview"]`,
+      )?.shadowRoot,
+    ).toBe(carnivalShadowRoot);
+    expect(carnivalShadowPreviewRoot?.style.getPropertyValue("--accent")).toBe(
+      "#7257E6",
+    );
+    expect(prismSlidePreviewButton.querySelectorAll("span")).toHaveLength(1);
+
+    const templateButton = queryAllByRoleFast("button", templateDialog).find(
+      (candidate) => {
+        return (
+          candidate.textContent?.replace(/\s+/g, " ").trim() === "Template"
+        );
+      },
+    );
+    if (!templateButton) {
+      throw new Error("Template button not found");
+    }
+    click(templateButton);
+    click(screen.getByLabelText(`Preview ${template.title} at current slide`));
+
+    await waitFor(() => {
+      expect(
+        within(templateDialog).getByLabelText("Preview slide 1"),
+      ).toHaveAttribute("aria-pressed", "true");
+    });
+    expect(screen.getByLabelText("Select style Funfair")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
   });
 
   it("selects an illustration style from the picker", async () => {


### PR DESCRIPTION
## What

Two tests in `turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx` exhausted the 5000ms per-test budget in Turbo run [33618389143](https://github.com/vm0-ai/vm0/actions/runs/33618389143) (`test-app (1)`, push to `main` at `03c37ce80`):

- `inserts multiple inline templates and sends a template-only message` (5653ms)
- `navigates presentation template detail previews from the main preview` (5185ms)

This gives both of them margin again without touching a single assertion.

## Why it was not a race

The trigger was uniform host contention. Every phase of the shard was inflated versus a green `test-app (1)` run eight minutes earlier, including the phases that do no I/O:

| phase | failing (33618389143) | green (33614698451) | ratio |
|---|---|---|---|
| transform | 41.13s | 25.65s | ~1.60x |
| setup | 52.98s | 38.42s | ~1.38x |
| import | 104.14s | 70.64s | ~1.47x |
| environment | 12.68s | 9.52s | ~1.33x |
| tests | 325.79s | 217.14s | ~1.50x |

The slow host did not create a defect; it exposed two tests that had no headroom. On **green** runs of the same shard they already used most of the budget:

| test | green 33616627606 | green 33614698451 | failing run |
|---|---|---|---|
| `inserts multiple inline templates...` | 2843ms (57%) | 3213ms (64%) | 5653ms |
| `navigates presentation template detail previews...` | 2803ms (56%) | 3885ms (78%) | 5185ms |

The `[W][Realtime] ably catch-up failed ApiError: HTTP 500` warning is **not** causal. It is emitted by every test in this file, on green runs as well as the failing one, before and after this change.

## Where the time went

Instrumenting the two tests with `performance.now()` marks (full-file runs, never `-t`):

- `inserts multiple inline templates...`: **1318ms of 2136ms was page bootstrap.** Its own interaction sequence costs ~760ms. As the file's first test it also absorbs a one-time cost for evaluating the chat-page module graph and rendering it — measured at ~630ms locally, ~900ms in CI (the file's next structurally similar test, `sends a video template without any run parameters on it`, runs at 1657-1783ms on the same green runs).
- `navigates presentation template detail previews...`: bootstrap 457ms, open + slide assertions 332ms, theme switch 76ms, back-and-reopen 331ms, keyboard navigation 758ms.

## The change

1. **Move `places the template control immediately after the legacy attach button by default` to the front of the suite.** The one-time module-evaluation and first-render cost lands on whichever test renders the chat page first; it now lands on the file's cheapest page-rendering assertion instead of on one of its longest interaction sequences. A comment records why the first test must stay cheap.
2. **Split the theme lifecycle out of the detail-preview navigation test.** Navigation keeps the render assertions that share its warm preview state, so neither test re-pays for loading a cold detail preview; the new `restores the default presentation detail theme when the preview reopens` owns the Candy party accent swap, the in-place shadow-root restyle, and the reset to Funfair on reopen.

Both business contracts are preserved verbatim: inserting multiple inline templates still sends a template-only message, and detail previews are still navigable from the main preview, the theme rail, and the slide thumbnails. No retries, sleeps, raised timeouts, skipped tests, weakened assertions, or swallowed rejections. `testTimeout` is unchanged.

A seam that splits `inserts multiple inline templates...` was measured and rejected: each half re-pays page bootstrap, so it moved the median only 5%.

## Validation

5 clean full-file runs before and after, on the same idle 2-core box (medians, with per-run maxima):

| test | median before | median after | max before | max after |
|---|---|---|---|---|
| `inserts multiple inline templates...` | 1903ms | **1414ms** | 2027ms | 1450ms |
| `navigates presentation template detail previews...` | 1817ms | **1634ms** | 2063ms | 1881ms |
| `restores the default presentation detail theme...` | n/a (new) | 1372ms | n/a | 2109ms |
| `places the template control...` (now first) | 367ms | 969ms | 393ms | 1258ms |

The idle box understates the gain, because bootstrap and contention scale together. Re-running the same file under three `node` busy loops on those two cores reproduces the CI failure on `main` and clears it here:

| test | `main` under load | this branch under load |
|---|---|---|
| `inserts multiple inline templates...` | **5200ms — timed out** | 3412ms — passed |
| `navigates presentation template detail previews...` | 4692ms (94% of budget) | 2715ms |
| `restores the default presentation detail theme...` | n/a | 2835ms |

Also run: `prettier --check`, `oxlint --deny-warnings`, `eslint --max-warnings 0`, `tsc -p tsconfig.tests.json --noEmit`, `git diff --check`. All clean. These are happy-dom component tests, so browser validation does not apply.

## Known, not addressed here

The rest of this file still sits close to the wall — on green CI its tests plateau at 2.4-3.9s against 5000ms, and under the local contention harness `uses the presentation detail theme for template selection` reaches 4843ms on `main`. Two other `test-app` composer files failed the same way earlier the same day (`chat-composer-model-selection-and-providers.test.tsx`, `chat-thread-idb.test.tsx`). Composer tests as a family carry too little margin; the shared driver is that every test pays chat-page bootstrap inside its own per-test budget. That is a separate, larger piece of work and is deliberately out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
