### PR TITLE
feat(mcp): add oauth scope reauthorization

### DIFF
--- a/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
@@ -120,6 +120,8 @@ describe("auth tokens", () => {
 
   it("generates one Okou-scoped run token with the complete run claims", () => {
     const computerUseHostId = "00000000-0000-4000-8000-000000000001";
+    const customConnectorId = "00000000-0000-4000-8000-000000000002";
+    const customConnectorSourceId = "00000000-0000-4000-8000-000000000003";
     const okouToken = generateOkouToken(
       "user_shared",
       "run_shared",
@@ -130,6 +132,9 @@ describe("auth tokens", () => {
         computerUseHostId,
         cloudBrowserEnabled: true,
         imageRecognitionAvailable: true,
+        customConnectorSourceIds: {
+          [customConnectorId]: customConnectorSourceId,
+        },
       },
     );
 
@@ -142,6 +147,9 @@ describe("auth tokens", () => {
       orgId: "org_shared",
       computerUseHostId,
       cloudBrowserEnabled: true,
+      customConnectorSourceIds: {
+        [customConnectorId]: customConnectorSourceId,
+      },
       capabilities: expect.arrayContaining([
         "banking:read",
         "browser:read",
@@ -160,6 +168,9 @@ describe("auth tokens", () => {
       publicBrand: "okou",
       computerUseHostId,
       cloudBrowserEnabled: true,
+      customConnectorSourceIds: {
+        [customConnectorId]: customConnectorSourceId,
+      },
     });
   });
 

--- a/turbo/apps/api/src/signals/auth/auth-context.ts
+++ b/turbo/apps/api/src/signals/auth/auth-context.ts
@@ -150,6 +150,9 @@ const agentAuth$ = command(
       ...(agentAuth.computerUseHostId
         ? { computerUseHostId: agentAuth.computerUseHostId }
         : {}),
+      ...(agentAuth.customConnectorSourceIds
+        ? { customConnectorSourceIds: agentAuth.customConnectorSourceIds }
+        : {}),
     };
 
     const membership = await set(

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -42,6 +42,7 @@ interface OkouTokenOptions {
   readonly computerUseHostId?: string;
   readonly cloudBrowserEnabled?: boolean;
   readonly imageRecognitionAvailable?: boolean;
+  readonly customConnectorSourceIds?: Readonly<Record<string, string>>;
 }
 
 const jwtBaseSchema = z.object({
@@ -83,6 +84,9 @@ const okouTokenPayloadSchema = jwtBaseSchema.extend({
   publicBrand: publicBrandSchema.optional(),
   computerUseHostId: z.string().uuid().optional(),
   cloudBrowserEnabled: z.literal(true).optional(),
+  customConnectorSourceIds: z
+    .record(z.string().uuid(), z.string().uuid())
+    .optional(),
 });
 
 type OkouTokenClaims = Omit<z.infer<typeof okouTokenPayloadSchema>, "scope">;
@@ -282,6 +286,9 @@ export function verifyOkouToken(token: string): AgentAuth | null {
     ...(parsed.data.cloudBrowserEnabled
       ? { cloudBrowserEnabled: parsed.data.cloudBrowserEnabled }
       : {}),
+    ...(parsed.data.customConnectorSourceIds
+      ? { customConnectorSourceIds: parsed.data.customConnectorSourceIds }
+      : {}),
   };
 }
 
@@ -376,6 +383,9 @@ function buildOkouTokenClaims(
     ...(capabilities.includes("browser:write") &&
     options?.cloudBrowserEnabled === true
       ? { cloudBrowserEnabled: true as const }
+      : {}),
+    ...(options?.customConnectorSourceIds
+      ? { customConnectorSourceIds: options.customConnectorSourceIds }
       : {}),
     iat: nowSeconds,
     exp: nowSeconds + 2 * 60 * 60,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -221,6 +221,7 @@ interface CustomConnectorOAuth2ProviderRecorder {
 
 interface CustomConnectorOAuth2ProviderOptions {
   readonly initialExpiresIn?: number;
+  readonly authorizationCodeScopes?: readonly string[];
   readonly initialRefreshToken?: string | null;
   readonly initialScope?: string;
   readonly refreshResponse?: (attempt: number) => Response | Promise<Response>;
@@ -292,6 +293,7 @@ interface AutomaticMcpOAuthProviderOptions {
   readonly resourceMetadataStatus?: number;
   readonly challengeScope?: string | null;
   readonly metadataScopes?: readonly string[];
+  readonly authorizationCodeScopes?: readonly string[];
   readonly refreshError?:
     | "invalid_client"
     | "invalid_grant"
@@ -311,6 +313,7 @@ interface AutomaticMcpOAuthProviderRecorder {
   readonly endpoint: string;
   readonly issuer: string;
   readonly registrationBodies: readonly Record<string, unknown>[];
+  advertiseAuthorizationServers(issuers: readonly string[]): void;
   authorizationServerDiscoveryCalls(): number;
   readonly tokenBodies: readonly URLSearchParams[];
   readonly tokenAuthorizationHeaders: readonly (string | null)[];
@@ -334,7 +337,6 @@ export function mockAutomaticMcpOAuthProvider(
   const registrationUrl = `${issuer}/register`;
   const resourceMetadata = {
     resource: options.resource ?? endpoint,
-    authorization_servers: [issuer],
     scopes_supported: [...(options.metadataScopes ?? ["metadata-fallback"])],
   };
   const tokenEndpointAuthMethod =
@@ -367,7 +369,9 @@ export function mockAutomaticMcpOAuthProvider(
   const tokenBodies: URLSearchParams[] = [];
   const tokenAuthorizationHeaders: (string | null)[] = [];
   let authorizationServerDiscoveryCallCount = 0;
+  let advertisedAuthorizationServers: readonly string[] = [issuer];
   let refreshAttempts = 0;
+  let authorizationCodeAttempts = 0;
   const authorizationServerDiscoveryBarrier =
     options.synchronizeAuthorizationServerDiscovery
       ? createDeferredPromise<void>(AbortSignal.any([]))
@@ -393,6 +397,12 @@ export function mockAutomaticMcpOAuthProvider(
     }
   };
   server.use(
+    http.get(endpoint, () => {
+      return new HttpResponse(null, {
+        status: 405,
+        headers: { allow: "POST" },
+      });
+    }),
     http.post(endpoint, async ({ request }) => {
       if (options.authentication === "none") {
         const body = z
@@ -439,7 +449,10 @@ export function mockAutomaticMcpOAuthProvider(
             { error: "resource_metadata_unavailable" },
             { status: options.resourceMetadataStatus },
           )
-        : HttpResponse.json(resourceMetadata);
+        : HttpResponse.json({
+            ...resourceMetadata,
+            authorization_servers: [...advertisedAuthorizationServers],
+          });
     }),
     http.get(
       "https://automatic-mcp.example.test/.well-known/oauth-protected-resource/server",
@@ -455,7 +468,10 @@ export function mockAutomaticMcpOAuthProvider(
               { error: "resource_metadata_unavailable" },
               { status: options.resourceMetadataStatus },
             )
-          : HttpResponse.json(resourceMetadata);
+          : HttpResponse.json({
+              ...resourceMetadata,
+              authorization_servers: [...advertisedAuthorizationServers],
+            });
       },
     ),
     http.get(`${issuer}/.well-known/oauth-authorization-server`, async () => {
@@ -504,6 +520,8 @@ export function mockAutomaticMcpOAuthProvider(
       const refresh = body.get("grant_type") === "refresh_token";
       if (refresh) {
         refreshAttempts += 1;
+      } else {
+        authorizationCodeAttempts += 1;
       }
       const refreshError = refresh
         ? (options.refreshErrors?.[refreshAttempts - 1] ?? options.refreshError)
@@ -523,7 +541,9 @@ export function mockAutomaticMcpOAuthProvider(
         ...(!refresh ? { refresh_token: "automatic-refresh-token" } : {}),
         token_type: "Bearer",
         expires_in: refresh ? 3600 : (options.initialExpiresIn ?? 0),
-        scope: "read write",
+        scope:
+          options.authorizationCodeScopes?.[authorizationCodeAttempts - 1] ??
+          "read write",
       });
     }),
   );
@@ -531,6 +551,9 @@ export function mockAutomaticMcpOAuthProvider(
     endpoint,
     issuer,
     registrationBodies,
+    advertiseAuthorizationServers(issuers: readonly string[]): void {
+      advertisedAuthorizationServers = [...issuers];
+    },
     authorizationServerDiscoveryCalls: () => {
       return authorizationServerDiscoveryCallCount;
     },

--- a/turbo/apps/api/src/signals/routes/__tests__/mcp-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mcp-connectors.test.ts
@@ -6,11 +6,13 @@ import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { mockClerkMembership } from "./helpers/api-bdd-clerk";
 import {
   createConnectorBddApi,
   manualHttpCustomConnectorCreateBody,
+  mockAutomaticMcpOAuthProvider,
 } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createRouteMocks } from "./helpers/route-test";
@@ -75,6 +77,14 @@ async function createRunForAgent(actor: ApiTestUser, agentId: string) {
     vars: { OKOU_AGENT_ID: agentId },
     secrets: { OKOU_TOKEN: "mcp-discovery-okou-token" },
   });
+}
+
+function stateFromAuthorizationUrl(authorizationUrl: string): string {
+  const state = new URL(authorizationUrl).searchParams.get("state");
+  if (!state) {
+    throw new Error("Expected connector authorization URL to include state");
+  }
+  return state;
 }
 
 describe("GET /api/mcp-connectors", () => {
@@ -255,5 +265,288 @@ describe("GET /api/mcp-connectors", () => {
     expect(unauthenticated.status).toBe(401);
     expect(missingCapability.status).toBe(403);
     expect(session.status).toBe(403);
+  });
+});
+
+describe("POST /api/mcp-connectors/:id/oauth2/reauthorize", () => {
+  it.each(["cimd", "dcr"] as const)(
+    "reauthorizes the exact Automatic OAuth account pinned to the run with %s",
+    async (registration) => {
+      bdd.acceptAgentStorageWrites();
+      runs.acceptStorageDownloads();
+      runs.acceptTelemetryIngest();
+      const runnerGroup = runs.configureRunnerGroup();
+      mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+      mockEnv("OKOU_WEB_URL", "https://www.vm0.ai");
+      mockEnv("APP_URL", "https://app.vm0.ai");
+      const provider = mockAutomaticMcpOAuthProvider(context, {
+        registration,
+        initialExpiresIn: 3600,
+        authorizationCodeScopes: ["read", "read", "read admin"],
+      });
+      const actor = bdd.user({ orgRole: "org:admin" });
+      await runs.grantProEntitlement(actor);
+      await runs.ensureOrgModelProvider(actor);
+      const agent = await bdd.createAgent(actor, {
+        displayName: "MCP scope reauthorization Agent",
+      });
+      await connectors.updateFeatureSwitches(actor, {
+        [FeatureSwitchKey.CustomConnectorMcp]: true,
+        [FeatureSwitchKey.ConnectorAccounts]: true,
+      });
+      const connector = await connectors.createCustomConnector(actor, {
+        kind: "mcp",
+        displayName: "MCP scope reauthorization",
+        endpoint: provider.endpoint,
+        transport: "streamable-http",
+        fields: [],
+        headerInjections: [],
+        queryInjections: [],
+        authMode: "automatic",
+      });
+      const firstAuthorization = await connectors.startCustomConnectorOAuth2(
+        actor,
+        connector.id,
+        undefined,
+        { intent: "add", displayName: "Pinned account" },
+      );
+      await connectors.completeCustomConnectorOAuth2Callback({
+        code: "pinned-account-code",
+        state: stateFromAuthorizationUrl(firstAuthorization),
+        iss: provider.issuer,
+      });
+      const secondAuthorization = await connectors.startCustomConnectorOAuth2(
+        actor,
+        connector.id,
+        undefined,
+        { intent: "add", displayName: "Sibling account" },
+      );
+      await connectors.completeCustomConnectorOAuth2Callback({
+        code: "sibling-account-code",
+        state: stateFromAuthorizationUrl(secondAuthorization),
+        iss: provider.issuer,
+      });
+      const initialAccounts = await connectors.listCustomConnectorAccounts(
+        actor,
+        connector.id,
+      );
+      const pinnedAccount = initialAccounts.find((account) => {
+        return account.isDefault;
+      });
+      const siblingAccount = initialAccounts.find((account) => {
+        return !account.isDefault;
+      });
+      if (!pinnedAccount || !siblingAccount) {
+        throw new Error("Expected default and sibling MCP accounts");
+      }
+      await connectors.updateAgentCustomConnectors(actor, agent.agentId, [
+        connector.id,
+      ]);
+      const run = await runs.createRun(
+        actor,
+        {
+          agentId: agent.agentId,
+          prompt: "Use the MCP connector with incremental scope",
+          modelProvider: "anthropic-api-key",
+        },
+        "okou",
+      );
+      expect(run.status).toBe("pending");
+      await runs.heartbeatRunner(runnerGroup);
+      const claim = await runs.claimRunnerJob(run.runId);
+      const okouToken = claim.platformEnvironment.OKOU_TOKEN;
+      if (!okouToken) {
+        throw new Error("Expected the claimed run to include an Okou token");
+      }
+      const registrationCount = provider.registrationBodies.length;
+      provider.advertiseAuthorizationServers([
+        "https://alternate-issuer.example.test",
+        provider.issuer,
+      ]);
+
+      const response = await accept(
+        client().reauthorizeOAuth({
+          headers: headers(okouToken),
+          params: { id: connector.id },
+          body: { scopes: ["admin"] },
+        }),
+        [200],
+      );
+
+      const authorizationUrl = new URL(response.body.authorizationUrl);
+      expect(authorizationUrl.searchParams.get("scope")).toBe("read admin");
+      expect(response.body.expiresAt).toStrictEqual(expect.any(String));
+      expect(provider.registrationBodies).toHaveLength(registrationCount);
+      await connectors.completeCustomConnectorOAuth2Callback({
+        code: "scope-upgrade-code",
+        state: stateFromAuthorizationUrl(response.body.authorizationUrl),
+        iss: provider.issuer,
+      });
+      const upgradedAccounts = await connectors.listCustomConnectorAccounts(
+        actor,
+        connector.id,
+      );
+      expect(
+        upgradedAccounts.find((account) => {
+          return account.id === pinnedAccount.id;
+        })?.oauthScopes,
+      ).toStrictEqual(["read", "admin"]);
+      expect(
+        upgradedAccounts.find((account) => {
+          return account.id === siblingAccount.id;
+        })?.oauthScopes,
+      ).toStrictEqual(["read"]);
+      provider.advertiseAuthorizationServers([
+        "https://alternate-issuer.example.test",
+      ]);
+      const removedIssuer = await accept(
+        client().reauthorizeOAuth({
+          headers: headers(okouToken),
+          params: { id: connector.id },
+          body: { scopes: ["owner"] },
+        }),
+        [409],
+      );
+      expect(removedIssuer.body.error.code).toBe("CONFLICT");
+      await runs.requestCancelRun(actor, run.runId, [200]);
+    },
+  );
+
+  it("rejects Automatic accounts resolved to no authentication", async () => {
+    bdd.acceptAgentStorageWrites();
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    const runnerGroup = runs.configureRunnerGroup();
+    mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+    mockEnv("OKOU_WEB_URL", "https://www.vm0.ai");
+    mockEnv("APP_URL", "https://app.vm0.ai");
+    mockAutomaticMcpOAuthProvider(context, {
+      registration: "cimd",
+      authentication: "none",
+    });
+    const actor = bdd.user({ orgRole: "org:admin" });
+    await runs.grantProEntitlement(actor);
+    await runs.ensureOrgModelProvider(actor);
+    const agent = await bdd.createAgent(actor, {
+      displayName: "MCP no-auth reauthorization Agent",
+    });
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.CustomConnectorMcp]: true,
+    });
+    const connector = await connectors.createCustomConnector(actor, {
+      kind: "mcp",
+      displayName: "MCP no-auth reauthorization",
+      endpoint: "https://automatic-mcp.example.test/server",
+      transport: "streamable-http",
+      fields: [],
+      headerInjections: [],
+      queryInjections: [],
+      authMode: "automatic",
+    });
+    const connected = await connectors.requestStartCustomConnectorOAuth2(
+      actor,
+      connector.id,
+      [200],
+      agent.agentId,
+    );
+    if ("error" in connected.body || connected.body.result !== "connected") {
+      throw new Error("Expected Automatic MCP no-auth connection");
+    }
+    await connectors.updateAgentCustomConnectors(actor, agent.agentId, [
+      connector.id,
+    ]);
+    const run = await runs.createRun(
+      actor,
+      {
+        agentId: agent.agentId,
+        prompt: "Use the no-auth MCP connector",
+        modelProvider: "anthropic-api-key",
+      },
+      "okou",
+    );
+    expect(run.status).toBe("pending");
+    await runs.heartbeatRunner(runnerGroup);
+    const claim = await runs.claimRunnerJob(run.runId);
+    const okouToken = claim.platformEnvironment.OKOU_TOKEN;
+    if (!okouToken) {
+      throw new Error("Expected the claimed run to include an Okou token");
+    }
+
+    const response = await accept(
+      client().reauthorizeOAuth({
+        headers: headers(okouToken),
+        params: { id: connector.id },
+        body: { scopes: ["admin"] },
+      }),
+      [409],
+    );
+
+    expect(response.body.error.code).toBe("CONFLICT");
+    await runs.requestCancelRun(actor, run.runId, [200]);
+  });
+
+  it("requires agent authentication with connector write capability", async () => {
+    const actor = bdd.user();
+    mockClerkMembership(context, actor, "org:admin");
+    const runId = randomUUID();
+    const connectorId = randomUUID();
+
+    const unauthenticated = await accept(
+      client().reauthorizeOAuth({
+        headers: {},
+        params: { id: connectorId },
+        body: { scopes: ["admin"] },
+      }),
+      [401],
+    );
+    const missingCapability = await accept(
+      client().reauthorizeOAuth({
+        headers: headers(
+          runs.okouTokenForRunWithCapabilities(actor, runId, []),
+        ),
+        params: { id: connectorId },
+        body: { scopes: ["admin"] },
+      }),
+      [403],
+    );
+    mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
+    const session = await accept(
+      client().reauthorizeOAuth({
+        headers: headers("clerk-session"),
+        params: { id: connectorId },
+        body: { scopes: ["admin"] },
+      }),
+      [403],
+    );
+    const unpinned = await accept(
+      client().reauthorizeOAuth({
+        headers: headers(
+          runs.okouTokenForRunWithCapabilities(actor, runId, [
+            "connector:write",
+          ]),
+        ),
+        params: { id: connectorId },
+        body: { scopes: ["admin"] },
+      }),
+      [409],
+    );
+    const malformedScope = await accept(
+      client().reauthorizeOAuth({
+        headers: headers(
+          runs.okouTokenForRunWithCapabilities(actor, runId, [
+            "connector:write",
+          ]),
+        ),
+        params: { id: connectorId },
+        body: { scopes: ["invalid scope"] },
+      }),
+      [400],
+    );
+
+    expect(unauthenticated.status).toBe(401);
+    expect(missingCapability.status).toBe(403);
+    expect(session.status).toBe(403);
+    expect(unpinned.body.error.code).toBe("CONFLICT");
+    expect(malformedScope.body.error.code).toBe("BAD_REQUEST");
   });
 });

--- a/turbo/apps/api/src/signals/routes/mcp-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/mcp-connectors.ts
@@ -1,9 +1,12 @@
-import { computed } from "ccstate";
+import { command, computed } from "ccstate";
 import { mcpConnectorsContract } from "@okouai/api-contracts/contracts/mcp-connectors";
 
+import { conflict } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
+import { bodyResultOf, pathParamsOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
+import { startCustomConnectorAutomaticOAuthReauthorization$ } from "../services/custom-connector-oauth2.service";
 import { runMcpConnectorList } from "../services/run-mcp-connectors.service";
 
 const listRunMcpConnectorsInner$ = computed(async (get) => {
@@ -21,6 +24,44 @@ const listRunMcpConnectorsInner$ = computed(async (get) => {
   return { status: 200 as const, body: { connectors: [...connectors] } };
 });
 
+const reauthorizeMcpOAuthInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    if (auth.tokenType !== "agent") {
+      throw new Error(
+        "Run MCP connector reauthorization route requires agent authentication",
+      );
+    }
+    const params = get(pathParamsOf(mcpConnectorsContract.reauthorizeOAuth));
+    const body = await get(
+      bodyResultOf(mcpConnectorsContract.reauthorizeOAuth),
+    );
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+    const connectionId = auth.customConnectorSourceIds?.[params.id];
+    if (!connectionId) {
+      return conflict("MCP OAuth reauthorization is unavailable for this run");
+    }
+    const result = await set(
+      startCustomConnectorAutomaticOAuthReauthorization$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        connectorId: params.id,
+        connectionId,
+        scopes: body.data.scopes,
+      },
+      signal,
+    );
+    if ("status" in result) {
+      return result;
+    }
+    return { status: 200 as const, body: result };
+  },
+);
+
 export const mcpConnectorsRoutes: readonly RouteEntry[] = [
   {
     route: mcpConnectorsContract.list,
@@ -32,6 +73,18 @@ export const mcpConnectorsRoutes: readonly RouteEntry[] = [
         requiredCapability: "connector:read",
       },
       listRunMcpConnectorsInner$,
+    ),
+  },
+  {
+    route: mcpConnectorsContract.reauthorizeOAuth,
+    handler: authRoute(
+      {
+        accept: ["agent"],
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "connector:write",
+      },
+      reauthorizeMcpOAuthInner$,
     ),
   },
 ];

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -7326,6 +7326,12 @@ function preparedRunnerJobBody(
   if (!args.includeOkouTokenSecret) {
     return args.body;
   }
+  const customConnectorSourceEntries =
+    args.customConnectorContext.targets.flatMap((target) => {
+      return target.kind === "custom" && target.sourceId
+        ? [[target.customConnectorId, target.sourceId] as const]
+        : [];
+    });
   const okouToken = generateOkouToken(
     args.userId,
     args.run.id,
@@ -7338,6 +7344,13 @@ function preparedRunnerJobBody(
         : {}),
       cloudBrowserEnabled: args.okouTokenCloudBrowserEnabled === true,
       imageRecognitionAvailable: args.imageRecognitionAvailable,
+      ...(customConnectorSourceEntries.length === 0
+        ? {}
+        : {
+            customConnectorSourceIds: Object.fromEntries(
+              customConnectorSourceEntries,
+            ),
+          }),
     },
   );
   return withOkouTokenSecret(args.body, okouToken);

--- a/turbo/apps/api/src/signals/services/custom-connector-automatic-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-automatic-oauth.service.ts
@@ -450,6 +450,7 @@ async function discoverAutomaticOAuthAuthority(
     readonly endpoint: string;
     readonly resourceMetadataUrl: URL | null;
     readonly challengeScope?: string;
+    readonly expectedIssuer?: string;
   },
   signal: AbortSignal,
 ): Promise<DiscoveredAutomaticOAuthAuthority> {
@@ -477,11 +478,18 @@ async function discoverAutomaticOAuthAuthority(
       "MCP OAuth protected resource metadata does not match the connector endpoint",
     );
   }
-  const advertisedIssuer = protectedResourceMetadata.authorization_servers?.[0];
+  const advertisedIssuers = protectedResourceMetadata.authorization_servers;
+  const advertisedIssuer = args.expectedIssuer
+    ? advertisedIssuers?.find((candidate) => {
+        return candidate === args.expectedIssuer;
+      })
+    : advertisedIssuers?.[0];
   if (!advertisedIssuer) {
     throw new CustomConnectorAutomaticOAuthError(
       "incompatible",
-      "MCP OAuth protected resource metadata does not advertise an authorization server",
+      args.expectedIssuer
+        ? "MCP OAuth protected resource metadata no longer advertises the bound authorization server"
+        : "MCP OAuth protected resource metadata does not advertise an authorization server",
     );
   }
   const issuer = requiredHttpsUrl(advertisedIssuer, "issuer");
@@ -948,6 +956,133 @@ interface CustomConnectorAutomaticOAuthAuthorization {
   readonly context: CustomConnectorAutomaticOAuthStateContext;
 }
 
+async function discoverBoundAutomaticOAuthAuthority(
+  args: {
+    readonly binding: CustomConnectorAutomaticOAuthBinding;
+    readonly endpoint: string;
+  },
+  signal: AbortSignal,
+): Promise<DiscoveredAutomaticOAuthAuthority> {
+  const discovered = await settle(
+    discoverAutomaticOAuthAuthority(
+      {
+        endpoint: args.endpoint,
+        resourceMetadataUrl: args.binding.resourceMetadataUrl
+          ? new URL(args.binding.resourceMetadataUrl)
+          : null,
+        expectedIssuer: args.binding.issuer,
+      },
+      signal,
+    ),
+    signal,
+  );
+  if (!discovered.ok) {
+    const error = discovered.error;
+    if (
+      error instanceof CustomConnectorAutomaticOAuthError &&
+      error.kind === "temporary"
+    ) {
+      throw error;
+    }
+    if (error instanceof CustomConnectorAutomaticOAuthError) {
+      throw new CustomConnectorAutomaticOAuthError(
+        "binding-drift",
+        "MCP OAuth authority changed",
+        error,
+      );
+    }
+    throw error;
+  }
+  const authority = discovered.value;
+  if (
+    authority.issuer !== args.binding.issuer ||
+    authority.resource !== args.binding.resource ||
+    authority.tokenEndpoint !== args.binding.tokenEndpoint ||
+    (args.binding.registrationMethod === "cimd" &&
+      authority.authorizationServerMetadata
+        .client_id_metadata_document_supported !== true) ||
+    !(
+      supportedTokenAuthMethods(authority.authorizationServerMetadata)
+        .length === 0 ||
+      supportedTokenAuthMethods(authority.authorizationServerMetadata).includes(
+        args.binding.tokenEndpointAuthMethod,
+      )
+    )
+  ) {
+    throw new CustomConnectorAutomaticOAuthError(
+      "binding-drift",
+      "MCP OAuth authority changed",
+    );
+  }
+  return authority;
+}
+
+export async function prepareCustomConnectorAutomaticOAuthReauthorization(
+  args: {
+    readonly db: Db;
+    readonly binding: CustomConnectorAutomaticOAuthBinding;
+    readonly storageVersion: number;
+    readonly endpoint: string;
+    readonly redirectUri: string;
+    readonly cimdClientId: string;
+    readonly requestedScope: string;
+    readonly state: string;
+    readonly featureContext: FeatureSwitchContext;
+  },
+  signal: AbortSignal,
+): Promise<CustomConnectorAutomaticOAuthAuthorization> {
+  const authority = await discoverBoundAutomaticOAuthAuthority(args, signal);
+  const clientInformation = await boundClientInformation({
+    ...args,
+    context: boundClientContext(args.binding),
+  });
+  signal.throwIfAborted();
+  const authorization = await automaticOAuthRemote(
+    "authorization request",
+    signal,
+    async () => {
+      return await startAuthorization(args.binding.issuer, {
+        metadata: authority.authorizationServerMetadata,
+        clientInformation,
+        redirectUrl: args.redirectUri,
+        scope: args.requestedScope,
+        state: args.state,
+        resource: new URL(args.binding.resource),
+      });
+    },
+  );
+  const contextBase = {
+    version: 1,
+    oauthSetup: "automatic",
+    connectorId: args.binding.customConnectorId,
+    storageVersion: args.storageVersion,
+    issuer: args.binding.issuer,
+    resource: args.binding.resource,
+    resourceMetadataUrl: args.binding.resourceMetadataUrl,
+    authorizationEndpoint: authority.authorizationEndpoint,
+    tokenEndpoint: args.binding.tokenEndpoint,
+    authorizationResponseIssParameterSupported:
+      authority.authorizationResponseIssParameterSupported,
+    clientId: args.binding.clientId,
+    tokenEndpointAuthMethod: args.binding.tokenEndpointAuthMethod,
+  } as const;
+  const context: CustomConnectorAutomaticOAuthStateContext =
+    args.binding.registrationMethod === "dcr"
+      ? {
+          ...contextBase,
+          registrationMethod: "dcr",
+          dcrRegistrationId: args.binding.dcrRegistration.id,
+        }
+      : { ...contextBase, registrationMethod: "cimd" };
+  return {
+    kind: "oauth",
+    authorizationUrl: authorization.authorizationUrl.toString(),
+    codeVerifier: authorization.codeVerifier,
+    requestedScope: args.requestedScope,
+    context,
+  };
+}
+
 interface CustomConnectorAutomaticNoAuth {
   readonly kind: "none";
 }
@@ -1249,56 +1384,7 @@ export async function refreshCustomConnectorAutomaticOAuthToken(
   },
   signal: AbortSignal,
 ): Promise<CustomConnectorAutomaticOAuthTokenResult> {
-  const discovered = await settle(
-    discoverAutomaticOAuthAuthority(
-      {
-        endpoint: args.endpoint,
-        resourceMetadataUrl: args.binding.resourceMetadataUrl
-          ? new URL(args.binding.resourceMetadataUrl)
-          : null,
-      },
-      signal,
-    ),
-    signal,
-  );
-  if (!discovered.ok) {
-    const error = discovered.error;
-    if (
-      error instanceof CustomConnectorAutomaticOAuthError &&
-      error.kind === "temporary"
-    ) {
-      throw error;
-    }
-    if (error instanceof CustomConnectorAutomaticOAuthError) {
-      throw new CustomConnectorAutomaticOAuthError(
-        "binding-drift",
-        "MCP OAuth authority changed",
-        error,
-      );
-    }
-    throw error;
-  }
-  const authority = discovered.value;
-  if (
-    authority.issuer !== args.binding.issuer ||
-    authority.resource !== args.binding.resource ||
-    authority.tokenEndpoint !== args.binding.tokenEndpoint ||
-    (args.binding.registrationMethod === "cimd" &&
-      authority.authorizationServerMetadata
-        .client_id_metadata_document_supported !== true) ||
-    !(
-      supportedTokenAuthMethods(authority.authorizationServerMetadata)
-        .length === 0 ||
-      supportedTokenAuthMethods(authority.authorizationServerMetadata).includes(
-        args.binding.tokenEndpointAuthMethod,
-      )
-    )
-  ) {
-    throw new CustomConnectorAutomaticOAuthError(
-      "binding-drift",
-      "MCP OAuth authority changed",
-    );
-  }
+  const authority = await discoverBoundAutomaticOAuthAuthority(args, signal);
   const clientInformation = await boundClientInformation({
     ...args,
     context: boundClientContext(args.binding),

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -5,6 +5,10 @@ import { command } from "ccstate";
 import { and, eq, exists } from "drizzle-orm";
 import { z } from "zod";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
+import {
+  mcpOAuthScopeListSchema,
+  mcpOAuthScopeTokenSchema,
+} from "@okouai/api-contracts/contracts/mcp-connectors";
 import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
 import type { OAuthClientMetadata } from "@modelcontextprotocol/client";
 import {
@@ -84,6 +88,7 @@ import {
   isAutomaticOAuthInvalidClient,
   isAutomaticOAuthInvalidGrant,
   prepareCustomConnectorAutomaticOAuthAuthorization,
+  prepareCustomConnectorAutomaticOAuthReauthorization,
   readCustomConnectorAutomaticOAuthBinding,
   refreshCustomConnectorAutomaticOAuthToken,
   retireCustomConnectorDcrRegistration,
@@ -744,6 +749,7 @@ async function persistCustomConnectorOAuthStart(
   signal: AbortSignal,
 ) {
   const { db, connector, args, featureContext, prepared } = context;
+  const expiresAt = connectorOAuthStateExpiresAt();
   const result = await db.transaction(async (tx) => {
     await lockCustomConnectorOAuth2CredentialContract({
       db: tx,
@@ -762,7 +768,7 @@ async function persistCustomConnectorOAuthStart(
         connectorAccountSiblingWritesEnabled(featureContext),
     });
     if (resolution.kind !== "ready") {
-      return { resolution, connectionId: null };
+      return { resolution, connectionId: null, expiresAt };
     }
     const oauthStateId = await insertConnectorOAuthState(tx, {
       state: prepared.state,
@@ -779,11 +785,12 @@ async function persistCustomConnectorOAuthStart(
       codeVerifier: prepared.codeVerifier,
       oauthContext: JSON.stringify(prepared.context),
       accountMutation: args.account,
-      expiresAt: connectorOAuthStateExpiresAt(),
+      expiresAt,
     });
     return {
       resolution,
       connectionId: args.account.intent === "add" ? oauthStateId : null,
+      expiresAt,
     };
   });
   signal.throwIfAborted();
@@ -1029,6 +1036,166 @@ export const startCustomConnectorOAuth2$ = command(
       result: "authorization" as const,
       authorizationUrl: prepared.authorizationUrl,
       connectionId: mutationStart.connectionId ?? undefined,
+    };
+  },
+);
+
+function automaticOAuthReauthorizationScopes(
+  connection: Pick<StoredConnection, "oauthScopes">,
+  challengedScopes: readonly string[],
+): readonly string[] | null {
+  const storedScopes = connection.oauthScopes
+    ? z
+        .array(mcpOAuthScopeTokenSchema)
+        .max(100)
+        .parse(safeJsonParse(connection.oauthScopes))
+    : [];
+  const parsed = mcpOAuthScopeListSchema.safeParse([
+    ...new Set([...storedScopes, ...challengedScopes]),
+  ]);
+  return parsed.success ? parsed.data : null;
+}
+
+function automaticOAuthReauthorizationFailure(error: unknown) {
+  if (!(error instanceof CustomConnectorAutomaticOAuthError)) {
+    throw error;
+  }
+  return error.kind === "temporary"
+    ? badGateway(
+        "MCP OAuth provider is temporarily unavailable. Please try again.",
+      )
+    : conflict("MCP OAuth authority or client binding changed");
+}
+
+function automaticOAuthReauthorizationUnavailable(
+  target: "account" | "connector",
+) {
+  return conflict(
+    `MCP OAuth reauthorization is unavailable for this ${target}`,
+  );
+}
+
+export const startCustomConnectorAutomaticOAuthReauthorization$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly connectorId: string;
+      readonly connectionId: string;
+      readonly scopes: readonly string[];
+    },
+    signal: AbortSignal,
+  ) => {
+    const connector = await get(
+      getCustomConnectorById({
+        orgId: args.orgId,
+        connectorId: args.connectorId,
+      }),
+    );
+    signal.throwIfAborted();
+    if (!connector || !isAutomaticOAuthConnector(connector)) {
+      return automaticOAuthReauthorizationUnavailable("connector");
+    }
+    const featureContext = await get(
+      userFeatureSwitchContext(args.orgId, args.userId),
+    );
+    signal.throwIfAborted();
+    if (customConnectorOAuthMcpIsDisabled(connector, featureContext)) {
+      return customConnectorMcpDisabledResponse();
+    }
+    const db = set(writeDb$);
+    const connection = await loadConnection({
+      db,
+      orgId: args.orgId,
+      userId: args.userId,
+      customConnectorId: connector.id,
+      memberConnectorId: args.connectionId,
+      storageVersion: connector.storageVersion,
+      definitionAuthMode: "automatic",
+    });
+    signal.throwIfAborted();
+    if (
+      !connection ||
+      connection.needsReconnect ||
+      !connection.encryptedAccessToken ||
+      !connectionAccessTokenIsCurrent(connection)
+    ) {
+      return automaticOAuthReauthorizationUnavailable("account");
+    }
+    const binding = await readCustomConnectorAutomaticOAuthBinding(
+      db,
+      connection.id,
+    );
+    signal.throwIfAborted();
+    if (!binding || binding.customConnectorId !== connector.id) {
+      return automaticOAuthReauthorizationUnavailable("account");
+    }
+    const scopes = automaticOAuthReauthorizationScopes(connection, args.scopes);
+    if (!scopes) {
+      return badRequestMessage("MCP OAuth scope request is too large");
+    }
+    const clientMetadata = configuredOkouMcpOAuthClientMetadata();
+    const [redirectUri] = clientMetadata.redirect_uris;
+    if (!redirectUri) {
+      throw new Error("Okou MCP OAuth callback is unavailable");
+    }
+    const state = generateConnectorOAuthState("okou");
+    const preparedResult = await settle(
+      prepareCustomConnectorAutomaticOAuthReauthorization(
+        {
+          db,
+          binding,
+          storageVersion: connector.storageVersion,
+          endpoint: connector.endpoint,
+          redirectUri,
+          cimdClientId: clientMetadata.client_id,
+          requestedScope: scopes.join(" "),
+          state,
+          featureContext,
+        },
+        signal,
+      ),
+      signal,
+    );
+    if (!preparedResult.ok) {
+      return automaticOAuthReauthorizationFailure(preparedResult.error);
+    }
+    const prepared = preparedResult.value;
+    const persisted = await persistCustomConnectorOAuthStart(
+      {
+        db,
+        connector,
+        args: {
+          orgId: args.orgId,
+          userId: args.userId,
+          connectorId: args.connectorId,
+          redirectUri,
+          publicBrand: "okou",
+          account: {
+            intent: "reconnect",
+            connectionId: args.connectionId,
+          },
+        },
+        featureContext,
+        prepared: {
+          oauthSetup: "automatic",
+          redirectUri,
+          state,
+          authorizationUrl: prepared.authorizationUrl,
+          codeVerifier: prepared.codeVerifier,
+          oauthRequestedScopes: prepared.requestedScope,
+          context: prepared.context,
+        },
+      },
+      signal,
+    );
+    if (persisted.resolution.kind !== "ready") {
+      return automaticOAuthReauthorizationUnavailable("account");
+    }
+    return {
+      authorizationUrl: prepared.authorizationUrl,
+      expiresAt: persisted.expiresAt.toISOString(),
     };
   },
 );
@@ -1346,6 +1513,7 @@ interface StoredConnection {
   readonly id: string;
   readonly tokenExpiresAt: Date | null;
   readonly needsReconnect: boolean;
+  readonly oauthScopes: string | null;
   readonly encryptedAccessToken: string | null;
   readonly encryptedRefreshToken: string | null;
   readonly encryptedIdToken: string | null;
@@ -1366,6 +1534,7 @@ async function loadConnection(args: {
       id: connectors.id,
       tokenExpiresAt: connectors.tokenExpiresAt,
       needsReconnect: connectors.needsReconnect,
+      oauthScopes: connectors.oauthScopes,
     })
     .from(connectors)
     .where(
@@ -1430,6 +1599,7 @@ async function loadConnection(args: {
     id: connection.id,
     tokenExpiresAt: connection.tokenExpiresAt,
     needsReconnect: connection.needsReconnect,
+    oauthScopes: connection.oauthScopes,
     encryptedAccessToken:
       tokenRows.find((row) => {
         return (

--- a/turbo/apps/api/src/types/auth.ts
+++ b/turbo/apps/api/src/types/auth.ts
@@ -49,6 +49,7 @@ export type AgentAuthContext =
       readonly capabilities: readonly Capability[];
       readonly publicBrand: PublicBrand;
       readonly computerUseHostId?: string;
+      readonly customConnectorSourceIds?: Readonly<Record<string, string>>;
     }
   | {
       readonly tokenType: "agent";
@@ -87,6 +88,7 @@ export interface AgentAuth {
   readonly publicBrand: PublicBrand;
   readonly computerUseHostId?: string;
   readonly cloudBrowserEnabled?: true;
+  readonly customConnectorSourceIds?: Readonly<Record<string, string>>;
 }
 
 export interface CliAuth {

--- a/turbo/apps/cli/src/commands/mcp/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/mcp/__tests__/index.test.ts
@@ -658,6 +658,49 @@ describe("okou mcp command", () => {
     ).toHaveLength(1);
   });
 
+  it("keeps scope reauthorization inside the command deadline", async () => {
+    stubConnectorList();
+    const seen = stubMcpServer({
+      era: "modern",
+      listResponse: () => {
+        return insufficientScopeResponse("admin");
+      },
+    });
+    server.use(
+      http.post(
+        `http://localhost:3000/api/mcp-connectors/${CONNECTOR_ID}/oauth2/reauthorize`,
+        async () => {
+          await delay(2_000);
+          return HttpResponse.json({
+            authorizationUrl: "https://authorize.example.test/consent",
+            expiresAt: "2026-09-03T12:15:00.000Z",
+          });
+        },
+      ),
+    );
+
+    await expect(
+      mcpCommand.parseAsync([
+        "node",
+        "okou",
+        "call",
+        "_acme-mcp",
+        "search",
+        "--input",
+        "{}",
+        "--timeout",
+        "1s",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(outputText(consoleError)).toContain("timed out after 1s");
+    expect(
+      seen.filter((request) => {
+        return request.method === "tools/list";
+      }),
+    ).toHaveLength(1);
+  });
+
   it("keeps an oversized insufficient-scope challenge generic", async () => {
     stubConnectorList();
     stubMcpServer({

--- a/turbo/apps/cli/src/commands/mcp/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/mcp/__tests__/index.test.ts
@@ -208,6 +208,15 @@ function outputText(spy: ReturnType<typeof vi.spyOn>): string {
   return spy.mock.calls.flat().join("\n");
 }
 
+function insufficientScopeResponse(scope: string): Response {
+  return new HttpResponse(null, {
+    status: 403,
+    headers: {
+      "www-authenticate": `Bearer error="insufficient_scope", scope="${scope}", resource_metadata="https://untrusted.example.test/oauth-resource", error_description="upstream-secret-description"`,
+    },
+  });
+}
+
 describe("okou mcp command", () => {
   const exit = vi.spyOn(process, "exit").mockImplementation(processExit);
   const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -574,6 +583,109 @@ describe("okou mcp command", () => {
     expect(errors).toContain("MCP server request failed");
     expect(errors).not.toContain(upstreamSecret);
     expect(errors).not.toContain("Error POSTing");
+  });
+
+  it("requests exact-run reauthorization for a valid insufficient-scope challenge without retrying", async () => {
+    stubConnectorList();
+    const seen = stubMcpServer({
+      era: "modern",
+      listResponse: () => {
+        return insufficientScopeResponse("read write read");
+      },
+    });
+    let requestedScopes: unknown;
+    server.use(
+      http.post(
+        `http://localhost:3000/api/mcp-connectors/${CONNECTOR_ID}/oauth2/reauthorize`,
+        async ({ request }) => {
+          requestedScopes = await request.json();
+          return HttpResponse.json({
+            authorizationUrl: "https://authorize.example.test/consent",
+            expiresAt: "2026-09-03T12:15:00.000Z",
+          });
+        },
+      ),
+    );
+
+    await expect(
+      mcpCommand.parseAsync(["node", "okou", "list-tools", "_acme-mcp"]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(requestedScopes).toStrictEqual({ scopes: ["read", "write"] });
+    expect(
+      seen.filter((request) => {
+        return request.method === "tools/list";
+      }),
+    ).toHaveLength(1);
+    const errors = outputText(consoleError);
+    expect(errors).toContain(
+      "[Authorize MCP connector](https://authorize.example.test/consent)",
+    );
+    expect(errors).toContain("The failed MCP request was not retried");
+    expect(errors).toContain("Start a new run after authorization");
+    expect(errors).not.toContain("upstream-secret-description");
+    expect(errors).not.toContain("untrusted.example.test");
+  });
+
+  it("reports an older API without retrying the insufficient-scope request", async () => {
+    stubConnectorList();
+    const seen = stubMcpServer({
+      era: "modern",
+      listResponse: () => {
+        return insufficientScopeResponse("admin");
+      },
+    });
+    server.use(
+      http.post(
+        `http://localhost:3000/api/mcp-connectors/${CONNECTOR_ID}/oauth2/reauthorize`,
+        () => {
+          return HttpResponse.json({ error: "Not found" }, { status: 404 });
+        },
+      ),
+    );
+
+    await expect(
+      mcpCommand.parseAsync(["node", "okou", "list-tools", "_acme-mcp"]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(outputText(consoleError)).toContain(
+      "MCP scope reauthorization is unavailable on the current API",
+    );
+    expect(
+      seen.filter((request) => {
+        return request.method === "tools/list";
+      }),
+    ).toHaveLength(1);
+  });
+
+  it("keeps an oversized insufficient-scope challenge generic", async () => {
+    stubConnectorList();
+    stubMcpServer({
+      era: "modern",
+      listResponse: () => {
+        return insufficientScopeResponse("x".repeat(257));
+      },
+    });
+    let apiCalls = 0;
+    server.use(
+      http.post(
+        `http://localhost:3000/api/mcp-connectors/${CONNECTOR_ID}/oauth2/reauthorize`,
+        () => {
+          apiCalls += 1;
+          return HttpResponse.json({
+            authorizationUrl: "https://authorize.example.test/consent",
+            expiresAt: "2026-09-03T12:15:00.000Z",
+          });
+        },
+      ),
+    );
+
+    await expect(
+      mcpCommand.parseAsync(["node", "okou", "list-tools", "_acme-mcp"]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(apiCalls).toBe(0);
+    expect(outputText(consoleError)).toContain("MCP server request failed");
   });
 
   it("rejects an unknown tool without sending tools/call", async () => {

--- a/turbo/apps/cli/src/commands/mcp/client.ts
+++ b/turbo/apps/cli/src/commands/mcp/client.ts
@@ -1,12 +1,19 @@
 import {
   Client,
+  InsufficientScopeError,
   StreamableHTTPClientTransport,
   type CallToolResult,
   type FetchLike,
   type JSONObject,
   type Tool,
 } from "@modelcontextprotocol/client";
-import type { McpConnector } from "@okouai/api-contracts/contracts/mcp-connectors";
+import {
+  mcpOAuthScopeListSchema,
+  type McpConnector,
+} from "@okouai/api-contracts/contracts/mcp-connectors";
+
+import { reauthorizeRunMcpConnectorOAuth } from "../../lib/api/domains/connectors";
+import { ApiRequestError } from "../../lib/api/core/client-factory";
 
 declare const __CLI_VERSION__: string;
 
@@ -159,18 +166,69 @@ async function closeMcpClient(
   return cleanupWarning;
 }
 
-function safeMcpError(
+function parseRequiredScopes(error: InsufficientScopeError): string[] | null {
+  if (!error.requiredScope) {
+    return null;
+  }
+  const scopes = [
+    ...new Set(error.requiredScope.split(/\s+/u).filter(Boolean)),
+  ];
+  const parsed = mcpOAuthScopeListSchema.safeParse(scopes);
+  return parsed.success ? parsed.data : null;
+}
+
+async function insufficientScopeError(
+  connector: McpConnector,
+  error: InsufficientScopeError,
+): Promise<Error> {
+  const scopes = parseRequiredScopes(error);
+  if (!scopes) {
+    return new Error("MCP server request failed");
+  }
+  try {
+    const authorization = await reauthorizeRunMcpConnectorOAuth(
+      connector.id,
+      scopes,
+    );
+    if (!authorization) {
+      return new Error(
+        "MCP scope reauthorization is unavailable on the current API. The failed MCP request was not retried; start a new run after the API is updated.",
+      );
+    }
+    return new Error(
+      [
+        "This MCP connector needs additional authorization for future runs:",
+        `[Authorize MCP connector](${authorization.authorizationUrl})`,
+        `This link expires at ${authorization.expiresAt}.`,
+        "The failed MCP request was not retried. Start a new run after authorization.",
+      ].join("\n"),
+    );
+  } catch (reauthorizationError) {
+    if (reauthorizationError instanceof ApiRequestError) {
+      return new Error(
+        `MCP scope reauthorization failed: ${reauthorizationError.message}. The failed MCP request was not retried.`,
+      );
+    }
+    return new Error("MCP server request failed");
+  }
+}
+
+async function safeMcpError(
+  connector: McpConnector,
   error: unknown,
   deadlineSignal: AbortSignal,
   deadlineAt: number,
   timeoutSeconds: number,
-): Error {
+): Promise<Error> {
   if (
     deadlineSignal.aborted ||
     Date.now() >= deadlineAt ||
     error instanceof McpDeadlineError
   ) {
     return new Error(`MCP command timed out after ${timeoutSeconds}s`);
+  }
+  if (error instanceof InsufficientScopeError) {
+    return await insufficientScopeError(connector, error);
   }
   if (error instanceof McpCommandError) {
     return new Error(error.message);
@@ -240,7 +298,8 @@ async function runMcpOperation<T>(
   } catch (error) {
     outcome = {
       ok: false,
-      error: safeMcpError(
+      error: await safeMcpError(
+        connector,
         error,
         deadlineController.signal,
         deadlineAt,

--- a/turbo/apps/cli/src/commands/mcp/client.ts
+++ b/turbo/apps/cli/src/commands/mcp/client.ts
@@ -180,6 +180,7 @@ function parseRequiredScopes(error: InsufficientScopeError): string[] | null {
 async function insufficientScopeError(
   connector: McpConnector,
   error: InsufficientScopeError,
+  deadlineSignal: AbortSignal,
 ): Promise<Error> {
   const scopes = parseRequiredScopes(error);
   if (!scopes) {
@@ -189,6 +190,7 @@ async function insufficientScopeError(
     const authorization = await reauthorizeRunMcpConnectorOAuth(
       connector.id,
       scopes,
+      deadlineSignal,
     );
     if (!authorization) {
       return new Error(
@@ -228,7 +230,14 @@ async function safeMcpError(
     return new Error(`MCP command timed out after ${timeoutSeconds}s`);
   }
   if (error instanceof InsufficientScopeError) {
-    return await insufficientScopeError(connector, error);
+    const reauthorizationError = await insufficientScopeError(
+      connector,
+      error,
+      deadlineSignal,
+    );
+    return deadlineSignal.aborted || Date.now() >= deadlineAt
+      ? new Error(`MCP command timed out after ${timeoutSeconds}s`)
+      : reauthorizationError;
   }
   if (error instanceof McpCommandError) {
     return new Error(error.message);

--- a/turbo/apps/cli/src/lib/api/domains/connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/connectors.ts
@@ -307,6 +307,7 @@ export async function listRunMcpConnectors(): Promise<McpConnector[]> {
 export async function reauthorizeRunMcpConnectorOAuth(
   connectorId: string,
   scopes: readonly string[],
+  signal: AbortSignal,
 ): Promise<McpConnectorOAuthReauthorizationResponse | null> {
   const config = await getClientConfig();
   const client = initClient(mcpConnectorsContract, config);
@@ -314,6 +315,7 @@ export async function reauthorizeRunMcpConnectorOAuth(
     headers: {},
     params: { id: connectorId },
     body: { scopes: [...scopes] },
+    fetchOptions: { signal },
   });
   if (result.status === 200) {
     return mcpConnectorOAuthReauthorizationResponseSchema.parse(result.body);

--- a/turbo/apps/cli/src/lib/api/domains/connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/connectors.ts
@@ -39,6 +39,8 @@ import {
   type UpdateCustomConnectorBody,
 } from "@okouai/api-contracts/contracts/custom-connectors";
 import {
+  mcpConnectorOAuthReauthorizationResponseSchema,
+  type McpConnectorOAuthReauthorizationResponse,
   mcpConnectorListResponseSchema,
   mcpConnectorsContract,
   type McpConnector,
@@ -300,6 +302,26 @@ export async function listRunMcpConnectors(): Promise<McpConnector[]> {
   }
 
   handleError(result, "Failed to list MCP connectors for this run");
+}
+
+export async function reauthorizeRunMcpConnectorOAuth(
+  connectorId: string,
+  scopes: readonly string[],
+): Promise<McpConnectorOAuthReauthorizationResponse | null> {
+  const config = await getClientConfig();
+  const client = initClient(mcpConnectorsContract, config);
+  const result = await client.reauthorizeOAuth({
+    headers: {},
+    params: { id: connectorId },
+    body: { scopes: [...scopes] },
+  });
+  if (result.status === 200) {
+    return mcpConnectorOAuthReauthorizationResponseSchema.parse(result.body);
+  }
+  if (result.status === 404) {
+    return null;
+  }
+  handleError(result, "Failed to reauthorize MCP OAuth scopes");
 }
 
 export async function createCustomConnector(

--- a/turbo/packages/api-contracts/src/contracts/mcp-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/mcp-connectors.ts
@@ -19,6 +19,35 @@ export const mcpConnectorListResponseSchema = z.object({
   connectors: z.array(mcpConnectorSchema),
 });
 
+export const mcpOAuthScopeTokenSchema = z
+  .string()
+  .min(1)
+  .max(256)
+  .regex(/^[\x21\x23-\x5b\x5d-\x7e]+$/u);
+
+export const mcpOAuthScopeListSchema = z
+  .array(mcpOAuthScopeTokenSchema)
+  .min(1)
+  .max(100)
+  .refine((scopes) => {
+    return new Set(scopes).size === scopes.length;
+  }, "MCP OAuth scopes must be unique");
+
+export const mcpConnectorOAuthReauthorizationRequestSchema = z.object({
+  scopes: mcpOAuthScopeListSchema,
+});
+export type McpConnectorOAuthReauthorizationRequest = z.infer<
+  typeof mcpConnectorOAuthReauthorizationRequestSchema
+>;
+
+export const mcpConnectorOAuthReauthorizationResponseSchema = z.object({
+  authorizationUrl: z.string().url(),
+  expiresAt: z.iso.datetime(),
+});
+export type McpConnectorOAuthReauthorizationResponse = z.infer<
+  typeof mcpConnectorOAuthReauthorizationResponseSchema
+>;
+
 export const mcpConnectorsContract = c.router({
   list: {
     method: "GET",
@@ -31,6 +60,24 @@ export const mcpConnectorsContract = c.router({
       500: apiErrorSchema,
     },
     summary: "List MCP connectors authorized for the current Agent Run",
+  },
+  reauthorizeOAuth: {
+    method: "POST",
+    path: "/api/mcp-connectors/:id/oauth2/reauthorize",
+    headers: authHeadersSchema,
+    pathParams: z.object({ id: z.string().uuid() }),
+    body: mcpConnectorOAuthReauthorizationRequestSchema,
+    responses: {
+      200: mcpConnectorOAuthReauthorizationResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      409: apiErrorSchema,
+      500: apiErrorSchema,
+      502: apiErrorSchema,
+    },
+    summary: "Reauthorize MCP OAuth scopes for the current Agent Run",
   },
 });
 


### PR DESCRIPTION
## Summary

- surface standards-valid MCP `insufficient_scope` challenges as an Okou authorization link without replaying the failed tool request
- bind reauthorization to the exact Custom connector account captured in the signed Agent Run token, union existing and challenged scopes, and fail closed for stale or mismatched run/account state
- revalidate the persisted OAuth authority, reuse its CIMD or DCR client, and complete the existing exact-account reconnect callback flow
- keep the reauthorization API request inside the MCP command's overall deadline
- keep new CLI clients actionable against older API deployments that do not yet expose the additive route

## Deployment compatibility

- the API route and Agent Run token claim are additive
- old tokens without the account binding fail closed; old consumers ignore the optional claim
- the runner/firewall protocol and current-run credential snapshot are unchanged

## Explicit exclusions

- no UI changes or authorization-server selector
- no automatic request replay or current-run credential upgrade
- no reauthorization for no-auth, manual auth, or organization-managed Custom OAuth connectors

## Validation

- `pnpm format`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @okouai/cli lint`
- `pnpm check-types`
- `pnpm -F @okouai/api-contracts test`
- `pnpm -F api exec vitest run src/signals/auth/__tests__/tokens.test.ts src/signals/routes/__tests__/mcp-connectors.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/mcp-connectors.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts`
- `pnpm -F @okouai/cli exec vitest run src/commands/mcp/__tests__/index.test.ts`
- `pnpm knip`

Closes #30885

Parent context: #30466
