### PR TITLE
refactor(api): rename model provider gateway runtime secret

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/model-provider-gateways.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/model-provider-gateways.test.ts
@@ -392,7 +392,7 @@ describe("custom model provider gateway routes", () => {
             hostPolicy: { kind: "publicDestination" },
             auth: {
               headers: {
-                Authorization: `Bearer \${{ secrets.VM0_MODEL_PROVIDER_API_KEY }}`,
+                Authorization: `Bearer \${{ secrets.OKOU_MODEL_PROVIDER_API_KEY }}`,
               },
             },
           },
@@ -411,7 +411,7 @@ describe("custom model provider gateway routes", () => {
             headerEntries: [
               {
                 name: "Authorization",
-                value: `Bearer \${{ secrets.VM0_MODEL_PROVIDER_API_KEY }}`,
+                value: `Bearer \${{ secrets.OKOU_MODEL_PROVIDER_API_KEY }}`,
               },
             ],
           },
@@ -496,7 +496,7 @@ describe("custom model provider gateway routes", () => {
             base: "https://gateway.example.com/openai/v1/responses",
             auth: {
               headers: {
-                "x-api-key": `\${{ secrets.VM0_MODEL_PROVIDER_API_KEY }}`,
+                "x-api-key": `\${{ secrets.OKOU_MODEL_PROVIDER_API_KEY }}`,
               },
             },
           },

--- a/turbo/apps/api/src/signals/services/model-provider-gateway-runtime.ts
+++ b/turbo/apps/api/src/signals/services/model-provider-gateway-runtime.ts
@@ -10,7 +10,7 @@ import {
 } from "@okouai/api-contracts/contracts/model-provider-gateways";
 import type { ExpandedFirewallConfig } from "@okouai/connectors/firewall-types";
 
-export const GATEWAY_RUNTIME_SECRET_NAME = "VM0_MODEL_PROVIDER_API_KEY";
+export const GATEWAY_RUNTIME_SECRET_NAME = "OKOU_MODEL_PROVIDER_API_KEY";
 
 interface CompileModelProviderGatewayRuntimeArgs {
   readonly surfaceId: string;


### PR DESCRIPTION
## Summary

- rename the API-owned per-run model-provider gateway secret-map key from `VM0_MODEL_PROVIDER_API_KEY` to `OKOU_MODEL_PROVIDER_API_KEY`
- update the Anthropic and OpenAI-compatible route assertions for the exact rendered firewall references
- preserve credential bytes, provider environment values, header rendering, inline firewall placeholders, model/framework admission, Codex runtime configuration, and secret non-disclosure

## Verification

- `pnpm exec prettier --check apps/api/src/signals/services/model-provider-gateway-runtime.ts apps/api/src/signals/routes/__tests__/model-provider-gateways.test.ts`
- `pnpm -F api lint`
- focused oxlint, type-aware oxlint, and ESLint for both changed files
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- exact-literal inventory: zero `VM0_MODEL_PROVIDER_API_KEY` occurrences and four intended `OKOU_MODEL_PROVIDER_API_KEY` occurrences
- symbol-caller inventory confirms the constant remains shared by the per-run secret map, rendered reference, and inline placeholder map
- `git diff --check`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/model-provider-gateways.test.ts` was attempted, but this runtime has no local PostgreSQL or Docker; setup stopped before test execution with `ECONNREFUSED` on localhost:5432. PR CI provides the repository-standard pgvector service.

## Fallbacks

None. The API emits the per-run secret-map key, every `${{ secrets.NAME }}` reference, and the inline firewall placeholder together inside the same execution context. Existing in-flight or historical contexts retain their internally matching legacy name/reference pair, while newly created contexts use the canonical pair. No alias, dual writer, compatibility reader, telemetry branch, or tombstone is needed.

Closes #31192

Parent: #28914
