### PR TITLE
fix(mail): preserve exact reconnect account

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
@@ -475,6 +475,21 @@ describe("POST /api/mail/drafts/link", () => {
       [200],
     );
     expect(gmail.draftReadCount).toBe(2);
+
+    gmail.unauthorized = true;
+    const reconnect = await accept(
+      client().getDraft({
+        headers: authHeaders(),
+        params: { mailDraftId: linked.body.mailDraftId },
+      }),
+      [200],
+    );
+    expect(reconnect.body.mailDraft.reconnectConnectionId).toBe(
+      selectedConnectorId,
+    );
+    expect(reconnect.body.mailDraft.reconnectConnectionId).not.toBe(
+      fixture.gmail.id,
+    );
   });
 
   it("does not fall back from a reconnect-required thread selection", async () => {
@@ -1071,7 +1086,70 @@ describe("POST /api/mail/drafts/link", () => {
       status: "draft",
       subject: "Attachment review",
     });
+    expect(detached.body.mailDraft.reconnectConnectionId).toBeUndefined();
     expect(gmail.draftReadCount).toBe(1);
+  });
+
+  it("retains the resolved account when a legacy draft needs reconnect", async () => {
+    const fixture = await seedGmailMailCardFixture();
+    mockGmailDraftApi();
+    const linked = await linkDraft(fixture);
+
+    mockGmailConnectorOAuth({
+      accessToken: "replacement-gmail-token",
+      subject: "replacement-gmail-account",
+      email: "replacement@example.com",
+    });
+    const replacement = await connectors.startOauth(
+      fixture.actor,
+      "gmail",
+      "oauth",
+    );
+    const replacementState = new URL(
+      replacement.authorizationUrl,
+    ).searchParams.get("state");
+    if (!replacementState) {
+      throw new Error("Expected Gmail OAuth state");
+    }
+    await connectors.completeOauthCallback("gmail", {
+      code: "replace-original-mail-account",
+      state: replacementState,
+    });
+
+    const recoveredConnectorId = await addGmailAccount(fixture, {
+      accessToken: "recovered-gmail-token",
+      email: "sender@example.com",
+      subject: "recovered-gmail-account",
+    });
+    await connectors.setDefaultBuiltinConnectorAccount(
+      fixture.actor,
+      "gmail",
+      recoveredConnectorId,
+    );
+    const orgId = fixture.actor.orgId;
+    if (!orgId) {
+      throw new Error("Expected an organization-scoped mail fixture");
+    }
+    await setConnectorAccountState(context, {
+      orgId,
+      userId: fixture.actor.userId,
+      connectorId: recoveredConnectorId,
+      needsReconnect: true,
+    });
+
+    const recovered = await accept(
+      client().getDraft({
+        headers: authHeaders(),
+        params: { mailDraftId: linked.body.mailDraftId },
+      }),
+      [200],
+    );
+    expect(recovered.body.mailDraft).toMatchObject({
+      accessStatus: "reconnect",
+      reconnectConnectionId: recoveredConnectorId,
+      subject: "Attachment review",
+    });
+    expect(recoveredConnectorId).not.toBe(fixture.gmail.id);
   });
 
   it("rejects a missing Gmail draft and cross-chat relinking", async () => {

--- a/turbo/apps/api/src/signals/services/mail-draft.service.ts
+++ b/turbo/apps/api/src/signals/services/mail-draft.service.ts
@@ -279,6 +279,12 @@ interface MailAccess {
   readonly connection: MailConnection;
 }
 
+interface MailAccessFailure {
+  readonly kind: "conflict";
+  readonly message: string;
+  readonly reconnectConnectionId?: string;
+}
+
 function linkResult(mailDraftId: string): MailDraftLinkResult {
   return {
     kind: "ok",
@@ -1012,6 +1018,7 @@ function responseDraft(args: {
   readonly details: MailDetails | null;
   readonly detailAvailable: boolean;
   readonly accessStatus?: "ready" | "reconnect";
+  readonly reconnectConnectionId?: string;
 }): MailDraft {
   const details = responseDetails(args.row, args.details);
   return mailDraftSchema.parse({
@@ -1027,6 +1034,7 @@ function responseDraft(args: {
     bodyHtml: details.bodyHtml,
     inlineImages: details.inlineImages,
     accessStatus: args.accessStatus ?? "ready",
+    reconnectConnectionId: args.reconnectConnectionId,
     replyTo: details.replyTo,
     inReplyTo: details.inReplyTo,
     references: details.references,
@@ -1081,7 +1089,10 @@ async function runGmailOperation<T>(
   return { kind: "reconnect" };
 }
 
-function reconnectDraftResult(row: MailDraftRow): MailDraftResult {
+function reconnectDraftResult(
+  row: MailDraftRow,
+  reconnectConnectionId?: string,
+): MailDraftResult {
   return okResult(
     row.id,
     responseDraft({
@@ -1089,7 +1100,18 @@ function reconnectDraftResult(row: MailDraftRow): MailDraftResult {
       details: null,
       detailAvailable: false,
       accessStatus: "reconnect",
+      reconnectConnectionId,
     }),
+  );
+}
+
+function accessReconnectDraftResult(
+  row: MailDraftRow,
+  access: MailAccessFailure,
+): MailDraftResult {
+  return reconnectDraftResult(
+    row,
+    access.reconnectConnectionId ?? row.connectorId ?? undefined,
   );
 }
 
@@ -1132,7 +1154,7 @@ async function accessForRow(
     readonly row: MailDraftRow;
   },
   signal: AbortSignal,
-): Promise<MailAccess | MailDraftErrorResult> {
+): Promise<MailAccess | MailAccessFailure> {
   const connection = await connectionForRow(args);
   if (!connection) {
     return { kind: "conflict", message: "Reconnect Gmail before continuing" };
@@ -1149,7 +1171,11 @@ async function accessForRow(
   );
   return access.kind === "ok"
     ? { ...access, connection }
-    : { kind: "conflict", message: access.message };
+    : {
+        kind: "conflict",
+        message: access.message,
+        reconnectConnectionId: connection.connectorId,
+      };
 }
 
 async function persistLinkedDraft(args: {
@@ -1276,7 +1302,9 @@ async function getMailDraft(
       responseDraft({ row: args.row, details: null, detailAvailable: false }),
     );
     if (access.kind !== "ok" || !sentGmailMessageId) {
-      return access.kind === "ok" ? stored : reconnectDraftResult(args.row);
+      return access.kind === "ok"
+        ? stored
+        : accessReconnectDraftResult(args.row, access);
     }
     let sent: GmailSentValue | null = null;
     const sentResult = await runGmailOperation(
@@ -1301,7 +1329,7 @@ async function getMailDraft(
     );
     signal.throwIfAborted();
     if (sentResult.kind === "reconnect") {
-      return reconnectDraftResult(args.row);
+      return reconnectDraftResult(args.row, access.connection.connectorId);
     }
     if (sentResult.kind === "error") {
       L.warn("Failed to enrich sent Gmail draft card", {
@@ -1324,7 +1352,7 @@ async function getMailDraft(
       : stored;
   }
   if (access.kind !== "ok") {
-    return reconnectDraftResult(args.row);
+    return accessReconnectDraftResult(args.row, access);
   }
   const gmailResult = await runGmailOperation(
     {
@@ -1348,7 +1376,7 @@ async function getMailDraft(
   );
   signal.throwIfAborted();
   if (gmailResult.kind === "reconnect") {
-    return reconnectDraftResult(args.row);
+    return reconnectDraftResult(args.row, access.connection.connectorId);
   }
   if (gmailResult.kind === "error") {
     throw gmailResult.error;

--- a/turbo/apps/cli/src/commands/mail/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/mail/__tests__/index.test.ts
@@ -111,6 +111,19 @@ describe("okou mail", () => {
     expect(listOutput).toContain("unavailable");
 
     mockConsoleLog.mockClear();
+    await mailCommand.parseAsync(["node", "cli", "connect", "gmail", "--json"]);
+
+    expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toStrictEqual(
+      {
+        provider: "gmail",
+        action: "ready",
+        url: null,
+        context: "run",
+        connectionId: RUN_GMAIL_CONNECTION_ID,
+      },
+    );
+
+    mockConsoleLog.mockClear();
     await mailCommand.parseAsync([
       "node",
       "cli",

--- a/turbo/apps/cli/src/commands/mail/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/mail/__tests__/index.test.ts
@@ -9,11 +9,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { server } from "../../../mocks/server";
 import {
-  authCodeMethod,
   catalogItem,
-  catalogStatusItem,
   stubConnectorCatalog,
-  stubConnectorCatalogStatus,
 } from "../../__tests__/helpers/connector-catalog";
 import { stubCustomConnectors } from "../../__tests__/helpers/custom-connectors";
 import { mailCommand } from "../index";
@@ -22,52 +19,6 @@ const AGENT_ID = "550e8400-e29b-41d4-a716-446655440000";
 const THREAD_ID = "550e8400-e29b-41d4-a716-446655440001";
 const MAIL_DRAFT_ID = "550e8400-e29b-41d4-a716-446655440002";
 const RUN_GMAIL_CONNECTION_ID = "550e8400-e29b-41d4-a716-446655440003";
-
-function stubAgentContext(enabledConnectorSlugs: readonly string[]) {
-  return [
-    http.get(`http://localhost:3000/api/agents/${AGENT_ID}`, () => {
-      return HttpResponse.json({
-        agentId: AGENT_ID,
-        ownerId: "owner-1",
-        description: null,
-        displayName: "Mail agent",
-        sound: null,
-        avatarUrl: null,
-      });
-    }),
-    http.get(
-      `http://localhost:3000/api/agents/${AGENT_ID}/user-connectors`,
-      () => {
-        return HttpResponse.json({
-          enabledConnectorSlugs: [...enabledConnectorSlugs],
-        });
-      },
-    ),
-  ];
-}
-
-function mailCatalog() {
-  return stubConnectorCatalogStatus([
-    catalogStatusItem({
-      connectorSlug: "gmail",
-      label: "Gmail",
-      authMethods: [authCodeMethod()],
-      connected: true,
-      connectionStatus: "connected",
-      connection: {
-        authMethod: "oauth",
-        externalUsername: null,
-        externalEmail: "sender@example.com",
-        reconnectReason: null,
-      },
-    }),
-    catalogStatusItem({
-      connectorSlug: "outlook-mail",
-      label: "Outlook Mail",
-      authMethods: [authCodeMethod()],
-    }),
-  ]);
-}
 
 describe("okou mail", () => {
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -114,7 +65,7 @@ describe("okou mail", () => {
     rmSync(directory, { recursive: true, force: true });
   });
 
-  it("lists the exact mail account used by the run and returns a connect link", async () => {
+  it("lists the exact mail account used by the run and keeps unadmitted mail unavailable", async () => {
     server.use(
       stubConnectorCatalog([
         catalogItem({ connectorSlug: "gmail", label: "Gmail" }),
@@ -159,7 +110,6 @@ describe("okou mail", () => {
     expect(listOutput).toContain("outlook");
     expect(listOutput).toContain("unavailable");
 
-    server.use(mailCatalog(), ...stubAgentContext(["gmail"]));
     mockConsoleLog.mockClear();
     await mailCommand.parseAsync([
       "node",
@@ -172,8 +122,58 @@ describe("okou mail", () => {
     expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toStrictEqual(
       {
         provider: "outlook",
-        action: "connect",
-        url: `http://localhost:3000/connectors/outlook-mail/connect?agentId=${AGENT_ID}`,
+        action: "unavailable",
+        url: null,
+        context: "run",
+        connectionId: null,
+      },
+    );
+  });
+
+  it("returns an exact reconnect link for the Gmail account used by the run", async () => {
+    server.use(
+      stubConnectorCatalog([
+        catalogItem({ connectorSlug: "gmail", label: "Gmail" }),
+        catalogItem({
+          connectorSlug: "outlook-mail",
+          label: "Outlook Mail",
+        }),
+      ]),
+      stubCustomConnectors([]),
+      http.post(
+        "http://localhost:3000/api/connector-accounts/inspect",
+        async ({ request }) => {
+          const body = connectorAccountsContract.inspect.body.parse(
+            await request.json(),
+          );
+          return HttpResponse.json({
+            results: body.selections.map((selection) => {
+              return {
+                kind: "available" as const,
+                ...selection,
+                authMethod: "oauth" as const,
+                displayName: "Selected Gmail",
+                externalId: "selected-gmail-account",
+                externalUsername: null,
+                externalEmail: "selected@example.com",
+                connectionStatus: "reconnect-required" as const,
+                reconnectReason: "authorization_expired_or_revoked" as const,
+              };
+            }),
+          });
+        },
+      ),
+    );
+
+    await mailCommand.parseAsync(["node", "cli", "connect", "gmail", "--json"]);
+
+    expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toStrictEqual(
+      {
+        provider: "gmail",
+        action: "reconnect",
+        url: `http://localhost:3000/connectors/gmail/reconnect/${RUN_GMAIL_CONNECTION_ID}?agentId=${AGENT_ID}`,
+        context: "run",
+        connectionId: RUN_GMAIL_CONNECTION_ID,
       },
     );
   });
@@ -210,6 +210,18 @@ describe("okou mail", () => {
     expect(output).toContain("unavailable");
     expect(output).not.toContain("sender@example.com");
     expect(output).not.toContain("ready");
+
+    mockConsoleLog.mockClear();
+    await mailCommand.parseAsync(["node", "cli", "connect", "gmail", "--json"]);
+    expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toStrictEqual(
+      {
+        provider: "gmail",
+        action: "unavailable",
+        url: null,
+        context: "run",
+        connectionId: RUN_GMAIL_CONNECTION_ID,
+      },
+    );
   });
 
   it("links an existing Gmail draft and prints only the review URL", async () => {

--- a/turbo/apps/cli/src/commands/mail/connect.ts
+++ b/turbo/apps/cli/src/commands/mail/connect.ts
@@ -4,8 +4,14 @@ import { Command } from "commander";
 import { listConnectorCatalogStatus } from "../../lib/api/domains/connectors";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { getPlatformOrigin } from "../doctor/platform-url";
+import { connectorActionUrl } from "../connector/action-url";
 import { resolveAgentContext } from "../connector/agent-context";
 import { findConnectorStatusItem } from "../connector/public-catalog";
+import {
+  isRunBoundConnectorContext,
+  resolveRunConnectorAccountView,
+  runConnectorAccountUnavailableMessage,
+} from "../connector/run-account-context";
 import {
   MAIL_CONNECTOR_SLUG_BY_PROVIDER,
   currentAgentId,
@@ -16,6 +22,93 @@ interface ConnectOptions {
   readonly json?: boolean;
 }
 
+type MailProvider = ReturnType<typeof parseMailProvider>;
+
+function printRunUnavailable(
+  provider: MailProvider,
+  options: ConnectOptions,
+  message: string,
+  connectionId: string | null,
+): void {
+  if (options.json) {
+    console.log(
+      JSON.stringify({
+        provider,
+        action: "unavailable",
+        url: null,
+        context: "run",
+        connectionId,
+      }),
+    );
+    return;
+  }
+  console.log(message);
+}
+
+async function printRunConnect(
+  provider: MailProvider,
+  connectorSlug: (typeof MAIL_CONNECTOR_SLUG_BY_PROVIDER)[MailProvider],
+  options: ConnectOptions,
+): Promise<void> {
+  const [view, origin] = await Promise.all([
+    resolveRunConnectorAccountView(),
+    getPlatformOrigin(),
+  ]);
+  if (view.state === "unavailable") {
+    printRunUnavailable(
+      provider,
+      options,
+      runConnectorAccountUnavailableMessage(view.reason),
+      null,
+    );
+    return;
+  }
+  const connector = view.connectors.find((candidate) => {
+    return candidate.slug === connectorSlug;
+  });
+  if (connector?.account.state !== "available") {
+    printRunUnavailable(
+      provider,
+      options,
+      "Account used by this run is unavailable. Reconnect or change the thread selection, then start a new run.",
+      connector?.account.connectionId ?? null,
+    );
+    return;
+  }
+  const account = connector.account;
+  const reconnect = account.metadata.connectionStatus === "reconnect-required";
+  const url = reconnect
+    ? connectorActionUrl({
+        origin,
+        path: `/connectors/${connectorSlug}/reconnect/${account.connectionId}`,
+        agentId: currentAgentId(),
+      })
+    : null;
+  if (options.json) {
+    console.log(
+      JSON.stringify({
+        provider,
+        action: reconnect ? "reconnect" : "ready",
+        url,
+        context: "run",
+        connectionId: account.connectionId,
+      }),
+    );
+    return;
+  }
+  if (url) {
+    console.log(
+      `Reconnect ${connector.connectorLabel}: [Reconnect ${connector.connectorLabel}](${url})`,
+    );
+    return;
+  }
+  console.log(chalk.green(`✓ ${connector.connectorLabel} is ready`));
+  console.log(chalk.dim(`  Sender: ${account.metadata.externalEmail ?? "-"}`));
+  console.log(
+    chalk.dim("  After creating a Gmail draft: okou mail link <draft-id>"),
+  );
+}
+
 export const connectCommand = new Command()
   .name("connect")
   .description("Get a connect or authorization link for a mail provider")
@@ -24,8 +117,12 @@ export const connectCommand = new Command()
   .action(
     withErrorHandler(async (providerValue: string, options: ConnectOptions) => {
       const provider = parseMailProvider(providerValue);
-      const agentId = currentAgentId();
       const connectorSlug = MAIL_CONNECTOR_SLUG_BY_PROVIDER[provider];
+      if (isRunBoundConnectorContext()) {
+        await printRunConnect(provider, connectorSlug, options);
+        return;
+      }
+      const agentId = currentAgentId();
       const [{ connectors }, agent, origin] = await Promise.all([
         listConnectorCatalogStatus(),
         resolveAgentContext(agentId),

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -238,6 +238,10 @@ const ROUTE_CONFIG = [
     setup: setupAuthPageWrapper(setupDirectedAuthorizePage$),
   },
   {
+    path: ROUTES.directedReconnect,
+    setup: setupAuthPageWrapper(setupDirectedConnectPage$),
+  },
+  {
     path: ROUTES.directedConnect,
     setup: setupAuthPageWrapper(setupDirectedConnectPage$),
   },

--- a/turbo/apps/platform/src/signals/connectors-page/directed-connect-slug.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-connect-slug.ts
@@ -1,5 +1,9 @@
 import { command, computed, state } from "ccstate";
 import {
+  connectorAccountsContract,
+  type ConnectorAccountConnection,
+} from "@okouai/api-contracts/contracts/connector-accounts";
+import {
   connectorSlugSchema,
   type ConnectorSlug,
 } from "@okouai/api-contracts/contracts/connector-identity";
@@ -7,8 +11,12 @@ import {
   customConnectorSlugSchema,
   type CustomConnectorSlug,
 } from "@okouai/api-contracts/contracts/custom-connectors";
+import { z } from "zod";
+import { accept } from "../../lib/accept.ts";
+import { apiClient$ } from "../api-client.ts";
 import { pathParams$, searchParams$ } from "../route.ts";
 import { agents$ } from "../agent.ts";
+import { pageSignal$ } from "../page-signal.ts";
 import { resetManualGrantForm$ } from "../okou-page/settings/connectors.ts";
 
 /**
@@ -31,6 +39,45 @@ export const directedConnectCustomSlug$ = computed(
       typeof connectorSlug === "string" ? connectorSlug.toLowerCase() : null,
     );
     return parsed.success ? parsed.data : null;
+  },
+);
+
+type DirectedConnectAccountTarget =
+  | { readonly kind: "default" }
+  | { readonly kind: "invalid" }
+  | { readonly kind: "exact"; readonly connectionId: string };
+
+export const directedConnectAccountTarget$ = computed(
+  (get): DirectedConnectAccountTarget => {
+    const connectionId = get(pathParams$)?.connectionId;
+    if (connectionId === undefined) {
+      return { kind: "default" };
+    }
+    const parsed = z.uuid().safeParse(connectionId);
+    return parsed.success
+      ? { kind: "exact", connectionId: parsed.data }
+      : { kind: "invalid" };
+  },
+);
+
+export const directedConnectExactAccount$ = computed(
+  async (get): Promise<ConnectorAccountConnection | null> => {
+    const target = get(directedConnectAccountTarget$);
+    const connectorSlug = get(directedConnectSlug$);
+    if (target.kind !== "exact" || !connectorSlug) {
+      return null;
+    }
+    const signal = get(pageSignal$);
+    const result = await accept(
+      get(apiClient$)(connectorAccountsContract).connection({
+        params: { connectionId: target.connectionId },
+        query: { kind: "builtin", connectorSlug },
+        fetchOptions: { signal },
+      }),
+      [200, 404],
+    );
+    signal.throwIfAborted();
+    return result.status === 200 ? result.body : null;
   },
 );
 

--- a/turbo/apps/platform/src/signals/okou-page/onboard-guard.ts
+++ b/turbo/apps/platform/src/signals/okou-page/onboard-guard.ts
@@ -23,6 +23,7 @@ const ONBOARDING_GUARDED_PATHS = [
   ROUTES.connectors,
   ROUTES.directedAuthorize,
   ROUTES.directedConnect,
+  ROUTES.directedReconnect,
   ROUTES.exportData,
   ROUTES.githubConnect,
   ROUTES.home,

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -31,6 +31,7 @@ export const ROUTES = {
   connectorCallbackResult: "/connectors/:connectorSlug/callback/:status",
   connectorRedirecting: "/connectors/:connectorSlug/redirecting",
   directedConnect: "/connectors/:connectorSlug/connect",
+  directedReconnect: "/connectors/:connectorSlug/reconnect/:connectionId",
   directedAuthorize: "/connectors/:connectorSlug/authorize",
   settings: "/settings",
   settingsSlack: "/settings/slack",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
@@ -2987,6 +2987,8 @@ describe("chat event action cards", () => {
     const threadId = "c0000000-0000-4000-a000-00000000001b";
     const mailDraftId = "c0000000-0000-4000-a000-00000000001c";
     const mailDraftUrl = `https://app.vm0.ai/mail/drafts/${mailDraftId}`;
+    const defaultConnectionId = "c0000000-0000-4000-a000-00000000001e";
+    const reconnectConnectionId = "c0000000-0000-4000-a000-00000000001f";
     const createdAt = "2026-07-14T10:00:00.000Z";
     const authWindow = context.mocks.browser.authWindow();
     Object.defineProperty(authWindow, "location", {
@@ -3022,6 +3024,7 @@ describe("chat event action cards", () => {
               ? "reconnect-required"
               : "connected",
             connection: {
+              id: defaultConnectionId,
               authMethod: "oauth",
               externalUsername: null,
               externalEmail: "sender@example.com",
@@ -3046,11 +3049,47 @@ describe("chat event action cards", () => {
     });
     context.mocks.api(
       connectorOauthStartContract.start,
-      ({ params, respond }) => {
+      ({ body, params, respond }) => {
         oauthStartRequests += 1;
         expect(params.connectorSlug).toBe("gmail");
+        expect(body.account).toStrictEqual({
+          intent: "reconnect",
+          connectionId: reconnectConnectionId,
+        });
         return respond(200, {
           authorizationUrl: "https://accounts.google.test/oauth",
+        });
+      },
+    );
+    context.mocks.api(
+      connectorAccountsContract.connection,
+      ({ params, query, respond }) => {
+        expect(params.connectionId).toBe(reconnectConnectionId);
+        expect(query).toStrictEqual({
+          kind: "builtin",
+          connectorSlug: "gmail",
+        });
+        return respond(200, {
+          id: reconnectConnectionId,
+          target: { kind: "builtin", connectorSlug: "gmail" },
+          authMethod: "oauth",
+          displayName: "Draft sender",
+          isDefault: false,
+          externalId: "draft-sender",
+          externalUsername: null,
+          externalEmail: "sender@example.com",
+          oauthScopes: [],
+          connectionStatus: reconnectRequired
+            ? "reconnect-required"
+            : "connected",
+          reconnectReason: reconnectRequired
+            ? "authorization_expired_or_revoked"
+            : null,
+          tokenExpiresAt: null,
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: reconnectRequired
+            ? "2026-01-01T00:00:00Z"
+            : "2026-01-01T00:00:01Z",
         });
       },
     );
@@ -3073,6 +3112,9 @@ describe("chat event action cards", () => {
           subject: "Reconnect required",
           body: "",
           accessStatus: reconnectRequired ? "reconnect" : "ready",
+          reconnectConnectionId: reconnectRequired
+            ? reconnectConnectionId
+            : undefined,
           status: "draft",
           detailAvailable: !reconnectRequired,
           gmailDraftId: "r-reconnect",
@@ -3156,6 +3198,97 @@ describe("chat event action cards", () => {
     });
     expect(draftRequests).toBe(2);
     expect(hasSubscription("connector:changed")).toBeFalsy();
+  });
+
+  it("does not reconnect a legacy mail response without an exact account", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "c0000000-0000-4000-a000-000000000020";
+    const mailDraftId = "c0000000-0000-4000-a000-000000000021";
+    const mailDraftUrl = `https://app.vm0.ai/mail/drafts/${mailDraftId}`;
+    const createdAt = "2026-07-14T10:00:00.000Z";
+    let oauthStartRequests = 0;
+
+    context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
+      return respond(200, {
+        connectors: [
+          publicConnectorStatusItem({
+            slug: "gmail",
+            label: "Gmail",
+            connected: true,
+            connectionStatus: "reconnect-required",
+            connection: {
+              id: crypto.randomUUID(),
+              authMethod: "oauth",
+              externalUsername: null,
+              externalEmail: "default@example.com",
+              reconnectReason: "authorization_expired_or_revoked",
+            },
+            authMethods: [
+              {
+                id: "oauth",
+                label: "OAuth",
+                description: null,
+                grantKind: "auth-code",
+                manualFields: [],
+                startOptions: [],
+              },
+            ],
+            singleAuthCodeAuthMethodId: "oauth",
+          }),
+        ],
+      });
+    });
+    context.mocks.api(connectorOauthStartContract.start, ({ never }) => {
+      oauthStartRequests += 1;
+      return never();
+    });
+    context.mocks.api(mailContract.getDraft, ({ respond }) => {
+      return respond(200, {
+        mailDraftId,
+        mailDraftUrl,
+        mailDraft: {
+          version: 3,
+          provider: "gmail",
+          from: "sender@example.com",
+          to: [],
+          cc: [],
+          bcc: [],
+          subject: "Legacy reconnect",
+          body: "",
+          accessStatus: "reconnect",
+          status: "draft",
+          detailAvailable: false,
+          gmailDraftId: "r-legacy-reconnect",
+          gmailThreadId: "gmail-thread-id",
+          gmailMessageId: "gmail-message-id",
+          references: [],
+          attachments: [],
+          createdAt,
+          updatedAt: createdAt,
+        },
+      });
+    });
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Legacy reconnect",
+      chatEvents: [
+        {
+          id: "c0000000-0000-4000-a000-000000000022",
+          role: "assistant",
+          content: mailDraftUrl,
+          createdAt,
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const card = await screen.findByLabelText(
+      "Reconnect Gmail to access email: Legacy reconnect",
+    );
+    expect(card).toBeDisabled();
+    await user.click(card);
+    expect(oauthStartRequests).toBe(0);
   });
 
   it("renders a deleted email card without an interactive sidebar trigger", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/directed-connect-page.test.tsx
@@ -24,6 +24,7 @@ import {
   connectorCatalogContract,
   type PublicConnectorCatalogStatusItem,
 } from "@okouai/api-contracts/contracts/connector-catalog";
+import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
 import { screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
@@ -1152,6 +1153,127 @@ describe("directed connector connect page", () => {
     expect(startedAgentId).toBe(AGENT_ID);
     expect(startedAuthorizeAgent).toBeTruthy();
     expect(startedConnectionId).toBe(connectionId);
+  });
+
+  it("reconnects the route-selected account instead of the default account", async () => {
+    const defaultConnectionId = crypto.randomUUID();
+    const selectedConnectionId = crypto.randomUUID();
+    const connector = publicOAuthConnectorStatus({
+      slug: "github",
+      label: "Public GitHub",
+      singleAuthCodeAuthMethodId: null,
+    });
+    mockPublicConnectorStatus({
+      ...connector,
+      connected: true,
+      connectionStatus: "connected",
+      connection: {
+        id: defaultConnectionId,
+        authMethod: "oauth",
+        externalUsername: "default-account",
+        externalEmail: null,
+        reconnectReason: null,
+      },
+    });
+    context.mocks.api(
+      connectorAccountsContract.connection,
+      ({ params, query, respond }) => {
+        expect(params.connectionId).toBe(selectedConnectionId);
+        expect(query).toStrictEqual({
+          kind: "builtin",
+          connectorSlug: "github",
+        });
+        return respond(200, {
+          id: selectedConnectionId,
+          target: { kind: "builtin", connectorSlug: "github" },
+          authMethod: "oauth",
+          displayName: "Selected account",
+          isDefault: false,
+          externalId: "selected-account",
+          externalUsername: "selected-account",
+          externalEmail: null,
+          oauthScopes: [],
+          connectionStatus: "reconnect-required",
+          reconnectReason: "authorization_expired_or_revoked",
+          tokenExpiresAt: null,
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z",
+        });
+      },
+    );
+    const authWindow = context.mocks.browser.authWindow();
+    Object.defineProperty(authWindow, "location", {
+      value: { href: "" },
+      configurable: true,
+    });
+    context.mocks.browser.open(authWindow);
+    let startedConnectionId: string | null = null;
+    context.mocks.api(
+      connectorOauthStartContract.start,
+      ({ body, respond }) => {
+        if (body.account.intent === "reconnect") {
+          startedConnectionId = body.account.connectionId;
+        }
+        return respond(200, {
+          authorizationUrl: "https://oauth.test/github/reconnect",
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/github/reconnect/${selectedConnectionId}?agentId=${AGENT_ID}`,
+    });
+
+    await screen.findByText("Public GitHub connected");
+    click(getButtonByText("Reconnect"));
+    const dialog = await screen.findByRole("dialog", {
+      name: "Public GitHub",
+    });
+    click(getButtonByText("Reconnect", dialog));
+
+    await waitFor(() => {
+      expect(startedConnectionId).toBe(selectedConnectionId);
+    });
+    expect(startedConnectionId).not.toBe(defaultConnectionId);
+  });
+
+  it("does not fall back when an exact reconnect account is unavailable", async () => {
+    const selectedConnectionId = crypto.randomUUID();
+    mockPublicConnectorStatus(
+      publicOAuthConnectorStatus({
+        slug: "github",
+        label: "Public GitHub",
+        singleAuthCodeAuthMethodId: "oauth",
+      }),
+    );
+    let accountReads = 0;
+    context.mocks.api(
+      connectorAccountsContract.connection,
+      ({ params, respond }) => {
+        accountReads += 1;
+        expect(params.connectionId).toBe(selectedConnectionId);
+        return respond(404, {
+          error: { code: "NOT_FOUND", message: "Account not found" },
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/github/reconnect/${selectedConnectionId}?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(accountReads).toBe(1);
+    });
+    expect(
+      queryAllByRoleFast("button").filter((button) => {
+        return ["Connect", "Reconnect"].includes(
+          button.textContent?.trim() ?? "",
+        );
+      }),
+    ).toStrictEqual([]);
   });
 
   it("asks the server to connect and authorize a manual grant", async () => {

--- a/turbo/apps/platform/src/views/okou-page/directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/directed-connect-page.tsx
@@ -6,7 +6,10 @@ import {
   type ConnectorSlug,
 } from "@okouai/api-contracts/contracts/connector-identity";
 import type { PublicConnectorCatalogAuthMethodDetail } from "@okouai/api-contracts/contracts/connector-catalog";
-import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
+import type {
+  ConnectorAccountConnection,
+  ConnectorAccountMutationIntent,
+} from "@okouai/api-contracts/contracts/connector-accounts";
 import type {
   CustomConnectorResponse,
   CustomConnectorSlug,
@@ -52,6 +55,8 @@ import {
 import {
   directedConnectSlug$,
   directedConnectCustomSlug$,
+  directedConnectAccountTarget$,
+  directedConnectExactAccount$,
   directedConnectAgentId$,
   directedConnectAgentName$,
   manualGrantDialogKey$,
@@ -84,6 +89,7 @@ import { customConnectorMcpEnabled$ } from "../../signals/external/feature-switc
 import {
   defaultBuiltinConnectorAccountOptions,
   defaultCustomConnectorAccountOptions,
+  type ConnectorAccountMutationOptions,
   type DefaultConnectorAccountMutationOptions,
 } from "../../signals/okou-page/settings/connector-account-dialogs.ts";
 
@@ -92,6 +98,7 @@ function runDirectedConnect(
     item: PlatformConnectorCatalogStatusItem;
     connectorSlug: ConnectorSlug;
     agentId: string | null;
+    accountOptions: ConnectorAccountMutationOptions;
     connect: (
       connectorSlug: ConnectorSlug,
       method: PublicConnectorCatalogAuthMethodDetail,
@@ -125,10 +132,6 @@ function runDirectedConnect(
   },
   signal: AbortSignal,
 ): void {
-  const accountOptions = defaultBuiltinConnectorAccountOptions(params.item);
-  if (!accountOptions) {
-    return;
-  }
   const launchMode = getConnectorStatusConnectLaunchMode(params.item);
   if (
     launchMode === "modal" &&
@@ -172,7 +175,7 @@ function runDirectedConnect(
             ...(params.agentId
               ? { agentId: params.agentId }
               : { authorizeVisibleAgents: true }),
-            ...accountOptions,
+            ...params.accountOptions,
           },
           signal,
         );
@@ -194,7 +197,7 @@ function runDirectedConnect(
               ...(params.agentId
                 ? { agentId: params.agentId }
                 : { authorizeVisibleAgents: true }),
-              ...accountOptions,
+              ...params.accountOptions,
             },
           },
           signal,
@@ -220,7 +223,7 @@ function ManualGrantForm({
   agentId: string | null;
   connectorLabel: string;
   manualGrantMethod: PublicConnectorCatalogAuthMethodDetail;
-  accountOptions: DefaultConnectorAccountMutationOptions;
+  accountOptions: ConnectorAccountMutationOptions;
   onSuccess: () => void | Promise<void>;
 }) {
   const { t } = useTranslation();
@@ -339,7 +342,7 @@ function ManualGrantDialog({
   icon: PlatformConnectorCatalogStatusItem["icon"] | undefined;
   connectorLabel: string;
   manualGrantMethod: PublicConnectorCatalogAuthMethodDetail | null;
-  accountOptions: DefaultConnectorAccountMutationOptions | null;
+  accountOptions: ConnectorAccountMutationOptions | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSuccess: () => void | Promise<void>;
@@ -435,27 +438,23 @@ function ConnectActions({
 function DirectedConnectModal({
   open,
   item,
+  accountOptions,
+  reconnectAuthMethod,
   agentId,
   onClose,
   onSuccess,
 }: {
   readonly open: boolean;
   readonly item: PlatformConnectorCatalogStatusItem | undefined;
+  readonly accountOptions: ConnectorAccountMutationOptions | null;
+  readonly reconnectAuthMethod: ConnectorAuthMethodId | undefined;
   readonly agentId: string | null;
   readonly onClose: () => void;
   readonly onSuccess: () => void | Promise<void>;
 }) {
-  if (!open || !item) {
+  if (!open || !item || !accountOptions) {
     return null;
   }
-  const accountOptions = defaultBuiltinConnectorAccountOptions(item);
-  if (!accountOptions) {
-    return null;
-  }
-  const reconnectAuthMethod =
-    accountOptions.account.intent === "reconnect"
-      ? item.connection?.authMethod
-      : undefined;
   return (
     <ConnectModal
       item={item}
@@ -472,6 +471,8 @@ function DirectedConnectModal({
 function DirectedConnectDialogs({
   connectorSlug,
   item,
+  accountOptions,
+  reconnectAuthMethod,
   icon,
   connectorLabel,
   manualGrantMethod,
@@ -484,6 +485,8 @@ function DirectedConnectDialogs({
 }: {
   readonly connectorSlug: ConnectorSlug;
   readonly item: PlatformConnectorCatalogStatusItem | undefined;
+  readonly accountOptions: ConnectorAccountMutationOptions | null;
+  readonly reconnectAuthMethod: ConnectorAuthMethodId | undefined;
   readonly icon: PlatformConnectorCatalogStatusItem["icon"] | undefined;
   readonly connectorLabel: string;
   readonly manualGrantMethod: PublicConnectorCatalogAuthMethodDetail | null;
@@ -494,9 +497,6 @@ function DirectedConnectDialogs({
   readonly setConnectModalOpen: (open: boolean) => void;
   readonly onSuccess: () => void | Promise<void>;
 }) {
-  const accountOptions = item
-    ? defaultBuiltinConnectorAccountOptions(item)
-    : null;
   return (
     <>
       <ManualGrantDialog
@@ -513,6 +513,8 @@ function DirectedConnectDialogs({
       <DirectedConnectModal
         open={connectModalOpen}
         item={item}
+        accountOptions={accountOptions}
+        reconnectAuthMethod={reconnectAuthMethod}
         agentId={agentId ?? null}
         onClose={() => {
           setConnectModalOpen(false);
@@ -532,12 +534,16 @@ function useDirectedConnectConnectorSlug(): ConnectorSlug | null {
   return parsed.success ? parsed.data : null;
 }
 
-function useDirectedConnectCatalogState(connectorSlug: ConnectorSlug | null): {
+interface DirectedConnectCatalogState {
   readonly item: PlatformConnectorCatalogStatusItem | undefined;
   readonly isConnected: boolean;
   readonly isLoading: boolean;
   readonly unavailable: boolean;
-} {
+}
+
+function useDirectedConnectCatalogState(
+  connectorSlug: ConnectorSlug | null,
+): DirectedConnectCatalogState {
   const justConnected = useGet(justConnectedSlugs$);
   const allLoadable = useLastLoadable(connectorCatalogStatus$);
   const catalogLoaded = allLoadable.state === "hasData";
@@ -562,6 +568,105 @@ function useDirectedConnectCatalogState(connectorSlug: ConnectorSlug | null): {
       catalogLoaded &&
       !item &&
       !optimisticallyConnected,
+  };
+}
+
+type DirectedConnectAccountState =
+  | { readonly kind: "default" }
+  | { readonly kind: "loading" }
+  | { readonly kind: "unavailable" }
+  | {
+      readonly kind: "exact";
+      readonly account: ConnectorAccountConnection;
+    };
+
+function useDirectedConnectAccountState(): DirectedConnectAccountState {
+  const target = useGet(directedConnectAccountTarget$);
+  const accountLoadable = useLastLoadable(directedConnectExactAccount$);
+  if (target.kind === "default") {
+    return target;
+  }
+  if (target.kind === "invalid") {
+    return { kind: "unavailable" };
+  }
+  if (accountLoadable.state === "loading") {
+    return { kind: "loading" };
+  }
+  if (accountLoadable.state === "hasData" && accountLoadable.data) {
+    return { kind: "exact", account: accountLoadable.data };
+  }
+  return { kind: "unavailable" };
+}
+
+interface DirectedConnectPresentation {
+  readonly accountOptions: ConnectorAccountMutationOptions | null;
+  readonly reconnectAuthMethod: ConnectorAuthMethodId | undefined;
+  readonly isConnected: boolean;
+  readonly isLoading: boolean;
+  readonly unavailable: boolean;
+}
+
+function directedConnectPresentation(args: {
+  readonly accountState: DirectedConnectAccountState;
+  readonly catalogState: DirectedConnectCatalogState;
+}): DirectedConnectPresentation {
+  const { accountState, catalogState } = args;
+  if (catalogState.unavailable || accountState.kind === "unavailable") {
+    return {
+      accountOptions: null,
+      reconnectAuthMethod: undefined,
+      isConnected: false,
+      isLoading: false,
+      unavailable: true,
+    };
+  }
+  if (accountState.kind === "loading") {
+    return {
+      accountOptions: null,
+      reconnectAuthMethod: undefined,
+      isConnected: catalogState.isConnected,
+      isLoading: true,
+      unavailable: false,
+    };
+  }
+  if (accountState.kind === "exact") {
+    return {
+      accountOptions: {
+        account: {
+          intent: "reconnect",
+          connectionId: accountState.account.id,
+        },
+      },
+      reconnectAuthMethod: accountState.account.authMethod,
+      isConnected: true,
+      isLoading: catalogState.isLoading,
+      unavailable: false,
+    };
+  }
+  const accountOptions = defaultBuiltinConnectorAccountOptions(
+    catalogState.item,
+  );
+  return {
+    accountOptions,
+    reconnectAuthMethod:
+      accountOptions?.account.intent === "reconnect"
+        ? catalogState.item?.connection?.authMethod
+        : undefined,
+    isConnected: catalogState.isConnected,
+    isLoading: catalogState.isLoading,
+    unavailable: false,
+  };
+}
+
+function useDirectedConnectPresentation(connectorSlug: ConnectorSlug | null): {
+  readonly item: PlatformConnectorCatalogStatusItem | undefined;
+  readonly presentation: DirectedConnectPresentation;
+} {
+  const accountState = useDirectedConnectAccountState();
+  const catalogState = useDirectedConnectCatalogState(connectorSlug);
+  return {
+    item: catalogState.item,
+    presentation: directedConnectPresentation({ accountState, catalogState }),
   };
 }
 
@@ -670,8 +775,7 @@ function DirectedConnectCard() {
   const connect = useSet(connectConnectorOAuthAuthCode$);
   const connectNoAuth = useSet(connectConnectorNoAuth$);
   const signal = useGet(pageSignal$);
-  const { item, isConnected, isLoading, unavailable } =
-    useDirectedConnectCatalogState(connectorSlug);
+  const { item, presentation } = useDirectedConnectPresentation(connectorSlug);
   const setManualGrantDialogKey = useSet(setManualGrantDialogKey$);
   const setDirectedConnectModalKey = useSet(setDirectedConnectModalKey$);
   const actionCallback = useGet(routeChatActionCallback$);
@@ -693,13 +797,12 @@ function DirectedConnectCard() {
     pollingAuthCodeSlug === connectorSlug ||
     pollingDeviceAuthSlug === connectorSlug ||
     connectFlowSlug === connectorSlug;
-  if (unavailable) {
+  if (presentation.unavailable) {
     return null;
   }
   const authMethods = item?.authMethods ?? [];
-  const accountOptions = item
-    ? defaultBuiltinConnectorAccountOptions(item)
-    : null;
+  const { accountOptions, reconnectAuthMethod, isConnected, isLoading } =
+    presentation;
   const manualGrantMethod = item
     ? getOnlyManualConnectorStatusAuthMethod(item)
     : null;
@@ -728,6 +831,7 @@ function DirectedConnectCard() {
         item,
         connectorSlug,
         agentId,
+        accountOptions,
         connect,
         connectNoAuth,
         openManualGrantDialog: () => {
@@ -766,6 +870,8 @@ function DirectedConnectCard() {
       <DirectedConnectDialogs
         connectorSlug={connectorSlug}
         item={item}
+        accountOptions={accountOptions}
+        reconnectAuthMethod={reconnectAuthMethod}
         icon={item?.icon}
         connectorLabel={connectorLabel}
         manualGrantMethod={manualGrantMethod}
@@ -937,6 +1043,10 @@ function CustomDirectedConnectCard({
 
 export function DirectedConnectPage() {
   const customConnectorSlug = useGet(directedConnectCustomSlug$);
+  const accountTarget = useGet(directedConnectAccountTarget$);
+  if (customConnectorSlug && accountTarget.kind !== "default") {
+    return null;
+  }
   return customConnectorSlug ? (
     <CustomDirectedConnectCard connectorSlug={customConnectorSlug} />
   ) : (

--- a/turbo/apps/platform/src/views/okou-page/mail-draft-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/mail-draft-card.tsx
@@ -188,8 +188,12 @@ export function MailDraftCard({ signals }: MailDraftCardProps) {
   const selectedMailDraftId = useGet(activeSidebarMailDraftId$);
   const openSidebar = useSet(openThreadMailDraft$);
   const reloadDraft = useSet(signals.reloadDraft$);
+  const reconnectConnectionId =
+    draftLoadable.state === "hasData"
+      ? draftLoadable.data?.reconnectConnectionId
+      : undefined;
   const { connectorIcon, reconnect, reconnectDisabled, reconnecting } =
-    useGmailReconnect(reloadDraft);
+    useGmailReconnect(reconnectConnectionId, reloadDraft);
 
   if (draftLoadable.state === "loading") {
     return (

--- a/turbo/apps/platform/src/views/okou-page/mail-draft-sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/mail-draft-sidebar.tsx
@@ -144,13 +144,17 @@ function UnavailableMailDraftSidebar({
 
 function GmailReconnectButton({
   signals,
+  connectionId,
 }: {
   readonly signals: MailDraftSignals;
+  readonly connectionId: string | undefined;
 }) {
   const { t } = useTranslation();
   const reloadDraft = useSet(signals.reloadDraft$);
-  const { reconnect, reconnectDisabled, reconnecting } =
-    useGmailReconnect(reloadDraft);
+  const { reconnect, reconnectDisabled, reconnecting } = useGmailReconnect(
+    connectionId,
+    reloadDraft,
+  );
   return (
     <Button
       type="button"
@@ -1169,7 +1173,12 @@ export function MailDraftSidebar({ signals, onClose }: MailDraftSidebarProps) {
         message={t(($) => {
           return $.chat.mail.reconnectDescription;
         })}
-        action={<GmailReconnectButton signals={signals} />}
+        action={
+          <GmailReconnectButton
+            signals={signals}
+            connectionId={draftLoadable.data.reconnectConnectionId}
+          />
+        }
       />
     );
   }

--- a/turbo/apps/platform/src/views/okou-page/use-gmail-reconnect.ts
+++ b/turbo/apps/platform/src/views/okou-page/use-gmail-reconnect.ts
@@ -9,7 +9,10 @@ import {
 } from "../../signals/okou-page/settings/connectors.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 
-export function useGmailReconnect(onSuccess: () => void | Promise<void>) {
+export function useGmailReconnect(
+  connectionId: string | undefined,
+  onSuccess: () => void | Promise<void>,
+) {
   const catalogBySlug = useLastResolved(connectorCatalogStatusBySlug$);
   const connectFlowConnectorSlug = useGet(connectFlowConnectorSlug$);
   const connect = useSet(connectConnectorOAuthAuthCodeAndSettle$);
@@ -24,9 +27,17 @@ export function useGmailReconnect(onSuccess: () => void | Promise<void>) {
     connectorIcon: connector?.icon,
     reconnecting,
     reconnectDisabled:
-      !connector || !authMethod || connectFlowConnectorSlug !== null,
+      !connectionId ||
+      !connector ||
+      !authMethod ||
+      connectFlowConnectorSlug !== null,
     reconnect() {
-      if (!connector || !authMethod || connectFlowConnectorSlug !== null) {
+      if (
+        !connectionId ||
+        !connector ||
+        !authMethod ||
+        connectFlowConnectorSlug !== null
+      ) {
         return;
       }
       detach(
@@ -39,6 +50,7 @@ export function useGmailReconnect(onSuccess: () => void | Promise<void>) {
               authorizeVisibleAgents: true,
               connectorLabel: connector.label,
               connectorIcon: connector.icon,
+              account: { intent: "reconnect", connectionId },
             },
           },
           signal,

--- a/turbo/packages/api-contracts/src/contracts/mail.ts
+++ b/turbo/packages/api-contracts/src/contracts/mail.ts
@@ -34,6 +34,7 @@ const mailDraftBaseSchema = z.object({
   bodyHtml: z.string().optional(),
   inlineImages: z.array(mailInlineImageSchema).optional(),
   accessStatus: z.enum(["ready", "reconnect"]).optional(),
+  reconnectConnectionId: z.uuid().optional(),
   replyTo: z.string().optional(),
   inReplyTo: z.string().optional(),
   references: z.array(z.string()),


### PR DESCRIPTION
## Summary

- include the exact Gmail connection ID in reconnect-required mail draft responses when the API can resolve it
- make mail draft reconnect actions and a new directed reconnect route target that exact account without default-account fallback
- make run-bound `okou mail connect` report or reconnect the exact account projected into the run

## Compatibility

- the mail response field is additive and optional, so older Platform clients ignore it
- newer Platform clients disable reconnect when an older API omits the exact target
- the exact reconnect URL uses a distinct route, so older Platform deployments fail closed instead of interpreting it as a default-account connect link

## Out of scope

- no connector default or thread selection is changed
- no new mail failure reasons or status values are introduced

## Validation

- `pnpm format`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/cli lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/mail.test.ts`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/directed-connect-page.test.tsx`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-event-action-cards.test.tsx`
- `pnpm -F @okouai/cli exec vitest run src/commands/mail/__tests__/index.test.ts`

Closes #31212

Parent: #30585
