### PR TITLE
refactor(runtime): remove retired working-directory environment tombstone

### DIFF
--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -474,10 +474,6 @@ pub const CANONICAL_MOCK_CLAUDE_PATH_ENV: &str = "OKOU_MOCK_CLAUDE_PATH";
 /// Unset means the guest-agent uses its compiled default mock binary path.
 pub const CANONICAL_MOCK_CODEX_PATH_ENV: &str = "OKOU_MOCK_CODEX_PATH";
 
-/// Retired runner bootstrap key that must remain protected at the user-env
-/// boundary.
-pub const WORKING_DIR_ENV: &str = "VM0_WORKING_DIR";
-
 /// Retained legacy Guest Agent tuning inputs that local user env may provide.
 ///
 /// These are the only `VM0_` keys intentionally allowed to cross the local
@@ -887,7 +883,6 @@ mod tests {
             PI_LAUNCH_PAYLOAD_FILE_ENV,
             PI_MODEL_CONFIG_ENV,
             CONNECTOR_ACCOUNT_CONTEXT_FILE_ENV,
-            WORKING_DIR_ENV,
             "VM0_USER_ENV_FILE",
             CANONICAL_USER_ENV_FILE_ENV,
             "VM0_RUN_PAYLOAD_FILE",

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -471,7 +471,6 @@ fn build_env_json_required_keys() {
     );
     assert!(!env.contains_key("VM0_GUEST_RUNTIME_DIR"));
     assert!(!env.contains_key("VM0_PROMPT"));
-    assert!(!env.contains_key("VM0_WORKING_DIR"));
     // Guest-agent needs these to post /complete with full metadata when
     // checkpoint lands before sandbox teardown.
     assert_eq!(
@@ -849,7 +848,6 @@ fn build_env_json_codex_keeps_shared_runner_env() {
         "019e9154-c304-70f0-adde-36efb1be1701"
     );
     assert!(!env.contains_key("VM0_RESUME_SESSION_ID"));
-    assert!(!env.contains_key("VM0_WORKING_DIR"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- delete the retired `WORKING_DIR_ENV` / `VM0_WORKING_DIR` tombstone constant and its guest-contract self-inventory entry
- remove the two Runner negative assertions that only pinned the retired environment spelling
- preserve the canonical `/home/user/workspace` contract, namespace-wide `OKOU_*` / `VM0_*` guard, retained Guest Agent timing mappings, and unrelated RunPayload diagnostics byte-for-byte

Closes #31235

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `CARGO_BUILD_JOBS=2 cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts --all-features --all-targets -- -D warnings`
- `CARGO_BUILD_JOBS=2 cargo clippy --manifest-path crates/Cargo.toml -p runner --all-features --all-targets -- -D warnings`
- `CARGO_BUILD_JOBS=2 cargo check --manifest-path crates/Cargo.toml -p guest-contracts --all-features --all-targets`
- `CARGO_BUILD_JOBS=2 cargo check --manifest-path crates/Cargo.toml -p runner --all-features --all-targets`
- `CARGO_BUILD_JOBS=2 cargo test --manifest-path crates/Cargo.toml -p guest-contracts env::tests` (13 passed)
- repository-wide exact inventories for `VM0_WORKING_DIR` and `WORKING_DIR_ENV` (0 occurrences each)
- `git diff --check`

The focused Runner env module command compiled all dependencies but the local GNU linker was killed twice with exit 137 in this 3.8 GiB, no-swap container before tests could execute, including a constrained retry with one Cargo job, debug symbols disabled, and `--no-keep-memory`. Protected PR CI provides the authoritative Runner test coverage.

## Overlap audit

- fully paginated 20 open PRs and 877/877 declared changed files against the final base
- only stale #25722 overlaps the two files, through unrelated Cloudflare Access constants and host-env fixtures; it is not a functional dependency
