### PR TITLE
feat(desktop): record when the user types, as bursts, in the recording sidecar

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/ClickMapping.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/ClickMapping.swift
@@ -270,3 +270,33 @@ public struct PointerTrailPolicy: Equatable, Sendable {
             || abs(y - previous.screenY) >= minimumDistancePoints
     }
 }
+
+/// A stretch of keyboard activity, in milliseconds on the recording's timeline.
+public struct TypingBurst: Equatable, Sendable {
+    public let startMs: Int
+    public let endMs: Int
+
+    public init(startMs: Int, endMs: Int) {
+        self.startMs = startMs
+        self.endMs = endMs
+    }
+}
+
+/// Groups key-down moments into bursts.
+///
+/// Only *when* keys went down is known, never which keys: that is all a camera
+/// needs to stay on the field being typed into, and it keeps the track from
+/// being a record of what was typed. A gap longer than `gapMs` ends a burst; a
+/// burst ends at its last key-down, so a single shortcut is a burst of length
+/// zero that consumers can tell apart from real typing.
+public func typingBursts(fromKeyDownOffsetsMs offsets: [Int], gapMs: Int = 800) -> [TypingBurst] {
+    var bursts: [TypingBurst] = []
+    for offset in offsets.sorted() {
+        if let last = bursts.last, offset - last.endMs <= gapMs {
+            bursts[bursts.count - 1] = TypingBurst(startMs: last.startMs, endMs: offset)
+        } else {
+            bursts.append(TypingBurst(startMs: offset, endMs: offset))
+        }
+    }
+    return bursts
+}

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/ClickTrackRecorder.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/ClickTrackRecorder.swift
@@ -34,6 +34,16 @@ private let clickTapCallback: CGEventTapCallBack = { _, type, event, refcon in
     return Unmanaged.passUnretained(event)
 }
 
+private let keyTapCallback: CGEventTapCallBack = { _, type, event, refcon in
+    guard let refcon else {
+        return Unmanaged.passUnretained(event)
+    }
+    let recorder = Unmanaged<ClickTrackRecorder>.fromOpaque(refcon)
+        .takeUnretainedValue()
+    recorder.handleKey(type: type, event: event)
+    return Unmanaged.passUnretained(event)
+}
+
 /// Records where and when the user clicked, and where the pointer went, for
 /// the whole session's duration.
 ///
@@ -42,9 +52,12 @@ private let clickTapCallback: CGEventTapCallBack = { _, type, event, refcon in
 /// separate Input Monitoring grant, whereas the session level rides the
 /// Accessibility grant the app already holds.
 ///
-/// Only mouse-down events are observed by the tap. Keystrokes are deliberately
-/// not captured: recording characters the user types would make this a
-/// keylogger, and nothing downstream needs them.
+/// The click tap observes mouse-down events only. A second, separate tap
+/// observes key-down events and keeps nothing but their timestamps: a camera
+/// needs to know *when* the user was typing so it can stay on the field, and
+/// nothing downstream needs to know *what* was typed. Key codes, characters and
+/// modifier flags are never read, so the track cannot become a keylogger. The
+/// two taps are separate so a refused keyboard tap cannot cost the click track.
 ///
 /// The pointer trail is sampled on a timer rather than through the tap.
 /// Reading the pointer position needs no permission, so the trail survives a
@@ -57,8 +70,11 @@ final class ClickTrackRecorder: @unchecked Sendable {
     private let lock = NSLock()
     private var clicks: [CapturedClick] = []
     private var samples: [CapturedPointerSample] = []
+    private var keyDowns: [UInt64] = []
     private var tap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
+    private var keyTap: CFMachPort?
+    private var keyRunLoopSource: CFRunLoopSource?
     private var warnings: [String] = []
     private let trailQueue = DispatchQueue(label: "ai.okou.recorder.pointer-trail")
     private let trailPolicy = PointerTrailPolicy()
@@ -106,24 +122,59 @@ final class ClickTrackRecorder: @unchecked Sendable {
         tap = eventTap
         runLoopSource = source
         lock.unlock()
+
+        startKeyTiming()
+    }
+
+    /// Observes when keys go down, and nothing else about them.
+    private func startKeyTiming() {
+        guard
+            let eventTap = CGEvent.tapCreate(
+                tap: .cgAnnotatedSessionEventTap,
+                place: .tailAppendEventTap,
+                options: .listenOnly,
+                eventsOfInterest: CGEventMask(1 << CGEventType.keyDown.rawValue),
+                callback: keyTapCallback,
+                userInfo: Unmanaged.passUnretained(self).toOpaque()
+            )
+        else {
+            lock.lock()
+            warnings.append(
+                "Typing timing is unavailable; grant Accessibility access to Okou to record when you type."
+            )
+            lock.unlock()
+            return
+        }
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        CGEvent.tapEnable(tap: eventTap, enable: true)
+
+        lock.lock()
+        keyTap = eventTap
+        keyRunLoopSource = source
+        lock.unlock()
     }
 
     func stop() {
         lock.lock()
         let eventTap = tap
         let source = runLoopSource
+        let keyEventTap = keyTap
+        let keySource = keyRunLoopSource
         let timer = trailTimer
         tap = nil
         runLoopSource = nil
+        keyTap = nil
+        keyRunLoopSource = nil
         trailTimer = nil
         lock.unlock()
 
         timer?.cancel()
 
-        if let eventTap {
+        for eventTap in [eventTap, keyEventTap].compactMap({ $0 }) {
             CGEvent.tapEnable(tap: eventTap, enable: false)
         }
-        if let source {
+        for source in [source, keySource].compactMap({ $0 }) {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
         }
     }
@@ -168,6 +219,27 @@ final class ClickTrackRecorder: @unchecked Sendable {
         )
         lock.lock()
         samples.append(sample)
+        lock.unlock()
+    }
+
+    /// Called on the run loop that owns the keyboard tap. Reads the timestamp
+    /// and nothing else from the event.
+    fileprivate func handleKey(type: CGEventType, event: CGEvent) {
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            lock.lock()
+            let eventTap = keyTap
+            lock.unlock()
+            if let eventTap {
+                CGEvent.tapEnable(tap: eventTap, enable: true)
+            }
+            return
+        }
+        guard type == .keyDown else {
+            return
+        }
+        let nanoseconds = event.timestamp
+        lock.lock()
+        keyDowns.append(nanoseconds)
         lock.unlock()
     }
 
@@ -216,12 +288,14 @@ final class ClickTrackRecorder: @unchecked Sendable {
     ) -> (
         clicks: [[String: Any]],
         pointerEvents: [[String: Any]],
+        typingBursts: [[String: Any]],
         droppedOutOfFrame: Int,
         warnings: [String]
     ) {
         lock.lock()
         let captured = clicks
         let capturedSamples = samples
+        let capturedKeyDowns = keyDowns
         let capturedWarnings = warnings
         lock.unlock()
 
@@ -279,9 +353,21 @@ final class ClickTrackRecorder: @unchecked Sendable {
         events.sort { left, right in
             left.tMs == right.tMs ? left.order < right.order : left.tMs < right.tMs
         }
+        // Key-downs before the first frame or inside a pause are moments the
+        // video does not contain, exactly like clicks there.
+        let keyOffsets = capturedKeyDowns.compactMap { nanoseconds -> Int? in
+            guard let offsetMs = timeline.offsetMilliseconds(atNanoseconds: nanoseconds) else {
+                return nil
+            }
+            return mediaMs(offsetMs)
+        }
+        let bursts: [[String: Any]] = typingBursts(fromKeyDownOffsetsMs: keyOffsets).map { burst in
+            ["startMs": burst.startMs, "endMs": burst.endMs]
+        }
         return (
             described,
             events.map { $0.json },
+            bursts,
             projection.droppedOutOfFrame,
             capturedWarnings
         )

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
@@ -857,7 +857,7 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
                     geometry: geometry,
                     outputSize: outputSize
                 )
-            } ?? (clicks: [], pointerEvents: [], droppedOutOfFrame: 0, warnings: [])
+            } ?? (clicks: [], pointerEvents: [], typingBursts: [], droppedOutOfFrame: 0, warnings: [])
 
         let payload: [String: Any] = [
             "version": 1,
@@ -873,6 +873,7 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
             ],
             "clicks": projected.clicks,
             "pointerEvents": projected.pointerEvents,
+            "typingBursts": projected.typingBursts,
             "droppedOutOfFrameClicks": projected.droppedOutOfFrame,
             "warnings": projected.warnings,
         ]

--- a/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/ClickMappingTests.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/ClickMappingTests.swift
@@ -363,3 +363,41 @@ struct PointerSampleProjectionTests {
         #expect(trail.first?.point.normalizedY == 0.5)
     }
 }
+
+struct TypingBurstTests {
+    @Test
+    func groupsKeyDownsCloserThanTheGapIntoOneBurst() {
+        let bursts = typingBursts(fromKeyDownOffsetsMs: [1_000, 1_150, 1_400, 1_900])
+
+        #expect(bursts == [TypingBurst(startMs: 1_000, endMs: 1_900)])
+    }
+
+    @Test
+    func splitsAtAGapLongerThanTheLimit() {
+        let bursts = typingBursts(fromKeyDownOffsetsMs: [1_000, 1_200, 2_100, 2_300])
+
+        #expect(bursts == [
+            TypingBurst(startMs: 1_000, endMs: 1_200),
+            TypingBurst(startMs: 2_100, endMs: 2_300),
+        ])
+    }
+
+    /// A shortcut is one key-down: a burst of length zero, which a camera can
+    /// tell apart from typing without knowing which key it was.
+    @Test
+    func reportsALoneKeyDownAsAZeroLengthBurst() {
+        #expect(typingBursts(fromKeyDownOffsetsMs: [5_000]) == [TypingBurst(startMs: 5_000, endMs: 5_000)])
+    }
+
+    @Test
+    func ordersKeyDownsBeforeGrouping() {
+        let bursts = typingBursts(fromKeyDownOffsetsMs: [1_400, 1_000, 1_150])
+
+        #expect(bursts == [TypingBurst(startMs: 1_000, endMs: 1_400)])
+    }
+
+    @Test
+    func reportsNothingWithoutKeyDowns() {
+        #expect(typingBursts(fromKeyDownOffsetsMs: []).isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

The recording sidecar now says **when** the user was typing, as bursts, so a camera can stay on the field being typed into instead of zooming out mid-sentence. Stacked on #31179 (pointer trail), which sits on #31167; merge order is #31167 → #31179 → this.

## Privacy design

- A second, separate listen-only event tap observes key-down events and keeps **nothing but their timestamps**. Key codes, characters and modifier flags are never read, so the track cannot become a record of what was typed.
- Timestamps are grouped into bursts split by an 800 ms gap before they are written; the sidecar never contains individual keystrokes. A lone shortcut is a burst of length zero, which consumers can tell apart from real typing without knowing which key it was.
- The keyboard tap is separate from the click tap so a refused one cannot cost the click track; a refusal is reported as a warning on the finished recording. It rides the same Accessibility grant as the click tap.

## Sidecar shape

```json
"typingBursts": [{ "startMs": 6600, "endMs": 9800 }, { "startMs": 12100, "endMs": 12100 }]
```

Mapped onto the recording's timeline like clicks: key-downs before the first frame or inside a pause are dropped.

## How the camera will use it

Typing within a shot keeps the camera on the last click target and resets the zoom-out hold; a burst shorter than a second is treated as a shortcut and ignored. That logic lands with the trail-timed camera in the CLI.

## Test plan

- [ ] macOS CI compiles the helper and runs `ScreenRecorderCoreTests` (`TypingBurstTests`)
- [ ] Dev build: click into a text field, type a sentence, pause, type again; the sidecar shows two bursts with plausible start/end times and no per-key entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
