### PR TITLE
fix(cli): keep the camera render from segfaulting once the crop starts moving

### DIFF
--- a/turbo/apps/cli/src/commands/video/__tests__/camera.test.ts
+++ b/turbo/apps/cli/src/commands/video/__tests__/camera.test.ts
@@ -229,6 +229,42 @@ describe("okou video camera command", () => {
     );
   });
 
+  it("keeps a pass-through stage between the moving crop and the scaler", async () => {
+    // Wired straight into `scale`, a crop whose size changes mid-stream never
+    // gets rescaled and the encoder segfaults on the first zoomed frame; the
+    // `null` stage in between is what makes `scale` notice the change.
+    const videoPath = join(directory, "recording.mp4");
+    const eventsPath = join(directory, "recording.clicks.json");
+    const outputPath = join(directory, "draft.mp4");
+    writeFileSync(videoPath, Buffer.from("source-video"));
+    writeFileSync(
+      eventsPath,
+      JSON.stringify({
+        version: 1,
+        recording: {
+          durationMs: 10_000,
+          video: { width: 1920, height: 1080, frameRate: 30 },
+        },
+        clicks: [{ tMs: 2_000, normalized: { x: 0.12, y: 0.22 } }],
+        pointerEvents: [
+          { tMs: 2_000, kind: "click", normalized: { x: 0.12, y: 0.22 } },
+        ],
+      }),
+    );
+
+    await cameraCommand.parseAsync(
+      ["--file", videoPath, "--events", eventsPath, "--output", outputPath],
+      { from: "user" },
+    );
+
+    const ffmpegCall = vi.mocked(execFileSync).mock.calls.find((call) => {
+      return call[0] === "ffmpeg";
+    });
+    const filterIndex = ffmpegCall?.[1]?.indexOf("-vf") ?? -1;
+    const filter = ffmpegCall?.[1]?.[filterIndex + 1];
+    expect(filter).toMatch(/crop@camera=[^,]*,null,scale=1920:1080:/u);
+  });
+
   it("uses the existing VM0 demo capture event format", async () => {
     const videoPath = join(directory, "browser-recording.webm");
     const eventsPath = join(directory, "browser-recording.events.json");

--- a/turbo/apps/cli/src/commands/video/camera.ts
+++ b/turbo/apps/cli/src/commands/video/camera.ts
@@ -144,10 +144,21 @@ function renderVideo(
   try {
     const commandsPath = join(temporaryDirectory, "camera.commands");
     writeFileSync(commandsPath, createFfmpegCameraCommands(plan));
+    // The `null` stage between the crop and the scaler is load-bearing. When
+    // a command changes the crop's w or h, `crop` rewrites the size of its
+    // own output link, and `scale` decides whether to reconfigure by comparing
+    // each frame with the link it reads from. Wired directly, that link is the
+    // one `crop` just rewrote, so `scale` never sees a change; and because the
+    // first frames are full size it never built a scaler at all, so it hands
+    // the shrunken frames straight to the encoder, which was opened for the
+    // full size, reads past the end of their buffer and dies with SIGSEGV.
+    // `null` keeps its own link size, so `scale` sees every size change and
+    // rescales the frame. Reproduced on ffmpeg 6.1 and 7.0 (#31169).
     const filter = [
       `fps=${plan.source.frameRate.toString()}`,
       `sendcmd=f='${commandsPath}'`,
       `crop@camera=w=${plan.source.width.toString()}:h=${plan.source.height.toString()}:x=0:y=0:exact=1`,
+      "null",
       `scale=${plan.source.width.toString()}:${plan.source.height.toString()}:flags=lanczos`,
       "setsar=1",
     ].join(",");


### PR DESCRIPTION
## Summary

Every camera plan with at least one range crashed ffmpeg with SIGSEGV, on 6.1.1 and 7.0.2 alike, so `okou video camera` only ever completed on plans with nothing to do (`cameraRanges: 0`). Fixes #31169.

## Cause

The render chain was `fps → sendcmd → crop@camera → scale → setsar`.

- When a `sendcmd` command changes the crop's `w` or `h`, the `crop` filter rewrites the size of its **own output link** (`config_output`).
- The `scale` filter decides whether to reconfigure by comparing each incoming frame with **the link it reads from**. Wired directly, that link is the one `crop` just rewrote, so the frame always matches and `scale` never reconfigures.
- Because the first frames are full size, `scale` never built a scaler at all (input == output means pass-through). It therefore forwards the shrunken cropped frames untouched to libx264, which was opened for 1920×1144, reads past the end of their buffer and dies.

Isolation on a real recording (23 s, three zoom ranges):

| chain / sink | result |
|---|---|
| `crop → scale`, `-f null` or rawvideo sink | fine (nothing reads beyond the frame) |
| `crop → scale → libx264` | SIGSEGV, also with `-filter_threads 1 -threads 1`, without `exact=1`, with even sizes, with bilinear |
| `crop → null → scale → libx264` | renders all 693 frames at 1920×1144 |
| `crop → setsar → scale → libx264` | same, renders fine |

## Change

A `null` stage between the crop and the scaler. It keeps its own link size, so `scale` sees the size change on every frame and rescales it. The test pins the chain shape (`crop@camera=…,null,scale=…`), since the crash itself cannot be reproduced with the mocked ffmpeg.

## Test plan

- [x] Real recording that crashed before renders end to end with this chain (ffmpeg 6.1.1)
- [x] `vitest` for the camera command, `lint`, `tsc`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
