### PR TITLE
perf(api): skip redundant drains for admitted goals

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -799,18 +799,22 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function sandboxOperationEventsForRun(
-  runId: string,
-): readonly Record<string, unknown>[] {
+function sandboxOperationEvents(): readonly Record<string, unknown>[] {
   return context.mocks.axiom.sdkIngest.mock.calls.flatMap((call) => {
     const dataset = call[0];
     const events = call[1];
     if (dataset !== "vm0-sandbox-op-log-dev" || !Array.isArray(events)) {
       return [];
     }
-    return events.filter((event): event is Record<string, unknown> => {
-      return isRecord(event) && event.run_id === runId;
-    });
+    return events.filter(isRecord);
+  });
+}
+
+function sandboxOperationEventsForRun(
+  runId: string,
+): readonly Record<string, unknown>[] {
+  return sandboxOperationEvents().filter((event) => {
+    return event.run_id === runId;
   });
 }
 
@@ -873,6 +877,7 @@ async function expectGoalDrainPreCreateTiming(args: {
   readonly runId: string;
   readonly schedulerOrigin: "chat_callback" | "terminal_callback_fallback";
   readonly builtInModelContext: boolean;
+  readonly skippedHigherPriorityDrains?: boolean;
   readonly forbiddenValues: readonly string[];
 }): Promise<void> {
   const expectedActionTypes = [
@@ -944,6 +949,17 @@ async function expectGoalDrainPreCreateTiming(args: {
     0,
   );
   expect(schedulerPhaseDuration).toBe(Number(schedulerStartGap.duration_ms));
+  const higherPriorityDrainDurations = [
+    "api_dispatch_pre_create_zero_goal_drain_scheduler_user_message_drain",
+    "api_dispatch_pre_create_zero_goal_drain_scheduler_workflow_drain",
+  ].map((actionType) => {
+    return timingEventsForAction(goalDrainEvents, actionType)[0]?.duration_ms;
+  });
+  expect(higherPriorityDrainDurations).toStrictEqual(
+    args.skippedHigherPriorityDrains
+      ? [0, 0]
+      : [expect.any(Number), expect.any(Number)],
+  );
 
   const entrypointGapEvents = timingEventsForAction(
     allEvents,
@@ -1836,6 +1852,60 @@ describe("CHAT-02: completed chat callback", () => {
     await waitForRunStatus(actor, claimed.runId, "cancelled");
   }, 90_000);
 
+  it("runs a queued prompt before an admitted goal fast path", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    await enableGoalWorkflows(actor);
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const first = await startChatRun(actor, {
+      agentId,
+      prompt: "finish before queued goal interruption",
+    });
+    const goalBrief = "Continue after the queued prompt";
+    await createGoalForRun(actor, first.runId, goalBrief);
+    const queuedMessageId = await queueChatEvent(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "run before the admitted goal",
+    });
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(0, "completed before queued goal interruption"),
+    ]);
+
+    const sandboxHeaders = await claimChatRun(runnerGroup, first.runId);
+    await completeChatRunOk(first.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+
+    const messages = await waitForThreadMessages(
+      actor,
+      first.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return (
+            message.revokesEventId === queuedMessageId &&
+            message.runId !== undefined
+          );
+        });
+      },
+    );
+    const claimedPrompt = userMessages(messages.events).find((message) => {
+      return message.revokesEventId === queuedMessageId;
+    });
+    if (!claimedPrompt?.runId) {
+      throw new Error("Expected the queued prompt to win goal priority");
+    }
+    expect(chatEventDisplayText(claimedPrompt)).toBe(
+      "run before the admitted goal",
+    );
+    await expect(goalRunIds(first.threadId)).resolves.toHaveLength(0);
+    await expect(goalQueueEventIds(first.threadId)).resolves.toHaveLength(1);
+
+    await api.requestCancelRun(actor, claimedPrompt.runId, [200]);
+    await waitForRunStatus(actor, claimedPrompt.runId, "cancelled");
+    await flushWaitUntilForTest();
+  }, 90_000);
+
   it("sources the goal system prompt from thread goals", async () => {
     const { actor, agentId, runnerGroup, providerId } =
       await entitledChatActor();
@@ -1908,6 +1978,7 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
       runId: goalContinuation.runId,
       schedulerOrigin: "chat_callback",
       builtInModelContext: true,
+      skippedHigherPriorityDrains: true,
       forbiddenValues: [
         goalBrief,
         goalObjective,
@@ -2599,6 +2670,40 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     ).toBeUndefined();
     expect(userRun.runId).toBeDefined();
     await expect(goalRunIds(first.threadId)).resolves.toHaveLength(0);
+    await flushWaitUntilForTest();
+
+    let lostGoalRunId: string | undefined;
+    await expect
+      .poll(() => {
+        const lostClaim = sandboxOperationEvents().find((event) => {
+          return (
+            event.op_type === "api_dispatch_claim_queue_first_message" &&
+            event.api_start_source === "goal_input" &&
+            event.queue_first_claim_result === "lost" &&
+            event.queue_first_launch_outcome === "claim_lost"
+          );
+        });
+        lostGoalRunId =
+          typeof lostClaim?.run_id === "string" ? lostClaim.run_id : undefined;
+        return lostGoalRunId;
+      })
+      .toBeDefined();
+    if (!lostGoalRunId) {
+      throw new Error("Expected the prepared goal to lose its final claim");
+    }
+    const lostGoalTiming = goalDrainPreCreateTimingEventsForRun(lostGoalRunId);
+    for (const actionType of [
+      "api_dispatch_pre_create_zero_goal_drain_scheduler_user_message_drain",
+      "api_dispatch_pre_create_zero_goal_drain_scheduler_workflow_drain",
+    ]) {
+      expect(timingEventsForAction(lostGoalTiming, actionType)).toStrictEqual([
+        expect.objectContaining({
+          duration_ms: 0,
+          goal_scheduler_origin: "chat_callback",
+          queue_first_launch_outcome: "claim_lost",
+        }),
+      ]);
+    }
 
     const paused = await accept(
       goalsClient().pause({

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
@@ -644,6 +644,51 @@ describe("workflow queue", () => {
     await runsApi.requestCancelRun(scenario.actor, user.body.runId, [200]);
   });
 
+  it("falls back to a pending automation ahead of an admitted goal", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const goal = await createActiveGoalQueueEventFixture({
+      threadId: automation.threadId,
+      orgId: scenario.orgId,
+      userId: scenario.userId,
+      agentId: scenario.agentId,
+      objective: "continue after the hinted automation fallback",
+      objectiveBrief: "Continue after the hinted automation fallback",
+    });
+    const automationEventId = await admitWorkflowAutomationEventFixture({
+      automationId: automation.automationId,
+      chatThreadId: automation.threadId,
+      triggerBrief: "automation wins the hinted goal fallback",
+    });
+
+    await drainChatThreadQueueFixture({
+      threadId: automation.threadId,
+      signal: context.signal,
+      goalContinuationAdmitted: true,
+    });
+
+    const [workflowRunId] = await workflowRunIds(automation.threadId);
+    if (!workflowRunId) {
+      throw new Error("Expected the pending automation to create a run");
+    }
+    await expect(
+      pendingAutomationEvents(automation.threadId),
+    ).resolves.toHaveLength(0);
+    const goalQueue = await readGoalQueueStateFixture(automation.threadId);
+    expect(goalQueue.runIds).toHaveLength(0);
+    expect(goalQueue.eventIds).toContain(goal.eventId);
+    const events = await wf.readThreadEvents(automation.threadId);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        eventType: "input.prompt",
+        revokesEventId: automationEventId,
+        runId: workflowRunId,
+      }),
+    );
+
+    await runsApi.requestCancelRun(scenario.actor, workflowRunId, [200]);
+  });
+
   it("runs a newer automation event before a pending goal continuation on the same thread", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);

--- a/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
@@ -137,7 +137,12 @@ const dispatchInternalCallback$ = command(
           handleChatInternalCallback$,
           {
             callback: input.envelope,
-            drainThreadQueue: async (chatThreadId, inputSignal, timing) => {
+            drainThreadQueue: async (
+              chatThreadId,
+              inputSignal,
+              timing,
+              goalContinuationAdmitted,
+            ) => {
               await set(
                 drainChatThreadQueueForThread$,
                 {
@@ -145,13 +150,16 @@ const dispatchInternalCallback$ = command(
                   dispatchFailedCallbacks: dispatchFailedRunCallbacks,
                   goalSchedulerOrigin: "chat_callback",
                   timing,
+                  ...(goalContinuationAdmitted === undefined
+                    ? {}
+                    : { goalContinuationAdmitted }),
                 },
                 inputSignal,
               );
             },
             handleTerminalGoal: input.handleTerminalGoal
               ? async (runId, inputSignal) => {
-                  await tapError(
+                  const result = await tapError(
                     set(
                       handleTerminalGoalContinuation$,
                       {
@@ -166,6 +174,9 @@ const dispatchInternalCallback$ = command(
                         error,
                       });
                     },
+                  );
+                  return (
+                    result?.kind === "enqueued" || result?.kind === "coalesced"
                   );
                 }
               : undefined,

--- a/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
@@ -150,9 +150,7 @@ const dispatchInternalCallback$ = command(
                   dispatchFailedCallbacks: dispatchFailedRunCallbacks,
                   goalSchedulerOrigin: "chat_callback",
                   timing,
-                  ...(goalContinuationAdmitted === undefined
-                    ? {}
-                    : { goalContinuationAdmitted }),
+                  goalContinuationAdmitted,
                 },
                 inputSignal,
               );

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -372,6 +372,10 @@ export class GoalSchedulerTimingCollector {
     this.previousBoundaryAt = boundedFinishedAt;
   }
 
+  checkpointZero(actionType: GoalSchedulerTimingActionType): void {
+    this.checkpoint(actionType, this.previousBoundaryAt);
+  }
+
   appendTo(
     timing: ApiDispatchTimingCollector,
     dimensions: ApiDispatchTimingDimensions,

--- a/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
@@ -51,6 +51,7 @@ interface DrainChatThreadQueueInput {
   readonly apiStartTime?: number;
   readonly chatThreadId: string;
   readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
+  readonly goalContinuationAdmitted?: boolean;
   readonly goalSchedulerOrigin?: GoalSchedulerTimingOrigin;
   readonly goalSchedulerTiming?: GoalSchedulerTimingCollector;
   readonly queueItemCreatedBefore?: Date;
@@ -113,11 +114,12 @@ export async function notifyRunningChatRunOfPendingInput(
 
 /**
  * The single per-thread scheduler entry: terminal run callbacks, cancel,
- * resume, and the stale sweep all converge here. User messages are attempted
- * first; workflow automation remains second and goal continuation third. Each
- * later drain observes a newly-created active run and stops. The final claims
- * serialize on the same thread row and fold pending events by class priority,
- * then original `created_at` and id.
+ * resume, and the stale sweep all converge here. The standard path attempts
+ * user messages first, workflow automation second, and goal continuation
+ * third. A terminal callback that just admitted a durable goal may try the
+ * existing priority-aware goal selector first; any miss returns to a fresh
+ * standard attempt. The final claims serialize on the same thread row and fold
+ * pending events by class priority, then original `created_at` and id.
  *
  * This entry is the designated mounting point for a future unified per-thread
  * rate limiter: admission delays belong here, before either drain half runs.
@@ -128,83 +130,120 @@ export const drainChatThreadQueueForThread$ = command(
     input: DrainChatThreadQueueInput,
     signal: AbortSignal,
   ): Promise<WorkflowQueueDrainResult | null> => {
-    const schedulerEnteredAt = now();
+    let schedulerEnteredAt = now();
     const apiStartTime = input.apiStartTime ?? schedulerEnteredAt;
-    const goalSchedulerTiming =
+    let goalSchedulerTiming =
       input.goalSchedulerTiming ??
       new GoalSchedulerTimingCollector(
         apiStartTime,
         input.goalSchedulerOrigin ?? "direct",
       );
-    if (!input.goalSchedulerTiming) {
+    let timingHasPreEntry = input.goalSchedulerTiming !== undefined;
+    let tryAdmittedGoal = input.goalContinuationAdmitted === true;
+    const db = set(writeDb$);
+
+    for (let schedulerAttempt = 0; schedulerAttempt < 2; schedulerAttempt++) {
+      if (!timingHasPreEntry) {
+        goalSchedulerTiming.checkpoint(
+          "api_dispatch_pre_create_zero_goal_drain_scheduler_pre_entry",
+          schedulerEnteredAt,
+        );
+      }
+      // Run-based drains close their database lookup at this common entry, so
+      // that phase also includes the command handoff. Direct drains emit the
+      // same action with zero duration to keep one fixed per-run action set.
       goalSchedulerTiming.checkpoint(
-        "api_dispatch_pre_create_zero_goal_drain_scheduler_pre_entry",
+        "api_dispatch_pre_create_zero_goal_drain_scheduler_run_thread_lookup",
         schedulerEnteredAt,
       );
+      const notifiedRunningRun = await notifyRunningChatRunOfPendingInput(
+        db,
+        input.chatThreadId,
+      );
+      signal.throwIfAborted();
+      goalSchedulerTiming.checkpoint(
+        "api_dispatch_pre_create_zero_goal_drain_scheduler_notify_running_run",
+      );
+      if (notifiedRunningRun) {
+        return null;
+      }
+
+      if (tryAdmittedGoal) {
+        const launched = await set(
+          drainGoalQueueForThread$,
+          {
+            chatThreadId: input.chatThreadId,
+            apiStartTime,
+            admittedGoalFastPath: true,
+            dispatchFailedCallbacks: input.dispatchFailedCallbacks,
+            goalSchedulerTiming,
+            queueItemCreatedBefore: input.queueItemCreatedBefore,
+          },
+          signal,
+        );
+        signal.throwIfAborted();
+        L.debug("Admitted goal scheduler fast path completed", {
+          outcome: launched ? "launched" : "fallback",
+        });
+        if (launched) {
+          return null;
+        }
+        tryAdmittedGoal = false;
+        schedulerEnteredAt = now();
+        goalSchedulerTiming = new GoalSchedulerTimingCollector(
+          apiStartTime,
+          goalSchedulerTiming.origin,
+        );
+        timingHasPreEntry = false;
+        continue;
+      }
+
+      await set(
+        drainQueuedUserMessagesForThread$,
+        {
+          chatThreadId: input.chatThreadId,
+          apiStartTime,
+          queueItemCreatedBefore: input.queueItemCreatedBefore,
+          timing: input.timing,
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+      goalSchedulerTiming.checkpoint(
+        "api_dispatch_pre_create_zero_goal_drain_scheduler_user_message_drain",
+      );
+      const workflowResult = await set(
+        drainWorkflowQueueForThread$,
+        {
+          chatThreadId: input.chatThreadId,
+          apiStartTime,
+          dispatchFailedCallbacks: input.dispatchFailedCallbacks,
+          queueItemCreatedBefore: input.queueItemCreatedBefore,
+          ...(input.automationEventLaunch
+            ? { automationEventLaunch: input.automationEventLaunch }
+            : {}),
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+      goalSchedulerTiming.checkpoint(
+        "api_dispatch_pre_create_zero_goal_drain_scheduler_workflow_drain",
+      );
+      await set(
+        drainGoalQueueForThread$,
+        {
+          chatThreadId: input.chatThreadId,
+          apiStartTime,
+          dispatchFailedCallbacks: input.dispatchFailedCallbacks,
+          goalSchedulerTiming,
+          queueItemCreatedBefore: input.queueItemCreatedBefore,
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+      return workflowResult;
     }
-    // Run-based drains close their database lookup at this common entry, so
-    // that phase also includes the command handoff. Direct drains emit the
-    // same action with zero duration to keep one fixed per-run action set.
-    goalSchedulerTiming.checkpoint(
-      "api_dispatch_pre_create_zero_goal_drain_scheduler_run_thread_lookup",
-      schedulerEnteredAt,
-    );
-    const db = set(writeDb$);
-    const notifiedRunningRun = await notifyRunningChatRunOfPendingInput(
-      db,
-      input.chatThreadId,
-    );
-    signal.throwIfAborted();
-    goalSchedulerTiming.checkpoint(
-      "api_dispatch_pre_create_zero_goal_drain_scheduler_notify_running_run",
-    );
-    if (notifiedRunningRun) {
-      return null;
-    }
-    await set(
-      drainQueuedUserMessagesForThread$,
-      {
-        chatThreadId: input.chatThreadId,
-        apiStartTime,
-        queueItemCreatedBefore: input.queueItemCreatedBefore,
-        timing: input.timing,
-      },
-      signal,
-    );
-    signal.throwIfAborted();
-    goalSchedulerTiming.checkpoint(
-      "api_dispatch_pre_create_zero_goal_drain_scheduler_user_message_drain",
-    );
-    const workflowResult = await set(
-      drainWorkflowQueueForThread$,
-      {
-        chatThreadId: input.chatThreadId,
-        apiStartTime,
-        dispatchFailedCallbacks: input.dispatchFailedCallbacks,
-        queueItemCreatedBefore: input.queueItemCreatedBefore,
-        ...(input.automationEventLaunch
-          ? { automationEventLaunch: input.automationEventLaunch }
-          : {}),
-      },
-      signal,
-    );
-    signal.throwIfAborted();
-    goalSchedulerTiming.checkpoint(
-      "api_dispatch_pre_create_zero_goal_drain_scheduler_workflow_drain",
-    );
-    await set(
-      drainGoalQueueForThread$,
-      {
-        chatThreadId: input.chatThreadId,
-        apiStartTime,
-        dispatchFailedCallbacks: input.dispatchFailedCallbacks,
-        goalSchedulerTiming,
-        queueItemCreatedBefore: input.queueItemCreatedBefore,
-      },
-      signal,
-    );
-    signal.throwIfAborted();
-    return workflowResult;
+    return null;
   },
 );
 

--- a/turbo/apps/api/src/signals/services/goal-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/goal-queue-drain.service.ts
@@ -45,6 +45,7 @@ const GOAL_CONTINUATION_PROMPT = "Continue the active thread goal.";
 
 type GoalDrainAttempt = "initial" | "retry";
 type GoalDrainTimingRole = "waiting" | "phase" | "aggregate";
+type GoalLaunchDisposition = "continue" | "launched" | "stopped";
 type QueueFirstAgentRunInput = Parameters<
   (typeof createQueueFirstAgentRun$)["write"]
 >[1];
@@ -479,20 +480,20 @@ async function handleGoalLaunchResult(
     readonly result: RunGoalResult;
   },
   signal: AbortSignal,
-): Promise<"continue" | "done"> {
+): Promise<GoalLaunchDisposition> {
   if (args.result.kind === "ok") {
     await publishGoalQueueChanged(args.event, signal);
-    return "done";
+    return "launched";
   }
   if (args.result.kind === "enqueued") {
     const stillValid = await loadGoalQueueTarget(args.db, args.event);
     signal.throwIfAborted();
     if (!stillValid) {
       await revokeGoalEvent(args.db, args.event, signal);
-      return "done";
+      return "stopped";
     }
     return stillValid.stateRevision === args.goal.stateRevision
-      ? "done"
+      ? "stopped"
       : "continue";
   }
 
@@ -517,32 +518,55 @@ async function handleGoalLaunchResult(
     pauseResult: settlement.kind === "rejected" ? "ok" : "not_paused",
     settlement: settlement.kind,
   });
-  return "done";
+  return "stopped";
+}
+
+interface DrainGoalQueueArgs {
+  readonly chatThreadId: string;
+  readonly apiStartTime: number;
+  readonly admittedGoalFastPath?: boolean;
+  readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
+  readonly goalSchedulerTiming: GoalSchedulerTimingCollector;
+  readonly queueItemCreatedBefore?: Date;
+}
+
+function appendGoalSchedulerTiming(
+  args: DrainGoalQueueArgs,
+  timing: ApiDispatchTimingCollector,
+  drainStartedAt: number,
+): void {
+  if (args.admittedGoalFastPath) {
+    args.goalSchedulerTiming.checkpointZero(
+      "api_dispatch_pre_create_zero_goal_drain_scheduler_user_message_drain",
+    );
+    args.goalSchedulerTiming.checkpointZero(
+      "api_dispatch_pre_create_zero_goal_drain_scheduler_workflow_drain",
+    );
+  }
+  args.goalSchedulerTiming.checkpoint(
+    "api_dispatch_pre_create_zero_goal_drain_scheduler_goal_handoff",
+    drainStartedAt,
+  );
+  args.goalSchedulerTiming.appendTo(
+    timing,
+    goalDrainTimingDimensions({ role: "phase" }),
+  );
 }
 
 export const drainGoalQueueForThread$ = command(
   async (
     { set },
-    args: {
-      readonly chatThreadId: string;
-      readonly apiStartTime: number;
-      readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
-      readonly goalSchedulerTiming: GoalSchedulerTimingCollector;
-      readonly queueItemCreatedBefore?: Date;
-    },
+    args: DrainGoalQueueArgs,
     signal: AbortSignal,
-  ): Promise<void> => {
+  ): Promise<boolean> => {
     const drainStartedAt = now();
     const apiStartTime = args.apiStartTime;
     const timing = new ApiDispatchTimingCollector();
-    args.goalSchedulerTiming.checkpoint(
-      "api_dispatch_pre_create_zero_goal_drain_scheduler_goal_handoff",
-      drainStartedAt,
-    );
-    args.goalSchedulerTiming.appendTo(
-      timing,
-      goalDrainTimingDimensions({ role: "phase" }),
-    );
+    let schedulerTimingAppended = false;
+    if (!args.admittedGoalFastPath) {
+      appendGoalSchedulerTiming(args, timing, drainStartedAt);
+      schedulerTimingAppended = true;
+    }
     timing.recordElapsed(
       "api_dispatch_pre_create_zero_goal_drain_scheduler_start_gap",
       "nested",
@@ -576,7 +600,11 @@ export const drainGoalQueueForThread$ = command(
       );
       signal.throwIfAborted();
       if (!event) {
-        return;
+        return false;
+      }
+      if (!schedulerTimingAppended) {
+        appendGoalSchedulerTiming(args, timing, drainStartedAt);
+        schedulerTimingAppended = true;
       }
       timing.recordElapsed(
         "api_dispatch_pre_create_zero_goal_drain_event_queue_age",
@@ -636,7 +664,8 @@ export const drainGoalQueueForThread$ = command(
       if (disposition === "continue") {
         continue;
       }
-      return;
+      return disposition === "launched";
     }
+    return false;
   },
 );

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -635,8 +635,8 @@ interface ChatCallbackDependencies {
   readonly drainThreadQueue?: (
     chatThreadId: string,
     signal: AbortSignal,
-    timing?: ChatCallbackPreCreateTimingCollector,
-    goalContinuationAdmitted?: boolean,
+    timing: ChatCallbackPreCreateTimingCollector | undefined,
+    goalContinuationAdmitted: boolean,
   ) => Promise<void>;
   readonly handleTerminalGoal?: (
     runId: string,

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -636,11 +636,12 @@ interface ChatCallbackDependencies {
     chatThreadId: string,
     signal: AbortSignal,
     timing?: ChatCallbackPreCreateTimingCollector,
+    goalContinuationAdmitted?: boolean,
   ) => Promise<void>;
   readonly handleTerminalGoal?: (
     runId: string,
     signal: AbortSignal,
-  ) => Promise<void>;
+  ) => Promise<boolean>;
 }
 
 interface ChatThreadForRunRow {
@@ -4483,6 +4484,7 @@ async function maybeDrainThreadQueueForTerminalCallback(
   args: {
     readonly enabled: boolean;
     readonly chatThreadId: string;
+    readonly goalContinuationAdmitted: boolean;
     readonly dependencies: ChatCallbackDependencies;
     readonly timing: ChatCallbackPreCreateTimingCollector;
   },
@@ -4493,7 +4495,12 @@ async function maybeDrainThreadQueueForTerminalCallback(
   }
 
   const result = await settle(
-    args.dependencies.drainThreadQueue(args.chatThreadId, signal, args.timing),
+    args.dependencies.drainThreadQueue(
+      args.chatThreadId,
+      signal,
+      args.timing,
+      args.goalContinuationAdmitted,
+    ),
     signal,
   );
   return result.ok ? { ok: true } : { ok: false, error: result.error };
@@ -4559,6 +4566,7 @@ async function handleTerminalChatCallbackPreparationFailure(
     readonly runId: string;
     readonly error: unknown;
     readonly chatThreadId: string;
+    readonly goalContinuationAdmitted: boolean;
     readonly slackDelivery: SlackDeliveryTarget | undefined;
     readonly feishuDelivery: FeishuDeliveryTarget | undefined;
     readonly dependencies: ChatCallbackDependencies;
@@ -4570,6 +4578,7 @@ async function handleTerminalChatCallbackPreparationFailure(
     {
       enabled: true,
       chatThreadId: args.chatThreadId,
+      goalContinuationAdmitted: args.goalContinuationAdmitted,
       dependencies: args.dependencies,
       timing: args.timing,
     },
@@ -4718,6 +4727,7 @@ interface TerminalChatCallbackArgs {
   readonly db: Db;
   readonly callback: InternalRunCallbackEnvelope;
   readonly payload: ChatCallbackPayload;
+  readonly goalContinuationAdmitted: boolean;
   readonly suppressWebPushForActiveGoal: boolean;
   readonly dependencies: ChatCallbackDependencies;
 }
@@ -4788,12 +4798,38 @@ async function clearTerminalIntegrationStatus(
   );
 }
 
+async function drainAndClearTerminalChatThread(
+  args: {
+    readonly callback: TerminalChatCallbackArgs;
+    readonly chatThreadId: string;
+    readonly timing: ChatCallbackPreCreateTimingCollector;
+    readonly work: TerminalChatCallbackWork;
+  },
+  signal: AbortSignal,
+): Promise<DrainOutcome> {
+  const result = await maybeDrainThreadQueueForTerminalCallback(
+    {
+      enabled: args.work.shouldDrainThreadQueue,
+      chatThreadId: args.chatThreadId,
+      goalContinuationAdmitted: args.callback.goalContinuationAdmitted,
+      dependencies: args.callback.dependencies,
+      timing: args.timing,
+    },
+    signal,
+  );
+  await clearTerminalIntegrationStatus(
+    args.callback,
+    args.chatThreadId,
+    signal,
+  );
+  return result;
+}
+
 async function processTerminalChatCallback(
   args: TerminalChatCallbackArgs,
   signal: AbortSignal,
 ): Promise<void> {
-  const runId = args.callback.runId;
-  const callbackStatus = args.callback.status;
+  const { runId, status: callbackStatus } = args.callback;
   if (callbackStatus === "progress") {
     return;
   }
@@ -4868,6 +4904,7 @@ async function processTerminalChatCallback(
         runId,
         error: prepared.error,
         chatThreadId: chatThread.chatThreadId,
+        goalContinuationAdmitted: args.goalContinuationAdmitted,
         slackDelivery: args.payload.slackDelivery,
         feishuDelivery: args.payload.feishuDelivery,
         dependencies: args.dependencies,
@@ -4893,23 +4930,20 @@ async function processTerminalChatCallback(
     signal,
   );
 
-  const drainResult = await maybeDrainThreadQueueForTerminalCallback(
+  const drainResult = await drainAndClearTerminalChatThread(
     {
-      enabled: work.shouldDrainThreadQueue,
       chatThreadId: chatThread.chatThreadId,
-      dependencies: args.dependencies,
+      callback: args,
       timing,
+      work,
     },
     signal,
   );
-  await clearTerminalIntegrationStatus(args, chatThread.chatThreadId, signal);
 
   const deferredSideEffects = work.deferredSideEffects;
   if (deferredSideEffects) {
-    // Queue drain may launch another goal iteration or pause the goal when
-    // continuation cannot launch. Decide only after that transition so the
-    // last real run fires when the goal stops, while intermediate runs stay
-    // quiet.
+    // Decide after queue drain so the final real run fires only when the goal
+    // stops, while intermediate runs stay quiet.
     const suppressChatRunFinishedForActiveGoal = await runHasActiveGoal(
       args.db,
       runId,
@@ -5015,6 +5049,7 @@ function buildQueuedChatDispatchFailedCallbacks(
           payload,
         },
         payload,
+        goalContinuationAdmitted: false,
         suppressWebPushForActiveGoal: suppressForActiveGoal,
         dependencies: withoutQueuedRunDependency(args.dependencies),
       },
@@ -5168,7 +5203,11 @@ async function handleChatInternalCallback(
     args.callback.runId,
   );
   signal.throwIfAborted();
-  await args.dependencies.handleTerminalGoal?.(args.callback.runId, signal);
+  const goalContinuationAdmitted =
+    (await args.dependencies.handleTerminalGoal?.(
+      args.callback.runId,
+      signal,
+    )) ?? false;
   signal.throwIfAborted();
   // The webhook sender (dispatchRunCallbacks) awaits this response only to
   // record delivery; it does not retry and nothing downstream reads the body.
@@ -5186,6 +5225,7 @@ async function handleChatInternalCallback(
           db: args.db,
           callback: args.callback,
           payload: payload.data,
+          goalContinuationAdmitted,
           suppressWebPushForActiveGoal,
           dependencies: args.dependencies,
         },

--- a/turbo/apps/api/src/test-fixtures/goal-queue.ts
+++ b/turbo/apps/api/src/test-fixtures/goal-queue.ts
@@ -81,6 +81,7 @@ export async function readGoalQueueStateFixture(threadId: string): Promise<{
 export async function drainChatThreadQueueFixture(args: {
   readonly threadId: string;
   readonly signal: AbortSignal;
+  readonly goalContinuationAdmitted?: boolean;
   readonly queueItemCreatedBefore?: Date;
 }): Promise<void> {
   await createStore().set(
@@ -88,6 +89,9 @@ export async function drainChatThreadQueueFixture(args: {
     {
       chatThreadId: args.threadId,
       dispatchFailedCallbacks: dispatchFailedRunCallbacks,
+      ...(args.goalContinuationAdmitted === undefined
+        ? {}
+        : { goalContinuationAdmitted: args.goalContinuationAdmitted }),
       queueItemCreatedBefore: args.queueItemCreatedBefore,
     },
     args.signal,


### PR DESCRIPTION
## Summary

- carry confirmed durable goal admission into the terminal callback scheduler as a bounded fast-path hint
- try the existing locked goal selector before redundant empty user-message and workflow drains, then re-enter the standard scheduler on any non-launch
- preserve the fixed dispatch timing action set and add low-cardinality outcome logging plus integration coverage for priority and claim-loss races

## Correctness and compatibility

- the admission hint is not launch authority; the locked selector and final queue-first claim remain authoritative
- queued user messages and workflow automations continue to outrank goal continuations
- no database schema, public API, runner protocol, persisted payload, or feature-switch changes are required, so mixed revisions remain compatible

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts src/signals/routes/__tests__/workflow-queue.test.ts --maxWorkers=1 --silent=passed-only` (89 tests passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `lefthook run pre-commit`
- `git diff --check`

Closes #31150

Parent: #24203
