### PR TITLE
perf(runner): batch idle pressure eviction

### DIFF
--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -52,7 +52,7 @@ use super::active_runs::{ActiveRunHandoffRequest, ActiveRunReuseState};
 use super::factory_lifecycle::SharedFactory;
 use super::idle_lifecycle::{
     IdlePressureRequest, IdlePressureSelection, ReservedIdleActivation,
-    select_idle_entry_for_pressure,
+    select_idle_entries_for_pressure,
 };
 use super::job_discovery::{
     ClaimedActivationGuard, ClaimedJobSetup, FinalizingAdmission, ReadyClaimedResource,
@@ -775,25 +775,30 @@ async fn acquire_fallback_resource(
     let cancel = cancellation.token();
     let mut retiring_leases = Vec::new();
     loop {
-        if let Some(reservation) = reserve_fallback_exact(
-            cancellation,
-            reuse_key,
-            profile_name,
-            device_rate_limits,
-            history_generation_run_id,
-            ctx,
-        )
-        .await?
-        {
-            return Ok(FinalizingResource::Exact(reservation));
-        }
-        match ResourceBudget::try_substitute_leases(
+        match select_idle_entries_for_pressure(
+            &ctx.idle_pool,
+            &ctx.status,
+            &ctx.idle_destroy_tracker,
             &ctx.budget,
             std::mem::take(&mut retiring_leases),
-            vcpu,
-            memory_mb,
-        ) {
-            Ok(lease) => {
+            IdlePressureRequest {
+                run_id,
+                reuse_key: Some(reuse_key),
+                profile_name,
+                device_rate_limits,
+                history_generation_run_id: Some(history_generation_run_id),
+                vcpu,
+                memory_mb,
+                context: "finalizing_fallback_oldest",
+            },
+        )
+        .await
+        {
+            IdlePressureSelection::Reusable(reservation) => {
+                let reservation = accept_fallback_exact(cancellation, reservation, ctx).await?;
+                return Ok(FinalizingResource::Exact(reservation));
+            }
+            IdlePressureSelection::Fresh(lease) => {
                 if let Some(reservation) = reserve_fallback_exact(
                     cancellation,
                     reuse_key,
@@ -809,37 +814,7 @@ async fn acquire_fallback_resource(
                 }
                 return Ok(FinalizingResource::Fresh(lease));
             }
-            Err(retained) => retiring_leases = retained,
-        }
-        match select_idle_entry_for_pressure(
-            &ctx.idle_pool,
-            &ctx.status,
-            &ctx.idle_destroy_tracker,
-            IdlePressureRequest {
-                reuse_key: Some(reuse_key),
-                profile_name,
-                device_rate_limits,
-                history_generation_run_id: Some(history_generation_run_id),
-                context: "finalizing_fallback_oldest",
-            },
-        )
-        .await
-        {
-            IdlePressureSelection::Reusable(reservation) => {
-                let reservation = accept_fallback_exact(cancellation, reservation, ctx).await?;
-                return Ok(FinalizingResource::Exact(reservation));
-            }
-            IdlePressureSelection::Retiring(retiring) => {
-                info!(
-                    run_id = %run_id,
-                    profile = %retiring.profile_name(),
-                    "evicting idle sandbox for finalizing fallback"
-                );
-                retiring_leases.push(retiring.into_budget_lease());
-                ctx.reuse_state_notify.notify_one();
-                continue;
-            }
-            IdlePressureSelection::Empty => {}
+            IdlePressureSelection::Exhausted(retained) => retiring_leases = retained,
         }
 
         info!(run_id = %run_id, "finalizing fallback waiting for fresh capacity");

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -16,8 +16,10 @@ use crate::idle_pool::{
     IdlePoolPressureSelection, IdlePoolSnapshot, ReservedIdleSandbox,
 };
 use crate::ids::RunId;
-use crate::resource_budget::BudgetLease;
+use crate::paths::short_digest;
+use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::status::{StatusResult, StatusTracker};
+use crate::types::reuse_key_kind;
 
 pub(super) type SharedIdlePool = Arc<tokio::sync::Mutex<IdlePool>>;
 
@@ -105,17 +107,20 @@ pub(super) struct RetiringIdleEntry {
 }
 
 pub(super) struct IdlePressureRequest<'a> {
+    pub(super) run_id: RunId,
     pub(super) reuse_key: Option<&'a str>,
     pub(super) profile_name: &'a str,
     pub(super) device_rate_limits: &'a Option<DeviceRateLimits>,
     pub(super) history_generation_run_id: Option<RunId>,
+    pub(super) vcpu: u32,
+    pub(super) memory_mb: u32,
     pub(super) context: &'static str,
 }
 
 pub(super) enum IdlePressureSelection {
     Reusable(ReservedIdleActivation),
-    Retiring(RetiringIdleEntry),
-    Empty,
+    Fresh(BudgetLease),
+    Exhausted(Vec<BudgetLease>),
 }
 
 /// A parked sandbox reservation paired with the idle snapshot captured by the
@@ -169,47 +174,108 @@ impl RetiringIdleEntry {
     }
 }
 
-/// Prefer a matching reusable entry; otherwise remove the oldest idle entry.
-/// The pool decision is atomic, and an evicted payload obtains durable cleanup
-/// ownership before the status write yields or its lease can be handed off.
-pub(super) async fn select_idle_entry_for_pressure(
+/// Prefer a matching reusable entry; otherwise retire only enough oldest idle
+/// entries for the incoming resource shape.
+///
+/// The idle pool stays locked while one deterministic oldest-first ordering is
+/// consumed. Resource-budget substitution takes only its short synchronous
+/// mutex inside that pool lock and never carries a guard across an await. Every
+/// evicted payload obtains tracked cleanup ownership before the final pool
+/// snapshot is captured and persisted once.
+pub(super) async fn select_idle_entries_for_pressure(
     idle_pool: &SharedIdlePool,
     status: &StatusTracker,
     tracker: &IdleDestroyTracker,
+    budget: &Arc<ResourceBudget>,
+    mut retiring_leases: Vec<BudgetLease>,
     request: IdlePressureRequest<'_>,
 ) -> IdlePressureSelection {
     let (selection, snapshot) = {
         let mut pool = idle_pool.lock().await;
-        let selection = pool.reserve_reusable_or_evict_oldest(
+        match pool.reserve_reusable_or_order_oldest(
             request.reuse_key,
             request.profile_name,
             request.device_rate_limits,
             request.history_generation_run_id,
-        );
-        let snapshot = pool.status_snapshot();
-        (selection, snapshot)
+        ) {
+            IdlePoolPressureSelection::Reusable(reservation) => {
+                drop(retiring_leases);
+                let snapshot = pool.status_snapshot();
+                (
+                    IdlePressureSelection::Reusable(ReservedIdleActivation {
+                        reservation,
+                        idle_snapshot: snapshot,
+                    }),
+                    None,
+                )
+            }
+            IdlePoolPressureSelection::OldestFirst(reuse_keys) => {
+                let mut mutated = false;
+                let mut fresh_lease = try_substitute_retiring_leases(
+                    budget,
+                    &mut retiring_leases,
+                    request.vcpu,
+                    request.memory_mb,
+                );
+                for reuse_key in reuse_keys {
+                    if fresh_lease.is_some() {
+                        break;
+                    }
+                    let Some(job) = pool.evict_for_pressure(&reuse_key) else {
+                        continue;
+                    };
+                    mutated = true;
+                    let retiring = retire_idle_destroy_job(tracker, job, request.context);
+                    info!(
+                        run_id = %request.run_id,
+                        context = request.context,
+                        reuse_key_fingerprint = %short_digest(retiring.reuse_key()),
+                        reuse_key_kind = reuse_key_kind(retiring.reuse_key()),
+                        profile = %retiring.profile_name(),
+                        vcpu = retiring.budget_vcpu(),
+                        memory_mb = retiring.budget_memory_mb(),
+                        "evicting idle sandbox for admission pressure"
+                    );
+                    retiring_leases.push(retiring.into_budget_lease());
+                    fresh_lease = try_substitute_retiring_leases(
+                        budget,
+                        &mut retiring_leases,
+                        request.vcpu,
+                        request.memory_mb,
+                    );
+                }
+                let selection = match fresh_lease {
+                    Some(lease) => IdlePressureSelection::Fresh(lease),
+                    None => IdlePressureSelection::Exhausted(retiring_leases),
+                };
+                let snapshot = mutated.then(|| pool.status_snapshot());
+                (selection, snapshot)
+            }
+        }
     };
-    match selection {
-        IdlePoolPressureSelection::Reusable(reservation) => {
-            IdlePressureSelection::Reusable(ReservedIdleActivation {
-                reservation,
-                idle_snapshot: snapshot,
-            })
+    if let Some(snapshot) = snapshot {
+        set_idle_status_snapshot(status, snapshot).await;
+    }
+    selection
+}
+
+fn try_substitute_retiring_leases(
+    budget: &Arc<ResourceBudget>,
+    retiring_leases: &mut Vec<BudgetLease>,
+    vcpu: u32,
+    memory_mb: u32,
+) -> Option<BudgetLease> {
+    match ResourceBudget::try_substitute_leases(
+        budget,
+        std::mem::take(retiring_leases),
+        vcpu,
+        memory_mb,
+    ) {
+        Ok(lease) => Some(lease),
+        Err(retained) => {
+            *retiring_leases = retained;
+            None
         }
-        IdlePoolPressureSelection::Evicted(job) => {
-            let reuse_key = job.reuse_key().to_owned();
-            let profile_name = job.profile_name().to_owned();
-            let budget_lease =
-                spawn_idle_destroy_job_retaining_lease(tracker, *job, request.context);
-            let selection = IdlePressureSelection::Retiring(RetiringIdleEntry {
-                budget_lease,
-                reuse_key,
-                profile_name,
-            });
-            set_idle_status_snapshot(status, snapshot).await;
-            selection
-        }
-        IdlePoolPressureSelection::Empty => IdlePressureSelection::Empty,
     }
 }
 
@@ -289,14 +355,21 @@ pub(super) fn spawn_idle_destroy_job(
     tracker.spawn_job(job, context);
 }
 
-fn spawn_idle_destroy_job_retaining_lease(
+fn retire_idle_destroy_job(
     tracker: &IdleDestroyTracker,
     job: IdleDestroyJob,
     context: &'static str,
-) -> BudgetLease {
+) -> RetiringIdleEntry {
+    let reuse_key = job.reuse_key().to_owned();
+    let profile_name = job.profile_name().to_owned();
     let (payload, budget_lease) = job.into_retiring_parts();
     tracker.spawn_payload(payload, context);
-    budget_lease
+    tracker.reuse_state_notify.notify_one();
+    RetiringIdleEntry {
+        budget_lease,
+        reuse_key,
+        profile_name,
+    }
 }
 
 /// Destroy idle entries in parallel and wait until their leases are dropped.

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -13,7 +13,7 @@ use tracing::{info, warn};
 
 use crate::idle_pool::{
     DestroyOutcome, IdleDestroyJob, IdleDestroyPayload, IdleDestroyResult, IdlePool,
-    IdlePoolPressureSelection, IdlePoolSnapshot, ReservedIdleSandbox,
+    IdlePoolSnapshot, ReservedIdleSandbox,
 };
 use crate::ids::RunId;
 use crate::paths::short_digest;
@@ -192,35 +192,31 @@ pub(super) async fn select_idle_entries_for_pressure(
 ) -> IdlePressureSelection {
     let (selection, snapshot) = {
         let mut pool = idle_pool.lock().await;
-        match pool.reserve_reusable_or_order_oldest(
+        if let Some(reservation) = pool.reserve_reusable_for_pressure(
             request.reuse_key,
             request.profile_name,
             request.device_rate_limits,
             request.history_generation_run_id,
         ) {
-            IdlePoolPressureSelection::Reusable(reservation) => {
-                drop(retiring_leases);
-                let snapshot = pool.status_snapshot();
-                (
-                    IdlePressureSelection::Reusable(ReservedIdleActivation {
-                        reservation,
-                        idle_snapshot: snapshot,
-                    }),
-                    None,
-                )
-            }
-            IdlePoolPressureSelection::OldestFirst(reuse_keys) => {
-                let mut mutated = false;
-                let mut fresh_lease = try_substitute_retiring_leases(
-                    budget,
-                    &mut retiring_leases,
-                    request.vcpu,
-                    request.memory_mb,
-                );
-                for reuse_key in reuse_keys {
-                    if fresh_lease.is_some() {
-                        break;
-                    }
+            drop(retiring_leases);
+            let snapshot = pool.status_snapshot();
+            (
+                IdlePressureSelection::Reusable(ReservedIdleActivation {
+                    reservation: Box::new(reservation),
+                    idle_snapshot: snapshot,
+                }),
+                None,
+            )
+        } else {
+            let mut mutated = false;
+            let mut fresh_lease = try_substitute_retiring_leases(
+                budget,
+                &mut retiring_leases,
+                request.vcpu,
+                request.memory_mb,
+            );
+            if fresh_lease.is_none() {
+                for reuse_key in pool.oldest_first_pressure_keys() {
                     let Some(job) = pool.evict_for_pressure(&reuse_key) else {
                         continue;
                     };
@@ -243,14 +239,17 @@ pub(super) async fn select_idle_entries_for_pressure(
                         request.vcpu,
                         request.memory_mb,
                     );
+                    if fresh_lease.is_some() {
+                        break;
+                    }
                 }
-                let selection = match fresh_lease {
-                    Some(lease) => IdlePressureSelection::Fresh(lease),
-                    None => IdlePressureSelection::Exhausted(retiring_leases),
-                };
-                let snapshot = mutated.then(|| pool.status_snapshot());
-                (selection, snapshot)
             }
+            let selection = match fresh_lease {
+                Some(lease) => IdlePressureSelection::Fresh(lease),
+                None => IdlePressureSelection::Exhausted(retiring_leases),
+            };
+            let snapshot = mutated.then(|| pool.status_snapshot());
+            (selection, snapshot)
         }
     };
     if let Some(snapshot) = snapshot {

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -112,7 +112,7 @@ use super::idle_lifecycle::{
     IdleDestroyTracker, IdlePressureRequest, IdlePressureSelection, ReservedIdleActivation,
     SharedIdlePool, add_preparing_run_with_idle_status_snapshot,
     add_running_run_with_idle_status_snapshot, destroy_idle_jobs_and_wait,
-    select_idle_entry_for_pressure, set_idle_status_snapshot, spawn_idle_destroy_job,
+    select_idle_entries_for_pressure, set_idle_status_snapshot, spawn_idle_destroy_job,
 };
 use super::job_spawn::{JobProfile, SpawnContext, SpawnJobRequest, spawn_job};
 use super::ownership::{OwnershipTransitions, RunSandbox};
@@ -1522,63 +1522,43 @@ async fn acquire_local_admission_resource(
     device_rate_limits: &Option<sandbox::DeviceRateLimits>,
     ctx: &mut DiscoveredJobContext<'_>,
 ) -> Option<LocalAdmissionResource> {
-    let mut retiring_leases = Vec::new();
-    loop {
-        if let Some(reuse_key) = candidate.reuse_key()
-            && let Some(reservation) =
-                reserve_reusable_idle(reuse_key, profile_name, device_rate_limits, None, ctx).await
-        {
-            return Some(LocalAdmissionResource::Reusable(reservation));
+    match select_idle_entries_for_pressure(
+        ctx.idle_pool,
+        ctx.status,
+        &ctx.spawn_ctx.idle_destroy_tracker,
+        ctx.budget,
+        Vec::new(),
+        IdlePressureRequest {
+            run_id: candidate.run_id(),
+            reuse_key: candidate.reuse_key(),
+            profile_name,
+            device_rate_limits,
+            history_generation_run_id: None,
+            vcpu: job_vcpu,
+            memory_mb: job_memory,
+            context: "candidate_admission_oldest",
+        },
+    )
+    .await
+    {
+        IdlePressureSelection::Reusable(reservation) => {
+            Some(LocalAdmissionResource::Reusable(reservation))
         }
-
-        if retiring_leases.is_empty() {
-            if let Some(lease) = ResourceBudget::try_reserve_lease(ctx.budget, job_vcpu, job_memory)
+        IdlePressureSelection::Fresh(lease) => {
+            if let Some(reuse_key) = candidate.reuse_key()
+                && let Some(reservation) =
+                    reserve_reusable_idle(reuse_key, profile_name, device_rate_limits, None, ctx)
+                        .await
             {
-                return Some(LocalAdmissionResource::Fresh(lease));
-            }
-        } else {
-            match ResourceBudget::try_substitute_leases(
-                ctx.budget,
-                std::mem::take(&mut retiring_leases),
-                job_vcpu,
-                job_memory,
-            ) {
-                Ok(lease) => return Some(LocalAdmissionResource::Fresh(lease)),
-                Err(retained) => retiring_leases = retained,
-            }
-        }
-
-        let pressure_selection = select_idle_entry_for_pressure(
-            ctx.idle_pool,
-            ctx.status,
-            &ctx.spawn_ctx.idle_destroy_tracker,
-            IdlePressureRequest {
-                reuse_key: candidate.reuse_key(),
-                profile_name,
-                device_rate_limits,
-                history_generation_run_id: None,
-                context: "candidate_admission_oldest",
-            },
-        )
-        .await;
-        let retiring = match pressure_selection {
-            IdlePressureSelection::Reusable(reservation) => {
+                drop(lease);
                 return Some(LocalAdmissionResource::Reusable(reservation));
             }
-            IdlePressureSelection::Retiring(retiring) => retiring,
-            IdlePressureSelection::Empty => return None,
-        };
-        info!(
-            run_id = %candidate.run_id(),
-            reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(retiring.reuse_key()),
-            reuse_key_kind = reuse_key_kind(retiring.reuse_key()),
-            profile = %retiring.profile_name(),
-            vcpu = retiring.budget_vcpu(),
-            memory_mb = retiring.budget_memory_mb(),
-            "evicting idle sandbox for candidate admission"
-        );
-        retiring_leases.push(retiring.into_budget_lease());
-        ctx.spawn_ctx.reuse_state_notify.notify_one();
+            Some(LocalAdmissionResource::Fresh(lease))
+        }
+        IdlePressureSelection::Exhausted(retiring_leases) => {
+            drop(retiring_leases);
+            None
+        }
     }
 }
 

--- a/crates/runner/src/cmd/start/tests/budget.rs
+++ b/crates/runner/src/cmd/start/tests/budget.rs
@@ -463,51 +463,57 @@ async fn budget_pressure_evicts_oldest_idle_regardless_of_age() {
     shutdown(&env, run_handle).await;
 }
 
-#[tokio::test(start_paused = true)]
-async fn larger_profile_retires_only_the_required_oldest_idle_entries() {
-    let (config, env) = mock_run_config(two_profiles(), 7, 12288, 4);
+#[tokio::test]
+async fn larger_profile_batches_required_oldest_idle_entries_before_status_write() {
+    let destroy_gate = sandbox_mock::MockLifecycleGate::new();
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let idle_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    idle_overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+    let fresh_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    fresh_overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    let (mut config, env) =
+        mock_run_config_with_overrides(two_profiles(), 7, 12288, 4, fresh_overrides);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let budget = Arc::clone(&config.capacity.budget);
     let status_path = env._temp_dir.path().join("status.json");
-    let now = std::time::Instant::now();
+    let status_write_started = Arc::new(tokio::sync::Notify::new());
+    let status_write_release = Arc::new(tokio::sync::Semaphore::new(0));
+    let status = Arc::new(StatusTracker::new_with_write_gate(
+        status_path.clone(),
+        3,
+        Arc::clone(&status_write_started),
+        Arc::clone(&status_write_release),
+    ));
+    config.shared.status = Arc::clone(&status);
 
-    seed_idle_pool_with_timing(
+    seed_idle_pool_with_overrides(
         &idle_pool,
         &budget,
-        TestParkedIdleCandidateSpec {
-            reuse_key: "sess-oldest",
-            profile_name: "vm0/default",
-            vcpu: 2,
-            memory_mb: 4096,
-            history_generation_run_id: None,
-            parked_at: now - Duration::from_secs(100),
-        },
+        &idle_overrides,
+        "sess-oldest",
+        "vm0/default",
+        2,
+        4096,
     )
     .await;
-    seed_idle_pool_with_timing(
+    seed_idle_pool_with_overrides(
         &idle_pool,
         &budget,
-        TestParkedIdleCandidateSpec {
-            reuse_key: "sess-middle",
-            profile_name: "vm0/default",
-            vcpu: 2,
-            memory_mb: 4096,
-            history_generation_run_id: None,
-            parked_at: now - Duration::from_secs(50),
-        },
+        &idle_overrides,
+        "sess-middle",
+        "vm0/default",
+        2,
+        4096,
     )
     .await;
-    seed_idle_pool_with_timing(
+    seed_idle_pool_with_overrides(
         &idle_pool,
         &budget,
-        TestParkedIdleCandidateSpec {
-            reuse_key: "sess-newest",
-            profile_name: "vm0/default",
-            vcpu: 2,
-            memory_mb: 4096,
-            history_generation_run_id: None,
-            parked_at: now - Duration::from_secs(10),
-        },
+        &idle_overrides,
+        "sess-newest",
+        "vm0/default",
+        2,
+        4096,
     )
     .await;
     assert!(
@@ -516,21 +522,25 @@ async fn larger_profile_retires_only_the_required_oldest_idle_entries() {
     );
 
     let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
 
     let run_id = RunId::new_v4();
+    let idle_write_started = status_write_started.notified();
     push_job(&env, run_id, "vm0/large", Some(minimal_context(run_id)));
+    tokio::select! {
+        () = idle_write_started => {}
+        completion = env.handle.wait_completion(run_id, Duration::from_secs(5)) => {
+            panic!("large run completed before batched idle status write: {completion:?}");
+        }
+    }
 
-    let completion = env
-        .handle
-        .wait_completion(run_id, Duration::from_secs(5))
-        .await;
-    assert!(
-        completion.is_some(),
-        "large job should complete after two oldest idle entries retire"
-    );
-    assert_eq!(completion.unwrap().exit_code, 0);
-
-    wait_budget_count(&budget, 1, Duration::from_secs(5)).await;
+    destroy_gate
+        .wait_entered(2, Duration::from_secs(5))
+        .await
+        .expect("both required idle destroys should be tracker-owned before status persistence");
+    assert_eq!(wait_gate.entered_count(), 0);
+    assert_eq!(status.idle_info_update_request_count(), 1);
+    assert_eq!(budget.allocated(), (6, 12288, 2));
 
     let reuse_keys = idle_pool.lock().await.held_reuse_keys();
     assert_eq!(
@@ -538,12 +548,31 @@ async fn larger_profile_retires_only_the_required_oldest_idle_entries() {
         vec!["sess-newest".to_string()],
         "only the newest unneeded idle entry should remain"
     );
+
+    status_write_release.add_permits(1);
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("large fresh sandbox should activate after one idle status write");
+    assert_eq!(status.idle_info_update_request_count(), 1);
     assert_eq!(
         status_idle_reuse_keys(&status_path).await,
         vec!["sess-newest".to_string()],
         "status.json should reflect only the remaining idle sandbox"
     );
 
+    wait_gate.release_one();
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("large job should complete while retired cleanup remains blocked");
+    assert_eq!(completion.exit_code, 0);
+    wait_budget_count(&budget, 1, Duration::from_secs(5)).await;
+
+    destroy_gate.release_one();
+    destroy_gate.release_one();
+    destroy_gate.release_one();
     shutdown(&env, run_handle).await;
 }
 

--- a/crates/runner/src/cmd/start/tests/budget.rs
+++ b/crates/runner/src/cmd/start/tests/budget.rs
@@ -490,7 +490,7 @@ async fn larger_profile_batches_required_oldest_idle_entries_before_status_write
         &idle_pool,
         &budget,
         &idle_overrides,
-        "sess-oldest",
+        "sess-a-oldest",
         "vm0/default",
         2,
         4096,
@@ -500,7 +500,7 @@ async fn larger_profile_batches_required_oldest_idle_entries_before_status_write
         &idle_pool,
         &budget,
         &idle_overrides,
-        "sess-middle",
+        "sess-b-middle",
         "vm0/default",
         2,
         4096,
@@ -510,7 +510,7 @@ async fn larger_profile_batches_required_oldest_idle_entries_before_status_write
         &idle_pool,
         &budget,
         &idle_overrides,
-        "sess-newest",
+        "sess-c-newest",
         "vm0/default",
         2,
         4096,
@@ -545,7 +545,7 @@ async fn larger_profile_batches_required_oldest_idle_entries_before_status_write
     let reuse_keys = idle_pool.lock().await.held_reuse_keys();
     assert_eq!(
         reuse_keys,
-        vec!["sess-newest".to_string()],
+        vec!["sess-c-newest".to_string()],
         "only the newest unneeded idle entry should remain"
     );
 
@@ -557,7 +557,7 @@ async fn larger_profile_batches_required_oldest_idle_entries_before_status_write
     assert_eq!(status.idle_info_update_request_count(), 1);
     assert_eq!(
         status_idle_reuse_keys(&status_path).await,
-        vec!["sess-newest".to_string()],
+        vec!["sess-c-newest".to_string()],
         "status.json should reflect only the remaining idle sandbox"
     );
 

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -178,13 +178,14 @@ impl IdlePool {
         Some(ReservedIdleSandbox { entry })
     }
 
-    /// Reserve a matching idle entry or select the oldest entry for pressure
+    /// Reserve a matching idle entry or order all current entries for pressure
     /// eviction in one pool transition.
     ///
-    /// Keeping both decisions under the caller's exclusive `&mut` access
-    /// prevents an entry parked between a match check and eviction from being
-    /// destroyed instead of reused.
-    pub(crate) fn reserve_reusable_or_evict_oldest(
+    /// The caller must retain exclusive pool access while consuming the
+    /// returned keys. This prevents an entry parked between the match check and
+    /// eviction from being destroyed instead of reused, and avoids rescanning
+    /// the shrinking pool for every eviction.
+    pub(crate) fn reserve_reusable_or_order_oldest(
         &mut self,
         reuse_key: Option<&str>,
         profile_name: &str,
@@ -204,10 +205,17 @@ impl IdlePool {
             return IdlePoolPressureSelection::Reusable(Box::new(reservation));
         }
 
-        match self.evict_oldest() {
-            Some(job) => IdlePoolPressureSelection::Evicted(Box::new(job)),
-            None => IdlePoolPressureSelection::Empty,
-        }
+        let mut ordered_entries: Vec<(Instant, String)> = self
+            .entries
+            .iter()
+            .map(|(reuse_key, entry)| (entry.parked_at, reuse_key.clone()))
+            .collect();
+        ordered_entries.sort_unstable();
+        let reuse_keys = ordered_entries
+            .into_iter()
+            .map(|(_, reuse_key)| reuse_key)
+            .collect();
+        IdlePoolPressureSelection::OldestFirst(reuse_keys)
     }
 
     pub fn restore_reserved(
@@ -226,21 +234,12 @@ impl IdlePool {
         RestoreReservedIdleResult::Restored
     }
 
-    /// Evict the oldest idle entry (by park time). Used for resource
-    /// pressure relief.
-    pub fn evict_oldest(&mut self) -> Option<IdleDestroyJob> {
-        let oldest_key = self
-            .entries
-            .iter()
-            .min_by(|(left_key, left), (right_key, right)| {
-                left.parked_at
-                    .cmp(&right.parked_at)
-                    .then_with(|| left_key.cmp(right_key))
-            })
-            .map(|(k, _)| k.clone())?;
+    /// Evict an entry selected by a pressure ordering captured under the same
+    /// exclusive pool access.
+    pub(crate) fn evict_for_pressure(&mut self, reuse_key: &str) -> Option<IdleDestroyJob> {
         let job = self
             .entries
-            .remove(&oldest_key)
+            .remove(reuse_key)
             .map(IdleEntry::into_destroy_job);
         if job.is_some() {
             self.bump_revision();
@@ -378,8 +377,7 @@ pub enum ParkResult {
 #[must_use = "pressure selection must reserve, track, or explicitly handle idle ownership"]
 pub(crate) enum IdlePoolPressureSelection {
     Reusable(Box<ReservedIdleSandbox>),
-    Evicted(Box<IdleDestroyJob>),
-    Empty,
+    OldestFirst(Vec<String>),
 }
 
 #[cfg(test)]

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -178,21 +178,15 @@ impl IdlePool {
         Some(ReservedIdleSandbox { entry })
     }
 
-    /// Reserve a matching idle entry or order all current entries for pressure
-    /// eviction in one pool transition.
-    ///
-    /// The caller must retain exclusive pool access while consuming the
-    /// returned keys. This prevents an entry parked between the match check and
-    /// eviction from being destroyed instead of reused, and avoids rescanning
-    /// the shrinking pool for every eviction.
-    pub(crate) fn reserve_reusable_or_order_oldest(
+    /// Reserve a matching idle entry before pressure eviction begins.
+    pub(crate) fn reserve_reusable_for_pressure(
         &mut self,
         reuse_key: Option<&str>,
         profile_name: &str,
         device_rate_limits: &Option<DeviceRateLimits>,
         history_generation_run_id: Option<RunId>,
-    ) -> IdlePoolPressureSelection {
-        let reservation = reuse_key.and_then(|reuse_key| match history_generation_run_id {
+    ) -> Option<ReservedIdleSandbox> {
+        reuse_key.and_then(|reuse_key| match history_generation_run_id {
             Some(history_generation_run_id) => self.reserve_reusable_generation(
                 reuse_key,
                 profile_name,
@@ -200,22 +194,21 @@ impl IdlePool {
                 history_generation_run_id,
             ),
             None => self.reserve_reusable(reuse_key, profile_name, device_rate_limits),
-        });
-        if let Some(reservation) = reservation {
-            return IdlePoolPressureSelection::Reusable(Box::new(reservation));
-        }
+        })
+    }
 
+    /// Order all current entries for pressure eviction without mutating them.
+    pub(crate) fn oldest_first_pressure_keys(&self) -> Vec<String> {
         let mut ordered_entries: Vec<(Instant, String)> = self
             .entries
             .iter()
             .map(|(reuse_key, entry)| (entry.parked_at, reuse_key.clone()))
             .collect();
         ordered_entries.sort_unstable();
-        let reuse_keys = ordered_entries
+        ordered_entries
             .into_iter()
             .map(|(_, reuse_key)| reuse_key)
-            .collect();
-        IdlePoolPressureSelection::OldestFirst(reuse_keys)
+            .collect()
     }
 
     pub fn restore_reserved(
@@ -372,12 +365,6 @@ pub enum ParkResult {
     Replaced(IdleDestroyJob),
     /// Parking is closed/soft-draining or at capacity; the entry could not be parked.
     Rejected(RejectedParkedIdleCandidate),
-}
-
-#[must_use = "pressure selection must reserve, track, or explicitly handle idle ownership"]
-pub(crate) enum IdlePoolPressureSelection {
-    Reusable(Box<ReservedIdleSandbox>),
-    OldestFirst(Vec<String>),
 }
 
 #[cfg(test)]

--- a/crates/runner/src/idle_pool/pool_tests.rs
+++ b/crates/runner/src/idle_pool/pool_tests.rs
@@ -284,7 +284,7 @@ async fn rejected_parked_idle_candidate_returns_active_owned_lease() {
 }
 
 #[test]
-fn evict_oldest() {
+fn pressure_ordering_evicts_oldest_first() {
     let mut pool = IdlePool::new(pool_config(0));
     let now = Instant::now();
 
@@ -296,14 +296,20 @@ fn evict_oldest() {
     );
     let _ = park_at(&mut pool, "new", make_candidate_for("new", 4, 4096), now);
 
-    let evicted = pool.evict_oldest().unwrap();
+    let IdlePoolPressureSelection::OldestFirst(reuse_keys) =
+        pool.reserve_reusable_or_order_oldest(None, "vm0/default", &None, None)
+    else {
+        panic!("pressure selection without a reuse key should order idle entries");
+    };
+    assert_eq!(reuse_keys, vec!["old", "new"]);
+    let evicted = pool.evict_for_pressure(&reuse_keys[0]).unwrap();
     assert_eq!(evicted.budget_vcpu(), 2); // the old one
     assert_eq!(pool.len(), 1);
     assert!(pool.take("new").is_some());
 }
 
 #[test]
-fn evict_oldest_breaks_equal_park_time_by_reuse_key() {
+fn pressure_ordering_breaks_equal_park_time_by_reuse_key() {
     let mut pool = IdlePool::new(pool_config(0));
     let parked_at = Instant::now();
     for reuse_key in ["session-z", "session-a", "session-m"] {
@@ -315,8 +321,12 @@ fn evict_oldest_breaks_equal_park_time_by_reuse_key() {
         );
     }
 
-    let evicted = pool.evict_oldest().unwrap();
-    assert_eq!(evicted.reuse_key(), "session-a");
+    let IdlePoolPressureSelection::OldestFirst(reuse_keys) =
+        pool.reserve_reusable_or_order_oldest(None, "vm0/default", &None, None)
+    else {
+        panic!("pressure selection without a reuse key should order idle entries");
+    };
+    assert_eq!(reuse_keys, vec!["session-a", "session-m", "session-z"]);
 }
 
 #[test]
@@ -340,7 +350,7 @@ fn pressure_selection_reserves_exact_match_before_oldest_eviction() {
         parked_at,
     );
 
-    let selection = pool.reserve_reusable_or_evict_oldest(
+    let selection = pool.reserve_reusable_or_order_oldest(
         Some("session-matching"),
         "vm0/default",
         &None,
@@ -358,9 +368,14 @@ fn pressure_selection_reserves_exact_match_before_oldest_eviction() {
 }
 
 #[test]
-fn evict_oldest_empty_returns_none() {
+fn pressure_ordering_empty_returns_no_keys() {
     let mut pool = IdlePool::new(pool_config(0));
-    assert!(pool.evict_oldest().is_none());
+    let IdlePoolPressureSelection::OldestFirst(reuse_keys) =
+        pool.reserve_reusable_or_order_oldest(None, "vm0/default", &None, None)
+    else {
+        panic!("empty pressure selection should return an empty ordering");
+    };
+    assert!(reuse_keys.is_empty());
 }
 
 #[test]

--- a/crates/runner/src/idle_pool/pool_tests.rs
+++ b/crates/runner/src/idle_pool/pool_tests.rs
@@ -296,11 +296,7 @@ fn pressure_ordering_evicts_oldest_first() {
     );
     let _ = park_at(&mut pool, "new", make_candidate_for("new", 4, 4096), now);
 
-    let IdlePoolPressureSelection::OldestFirst(reuse_keys) =
-        pool.reserve_reusable_or_order_oldest(None, "vm0/default", &None, None)
-    else {
-        panic!("pressure selection without a reuse key should order idle entries");
-    };
+    let reuse_keys = pool.oldest_first_pressure_keys();
     assert_eq!(reuse_keys, vec!["old", "new"]);
     let evicted = pool.evict_for_pressure(&reuse_keys[0]).unwrap();
     assert_eq!(evicted.budget_vcpu(), 2); // the old one
@@ -321,11 +317,7 @@ fn pressure_ordering_breaks_equal_park_time_by_reuse_key() {
         );
     }
 
-    let IdlePoolPressureSelection::OldestFirst(reuse_keys) =
-        pool.reserve_reusable_or_order_oldest(None, "vm0/default", &None, None)
-    else {
-        panic!("pressure selection without a reuse key should order idle entries");
-    };
+    let reuse_keys = pool.oldest_first_pressure_keys();
     assert_eq!(reuse_keys, vec!["session-a", "session-m", "session-z"]);
 }
 
@@ -350,31 +342,25 @@ fn pressure_selection_reserves_exact_match_before_oldest_eviction() {
         parked_at,
     );
 
-    let selection = pool.reserve_reusable_or_order_oldest(
+    let selection = pool.reserve_reusable_for_pressure(
         Some("session-matching"),
         "vm0/default",
         &None,
         Some(history_generation_run_id),
     );
 
-    let IdlePoolPressureSelection::Reusable(reservation) = selection else {
-        panic!("matching entry must be reserved before pressure eviction");
-    };
+    let reservation = selection.expect("matching entry must be reserved before pressure eviction");
     assert_eq!(pool.held_reuse_keys(), vec!["session-unrelated"]);
     assert!(matches!(
-        pool.restore_reserved(*reservation),
+        pool.restore_reserved(reservation),
         RestoreReservedIdleResult::Restored
     ));
 }
 
 #[test]
 fn pressure_ordering_empty_returns_no_keys() {
-    let mut pool = IdlePool::new(pool_config(0));
-    let IdlePoolPressureSelection::OldestFirst(reuse_keys) =
-        pool.reserve_reusable_or_order_oldest(None, "vm0/default", &None, None)
-    else {
-        panic!("empty pressure selection should return an empty ordering");
-    };
+    let pool = IdlePool::new(pool_config(0));
+    let reuse_keys = pool.oldest_first_pressure_keys();
     assert!(reuse_keys.is_empty());
 }
 

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -342,6 +342,8 @@ pub struct StatusTracker {
     persistence: Arc<PersistenceCoordinator>,
     #[cfg(test)]
     write_gate: Option<StatusWriteGate>,
+    #[cfg(test)]
+    idle_info_update_requests: AtomicU64,
 }
 
 struct MutableState {
@@ -395,6 +397,8 @@ impl StatusTracker {
             persistence: Arc::new(PersistenceCoordinator::new()),
             #[cfg(test)]
             write_gate: None,
+            #[cfg(test)]
+            idle_info_update_requests: AtomicU64::new(0),
         }
     }
 
@@ -430,6 +434,11 @@ impl StatusTracker {
             release,
         });
         tracker
+    }
+
+    #[cfg(test)]
+    pub(crate) fn idle_info_update_request_count(&self) -> u64 {
+        self.idle_info_update_requests.load(Ordering::Relaxed)
     }
 
     /// Transition the reported lifecycle mode and flush the status file.
@@ -632,6 +641,9 @@ impl StatusTracker {
         revision: u64,
         idle_sandboxes: Vec<IdleSandbox>,
     ) -> StatusResult<bool> {
+        #[cfg(test)]
+        self.idle_info_update_requests
+            .fetch_add(1, Ordering::Relaxed);
         let snapshot = {
             let mut state = self.state.lock().await;
             let applied = apply_idle_info_at_revision(&mut state, revision, idle_sandboxes);


### PR DESCRIPTION
## Summary

- batch oldest-first idle eviction for a single admission decision instead of rescanning the pool after every retired sandbox
- atomically substitute retired idle leases until the incoming CPU, memory, and job-count requirements can be admitted
- register cleanup for every retired sandbox before persisting one final idle snapshot, while preserving exact-reuse checks around the status write
- add an admission integration test that proves two required evictions trigger exactly one idle-only status update

## Scope

This changes only local runner idle-pressure admission and its tests. It does not change APIs, persisted schemas, queue payloads, or runner protocols.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-features` (3,408 passed; 24 ignored)

Closes #31138
