### PR TITLE
refactor(api): remove terminal preview job-reference legacy reader

### DIFF
--- a/turbo/apps/api/src/lib/log.ts
+++ b/turbo/apps/api/src/lib/log.ts
@@ -38,8 +38,6 @@ interface Logger {
   level: Level;
 }
 
-type RetainedAliasResolutionEvent = "stripe_preview_job_ref_alias_resolution";
-
 class LoggerRegistry {
   private readonly store = new Map<string, Logger>();
 
@@ -349,14 +347,6 @@ export function logger(name: string): Logger {
   const loggerInstance = createLogger(name);
   registry.set(name, loggerInstance);
   return loggerInstance;
-}
-
-export function logAliasResolutionInfo(
-  loggerInstance: Pick<Logger, "info">,
-  event: RetainedAliasResolutionEvent,
-  fields: Readonly<Record<string, string>>,
-): void {
-  loggerInstance.info(event, fields);
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -1777,7 +1777,7 @@ describe("POST /api/billing/checkout", () => {
 
   it("tags preview Stripe checkout objects with the current job ref", async () => {
     mockEnv("ENV", "preview");
-    mockOptionalEnv("VM0_PREVIEW_JOB_REF", "pr-123");
+    mockOptionalEnv("OKOU_PREVIEW_JOB_REF", "pr-123");
     const fixture = await trackedSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
@@ -13960,7 +13960,7 @@ describe("usage pack allocation management", () => {
   it("ignores invitation PaymentIntents from another preview job", async () => {
     const purchase = await beginInvitationPurchase();
     mockEnv("ENV", "preview");
-    mockOptionalEnv("VM0_PREVIEW_JOB_REF", "pr-current");
+    mockOptionalEnv("OKOU_PREVIEW_JOB_REF", "pr-current");
 
     await postManagedUsagePackEvent("payment_intent.succeeded", {
       id: purchase.paymentIntentId,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -6540,7 +6540,7 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
     const actor = bdd.user();
     const granted = await runs.grantProEntitlement(actor);
     mockEnv("ENV", "preview");
-    mockOptionalEnv("VM0_PREVIEW_JOB_REF", "pr-bdd-123");
+    mockOptionalEnv("OKOU_PREVIEW_JOB_REF", "pr-bdd-123");
 
     const mismatchedMetadata = {
       vm0_environment: "preview",

--- a/turbo/apps/api/src/signals/services/__tests__/stripe-preview-metadata.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/stripe-preview-metadata.service.test.ts
@@ -1,244 +1,75 @@
-import { createHash } from "node:crypto";
-
-import { EVENT } from "@axiomhq/logging";
 import { describe, expect, it } from "vitest";
 
-import { testContext } from "../../../__tests__/test-context";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import {
   isCurrentStripePreviewMetadata,
   stripePreviewMetadata,
 } from "../stripe-preview-metadata.service";
 
-const context = testContext();
+const PREVIEW_JOB_REF_ENV_KEY = "OKOU_PREVIEW_JOB_REF";
 
-const CANONICAL_PREVIEW_JOB_REF_ENV_KEY = "OKOU_PREVIEW_JOB_REF";
-const LEGACY_PREVIEW_JOB_REF_ENV_KEY = "VM0_PREVIEW_JOB_REF";
-const PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT =
-  "stripe_preview_job_ref_alias_resolution";
-const PREVIEW_JOB_REF_LOG_CONTEXT = "StripePreviewMetadata";
-
-type PreviewJobRefAliasState =
-  | "absent"
-  | "canonical-only"
-  | "legacy-only"
-  | "equal-dual"
-  | "conflicting-dual";
-
-interface PreviewJobRefAliasFixture {
-  readonly name: string;
-  readonly canonical: string | undefined;
-  readonly legacy: string | undefined;
-  readonly state: PreviewJobRefAliasState;
-  readonly jobRef: string | null;
-}
-
-const PREVIEW_JOB_REF_ALIAS_FIXTURES: readonly PreviewJobRefAliasFixture[] = [
-  {
-    name: "absent aliases",
-    canonical: undefined,
-    legacy: undefined,
-    state: "absent",
-    jobRef: null,
-  },
-  {
-    name: "empty canonical alias",
-    canonical: "",
-    legacy: undefined,
-    state: "absent",
-    jobRef: null,
-  },
-  {
-    name: "empty legacy alias",
-    canonical: undefined,
-    legacy: "",
-    state: "absent",
-    jobRef: null,
-  },
-  {
-    name: "empty dual aliases",
-    canonical: "",
-    legacy: "",
-    state: "absent",
-    jobRef: null,
-  },
-  {
-    name: "canonical-only alias",
-    canonical: "canonical-preview-job",
-    legacy: undefined,
-    state: "canonical-only",
-    jobRef: "canonical-preview-job",
-  },
-  {
-    name: "canonical-only alias with an empty legacy value",
-    canonical: "canonical-preview-job",
-    legacy: "",
-    state: "canonical-only",
-    jobRef: "canonical-preview-job",
-  },
-  {
-    name: "legacy-only alias",
-    canonical: undefined,
-    legacy: "legacy-preview-job",
-    state: "legacy-only",
-    jobRef: "legacy-preview-job",
-  },
-  {
-    name: "legacy-only alias with an empty canonical value",
-    canonical: "",
-    legacy: "legacy-preview-job",
-    state: "legacy-only",
-    jobRef: "legacy-preview-job",
-  },
-  {
-    name: "equal dual aliases",
-    canonical: "shared-preview-job",
-    legacy: "shared-preview-job",
-    state: "equal-dual",
-    jobRef: "shared-preview-job",
-  },
-];
-
-function configureAliases(
+function configurePreview(
   environment: "preview" | "production",
-  canonical: string | undefined,
-  legacy: string | undefined,
+  jobRef: string | undefined,
 ): void {
   mockEnv("ENV", environment);
-  mockOptionalEnv(CANONICAL_PREVIEW_JOB_REF_ENV_KEY, canonical);
-  mockOptionalEnv(LEGACY_PREVIEW_JOB_REF_ENV_KEY, legacy);
+  mockOptionalEnv(PREVIEW_JOB_REF_ENV_KEY, jobRef);
 }
 
-function aliasEvidence(
-  state: PreviewJobRefAliasState,
-): Record<string, unknown> {
-  return {
-    [EVENT]: { source: "api" },
-    canonicalKey: CANONICAL_PREVIEW_JOB_REF_ENV_KEY,
-    legacyKey: LEGACY_PREVIEW_JOB_REF_ENV_KEY,
-    state,
-    context: PREVIEW_JOB_REF_LOG_CONTEXT,
-  };
-}
+describe("Stripe preview metadata", () => {
+  it.each([
+    ["absent", undefined],
+    ["empty", ""],
+  ] as const)(
+    "keeps no-job behavior when the job reference is %s",
+    (_, jobRef) => {
+      configurePreview("preview", jobRef);
 
-function expectValueFree(diagnostics: string, values: readonly string[]): void {
-  for (const value of values) {
-    const forbiddenDerivatives = [
-      value,
-      String(value.length),
-      createHash("sha256").update(value).digest("hex"),
-      JSON.stringify(value),
-    ];
-    for (const derivative of forbiddenDerivatives) {
-      expect(diagnostics).not.toContain(derivative);
-    }
-  }
-}
+      expect(stripePreviewMetadata()).toStrictEqual({});
+      expect(isCurrentStripePreviewMetadata(null)).toBeTruthy();
+      expect(
+        isCurrentStripePreviewMetadata({
+          vm0_environment: "preview",
+          job_ref: "another-preview-job",
+        }),
+      ).toBeTruthy();
+    },
+  );
 
-describe("Stripe preview metadata job reference aliases", () => {
-  it("resolves the matrix with one value-free info event per state", () => {
-    const reportedStates = new Set<PreviewJobRefAliasState>();
+  it("adds exact metadata and matches the current preview job", () => {
+    configurePreview("preview", "current-preview-job");
+    const currentMetadata = {
+      vm0_environment: "preview",
+      job_ref: "current-preview-job",
+    };
 
-    for (const {
-      canonical,
-      legacy,
-      state,
-      jobRef,
-    } of PREVIEW_JOB_REF_ALIAS_FIXTURES) {
-      configureAliases("preview", canonical, legacy);
-      const logCount = context.mocks.axiomLogging.info.mock.calls.filter(
-        ([message]) => {
-          return message === PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT;
-        },
-      ).length;
-      const expectedMetadata: Readonly<Record<string, string>> = jobRef
-        ? { vm0_environment: "preview", job_ref: jobRef }
-        : {};
-
-      expect(stripePreviewMetadata()).toStrictEqual(expectedMetadata);
-      expect(isCurrentStripePreviewMetadata(expectedMetadata)).toBeTruthy();
-      expect(isCurrentStripePreviewMetadata(null)).toBe(jobRef === null);
-
-      const aliasResolutionCalls = context.mocks.axiomLogging.info.mock.calls
-        .filter(([message]) => {
-          return message === PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT;
-        })
-        .slice(logCount);
-      const expectedCalls = reportedStates.has(state)
-        ? []
-        : [[PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT, aliasEvidence(state)]];
-      expect(aliasResolutionCalls).toStrictEqual(expectedCalls);
-      reportedStates.add(state);
-      const configuredValues = [canonical, legacy].filter(
-        (value): value is string => {
-          return Boolean(value);
-        },
-      );
-      expectValueFree(JSON.stringify(aliasResolutionCalls), configuredValues);
-    }
-
-    expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalledWith(
-      PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT,
-      expect.anything(),
-    );
-    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
-  });
-
-  it("fails closed on unequal dual aliases without exposing either value", () => {
-    const canonical = "canonical-job-ref-must-not-leak";
-    const legacy = "legacy-job-ref-must-not-leak";
-    configureAliases("preview", canonical, legacy);
-    const expectedMessage =
-      "Preview job reference aliases conflict: canonicalKey=OKOU_PREVIEW_JOB_REF legacyKey=VM0_PREVIEW_JOB_REF state=conflicting-dual";
-
-    expect(() => {
-      stripePreviewMetadata();
-    }).toThrow(expectedMessage);
-    expect(() => {
+    expect(stripePreviewMetadata()).toStrictEqual(currentMetadata);
+    expect(isCurrentStripePreviewMetadata(currentMetadata)).toBeTruthy();
+    expect(
+      isCurrentStripePreviewMetadata({
+        ...currentMetadata,
+        purpose: "checkout",
+      }),
+    ).toBeTruthy();
+    expect(
       isCurrentStripePreviewMetadata({
         vm0_environment: "preview",
-        job_ref: "metadata-job-ref",
-      });
-    }).toThrow(expectedMessage);
-
-    expect(context.mocks.axiomLogging.warn.mock.calls).toStrictEqual([
-      [
-        PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT,
-        aliasEvidence("conflicting-dual"),
-      ],
-    ]);
-    const diagnostics = JSON.stringify({
-      error: expectedMessage,
-      logs: context.mocks.axiomLogging.warn.mock.calls,
-    });
-    expectValueFree(diagnostics, [canonical, legacy]);
-    expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalledWith(
-      PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT,
-      expect.anything(),
-    );
-    expect(context.mocks.axiomLogging.info).not.toHaveBeenCalledWith(
-      PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT,
-      expect.anything(),
-    );
+        job_ref: "another-preview-job",
+      }),
+    ).toBeFalsy();
+    expect(
+      isCurrentStripePreviewMetadata({
+        vm0_environment: "production",
+        job_ref: "current-preview-job",
+      }),
+    ).toBeFalsy();
+    expect(isCurrentStripePreviewMetadata(null)).toBeFalsy();
   });
 
-  it("ignores preview alias conflicts outside preview deployments", () => {
-    configureAliases(
-      "production",
-      "canonical-production-job-ref",
-      "legacy-production-job-ref",
-    );
+  it("keeps non-preview behavior unchanged", () => {
+    configurePreview("production", "production-job-ref");
 
     expect(stripePreviewMetadata()).toStrictEqual({});
     expect(isCurrentStripePreviewMetadata(null)).toBeTruthy();
-    expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalledWith(
-      PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT,
-      expect.anything(),
-    );
-    expect(context.mocks.axiomLogging.info).not.toHaveBeenCalledWith(
-      PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT,
-      expect.anything(),
-    );
-    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
   });
 });

--- a/turbo/apps/api/src/signals/services/stripe-preview-metadata.service.ts
+++ b/turbo/apps/api/src/signals/services/stripe-preview-metadata.service.ts
@@ -1,83 +1,14 @@
 import { env, optionalEnv } from "../../lib/env";
-import { logAliasResolutionInfo, logger } from "../../lib/log";
-import { singleton } from "../../lib/singleton";
 
 const PREVIEW_ENVIRONMENT_METADATA_KEY = "vm0_environment";
 const PREVIEW_JOB_REF_METADATA_KEY = "job_ref";
-const CANONICAL_PREVIEW_JOB_REF_ENV_KEY = "OKOU_PREVIEW_JOB_REF";
-const LEGACY_PREVIEW_JOB_REF_ENV_KEY = "VM0_PREVIEW_JOB_REF";
-const PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT =
-  "stripe_preview_job_ref_alias_resolution";
+const PREVIEW_JOB_REF_ENV_KEY = "OKOU_PREVIEW_JOB_REF";
 
-const log = logger("StripePreviewMetadata");
-
-type PreviewJobRefAliasState =
-  | "absent"
-  | "canonical-only"
-  | "legacy-only"
-  | "equal-dual"
-  | "conflicting-dual";
-
-const reportedStates = singleton(() => {
-  return new Set<PreviewJobRefAliasState>();
-});
-
-function reportResolution(state: PreviewJobRefAliasState): void {
-  const states = reportedStates();
-  if (states.has(state)) {
-    return;
-  }
-  states.add(state);
-
-  const fields = {
-    canonicalKey: CANONICAL_PREVIEW_JOB_REF_ENV_KEY,
-    legacyKey: LEGACY_PREVIEW_JOB_REF_ENV_KEY,
-    state,
-  };
-  if (state === "conflicting-dual") {
-    log.warn(PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT, fields);
-    return;
-  }
-  logAliasResolutionInfo(log, PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT, fields);
-}
-
-// The repository-owned preview action now emits only OKOU_PREVIEW_JOB_REF.
-// This dual reader and value-free source telemetry remain for old
-// checkout/rerun visibility, active old-preview compatibility, and external
-// legacy input. Remove them only in a later #28914 cleanup after those sources
-// and the supported rollback window are proven drained.
 function resolveStripePreviewJobRef(): string | null {
   if (env("ENV") !== "preview") {
     return null;
   }
-
-  const canonical = optionalEnv(CANONICAL_PREVIEW_JOB_REF_ENV_KEY);
-  const legacy = optionalEnv(LEGACY_PREVIEW_JOB_REF_ENV_KEY);
-  if (canonical && legacy && canonical !== legacy) {
-    reportResolution("conflicting-dual");
-    throw new Error(
-      `Preview job reference aliases conflict: canonicalKey=${CANONICAL_PREVIEW_JOB_REF_ENV_KEY} legacyKey=${LEGACY_PREVIEW_JOB_REF_ENV_KEY} state=conflicting-dual`,
-    );
-  }
-
-  let jobRef: string | null;
-  let state: PreviewJobRefAliasState;
-  if (canonical && legacy) {
-    jobRef = canonical;
-    state = "equal-dual";
-  } else if (canonical) {
-    jobRef = canonical;
-    state = "canonical-only";
-  } else if (legacy) {
-    jobRef = legacy;
-    state = "legacy-only";
-  } else {
-    jobRef = null;
-    state = "absent";
-  }
-
-  reportResolution(state);
-  return jobRef;
+  return optionalEnv(PREVIEW_JOB_REF_ENV_KEY) ?? null;
 }
 
 export function stripePreviewMetadata(): Record<string, string> {


### PR DESCRIPTION
## Summary

- make `OKOU_PREVIEW_JOB_REF` the sole Stripe preview job-reference runtime input
- remove the terminal alias conflict, telemetry, singleton state, migration comments, and now-unused logging helper
- preserve the `ENV === "preview"` boundary, persisted `vm0_environment` / `job_ref` metadata, exact current-job matching, empty/absent behavior, and non-preview behavior
- update the three broader test mocks to use the canonical input

Closes #31145
Parent: #28914

## Scope evidence

- based on `f23ecec9f8582cdd9a90281af7833266d7fb84ca`
- audited all 42 open pull requests and all 790 declared changed-file records across 43 non-empty file pages before editing; only stale #25722 overlaps a target path (`log.ts`), and this PR does not wait for or mutate it
- follows the final owner-approved #30806 supported-scope exception: the exact old Vercel preview and orphan test Runner are unsupported test artifacts, remain untouched, and this PR makes no global-zero-traffic claim
- leaves `.github/actions/**`, `.github/workflows/**`, and the canonical writer test unchanged

## Verification

- `pnpm exec prettier --check apps/api/src/lib/log.ts apps/api/src/signals/routes/__tests__/billing-checkout.test.ts apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts apps/api/src/signals/services/__tests__/stripe-preview-metadata.service.test.ts apps/api/src/signals/services/stripe-preview-metadata.service.ts`
- `pnpm --filter api run lint`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/services/__tests__/stripe-preview-metadata.service.test.ts` (4 passed)
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/billing-checkout.test.ts` (204 passed)
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts` (64 passed)
- `pnpm knip`
- `git diff --check origin/main...HEAD`

## Literal inventory

The exact `VM0_PREVIEW_JOB_REF` literal no longer exists in runtime code or ordinary tests. Its only two remaining occurrences are the unchanged canonical-writer regression assertions in `.github/scripts/tests/web-api-env-action-test.sh` that require the legacy key to be absent.
