### PR TITLE
test(runner): stabilize tool oom containment

### DIFF
--- a/.github/scripts/runner-behavior-process-containment-remote.sh
+++ b/.github/scripts/runner-behavior-process-containment-remote.sh
@@ -619,14 +619,16 @@ echo "--- Pressure: group-kill only the high-memory Bash tool ---"
 MEMORY_CHAT_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
 MEMORY_SESSION_ID="e2e-process-containment-memory"
 SECONDS=0
-MEMORY_RESULT=$(sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+if ! MEMORY_RESULT=$(sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   --timeout 30 \
   --chat-thread-id "$MEMORY_CHAT_THREAD_ID" \
   --session-id "$MEMORY_SESSION_ID" \
   --feature-flag sandboxReuse=true \
   --prompt '@parallel-shell-tool-oom' \
-  --active-input 'after=1s,text=memory-pressure-control') \
-  || fail "memory-pressure run did not recover after the offender tool group was killed"
+  --active-input 'after=1s,text=memory-pressure-control'); then
+  printf '%s\n' "$MEMORY_RESULT"
+  fail "memory-pressure submit failed before tool OOM isolation completed"
+fi
 MEMORY_ELAPSED=$SECONDS
 printf '%s\n' "$MEMORY_RESULT"
 [ "$MEMORY_ELAPSED" -lt 20 ] \

--- a/crates/guest-mock-claude/src/process/fixtures.rs
+++ b/crates/guest-mock-claude/src/process/fixtures.rs
@@ -28,7 +28,9 @@ const POST_RESULT_RELEASE_TWO_SOCKET: &str = ".vm0-post-result-release-2.sock";
 const TRANSCRIPT_FENCE_PADDING_BYTES: usize = 16 * 1024;
 const STDOUT_STREAM_CHUNK_BYTES: usize = 8 * 1024;
 const TOOL_OOM_PARENT_HEADROOM_BYTES: u64 = 192 * 1024 * 1024;
-const TOOL_OOM_READY_TIMEOUT: Duration = Duration::from_secs(5);
+const TOOL_MARKER_TIMEOUT: Duration = Duration::from_secs(5);
+const TOOL_COMPLETION_TIMEOUT: Duration = Duration::from_secs(5);
+const TOOL_OOM_CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(15);
 const TOOL_OOM_POLL_INTERVAL: Duration = Duration::from_millis(10);
 const TOOL_OOM_SURVIVOR_CGROUP: &str = "/tmp/vm0-tool-oom-survivor.cgroup";
 const TOOL_OOM_OFFENDER_CGROUP: &str = "/tmp/vm0-tool-oom-offender.cgroup";
@@ -630,7 +632,7 @@ fn verify_parallel_shell_tool_oom() -> Result<String, String> {
             .offender
             .as_mut()
             .ok_or_else(|| "offender process is missing".to_string())?,
-        TOOL_OOM_READY_TIMEOUT,
+        TOOL_OOM_CONVERGENCE_TIMEOUT,
         "offender Bash tool",
     )?;
     fixture.offender = None;
@@ -656,7 +658,7 @@ fn verify_parallel_shell_tool_oom() -> Result<String, String> {
     std::fs::write(TOOL_OOM_SURVIVOR_RELEASE, b"release\n")
         .map_err(|error| format!("release survivor Bash tool: {error}"))?;
     let survivor_status =
-        wait_for_child_exit(survivor, TOOL_OOM_READY_TIMEOUT, "survivor Bash tool")?;
+        wait_for_child_exit(survivor, TOOL_COMPLETION_TIMEOUT, "survivor Bash tool")?;
     fixture.survivor = None;
     if !survivor_status.success() {
         return Err(format!(
@@ -728,7 +730,7 @@ fn spawn_bash_tool(script: &str) -> Result<Child, String> {
 }
 
 fn wait_for_tool_marker(path: &str, child: &mut Child) -> Result<String, String> {
-    let deadline = Instant::now() + TOOL_OOM_READY_TIMEOUT;
+    let deadline = Instant::now() + TOOL_MARKER_TIMEOUT;
     loop {
         match std::fs::read_to_string(path) {
             Ok(contents) if !contents.trim().is_empty() => return Ok(contents.trim().to_string()),


### PR DESCRIPTION
## Summary

- give the real cgroup OOM offender a dedicated 15-second convergence deadline
- keep marker readiness and controlled survivor completion bounded at five seconds
- print the captured runner result before reporting a failed memory-pressure submit

## Scope

The test still uses the same allocator, 192 MiB workload headroom, 30-second runner timeout, sub-20-second successful completion assertion, group-kill checks, survivor checks, resource diagnostics, and sandbox-reuse validation. This PR does not change CI lane distribution, retries, skips, production runner behavior, APIs, protocols, profiles, persisted state, or deployment behavior.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-mock-claude --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-mock-claude --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-claude`
- `bash -n .github/scripts/runner-behavior-process-containment-remote.sh`
- `bash -n .github/scripts/runner-behavior-process-containment.sh`
- `.github/scripts/tests/runner-behavior-durable-test.sh`
- `git diff --check`

Closes #31178
