### PR TITLE
test(e2e): keep runner poll json parseable after retries

### DIFF
--- a/.github/scripts/tests/runner-api-curl-test.sh
+++ b/.github/scripts/tests/runner-api-curl-test.sh
@@ -126,7 +126,7 @@ curl() {
             attempt="$(record_curl_attempt)"
             if [[ "$MOCK_CURL_MODE" == "no-response-then-success" ]] &&
                 ((attempt > 1)); then
-                printf '{"ok":true}\n'
+                printf '%s\n' "$MOCK_CURL_RETRY_SUCCESS_BODY"
                 return 0
             fi
             echo "curl: (28) Operation timed out after 30002 milliseconds with 0 bytes received" >&2
@@ -176,9 +176,18 @@ run_agent_teardown() {
     fi
 }
 
+run_wait_for_run() {
+    if runner_wait_for_run "$1" 2 >"$stdout_file" 2>"$stderr_file"; then
+        request_status=0
+    else
+        request_status=$?
+    fi
+}
+
 export E2E_API_URL="https://pr-27981-api.vm6.ai/"
 export E2E_API_TOKEN="sensitive-api-token"
 export VERCEL_AUTOMATION_BYPASS_SECRET="sensitive-bypass-secret"
+MOCK_CURL_RETRY_SUCCESS_BODY='{"ok":true}'
 payload='{"secret":"sensitive-request-payload"}'
 MOCK_CURL_EXPECTED_VERCEL_URL='https://vercel.com/okou/vm0-api/logs?search=requestHost%3Apr-27981-api.vm6.ai+requestPath%3A%2Fapi%2Fchat%2Fevents+status%3A429&timeline=past12Hours'
 MOCK_CURL_EXPECTED_VERCEL_WRITE_OUT='%{onerror}%{stderr}Vercel logs: https://vercel.com/okou/vm0-api/logs?search=requestHost%%3Apr-27981-api.vm6.ai+requestPath%%3A%%2Fapi%%2Fchat%%2Fevents+status%%3A%{http_code}&timeline=past12Hours\n'
@@ -238,9 +247,29 @@ run_request "/api/runs/run-1/context"
 assert_status 0
 assert_curl_attempts 2
 assert_file_equals $'{"ok":true}\n' "$stdout_file"
-assert_file_equals "${stall_stderr}${retry_stderr}" "$stderr_file"
+assert_file_equals '' "$stderr_file"
+
+# Polling helpers merge transport streams before parsing. A recovered timeout
+# must therefore be quiet so the successful response remains one JSON value.
+run_vercel_logs_search='https://vercel.com/okou/vm0-api/logs?search=requestHost%3Apr-27981-api.vm6.ai+requestPath%3A%2Fapi%2Fruns%2Frun-1'
+MOCK_CURL_EXPECTED_URL="https://pr-27981-api.vm6.ai/api/runs/run-1"
+MOCK_CURL_EXPECTED_VERCEL_URL="${run_vercel_logs_search}+status%3A000&timeline=past12Hours"
+MOCK_CURL_EXPECTED_VERCEL_WRITE_OUT='%{onerror}%{stderr}Vercel logs: https://vercel.com/okou/vm0-api/logs?search=requestHost%%3Apr-27981-api.vm6.ai+requestPath%%3A%%2Fapi%%2Fruns%%2Frun-1+status%%3A%{http_code}&timeline=past12Hours\n'
+MOCK_CURL_MODE=no-response-then-success
+MOCK_CURL_RETRY_SUCCESS_BODY='{"id":"run-1","status":"completed"}'
+reset_curl_attempts
+RUNNER_RUN_POLL_INTERVAL_SECONDS=0 run_wait_for_run "run-1"
+assert_status 0
+assert_curl_attempts 2
+assert_file_equals $'{"id":"run-1","status":"completed"}\n' "$stdout_file"
+assert_file_equals '' "$stderr_file"
+jq -e '.id == "run-1" and .status == "completed"' "$stdout_file" \
+    >/dev/null || fail "poll response was not one completed-run JSON document"
 
 MOCK_CURL_MODE=no-response
+MOCK_CURL_EXPECTED_URL="https://pr-27981-api.vm6.ai/api/runs/run-1/context"
+MOCK_CURL_EXPECTED_VERCEL_URL="${context_vercel_logs_search}+status%3A000&timeline=past12Hours"
+MOCK_CURL_EXPECTED_VERCEL_WRITE_OUT='%{onerror}%{stderr}Vercel logs: https://vercel.com/okou/vm0-api/logs?search=requestHost%%3Apr-27981-api.vm6.ai+requestPath%%3A%%2Fapi%%2Fruns%%2Frun-1%%2Fcontext+status%%3A%{http_code}&timeline=past12Hours\n'
 reset_curl_attempts
 run_request "/api/runs/run-1/context"
 assert_status 28

--- a/e2e/helpers/runner-chat.bash
+++ b/e2e/helpers/runner-chat.bash
@@ -97,6 +97,12 @@ runner_api_curl() {
     # appended behind a marker and read back from the last occurrence. That
     # keeps the emitted response byte-for-byte identical to an unbuffered curl.
     local exit_marker=$'\nRUNNER_API_CURL_EXIT:'
+
+    # Bats combines both streams in `$output`. Hold transient diagnostics until
+    # the overall request fails so a recovered GET remains machine-readable.
+    local diagnostics_file
+    diagnostics_file="$(mktemp "${BATS_TEST_TMPDIR:-/tmp}/runner-api-curl-stderr.XXXXXX")" || return
+
     local body="" curl_status=0 attempt
     for ((attempt = 1; attempt <= max_attempts; attempt += 1)); do
         body="$(
@@ -106,7 +112,8 @@ runner_api_curl() {
                 --max-time "${E2E_CURL_MAX_TIME_SECONDS:-30}" \
                 "${headers[@]}" \
                 "$@" \
-                "$request_url"
+                "$request_url" \
+                2>>"$diagnostics_file"
             printf '%s%d' "$exit_marker" "$?"
         )"
         curl_status="${body##*"$exit_marker"}"
@@ -117,12 +124,13 @@ runner_api_curl() {
             break
         fi
         printf 'runner_api_curl retrying %s after no response (attempt %d of %d)\n' \
-            "$diagnostic_url" "$attempt" "$max_attempts" >&2
+            "$diagnostic_url" "$attempt" "$max_attempts" >>"$diagnostics_file"
     done
 
     printf '%s' "$body"
 
     if ((curl_status != 0)); then
+        cat "$diagnostics_file" >&2
         printf 'runner_api_curl failed: url=%s curl_status=%d\n' \
             "$diagnostic_url" "$curl_status" >&2
         if ((curl_status == no_response_status)); then
@@ -134,6 +142,7 @@ runner_api_curl() {
                 "$attempt" "$vercel_logs_url_prefix" >&2
         fi
     fi
+    rm -f "$diagnostics_file"
     return "$curl_status"
 }
 


### PR DESCRIPTION
## Summary

- buffer runner API retry diagnostics until the overall request fails
- keep timeout-then-success responses data-only for JSON polling consumers
- cover the recovered-timeout path through `runner_wait_for_run` while preserving final-failure diagnostics and retry safety tests

## Scope

This changes only the runner E2E harness diagnostic stream contract. Retry eligibility, request semantics, response bodies, exit statuses, and production behavior are unchanged.

## Validation

- `bash -n e2e/helpers/runner-chat.bash .github/scripts/tests/runner-api-curl-test.sh`
- `shellcheck -s bash -x e2e/helpers/runner-chat.bash .github/scripts/tests/runner-api-curl-test.sh`
- `.github/scripts/tests/runner-api-curl-test.sh`
- `.github/scripts/check-workflow-shell-compatibility.sh .github/workflows/security.yml`
- `git diff --check`

Closes #31206
