### PR TITLE
fix(desktop): stop applying the mach timebase to click timestamps that are already nanoseconds

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/ClickMapping.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/ClickMapping.swift
@@ -75,7 +75,8 @@ extension CaptureGeometry {
 /// Kept free of CoreGraphics types so the projection below can be exercised
 /// without a capture device or an event tap.
 public struct CapturedClick: Equatable, Sendable {
-    public let ticks: UInt64
+    /// `CGEvent.timestamp`: nanoseconds since boot on the host clock.
+    public let nanoseconds: UInt64
     public let screenX: Double
     public let screenY: Double
     public let button: String
@@ -89,7 +90,7 @@ public struct CapturedClick: Equatable, Sendable {
     public let geometry: CaptureGeometry?
 
     public init(
-        ticks: UInt64,
+        nanoseconds: UInt64,
         screenX: Double,
         screenY: Double,
         button: String,
@@ -97,7 +98,7 @@ public struct CapturedClick: Equatable, Sendable {
         modifiers: [String],
         geometry: CaptureGeometry? = nil
     ) {
-        self.ticks = ticks
+        self.nanoseconds = nanoseconds
         self.screenX = screenX
         self.screenY = screenY
         self.button = button
@@ -138,7 +139,8 @@ public func projectClicks(
     var droppedOutOfFrame = 0
 
     for click in clicks {
-        guard let offsetMs = timeline.offsetMilliseconds(atTicks: click.ticks) else {
+        guard let offsetMs = timeline.offsetMilliseconds(atNanoseconds: click.nanoseconds)
+        else {
             continue
         }
         guard
@@ -165,35 +167,28 @@ public func projectClicks(
     return (projected, droppedOutOfFrame)
 }
 
-/// Converts `CGEvent` timestamps onto the recording's timeline.
+/// Places `CGEvent` timestamps on the recording's timeline.
 ///
-/// `CGEvent.timestamp` is mach absolute time in raw tick units, which are not
-/// nanoseconds on every machine; the timebase ratio has to be applied or every
-/// click lands at the wrong moment in the video.
+/// `CGEvent.timestamp` is nanoseconds since boot on the same host clock that
+/// stamps the captured frames. It is not raw `mach_absolute_time` ticks: the
+/// system has already applied the timebase. Applying it a second time here
+/// multiplied every offset by 125/3 on Apple silicon, which reported a click
+/// two seconds into a recording as 97 days into it, and looked fine on Intel
+/// machines only because their ratio is 1/1.
 public struct ClickTimeline: Equatable, Sendable {
-    public let startTicks: UInt64
-    public let timebaseNumerator: UInt32
-    public let timebaseDenominator: UInt32
+    /// Host-clock time of the first captured frame, in nanoseconds.
+    public let startNanoseconds: UInt64
 
-    public init(
-        startTicks: UInt64,
-        timebaseNumerator: UInt32,
-        timebaseDenominator: UInt32
-    ) {
-        self.startTicks = startTicks
-        self.timebaseNumerator = timebaseNumerator
-        self.timebaseDenominator = max(1, timebaseDenominator)
+    public init(startNanoseconds: UInt64) {
+        self.startNanoseconds = startNanoseconds
     }
 
     /// Milliseconds from the start of the recording, or `nil` for an event that
     /// predates it.
-    public func offsetMilliseconds(atTicks ticks: UInt64) -> Int? {
-        guard ticks >= startTicks else {
+    public func offsetMilliseconds(atNanoseconds nanoseconds: UInt64) -> Int? {
+        guard nanoseconds >= startNanoseconds else {
             return nil
         }
-        let elapsedTicks = Double(ticks - startTicks)
-        let nanoseconds =
-            elapsedTicks * Double(timebaseNumerator) / Double(timebaseDenominator)
-        return Int((nanoseconds / 1_000_000).rounded())
+        return Int((Double(nanoseconds - startNanoseconds) / 1_000_000).rounded())
     }
 }

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/ClickTrackRecorder.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/ClickTrackRecorder.swift
@@ -128,7 +128,7 @@ final class ClickTrackRecorder: @unchecked Sendable {
         }
         let location = event.location
         let click = CapturedClick(
-            ticks: event.timestamp,
+            nanoseconds: event.timestamp,
             screenX: Double(location.x),
             screenY: Double(location.y),
             button: button,

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
@@ -412,7 +412,6 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
     private let sampleQueue = DispatchQueue(label: "ai.okou.recorder.samples")
 
     private let clickTracker = ClickTrackRecorder()
-    private var timebase = mach_timebase_info_data_t()
 
     private var state: RecorderSessionState = .ready
     /// Set when the stream ended without `stop` being called. The session stays
@@ -470,7 +469,6 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         self.audioPlan = audioPlan
         self.windowID = windowID
         super.init()
-        mach_timebase_info(&timebase)
     }
 
     private func currentGeometryNow() -> CaptureGeometry {
@@ -525,20 +523,19 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         lock.unlock()
     }
 
-    /// Converts a host-clock presentation timestamp back into the raw mach tick
-    /// units `CGEvent.timestamp` reports, so clicks and frames share one origin.
+    /// A host-clock presentation timestamp in the nanoseconds `CGEvent.timestamp`
+    /// reports, so clicks and frames share one origin.
     ///
-    /// Returns `nil` rather than a zero anchor when the timestamp cannot be
-    /// converted: anchoring at tick 0 would place every click at its offset from
-    /// system boot instead of from the recording, which is a confidently wrong
-    /// answer. The caller leaves the timeline unset and the track comes out
-    /// empty.
-    private func hostTicks(from time: CMTime) -> UInt64? {
+    /// Returns `nil` rather than a zero anchor when the timestamp is unusable:
+    /// anchoring at 0 would place every click at its offset from system boot
+    /// instead of from the recording, which is a confidently wrong answer. The
+    /// caller leaves the timeline unset and the track comes out empty.
+    private func hostNanoseconds(from time: CMTime) -> UInt64? {
         let nanoseconds = CMTimeGetSeconds(time) * 1_000_000_000
-        guard nanoseconds > 0, timebase.numer > 0 else {
+        guard nanoseconds.isFinite, nanoseconds > 0 else {
             return nil
         }
-        return UInt64(nanoseconds * Double(timebase.denom) / Double(timebase.numer))
+        return UInt64(nanoseconds)
     }
 
     var describedGeometry: [String: Any] {
@@ -1092,12 +1089,8 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
             sessionStartedAt = timestamp
             // Anchor clicks on the very same frame the video starts on rather
             // than on when `start` was called, so the two timelines cannot drift.
-            if let startTicks = hostTicks(from: timestamp) {
-                clickTimeline = ClickTimeline(
-                    startTicks: startTicks,
-                    timebaseNumerator: timebase.numer,
-                    timebaseDenominator: timebase.denom
-                )
+            if let startNanoseconds = hostNanoseconds(from: timestamp) {
+                clickTimeline = ClickTimeline(startNanoseconds: startNanoseconds)
             }
         }
         let input = writerInputLocked(for: type)

--- a/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/ClickMappingTests.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/ClickMappingTests.swift
@@ -101,51 +101,32 @@ struct ClickMappingTests {
 }
 
 struct ClickTimelineTests {
-    /// Apple silicon reports 125/3 nanoseconds per tick rather than 1/1, so a
-    /// timeline that ignores the ratio is wrong by ~40x on those machines.
-    private let appleSilicon = ClickTimeline(
-        startTicks: 1_000,
-        timebaseNumerator: 125,
-        timebaseDenominator: 3
-    )
+    /// A first frame stamped 57 hours after boot, which is what both
+    /// `CGEvent.timestamp` and the host clock count from.
+    private let timeline = ClickTimeline(startNanoseconds: 207_760_000_000_000)
 
+    /// `CGEvent.timestamp` is already nanoseconds. Treating it as raw mach ticks
+    /// and applying the 125/3 Apple silicon timebase multiplied every offset by
+    /// ~41.7, so this click 2.2 s into a 23 s recording came out 97 days in and
+    /// no downstream consumer could find a single click inside the video.
     @Test
-    func convertsTicksToMillisecondsUsingTheTimebaseRatio() {
-        // 24_000 ticks * 125/3 = 1_000_000ns = 1ms
-        #expect(appleSilicon.offsetMilliseconds(atTicks: 25_000) == 1)
+    func placesAClickAtItsOffsetInPlainNanoseconds() {
+        #expect(timeline.offsetMilliseconds(atNanoseconds: 207_762_200_000_000) == 2_200)
     }
 
     @Test
     func reportsZeroAtTheStartOfTheRecording() {
-        #expect(appleSilicon.offsetMilliseconds(atTicks: 1_000) == 0)
+        #expect(timeline.offsetMilliseconds(atNanoseconds: 207_760_000_000_000) == 0)
     }
 
     @Test
     func dropsEventsThatPredateTheRecording() {
-        #expect(appleSilicon.offsetMilliseconds(atTicks: 999) == nil)
+        #expect(timeline.offsetMilliseconds(atNanoseconds: 207_759_999_999_999) == nil)
     }
 
     @Test
-    func handlesTheOneToOneTimebase() {
-        let intel = ClickTimeline(
-            startTicks: 0,
-            timebaseNumerator: 1,
-            timebaseDenominator: 1
-        )
-
-        #expect(intel.offsetMilliseconds(atTicks: 2_000_000) == 2)
-    }
-
-    @Test
-    func neverDividesByAZeroDenominator() {
-        let degenerate = ClickTimeline(
-            startTicks: 0,
-            timebaseNumerator: 1,
-            timebaseDenominator: 0
-        )
-
-        #expect(degenerate.timebaseDenominator == 1)
-        #expect(degenerate.offsetMilliseconds(atTicks: 1_000_000) == 1)
+    func roundsToTheNearestMillisecond() {
+        #expect(timeline.offsetMilliseconds(atNanoseconds: 207_760_001_500_000) == 2)
     }
 }
 
@@ -158,15 +139,11 @@ struct ClickProjectionTests {
         scale: 2
     )
     private let outputSize = OutputSize(width: 1920, height: 960)
-    private let timeline = ClickTimeline(
-        startTicks: 24_000,
-        timebaseNumerator: 1,
-        timebaseDenominator: 1
-    )
+    private let timeline = ClickTimeline(startNanoseconds: 24_000)
 
-    private func click(ticks: UInt64, x: Double, y: Double) -> CapturedClick {
+    private func click(nanoseconds: UInt64, x: Double, y: Double) -> CapturedClick {
         return CapturedClick(
-            ticks: ticks,
+            nanoseconds: nanoseconds,
             screenX: x,
             screenY: y,
             button: "left",
@@ -178,7 +155,7 @@ struct ClickProjectionTests {
     @Test
     func projectsAClickThatLandedInsideTheRecording() {
         let projection = projectClicks(
-            [click(ticks: 2_024_000, x: 500, y: 250)],
+            [click(nanoseconds: 2_024_000, x: 500, y: 250)],
             timeline: timeline,
             geometry: display,
             outputSize: outputSize
@@ -201,7 +178,7 @@ struct ClickProjectionTests {
     @Test
     func dropsClicksFromBeforeTheFirstFrameWithoutCountingThemOutOfFrame() {
         let projection = projectClicks(
-            [click(ticks: 1_000, x: 500, y: 250)],
+            [click(nanoseconds: 1_000, x: 500, y: 250)],
             timeline: timeline,
             geometry: display,
             outputSize: outputSize
@@ -228,7 +205,7 @@ struct ClickProjectionTests {
         let projection = projectClicks(
             [
                 CapturedClick(
-                    ticks: 2_024_000,
+                    nanoseconds: 2_024_000,
                     screenX: 600,
                     screenY: 350,
                     button: "left",
@@ -252,7 +229,7 @@ struct ClickProjectionTests {
     @Test
     func countsClicksThatLandedOutsideTheCapturedRegion() {
         let projection = projectClicks(
-            [click(ticks: 2_024_000, x: 1_500, y: 250)],
+            [click(nanoseconds: 2_024_000, x: 1_500, y: 250)],
             timeline: timeline,
             geometry: display,
             outputSize: outputSize
@@ -266,9 +243,9 @@ struct ClickProjectionTests {
     func separatesTheTwoDropReasonsInOneRecording() {
         let projection = projectClicks(
             [
-                click(ticks: 1_000, x: 500, y: 250),
-                click(ticks: 2_024_000, x: 1_500, y: 250),
-                click(ticks: 3_024_000, x: 500, y: 250),
+                click(nanoseconds: 1_000, x: 500, y: 250),
+                click(nanoseconds: 2_024_000, x: 1_500, y: 250),
+                click(nanoseconds: 3_024_000, x: 500, y: 250),
             ],
             timeline: timeline,
             geometry: display,


### PR DESCRIPTION
## Summary

Every click in a desktop recording's `clicks.json` was stamped about 41.7 times too late on Apple silicon, so no consumer could place a single click inside the video. Stacked on #31112 (base branch); it retargets to `main` once that merges.

`CGEvent.timestamp` is nanoseconds since boot on the host clock, not raw `mach_absolute_time` ticks. The click timeline converted the first frame's host-clock timestamp into ticks and then scaled the difference back by the 125/3 Apple silicon timebase, applying the ratio a second time. A click 2.2 s into a 23 s recording came out 97 days in. Intel machines, whose ratio is 1/1, never showed it.

## Evidence

From a real 23 s recording made today (9 clicks):

| | first click | second | third | last |
|---|---|---|---|---|
| `tMs` in the sidecar | 8 449 281 129 | 8 449 467 874 | 8 449 513 566 | 8 450 027 448 |
| gap ÷ 41.667 | 0 s | 4.48 s | 5.58 s | 17.91 s |
| visible UI change at that click's position | 2.25 s | 6.57 s | 7.76 s | 20.13 s |

With the first click anchored at 2.2 s, all nine clicks land on a visible UI change at their own position within about 0.1 s. Under the alternative reading (raw ms), the clicks would span 746 s of a 23 s recording.

This is the actual root cause behind the "clicks don't match the video" report; the pause and moved-window fixes in #31112 are real but secondary.

## Change

- `ClickTimeline` anchors on the first frame's host-clock nanoseconds and takes the event timestamp as nanoseconds. The `mach_timebase_info` lookup and the tick conversion are gone.
- `CapturedClick.ticks` is renamed to `nanoseconds` so the unit is in the name.
- `ClickTimelineTests` now pin the plain-nanosecond contract (2.2 s stays 2.2 s, zero at the first frame, earlier events dropped, rounding).

## Test plan

- [ ] macOS CI (`Desktop` / `build-macos-arm64`) compiles the helper and runs `ScreenRecorderCoreTests`
- [ ] Re-record on the dev build and confirm `clicks[].tMs` are small numbers inside `durationMs`, then `okou video camera --events` reports `cameraRanges > 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
