### PR TITLE
test(app): settle chat bootstrap before the pending-detail rename assert

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-history-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-history-navigation.test.tsx
@@ -1072,10 +1072,12 @@ describe("chat lifecycle", () => {
       },
     );
 
-    // Thread detail never responds in this scenario, so page bootstrap has no
-    // settled completion to await. Readiness comes from the rendered thread
-    // instead, per the `detachedSetupPage` contract.
-    detachedSetupPage({
+    // Thread detail never responds here, but the app skeleton does not wait on
+    // it: it retires on `initialEventsReady$`, which the events handler above
+    // satisfies. `setupPageAndWaitForContent` is itself detached, so gating on
+    // the skeleton settles bootstrap without awaiting the pending thread
+    // detail, and keeps page startup out of the `findBy` polling budget below.
+    await setupPageAndWaitForContent({
       context,
       path: `/chats/${EVENT_SOURCED_RENAME_THREAD_ID}`,
       sharedWorkerTestTransport: "message-port",


### PR DESCRIPTION
## Summary

Repairs the probable-flaky test `chat lifecycle > renames the event-sourced current chat while thread detail is pending` in `turbo/apps/platform/src/views/okou-page/__tests__/chat-history-navigation.test.tsx`.

Triggering run: [Turbo run 33629058269](https://github.com/vm0-ai/vm0/actions/runs/33629058269), job [`test-app (5)`](https://github.com/vm0-ai/vm0/actions/runs/33629058269/job/100243778538), `merge_group` at head SHA `22300e01a18130a1306b0a453fd1ec34b32cd341`.

```
TestingLibraryElementError: Unable to find a label with the text of: Chat thread
<div ... data-testid="app-skeleton" role="status">
```

## Finding: one shared root cause, not three independent ones

This is the third occurrence of the same symptom in three days, each in a different file, after two fixes already merged:

- #30936 `test(platform): settle chat bootstrap before asserting the composer` — `chat-thread-idb.test.tsx`
- #31009 `docs(platform): explain the queue drawer bootstrap settle point` — `queue-drawer.test.tsx`

| occurrence | shard | phase inflation vs green |
|---|---|---|
| `chat-thread-idb` (run 33579922723) | test-app (4) | uniform ~1.5x across all phases |
| `queue-drawer` (run 33586766441) | test-app (7) | none — within 11% of green |
| this one (run 33629058269) | test-app (5) | mild — `tests` 248.06s vs 212.18/166.56/210.75 |

**The three cases share a root cause.** `detachedSetupPage()` starts the real app bootstrap and returns immediately, so the *next* Testing Library query absorbs the entire page startup inside its own polling budget. That budget is the default `asyncUtilTimeout` of **1000 ms** — the app sets no `configure({ asyncUtilTimeout })`. When startup outruns 1000 ms the query gives up while `data-testid="app-skeleton"` is still mounted, which is exactly the reported DOM. The label was never missing; it had not arrived yet.

That explains the otherwise puzzling environment column: the failure does not need a contended host, only a stall longer than the remaining margin, so it surfaces under heavy, normal, and mild load alike.

The remedy already exists as a shared, reusable helper — `setupPageAndWaitForContent` in `src/__tests__/page-helper.ts` — introduced before these repairs. It is itself detached, and resolves off a `MutationObserver` when the app skeleton unmounts or goes `aria-hidden`. This file already imports it and uses it in four other tests; **this call site simply did not adopt it.** Adopting it is therefore the minimal correct change, and it is what #30936 did for its file.

## Why this test kept `detachedSetupPage`

The removed comment claimed page bootstrap had "no settled completion to await" because `chatThreadByIdContract.get` is mocked with `never()`. That premise was wrong: the skeleton does not wait on thread detail. It retires from `ChatThreadAppSkeletonHandoff` on `thread.initialEventsReady$` (`chat-thread-page.tsx:2804-2816`), which the test's own `chatThreadsContract.events` handler satisfies. The handoff `<span>` is rendered inside the same `<section aria-label="Chat thread">`, so the skeleton retiring is strictly *later* than the label becoming queryable — a sound and stronger gate.

## Evidence

Instrumented `findByLabelText("Chat thread")` on an idle machine, full-file runs (a `-t`-filtered run misattributes one-time module init and reports a misleading ~1040 ms):

| call site | budget consumed / 1000 ms |
|---|---|
| this test (`message-port`) | 352 / 418 / 430 ms |
| sibling "opens the current chat rename dialog with F2" (`direct`) | 438 / 524 / 462 ms |

Two things follow. Transport is **not** the differentiator — the `direct` sibling is slower. And the margin is only ~2.3x at baseline, so a single stall window is enough. The exposure is uniform rather than specific to this test, which is precisely why the symptom keeps relocating.

Reproduced the exact CI error locally by running the file under CPU contention (2 cores, 6 busy loops), 3 runs per arm:

- **on `main`:** the fingerprinted test failed **2 / 3** with `Unable to find a label with the text of: Chat thread`
- **with this change:** the fingerprinted test passed **3 / 3**

(That stress level is harsher than CI, so unrelated tests in the file hit the 5000 ms *test* timeout in both arms. Those are a different failure mode; the specific CI symptom appeared only on `main`.)

## Scope note

`detachedSetupPage` is used at ~1000 call sites across ~110 app test files, while `setupPageAndWaitForContent` is used in 13. The latent surface is large, but converting it wholesale is not a flaky-repair change and would not be reviewable — this PR fixes only the fingerprinted site. The finding above is the durable output.

## Contract preserved

The business assertion is untouched: the test still proves the event-sourced current chat can be renamed **while thread detail is pending**. `chatThreadByIdContract.get` still returns `never()`, the test still asserts the pending-detail title `"Thread detail should stay pending"` never renders, and the rename request, optimistic title, and post-`threadListChanged` `document.title` assertions are unchanged. No retry, sleep, raised timeout, skip, weakened assertion, or manual detached cleanup.

## Validation

- Target file, 5 consecutive full-file runs, unloaded: **30/30 passed each time**
- Contention A/B above
- `chat-thread-idb.test.tsx` + `queue-drawer.test.tsx` (same helper): **18/18 passed**
- `prettier --check`, `oxlint --deny-warnings`, `eslint --max-warnings 0`, `tsc --noEmit`, `git diff --check`: clean

Live browser validation is not applicable — this is a happy-dom component test with no app, API, or preview surface involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
