### PR TITLE
feat(platform): send timezone on onboarding completion

### DIFF
--- a/turbo/apps/platform/src/signals/onboarding/onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/onboarding/onboarding-actions.ts
@@ -47,9 +47,11 @@ export const completeOnboarding$ = command(
     }
 
     const onboardingClient = createClient(onboardingCompleteContract);
+    const timezone =
+      new Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
     await accept(
       onboardingClient.complete({
-        body: {},
+        body: { timezone },
         fetchOptions: { signal },
       }),
       [200],

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -38,10 +38,7 @@ import {
 } from "../../../__tests__/presentation-onboarding-fixture.ts";
 import { pathname } from "../../../signals/location.ts";
 import { localStorageSignals } from "../../../signals/external/local-storage.ts";
-import {
-  ONBOARDING_CHECKOUT_STATE_PARAM,
-  onboardingDraft$,
-} from "../../../signals/onboarding/onboarding-state.ts";
+import { ONBOARDING_CHECKOUT_STATE_PARAM } from "../../../signals/onboarding/onboarding-state.ts";
 import { ROUTES } from "../../../signals/route-paths.ts";
 import { detachedNavigateTo$, searchParams$ } from "../../../signals/route.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -50,8 +47,9 @@ import { mockChatLifecycle } from "../../okou-page/__tests__/chat-test-helpers.t
 const context = testContext();
 const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 const STALE_AGENT_ID = "c0000000-0000-4000-a000-000000000099";
-const { get$: lastUsedAgentId$, set$: setLastUsedAgentId$ } =
-  localStorageSignals("zero.lastUsedAgentId");
+const { set$: setLastUsedAgentId$ } = localStorageSignals(
+  "zero.lastUsedAgentId",
+);
 
 function onboardingAgent(agentId: string): AgentResponse {
   return {
@@ -324,8 +322,6 @@ describe("onboarding flow", () => {
           });
         },
       );
-      context.store.set(setLastUsedAgentId$, STALE_AGENT_ID);
-
       await openMakePage();
 
       const slackOption = firstItem(screen.getAllByRole("radio"));
@@ -344,8 +340,6 @@ describe("onboarding flow", () => {
         expect(pathname()).toBe(ROUTES.works);
       });
       expect(completionBody).toStrictEqual({ timezone: expectedTimezone });
-      expect(context.store.get(lastUsedAgentId$)).toBeNull();
-      expect(context.store.get(onboardingDraft$).choice).toBeNull();
     },
   );
 

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -19,6 +19,7 @@ import {
   connectorManualGrantContract,
   connectorOauthStartContract,
 } from "@okouai/api-contracts/contracts/connectors";
+import { onboardingCompleteContract } from "@okouai/api-contracts/contracts/onboarding";
 import {
   agentsMainContract,
   type AgentResponse,
@@ -37,7 +38,10 @@ import {
 } from "../../../__tests__/presentation-onboarding-fixture.ts";
 import { pathname } from "../../../signals/location.ts";
 import { localStorageSignals } from "../../../signals/external/local-storage.ts";
-import { ONBOARDING_CHECKOUT_STATE_PARAM } from "../../../signals/onboarding/onboarding-state.ts";
+import {
+  ONBOARDING_CHECKOUT_STATE_PARAM,
+  onboardingDraft$,
+} from "../../../signals/onboarding/onboarding-state.ts";
 import { ROUTES } from "../../../signals/route-paths.ts";
 import { detachedNavigateTo$, searchParams$ } from "../../../signals/route.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -46,9 +50,8 @@ import { mockChatLifecycle } from "../../okou-page/__tests__/chat-test-helpers.t
 const context = testContext();
 const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 const STALE_AGENT_ID = "c0000000-0000-4000-a000-000000000099";
-const { set$: setLastUsedAgentId$ } = localStorageSignals(
-  "zero.lastUsedAgentId",
-);
+const { get$: lastUsedAgentId$, set$: setLastUsedAgentId$ } =
+  localStorageSignals("zero.lastUsedAgentId");
 
 function onboardingAgent(agentId: string): AgentResponse {
   return {
@@ -288,25 +291,63 @@ function chooseTemplate(
 }
 
 describe("onboarding flow", () => {
-  it("leads with Slack and opens its setup after completing onboarding", async () => {
-    await openMakePage();
+  it.each([
+    {
+      browserTimezone: "Asia/Shanghai",
+      expectedTimezone: "Asia/Shanghai",
+      scenario: "browser-resolved",
+    },
+    {
+      browserTimezone: "",
+      expectedTimezone: "UTC",
+      scenario: "fallback",
+    },
+  ])(
+    "sends the $scenario timezone before opening Slack setup",
+    async ({ browserTimezone, expectedTimezone }) => {
+      const resolvedOptions = new Intl.DateTimeFormat().resolvedOptions();
+      vi.spyOn(
+        Intl.DateTimeFormat.prototype,
+        "resolvedOptions",
+      ).mockReturnValue({
+        ...resolvedOptions,
+        timeZone: browserTimezone,
+      });
+      let completionBody: unknown;
+      context.mocks.api(
+        onboardingCompleteContract.complete,
+        ({ body, respond }) => {
+          completionBody = body;
+          return respond(200, {
+            onboardingComplete: true,
+            needsOnboarding: false,
+          });
+        },
+      );
+      context.store.set(setLastUsedAgentId$, STALE_AGENT_ID);
 
-    const slackOption = firstItem(screen.getAllByRole("radio"));
-    expect(slackOption).toHaveTextContent("Chat with Okou in Slack");
-    expect(
-      screen.getByTestId("onboarding-slack-illustration"),
-    ).toBeInTheDocument();
-    expect(screen.getByTestId("onboarding-slack-icon")).toHaveAttribute(
-      "src",
-      expect.stringContaining("slack-198390069136.svg"),
-    );
+      await openMakePage();
 
-    click(slackOption);
+      const slackOption = firstItem(screen.getAllByRole("radio"));
+      expect(slackOption).toHaveTextContent("Chat with Okou in Slack");
+      expect(
+        screen.getByTestId("onboarding-slack-illustration"),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("onboarding-slack-icon")).toHaveAttribute(
+        "src",
+        expect.stringContaining("slack-198390069136.svg"),
+      );
 
-    await waitFor(() => {
-      expect(pathname()).toBe(ROUTES.works);
-    });
-  });
+      click(slackOption);
+
+      await waitFor(() => {
+        expect(pathname()).toBe(ROUTES.works);
+      });
+      expect(completionBody).toStrictEqual({ timezone: expectedTimezone });
+      expect(context.store.get(lastUsedAgentId$)).toBeNull();
+      expect(context.store.get(onboardingDraft$).choice).toBeNull();
+    },
+  );
 
   it.each([
     ["Generate a presentation", "Generate slides and speaker", "Presentation"],


### PR DESCRIPTION
## Summary

- resolve the browser timezone once in the centralized Platform onboarding-completion action
- send the non-empty IANA timezone unchanged and fall back to `UTC` for an empty browser value
- verify the exact request body and successful navigation through the typed onboarding contract mock

## Rolling deployment safety

Phase A added the optional onboarding `timezone` field and was fully promoted and accepted in production before this Platform sender change. The new Platform request therefore reaches an already-compatible API, while the API continues to accept the previous empty body from older Platform clients.

Redeem-code ordering, abort handling, role telemetry, state cleanup, and navigation behavior remain unchanged. This PR leaves `MORNING_BRIEF_DEFAULT_ACTIVATION_AT` as `null`, does not change either the `MorningBrief` or `OfficialWorkflows` feature switch, and makes no API, database, provisioning, preference, schedule, result-email, or release change.

## Fallbacks

- `onboarding-actions.ts:completeOnboarding$` sends `UTC` when the browser's `Intl.DateTimeFormat().resolvedOptions().timeZone` value is empty. Surface: browser-provided external data, not cross-version compatibility. This is the permanent safe default required by #31228, so there is no rollout removal gate or follow-up cleanup.

## Verification

- `pnpm exec prettier --check apps/platform/src/signals/onboarding/onboarding-actions.ts apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm knip --workspace @okouai/app`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/onboarding/__tests__/onboarding-flow.test.tsx --silent=passed-only` (43 passed)
- `pnpm -F @okouai/app exec vitest run src/views/onboarding/__tests__/onboarding-role-telemetry.test.tsx --silent=passed-only` (1 passed)

Refs #31156

Closes #31228
