### PR TITLE
feat(desktop): record the pointer trail alongside clicks in the recording sidecar

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/ClickMapping.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/ClickMapping.swift
@@ -192,3 +192,81 @@ public struct ClickTimeline: Equatable, Sendable {
         return Int((Double(nanoseconds - startNanoseconds) / 1_000_000).rounded())
     }
 }
+
+/// One pointer position observed while recording, in the plain values the
+/// sampler captured: a click without the button facts.
+public struct CapturedPointerSample: Equatable, Sendable {
+    /// Host-clock nanoseconds, the same clock `CGEvent.timestamp` uses.
+    public let nanoseconds: UInt64
+    public let screenX: Double
+    public let screenY: Double
+    /// See `CapturedClick.geometry`.
+    public let geometry: CaptureGeometry?
+
+    public init(
+        nanoseconds: UInt64,
+        screenX: Double,
+        screenY: Double,
+        geometry: CaptureGeometry? = nil
+    ) {
+        self.nanoseconds = nanoseconds
+        self.screenX = screenX
+        self.screenY = screenY
+        self.geometry = geometry
+    }
+}
+
+/// A pointer sample placed on the recording's timeline and geometry.
+public struct ProjectedPointerSample: Equatable, Sendable {
+    public let offsetMs: Int
+    public let point: MappedClickPoint
+}
+
+/// Places pointer samples onto the recording.
+///
+/// Samples from before the first frame and samples outside the captured
+/// region are dropped without being counted. A trail is only useful where the
+/// video can show it, and unlike a click, a pointer resting outside the region
+/// is not an event anyone downstream needs to hear about.
+public func projectPointerSamples(
+    _ samples: [CapturedPointerSample],
+    timeline: ClickTimeline,
+    geometry: CaptureGeometry,
+    outputSize: OutputSize
+) -> [ProjectedPointerSample] {
+    return samples.compactMap { sample -> ProjectedPointerSample? in
+        guard
+            let offsetMs = timeline.offsetMilliseconds(atNanoseconds: sample.nanoseconds),
+            let point = (sample.geometry ?? geometry).mapClick(
+                screenX: sample.screenX,
+                screenY: sample.screenY,
+                outputSize: outputSize
+            )
+        else {
+            return nil
+        }
+        return ProjectedPointerSample(offsetMs: offsetMs, point: point)
+    }
+}
+
+/// Decides which pointer positions are worth keeping.
+///
+/// The sampler asks at a fixed rate, and a pointer that has not moved since
+/// the last kept sample adds nothing but bytes to the track: a still pointer is
+/// already described by the previous sample lasting longer. The first sample
+/// is always kept.
+public struct PointerTrailPolicy: Equatable, Sendable {
+    public let minimumDistancePoints: Double
+
+    public init(minimumDistancePoints: Double = 0.5) {
+        self.minimumDistancePoints = minimumDistancePoints
+    }
+
+    public func shouldKeep(x: Double, y: Double, previous: CapturedPointerSample?) -> Bool {
+        guard let previous else {
+            return true
+        }
+        return abs(x - previous.screenX) >= minimumDistancePoints
+            || abs(y - previous.screenY) >= minimumDistancePoints
+    }
+}

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/ClickTrackRecorder.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/ClickTrackRecorder.swift
@@ -34,31 +34,45 @@ private let clickTapCallback: CGEventTapCallBack = { _, type, event, refcon in
     return Unmanaged.passUnretained(event)
 }
 
-/// Records where and when the user clicked, for the whole session's duration.
+/// Records where and when the user clicked, and where the pointer went, for
+/// the whole session's duration.
 ///
 /// The tap is listen-only and never modifies events. It is created at session
 /// level rather than HID level because a HID-level listening tap requires the
 /// separate Input Monitoring grant, whereas the session level rides the
 /// Accessibility grant the app already holds.
 ///
-/// Only mouse-down events are observed. Keystrokes are deliberately not
-/// captured: recording characters the user types would make this a keylogger,
-/// and nothing downstream needs them.
+/// Only mouse-down events are observed by the tap. Keystrokes are deliberately
+/// not captured: recording characters the user types would make this a
+/// keylogger, and nothing downstream needs them.
+///
+/// The pointer trail is sampled on a timer rather than through the tap.
+/// Reading the pointer position needs no permission, so the trail survives a
+/// refused tap, and a fixed rate bounds the track's size no matter how fast
+/// the mouse reports; the tap would have to be throttled anyway.
 final class ClickTrackRecorder: @unchecked Sendable {
+    /// Enough for a camera to follow the pointer smoothly; more only adds bytes.
+    private static let trailInterval = DispatchTimeInterval.milliseconds(33)
+
     private let lock = NSLock()
     private var clicks: [CapturedClick] = []
+    private var samples: [CapturedPointerSample] = []
     private var tap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
     private var warnings: [String] = []
+    private let trailQueue = DispatchQueue(label: "ai.okou.recorder.pointer-trail")
+    private let trailPolicy = PointerTrailPolicy()
+    private var trailTimer: DispatchSourceTimer?
     /// Where the captured region stands right now, for a source that moves.
     /// Asked at each click, so the click is projected through the geometry of
     /// its own moment rather than the recording's first. Set before `start`.
     var geometryProvider: (() -> CaptureGeometry?)?
 
-    /// Starts observing clicks. Never throws: losing the click track must not
-    /// cost the user their video, so a refused tap is reported as a warning on
-    /// the finished recording instead.
+    /// Starts observing clicks and sampling the pointer. Never throws: losing
+    /// the click track must not cost the user their video, so a refused tap is
+    /// reported as a warning on the finished recording instead.
     func start() {
+        startPointerTrail()
         let mask =
             (1 << CGEventType.leftMouseDown.rawValue)
             | (1 << CGEventType.rightMouseDown.rawValue)
@@ -98,9 +112,13 @@ final class ClickTrackRecorder: @unchecked Sendable {
         lock.lock()
         let eventTap = tap
         let source = runLoopSource
+        let timer = trailTimer
         tap = nil
         runLoopSource = nil
+        trailTimer = nil
         lock.unlock()
+
+        timer?.cancel()
 
         if let eventTap {
             CGEvent.tapEnable(tap: eventTap, enable: false)
@@ -108,6 +126,49 @@ final class ClickTrackRecorder: @unchecked Sendable {
         if let source {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
         }
+    }
+
+    private func startPointerTrail() {
+        let timer = DispatchSource.makeTimerSource(queue: trailQueue)
+        timer.schedule(
+            deadline: .now(),
+            repeating: Self.trailInterval,
+            leeway: .milliseconds(5)
+        )
+        timer.setEventHandler { [weak self] in
+            self?.samplePointer()
+        }
+        timer.resume()
+        lock.lock()
+        trailTimer = timer
+        lock.unlock()
+    }
+
+    /// Reads where the pointer is right now and keeps it if it moved.
+    ///
+    /// The timestamp is taken from the same clock `CGEvent.timestamp` and the
+    /// captured frames use, so the sample lands on the recording's timeline
+    /// exactly like a click does.
+    private func samplePointer() {
+        guard let location = CGEvent(source: nil)?.location else {
+            return
+        }
+        let nanoseconds = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+        lock.lock()
+        let previous = samples.last
+        lock.unlock()
+        guard trailPolicy.shouldKeep(x: location.x, y: location.y, previous: previous) else {
+            return
+        }
+        let sample = CapturedPointerSample(
+            nanoseconds: nanoseconds,
+            screenX: Double(location.x),
+            screenY: Double(location.y),
+            geometry: geometryProvider?()
+        )
+        lock.lock()
+        samples.append(sample)
+        lock.unlock()
     }
 
     /// Called on the run loop that owns the tap. Deliberately does no more than
@@ -141,18 +202,26 @@ final class ClickTrackRecorder: @unchecked Sendable {
         lock.unlock()
     }
 
-    /// Projects the captured clicks onto the recording's timeline and geometry.
+    /// Projects the captured clicks and pointer samples onto the recording's
+    /// timeline and geometry.
     ///
-    /// `projectClicks` owns the two drop rules; this only renders the result as
-    /// JSON.
+    /// `projectClicks` and `projectPointerSamples` own the drop rules; this
+    /// only renders the result as JSON. `pointerEvents` is the one stream a
+    /// camera wants: clicks and moves together, in time order.
     func track(
         timeline: ClickTimeline,
         pauses: PauseTimeline,
         geometry: CaptureGeometry,
         outputSize: OutputSize
-    ) -> (clicks: [[String: Any]], droppedOutOfFrame: Int, warnings: [String]) {
+    ) -> (
+        clicks: [[String: Any]],
+        pointerEvents: [[String: Any]],
+        droppedOutOfFrame: Int,
+        warnings: [String]
+    ) {
         lock.lock()
         let captured = clicks
+        let capturedSamples = samples
         let capturedWarnings = warnings
         lock.unlock()
 
@@ -162,19 +231,31 @@ final class ClickTrackRecorder: @unchecked Sendable {
             geometry: geometry,
             outputSize: outputSize
         )
-        // Clicks travel the same timeline as the frames: one made during a
-        // pause is at a moment the video does not contain, and one made after a
-        // pause would otherwise point past where it actually happened.
-        let described: [[String: Any]] = projection.clicks.compactMap { click in
-            guard
-                let mediaSeconds = pauses.mediaTime(
-                    forCaptureTime: Double(click.offsetMs) / 1000
-                )
+        let trail = projectPointerSamples(
+            capturedSamples,
+            timeline: timeline,
+            geometry: geometry,
+            outputSize: outputSize
+        )
+        // Clicks and samples travel the same timeline as the frames: one made
+        // during a pause is at a moment the video does not contain, and one
+        // made after a pause would otherwise point past where it actually
+        // happened.
+        func mediaMs(_ offsetMs: Int) -> Int? {
+            guard let seconds = pauses.mediaTime(forCaptureTime: Double(offsetMs) / 1000)
             else {
                 return nil
             }
-            return [
-                "tMs": Int((mediaSeconds * 1000).rounded()),
+            return Int((seconds * 1000).rounded())
+        }
+        var described: [[String: Any]] = []
+        var events: [(tMs: Int, order: Int, json: [String: Any])] = []
+        for click in projection.clicks {
+            guard let tMs = mediaMs(click.offsetMs) else {
+                continue
+            }
+            described.append([
+                "tMs": tMs,
                 "button": click.button,
                 "clickCount": click.clickCount,
                 "modifiers": click.modifiers,
@@ -183,8 +264,41 @@ final class ClickTrackRecorder: @unchecked Sendable {
                 "normalized": [
                     "x": click.point.normalizedX, "y": click.point.normalizedY,
                 ],
-            ] as [String: Any]
+            ])
+            events.append((tMs, 0, pointerEvent(tMs: tMs, kind: "click", point: click.point)))
         }
-        return (described, projection.droppedOutOfFrame, capturedWarnings)
+        for sample in trail {
+            guard let tMs = mediaMs(sample.offsetMs) else {
+                continue
+            }
+            events.append((tMs, 1, pointerEvent(tMs: tMs, kind: "move", point: sample.point)))
+        }
+        // A click and a move at the same millisecond list the click first, so
+        // a consumer reading the stream in order sees the click land where the
+        // trail has just arrived.
+        events.sort { left, right in
+            left.tMs == right.tMs ? left.order < right.order : left.tMs < right.tMs
+        }
+        return (
+            described,
+            events.map { $0.json },
+            projection.droppedOutOfFrame,
+            capturedWarnings
+        )
+    }
+
+    /// One entry of the pointer stream. Positions are rounded to a ten
+    /// thousandth of the frame: a 4K frame is still resolved to a pixel, and
+    /// the thirty-per-second trail stays a fraction of the video's size.
+    private func pointerEvent(tMs: Int, kind: String, point: MappedClickPoint) -> [String: Any] {
+        func rounded(_ value: Double) -> Double {
+            return (value * 10_000).rounded() / 10_000
+        }
+        return [
+            "tMs": tMs,
+            "kind": kind,
+            "frame": ["x": point.frameX, "y": point.frameY],
+            "normalized": ["x": rounded(point.normalizedX), "y": rounded(point.normalizedY)],
+        ]
     }
 }

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
@@ -857,7 +857,7 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
                     geometry: geometry,
                     outputSize: outputSize
                 )
-            } ?? (clicks: [], droppedOutOfFrame: 0, warnings: [])
+            } ?? (clicks: [], pointerEvents: [], droppedOutOfFrame: 0, warnings: [])
 
         let payload: [String: Any] = [
             "version": 1,
@@ -872,6 +872,7 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
                 "capture": describedGeometry,
             ],
             "clicks": projected.clicks,
+            "pointerEvents": projected.pointerEvents,
             "droppedOutOfFrameClicks": projected.droppedOutOfFrame,
             "warnings": projected.warnings,
         ]

--- a/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/ClickMappingTests.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/ClickMappingTests.swift
@@ -257,3 +257,109 @@ struct ClickProjectionTests {
         #expect(projection.droppedOutOfFrame == 1)
     }
 }
+
+struct PointerTrailPolicyTests {
+    private let policy = PointerTrailPolicy()
+
+    @Test
+    func keepsTheFirstSample() {
+        #expect(policy.shouldKeep(x: 10, y: 10, previous: nil))
+    }
+
+    /// The sampler runs thirty times a second whether or not the mouse moved;
+    /// a resting pointer would otherwise fill the track with copies.
+    @Test
+    func skipsAPointerThatHasNotMoved() {
+        let previous = CapturedPointerSample(nanoseconds: 1, screenX: 10, screenY: 10)
+
+        #expect(!policy.shouldKeep(x: 10.2, y: 9.9, previous: previous))
+    }
+
+    @Test
+    func keepsAPointerThatMoved() {
+        let previous = CapturedPointerSample(nanoseconds: 1, screenX: 10, screenY: 10)
+
+        #expect(policy.shouldKeep(x: 11, y: 10, previous: previous))
+        #expect(policy.shouldKeep(x: 10, y: 9, previous: previous))
+    }
+}
+
+struct PointerSampleProjectionTests {
+    private let display = CaptureGeometry(
+        originX: 0,
+        originY: 0,
+        widthPoints: 1000,
+        heightPoints: 500,
+        scale: 2
+    )
+    private let outputSize = OutputSize(width: 1920, height: 960)
+    private let timeline = ClickTimeline(startNanoseconds: 24_000)
+
+    @Test
+    func placesASampleAtItsOffsetAndPosition() {
+        let trail = projectPointerSamples(
+            [CapturedPointerSample(nanoseconds: 2_024_000, screenX: 500, screenY: 250)],
+            timeline: timeline,
+            geometry: display,
+            outputSize: outputSize
+        )
+
+        #expect(trail.count == 1)
+        #expect(trail.first?.offsetMs == 2)
+        #expect(trail.first?.point.frameX == 960)
+        #expect(trail.first?.point.frameY == 480)
+        #expect(trail.first?.point.normalizedX == 0.5)
+    }
+
+    /// The sampler starts with the tap, before `SCStream` delivers a frame.
+    @Test
+    func dropsSamplesFromBeforeTheFirstFrame() {
+        let trail = projectPointerSamples(
+            [CapturedPointerSample(nanoseconds: 1_000, screenX: 500, screenY: 250)],
+            timeline: timeline,
+            geometry: display,
+            outputSize: outputSize
+        )
+
+        #expect(trail.isEmpty)
+    }
+
+    @Test
+    func dropsSamplesOutsideTheCapturedRegion() {
+        let trail = projectPointerSamples(
+            [CapturedPointerSample(nanoseconds: 2_024_000, screenX: 1_500, screenY: 250)],
+            timeline: timeline,
+            geometry: display,
+            outputSize: outputSize
+        )
+
+        #expect(trail.isEmpty)
+    }
+
+    @Test
+    func projectsASampleThroughTheGeometryOfItsOwnMoment() {
+        let moved = CaptureGeometry(
+            originX: 100,
+            originY: 100,
+            widthPoints: 1000,
+            heightPoints: 500,
+            scale: 2
+        )
+        let trail = projectPointerSamples(
+            [
+                CapturedPointerSample(
+                    nanoseconds: 2_024_000,
+                    screenX: 600,
+                    screenY: 350,
+                    geometry: moved
+                )
+            ],
+            timeline: timeline,
+            geometry: display,
+            outputSize: outputSize
+        )
+
+        #expect(trail.first?.point.normalizedX == 0.5)
+        #expect(trail.first?.point.normalizedY == 0.5)
+    }
+}


### PR DESCRIPTION
## Summary

The recording sidecar now carries the pointer trail, not just clicks. A camera that follows the cursor the way Screen Studio does needs to know where the pointer went between clicks; until now `clicks.json` only had the clicks, so the best any consumer could do was jump from click to click.

Stacked on #31167 (base branch), which sits on #31112 (in the merge queue). It has to be: samples are stamped and projected through the nanosecond `ClickTimeline` that #31167 introduces, and use the per-moment geometry hook from #31112. Merge order is #31112 → #31167 → this; GitHub retargets each PR as its base merges.

## What the helper does

- Samples the pointer position 30 times a second for the whole session, on a timer rather than through the event tap. Reading the position needs no permission, so the trail survives a refused Accessibility tap, and a fixed rate bounds the track's size however fast the mouse reports.
- Keeps a sample only when the pointer moved since the last kept one, and rounds positions to a ten-thousandth of the frame. A still pointer costs nothing; a minute of continuous motion is a few hundred kilobytes.
- Stamps samples from `CLOCK_UPTIME_RAW`, the same uptime clock behind `CGEvent.timestamp` and the captured frames' presentation times, and projects each through the geometry of its own moment, like clicks.
- Drops samples that predate the first frame, fall outside the captured region, or land inside a pause, without counting them.

## Sidecar shape

`clicks` is unchanged. New `pointerEvents` is one time-ordered stream, which is the shape `okou video camera` already reads for desktop tracks (`desktopSamples` prefers it when present):

```json
{ "tMs": 1876, "kind": "move",  "frame": { "x": 1630, "y": 560 }, "normalized": { "x": 0.8489, "y": 0.4895 } }
{ "tMs": 1876, "kind": "click", "frame": { "x": 1636, "y": 561 }, "normalized": { "x": 0.852,  "y": 0.4904 } }
```

A click and a move at the same millisecond list the click first.

## Effect on the current camera command

With moves present, the v1 plan groups pointer travel into focuses the same way it already does for browser demo captures, so the first cut will pan with the cursor more than it does from clicks alone. That is the input the calmer follow-cursor camera (proposed in the review thread) is designed for; it lands separately in the CLI.

## Test plan

- [ ] macOS CI (`Desktop` / `build-macos-arm64`) compiles the helper and runs `ScreenRecorderCoreTests` (`PointerTrailPolicyTests`, `PointerSampleProjectionTests`)
- [ ] Dev build: record, move the mouse around, confirm `pointerEvents` in the sidecar is ordered, has `move` and `click` kinds, and stays small while the pointer rests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
