### PR TITLE
perf(api): skip credit reads for external model admission

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -5092,6 +5092,9 @@ describe("CHAT-02: model-first provider policies", () => {
   it("routes model policy providers into the runner claim", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
+    const orgId = requireOrgId(actor);
+    // External model admission depends on plan capabilities, not VM0 credits.
+    await seedOrgMetadata({ orgId, tier: "pro", credits: 0 });
     const { providerId: deepseekId } = await upsertOrgModelProvider(actor, {
       type: "deepseek",
       secret: "selected-deepseek-key",
@@ -5172,6 +5175,9 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(followUpEnvironment.OPENAI_MODEL).toBe("deepseek-v4-flash");
     await cancelChatRun(actor, followUp.runId);
 
+    // Restore spendable credits before exercising the built-in branch.
+    await seedOrgMetadata({ orgId, tier: "pro", credits: 1_000_000 });
+
     // A vm0 provider pin in an entitled org passes the spendable-credits
     // admission. The outcome past admission is race-dependent on the shared
     // database: 503 when no vm0 execution key exists (no public provisioning
@@ -5186,11 +5192,8 @@ describe("CHAT-02: model-first provider policies", () => {
         modelProviderId: null,
       },
     ]);
-    if (!actor.orgId) {
-      throw new Error("Expected the built-in admission actor to have an org");
-    }
     await setOrgModelPolicyProviderTypeFixture({
-      orgId: actor.orgId,
+      orgId,
       model: "claude-sonnet-5",
       defaultProviderType: "built-in",
     });

--- a/turbo/apps/api/src/signals/services/model-selection.service.ts
+++ b/turbo/apps/api/src/signals/services/model-selection.service.ts
@@ -32,7 +32,10 @@ import { and, eq, or } from "drizzle-orm";
 import { badRequestMessage, insufficientCredits } from "../../lib/error";
 import type { Db } from "../external/db";
 import { ensureOrgModelPolicies } from "./model-policy.service";
-import { checkOrgCreditsForRunAdmission } from "./run-admission.service";
+import {
+  checkOrgCreditsForRunAdmission,
+  checkOrgPlanRunAdmission,
+} from "./run-admission.service";
 import {
   loadOrgPlanCapabilities,
   type OrgPlanCapabilities,
@@ -666,13 +669,19 @@ export async function resolveModelFirstProviderAdmission(params: {
       ),
     };
   }
-  const error = await checkOrgCreditsForRunAdmission({
-    db: params.db,
-    orgId: params.orgId,
-    userId: params.userId,
-    modelProviderType: effectiveModelProvider,
-    selectedModel,
-  });
+  const error = isBuiltInModelProviderType(effectiveModelProvider)
+    ? await checkOrgCreditsForRunAdmission({
+        db: params.db,
+        orgId: params.orgId,
+        userId: params.userId,
+        modelProviderType: effectiveModelProvider,
+        selectedModel,
+      })
+    : checkOrgPlanRunAdmission({
+        capabilities: await loadOrgPlanCapabilities(params.db, params.orgId),
+        modelProviderType: effectiveModelProvider,
+        selectedModel,
+      });
   return { effectiveModelProvider, cliAgentType, error };
 }
 


### PR DESCRIPTION
## Summary

- select model-first admission state from the already resolved effective provider
- load only fresh plan capabilities for external, unknown, or absent providers
- preserve the complete credit, usage-pack, and allowance path for built-in providers
- exercise external provider routing with zero VM0 credits through the chat route integration

## Why

`resolveModelFirstProviderAdmission()` previously resolved full organization credit availability for every provider. External/BYOK admission only consumes plan status, BYOK support, and restricted-model policy, so the credit balance, expired-grant, and usage-pack reads were discarded before returning success.

This preflight is a separate freshness boundary from the final admission consolidated in #21621. The final authoritative admission remains unchanged and independently fresh.

## Behavior and compatibility

- Provider classification uses `effectiveModelProvider` after ownership-aware provider resolution and compatibility validation.
- Built-in providers continue to call `checkOrgCreditsForRunAdmission()` unchanged.
- Other provider values reuse `loadOrgPlanCapabilities()` and `checkOrgPlanRunAdmission()`.
- No database schema, persisted state, HTTP contract, queue payload, Runner protocol, telemetry schema, or coordinated deployment change.

The observed 48 ms p90 is the complete mature goal persisted-model-policy boundary, not a claimed saving. Actual rollout impact requires a containing fixed API/Runner pair.

## Validation

- `pnpm exec prettier --write apps/api/src/signals/services/model-selection.service.ts apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts --testNamePattern "routes model policy providers into the runner claim"` — 1 passed
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts` — 160 passed
- `pnpm knip --workspace api`
- pre-commit hook: repository Knip and Turbo type checks passed

Closes #31223

Parent objective: #24203
