### PR TITLE
feat(cli): replace the camera algorithm with a click-focused, trail-timed camera

### DIFF
--- a/turbo/apps/cli/src/commands/video/__tests__/camera.test.ts
+++ b/turbo/apps/cli/src/commands/video/__tests__/camera.test.ts
@@ -106,30 +106,37 @@ describe("okou video camera command", () => {
       planPath: string;
       reviewPath: string;
       reviewFrames: number;
-      cameraRanges: number;
+      cameraShots: number;
+      cameraMoves: number;
     };
-    expect(result).toMatchObject({ outputPath, cameraRanges: 1 });
+    expect(result).toMatchObject({ outputPath, cameraShots: 1 });
+    expect(result.cameraMoves).toBeGreaterThanOrEqual(2);
     const plan = JSON.parse(readFileSync(result.planPath, "utf8")) as {
       algorithm: string;
-      ranges: {
+      content: { x: number; y: number; width: number; height: number };
+      shots: {
         startMs: number;
         endMs: number;
-        scale: number;
-        focuses: readonly unknown[];
+        baseZoom: number;
+        keys: { startMs: number; durationMs: number; clickMs?: number }[];
       }[];
     };
-    expect(plan.algorithm).toBe("screen-studio-compatible-v1");
-    expect(plan.ranges).toEqual([
-      expect.objectContaining({
-        startMs: 1_700,
-        endMs: 7_000,
-        scale: 2,
-        focuses: expect.arrayContaining([
-          expect.any(Object),
-          expect.any(Object),
-        ]),
+    expect(plan.algorithm).toBe("click-camera-v2");
+    // no letterbox detected through the mocked ffmpeg: the whole frame is content
+    expect(plan.content).toEqual({ x: 0, y: 0, width: 1920, height: 1080 });
+    expect(plan.shots).toHaveLength(1);
+    const shot = plan.shots[0];
+    // the pointer settled on the first click's spot 300 ms early, so the
+    // zoom-in lands 150 ms after that instead of on the click: it starts at
+    // 1700 + 150 - 800; the shot holds 2.2 s past the last click
+    expect(shot?.startMs).toBe(1_050);
+    expect(shot?.endMs).toBe(4_500 + 2_200);
+    expect(shot?.keys[0]).toMatchObject({ durationMs: 800, clickMs: 2_000 });
+    expect(
+      shot?.keys.some((key) => {
+        return key.clickMs === 4_500;
       }),
-    ]);
+    ).toBe(true);
     const review = JSON.parse(readFileSync(result.reviewPath, "utf8")) as {
       checkpoints: {
         timeMs: number;
@@ -149,9 +156,9 @@ describe("okou video camera command", () => {
         expect.objectContaining({ kind: "click" }),
         expect.objectContaining({ kind: "click-after", offsetMs: 500 }),
         expect.objectContaining({ kind: "click-after", offsetMs: 1_500 }),
-        expect.objectContaining({ kind: "pan-midpoint" }),
-        expect.objectContaining({ kind: "zoom-enter" }),
-        expect.objectContaining({ kind: "zoom-exit" }),
+        expect.objectContaining({ kind: "move-start" }),
+        expect.objectContaining({ kind: "move-end" }),
+        expect.objectContaining({ kind: "shot-end" }),
         expect.objectContaining({ kind: "maximum-camera-speed" }),
       ]),
     );
@@ -163,10 +170,12 @@ describe("okou video camera command", () => {
     );
 
     const generatedCommands = readFileSync(outputPath, "utf8");
+    // the wide shot before the first click, and the 2.2x focus on the click
     expect(generatedCommands).toContain("crop@camera w 1920.000000");
-    expect(generatedCommands).toContain("crop@camera w 960.000000");
+    // 1920 / 2.2, as the plan stores it (three decimals)
+    expect(generatedCommands).toContain("crop@camera w 872.727000");
     const ffmpegCall = vi.mocked(execFileSync).mock.calls.find((call) => {
-      return call[0] === "ffmpeg";
+      return call[0] === "ffmpeg" && call[1]?.includes("libx264");
     });
     expect(ffmpegCall?.[1]).toEqual(
       expect.arrayContaining([
@@ -222,7 +231,7 @@ describe("okou video camera command", () => {
     };
     expect(plan.source.frameRate).toBe(30);
     const ffmpegCall = vi.mocked(execFileSync).mock.calls.find((call) => {
-      return call[0] === "ffmpeg";
+      return call[0] === "ffmpeg" && call[1]?.includes("libx264");
     });
     expect(ffmpegCall?.[1]).toEqual(
       expect.arrayContaining(["-vf", expect.stringMatching(/^fps=30,/u)]),
@@ -258,7 +267,7 @@ describe("okou video camera command", () => {
     );
 
     const ffmpegCall = vi.mocked(execFileSync).mock.calls.find((call) => {
-      return call[0] === "ffmpeg";
+      return call[0] === "ffmpeg" && call[1]?.includes("libx264");
     });
     const filterIndex = ffmpegCall?.[1]?.indexOf("-vf") ?? -1;
     const filter = ffmpegCall?.[1]?.[filterIndex + 1];
@@ -304,28 +313,27 @@ describe("okou video camera command", () => {
 
     const result = JSON.parse(stdout()) as {
       planPath: string;
-      cameraRanges: number;
+      cameraShots: number;
     };
-    expect(result.cameraRanges).toBe(1);
+    expect(result.cameraShots).toBe(1);
     const plan = JSON.parse(readFileSync(result.planPath, "utf8")) as {
-      ranges: {
+      shots: {
         startMs: number;
         endMs: number;
-        focuses: { x: number; y: number }[];
+        keys: { clickMs?: number; rect: { width: number } }[];
       }[];
     };
-    expect(plan.ranges).toEqual([
+    // pointerdown at 2000 and 5000 ms (after the 500 ms go offset: 1500 and 4500)
+    expect(plan.shots).toEqual([
       expect.objectContaining({
-        startMs: 1_200,
-        endMs: 7_000,
-        focuses: expect.arrayContaining([
-          expect.objectContaining({
-            x: expect.any(Number),
-            y: expect.any(Number),
-          }),
+        endMs: 4_500 + 2_200,
+        keys: expect.arrayContaining([
+          expect.objectContaining({ clickMs: 1_500 }),
+          expect.objectContaining({ clickMs: 4_500 }),
         ]),
       }),
     ]);
+    expect(plan.shots[0]?.startMs).toBeLessThan(1_500);
   });
 
   it("renders an AI-edited camera plan without regenerating it", async () => {
@@ -336,26 +344,29 @@ describe("okou video camera command", () => {
     writeFileSync(
       planPath,
       JSON.stringify({
-        version: 1,
-        algorithm: "screen-studio-compatible-v1",
+        version: 2,
+        algorithm: "click-camera-v2",
         source: {
           durationMs: 10_000,
           width: 1920,
           height: 1080,
           frameRate: 30,
         },
-        ranges: [
+        content: { x: 0, y: 0, width: 1920, height: 1080 },
+        shots: [
           {
-            id: "camera-001",
+            id: "shot-001",
             startMs: 1_000,
             endMs: 4_000,
-            scale: 1.5,
-            focuses: [
+            baseZoom: 1.5,
+            keys: [
               {
-                id: "camera-001-focus-001",
+                id: "shot-001-key-001",
                 startMs: 1_000,
-                x: 0.5,
-                y: 0.5,
+                durationMs: 800,
+                rect: { x: 320, y: 180, width: 1280 },
+                reason: "zoom in on click at 1800 ms",
+                clickMs: 1_800,
               },
             ],
           },
@@ -374,8 +385,8 @@ describe("okou video camera command", () => {
       "crop@camera w 1280.000000",
     );
     const unchangedPlan = JSON.parse(readFileSync(planPath, "utf8")) as {
-      ranges: { scale: number }[];
+      shots: { baseZoom: number }[];
     };
-    expect(unchangedPlan.ranges[0]?.scale).toBe(1.5);
+    expect(unchangedPlan.shots[0]?.baseZoom).toBe(1.5);
   });
 });

--- a/turbo/apps/cli/src/commands/video/camera-plan.ts
+++ b/turbo/apps/cli/src/commands/video/camera-plan.ts
@@ -1,29 +1,103 @@
 import { z } from "zod";
 
-const DEFAULT_ZOOM = 2;
-const EDGE_SNAP_RATIO = 0.25;
-const LEAD_IN_MS = 300;
-const HOLD_AFTER_CLICK_MS = 2_500;
-const TAIL_PADDING_MS = 800;
-const LAST_CLICK_PADDING_MS = 1_000;
-const MERGE_GAP_MS = 500;
-const MAX_GROUP_WIDTH = 0.25;
-const MAX_GROUP_HEIGHT = 0.35;
-const SPRING_MASS = 2.25;
-const SPRING_STIFFNESS = 200;
-const SPRING_DAMPING = 40;
-const SPRING_PRECISION = 0.002;
+/**
+ * Click-driven camera, second algorithm.
+ *
+ * The camera exists to show clicks and typing. Everything else about the
+ * pointer is used only to keep the picture calm:
+ *
+ * - A click pushes the camera in on what was clicked: the element the click
+ *   hit when the recording says what that was, else the point. The move is a
+ *   finite ease-in-out that ends on the click, so the click lands in a frame
+ *   that has already settled. After a click the camera stays put for a beat
+ *   before it may leave, and the one thing that must never happen, a click
+ *   outside the frame, is verified against the simulated camera and repaired
+ *   by starting a move earlier.
+ * - Between clicks the camera pulls back to the shot's base framing, which
+ *   fits every click of the shot, so the viewer keeps their bearings. A click
+ *   that changed the page around it pulls back early, so the viewer sees the
+ *   result rather than the spot that used to be a menu.
+ * - Typing keeps the camera on the field it was typed into.
+ * - Drags, jitter and a pointer parked outside the frame move nothing.
+ */
+
+const BASE_ZOOM_MAX = 2;
+const BASE_ZOOM_MIN = 1.5;
+const FOCUS_ZOOM = 2.2;
+/** Fraction of the viewport a click point must end up inside. */
+const COMFORT = 0.5;
+/** Viewport left around a framed element. */
+const ELEMENT_MARGIN = 0.08;
+/** An element larger than this share of the content is a container, not a target. */
+const ELEMENT_MAX_AREA = 0.6;
+const HOLD_MS = 2_200;
+const MERGE_GAP_MS = 6_000;
+const MIN_SHOT_MS = 2_500;
+const KEEP_TO_END_MS = 1_500;
+const ZOOM_IN_MS = 800;
+const PUSH_MS = 650;
+const PULL_MS = 800;
+const ZOOM_OUT_MS = 1_000;
+/** Only pull back to the base framing when the next push-in is at least this far off. */
+const PULL_GAP_MS = 1_200;
+/** After a click the camera stays put this long before its next move. */
+const DWELL_MS = 700;
+/** A pointer at rest on the target this long before the click lets the camera arrive early. */
+const EARLY_ARRIVAL_MS = 300;
+const ARRIVAL_RADIUS_PX = 60;
+const SMOOTH_WINDOW_MS = 100;
+/** A burst shorter than this is a shortcut, not typing. */
+const TYPING_MIN_MS = 1_000;
+/** Share of pixels that changed after a click for the page to count as changed. */
+const REACTION_LOCAL = 0.12;
+const REACTION_PAGE = 0.35;
+const REACTION_RELEASE_MS = 300;
+/** A click must sit at least this far inside the frame at its own moment. */
+const CLICK_MARGIN = 0.06;
+const MAX_REPAIR_ROUNDS = 20;
+
+const FRAMED_ROLES = new Set([
+  "AXTextField",
+  "AXTextArea",
+  "AXComboBox",
+  "AXSearchField",
+  "AXButton",
+  "AXPopUpButton",
+  "AXMenuButton",
+  "AXMenuItem",
+  "AXCheckBox",
+  "AXRadioButton",
+  "AXLink",
+  "AXTab",
+  "AXCell",
+  "AXRow",
+]);
 
 const normalizedPointSchema = z.object({
   x: z.number().min(0).max(1),
   y: z.number().min(0).max(1),
 });
 
+const normalizedRectSchema = z.object({
+  x: z.number().min(0).max(1),
+  y: z.number().min(0).max(1),
+  width: z.number().min(0).max(1),
+  height: z.number().min(0).max(1),
+});
+
+const clickElementSchema = z
+  .object({
+    role: z.string(),
+    normalized: normalizedRectSchema,
+  })
+  .passthrough();
+
 const trackedPointerEventSchema = z
   .object({
     tMs: z.number().int().nonnegative(),
     kind: z.enum(["click", "move"]),
     normalized: normalizedPointSchema,
+    element: clickElementSchema.optional(),
   })
   .passthrough();
 
@@ -31,8 +105,21 @@ const trackedClickSchema = z
   .object({
     tMs: z.number().int().nonnegative(),
     normalized: normalizedPointSchema,
+    element: clickElementSchema.optional(),
   })
   .passthrough();
+
+const typingBurstSchema = z.object({
+  startMs: z.number().int().nonnegative(),
+  endMs: z.number().int().nonnegative(),
+});
+
+const pixelRectSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  width: z.number().positive(),
+  height: z.number().positive(),
+});
 
 const desktopInputTrackSchema = z
   .object({
@@ -47,10 +134,15 @@ const desktopInputTrackSchema = z
             frameRate: z.number().positive(),
           })
           .passthrough(),
+        content: z
+          .object({ pixelRect: pixelRectSchema.optional() })
+          .passthrough()
+          .optional(),
       })
       .passthrough(),
     clicks: z.array(trackedClickSchema).default([]),
     pointerEvents: z.array(trackedPointerEventSchema).optional(),
+    typingBursts: z.array(typingBurstSchema).optional(),
   })
   .passthrough();
 
@@ -88,75 +180,78 @@ const demoPointerSampleSchema = z
   })
   .passthrough();
 
-const cameraFocusSchema = z.object({
-  id: z.string().min(1),
-  startMs: z.number().int().nonnegative(),
-  x: z.number().min(0).max(1),
-  y: z.number().min(0).max(1),
+const viewportSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  width: z.number().positive(),
 });
 
-const cameraRangeSchema = z
+const cameraKeySchema = z.object({
+  id: z.string().min(1),
+  startMs: z.number().int(),
+  durationMs: z.number().int().positive(),
+  rect: viewportSchema,
+  reason: z.string(),
+  clickMs: z.number().int().nonnegative().optional(),
+});
+
+const cameraShotSchema = z
   .object({
     id: z.string().min(1),
     startMs: z.number().int().nonnegative(),
     endMs: z.number().int().positive(),
-    scale: z.number().min(1).max(4),
-    focuses: z.array(cameraFocusSchema).min(1),
+    baseZoom: z.number().min(1).max(4),
+    keys: z.array(cameraKeySchema).min(1),
   })
   .refine(
-    (range) => {
-      return range.endMs > range.startMs;
+    (shot) => {
+      return shot.endMs > shot.startMs;
     },
-    {
-      message: "Camera range endMs must be greater than startMs",
-    },
+    { message: "Camera shot endMs must be greater than startMs" },
   );
 
 export const cameraPlanSchema = z
   .object({
-    version: z.literal(1),
-    algorithm: z.literal("screen-studio-compatible-v1"),
+    version: z.literal(2),
+    algorithm: z.literal("click-camera-v2"),
     source: z.object({
       durationMs: z.number().int().positive(),
       width: z.number().int().positive(),
       height: z.number().int().positive(),
       frameRate: z.number().positive().max(240),
     }),
-    ranges: z.array(cameraRangeSchema),
+    content: pixelRectSchema,
+    shots: z.array(cameraShotSchema),
   })
   .superRefine((plan, context) => {
     let previousEndMs = 0;
-    for (const [rangeIndex, range] of plan.ranges.entries()) {
-      if (range.startMs < previousEndMs) {
+    for (const [shotIndex, shot] of plan.shots.entries()) {
+      if (shot.startMs < previousEndMs) {
         context.addIssue({
           code: "custom",
-          path: ["ranges", rangeIndex, "startMs"],
-          message: "Camera ranges must be ordered and must not overlap",
+          path: ["shots", shotIndex, "startMs"],
+          message: "Camera shots must be ordered and must not overlap",
         });
       }
-      if (range.endMs > plan.source.durationMs) {
+      if (shot.endMs > plan.source.durationMs) {
         context.addIssue({
           code: "custom",
-          path: ["ranges", rangeIndex, "endMs"],
-          message: "Camera range exceeds the source duration",
+          path: ["shots", shotIndex, "endMs"],
+          message: "Camera shot exceeds the source duration",
         });
       }
-      let previousFocusMs = range.startMs;
-      for (const [focusIndex, focus] of range.focuses.entries()) {
-        if (
-          focus.startMs < range.startMs ||
-          focus.startMs >= range.endMs ||
-          focus.startMs < previousFocusMs
-        ) {
+      let previousKeyMs = Number.NEGATIVE_INFINITY;
+      for (const [keyIndex, key] of shot.keys.entries()) {
+        if (key.startMs < previousKeyMs) {
           context.addIssue({
             code: "custom",
-            path: ["ranges", rangeIndex, "focuses", focusIndex, "startMs"],
-            message: "Camera focuses must be ordered and inside their range",
+            path: ["shots", shotIndex, "keys", keyIndex, "startMs"],
+            message: "Camera keys must be ordered inside their shot",
           });
         }
-        previousFocusMs = focus.startMs;
+        previousKeyMs = key.startMs;
       }
-      previousEndMs = range.endMs;
+      previousEndMs = shot.endMs;
     }
   });
 
@@ -172,6 +267,24 @@ export interface VideoSource {
   readonly frameRate: number;
 }
 
+export interface PixelRect {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+/**
+ * What the command learned from the video itself before planning: where the
+ * content sits (a letterbox band is not content) and how much the picture
+ * changed right after each click.
+ */
+export interface SourceAnalysis {
+  readonly contentRect: PixelRect | null;
+  /** Click time in ms to the share of pixels that changed within 400 ms of it. */
+  readonly reactions: ReadonlyMap<number, number>;
+}
+
 export interface CameraFrameState {
   readonly timeMs: number;
   readonly scale: number;
@@ -181,6 +294,12 @@ export interface CameraFrameState {
   readonly cropY: number;
 }
 
+interface Viewport {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+}
+
 interface PointerSample {
   readonly tMs: number;
   readonly kind: "click" | "move";
@@ -188,33 +307,30 @@ interface PointerSample {
   readonly y: number;
 }
 
-interface CameraWindow {
-  readonly startMs: number;
-  readonly endMs: number;
+interface ClickTarget {
+  readonly tMs: number;
+  readonly x: number;
+  readonly y: number;
+  readonly element: PixelRect | null;
+  readonly elementRole: string | null;
 }
 
-interface PointerGroup {
-  count: number;
-  firstMs: number;
-  maximumX: number;
-  maximumY: number;
-  minimumX: number;
-  minimumY: number;
-  totalX: number;
-  totalY: number;
+interface PlannedKey {
+  startMs: number;
+  readonly rect: Viewport;
+  readonly durationMs: number;
+  readonly reason: string;
+  readonly click: ClickTarget | null;
+  /** When the camera may leave this key's framing. */
+  releaseMs: number;
 }
 
-interface CameraTarget {
-  readonly key: string;
-  readonly scale: number;
-  readonly translationX: number;
-  readonly translationY: number;
-}
-
-interface CameraTransform {
-  readonly scale: number;
-  readonly translationX: number;
-  readonly translationY: number;
+interface PlannedShot {
+  readonly clicks: ClickTarget[];
+  startMs: number;
+  endMs: number;
+  baseZoom: number;
+  keys: PlannedKey[];
 }
 
 function isDemoCaptureTrack(track: InputTrack): track is DemoCaptureTrack {
@@ -309,102 +425,689 @@ export function inputTrackVideoSource(track: InputTrack): VideoSource {
   };
 }
 
-function cameraWindows(
-  samples: readonly PointerSample[],
-  durationMs: number,
-): readonly CameraWindow[] {
-  const candidates = samples
-    .filter((sample) => {
-      return (
-        sample.kind === "click" &&
-        sample.tMs < durationMs - LAST_CLICK_PADDING_MS
-      );
-    })
-    .map((sample) => {
-      return {
-        startMs: Math.max(1, sample.tMs - LEAD_IN_MS),
-        endMs: Math.min(
-          durationMs - TAIL_PADDING_MS,
-          sample.tMs + HOLD_AFTER_CLICK_MS,
-        ),
-      };
-    })
-    .filter((window) => {
-      return window.endMs > window.startMs;
-    });
-
-  const merged: CameraWindow[] = [];
-  for (const candidate of candidates) {
-    const previous = merged.at(-1);
-    if (previous && candidate.startMs - previous.endMs <= MERGE_GAP_MS) {
-      merged[merged.length - 1] = {
-        startMs: previous.startMs,
-        endMs: Math.max(previous.endMs, candidate.endMs),
-      };
-    } else {
-      merged.push(candidate);
-    }
+function trackTypingBursts(
+  track: InputTrack,
+): readonly { readonly startMs: number; readonly endMs: number }[] {
+  if (isDemoCaptureTrack(track)) {
+    return [];
   }
-  return merged;
+  return (track.typingBursts ?? [])
+    .filter((burst) => {
+      return burst.endMs - burst.startMs >= TYPING_MIN_MS;
+    })
+    .sort((left, right) => {
+      return left.startMs - right.startMs;
+    });
 }
 
-function pointerGroup(sample: PointerSample): PointerGroup {
+function trackContentRect(track: InputTrack): PixelRect | null {
+  if (isDemoCaptureTrack(track)) {
+    return null;
+  }
+  return track.recording.content?.pixelRect ?? null;
+}
+
+function clickTargets(
+  track: InputTrack,
+  source: VideoSource,
+  content: PixelRect,
+): readonly ClickTarget[] {
+  const elementsByTime = new Map<
+    number,
+    { readonly role: string; readonly rect: PixelRect }
+  >();
+  if (!isDemoCaptureTrack(track)) {
+    const carriers = [
+      ...track.clicks,
+      ...(track.pointerEvents ?? []).filter((event) => {
+        return event.kind === "click";
+      }),
+    ];
+    for (const carrier of carriers) {
+      const element = carrier.element;
+      if (!element || !FRAMED_ROLES.has(element.role)) {
+        continue;
+      }
+      const rect = {
+        x: element.normalized.x * source.width,
+        y: element.normalized.y * source.height,
+        width: element.normalized.width * source.width,
+        height: element.normalized.height * source.height,
+      };
+      const share =
+        (rect.width * rect.height) / (content.width * content.height);
+      if (rect.width < 8 || rect.height < 8 || share > ELEMENT_MAX_AREA) {
+        continue;
+      }
+      elementsByTime.set(carrier.tMs, { role: element.role, rect });
+    }
+  }
+  return samplesFromTrack(track)
+    .filter((sample) => {
+      return sample.kind === "click" && sample.tMs <= source.durationMs;
+    })
+    .map((sample) => {
+      const element = elementsByTime.get(sample.tMs) ?? null;
+      return {
+        tMs: sample.tMs,
+        x: sample.x * source.width,
+        y: sample.y * source.height,
+        element: element?.rect ?? null,
+        elementRole: element?.role ?? null,
+      };
+    });
+}
+
+/** The pointer's path with the jitter taken out: a short median in time. */
+function smoothedTrail(
+  samples: readonly PointerSample[],
+  source: VideoSource,
+): readonly { readonly tMs: number; readonly x: number; readonly y: number }[] {
+  const moves = samples.filter((sample) => {
+    return sample.kind === "move";
+  });
+  const median = (values: number[]): number => {
+    const sorted = values.slice().sort((left, right) => {
+      return left - right;
+    });
+    return sorted[Math.floor(sorted.length / 2)] ?? 0;
+  };
+  return moves.map((move, index) => {
+    const xs: number[] = [];
+    const ys: number[] = [];
+    for (
+      let other = index;
+      other >= 0 && move.tMs - (moves[other]?.tMs ?? 0) <= SMOOTH_WINDOW_MS / 2;
+      other -= 1
+    ) {
+      const sample = moves[other];
+      if (sample) {
+        xs.push(sample.x * source.width);
+        ys.push(sample.y * source.height);
+      }
+    }
+    for (
+      let other = index + 1;
+      other < moves.length &&
+      (moves[other]?.tMs ?? 0) - move.tMs <= SMOOTH_WINDOW_MS / 2;
+      other += 1
+    ) {
+      const sample = moves[other];
+      if (sample) {
+        xs.push(sample.x * source.width);
+        ys.push(sample.y * source.height);
+      }
+    }
+    return { tMs: move.tMs, x: median(xs), y: median(ys) };
+  });
+}
+
+class CameraGeometry {
+  constructor(
+    readonly source: VideoSource,
+    readonly content: PixelRect,
+  ) {}
+
+  height(width: number): number {
+    return (width * this.source.height) / this.source.width;
+  }
+
+  /**
+   * Keeps a viewport inside the content area, continuously. A viewport wider
+   * than the content sits at its left edge; there is no separate frame-sized
+   * regime, because switching regimes as the width crossed the content width
+   * made the viewport reverse for one frame mid zoom.
+   */
+  clamp(viewport: Viewport): Viewport {
+    const width = Math.min(
+      Math.max(viewport.width, this.source.width / 4),
+      this.source.width,
+    );
+    const height = this.height(width);
+    const maxX = this.content.x + Math.max(0, this.content.width - width);
+    const maxY = this.content.y + Math.max(0, this.content.height - height);
+    return {
+      x: Math.min(Math.max(viewport.x, this.content.x), maxX),
+      y: Math.min(Math.max(viewport.y, this.content.y), maxY),
+      width,
+    };
+  }
+
+  /**
+   * The wide shot is the content area itself, not the whole frame: with every
+   * target inside the content area, a straight interpolation between any two
+   * of them stays inside it, so no frame of a move ever needs clamping and a
+   * letterbox band never appears.
+   */
+  wide(): Viewport {
+    const width = Math.min(
+      this.content.width,
+      (this.content.height * this.source.width) / this.source.height,
+    );
+    return this.clamp({
+      x: this.content.x,
+      y: this.content.y + (this.content.height - this.height(width)) / 2,
+      width,
+    });
+  }
+
+  centered(x: number, y: number, width: number): Viewport {
+    return this.clamp({
+      x: x - width / 2,
+      y: y - this.height(width) / 2,
+      width,
+    });
+  }
+
+  focus(click: ClickTarget): Viewport {
+    let width = this.source.width / FOCUS_ZOOM;
+    if (click.element) {
+      const element = click.element;
+      width = Math.min(
+        this.content.width,
+        Math.max(
+          width,
+          element.width / (1 - 2 * ELEMENT_MARGIN),
+          ((element.height / (1 - 2 * ELEMENT_MARGIN)) * this.source.width) /
+            this.source.height,
+        ),
+      );
+      return this.centered(
+        element.x + element.width / 2,
+        element.y + element.height / 2,
+        width,
+      );
+    }
+    return this.centered(click.x, click.y, width);
+  }
+
+  base(shot: PlannedShot): Viewport {
+    const xs = shot.clicks.map((click) => {
+      return click.x;
+    });
+    const ys = shot.clicks.map((click) => {
+      return click.y;
+    });
+    return this.centered(
+      (Math.min(...xs) + Math.max(...xs)) / 2,
+      (Math.min(...ys) + Math.max(...ys)) / 2,
+      this.source.width / shot.baseZoom,
+    );
+  }
+
+  fitZoom(clicks: readonly ClickTarget[]): number {
+    const xs = clicks.map((click) => {
+      return click.x;
+    });
+    const ys = clicks.map((click) => {
+      return click.y;
+    });
+    const spreadX = Math.max(...xs) - Math.min(...xs);
+    const spreadY = Math.max(...ys) - Math.min(...ys);
+    const zoom = Math.min(
+      this.source.width / Math.max(spreadX / COMFORT, 1),
+      this.source.height / Math.max(spreadY / COMFORT, 1),
+      BASE_ZOOM_MAX,
+    );
+    return Math.max(BASE_ZOOM_MIN, zoom);
+  }
+
+  contains(viewport: Viewport, x: number, y: number, margin: number): boolean {
+    const height = this.height(viewport.width);
+    const marginPx = viewport.width * margin;
+    return (
+      x >= viewport.x + marginPx &&
+      x <= viewport.x + viewport.width - marginPx &&
+      y >= viewport.y + marginPx &&
+      y <= viewport.y + height - marginPx
+    );
+  }
+}
+
+function sameViewport(left: Viewport, right: Viewport): boolean {
+  return (
+    Math.abs(left.x - right.x) < 1 &&
+    Math.abs(left.y - right.y) < 1 &&
+    Math.abs(left.width - right.width) < 1
+  );
+}
+
+function arrivalMs(
+  click: ClickTarget,
+  trail: readonly {
+    readonly tMs: number;
+    readonly x: number;
+    readonly y: number;
+  }[],
+): number {
+  let arrival = click.tMs;
+  for (let index = trail.length - 1; index >= 0; index -= 1) {
+    const sample = trail[index];
+    if (!sample || sample.tMs > click.tMs) {
+      continue;
+    }
+    if (
+      Math.hypot(sample.x - click.x, sample.y - click.y) <= ARRIVAL_RADIUS_PX
+    ) {
+      arrival = sample.tMs;
+    } else {
+      break;
+    }
+  }
+  return arrival;
+}
+
+function typingEndAfter(
+  bursts: readonly { readonly startMs: number; readonly endMs: number }[],
+  fromMs: number,
+  untilMs: number,
+): number | null {
+  let end: number | null = null;
+  for (const burst of bursts) {
+    if (burst.startMs >= fromMs && burst.startMs < untilMs) {
+      end = Math.max(end ?? 0, burst.endMs);
+    }
+  }
+  return end;
+}
+
+function groupShots(
+  clicks: readonly ClickTarget[],
+  bursts: readonly { readonly startMs: number; readonly endMs: number }[],
+  durationMs: number,
+): PlannedShot[] {
+  const shots: PlannedShot[] = [];
+  for (const click of clicks) {
+    const last = shots.at(-1);
+    const lastClick = last?.clicks.at(-1);
+    if (last && lastClick && click.tMs - lastClick.tMs <= MERGE_GAP_MS) {
+      last.clicks.push(click);
+    } else {
+      shots.push({
+        clicks: [click],
+        startMs: 0,
+        endMs: 0,
+        baseZoom: 1,
+        keys: [],
+      });
+    }
+  }
+  for (const shot of shots) {
+    const lastClick = shot.clicks.at(-1);
+    if (!lastClick) {
+      continue;
+    }
+    shot.endMs = lastClick.tMs + HOLD_MS;
+    const typedUntil = typingEndAfter(
+      bursts,
+      lastClick.tMs,
+      shot.endMs + 1_500,
+    );
+    if (typedUntil !== null) {
+      shot.endMs = Math.max(shot.endMs, typedUntil + HOLD_MS);
+    }
+    if (shot.endMs >= durationMs - KEEP_TO_END_MS) {
+      shot.endMs = durationMs;
+    }
+    shot.startMs = Math.max(0, (shot.clicks[0]?.tMs ?? 0) - ZOOM_IN_MS);
+  }
+  const merged: PlannedShot[] = [];
+  for (const shot of shots) {
+    const previous = merged.at(-1);
+    if (
+      previous &&
+      (shot.endMs - shot.startMs < MIN_SHOT_MS ||
+        shot.startMs - previous.endMs < 3_500)
+    ) {
+      previous.clicks.push(...shot.clicks);
+      previous.endMs = shot.endMs;
+    } else {
+      merged.push(shot);
+    }
+  }
+  return merged.map((shot) => {
+    return { ...shot, endMs: Math.min(shot.endMs, durationMs) };
+  });
+}
+
+type Trail = readonly {
+  readonly tMs: number;
+  readonly x: number;
+  readonly y: number;
+}[];
+type TypingBursts = readonly {
+  readonly startMs: number;
+  readonly endMs: number;
+}[];
+
+function describeClick(click: ClickTarget): string {
+  return click.elementRole
+    ? `click at ${String(click.tMs)} ms on ${click.elementRole}`
+    : `click at ${String(click.tMs)} ms`;
+}
+
+/** When a move for this click should be done: on the click, or a beat after the pointer settled early on it. */
+function moveEndMs(click: ClickTarget, trail: Trail): number {
+  const arrival = arrivalMs(click, trail);
+  return click.tMs - arrival >= EARLY_ARRIVAL_MS ? arrival + 150 : click.tMs;
+}
+
+function pushInKey(args: {
+  readonly click: ClickTarget;
+  readonly index: number;
+  readonly next: ClickTarget | null;
+  readonly previous: PlannedKey | undefined;
+  readonly rect: Viewport;
+  readonly trail: Trail;
+  readonly bursts: TypingBursts;
+  readonly reaction: number;
+  readonly durationMs: number;
+}): PlannedKey {
+  const { click, index, next, previous, rect, trail, bursts, reaction } = args;
+  const endMs = moveEndMs(click, trail);
+  let startMs = endMs - args.durationMs;
+  if (previous) {
+    startMs = Math.max(startMs, previous.releaseMs);
+  }
+  let releaseMs = click.tMs + DWELL_MS;
+  const typedUntil = typingEndAfter(
+    bursts,
+    click.tMs,
+    next ? next.tMs : args.durationMs + Number.MAX_SAFE_INTEGER / 2,
+  );
+  if (typedUntil !== null) {
+    releaseMs = Math.max(releaseMs, typedUntil + DWELL_MS);
+  } else if (reaction >= REACTION_LOCAL) {
+    releaseMs = Math.min(releaseMs, click.tMs + REACTION_RELEASE_MS);
+  }
+  const lateMs = startMs + args.durationMs - click.tMs;
+  const verb = index === 0 ? "zoom in" : "push in";
   return {
-    count: 1,
-    firstMs: sample.tMs,
-    maximumX: sample.x,
-    maximumY: sample.y,
-    minimumX: sample.x,
-    minimumY: sample.y,
-    totalX: sample.x,
-    totalY: sample.y,
+    startMs,
+    rect,
+    durationMs: args.durationMs,
+    reason:
+      `${verb} on ${describeClick(click)}` +
+      (lateMs > 0 ? `, arriving ${String(lateMs)} ms after it` : "") +
+      (typedUntil !== null
+        ? `, holding through typing until ${String(typedUntil)} ms`
+        : ""),
+    click,
+    releaseMs,
   };
 }
 
-function focusGroups(
-  samples: readonly PointerSample[],
-  window: CameraWindow,
-  rangeIndex: number,
-): CameraPlan["ranges"][number]["focuses"] {
-  const inWindow = samples.filter((sample) => {
-    return sample.tMs >= window.startMs && sample.tMs < window.endMs;
-  });
-  const groups: PointerGroup[] = [];
-
-  for (const sample of inWindow) {
-    const current = groups.at(-1);
-    if (!current) {
-      groups.push(pointerGroup(sample));
-      continue;
-    }
-    const minimumX = Math.min(current.minimumX, sample.x);
-    const maximumX = Math.max(current.maximumX, sample.x);
-    const minimumY = Math.min(current.minimumY, sample.y);
-    const maximumY = Math.max(current.maximumY, sample.y);
-    if (
-      maximumX - minimumX <= MAX_GROUP_WIDTH &&
-      maximumY - minimumY <= MAX_GROUP_HEIGHT
-    ) {
-      current.count += 1;
-      current.maximumX = maximumX;
-      current.maximumY = maximumY;
-      current.minimumX = minimumX;
-      current.minimumY = minimumY;
-      current.totalX += sample.x;
-      current.totalY += sample.y;
-    } else {
-      groups.push(pointerGroup(sample));
-    }
+function pullBackKey(args: {
+  readonly click: ClickTarget;
+  readonly from: PlannedKey;
+  readonly next: ClickTarget | null;
+  readonly base: Viewport;
+  readonly wide: Viewport;
+  readonly trail: Trail;
+  readonly reaction: number;
+  readonly shotEndMs: number;
+}): PlannedKey | null {
+  const { click, from, next, reaction } = args;
+  const pageChanged = reaction >= REACTION_PAGE;
+  const target = pageChanged ? args.wide : args.base;
+  const nextStartMs = next
+    ? Math.max(moveEndMs(next, args.trail) - PUSH_MS, from.releaseMs)
+    : null;
+  const farEnough =
+    nextStartMs === null || nextStartMs - from.releaseMs >= PULL_GAP_MS;
+  if ((!farEnough && !pageChanged) || sameViewport(target, from.rect)) {
+    return null;
   }
+  if (next === null && from.releaseMs + PULL_MS >= args.shotEndMs) {
+    return null;
+  }
+  const reason = pageChanged
+    ? `pull back to the wide shot: the page changed after the ${describeClick(click)}`
+    : reaction >= REACTION_LOCAL
+      ? `pull back early: the picture changed after the ${describeClick(click)}`
+      : `pull back to the base framing after the ${describeClick(click)}`;
+  return {
+    startMs: from.releaseMs,
+    rect: target,
+    durationMs: PULL_MS,
+    reason,
+    click: null,
+    releaseMs: from.releaseMs + PULL_MS,
+  };
+}
 
-  return groups.map((group, focusIndex) => {
+function planKeys(
+  shot: PlannedShot,
+  geometry: CameraGeometry,
+  trail: Trail,
+  bursts: TypingBursts,
+  reactions: ReadonlyMap<number, number>,
+): PlannedKey[] {
+  const base = geometry.base(shot);
+  const wide = geometry.wide();
+  const keys: PlannedKey[] = [];
+  shot.clicks.forEach((click, index) => {
+    const next = shot.clicks[index + 1] ?? null;
+    const previous = keys.at(-1);
+    const rect = geometry.focus(click);
+    if (previous?.click && sameViewport(rect, previous.rect)) {
+      previous.releaseMs = Math.max(previous.releaseMs, click.tMs + DWELL_MS);
+      return;
+    }
+    const reaction = reactions.get(click.tMs) ?? 0;
+    const pushIn = pushInKey({
+      click,
+      index,
+      next,
+      previous,
+      rect,
+      trail,
+      bursts,
+      reaction,
+      durationMs: index === 0 ? ZOOM_IN_MS : PUSH_MS,
+    });
+    keys.push(pushIn);
+    const pullBack = pullBackKey({
+      click,
+      from: pushIn,
+      next,
+      base,
+      wide,
+      trail,
+      reaction,
+      shotEndMs: shot.endMs,
+    });
+    if (pullBack) {
+      keys.push(pullBack);
+    }
+  });
+  return keys;
+}
+
+/** Zero velocity and acceleration at both ends; the move has a clear start and stop. */
+function ease(progress: number): number {
+  const clamped = Math.min(1, Math.max(0, progress));
+  return clamped * clamped * clamped * (clamped * (clamped * 6 - 15) + 10);
+}
+
+function simulate(
+  shots: readonly PlannedShot[],
+  geometry: CameraGeometry,
+  source: VideoSource,
+): readonly CameraFrameState[] {
+  const frameMs = 1_000 / source.frameRate;
+  const frameCount = Math.max(
+    1,
+    Math.ceil((source.durationMs / 1_000) * source.frameRate),
+  );
+  const wide = geometry.wide();
+  const frames: CameraFrameState[] = [];
+  let current = wide;
+  let move: {
+    readonly startMs: number;
+    readonly from: Viewport;
+    readonly to: Viewport;
+    readonly durationMs: number;
+  } | null = null;
+  let activeId: string | null = null;
+
+  for (let frameIndex = 0; frameIndex < frameCount; frameIndex += 1) {
+    const timeMs = frameIndex * frameMs;
+    const shotIndex = shots.findIndex((shot) => {
+      return shot.startMs <= timeMs && timeMs < shot.endMs;
+    });
+    const shot = shots[shotIndex];
+    let wanted: {
+      readonly id: string;
+      readonly rect: Viewport;
+      readonly durationMs: number;
+      readonly startMs: number;
+    };
+    if (shot) {
+      const active = shot.keys.filter((key) => {
+        return key.startMs <= timeMs;
+      });
+      const key = active.at(-1);
+      wanted = key
+        ? {
+            id: `shot-${String(shotIndex)}-key-${String(shot.keys.indexOf(key))}`,
+            rect: key.rect,
+            durationMs: key.durationMs,
+            startMs: key.startMs,
+          }
+        : {
+            id: `shot-${String(shotIndex)}-wide`,
+            rect: wide,
+            durationMs: ZOOM_OUT_MS,
+            startMs: shot.startMs,
+          };
+    } else {
+      let previousIndex = -1;
+      for (let index = shots.length - 1; index >= 0; index -= 1) {
+        if ((shots[index]?.endMs ?? Number.POSITIVE_INFINITY) <= timeMs) {
+          previousIndex = index;
+          break;
+        }
+      }
+      const previous = shots[previousIndex];
+      wanted = {
+        id: previous ? `after-shot-${String(previousIndex)}` : "idle",
+        rect: wide,
+        durationMs: ZOOM_OUT_MS,
+        startMs: previous?.endMs ?? 0,
+      };
+    }
+    if (wanted.id !== activeId) {
+      activeId = wanted.id;
+      if (!sameViewport(wanted.rect, current)) {
+        move = {
+          startMs: Math.max(wanted.startMs, timeMs - frameMs),
+          from: current,
+          to: wanted.rect,
+          durationMs: wanted.durationMs,
+        };
+      }
+    }
+    if (move) {
+      const progress = (timeMs - move.startMs) / move.durationMs;
+      const eased = ease(progress);
+      current = {
+        x: move.from.x + (move.to.x - move.from.x) * eased,
+        y: move.from.y + (move.to.y - move.from.y) * eased,
+        width: move.from.width + (move.to.width - move.from.width) * eased,
+      };
+      if (progress >= 1) {
+        current = move.to;
+        move = null;
+      }
+    }
+    const viewport = geometry.clamp(current);
+    frames.push({
+      timeMs,
+      scale: source.width / viewport.width,
+      cropWidth: viewport.width,
+      cropHeight: geometry.height(viewport.width),
+      cropX: viewport.x,
+      cropY: viewport.y,
+    });
+  }
+  return frames;
+}
+
+function frameAt(
+  frames: readonly CameraFrameState[],
+  timeMs: number,
+  frameRate: number,
+): CameraFrameState | undefined {
+  const index = Math.min(
+    frames.length - 1,
+    Math.max(0, Math.round((timeMs / 1_000) * frameRate)),
+  );
+  return frames[index];
+}
+
+function clickInFrame(
+  frames: readonly CameraFrameState[],
+  click: ClickTarget,
+  source: VideoSource,
+  margin: number,
+): boolean {
+  const frame = frameAt(frames, click.tMs, source.frameRate);
+  if (!frame) {
+    return false;
+  }
+  const marginPx = frame.cropWidth * margin;
+  return (
+    click.x >= frame.cropX + marginPx &&
+    click.x <= frame.cropX + frame.cropWidth - marginPx &&
+    click.y >= frame.cropY + marginPx &&
+    click.y <= frame.cropY + frame.cropHeight - marginPx
+  );
+}
+
+function toPlanShots(shots: readonly PlannedShot[]): CameraPlan["shots"] {
+  return shots.map((shot, shotIndex) => {
+    const id = `shot-${String(shotIndex + 1).padStart(3, "0")}`;
     return {
-      id: `camera-${String(rangeIndex + 1).padStart(3, "0")}-focus-${String(
-        focusIndex + 1,
-      ).padStart(3, "0")}`,
-      startMs: focusIndex === 0 ? window.startMs : group.firstMs,
-      x: group.totalX / group.count,
-      y: group.totalY / group.count,
+      id,
+      startMs: Math.round(shot.startMs),
+      endMs: Math.round(shot.endMs),
+      baseZoom: shot.baseZoom,
+      keys: shot.keys.map((key, keyIndex) => {
+        return {
+          id: `${id}-key-${String(keyIndex + 1).padStart(3, "0")}`,
+          startMs: Math.round(key.startMs),
+          durationMs: key.durationMs,
+          rect: {
+            x: Math.round(key.rect.x * 1_000) / 1_000,
+            y: Math.round(key.rect.y * 1_000) / 1_000,
+            width: Math.round(key.rect.width * 1_000) / 1_000,
+          },
+          reason: key.reason,
+          ...(key.click ? { clickMs: key.click.tMs } : {}),
+        };
+      }),
+    };
+  });
+}
+
+function fromPlanShots(plan: CameraPlan): PlannedShot[] {
+  return plan.shots.map((shot) => {
+    return {
+      clicks: [],
+      startMs: shot.startMs,
+      endMs: shot.endMs,
+      baseZoom: shot.baseZoom,
+      keys: shot.keys.map((key) => {
+        return {
+          startMs: key.startMs,
+          rect: key.rect,
+          durationMs: key.durationMs,
+          reason: key.reason,
+          click: null,
+          releaseMs: key.startMs + key.durationMs,
+        };
+      }),
     };
   });
 }
@@ -412,6 +1115,7 @@ function focusGroups(
 export function createCameraPlan(
   track: InputTrack,
   source: VideoSource,
+  analysis: SourceAnalysis,
 ): CameraPlan {
   const describedSource = inputTrackVideoSource(track);
   if (
@@ -424,181 +1128,70 @@ export function createCameraPlan(
     throw new Error("Pointer events do not match the source video duration");
   }
 
-  const samples = samplesFromTrack(track).filter((sample) => {
-    return sample.tMs <= source.durationMs;
-  });
-  const ranges = cameraWindows(samples, source.durationMs).map(
-    (window, rangeIndex) => {
-      return {
-        id: `camera-${String(rangeIndex + 1).padStart(3, "0")}`,
-        startMs: window.startMs,
-        endMs: window.endMs,
-        scale: DEFAULT_ZOOM,
-        focuses: focusGroups(samples, window, rangeIndex),
-      };
-    },
-  );
-
-  return cameraPlanSchema.parse({
-    version: 1,
-    algorithm: "screen-studio-compatible-v1",
-    source,
-    ranges,
-  });
-}
-
-function snappedPosition(position: number): number {
-  if (position < EDGE_SNAP_RATIO) {
-    return 0;
+  const content: PixelRect = trackContentRect(track) ??
+    analysis.contentRect ?? {
+      x: 0,
+      y: 0,
+      width: source.width,
+      height: source.height,
+    };
+  const geometry = new CameraGeometry(source, content);
+  const samples = samplesFromTrack(track);
+  const trail = smoothedTrail(samples, source);
+  const bursts = trackTypingBursts(track);
+  const clicks = clickTargets(track, source, content);
+  const shots = groupShots(clicks, bursts, source.durationMs);
+  for (const shot of shots) {
+    shot.baseZoom = geometry.fitZoom(shot.clicks);
+    shot.keys = planKeys(shot, geometry, trail, bursts, analysis.reactions);
+    const firstKey = shot.keys[0];
+    if (firstKey) {
+      shot.startMs = Math.max(0, Math.min(shot.startMs, firstKey.startMs));
+    }
   }
-  if (position > 1 - EDGE_SNAP_RATIO) {
-    return 1;
-  }
-  return position;
-}
 
-function targetAt(plan: CameraPlan, timeMs: number): CameraTarget {
-  const range = plan.ranges.find((candidate) => {
-    return timeMs >= candidate.startMs && timeMs < candidate.endMs;
-  });
-  if (!range) {
-    return { key: "full-frame", scale: 1, translationX: 0, translationY: 0 };
-  }
-  let focus: CameraPlan["ranges"][number]["focuses"][number] | undefined;
-  for (let index = range.focuses.length - 1; index >= 0; index -= 1) {
-    const candidate = range.focuses[index];
-    if (candidate && candidate.startMs <= timeMs) {
-      focus = candidate;
+  // The one thing that must not happen is a click outside the frame. Check
+  // every click against the simulated camera and start a late move earlier
+  // until its click sits comfortably inside.
+  for (let round = 0; round < MAX_REPAIR_ROUNDS; round += 1) {
+    const frames = simulate(shots, geometry, source);
+    let repaired = false;
+    for (const shot of shots) {
+      for (const key of shot.keys) {
+        if (
+          key.click &&
+          !clickInFrame(frames, key.click, source, CLICK_MARGIN)
+        ) {
+          key.startMs -= 100;
+          shot.startMs = Math.max(0, Math.min(shot.startMs, key.startMs));
+          repaired = true;
+        }
+      }
+    }
+    if (!repaired) {
       break;
     }
   }
-  if (!focus) {
-    throw new Error(`Camera range ${range.id} has no focus`);
-  }
-  return {
-    key: `${range.id}:${focus.id}`,
-    scale: range.scale,
-    translationX:
-      -plan.source.width * (range.scale - 1) * snappedPosition(focus.x),
-    translationY:
-      -plan.source.height * (range.scale - 1) * snappedPosition(focus.y),
-  };
-}
 
-function springProgress(elapsedMs: number): number {
-  if (elapsedMs <= 0) {
-    return 0;
-  }
-  const seconds = elapsedMs / 1_000;
-  const naturalFrequency = Math.sqrt(SPRING_STIFFNESS / SPRING_MASS);
-  const decay = SPRING_DAMPING / (2 * SPRING_MASS);
-  const dampedFrequency = Math.sqrt(
-    Math.max(0, naturalFrequency * naturalFrequency - decay * decay),
-  );
-  const response =
-    dampedFrequency === 0
-      ? 1 - Math.exp(-decay * seconds) * (1 + decay * seconds)
-      : 1 -
-        Math.exp(-decay * seconds) *
-          (Math.cos(dampedFrequency * seconds) +
-            (decay / dampedFrequency) * Math.sin(dampedFrequency * seconds));
-  if (Math.abs(1 - response) < SPRING_PRECISION) {
-    return 1;
-  }
-  return Math.max(0, Math.min(1, response));
-}
-
-export function cameraTransitionMidpointMs(frameRate: number): number {
-  const maximumFrames = Math.ceil(frameRate * 2);
-  for (let frameIndex = 1; frameIndex <= maximumFrames; frameIndex += 1) {
-    const elapsedMs = (frameIndex * 1_000) / frameRate;
-    if (springProgress(elapsedMs) >= 0.5) {
-      return Math.round(elapsedMs);
-    }
-  }
-  return 250;
-}
-
-function interpolate(
-  from: CameraTransform,
-  to: CameraTarget,
-  progress: number,
-): CameraTransform {
-  return {
-    scale: from.scale + (to.scale - from.scale) * progress,
-    translationX:
-      from.translationX + (to.translationX - from.translationX) * progress,
-    translationY:
-      from.translationY + (to.translationY - from.translationY) * progress,
-  };
-}
-
-function commandNumber(value: number): string {
-  const rounded = Math.abs(value) < 0.000_000_5 ? 0 : value;
-  return rounded.toFixed(6);
+  return cameraPlanSchema.parse({
+    version: 2,
+    algorithm: "click-camera-v2",
+    source,
+    content,
+    shots: toPlanShots(shots),
+  });
 }
 
 export function createCameraFrameStates(
   plan: CameraPlan,
 ): readonly CameraFrameState[] {
-  const frameCount = Math.max(
-    1,
-    Math.ceil((plan.source.durationMs / 1_000) * plan.source.frameRate),
-  );
-  const initial: CameraTransform = {
-    scale: 1,
-    translationX: 0,
-    translationY: 0,
-  };
-  let activeTarget = targetAt(plan, 0);
-  let transitionStartMs = 0;
-  let transitionFrom = initial;
-  let current = initial;
-  const frames: CameraFrameState[] = [];
+  const geometry = new CameraGeometry(plan.source, plan.content);
+  return simulate(fromPlanShots(plan), geometry, plan.source);
+}
 
-  for (let frameIndex = 0; frameIndex < frameCount; frameIndex += 1) {
-    const timeMs = (frameIndex * 1_000) / plan.source.frameRate;
-    const target = targetAt(plan, timeMs);
-    if (target.key !== activeTarget.key) {
-      const progress = springProgress(timeMs - transitionStartMs);
-      current = interpolate(transitionFrom, activeTarget, progress);
-      transitionFrom = current;
-      transitionStartMs = timeMs;
-      activeTarget = target;
-    }
-    current = interpolate(
-      transitionFrom,
-      activeTarget,
-      springProgress(timeMs - transitionStartMs),
-    );
-
-    const cropWidth = plan.source.width / current.scale;
-    const cropHeight = plan.source.height / current.scale;
-    const cropX = Math.max(
-      0,
-      Math.min(
-        plan.source.width - cropWidth,
-        -current.translationX / current.scale,
-      ),
-    );
-    const cropY = Math.max(
-      0,
-      Math.min(
-        plan.source.height - cropHeight,
-        -current.translationY / current.scale,
-      ),
-    );
-    frames.push({
-      timeMs,
-      scale: current.scale,
-      cropWidth,
-      cropHeight,
-      cropX,
-      cropY,
-    });
-  }
-
-  return frames;
+function commandNumber(value: number): string {
+  const rounded = Math.abs(value) < 0.000_000_5 ? 0 : value;
+  return rounded.toFixed(6);
 }
 
 export function createFfmpegCameraCommands(plan: CameraPlan): string {

--- a/turbo/apps/cli/src/commands/video/camera-review.ts
+++ b/turbo/apps/cli/src/commands/video/camera-review.ts
@@ -1,7 +1,4 @@
-import {
-  cameraTransitionMidpointMs,
-  createCameraFrameStates,
-} from "./camera-plan";
+import { createCameraFrameStates } from "./camera-plan";
 import type { CameraPlan, CameraFrameState } from "./camera-plan";
 
 const CLICK_BEFORE_MS = 300;
@@ -15,9 +12,9 @@ export type CameraCheckpointReason =
       readonly clickMs: number;
       readonly offsetMs: (typeof CLICK_AFTER_MS)[number];
     }
-  | { readonly kind: "pan-midpoint"; readonly focusId: string }
-  | { readonly kind: "zoom-enter"; readonly rangeId: string }
-  | { readonly kind: "zoom-exit"; readonly rangeId: string }
+  | { readonly kind: "move-start"; readonly keyId: string }
+  | { readonly kind: "move-end"; readonly keyId: string }
+  | { readonly kind: "shot-end"; readonly shotId: string }
   | { readonly kind: "maximum-camera-speed" };
 
 export interface CameraReviewCheckpoint {
@@ -102,15 +99,13 @@ export function createCameraReviewCheckpoints(
     }
   }
 
-  const panHalfTimeMs = cameraTransitionMidpointMs(plan.source.frameRate);
-  for (const range of plan.ranges) {
-    add(range.startMs, { kind: "zoom-enter", rangeId: range.id });
-    add(range.endMs, { kind: "zoom-exit", rangeId: range.id });
-    for (const focus of range.focuses.slice(1)) {
-      add(Math.min(focus.startMs + panHalfTimeMs, range.endMs), {
-        kind: "pan-midpoint",
-        focusId: focus.id,
-      });
+  for (const shot of plan.shots) {
+    for (const key of shot.keys) {
+      add(Math.max(0, key.startMs), { kind: "move-start", keyId: key.id });
+      add(key.startMs + key.durationMs, { kind: "move-end", keyId: key.id });
+    }
+    if (shot.endMs < plan.source.durationMs) {
+      add(shot.endMs, { kind: "shot-end", shotId: shot.id });
     }
   }
 

--- a/turbo/apps/cli/src/commands/video/camera.ts
+++ b/turbo/apps/cli/src/commands/video/camera.ts
@@ -22,7 +22,12 @@ import {
   inputTrackSchema,
   inputTrackVideoSource,
 } from "./camera-plan";
-import type { CameraPlan, VideoSource } from "./camera-plan";
+import type {
+  CameraPlan,
+  PixelRect,
+  SourceAnalysis,
+  VideoSource,
+} from "./camera-plan";
 import {
   createCameraReviewCheckpoints,
   type CameraReviewCheckpoint,
@@ -96,6 +101,127 @@ function probeVideo(path: string, declared: VideoSource): VideoSource {
     width: video.width,
     height: video.height,
     frameRate: declared.frameRate,
+  };
+}
+
+const REACTION_DELAY_MS = 400;
+const REACTION_PROBE_WIDTH = 160;
+const REACTION_PIXEL_DELTA = 40;
+
+/**
+ * Where the content sits in the frame. A window that was narrowed while it was
+ * recorded leaves a black band the camera must never zoom into; ffmpeg's crop
+ * detector finds the band from the first seconds of the video.
+ */
+function detectContentRect(
+  inputPath: string,
+  source: VideoSource,
+): PixelRect | null {
+  const raw = execFileSync(
+    "ffmpeg",
+    [
+      "-v",
+      "error",
+      "-t",
+      "5",
+      "-i",
+      inputPath,
+      "-vf",
+      "cropdetect=limit=24:round=2:reset=0,metadata=print:file=-",
+      "-f",
+      "null",
+      "-",
+    ],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+  const values = new Map<string, number>();
+  for (const line of raw.toString("utf8").split("\n")) {
+    const match = /lavfi\.cropdetect\.(w|h|x|y)=(-?\d+)/u.exec(line);
+    if (match?.[1] && match[2]) {
+      values.set(match[1], Number(match[2]));
+    }
+  }
+  const width = values.get("w");
+  const height = values.get("h");
+  const x = values.get("x");
+  const y = values.get("y");
+  if (
+    width === undefined ||
+    height === undefined ||
+    x === undefined ||
+    y === undefined ||
+    width < source.width * 0.8 ||
+    height < source.height * 0.8
+  ) {
+    return null;
+  }
+  return { x, y, width, height };
+}
+
+function probeFrame(inputPath: string, timeMs: number): Buffer {
+  return execFileSync(
+    "ffmpeg",
+    [
+      "-v",
+      "error",
+      "-ss",
+      (timeMs / 1_000).toFixed(3),
+      "-i",
+      inputPath,
+      "-frames:v",
+      "1",
+      "-vf",
+      `scale=${String(REACTION_PROBE_WIDTH)}:-2,format=gray`,
+      "-f",
+      "rawvideo",
+      "-",
+    ],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+}
+
+/**
+ * How much of the picture changed right after each click. A click that
+ * closed a menu or navigated away leaves nothing to look at where it landed,
+ * so the camera pulls back early instead of dwelling on the spot.
+ */
+function measureClickReactions(
+  inputPath: string,
+  clickTimes: readonly number[],
+  source: VideoSource,
+): ReadonlyMap<number, number> {
+  const reactions = new Map<number, number>();
+  for (const clickMs of clickTimes) {
+    if (clickMs + REACTION_DELAY_MS > source.durationMs) {
+      continue;
+    }
+    const before = probeFrame(inputPath, clickMs);
+    const after = probeFrame(inputPath, clickMs + REACTION_DELAY_MS);
+    const length = Math.min(before.length, after.length);
+    if (length === 0) {
+      continue;
+    }
+    let changed = 0;
+    for (let index = 0; index < length; index += 1) {
+      const left = before[index] ?? 0;
+      const right = after[index] ?? 0;
+      if (Math.abs(left - right) > REACTION_PIXEL_DELTA) {
+        changed += 1;
+      }
+    }
+    reactions.set(clickMs, changed / length);
+  }
+  return reactions;
+}
+
+function analyzeSource(
+  inputPath: string,
+  clickTimes: readonly number[],
+  source: VideoSource,
+): SourceAnalysis {
+  return {
+    contentRect: detectContentRect(inputPath, source),
+    reactions: measureClickReactions(inputPath, clickTimes, source),
   };
 }
 
@@ -292,7 +418,7 @@ Output:
 
 Notes:
   - Exactly one of --events or --plan is required
-  - The generated camera plan is editable JSON; change ranges, scale, or focus points and render again
+  - The generated camera plan is editable JSON: each shot lists timed moves (keys) with the viewport they land on; edit and render again
   - Requires ffmpeg and ffprobe on PATH`,
   )
   .action(
@@ -335,7 +461,11 @@ Notes:
         const track = inputTrackSchema.parse(parseJsonFile(eventsPath));
         clickTimes = inputTrackClickTimes(track);
         const source = probeVideo(inputPath, inputTrackVideoSource(track));
-        plan = createCameraPlan(track, source);
+        plan = createCameraPlan(
+          track,
+          source,
+          analyzeSource(inputPath, clickTimes, source),
+        );
         planPath = resolve(options.planOutput ?? defaultPlanPath(outputPath));
         if (
           planPath === eventsPath ||
@@ -407,7 +537,10 @@ Notes:
           width: plan.source.width,
           height: plan.source.height,
           frameRate: plan.source.frameRate,
-          cameraRanges: plan.ranges.length,
+          cameraShots: plan.shots.length,
+          cameraMoves: plan.shots.reduce((count, shot) => {
+            return count + shot.keys.length;
+          }, 0),
           sizeBytes: statSync(outputPath).size,
           renderMs,
         })}\n`,


### PR DESCRIPTION
## Summary

Replaces the camera algorithm behind `okou video camera` with one designed around clicks and typing, reviewed against Screen Studio and validated on real desktop recordings (with the pointer trail fitted from the video where the recorder had not recorded it yet).

### What was wrong with v1

Measured on a 13 s recording with six clicks: a spring that settled in 0.4 s (zoom rate 3.6×/s, pans over 3000 px/s), a pan for every focus change, a zoom-out and zoom-in inside a 2.4 s gap, focus points snapped to the frame edge, and the letterbox band of a resized window zoomed into. It read as jitter, not camera work.

### The new camera

- **Clicks and typing are the only things that move the camera.** Drags, jitter and a pointer parked outside the frame move nothing.
- **Push in on what was clicked.** The element the click hit when the recording says so (`element.role` in `AXTextField`, `AXTextArea`, `AXButton`, `AXMenuItem`, …, framed with an 8% margin, zooming out just enough if it does not fit), else the point, at 2.2×. A finite ease-in-out ends **on the click**, so the click lands in a frame that has settled.
- **A beat after each click** (700 ms) before the camera may leave it; a move that then arrives after the next click is fine as long as that click is in frame.
- **Pull back between clicks** to the shot's base framing (1.5–2×, fitting every click of the shot) when the next push-in is more than 1.2 s away. A click after which more than 12% of the picture changed pulls back early; more than 35% (a page navigation) pulls back to the wide shot. Measured with two small ffmpeg frame probes per click.
- **Typing holds** the camera on the field it was typed into (`typingBursts` from the recorder; bursts under 1 s are shortcuts).
- **No click outside the frame, ever.** The plan is simulated and every click checked against the viewport at its own moment; a late move is started earlier until the click sits inside with a 6% margin.
- **The wide shot is the content area**, found with ffmpeg's crop detector (or `recording.content.pixelRect` from the recorder), so a letterbox band never appears and straight interpolation between viewports never needs clamping mid-flight (the clamp switch used to reverse the viewport for one frame).

### Plan format

`version: 2`, `algorithm: "click-camera-v2"`: shots with `baseZoom` and timed `keys`, each landing on an explicit viewport (`rect: {x, y, width}`, height follows the aspect) with a human-readable `reason` and the `clickMs` it serves. Still editable JSON. The review manifest marks `move-start`, `move-end` and `shot-end` instead of range boundaries. The command output reports `cameraShots` and `cameraMoves`.

### On the real recording

```
content: 1822×1144 at 0,0 (the band on the right is excluded)
   141 ms +800  zoom in on click at 941 ms on AXTextArea
  1641 ms +650  push in on click at 1876 ms, arriving 415 ms after it
  2576 ms +650  push in on click at 3209 ms, arriving 17 ms after it
  4033 ms +650  push in on click at 5199 ms
  5899 ms +650  push in on click at 6246 ms on AXTextArea, holding through typing until 9800 ms
 10500 ms +650  push in on click at 11354 ms
 12054 ms +800  pull back to the base framing
```

Six of six clicks in frame at their own moment; zoom rate peak 1.0×/s; no direction reversals.

## Test plan

- [x] `vitest` for the camera command (plan shape, demo-capture format, edited-plan render, frame rate, crop chain), `lint`, `tsc`, `knip`
- [x] Real recording rendered end to end through `dist/okou.js video camera`; review frames checked at each click
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
