### PR TITLE
fix: target selected google drive account for artifact recovery

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -10,6 +10,7 @@ import { testCronCleanupSandboxesStateContract } from "@okouai/api-contracts/con
 import {
   chatThreadConnectorSelectionContract,
   chatThreadsContract,
+  type ChatThreadArtifactGoogleDriveSync,
   type ChatEvent,
   type UserMessageInputDocument,
 } from "@okouai/api-contracts/contracts/chat-threads";
@@ -402,14 +403,14 @@ type ThreadArtifacts = Awaited<ReturnType<typeof chat.listThreadArtifacts>>;
 
 function expectDriveStatuses(
   artifacts: ThreadArtifacts,
-  status: "disconnected" | "not_synced" | "unknown",
+  expected: ChatThreadArtifactGoogleDriveSync,
 ): void {
   const files = artifacts.runs.flatMap((run) => {
     return run.files;
   });
   expect(files.length).toBeGreaterThan(0);
   for (const file of files) {
-    expect(file.googleDriveSync).toStrictEqual({ status });
+    expect(file.googleDriveSync).toStrictEqual(expected);
   }
 }
 
@@ -3303,6 +3304,10 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
       contentType: "application/pdf",
       googleDriveSync: { status: "disconnected" },
     });
+    expectDriveStatuses(artifacts, {
+      status: "disconnected",
+      recovery: { action: "connect" },
+    });
 
     // Sync requires a connected Drive.
     const noConnector = await chat.requestSyncThreadArtifact(
@@ -3335,7 +3340,10 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
 
     // A connected Drive still needs to be enabled for the thread's agent.
     artifacts = await chat.listThreadArtifacts(actor, run.threadId);
-    expectDriveStatuses(artifacts, "disconnected");
+    expectDriveStatuses(artifacts, {
+      status: "disconnected",
+      recovery: { action: "authorize" },
+    });
     const disabledForAgent = await chat.requestSyncThreadArtifact(
       actor,
       run.threadId,
@@ -3486,7 +3494,7 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
     });
     for (let attempt = 0; attempt < 2; attempt += 1) {
       artifacts = await chat.listThreadArtifacts(actor, run.threadId);
-      expectDriveStatuses(artifacts, "unknown");
+      expectDriveStatuses(artifacts, { status: "unknown" });
     }
     expect(transientRefresh.refreshBodies).toHaveLength(2);
     await expect(
@@ -3500,7 +3508,10 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
       return { status: 401 };
     });
     artifacts = await chat.listThreadArtifacts(actor, run.threadId);
-    expectDriveStatuses(artifacts, "disconnected");
+    expectDriveStatuses(artifacts, {
+      status: "disconnected",
+      recovery: { action: "reconnect", connectionId: connected.id },
+    });
     await expect(
       connectorsApi.readConnectorBySlug(actor, "google-drive"),
     ).resolves.toMatchObject({
@@ -3508,7 +3519,10 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
       reconnectReason: "authorization_expired_or_revoked",
     });
     artifacts = await chat.listThreadArtifacts(actor, run.threadId);
-    expectDriveStatuses(artifacts, "disconnected");
+    expectDriveStatuses(artifacts, {
+      status: "disconnected",
+      recovery: { action: "reconnect", connectionId: connected.id },
+    });
     expect(terminalRefresh.refreshBodies).toHaveLength(1);
     expect(terminalList.authorizationHeaders).toHaveLength(1);
 
@@ -3570,7 +3584,10 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
       return { status: 401 };
     });
     artifacts = await chat.listThreadArtifacts(actor, run.threadId);
-    expectDriveStatuses(artifacts, "disconnected");
+    expectDriveStatuses(artifacts, {
+      status: "disconnected",
+      recovery: { action: "reconnect", connectionId: connected.id },
+    });
     expect(sessionExpiredRefresh.refreshBodies).toHaveLength(1);
     await expect(
       connectorsApi.readConnectorBySlug(actor, "google-drive"),
@@ -3596,7 +3613,10 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
       state: stateFromAuthorizationUrl(secondReconnectStart.authorizationUrl),
     });
     artifacts = await chat.listThreadArtifacts(actor, run.threadId);
-    expectDriveStatuses(artifacts, "disconnected");
+    expectDriveStatuses(artifacts, {
+      status: "disconnected",
+      recovery: { action: "reconnect", connectionId: connected.id },
+    });
     expect(unknownSubtypeRefresh.refreshBodies).toHaveLength(1);
     await expect(
       connectorsApi.readConnectorBySlug(actor, "google-drive"),
@@ -3702,14 +3722,22 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
     });
     await api.enableAgentConnectors(actor, agentId, ["google-drive"]);
 
+    const defaultRefresh = mockGoogleDriveConnectorOAuth();
     const defaultStatusRecorder = mockGoogleDriveFilesList(() => {
-      return { status: 200, files: [] };
+      return { status: 401 };
     });
     let artifacts = await chat.listThreadArtifacts(actor, run.threadId);
-    expectDriveStatuses(artifacts, "not_synced");
+    expectDriveStatuses(artifacts, {
+      status: "disconnected",
+      recovery: {
+        action: "reconnect",
+        connectionId: defaultAccount.id,
+      },
+    });
     expect(defaultStatusRecorder.authorizationHeaders).toStrictEqual([
       "Bearer drive-access-drive-default",
     ]);
+    expect(defaultRefresh.refreshBodies).toHaveLength(1);
 
     const selected = await accept(
       chatThreadConnectorSelectionsClient().update({
@@ -3724,11 +3752,20 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
     );
     expect(selected.body.connectionId).toBe(selectedAccount.id);
 
+    await api.enableAgentConnectors(actor, agentId, []);
+    artifacts = await chat.listThreadArtifacts(actor, run.threadId);
+    expectDriveStatuses(artifacts, {
+      status: "disconnected",
+      recovery: { action: "authorize" },
+    });
+    expect(defaultStatusRecorder.authorizationHeaders).toHaveLength(1);
+
+    await api.enableAgentConnectors(actor, agentId, ["google-drive"]);
     const selectedStatusRecorder = mockGoogleDriveFilesList(() => {
       return { status: 200, files: [] };
     });
     artifacts = await chat.listThreadArtifacts(actor, run.threadId);
-    expectDriveStatuses(artifacts, "not_synced");
+    expectDriveStatuses(artifacts, { status: "not_synced" });
     expect(selectedStatusRecorder.authorizationHeaders).toStrictEqual([
       "Bearer drive-access-drive-selected",
     ]);
@@ -3756,12 +3793,37 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
       "Bearer drive-access-drive-selected",
     ]);
 
+    mockGoogleDriveConnectorOAuth({
+      userInfo: {
+        id: "bdd-drive-default-user-id",
+        email: "bdd-drive-default@example.test",
+        name: "BDD Drive Default",
+      },
+    });
+    const defaultReconnectStart = await connectorsApi.startOauth(
+      actor,
+      "google-drive",
+      "oauth",
+      undefined,
+      { intent: "reconnect", connectionId: defaultAccount.id },
+    );
+    await connectorsApi.completeOauthCallback("google-drive", {
+      code: "drive-default-reconnected",
+      state: stateFromAuthorizationUrl(defaultReconnectStart.authorizationUrl),
+    });
+
     const terminalRefresh = mockGoogleDriveConnectorOAuth();
     const terminalStatusRecorder = mockGoogleDriveFilesList(() => {
       return { status: 401 };
     });
     artifacts = await chat.listThreadArtifacts(actor, run.threadId);
-    expectDriveStatuses(artifacts, "disconnected");
+    expectDriveStatuses(artifacts, {
+      status: "disconnected",
+      recovery: {
+        action: "reconnect",
+        connectionId: selectedAccount.id,
+      },
+    });
     expect(terminalStatusRecorder.authorizationHeaders).toStrictEqual([
       "Bearer drive-access-drive-selected",
     ]);

--- a/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import { command, computed, type Command, type Computed } from "ccstate";
 import type {
+  ChatThreadArtifactGoogleDriveRecovery,
   ChatThreadArtifactGoogleDriveSync,
   ChatThreadArtifactRun,
 } from "@okouai/api-contracts/contracts/chat-threads";
@@ -78,14 +79,28 @@ type DriveStatusLookup =
       readonly type: "ready";
       readonly syncedByKey: ReadonlyMap<string, DriveSyncResult>;
     }
-  | { readonly type: "disconnected" }
+  | {
+      readonly type: "disconnected";
+      readonly recovery: ChatThreadArtifactGoogleDriveRecovery;
+    }
   | { readonly type: "unknown" };
 
 interface ConnectorTokens {
   readonly accessToken: string;
   readonly connection: ConnectorCredentialConnection;
-  readonly needsReconnect: boolean;
 }
+
+type DriveConnectorAccountResolution =
+  | { readonly type: "resolved"; readonly connectorId: string }
+  | { readonly type: "connect" }
+  | { readonly type: "unavailable" };
+
+type DriveConnectionLoadResult =
+  | { readonly type: "ready"; readonly tokens: ConnectorTokens }
+  | {
+      readonly type: "disconnected";
+      readonly recovery: ChatThreadArtifactGoogleDriveRecovery;
+    };
 
 type DriveRefreshResult =
   | { readonly type: "ok"; readonly accessToken: string }
@@ -130,14 +145,14 @@ async function threadAllowsGoogleDriveArtifactSync(
   return authorization !== undefined;
 }
 
-async function resolveDriveConnectorId(
+async function resolveDriveConnectorAccount(
   db: ReadonlyDb,
   args: {
     readonly orgId: string;
     readonly userId: string;
     readonly threadId: string;
   },
-): Promise<string | null> {
+): Promise<DriveConnectorAccountResolution> {
   const [selection] = await db
     .select({ connectorId: chatThreadConnectorSelections.connectorId })
     .from(chatThreads)
@@ -169,24 +184,35 @@ async function resolveDriveConnectorId(
         : { kind: "default" },
     },
   });
-  return resolution.kind === "resolved" ? resolution.account.connectorId : null;
+  if (resolution.kind === "resolved") {
+    return {
+      type: "resolved",
+      connectorId: resolution.account.connectorId,
+    };
+  }
+  return !selection && resolution.kind === "missing-default"
+    ? { type: "connect" }
+    : { type: "unavailable" };
 }
 
-async function loadDriveTokens(args: {
+async function loadDriveConnection(args: {
   readonly db: ReadonlyDb;
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly orgId: string;
   readonly snapshot: ConnectorRuntimeSnapshot;
   readonly threadId: string;
   readonly userId: string;
-}): Promise<ConnectorTokens | null> {
-  const connectorId = await resolveDriveConnectorId(args.db, {
+}): Promise<DriveConnectionLoadResult> {
+  const resolution = await resolveDriveConnectorAccount(args.db, {
     orgId: args.orgId,
     userId: args.userId,
     threadId: args.threadId,
   });
-  if (connectorId === null) {
-    return null;
+  if (resolution.type !== "resolved") {
+    return {
+      type: "disconnected",
+      recovery: { action: resolution.type },
+    };
   }
   const loaded = await loadConnectorCredentialConnection({
     db: args.db,
@@ -194,18 +220,33 @@ async function loadDriveTokens(args: {
     orgId: args.orgId,
     userId: args.userId,
     connectorSlug: "google-drive",
-    connectorId,
+    connectorId: resolution.connectorId,
   });
   if (loaded.kind !== "ok") {
-    return null;
+    return {
+      type: "disconnected",
+      recovery: { action: "unavailable" },
+    };
   }
   const connection = loaded.connection;
+  if (connection.needsReconnect) {
+    return {
+      type: "disconnected",
+      recovery: {
+        action: "reconnect",
+        connectionId: connection.connectorId,
+      },
+    };
+  }
   const accessTokenValueRef = connectorCredentialRuntimeValueRef(
     connection,
     GOOGLE_DRIVE_ACCESS_TOKEN_ENVIRONMENT_NAME,
   );
   if (accessTokenValueRef === null) {
-    return null;
+    return {
+      type: "disconnected",
+      recovery: { action: "unavailable" },
+    };
   }
   const values = await loadConnectorCredentialValues({
     connection,
@@ -215,12 +256,17 @@ async function loadDriveTokens(args: {
   });
   const accessToken = values.get(accessTokenValueRef);
   if (!accessToken) {
-    return null;
+    return {
+      type: "disconnected",
+      recovery: { action: "unavailable" },
+    };
   }
   return {
-    accessToken,
-    connection,
-    needsReconnect: connection.needsReconnect,
+    type: "ready",
+    tokens: {
+      accessToken,
+      connection,
+    },
   };
 }
 
@@ -373,7 +419,7 @@ function resolveGoogleDriveArtifactSyncStatus(
   fileId: string,
 ): ChatThreadArtifactGoogleDriveSync {
   if (lookup.type === "disconnected") {
-    return { status: "disconnected" };
+    return { status: "disconnected", recovery: lookup.recovery };
   }
   if (lookup.type === "unknown") {
     return { status: "unknown" };
@@ -417,19 +463,13 @@ export function googleDriveArtifactStatusLookup(args: {
 }): Command<Promise<DriveStatusLookup>, [AbortSignal]> {
   return command(async ({ get, set }, signal): Promise<DriveStatusLookup> => {
     if (!args.orgId) {
-      return { type: "disconnected" };
+      return {
+        type: "disconnected",
+        recovery: { action: "unavailable" },
+      };
     }
     const db = get(db$);
     const writeDb = set(writeDb$);
-    const authorized = await threadAllowsGoogleDriveArtifactSync(db, {
-      orgId: args.orgId,
-      userId: args.userId,
-      threadId: args.threadId,
-    });
-    signal.throwIfAborted();
-    if (!authorized) {
-      return { type: "disconnected" };
-    }
     const featureSwitchOverrides = await get(
       userFeatureSwitchOverrides(args.orgId, args.userId),
     );
@@ -441,7 +481,7 @@ export function googleDriveArtifactStatusLookup(args: {
     };
     const snapshot = await loadConnectorRuntimeSnapshot(db);
     signal.throwIfAborted();
-    const tokens = await loadDriveTokens({
+    const connection = await loadDriveConnection({
       db,
       orgId: args.orgId,
       userId: args.userId,
@@ -450,9 +490,22 @@ export function googleDriveArtifactStatusLookup(args: {
       snapshot,
     });
     signal.throwIfAborted();
-    if (!tokens || tokens.needsReconnect) {
-      return { type: "disconnected" };
+    if (connection.type === "disconnected") {
+      return connection;
     }
+    const authorized = await threadAllowsGoogleDriveArtifactSync(db, {
+      orgId: args.orgId,
+      userId: args.userId,
+      threadId: args.threadId,
+    });
+    signal.throwIfAborted();
+    if (!authorized) {
+      return {
+        type: "disconnected",
+        recovery: { action: "authorize" },
+      };
+    }
+    const { tokens } = connection;
     // Schema-parse failure or transient network error — treat as "unknown"
     // rather than failing the whole artifacts response. Request aborts still
     // propagate; the status deadline remains an unknown provider outcome.
@@ -482,7 +535,13 @@ export function googleDriveArtifactStatusLookup(args: {
       return { type: "unknown" };
     }
     if (files === "reconnect-required") {
-      return { type: "disconnected" };
+      return {
+        type: "disconnected",
+        recovery: {
+          action: "reconnect",
+          connectionId: tokens.connection.connectorId,
+        },
+      };
     }
     return { type: "ready", syncedByKey: buildStatusMap(files) };
   });
@@ -1141,7 +1200,7 @@ export const syncArtifactToGoogleDrive$ = command(
     };
     const snapshot = await loadConnectorRuntimeSnapshot(db);
     signal.throwIfAborted();
-    const tokens = await loadDriveTokens({
+    const connection = await loadDriveConnection({
       db,
       orgId: args.orgId,
       userId: args.userId,
@@ -1150,9 +1209,10 @@ export const syncArtifactToGoogleDrive$ = command(
       snapshot,
     });
     signal.throwIfAborted();
-    if (!tokens || tokens.needsReconnect) {
+    if (connection.type === "disconnected") {
       return badRequestMessage("Connect Google Drive before syncing artifacts");
     }
+    const { tokens } = connection;
 
     const artifact = await loadArtifactFile(db, {
       threadId: args.threadId,

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -521,7 +521,6 @@
       "agentLoading": "Der Agent wird noch geladen",
       "connect": "Verbinden Sie Google Drive",
       "connectTooltip": "Verbinden Sie Google Drive, um Artefakte hochzuladen",
-      "failedToOpenConnect": "Die Google Drive-Verbindungsseite konnte nicht geöffnet werden",
       "noArtifacts": "Keine zu synchronisierenden Artefakte",
       "partial_one": "{{synced}} von {{count}} Datei mit Google Drive synchronisiert",
       "partial_other": "{{synced}} von {{count}} Dateien mit Google Drive synchronisiert",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -521,7 +521,6 @@
       "agentLoading": "Agent is still loading",
       "connect": "Connect Google Drive",
       "connectTooltip": "Connect Google Drive to upload artifacts",
-      "failedToOpenConnect": "Failed to open Google Drive connection page",
       "noArtifacts": "No artifacts to sync",
       "partial_one": "Synced {{synced}} of {{count}} file to Google Drive",
       "partial_other": "Synced {{synced}} of {{count}} files to Google Drive",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -536,7 +536,6 @@
       "agentLoading": "El agente sigue cargando",
       "connect": "Conectar Google Drive",
       "connectTooltip": "Conecta Google Drive para subir artefactos",
-      "failedToOpenConnect": "No se pudo abrir la página de conexión de Google Drive",
       "noArtifacts": "No hay artefactos que sincronizar",
       "partial_one": "Se sincronizó {{synced}} de {{count}} archivo con Google Drive",
       "partial_many": "Se sincronizaron {{synced}} de {{count}} archivos con Google Drive",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -536,7 +536,6 @@
       "agentLoading": "L'agent est encore en cours de chargement",
       "connect": "Connecter Google Drive",
       "connectTooltip": "Connecter Google Drive pour télécharger des artéfacts",
-      "failedToOpenConnect": "Échec de l'ouverture de la page de connexion Google Drive",
       "noArtifacts": "Aucun artéfact à synchroniser",
       "partial_one": "{{synced}} sur {{count}} fichier synchronisé sur Google Drive",
       "partial_many": "{{synced}} sur {{count}} fichiers synchronisés sur Google Drive",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -521,7 +521,6 @@
       "agentLoading": "एजेंट अभी भी लोड हो रहा है",
       "connect": "Google Drive कनेक्ट करें",
       "connectTooltip": "आर्टिफ़ैक्ट अपलोड करने के लिए Google Drive कनेक्ट करें",
-      "failedToOpenConnect": "Google Drive कनेक्शन पृष्ठ खोलने में विफल",
       "noArtifacts": "सिंक करने के लिए कोई आर्टिफ़ैक्ट नहीं",
       "partial_one": "{{count}} फ़ाइल में से {{synced}} को Google Drive में समन्वयित किया गया",
       "partial_other": "{{count}} फ़ाइलों में से {{synced}} को Google Drive में समन्वयित किया गया",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -520,7 +520,6 @@
       "agentLoading": "Agen masih memuat",
       "connect": "Hubungkan Google Drive",
       "connectTooltip": "Hubungkan Google Drive untuk mengunggah artefak",
-      "failedToOpenConnect": "Gagal membuka halaman koneksi Google Drive",
       "noArtifacts": "Tidak ada artefak untuk disinkronkan",
       "partial_one": "Tersinkron {{synced}} dari {{count}} file ke Google Drive",
       "partial_other": "Tersinkron {{synced}} dari {{count}} file ke Google Drive",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -536,7 +536,6 @@
       "agentLoading": "L'agente è ancora in fase di caricamento",
       "connect": "Connetti Google Drive",
       "connectTooltip": "Connetti Google Drive per caricare gli artefatti",
-      "failedToOpenConnect": "Impossibile aprire la pagina di connessione a Google Drive",
       "noArtifacts": "Nessun artefatto da sincronizzare",
       "partial_one": "Sincronizzazione completata per {{synced}} file su {{count}} in Google Drive",
       "partial_many": "Sincronizzazione completata per {{synced}} file su {{count}} in Google Drive",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -520,7 +520,6 @@
       "agentLoading": "エージェントを読み込み中",
       "connect": "Google Drive を接続します",
       "connectTooltip": "Google Drive を接続してアーティファクトをアップロードする",
-      "failedToOpenConnect": "Google Drive 接続ページを開けませんでした",
       "noArtifacts": "同期するアーティファクトがありません",
       "partial_one": "{{count}} ファイルの {{synced}} を Google Drive に同期しました",
       "partial_other": "{{count}} ファイルの {{synced}} を Google Drive に同期しました",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -520,7 +520,6 @@
       "agentLoading": "에이전트가 아직 로딩 중입니다",
       "connect": "Google Drive 연결",
       "connectTooltip": "아티팩트 업로드를 위해 Google Drive를 연결하세요",
-      "failedToOpenConnect": "Google Drive 연결 페이지를 열지 못했습니다",
       "noArtifacts": "동기화할 아티팩트가 없습니다",
       "partial_one": "{{count}}개 중 {{synced}}개 파일을 Google Drive에 동기화했습니다",
       "partial_other": "{{count}}개 중 {{synced}}개 파일을 Google Drive에 동기화했습니다",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -536,7 +536,6 @@
       "agentLoading": "O agente ainda está carregando",
       "connect": "Conectar o Google Drive",
       "connectTooltip": "Conecte o Google Drive para enviar artefatos",
-      "failedToOpenConnect": "Não foi possível abrir a página de conexão do Google Drive",
       "noArtifacts": "Nenhum artefato para sincronizar",
       "partial_one": "{{synced}} de {{count}} arquivo sincronizado com o Google Drive",
       "partial_many": "{{synced}} de {{count}} arquivos sincronizados com o Google Drive",

--- a/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
@@ -1,17 +1,9 @@
-import { command } from "ccstate";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import { chatThreadArtifactsContract } from "@okouai/api-contracts/contracts/chat-threads";
 import { userConnectorsContract } from "@okouai/api-contracts/contracts/user-connectors";
 import { accept } from "../../lib/accept.ts";
 import { i18n } from "../../i18n/index.ts";
-import { apiClient$, type ApiClientFactory } from "../api-client.ts";
-import { isConnectorChangedPayloadFor } from "../connector-change.ts";
-import { connectors$, reloadConnectors$ } from "../external/connectors.ts";
-import { setAblyPayloadLoop$ } from "../realtime.ts";
-import {
-  isAgentConnectorAuthorized,
-  reloadAgentConnectorAuthorizations$,
-} from "../okou-page/agent-connector-authorizations.ts";
+import type { ApiClientFactory } from "../api-client.ts";
 import { settle, withCleanup } from "../utils.ts";
 
 type ArtifactGoogleDriveSyncParams = {
@@ -194,7 +186,7 @@ export async function syncArtifactFileToGoogleDrive(
   );
 }
 
-async function authorizeGoogleDriveForAgent(
+export async function authorizeGoogleDriveForAgent(
   params: {
     readonly agentId: string;
     readonly createClient: ApiClientFactory;
@@ -215,71 +207,3 @@ async function authorizeGoogleDriveForAgent(
   );
   signal.throwIfAborted();
 }
-
-export const waitForGoogleDriveAuthorization$ = command(
-  async (
-    { get, set },
-    params: {
-      readonly agentId: string;
-      readonly authorizeConnected?: boolean;
-    },
-    signal: AbortSignal,
-  ): Promise<void> => {
-    if (params.authorizeConnected) {
-      await authorizeGoogleDriveForAgent(
-        {
-          agentId: params.agentId,
-          createClient: get(apiClient$),
-        },
-        signal,
-      );
-    }
-
-    const authorizationReady$ = command(
-      async ({ get, set }, sig: AbortSignal): Promise<boolean> => {
-        set(reloadConnectors$);
-        set(reloadAgentConnectorAuthorizations$);
-        const [{ connectors }, authorized] = await Promise.all([
-          get(connectors$),
-          get(
-            isAgentConnectorAuthorized({
-              agentId: params.agentId,
-              connectorSlug: "google-drive",
-            }),
-          ),
-        ]);
-        sig.throwIfAborted();
-        const connected = connectors.some((connector) => {
-          return (
-            connector.slug === "google-drive" &&
-            connector.connectionStatus === "connected"
-          );
-        });
-        return connected && authorized;
-      },
-    );
-
-    if (await set(authorizationReady$, signal)) {
-      return;
-    }
-    signal.throwIfAborted();
-    const matchingConnectorChanged$ = command(
-      async ({ set }, payload: unknown, sig: AbortSignal): Promise<boolean> => {
-        if (!isConnectorChangedPayloadFor(payload, "google-drive")) {
-          return false;
-        }
-        return await set(authorizationReady$, sig);
-      },
-    );
-    await set(
-      setAblyPayloadLoop$,
-      {
-        topic: "connector:changed",
-        loopCommand$: matchingConnectorChanged$,
-        catchUpCommand$: authorizationReady$,
-        options: { runOnSubscribe: true },
-      },
-      signal,
-    );
-  },
-);

--- a/turbo/apps/platform/src/signals/okou-page/attachment-chips.ts
+++ b/turbo/apps/platform/src/signals/okou-page/attachment-chips.ts
@@ -19,7 +19,10 @@ import {
   type ObjectUrlResource,
 } from "../object-url-resource.ts";
 import { rootSignal$ } from "../root-signal.ts";
-import type { ImageAnnotation } from "@okouai/api-contracts/contracts/chat-threads";
+import type {
+  ChatThreadArtifactGoogleDriveRecovery,
+  ImageAnnotation,
+} from "@okouai/api-contracts/contracts/chat-threads";
 import { createZoomableImageCanvasSignals } from "../zoomable-image-canvas.ts";
 
 // ---------------------------------------------------------------------------
@@ -36,6 +39,9 @@ export type AttachmentArtifactMetadata = {
   readonly fileId: string;
   readonly filename: string;
   readonly googleDriveDisconnected: boolean;
+  readonly googleDriveRecovery:
+    | ChatThreadArtifactGoogleDriveRecovery
+    | undefined;
   readonly googleDriveSynced: boolean;
   readonly onSyncSuccess?: () => void;
   readonly runId: string;

--- a/turbo/apps/platform/src/views/okou-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/thread-sidebar.test.tsx
@@ -1031,13 +1031,15 @@ describe("thread-owned utility sidebar", () => {
 
   it.each([
     {
-      intent: "add",
+      scenario: "legacy add",
       initialConnector: null,
       catalogStatus: googleDriveCatalogStatus(),
       account: { intent: "add" as const },
+      recovery: undefined,
+      accountAware: false,
     },
     {
-      intent: "reconnect",
+      scenario: "legacy reconnect",
       initialConnector: googleDriveConnector({
         connectionStatus: "reconnect-required",
         reconnectReason: "authorization_expired_or_revoked",
@@ -1057,10 +1059,26 @@ describe("thread-owned utility sidebar", () => {
         intent: "reconnect" as const,
         connectionId: googleDriveConnector().id,
       },
+      recovery: undefined,
+      accountAware: false,
+    },
+    {
+      scenario: "current connect",
+      initialConnector: null,
+      catalogStatus: googleDriveCatalogStatus(),
+      account: { intent: "add" as const },
+      recovery: { action: "connect" as const },
+      accountAware: true,
     },
   ])(
-    "connects Google Drive from an artifact with explicit $intent intent",
-    async ({ initialConnector, catalogStatus, account }) => {
+    "connects Google Drive from an artifact with $scenario recovery",
+    async ({
+      initialConnector,
+      catalogStatus,
+      account,
+      recovery,
+      accountAware,
+    }) => {
       const user = userEvent.setup({ delay: null });
       const markdownUrl =
         "https://cdn.vm7.io/artifacts/test/run-sidebar/drive-connect-notes.md";
@@ -1069,7 +1087,10 @@ describe("thread-owned utility sidebar", () => {
         threadArtifactFile(markdownUrl, {
           id: "artifact-drive-connect-notes",
           filename: "drive-connect-notes.md",
-          googleDriveSync: { status: "disconnected" },
+          googleDriveSync: {
+            status: "disconnected",
+            ...(recovery ? { recovery } : {}),
+          },
         }),
       ];
 
@@ -1101,6 +1122,25 @@ describe("thread-owned utility sidebar", () => {
       let agentAuthorized = false;
       let oauthStarted = false;
       let artifactSynced = false;
+      let accountSummaryReadCount = 0;
+      context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
+        accountSummaryReadCount += 1;
+        return respond(200, {
+          summaries: connectorConnected
+            ? [
+                {
+                  target: {
+                    kind: "builtin",
+                    connectorSlug: "google-drive",
+                  },
+                  accountCount: 1,
+                  attentionCount: 0,
+                  defaultConnection: null,
+                },
+              ]
+            : [],
+        });
+      });
       context.mocks.api(connectorsMainContract.list, ({ respond }) => {
         return respond(200, {
           connectors: connectorConnected
@@ -1197,6 +1237,7 @@ describe("thread-owned utility sidebar", () => {
       await waitFor(() => {
         expect(artifactSynced).toBeTruthy();
         expect(screen.getByText("Synced to Google Drive")).toBeInTheDocument();
+        expect(accountSummaryReadCount > 0).toBe(accountAware);
       });
     },
   );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/thread-sidebar.test.tsx
@@ -7,6 +7,10 @@ import {
 } from "@okouai/api-contracts/contracts/artifact-catalog";
 import type { ConnectorResponse } from "@okouai/api-contracts/contracts/connector-schemas";
 import {
+  connectorAccountsContract,
+  type ConnectorAccountConnection,
+} from "@okouai/api-contracts/contracts/connector-accounts";
+import {
   chatThreadByIdContract,
   chatThreadArtifactsContract,
   chatThreadEventsContract,
@@ -58,6 +62,7 @@ const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 const THREAD_ID = "b0000000-0000-4000-a000-000000000050";
 const THREAD_PATH = `/chats/${THREAD_ID}`;
 const ARTIFACT_ID = "a0000000-0000-4000-a000-000000000001";
+const SELECTED_DRIVE_CONNECTION_ID = "22222222-2222-4222-8222-222222222222";
 
 type OfficePreviewFixture = {
   readonly filename: string;
@@ -228,6 +233,28 @@ function googleDriveConnector(
     oauthScopes: ["drive.file"],
     connectionStatus: "connected",
     reconnectReason: null,
+    tokenExpiresAt: null,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function googleDriveAccountConnection(
+  overrides: Partial<ConnectorAccountConnection> = {},
+): ConnectorAccountConnection {
+  return {
+    id: SELECTED_DRIVE_CONNECTION_ID,
+    target: { kind: "builtin", connectorSlug: "google-drive" },
+    authMethod: "oauth",
+    displayName: "Selected Drive",
+    isDefault: false,
+    externalId: "selected-drive-external-id",
+    externalUsername: "selected-drive-user",
+    externalEmail: "selected-drive@example.test",
+    oauthScopes: ["drive.file"],
+    connectionStatus: "reconnect-required",
+    reconnectReason: "authorization_expired_or_revoked",
     tokenExpiresAt: null,
     createdAt: "2026-01-01T00:00:00Z",
     updatedAt: "2026-01-01T00:00:00Z",
@@ -899,7 +926,10 @@ describe("thread-owned utility sidebar", () => {
       threadArtifactFile(markdownUrl, {
         id: "artifact-drive-agent-notes",
         filename: "drive-agent-notes.md",
-        googleDriveSync: { status: "disconnected" },
+        googleDriveSync: {
+          status: "disconnected",
+          recovery: { action: "authorize" },
+        },
       }),
     ];
 
@@ -918,7 +948,14 @@ describe("thread-owned utility sidebar", () => {
         ],
       ]),
     );
-    context.mocks.data.connectors([googleDriveConnector()]);
+    context.mocks.data.connectors([
+      googleDriveConnector({
+        id: "22222222-2222-4222-8222-222222222222",
+        connectionStatus: "reconnect-required",
+        reconnectReason: "authorization_expired_or_revoked",
+      }),
+      googleDriveConnector(),
+    ]);
     context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
       return respond(200, { connectors: [] });
     });
@@ -1067,7 +1104,11 @@ describe("thread-owned utility sidebar", () => {
       context.mocks.api(connectorsMainContract.list, ({ respond }) => {
         return respond(200, {
           connectors: connectorConnected
-            ? [googleDriveConnector()]
+            ? [
+                googleDriveConnector({
+                  updatedAt: "2026-01-01T00:00:01Z",
+                }),
+              ]
             : initialConnector
               ? [initialConnector]
               : [],
@@ -1159,6 +1200,220 @@ describe("thread-owned utility sidebar", () => {
       });
     },
   );
+
+  it("reconnects the selected Drive account before syncing the artifact", async () => {
+    const user = userEvent.setup({ delay: null });
+    const markdownUrl =
+      "https://cdn.vm7.io/artifacts/test/run-sidebar/drive-selected-notes.md";
+    const summary = catalogArtifact({ title: "drive-selected-notes.md" });
+    const artifactFiles = [
+      threadArtifactFile(markdownUrl, {
+        id: "artifact-drive-selected-notes",
+        filename: "drive-selected-notes.md",
+        googleDriveSync: {
+          status: "disconnected",
+          recovery: {
+            action: "reconnect",
+            connectionId: SELECTED_DRIVE_CONNECTION_ID,
+          },
+        },
+      }),
+    ];
+
+    setupArtifactCatalog(
+      [summary],
+      new Map([
+        [
+          summary.id,
+          catalogFileDetail({
+            contentType: "text/markdown",
+            filename: "drive-selected-notes.md",
+            fileId: "f0000000-0000-4000-a000-000000000005",
+            summary,
+            url: markdownUrl,
+          }),
+        ],
+      ]),
+    );
+    context.mocks.data.connectors([
+      googleDriveConnector(),
+      googleDriveConnector({
+        id: SELECTED_DRIVE_CONNECTION_ID,
+        externalId: "selected-drive-external-id",
+        externalUsername: "selected-drive-user",
+        externalEmail: "selected-drive@example.test",
+        connectionStatus: "reconnect-required",
+        reconnectReason: "authorization_expired_or_revoked",
+      }),
+    ]);
+    context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
+      return respond(200, {
+        connectors: [googleDriveCatalogStatus()],
+      });
+    });
+    context.mocks.http.get(markdownUrl, () => {
+      return new Response("# Selected notes\n\nReady for Drive.", {
+        headers: { "Content-Type": "text/plain" },
+      });
+    });
+
+    let accountUpdatedAt = "2026-01-01T00:00:00Z";
+    let accountReadCount = 0;
+    context.mocks.api(
+      connectorAccountsContract.connection,
+      ({ params, query, respond }) => {
+        expect(params.connectionId).toBe(SELECTED_DRIVE_CONNECTION_ID);
+        expect(query).toStrictEqual({
+          kind: "builtin",
+          connectorSlug: "google-drive",
+        });
+        accountReadCount += 1;
+        return respond(
+          200,
+          googleDriveAccountConnection({ updatedAt: accountUpdatedAt }),
+        );
+      },
+    );
+
+    let oauthStarted = false;
+    let artifactSynced = false;
+    const authWindow = context.mocks.browser.authWindow();
+    Object.defineProperty(authWindow, "location", {
+      value: { href: "" },
+      configurable: true,
+    });
+    context.mocks.browser.open(authWindow);
+    context.mocks.api(
+      connectorOauthStartContract.start,
+      ({ body, params, respond }) => {
+        expect(params.connectorSlug).toBe("google-drive");
+        expect(body).toStrictEqual({
+          account: {
+            intent: "reconnect",
+            connectionId: SELECTED_DRIVE_CONNECTION_ID,
+          },
+          authMethod: "oauth",
+          agentId: AGENT_ID,
+          authorizeAgent: true,
+          callbackTarget: "app",
+        });
+        oauthStarted = true;
+        return respond(200, {
+          authorizationUrl: "https://accounts.google.test/drive/authorize",
+        });
+      },
+    );
+    context.mocks.api(
+      chatThreadArtifactsContract.syncGoogleDrive,
+      ({ body, respond }) => {
+        expect(accountUpdatedAt).toBe("2026-01-01T00:00:01Z");
+        expect(body).toStrictEqual({
+          runId: "run-sidebar",
+          fileId: "artifact-drive-selected-notes",
+        });
+        artifactFiles[0] = {
+          ...artifactFiles[0]!,
+          googleDriveSync: {
+            status: "synced",
+            id: "drive-file-selected-notes",
+            name: "drive-selected-notes.md",
+            webViewLink: "https://drive.test/drive-selected-notes",
+          },
+        };
+        artifactSynced = true;
+        return respond(200, {
+          id: "drive-file-selected-notes",
+          name: "drive-selected-notes.md",
+          webViewLink: "https://drive.test/drive-selected-notes",
+        });
+      },
+    );
+
+    setupChatThread({ artifactFiles });
+    await openCatalogArtifact("drive-selected-notes.md");
+    await screen.findByText("Ready for Drive.");
+
+    await user.click(screen.getByLabelText("Download artifact"));
+    await user.click(await screen.findByText("Connect Google Drive"));
+    await waitFor(() => {
+      expect(oauthStarted).toBeTruthy();
+    });
+
+    const readsBeforeSiblingEvent = accountReadCount;
+    context.mocks.ably.trigger("connector:changed", {
+      connectorSlug: "google-drive",
+    });
+    await waitFor(() => {
+      expect(accountReadCount).toBeGreaterThan(readsBeforeSiblingEvent);
+    });
+    expect(artifactSynced).toBeFalsy();
+
+    accountUpdatedAt = "2026-01-01T00:00:01Z";
+    context.mocks.ably.trigger("connector:changed", {
+      connectorSlug: "google-drive",
+    });
+    await waitFor(() => {
+      expect(artifactSynced).toBeTruthy();
+      expect(screen.getByText("Synced to Google Drive")).toBeInTheDocument();
+    });
+  });
+
+  it("does not mutate a sibling when selected Drive recovery is unavailable", async () => {
+    const user = userEvent.setup({ delay: null });
+    const markdownUrl =
+      "https://cdn.vm7.io/artifacts/test/run-sidebar/drive-unavailable-notes.md";
+    const summary = catalogArtifact({ title: "drive-unavailable-notes.md" });
+
+    setupArtifactCatalog(
+      [summary],
+      new Map([
+        [
+          summary.id,
+          catalogFileDetail({
+            contentType: "text/markdown",
+            filename: "drive-unavailable-notes.md",
+            fileId: "f0000000-0000-4000-a000-000000000006",
+            summary,
+            url: markdownUrl,
+          }),
+        ],
+      ]),
+    );
+    context.mocks.data.connectors([googleDriveConnector()]);
+    context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
+      return respond(200, {
+        connectors: [googleDriveCatalogStatus()],
+      });
+    });
+    context.mocks.http.get(markdownUrl, () => {
+      return new Response("# Unavailable notes\n\nNo safe recovery.", {
+        headers: { "Content-Type": "text/plain" },
+      });
+    });
+
+    setupChatThread({
+      artifactFiles: [
+        threadArtifactFile(markdownUrl, {
+          id: "artifact-drive-unavailable-notes",
+          filename: "drive-unavailable-notes.md",
+          googleDriveSync: {
+            status: "disconnected",
+            recovery: { action: "unavailable" },
+          },
+        }),
+      ],
+    });
+    await openCatalogArtifact("drive-unavailable-notes.md");
+    await screen.findByText("No safe recovery.");
+
+    await user.click(screen.getByLabelText("Download artifact"));
+    await waitFor(() => {
+      expect(menuItemByText("Connect Google Drive")).toHaveAttribute(
+        "aria-disabled",
+        "true",
+      );
+    });
+  });
 
   it("shows empty and unavailable CSV states from catalog details", async () => {
     const emptyCsvUrl =

--- a/turbo/apps/platform/src/views/okou-page/artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/okou-page/artifact-actions.tsx
@@ -13,22 +13,16 @@ import {
   BrandGoogleDrive,
 } from "@okouai/ui";
 import { toast } from "@okouai/ui/components/ui/sonner";
-import { isConnectorAppOauthCallbackEnabled } from "@okouai/connectors/app-oauth-callback";
-import {
-  connectorOauthStartContract,
-  connectorOpenIdStartContract,
-} from "@okouai/api-contracts/contracts/connectors";
-import type { ChatThreadArtifactFile } from "@okouai/api-contracts/contracts/chat-threads";
+import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
+import type {
+  ChatThreadArtifactFile,
+  ChatThreadArtifactGoogleDriveRecovery,
+} from "@okouai/api-contracts/contracts/chat-threads";
 import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
-import { accept } from "../../lib/accept.ts";
 import { i18n } from "../../i18n/index.ts";
 import { downloadAttachment$ } from "../../signals/attachment-download.ts";
-import {
-  OAUTH_API_BASE,
-  apiClient$,
-  type ApiClientFactory,
-} from "../../signals/api-client.ts";
+import { apiClient$ } from "../../signals/api-client.ts";
 import {
   connectorCatalogStatusBySlug$,
   connectors$,
@@ -44,14 +38,13 @@ import {
   startArtifactDownload$,
 } from "../../signals/okou-page/artifact-actions.ts";
 import {
+  authorizeGoogleDriveForAgent,
   syncArtifactFileToGoogleDrive,
-  waitForGoogleDriveAuthorization$,
 } from "../../signals/chat-page/artifact-google-drive-sync.ts";
 import {
+  connectConnectorOAuthAuthCodeAndSettle$,
   getOnlyAvailableCatalogBrowserAuthMethodDetail,
-  type ConnectorCatalogBrowserAuthMethodDetail,
 } from "../../signals/okou-page/settings/connectors.ts";
-import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
 import { defaultBuiltinConnectorAccountOptions } from "../../signals/okou-page/settings/connector-account-dialogs.ts";
 import { copyAttachmentLinkToClipboard } from "./attachment-url.ts";
 import { useAttachmentShareUrl } from "./attachment-resource.ts";
@@ -91,22 +84,13 @@ function artifactDownloadFilename(
     : filename;
 }
 
-type WaitForGoogleDriveAuthorizationFn = (
-  params: {
-    readonly agentId: string;
-    readonly authorizeConnected?: boolean;
-  },
-  signal: AbortSignal,
-) => Promise<unknown>;
-
-type GoogleDriveReadyRun = () => Promise<void>;
-
 export type ArtifactDownloadSyncTarget = {
   readonly agentId: string | null | undefined;
   readonly disconnected: boolean;
   readonly fileId: string;
   readonly filename: string;
   readonly onSyncSuccess: () => void;
+  readonly recovery: ChatThreadArtifactGoogleDriveRecovery | undefined;
   readonly runId: string;
   readonly synced: boolean;
   readonly threadId: string;
@@ -126,148 +110,6 @@ function isPlainPrimaryLinkClick(
     !event.metaKey &&
     !event.shiftKey
   );
-}
-
-function runWhenGoogleDriveReady(
-  params: {
-    agentId: string | null | undefined;
-    authorizeConnected: boolean;
-    run: GoogleDriveReadyRun;
-    waitForGoogleDriveAuthorization: WaitForGoogleDriveAuthorizationFn;
-    operation: string;
-  },
-  pageSignal: AbortSignal,
-): void {
-  if (!params.agentId) {
-    toast.error(
-      i18n.t(($) => {
-        return $.artifacts.googleDrive.agentLoading;
-      }),
-    );
-    return;
-  }
-  const agentId = params.agentId;
-  detach(
-    (async () => {
-      await params.waitForGoogleDriveAuthorization(
-        { agentId, authorizeConnected: params.authorizeConnected },
-        pageSignal,
-      );
-      await params.run();
-    })(),
-    Reason.DomCallback,
-    params.operation,
-  );
-}
-
-function startGoogleDriveConnectAndRun(
-  params: {
-    agentId: string | null | undefined;
-    authMethod: ConnectorCatalogBrowserAuthMethodDetail;
-    connector: PlatformConnectorCatalogStatusItem;
-    createClient: ApiClientFactory;
-    run: GoogleDriveReadyRun;
-    waitForGoogleDriveAuthorization: WaitForGoogleDriveAuthorizationFn;
-    operation: string;
-  },
-  pageSignal: AbortSignal,
-): void {
-  if (!params.agentId) {
-    toast.error(
-      i18n.t(($) => {
-        return $.artifacts.googleDrive.agentLoading;
-      }),
-    );
-    return;
-  }
-  const agentId = params.agentId;
-  const account = defaultBuiltinConnectorAccountOptions(
-    params.connector,
-  )?.account;
-  if (!account) {
-    return;
-  }
-  const authWindow = window.open(
-    "about:blank",
-    "_blank",
-    "width=600,height=700",
-  );
-  if (!authWindow) {
-    toast.error(
-      i18n.t(($) => {
-        return $.artifacts.googleDrive.failedToOpenConnect;
-      }),
-    );
-    return;
-  }
-  detach(
-    (async () => {
-      const request = {
-        params: { connectorSlug: params.connector.slug },
-        body: {
-          account,
-          authMethod: params.authMethod.id,
-          agentId,
-          authorizeAgent: true as const,
-        },
-        fetchOptions: { signal: pageSignal },
-      };
-      const result =
-        params.authMethod.grantKind === "openid-auth"
-          ? await accept(
-              params
-                .createClient(connectorOpenIdStartContract, {
-                  apiBase: "api",
-                })
-                .start(request),
-              [200],
-            )
-          : await accept(
-              params
-                .createClient(connectorOauthStartContract, {
-                  apiBase: OAUTH_API_BASE,
-                })
-                .start({
-                  ...request,
-                  body: {
-                    ...request.body,
-                    ...(isConnectorAppOauthCallbackEnabled(
-                      params.connector.slug,
-                    )
-                      ? { callbackTarget: "app" as const }
-                      : {}),
-                  },
-                }),
-              [200],
-            );
-      pageSignal.throwIfAborted();
-      authWindow.location.href = result.body.authorizationUrl;
-    })(),
-    Reason.DomCallback,
-    "artifact google drive oauth start",
-  );
-  runWhenGoogleDriveReady(
-    {
-      agentId,
-      authorizeConnected: false,
-      run: params.run,
-      waitForGoogleDriveAuthorization: params.waitForGoogleDriveAuthorization,
-      operation: params.operation,
-    },
-    pageSignal,
-  );
-}
-
-function authorizeGoogleDriveAndRun(
-  params: {
-    agentId: string | null | undefined;
-    run: GoogleDriveReadyRun;
-    waitForGoogleDriveAuthorization: WaitForGoogleDriveAuthorizationFn;
-    operation: string;
-  },
-  pageSignal: AbortSignal,
-): void {
-  runWhenGoogleDriveReady({ ...params, authorizeConnected: true }, pageSignal);
 }
 
 function iconButtonClassName(className?: string): string {
@@ -429,24 +271,166 @@ function GoogleDriveDisabledMenuItem({
   );
 }
 
+type GoogleDrivePendingAction =
+  | { readonly kind: "authorize" }
+  | {
+      readonly kind: "connect";
+      readonly account: ConnectorAccountMutationIntent;
+      readonly useDefaultConnectorProjection: boolean;
+    }
+  | { readonly kind: "unavailable" };
+
+function resolveGoogleDrivePendingAction(args: {
+  readonly recovery: ChatThreadArtifactGoogleDriveRecovery | undefined;
+  readonly connected: boolean;
+  readonly legacyAccountOptions: ReturnType<
+    typeof defaultBuiltinConnectorAccountOptions
+  >;
+}): GoogleDrivePendingAction {
+  if (args.recovery) {
+    switch (args.recovery.action) {
+      case "authorize": {
+        return { kind: "authorize" };
+      }
+      case "connect": {
+        return {
+          kind: "connect",
+          account: { intent: "add" },
+          useDefaultConnectorProjection: false,
+        };
+      }
+      case "reconnect": {
+        return {
+          kind: "connect",
+          account: {
+            intent: "reconnect",
+            connectionId: args.recovery.connectionId,
+          },
+          useDefaultConnectorProjection: false,
+        };
+      }
+      case "unavailable": {
+        return { kind: "unavailable" };
+      }
+    }
+  }
+  if (args.connected) {
+    return { kind: "authorize" };
+  }
+  return args.legacyAccountOptions
+    ? { kind: "connect", ...args.legacyAccountOptions }
+    : { kind: "unavailable" };
+}
+
+function useGoogleDriveMenuAction(
+  syncTarget: ArtifactDownloadSyncTarget | undefined,
+  availability: ReturnType<typeof useGoogleDriveAvailability>,
+): () => void {
+  const createClient = useGet(apiClient$);
+  const pageSignal = useGet(pageSignal$);
+  const connectGoogleDrive = useSet(connectConnectorOAuthAuthCodeAndSettle$);
+
+  return () => {
+    if (!syncTarget) {
+      return;
+    }
+    const run = async () => {
+      const success = await syncArtifactFileToGoogleDrive(
+        {
+          createClient,
+          threadId: syncTarget.threadId,
+          runId: syncTarget.runId,
+          fileId: syncTarget.fileId,
+          filename: syncTarget.filename,
+        },
+        pageSignal,
+      );
+      if (success) {
+        syncTarget.onSyncSuccess();
+      }
+    };
+    if (availability.googleDriveReady) {
+      detach(run(), Reason.DomCallback, "artifact google drive sync");
+      return;
+    }
+    const action = resolveGoogleDrivePendingAction({
+      recovery: syncTarget.recovery,
+      connected: availability.googleDriveConnected,
+      legacyAccountOptions: defaultBuiltinConnectorAccountOptions(
+        availability.googleDriveConnector ?? undefined,
+      ),
+    });
+    if (action.kind === "unavailable") {
+      return;
+    }
+    if (!syncTarget.agentId) {
+      toast.error(
+        i18n.t(($) => {
+          return $.artifacts.googleDrive.agentLoading;
+        }),
+      );
+      return;
+    }
+    const agentId = syncTarget.agentId;
+    if (action.kind === "authorize") {
+      detach(
+        (async () => {
+          await authorizeGoogleDriveForAgent(
+            { agentId, createClient },
+            pageSignal,
+          );
+          await run();
+        })(),
+        Reason.DomCallback,
+        "artifact google drive authorize sync",
+      );
+      return;
+    }
+    if (
+      !availability.googleDriveConnector ||
+      !availability.googleDriveAuthMethod
+    ) {
+      return;
+    }
+    detach(
+      connectGoogleDrive(
+        {
+          connectorSlug: GOOGLE_DRIVE_CONNECTOR_SLUG,
+          method: availability.googleDriveAuthMethod,
+          onSuccess: run,
+          options: {
+            account: action.account,
+            agentId,
+            connectorIcon: availability.googleDriveConnector.icon,
+            connectorLabel: availability.googleDriveConnector.label,
+            ...(action.useDefaultConnectorProjection
+              ? { useDefaultConnectorProjection: true }
+              : {}),
+          },
+        },
+        pageSignal,
+      ),
+      Reason.DomCallback,
+      "artifact google drive connect sync",
+    );
+  };
+}
+
 function GoogleDriveMenuItem({
   syncTarget,
 }: {
   syncTarget?: ArtifactDownloadSyncTarget;
 }) {
   const { t } = useTranslation();
+  const availability = useGoogleDriveAvailability(syncTarget);
+  const syncOrConnect = useGoogleDriveMenuAction(syncTarget, availability);
   const {
     connectorListLoaded,
     googleDriveAuthMethod,
     googleDriveConnected,
     googleDriveConnector,
     googleDriveReady,
-  } = useGoogleDriveAvailability(syncTarget);
-  const createClient = useGet(apiClient$);
-  const pageSignal = useGet(pageSignal$);
-  const waitForGoogleDriveAuthorization = useSet(
-    waitForGoogleDriveAuthorization$,
-  );
+  } = availability;
 
   if (!syncTarget) {
     return <GoogleDriveDisabledMenuItem kind="upload" />;
@@ -464,55 +448,6 @@ function GoogleDriveMenuItem({
       />
     );
   }
-
-  const syncOrConnect = () => {
-    const run = async () => {
-      const success = await syncArtifactFileToGoogleDrive(
-        {
-          createClient,
-          threadId: syncTarget.threadId,
-          runId: syncTarget.runId,
-          fileId: syncTarget.fileId,
-          filename: syncTarget.filename,
-        },
-        pageSignal,
-      );
-      if (success) {
-        syncTarget.onSyncSuccess();
-      }
-    };
-    if (googleDriveReady) {
-      detach(run(), Reason.DomCallback, "artifact google drive sync");
-      return;
-    }
-    if (googleDriveConnected) {
-      authorizeGoogleDriveAndRun(
-        {
-          agentId: syncTarget.agentId,
-          run,
-          waitForGoogleDriveAuthorization,
-          operation: "artifact google drive authorize sync",
-        },
-        pageSignal,
-      );
-      return;
-    }
-    if (!googleDriveConnector || !googleDriveAuthMethod) {
-      return;
-    }
-    startGoogleDriveConnectAndRun(
-      {
-        agentId: syncTarget.agentId,
-        authMethod: googleDriveAuthMethod,
-        connector: googleDriveConnector,
-        createClient,
-        run,
-        waitForGoogleDriveAuthorization,
-        operation: "artifact google drive connect sync",
-      },
-      pageSignal,
-    );
-  };
 
   if (googleDriveReady) {
     return (
@@ -532,8 +467,13 @@ function GoogleDriveMenuItem({
           render={
             <DropdownMenuItem
               disabled={
-                !googleDriveConnected &&
-                (!googleDriveConnector || !googleDriveAuthMethod)
+                syncTarget.recovery?.action === "unavailable" ||
+                ((syncTarget.recovery?.action === "connect" ||
+                  syncTarget.recovery?.action === "reconnect") &&
+                  (!googleDriveConnector || !googleDriveAuthMethod)) ||
+                (syncTarget.recovery === undefined &&
+                  !googleDriveConnected &&
+                  (!googleDriveConnector || !googleDriveAuthMethod))
               }
               onClick={syncOrConnect}
             >

--- a/turbo/apps/platform/src/views/okou-page/artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/artifact-sidebar.tsx
@@ -465,6 +465,10 @@ function artifactSidebarSyncTarget(params: {
   return {
     agentId: params.agentId,
     disconnected: params.item.file.googleDriveSync?.status === "disconnected",
+    recovery:
+      params.item.file.googleDriveSync?.status === "disconnected"
+        ? params.item.file.googleDriveSync.recovery
+        : undefined,
     fileId: params.item.file.id,
     filename: params.item.file.filename,
     onSyncSuccess: params.onSyncSuccess,

--- a/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
@@ -339,6 +339,7 @@ function artifactDialogSyncTarget(
   return {
     agentId: artifact.agentId,
     disconnected: artifact.googleDriveDisconnected,
+    recovery: artifact.googleDriveRecovery,
     fileId: artifact.fileId,
     filename: artifact.filename,
     onSyncSuccess:
@@ -386,6 +387,10 @@ function artifactDialogMetadataFromItem(params: {
     filename: params.item.file.filename,
     googleDriveDisconnected:
       params.item.file.googleDriveSync?.status === "disconnected",
+    googleDriveRecovery:
+      params.item.file.googleDriveSync?.status === "disconnected"
+        ? params.item.file.googleDriveSync.recovery
+        : undefined,
     googleDriveSynced: params.item.file.googleDriveSync?.status === "synced",
     onSyncSuccess: params.onSyncSuccess,
     runId: params.item.runId,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 
 import { imageModelIdSchema } from "../image-models";
 import {
@@ -7,12 +8,45 @@ import {
   chatThreadComputerUseHostContract,
   chatThreadDraftSchema,
   chatThreadEventSchema,
+  chatThreadArtifactGoogleDriveSyncSchema,
   chatThreadsContract,
   chatEventSchema,
   generationTemplateRequestSchema,
   userMessageDocumentSchema,
   userMessageInputDocumentSchema,
 } from "../chat-threads";
+
+describe("google drive artifact recovery contract", () => {
+  it("keeps disconnected recovery additive across API and Platform versions", () => {
+    const legacyDisconnected = { status: "disconnected" } as const;
+    const exactReconnect = {
+      status: "disconnected",
+      recovery: {
+        action: "reconnect",
+        connectionId: "11111111-1111-4111-8111-111111111111",
+      },
+    } as const;
+    const previousDisconnectedSchema = z.object({
+      status: z.literal("disconnected"),
+    });
+
+    expect(
+      chatThreadArtifactGoogleDriveSyncSchema.parse(legacyDisconnected),
+    ).toStrictEqual(legacyDisconnected);
+    expect(previousDisconnectedSchema.parse(exactReconnect)).toStrictEqual(
+      legacyDisconnected,
+    );
+    expect(
+      chatThreadArtifactGoogleDriveSyncSchema.parse(exactReconnect),
+    ).toStrictEqual(exactReconnect);
+    expect(
+      chatThreadArtifactGoogleDriveSyncSchema.safeParse({
+        status: "disconnected",
+        recovery: { action: "reconnect", connectionId: "not-a-uuid" },
+      }).success,
+    ).toBe(false);
+  });
+});
 
 describe("chat message response contract", () => {
   const workflowId = "11111111-1111-4111-8111-111111111111";

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -215,6 +215,19 @@ const resolvedAttachFileSchema = attachFileSchema.extend({
   assetRef: assetRefSchema.optional(),
 });
 
+const chatThreadArtifactGoogleDriveRecoverySchema = z.discriminatedUnion(
+  "action",
+  [
+    z.object({ action: z.literal("authorize") }),
+    z.object({ action: z.literal("connect") }),
+    z.object({
+      action: z.literal("reconnect"),
+      connectionId: z.uuid(),
+    }),
+    z.object({ action: z.literal("unavailable") }),
+  ],
+);
+
 const chatThreadArtifactGoogleDriveSyncSchema = z.discriminatedUnion("status", [
   z.object({
     status: z.literal("synced"),
@@ -223,7 +236,10 @@ const chatThreadArtifactGoogleDriveSyncSchema = z.discriminatedUnion("status", [
     webViewLink: z.string().nullable(),
   }),
   z.object({ status: z.literal("not_synced") }),
-  z.object({ status: z.literal("disconnected") }),
+  z.object({
+    status: z.literal("disconnected"),
+    recovery: chatThreadArtifactGoogleDriveRecoverySchema.optional(),
+  }),
   z.object({ status: z.literal("unknown") }),
 ]);
 
@@ -1948,6 +1964,7 @@ export {
   imageAnnotationSchema,
   imageAnnotationMarkSchema,
   chatThreadArtifactFileSchema,
+  chatThreadArtifactGoogleDriveRecoverySchema,
   chatThreadArtifactGoogleDriveSyncSchema,
   chatThreadArtifactRunSchema,
 };
@@ -2064,5 +2081,8 @@ export type ChatThreadArtifactFile = z.infer<
 >;
 export type ChatThreadArtifactGoogleDriveSync = z.infer<
   typeof chatThreadArtifactGoogleDriveSyncSchema
+>;
+export type ChatThreadArtifactGoogleDriveRecovery = z.infer<
+  typeof chatThreadArtifactGoogleDriveRecoverySchema
 >;
 export type ChatThreadArtifactRun = z.infer<typeof chatThreadArtifactRunSchema>;


### PR DESCRIPTION
## Summary

- project an explicit Google Drive recovery action from the API for each disconnected artifact, including the exact account ID for reconnects
- route artifact authorization and OAuth through the shared account-aware connector flow so sibling account events cannot complete the wrong recovery
- preserve rolling-deployment compatibility by making recovery metadata additive and retaining a bounded fallback for older API responses

## Scope

- keeps the existing thread connector selection table and canonical account-deletion behavior unchanged
- keeps default-account inheritance unchanged when a thread has no explicit selection
- does not add a database migration or change artifact sync persistence

## Validation

- `pnpm format`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/api-contracts --workspace api --workspace @okouai/app`
- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/chat-threads.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/thread-sidebar.test.tsx`
- pre-commit full Turbo Knip and type checks

Closes #31213

Parent: #30585
