### PR TITLE
feat(desktop): map clicks through each frame's content rect and record the element they hit

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/ClickMapping.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderCore/ClickMapping.swift
@@ -88,6 +88,11 @@ public struct CapturedClick: Equatable, Sendable {
     /// through the window's position at that moment, not the one it had when
     /// the capture was prepared. `nil` means the recording's geometry applies.
     public let geometry: CaptureGeometry?
+    /// Where the content sat in the frame at that moment; preferred over
+    /// `geometry` when present, because it accounts for letterboxing.
+    public let mapping: ContentMapping?
+    /// The UI element under the click, when it could be looked up.
+    public let element: CapturedElement?
 
     public init(
         nanoseconds: UInt64,
@@ -96,7 +101,9 @@ public struct CapturedClick: Equatable, Sendable {
         button: String,
         clickCount: Int,
         modifiers: [String],
-        geometry: CaptureGeometry? = nil
+        geometry: CaptureGeometry? = nil,
+        mapping: ContentMapping? = nil,
+        element: CapturedElement? = nil
     ) {
         self.nanoseconds = nanoseconds
         self.screenX = screenX
@@ -105,6 +112,23 @@ public struct CapturedClick: Equatable, Sendable {
         self.clickCount = clickCount
         self.modifiers = modifiers
         self.geometry = geometry
+        self.mapping = mapping
+        self.element = element
+    }
+
+    /// The same click with its element filled in, once the lookup finished.
+    public func withElement(_ element: CapturedElement?) -> CapturedClick {
+        return CapturedClick(
+            nanoseconds: nanoseconds,
+            screenX: screenX,
+            screenY: screenY,
+            button: button,
+            clickCount: clickCount,
+            modifiers: modifiers,
+            geometry: geometry,
+            mapping: mapping,
+            element: element
+        )
     }
 }
 
@@ -115,6 +139,7 @@ public struct ProjectedClick: Equatable, Sendable {
     public let clickCount: Int
     public let modifiers: [String]
     public let point: MappedClickPoint
+    public let element: ProjectedElement?
 }
 
 /// Places captured clicks onto the recording.
@@ -144,11 +169,16 @@ public func projectClicks(
             continue
         }
         guard
-            let point = (click.geometry ?? geometry).mapClick(
+            let point = click.mapping?.mapPoint(
                 screenX: click.screenX,
                 screenY: click.screenY,
                 outputSize: outputSize
             )
+                ?? (click.geometry ?? geometry).mapClick(
+                    screenX: click.screenX,
+                    screenY: click.screenY,
+                    outputSize: outputSize
+                )
         else {
             droppedOutOfFrame += 1
             continue
@@ -159,7 +189,15 @@ public func projectClicks(
                 button: click.button,
                 clickCount: click.clickCount,
                 modifiers: click.modifiers,
-                point: point
+                point: point,
+                element: click.element.flatMap {
+                    projectElement(
+                        $0,
+                        mapping: click.mapping,
+                        geometry: click.geometry ?? geometry,
+                        outputSize: outputSize
+                    )
+                }
             )
         )
     }
@@ -202,17 +240,21 @@ public struct CapturedPointerSample: Equatable, Sendable {
     public let screenY: Double
     /// See `CapturedClick.geometry`.
     public let geometry: CaptureGeometry?
+    /// See `CapturedClick.mapping`.
+    public let mapping: ContentMapping?
 
     public init(
         nanoseconds: UInt64,
         screenX: Double,
         screenY: Double,
-        geometry: CaptureGeometry? = nil
+        geometry: CaptureGeometry? = nil,
+        mapping: ContentMapping? = nil
     ) {
         self.nanoseconds = nanoseconds
         self.screenX = screenX
         self.screenY = screenY
         self.geometry = geometry
+        self.mapping = mapping
     }
 }
 
@@ -237,11 +279,16 @@ public func projectPointerSamples(
     return samples.compactMap { sample -> ProjectedPointerSample? in
         guard
             let offsetMs = timeline.offsetMilliseconds(atNanoseconds: sample.nanoseconds),
-            let point = (sample.geometry ?? geometry).mapClick(
+            let point = sample.mapping?.mapPoint(
                 screenX: sample.screenX,
                 screenY: sample.screenY,
                 outputSize: outputSize
             )
+                ?? (sample.geometry ?? geometry).mapClick(
+                    screenX: sample.screenX,
+                    screenY: sample.screenY,
+                    outputSize: outputSize
+                )
         else {
             return nil
         }
@@ -299,4 +346,163 @@ public func typingBursts(fromKeyDownOffsetsMs offsets: [Int], gapMs: Int = 800) 
         }
     }
     return bursts
+}
+
+/// Where the captured content sits in both worlds: on screen, in global
+/// points, and in the encoded frame, in pixels.
+///
+/// ScreenCaptureKit scales a window into the frame and, once the window's
+/// aspect no longer matches the frame it was sized for, letterboxes it. The
+/// frame's size then says nothing about where the content is: on a window
+/// narrowed mid-recording, mapping through the frame size put every click 5%
+/// too far right and 76 px too low. Every frame carries its content rectangle,
+/// and mapping through that is exact.
+public struct ContentMapping: Equatable, Sendable {
+    public let screenOriginX: Double
+    public let screenOriginY: Double
+    public let screenWidth: Double
+    public let screenHeight: Double
+    public let pixelOriginX: Double
+    public let pixelOriginY: Double
+    public let pixelWidth: Double
+    public let pixelHeight: Double
+
+    public init(
+        screenOriginX: Double,
+        screenOriginY: Double,
+        screenWidth: Double,
+        screenHeight: Double,
+        pixelOriginX: Double,
+        pixelOriginY: Double,
+        pixelWidth: Double,
+        pixelHeight: Double
+    ) {
+        self.screenOriginX = screenOriginX
+        self.screenOriginY = screenOriginY
+        self.screenWidth = screenWidth
+        self.screenHeight = screenHeight
+        self.pixelOriginX = pixelOriginX
+        self.pixelOriginY = pixelOriginY
+        self.pixelWidth = pixelWidth
+        self.pixelHeight = pixelHeight
+    }
+
+    var isUsable: Bool {
+        return screenWidth > 0 && screenHeight > 0 && pixelWidth > 0 && pixelHeight > 0
+    }
+
+    /// The frame pixel a screen point lands on, without checking bounds.
+    func pixel(screenX: Double, screenY: Double) -> (x: Double, y: Double) {
+        return (
+            pixelOriginX + (screenX - screenOriginX) / screenWidth * pixelWidth,
+            pixelOriginY + (screenY - screenOriginY) / screenHeight * pixelHeight
+        )
+    }
+
+    /// Maps a global screen point into the frame, or `nil` when it is outside
+    /// the captured content. `normalized` is the point as a fraction of the
+    /// whole frame, which is what a camera multiplies by the video size.
+    public func mapPoint(screenX: Double, screenY: Double, outputSize: OutputSize) -> MappedClickPoint? {
+        guard isUsable else {
+            return nil
+        }
+        let relativeX = (screenX - screenOriginX) / screenWidth
+        let relativeY = (screenY - screenOriginY) / screenHeight
+        guard relativeX >= 0, relativeX < 1, relativeY >= 0, relativeY < 1 else {
+            return nil
+        }
+        let point = pixel(screenX: screenX, screenY: screenY)
+        return MappedClickPoint(
+            screenX: screenX,
+            screenY: screenY,
+            frameX: Int(point.x.rounded(.down)),
+            frameY: Int(point.y.rounded(.down)),
+            normalizedX: point.x / Double(outputSize.width),
+            normalizedY: point.y / Double(outputSize.height)
+        )
+    }
+}
+
+/// The UI element a click landed on: what was hit, never what it contained.
+public struct CapturedElement: Equatable, Sendable {
+    public let role: String
+    public let subrole: String?
+    /// The element's frame in global screen points.
+    public let screenX: Double
+    public let screenY: Double
+    public let screenWidth: Double
+    public let screenHeight: Double
+
+    public init(
+        role: String,
+        subrole: String?,
+        screenX: Double,
+        screenY: Double,
+        screenWidth: Double,
+        screenHeight: Double
+    ) {
+        self.role = role
+        self.subrole = subrole
+        self.screenX = screenX
+        self.screenY = screenY
+        self.screenWidth = screenWidth
+        self.screenHeight = screenHeight
+    }
+}
+
+/// An element's frame placed in the encoded frame, clipped to it.
+public struct ProjectedElement: Equatable, Sendable {
+    public let role: String
+    public let subrole: String?
+    public let frameX: Int
+    public let frameY: Int
+    public let frameWidth: Int
+    public let frameHeight: Int
+}
+
+/// Places an element's screen frame into the encoded frame, through the
+/// content mapping of the click's moment when there is one and the capture
+/// geometry otherwise. Returns `nil` for an element entirely outside the frame.
+public func projectElement(
+    _ element: CapturedElement,
+    mapping: ContentMapping?,
+    geometry: CaptureGeometry,
+    outputSize: OutputSize
+) -> ProjectedElement? {
+    func pixel(_ x: Double, _ y: Double) -> (x: Double, y: Double)? {
+        if let mapping {
+            guard mapping.isUsable else {
+                return nil
+            }
+            return mapping.pixel(screenX: x, screenY: y)
+        }
+        guard geometry.widthPoints > 0, geometry.heightPoints > 0 else {
+            return nil
+        }
+        return (
+            (x - geometry.originX) / geometry.widthPoints * Double(outputSize.width),
+            (y - geometry.originY) / geometry.heightPoints * Double(outputSize.height)
+        )
+    }
+    guard
+        let topLeft = pixel(element.screenX, element.screenY),
+        let bottomRight = pixel(element.screenX + element.screenWidth, element.screenY + element.screenHeight)
+    else {
+        return nil
+    }
+    let left = max(0, topLeft.x)
+    let top = max(0, topLeft.y)
+    let right = min(Double(outputSize.width), bottomRight.x)
+    let bottom = min(Double(outputSize.height), bottomRight.y)
+    guard right - left >= 1, bottom - top >= 1 else {
+        return nil
+    }
+    return ProjectedElement(
+        role: element.role,
+        subrole: element.subrole,
+        frameX: Int(left.rounded(.down)),
+        frameY: Int(top.rounded(.down)),
+        frameWidth: Int((right - left).rounded()),
+        frameHeight: Int((bottom - top).rounded())
+    )
 }

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/ClickTrackRecorder.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/ClickTrackRecorder.swift
@@ -1,6 +1,97 @@
+import ApplicationServices
 import CoreGraphics
 import Foundation
 import ScreenRecorderCore
+
+/// Roles worth walking up to from whatever leaf a click landed on. A click on
+/// the placeholder text of a field belongs to the field; a click on a button's
+/// icon belongs to the button.
+private let targetRoles: Set<String> = [
+    "AXTextField", "AXTextArea", "AXComboBox", "AXSearchField",
+    "AXButton", "AXPopUpButton", "AXMenuButton", "AXMenuItem", "AXMenuBarItem",
+    "AXCheckBox", "AXRadioButton", "AXLink", "AXTab", "AXSlider",
+    "AXDisclosureTriangle", "AXCell", "AXRow", "AXIncrementor", "AXColorWell",
+]
+
+private func attributeValue(_ element: AXUIElement, _ attribute: String) -> AnyObject? {
+    var value: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success else {
+        return nil
+    }
+    return value
+}
+
+private func rect(of element: AXUIElement) -> CGRect? {
+    guard
+        let positionValue = attributeValue(element, kAXPositionAttribute),
+        let sizeValue = attributeValue(element, kAXSizeAttribute),
+        CFGetTypeID(positionValue) == AXValueGetTypeID(),
+        CFGetTypeID(sizeValue) == AXValueGetTypeID()
+    else {
+        return nil
+    }
+    var position = CGPoint.zero
+    var size = CGSize.zero
+    guard
+        AXValueGetValue(positionValue as! AXValue, .cgPoint, &position),
+        AXValueGetValue(sizeValue as! AXValue, .cgSize, &size)
+    else {
+        return nil
+    }
+    return CGRect(origin: position, size: size)
+}
+
+/// The UI element under a screen point, described by role and frame only.
+///
+/// Walks up from the leaf that was hit to the nearest control-like ancestor,
+/// so a click on a field's placeholder reports the field. Reads nothing else:
+/// no titles, no values, no descriptions, so a text field's contents never
+/// reach the track.
+private func elementAt(_ point: CGPoint) -> CapturedElement? {
+    let system = AXUIElementCreateSystemWide()
+    AXUIElementSetMessagingTimeout(system, 0.3)
+    var hit: AXUIElement?
+    guard
+        AXUIElementCopyElementAtPosition(system, Float(point.x), Float(point.y), &hit) == .success,
+        let hit
+    else {
+        return nil
+    }
+    var element = hit
+    var role = attributeValue(element, kAXRoleAttribute) as? String ?? ""
+    var depth = 0
+    while !targetRoles.contains(role), depth < 8 {
+        guard
+            let parent = attributeValue(element, kAXParentAttribute),
+            CFGetTypeID(parent) == AXUIElementGetTypeID()
+        else {
+            break
+        }
+        let parentElement = parent as! AXUIElement
+        let parentRole = attributeValue(parentElement, kAXRoleAttribute) as? String ?? ""
+        if parentRole == "AXWindow" || parentRole == "AXApplication" || parentRole == "AXWebArea" {
+            break
+        }
+        element = parentElement
+        role = parentRole
+        depth += 1
+    }
+    if !targetRoles.contains(role) {
+        element = hit
+        role = attributeValue(hit, kAXRoleAttribute) as? String ?? ""
+    }
+    guard !role.isEmpty, let frame = rect(of: element) else {
+        return nil
+    }
+    return CapturedElement(
+        role: role,
+        subrole: attributeValue(element, kAXSubroleAttribute) as? String,
+        screenX: Double(frame.origin.x),
+        screenY: Double(frame.origin.y),
+        screenWidth: Double(frame.width),
+        screenHeight: Double(frame.height)
+    )
+}
 
 private func buttonName(for type: CGEventType) -> String? {
     switch type {
@@ -83,6 +174,10 @@ final class ClickTrackRecorder: @unchecked Sendable {
     /// Asked at each click, so the click is projected through the geometry of
     /// its own moment rather than the recording's first. Set before `start`.
     var geometryProvider: (() -> CaptureGeometry?)?
+    /// Where the content sits in the frame right now; see `ContentMapping`.
+    var mappingProvider: (() -> ContentMapping?)?
+    private let elementQueue = DispatchQueue(label: "ai.okou.recorder.click-elements")
+    private var elements: [Int: CapturedElement] = [:]
 
     /// Starts observing clicks and sampling the pointer. Never throws: losing
     /// the click track must not cost the user their video, so a refused tap is
@@ -215,7 +310,8 @@ final class ClickTrackRecorder: @unchecked Sendable {
             nanoseconds: nanoseconds,
             screenX: Double(location.x),
             screenY: Double(location.y),
-            geometry: geometryProvider?()
+            geometry: geometryProvider?(),
+            mapping: mappingProvider?()
         )
         lock.lock()
         samples.append(sample)
@@ -267,11 +363,23 @@ final class ClickTrackRecorder: @unchecked Sendable {
             button: button,
             clickCount: Int(event.getIntegerValueField(.mouseEventClickState)),
             modifiers: modifierNames(for: event.flags),
-            geometry: geometryProvider?()
+            geometry: geometryProvider?(),
+            mapping: mappingProvider?()
         )
         lock.lock()
         clicks.append(click)
+        let index = clicks.count - 1
         lock.unlock()
+        // The element lookup talks to the clicked application and can take a
+        // while; the tap callback must stay instant, so it happens elsewhere.
+        elementQueue.async { [weak self] in
+            guard let self, let element = elementAt(location) else {
+                return
+            }
+            self.lock.lock()
+            self.elements[index] = element
+            self.lock.unlock()
+        }
     }
 
     /// Projects the captured clicks and pointer samples onto the recording's
@@ -292,8 +400,13 @@ final class ClickTrackRecorder: @unchecked Sendable {
         droppedOutOfFrame: Int,
         warnings: [String]
     ) {
+        // Let element lookups still in flight finish; each is bounded by the
+        // accessibility messaging timeout, so this cannot hang the recording.
+        elementQueue.sync {}
         lock.lock()
-        let captured = clicks
+        let captured = clicks.enumerated().map { index, click in
+            click.withElement(elements[index])
+        }
         let capturedSamples = samples
         let capturedKeyDowns = keyDowns
         let capturedWarnings = warnings
@@ -328,7 +441,7 @@ final class ClickTrackRecorder: @unchecked Sendable {
             guard let tMs = mediaMs(click.offsetMs) else {
                 continue
             }
-            described.append([
+            var entry: [String: Any] = [
                 "tMs": tMs,
                 "button": click.button,
                 "clickCount": click.clickCount,
@@ -338,8 +451,14 @@ final class ClickTrackRecorder: @unchecked Sendable {
                 "normalized": [
                     "x": click.point.normalizedX, "y": click.point.normalizedY,
                 ],
-            ])
-            events.append((tMs, 0, pointerEvent(tMs: tMs, kind: "click", point: click.point)))
+            ]
+            var event = pointerEvent(tMs: tMs, kind: "click", point: click.point)
+            if let element = click.element.map({ describe($0, outputSize: outputSize) }) {
+                entry["element"] = element
+                event["element"] = element
+            }
+            described.append(entry)
+            events.append((tMs, 0, event))
         }
         for sample in trail {
             guard let tMs = mediaMs(sample.offsetMs) else {
@@ -371,6 +490,27 @@ final class ClickTrackRecorder: @unchecked Sendable {
             projection.droppedOutOfFrame,
             capturedWarnings
         )
+    }
+
+    /// The element a click landed on, in frame pixels and frame fractions.
+    private func describe(_ element: ProjectedElement, outputSize: OutputSize) -> [String: Any] {
+        var described: [String: Any] = [
+            "role": element.role,
+            "frame": [
+                "x": element.frameX, "y": element.frameY,
+                "width": element.frameWidth, "height": element.frameHeight,
+            ],
+            "normalized": [
+                "x": Double(element.frameX) / Double(outputSize.width),
+                "y": Double(element.frameY) / Double(outputSize.height),
+                "width": Double(element.frameWidth) / Double(outputSize.width),
+                "height": Double(element.frameHeight) / Double(outputSize.height),
+            ],
+        ]
+        if let subrole = element.subrole {
+            described["subrole"] = subrole
+        }
+        return described
     }
 
     /// One entry of the pointer stream. Positions are rounded to a ten

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ScreenRecorderHelper/main.swift
@@ -450,6 +450,8 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
     private let windowID: CGWindowID?
     private var currentGeometry: CaptureGeometry
     private var windowBoundsTimer: DispatchSourceTimer?
+    /// The content's rectangle inside the frame, in pixels, from the latest frame.
+    private var contentPixelRect: CGRect?
 
     init(
         id: String,
@@ -475,6 +477,78 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         lock.lock()
         defer { lock.unlock() }
         return currentGeometry
+    }
+
+    /// Where the content sits in the frame right now: the captured region's
+    /// screen bounds paired with the content rectangle the latest frame
+    /// reported. `nil` until the first frame has said where the content is.
+    private func currentMappingNow() -> ContentMapping? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let pixelRect = contentPixelRect else {
+            return nil
+        }
+        return ContentMapping(
+            screenOriginX: currentGeometry.originX,
+            screenOriginY: currentGeometry.originY,
+            screenWidth: currentGeometry.widthPoints,
+            screenHeight: currentGeometry.heightPoints,
+            pixelOriginX: pixelRect.origin.x,
+            pixelOriginY: pixelRect.origin.y,
+            pixelWidth: pixelRect.width,
+            pixelHeight: pixelRect.height
+        )
+    }
+
+    /// Reads where this frame's content sits, from the frame's own attachments.
+    ///
+    /// `contentRect` is in points and `scaleFactor` turns it into pixels. If
+    /// that product does not fit the frame, the rectangle was already in
+    /// pixels and is used as is; either way the result is checked against the
+    /// frame rather than trusted.
+    private func noteContentRect(_ sampleBuffer: CMSampleBuffer) {
+        guard
+            let attachments = CMSampleBufferGetSampleAttachmentsArray(
+                sampleBuffer,
+                createIfNecessary: false
+            ) as? [[SCStreamFrameInfo: Any]],
+            let info = attachments.first,
+            let rectValue = info[.contentRect] as? NSDictionary,
+            let contentRect = CGRect(dictionaryRepresentation: rectValue as CFDictionary),
+            contentRect.width > 0, contentRect.height > 0
+        else {
+            return
+        }
+        let scaleFactor = (info[.scaleFactor] as? NSNumber)?.doubleValue ?? 1
+        let frameWidth = Double(outputSize.width)
+        let frameHeight = Double(outputSize.height)
+        var pixelRect = CGRect(
+            x: contentRect.origin.x * scaleFactor,
+            y: contentRect.origin.y * scaleFactor,
+            width: contentRect.width * scaleFactor,
+            height: contentRect.height * scaleFactor
+        )
+        if pixelRect.maxX > frameWidth + 1 || pixelRect.maxY > frameHeight + 1 {
+            pixelRect = contentRect
+        }
+        guard pixelRect.maxX <= frameWidth + 1, pixelRect.maxY <= frameHeight + 1 else {
+            return
+        }
+        lock.lock()
+        let changed = contentPixelRect.map { $0 != pixelRect } ?? true
+        contentPixelRect = pixelRect
+        lock.unlock()
+        if changed {
+            FileHandle.standardError.write(
+                Data(
+                    String(
+                        format: "content rect in frame: %.0fx%.0f at (%.0f, %.0f) of %dx%d\n",
+                        pixelRect.width, pixelRect.height, pixelRect.origin.x, pixelRect.origin.y,
+                        outputSize.width, outputSize.height
+                    ).utf8
+                )
+            )
+        }
     }
 
     /// Follows the recorded window's bounds while recording. Four times a
@@ -536,6 +610,23 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
             return nil
         }
         return UInt64(nanoseconds)
+    }
+
+    /// Where the content sat in the frame at the end, for anyone checking a
+    /// letterboxed recording against its track.
+    var describedContent: [String: Any] {
+        lock.lock()
+        let pixelRect = contentPixelRect
+        lock.unlock()
+        guard let pixelRect else {
+            return [:]
+        }
+        return [
+            "pixelRect": [
+                "x": pixelRect.origin.x, "y": pixelRect.origin.y,
+                "width": pixelRect.width, "height": pixelRect.height,
+            ]
+        ]
     }
 
     var describedGeometry: [String: Any] {
@@ -671,6 +762,9 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         lock.lock()
         startedAtUnixMs = Int(Date().timeIntervalSince1970 * 1000)
         lock.unlock()
+        clickTracker.mappingProvider = { [weak self] in
+            self?.currentMappingNow()
+        }
         clickTracker.geometryProvider = { [weak self] in
             self?.currentGeometryNow()
         }
@@ -870,6 +964,7 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
                     "frameRate": Int(captureFrameRate),
                 ],
                 "capture": describedGeometry,
+                "content": describedContent,
             ],
             "clicks": projected.clicks,
             "pointerEvents": projected.pointerEvents,
@@ -1062,6 +1157,9 @@ private final class RecorderSession: NSObject, SCStreamDelegate, SCStreamOutput,
         // idle, blank, and the bookkeeping frames around start and stop. They
         // are not images the encoder can take, and handing one to the writer
         // is a way to fail it. Only a complete frame goes on.
+        if type == .screen {
+            noteContentRect(sampleBuffer)
+        }
         if type == .screen, !isCompleteFrame(sampleBuffer) {
             return
         }

--- a/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/ClickMappingTests.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Tests/ScreenRecorderCoreTests/ClickMappingTests.swift
@@ -401,3 +401,100 @@ struct TypingBurstTests {
         #expect(typingBursts(fromKeyDownOffsetsMs: []).isEmpty)
     }
 }
+
+struct ContentMappingTests {
+    /// A 1512-point window narrowed to 1435 points mid-recording: the frame
+    /// stayed 1920 wide, the content shrank to 1822 pixels with a black band
+    /// on the right. Mapping through the frame size put clicks in the band.
+    private let letterboxed = ContentMapping(
+        screenOriginX: 572,
+        screenOriginY: 1520,
+        screenWidth: 1435,
+        screenHeight: 902,
+        pixelOriginX: 0,
+        pixelOriginY: 0,
+        pixelWidth: 1822,
+        pixelHeight: 1144
+    )
+    private let outputSize = OutputSize(width: 1920, height: 1144)
+
+    @Test
+    func mapsThroughTheContentRectangleNotTheFrame() {
+        // the content's right edge is pixel 1822, not the frame's 1920
+        #expect(letterboxed.mapPoint(screenX: 572 + 1435, screenY: 1520 + 451, outputSize: outputSize) == nil)
+        let inside = letterboxed.mapPoint(screenX: 572 + 1434, screenY: 1520 + 451, outputSize: outputSize)
+        #expect(inside?.frameX == 1820)
+        #expect(inside?.frameY == 572)
+    }
+
+    @Test
+    func normalizesAgainstTheWholeFrame() {
+        let point = letterboxed.mapPoint(screenX: 572 + 717.5, screenY: 1520 + 451, outputSize: outputSize)
+
+        #expect(point?.frameX == 911)
+        #expect(abs((point?.normalizedX ?? 0) - 911 / 1920) < 0.001)
+        #expect(abs((point?.normalizedY ?? 0) - 0.5) < 0.001)
+    }
+
+    @Test
+    func rejectsPointsOutsideTheContent() {
+        #expect(letterboxed.mapPoint(screenX: 571, screenY: 1600, outputSize: outputSize) == nil)
+        #expect(letterboxed.mapPoint(screenX: 700, screenY: 1519, outputSize: outputSize) == nil)
+    }
+
+    @Test
+    func aClickPrefersItsMappingOverTheGeometry() {
+        let geometry = CaptureGeometry(originX: 572, originY: 1520, widthPoints: 1512, heightPoints: 902, scale: 2)
+        let projection = projectClicks(
+            [
+                CapturedClick(
+                    nanoseconds: 2_024_000,
+                    screenX: 572 + 717.5,
+                    screenY: 1520 + 451,
+                    button: "left",
+                    clickCount: 1,
+                    modifiers: [],
+                    mapping: letterboxed
+                )
+            ],
+            timeline: ClickTimeline(startNanoseconds: 24_000),
+            geometry: geometry,
+            outputSize: outputSize
+        )
+
+        // through the prepare-time geometry this click would have landed at pixel 911 * 1920 / 1822
+        #expect(projection.clicks.first?.point.frameX == 911)
+    }
+
+    @Test
+    func projectsAnElementFrameAndClipsItToTheFrame() {
+        let field = CapturedElement(
+            role: "AXTextArea",
+            subrole: nil,
+            screenX: 572 + 100,
+            screenY: 1520 + 300,
+            screenWidth: 1400,
+            screenHeight: 150
+        )
+        let projected = projectElement(
+            field,
+            mapping: letterboxed,
+            geometry: CaptureGeometry(originX: 0, originY: 0, widthPoints: 1, heightPoints: 1, scale: 1),
+            outputSize: outputSize
+        )
+
+        #expect(projected?.role == "AXTextArea")
+        #expect(projected?.frameX == 126)
+        #expect(projected?.frameY == 380)
+        // 100 + 1400 points reach pixel 1904: past the content's 1822 but inside the frame
+        #expect(projected?.frameWidth == 1778)
+        #expect(projected?.frameHeight == 190)
+    }
+
+    @Test
+    func dropsAnElementEntirelyOutsideTheFrame() {
+        let offscreen = CapturedElement(role: "AXButton", subrole: nil, screenX: 0, screenY: 0, screenWidth: 100, screenHeight: 40)
+
+        #expect(projectElement(offscreen, mapping: letterboxed, geometry: CaptureGeometry(originX: 572, originY: 1520, widthPoints: 1435, heightPoints: 902, scale: 2), outputSize: outputSize) == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Two things a click-driven camera needs from the recorder and could not get. Stacked on #31186 (typing bursts); merge order #31186 → this.

### Coordinates were wrong on a resized window

ScreenCaptureKit scales a window into the frame and, once the window's aspect no longer matches the frame it was sized for, letterboxes it. The track mapped clicks through the prepare-time geometry and the frame size. Calibrating a real recording against the cursor drawn in the video gave:

```
x_px = 1825 · normalized.x − 2     (the frame is 1920 wide; the content was 1822)
y_px = 1043 · normalized.y + 76
```

so every click was 5% too far right and 76 px too low, and the pointer trail with them.

- Every frame carries its content rectangle. The helper reads `SCStreamFrameInfo.contentRect` × `scaleFactor`, checks the result against the frame (falls back to treating the rect as pixels if the product does not fit), and projects clicks, pointer samples and element frames through the content rectangle of their own moment (`ContentMapping`), with the prepare-time geometry only as a fallback before the first frame.
- `normalized` is now a fraction of the **whole frame**, which is what `okou video camera` multiplies by the video size. Before it was a fraction of the captured region, which differed from the frame whenever there was a band.
- The last content rectangle is written as `recording.content.pixelRect`, and the helper logs it to stderr when it changes.

### Clicks now say what they hit

A click in a text field means the field, wherever in it the pointer was. The helper looks up the accessibility element under each click, walks from the leaf that was hit to the nearest control-like ancestor (`AXTextField`, `AXTextArea`, `AXButton`, `AXMenuItem`, `AXLink`, `AXTab`, …), and records:

```json
"element": { "role": "AXTextArea", "frame": { "x": 667, "y": 446, "width": 1082, "height": 183 }, "normalized": { ... } }
```

Nothing else is read: no titles, values or descriptions, so a field's contents never reach the track. The lookup runs off the tap callback on its own queue with a 300 ms accessibility messaging timeout, and is attached to the click when the track is written.

## Test plan

- [ ] macOS CI compiles the helper and runs `ScreenRecorderCoreTests` (`ContentMappingTests`)
- [ ] Dev build: record a window, narrow it mid-recording, click; `frame` coordinates land on the cursor in the video and `recording.content.pixelRect` shows the band
- [ ] Click into a text field's placeholder: the click carries `element.role == "AXTextArea"` (Chrome/Electron expose web fields once an accessibility client connects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
