### PR TITLE
feat(pi-memory): add per-storage phase 2 control plane

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -396,6 +396,11 @@ export default [
       // with the sandbox runtime; route output cannot expose its full virtual
       // filesystem, ignore-rule, and precedence matrix.
       "src/signals/services/__tests__/pi-resource-snapshot.service.test.ts",
+      // Slice 4a intentionally has no Phase 2 worker or public mutation API.
+      // These real-PostgreSQL tests pin its finite lease/retry/finalization and
+      // bounded-selection matrices until a later slice exposes that boundary.
+      "src/signals/services/__tests__/pi-memory-phase2-job.service.test.ts",
+      "src/signals/services/__tests__/pi-memory-phase2-selection.service.test.ts",
       // Terra route activation is explicitly deferred. This compatibility
       // slice must pin the pre-admission provider/transport contract before a
       // production endpoint can expose Pi-owned Terra behavior.
@@ -530,6 +535,12 @@ export default [
       // with the sandbox runtime; route output cannot expose its full virtual
       // filesystem, ignore-rule, and precedence matrix.
       "src/signals/services/__tests__/pi-resource-snapshot.service.test.ts",
+      // Slice 4a intentionally has no Phase 2 worker or public mutation API.
+      // Keep its exact PostgreSQL concurrency and selection contract isolated
+      // to these tests and their fixture until a later slice exposes a route.
+      "src/signals/services/__tests__/pi-memory-phase2-job.service.test.ts",
+      "src/signals/services/__tests__/pi-memory-phase2-selection.service.test.ts",
+      "src/signals/services/__tests__/pi-memory-phase2-job.test-fixture.ts",
       // Terra route activation is explicitly deferred, so its pre-admission
       // provider/transport compatibility matrix has no endpoint boundary yet.
       "src/signals/services/__tests__/pi-sandbox-config.test.ts",

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -5981,6 +5981,8 @@ describe("CHAT-02: model-first provider policies", () => {
     await expect(
       commitPiMemoryStage1CandidateFixture({
         memoryStorageId: firstCandidate.memoryStorageId,
+        orgId,
+        userId: actor.userId,
         piSessionId: firstCandidate.piSessionId,
         sourceHistoryHash: firstCandidate.sourceHistoryHash,
         leaseToken: staleLeaseToken,
@@ -6011,6 +6013,8 @@ describe("CHAT-02: model-first provider policies", () => {
     await expect(
       commitPiMemoryStage1CandidateFixture({
         memoryStorageId: replacedCandidate.memoryStorageId,
+        orgId,
+        userId: actor.userId,
         piSessionId: replacedCandidate.piSessionId,
         sourceHistoryHash: replacedCandidate.sourceHistoryHash,
         leaseToken: currentLeaseToken,
@@ -6021,6 +6025,8 @@ describe("CHAT-02: model-first provider policies", () => {
     await expect(
       commitPiMemoryStage1CandidateFixture({
         memoryStorageId: replacedCandidate.memoryStorageId,
+        orgId,
+        userId: actor.userId,
         piSessionId: replacedCandidate.piSessionId,
         sourceHistoryHash: replacedCandidate.sourceHistoryHash,
         leaseToken: currentLeaseToken,
@@ -6106,6 +6112,8 @@ describe("CHAT-02: model-first provider policies", () => {
     await expect(
       commitPiMemoryStage1CandidateFixture({
         memoryStorageId: thirdCandidate.memoryStorageId,
+        orgId,
+        userId: actor.userId,
         piSessionId: thirdCandidate.piSessionId,
         sourceHistoryHash: thirdCandidate.sourceHistoryHash,
         leaseToken: currentLeaseToken,
@@ -6116,6 +6124,8 @@ describe("CHAT-02: model-first provider policies", () => {
     await expect(
       commitPiMemoryStage1CandidateFixture({
         memoryStorageId: thirdCandidate.memoryStorageId,
+        orgId,
+        userId: actor.userId,
         piSessionId: thirdCandidate.piSessionId,
         sourceHistoryHash: thirdCandidate.sourceHistoryHash,
         leaseToken: thirdLeaseToken,

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -18,6 +18,7 @@ import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createOpsLogsApi } from "./helpers/api-bdd-ops-logs";
 import { createRunsApi } from "./helpers/api-bdd-runs";
+import { createStoragesBddApi } from "./helpers/api-bdd-storages";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import {
   aggregateModelStatsFixture,
@@ -41,6 +42,7 @@ import {
 import { commitMemoryVersion } from "./helpers/memory";
 import { createFixtureTracker } from "./helpers/route-test";
 import { agentInstructionsRoutes } from "../agent-instructions";
+import { seedPiMemoryPhase2ExportJobFixture } from "../../../test-fixtures/pi-memory-stage1-candidates";
 
 /* BILL-02 model stats and OPS-01 user export. */
 
@@ -1345,7 +1347,7 @@ describe("OPS-01: user data export", () => {
     expect(messages[0]?.content).not.toContain("stale export content");
   });
 
-  it("exports only agent instruction files, workflow files, and memory files", async () => {
+  it("exports only safe agent, workflow, and memory control-plane data", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const misc = createMiscRoutesApi(context);
@@ -1402,8 +1404,15 @@ describe("OPS-01: user data export", () => {
     // Create the memory artifact head version through the product storage
     // upload flow, then place the mocked archive at the S3 key the product
     // assigned to it.
+    createStoragesBddApi(context).mockStoragePresignedUrls();
     const memory = await commitMemoryVersion(context, actor, memoryFiles);
     putMemoryArchive(misc, memory.s3Key, memoryFiles);
+    const phase2Secrets = await seedPiMemoryPhase2ExportJobFixture({
+      memoryStorageId: memory.storageId,
+      orgId: actor.orgId,
+      userId: actor.userId,
+      currentTime: new Date(exportStartAt),
+    });
 
     mockNow(exportStartAt);
     context.mocks.s3.getSignedUrl.mockResolvedValue(downloadUrl);
@@ -1443,6 +1452,35 @@ describe("OPS-01: user data export", () => {
     expect(zipText(zip, `memory/${actor.orgId}/notes/profile.md`)).toBe(
       "Memory supporting note",
     );
+    const phase2JobsText = zipText(zip, "memory/phase2-jobs.json");
+    const phase2Jobs = JSON.parse(phase2JobsText) as readonly Record<
+      string,
+      unknown
+    >[];
+    expect(phase2Jobs).toStrictEqual([
+      {
+        memoryStorageId: memory.storageId,
+        orgId: actor.orgId,
+        userId: actor.userId,
+        status: "leased",
+        inputRevision: 2,
+        completedRevision: 0,
+        claimedRevision: 1,
+        leaseExpiresAt: new Date(exportStartAt + 60 * 60 * 1000).toISOString(),
+        retryCount: 1,
+        retryAt: null,
+        lastErrorClass: null,
+        lastSucceededAt: new Date(
+          exportStartAt - 24 * 60 * 60 * 1000,
+        ).toISOString(),
+        claimedSelectedCount: 1,
+        claimedSelectedUtf8Bytes: 42,
+        createdAt: new Date(exportStartAt - 2 * 60 * 60 * 1000).toISOString(),
+        updatedAt: new Date(exportStartAt).toISOString(),
+      },
+    ]);
+    expect(phase2JobsText).not.toContain(phase2Secrets.leaseToken);
+    expect(phase2JobsText).not.toContain(phase2Secrets.selectionDigest);
 
     const manifest = JSON.parse(zipText(zip, "export-manifest.json")) as {
       readonly counts: {
@@ -1450,6 +1488,7 @@ describe("OPS-01: user data export", () => {
         readonly workflowFiles: number;
         readonly memoryFiles: number;
         readonly memoryStage1Candidates: number;
+        readonly memoryPhase2Jobs: number;
         readonly conversationThreads: number;
         readonly sessionHistories: number;
       };
@@ -1459,6 +1498,7 @@ describe("OPS-01: user data export", () => {
       workflowFiles: 2,
       memoryFiles: 2,
       memoryStage1Candidates: 0,
+      memoryPhase2Jobs: 1,
       conversationThreads: 0,
       sessionHistories: 0,
     });

--- a/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-job.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-job.service.test.ts
@@ -1,0 +1,761 @@
+/* oxlint-disable jest/prefer-expect-resolves, vitest/prefer-to-be-falsy, vitest/prefer-to-be-truthy -- Direct state-machine assertions keep each PostgreSQL transition and fence visually paired. */
+import { randomUUID } from "node:crypto";
+
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import { blobs } from "@okouai/db/schema/blob";
+import { piMemoryStage1Candidates } from "@okouai/db/schema/pi-memory-stage1-candidate";
+import { storages } from "@okouai/db/schema/storage";
+
+import { db } from "../../../lib/db";
+import { commitPiMemoryStage1Candidate } from "../pi-memory-stage1-candidate.service";
+import {
+  advancePiMemoryPhase2InputRevision,
+  claimPiMemoryPhase2Job,
+  failPiMemoryPhase2Job,
+  heartbeatPiMemoryPhase2Job,
+  PI_MEMORY_PHASE2_RETRY_DELAY_MS,
+  PI_MEMORY_PHASE2_SUCCESS_COOLDOWN_MS,
+  succeedPiMemoryPhase2Job,
+} from "../pi-memory-phase2-job.service";
+import {
+  createPhase2TestScope,
+  insertPendingPhase2Job,
+  insertPhase2Candidates,
+  readPhase2Job,
+  replacePhase2CandidateSource,
+} from "./pi-memory-phase2-job.test-fixture";
+
+const NOW = Object.freeze(new Date("2026-09-03T04:00:00.000Z"));
+
+describe("Pi memory Phase 2 job transitions", () => {
+  it("transactionally advances exactly once per fresh successful Stage 1 commit", async () => {
+    const scope = await createPhase2TestScope("stage1-commit");
+    const leaseExpiresAt = new Date(NOW.getTime() + 60_000);
+    const leaseTokens = [randomUUID(), randomUUID(), randomUUID()];
+    const hashes = await insertPhase2Candidates(scope, [
+      {
+        piSessionId: "session-a",
+        status: "leased",
+        leaseToken: leaseTokens[0],
+        leaseExpiresAt,
+      },
+      {
+        piSessionId: "session-b",
+        status: "leased",
+        leaseToken: leaseTokens[1],
+        leaseExpiresAt,
+      },
+      {
+        piSessionId: "session-failure",
+        status: "leased",
+        leaseToken: leaseTokens[2],
+        leaseExpiresAt,
+      },
+    ]);
+
+    const [first, second] = await Promise.all([
+      db().transaction(async (tx) => {
+        return await commitPiMemoryStage1Candidate(tx, {
+          ...scope,
+          piSessionId: "session-a",
+          sourceHistoryHash: hashes[0] as string,
+          leaseToken: leaseTokens[0] as string,
+          committedAt: NOW,
+          result: {
+            kind: "succeeded",
+            rawMemory: "first raw memory",
+            rolloutSummary: "first summary",
+          },
+        });
+      }),
+      db().transaction(async (tx) => {
+        return await commitPiMemoryStage1Candidate(tx, {
+          ...scope,
+          piSessionId: "session-b",
+          sourceHistoryHash: hashes[1] as string,
+          leaseToken: leaseTokens[1] as string,
+          committedAt: NOW,
+          result: { kind: "succeeded_no_output" },
+        });
+      }),
+    ]);
+    expect([first, second]).toStrictEqual([true, true]);
+    expect(await readPhase2Job(scope)).toMatchObject({
+      status: "pending",
+      inputRevision: 2,
+      completedRevision: 0,
+      retryCount: 0,
+    });
+
+    const failed = await db().transaction(async (tx) => {
+      return await commitPiMemoryStage1Candidate(tx, {
+        ...scope,
+        piSessionId: "session-failure",
+        sourceHistoryHash: hashes[2] as string,
+        leaseToken: leaseTokens[2] as string,
+        committedAt: NOW,
+        result: {
+          kind: "retryable_failure",
+          retryAt: new Date(NOW.getTime() + 60_000),
+          errorClass: "provider_timeout",
+        },
+      });
+    });
+    expect(failed).toBe(true);
+    expect((await readPhase2Job(scope))?.inputRevision).toBe(2);
+
+    const replay = await db().transaction(async (tx) => {
+      return await commitPiMemoryStage1Candidate(tx, {
+        ...scope,
+        piSessionId: "session-a",
+        sourceHistoryHash: hashes[0] as string,
+        leaseToken: leaseTokens[0] as string,
+        committedAt: NOW,
+        result: { kind: "succeeded_no_output" },
+      });
+    });
+    expect(replay).toBe(false);
+    expect((await readPhase2Job(scope))?.inputRevision).toBe(2);
+  });
+
+  it("rolls back Stage 1 success if enqueue cannot advance", async () => {
+    const scope = await createPhase2TestScope("enqueue-rollback");
+    const leaseToken = randomUUID();
+    const [sourceHistoryHash] = await insertPhase2Candidates(scope, [
+      {
+        piSessionId: "rollback-session",
+        status: "leased",
+        leaseToken,
+        leaseExpiresAt: new Date(NOW.getTime() + 60_000),
+      },
+    ]);
+    await insertPendingPhase2Job(scope, {
+      inputRevision: 2_147_483_647,
+    });
+
+    await expect(
+      db().transaction(async (tx) => {
+        return await commitPiMemoryStage1Candidate(tx, {
+          ...scope,
+          piSessionId: "rollback-session",
+          sourceHistoryHash: sourceHistoryHash as string,
+          leaseToken,
+          committedAt: NOW,
+          result: { kind: "succeeded_no_output" },
+        });
+      }),
+    ).rejects.toThrow("Failed query");
+
+    const [candidate] = await db()
+      .select({
+        status: piMemoryStage1Candidates.status,
+        leaseToken: piMemoryStage1Candidates.leaseToken,
+      })
+      .from(piMemoryStage1Candidates)
+      .where(
+        and(
+          eq(piMemoryStage1Candidates.memoryStorageId, scope.memoryStorageId),
+          eq(piMemoryStage1Candidates.piSessionId, "rollback-session"),
+        ),
+      );
+    expect(candidate).toStrictEqual({ status: "leased", leaseToken });
+    expect((await readPhase2Job(scope))?.inputRevision).toBe(2_147_483_647);
+  });
+
+  it("commits Stage 1 successes for different Storages independently", async () => {
+    const firstScope = await createPhase2TestScope("stage1-independent-a");
+    const secondScope = await createPhase2TestScope("stage1-independent-b");
+    const firstToken = randomUUID();
+    const secondToken = randomUUID();
+    const expiresAt = new Date(NOW.getTime() + 60_000);
+    const [firstHashes, secondHashes] = await Promise.all([
+      insertPhase2Candidates(firstScope, [
+        {
+          piSessionId: "independent-a",
+          status: "leased",
+          leaseToken: firstToken,
+          leaseExpiresAt: expiresAt,
+        },
+      ]),
+      insertPhase2Candidates(secondScope, [
+        {
+          piSessionId: "independent-b",
+          status: "leased",
+          leaseToken: secondToken,
+          leaseExpiresAt: expiresAt,
+        },
+      ]),
+    ]);
+
+    await Promise.all([
+      db().transaction(async (tx) => {
+        await commitPiMemoryStage1Candidate(tx, {
+          ...firstScope,
+          piSessionId: "independent-a",
+          sourceHistoryHash: firstHashes[0] as string,
+          leaseToken: firstToken,
+          committedAt: NOW,
+          result: { kind: "succeeded_no_output" },
+        });
+      }),
+      db().transaction(async (tx) => {
+        await commitPiMemoryStage1Candidate(tx, {
+          ...secondScope,
+          piSessionId: "independent-b",
+          sourceHistoryHash: secondHashes[0] as string,
+          leaseToken: secondToken,
+          committedAt: NOW,
+          result: { kind: "succeeded_no_output" },
+        });
+      }),
+    ]);
+    expect((await readPhase2Job(firstScope))?.inputRevision).toBe(1);
+    expect((await readPhase2Job(secondScope))?.inputRevision).toBe(1);
+  });
+
+  it("preserves a live lease while advancing only its input revision", async () => {
+    const scope = await createPhase2TestScope("leased-advance");
+    const leaseToken = randomUUID();
+    const leaseExpiresAt = new Date(NOW.getTime() + 60_000);
+    await insertPendingPhase2Job(scope, {
+      status: "leased",
+      inputRevision: 1,
+      claimedRevision: 1,
+      leaseToken,
+      leaseExpiresAt,
+      retryCount: 2,
+      claimedSelectionDigest: "b".repeat(64),
+      claimedSelectedCount: 7,
+      claimedSelectedUtf8Bytes: 99,
+      updatedAt: new Date(NOW.getTime() - 1000),
+    });
+
+    await db().transaction(async (tx) => {
+      await advancePiMemoryPhase2InputRevision(tx, {
+        ...scope,
+        enqueuedAt: NOW,
+      });
+    });
+    expect(await readPhase2Job(scope)).toMatchObject({
+      status: "leased",
+      inputRevision: 2,
+      completedRevision: 0,
+      claimedRevision: 1,
+      leaseToken,
+      leaseExpiresAt,
+      retryCount: 2,
+      claimedSelectionDigest: "b".repeat(64),
+      claimedSelectedCount: 7,
+      claimedSelectedUtf8Bytes: 99,
+      updatedAt: NOW,
+    });
+  });
+
+  it("claims at most once per Storage while independent Storages proceed", async () => {
+    const firstScope = await createPhase2TestScope("claim-race-a");
+    const secondScope = await createPhase2TestScope("claim-race-b");
+    await insertPendingPhase2Job(firstScope, { updatedAt: NOW });
+    await insertPendingPhase2Job(secondScope, { updatedAt: NOW });
+
+    const sameStorage = await Promise.all([
+      claimPiMemoryPhase2Job(db(), {
+        currentTime: NOW,
+        scope: firstScope,
+      }),
+      claimPiMemoryPhase2Job(db(), {
+        currentTime: NOW,
+        scope: firstScope,
+      }),
+    ]);
+    expect(sameStorage.filter(Boolean)).toHaveLength(1);
+
+    const independent = await claimPiMemoryPhase2Job(db(), {
+      currentTime: NOW,
+      scope: secondScope,
+    });
+    expect(independent).toMatchObject(secondScope);
+  });
+
+  it("enforces lease fences, retry boundaries, attempt limits, and new-input reset", async () => {
+    const scope = await createPhase2TestScope("fences");
+    await insertPendingPhase2Job(scope);
+    const claimed = await claimPiMemoryPhase2Job(db(), {
+      currentTime: NOW,
+      scope,
+    });
+    expect(claimed).not.toBeNull();
+    if (!claimed) {
+      throw new Error("Expected a claimed job");
+    }
+
+    expect(
+      await heartbeatPiMemoryPhase2Job(db(), {
+        ...scope,
+        leaseToken: randomUUID(),
+        claimedRevision: claimed.claimedRevision,
+        currentTime: new Date(NOW.getTime() + 1000),
+      }),
+    ).toBe(false);
+    expect(
+      await heartbeatPiMemoryPhase2Job(db(), {
+        ...scope,
+        leaseToken: claimed.leaseToken,
+        claimedRevision: claimed.claimedRevision,
+        currentTime: claimed.leaseExpiresAt,
+      }),
+    ).toBe(false);
+    expect(
+      await heartbeatPiMemoryPhase2Job(db(), {
+        ...scope,
+        leaseToken: claimed.leaseToken,
+        claimedRevision: claimed.claimedRevision,
+        currentTime: new Date(NOW.getTime() + 1000),
+      }),
+    ).toBe(true);
+
+    const failedAt = new Date(NOW.getTime() + 2000);
+    expect(
+      await failPiMemoryPhase2Job(db(), {
+        ...scope,
+        leaseToken: randomUUID(),
+        claimedRevision: claimed.claimedRevision,
+        currentTime: failedAt,
+        errorClass: "provider_timeout",
+      }),
+    ).toBe(false);
+    expect(
+      await failPiMemoryPhase2Job(db(), {
+        ...scope,
+        leaseToken: claimed.leaseToken,
+        claimedRevision: claimed.claimedRevision,
+        currentTime: failedAt,
+        errorClass: "provider_timeout",
+      }),
+    ).toBe(true);
+    expect(await readPhase2Job(scope)).toMatchObject({
+      status: "retryable_failure",
+      retryCount: 1,
+      retryAt: new Date(failedAt.getTime() + PI_MEMORY_PHASE2_RETRY_DELAY_MS),
+      lastErrorClass: "provider_timeout",
+    });
+
+    expect(
+      await claimPiMemoryPhase2Job(db(), {
+        currentTime: new Date(
+          failedAt.getTime() + PI_MEMORY_PHASE2_RETRY_DELAY_MS - 1,
+        ),
+        scope,
+      }),
+    ).toBeNull();
+    const retryAt = new Date(
+      failedAt.getTime() + PI_MEMORY_PHASE2_RETRY_DELAY_MS,
+    );
+    const second = await claimPiMemoryPhase2Job(db(), {
+      currentTime: retryAt,
+      scope,
+    });
+    expect(second).not.toBeNull();
+    if (!second) {
+      throw new Error("Expected second attempt");
+    }
+    await failPiMemoryPhase2Job(db(), {
+      ...scope,
+      leaseToken: second.leaseToken,
+      claimedRevision: second.claimedRevision,
+      currentTime: new Date(retryAt.getTime() + 1),
+      errorClass: "provider_timeout",
+    });
+    const thirdAt = new Date(
+      retryAt.getTime() + 1 + PI_MEMORY_PHASE2_RETRY_DELAY_MS,
+    );
+    const third = await claimPiMemoryPhase2Job(db(), {
+      currentTime: thirdAt,
+      scope,
+    });
+    expect(third).not.toBeNull();
+    if (!third) {
+      throw new Error("Expected third attempt");
+    }
+    await failPiMemoryPhase2Job(db(), {
+      ...scope,
+      leaseToken: third.leaseToken,
+      claimedRevision: third.claimedRevision,
+      currentTime: new Date(thirdAt.getTime() + 1),
+      errorClass: "provider_timeout",
+    });
+    expect(await readPhase2Job(scope)).toMatchObject({
+      status: "terminal_failure",
+      retryCount: 3,
+      retryAt: null,
+      lastErrorClass: "provider_timeout",
+    });
+
+    const enqueuedAt = new Date(thirdAt.getTime() + 2);
+    await db().transaction(async (tx) => {
+      await advancePiMemoryPhase2InputRevision(tx, { ...scope, enqueuedAt });
+    });
+    expect(await readPhase2Job(scope)).toMatchObject({
+      status: "pending",
+      inputRevision: 2,
+      retryCount: 0,
+      lastErrorClass: null,
+    });
+  });
+
+  it("rejects every wrong or expired fence without changing job or markers", async () => {
+    const scope = await createPhase2TestScope("rejected-fences");
+    const [sourceHistoryHash] = await insertPhase2Candidates(scope, [
+      { piSessionId: "fenced-candidate" },
+    ]);
+    await db()
+      .update(piMemoryStage1Candidates)
+      .set({ lastSelectedSourceHistoryHash: sourceHistoryHash as string })
+      .where(
+        and(
+          eq(piMemoryStage1Candidates.memoryStorageId, scope.memoryStorageId),
+          eq(piMemoryStage1Candidates.piSessionId, "fenced-candidate"),
+        ),
+      );
+    await insertPendingPhase2Job(scope);
+    const claimed = await claimPiMemoryPhase2Job(db(), {
+      currentTime: NOW,
+      scope,
+    });
+    expect(claimed).not.toBeNull();
+    if (!claimed) {
+      throw new Error("Expected fenced claim");
+    }
+    const before = await readPhase2Job(scope);
+    const invalidFences = [
+      { ...scope, orgId: `${scope.orgId}-wrong` },
+      { ...scope, userId: `${scope.userId}-wrong` },
+      { ...scope, memoryStorageId: randomUUID() },
+      { ...scope, leaseToken: randomUUID() },
+      { ...scope, claimedRevision: claimed.claimedRevision + 1 },
+      { ...scope, currentTime: claimed.leaseExpiresAt },
+    ];
+    for (const invalid of invalidFences) {
+      const fence = {
+        ...scope,
+        leaseToken: claimed.leaseToken,
+        claimedRevision: claimed.claimedRevision,
+        currentTime: new Date(NOW.getTime() + 1),
+        ...invalid,
+      };
+      expect(await heartbeatPiMemoryPhase2Job(db(), fence)).toBe(false);
+      expect(
+        await failPiMemoryPhase2Job(db(), {
+          ...fence,
+          errorClass: "rejected_fence",
+        }),
+      ).toBe(false);
+      expect(
+        await succeedPiMemoryPhase2Job(db(), {
+          ...fence,
+          selected: claimed.selected,
+        }),
+      ).toBe(false);
+    }
+    expect(await readPhase2Job(scope)).toStrictEqual(before);
+
+    await db().transaction(async (tx) => {
+      await advancePiMemoryPhase2InputRevision(tx, {
+        ...scope,
+        enqueuedAt: new Date(NOW.getTime() + 2),
+      });
+    });
+    expect(
+      await failPiMemoryPhase2Job(db(), {
+        ...scope,
+        leaseToken: claimed.leaseToken,
+        claimedRevision: claimed.claimedRevision,
+        currentTime: new Date(NOW.getTime() + 3),
+        errorClass: "old_revision_failed",
+      }),
+    ).toBe(true);
+    expect(await readPhase2Job(scope)).toMatchObject({
+      status: "pending",
+      inputRevision: 2,
+      completedRevision: 0,
+      retryCount: 0,
+      lastErrorClass: null,
+    });
+    const [marker] = await db()
+      .select({
+        value: piMemoryStage1Candidates.lastSelectedSourceHistoryHash,
+      })
+      .from(piMemoryStage1Candidates)
+      .where(
+        and(
+          eq(piMemoryStage1Candidates.memoryStorageId, scope.memoryStorageId),
+          eq(piMemoryStage1Candidates.piSessionId, "fenced-candidate"),
+        ),
+      );
+    expect(marker?.value).toBe(sourceHistoryHash);
+  });
+
+  it("counts stale lease takeovers and resets attempts for newer input", async () => {
+    const scope = await createPhase2TestScope("stale-takeover");
+    await insertPendingPhase2Job(scope);
+    const first = await claimPiMemoryPhase2Job(db(), {
+      currentTime: NOW,
+      scope,
+    });
+    expect(first).not.toBeNull();
+    if (!first) {
+      throw new Error("Expected initial claim");
+    }
+    const firstExpiry = first.leaseExpiresAt;
+    const second = await claimPiMemoryPhase2Job(db(), {
+      currentTime: firstExpiry,
+      scope,
+    });
+    expect(second?.leaseToken).not.toBe(first.leaseToken);
+    expect((await readPhase2Job(scope))?.retryCount).toBe(1);
+
+    await db().transaction(async (tx) => {
+      await advancePiMemoryPhase2InputRevision(tx, {
+        ...scope,
+        enqueuedAt: new Date(firstExpiry.getTime() + 1),
+      });
+    });
+    const third = await claimPiMemoryPhase2Job(db(), {
+      currentTime: second?.leaseExpiresAt ?? new Date(0),
+      scope,
+    });
+    expect(third?.claimedRevision).toBe(2);
+    expect((await readPhase2Job(scope))?.retryCount).toBe(0);
+    if (!second || !third) {
+      throw new Error("Expected both takeover claims");
+    }
+    expect(
+      await heartbeatPiMemoryPhase2Job(db(), {
+        ...scope,
+        leaseToken: second.leaseToken,
+        claimedRevision: second.claimedRevision,
+        currentTime: new Date(second.leaseExpiresAt.getTime() - 1),
+      }),
+    ).toBe(false);
+    expect(
+      await failPiMemoryPhase2Job(db(), {
+        ...scope,
+        leaseToken: second.leaseToken,
+        claimedRevision: second.claimedRevision,
+        currentTime: new Date(second.leaseExpiresAt.getTime() - 1),
+        errorClass: "stale_owner",
+      }),
+    ).toBe(false);
+    expect(
+      await succeedPiMemoryPhase2Job(db(), {
+        ...scope,
+        leaseToken: second.leaseToken,
+        claimedRevision: second.claimedRevision,
+        currentTime: new Date(second.leaseExpiresAt.getTime() - 1),
+        selected: second.selected,
+      }),
+    ).toBe(false);
+    expect((await readPhase2Job(scope))?.leaseToken).toBe(third.leaseToken);
+  });
+
+  it("honors the exact six-hour success cooldown boundary", async () => {
+    const scope = await createPhase2TestScope("cooldown");
+    await insertPendingPhase2Job(scope, {
+      inputRevision: 2,
+      completedRevision: 1,
+      lastSucceededAt: NOW,
+    });
+    expect(
+      await claimPiMemoryPhase2Job(db(), {
+        currentTime: new Date(
+          NOW.getTime() + PI_MEMORY_PHASE2_SUCCESS_COOLDOWN_MS - 1,
+        ),
+        scope,
+      }),
+    ).toBeNull();
+    expect(
+      await claimPiMemoryPhase2Job(db(), {
+        currentTime: new Date(
+          NOW.getTime() + PI_MEMORY_PHASE2_SUCCESS_COOLDOWN_MS,
+        ),
+        scope,
+      }),
+    ).not.toBeNull();
+  });
+
+  it("finalizes only the frozen tuple set and preserves newer input", async () => {
+    const scope = await createPhase2TestScope("success");
+    const oldHash = (
+      await insertPhase2Candidates(scope, [
+        {
+          piSessionId: "old-unselected",
+          sourceCompletedAt: new Date(NOW.getTime() - 31 * 24 * 60 * 60 * 1000),
+        },
+      ])
+    )[0] as string;
+    await db()
+      .update(piMemoryStage1Candidates)
+      .set({ lastSelectedSourceHistoryHash: oldHash })
+      .where(
+        and(
+          eq(piMemoryStage1Candidates.memoryStorageId, scope.memoryStorageId),
+          eq(piMemoryStage1Candidates.piSessionId, "old-unselected"),
+        ),
+      );
+    await insertPhase2Candidates(scope, [
+      { piSessionId: "selected-a", rawMemory: "A" },
+      { piSessionId: "selected-b", rawMemory: "BB" },
+    ]);
+    await insertPendingPhase2Job(scope);
+    const claimed = await claimPiMemoryPhase2Job(db(), {
+      currentTime: NOW,
+      scope,
+    });
+    expect(
+      claimed?.selected.map((candidate) => {
+        return candidate.piSessionId;
+      }),
+    ).toStrictEqual(["selected-a", "selected-b"]);
+    if (!claimed) {
+      throw new Error("Expected selection claim");
+    }
+
+    expect(
+      await succeedPiMemoryPhase2Job(db(), {
+        ...scope,
+        leaseToken: claimed.leaseToken,
+        claimedRevision: claimed.claimedRevision,
+        currentTime: new Date(NOW.getTime() + 1),
+        selected: [...claimed.selected].reverse(),
+      }),
+    ).toBe(false);
+    await replacePhase2CandidateSource({
+      scope,
+      piSessionId: "selected-a",
+      sourceCompletedAt: new Date(NOW.getTime() + 2),
+    });
+    await db().transaction(async (tx) => {
+      await advancePiMemoryPhase2InputRevision(tx, {
+        ...scope,
+        enqueuedAt: new Date(NOW.getTime() + 2),
+      });
+    });
+    expect(
+      await succeedPiMemoryPhase2Job(db(), {
+        ...scope,
+        leaseToken: claimed.leaseToken,
+        claimedRevision: claimed.claimedRevision,
+        currentTime: new Date(NOW.getTime() + 3),
+        selected: claimed.selected,
+      }),
+    ).toBe(true);
+
+    expect(await readPhase2Job(scope)).toMatchObject({
+      status: "pending",
+      inputRevision: 2,
+      completedRevision: 1,
+      claimedRevision: null,
+      retryCount: 0,
+      lastSucceededAt: new Date(NOW.getTime() + 3),
+    });
+    const markers = await db()
+      .select({
+        piSessionId: piMemoryStage1Candidates.piSessionId,
+        sourceHistoryHash: piMemoryStage1Candidates.sourceHistoryHash,
+        marker: piMemoryStage1Candidates.lastSelectedSourceHistoryHash,
+      })
+      .from(piMemoryStage1Candidates)
+      .where(
+        and(
+          eq(piMemoryStage1Candidates.memoryStorageId, scope.memoryStorageId),
+          eq(piMemoryStage1Candidates.orgId, scope.orgId),
+          eq(piMemoryStage1Candidates.userId, scope.userId),
+        ),
+      );
+    expect(
+      Object.fromEntries(
+        markers.map((candidate) => {
+          return [candidate.piSessionId, candidate.marker];
+        }),
+      ),
+    ).toStrictEqual({
+      "old-unselected": null,
+      "selected-a": null,
+      "selected-b": markers.find((row) => {
+        return row.piSessionId === "selected-b";
+      })?.sourceHistoryHash,
+    });
+  });
+
+  it("accepts an empty selection and clears every old marker", async () => {
+    const scope = await createPhase2TestScope("empty-success");
+    const [oldHash] = await insertPhase2Candidates(scope, [
+      {
+        piSessionId: "old-marker",
+        sourceCompletedAt: new Date(NOW.getTime() - 31 * 24 * 60 * 60 * 1000),
+      },
+    ]);
+    await db()
+      .update(piMemoryStage1Candidates)
+      .set({ lastSelectedSourceHistoryHash: oldHash as string })
+      .where(
+        eq(piMemoryStage1Candidates.memoryStorageId, scope.memoryStorageId),
+      );
+    await insertPendingPhase2Job(scope);
+    const claimed = await claimPiMemoryPhase2Job(db(), {
+      currentTime: NOW,
+      scope,
+    });
+    expect(claimed?.selected).toStrictEqual([]);
+    if (!claimed) {
+      throw new Error("Expected empty selection claim");
+    }
+    expect(
+      await succeedPiMemoryPhase2Job(db(), {
+        ...scope,
+        leaseToken: claimed.leaseToken,
+        claimedRevision: claimed.claimedRevision,
+        currentTime: new Date(NOW.getTime() + 1),
+        selected: [],
+      }),
+    ).toBe(true);
+    expect(await readPhase2Job(scope)).toMatchObject({
+      status: "idle",
+      inputRevision: 1,
+      completedRevision: 1,
+    });
+    const [candidate] = await db()
+      .select({
+        marker: piMemoryStage1Candidates.lastSelectedSourceHistoryHash,
+      })
+      .from(piMemoryStage1Candidates)
+      .where(
+        eq(piMemoryStage1Candidates.memoryStorageId, scope.memoryStorageId),
+      );
+    expect(candidate?.marker).toBeNull();
+  });
+
+  it("cascades control state without deleting the referenced history blob", async () => {
+    const scope = await createPhase2TestScope("delete-cascade");
+    const [hash] = await insertPhase2Candidates(scope, [
+      { piSessionId: "retained-history" },
+    ]);
+    await insertPendingPhase2Job(scope);
+    await db().delete(storages).where(eq(storages.id, scope.memoryStorageId));
+
+    expect(await readPhase2Job(scope)).toBeUndefined();
+    const [candidate] = await db()
+      .select()
+      .from(piMemoryStage1Candidates)
+      .where(
+        eq(piMemoryStage1Candidates.memoryStorageId, scope.memoryStorageId),
+      );
+    expect(candidate).toBeUndefined();
+    const [historyBlob] = await db()
+      .select({ hash: blobs.hash })
+      .from(blobs)
+      .where(eq(blobs.hash, hash as string));
+    expect(historyBlob).toStrictEqual({ hash });
+  });
+});

--- a/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-job.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-job.service.test.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable jest/prefer-expect-resolves, vitest/prefer-to-be-falsy, vitest/prefer-to-be-truthy -- Direct state-machine assertions keep each PostgreSQL transition and fence visually paired. */
 import { randomUUID } from "node:crypto";
 
 import { and, eq } from "drizzle-orm";
@@ -82,7 +81,7 @@ describe("Pi memory Phase 2 job transitions", () => {
       }),
     ]);
     expect([first, second]).toStrictEqual([true, true]);
-    expect(await readPhase2Job(scope)).toMatchObject({
+    await expect(readPhase2Job(scope)).resolves.toMatchObject({
       status: "pending",
       inputRevision: 2,
       completedRevision: 0,
@@ -103,7 +102,7 @@ describe("Pi memory Phase 2 job transitions", () => {
         },
       });
     });
-    expect(failed).toBe(true);
+    expect(failed).toBeTruthy();
     expect((await readPhase2Job(scope))?.inputRevision).toBe(2);
 
     const replay = await db().transaction(async (tx) => {
@@ -116,7 +115,7 @@ describe("Pi memory Phase 2 job transitions", () => {
         result: { kind: "succeeded_no_output" },
       });
     });
-    expect(replay).toBe(false);
+    expect(replay).toBeFalsy();
     expect((await readPhase2Job(scope))?.inputRevision).toBe(2);
   });
 
@@ -238,7 +237,7 @@ describe("Pi memory Phase 2 job transitions", () => {
         enqueuedAt: NOW,
       });
     });
-    expect(await readPhase2Job(scope)).toMatchObject({
+    await expect(readPhase2Job(scope)).resolves.toMatchObject({
       status: "leased",
       inputRevision: 2,
       completedRevision: 0,
@@ -290,65 +289,65 @@ describe("Pi memory Phase 2 job transitions", () => {
       throw new Error("Expected a claimed job");
     }
 
-    expect(
-      await heartbeatPiMemoryPhase2Job(db(), {
+    await expect(
+      heartbeatPiMemoryPhase2Job(db(), {
         ...scope,
         leaseToken: randomUUID(),
         claimedRevision: claimed.claimedRevision,
         currentTime: new Date(NOW.getTime() + 1000),
       }),
-    ).toBe(false);
-    expect(
-      await heartbeatPiMemoryPhase2Job(db(), {
+    ).resolves.toBeFalsy();
+    await expect(
+      heartbeatPiMemoryPhase2Job(db(), {
         ...scope,
         leaseToken: claimed.leaseToken,
         claimedRevision: claimed.claimedRevision,
         currentTime: claimed.leaseExpiresAt,
       }),
-    ).toBe(false);
-    expect(
-      await heartbeatPiMemoryPhase2Job(db(), {
+    ).resolves.toBeFalsy();
+    await expect(
+      heartbeatPiMemoryPhase2Job(db(), {
         ...scope,
         leaseToken: claimed.leaseToken,
         claimedRevision: claimed.claimedRevision,
         currentTime: new Date(NOW.getTime() + 1000),
       }),
-    ).toBe(true);
+    ).resolves.toBeTruthy();
 
     const failedAt = new Date(NOW.getTime() + 2000);
-    expect(
-      await failPiMemoryPhase2Job(db(), {
+    await expect(
+      failPiMemoryPhase2Job(db(), {
         ...scope,
         leaseToken: randomUUID(),
         claimedRevision: claimed.claimedRevision,
         currentTime: failedAt,
         errorClass: "provider_timeout",
       }),
-    ).toBe(false);
-    expect(
-      await failPiMemoryPhase2Job(db(), {
+    ).resolves.toBeFalsy();
+    await expect(
+      failPiMemoryPhase2Job(db(), {
         ...scope,
         leaseToken: claimed.leaseToken,
         claimedRevision: claimed.claimedRevision,
         currentTime: failedAt,
         errorClass: "provider_timeout",
       }),
-    ).toBe(true);
-    expect(await readPhase2Job(scope)).toMatchObject({
+    ).resolves.toBeTruthy();
+    await expect(readPhase2Job(scope)).resolves.toMatchObject({
       status: "retryable_failure",
       retryCount: 1,
       retryAt: new Date(failedAt.getTime() + PI_MEMORY_PHASE2_RETRY_DELAY_MS),
       lastErrorClass: "provider_timeout",
     });
 
-    expect(
-      await claimPiMemoryPhase2Job(db(), {
+    await expect(
+      claimPiMemoryPhase2Job(db(), {
         currentTime: new Date(
           failedAt.getTime() + PI_MEMORY_PHASE2_RETRY_DELAY_MS - 1,
         ),
         scope,
       }),
-    ).toBeNull();
+    ).resolves.toBeNull();
     const retryAt = new Date(
       failedAt.getTime() + PI_MEMORY_PHASE2_RETRY_DELAY_MS,
     );
@@ -385,7 +384,7 @@ describe("Pi memory Phase 2 job transitions", () => {
       currentTime: new Date(thirdAt.getTime() + 1),
       errorClass: "provider_timeout",
     });
-    expect(await readPhase2Job(scope)).toMatchObject({
+    await expect(readPhase2Job(scope)).resolves.toMatchObject({
       status: "terminal_failure",
       retryCount: 3,
       retryAt: null,
@@ -396,7 +395,7 @@ describe("Pi memory Phase 2 job transitions", () => {
     await db().transaction(async (tx) => {
       await advancePiMemoryPhase2InputRevision(tx, { ...scope, enqueuedAt });
     });
-    expect(await readPhase2Job(scope)).toMatchObject({
+    await expect(readPhase2Job(scope)).resolves.toMatchObject({
       status: "pending",
       inputRevision: 2,
       retryCount: 0,
@@ -444,21 +443,23 @@ describe("Pi memory Phase 2 job transitions", () => {
         currentTime: new Date(NOW.getTime() + 1),
         ...invalid,
       };
-      expect(await heartbeatPiMemoryPhase2Job(db(), fence)).toBe(false);
-      expect(
-        await failPiMemoryPhase2Job(db(), {
+      await expect(
+        heartbeatPiMemoryPhase2Job(db(), fence),
+      ).resolves.toBeFalsy();
+      await expect(
+        failPiMemoryPhase2Job(db(), {
           ...fence,
           errorClass: "rejected_fence",
         }),
-      ).toBe(false);
-      expect(
-        await succeedPiMemoryPhase2Job(db(), {
+      ).resolves.toBeFalsy();
+      await expect(
+        succeedPiMemoryPhase2Job(db(), {
           ...fence,
           selected: claimed.selected,
         }),
-      ).toBe(false);
+      ).resolves.toBeFalsy();
     }
-    expect(await readPhase2Job(scope)).toStrictEqual(before);
+    await expect(readPhase2Job(scope)).resolves.toStrictEqual(before);
 
     await db().transaction(async (tx) => {
       await advancePiMemoryPhase2InputRevision(tx, {
@@ -466,16 +467,16 @@ describe("Pi memory Phase 2 job transitions", () => {
         enqueuedAt: new Date(NOW.getTime() + 2),
       });
     });
-    expect(
-      await failPiMemoryPhase2Job(db(), {
+    await expect(
+      failPiMemoryPhase2Job(db(), {
         ...scope,
         leaseToken: claimed.leaseToken,
         claimedRevision: claimed.claimedRevision,
         currentTime: new Date(NOW.getTime() + 3),
         errorClass: "old_revision_failed",
       }),
-    ).toBe(true);
-    expect(await readPhase2Job(scope)).toMatchObject({
+    ).resolves.toBeTruthy();
+    await expect(readPhase2Job(scope)).resolves.toMatchObject({
       status: "pending",
       inputRevision: 2,
       completedRevision: 0,
@@ -530,32 +531,32 @@ describe("Pi memory Phase 2 job transitions", () => {
     if (!second || !third) {
       throw new Error("Expected both takeover claims");
     }
-    expect(
-      await heartbeatPiMemoryPhase2Job(db(), {
+    await expect(
+      heartbeatPiMemoryPhase2Job(db(), {
         ...scope,
         leaseToken: second.leaseToken,
         claimedRevision: second.claimedRevision,
         currentTime: new Date(second.leaseExpiresAt.getTime() - 1),
       }),
-    ).toBe(false);
-    expect(
-      await failPiMemoryPhase2Job(db(), {
+    ).resolves.toBeFalsy();
+    await expect(
+      failPiMemoryPhase2Job(db(), {
         ...scope,
         leaseToken: second.leaseToken,
         claimedRevision: second.claimedRevision,
         currentTime: new Date(second.leaseExpiresAt.getTime() - 1),
         errorClass: "stale_owner",
       }),
-    ).toBe(false);
-    expect(
-      await succeedPiMemoryPhase2Job(db(), {
+    ).resolves.toBeFalsy();
+    await expect(
+      succeedPiMemoryPhase2Job(db(), {
         ...scope,
         leaseToken: second.leaseToken,
         claimedRevision: second.claimedRevision,
         currentTime: new Date(second.leaseExpiresAt.getTime() - 1),
         selected: second.selected,
       }),
-    ).toBe(false);
+    ).resolves.toBeFalsy();
     expect((await readPhase2Job(scope))?.leaseToken).toBe(third.leaseToken);
   });
 
@@ -566,22 +567,22 @@ describe("Pi memory Phase 2 job transitions", () => {
       completedRevision: 1,
       lastSucceededAt: NOW,
     });
-    expect(
-      await claimPiMemoryPhase2Job(db(), {
+    await expect(
+      claimPiMemoryPhase2Job(db(), {
         currentTime: new Date(
           NOW.getTime() + PI_MEMORY_PHASE2_SUCCESS_COOLDOWN_MS - 1,
         ),
         scope,
       }),
-    ).toBeNull();
-    expect(
-      await claimPiMemoryPhase2Job(db(), {
+    ).resolves.toBeNull();
+    await expect(
+      claimPiMemoryPhase2Job(db(), {
         currentTime: new Date(
           NOW.getTime() + PI_MEMORY_PHASE2_SUCCESS_COOLDOWN_MS,
         ),
         scope,
       }),
-    ).not.toBeNull();
+    ).resolves.not.toBeNull();
   });
 
   it("finalizes only the frozen tuple set and preserves newer input", async () => {
@@ -621,15 +622,15 @@ describe("Pi memory Phase 2 job transitions", () => {
       throw new Error("Expected selection claim");
     }
 
-    expect(
-      await succeedPiMemoryPhase2Job(db(), {
+    await expect(
+      succeedPiMemoryPhase2Job(db(), {
         ...scope,
         leaseToken: claimed.leaseToken,
         claimedRevision: claimed.claimedRevision,
         currentTime: new Date(NOW.getTime() + 1),
         selected: [...claimed.selected].reverse(),
       }),
-    ).toBe(false);
+    ).resolves.toBeFalsy();
     await replacePhase2CandidateSource({
       scope,
       piSessionId: "selected-a",
@@ -641,17 +642,17 @@ describe("Pi memory Phase 2 job transitions", () => {
         enqueuedAt: new Date(NOW.getTime() + 2),
       });
     });
-    expect(
-      await succeedPiMemoryPhase2Job(db(), {
+    await expect(
+      succeedPiMemoryPhase2Job(db(), {
         ...scope,
         leaseToken: claimed.leaseToken,
         claimedRevision: claimed.claimedRevision,
         currentTime: new Date(NOW.getTime() + 3),
         selected: claimed.selected,
       }),
-    ).toBe(true);
+    ).resolves.toBeTruthy();
 
-    expect(await readPhase2Job(scope)).toMatchObject({
+    await expect(readPhase2Job(scope)).resolves.toMatchObject({
       status: "pending",
       inputRevision: 2,
       completedRevision: 1,
@@ -711,16 +712,16 @@ describe("Pi memory Phase 2 job transitions", () => {
     if (!claimed) {
       throw new Error("Expected empty selection claim");
     }
-    expect(
-      await succeedPiMemoryPhase2Job(db(), {
+    await expect(
+      succeedPiMemoryPhase2Job(db(), {
         ...scope,
         leaseToken: claimed.leaseToken,
         claimedRevision: claimed.claimedRevision,
         currentTime: new Date(NOW.getTime() + 1),
         selected: [],
       }),
-    ).toBe(true);
-    expect(await readPhase2Job(scope)).toMatchObject({
+    ).resolves.toBeTruthy();
+    await expect(readPhase2Job(scope)).resolves.toMatchObject({
       status: "idle",
       inputRevision: 1,
       completedRevision: 1,
@@ -736,6 +737,64 @@ describe("Pi memory Phase 2 job transitions", () => {
     expect(candidate?.marker).toBeNull();
   });
 
+  it("finalizes the immutable selection snapshot validated before lock waits", async () => {
+    const scope = await createPhase2TestScope("immutable-success-input");
+    const [sourceHistoryHash] = await insertPhase2Candidates(scope, [
+      { piSessionId: "immutable-selected" },
+    ]);
+    await insertPendingPhase2Job(scope);
+    const claimed = await claimPiMemoryPhase2Job(db(), {
+      currentTime: NOW,
+      scope,
+    });
+    expect(claimed).not.toBeNull();
+    if (!claimed) {
+      throw new Error("Expected immutable selection claim");
+    }
+    const mutableSelection = [...claimed.selected];
+    let completion: Promise<boolean> | undefined;
+    await db().transaction(async (tx) => {
+      await tx
+        .select({ piSessionId: piMemoryStage1Candidates.piSessionId })
+        .from(piMemoryStage1Candidates)
+        .where(
+          and(
+            eq(piMemoryStage1Candidates.memoryStorageId, scope.memoryStorageId),
+            eq(piMemoryStage1Candidates.orgId, scope.orgId),
+            eq(piMemoryStage1Candidates.userId, scope.userId),
+          ),
+        )
+        .for("update", { of: piMemoryStage1Candidates });
+      completion = succeedPiMemoryPhase2Job(db(), {
+        ...scope,
+        leaseToken: claimed.leaseToken,
+        claimedRevision: claimed.claimedRevision,
+        currentTime: new Date(NOW.getTime() + 1),
+        selected: mutableSelection,
+      });
+      mutableSelection.splice(0);
+    });
+    if (!completion) {
+      throw new Error("Expected in-flight completion");
+    }
+    await expect(completion).resolves.toBeTruthy();
+
+    const [candidate] = await db()
+      .select({
+        marker: piMemoryStage1Candidates.lastSelectedSourceHistoryHash,
+      })
+      .from(piMemoryStage1Candidates)
+      .where(
+        and(
+          eq(piMemoryStage1Candidates.memoryStorageId, scope.memoryStorageId),
+          eq(piMemoryStage1Candidates.orgId, scope.orgId),
+          eq(piMemoryStage1Candidates.userId, scope.userId),
+          eq(piMemoryStage1Candidates.piSessionId, "immutable-selected"),
+        ),
+      );
+    expect(candidate?.marker).toBe(sourceHistoryHash);
+  });
+
   it("cascades control state without deleting the referenced history blob", async () => {
     const scope = await createPhase2TestScope("delete-cascade");
     const [hash] = await insertPhase2Candidates(scope, [
@@ -744,7 +803,7 @@ describe("Pi memory Phase 2 job transitions", () => {
     await insertPendingPhase2Job(scope);
     await db().delete(storages).where(eq(storages.id, scope.memoryStorageId));
 
-    expect(await readPhase2Job(scope)).toBeUndefined();
+    await expect(readPhase2Job(scope)).resolves.toBeUndefined();
     const [candidate] = await db()
       .select()
       .from(piMemoryStage1Candidates)

--- a/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-job.test-fixture.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-job.test-fixture.ts
@@ -1,0 +1,259 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import { and, eq, inArray } from "drizzle-orm";
+import { onTestFinished } from "vitest";
+
+import { MEMORY_ARTIFACT_NAME } from "@okouai/core/storage-names";
+import { blobs } from "@okouai/db/schema/blob";
+import { piMemoryPhase2Jobs } from "@okouai/db/schema/pi-memory-phase2-job";
+import { piMemoryStage1Candidates } from "@okouai/db/schema/pi-memory-stage1-candidate";
+import { storages } from "@okouai/db/schema/storage";
+
+import { db } from "../../../lib/db";
+
+const fixtureHashes = Symbol("fixtureHashes");
+
+interface Phase2TestScope {
+  readonly memoryStorageId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly [fixtureHashes]: Set<string>;
+}
+
+export interface Phase2CandidateInput {
+  readonly piSessionId: string;
+  readonly sourceHistoryHash?: string;
+  readonly sourceCompletedAt?: Date;
+  readonly status?:
+    | "pending"
+    | "leased"
+    | "succeeded"
+    | "succeeded_no_output"
+    | "retryable_failure"
+    | "terminal_failure";
+  readonly rawMemory?: string | null;
+  readonly rolloutSummary?: string | null;
+  readonly rolloutSlug?: string | null;
+  readonly generatedAt?: Date | null;
+  readonly leaseToken?: string | null;
+  readonly leaseExpiresAt?: Date | null;
+  readonly retryAt?: Date | null;
+  readonly retryCount?: number;
+  readonly lastErrorClass?: string | null;
+  readonly usageCount?: number;
+  readonly lastUsedAt?: Date | null;
+  readonly lastSelectedSourceHistoryHash?: string | null;
+}
+
+type Phase2CandidateStatus = Exclude<Phase2CandidateInput["status"], undefined>;
+
+function candidateHash(scope: Phase2TestScope, piSessionId: string): string {
+  return createHash("sha256")
+    .update(`${scope.memoryStorageId}:${piSessionId}:${randomUUID()}`)
+    .digest("hex");
+}
+
+async function insertFixtureBlobs(
+  scope: Phase2TestScope,
+  hashes: readonly string[],
+): Promise<void> {
+  for (const hash of hashes) {
+    scope[fixtureHashes].add(hash);
+  }
+  if (hashes.length === 0) {
+    return;
+  }
+  await db()
+    .insert(blobs)
+    .values(
+      hashes.map((hash) => {
+        return {
+          hash,
+          rawSize: 1,
+          encoding: "identity",
+          encodedSize: 1,
+          refCount: 1,
+        };
+      }),
+    )
+    .onConflictDoNothing();
+}
+
+export async function createPhase2TestScope(
+  label: string,
+): Promise<Phase2TestScope> {
+  const scope = {
+    memoryStorageId: randomUUID(),
+    orgId: `phase2-${label}-org-${randomUUID()}`,
+    userId: `phase2-${label}-user-${randomUUID()}`,
+  } as Phase2TestScope;
+  Object.defineProperty(scope, fixtureHashes, {
+    value: new Set<string>(),
+    enumerable: false,
+  });
+  await db()
+    .insert(storages)
+    .values({
+      id: scope.memoryStorageId,
+      orgId: scope.orgId,
+      userId: scope.userId,
+      name: MEMORY_ARTIFACT_NAME,
+      s3Prefix: `${scope.orgId}/${scope.memoryStorageId}`,
+    });
+  onTestFinished(async () => {
+    await db().delete(storages).where(eq(storages.id, scope.memoryStorageId));
+    const hashes = [...scope[fixtureHashes]];
+    if (hashes.length > 0) {
+      await db().delete(blobs).where(inArray(blobs.hash, hashes));
+    }
+  });
+  return scope;
+}
+
+export async function insertPhase2Candidates(
+  scope: Phase2TestScope,
+  inputs: readonly Phase2CandidateInput[],
+): Promise<readonly string[]> {
+  const now = new Date("2026-09-03T04:00:00.000Z");
+  const hashes = inputs.map((input) => {
+    return input.sourceHistoryHash ?? candidateHash(scope, input.piSessionId);
+  });
+  await insertFixtureBlobs(scope, hashes);
+  await db()
+    .insert(piMemoryStage1Candidates)
+    .values(
+      inputs.map((input, index) => {
+        return phase2CandidateRow(scope, input, hashes[index] as string, now);
+      }),
+    );
+  return hashes;
+}
+
+function phase2CandidateOutput(
+  input: Phase2CandidateInput,
+  status: Phase2CandidateStatus,
+  sourceCompletedAt: Date,
+) {
+  if (status === "succeeded") {
+    return {
+      rawMemory: input.rawMemory ?? "raw memory",
+      rolloutSummary: input.rolloutSummary ?? "rollout summary",
+      rolloutSlug: input.rolloutSlug ?? null,
+      generatedAt: input.generatedAt ?? sourceCompletedAt,
+    };
+  }
+  return {
+    rawMemory: null,
+    rolloutSummary: null,
+    rolloutSlug: null,
+    generatedAt:
+      status === "succeeded_no_output"
+        ? (input.generatedAt ?? sourceCompletedAt)
+        : null,
+  };
+}
+
+function phase2CandidateRow(
+  scope: Phase2TestScope,
+  input: Phase2CandidateInput,
+  sourceHistoryHash: string,
+  now: Date,
+): typeof piMemoryStage1Candidates.$inferInsert {
+  const status = input.status ?? "succeeded";
+  const sourceCompletedAt = input.sourceCompletedAt ?? now;
+  return {
+    memoryStorageId: scope.memoryStorageId,
+    orgId: scope.orgId,
+    userId: scope.userId,
+    piSessionId: input.piSessionId,
+    sourceRunId: randomUUID(),
+    sourceHistoryHash,
+    sourceCompletedAt,
+    eligibleAt: sourceCompletedAt,
+    status,
+    leaseToken: input.leaseToken ?? null,
+    leaseExpiresAt: input.leaseExpiresAt ?? null,
+    retryAt: input.retryAt ?? null,
+    retryCount: input.retryCount ?? (status === "terminal_failure" ? 3 : 0),
+    lastErrorClass:
+      input.lastErrorClass ??
+      (status === "terminal_failure" ? "attempts_exhausted" : null),
+    ...phase2CandidateOutput(input, status, sourceCompletedAt),
+    usageCount: input.usageCount ?? 0,
+    lastUsedAt: input.lastUsedAt ?? null,
+    lastSelectedSourceHistoryHash: input.lastSelectedSourceHistoryHash ?? null,
+  };
+}
+
+export async function insertPendingPhase2Job(
+  scope: Phase2TestScope,
+  overrides: Partial<typeof piMemoryPhase2Jobs.$inferInsert> = {},
+): Promise<void> {
+  await db()
+    .insert(piMemoryPhase2Jobs)
+    .values({
+      ...scope,
+      status: "pending",
+      inputRevision: 1,
+      completedRevision: 0,
+      retryCount: 0,
+      ...overrides,
+    });
+}
+
+export async function readPhase2Job(scope: Phase2TestScope) {
+  const [job] = await db()
+    .select()
+    .from(piMemoryPhase2Jobs)
+    .where(
+      and(
+        eq(piMemoryPhase2Jobs.memoryStorageId, scope.memoryStorageId),
+        eq(piMemoryPhase2Jobs.orgId, scope.orgId),
+        eq(piMemoryPhase2Jobs.userId, scope.userId),
+      ),
+    );
+  return job;
+}
+
+export async function replacePhase2CandidateSource(args: {
+  readonly scope: Phase2TestScope;
+  readonly piSessionId: string;
+  readonly sourceCompletedAt: Date;
+}): Promise<string> {
+  const hash = candidateHash(args.scope, `${args.piSessionId}-replacement`);
+  await insertFixtureBlobs(args.scope, [hash]);
+  await db()
+    .update(piMemoryStage1Candidates)
+    .set({
+      sourceRunId: randomUUID(),
+      sourceHistoryHash: hash,
+      sourceCompletedAt: args.sourceCompletedAt,
+      eligibleAt: args.sourceCompletedAt,
+      status: "pending",
+      leaseToken: null,
+      leaseExpiresAt: null,
+      retryAt: null,
+      retryCount: 0,
+      lastErrorClass: null,
+      rawMemory: null,
+      rolloutSummary: null,
+      rolloutSlug: null,
+      generatedAt: null,
+      lastSelectedSourceHistoryHash: null,
+      usageCount: 0,
+      lastUsedAt: null,
+      updatedAt: args.sourceCompletedAt,
+    })
+    .where(
+      and(
+        eq(
+          piMemoryStage1Candidates.memoryStorageId,
+          args.scope.memoryStorageId,
+        ),
+        eq(piMemoryStage1Candidates.orgId, args.scope.orgId),
+        eq(piMemoryStage1Candidates.userId, args.scope.userId),
+        eq(piMemoryStage1Candidates.piSessionId, args.piSessionId),
+      ),
+    );
+  return hash;
+}

--- a/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-selection.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-selection.service.test.ts
@@ -1,0 +1,313 @@
+/* oxlint-disable jest/prefer-expect-resolves, vitest/prefer-to-be-falsy, vitest/prefer-to-be-truthy -- Direct state-machine assertions keep each selection fence visually paired. */
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import {
+  PI_MEMORY_PHASE2_MAX_ATTEMPTS,
+  PI_MEMORY_PHASE2_MAX_SELECTED_CANDIDATES,
+  PI_MEMORY_PHASE2_MAX_SELECTED_UTF8_BYTES,
+} from "@okouai/db/schema/pi-memory-phase2-job";
+import { piMemoryStage1Candidates } from "@okouai/db/schema/pi-memory-stage1-candidate";
+
+import { db } from "../../../lib/db";
+import {
+  claimPiMemoryPhase2Job,
+  failPiMemoryPhase2Job,
+  PI_MEMORY_PHASE2_EXPECTED_HEARTBEAT_CADENCE_MS,
+  PI_MEMORY_PHASE2_LEASE_DURATION_MS,
+  PI_MEMORY_PHASE2_MAX_UNUSED_AGE_MS,
+  PI_MEMORY_PHASE2_RETRY_DELAY_MS,
+  PI_MEMORY_PHASE2_SUCCESS_COOLDOWN_MS,
+  piMemoryPhase2SelectionDigest,
+  succeedPiMemoryPhase2Job,
+} from "../pi-memory-phase2-job.service";
+import {
+  createPhase2TestScope,
+  insertPendingPhase2Job,
+  insertPhase2Candidates,
+  type Phase2CandidateInput,
+} from "./pi-memory-phase2-job.test-fixture";
+
+const NOW = Object.freeze(new Date("2026-09-03T04:00:00.000Z"));
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe("Pi memory Phase 2 selection", () => {
+  it("pins every timing, attempt, count, byte, and digest constant", () => {
+    expect(PI_MEMORY_PHASE2_LEASE_DURATION_MS).toBe(60 * 60 * 1000);
+    expect(PI_MEMORY_PHASE2_EXPECTED_HEARTBEAT_CADENCE_MS).toBe(90 * 1000);
+    expect(PI_MEMORY_PHASE2_RETRY_DELAY_MS).toBe(60 * 60 * 1000);
+    expect(PI_MEMORY_PHASE2_SUCCESS_COOLDOWN_MS).toBe(6 * 60 * 60 * 1000);
+    expect(PI_MEMORY_PHASE2_MAX_UNUSED_AGE_MS).toBe(30 * DAY_MS);
+    expect(PI_MEMORY_PHASE2_MAX_ATTEMPTS).toBe(3);
+    expect(PI_MEMORY_PHASE2_MAX_SELECTED_CANDIDATES).toBe(256);
+    expect(PI_MEMORY_PHASE2_MAX_SELECTED_UTF8_BYTES).toBe(21_036_800);
+
+    expect(piMemoryPhase2SelectionDigest([])).toBe(
+      "f95c6835f8a93234e88b26bc2162bd3cf8defd709037f6eefb14ee6ae3d56e48",
+    );
+    expect(
+      piMemoryPhase2SelectionDigest([
+        { piSessionId: "session-a", sourceHistoryHash: "a".repeat(64) },
+      ]),
+    ).toBe("24a9bc5c377eb5bfc66e9976218eb1c99ecb6461e2593788b2c752f4437288b2");
+    expect(
+      piMemoryPhase2SelectionDigest([
+        { piSessionId: "a", sourceHistoryHash: "1".repeat(64) },
+        { piSessionId: "b", sourceHistoryHash: "2".repeat(64) },
+      ]),
+    ).toBe("fa8384918a4cc1c202520f720d75e61fcebac6c0124eff016b9d4462fede1ea3");
+  });
+
+  it("uses the exact age boundary, excludes blank/no-output rows, and returns session order", async () => {
+    const scope = await createPhase2TestScope("age");
+    const oldestAllowed = new Date(
+      NOW.getTime() - PI_MEMORY_PHASE2_MAX_UNUSED_AGE_MS,
+    );
+    await insertPhase2Candidates(scope, [
+      {
+        piSessionId: "z-used-boundary",
+        sourceCompletedAt: new Date(oldestAllowed.getTime() - DAY_MS),
+        lastUsedAt: oldestAllowed,
+      },
+      {
+        piSessionId: "used-too-old",
+        sourceCompletedAt: NOW,
+        lastUsedAt: new Date(oldestAllowed.getTime() - 1),
+      },
+      {
+        piSessionId: "a-source-boundary",
+        sourceCompletedAt: oldestAllowed,
+      },
+      {
+        piSessionId: "source-too-old",
+        sourceCompletedAt: new Date(oldestAllowed.getTime() - 1),
+      },
+      {
+        piSessionId: "blank",
+        rawMemory: " \n ",
+        rolloutSummary: "\t",
+      },
+      {
+        piSessionId: "no-output",
+        status: "succeeded_no_output",
+      },
+    ]);
+    await insertPendingPhase2Job(scope);
+
+    const claimed = await claimPiMemoryPhase2Job(db(), {
+      currentTime: NOW,
+      scope,
+    });
+    expect(
+      claimed?.selected.map((candidate) => {
+        return candidate.piSessionId;
+      }),
+    ).toStrictEqual(["a-source-boundary", "z-used-boundary"]);
+  });
+
+  it("applies every ranking tier before the 256-row boundary", async () => {
+    expect.assertions(12);
+    async function expectBoundaryWinner(
+      label: string,
+      better: Phase2CandidateInput,
+      worse: Phase2CandidateInput,
+    ): Promise<void> {
+      const scope = await createPhase2TestScope(`ranking-${label}`);
+      const fillers = Array.from({ length: 255 }, (_, index) => {
+        return {
+          piSessionId: `filler-${index.toString().padStart(3, "0")}`,
+          usageCount: 10,
+          sourceCompletedAt: NOW,
+          lastUsedAt: NOW,
+        } satisfies Phase2CandidateInput;
+      });
+      await insertPhase2Candidates(scope, [...fillers, better, worse]);
+      await insertPendingPhase2Job(scope);
+      const claimed = await claimPiMemoryPhase2Job(db(), {
+        currentTime: NOW,
+        scope,
+      });
+      const ids = new Set(
+        claimed?.selected.map((candidate) => {
+          return candidate.piSessionId;
+        }),
+      );
+      expect(ids.size).toBe(256);
+      expect(ids.has(better.piSessionId)).toBe(true);
+      expect(ids.has(worse.piSessionId)).toBe(false);
+    }
+
+    await expectBoundaryWinner(
+      "usage",
+      { piSessionId: "better-usage", usageCount: 2 },
+      { piSessionId: "worse-usage", usageCount: 1 },
+    );
+    await expectBoundaryWinner(
+      "effective-date",
+      {
+        piSessionId: "better-effective-date",
+        lastUsedAt: NOW,
+        sourceCompletedAt: new Date(NOW.getTime() - 2),
+      },
+      {
+        piSessionId: "worse-effective-date",
+        lastUsedAt: new Date(NOW.getTime() - 1),
+        sourceCompletedAt: NOW,
+      },
+    );
+    await expectBoundaryWinner(
+      "source-date",
+      {
+        piSessionId: "better-source-date",
+        lastUsedAt: NOW,
+        sourceCompletedAt: NOW,
+      },
+      {
+        piSessionId: "worse-source-date",
+        lastUsedAt: NOW,
+        sourceCompletedAt: new Date(NOW.getTime() - 1),
+      },
+    );
+    await expectBoundaryWinner(
+      "session-id",
+      {
+        piSessionId: "z-better-session-id",
+        lastUsedAt: NOW,
+        sourceCompletedAt: NOW,
+      },
+      {
+        piSessionId: "a-worse-session-id",
+        lastUsedAt: NOW,
+        sourceCompletedAt: NOW,
+      },
+    );
+  });
+
+  it("accepts the exact payload cap and stops before a one-byte overflow", async () => {
+    const scope = await createPhase2TestScope("payload-cap");
+    const rawMemory = "r".repeat(64 * 1024);
+    const rolloutSummary = "s".repeat(16 * 1024);
+    const rolloutSlug = "g".repeat(255);
+    expect(
+      Buffer.byteLength(rawMemory) +
+        Buffer.byteLength(rolloutSummary) +
+        Buffer.byteLength(rolloutSlug),
+    ).toBe(82_175);
+    await insertPhase2Candidates(
+      scope,
+      Array.from({ length: 257 }, (_, index) => {
+        return {
+          piSessionId: `session-${index.toString().padStart(3, "0")}`,
+          rawMemory,
+          rolloutSummary,
+          rolloutSlug,
+          sourceCompletedAt: NOW,
+        };
+      }),
+    );
+    await insertPendingPhase2Job(scope);
+
+    const exact = await claimPiMemoryPhase2Job(db(), {
+      currentTime: NOW,
+      scope,
+    });
+    expect(exact?.selected).toHaveLength(256);
+    expect(
+      await failPiMemoryPhase2Job(db(), {
+        ...scope,
+        leaseToken: exact?.leaseToken ?? "missing",
+        claimedRevision: exact?.claimedRevision ?? -1,
+        currentTime: new Date(NOW.getTime() + 1),
+        errorClass: "test_retry",
+      }),
+    ).toBe(true);
+
+    const topRanked = exact?.selected.find((candidate) => {
+      return candidate.piSessionId === "session-256";
+    });
+    expect(topRanked).toBeDefined();
+    if (!topRanked) {
+      throw new Error("Expected top-ranked candidate");
+    }
+    await db()
+      .update(piMemoryStage1Candidates)
+      .set({ rawMemory: `${topRanked.rawMemory}x` })
+      .where(
+        and(
+          eq(piMemoryStage1Candidates.memoryStorageId, scope.memoryStorageId),
+          eq(piMemoryStage1Candidates.piSessionId, "session-256"),
+        ),
+      );
+    const oneByteOver = await claimPiMemoryPhase2Job(db(), {
+      currentTime: new Date(
+        NOW.getTime() + 1 + PI_MEMORY_PHASE2_RETRY_DELAY_MS,
+      ),
+      scope,
+    });
+    expect(oneByteOver?.selected).toHaveLength(255);
+    expect(
+      oneByteOver?.selected.some((candidate) => {
+        return candidate.piSessionId === "session-001";
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects mutated, duplicate, and over-cap completion selections", async () => {
+    const scope = await createPhase2TestScope("completion-metadata");
+    await insertPhase2Candidates(scope, [
+      { piSessionId: "selected", rawMemory: "exact bytes" },
+    ]);
+    await insertPendingPhase2Job(scope);
+    const claimed = await claimPiMemoryPhase2Job(db(), {
+      currentTime: NOW,
+      scope,
+    });
+    expect(claimed?.selected).toHaveLength(1);
+    if (!claimed) {
+      throw new Error("Expected completion metadata claim");
+    }
+    const fence = {
+      ...scope,
+      leaseToken: claimed.leaseToken,
+      claimedRevision: claimed.claimedRevision,
+      currentTime: new Date(NOW.getTime() + 1),
+    };
+    expect(
+      await succeedPiMemoryPhase2Job(db(), {
+        ...fence,
+        selected: [
+          {
+            ...(claimed.selected[0] as (typeof claimed.selected)[number]),
+            rawMemory: "changed byte count",
+          },
+        ],
+      }),
+    ).toBe(false);
+    expect(
+      await succeedPiMemoryPhase2Job(db(), {
+        ...fence,
+        selected: [
+          claimed.selected[0] as (typeof claimed.selected)[number],
+          claimed.selected[0] as (typeof claimed.selected)[number],
+        ],
+      }),
+    ).toBe(false);
+    expect(
+      await succeedPiMemoryPhase2Job(db(), {
+        ...fence,
+        selected: [
+          {
+            ...(claimed.selected[0] as (typeof claimed.selected)[number]),
+            rawMemory: "x".repeat(PI_MEMORY_PHASE2_MAX_SELECTED_UTF8_BYTES + 1),
+          },
+        ],
+      }),
+    ).toBe(false);
+    expect(
+      await succeedPiMemoryPhase2Job(db(), {
+        ...fence,
+        selected: claimed.selected,
+      }),
+    ).toBe(true);
+  });
+});

--- a/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-selection.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-selection.service.test.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable jest/prefer-expect-resolves, vitest/prefer-to-be-falsy, vitest/prefer-to-be-truthy -- Direct state-machine assertions keep each selection fence visually paired. */
 import { and, eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 
@@ -6,6 +5,7 @@ import {
   PI_MEMORY_PHASE2_MAX_ATTEMPTS,
   PI_MEMORY_PHASE2_MAX_SELECTED_CANDIDATES,
   PI_MEMORY_PHASE2_MAX_SELECTED_UTF8_BYTES,
+  piMemoryPhase2Jobs,
 } from "@okouai/db/schema/pi-memory-phase2-job";
 import { piMemoryStage1Candidates } from "@okouai/db/schema/pi-memory-stage1-candidate";
 
@@ -83,6 +83,15 @@ describe("Pi memory Phase 2 selection", () => {
         sourceCompletedAt: new Date(oldestAllowed.getTime() - 1),
       },
       {
+        piSessionId: "used-in-future",
+        sourceCompletedAt: oldestAllowed,
+        lastUsedAt: new Date(NOW.getTime() + 1),
+      },
+      {
+        piSessionId: "source-in-future",
+        sourceCompletedAt: new Date(NOW.getTime() + 1),
+      },
+      {
         piSessionId: "blank",
         rawMemory: " \n ",
         rolloutSummary: "\t",
@@ -133,8 +142,8 @@ describe("Pi memory Phase 2 selection", () => {
         }),
       );
       expect(ids.size).toBe(256);
-      expect(ids.has(better.piSessionId)).toBe(true);
-      expect(ids.has(worse.piSessionId)).toBe(false);
+      expect(ids.has(better.piSessionId)).toBeTruthy();
+      expect(ids.has(worse.piSessionId)).toBeFalsy();
     }
 
     await expectBoundaryWinner(
@@ -212,15 +221,15 @@ describe("Pi memory Phase 2 selection", () => {
       scope,
     });
     expect(exact?.selected).toHaveLength(256);
-    expect(
-      await failPiMemoryPhase2Job(db(), {
+    await expect(
+      failPiMemoryPhase2Job(db(), {
         ...scope,
         leaseToken: exact?.leaseToken ?? "missing",
         claimedRevision: exact?.claimedRevision ?? -1,
         currentTime: new Date(NOW.getTime() + 1),
         errorClass: "test_retry",
       }),
-    ).toBe(true);
+    ).resolves.toBeTruthy();
 
     const topRanked = exact?.selected.find((candidate) => {
       return candidate.piSessionId === "session-256";
@@ -249,14 +258,25 @@ describe("Pi memory Phase 2 selection", () => {
       oneByteOver?.selected.some((candidate) => {
         return candidate.piSessionId === "session-001";
       }),
-    ).toBe(false);
+    ).toBeFalsy();
   });
 
-  it("rejects mutated, duplicate, and over-cap completion selections", async () => {
+  it("rejects every invalid completion selection without partial mutation", async () => {
     const scope = await createPhase2TestScope("completion-metadata");
-    await insertPhase2Candidates(scope, [
+    const [sourceHistoryHash] = await insertPhase2Candidates(scope, [
       { piSessionId: "selected", rawMemory: "exact bytes" },
     ]);
+    await db()
+      .update(piMemoryStage1Candidates)
+      .set({ lastSelectedSourceHistoryHash: sourceHistoryHash as string })
+      .where(
+        and(
+          eq(piMemoryStage1Candidates.memoryStorageId, scope.memoryStorageId),
+          eq(piMemoryStage1Candidates.orgId, scope.orgId),
+          eq(piMemoryStage1Candidates.userId, scope.userId),
+          eq(piMemoryStage1Candidates.piSessionId, "selected"),
+        ),
+      );
     await insertPendingPhase2Job(scope);
     const claimed = await claimPiMemoryPhase2Job(db(), {
       currentTime: NOW,
@@ -272,42 +292,75 @@ describe("Pi memory Phase 2 selection", () => {
       claimedRevision: claimed.claimedRevision,
       currentTime: new Date(NOW.getTime() + 1),
     };
-    expect(
-      await succeedPiMemoryPhase2Job(db(), {
-        ...fence,
-        selected: [
-          {
+    const jobBefore = await db()
+      .select()
+      .from(piMemoryPhase2Jobs)
+      .where(eq(piMemoryPhase2Jobs.memoryStorageId, scope.memoryStorageId));
+    async function expectRejected(
+      selected: Parameters<typeof succeedPiMemoryPhase2Job>[1]["selected"],
+    ): Promise<void> {
+      await expect(
+        succeedPiMemoryPhase2Job(db(), {
+          ...fence,
+          selected,
+        }),
+      ).resolves.toBeFalsy();
+      await expect(
+        db()
+          .select()
+          .from(piMemoryPhase2Jobs)
+          .where(eq(piMemoryPhase2Jobs.memoryStorageId, scope.memoryStorageId)),
+      ).resolves.toStrictEqual(jobBefore);
+      await expect(
+        db()
+          .select({
+            marker: piMemoryStage1Candidates.lastSelectedSourceHistoryHash,
+          })
+          .from(piMemoryStage1Candidates)
+          .where(
+            and(
+              eq(
+                piMemoryStage1Candidates.memoryStorageId,
+                scope.memoryStorageId,
+              ),
+              eq(piMemoryStage1Candidates.piSessionId, "selected"),
+            ),
+          ),
+      ).resolves.toStrictEqual([{ marker: sourceHistoryHash }]);
+    }
+
+    await expectRejected([
+      {
+        ...(claimed.selected[0] as (typeof claimed.selected)[number]),
+        rawMemory: "changed byte count",
+      },
+    ]);
+    await expectRejected([
+      claimed.selected[0] as (typeof claimed.selected)[number],
+      claimed.selected[0] as (typeof claimed.selected)[number],
+    ]);
+    await expectRejected([
+      {
+        ...(claimed.selected[0] as (typeof claimed.selected)[number]),
+        rawMemory: "x".repeat(PI_MEMORY_PHASE2_MAX_SELECTED_UTF8_BYTES + 1),
+      },
+    ]);
+    await expectRejected(
+      Array.from(
+        { length: PI_MEMORY_PHASE2_MAX_SELECTED_CANDIDATES + 1 },
+        (_, index) => {
+          return {
             ...(claimed.selected[0] as (typeof claimed.selected)[number]),
-            rawMemory: "changed byte count",
-          },
-        ],
-      }),
-    ).toBe(false);
-    expect(
-      await succeedPiMemoryPhase2Job(db(), {
-        ...fence,
-        selected: [
-          claimed.selected[0] as (typeof claimed.selected)[number],
-          claimed.selected[0] as (typeof claimed.selected)[number],
-        ],
-      }),
-    ).toBe(false);
-    expect(
-      await succeedPiMemoryPhase2Job(db(), {
-        ...fence,
-        selected: [
-          {
-            ...(claimed.selected[0] as (typeof claimed.selected)[number]),
-            rawMemory: "x".repeat(PI_MEMORY_PHASE2_MAX_SELECTED_UTF8_BYTES + 1),
-          },
-        ],
-      }),
-    ).toBe(false);
-    expect(
-      await succeedPiMemoryPhase2Job(db(), {
+            piSessionId: `unique-${index.toString().padStart(3, "0")}`,
+          };
+        },
+      ),
+    );
+    await expect(
+      succeedPiMemoryPhase2Job(db(), {
         ...fence,
         selected: claimed.selected,
       }),
-    ).toBe(true);
+    ).resolves.toBeTruthy();
   });
 });

--- a/turbo/apps/api/src/signals/services/pi-memory-phase2-job.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-phase2-job.service.ts
@@ -1,0 +1,671 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import { MEMORY_ARTIFACT_NAME } from "@okouai/core/storage-names";
+import {
+  PI_MEMORY_PHASE2_MAX_ATTEMPTS,
+  PI_MEMORY_PHASE2_MAX_SELECTED_CANDIDATES,
+  PI_MEMORY_PHASE2_MAX_SELECTED_UTF8_BYTES,
+  piMemoryPhase2Jobs,
+} from "@okouai/db/schema/pi-memory-phase2-job";
+import { piMemoryStage1Candidates } from "@okouai/db/schema/pi-memory-stage1-candidate";
+import { storages } from "@okouai/db/schema/storage";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  gt,
+  gte,
+  isNotNull,
+  isNull,
+  lte,
+  or,
+  sql,
+} from "drizzle-orm";
+
+import type { ApiDb, Tx } from "../../lib/db-types";
+
+export const PI_MEMORY_PHASE2_LEASE_DURATION_MS = 60 * 60 * 1000;
+export const PI_MEMORY_PHASE2_EXPECTED_HEARTBEAT_CADENCE_MS = 90 * 1000;
+export const PI_MEMORY_PHASE2_RETRY_DELAY_MS = 60 * 60 * 1000;
+export const PI_MEMORY_PHASE2_SUCCESS_COOLDOWN_MS = 6 * 60 * 60 * 1000;
+export const PI_MEMORY_PHASE2_MAX_UNUSED_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+const PI_MEMORY_PHASE2_SELECTION_ENCODING = "vm0.pi-memory.phase2.selection.v1";
+
+interface PiMemoryPhase2OwnerScope {
+  readonly memoryStorageId: string;
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+interface PiMemoryPhase2SelectedCandidate {
+  readonly piSessionId: string;
+  readonly sourceHistoryHash: string;
+  readonly rawMemory: string;
+  readonly rolloutSummary: string;
+  readonly rolloutSlug: string | null;
+}
+
+interface ClaimedPiMemoryPhase2Job extends PiMemoryPhase2OwnerScope {
+  readonly leaseToken: string;
+  readonly leaseExpiresAt: Date;
+  readonly claimedRevision: number;
+  readonly selected: readonly PiMemoryPhase2SelectedCandidate[];
+}
+
+interface ClaimPiMemoryPhase2JobArgs {
+  readonly currentTime: Date;
+  readonly scope?: PiMemoryPhase2OwnerScope;
+}
+
+interface PiMemoryPhase2LeaseFence extends PiMemoryPhase2OwnerScope {
+  readonly leaseToken: string;
+  readonly claimedRevision: number;
+  readonly currentTime: Date;
+}
+
+interface PiMemoryPhase2SelectionMetadata {
+  readonly digest: string;
+  readonly count: number;
+  readonly utf8Bytes: number;
+}
+
+function uint32Buffer(value: number): Buffer {
+  const buffer = Buffer.alloc(4);
+  buffer.writeUInt32BE(value);
+  return buffer;
+}
+
+export function piMemoryPhase2SelectionDigest(
+  selected: readonly Pick<
+    PiMemoryPhase2SelectedCandidate,
+    "piSessionId" | "sourceHistoryHash"
+  >[],
+): string {
+  const version = Buffer.from(PI_MEMORY_PHASE2_SELECTION_ENCODING, "utf8");
+  const parts: Buffer[] = [
+    uint32Buffer(version.length),
+    version,
+    uint32Buffer(selected.length),
+  ];
+  for (const candidate of selected) {
+    const piSessionId = Buffer.from(candidate.piSessionId, "utf8");
+    const sourceHistoryHash = Buffer.from(candidate.sourceHistoryHash, "utf8");
+    parts.push(
+      uint32Buffer(piSessionId.length),
+      piSessionId,
+      uint32Buffer(sourceHistoryHash.length),
+      sourceHistoryHash,
+    );
+  }
+  return createHash("sha256").update(Buffer.concat(parts)).digest("hex");
+}
+
+function candidateUtf8Bytes(
+  candidate: PiMemoryPhase2SelectedCandidate,
+): number {
+  return (
+    Buffer.byteLength(candidate.rawMemory, "utf8") +
+    Buffer.byteLength(candidate.rolloutSummary, "utf8") +
+    Buffer.byteLength(candidate.rolloutSlug ?? "", "utf8")
+  );
+}
+
+function selectionMetadata(
+  selected: readonly PiMemoryPhase2SelectedCandidate[],
+): PiMemoryPhase2SelectionMetadata | null {
+  if (selected.length > PI_MEMORY_PHASE2_MAX_SELECTED_CANDIDATES) {
+    return null;
+  }
+  const piSessionIds = new Set<string>();
+  let utf8Bytes = 0;
+  for (const candidate of selected) {
+    if (piSessionIds.has(candidate.piSessionId)) {
+      return null;
+    }
+    piSessionIds.add(candidate.piSessionId);
+    utf8Bytes += candidateUtf8Bytes(candidate);
+    if (utf8Bytes > PI_MEMORY_PHASE2_MAX_SELECTED_UTF8_BYTES) {
+      return null;
+    }
+  }
+  return {
+    digest: piMemoryPhase2SelectionDigest(selected),
+    count: selected.length,
+    utf8Bytes,
+  };
+}
+
+export async function advancePiMemoryPhase2InputRevision(
+  tx: Tx,
+  args: PiMemoryPhase2OwnerScope & { readonly enqueuedAt: Date },
+): Promise<void> {
+  const [advanced] = await tx
+    .insert(piMemoryPhase2Jobs)
+    .values({
+      memoryStorageId: args.memoryStorageId,
+      orgId: args.orgId,
+      userId: args.userId,
+      status: "pending",
+      inputRevision: 1,
+      completedRevision: 0,
+      retryCount: 0,
+      updatedAt: args.enqueuedAt,
+    })
+    .onConflictDoUpdate({
+      target: piMemoryPhase2Jobs.memoryStorageId,
+      set: {
+        orgId: args.orgId,
+        userId: args.userId,
+        status: sql`CASE
+          WHEN ${piMemoryPhase2Jobs.status} = 'leased' THEN 'leased'
+          ELSE 'pending'
+        END`,
+        inputRevision: sql`${piMemoryPhase2Jobs.inputRevision} + 1`,
+        claimedRevision: sql`CASE
+          WHEN ${piMemoryPhase2Jobs.status} = 'leased'
+          THEN ${piMemoryPhase2Jobs.claimedRevision}
+          ELSE NULL
+        END`,
+        leaseToken: sql`CASE
+          WHEN ${piMemoryPhase2Jobs.status} = 'leased'
+          THEN ${piMemoryPhase2Jobs.leaseToken}
+          ELSE NULL
+        END`,
+        leaseExpiresAt: sql`CASE
+          WHEN ${piMemoryPhase2Jobs.status} = 'leased'
+          THEN ${piMemoryPhase2Jobs.leaseExpiresAt}
+          ELSE NULL
+        END`,
+        retryCount: sql`CASE
+          WHEN ${piMemoryPhase2Jobs.status} = 'leased'
+          THEN ${piMemoryPhase2Jobs.retryCount}
+          ELSE 0
+        END`,
+        retryAt: null,
+        lastErrorClass: null,
+        claimedSelectionDigest: sql`CASE
+          WHEN ${piMemoryPhase2Jobs.status} = 'leased'
+          THEN ${piMemoryPhase2Jobs.claimedSelectionDigest}
+          ELSE NULL
+        END`,
+        claimedSelectedCount: sql`CASE
+          WHEN ${piMemoryPhase2Jobs.status} = 'leased'
+          THEN ${piMemoryPhase2Jobs.claimedSelectedCount}
+          ELSE NULL
+        END`,
+        claimedSelectedUtf8Bytes: sql`CASE
+          WHEN ${piMemoryPhase2Jobs.status} = 'leased'
+          THEN ${piMemoryPhase2Jobs.claimedSelectedUtf8Bytes}
+          ELSE NULL
+        END`,
+        updatedAt: args.enqueuedAt,
+      },
+    })
+    .returning({ memoryStorageId: piMemoryPhase2Jobs.memoryStorageId });
+  if (!advanced) {
+    throw new Error("Pi memory Phase 2 input revision did not advance");
+  }
+}
+
+function claimScopeCondition(scope: PiMemoryPhase2OwnerScope | undefined) {
+  return scope
+    ? and(
+        eq(piMemoryPhase2Jobs.memoryStorageId, scope.memoryStorageId),
+        eq(piMemoryPhase2Jobs.orgId, scope.orgId),
+        eq(piMemoryPhase2Jobs.userId, scope.userId),
+      )
+    : undefined;
+}
+
+async function selectClaimCandidates(
+  tx: Tx,
+  scope: PiMemoryPhase2OwnerScope,
+  currentTime: Date,
+): Promise<readonly PiMemoryPhase2SelectedCandidate[]> {
+  const oldestAllowed = new Date(
+    currentTime.getTime() - PI_MEMORY_PHASE2_MAX_UNUSED_AGE_MS,
+  );
+  const ranked = await tx
+    .select({
+      piSessionId: piMemoryStage1Candidates.piSessionId,
+      sourceHistoryHash: piMemoryStage1Candidates.sourceHistoryHash,
+      rawMemory: piMemoryStage1Candidates.rawMemory,
+      rolloutSummary: piMemoryStage1Candidates.rolloutSummary,
+      rolloutSlug: piMemoryStage1Candidates.rolloutSlug,
+    })
+    .from(piMemoryStage1Candidates)
+    .where(
+      and(
+        eq(piMemoryStage1Candidates.memoryStorageId, scope.memoryStorageId),
+        eq(piMemoryStage1Candidates.orgId, scope.orgId),
+        eq(piMemoryStage1Candidates.userId, scope.userId),
+        eq(piMemoryStage1Candidates.status, "succeeded"),
+        sql`(
+          btrim(${piMemoryStage1Candidates.rawMemory}, E' \t\n\r\f\v') <> '' OR
+          btrim(${piMemoryStage1Candidates.rolloutSummary}, E' \t\n\r\f\v') <> ''
+        )`,
+        or(
+          and(
+            isNotNull(piMemoryStage1Candidates.lastUsedAt),
+            gte(piMemoryStage1Candidates.lastUsedAt, oldestAllowed),
+          ),
+          and(
+            isNull(piMemoryStage1Candidates.lastUsedAt),
+            gte(piMemoryStage1Candidates.sourceCompletedAt, oldestAllowed),
+          ),
+        ),
+      ),
+    )
+    .orderBy(
+      desc(piMemoryStage1Candidates.usageCount),
+      desc(
+        sql`COALESCE(
+          ${piMemoryStage1Candidates.lastUsedAt},
+          ${piMemoryStage1Candidates.sourceCompletedAt}
+        )`,
+      ),
+      desc(piMemoryStage1Candidates.sourceCompletedAt),
+      desc(piMemoryStage1Candidates.piSessionId),
+    )
+    .limit(PI_MEMORY_PHASE2_MAX_SELECTED_CANDIDATES);
+
+  const selected: PiMemoryPhase2SelectedCandidate[] = [];
+  let selectedUtf8Bytes = 0;
+  for (const candidate of ranked) {
+    if (candidate.rawMemory === null || candidate.rolloutSummary === null) {
+      throw new Error("Succeeded Pi memory Stage 1 candidate has no output");
+    }
+    const snapshot = {
+      piSessionId: candidate.piSessionId,
+      sourceHistoryHash: candidate.sourceHistoryHash,
+      rawMemory: candidate.rawMemory,
+      rolloutSummary: candidate.rolloutSummary,
+      rolloutSlug: candidate.rolloutSlug,
+    };
+    const nextUtf8Bytes = selectedUtf8Bytes + candidateUtf8Bytes(snapshot);
+    if (nextUtf8Bytes > PI_MEMORY_PHASE2_MAX_SELECTED_UTF8_BYTES) {
+      break;
+    }
+    selected.push(snapshot);
+    selectedUtf8Bytes = nextUtf8Bytes;
+  }
+  return selected.sort((left, right) => {
+    if (left.piSessionId < right.piSessionId) {
+      return -1;
+    }
+    if (left.piSessionId > right.piSessionId) {
+      return 1;
+    }
+    return 0;
+  });
+}
+
+export async function claimPiMemoryPhase2Job(
+  db: ApiDb,
+  args: ClaimPiMemoryPhase2JobArgs,
+): Promise<ClaimedPiMemoryPhase2Job | null> {
+  return await db.transaction(async (tx) => {
+    const job = await lockNextClaimableJob(tx, args);
+    if (!job) {
+      return null;
+    }
+
+    const retryCount =
+      job.status === "leased"
+        ? job.claimedRevision === job.inputRevision
+          ? job.retryCount + 1
+          : 0
+        : job.retryCount;
+    if (retryCount >= PI_MEMORY_PHASE2_MAX_ATTEMPTS) {
+      await tx
+        .update(piMemoryPhase2Jobs)
+        .set({
+          status: "terminal_failure",
+          claimedRevision: null,
+          leaseToken: null,
+          leaseExpiresAt: null,
+          retryCount: PI_MEMORY_PHASE2_MAX_ATTEMPTS,
+          retryAt: null,
+          lastErrorClass: "lease_expired",
+          claimedSelectionDigest: null,
+          claimedSelectedCount: null,
+          claimedSelectedUtf8Bytes: null,
+          updatedAt: args.currentTime,
+        })
+        .where(
+          and(
+            eq(piMemoryPhase2Jobs.memoryStorageId, job.memoryStorageId),
+            eq(piMemoryPhase2Jobs.orgId, job.orgId),
+            eq(piMemoryPhase2Jobs.userId, job.userId),
+          ),
+        );
+      return null;
+    }
+
+    const scope = {
+      memoryStorageId: job.memoryStorageId,
+      orgId: job.orgId,
+      userId: job.userId,
+    };
+    const selected = await selectClaimCandidates(tx, scope, args.currentTime);
+    const metadata = selectionMetadata(selected);
+    if (metadata === null) {
+      throw new Error("Claimed Pi memory Phase 2 selection is out of bounds");
+    }
+    const leaseToken = randomUUID();
+    const leaseExpiresAt = new Date(
+      args.currentTime.getTime() + PI_MEMORY_PHASE2_LEASE_DURATION_MS,
+    );
+    const [leased] = await tx
+      .update(piMemoryPhase2Jobs)
+      .set({
+        status: "leased",
+        claimedRevision: job.inputRevision,
+        leaseToken,
+        leaseExpiresAt,
+        retryCount,
+        retryAt: null,
+        lastErrorClass: null,
+        claimedSelectionDigest: metadata.digest,
+        claimedSelectedCount: metadata.count,
+        claimedSelectedUtf8Bytes: metadata.utf8Bytes,
+        updatedAt: args.currentTime,
+      })
+      .where(
+        and(
+          eq(piMemoryPhase2Jobs.memoryStorageId, job.memoryStorageId),
+          eq(piMemoryPhase2Jobs.orgId, job.orgId),
+          eq(piMemoryPhase2Jobs.userId, job.userId),
+        ),
+      )
+      .returning({ memoryStorageId: piMemoryPhase2Jobs.memoryStorageId });
+    if (!leased) {
+      throw new Error("Locked Pi memory Phase 2 job could not be leased");
+    }
+    return {
+      ...scope,
+      leaseToken,
+      leaseExpiresAt,
+      claimedRevision: job.inputRevision,
+      selected,
+    };
+  });
+}
+
+interface LockedClaimableJob extends PiMemoryPhase2OwnerScope {
+  readonly status:
+    | "pending"
+    | "leased"
+    | "retryable_failure"
+    | "idle"
+    | "terminal_failure";
+  readonly inputRevision: number;
+  readonly completedRevision: number;
+  readonly claimedRevision: number | null;
+  readonly retryCount: number;
+}
+
+async function lockNextClaimableJob(
+  tx: Tx,
+  args: ClaimPiMemoryPhase2JobArgs,
+): Promise<LockedClaimableJob | null> {
+  const cooldownBoundary = new Date(
+    args.currentTime.getTime() - PI_MEMORY_PHASE2_SUCCESS_COOLDOWN_MS,
+  );
+  const [job] = await tx
+    .select({
+      memoryStorageId: piMemoryPhase2Jobs.memoryStorageId,
+      orgId: piMemoryPhase2Jobs.orgId,
+      userId: piMemoryPhase2Jobs.userId,
+      status: piMemoryPhase2Jobs.status,
+      inputRevision: piMemoryPhase2Jobs.inputRevision,
+      completedRevision: piMemoryPhase2Jobs.completedRevision,
+      claimedRevision: piMemoryPhase2Jobs.claimedRevision,
+      retryCount: piMemoryPhase2Jobs.retryCount,
+    })
+    .from(piMemoryPhase2Jobs)
+    .innerJoin(
+      storages,
+      and(
+        eq(storages.id, piMemoryPhase2Jobs.memoryStorageId),
+        eq(storages.orgId, piMemoryPhase2Jobs.orgId),
+        eq(storages.userId, piMemoryPhase2Jobs.userId),
+        eq(storages.name, MEMORY_ARTIFACT_NAME),
+      ),
+    )
+    .where(
+      and(
+        gt(
+          piMemoryPhase2Jobs.inputRevision,
+          piMemoryPhase2Jobs.completedRevision,
+        ),
+        or(
+          eq(piMemoryPhase2Jobs.status, "pending"),
+          and(
+            eq(piMemoryPhase2Jobs.status, "retryable_failure"),
+            lte(piMemoryPhase2Jobs.retryAt, args.currentTime),
+          ),
+          and(
+            eq(piMemoryPhase2Jobs.status, "leased"),
+            lte(piMemoryPhase2Jobs.leaseExpiresAt, args.currentTime),
+          ),
+        ),
+        or(
+          isNull(piMemoryPhase2Jobs.lastSucceededAt),
+          lte(piMemoryPhase2Jobs.lastSucceededAt, cooldownBoundary),
+        ),
+        claimScopeCondition(args.scope),
+      ),
+    )
+    .orderBy(
+      asc(piMemoryPhase2Jobs.updatedAt),
+      asc(piMemoryPhase2Jobs.memoryStorageId),
+    )
+    .limit(1)
+    .for("update", { of: piMemoryPhase2Jobs, skipLocked: true });
+  return job ?? null;
+}
+
+function exactLeaseCondition(args: PiMemoryPhase2LeaseFence) {
+  return and(
+    eq(piMemoryPhase2Jobs.memoryStorageId, args.memoryStorageId),
+    eq(piMemoryPhase2Jobs.orgId, args.orgId),
+    eq(piMemoryPhase2Jobs.userId, args.userId),
+    eq(piMemoryPhase2Jobs.status, "leased"),
+    eq(piMemoryPhase2Jobs.leaseToken, args.leaseToken),
+    eq(piMemoryPhase2Jobs.claimedRevision, args.claimedRevision),
+    gt(piMemoryPhase2Jobs.leaseExpiresAt, args.currentTime),
+  );
+}
+
+export async function heartbeatPiMemoryPhase2Job(
+  db: ApiDb,
+  args: PiMemoryPhase2LeaseFence,
+): Promise<boolean> {
+  const [heartbeat] = await db
+    .update(piMemoryPhase2Jobs)
+    .set({
+      leaseExpiresAt: new Date(
+        args.currentTime.getTime() + PI_MEMORY_PHASE2_LEASE_DURATION_MS,
+      ),
+      updatedAt: args.currentTime,
+    })
+    .where(exactLeaseCondition(args))
+    .returning({ memoryStorageId: piMemoryPhase2Jobs.memoryStorageId });
+  return heartbeat !== undefined;
+}
+
+export async function failPiMemoryPhase2Job(
+  db: ApiDb,
+  args: PiMemoryPhase2LeaseFence & { readonly errorClass: string },
+): Promise<boolean> {
+  return await db.transaction(async (tx) => {
+    const [job] = await tx
+      .select({
+        inputRevision: piMemoryPhase2Jobs.inputRevision,
+        retryCount: piMemoryPhase2Jobs.retryCount,
+      })
+      .from(piMemoryPhase2Jobs)
+      .where(exactLeaseCondition(args))
+      .limit(1)
+      .for("update", { of: piMemoryPhase2Jobs });
+    if (!job) {
+      return false;
+    }
+
+    const hasNewerInput = job.inputRevision > args.claimedRevision;
+    const retryCount = hasNewerInput ? 0 : job.retryCount + 1;
+    const terminal = retryCount >= PI_MEMORY_PHASE2_MAX_ATTEMPTS;
+    const [failed] = await tx
+      .update(piMemoryPhase2Jobs)
+      .set({
+        status: hasNewerInput
+          ? "pending"
+          : terminal
+            ? "terminal_failure"
+            : "retryable_failure",
+        claimedRevision: null,
+        leaseToken: null,
+        leaseExpiresAt: null,
+        retryCount,
+        retryAt:
+          hasNewerInput || terminal
+            ? null
+            : new Date(
+                args.currentTime.getTime() + PI_MEMORY_PHASE2_RETRY_DELAY_MS,
+              ),
+        lastErrorClass: hasNewerInput ? null : args.errorClass,
+        claimedSelectionDigest: null,
+        claimedSelectedCount: null,
+        claimedSelectedUtf8Bytes: null,
+        updatedAt: args.currentTime,
+      })
+      .where(exactLeaseCondition(args))
+      .returning({ memoryStorageId: piMemoryPhase2Jobs.memoryStorageId });
+    return failed !== undefined;
+  });
+}
+
+function selectionMatchesJob(
+  job: {
+    readonly claimedSelectionDigest: string | null;
+    readonly claimedSelectedCount: number | null;
+    readonly claimedSelectedUtf8Bytes: number | null;
+  },
+  metadata: PiMemoryPhase2SelectionMetadata,
+): boolean {
+  return (
+    job.claimedSelectionDigest === metadata.digest &&
+    job.claimedSelectedCount === metadata.count &&
+    job.claimedSelectedUtf8Bytes === metadata.utf8Bytes
+  );
+}
+
+export async function succeedPiMemoryPhase2Job(
+  db: ApiDb,
+  args: PiMemoryPhase2LeaseFence & {
+    readonly selected: readonly PiMemoryPhase2SelectedCandidate[];
+  },
+): Promise<boolean> {
+  const metadata = selectionMetadata(args.selected);
+  if (metadata === null) {
+    return false;
+  }
+
+  return await db.transaction(async (tx) => {
+    await tx
+      .select({ piSessionId: piMemoryStage1Candidates.piSessionId })
+      .from(piMemoryStage1Candidates)
+      .where(
+        and(
+          eq(piMemoryStage1Candidates.memoryStorageId, args.memoryStorageId),
+          eq(piMemoryStage1Candidates.orgId, args.orgId),
+          eq(piMemoryStage1Candidates.userId, args.userId),
+        ),
+      )
+      .orderBy(asc(piMemoryStage1Candidates.piSessionId))
+      .for("update", { of: piMemoryStage1Candidates });
+    const [job] = await tx
+      .select({
+        claimedSelectionDigest: piMemoryPhase2Jobs.claimedSelectionDigest,
+        claimedSelectedCount: piMemoryPhase2Jobs.claimedSelectedCount,
+        claimedSelectedUtf8Bytes: piMemoryPhase2Jobs.claimedSelectedUtf8Bytes,
+      })
+      .from(piMemoryPhase2Jobs)
+      .where(exactLeaseCondition(args))
+      .limit(1)
+      .for("update", { of: piMemoryPhase2Jobs });
+    if (!job || !selectionMatchesJob(job, metadata)) {
+      return false;
+    }
+
+    await tx
+      .update(piMemoryStage1Candidates)
+      .set({ lastSelectedSourceHistoryHash: null })
+      .where(
+        and(
+          eq(piMemoryStage1Candidates.memoryStorageId, args.memoryStorageId),
+          eq(piMemoryStage1Candidates.orgId, args.orgId),
+          eq(piMemoryStage1Candidates.userId, args.userId),
+          isNotNull(piMemoryStage1Candidates.lastSelectedSourceHistoryHash),
+        ),
+      );
+    for (const selected of args.selected) {
+      await tx
+        .update(piMemoryStage1Candidates)
+        .set({
+          lastSelectedSourceHistoryHash: selected.sourceHistoryHash,
+        })
+        .where(
+          and(
+            eq(piMemoryStage1Candidates.memoryStorageId, args.memoryStorageId),
+            eq(piMemoryStage1Candidates.orgId, args.orgId),
+            eq(piMemoryStage1Candidates.userId, args.userId),
+            eq(piMemoryStage1Candidates.status, "succeeded"),
+            eq(piMemoryStage1Candidates.piSessionId, selected.piSessionId),
+            eq(
+              piMemoryStage1Candidates.sourceHistoryHash,
+              selected.sourceHistoryHash,
+            ),
+          ),
+        );
+    }
+
+    const [completed] = await tx
+      .update(piMemoryPhase2Jobs)
+      .set({
+        status: sql`CASE
+            WHEN ${piMemoryPhase2Jobs.inputRevision} = ${args.claimedRevision}
+            THEN 'idle'
+            ELSE 'pending'
+          END`,
+        completedRevision: args.claimedRevision,
+        claimedRevision: null,
+        leaseToken: null,
+        leaseExpiresAt: null,
+        retryCount: 0,
+        retryAt: null,
+        lastErrorClass: null,
+        lastSucceededAt: args.currentTime,
+        claimedSelectionDigest: null,
+        claimedSelectedCount: null,
+        claimedSelectedUtf8Bytes: null,
+        updatedAt: args.currentTime,
+      })
+      .where(
+        and(
+          exactLeaseCondition(args),
+          eq(piMemoryPhase2Jobs.claimedSelectionDigest, metadata.digest),
+          eq(piMemoryPhase2Jobs.claimedSelectedCount, metadata.count),
+          eq(piMemoryPhase2Jobs.claimedSelectedUtf8Bytes, metadata.utf8Bytes),
+        ),
+      )
+      .returning({ memoryStorageId: piMemoryPhase2Jobs.memoryStorageId });
+    if (!completed) {
+      throw new Error("Locked Pi memory Phase 2 job could not be completed");
+    }
+    return true;
+  });
+}

--- a/turbo/apps/api/src/signals/services/pi-memory-phase2-job.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-phase2-job.service.ts
@@ -250,10 +250,12 @@ async function selectClaimCandidates(
           and(
             isNotNull(piMemoryStage1Candidates.lastUsedAt),
             gte(piMemoryStage1Candidates.lastUsedAt, oldestAllowed),
+            lte(piMemoryStage1Candidates.lastUsedAt, currentTime),
           ),
           and(
             isNull(piMemoryStage1Candidates.lastUsedAt),
             gte(piMemoryStage1Candidates.sourceCompletedAt, oldestAllowed),
+            lte(piMemoryStage1Candidates.sourceCompletedAt, currentTime),
           ),
         ),
       ),
@@ -569,7 +571,10 @@ export async function succeedPiMemoryPhase2Job(
     readonly selected: readonly PiMemoryPhase2SelectedCandidate[];
   },
 ): Promise<boolean> {
-  const metadata = selectionMetadata(args.selected);
+  const selectedSnapshot = args.selected.map((candidate) => {
+    return { ...candidate };
+  });
+  const metadata = selectionMetadata(selectedSnapshot);
   if (metadata === null) {
     return false;
   }
@@ -612,7 +617,7 @@ export async function succeedPiMemoryPhase2Job(
           isNotNull(piMemoryStage1Candidates.lastSelectedSourceHistoryHash),
         ),
       );
-    for (const selected of args.selected) {
+    for (const selected of selectedSnapshot) {
       await tx
         .update(piMemoryStage1Candidates)
         .set({

--- a/turbo/apps/api/src/signals/services/pi-memory-stage1-candidate.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-stage1-candidate.service.ts
@@ -8,6 +8,7 @@ import { storages } from "@okouai/db/schema/storage";
 
 import type { Tx } from "../../lib/db-types";
 import { nowDate } from "../../lib/time";
+import { advancePiMemoryPhase2InputRevision } from "./pi-memory-phase2-job.service";
 import { newStorageS3Location } from "./storage-s3-prefix.utils";
 
 export type PiMemoryStage1AdmissionSkipReason =
@@ -266,6 +267,8 @@ export type PiMemoryStage1CommitResult =
 
 interface CommitPiMemoryStage1CandidateArgs {
   readonly memoryStorageId: string;
+  readonly orgId: string;
+  readonly userId: string;
   readonly piSessionId: string;
   readonly sourceHistoryHash: string;
   readonly leaseToken: string;
@@ -333,6 +336,8 @@ export async function commitPiMemoryStage1Candidate(
     .where(
       and(
         eq(piMemoryStage1Candidates.memoryStorageId, args.memoryStorageId),
+        eq(piMemoryStage1Candidates.orgId, args.orgId),
+        eq(piMemoryStage1Candidates.userId, args.userId),
         eq(piMemoryStage1Candidates.piSessionId, args.piSessionId),
         eq(piMemoryStage1Candidates.sourceHistoryHash, args.sourceHistoryHash),
         eq(piMemoryStage1Candidates.status, "leased"),
@@ -341,5 +346,19 @@ export async function commitPiMemoryStage1Candidate(
       ),
     )
     .returning({ memoryStorageId: piMemoryStage1Candidates.memoryStorageId });
-  return committed !== undefined;
+  if (!committed) {
+    return false;
+  }
+  if (
+    args.result.kind === "succeeded" ||
+    args.result.kind === "succeeded_no_output"
+  ) {
+    await advancePiMemoryPhase2InputRevision(tx, {
+      memoryStorageId: args.memoryStorageId,
+      orgId: args.orgId,
+      userId: args.userId,
+      enqueuedAt: args.committedAt,
+    });
+  }
+  return true;
 }

--- a/turbo/apps/api/src/signals/services/pi-memory-stage1-worker.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-stage1-worker.service.ts
@@ -547,6 +547,8 @@ async function commitWorkResult(
   return await db.transaction(async (tx) => {
     return await commitPiMemoryStage1Candidate(tx, {
       memoryStorageId: work.memoryStorageId,
+      orgId: work.orgId,
+      userId: work.userId,
       piSessionId: work.piSessionId,
       sourceHistoryHash: work.sourceHistoryHash,
       leaseToken: work.leaseToken,

--- a/turbo/apps/api/src/signals/services/user-export.service.ts
+++ b/turbo/apps/api/src/signals/services/user-export.service.ts
@@ -27,6 +27,7 @@ import { blobs } from "@okouai/db/schema/blob";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
 import { exportJobs } from "@okouai/db/schema/export-job";
 import { emailOutbox } from "@okouai/db/schema/email-outbox";
+import { piMemoryPhase2Jobs } from "@okouai/db/schema/pi-memory-phase2-job";
 import { piMemoryStage1Candidates } from "@okouai/db/schema/pi-memory-stage1-candidate";
 import { storages, storageVersions } from "@okouai/db/schema/storage";
 import { userCache } from "@okouai/db/schema/user-cache";
@@ -738,6 +739,55 @@ function collectPiMemoryStage1Candidates(
   });
 }
 
+function collectPiMemoryPhase2Jobs(
+  runtime: ExportRuntime,
+  userId: string,
+  signal: AbortSignal,
+): Computed<
+  Promise<{ readonly entries: readonly ZipEntry[]; readonly count: number }>
+> {
+  return computed(async () => {
+    const rows = await runtime.db
+      .select({
+        memoryStorageId: piMemoryPhase2Jobs.memoryStorageId,
+        orgId: piMemoryPhase2Jobs.orgId,
+        userId: piMemoryPhase2Jobs.userId,
+        status: piMemoryPhase2Jobs.status,
+        inputRevision: piMemoryPhase2Jobs.inputRevision,
+        completedRevision: piMemoryPhase2Jobs.completedRevision,
+        claimedRevision: piMemoryPhase2Jobs.claimedRevision,
+        leaseExpiresAt: piMemoryPhase2Jobs.leaseExpiresAt,
+        retryCount: piMemoryPhase2Jobs.retryCount,
+        retryAt: piMemoryPhase2Jobs.retryAt,
+        lastErrorClass: piMemoryPhase2Jobs.lastErrorClass,
+        lastSucceededAt: piMemoryPhase2Jobs.lastSucceededAt,
+        claimedSelectedCount: piMemoryPhase2Jobs.claimedSelectedCount,
+        claimedSelectedUtf8Bytes: piMemoryPhase2Jobs.claimedSelectedUtf8Bytes,
+        createdAt: piMemoryPhase2Jobs.createdAt,
+        updatedAt: piMemoryPhase2Jobs.updatedAt,
+      })
+      .from(piMemoryPhase2Jobs)
+      .where(eq(piMemoryPhase2Jobs.userId, userId))
+      .orderBy(
+        asc(piMemoryPhase2Jobs.orgId),
+        asc(piMemoryPhase2Jobs.memoryStorageId),
+      );
+    signal.throwIfAborted();
+    return {
+      entries:
+        rows.length === 0
+          ? []
+          : [
+              {
+                path: "memory/phase2-jobs.json",
+                content: JSON.stringify(rows, null, 2),
+              },
+            ],
+      count: rows.length,
+    };
+  });
+}
+
 interface ResolveSessionHistoryArgs {
   readonly sessionId: string;
   readonly hash: string | null;
@@ -991,6 +1041,9 @@ function collectUserData(
     const memoryStage1Candidates = await get(
       collectPiMemoryStage1Candidates(runtime, userId, signal),
     );
+    const memoryPhase2Jobs = await get(
+      collectPiMemoryPhase2Jobs(runtime, userId, signal),
+    );
     const conversationsResult = await get(
       collectConversationMessages(runtime, userId, signal),
     );
@@ -999,6 +1052,7 @@ function collectUserData(
       ...workflows.entries,
       ...memory.entries,
       ...memoryStage1Candidates.entries,
+      ...memoryPhase2Jobs.entries,
       ...conversationsResult.entries,
     ];
 
@@ -1014,6 +1068,7 @@ function collectUserData(
             workflowFiles: workflows.count,
             memoryFiles: memory.count,
             memoryStage1Candidates: memoryStage1Candidates.count,
+            memoryPhase2Jobs: memoryPhase2Jobs.count,
             conversationThreads: conversationsResult.threadCount,
             sessionHistories: conversationsResult.sessionHistoryCount,
           },

--- a/turbo/apps/api/src/test-fixtures/pi-memory-stage1-candidates.ts
+++ b/turbo/apps/api/src/test-fixtures/pi-memory-stage1-candidates.ts
@@ -2,6 +2,7 @@ import { and, eq } from "drizzle-orm";
 
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { conversations } from "@okouai/db/schema/conversation";
+import { piMemoryPhase2Jobs } from "@okouai/db/schema/pi-memory-phase2-job";
 import { piMemoryStage1Candidates } from "@okouai/db/schema/pi-memory-stage1-candidate";
 import { storages } from "@okouai/db/schema/storage";
 
@@ -40,6 +41,39 @@ export function piMemoryStage1AdmissionPrerequisiteSkipReasonFixture(
     idleDelayMs: 30 * 60 * 1000,
     ...overrides,
   });
+}
+
+export async function seedPiMemoryPhase2ExportJobFixture(args: {
+  readonly memoryStorageId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly currentTime: Date;
+}): Promise<{ readonly leaseToken: string; readonly selectionDigest: string }> {
+  const leaseToken = "00000000-0000-4000-8000-000000031237";
+  const selectionDigest = "a".repeat(64);
+  await db()
+    .insert(piMemoryPhase2Jobs)
+    .values({
+      memoryStorageId: args.memoryStorageId,
+      orgId: args.orgId,
+      userId: args.userId,
+      status: "leased",
+      inputRevision: 2,
+      completedRevision: 0,
+      claimedRevision: 1,
+      leaseToken,
+      leaseExpiresAt: new Date(args.currentTime.getTime() + 60 * 60 * 1000),
+      retryCount: 1,
+      lastSucceededAt: new Date(
+        args.currentTime.getTime() - 24 * 60 * 60 * 1000,
+      ),
+      claimedSelectionDigest: selectionDigest,
+      claimedSelectedCount: 1,
+      claimedSelectedUtf8Bytes: 42,
+      createdAt: new Date(args.currentTime.getTime() - 2 * 60 * 60 * 1000),
+      updatedAt: args.currentTime,
+    });
+  return { leaseToken, selectionDigest };
 }
 
 export async function readPiMemoryStage1CandidateFixture(args: {
@@ -131,6 +165,8 @@ export async function leasePiMemoryStage1CandidateFixture(args: {
 
 export async function commitPiMemoryStage1CandidateFixture(args: {
   readonly memoryStorageId: string;
+  readonly orgId: string;
+  readonly userId: string;
   readonly piSessionId: string;
   readonly sourceHistoryHash: string;
   readonly leaseToken: string;

--- a/turbo/packages/db/scripts/test-migration-consistency-schema.ts
+++ b/turbo/packages/db/scripts/test-migration-consistency-schema.ts
@@ -111,6 +111,7 @@ import {
 import { validateSlackOfficialBrandMigration } from "./test-slack-official-brand-migration";
 import { validatePermanentSlackPublicBrandState } from "./test-slack-public-brand-permanent";
 import { validatePiMemoryStage1SelectionWatermarkMigration } from "./test-pi-memory-stage1-selection-watermark-migration";
+import { validatePiMemoryPhase2JobMigration } from "./test-pi-memory-phase2-job-migration";
 import { validateWorkflowCompatibilityViews } from "./test-workflow-compatibility-views";
 import { LEGACY_DATABASE_IDENTITY_MANIFEST } from "./legacy-database-identity-manifest";
 import {
@@ -11284,6 +11285,7 @@ async function main(): Promise<void> {
     await validateOkouDebugFeatureSwitchKeyRename();
     await validateSlackOfficialBrandMigration();
     await validatePiMemoryStage1SelectionWatermarkMigration();
+    await validatePiMemoryPhase2JobMigration();
     await validateAgentDraftsCompatibilityRelation();
     await validateChatSearchDeleteCompatibility(dbUrl.toString());
     await validateWorkflowCompatibilityViews();

--- a/turbo/packages/db/scripts/test-pi-memory-phase2-job-migration.ts
+++ b/turbo/packages/db/scripts/test-pi-memory-phase2-job-migration.ts
@@ -1,0 +1,321 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Client } from "pg";
+
+import { applyMigrationsFromDirectoryUpToTag } from "./migration-consistency-helpers";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const migrationsDirectory = path.join(scriptDirectory, "../src/migrations");
+const previousMigration = "1059_restore_pi_memory_selection_watermark";
+const phase2JobMigration = "1060_steady_talisman";
+const testDatabase = "migration_pi_memory_phase2_jobs";
+
+interface CandidateSnapshot {
+  readonly createdAt: Date;
+  readonly eligibleAt: Date;
+  readonly generatedAt: Date | null;
+  readonly lastErrorClass: string | null;
+  readonly lastSelectedSourceHistoryHash: string | null;
+  readonly lastUsedAt: Date | null;
+  readonly leaseExpiresAt: Date | null;
+  readonly leaseToken: string | null;
+  readonly memoryStorageId: string;
+  readonly orgId: string;
+  readonly piSessionId: string;
+  readonly rawMemory: string | null;
+  readonly retryAt: Date | null;
+  readonly retryCount: number;
+  readonly rolloutSlug: string | null;
+  readonly rolloutSummary: string | null;
+  readonly sourceCompletedAt: Date;
+  readonly sourceHistoryHash: string;
+  readonly sourceRunId: string;
+  readonly status: string;
+  readonly updatedAt: Date;
+  readonly usageCount: number;
+  readonly userId: string;
+}
+
+interface JobSnapshot {
+  readonly memoryStorageId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly status: string;
+  readonly inputRevision: number;
+  readonly completedRevision: number;
+  readonly claimedRevision: number | null;
+  readonly leaseToken: string | null;
+  readonly leaseExpiresAt: Date | null;
+  readonly retryCount: number;
+  readonly retryAt: Date | null;
+  readonly lastErrorClass: string | null;
+  readonly lastSucceededAt: Date | null;
+  readonly claimedSelectionDigest: string | null;
+  readonly claimedSelectedCount: number | null;
+  readonly claimedSelectedUtf8Bytes: number | null;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+function databaseUrlFor(baseUrl: string, database: string): string {
+  const url = new URL(baseUrl);
+  url.pathname = `/${database}`;
+  return url.toString();
+}
+
+async function readCandidates(client: Client): Promise<CandidateSnapshot[]> {
+  const result = await client.query<CandidateSnapshot>(`
+    SELECT
+      "memory_storage_id" AS "memoryStorageId",
+      "org_id" AS "orgId",
+      "user_id" AS "userId",
+      "pi_session_id" AS "piSessionId",
+      "source_run_id" AS "sourceRunId",
+      "source_history_hash" AS "sourceHistoryHash",
+      "source_completed_at" AS "sourceCompletedAt",
+      "eligible_at" AS "eligibleAt",
+      "status",
+      "lease_token" AS "leaseToken",
+      "lease_expires_at" AS "leaseExpiresAt",
+      "retry_at" AS "retryAt",
+      "retry_count" AS "retryCount",
+      "last_error_class" AS "lastErrorClass",
+      "raw_memory" AS "rawMemory",
+      "rollout_summary" AS "rolloutSummary",
+      "rollout_slug" AS "rolloutSlug",
+      "generated_at" AS "generatedAt",
+      "last_selected_source_history_hash" AS "lastSelectedSourceHistoryHash",
+      "usage_count" AS "usageCount",
+      "last_used_at" AS "lastUsedAt",
+      "created_at" AS "createdAt",
+      "updated_at" AS "updatedAt"
+    FROM "pi_memory_stage1_candidates"
+    ORDER BY "memory_storage_id", "pi_session_id"
+  `);
+  return result.rows;
+}
+
+async function readJobs(client: Client): Promise<JobSnapshot[]> {
+  const result = await client.query<JobSnapshot>(`
+    SELECT
+      "memory_storage_id" AS "memoryStorageId",
+      "org_id" AS "orgId",
+      "user_id" AS "userId",
+      "status",
+      "input_revision" AS "inputRevision",
+      "completed_revision" AS "completedRevision",
+      "claimed_revision" AS "claimedRevision",
+      "lease_token" AS "leaseToken",
+      "lease_expires_at" AS "leaseExpiresAt",
+      "retry_count" AS "retryCount",
+      "retry_at" AS "retryAt",
+      "last_error_class" AS "lastErrorClass",
+      "last_succeeded_at" AS "lastSucceededAt",
+      "claimed_selection_digest" AS "claimedSelectionDigest",
+      "claimed_selected_count" AS "claimedSelectedCount",
+      "claimed_selected_utf8_bytes" AS "claimedSelectedUtf8Bytes",
+      "created_at" AS "createdAt",
+      "updated_at" AS "updatedAt"
+    FROM "pi_memory_phase2_jobs"
+    ORDER BY "memory_storage_id"
+  `);
+  return result.rows;
+}
+
+export async function validatePiMemoryPhase2JobMigration(): Promise<void> {
+  console.log("=== Validate Pi memory Phase 2 job migration ===\n");
+  const databaseUrl = process.env.DATABASE_URL;
+  assert.ok(databaseUrl, "DATABASE_URL is required");
+  const admin = new Client({
+    connectionString: databaseUrlFor(databaseUrl, "postgres"),
+  });
+  await admin.connect();
+  await admin.query(`DROP DATABASE IF EXISTS "${testDatabase}" WITH (FORCE)`);
+  await admin.query(`CREATE DATABASE "${testDatabase}"`);
+
+  const client = new Client({
+    connectionString: databaseUrlFor(databaseUrl, testDatabase),
+  });
+  await client.connect();
+  try {
+    await applyMigrationsFromDirectoryUpToTag(
+      client,
+      migrationsDirectory,
+      previousMigration,
+    );
+    const fixture = {
+      successfulStorageId: "00000000-0000-4000-8000-000000312371",
+      unsuccessfulStorageId: "00000000-0000-4000-8000-000000312372",
+      noOutputStorageId: "00000000-0000-4000-8000-000000312373",
+      successfulOrgId: "pi-memory-phase2-success-org",
+      successfulUserId: "pi-memory-phase2-success-user",
+      unsuccessfulOrgId: "pi-memory-phase2-unsuccessful-org",
+      unsuccessfulUserId: "pi-memory-phase2-unsuccessful-user",
+      noOutputOrgId: "pi-memory-phase2-no-output-org",
+      noOutputUserId: "pi-memory-phase2-no-output-user",
+      hashes: ["a", "b", "c", "d", "e"].map((value) => {
+        return value.repeat(64);
+      }),
+    } as const;
+    await client.query(
+      `
+        INSERT INTO "blobs" (
+          "hash", "raw_size", "ref_count", "encoding", "encoded_size"
+        )
+        SELECT hash, 1, 1, 'identity', 1
+        FROM unnest($1::varchar[]) AS hash
+      `,
+      [fixture.hashes],
+    );
+    await client.query(
+      `
+        INSERT INTO "storages" (
+          "id", "org_id", "user_id", "name", "s3_prefix"
+        ) VALUES
+          ($1::uuid, $2, $3, 'memory', $2 || '/' || ($1::uuid)::text),
+          ($4::uuid, $5, $6, 'memory', $5 || '/' || ($4::uuid)::text),
+          ($7::uuid, $8, $9, 'memory', $8 || '/' || ($7::uuid)::text)
+      `,
+      [
+        fixture.successfulStorageId,
+        fixture.successfulOrgId,
+        fixture.successfulUserId,
+        fixture.unsuccessfulStorageId,
+        fixture.unsuccessfulOrgId,
+        fixture.unsuccessfulUserId,
+        fixture.noOutputStorageId,
+        fixture.noOutputOrgId,
+        fixture.noOutputUserId,
+      ],
+    );
+    await client.query(
+      `
+        INSERT INTO "pi_memory_stage1_candidates" (
+          "memory_storage_id", "org_id", "user_id", "pi_session_id",
+          "source_run_id", "source_history_hash", "source_completed_at",
+          "eligible_at", "status", "retry_count", "last_error_class",
+          "raw_memory", "rollout_summary", "rollout_slug", "generated_at",
+          "usage_count", "last_used_at", "created_at", "updated_at"
+        ) VALUES
+          (
+            $1, $2, $3, 'success-a',
+            '00000000-0000-4000-8000-000000312381', $10,
+            '2026-09-02 01:02:03', '2026-09-02 01:32:03', 'succeeded', 2,
+            NULL, 'preserved raw memory', 'preserved rollout summary',
+            'preserved-slug', '2026-09-02 02:03:04', 7,
+            '2026-09-02 03:04:05', '2026-09-02 00:01:02',
+            '2026-09-02 04:05:06'
+          ),
+          (
+            $1, $2, $3, 'success-b',
+            '00000000-0000-4000-8000-000000312382', $11,
+            '2026-09-02 05:06:07', '2026-09-02 05:36:07', 'succeeded', 0,
+            NULL, 'second raw memory', 'second rollout summary', NULL,
+            '2026-09-02 06:07:08', 3, NULL,
+            '2026-09-02 00:02:03', '2026-09-02 08:09:10'
+          ),
+          (
+            $4, $5, $6, 'pending-only',
+            '00000000-0000-4000-8000-000000312383', $12,
+            '2026-09-02 09:10:11', '2026-09-02 09:40:11', 'pending', 0,
+            NULL, NULL, NULL, NULL, NULL, 0, NULL,
+            '2026-09-02 00:03:04', '2026-09-02 10:11:12'
+          ),
+          (
+            $4, $5, $6, 'terminal-only',
+            '00000000-0000-4000-8000-000000312384', $13,
+            '2026-09-02 11:12:13', '2026-09-02 11:42:13',
+            'terminal_failure', 5, 'attempts_exhausted', NULL, NULL, NULL,
+            NULL, 0, NULL, '2026-09-02 00:04:05',
+            '2026-09-02 12:13:14'
+          ),
+          (
+            $7, $8, $9, 'no-output',
+            '00000000-0000-4000-8000-000000312385', $14,
+            '2026-09-02 13:14:15', '2026-09-02 13:44:15',
+            'succeeded_no_output', 1, NULL, NULL, NULL, NULL,
+            '2026-09-02 14:15:16', 4, '2026-09-02 15:16:17',
+            '2026-09-02 00:05:06', '2026-09-02 16:17:18'
+          )
+      `,
+      [
+        fixture.successfulStorageId,
+        fixture.successfulOrgId,
+        fixture.successfulUserId,
+        fixture.unsuccessfulStorageId,
+        fixture.unsuccessfulOrgId,
+        fixture.unsuccessfulUserId,
+        fixture.noOutputStorageId,
+        fixture.noOutputOrgId,
+        fixture.noOutputUserId,
+        ...fixture.hashes,
+      ],
+    );
+    const candidatesBefore = await readCandidates(client);
+
+    await applyMigrationsFromDirectoryUpToTag(
+      client,
+      migrationsDirectory,
+      phase2JobMigration,
+    );
+    assert.deepEqual(await readCandidates(client), candidatesBefore);
+
+    const jobs = await readJobs(client);
+    assert.deepEqual(
+      jobs.map((job) => {
+        const { createdAt, updatedAt, ...portable } = job;
+        assert.ok(createdAt instanceof Date);
+        assert.deepEqual(updatedAt, createdAt);
+        return portable;
+      }),
+      [
+        {
+          memoryStorageId: fixture.successfulStorageId,
+          orgId: fixture.successfulOrgId,
+          userId: fixture.successfulUserId,
+          status: "pending",
+          inputRevision: 1,
+          completedRevision: 0,
+          claimedRevision: null,
+          leaseToken: null,
+          leaseExpiresAt: null,
+          retryCount: 0,
+          retryAt: null,
+          lastErrorClass: null,
+          lastSucceededAt: null,
+          claimedSelectionDigest: null,
+          claimedSelectedCount: null,
+          claimedSelectedUtf8Bytes: null,
+        },
+        {
+          memoryStorageId: fixture.noOutputStorageId,
+          orgId: fixture.noOutputOrgId,
+          userId: fixture.noOutputUserId,
+          status: "pending",
+          inputRevision: 1,
+          completedRevision: 0,
+          claimedRevision: null,
+          leaseToken: null,
+          leaseExpiresAt: null,
+          retryCount: 0,
+          retryAt: null,
+          lastErrorClass: null,
+          lastSucceededAt: null,
+          claimedSelectionDigest: null,
+          claimedSelectedCount: null,
+          claimedSelectedUtf8Bytes: null,
+        },
+      ],
+    );
+
+    console.log("   ✅ successful stores backfill exactly one pending job");
+    console.log("   ✅ unsuccessful-only stores remain job-free");
+    console.log("   ✅ owner identity and all Stage 1 bytes remain exact\n");
+  } finally {
+    await client.end();
+    await admin.query(`DROP DATABASE IF EXISTS "${testDatabase}" WITH (FORCE)`);
+    await admin.end();
+  }
+}

--- a/turbo/packages/db/src/__tests__/pi-memory-phase2-job-schema.test.ts
+++ b/turbo/packages/db/src/__tests__/pi-memory-phase2-job-schema.test.ts
@@ -1,0 +1,109 @@
+import { getTableConfig, PgDialect } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+
+import {
+  PI_MEMORY_PHASE2_JOB_STATUSES,
+  PI_MEMORY_PHASE2_MAX_ATTEMPTS,
+  PI_MEMORY_PHASE2_MAX_SELECTED_CANDIDATES,
+  PI_MEMORY_PHASE2_MAX_SELECTED_UTF8_BYTES,
+  piMemoryPhase2Jobs,
+} from "../schema/pi-memory-phase2-job";
+import { storages } from "../schema/storage";
+
+describe("Pi memory Phase 2 job schema", () => {
+  it("owns one job per exact Storage owner with claim and export indexes", () => {
+    const config = getTableConfig(piMemoryPhase2Jobs);
+    expect(config.primaryKeys).toHaveLength(1);
+    expect(config.primaryKeys[0]?.getName()).toBe("pi_memory_phase2_jobs_pkey");
+    expect(
+      config.primaryKeys[0]?.columns.map((column) => {
+        return column.name;
+      }),
+    ).toStrictEqual(["memory_storage_id"]);
+
+    const ownerForeignKey = config.foreignKeys.find((foreignKey) => {
+      return foreignKey.getName() === "pi_memory_phase2_jobs_storage_owner_fk";
+    });
+    expect(ownerForeignKey?.onDelete).toBe("cascade");
+    expect(ownerForeignKey?.reference().foreignTable).toBe(storages);
+    expect(
+      ownerForeignKey?.reference().columns.map((column) => {
+        return column.name;
+      }),
+    ).toStrictEqual(["memory_storage_id", "org_id", "user_id"]);
+
+    expect(
+      config.indexes.map((candidate) => {
+        return candidate.config.name;
+      }),
+    ).toStrictEqual([
+      "idx_pi_memory_phase2_jobs_claimable",
+      "idx_pi_memory_phase2_jobs_user_export",
+    ]);
+    expect(config.columns).toHaveLength(18);
+  });
+
+  it("pins every status, revision, retry, selection, and payload boundary", () => {
+    expect(PI_MEMORY_PHASE2_JOB_STATUSES).toStrictEqual([
+      "idle",
+      "pending",
+      "leased",
+      "retryable_failure",
+      "terminal_failure",
+    ]);
+    expect(PI_MEMORY_PHASE2_MAX_ATTEMPTS).toBe(3);
+    expect(PI_MEMORY_PHASE2_MAX_SELECTED_CANDIDATES).toBe(256);
+    expect(PI_MEMORY_PHASE2_MAX_SELECTED_UTF8_BYTES).toBe(21_036_800);
+
+    const dialect = new PgDialect();
+    const checks = Object.fromEntries(
+      getTableConfig(piMemoryPhase2Jobs).checks.map((candidate) => {
+        return [candidate.name, dialect.sqlToQuery(candidate.value).sql];
+      }),
+    );
+    expect(Object.keys(checks)).toStrictEqual([
+      "pi_memory_phase2_jobs_status_check",
+      "pi_memory_phase2_jobs_revisions_check",
+      "pi_memory_phase2_jobs_retry_count_check",
+      "pi_memory_phase2_jobs_error_class_check",
+      "pi_memory_phase2_jobs_selection_check",
+      "pi_memory_phase2_jobs_state_check",
+    ]);
+    expect(checks.pi_memory_phase2_jobs_status_check).toContain(
+      "terminal_failure",
+    );
+    expect(checks.pi_memory_phase2_jobs_revisions_check).toContain(
+      '"completed_revision" < "pi_memory_phase2_jobs"."claimed_revision"',
+    );
+    expect(checks.pi_memory_phase2_jobs_retry_count_check).toContain("<= 3");
+    expect(checks.pi_memory_phase2_jobs_error_class_check).toContain("{0,127}");
+    expect(checks.pi_memory_phase2_jobs_selection_check).toContain("<= 256");
+    expect(checks.pi_memory_phase2_jobs_selection_check).toContain(
+      '"claimed_selected_count" IS NOT NULL',
+    );
+    expect(checks.pi_memory_phase2_jobs_selection_check).toContain(
+      "<= 21036800",
+    );
+
+    const stateCheck = checks.pi_memory_phase2_jobs_state_check;
+    expect(stateCheck).toBeDefined();
+    if (stateCheck === undefined) {
+      throw new Error("Expected the Pi memory Phase 2 state constraint");
+    }
+    expect(stateCheck).toMatch(
+      /"status" = 'idle'[\s\S]*?"completed_revision" = "pi_memory_phase2_jobs"\."input_revision"/u,
+    );
+    expect(stateCheck).toMatch(
+      /"status" = 'pending'[\s\S]*?"completed_revision" < "pi_memory_phase2_jobs"\."input_revision"/u,
+    );
+    expect(stateCheck).toMatch(
+      /"status" = 'leased'[\s\S]*?"claimed_revision" IS NOT NULL[\s\S]*?"claimed_selection_digest" IS NOT NULL/u,
+    );
+    expect(stateCheck).toMatch(
+      /"status" = 'retryable_failure'[\s\S]*?"retry_count" < 3/u,
+    );
+    expect(stateCheck).toMatch(
+      /"status" = 'terminal_failure'[\s\S]*?"retry_count" = 3/u,
+    );
+  });
+});

--- a/turbo/packages/db/src/index.ts
+++ b/turbo/packages/db/src/index.ts
@@ -130,6 +130,7 @@ import * as presentationTemplateSchema from "./schema/presentation-template";
 import * as piResourceSnapshotSchema from "./schema/pi-resource-snapshot";
 import * as memorySummaryProjectionSchema from "./schema/memory-summary-projection";
 import * as piMemoryStage1CandidateSchema from "./schema/pi-memory-stage1-candidate";
+import * as piMemoryPhase2JobSchema from "./schema/pi-memory-phase2-job";
 
 export const schema = {
   ...userSchema,
@@ -264,6 +265,7 @@ export const schema = {
   ...piResourceSnapshotSchema,
   ...memorySummaryProjectionSchema,
   ...piMemoryStage1CandidateSchema,
+  ...piMemoryPhase2JobSchema,
 };
 
 export type DatabaseSchema = typeof schema;

--- a/turbo/packages/db/src/migrations/1060_steady_talisman.sql
+++ b/turbo/packages/db/src/migrations/1060_steady_talisman.sql
@@ -1,0 +1,136 @@
+CREATE TABLE "pi_memory_phase2_jobs" (
+	"memory_storage_id" uuid NOT NULL,
+	"org_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"status" varchar(32) DEFAULT 'pending' NOT NULL,
+	"input_revision" integer DEFAULT 1 NOT NULL,
+	"completed_revision" integer DEFAULT 0 NOT NULL,
+	"claimed_revision" integer,
+	"lease_token" uuid,
+	"lease_expires_at" timestamp,
+	"retry_count" integer DEFAULT 0 NOT NULL,
+	"retry_at" timestamp,
+	"last_error_class" varchar(128),
+	"last_succeeded_at" timestamp,
+	"claimed_selection_digest" varchar(64),
+	"claimed_selected_count" integer,
+	"claimed_selected_utf8_bytes" integer,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "pi_memory_phase2_jobs_pkey" PRIMARY KEY("memory_storage_id"),
+	CONSTRAINT "pi_memory_phase2_jobs_status_check" CHECK ("pi_memory_phase2_jobs"."status" IN ('idle', 'pending', 'leased', 'retryable_failure', 'terminal_failure')),
+	CONSTRAINT "pi_memory_phase2_jobs_revisions_check" CHECK ("pi_memory_phase2_jobs"."input_revision" > 0 AND
+          "pi_memory_phase2_jobs"."completed_revision" >= 0 AND
+          "pi_memory_phase2_jobs"."completed_revision" <= "pi_memory_phase2_jobs"."input_revision" AND
+          (
+            "pi_memory_phase2_jobs"."claimed_revision" IS NULL OR (
+              "pi_memory_phase2_jobs"."completed_revision" < "pi_memory_phase2_jobs"."claimed_revision" AND
+              "pi_memory_phase2_jobs"."claimed_revision" <= "pi_memory_phase2_jobs"."input_revision"
+            )
+          )),
+	CONSTRAINT "pi_memory_phase2_jobs_retry_count_check" CHECK ("pi_memory_phase2_jobs"."retry_count" >= 0 AND "pi_memory_phase2_jobs"."retry_count" <= 3),
+	CONSTRAINT "pi_memory_phase2_jobs_error_class_check" CHECK ("pi_memory_phase2_jobs"."last_error_class" IS NULL OR "pi_memory_phase2_jobs"."last_error_class" ~ '^[a-z][a-z0-9_]{0,127}$'),
+	CONSTRAINT "pi_memory_phase2_jobs_selection_check" CHECK ((
+          "pi_memory_phase2_jobs"."claimed_selection_digest" IS NULL AND
+          "pi_memory_phase2_jobs"."claimed_selected_count" IS NULL AND
+          "pi_memory_phase2_jobs"."claimed_selected_utf8_bytes" IS NULL
+        ) OR (
+          "pi_memory_phase2_jobs"."claimed_selection_digest" IS NOT NULL AND
+          "pi_memory_phase2_jobs"."claimed_selected_count" IS NOT NULL AND
+          "pi_memory_phase2_jobs"."claimed_selected_utf8_bytes" IS NOT NULL AND
+          "pi_memory_phase2_jobs"."claimed_selection_digest" ~ '^[0-9a-f]{64}$' AND
+          "pi_memory_phase2_jobs"."claimed_selected_count" >= 0 AND
+          "pi_memory_phase2_jobs"."claimed_selected_count" <= 256 AND
+          "pi_memory_phase2_jobs"."claimed_selected_utf8_bytes" >= 0 AND
+          "pi_memory_phase2_jobs"."claimed_selected_utf8_bytes" <= 21036800
+        )),
+	CONSTRAINT "pi_memory_phase2_jobs_state_check" CHECK ((
+          "pi_memory_phase2_jobs"."status" = 'idle' AND
+          "pi_memory_phase2_jobs"."completed_revision" = "pi_memory_phase2_jobs"."input_revision" AND
+          "pi_memory_phase2_jobs"."claimed_revision" IS NULL AND
+          "pi_memory_phase2_jobs"."lease_token" IS NULL AND
+          "pi_memory_phase2_jobs"."lease_expires_at" IS NULL AND
+          "pi_memory_phase2_jobs"."retry_count" = 0 AND
+          "pi_memory_phase2_jobs"."retry_at" IS NULL AND
+          "pi_memory_phase2_jobs"."last_error_class" IS NULL AND
+          "pi_memory_phase2_jobs"."claimed_selection_digest" IS NULL AND
+          "pi_memory_phase2_jobs"."claimed_selected_count" IS NULL AND
+          "pi_memory_phase2_jobs"."claimed_selected_utf8_bytes" IS NULL
+        ) OR (
+          "pi_memory_phase2_jobs"."status" = 'pending' AND
+          "pi_memory_phase2_jobs"."completed_revision" < "pi_memory_phase2_jobs"."input_revision" AND
+          "pi_memory_phase2_jobs"."claimed_revision" IS NULL AND
+          "pi_memory_phase2_jobs"."lease_token" IS NULL AND
+          "pi_memory_phase2_jobs"."lease_expires_at" IS NULL AND
+          "pi_memory_phase2_jobs"."retry_count" = 0 AND
+          "pi_memory_phase2_jobs"."retry_at" IS NULL AND
+          "pi_memory_phase2_jobs"."last_error_class" IS NULL AND
+          "pi_memory_phase2_jobs"."claimed_selection_digest" IS NULL AND
+          "pi_memory_phase2_jobs"."claimed_selected_count" IS NULL AND
+          "pi_memory_phase2_jobs"."claimed_selected_utf8_bytes" IS NULL
+        ) OR (
+          "pi_memory_phase2_jobs"."status" = 'leased' AND
+          "pi_memory_phase2_jobs"."claimed_revision" IS NOT NULL AND
+          "pi_memory_phase2_jobs"."completed_revision" < "pi_memory_phase2_jobs"."claimed_revision" AND
+          "pi_memory_phase2_jobs"."claimed_revision" <= "pi_memory_phase2_jobs"."input_revision" AND
+          "pi_memory_phase2_jobs"."lease_token" IS NOT NULL AND
+          "pi_memory_phase2_jobs"."lease_expires_at" IS NOT NULL AND
+          "pi_memory_phase2_jobs"."retry_count" >= 0 AND
+          "pi_memory_phase2_jobs"."retry_count" < 3 AND
+          "pi_memory_phase2_jobs"."retry_at" IS NULL AND
+          "pi_memory_phase2_jobs"."last_error_class" IS NULL AND
+          "pi_memory_phase2_jobs"."claimed_selection_digest" IS NOT NULL AND
+          "pi_memory_phase2_jobs"."claimed_selected_count" IS NOT NULL AND
+          "pi_memory_phase2_jobs"."claimed_selected_utf8_bytes" IS NOT NULL
+        ) OR (
+          "pi_memory_phase2_jobs"."status" = 'retryable_failure' AND
+          "pi_memory_phase2_jobs"."completed_revision" < "pi_memory_phase2_jobs"."input_revision" AND
+          "pi_memory_phase2_jobs"."claimed_revision" IS NULL AND
+          "pi_memory_phase2_jobs"."lease_token" IS NULL AND
+          "pi_memory_phase2_jobs"."lease_expires_at" IS NULL AND
+          "pi_memory_phase2_jobs"."retry_count" > 0 AND
+          "pi_memory_phase2_jobs"."retry_count" < 3 AND
+          "pi_memory_phase2_jobs"."retry_at" IS NOT NULL AND
+          "pi_memory_phase2_jobs"."last_error_class" IS NOT NULL AND
+          "pi_memory_phase2_jobs"."claimed_selection_digest" IS NULL AND
+          "pi_memory_phase2_jobs"."claimed_selected_count" IS NULL AND
+          "pi_memory_phase2_jobs"."claimed_selected_utf8_bytes" IS NULL
+        ) OR (
+          "pi_memory_phase2_jobs"."status" = 'terminal_failure' AND
+          "pi_memory_phase2_jobs"."completed_revision" < "pi_memory_phase2_jobs"."input_revision" AND
+          "pi_memory_phase2_jobs"."claimed_revision" IS NULL AND
+          "pi_memory_phase2_jobs"."lease_token" IS NULL AND
+          "pi_memory_phase2_jobs"."lease_expires_at" IS NULL AND
+          "pi_memory_phase2_jobs"."retry_count" = 3 AND
+          "pi_memory_phase2_jobs"."retry_at" IS NULL AND
+          "pi_memory_phase2_jobs"."last_error_class" IS NOT NULL AND
+          "pi_memory_phase2_jobs"."claimed_selection_digest" IS NULL AND
+          "pi_memory_phase2_jobs"."claimed_selected_count" IS NULL AND
+          "pi_memory_phase2_jobs"."claimed_selected_utf8_bytes" IS NULL
+        ))
+);
+--> statement-breakpoint
+ALTER TABLE "pi_memory_phase2_jobs" ADD CONSTRAINT "pi_memory_phase2_jobs_storage_owner_fk" FOREIGN KEY ("memory_storage_id","org_id","user_id") REFERENCES "public"."storages"("id","org_id","user_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_pi_memory_phase2_jobs_claimable" ON "pi_memory_phase2_jobs" USING btree ("status","retry_at","lease_expires_at","last_succeeded_at","updated_at","memory_storage_id") WHERE "pi_memory_phase2_jobs"."completed_revision" < "pi_memory_phase2_jobs"."input_revision" AND "pi_memory_phase2_jobs"."status" IN ('pending', 'leased', 'retryable_failure');--> statement-breakpoint
+CREATE INDEX "idx_pi_memory_phase2_jobs_user_export" ON "pi_memory_phase2_jobs" USING btree ("user_id","org_id","memory_storage_id");
+--> statement-breakpoint
+INSERT INTO "pi_memory_phase2_jobs" (
+	"memory_storage_id",
+	"org_id",
+	"user_id",
+	"status",
+	"input_revision",
+	"completed_revision",
+	"retry_count"
+)
+SELECT DISTINCT
+	"memory_storage_id",
+	"org_id",
+	"user_id",
+	'pending',
+	1,
+	0,
+	0
+FROM "pi_memory_stage1_candidates"
+WHERE "status" IN ('succeeded', 'succeeded_no_output')
+ON CONFLICT ("memory_storage_id") DO NOTHING;

--- a/turbo/packages/db/src/migrations/meta/1060_snapshot.json
+++ b/turbo/packages/db/src/migrations/meta/1060_snapshot.json
@@ -1,0 +1,29705 @@
+{
+  "id": "e6a93342-5789-4228-8c4c-5525535652e3",
+  "prevId": "122d75d1-8a1b-4657-a2c3-172e8c8bd295",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.active_input_deliveries": {
+      "name": "active_input_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        }
+      },
+      "indexes": {
+        "active_input_deliveries_run_open_unique": {
+          "name": "active_input_deliveries_run_open_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"active_input_deliveries\".\"status\" = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "active_input_deliveries_thread_open_idx": {
+          "name": "active_input_deliveries_thread_open_idx",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"active_input_deliveries\".\"status\" = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "active_input_deliveries_run_id_agent_runs_id_fk": {
+          "name": "active_input_deliveries_run_id_agent_runs_id_fk",
+          "tableFrom": "active_input_deliveries",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "active_input_deliveries_chat_thread_id_chat_threads_id_fk": {
+          "name": "active_input_deliveries_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "active_input_deliveries",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "active_input_deliveries_status_check": {
+          "name": "active_input_deliveries_status_check",
+          "value": "\"active_input_deliveries\".\"status\" IN ('open', 'settled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.active_input_delivery_items": {
+      "name": "active_input_delivery_items",
+      "schema": "",
+      "columns": {
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "active_input_delivery_items_delivery_position_unique": {
+          "name": "active_input_delivery_items_delivery_position_unique",
+          "columns": [
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "active_input_delivery_items_source_open_unique": {
+          "name": "active_input_delivery_items_source_open_unique",
+          "columns": [
+            {
+              "expression": "source_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"active_input_delivery_items\".\"disposition\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "active_input_delivery_items_delivery_id_active_input_deliveries_id_fk": {
+          "name": "active_input_delivery_items_delivery_id_active_input_deliveries_id_fk",
+          "tableFrom": "active_input_delivery_items",
+          "tableTo": "active_input_deliveries",
+          "columnsFrom": [
+            "delivery_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "active_input_delivery_items_source_event_id_chat_events_id_fk": {
+          "name": "active_input_delivery_items_source_event_id_chat_events_id_fk",
+          "tableFrom": "active_input_delivery_items",
+          "tableTo": "chat_events",
+          "columnsFrom": [
+            "source_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "active_input_delivery_items_delivery_id_source_event_id_pk": {
+          "name": "active_input_delivery_items_delivery_id_source_event_id_pk",
+          "columns": [
+            "delivery_id",
+            "source_event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "active_input_delivery_items_position_check": {
+          "name": "active_input_delivery_items_position_check",
+          "value": "\"active_input_delivery_items\".\"position\" >= 0"
+        },
+        "active_input_delivery_items_disposition_check": {
+          "name": "active_input_delivery_items_disposition_check",
+          "value": "\"active_input_delivery_items\".\"disposition\" IS NULL OR \"active_input_delivery_items\".\"disposition\" IN ('delivered', 'released', 'expired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_drafts": {
+      "name": "agent_drafts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_user_message": {
+          "name": "draft_user_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_attachments": {
+          "name": "draft_attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_drafts_user_org_agent": {
+          "name": "idx_agent_drafts_user_org_agent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_drafts_agent_id_agents_id_fk": {
+          "name": "agent_drafts_agent_id_agents_id_fk",
+          "tableFrom": "agent_drafts",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_drafts_draft_user_message_check": {
+          "name": "agent_drafts_draft_user_message_check",
+          "value": "\"agent_drafts\".\"draft_user_message\" IS NOT NULL\n          OR COALESCE(\"agent_drafts\".\"draft_attachments\", '[]'::jsonb) = '[]'::jsonb"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_run_callbacks": {
+      "name": "agent_run_callbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_kind": {
+          "name": "internal_kind",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_run_callbacks_run_id": {
+          "name": "idx_agent_run_callbacks_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_callbacks_pending": {
+          "name": "idx_agent_run_callbacks_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_callbacks_run_id_agent_runs_id_fk": {
+          "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_callbacks",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_queue": {
+      "name": "agent_run_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_params": {
+          "name": "encrypted_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_run_queue_user_created_idx": {
+          "name": "agent_run_queue_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_org_created_idx": {
+          "name": "agent_run_queue_org_created_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_expires_at_idx": {
+          "name": "agent_run_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_queue_run_id_agent_runs_id_fk": {
+          "name": "agent_run_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "continued_from_session_id": {
+          "name": "continued_from_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "append_system_prompt": {
+          "name": "append_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_names": {
+          "name": "secret_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_mounts": {
+          "name": "storage_mounts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launch_snapshot": {
+          "name": "launch_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_workflow_provenance": {
+          "name": "official_workflow_provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_reuse_result": {
+          "name": "sandbox_reuse_result",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_reuse_result": {
+          "name": "workspace_reuse_result",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_recovery_completed": {
+          "name": "cancellation_recovery_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_sequence": {
+          "name": "last_event_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_id": {
+          "name": "runner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_heartbeat_generation": {
+          "name": "runner_heartbeat_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_hostname": {
+          "name": "runner_hostname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_version": {
+          "name": "runner_version",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_input_enabled": {
+          "name": "active_input_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autonomy_budget": {
+          "name": "autonomy_budget",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_automation_id": {
+          "name": "workflow_automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_credential_scope": {
+          "name": "model_provider_credential_scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_runtime_provider": {
+          "name": "model_runtime_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_runtime_model": {
+          "name": "model_runtime_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "built_in_model_key_id": {
+          "name": "built_in_model_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_service_tier": {
+          "name": "codex_service_tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_video_model": {
+          "name": "selected_video_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_image_model": {
+          "name": "selected_image_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_started_at": {
+          "name": "api_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_assistant_event_acknowledged_at": {
+          "name": "first_assistant_event_acknowledged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_brief": {
+          "name": "trigger_brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_user_created": {
+          "name": "idx_agent_runs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org": {
+          "name": "idx_agent_runs_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_status_heartbeat": {
+          "name": "idx_agent_runs_status_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_running_heartbeat": {
+          "name": "idx_agent_runs_running_heartbeat",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org_status_created": {
+          "name": "idx_agent_runs_org_status_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_session": {
+          "name": "idx_agent_runs_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_chat_thread_id": {
+          "name": "idx_agent_runs_chat_thread_id",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_runs\".\"chat_thread_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_workflow_automation": {
+          "name": "idx_agent_runs_workflow_automation",
+          "columns": [
+            {
+              "expression": "workflow_automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_runs\".\"workflow_automation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_goal": {
+          "name": "idx_agent_runs_goal",
+          "columns": [
+            {
+              "expression": "goal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_runs\".\"goal_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_session_id_agent_sessions_id_fk": {
+          "name": "agent_runs_session_id_agent_sessions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_runs_workflow_automation_id_workflow_automations_id_fk": {
+          "name": "agent_runs_workflow_automation_id_workflow_automations_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "workflow_automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_runs_goal_id_thread_goals_id_fk": {
+          "name": "agent_runs_goal_id_thread_goals_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "thread_goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_runs_chat_thread_id_chat_threads_id_fk": {
+          "name": "agent_runs_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_runs_autonomy_budget_check": {
+          "name": "agent_runs_autonomy_budget_check",
+          "value": "\"agent_runs\".\"autonomy_budget\" >= 0 AND \"agent_runs\".\"autonomy_budget\" <= 10"
+        },
+        "agent_runs_metadata_presence_check": {
+          "name": "agent_runs_metadata_presence_check",
+          "value": "(\n          (\n            \"agent_runs\".\"trigger_source\" IS NULL AND\n            \"agent_runs\".\"autonomy_budget\" IS NULL AND\n            \"agent_runs\".\"workflow_automation_id\" IS NULL AND\n            \"agent_runs\".\"goal_id\" IS NULL AND\n            \"agent_runs\".\"model_provider\" IS NULL AND\n            \"agent_runs\".\"model_provider_id\" IS NULL AND\n            \"agent_runs\".\"model_provider_credential_scope\" IS NULL AND\n            \"agent_runs\".\"selected_model\" IS NULL AND\n            \"agent_runs\".\"model_runtime_provider\" IS NULL AND\n            \"agent_runs\".\"model_runtime_model\" IS NULL AND\n            \"agent_runs\".\"built_in_model_key_id\" IS NULL AND\n            \"agent_runs\".\"codex_service_tier\" IS NULL AND\n            \"agent_runs\".\"selected_video_model\" IS NULL AND\n            \"agent_runs\".\"selected_image_model\" IS NULL AND\n            \"agent_runs\".\"chat_thread_id\" IS NULL AND\n            \"agent_runs\".\"api_started_at\" IS NULL AND\n            \"agent_runs\".\"first_assistant_event_acknowledged_at\" IS NULL AND\n            \"agent_runs\".\"summary\" IS NULL AND\n            \"agent_runs\".\"trigger_brief\" IS NULL\n          ) OR (\n            \"agent_runs\".\"trigger_source\" IS NOT NULL AND\n            \"agent_runs\".\"autonomy_budget\" IS NOT NULL\n          )\n        )"
+        },
+        "agent_runs_launch_snapshot_check": {
+          "name": "agent_runs_launch_snapshot_check",
+          "value": "(\n          \"agent_runs\".\"launch_snapshot\" IS NULL OR (\n            jsonb_typeof(\"agent_runs\".\"launch_snapshot\") = 'object' AND\n            jsonb_typeof(\"agent_runs\".\"launch_snapshot\" -> 'framework') = 'string' AND\n            \"agent_runs\".\"launch_snapshot\" ->> 'framework' = ANY (\n              ARRAY['claude-code', 'codex', 'pi']\n            ) AND\n            jsonb_typeof(\n              \"agent_runs\".\"launch_snapshot\" -> 'runnerProfile'\n            ) = 'string' AND\n            char_length(\"agent_runs\".\"launch_snapshot\" ->> 'runnerProfile') >= 1 AND\n            char_length(\"agent_runs\".\"launch_snapshot\" ->> 'runnerProfile') <= 255 AND\n            (\n              (\n                \"agent_runs\".\"launch_snapshot\" ?& ARRAY[\n                  'schemaVersion',\n                  'framework',\n                  'runnerProfile'\n                ] AND\n                (\n                  \"agent_runs\".\"launch_snapshot\" -\n                  'schemaVersion' -\n                  'framework' -\n                  'runnerProfile'\n                ) = '{}'::jsonb AND\n                \"agent_runs\".\"launch_snapshot\" -> 'schemaVersion' = '1'::jsonb\n              ) OR (\n                \"agent_runs\".\"launch_snapshot\" ?& ARRAY[\n                  'schemaVersion',\n                  'framework',\n                  'runnerProfile',\n                  'piMemoryGenerationEnabled'\n                ] AND\n                (\n                  \"agent_runs\".\"launch_snapshot\" -\n                  'schemaVersion' -\n                  'framework' -\n                  'runnerProfile' -\n                  'piMemoryGenerationEnabled'\n                ) = '{}'::jsonb AND\n                \"agent_runs\".\"launch_snapshot\" -> 'schemaVersion' = '2'::jsonb AND\n                jsonb_typeof(\n                  \"agent_runs\".\"launch_snapshot\" -> 'piMemoryGenerationEnabled'\n                ) = 'boolean'\n              )\n            )\n          )\n        )"
+        },
+        "agent_runs_official_workflow_provenance_check": {
+          "name": "agent_runs_official_workflow_provenance_check",
+          "value": "(\n          \"agent_runs\".\"official_workflow_provenance\" IS NULL OR (\n            jsonb_typeof(\"agent_runs\".\"official_workflow_provenance\") = 'object' AND\n            \"agent_runs\".\"official_workflow_provenance\" ?& ARRAY[\n              'schemaVersion',\n              'definitions'\n            ] AND\n            (\n              \"agent_runs\".\"official_workflow_provenance\" -\n              'schemaVersion' -\n              'definitions'\n            ) = '{}'::jsonb AND\n            \"agent_runs\".\"official_workflow_provenance\" -> 'schemaVersion' = '1'::jsonb AND\n            jsonb_typeof(\n              \"agent_runs\".\"official_workflow_provenance\" -> 'definitions'\n            ) = 'array' AND\n            jsonb_array_length(\n              \"agent_runs\".\"official_workflow_provenance\" -> 'definitions'\n            ) > 0 AND\n            NOT jsonb_path_exists(\n              \"agent_runs\".\"official_workflow_provenance\",\n              '$.definitions[*] ? (\n                @.type() != \"object\" ||\n                !exists(@.name) ||\n                @.name.type() != \"string\" ||\n                !(@.name like_regex \"^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$\") ||\n                !exists(@.revision) ||\n                @.revision.type() != \"string\" ||\n                !(@.revision like_regex \"^[0-9a-f]{64}$\") ||\n                !exists(@.artifact) ||\n                @.artifact.type() != \"object\" ||\n                exists(\n                  @.keyvalue() ? (\n                    @.key != \"name\" &&\n                    @.key != \"revision\" &&\n                    @.key != \"artifact\"\n                  )\n                ) ||\n                !exists(@.artifact.orgId) ||\n                @.artifact.orgId != \"__system__\" ||\n                !exists(@.artifact.userId) ||\n                @.artifact.userId != \"__org__\" ||\n                !exists(@.artifact.storageName) ||\n                @.artifact.storageName.type() != \"string\" ||\n                !(@.artifact.storageName like_regex \"^.{1,255}.?$\") ||\n                !exists(@.artifact.storageId) ||\n                @.artifact.storageId.type() != \"string\" ||\n                !(@.artifact.storageId like_regex \"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$\") ||\n                !exists(@.artifact.storageVersion) ||\n                @.artifact.storageVersion.type() != \"string\" ||\n                !(@.artifact.storageVersion like_regex \"^[0-9a-f]{64}$\") ||\n                exists(\n                  @.artifact.keyvalue() ? (\n                    @.key != \"orgId\" &&\n                    @.key != \"userId\" &&\n                    @.key != \"storageName\" &&\n                    @.key != \"storageId\" &&\n                    @.key != \"storageVersion\"\n                  )\n                )\n              )'\n            )\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_mounts": {
+          "name": "storage_mounts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_sessions_user_agent": {
+          "name": "idx_agent_sessions_user_agent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_sessions_org": {
+          "name": "idx_agent_sessions_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_agent_id_agents_id_fk": {
+          "name": "agent_sessions_agent_id_agents_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_conversation_id_conversations_id_fk": {
+          "name": "agent_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_type": {
+          "name": "cli_agent_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_id": {
+          "name": "cli_agent_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_history": {
+          "name": "cli_agent_session_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_agent_session_history_hash": {
+          "name": "cli_agent_session_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_run_id_agent_runs_id_fk": {
+          "name": "conversations_run_id_agent_runs_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_run_id_unique": {
+          "name": "conversations_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sound": {
+          "name": "sound",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefer_personal_provider": {
+          "name": "prefer_personal_provider",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agents_org_name": {
+          "name": "idx_agents_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_org": {
+          "name": "idx_agents_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_model_provider_id_model_providers_id_fk": {
+          "name": "agents_model_provider_id_model_providers_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_chat_thread_routes": {
+      "name": "agentphone_chat_thread_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agentphone_user_link_id": {
+          "name": "agentphone_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentphone_chat_thread_routes_link_root": {
+          "name": "idx_agentphone_chat_thread_routes_link_root",
+          "columns": [
+            {
+              "expression": "agentphone_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_chat_thread_routes_user_link": {
+          "name": "idx_agentphone_chat_thread_routes_user_link",
+          "columns": [
+            {
+              "expression": "agentphone_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_chat_thread_routes_conversation": {
+          "name": "idx_agentphone_chat_thread_routes_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentphone_chat_thread_routes_agentphone_user_link_id_agentphone_user_links_id_fk": {
+          "name": "agentphone_chat_thread_routes_agentphone_user_link_id_agentphone_user_links_id_fk",
+          "tableFrom": "agentphone_chat_thread_routes",
+          "tableTo": "agentphone_user_links",
+          "columnsFrom": [
+            "agentphone_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agentphone_chat_thread_routes_chat_thread_id_chat_threads_id_fk": {
+          "name": "agentphone_chat_thread_routes_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "agentphone_chat_thread_routes",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_messages": {
+      "name": "agentphone_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentphone_message_id": {
+          "name": "agentphone_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentphone_agent_id": {
+          "name": "agentphone_agent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentphone_user_link_id": {
+          "name": "agentphone_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_handle": {
+          "name": "phone_handle",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_number": {
+          "name": "to_number",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentphone_messages_agentphone_message": {
+          "name": "idx_agentphone_messages_agentphone_message",
+          "columns": [
+            {
+              "expression": "agentphone_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_messages_webhook_id": {
+          "name": "idx_agentphone_messages_webhook_id",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "webhook_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_messages_handle_created": {
+          "name": "idx_agentphone_messages_handle_created",
+          "columns": [
+            {
+              "expression": "phone_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_messages_user_link": {
+          "name": "idx_agentphone_messages_user_link",
+          "columns": [
+            {
+              "expression": "agentphone_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentphone_messages_agentphone_user_link_id_agentphone_user_links_id_fk": {
+          "name": "agentphone_messages_agentphone_user_link_id_agentphone_user_links_id_fk",
+          "tableFrom": "agentphone_messages",
+          "tableTo": "agentphone_user_links",
+          "columnsFrom": [
+            "agentphone_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_user_agent_preferences": {
+      "name": "agentphone_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_agent_id": {
+          "name": "selected_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agentphone_user_agent_preferences_selected_agent_id_agents_id_fk": {
+          "name": "agentphone_user_agent_preferences_selected_agent_id_agents_id_fk",
+          "tableFrom": "agentphone_user_agent_preferences",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "selected_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agentphone_user_agent_preferences_user_id_org_id_pk": {
+          "name": "agentphone_user_agent_preferences_user_id_org_id_pk",
+          "columns": [
+            "user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_user_links": {
+      "name": "agentphone_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone_handle": {
+          "name": "phone_handle",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentphone_user_links_phone_handle": {
+          "name": "idx_agentphone_user_links_phone_handle",
+          "columns": [
+            {
+              "expression": "phone_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_user_links_user_org": {
+          "name": "idx_agentphone_user_links_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_user_links_org": {
+          "name": "idx_agentphone_user_links_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_verification_send_cooldowns": {
+      "name": "agentphone_verification_send_cooldowns",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agentphone_verification_send_cooldowns_pkey": {
+          "name": "agentphone_verification_send_cooldowns_pkey",
+          "columns": [
+            "scope",
+            "scope_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.archived_task_runs": {
+      "name": "archived_task_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_run_id": {
+          "name": "archived_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_archived_task_runs_unique": {
+          "name": "idx_archived_task_runs_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifact_catalog_pending_files": {
+      "name": "artifact_catalog_pending_files",
+      "schema": "",
+      "columns": {
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artifact_catalog_pending_owner_idx": {
+          "name": "artifact_catalog_pending_owner_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifact_catalog_pending_files_file_id_run_uploaded_files_id_fk": {
+          "name": "artifact_catalog_pending_files_file_id_run_uploaded_files_id_fk",
+          "tableFrom": "artifact_catalog_pending_files",
+          "tableTo": "run_uploaded_files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logical_key": {
+          "name": "logical_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projection_file_id": {
+          "name": "projection_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projection_created_at": {
+          "name": "projection_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artifacts_kind_entity_unique": {
+          "name": "artifacts_kind_entity_unique",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_author_logical_key_unique": {
+          "name": "artifacts_author_logical_key_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "logical_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_author_created_idx": {
+          "name": "artifacts_author_created_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_author_kind_created_idx": {
+          "name": "artifacts_author_kind_created_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.image_artifacts": {
+      "name": "image_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation_job_id": {
+          "name": "generation_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "image_artifacts_file_unique": {
+          "name": "image_artifacts_file_unique",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "image_artifacts_file_id_run_uploaded_files_id_fk": {
+          "name": "image_artifacts_file_id_run_uploaded_files_id_fk",
+          "tableFrom": "image_artifacts",
+          "tableTo": "run_uploaded_files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "image_artifacts_generation_job_id_built_in_generation_jobs_id_fk": {
+          "name": "image_artifacts_generation_job_id_built_in_generation_jobs_id_fk",
+          "tableFrom": "image_artifacts",
+          "tableTo": "built_in_generation_jobs",
+          "columnsFrom": [
+            "generation_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.presentation_artifacts": {
+      "name": "presentation_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "hosted_site_id": {
+          "name": "hosted_site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation_job_id": {
+          "name": "generation_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "presentation_artifacts_site_unique": {
+          "name": "presentation_artifacts_site_unique",
+          "columns": [
+            {
+              "expression": "hosted_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "presentation_artifacts_hosted_site_id_hosted_sites_id_fk": {
+          "name": "presentation_artifacts_hosted_site_id_hosted_sites_id_fk",
+          "tableFrom": "presentation_artifacts",
+          "tableTo": "hosted_sites",
+          "columnsFrom": [
+            "hosted_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "presentation_artifacts_generation_job_id_built_in_generation_jobs_id_fk": {
+          "name": "presentation_artifacts_generation_job_id_built_in_generation_jobs_id_fk",
+          "tableFrom": "presentation_artifacts",
+          "tableTo": "built_in_generation_jobs",
+          "columnsFrom": [
+            "generation_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.video_artifacts": {
+      "name": "video_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation_job_id": {
+          "name": "generation_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "video_artifacts_file_unique": {
+          "name": "video_artifacts_file_unique",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "video_artifacts_file_id_run_uploaded_files_id_fk": {
+          "name": "video_artifacts_file_id_run_uploaded_files_id_fk",
+          "tableFrom": "video_artifacts",
+          "tableTo": "run_uploaded_files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "video_artifacts_generation_job_id_built_in_generation_jobs_id_fk": {
+          "name": "video_artifacts_generation_job_id_built_in_generation_jobs_id_fk",
+          "tableFrom": "video_artifacts",
+          "tableTo": "built_in_generation_jobs",
+          "columnsFrom": [
+            "generation_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banking_access_audit_events": {
+      "name": "banking_access_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finicity'"
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_banking_access_audit_org_user": {
+          "name": "idx_banking_access_audit_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_access_audit_run": {
+          "name": "idx_banking_access_audit_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_access_audit_created": {
+          "name": "idx_banking_access_audit_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banking_accounts": {
+      "name": "banking_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institution_name": {
+          "name": "institution_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institution_login_id": {
+          "name": "institution_login_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_number_last4": {
+          "name": "account_number_last4",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "repair_required_at": {
+          "name": "repair_required_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_banking_accounts_connection_provider_account": {
+          "name": "idx_banking_accounts_connection_provider_account",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_accounts_org_user": {
+          "name": "idx_banking_accounts_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banking_accounts_connection_id_banking_connections_id_fk": {
+          "name": "banking_accounts_connection_id_banking_connections_id_fk",
+          "tableFrom": "banking_accounts",
+          "tableTo": "banking_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banking_agent_enablements": {
+      "name": "banking_agent_enablements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_provider_ids": {
+          "name": "account_provider_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "operation_scopes": {
+          "name": "operation_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"accounts.read\",\"balances.read\",\"transactions.read\"]'::jsonb"
+        },
+        "allow_automation_runs": {
+          "name": "allow_automation_runs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_banking_agent_enablements_unique": {
+          "name": "idx_banking_agent_enablements_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_agent_enablements_agent_user": {
+          "name": "idx_banking_agent_enablements_agent_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banking_agent_enablements_connection_id_banking_connections_id_fk": {
+          "name": "banking_agent_enablements_connection_id_banking_connections_id_fk",
+          "tableFrom": "banking_agent_enablements",
+          "tableTo": "banking_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "banking_agent_enablements_agent_id_agents_id_fk": {
+          "name": "banking_agent_enablements_agent_id_agents_id_fk",
+          "tableFrom": "banking_agent_enablements",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banking_connect_events": {
+      "name": "banking_connect_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_occurred_at": {
+          "name": "provider_occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_banking_connect_events_session": {
+          "name": "idx_banking_connect_events_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banking_connect_events_session_id_banking_connect_sessions_id_fk": {
+          "name": "banking_connect_events_session_id_banking_connect_sessions_id_fk",
+          "tableFrom": "banking_connect_events",
+          "tableTo": "banking_connect_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banking_connect_sessions": {
+      "name": "banking_connect_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "institution_login_id": {
+          "name": "institution_login_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_at": {
+          "name": "done_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_banking_connect_sessions_owner": {
+          "name": "idx_banking_connect_sessions_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_connect_sessions_connection": {
+          "name": "idx_banking_connect_sessions_connection",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_connect_sessions_one_pending": {
+          "name": "idx_banking_connect_sessions_one_pending",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"banking_connect_sessions\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banking_connect_sessions_connection_id_banking_connections_id_fk": {
+          "name": "banking_connect_sessions_connection_id_banking_connections_id_fk",
+          "tableFrom": "banking_connect_sessions",
+          "tableTo": "banking_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banking_connections": {
+      "name": "banking_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finicity'"
+        },
+        "provider_customer_id": {
+          "name": "provider_customer_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "consent_expires_at": {
+          "name": "consent_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repair_required_at": {
+          "name": "repair_required_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit_metadata": {
+          "name": "audit_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_banking_connections_owner_provider": {
+          "name": "idx_banking_connections_owner_provider",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_connections_org_user": {
+          "name": "idx_banking_connections_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raw_size": {
+          "name": "raw_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encoding": {
+          "name": "encoding",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encoded_size": {
+          "name": "encoded_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blobs_ref_count": {
+          "name": "idx_blobs_ref_count",
+          "columns": [
+            {
+              "expression": "ref_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_authorization_requests": {
+      "name": "browser_authorization_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_token_hash": {
+          "name": "request_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_browser_authorization_requests_token_hash": {
+          "name": "uq_browser_authorization_requests_token_hash",
+          "columns": [
+            {
+              "expression": "request_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_browser_authorization_requests_owner": {
+          "name": "idx_browser_authorization_requests_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_browser_authorization_requests_expires": {
+          "name": "idx_browser_authorization_requests_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_profiles": {
+      "name": "browser_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_profile_id": {
+          "name": "provider_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_browser_profiles_owner": {
+          "name": "uq_browser_profiles_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_browser_profiles_provider_profile": {
+          "name": "uq_browser_profiles_provider_profile",
+          "columns": [
+            {
+              "expression": "provider_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_session_instances": {
+      "name": "browser_session_instances",
+      "schema": "",
+      "columns": {
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "browser_session_id": {
+          "name": "browser_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timeout_at": {
+          "name": "timeout_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_touched_at": {
+          "name": "last_touched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "idle_expires_at": {
+          "name": "idle_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now() + interval '10 minutes'"
+        },
+        "stop_requested_at": {
+          "name": "stop_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_browser_session_instances_session": {
+          "name": "idx_browser_session_instances_session",
+          "columns": [
+            {
+              "expression": "browser_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_browser_session_instances_thread": {
+          "name": "idx_browser_session_instances_thread",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_browser_session_instances_run_status": {
+          "name": "idx_browser_session_instances_run_status",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_browser_session_instances_reconcile": {
+          "name": "idx_browser_session_instances_reconcile",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_browser_session_instances_thread_owned": {
+          "name": "uq_browser_session_instances_thread_owned",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"browser_session_instances\".\"status\" IN ('active', 'stopping')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "browser_session_instances_browser_session_id_browser_sessions_id_fk": {
+          "name": "browser_session_instances_browser_session_id_browser_sessions_id_fk",
+          "tableFrom": "browser_session_instances",
+          "tableTo": "browser_sessions",
+          "columnsFrom": [
+            "browser_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_session_resize_states": {
+      "name": "browser_session_resize_states",
+      "schema": "",
+      "columns": {
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "screen_width": {
+          "name": "screen_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "screen_height": {
+          "name": "screen_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "browser_session_resize_states_provider_session_id_browser_session_instances_provider_session_id_fk": {
+          "name": "browser_session_resize_states_provider_session_id_browser_session_instances_provider_session_id_fk",
+          "tableFrom": "browser_session_resize_states",
+          "tableTo": "browser_session_instances",
+          "columnsFrom": [
+            "provider_session_id"
+          ],
+          "columnsTo": [
+            "provider_session_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_session_screenshot_deletions": {
+      "name": "browser_session_screenshot_deletions",
+      "schema": "",
+      "columns": {
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_session_screenshots": {
+      "name": "browser_session_screenshots",
+      "schema": "",
+      "columns": {
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_session_tab_snapshots": {
+      "name": "browser_session_tab_snapshots",
+      "schema": "",
+      "columns": {
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "encrypted_tab_urls": {
+          "name": "encrypted_tab_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "browser_session_tab_snapshots_chat_thread_id_chat_threads_id_fk": {
+          "name": "browser_session_tab_snapshots_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "browser_session_tab_snapshots",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_sessions": {
+      "name": "browser_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_profile_id": {
+          "name": "browser_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_thread_profile_id": {
+          "name": "browser_thread_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_country_code": {
+          "name": "proxy_country_code",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_minutes": {
+          "name": "timeout_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspension_reason": {
+          "name": "suspension_reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_browser_sessions_chat_thread_created": {
+          "name": "idx_browser_sessions_chat_thread_created",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_browser_sessions_owner_created": {
+          "name": "idx_browser_sessions_owner_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_browser_sessions_reconcile": {
+          "name": "idx_browser_sessions_reconcile",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_browser_sessions_thread_owned": {
+          "name": "uq_browser_sessions_thread_owned",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"browser_sessions\".\"status\" IN ('creating', 'active', 'resuming', 'stopping')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "browser_sessions_run_id_agent_runs_id_fk": {
+          "name": "browser_sessions_run_id_agent_runs_id_fk",
+          "tableFrom": "browser_sessions",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "browser_sessions_browser_profile_id_browser_profiles_id_fk": {
+          "name": "browser_sessions_browser_profile_id_browser_profiles_id_fk",
+          "tableFrom": "browser_sessions",
+          "tableTo": "browser_profiles",
+          "columnsFrom": [
+            "browser_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "browser_sessions_browser_thread_profile_id_browser_thread_profiles_id_fk": {
+          "name": "browser_sessions_browser_thread_profile_id_browser_thread_profiles_id_fk",
+          "tableFrom": "browser_sessions",
+          "tableTo": "browser_thread_profiles",
+          "columnsFrom": [
+            "browser_thread_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_thread_profiles": {
+      "name": "browser_thread_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_profile_id": {
+          "name": "provider_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_browser_thread_profiles_thread": {
+          "name": "uq_browser_thread_profiles_thread",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_browser_thread_profiles_provider_profile": {
+          "name": "uq_browser_thread_profiles_provider_profile",
+          "columns": [
+            {
+              "expression": "provider_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_browser_thread_profiles_owner": {
+          "name": "idx_browser_thread_profiles_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.built_in_generation_jobs": {
+      "name": "built_in_generation_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_built_in_generation_jobs_user_created": {
+          "name": "idx_built_in_generation_jobs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_built_in_generation_jobs_org_status": {
+          "name": "idx_built_in_generation_jobs_org_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_built_in_generation_jobs_run": {
+          "name": "idx_built_in_generation_jobs_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "built_in_generation_jobs_run_id_agent_runs_id_fk": {
+          "name": "built_in_generation_jobs_run_id_agent_runs_id_fk",
+          "tableFrom": "built_in_generation_jobs",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.built_in_model_candidate_cooldown": {
+      "name": "built_in_model_candidate_cooldown",
+      "schema": "",
+      "columns": {
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_model": {
+          "name": "upstream_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unavailable_until": {
+          "name": "unavailable_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_observation_started_at": {
+          "name": "connection_observation_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_observation_until": {
+          "name": "connection_observation_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "built_in_model_candidate_cooldown_selected_model_provider_type_upstream_model_pk": {
+          "name": "built_in_model_candidate_cooldown_selected_model_provider_type_upstream_model_pk",
+          "columns": [
+            "selected_model",
+            "provider_type",
+            "upstream_model"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "built_in_model_cooldown_observation_pair_check": {
+          "name": "built_in_model_cooldown_observation_pair_check",
+          "value": "(\"built_in_model_candidate_cooldown\".\"connection_observation_started_at\" IS NULL AND \"built_in_model_candidate_cooldown\".\"connection_observation_until\" IS NULL) OR (\"built_in_model_candidate_cooldown\".\"connection_observation_started_at\" IS NOT NULL AND \"built_in_model_candidate_cooldown\".\"connection_observation_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.built_in_model_keys": {
+      "name": "built_in_model_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_built_in_model_keys_vendor": {
+          "name": "idx_built_in_model_keys_vendor",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_agent_run_context": {
+      "name": "chat_agent_run_context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_chat_thread_id": {
+          "name": "source_chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_agent_id": {
+          "name": "source_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_agentphone_context": {
+      "name": "chat_agentphone_context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_text": {
+          "name": "message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_context": {
+          "name": "thread_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_group": {
+          "name": "is_group",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_handle": {
+          "name": "phone_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_number": {
+          "name": "to_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_link_id": {
+          "name": "user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentphone_agent_id": {
+          "name": "agentphone_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_agentphone_context_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_agentphone_context_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_agentphone_context",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_automation_context": {
+      "name": "chat_automation_context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_brief": {
+          "name": "trigger_brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connector_source_id": {
+          "name": "connector_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "event_payload": {
+          "name": "event_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_automation_context_automation_id_idx": {
+          "name": "chat_automation_context_automation_id_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_automation_context_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_automation_context_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_automation_context",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_event_search_message_watermarks": {
+      "name": "chat_event_search_message_watermarks",
+      "schema": "",
+      "columns": {
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "indexed_seq_id": {
+          "name": "indexed_seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_event_search_messages": {
+      "name": "chat_event_search_messages",
+      "schema": "",
+      "columns": {
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq_id": {
+          "name": "seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_bigram": {
+          "name": "text_bigram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tsv": {
+          "name": "tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', text_bigram)",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "chat_event_search_messages_user_org_created_idx": {
+          "name": "chat_event_search_messages_user_org_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_event_search_messages_user_org_agent_id_created_idx": {
+          "name": "chat_event_search_messages_user_org_agent_id_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_event_search_messages_tsv_idx": {
+          "name": "chat_event_search_messages_tsv_idx",
+          "columns": [
+            {
+              "expression": "tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_event_search_messages_chat_thread_id_seq_id_pk": {
+          "name": "chat_event_search_messages_chat_thread_id_seq_id_pk",
+          "columns": [
+            "chat_thread_id",
+            "seq_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_event_snapshot_scan_state": {
+      "name": "chat_event_snapshot_scan_state",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor_chat_thread_id": {
+          "name": "cursor_chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cycle_upper_bound_last_message_at": {
+          "name": "cycle_upper_bound_last_message_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_event_snapshot_scan_state_scope_check": {
+          "name": "chat_event_snapshot_scan_state_scope_check",
+          "value": "\"chat_event_snapshot_scan_state\".\"scope\" = 'global'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.chat_event_snapshots": {
+      "name": "chat_event_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seq_id": {
+          "name": "last_seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_event_id": {
+          "name": "terminal_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_seq_id": {
+          "name": "terminal_seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_schema_version": {
+          "name": "archive_schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_event_snapshots_thread_idx": {
+          "name": "chat_event_snapshots_thread_idx",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_event_snapshots_object_key_idx": {
+          "name": "chat_event_snapshots_object_key_idx",
+          "columns": [
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_event_snapshots_thread_version_unique": {
+          "name": "chat_event_snapshots_thread_version_unique",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archive_schema_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_event_snapshots_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_event_snapshots_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_event_snapshots",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_event_snapshots_archive_schema_version_check": {
+          "name": "chat_event_snapshots_archive_schema_version_check",
+          "value": "\"chat_event_snapshots\".\"archive_schema_version\" = 7"
+        },
+        "chat_event_snapshots_terminal_cursor_check": {
+          "name": "chat_event_snapshots_terminal_cursor_check",
+          "value": "(\n          \"chat_event_snapshots\".\"terminal_event_id\" IS NULL\n          AND \"chat_event_snapshots\".\"terminal_seq_id\" = 0\n        ) OR (\n          \"chat_event_snapshots\".\"terminal_event_id\" IS NOT NULL\n          AND \"chat_event_snapshots\".\"terminal_seq_id\" > 0\n          AND \"chat_event_snapshots\".\"terminal_seq_id\" <= \"chat_event_snapshots\".\"last_seq_id\"\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.chat_events": {
+      "name": "chat_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokes_event_id": {
+          "name": "revokes_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_official_workflow_ids": {
+          "name": "required_official_workflow_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_type": {
+          "name": "context_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_event_sequence_number": {
+          "name": "run_event_sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_event_id": {
+          "name": "run_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq_id": {
+          "name": "seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_events_created_at_id": {
+          "name": "idx_chat_events_created_at_id",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_events_thread_created": {
+          "name": "idx_chat_events_thread_created",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_events_thread_run_terminal_created": {
+          "name": "idx_chat_events_thread_run_terminal_created",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"chat_events\".\"event_type\" IN ('run.completed', 'run.failed', 'run.cancelled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_events_run_id": {
+          "name": "idx_chat_events_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_events_revokes_event_id_not_null_unique": {
+          "name": "chat_events_revokes_event_id_not_null_unique",
+          "columns": [
+            {
+              "expression": "revokes_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"chat_events\".\"revokes_event_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_events_input_automation_context_idx": {
+          "name": "chat_events_input_automation_context_idx",
+          "columns": [
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"chat_events\".\"event_type\" = 'input.automation'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_events_pending_queue_idx": {
+          "name": "chat_events_pending_queue_idx",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"chat_events\".\"run_id\" IS NULL AND \"chat_events\".\"event_type\" IN ('input.prompt', 'input.automation', 'input.goal')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_events_run_event_seq_unique": {
+          "name": "chat_events_run_event_seq_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_event_sequence_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_events_thread_seq_unique": {
+          "name": "chat_events_thread_seq_unique",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_events_run_terminal_unique": {
+          "name": "chat_events_run_terminal_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"chat_events\".\"event_type\" IN ('run.completed', 'run.failed', 'run.cancelled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_events_control_interrupt_run_id_unique": {
+          "name": "chat_events_control_interrupt_run_id_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"chat_events\".\"event_type\" = 'control.interrupt' AND \"chat_events\".\"run_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_events_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_events_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_events",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_events_event_type_check": {
+          "name": "chat_events_event_type_check",
+          "value": "\"chat_events\".\"event_type\" IN (\n          'input.prompt',\n          'input.automation',\n          'input.goal',\n          'input.budget',\n          'input.rejected',\n          'output.message',\n          'output.error',\n          'output.thinking',\n          'output.followups',\n          'run.queued',\n          'run.dequeued',\n          'run.completed',\n          'run.failed',\n          'run.cancelled',\n          'control.interrupt',\n          'control.revoke',\n          'browser.open',\n          'browser.close',\n          'goal.open',\n          'goal.close',\n          'usage.recorded'\n        )"
+        },
+        "chat_events_input_user_message_payload_check": {
+          "name": "chat_events_input_user_message_payload_check",
+          "value": "\"chat_events\".\"event_type\" NOT IN ('input.prompt', 'input.budget', 'input.rejected')\n          OR (\n            \"chat_events\".\"payload\" IS NOT NULL\n            AND \"chat_events\".\"payload\" ? 'userMessage'\n          )"
+        },
+        "chat_events_input_payload_content_check": {
+          "name": "chat_events_input_payload_content_check",
+          "value": "\"chat_events\".\"event_type\" NOT IN ('input.prompt', 'input.budget', 'input.rejected')\n          OR \"chat_events\".\"payload\" IS NULL\n          OR NOT (\"chat_events\".\"payload\" ? 'content')"
+        },
+        "chat_events_official_workflow_queue_claim_check": {
+          "name": "chat_events_official_workflow_queue_claim_check",
+          "value": "\"chat_events\".\"required_official_workflow_ids\" IS NULL OR (\n          \"chat_events\".\"event_type\" = 'input.prompt'\n          AND cardinality(\"chat_events\".\"required_official_workflow_ids\") > 0\n        )"
+        },
+        "chat_events_goal_open_payload_check": {
+          "name": "chat_events_goal_open_payload_check",
+          "value": "\"chat_events\".\"event_type\" <> 'goal.open'\n          OR (\n            \"chat_events\".\"payload\" IS NOT NULL\n            AND \"chat_events\".\"payload\" ? 'content'\n            AND jsonb_typeof(\"chat_events\".\"payload\" -> 'content') = 'string'\n            AND \"chat_events\".\"payload\" ->> 'content' = btrim(\"chat_events\".\"payload\" ->> 'content')\n            AND char_length(\"chat_events\".\"payload\" ->> 'content') > 0\n            AND \"chat_events\".\"payload\" - 'content' = '{}'::jsonb\n          )"
+        },
+        "chat_events_goal_close_payload_check": {
+          "name": "chat_events_goal_close_payload_check",
+          "value": "\"chat_events\".\"event_type\" <> 'goal.close' OR \"chat_events\".\"payload\" IS NULL"
+        },
+        "chat_events_goal_marker_payload_check": {
+          "name": "chat_events_goal_marker_payload_check",
+          "value": "\"chat_events\".\"event_type\" NOT IN ('goal.open', 'goal.close')\n          OR (\n            \"chat_events\".\"run_id\" IS NULL\n            AND \"chat_events\".\"revokes_event_id\" IS NULL\n            AND \"chat_events\".\"context_type\" IS NULL\n            AND \"chat_events\".\"context_id\" IS NULL\n            AND \"chat_events\".\"run_event_sequence_number\" IS NULL\n            AND \"chat_events\".\"run_event_id\" IS NULL\n          )"
+        },
+        "chat_events_context_pair_check": {
+          "name": "chat_events_context_pair_check",
+          "value": "\"chat_events\".\"context_id\" IS NULL OR \"chat_events\".\"context_type\" IS NOT NULL"
+        },
+        "chat_events_context_type_check": {
+          "name": "chat_events_context_type_check",
+          "value": "\"chat_events\".\"context_type\" IN (\n          'web',\n          'slack',\n          'feishu',\n          'teams',\n          'telegram',\n          'github',\n          'agentphone',\n          'automation',\n          'goal',\n          'agent_run'\n        )"
+        },
+        "chat_events_input_context_type_check": {
+          "name": "chat_events_input_context_type_check",
+          "value": "\"chat_events\".\"event_type\" NOT IN ('input.prompt', 'input.automation', 'input.goal', 'input.budget')\n          OR \"chat_events\".\"context_type\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.chat_feishu_context": {
+      "name": "chat_feishu_context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_history": {
+          "name": "conversation_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_text": {
+          "name": "message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_files": {
+          "name": "message_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_type": {
+          "name": "chat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_in_thread": {
+          "name": "reply_in_thread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction_id": {
+          "name": "reaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_open_id": {
+          "name": "sender_open_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_feishu_context_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_feishu_context_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_feishu_context",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_github_context": {
+      "name": "chat_github_context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_number": {
+          "name": "subject_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_kind": {
+          "name": "subject_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_comment_id": {
+          "name": "trigger_comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_context": {
+          "name": "issue_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_text": {
+          "name": "message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_reaction_id": {
+          "name": "trigger_reaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_comment_body": {
+          "name": "trigger_comment_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_github_context_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_github_context_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_github_context",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_github_context_subject_kind_check": {
+          "name": "chat_github_context_subject_kind_check",
+          "value": "\"chat_github_context\".\"subject_kind\" IN ('issue', 'pull_request')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.chat_slack_context": {
+      "name": "chat_slack_context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_ts": {
+          "name": "message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_context": {
+          "name": "conversation_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_text": {
+          "name": "message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_files": {
+          "name": "message_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_assets": {
+          "name": "message_assets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mention_display_names": {
+          "name": "mention_display_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_display_name": {
+          "name": "sender_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_user_id": {
+          "name": "sender_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_ts": {
+          "name": "thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_thread_ts": {
+          "name": "route_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_slack_context_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_slack_context_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_slack_context",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_teams_context": {
+      "name": "chat_teams_context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_type": {
+          "name": "conversation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_context": {
+          "name": "thread_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_text": {
+          "name": "message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_files": {
+          "name": "message_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_name": {
+          "name": "tenant_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_url": {
+          "name": "service_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_app_id": {
+          "name": "teams_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_user_id": {
+          "name": "sender_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_display_name": {
+          "name": "sender_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_principal_name": {
+          "name": "sender_principal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_teams_context_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_teams_context_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_teams_context",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_telegram_context": {
+      "name": "chat_telegram_context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_thread_id": {
+          "name": "message_thread_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_text": {
+          "name": "message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_context": {
+          "name": "thread_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thinking_message_id": {
+          "name": "thinking_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_link_id": {
+          "name": "user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_link_kind": {
+          "name": "user_link_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_type": {
+          "name": "chat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_user_id": {
+          "name": "sender_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_display_name": {
+          "name": "sender_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_username": {
+          "name": "sender_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_language": {
+          "name": "sender_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_telegram_context_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_telegram_context_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_telegram_context",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_thread_connector_selections": {
+      "name": "chat_thread_connector_selections",
+      "schema": "",
+      "columns": {
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_slug": {
+          "name": "connector_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_connector_id": {
+          "name": "custom_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_chat_thread_connector_selections_thread_slug": {
+          "name": "idx_chat_thread_connector_selections_thread_slug",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"chat_thread_connector_selections\".\"connector_slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_thread_connector_selections_thread_custom_connector": {
+          "name": "idx_chat_thread_connector_selections_thread_custom_connector",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "custom_connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"chat_thread_connector_selections\".\"custom_connector_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_thread_connector_selections_connector": {
+          "name": "idx_chat_thread_connector_selections_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_thread_connector_selections_custom_connector": {
+          "name": "idx_chat_thread_connector_selections_custom_connector",
+          "columns": [
+            {
+              "expression": "custom_connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_chat_thread_connector_selections_thread": {
+          "name": "fk_chat_thread_connector_selections_thread",
+          "tableFrom": "chat_thread_connector_selections",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_chat_thread_connector_selections_connector_slug": {
+          "name": "fk_chat_thread_connector_selections_connector_slug",
+          "tableFrom": "chat_thread_connector_selections",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id",
+            "connector_slug"
+          ],
+          "columnsTo": [
+            "id",
+            "connector_slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fk_chat_thread_connector_selections_custom_connector": {
+          "name": "fk_chat_thread_connector_selections_custom_connector",
+          "tableFrom": "chat_thread_connector_selections",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id",
+            "custom_connector_id"
+          ],
+          "columnsTo": [
+            "id",
+            "custom_connector_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "chat_thread_connector_selections_thread_connector_pk": {
+          "name": "chat_thread_connector_selections_thread_connector_pk",
+          "columns": [
+            "chat_thread_id",
+            "connector_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_chat_thread_connector_selections_target": {
+          "name": "chk_chat_thread_connector_selections_target",
+          "value": "num_nonnulls(\"chat_thread_connector_selections\".\"connector_slug\", \"chat_thread_connector_selections\".\"custom_connector_id\") = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.chat_thread_event_sequences": {
+      "name": "chat_thread_event_sequences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seq_id": {
+          "name": "last_seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_thread_event_sequences_user_id_org_id_pk": {
+          "name": "chat_thread_event_sequences_user_id_org_id_pk",
+          "columns": [
+            "user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_thread_events": {
+      "name": "chat_thread_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq_id": {
+          "name": "seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "chat_thread_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computer_use_host_id": {
+          "name": "computer_use_host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_browser_enabled": {
+          "name": "cloud_browser_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_video_model": {
+          "name": "selected_video_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_image_model": {
+          "name": "selected_image_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_thread_events_user_org_created": {
+          "name": "idx_chat_thread_events_user_org_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_thread_events_thread_created": {
+          "name": "idx_chat_thread_events_thread_created",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_thread_events_user_org_seq_unique": {
+          "name": "chat_thread_events_user_org_seq_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_thread_events_computer_access_check": {
+          "name": "chat_thread_events_computer_access_check",
+          "value": "NOT (\"chat_thread_events\".\"cloud_browser_enabled\" AND \"chat_thread_events\".\"computer_use_host_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.chat_thread_snapshots": {
+      "name": "chat_thread_snapshots",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_event_id": {
+          "name": "latest_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_event_seq_id": {
+          "name": "latest_event_seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_threads": {
+          "name": "chat_threads",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_thread_snapshots_user_id_org_id_pk": {
+          "name": "chat_thread_snapshots_user_id_org_id_pk",
+          "columns": [
+            "user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_threads": {
+      "name": "chat_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_schedule_run_id": {
+          "name": "source_schedule_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_session_run_id": {
+          "name": "agent_session_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_user_message": {
+          "name": "draft_user_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_attachments": {
+          "name": "draft_attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_type": {
+          "name": "model_provider_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_credential_scope": {
+          "name": "model_provider_credential_scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_service_tier": {
+          "name": "codex_service_tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_video_model": {
+          "name": "selected_video_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_image_model": {
+          "name": "selected_image_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computer_use_host_id": {
+          "name": "computer_use_host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_browser_enabled": {
+          "name": "cloud_browser_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "renamed_at": {
+          "name": "renamed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_chat_event_seq_id": {
+          "name": "last_chat_event_seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_threads_user_agent_updated": {
+          "name": "idx_chat_threads_user_agent_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_last_read": {
+          "name": "idx_chat_threads_user_last_read",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_agent_pinned": {
+          "name": "idx_chat_threads_user_agent_pinned",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"chat_threads\".\"pinned_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_agent_last_message": {
+          "name": "idx_chat_threads_user_agent_last_message",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_agent_id_agents_id_fk": {
+          "name": "chat_threads_agent_id_agents_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_threads_agent_session_id_agent_sessions_id_fk": {
+          "name": "chat_threads_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "chat_threads_agent_session_run_id_agent_runs_id_fk": {
+          "name": "chat_threads_agent_session_run_id_agent_runs_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_session_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "chat_threads_computer_use_host_id_computer_use_hosts_id_fk": {
+          "name": "chat_threads_computer_use_host_id_computer_use_hosts_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "computer_use_hosts",
+          "columnsFrom": [
+            "computer_use_host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_threads_computer_access_check": {
+          "name": "chat_threads_computer_access_check",
+          "value": "NOT (\"chat_threads\".\"cloud_browser_enabled\" AND \"chat_threads\".\"computer_use_host_id\" IS NOT NULL)"
+        },
+        "chat_threads_draft_user_message_check": {
+          "name": "chat_threads_draft_user_message_check",
+          "value": "\"chat_threads\".\"draft_user_message\" IS NOT NULL\n          OR COALESCE(\"chat_threads\".\"draft_attachments\", '[]'::jsonb) = '[]'::jsonb"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.checkpoints": {
+      "name": "checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_mounts": {
+          "name": "storage_mounts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checkpoints_run_id_agent_runs_id_fk": {
+          "name": "checkpoints_run_id_agent_runs_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checkpoints_conversation_id_conversations_id_fk": {
+          "name": "checkpoints_conversation_id_conversations_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "checkpoints_run_id_unique": {
+          "name": "checkpoints_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_token_unique": {
+          "name": "cli_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compose_jobs": {
+      "name": "compose_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overwrite": {
+          "name": "overwrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_compose_jobs_user_status": {
+          "name": "idx_compose_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_created": {
+          "name": "idx_compose_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_user_active": {
+          "name": "idx_compose_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_use_authorization_requests": {
+      "name": "computer_use_authorization_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_token_hash": {
+          "name": "request_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_connection_id": {
+          "name": "slack_connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_connection_id": {
+          "name": "teams_connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_conversation_id": {
+          "name": "teams_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_thread_id": {
+          "name": "teams_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_auth_requests_token_hash": {
+          "name": "idx_computer_use_auth_requests_token_hash",
+          "columns": [
+            {
+              "expression": "request_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_auth_requests_org_user": {
+          "name": "idx_computer_use_auth_requests_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_auth_requests_expires": {
+          "name": "idx_computer_use_auth_requests_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "computer_use_auth_requests_source_check": {
+          "name": "computer_use_auth_requests_source_check",
+          "value": "source IN ('chat', 'slack', 'teams')"
+        },
+        "computer_use_auth_requests_scope_check": {
+          "name": "computer_use_auth_requests_scope_check",
+          "value": "(\n          source = 'chat'\n          AND chat_thread_id IS NOT NULL\n          AND slack_connection_id IS NULL\n          AND slack_channel_id IS NULL\n          AND slack_thread_ts IS NULL\n          AND teams_connection_id IS NULL\n          AND teams_conversation_id IS NULL\n          AND teams_thread_id IS NULL\n        ) OR (\n          source = 'slack'\n          AND chat_thread_id IS NULL\n          AND slack_connection_id IS NOT NULL\n          AND slack_channel_id IS NOT NULL\n          AND slack_thread_ts IS NOT NULL\n          AND teams_connection_id IS NULL\n          AND teams_conversation_id IS NULL\n          AND teams_thread_id IS NULL\n        ) OR (\n          source = 'teams'\n          AND chat_thread_id IS NULL\n          AND slack_connection_id IS NULL\n          AND slack_channel_id IS NULL\n          AND slack_thread_ts IS NULL\n          AND teams_connection_id IS NOT NULL\n          AND teams_conversation_id IS NOT NULL\n          AND teams_thread_id IS NOT NULL\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.computer_use_command_audit_events": {
+      "name": "computer_use_command_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approval_outcome": {
+          "name": "approval_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redacted_result": {
+          "name": "redacted_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_command_audit_command": {
+          "name": "idx_computer_use_command_audit_command",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_command_audit_org_user": {
+          "name": "idx_computer_use_command_audit_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_command_audit_created": {
+          "name": "idx_computer_use_command_audit_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_use_command_audit_events_command_id_computer_use_commands_id_fk": {
+          "name": "computer_use_command_audit_events_command_id_computer_use_commands_id_fk",
+          "tableFrom": "computer_use_command_audit_events",
+          "tableTo": "computer_use_commands",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "computer_use_command_audit_events_host_id_computer_use_hosts_id_fk": {
+          "name": "computer_use_command_audit_events_host_id_computer_use_hosts_id_fk",
+          "tableFrom": "computer_use_command_audit_events",
+          "tableTo": "computer_use_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_use_commands": {
+      "name": "computer_use_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_commands_host_status": {
+          "name": "idx_computer_use_commands_host_status",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_commands_org_user": {
+          "name": "idx_computer_use_commands_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_commands_created": {
+          "name": "idx_computer_use_commands_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_use_commands_host_id_computer_use_hosts_id_fk": {
+          "name": "computer_use_commands_host_id_computer_use_hosts_id_fk",
+          "tableFrom": "computer_use_commands",
+          "tableTo": "computer_use_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_use_hosts": {
+      "name": "computer_use_hosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_product": {
+          "name": "client_product",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'zero'"
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "os_version": {
+          "name": "os_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supported_capabilities": {
+          "name": "supported_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"accessibility\":false,\"screenRecording\":false}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'online'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_hosts_token_hash": {
+          "name": "idx_computer_use_hosts_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_hosts_active_installation": {
+          "name": "idx_computer_use_hosts_active_installation",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL AND revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_hosts_org_user": {
+          "name": "idx_computer_use_hosts_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_hosts_last_seen": {
+          "name": "idx_computer_use_hosts_last_seen",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "computer_use_hosts_client_product_check": {
+          "name": "computer_use_hosts_client_product_check",
+          "value": "client_product IN ('zero', 'okou')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connector_catalog_active_snapshot": {
+      "name": "connector_catalog_active_snapshot",
+      "schema": "",
+      "columns": {
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_version": {
+          "name": "catalog_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_key": {
+          "name": "catalog_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_digest": {
+          "name": "catalog_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_raw_size": {
+          "name": "catalog_raw_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_gzip": {
+          "name": "catalog_gzip",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connector_catalog_active_snapshot_sync_state_fk": {
+          "name": "connector_catalog_active_snapshot_sync_state_fk",
+          "tableFrom": "connector_catalog_active_snapshot",
+          "tableTo": "connector_catalog_sync_state",
+          "columnsFrom": [
+            "source_id",
+            "schema_version"
+          ],
+          "columnsTo": [
+            "source_id",
+            "schema_version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "connector_catalog_active_snapshot_pk": {
+          "name": "connector_catalog_active_snapshot_pk",
+          "columns": [
+            "source_id",
+            "schema_version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "connector_catalog_active_snapshot_schema_version_positive": {
+          "name": "connector_catalog_active_snapshot_schema_version_positive",
+          "value": "\"connector_catalog_active_snapshot\".\"schema_version\" > 0"
+        },
+        "connector_catalog_active_snapshot_catalog_raw_size_positive": {
+          "name": "connector_catalog_active_snapshot_catalog_raw_size_positive",
+          "value": "\"connector_catalog_active_snapshot\".\"catalog_raw_size\" > 0"
+        },
+        "connector_catalog_active_snapshot_catalog_digest_valid": {
+          "name": "connector_catalog_active_snapshot_catalog_digest_valid",
+          "value": "\"connector_catalog_active_snapshot\".\"catalog_digest\" ~ '^sha256:[a-f0-9]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connector_catalog_compatibility_evaluation": {
+      "name": "connector_catalog_compatibility_evaluation",
+      "schema": "",
+      "columns": {
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_version": {
+          "name": "catalog_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_digest": {
+          "name": "catalog_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executable_capability_digest": {
+          "name": "executable_capability_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_validation_backend_version": {
+          "name": "catalog_validation_backend_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "catalog_validation_build_commit_sha": {
+          "name": "catalog_validation_build_commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluated_at": {
+          "name": "evaluated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filtered_auth_methods": {
+          "name": "filtered_auth_methods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connector_catalog_compatibility_evaluation_sync_state_fk": {
+          "name": "connector_catalog_compatibility_evaluation_sync_state_fk",
+          "tableFrom": "connector_catalog_compatibility_evaluation",
+          "tableTo": "connector_catalog_sync_state",
+          "columnsFrom": [
+            "source_id",
+            "schema_version"
+          ],
+          "columnsTo": [
+            "source_id",
+            "schema_version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "connector_catalog_compatibility_evaluation_pk": {
+          "name": "connector_catalog_compatibility_evaluation_pk",
+          "columns": [
+            "source_id",
+            "schema_version",
+            "catalog_version",
+            "catalog_digest",
+            "executable_capability_digest"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "connector_catalog_compat_eval_schema_version_positive": {
+          "name": "connector_catalog_compat_eval_schema_version_positive",
+          "value": "\"connector_catalog_compatibility_evaluation\".\"schema_version\" > 0"
+        },
+        "connector_catalog_compatibility_evaluation_digest_valid": {
+          "name": "connector_catalog_compatibility_evaluation_digest_valid",
+          "value": "\"connector_catalog_compatibility_evaluation\".\"executable_capability_digest\" ~ '^sha256:[a-f0-9]{64}$'"
+        },
+        "connector_catalog_compatibility_catalog_digest_valid": {
+          "name": "connector_catalog_compatibility_catalog_digest_valid",
+          "value": "\"connector_catalog_compatibility_evaluation\".\"catalog_digest\" ~ '^sha256:[a-f0-9]{64}$'"
+        },
+        "connector_catalog_compat_validation_authority_complete": {
+          "name": "connector_catalog_compat_validation_authority_complete",
+          "value": "(\n          \"connector_catalog_compatibility_evaluation\".\"catalog_validation_backend_version\" IS NULL\n          AND \"connector_catalog_compatibility_evaluation\".\"catalog_validation_build_commit_sha\" IS NULL\n        ) OR (\n          \"connector_catalog_compatibility_evaluation\".\"catalog_validation_backend_version\" IS NOT NULL\n          AND \"connector_catalog_compatibility_evaluation\".\"catalog_validation_backend_version\" ~ '^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$'\n          AND (\n            \"connector_catalog_compatibility_evaluation\".\"catalog_validation_build_commit_sha\" IS NULL\n            OR \"connector_catalog_compatibility_evaluation\".\"catalog_validation_build_commit_sha\" ~ '^[a-f0-9]{40}$'\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connector_catalog_runtime_projection_sets": {
+      "name": "connector_catalog_runtime_projection_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_version": {
+          "name": "catalog_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_digest": {
+          "name": "catalog_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projection_version": {
+          "name": "projection_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_count": {
+          "name": "connector_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_validation_backend_version": {
+          "name": "catalog_validation_backend_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_validation_build_commit_sha": {
+          "name": "catalog_validation_build_commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connector_catalog_runtime_projection_sets_source_schema_unique": {
+          "name": "connector_catalog_runtime_projection_sets_source_schema_unique",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "schema_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connector_catalog_runtime_projection_sets_sync_state_fk": {
+          "name": "connector_catalog_runtime_projection_sets_sync_state_fk",
+          "tableFrom": "connector_catalog_runtime_projection_sets",
+          "tableTo": "connector_catalog_sync_state",
+          "columnsFrom": [
+            "source_id",
+            "schema_version"
+          ],
+          "columnsTo": [
+            "source_id",
+            "schema_version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "connector_catalog_projection_sets_schema_positive": {
+          "name": "connector_catalog_projection_sets_schema_positive",
+          "value": "\"connector_catalog_runtime_projection_sets\".\"schema_version\" > 0"
+        },
+        "connector_catalog_projection_sets_version_supported": {
+          "name": "connector_catalog_projection_sets_version_supported",
+          "value": "\"connector_catalog_runtime_projection_sets\".\"projection_version\" = 2"
+        },
+        "connector_catalog_projection_sets_count_positive": {
+          "name": "connector_catalog_projection_sets_count_positive",
+          "value": "\"connector_catalog_runtime_projection_sets\".\"connector_count\" > 0"
+        },
+        "connector_catalog_projection_sets_digest_valid": {
+          "name": "connector_catalog_projection_sets_digest_valid",
+          "value": "\"connector_catalog_runtime_projection_sets\".\"catalog_digest\" ~ '^sha256:[a-f0-9]{64}$'"
+        },
+        "connector_catalog_projection_sets_validator_complete": {
+          "name": "connector_catalog_projection_sets_validator_complete",
+          "value": "\"connector_catalog_runtime_projection_sets\".\"catalog_validation_backend_version\" ~ '^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$'\n          AND (\n            \"connector_catalog_runtime_projection_sets\".\"catalog_validation_build_commit_sha\" IS NULL\n            OR \"connector_catalog_runtime_projection_sets\".\"catalog_validation_build_commit_sha\" ~ '^[a-f0-9]{40}$'\n          )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connector_catalog_runtime_projections": {
+      "name": "connector_catalog_runtime_projections",
+      "schema": "",
+      "columns": {
+        "projection_set_id": {
+          "name": "projection_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_slug": {
+          "name": "connector_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_digest": {
+          "name": "connector_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_payload": {
+          "name": "connector_payload",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connector_catalog_runtime_projections_set_fk": {
+          "name": "connector_catalog_runtime_projections_set_fk",
+          "tableFrom": "connector_catalog_runtime_projections",
+          "tableTo": "connector_catalog_runtime_projection_sets",
+          "columnsFrom": [
+            "projection_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "connector_catalog_runtime_projections_pk": {
+          "name": "connector_catalog_runtime_projections_pk",
+          "columns": [
+            "projection_set_id",
+            "connector_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "connector_catalog_projections_connector_digest_valid": {
+          "name": "connector_catalog_projections_connector_digest_valid",
+          "value": "\"connector_catalog_runtime_projections\".\"connector_digest\" ~ '^sha256:[a-f0-9]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connector_catalog_sync_state": {
+      "name": "connector_catalog_sync_state",
+      "schema": "",
+      "columns": {
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_observed_catalog_version": {
+          "name": "last_observed_catalog_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_observed_catalog_key": {
+          "name": "last_observed_catalog_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_observed_catalog_digest": {
+          "name": "last_observed_catalog_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_observed_pointer_etag": {
+          "name": "last_observed_pointer_etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempt_outcome": {
+          "name": "last_attempt_outcome",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempt_reused_cached_rejection": {
+          "name": "last_attempt_reused_cached_rejection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_code": {
+          "name": "last_failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rejected_catalog_version": {
+          "name": "last_rejected_catalog_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rejected_catalog_key": {
+          "name": "last_rejected_catalog_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rejected_catalog_digest": {
+          "name": "last_rejected_catalog_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rejected_pointer_etag": {
+          "name": "last_rejected_pointer_etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rejected_failure_code": {
+          "name": "last_rejected_failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rejected_backend_version": {
+          "name": "last_rejected_backend_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rejected_build_commit_sha": {
+          "name": "last_rejected_build_commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_catalog_sync_state_pk": {
+          "name": "connector_catalog_sync_state_pk",
+          "columns": [
+            "source_id",
+            "schema_version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "connector_catalog_sync_state_schema_version_positive": {
+          "name": "connector_catalog_sync_state_schema_version_positive",
+          "value": "\"connector_catalog_sync_state\".\"schema_version\" > 0"
+        },
+        "connector_catalog_sync_state_revision_nonnegative": {
+          "name": "connector_catalog_sync_state_revision_nonnegative",
+          "value": "\"connector_catalog_sync_state\".\"revision\" >= 0"
+        },
+        "connector_catalog_sync_state_observed_identity_complete": {
+          "name": "connector_catalog_sync_state_observed_identity_complete",
+          "value": "(\n          \"connector_catalog_sync_state\".\"last_observed_catalog_version\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_observed_catalog_key\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_observed_catalog_digest\" IS NULL\n        ) OR (\n          \"connector_catalog_sync_state\".\"last_observed_catalog_version\" IS NOT NULL\n          AND \"connector_catalog_sync_state\".\"last_observed_catalog_key\" IS NOT NULL\n          AND \"connector_catalog_sync_state\".\"last_observed_catalog_digest\" IS NOT NULL\n        )"
+        },
+        "connector_catalog_sync_state_attempt_complete": {
+          "name": "connector_catalog_sync_state_attempt_complete",
+          "value": "(\n          \"connector_catalog_sync_state\".\"last_attempt_outcome\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_attempt_at\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_failure_code\" IS NULL\n        ) OR (\n          \"connector_catalog_sync_state\".\"last_attempt_outcome\" = 'rejected'\n          AND \"connector_catalog_sync_state\".\"last_attempt_at\" IS NOT NULL\n          AND \"connector_catalog_sync_state\".\"last_failure_code\" IS NOT NULL\n        ) OR (\n          \"connector_catalog_sync_state\".\"last_attempt_outcome\" IN ('accepted', 'unchanged')\n          AND \"connector_catalog_sync_state\".\"last_attempt_at\" IS NOT NULL\n          AND \"connector_catalog_sync_state\".\"last_failure_code\" IS NULL\n        )"
+        },
+        "connector_catalog_sync_state_attempt_cache_reuse_complete": {
+          "name": "connector_catalog_sync_state_attempt_cache_reuse_complete",
+          "value": "(\n          \"connector_catalog_sync_state\".\"last_attempt_outcome\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_attempt_reused_cached_rejection\" IS NULL\n        ) OR (\n          \"connector_catalog_sync_state\".\"last_attempt_outcome\" IS NOT NULL\n          AND \"connector_catalog_sync_state\".\"last_attempt_reused_cached_rejection\" IS NOT NULL\n          AND (\n            \"connector_catalog_sync_state\".\"last_attempt_reused_cached_rejection\" = FALSE\n            OR \"connector_catalog_sync_state\".\"last_attempt_outcome\" = 'rejected'\n          )\n        )"
+        },
+        "connector_catalog_sync_state_rejected_candidate_complete": {
+          "name": "connector_catalog_sync_state_rejected_candidate_complete",
+          "value": "(\n          \"connector_catalog_sync_state\".\"last_rejected_catalog_version\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_catalog_key\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_catalog_digest\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_pointer_etag\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_failure_code\" IS NULL\n        ) OR (\n          \"connector_catalog_sync_state\".\"last_rejected_failure_code\" IS NOT NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_failure_code\" <> 'source-unavailable'\n          AND (\n            (\n              \"connector_catalog_sync_state\".\"last_rejected_catalog_version\" IS NOT NULL\n              AND \"connector_catalog_sync_state\".\"last_rejected_catalog_key\" IS NOT NULL\n              AND \"connector_catalog_sync_state\".\"last_rejected_catalog_digest\" IS NOT NULL\n            ) OR \"connector_catalog_sync_state\".\"last_rejected_pointer_etag\" IS NOT NULL\n          )\n          AND (\n            (\n              \"connector_catalog_sync_state\".\"last_rejected_catalog_version\" IS NULL\n              AND \"connector_catalog_sync_state\".\"last_rejected_catalog_key\" IS NULL\n              AND \"connector_catalog_sync_state\".\"last_rejected_catalog_digest\" IS NULL\n            ) OR (\n              \"connector_catalog_sync_state\".\"last_rejected_catalog_version\" IS NOT NULL\n              AND \"connector_catalog_sync_state\".\"last_rejected_catalog_key\" IS NOT NULL\n              AND \"connector_catalog_sync_state\".\"last_rejected_catalog_digest\" IS NOT NULL\n            )\n          )\n        )"
+        },
+        "connector_catalog_sync_state_rejection_authority_complete": {
+          "name": "connector_catalog_sync_state_rejection_authority_complete",
+          "value": "(\n          \"connector_catalog_sync_state\".\"last_rejected_failure_code\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_backend_version\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_build_commit_sha\" IS NULL\n        ) OR (\n          \"connector_catalog_sync_state\".\"last_rejected_failure_code\" IS NOT NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_backend_version\" IS NOT NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_backend_version\" ~ '^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$'\n          AND (\n            \"connector_catalog_sync_state\".\"last_rejected_build_commit_sha\" IS NULL\n            OR \"connector_catalog_sync_state\".\"last_rejected_build_commit_sha\" ~ '^[a-f0-9]{40}$'\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connector_external_code_sessions": {
+      "name": "connector_external_code_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorize_agent": {
+          "name": "authorize_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "connector_slug": {
+          "name": "connector_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_external_code_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "session_token_hash": {
+          "name": "session_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_provider_state": {
+          "name": "encrypted_provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_mutation": {
+          "name": "account_mutation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_connector_id": {
+          "name": "completed_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_requested_scopes": {
+          "name": "oauth_requested_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_external_code_sessions_token": {
+          "name": "idx_connector_external_code_sessions_token",
+          "columns": [
+            {
+              "expression": "session_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_external_code_sessions_owner_slug_status": {
+          "name": "idx_connector_external_code_sessions_owner_slug_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auth_method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_external_code_sessions_expiration": {
+          "name": "idx_connector_external_code_sessions_expiration",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_oauth_device_authorization_sessions": {
+      "name": "connector_oauth_device_authorization_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorize_agent": {
+          "name": "authorize_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "connector_slug": {
+          "name": "connector_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_oauth_device_authorization_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'awaiting_user_authorization'"
+        },
+        "session_token_hash": {
+          "name": "session_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_provider_state": {
+          "name": "encrypted_provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_mutation": {
+          "name": "account_mutation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_connector_id": {
+          "name": "completed_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_requested_scopes": {
+          "name": "oauth_requested_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_uri": {
+          "name": "verification_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_uri_complete": {
+          "name": "verification_uri_complete",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_oauth_device_authorization_sessions_token": {
+          "name": "idx_connector_oauth_device_authorization_sessions_token",
+          "columns": [
+            {
+              "expression": "session_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_device_sessions_owner_slug_status": {
+          "name": "idx_connector_oauth_device_sessions_owner_slug_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auth_method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_device_authorization_sessions_expiration": {
+          "name": "idx_connector_oauth_device_authorization_sessions_expiration",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_oauth_states": {
+      "name": "connector_oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_slug": {
+          "name": "connector_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_connector_id": {
+          "name": "custom_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_version": {
+          "name": "storage_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorize_agent": {
+          "name": "authorize_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_requested_scopes": {
+          "name": "oauth_requested_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_context": {
+          "name": "oauth_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_mutation": {
+          "name": "account_mutation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_oauth_states_state": {
+          "name": "idx_connector_oauth_states_state",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_states_user_org": {
+          "name": "idx_connector_oauth_states_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_states_expires_at": {
+          "name": "idx_connector_oauth_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_connector_oauth_states_custom_connector": {
+          "name": "fk_connector_oauth_states_custom_connector",
+          "tableFrom": "connector_oauth_states",
+          "tableTo": "org_custom_connectors",
+          "columnsFrom": [
+            "custom_connector_id",
+            "org_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_connector_oauth_states_identity": {
+          "name": "chk_connector_oauth_states_identity",
+          "value": "num_nonnulls(\"connector_oauth_states\".\"connector_slug\", \"connector_oauth_states\".\"custom_connector_id\") = 1"
+        },
+        "chk_connector_oauth_states_custom_storage_version": {
+          "name": "chk_connector_oauth_states_custom_storage_version",
+          "value": "(\n          \"connector_oauth_states\".\"custom_connector_id\" IS NULL\n          AND \"connector_oauth_states\".\"storage_version\" IS NULL\n        ) OR (\n          \"connector_oauth_states\".\"custom_connector_id\" IS NOT NULL\n          AND (\n            \"connector_oauth_states\".\"storage_version\" IS NULL\n            OR \"connector_oauth_states\".\"storage_version\" > 0\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connector_slug": {
+          "name": "connector_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_connector_id": {
+          "name": "custom_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_version": {
+          "name": "storage_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_username": {
+          "name": "external_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_email": {
+          "name": "external_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_granted_scopes": {
+          "name": "oauth_granted_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_reconnect": {
+          "name": "needs_reconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reconnect_reason": {
+          "name": "reconnect_reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connectors_org": {
+          "name": "idx_connectors_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_stripe_oauth_external_id": {
+          "name": "idx_connectors_stripe_oauth_external_id",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connectors\".\"connector_slug\" = 'stripe' AND \"connectors\".\"auth_method\" = 'oauth'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org_user_custom_connector": {
+          "name": "idx_connectors_org_user_custom_connector",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "custom_connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connectors\".\"custom_connector_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org_user_custom_connector_default": {
+          "name": "idx_connectors_org_user_custom_connector_default",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "custom_connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"connectors\".\"custom_connector_id\" IS NOT NULL AND \"connectors\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org_user_slug": {
+          "name": "idx_connectors_org_user_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connectors\".\"connector_slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org_user_slug_default": {
+          "name": "idx_connectors_org_user_slug_default",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"connectors\".\"connector_slug\" IS NOT NULL AND \"connectors\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_connectors_custom_connector": {
+          "name": "fk_connectors_custom_connector",
+          "tableFrom": "connectors",
+          "tableTo": "org_custom_connectors",
+          "columnsFrom": [
+            "custom_connector_id",
+            "org_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "idx_connectors_id_org_user": {
+          "name": "idx_connectors_id_org_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "org_id",
+            "user_id"
+          ]
+        },
+        "idx_connectors_id_slug": {
+          "name": "idx_connectors_id_slug",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "connector_slug"
+          ]
+        },
+        "idx_connectors_id_custom_connector": {
+          "name": "idx_connectors_id_custom_connector",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "custom_connector_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "chk_connectors_identity": {
+          "name": "chk_connectors_identity",
+          "value": "num_nonnulls(\"connectors\".\"connector_slug\", \"connectors\".\"custom_connector_id\") = 1"
+        },
+        "chk_connectors_storage_version_positive": {
+          "name": "chk_connectors_storage_version_positive",
+          "value": "\"connectors\".\"storage_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credit_expires_record": {
+      "name": "credit_expires_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_credit_expires_org_active": {
+          "name": "idx_credit_expires_org_active",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "remaining > 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_credit_expires_invoice": {
+          "name": "uq_credit_expires_invoice",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "stripe_invoice_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_credit_expires_starter_grant": {
+          "name": "uq_credit_expires_starter_grant",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "source = 'starter_grant'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_connector_account_oauth_bindings": {
+      "name": "custom_connector_account_oauth_bindings",
+      "schema": "",
+      "columns": {
+        "connector_account_id": {
+          "name": "connector_account_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "custom_connector_id": {
+          "name": "custom_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_metadata_url": {
+          "name": "resource_metadata_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint": {
+          "name": "token_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_method": {
+          "name": "registration_method",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dcr_registration_id": {
+          "name": "dcr_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_custom_connector_account_oauth_bindings_connector": {
+          "name": "idx_custom_connector_account_oauth_bindings_connector",
+          "columns": [
+            {
+              "expression": "custom_connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_custom_connector_account_oauth_bindings_dcr": {
+          "name": "idx_custom_connector_account_oauth_bindings_dcr",
+          "columns": [
+            {
+              "expression": "dcr_registration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_custom_connector_account_oauth_bindings_account": {
+          "name": "fk_custom_connector_account_oauth_bindings_account",
+          "tableFrom": "custom_connector_account_oauth_bindings",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_account_id",
+            "custom_connector_id"
+          ],
+          "columnsTo": [
+            "id",
+            "custom_connector_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_custom_connector_account_oauth_bindings_dcr_registration": {
+          "name": "fk_custom_connector_account_oauth_bindings_dcr_registration",
+          "tableFrom": "custom_connector_account_oauth_bindings",
+          "tableTo": "org_custom_connector_dcr_registrations",
+          "columnsFrom": [
+            "dcr_registration_id",
+            "custom_connector_id"
+          ],
+          "columnsTo": [
+            "id",
+            "custom_connector_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_custom_connector_account_oauth_binding_identity": {
+          "name": "chk_custom_connector_account_oauth_binding_identity",
+          "value": "(\n          btrim(\"custom_connector_account_oauth_bindings\".\"issuer\") <> ''\n          AND btrim(\"custom_connector_account_oauth_bindings\".\"resource\") <> ''\n          AND btrim(\"custom_connector_account_oauth_bindings\".\"token_endpoint\") <> ''\n          AND btrim(\"custom_connector_account_oauth_bindings\".\"client_id\") <> ''\n          AND (\n            \"custom_connector_account_oauth_bindings\".\"resource_metadata_url\" IS NULL\n            OR btrim(\"custom_connector_account_oauth_bindings\".\"resource_metadata_url\") <> ''\n          )\n        )"
+        },
+        "chk_custom_connector_account_oauth_binding_token_auth_method": {
+          "name": "chk_custom_connector_account_oauth_binding_token_auth_method",
+          "value": "\"custom_connector_account_oauth_bindings\".\"token_endpoint_auth_method\" IN (\n          'none',\n          'client_secret_basic',\n          'client_secret_post'\n        )"
+        },
+        "chk_custom_connector_account_oauth_binding_registration": {
+          "name": "chk_custom_connector_account_oauth_binding_registration",
+          "value": "(\n          (\n            \"custom_connector_account_oauth_bindings\".\"registration_method\" = 'cimd'\n            AND \"custom_connector_account_oauth_bindings\".\"dcr_registration_id\" IS NULL\n            AND \"custom_connector_account_oauth_bindings\".\"token_endpoint_auth_method\" = 'none'\n          ) OR (\n            \"custom_connector_account_oauth_bindings\".\"registration_method\" = 'dcr'\n            AND \"custom_connector_account_oauth_bindings\".\"dcr_registration_id\" IS NOT NULL\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.desktop_auth_handoff_codes": {
+      "name": "desktop_auth_handoff_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_desktop_auth_handoff_codes_expires": {
+          "name": "idx_desktop_auth_handoff_codes_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_desktop_auth_handoff_codes_user_created": {
+          "name": "idx_desktop_auth_handoff_codes_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "desktop_auth_handoff_codes_code_hash_unique": {
+          "name": "desktop_auth_handoff_codes_code_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_code_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_outbox": {
+      "name": "email_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc_addresses": {
+          "name": "cc_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_run_id": {
+          "name": "source_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_workflow_automation_id": {
+          "name": "source_workflow_automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_id": {
+          "name": "resend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_outbox_drain_idx": {
+          "name": "email_outbox_drain_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_outbox_created_at_idx": {
+          "name": "email_outbox_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_outbox_source_run_automation_unique": {
+          "name": "email_outbox_source_run_automation_unique",
+          "columns": [
+            {
+              "expression": "source_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_workflow_automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "email_outbox_source_identity_check": {
+          "name": "email_outbox_source_identity_check",
+          "value": "(\n          \"email_outbox\".\"source_run_id\" IS NULL\n          AND \"email_outbox\".\"source_workflow_automation_id\" IS NULL\n        ) OR (\n          \"email_outbox\".\"source_run_id\" IS NOT NULL\n          AND \"email_outbox\".\"source_workflow_automation_id\" IS NOT NULL\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_suppressions_email_lower_idx": {
+          "name": "email_suppressions_email_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"email_address\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.export_jobs": {
+      "name": "export_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_urls": {
+          "name": "artifact_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_export_jobs_user_status": {
+          "name": "idx_export_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_created": {
+          "name": "idx_export_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_user_active": {
+          "name": "idx_export_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feishu_chat_ingress": {
+      "name": "feishu_chat_ingress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reaction_id": {
+          "name": "reaction_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_feishu_chat_ingress_installation_event": {
+          "name": "idx_feishu_chat_ingress_installation_event",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feishu_chat_ingress_installation_id_feishu_org_installations_id_fk": {
+          "name": "feishu_chat_ingress_installation_id_feishu_org_installations_id_fk",
+          "tableFrom": "feishu_chat_ingress",
+          "tableTo": "feishu_org_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_feishu_chat_ingress_status": {
+          "name": "chk_feishu_chat_ingress_status",
+          "value": "\"feishu_chat_ingress\".\"status\" IN ('pending', 'processing', 'processed', 'failed')"
+        },
+        "chk_feishu_chat_ingress_retry_count": {
+          "name": "chk_feishu_chat_ingress_retry_count",
+          "value": "\"feishu_chat_ingress\".\"retry_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feishu_chat_thread_routes": {
+      "name": "feishu_chat_thread_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_feishu_chat_thread_routes_conn_chat_thread_user": {
+          "name": "idx_feishu_chat_thread_routes_conn_chat_thread_user",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feishu_chat_thread_routes_connection_id_feishu_org_connections_id_fk": {
+          "name": "feishu_chat_thread_routes_connection_id_feishu_org_connections_id_fk",
+          "tableFrom": "feishu_chat_thread_routes",
+          "tableTo": "feishu_org_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feishu_chat_thread_routes_chat_thread_id_chat_threads_id_fk": {
+          "name": "feishu_chat_thread_routes_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "feishu_chat_thread_routes",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feishu_org_connections": {
+      "name": "feishu_org_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feishu_open_id": {
+          "name": "feishu_open_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feishu_user_name": {
+          "name": "feishu_user_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_feishu_org_connections_user_installation": {
+          "name": "idx_feishu_org_connections_user_installation",
+          "columns": [
+            {
+              "expression": "feishu_open_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feishu_org_connections_user_id_installation": {
+          "name": "idx_feishu_org_connections_user_id_installation",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feishu_org_connections_installation": {
+          "name": "idx_feishu_org_connections_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feishu_org_connections_connector": {
+          "name": "idx_feishu_org_connections_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"feishu_org_connections\".\"connector_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feishu_org_connections_installation_id_feishu_org_installations_id_fk": {
+          "name": "feishu_org_connections_installation_id_feishu_org_installations_id_fk",
+          "tableFrom": "feishu_org_connections",
+          "tableTo": "feishu_org_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feishu_org_connections_connector_id_connectors_id_fk": {
+          "name": "feishu_org_connections_connector_id_connectors_id_fk",
+          "tableFrom": "feishu_org_connections",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feishu_org_events": {
+      "name": "feishu_org_events",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feishu_org_events_installation_id_feishu_org_installations_id_fk": {
+          "name": "feishu_org_events_installation_id_feishu_org_installations_id_fk",
+          "tableFrom": "feishu_org_events",
+          "tableTo": "feishu_org_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feishu_org_events_pkey": {
+          "name": "feishu_org_events_pkey",
+          "columns": [
+            "installation_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feishu_org_installations": {
+      "name": "feishu_org_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_connector_id": {
+          "name": "custom_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_open_id": {
+          "name": "bot_open_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_name": {
+          "name": "bot_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_avatar_url": {
+          "name": "bot_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "encrypted_app_secret": {
+          "name": "encrypted_app_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_verification_token": {
+          "name": "encrypted_verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_encrypt_key": {
+          "name": "encrypted_encrypt_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_agent_id": {
+          "name": "default_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feishu_tenant_key": {
+          "name": "feishu_tenant_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feishu_tenant_name": {
+          "name": "feishu_tenant_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_tenant_access_token": {
+          "name": "encrypted_tenant_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_access_token_expires_at": {
+          "name": "tenant_access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "callback_verified_at": {
+          "name": "callback_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_completed_at": {
+          "name": "setup_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_received_at": {
+          "name": "message_received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_feishu_org_installations_org": {
+          "name": "idx_feishu_org_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feishu_org_installations_custom_connector": {
+          "name": "idx_feishu_org_installations_custom_connector",
+          "columns": [
+            {
+              "expression": "custom_connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feishu_org_installations_app": {
+          "name": "idx_feishu_org_installations_app",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feishu_org_installations_tenant": {
+          "name": "idx_feishu_org_installations_tenant",
+          "columns": [
+            {
+              "expression": "feishu_tenant_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feishu_org_installations_default_agent_id_agents_id_fk": {
+          "name": "feishu_org_installations_default_agent_id_agents_id_fk",
+          "tableFrom": "feishu_org_installations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "default_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_feishu_org_installations_custom_connector": {
+          "name": "fk_feishu_org_installations_custom_connector",
+          "tableFrom": "feishu_org_installations",
+          "tableTo": "org_custom_connectors",
+          "columnsFrom": [
+            "custom_connector_id",
+            "org_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feishu_user_agent_preferences": {
+      "name": "feishu_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_agent_id": {
+          "name": "selected_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feishu_user_agent_preferences_selected_agent_id_agents_id_fk": {
+          "name": "feishu_user_agent_preferences_selected_agent_id_agents_id_fk",
+          "tableFrom": "feishu_user_agent_preferences",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "selected_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feishu_user_agent_preferences_user_id_org_id_pk": {
+          "name": "feishu_user_agent_preferences_user_id_org_id_pk",
+          "columns": [
+            "user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_chat_thread_routes": {
+      "name": "github_chat_thread_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_number": {
+          "name": "subject_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_comment_id": {
+          "name": "last_comment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_chat_thread_routes_install_repo_subject_user": {
+          "name": "idx_github_chat_thread_routes_install_repo_subject_user",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_chat_thread_routes_installation_id_github_installations_id_fk": {
+          "name": "github_chat_thread_routes_installation_id_github_installations_id_fk",
+          "tableFrom": "github_chat_thread_routes",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_chat_thread_routes_chat_thread_id_chat_threads_id_fk": {
+          "name": "github_chat_thread_routes_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "github_chat_thread_routes",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_slug": {
+          "name": "app_slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'okou'"
+        },
+        "setup_public_brand": {
+          "name": "setup_public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_github_user_id": {
+          "name": "admin_github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_agent_id": {
+          "name": "default_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_configs": {
+          "name": "repo_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installations_org": {
+          "name": "idx_github_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_default_agent_id_agents_id_fk": {
+          "name": "github_installations_default_agent_id_agents_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "default_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_user_links": {
+      "name": "github_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_user_links_user_installation": {
+          "name": "idx_github_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "github_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_user_links_installation_id_github_installations_id_fk": {
+          "name": "github_user_links_installation_id_github_installations_id_fk",
+          "tableFrom": "github_user_links",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gmail_processed_events": {
+      "name": "gmail_processed_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "watch_state_id": {
+          "name": "watch_state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pubsub_message_id": {
+          "name": "pubsub_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "history_id": {
+          "name": "history_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gmail_processed_events_automation_event": {
+          "name": "idx_gmail_processed_events_automation_event",
+          "columns": [
+            {
+              "expression": "watch_state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "history_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gmail_processed_events_pubsub_message": {
+          "name": "idx_gmail_processed_events_pubsub_message",
+          "columns": [
+            {
+              "expression": "pubsub_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_processed_events_watch_state_id_gmail_watch_states_id_fk": {
+          "name": "gmail_processed_events_watch_state_id_gmail_watch_states_id_fk",
+          "tableFrom": "gmail_processed_events",
+          "tableTo": "gmail_watch_states",
+          "columnsFrom": [
+            "watch_state_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gmail_processed_events_automation_id_workflow_automations_id_fk": {
+          "name": "gmail_processed_events_automation_id_workflow_automations_id_fk",
+          "tableFrom": "gmail_processed_events",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gmail_watch_states": {
+      "name": "gmail_watch_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_name": {
+          "name": "topic_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_history_id": {
+          "name": "last_history_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watch_expiration_at": {
+          "name": "watch_expiration_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_watch_renewed_at": {
+          "name": "last_watch_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_rewatch": {
+          "name": "needs_rewatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gmail_watch_states_connector_topic": {
+          "name": "idx_gmail_watch_states_connector_topic",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gmail_watch_states_email_topic": {
+          "name": "idx_gmail_watch_states_email_topic",
+          "columns": [
+            {
+              "expression": "email_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gmail_watch_states_renewal": {
+          "name": "idx_gmail_watch_states_renewal",
+          "columns": [
+            {
+              "expression": "watch_expiration_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_watch_states_connector_id_connectors_id_fk": {
+          "name": "gmail_watch_states_connector_id_connectors_id_fk",
+          "tableFrom": "gmail_watch_states",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_calendar_event_snapshots": {
+      "name": "google_calendar_event_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "watch_state_id": {
+          "name": "watch_state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "etag": {
+          "name": "etag",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_created_at": {
+          "name": "event_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_updated_at": {
+          "name": "event_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_calendar_event_snapshots_event": {
+          "name": "idx_google_calendar_event_snapshots_event",
+          "columns": [
+            {
+              "expression": "watch_state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendar_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_calendar_event_snapshots_updated": {
+          "name": "idx_google_calendar_event_snapshots_updated",
+          "columns": [
+            {
+              "expression": "event_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_calendar_event_snapshots_watch_state_id_google_calendar_watch_states_id_fk": {
+          "name": "google_calendar_event_snapshots_watch_state_id_google_calendar_watch_states_id_fk",
+          "tableFrom": "google_calendar_event_snapshots",
+          "tableTo": "google_calendar_watch_states",
+          "columnsFrom": [
+            "watch_state_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_calendar_processed_events": {
+      "name": "google_calendar_processed_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "watch_state_id": {
+          "name": "watch_state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_state": {
+          "name": "resource_state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_change_key": {
+          "name": "event_change_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "event_created_at": {
+          "name": "event_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_updated_at": {
+          "name": "event_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_calendar_processed_events_automation_event": {
+          "name": "idx_google_calendar_processed_events_automation_event",
+          "columns": [
+            {
+              "expression": "watch_state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendar_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_change_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_calendar_processed_events_channel": {
+          "name": "idx_google_calendar_processed_events_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_calendar_processed_events_watch_state_id_google_calendar_watch_states_id_fk": {
+          "name": "google_calendar_processed_events_watch_state_id_google_calendar_watch_states_id_fk",
+          "tableFrom": "google_calendar_processed_events",
+          "tableTo": "google_calendar_watch_states",
+          "columnsFrom": [
+            "watch_state_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "google_calendar_processed_events_automation_id_workflow_automations_id_fk": {
+          "name": "google_calendar_processed_events_automation_id_workflow_automations_id_fk",
+          "tableFrom": "google_calendar_processed_events",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_calendar_watch_states": {
+      "name": "google_calendar_watch_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_token": {
+          "name": "channel_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_uri": {
+          "name": "resource_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_channel_id": {
+          "name": "previous_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_channel_token": {
+          "name": "previous_channel_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_resource_id": {
+          "name": "previous_resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_token": {
+          "name": "sync_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watch_expiration_at": {
+          "name": "watch_expiration_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_watch_renewed_at": {
+          "name": "last_watch_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_rewatch": {
+          "name": "needs_rewatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_calendar_watch_states_connector_calendar": {
+          "name": "idx_google_calendar_watch_states_connector_calendar",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_calendar_watch_states_channel": {
+          "name": "idx_google_calendar_watch_states_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_calendar_watch_states_resource": {
+          "name": "idx_google_calendar_watch_states_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_calendar_watch_states_renewal": {
+          "name": "idx_google_calendar_watch_states_renewal",
+          "columns": [
+            {
+              "expression": "watch_expiration_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_calendar_watch_states_connector_id_connectors_id_fk": {
+          "name": "google_calendar_watch_states_connector_id_connectors_id_fk",
+          "tableFrom": "google_calendar_watch_states",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_forms_automation_cursors": {
+      "name": "google_forms_automation_cursors",
+      "schema": "",
+      "columns": {
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watch_state_id": {
+          "name": "watch_state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_submitted_time": {
+          "name": "last_seen_submitted_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_forms_automation_cursors_watch": {
+          "name": "idx_google_forms_automation_cursors_watch",
+          "columns": [
+            {
+              "expression": "watch_state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_forms_automation_cursors_automation_id_workflow_automations_id_fk": {
+          "name": "google_forms_automation_cursors_automation_id_workflow_automations_id_fk",
+          "tableFrom": "google_forms_automation_cursors",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "google_forms_automation_cursors_watch_state_id_google_forms_watch_states_id_fk": {
+          "name": "google_forms_automation_cursors_watch_state_id_google_forms_watch_states_id_fk",
+          "tableFrom": "google_forms_automation_cursors",
+          "tableTo": "google_forms_watch_states",
+          "columnsFrom": [
+            "watch_state_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_forms_processed_events": {
+      "name": "google_forms_processed_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "watch_state_id": {
+          "name": "watch_state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pubsub_message_id": {
+          "name": "pubsub_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_submitted_time": {
+          "name": "last_submitted_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_forms_processed_events_automation_response": {
+          "name": "idx_google_forms_processed_events_automation_response",
+          "columns": [
+            {
+              "expression": "watch_state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_submitted_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_forms_processed_events_pubsub_message": {
+          "name": "idx_google_forms_processed_events_pubsub_message",
+          "columns": [
+            {
+              "expression": "pubsub_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_forms_processed_events_watch_state_id_google_forms_watch_states_id_fk": {
+          "name": "google_forms_processed_events_watch_state_id_google_forms_watch_states_id_fk",
+          "tableFrom": "google_forms_processed_events",
+          "tableTo": "google_forms_watch_states",
+          "columnsFrom": [
+            "watch_state_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "google_forms_processed_events_automation_id_workflow_automations_id_fk": {
+          "name": "google_forms_processed_events_automation_id_workflow_automations_id_fk",
+          "tableFrom": "google_forms_processed_events",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_forms_watch_states": {
+      "name": "google_forms_watch_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watch_id": {
+          "name": "watch_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_name": {
+          "name": "topic_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expire_time": {
+          "name": "expire_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_renewed_at": {
+          "name": "last_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_rewatch": {
+          "name": "needs_rewatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_forms_watch_states_connector_form": {
+          "name": "idx_google_forms_watch_states_connector_form",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "form_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_forms_watch_states_watch": {
+          "name": "idx_google_forms_watch_states_watch",
+          "columns": [
+            {
+              "expression": "watch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_forms_watch_states_renewal": {
+          "name": "idx_google_forms_watch_states_renewal",
+          "columns": [
+            {
+              "expression": "expire_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_forms_watch_states_connector_id_connectors_id_fk": {
+          "name": "google_forms_watch_states_connector_id_connectors_id_fk",
+          "tableFrom": "google_forms_watch_states",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_workspace_event_subscription_states": {
+      "name": "google_workspace_event_subscription_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_resource": {
+          "name": "target_resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_types_key": {
+          "name": "event_types_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_name": {
+          "name": "subscription_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pubsub_topic": {
+          "name": "pubsub_topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expire_time": {
+          "name": "expire_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_renewed_at": {
+          "name": "last_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_repair": {
+          "name": "needs_repair",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_workspace_event_subscription_scope": {
+          "name": "idx_google_workspace_event_subscription_scope",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pubsub_topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_types_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_workspace_event_subscription_name": {
+          "name": "idx_google_workspace_event_subscription_name",
+          "columns": [
+            {
+              "expression": "subscription_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_workspace_event_subscription_owner": {
+          "name": "idx_google_workspace_event_subscription_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_workspace_event_subscription_renewal": {
+          "name": "idx_google_workspace_event_subscription_renewal",
+          "columns": [
+            {
+              "expression": "expire_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_workspace_event_subscription_states_connector_id_connectors_id_fk": {
+          "name": "google_workspace_event_subscription_states_connector_id_connectors_id_fk",
+          "tableFrom": "google_workspace_event_subscription_states",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_workspace_processed_events": {
+      "name": "google_workspace_processed_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subscription_state_id": {
+          "name": "subscription_state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pubsub_message_id": {
+          "name": "pubsub_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_event_id": {
+          "name": "cloud_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cloud_event_type": {
+          "name": "cloud_event_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conference_record_name": {
+          "name": "conference_record_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_name": {
+          "name": "transcript_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_workspace_processed_events_automation_cloudevent": {
+          "name": "idx_google_workspace_processed_events_automation_cloudevent",
+          "columns": [
+            {
+              "expression": "subscription_state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cloud_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_workspace_processed_events_automation_transcript": {
+          "name": "idx_google_workspace_processed_events_automation_transcript",
+          "columns": [
+            {
+              "expression": "subscription_state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "transcript_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_workspace_processed_events_pubsub_message": {
+          "name": "idx_google_workspace_processed_events_pubsub_message",
+          "columns": [
+            {
+              "expression": "pubsub_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_workspace_processed_events_subscription_state_id_google_workspace_event_subscription_states_id_fk": {
+          "name": "google_workspace_processed_events_subscription_state_id_google_workspace_event_subscription_states_id_fk",
+          "tableFrom": "google_workspace_processed_events",
+          "tableTo": "google_workspace_event_subscription_states",
+          "columnsFrom": [
+            "subscription_state_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "google_workspace_processed_events_automation_id_workflow_automations_id_fk": {
+          "name": "google_workspace_processed_events_automation_id_workflow_automations_id_fk",
+          "tableFrom": "google_workspace_processed_events",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_deployments": {
+      "name": "hosted_deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "deployment_version": {
+          "name": "deployment_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_url": {
+          "name": "artifact_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "r2_prefix": {
+          "name": "r2_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrypoint": {
+          "name": "entrypoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/index.html'"
+        },
+        "spa_fallback": {
+          "name": "spa_fallback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_hosted_deployments_site": {
+          "name": "idx_hosted_deployments_site",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_deployments_site_version": {
+          "name": "idx_hosted_deployments_site_version",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deployment_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"hosted_deployments\".\"deployment_version\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_deployments_org": {
+          "name": "idx_hosted_deployments_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_deployments_status": {
+          "name": "idx_hosted_deployments_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hosted_deployments_site_id_hosted_sites_id_fk": {
+          "name": "hosted_deployments_site_id_hosted_sites_id_fk",
+          "tableFrom": "hosted_deployments",
+          "tableTo": "hosted_sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_hosted_deployments_site_public_brand": {
+          "name": "fk_hosted_deployments_site_public_brand",
+          "tableFrom": "hosted_deployments",
+          "tableTo": "hosted_sites",
+          "columnsFrom": [
+            "site_id",
+            "public_brand"
+          ],
+          "columnsTo": [
+            "id",
+            "public_brand"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_sites": {
+      "name": "hosted_sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_slug": {
+          "name": "requested_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_slug": {
+          "name": "public_slug",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_deployment_id": {
+          "name": "active_deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_deployment_version": {
+          "name": "active_deployment_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_deployment_version": {
+          "name": "next_deployment_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_from_run_id": {
+          "name": "created_from_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_hosted_sites_org": {
+          "name": "idx_hosted_sites_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_sites_org_slug": {
+          "name": "idx_hosted_sites_org_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_sites_org_chat_thread_requested_slug": {
+          "name": "idx_hosted_sites_org_chat_thread_requested_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"hosted_sites\".\"chat_thread_id\" IS NOT NULL AND \"hosted_sites\".\"requested_slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_sites_org_requested_slug_non_chat": {
+          "name": "idx_hosted_sites_org_requested_slug_non_chat",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"hosted_sites\".\"chat_thread_id\" IS NULL AND \"hosted_sites\".\"requested_slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_sites_public_slug": {
+          "name": "idx_hosted_sites_public_slug",
+          "columns": [
+            {
+              "expression": "public_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "idx_hosted_sites_id_public_brand": {
+          "name": "idx_hosted_sites_id_public_brand",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "public_brand"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.image_artifact_edit_snapshots": {
+      "name": "image_artifact_edit_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_url": {
+          "name": "artifact_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_image_artifact_edit_snapshots_owner_artifact": {
+          "name": "idx_image_artifact_edit_snapshots_owner_artifact",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_drafts": {
+      "name": "mail_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gmail_draft_id": {
+          "name": "gmail_draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gmail_thread_id": {
+          "name": "gmail_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gmail_message_id": {
+          "name": "gmail_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_gmail_message_id": {
+          "name": "sent_gmail_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_address": {
+          "name": "sender_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mail_drafts_chat_thread": {
+          "name": "idx_mail_drafts_chat_thread",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_drafts_connector_gmail_draft_unique": {
+          "name": "mail_drafts_connector_gmail_draft_unique",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gmail_draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_drafts_chat_thread_id_chat_threads_id_fk": {
+          "name": "mail_drafts_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "mail_drafts",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mail_drafts_connector_id_connectors_id_fk": {
+          "name": "mail_drafts_connector_id_connectors_id_fk",
+          "tableFrom": "mail_drafts",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_summary_projections": {
+      "name": "memory_summary_projections",
+      "schema": "",
+      "columns": {
+        "memory_storage_id": {
+          "name": "memory_storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_version_id": {
+          "name": "storage_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error_class": {
+          "name": "last_error_class",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_size": {
+          "name": "source_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_memory_summary_projections_pending": {
+          "name": "idx_memory_summary_projections_pending",
+          "columns": [
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "storage_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"memory_summary_projections\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_summary_projections_expired_lease": {
+          "name": "idx_memory_summary_projections_expired_lease",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "storage_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"memory_summary_projections\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_summary_projections_owner": {
+          "name": "idx_memory_summary_projections_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "storage_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_summary_projections_memory_storage_id_storages_id_fk": {
+          "name": "memory_summary_projections_memory_storage_id_storages_id_fk",
+          "tableFrom": "memory_summary_projections",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "memory_storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_summary_projections_storage_version_id_storage_versions_id_fk": {
+          "name": "memory_summary_projections_storage_version_id_storage_versions_id_fk",
+          "tableFrom": "memory_summary_projections",
+          "tableTo": "storage_versions",
+          "columnsFrom": [
+            "storage_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "memory_summary_projections_memory_storage_id_storage_version_id_pk": {
+          "name": "memory_summary_projections_memory_storage_id_storage_version_id_pk",
+          "columns": [
+            "memory_storage_id",
+            "storage_version_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "memory_summary_projections_status_check": {
+          "name": "memory_summary_projections_status_check",
+          "value": "\"memory_summary_projections\".\"status\" IN ('pending', 'running', 'ready', 'missing', 'invalid', 'over_limit')"
+        },
+        "memory_summary_projections_lease_check": {
+          "name": "memory_summary_projections_lease_check",
+          "value": "(\n          \"memory_summary_projections\".\"status\" = 'running'\n          AND \"memory_summary_projections\".\"lease_id\" IS NOT NULL\n          AND \"memory_summary_projections\".\"lease_expires_at\" IS NOT NULL\n        ) OR (\n          \"memory_summary_projections\".\"status\" <> 'running'\n          AND \"memory_summary_projections\".\"lease_id\" IS NULL\n          AND \"memory_summary_projections\".\"lease_expires_at\" IS NULL\n        )"
+        },
+        "memory_summary_projections_content_check": {
+          "name": "memory_summary_projections_content_check",
+          "value": "(\n          \"memory_summary_projections\".\"status\" = 'ready'\n          AND \"memory_summary_projections\".\"content\" IS NOT NULL\n          AND \"memory_summary_projections\".\"source_hash\" IS NOT NULL\n          AND \"memory_summary_projections\".\"source_size\" IS NOT NULL\n          AND \"memory_summary_projections\".\"token_count\" IS NOT NULL\n        ) OR (\n          \"memory_summary_projections\".\"status\" <> 'ready'\n          AND \"memory_summary_projections\".\"content\" IS NULL\n          AND \"memory_summary_projections\".\"source_hash\" IS NULL\n          AND \"memory_summary_projections\".\"source_size\" IS NULL\n          AND \"memory_summary_projections\".\"token_count\" IS NULL\n        )"
+        },
+        "memory_summary_projections_attempt_count_check": {
+          "name": "memory_summary_projections_attempt_count_check",
+          "value": "\"memory_summary_projections\".\"attempt_count\" >= 0"
+        },
+        "memory_summary_projections_source_size_check": {
+          "name": "memory_summary_projections_source_size_check",
+          "value": "\"memory_summary_projections\".\"source_size\" IS NULL OR \"memory_summary_projections\".\"source_size\" >= 0"
+        },
+        "memory_summary_projections_token_count_check": {
+          "name": "memory_summary_projections_token_count_check",
+          "value": "\"memory_summary_projections\".\"token_count\" IS NULL OR \"memory_summary_projections\".\"token_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.model_provider_account_secrets": {
+      "name": "model_provider_account_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "model_provider_account_id": {
+          "name": "model_provider_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_provider_account_secrets_account_name": {
+          "name": "idx_model_provider_account_secrets_account_name",
+          "columns": [
+            {
+              "expression": "model_provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_provider_account_secrets_model_provider_account_id_model_provider_accounts_id_fk": {
+          "name": "model_provider_account_secrets_model_provider_account_id_model_provider_accounts_id_fk",
+          "tableFrom": "model_provider_account_secrets",
+          "tableTo": "model_provider_accounts",
+          "columnsFrom": [
+            "model_provider_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider_accounts": {
+      "name": "model_provider_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_email": {
+          "name": "account_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_reconnect": {
+          "name": "needs_reconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_refresh_error_code": {
+          "name": "last_refresh_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_reset_period": {
+          "name": "subscription_reset_period",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_next_reset_at": {
+          "name": "subscription_next_reset_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_provider_accounts_provider": {
+          "name": "idx_model_provider_accounts_provider",
+          "columns": [
+            {
+              "expression": "model_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_accounts_owner_type": {
+          "name": "idx_model_provider_accounts_owner_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_accounts_one_active": {
+          "name": "idx_model_provider_accounts_one_active",
+          "columns": [
+            {
+              "expression": "model_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"model_provider_accounts\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_provider_accounts_model_provider_id_model_providers_id_fk": {
+          "name": "model_provider_accounts_model_provider_id_model_providers_id_fk",
+          "tableFrom": "model_provider_accounts",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider_auth_sessions": {
+      "name": "model_provider_auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "model_provider_auth_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'initializing'"
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_url": {
+          "name": "approval_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_code": {
+          "name": "verification_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_provider_state": {
+          "name": "encrypted_provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_model_provider_auth_sessions_owner_status": {
+          "name": "idx_model_provider_auth_sessions_owner_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_auth_sessions_expiration": {
+          "name": "idx_model_provider_auth_sessions_expiration",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_auth_sessions_sandbox": {
+          "name": "idx_model_provider_auth_sessions_sandbox",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"model_provider_auth_sessions\".\"sandbox_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider_connections": {
+      "name": "model_provider_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_provider_connections_org": {
+          "name": "idx_model_provider_connections_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_connections_secret": {
+          "name": "idx_model_provider_connections_secret",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_provider_connections_secret_id_secrets_id_fk": {
+          "name": "model_provider_connections_secret_id_secrets_id_fk",
+          "tableFrom": "model_provider_connections",
+          "tableTo": "secrets",
+          "columnsFrom": [
+            "secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider_surfaces": {
+      "name": "model_provider_surfaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_header_name": {
+          "name": "auth_header_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_header_template": {
+          "name": "auth_header_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_mappings": {
+          "name": "model_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_provider_surfaces_connection": {
+          "name": "idx_model_provider_surfaces_connection",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_surfaces_connection_protocol": {
+          "name": "idx_model_provider_surfaces_connection_protocol",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "protocol",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_provider_surfaces_connection_id_model_provider_connections_id_fk": {
+          "name": "model_provider_surfaces_connection_id_model_provider_connections_id_fk",
+          "tableFrom": "model_provider_surfaces",
+          "tableTo": "model_provider_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_model_provider_surfaces_protocol": {
+          "name": "chk_model_provider_surfaces_protocol",
+          "value": "\"model_provider_surfaces\".\"protocol\" IN ('anthropic-messages', 'openai-responses')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.model_providers": {
+      "name": "model_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_reconnect": {
+          "name": "needs_reconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_refresh_error_code": {
+          "name": "last_refresh_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_reset_period": {
+          "name": "subscription_reset_period",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_next_reset_at": {
+          "name": "subscription_next_reset_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_providers_secret": {
+          "name": "idx_model_providers_secret",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org": {
+          "name": "idx_model_providers_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org_user_type": {
+          "name": "idx_model_providers_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_one_default_per_user": {
+          "name": "idx_model_providers_one_default_per_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_providers_secret_id_secrets_id_fk": {
+          "name": "model_providers_secret_id_secrets_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "secrets",
+          "columnsFrom": [
+            "secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_stat": {
+      "name": "model_stat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "hour_start": {
+          "name": "hour_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_model_stat_hour_model": {
+          "name": "uq_model_stat_hour_model",
+          "columns": [
+            {
+              "expression": "hour_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_stat_hour_start": {
+          "name": "idx_model_stat_hour_start",
+          "columns": [
+            {
+              "expression": "hour_start",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_stat_model_hour": {
+          "name": "idx_model_stat_model_hour",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hour_start",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_usage_observation": {
+      "name": "model_usage_observation",
+      "schema": "",
+      "columns": {
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "aggregated_at": {
+          "name": "aggregated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_model_usage_observation_observed_at": {
+          "name": "idx_model_usage_observation_observed_at",
+          "columns": [
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notion_webhook_events": {
+      "name": "notion_webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "notion_event_id": {
+          "name": "notion_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notion_webhook_events_event_id": {
+          "name": "idx_notion_webhook_events_event_id",
+          "columns": [
+            {
+              "expression": "notion_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notion_webhook_events_page": {
+          "name": "idx_notion_webhook_events_page",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notion_webhook_secrets": {
+      "name": "notion_webhook_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_verification_token": {
+          "name": "encrypted_verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notion_webhook_secrets_active": {
+          "name": "idx_notion_webhook_secrets_active",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notion_webhook_secrets_active_single": {
+          "name": "idx_notion_webhook_secrets_active_single",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "active = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notion_workflow_pending_events": {
+      "name": "notion_workflow_pending_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_family": {
+          "name": "event_family",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new_child_page'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "first_notion_event_id": {
+          "name": "first_notion_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_notion_event_id": {
+          "name": "latest_notion_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_event_at": {
+          "name": "first_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_event_at": {
+          "name": "latest_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_event_context": {
+          "name": "latest_event_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_after": {
+          "name": "run_after",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_title": {
+          "name": "parent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_url": {
+          "name": "parent_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notion_pending_events_automation_page_family_active": {
+          "name": "idx_notion_pending_events_automation_page_family_active",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_family",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notion_pending_events_due": {
+          "name": "idx_notion_pending_events_due",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notion_pending_events_connector": {
+          "name": "idx_notion_pending_events_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notion_pending_events_page_pending": {
+          "name": "idx_notion_pending_events_page_pending",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notion_pending_events_scope": {
+          "name": "idx_notion_pending_events_scope",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notion_workflow_pending_events_automation_id_workflow_automations_id_fk": {
+          "name": "notion_workflow_pending_events_automation_id_workflow_automations_id_fk",
+          "tableFrom": "notion_workflow_pending_events",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notion_workflow_pending_events_connector_id_connectors_id_fk": {
+          "name": "notion_workflow_pending_events_connector_id_connectors_id_fk",
+          "tableFrom": "notion_workflow_pending_events",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.official_automation_result_email_claims": {
+      "name": "official_automation_result_email_claims",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_automation_id": {
+          "name": "workflow_automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_outbox_id": {
+          "name": "email_outbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "official_automation_result_email_claims_outbox_unique": {
+          "name": "official_automation_result_email_claims_outbox_unique",
+          "columns": [
+            {
+              "expression": "email_outbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "official_automation_result_email_claims_pkey": {
+          "name": "official_automation_result_email_claims_pkey",
+          "columns": [
+            "run_id",
+            "workflow_automation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.official_workflow_catalog_releases": {
+      "name": "official_workflow_catalog_releases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "official_workflow_catalog_release_hash_format": {
+          "name": "official_workflow_catalog_release_hash_format",
+          "value": "\"official_workflow_catalog_releases\".\"id\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.official_workflow_catalog_state": {
+      "name": "official_workflow_catalog_state",
+      "schema": "",
+      "columns": {
+        "authority": {
+          "name": "authority",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accepted_release_id": {
+          "name": "accepted_release_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "official_workflow_catalog_state_accepted_release_id_official_workflow_catalog_releases_id_fk": {
+          "name": "official_workflow_catalog_state_accepted_release_id_official_workflow_catalog_releases_id_fk",
+          "tableFrom": "official_workflow_catalog_state",
+          "tableTo": "official_workflow_catalog_releases",
+          "columnsFrom": [
+            "accepted_release_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "official_workflow_catalog_state_authority": {
+          "name": "official_workflow_catalog_state_authority",
+          "value": "\"official_workflow_catalog_state\".\"authority\" = 'official'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.official_workflow_definition_revisions": {
+      "name": "official_workflow_definition_revisions",
+      "schema": "",
+      "columns": {
+        "definition_name": {
+          "name": "definition_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_name": {
+          "name": "storage_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_version": {
+          "name": "storage_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "official_workflow_definition_revisions_storage_id_storages_id_fk": {
+          "name": "official_workflow_definition_revisions_storage_id_storages_id_fk",
+          "tableFrom": "official_workflow_definition_revisions",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "official_workflow_definition_revisions_storage_version_storage_versions_id_fk": {
+          "name": "official_workflow_definition_revisions_storage_version_storage_versions_id_fk",
+          "tableFrom": "official_workflow_definition_revisions",
+          "tableTo": "storage_versions",
+          "columnsFrom": [
+            "storage_version"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "official_workflow_definition_revisions_pk": {
+          "name": "official_workflow_definition_revisions_pk",
+          "columns": [
+            "definition_name",
+            "revision"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "official_workflow_definition_revision_hash_format": {
+          "name": "official_workflow_definition_revision_hash_format",
+          "value": "\"official_workflow_definition_revisions\".\"revision\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.official_workflow_reconciliation_work": {
+      "name": "official_workflow_reconciliation_work",
+      "schema": "",
+      "columns": {
+        "definition_name": {
+          "name": "definition_name",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requested_release_id": {
+          "name": "requested_release_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor_workflow_id": {
+          "name": "cursor_workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_official_workflow_reconciliation_work_due": {
+          "name": "idx_official_workflow_reconciliation_work_due",
+          "columns": [
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "definition_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "official_workflow_reconciliation_work_requested_release_id_official_workflow_catalog_releases_id_fk": {
+          "name": "official_workflow_reconciliation_work_requested_release_id_official_workflow_catalog_releases_id_fk",
+          "tableFrom": "official_workflow_reconciliation_work",
+          "tableTo": "official_workflow_catalog_releases",
+          "columnsFrom": [
+            "requested_release_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "official_workflow_reconciliation_work_state_check": {
+          "name": "official_workflow_reconciliation_work_state_check",
+          "value": "(\n          \"official_workflow_reconciliation_work\".\"state\" = 'pending'\n          AND \"official_workflow_reconciliation_work\".\"lease_id\" IS NULL\n          AND \"official_workflow_reconciliation_work\".\"lease_expires_at\" IS NULL\n        ) OR (\n          \"official_workflow_reconciliation_work\".\"state\" = 'running'\n          AND \"official_workflow_reconciliation_work\".\"lease_id\" IS NOT NULL\n          AND \"official_workflow_reconciliation_work\".\"lease_expires_at\" IS NOT NULL\n        )"
+        },
+        "official_workflow_reconciliation_work_attempt_count_check": {
+          "name": "official_workflow_reconciliation_work_attempt_count_check",
+          "value": "\"official_workflow_reconciliation_work\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_cache": {
+      "name": "org_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_concurrency_entitlements": {
+      "name": "org_concurrency_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_line_id": {
+          "name": "stripe_invoice_line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slots": {
+          "name": "slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_concurrency_entitlements_invoice_line": {
+          "name": "uq_org_concurrency_entitlements_invoice_line",
+          "columns": [
+            {
+              "expression": "stripe_invoice_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_concurrency_entitlements_org_active": {
+          "name": "idx_org_concurrency_entitlements_org_active",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_concurrency_entitlements_slots": {
+          "name": "chk_org_concurrency_entitlements_slots",
+          "value": "\"org_concurrency_entitlements\".\"slots\" > 0"
+        },
+        "chk_org_concurrency_entitlements_window": {
+          "name": "chk_org_concurrency_entitlements_window",
+          "value": "\"org_concurrency_entitlements\".\"expires_at\" > \"org_concurrency_entitlements\".\"starts_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_concurrency_subscriptions": {
+      "name": "org_concurrency_subscriptions",
+      "schema": "",
+      "columns": {
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slots": {
+          "name": "slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scheduled_slots": {
+          "name": "scheduled_slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_change_at": {
+          "name": "scheduled_change_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_concurrency_subscriptions_org": {
+          "name": "idx_org_concurrency_subscriptions_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_concurrency_subscriptions_status_period": {
+          "name": "idx_org_concurrency_subscriptions_status_period",
+          "columns": [
+            {
+              "expression": "subscription_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_concurrency_subscriptions_slots": {
+          "name": "chk_org_concurrency_subscriptions_slots",
+          "value": "\"org_concurrency_subscriptions\".\"slots\" > 0"
+        },
+        "chk_org_concurrency_subscriptions_scheduled_slots": {
+          "name": "chk_org_concurrency_subscriptions_scheduled_slots",
+          "value": "\"org_concurrency_subscriptions\".\"scheduled_slots\" IS NULL OR \"org_concurrency_subscriptions\".\"scheduled_slots\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_custom_connector_dcr_registrations": {
+      "name": "org_custom_connector_dcr_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_connector_id": {
+          "name": "custom_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_client_secret": {
+          "name": "encrypted_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_scopes": {
+          "name": "registered_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_custom_connector_dcr_registrations_org": {
+          "name": "idx_org_custom_connector_dcr_registrations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_org_custom_connector_dcr_registrations_connector": {
+          "name": "fk_org_custom_connector_dcr_registrations_connector",
+          "tableFrom": "org_custom_connector_dcr_registrations",
+          "tableTo": "org_custom_connectors",
+          "columnsFrom": [
+            "custom_connector_id",
+            "org_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_org_custom_connector_dcr_registration_id_connector": {
+          "name": "uq_org_custom_connector_dcr_registration_id_connector",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "custom_connector_id"
+          ]
+        },
+        "uq_org_custom_connector_dcr_registration_issuer": {
+          "name": "uq_org_custom_connector_dcr_registration_issuer",
+          "nullsNotDistinct": false,
+          "columns": [
+            "custom_connector_id",
+            "issuer"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_custom_connector_dcr_registration_identity": {
+          "name": "chk_org_custom_connector_dcr_registration_identity",
+          "value": "(\n          btrim(\"org_custom_connector_dcr_registrations\".\"issuer\") <> ''\n          AND btrim(\"org_custom_connector_dcr_registrations\".\"client_id\") <> ''\n          AND btrim(\"org_custom_connector_dcr_registrations\".\"redirect_uri\") <> ''\n        )"
+        },
+        "chk_org_custom_connector_dcr_registration_token_auth_method": {
+          "name": "chk_org_custom_connector_dcr_registration_token_auth_method",
+          "value": "(\n          (\n            \"org_custom_connector_dcr_registrations\".\"token_endpoint_auth_method\" = 'none'\n            AND \"org_custom_connector_dcr_registrations\".\"encrypted_client_secret\" IS NULL\n          ) OR (\n            \"org_custom_connector_dcr_registrations\".\"token_endpoint_auth_method\" IN (\n              'client_secret_basic',\n              'client_secret_post'\n            )\n            AND \"org_custom_connector_dcr_registrations\".\"encrypted_client_secret\" IS NOT NULL\n          )\n        )"
+        },
+        "chk_org_custom_connector_dcr_registration_expiry": {
+          "name": "chk_org_custom_connector_dcr_registration_expiry",
+          "value": "\"org_custom_connector_dcr_registrations\".\"expires_at\" IS NULL OR \"org_custom_connector_dcr_registrations\".\"expires_at\" > \"org_custom_connector_dcr_registrations\".\"issued_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_custom_connector_oauth_configs": {
+      "name": "org_custom_connector_oauth_configs",
+      "schema": "",
+      "columns": {
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_adapter": {
+          "name": "provider_adapter",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_client_secret": {
+          "name": "encrypted_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_url": {
+          "name": "token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pkce_method": {
+          "name": "pkce_method",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "authorization_params": {
+          "name": "authorization_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_org_custom_connector_oauth_configs_connector": {
+          "name": "fk_org_custom_connector_oauth_configs_connector",
+          "tableFrom": "org_custom_connector_oauth_configs",
+          "tableTo": "org_custom_connectors",
+          "columnsFrom": [
+            "connector_id",
+            "org_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_custom_connector_oauth_configs_provider_adapter": {
+          "name": "chk_org_custom_connector_oauth_configs_provider_adapter",
+          "value": "\"org_custom_connector_oauth_configs\".\"provider_adapter\" IN ('standard', 'feishu')"
+        },
+        "chk_org_custom_connector_oauth_configs_pkce_method": {
+          "name": "chk_org_custom_connector_oauth_configs_pkce_method",
+          "value": "\"org_custom_connector_oauth_configs\".\"pkce_method\" IN ('none', 'S256')"
+        },
+        "chk_org_custom_connector_oauth_configs_token_auth_method": {
+          "name": "chk_org_custom_connector_oauth_configs_token_auth_method",
+          "value": "\"org_custom_connector_oauth_configs\".\"token_endpoint_auth_method\" IN (\n          'client_secret_basic',\n          'client_secret_post'\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_custom_connectors": {
+      "name": "org_custom_connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix_templates": {
+          "name": "prefix_templates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "header_injections": {
+          "name": "header_injections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "query_injections": {
+          "name": "query_injections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "oauth_setup": {
+          "name": "oauth_setup",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "permission_bundle_ref": {
+          "name": "permission_bundle_ref",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_endpoint": {
+          "name": "mcp_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_transport": {
+          "name": "mcp_transport",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skill_markdown": {
+          "name": "skill_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skill_storage_version_id": {
+          "name": "skill_storage_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_version": {
+          "name": "storage_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_custom_connectors_org": {
+          "name": "idx_org_custom_connectors_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_custom_connectors_org_slug": {
+          "name": "idx_org_custom_connectors_org_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_custom_connectors_skill_storage_version": {
+          "name": "idx_org_custom_connectors_skill_storage_version",
+          "columns": [
+            {
+              "expression": "skill_storage_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_org_custom_connectors_skill_storage_version": {
+          "name": "fk_org_custom_connectors_skill_storage_version",
+          "tableFrom": "org_custom_connectors",
+          "tableTo": "storage_versions",
+          "columnsFrom": [
+            "skill_storage_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "idx_org_custom_connectors_id_org": {
+          "name": "idx_org_custom_connectors_id_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_custom_connectors_slug": {
+          "name": "chk_org_custom_connectors_slug",
+          "value": "left(\"org_custom_connectors\".\"slug\", 1) = '_'"
+        },
+        "chk_org_custom_connectors_auth_mode": {
+          "name": "chk_org_custom_connectors_auth_mode",
+          "value": "\"org_custom_connectors\".\"auth_mode\" IN ('none', 'manual', 'oauth', 'automatic')"
+        },
+        "chk_org_custom_connectors_oauth_setup": {
+          "name": "chk_org_custom_connectors_oauth_setup",
+          "value": "(\n          (\n            \"org_custom_connectors\".\"auth_mode\" IN ('none', 'manual')\n            AND \"org_custom_connectors\".\"oauth_setup\" IS NULL\n          ) OR (\n            \"org_custom_connectors\".\"auth_mode\" = 'oauth'\n            AND (\n              \"org_custom_connectors\".\"oauth_setup\" IS NULL\n              OR \"org_custom_connectors\".\"oauth_setup\" = 'custom'\n            )\n          ) OR (\n            \"org_custom_connectors\".\"auth_mode\" = 'automatic'\n            AND \"org_custom_connectors\".\"oauth_setup\" = 'automatic'\n          )\n        )"
+        },
+        "chk_org_custom_connectors_automatic_oauth_mcp": {
+          "name": "chk_org_custom_connectors_automatic_oauth_mcp",
+          "value": "(\n          \"org_custom_connectors\".\"auth_mode\" <> 'automatic'\n          OR (\n            \"org_custom_connectors\".\"mcp_endpoint\" IS NOT NULL\n            AND \"org_custom_connectors\".\"mcp_transport\" = 'streamable-http'\n          )\n        )"
+        },
+        "chk_org_custom_connectors_mcp": {
+          "name": "chk_org_custom_connectors_mcp",
+          "value": "(\n          jsonb_typeof(\"org_custom_connectors\".\"prefix_templates\") = 'array'\n          AND jsonb_typeof(\"org_custom_connectors\".\"fields\") = 'array'\n          AND jsonb_typeof(\"org_custom_connectors\".\"header_injections\") = 'array'\n          AND jsonb_typeof(\"org_custom_connectors\".\"query_injections\") = 'array'\n          AND (\n            (\n              \"org_custom_connectors\".\"mcp_endpoint\" IS NULL\n              AND \"org_custom_connectors\".\"mcp_transport\" IS NULL\n              AND \"org_custom_connectors\".\"prefix_templates\" <> '[]'::jsonb\n              AND (\n                (\n                  \"org_custom_connectors\".\"auth_mode\" = 'none'\n                  AND NOT jsonb_path_exists(\n                    \"org_custom_connectors\".\"fields\",\n                    '$[*] ? (@.kind == \"secret\")'\n                  )\n                  AND \"org_custom_connectors\".\"header_injections\" = '[]'::jsonb\n                  AND \"org_custom_connectors\".\"query_injections\" = '[]'::jsonb\n                ) OR (\n                  \"org_custom_connectors\".\"auth_mode\" IN ('manual', 'oauth')\n                  AND (\n                    \"org_custom_connectors\".\"header_injections\" <> '[]'::jsonb\n                    OR \"org_custom_connectors\".\"query_injections\" <> '[]'::jsonb\n                  )\n                )\n              )\n            ) OR (\n              \"org_custom_connectors\".\"mcp_endpoint\" IS NOT NULL\n              AND btrim(\"org_custom_connectors\".\"mcp_endpoint\") <> ''\n              AND \"org_custom_connectors\".\"mcp_transport\" IS NOT NULL\n              AND \"org_custom_connectors\".\"mcp_transport\" = 'streamable-http'\n              AND \"org_custom_connectors\".\"prefix_templates\" = '[]'::jsonb\n              AND (\n                (\n                  \"org_custom_connectors\".\"auth_mode\" IN ('none', 'automatic')\n                  AND \"org_custom_connectors\".\"fields\" = '[]'::jsonb\n                  AND \"org_custom_connectors\".\"header_injections\" = '[]'::jsonb\n                  AND \"org_custom_connectors\".\"query_injections\" = '[]'::jsonb\n                ) OR (\n                  \"org_custom_connectors\".\"auth_mode\" IN ('manual', 'oauth')\n                  AND (\n                    \"org_custom_connectors\".\"header_injections\" <> '[]'::jsonb\n                    OR \"org_custom_connectors\".\"query_injections\" <> '[]'::jsonb\n                  )\n                )\n              )\n              AND \"org_custom_connectors\".\"permission_bundle_ref\" IS NULL\n            )\n          )\n        )"
+        },
+        "chk_org_custom_connectors_storage_version_positive": {
+          "name": "chk_org_custom_connectors_storage_version_positive",
+          "value": "\"org_custom_connectors\".\"storage_version\" > 0"
+        },
+        "chk_org_custom_connectors_skill_size": {
+          "name": "chk_org_custom_connectors_skill_size",
+          "value": "\"org_custom_connectors\".\"skill_markdown\" IS NULL OR octet_length(\"org_custom_connectors\".\"skill_markdown\") <= 65536"
+        },
+        "chk_org_custom_connectors_skill_version_pair": {
+          "name": "chk_org_custom_connectors_skill_version_pair",
+          "value": "(\n          (\"org_custom_connectors\".\"skill_markdown\" IS NULL AND \"org_custom_connectors\".\"skill_storage_version_id\" IS NULL)\n          OR (\n            \"org_custom_connectors\".\"skill_markdown\" IS NOT NULL\n            AND \"org_custom_connectors\".\"skill_storage_version_id\" IS NOT NULL\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_members_cache": {
+      "name": "org_members_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_cache_org_id_user_id_pk": {
+          "name": "org_members_cache_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members_metadata": {
+      "name": "org_members_metadata",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translation_language": {
+          "name": "translation_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_role": {
+          "name": "onboarding_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_agent_ids": {
+          "name": "pinned_agent_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "send_mode": {
+          "name": "send_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enter'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color_theme": {
+          "name": "color_theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_video_model": {
+          "name": "selected_video_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_image_model": {
+          "name": "selected_image_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_done": {
+          "name": "onboarding_done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "morning_brief_default_eligible_at": {
+          "name": "morning_brief_default_eligible_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_network_bodies_remaining": {
+          "name": "capture_network_bodies_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_metadata_org_id_user_id_pk": {
+          "name": "org_members_metadata_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_metadata": {
+      "name": "org_metadata",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'limited-free-1'"
+        },
+        "default_agent_id": {
+          "name": "default_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_payment_pending": {
+          "name": "onboarding_payment_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pending_subscription_schedule_id": {
+          "name": "pending_subscription_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_subscription_target_tier": {
+          "name": "pending_subscription_target_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_subscription_change_at": {
+          "name": "pending_subscription_change_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_processed_invoice_id": {
+          "name": "last_processed_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_source_type": {
+          "name": "acquisition_source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_campaign_id": {
+          "name": "acquisition_campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_ad_group_id": {
+          "name": "acquisition_ad_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_campaign": {
+          "name": "acquisition_campaign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_utm_source": {
+          "name": "acquisition_utm_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_utm_medium": {
+          "name": "acquisition_utm_medium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_utm_content": {
+          "name": "acquisition_utm_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_utm_term": {
+          "name": "acquisition_utm_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_gclid": {
+          "name": "acquisition_gclid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_gbraid": {
+          "name": "acquisition_gbraid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_wbraid": {
+          "name": "acquisition_wbraid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_ga_client_id": {
+          "name": "acquisition_ga_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_landing_host": {
+          "name": "acquisition_landing_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_landing_path": {
+          "name": "acquisition_landing_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_referrer_domain": {
+          "name": "acquisition_referrer_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_recorded_at": {
+          "name": "acquisition_recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_enabled": {
+          "name": "auto_recharge_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_recharge_threshold": {
+          "name": "auto_recharge_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_amount": {
+          "name": "auto_recharge_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_pending_at": {
+          "name": "auto_recharge_pending_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acquisition_first_party_source": {
+          "name": "acquisition_first_party_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_org_stripe_customer": {
+          "name": "uq_org_stripe_customer",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_metadata_acquisition_campaign_id": {
+          "name": "idx_org_metadata_acquisition_campaign_id",
+          "columns": [
+            {
+              "expression": "acquisition_campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_metadata_acquisition_ad_group_id": {
+          "name": "idx_org_metadata_acquisition_ad_group_id",
+          "columns": [
+            {
+              "expression": "acquisition_ad_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_metadata_default_agent_id_agents_id_fk": {
+          "name": "org_metadata_default_agent_id_agents_id_fk",
+          "tableFrom": "org_metadata",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "default_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_model_policies": {
+      "name": "org_model_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_provider_type": {
+          "name": "default_provider_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'built-in'"
+        },
+        "credential_scope": {
+          "name": "credential_scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'org'"
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_surface_id": {
+          "name": "model_provider_surface_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_model_policies_org_model": {
+          "name": "idx_org_model_policies_org_model",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_model_policies_one_default_per_org": {
+          "name": "idx_org_model_policies_one_default_per_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_model_policies_provider": {
+          "name": "idx_org_model_policies_provider",
+          "columns": [
+            {
+              "expression": "model_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "model_provider_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_model_policies_surface": {
+          "name": "idx_org_model_policies_surface",
+          "columns": [
+            {
+              "expression": "model_provider_surface_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "model_provider_surface_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_model_policies_model_provider_id_model_providers_id_fk": {
+          "name": "org_model_policies_model_provider_id_model_providers_id_fk",
+          "tableFrom": "org_model_policies",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "org_model_policies_model_provider_surface_id_model_provider_surfaces_id_fk": {
+          "name": "org_model_policies_model_provider_surface_id_model_provider_surfaces_id_fk",
+          "tableFrom": "org_model_policies",
+          "tableTo": "model_provider_surfaces",
+          "columnsFrom": [
+            "model_provider_surface_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_model_policies_credential_scope": {
+          "name": "chk_org_model_policies_credential_scope",
+          "value": "credential_scope IN ('org', 'member')"
+        },
+        "chk_org_model_policies_member_scope_no_provider_id": {
+          "name": "chk_org_model_policies_member_scope_no_provider_id",
+          "value": "credential_scope <> 'member' OR (model_provider_id IS NULL AND model_provider_surface_id IS NULL)"
+        },
+        "chk_org_model_policies_builtin_route_no_provider_id": {
+          "name": "chk_org_model_policies_builtin_route_no_provider_id",
+          "value": "default_provider_type <> 'built-in' OR (model_provider_id IS NULL AND model_provider_surface_id IS NULL)"
+        },
+        "chk_org_model_policies_one_route_id": {
+          "name": "chk_org_model_policies_one_route_id",
+          "value": "model_provider_id IS NULL OR model_provider_surface_id IS NULL"
+        },
+        "chk_org_model_policies_member_scope_oauth_provider": {
+          "name": "chk_org_model_policies_member_scope_oauth_provider",
+          "value": "credential_scope <> 'member' OR default_provider_type IN ('claude-code-oauth-token', 'codex-oauth-token')"
+        },
+        "chk_org_model_policies_oauth_provider_member_scope": {
+          "name": "chk_org_model_policies_oauth_provider_member_scope",
+          "value": "default_provider_type NOT IN ('claude-code-oauth-token', 'codex-oauth-token') OR credential_scope = 'member'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_plan_entitlements": {
+      "name": "org_plan_entitlements",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_key": {
+          "name": "plan_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_rank": {
+          "name": "plan_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "base_concurrency_limit": {
+          "name": "base_concurrency_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "can_buy_concurrency": {
+          "name": "can_buy_concurrency",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "can_buy_credits": {
+          "name": "can_buy_credits",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "member_invite_usage_pack_required": {
+          "name": "member_invite_usage_pack_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "member_invitation_allowed": {
+          "name": "member_invitation_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_recharge_allowed": {
+          "name": "auto_recharge_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "support_byok": {
+          "name": "support_byok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "video_generation_allowed": {
+          "name": "video_generation_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "workflow_webhook_trigger_allowed": {
+          "name": "workflow_webhook_trigger_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "audio_lifetime_limit": {
+          "name": "audio_lifetime_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_daily_rate_limit": {
+          "name": "audio_daily_rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "audio_daily_duration_seconds": {
+          "name": "audio_daily_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at": {
+          "name": "cancel_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_version": {
+          "name": "metadata_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "metadata_hash": {
+          "name": "metadata_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "restricted_built_in_models": {
+          "name": "restricted_built_in_models",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_org_plan_entitlements_stripe_subscription": {
+          "name": "uq_org_plan_entitlements_stripe_subscription",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_plan_entitlements_status": {
+          "name": "idx_org_plan_entitlements_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_plan_entitlements_source": {
+          "name": "idx_org_plan_entitlements_source",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_plan_entitlements_expires": {
+          "name": "idx_org_plan_entitlements_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_plan_entitlements_plan_rank": {
+          "name": "chk_org_plan_entitlements_plan_rank",
+          "value": "\"org_plan_entitlements\".\"plan_rank\" >= 0"
+        },
+        "chk_org_plan_entitlements_base_concurrency": {
+          "name": "chk_org_plan_entitlements_base_concurrency",
+          "value": "\"org_plan_entitlements\".\"base_concurrency_limit\" >= 0"
+        },
+        "chk_org_plan_entitlements_audio_lifetime": {
+          "name": "chk_org_plan_entitlements_audio_lifetime",
+          "value": "\"org_plan_entitlements\".\"audio_lifetime_limit\" IS NULL OR \"org_plan_entitlements\".\"audio_lifetime_limit\" >= 0"
+        },
+        "chk_org_plan_entitlements_audio_daily_rate": {
+          "name": "chk_org_plan_entitlements_audio_daily_rate",
+          "value": "\"org_plan_entitlements\".\"audio_daily_rate_limit\" >= 0"
+        },
+        "chk_org_plan_entitlements_audio_daily_duration": {
+          "name": "chk_org_plan_entitlements_audio_daily_duration",
+          "value": "\"org_plan_entitlements\".\"audio_daily_duration_seconds\" >= 0"
+        },
+        "chk_org_plan_entitlements_period": {
+          "name": "chk_org_plan_entitlements_period",
+          "value": "\"org_plan_entitlements\".\"current_period_start\" IS NULL OR \"org_plan_entitlements\".\"current_period_end\" IS NULL OR \"org_plan_entitlements\".\"current_period_end\" > \"org_plan_entitlements\".\"current_period_start\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_promo_redemption": {
+      "name": "org_promo_redemption",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_key": {
+          "name": "campaign_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_session_id": {
+          "name": "stripe_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_promo_redemption": {
+          "name": "uq_org_promo_redemption",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "campaign_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_usage_allowance_entitlements": {
+      "name": "org_usage_allowance_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "short_window_seconds": {
+          "name": "short_window_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_window_units": {
+          "name": "short_window_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekly_window_seconds": {
+          "name": "weekly_window_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 604800
+        },
+        "weekly_window_units": {
+          "name": "weekly_window_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_usage_allowance_entitlements_org": {
+          "name": "uq_org_usage_allowance_entitlements_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_usage_allowance_entitlements_status": {
+          "name": "idx_org_usage_allowance_entitlements_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_usage_allowance_entitlements_stripe_subscription": {
+          "name": "idx_org_usage_allowance_entitlements_stripe_subscription",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_usage_allowance_short_window_seconds": {
+          "name": "chk_org_usage_allowance_short_window_seconds",
+          "value": "\"org_usage_allowance_entitlements\".\"short_window_seconds\" > 0"
+        },
+        "chk_org_usage_allowance_short_window_units": {
+          "name": "chk_org_usage_allowance_short_window_units",
+          "value": "\"org_usage_allowance_entitlements\".\"short_window_units\" > 0"
+        },
+        "chk_org_usage_allowance_weekly_window_seconds": {
+          "name": "chk_org_usage_allowance_weekly_window_seconds",
+          "value": "\"org_usage_allowance_entitlements\".\"weekly_window_seconds\" > 0"
+        },
+        "chk_org_usage_allowance_weekly_window_units": {
+          "name": "chk_org_usage_allowance_weekly_window_units",
+          "value": "\"org_usage_allowance_entitlements\".\"weekly_window_units\" > 0"
+        },
+        "chk_org_usage_allowance_entitlement_time": {
+          "name": "chk_org_usage_allowance_entitlement_time",
+          "value": "\"org_usage_allowance_entitlements\".\"expires_at\" IS NULL OR \"org_usage_allowance_entitlements\".\"expires_at\" > \"org_usage_allowance_entitlements\".\"effective_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_usage_allowance_windows": {
+      "name": "org_usage_allowance_windows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_limit": {
+          "name": "unit_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_units": {
+          "name": "consumed_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_run_id": {
+          "name": "created_by_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_usage_allowance_windows_org_kind_starts": {
+          "name": "idx_org_usage_allowance_windows_org_kind_starts",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_usage_allowance_windows_org_kind_expires": {
+          "name": "idx_org_usage_allowance_windows_org_kind_expires",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_usage_allowance_windows_entitlement_id_org_usage_allowance_entitlements_id_fk": {
+          "name": "org_usage_allowance_windows_entitlement_id_org_usage_allowance_entitlements_id_fk",
+          "tableFrom": "org_usage_allowance_windows",
+          "tableTo": "org_usage_allowance_entitlements",
+          "columnsFrom": [
+            "entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_usage_allowance_windows_created_by_run_id_agent_runs_id_fk": {
+          "name": "org_usage_allowance_windows_created_by_run_id_agent_runs_id_fk",
+          "tableFrom": "org_usage_allowance_windows",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "created_by_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_usage_allowance_windows_kind": {
+          "name": "chk_org_usage_allowance_windows_kind",
+          "value": "\"org_usage_allowance_windows\".\"kind\" IN ('short', 'weekly')"
+        },
+        "chk_org_usage_allowance_windows_limit": {
+          "name": "chk_org_usage_allowance_windows_limit",
+          "value": "\"org_usage_allowance_windows\".\"unit_limit\" > 0"
+        },
+        "chk_org_usage_allowance_windows_consumed": {
+          "name": "chk_org_usage_allowance_windows_consumed",
+          "value": "\"org_usage_allowance_windows\".\"consumed_units\" >= 0"
+        },
+        "chk_org_usage_allowance_windows_time": {
+          "name": "chk_org_usage_allowance_windows_time",
+          "value": "\"org_usage_allowance_windows\".\"expires_at\" > \"org_usage_allowance_windows\".\"starts_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_allowance_allocations": {
+      "name": "usage_allowance_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "usage_event_id": {
+          "name": "usage_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_window_id": {
+          "name": "short_window_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekly_window_id": {
+          "name": "weekly_window_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "units_applied": {
+          "name": "units_applied",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_allowance_allocations_usage_event": {
+          "name": "uq_usage_allowance_allocations_usage_event",
+          "columns": [
+            {
+              "expression": "usage_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_allowance_allocations_org": {
+          "name": "idx_usage_allowance_allocations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_allowance_allocations_run": {
+          "name": "idx_usage_allowance_allocations_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_allowance_allocations_usage_event_id_usage_event_id_fk": {
+          "name": "usage_allowance_allocations_usage_event_id_usage_event_id_fk",
+          "tableFrom": "usage_allowance_allocations",
+          "tableTo": "usage_event",
+          "columnsFrom": [
+            "usage_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_allowance_allocations_run_id_agent_runs_id_fk": {
+          "name": "usage_allowance_allocations_run_id_agent_runs_id_fk",
+          "tableFrom": "usage_allowance_allocations",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "usage_allowance_allocations_short_window_id_org_usage_allowance_windows_id_fk": {
+          "name": "usage_allowance_allocations_short_window_id_org_usage_allowance_windows_id_fk",
+          "tableFrom": "usage_allowance_allocations",
+          "tableTo": "org_usage_allowance_windows",
+          "columnsFrom": [
+            "short_window_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_allowance_allocations_weekly_window_id_org_usage_allowance_windows_id_fk": {
+          "name": "usage_allowance_allocations_weekly_window_id_org_usage_allowance_windows_id_fk",
+          "tableFrom": "usage_allowance_allocations",
+          "tableTo": "org_usage_allowance_windows",
+          "columnsFrom": [
+            "weekly_window_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_allowance_allocations_units": {
+          "name": "chk_usage_allowance_allocations_units",
+          "value": "\"usage_allowance_allocations\".\"units_applied\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pi_memory_phase2_jobs": {
+      "name": "pi_memory_phase2_jobs",
+      "schema": "",
+      "columns": {
+        "memory_storage_id": {
+          "name": "memory_storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "input_revision": {
+          "name": "input_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "completed_revision": {
+          "name": "completed_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claimed_revision": {
+          "name": "claimed_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "retry_at": {
+          "name": "retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_class": {
+          "name": "last_error_class",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_succeeded_at": {
+          "name": "last_succeeded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_selection_digest": {
+          "name": "claimed_selection_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_selected_count": {
+          "name": "claimed_selected_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_selected_utf8_bytes": {
+          "name": "claimed_selected_utf8_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_pi_memory_phase2_jobs_claimable": {
+          "name": "idx_pi_memory_phase2_jobs_claimable",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_succeeded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pi_memory_phase2_jobs\".\"completed_revision\" < \"pi_memory_phase2_jobs\".\"input_revision\" AND \"pi_memory_phase2_jobs\".\"status\" IN ('pending', 'leased', 'retryable_failure')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pi_memory_phase2_jobs_user_export": {
+          "name": "idx_pi_memory_phase2_jobs_user_export",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pi_memory_phase2_jobs_storage_owner_fk": {
+          "name": "pi_memory_phase2_jobs_storage_owner_fk",
+          "tableFrom": "pi_memory_phase2_jobs",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "memory_storage_id",
+            "org_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pi_memory_phase2_jobs_pkey": {
+          "name": "pi_memory_phase2_jobs_pkey",
+          "columns": [
+            "memory_storage_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pi_memory_phase2_jobs_status_check": {
+          "name": "pi_memory_phase2_jobs_status_check",
+          "value": "\"pi_memory_phase2_jobs\".\"status\" IN ('idle', 'pending', 'leased', 'retryable_failure', 'terminal_failure')"
+        },
+        "pi_memory_phase2_jobs_revisions_check": {
+          "name": "pi_memory_phase2_jobs_revisions_check",
+          "value": "\"pi_memory_phase2_jobs\".\"input_revision\" > 0 AND\n          \"pi_memory_phase2_jobs\".\"completed_revision\" >= 0 AND\n          \"pi_memory_phase2_jobs\".\"completed_revision\" <= \"pi_memory_phase2_jobs\".\"input_revision\" AND\n          (\n            \"pi_memory_phase2_jobs\".\"claimed_revision\" IS NULL OR (\n              \"pi_memory_phase2_jobs\".\"completed_revision\" < \"pi_memory_phase2_jobs\".\"claimed_revision\" AND\n              \"pi_memory_phase2_jobs\".\"claimed_revision\" <= \"pi_memory_phase2_jobs\".\"input_revision\"\n            )\n          )"
+        },
+        "pi_memory_phase2_jobs_retry_count_check": {
+          "name": "pi_memory_phase2_jobs_retry_count_check",
+          "value": "\"pi_memory_phase2_jobs\".\"retry_count\" >= 0 AND \"pi_memory_phase2_jobs\".\"retry_count\" <= 3"
+        },
+        "pi_memory_phase2_jobs_error_class_check": {
+          "name": "pi_memory_phase2_jobs_error_class_check",
+          "value": "\"pi_memory_phase2_jobs\".\"last_error_class\" IS NULL OR \"pi_memory_phase2_jobs\".\"last_error_class\" ~ '^[a-z][a-z0-9_]{0,127}$'"
+        },
+        "pi_memory_phase2_jobs_selection_check": {
+          "name": "pi_memory_phase2_jobs_selection_check",
+          "value": "(\n          \"pi_memory_phase2_jobs\".\"claimed_selection_digest\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_count\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_utf8_bytes\" IS NULL\n        ) OR (\n          \"pi_memory_phase2_jobs\".\"claimed_selection_digest\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_count\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_utf8_bytes\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selection_digest\" ~ '^[0-9a-f]{64}$' AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_count\" >= 0 AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_count\" <= 256 AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_utf8_bytes\" >= 0 AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_utf8_bytes\" <= 21036800\n        )"
+        },
+        "pi_memory_phase2_jobs_state_check": {
+          "name": "pi_memory_phase2_jobs_state_check",
+          "value": "(\n          \"pi_memory_phase2_jobs\".\"status\" = 'idle' AND\n          \"pi_memory_phase2_jobs\".\"completed_revision\" = \"pi_memory_phase2_jobs\".\"input_revision\" AND\n          \"pi_memory_phase2_jobs\".\"claimed_revision\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"lease_token\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"lease_expires_at\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"retry_count\" = 0 AND\n          \"pi_memory_phase2_jobs\".\"retry_at\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"last_error_class\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selection_digest\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_count\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_utf8_bytes\" IS NULL\n        ) OR (\n          \"pi_memory_phase2_jobs\".\"status\" = 'pending' AND\n          \"pi_memory_phase2_jobs\".\"completed_revision\" < \"pi_memory_phase2_jobs\".\"input_revision\" AND\n          \"pi_memory_phase2_jobs\".\"claimed_revision\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"lease_token\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"lease_expires_at\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"retry_count\" = 0 AND\n          \"pi_memory_phase2_jobs\".\"retry_at\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"last_error_class\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selection_digest\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_count\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_utf8_bytes\" IS NULL\n        ) OR (\n          \"pi_memory_phase2_jobs\".\"status\" = 'leased' AND\n          \"pi_memory_phase2_jobs\".\"claimed_revision\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"completed_revision\" < \"pi_memory_phase2_jobs\".\"claimed_revision\" AND\n          \"pi_memory_phase2_jobs\".\"claimed_revision\" <= \"pi_memory_phase2_jobs\".\"input_revision\" AND\n          \"pi_memory_phase2_jobs\".\"lease_token\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"lease_expires_at\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"retry_count\" >= 0 AND\n          \"pi_memory_phase2_jobs\".\"retry_count\" < 3 AND\n          \"pi_memory_phase2_jobs\".\"retry_at\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"last_error_class\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selection_digest\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_count\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_utf8_bytes\" IS NOT NULL\n        ) OR (\n          \"pi_memory_phase2_jobs\".\"status\" = 'retryable_failure' AND\n          \"pi_memory_phase2_jobs\".\"completed_revision\" < \"pi_memory_phase2_jobs\".\"input_revision\" AND\n          \"pi_memory_phase2_jobs\".\"claimed_revision\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"lease_token\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"lease_expires_at\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"retry_count\" > 0 AND\n          \"pi_memory_phase2_jobs\".\"retry_count\" < 3 AND\n          \"pi_memory_phase2_jobs\".\"retry_at\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"last_error_class\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selection_digest\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_count\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_utf8_bytes\" IS NULL\n        ) OR (\n          \"pi_memory_phase2_jobs\".\"status\" = 'terminal_failure' AND\n          \"pi_memory_phase2_jobs\".\"completed_revision\" < \"pi_memory_phase2_jobs\".\"input_revision\" AND\n          \"pi_memory_phase2_jobs\".\"claimed_revision\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"lease_token\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"lease_expires_at\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"retry_count\" = 3 AND\n          \"pi_memory_phase2_jobs\".\"retry_at\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"last_error_class\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selection_digest\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_count\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_utf8_bytes\" IS NULL\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pi_memory_stage1_candidates": {
+      "name": "pi_memory_stage1_candidates",
+      "schema": "",
+      "columns": {
+        "memory_storage_id": {
+          "name": "memory_storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pi_session_id": {
+          "name": "pi_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_run_id": {
+          "name": "source_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_history_hash": {
+          "name": "source_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_completed_at": {
+          "name": "source_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eligible_at": {
+          "name": "eligible_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_at": {
+          "name": "retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error_class": {
+          "name": "last_error_class",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_memory": {
+          "name": "raw_memory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollout_summary": {
+          "name": "rollout_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollout_slug": {
+          "name": "rollout_slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_selected_source_history_hash": {
+          "name": "last_selected_source_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_pi_memory_stage1_candidates_eligible": {
+          "name": "idx_pi_memory_stage1_candidates_eligible",
+          "columns": [
+            {
+              "expression": "eligible_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pi_memory_stage1_candidates\".\"status\" IN ('pending', 'retryable_failure')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pi_memory_stage1_candidates_expired_lease": {
+          "name": "idx_pi_memory_stage1_candidates_expired_lease",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pi_memory_stage1_candidates\".\"status\" = 'leased'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pi_memory_stage1_candidates_phase2": {
+          "name": "idx_pi_memory_stage1_candidates_phase2",
+          "columns": [
+            {
+              "expression": "memory_storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pi_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pi_memory_stage1_candidates\".\"status\" IN ('succeeded', 'succeeded_no_output')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pi_memory_stage1_candidates_source_history_hash_blobs_hash_fk": {
+          "name": "pi_memory_stage1_candidates_source_history_hash_blobs_hash_fk",
+          "tableFrom": "pi_memory_stage1_candidates",
+          "tableTo": "blobs",
+          "columnsFrom": [
+            "source_history_hash"
+          ],
+          "columnsTo": [
+            "hash"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pi_memory_stage1_candidates_storage_owner_fk": {
+          "name": "pi_memory_stage1_candidates_storage_owner_fk",
+          "tableFrom": "pi_memory_stage1_candidates",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "memory_storage_id",
+            "org_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pi_memory_stage1_candidates_pkey": {
+          "name": "pi_memory_stage1_candidates_pkey",
+          "columns": [
+            "memory_storage_id",
+            "pi_session_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pi_memory_stage1_candidates_status_check": {
+          "name": "pi_memory_stage1_candidates_status_check",
+          "value": "\"pi_memory_stage1_candidates\".\"status\" IN (\n          'pending',\n          'leased',\n          'succeeded',\n          'succeeded_no_output',\n          'retryable_failure',\n          'terminal_failure'\n        )"
+        },
+        "pi_memory_stage1_candidates_source_hash_check": {
+          "name": "pi_memory_stage1_candidates_source_hash_check",
+          "value": "\"pi_memory_stage1_candidates\".\"source_history_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "pi_memory_stage1_candidates_selected_hash_check": {
+          "name": "pi_memory_stage1_candidates_selected_hash_check",
+          "value": "\"pi_memory_stage1_candidates\".\"last_selected_source_history_hash\" IS NULL OR \"pi_memory_stage1_candidates\".\"last_selected_source_history_hash\" = \"pi_memory_stage1_candidates\".\"source_history_hash\""
+        },
+        "pi_memory_stage1_candidates_counts_check": {
+          "name": "pi_memory_stage1_candidates_counts_check",
+          "value": "\"pi_memory_stage1_candidates\".\"retry_count\" >= 0 AND \"pi_memory_stage1_candidates\".\"usage_count\" >= 0"
+        },
+        "pi_memory_stage1_candidates_lease_check": {
+          "name": "pi_memory_stage1_candidates_lease_check",
+          "value": "(\n          \"pi_memory_stage1_candidates\".\"status\" = 'leased' AND\n          \"pi_memory_stage1_candidates\".\"lease_token\" IS NOT NULL AND\n          \"pi_memory_stage1_candidates\".\"lease_expires_at\" IS NOT NULL\n        ) OR (\n          \"pi_memory_stage1_candidates\".\"status\" <> 'leased' AND\n          \"pi_memory_stage1_candidates\".\"lease_token\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"lease_expires_at\" IS NULL\n        )"
+        },
+        "pi_memory_stage1_candidates_state_check": {
+          "name": "pi_memory_stage1_candidates_state_check",
+          "value": "(\n          \"pi_memory_stage1_candidates\".\"status\" IN ('pending', 'leased') AND\n          \"pi_memory_stage1_candidates\".\"retry_at\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"last_error_class\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"raw_memory\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"rollout_summary\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"rollout_slug\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"generated_at\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"last_selected_source_history_hash\" IS NULL\n        ) OR (\n          \"pi_memory_stage1_candidates\".\"status\" = 'succeeded' AND\n          \"pi_memory_stage1_candidates\".\"retry_at\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"last_error_class\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"raw_memory\" IS NOT NULL AND\n          \"pi_memory_stage1_candidates\".\"rollout_summary\" IS NOT NULL AND\n          \"pi_memory_stage1_candidates\".\"generated_at\" IS NOT NULL\n        ) OR (\n          \"pi_memory_stage1_candidates\".\"status\" = 'succeeded_no_output' AND\n          \"pi_memory_stage1_candidates\".\"retry_at\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"last_error_class\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"raw_memory\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"rollout_summary\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"rollout_slug\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"generated_at\" IS NOT NULL\n        ) OR (\n          \"pi_memory_stage1_candidates\".\"status\" = 'retryable_failure' AND\n          \"pi_memory_stage1_candidates\".\"retry_at\" IS NOT NULL AND\n          \"pi_memory_stage1_candidates\".\"last_error_class\" IS NOT NULL AND\n          \"pi_memory_stage1_candidates\".\"raw_memory\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"rollout_summary\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"rollout_slug\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"generated_at\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"last_selected_source_history_hash\" IS NULL\n        ) OR (\n          \"pi_memory_stage1_candidates\".\"status\" = 'terminal_failure' AND\n          \"pi_memory_stage1_candidates\".\"retry_at\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"last_error_class\" IS NOT NULL AND\n          \"pi_memory_stage1_candidates\".\"raw_memory\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"rollout_summary\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"rollout_slug\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"generated_at\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"last_selected_source_history_hash\" IS NULL\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pi_resource_snapshots": {
+      "name": "pi_resource_snapshots",
+      "schema": "",
+      "columns": {
+        "digest": {
+          "name": "digest",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pi_resource_snapshots_created_at_idx": {
+          "name": "pi_resource_snapshots_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.presentation_templates": {
+      "name": "presentation_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_storage_key": {
+          "name": "source_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_filename": {
+          "name": "source_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_keys": {
+          "name": "page_keys",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "aspect_ratio": {
+          "name": "aspect_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_presentation_templates_owner_created": {
+          "name": "idx_presentation_templates_owner_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_presentation_templates_visibility": {
+          "name": "chk_presentation_templates_visibility",
+          "value": "\"presentation_templates\".\"visibility\" IN ('private', 'public')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_push_subscriptions_user_id": {
+          "name": "idx_push_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_push_subscriptions_endpoint": {
+          "name": "idx_push_subscriptions_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_built_in_admissions": {
+      "name": "run_built_in_admissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_run_builtin_admissions_run_status": {
+          "name": "idx_run_builtin_admissions_run_status",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_builtin_admissions_run_created": {
+          "name": "idx_run_builtin_admissions_run_created",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_builtin_admissions_expires_at": {
+          "name": "idx_run_builtin_admissions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_built_in_admissions_run_id_agent_runs_id_fk": {
+          "name": "run_built_in_admissions_run_id_agent_runs_id_fk",
+          "tableFrom": "run_built_in_admissions",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_output_materializations": {
+      "name": "chat_output_materializations",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "processed_through_sequence": {
+          "name": "processed_through_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": -1
+        },
+        "pending_sequence_numbers": {
+          "name": "pending_sequence_numbers",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::integer[]"
+        },
+        "latest_result_sequence": {
+          "name": "latest_result_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_result_text": {
+          "name": "latest_result_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_output_sequence": {
+          "name": "latest_output_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_output_text": {
+          "name": "latest_output_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_output_materializations_run_id_agent_runs_id_fk": {
+          "name": "chat_output_materializations_run_id_agent_runs_id_fk",
+          "tableFrom": "chat_output_materializations",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canonical_asset_deliveries": {
+      "name": "canonical_asset_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "canonical_asset_deliveries_asset_provider_operation_unique": {
+          "name": "canonical_asset_deliveries_asset_provider_operation_unique",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "canonical_asset_deliveries_asset_idx": {
+          "name": "canonical_asset_deliveries_asset_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canonical_asset_deliveries_asset_id_run_uploaded_files_id_fk": {
+          "name": "canonical_asset_deliveries_asset_id_run_uploaded_files_id_fk",
+          "tableFrom": "canonical_asset_deliveries",
+          "tableTo": "run_uploaded_files",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_uploaded_files": {
+      "name": "run_uploaded_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "asset_version": {
+          "name": "asset_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_level": {
+          "name": "access_level",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "materialization_status": {
+          "name": "materialization_status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum_sha256": {
+          "name": "checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "materialization_error": {
+          "name": "materialization_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_scope": {
+          "name": "idempotency_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_uploaded_files_run": {
+          "name": "idx_run_uploaded_files_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_uploaded_files_run_source_external": {
+          "name": "idx_run_uploaded_files_run_source_external",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_uploaded_files_source_external": {
+          "name": "idx_run_uploaded_files_source_external",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_uploaded_files_updated": {
+          "name": "idx_run_uploaded_files_updated",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"run_uploaded_files\".\"url\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_uploaded_files_canonical_idempotency_unique": {
+          "name": "run_uploaded_files_canonical_idempotency_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"run_uploaded_files\".\"asset_version\" = 1",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_uploaded_files_chat_thread_idx": {
+          "name": "run_uploaded_files_chat_thread_idx",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"run_uploaded_files\".\"chat_thread_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_uploaded_files_run_id_agent_runs_id_fk": {
+          "name": "run_uploaded_files_run_id_agent_runs_id_fk",
+          "tableFrom": "run_uploaded_files",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_uploaded_files_chat_thread_id_chat_threads_id_fk": {
+          "name": "run_uploaded_files_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "run_uploaded_files",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_job_queue": {
+      "name": "runner_job_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0/default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reuse_key": {
+          "name": "reuse_key",
+          "type": "varchar(263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_context": {
+          "name": "execution_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_job_queue_group_profile_idx": {
+          "name": "runner_job_queue_group_profile_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_job_queue_expires_at_idx": {
+          "name": "runner_job_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runner_job_queue_run_id_agent_runs_id_fk": {
+          "name": "runner_job_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "runner_job_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_state": {
+      "name": "runner_state",
+      "schema": "",
+      "columns": {
+        "runner_id": {
+          "name": "runner_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_generation": {
+          "name": "heartbeat_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "heartbeat_sequence": {
+          "name": "heartbeat_sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_vcpu": {
+          "name": "total_vcpu",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_memory_mb": {
+          "name": "total_memory_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_concurrent": {
+          "name": "max_concurrent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "allocated_vcpu": {
+          "name": "allocated_vcpu",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "allocated_memory_mb": {
+          "name": "allocated_memory_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "running_count": {
+          "name": "running_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "admittable_profiles": {
+          "name": "admittable_profiles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "held_sandbox_states": {
+          "name": "held_sandbox_states",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "held_workspace_states": {
+          "name": "held_workspace_states",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_state_group_idx": {
+          "name": "runner_state_group_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_state_last_seen_idx": {
+          "name": "runner_state_last_seen_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_telemetry": {
+      "name": "sandbox_telemetry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_telemetry_run_id": {
+          "name": "idx_sandbox_telemetry_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_telemetry_run_id_agent_runs_id_fk": {
+          "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
+          "tableFrom": "sandbox_telemetry",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_secrets_type": {
+          "name": "idx_secrets_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org": {
+          "name": "idx_secrets_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_connector": {
+          "name": "idx_secrets_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"secrets\".\"connector_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org_user_name_type": {
+          "name": "idx_secrets_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"secrets\".\"connector_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_connector_name": {
+          "name": "idx_secrets_connector_name",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"secrets\".\"connector_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_secrets_connector_owner": {
+          "name": "fk_secrets_connector_owner",
+          "tableFrom": "secrets",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id",
+            "org_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_secrets_connector_owner_type": {
+          "name": "chk_secrets_connector_owner_type",
+          "value": "(\"secrets\".\"type\" = 'connector') = (\"secrets\".\"connector_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.shared_threads": {
+      "name": "shared_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_chat_thread_id": {
+          "name": "source_chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shared_threads_user_created_idx": {
+          "name": "shared_threads_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shared_threads_source_created_idx": {
+          "name": "shared_threads_source_created_idx",
+          "columns": [
+            {
+              "expression": "source_chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shared_threads_source_chat_thread_id_chat_threads_id_fk": {
+          "name": "shared_threads_source_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "shared_threads",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "source_chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_path": {
+          "name": "full_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_hash": {
+          "name": "version_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frontmatter": {
+          "name": "frontmatter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skills_name": {
+          "name": "idx_skills_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skills_storage_id": {
+          "name": "idx_skills_storage_id",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skills_storage_id_storages_id_fk": {
+          "name": "skills_storage_id_storages_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skills_url_unique": {
+          "name": "skills_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_chat_ingress": {
+      "name": "slack_chat_ingress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_chat_ingress_event_id": {
+          "name": "idx_slack_chat_ingress_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_chat_ingress_route_id_slack_chat_thread_routes_id_fk": {
+          "name": "slack_chat_ingress_route_id_slack_chat_thread_routes_id_fk",
+          "tableFrom": "slack_chat_ingress",
+          "tableTo": "slack_chat_thread_routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_slack_chat_ingress_status": {
+          "name": "chk_slack_chat_ingress_status",
+          "value": "\"slack_chat_ingress\".\"status\" IN ('pending', 'processing', 'processed', 'failed')"
+        },
+        "chk_slack_chat_ingress_retry_count": {
+          "name": "chk_slack_chat_ingress_retry_count",
+          "value": "\"slack_chat_ingress\".\"retry_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_chat_thread_routes": {
+      "name": "slack_chat_thread_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_ts": {
+          "name": "thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_chat_thread_routes_conn_channel_thread_user": {
+          "name": "idx_slack_chat_thread_routes_conn_channel_thread_user",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_chat_thread_routes_connection_id_slack_org_connections_id_fk": {
+          "name": "slack_chat_thread_routes_connection_id_slack_org_connections_id_fk",
+          "tableFrom": "slack_chat_thread_routes",
+          "tableTo": "slack_org_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_chat_thread_routes_chat_thread_id_chat_threads_id_fk": {
+          "name": "slack_chat_thread_routes_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "slack_chat_thread_routes",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_connections": {
+      "name": "slack_org_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_connections_user_workspace": {
+          "name": "idx_slack_org_connections_user_workspace",
+          "columns": [
+            {
+              "expression": "slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_workspace": {
+          "name": "idx_slack_org_connections_workspace",
+          "columns": [
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_user_id_workspace": {
+          "name": "idx_slack_org_connections_user_id_workspace",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk": {
+          "name": "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk",
+          "tableFrom": "slack_org_connections",
+          "tableTo": "slack_org_installations",
+          "columnsFrom": [
+            "slack_workspace_id"
+          ],
+          "columnsTo": [
+            "slack_workspace_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_installations": {
+      "name": "slack_org_installations",
+      "schema": "",
+      "columns": {
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slack_workspace_name": {
+          "name": "slack_workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_scopes": {
+          "name": "bot_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'okou'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_installations_org": {
+          "name": "idx_slack_org_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_installations_org_unique": {
+          "name": "idx_slack_org_installations_org_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_user_agent_preferences": {
+      "name": "slack_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_agent_id": {
+          "name": "selected_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_user_agent_preferences_selected_agent_id_agents_id_fk": {
+          "name": "slack_user_agent_preferences_selected_agent_id_agents_id_fk",
+          "tableFrom": "slack_user_agent_preferences",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "selected_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "slack_user_agent_preferences_user_id_org_id_pk": {
+          "name": "slack_user_agent_preferences_user_id_org_id_pk",
+          "columns": [
+            "user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.socialkit_download_jobs": {
+      "name": "socialkit_download_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitting'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_job_id": {
+          "name": "provider_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_result": {
+          "name": "provider_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact": {
+          "name": "artifact",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_charged": {
+          "name": "credits_charged",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_socialkit_download_jobs_provider_job": {
+          "name": "uq_socialkit_download_jobs_provider_job",
+          "columns": [
+            {
+              "expression": "provider_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_socialkit_download_jobs_user_active": {
+          "name": "uq_socialkit_download_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('submitting', 'processing', 'materializing', 'artifact_failed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_socialkit_download_jobs_owner_created": {
+          "name": "idx_socialkit_download_jobs_owner_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_socialkit_download_jobs_reconcile": {
+          "name": "idx_socialkit_download_jobs_reconcile",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claim_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_socialkit_download_jobs_run": {
+          "name": "idx_socialkit_download_jobs_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "socialkit_download_jobs_run_id_agent_runs_id_fk": {
+          "name": "socialkit_download_jobs_run_id_agent_runs_id_fk",
+          "tableFrom": "socialkit_download_jobs",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_version_lineage": {
+      "name": "storage_version_lineage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storage_version_lineage_storage_version": {
+          "name": "idx_storage_version_lineage_storage_version",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storage_version_lineage_storage_parent": {
+          "name": "idx_storage_version_lineage_storage_parent",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storage_version_lineage_run": {
+          "name": "idx_storage_version_lineage_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_version_lineage_storage_id_storages_id_fk": {
+          "name": "storage_version_lineage_storage_id_storages_id_fk",
+          "tableFrom": "storage_version_lineage",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storage_version_lineage_run_id_agent_runs_id_fk": {
+          "name": "storage_version_lineage_run_id_agent_runs_id_fk",
+          "tableFrom": "storage_version_lineage",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_versions": {
+      "name": "storage_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archive_size": {
+          "name": "archive_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_versions_storage_id_storages_id_fk": {
+          "name": "storage_versions_storage_id_storages_id_fk",
+          "tableFrom": "storage_versions",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_storage_versions_archive_size_nonnegative": {
+          "name": "chk_storage_versions_archive_size_nonnegative",
+          "value": "\"storage_versions\".\"archive_size\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.storages": {
+      "name": "storages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storages_org": {
+          "name": "idx_storages_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_org_user_name": {
+          "name": "idx_storages_org_user_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storages_head_version_id_storage_versions_id_fk": {
+          "name": "storages_head_version_id_storage_versions_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "storage_versions",
+          "columnsFrom": [
+            "head_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "idx_storages_id_org_user": {
+          "name": "idx_storages_id_org_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_workflow_automation_health": {
+      "name": "stripe_workflow_automation_health",
+      "schema": "",
+      "columns": {
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_matching_event_received_at": {
+          "name": "last_matching_event_received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_delivery_id": {
+          "name": "latest_delivery_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_delivery_status": {
+          "name": "latest_delivery_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_delivery_status_at": {
+          "name": "latest_delivery_status_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stripe_workflow_automation_health_automation_id_workflow_automations_id_fk": {
+          "name": "stripe_workflow_automation_health_automation_id_workflow_automations_id_fk",
+          "tableFrom": "stripe_workflow_automation_health",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_workflow_deliveries": {
+      "name": "stripe_workflow_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "livemode": {
+          "name": "livemode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_event_created_at": {
+          "name": "stripe_event_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_reason": {
+          "name": "billing_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_at": {
+          "name": "skipped_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_stripe_workflow_deliveries_dedupe": {
+          "name": "idx_stripe_workflow_deliveries_dedupe",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "livemode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stripe_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stripe_workflow_deliveries_due": {
+          "name": "idx_stripe_workflow_deliveries_due",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claim_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"stripe_workflow_deliveries\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stripe_workflow_deliveries_automation": {
+          "name": "idx_stripe_workflow_deliveries_automation",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_storage_presigned_url_cache": {
+      "name": "system_storage_presigned_url_cache",
+      "schema": "",
+      "columns": {
+        "cache_key": {
+          "name": "cache_key",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system_storage'"
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_version_id": {
+          "name": "storage_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_org_id": {
+          "name": "resolved_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_endpoint": {
+          "name": "public_endpoint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "presigned_url": {
+          "name": "presigned_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_after": {
+          "name": "refresh_after",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_requested_at": {
+          "name": "last_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_system_storage_presigned_url_cache_refresh_after": {
+          "name": "idx_system_storage_presigned_url_cache_refresh_after",
+          "columns": [
+            {
+              "expression": "refresh_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_storage_presigned_url_cache_last_requested_at": {
+          "name": "idx_system_storage_presigned_url_cache_last_requested_at",
+          "columns": [
+            {
+              "expression": "last_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_storage_presigned_url_cache_active_refresh": {
+          "name": "idx_system_storage_presigned_url_cache_active_refresh",
+          "columns": [
+            {
+              "expression": "last_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "refresh_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_storage_presigned_url_cache_scope_refresh_after": {
+          "name": "idx_system_storage_presigned_url_cache_scope_refresh_after",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "refresh_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_storage_presigned_url_cache_scope_active_refresh": {
+          "name": "idx_system_storage_presigned_url_cache_scope_active_refresh",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "refresh_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams_chat_thread_routes": {
+      "name": "teams_chat_thread_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_teams_chat_thread_routes_conn_conversation_thread_user": {
+          "name": "idx_teams_chat_thread_routes_conn_conversation_thread_user",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_chat_thread_routes_connection_id_teams_org_connections_id_fk": {
+          "name": "teams_chat_thread_routes_connection_id_teams_org_connections_id_fk",
+          "tableFrom": "teams_chat_thread_routes",
+          "tableTo": "teams_org_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teams_chat_thread_routes_chat_thread_id_chat_threads_id_fk": {
+          "name": "teams_chat_thread_routes_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "teams_chat_thread_routes",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams_org_connections": {
+      "name": "teams_org_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "teams_user_id": {
+          "name": "teams_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_aad_object_id": {
+          "name": "teams_aad_object_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_tenant_id": {
+          "name": "teams_tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_user_display_name": {
+          "name": "teams_user_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_user_principal_name": {
+          "name": "teams_user_principal_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_teams_org_connections_user_tenant": {
+          "name": "idx_teams_org_connections_user_tenant",
+          "columns": [
+            {
+              "expression": "teams_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "teams_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "teams_user_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_teams_org_connections_aad_tenant": {
+          "name": "idx_teams_org_connections_aad_tenant",
+          "columns": [
+            {
+              "expression": "teams_aad_object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "teams_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "teams_aad_object_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_teams_org_connections_user_id_tenant": {
+          "name": "idx_teams_org_connections_user_id_tenant",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "teams_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_teams_org_connections_tenant": {
+          "name": "idx_teams_org_connections_tenant",
+          "columns": [
+            {
+              "expression": "teams_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_org_connections_teams_tenant_id_teams_org_installations_teams_tenant_id_fk": {
+          "name": "teams_org_connections_teams_tenant_id_teams_org_installations_teams_tenant_id_fk",
+          "tableFrom": "teams_org_connections",
+          "tableTo": "teams_org_installations",
+          "columnsFrom": [
+            "teams_tenant_id"
+          ],
+          "columnsTo": [
+            "teams_tenant_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams_org_installations": {
+      "name": "teams_org_installations",
+      "schema": "",
+      "columns": {
+        "teams_tenant_id": {
+          "name": "teams_tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "teams_tenant_name": {
+          "name": "teams_tenant_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_team_id": {
+          "name": "teams_team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_team_name": {
+          "name": "teams_team_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_app_id": {
+          "name": "teams_app_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_name": {
+          "name": "bot_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_url": {
+          "name": "service_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'okou'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_teams_org_installations_org": {
+          "name": "idx_teams_org_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_teams_org_installations_org_unique": {
+          "name": "idx_teams_org_installations_org_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams_user_agent_preferences": {
+      "name": "teams_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_agent_id": {
+          "name": "selected_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_user_agent_preferences_selected_agent_id_agents_id_fk": {
+          "name": "teams_user_agent_preferences_selected_agent_id_agents_id_fk",
+          "tableFrom": "teams_user_agent_preferences",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "selected_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "teams_user_agent_preferences_user_id_org_id_pk": {
+          "name": "teams_user_agent_preferences_user_id_org_id_pk",
+          "columns": [
+            "user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_chat_thread_routes": {
+      "name": "telegram_chat_thread_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_link_id": {
+          "name": "telegram_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_official_user_link_id": {
+          "name": "telegram_official_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_chat_thread_routes_chat_user_link": {
+          "name": "idx_telegram_chat_thread_routes_chat_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "telegram_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_chat_thread_routes_chat_official_link": {
+          "name": "idx_telegram_chat_thread_routes_chat_official_link",
+          "columns": [
+            {
+              "expression": "telegram_official_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "telegram_official_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_chat_thread_routes_user_link": {
+          "name": "idx_telegram_chat_thread_routes_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "telegram_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_chat_thread_routes_official_user_link": {
+          "name": "idx_telegram_chat_thread_routes_official_user_link",
+          "columns": [
+            {
+              "expression": "telegram_official_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "telegram_official_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_chat_thread_routes_telegram_user_link_id_telegram_user_links_id_fk": {
+          "name": "telegram_chat_thread_routes_telegram_user_link_id_telegram_user_links_id_fk",
+          "tableFrom": "telegram_chat_thread_routes",
+          "tableTo": "telegram_user_links",
+          "columnsFrom": [
+            "telegram_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_chat_thread_routes_telegram_official_user_link_id_telegram_official_user_links_id_fk": {
+          "name": "telegram_chat_thread_routes_telegram_official_user_link_id_telegram_official_user_links_id_fk",
+          "tableFrom": "telegram_chat_thread_routes",
+          "tableTo": "telegram_official_user_links",
+          "columnsFrom": [
+            "telegram_official_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_chat_thread_routes_chat_thread_id_chat_threads_id_fk": {
+          "name": "telegram_chat_thread_routes_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "telegram_chat_thread_routes",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_telegram_chat_thread_routes_one_owner": {
+          "name": "chk_telegram_chat_thread_routes_one_owner",
+          "value": "(telegram_user_link_id IS NOT NULL) <> (telegram_official_user_link_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.telegram_installations": {
+      "name": "telegram_installations",
+      "schema": "",
+      "columns": {
+        "telegram_bot_id": {
+          "name": "telegram_bot_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_agent_id": {
+          "name": "default_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_installations_owner": {
+          "name": "idx_telegram_installations_owner",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_installations_org": {
+          "name": "idx_telegram_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_installations_default_agent_id_agents_id_fk": {
+          "name": "telegram_installations_default_agent_id_agents_id_fk",
+          "tableFrom": "telegram_installations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "default_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_messages": {
+      "name": "telegram_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_org_id": {
+          "name": "official_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_user_link_id": {
+          "name": "official_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_username": {
+          "name": "from_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_display_name": {
+          "name": "from_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_mime_type": {
+          "name": "file_mime_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_width": {
+          "name": "file_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_height": {
+          "name": "file_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_duration": {
+          "name": "file_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entities": {
+          "name": "entities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_messages_unique": {
+          "name": "idx_telegram_messages_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_official_unique": {
+          "name": "idx_telegram_messages_official_unique",
+          "columns": [
+            {
+              "expression": "official_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "official_org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_chat": {
+          "name": "idx_telegram_messages_chat",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_official_chat": {
+          "name": "idx_telegram_messages_official_chat",
+          "columns": [
+            {
+              "expression": "official_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "official_org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_created_at": {
+          "name": "idx_telegram_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_messages_installation_id_telegram_installations_telegram_bot_id_fk": {
+          "name": "telegram_messages_installation_id_telegram_installations_telegram_bot_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "telegram_bot_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_messages_official_user_link_id_telegram_official_user_links_id_fk": {
+          "name": "telegram_messages_official_user_link_id_telegram_official_user_links_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_official_user_links",
+          "columnsFrom": [
+            "official_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_telegram_messages_one_owner": {
+          "name": "chk_telegram_messages_one_owner",
+          "value": "(installation_id IS NOT NULL) <> (official_org_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.telegram_official_user_links": {
+      "name": "telegram_official_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_username": {
+          "name": "telegram_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_display_name": {
+          "name": "telegram_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_official_user_links_tg_user": {
+          "name": "idx_telegram_official_user_links_tg_user",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_official_user_links_user_org": {
+          "name": "idx_telegram_official_user_links_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_official_user_links_org": {
+          "name": "idx_telegram_official_user_links_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_agent_preferences": {
+      "name": "telegram_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_agent_id": {
+          "name": "selected_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_user_agent_preferences_selected_agent_id_agents_id_fk": {
+          "name": "telegram_user_agent_preferences_selected_agent_id_agents_id_fk",
+          "tableFrom": "telegram_user_agent_preferences",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "selected_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "telegram_user_agent_preferences_user_id_org_id_pk": {
+          "name": "telegram_user_agent_preferences_user_id_org_id_pk",
+          "columns": [
+            "user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_links": {
+      "name": "telegram_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_username": {
+          "name": "telegram_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_display_name": {
+          "name": "telegram_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_user_links_user_installation": {
+          "name": "idx_telegram_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_user_links_user_id_installation": {
+          "name": "idx_telegram_user_links_user_id_installation",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_user_links_installation_id_telegram_installations_telegram_bot_id_fk": {
+          "name": "telegram_user_links_installation_id_telegram_installations_telegram_bot_id_fk",
+          "tableFrom": "telegram_user_links",
+          "tableTo": "telegram_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "telegram_bot_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_goals": {
+      "name": "thread_goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective_brief": {
+          "name": "objective_brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "autonomy_budget": {
+          "name": "autonomy_budget",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_thread_goals_chat_thread_unique": {
+          "name": "idx_thread_goals_chat_thread_unique",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thread_goals_org_owner": {
+          "name": "idx_thread_goals_org_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thread_goals_org_status": {
+          "name": "idx_thread_goals_org_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "thread_goals_chat_thread_id_chat_threads_id_fk": {
+          "name": "thread_goals_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "thread_goals",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_goals_agent_id_agents_id_fk": {
+          "name": "thread_goals_agent_id_agents_id_fk",
+          "tableFrom": "thread_goals",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "thread_goals_status_check": {
+          "name": "thread_goals_status_check",
+          "value": "status IN ('active', 'paused', 'blocked', 'complete')"
+        },
+        "thread_goals_autonomy_budget_check": {
+          "name": "thread_goals_autonomy_budget_check",
+          "value": "\"thread_goals\".\"autonomy_budget\" BETWEEN 0 AND 10"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_event_hourly_rollup": {
+      "name": "usage_event_hourly_rollup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "processed_hour": {
+          "name": "processed_hour",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_window_id": {
+          "name": "short_window_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_window_id": {
+          "name": "weekly_window_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits_charged": {
+          "name": "credits_charged",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowance_units": {
+          "name": "allowance_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_usage_event_hourly_rollup_org_hour": {
+          "name": "idx_usage_event_hourly_rollup_org_hour",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processed_hour",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_hourly_rollup_physical_grain": {
+          "name": "idx_usage_event_hourly_rollup_physical_grain",
+          "columns": [
+            {
+              "expression": "processed_hour",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "short_window_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weekly_window_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_hourly_rollup_run_id": {
+          "name": "idx_usage_event_hourly_rollup_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_hourly_rollup_user_id": {
+          "name": "idx_usage_event_hourly_rollup_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_hourly_rollup_short_window_id": {
+          "name": "idx_usage_event_hourly_rollup_short_window_id",
+          "columns": [
+            {
+              "expression": "short_window_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_hourly_rollup_weekly_window_id": {
+          "name": "idx_usage_event_hourly_rollup_weekly_window_id",
+          "columns": [
+            {
+              "expression": "weekly_window_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_event_hourly_rollup_run_id_agent_runs_id_fk": {
+          "name": "usage_event_hourly_rollup_run_id_agent_runs_id_fk",
+          "tableFrom": "usage_event_hourly_rollup",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fk_usage_event_hourly_rollup_short_window": {
+          "name": "fk_usage_event_hourly_rollup_short_window",
+          "tableFrom": "usage_event_hourly_rollup",
+          "tableTo": "org_usage_allowance_windows",
+          "columnsFrom": [
+            "short_window_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fk_usage_event_hourly_rollup_weekly_window": {
+          "name": "fk_usage_event_hourly_rollup_weekly_window",
+          "tableFrom": "usage_event_hourly_rollup",
+          "tableTo": "org_usage_allowance_windows",
+          "columnsFrom": [
+            "weekly_window_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_event_hourly_rollup_processed_hour": {
+          "name": "chk_usage_event_hourly_rollup_processed_hour",
+          "value": "\"usage_event_hourly_rollup\".\"processed_hour\" = date_trunc('hour', \"usage_event_hourly_rollup\".\"processed_hour\")"
+        },
+        "chk_usage_event_hourly_rollup_quantity": {
+          "name": "chk_usage_event_hourly_rollup_quantity",
+          "value": "\"usage_event_hourly_rollup\".\"quantity\" >= 0"
+        },
+        "chk_usage_event_hourly_rollup_credits_charged": {
+          "name": "chk_usage_event_hourly_rollup_credits_charged",
+          "value": "\"usage_event_hourly_rollup\".\"credits_charged\" >= 0"
+        },
+        "chk_usage_event_hourly_rollup_allowance_units": {
+          "name": "chk_usage_event_hourly_rollup_allowance_units",
+          "value": "\"usage_event_hourly_rollup\".\"allowance_units\" >= 0"
+        },
+        "chk_usage_event_hourly_rollup_allowance_window_pair": {
+          "name": "chk_usage_event_hourly_rollup_allowance_window_pair",
+          "value": "(\n          \"usage_event_hourly_rollup\".\"allowance_units\" = 0\n          AND \"usage_event_hourly_rollup\".\"short_window_id\" IS NULL\n          AND \"usage_event_hourly_rollup\".\"weekly_window_id\" IS NULL\n        ) OR (\n          \"usage_event_hourly_rollup\".\"allowance_units\" > 0\n          AND \"usage_event_hourly_rollup\".\"short_window_id\" IS NOT NULL\n          AND \"usage_event_hourly_rollup\".\"weekly_window_id\" IS NOT NULL\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_event": {
+      "name": "usage_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits_charged": {
+          "name": "credits_charged",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "billing_error": {
+          "name": "billing_error",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_usage_event_idempotency_key": {
+          "name": "uq_usage_event_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_run_id": {
+          "name": "idx_usage_event_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_org_status": {
+          "name": "idx_usage_event_org_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_org_created": {
+          "name": "idx_usage_event_org_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_model_created": {
+          "name": "idx_usage_event_model_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_event\".\"kind\" = 'model'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_org_user_status_processed": {
+          "name": "idx_usage_event_org_user_status_processed",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_processed_org_user": {
+          "name": "idx_usage_event_processed_org_user",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_event\".\"status\" = 'processed' AND \"usage_event\".\"processed_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_event_run_id_agent_runs_id_fk": {
+          "name": "usage_event_run_id_agent_runs_id_fk",
+          "tableFrom": "usage_event",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_credit_grants": {
+      "name": "usage_pack_credit_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_type": {
+          "name": "grant_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_amount": {
+          "name": "original_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remaining_amount": {
+          "name": "remaining_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pack_credit_grants_idempotency": {
+          "name": "uq_usage_pack_credit_grants_idempotency",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_credit_grants_member_spendable": {
+          "name": "idx_usage_pack_credit_grants_member_spendable",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grant_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_pack_credit_grants\".\"remaining_amount\" > 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_credit_grants_type": {
+          "name": "chk_usage_pack_credit_grants_type",
+          "value": "\"usage_pack_credit_grants\".\"grant_type\" IN ('purchased', 'bonus')"
+        },
+        "chk_usage_pack_credit_grants_original_amount": {
+          "name": "chk_usage_pack_credit_grants_original_amount",
+          "value": "\"usage_pack_credit_grants\".\"original_amount\" > 0"
+        },
+        "chk_usage_pack_credit_grants_remaining_amount": {
+          "name": "chk_usage_pack_credit_grants_remaining_amount",
+          "value": "\"usage_pack_credit_grants\".\"remaining_amount\" >= 0 AND \"usage_pack_credit_grants\".\"remaining_amount\" <= \"usage_pack_credit_grants\".\"original_amount\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_credit_refunds": {
+      "name": "usage_pack_credit_refunds",
+      "schema": "",
+      "columns": {
+        "credit_grant_id": {
+          "name": "credit_grant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_line_id": {
+          "name": "stripe_invoice_line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_amount_cents": {
+          "name": "source_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "refund_credits": {
+          "name": "refund_credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_amount_cents": {
+          "name": "requested_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_amount_cents": {
+          "name": "refunded_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_credit_note_id": {
+          "name": "stripe_credit_note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_refund_id": {
+          "name": "stripe_refund_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_usage_pack_credit_refunds_member": {
+          "name": "idx_usage_pack_credit_refunds_member",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_credit_refunds_reconcile": {
+          "name": "idx_usage_pack_credit_refunds_reconcile",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_credit_refunds_credit_note": {
+          "name": "uq_usage_pack_credit_refunds_credit_note",
+          "columns": [
+            {
+              "expression": "stripe_credit_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_credit_refunds\".\"stripe_credit_note_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_credit_refunds_refund": {
+          "name": "uq_usage_pack_credit_refunds_refund",
+          "columns": [
+            {
+              "expression": "stripe_refund_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_credit_refunds\".\"stripe_refund_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_pack_credit_refunds_credit_grant_id_usage_pack_credit_grants_id_fk": {
+          "name": "usage_pack_credit_refunds_credit_grant_id_usage_pack_credit_grants_id_fk",
+          "tableFrom": "usage_pack_credit_refunds",
+          "tableTo": "usage_pack_credit_grants",
+          "columnsFrom": [
+            "credit_grant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_credit_refunds_source": {
+          "name": "chk_usage_pack_credit_refunds_source",
+          "value": "(\"usage_pack_credit_refunds\".\"source_type\" = 'invoice' AND \"usage_pack_credit_refunds\".\"stripe_invoice_id\" IS NOT NULL AND \"usage_pack_credit_refunds\".\"stripe_payment_intent_id\" IS NULL) OR (\"usage_pack_credit_refunds\".\"source_type\" = 'payment_intent' AND \"usage_pack_credit_refunds\".\"stripe_invoice_id\" IS NULL AND \"usage_pack_credit_refunds\".\"stripe_invoice_line_id\" IS NULL AND \"usage_pack_credit_refunds\".\"stripe_payment_intent_id\" IS NOT NULL)"
+        },
+        "chk_usage_pack_credit_refunds_status": {
+          "name": "chk_usage_pack_credit_refunds_status",
+          "value": "\"usage_pack_credit_refunds\".\"status\" IN ('available', 'pending', 'processing', 'succeeded', 'failed')"
+        },
+        "chk_usage_pack_credit_refunds_source_amount": {
+          "name": "chk_usage_pack_credit_refunds_source_amount",
+          "value": "\"usage_pack_credit_refunds\".\"source_amount_cents\" >= 0"
+        },
+        "chk_usage_pack_credit_refunds_snapshot": {
+          "name": "chk_usage_pack_credit_refunds_snapshot",
+          "value": "(\"usage_pack_credit_refunds\".\"status\" = 'available' AND \"usage_pack_credit_refunds\".\"refund_credits\" IS NULL AND \"usage_pack_credit_refunds\".\"requested_amount_cents\" IS NULL) OR (\"usage_pack_credit_refunds\".\"status\" <> 'available' AND \"usage_pack_credit_refunds\".\"refund_credits\" > 0 AND \"usage_pack_credit_refunds\".\"requested_amount_cents\" > 0)"
+        },
+        "chk_usage_pack_credit_refunds_refunded_amount": {
+          "name": "chk_usage_pack_credit_refunds_refunded_amount",
+          "value": "\"usage_pack_credit_refunds\".\"refunded_amount_cents\" IS NULL OR \"usage_pack_credit_refunds\".\"refunded_amount_cents\" >= 0"
+        },
+        "chk_usage_pack_credit_refunds_attempt": {
+          "name": "chk_usage_pack_credit_refunds_attempt",
+          "value": "\"usage_pack_credit_refunds\".\"attempt\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_allocation_changes": {
+      "name": "usage_pack_allocation_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "usage_pack_subscription_id": {
+          "name": "usage_pack_subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_change_id": {
+          "name": "subscription_change_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_allocation_id": {
+          "name": "source_allocation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replacement_allocation_id": {
+          "name": "replacement_allocation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "source_usage_pack_usd": {
+          "name": "source_usage_pack_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_stripe_price_id": {
+          "name": "source_stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_usage_pack_usd": {
+          "name": "target_usage_pack_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_stripe_price_id": {
+          "name": "target_stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proration_timestamp": {
+          "name": "proration_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "immediate_amount_cents": {
+          "name": "immediate_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_recurring_amount_cents": {
+          "name": "next_recurring_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_schedule_id": {
+          "name": "stripe_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_pending_update_expires_at": {
+          "name": "stripe_pending_update_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pack_changes_active_org": {
+          "name": "uq_usage_pack_changes_active_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_allocation_changes\".\"subscription_change_id\" IS NULL AND \"usage_pack_allocation_changes\".\"status\" IN ('previewed', 'applying', 'pending_payment')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_changes_current_user": {
+          "name": "uq_usage_pack_changes_current_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(\"usage_pack_allocation_changes\".\"subscription_change_id\" IS NULL AND \"usage_pack_allocation_changes\".\"status\" IN ('previewed', 'applying', 'pending_payment')) OR \"usage_pack_allocation_changes\".\"status\" IN ('scheduled', 'applied')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_changes_stripe_invoice": {
+          "name": "uq_usage_pack_changes_stripe_invoice",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_allocation_changes\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_changes_subscription_status": {
+          "name": "idx_usage_pack_changes_subscription_status",
+          "columns": [
+            {
+              "expression": "usage_pack_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_changes_subscription_change": {
+          "name": "idx_usage_pack_changes_subscription_change",
+          "columns": [
+            {
+              "expression": "subscription_change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_changes_reconcile": {
+          "name": "idx_usage_pack_changes_reconcile",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_pack_allocation_changes_usage_pack_subscription_id_usage_pack_subscriptions_id_fk": {
+          "name": "usage_pack_allocation_changes_usage_pack_subscription_id_usage_pack_subscriptions_id_fk",
+          "tableFrom": "usage_pack_allocation_changes",
+          "tableTo": "usage_pack_subscriptions",
+          "columnsFrom": [
+            "usage_pack_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_pack_allocation_changes_subscription_change_id_usage_pack_subscription_changes_id_fk": {
+          "name": "usage_pack_allocation_changes_subscription_change_id_usage_pack_subscription_changes_id_fk",
+          "tableFrom": "usage_pack_allocation_changes",
+          "tableTo": "usage_pack_subscription_changes",
+          "columnsFrom": [
+            "subscription_change_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_pack_allocation_changes_source_allocation_id_usage_pack_allocations_id_fk": {
+          "name": "usage_pack_allocation_changes_source_allocation_id_usage_pack_allocations_id_fk",
+          "tableFrom": "usage_pack_allocation_changes",
+          "tableTo": "usage_pack_allocations",
+          "columnsFrom": [
+            "source_allocation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_changes_kind": {
+          "name": "chk_usage_pack_changes_kind",
+          "value": "\"usage_pack_allocation_changes\".\"kind\" IN ('addition', 'upgrade', 'downgrade', 'removal')"
+        },
+        "chk_usage_pack_changes_status": {
+          "name": "chk_usage_pack_changes_status",
+          "value": "\"usage_pack_allocation_changes\".\"status\" IN ('previewed', 'applying', 'pending_payment', 'scheduled', 'applied', 'completed', 'failed')"
+        },
+        "chk_usage_pack_changes_source": {
+          "name": "chk_usage_pack_changes_source",
+          "value": "(\"usage_pack_allocation_changes\".\"kind\" = 'addition' AND \"usage_pack_allocation_changes\".\"source_allocation_id\" IS NULL AND \"usage_pack_allocation_changes\".\"source_usage_pack_usd\" IS NULL AND \"usage_pack_allocation_changes\".\"source_stripe_price_id\" IS NULL) OR (\"usage_pack_allocation_changes\".\"kind\" <> 'addition' AND \"usage_pack_allocation_changes\".\"source_allocation_id\" IS NOT NULL AND \"usage_pack_allocation_changes\".\"source_usage_pack_usd\" IN (20, 50, 100, 200) AND \"usage_pack_allocation_changes\".\"source_stripe_price_id\" IS NOT NULL)"
+        },
+        "chk_usage_pack_changes_target_package": {
+          "name": "chk_usage_pack_changes_target_package",
+          "value": "(\"usage_pack_allocation_changes\".\"kind\" = 'removal' AND \"usage_pack_allocation_changes\".\"target_usage_pack_usd\" IS NULL AND \"usage_pack_allocation_changes\".\"target_stripe_price_id\" IS NULL) OR (\"usage_pack_allocation_changes\".\"kind\" <> 'removal' AND \"usage_pack_allocation_changes\".\"target_usage_pack_usd\" IN (20, 50, 100, 200) AND \"usage_pack_allocation_changes\".\"target_stripe_price_id\" IS NOT NULL)"
+        },
+        "chk_usage_pack_changes_amounts": {
+          "name": "chk_usage_pack_changes_amounts",
+          "value": "(\"usage_pack_allocation_changes\".\"immediate_amount_cents\" IS NULL OR \"usage_pack_allocation_changes\".\"immediate_amount_cents\" >= 0) AND (\"usage_pack_allocation_changes\".\"next_recurring_amount_cents\" IS NULL OR \"usage_pack_allocation_changes\".\"next_recurring_amount_cents\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_allocations": {
+      "name": "usage_pack_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "usage_pack_subscription_id": {
+          "name": "usage_pack_subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_pack_usd": {
+          "name": "usage_pack_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_payment'"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pack_allocations_current_user": {
+          "name": "uq_usage_pack_allocations_current_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_allocations\".\"user_id\" IS NOT NULL AND \"usage_pack_allocations\".\"status\" <> 'inactive'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_allocations_current_invitation": {
+          "name": "uq_usage_pack_allocations_current_invitation",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_allocations\".\"invitation_id\" IS NOT NULL AND \"usage_pack_allocations\".\"status\" <> 'inactive'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_allocations_subscription_status": {
+          "name": "idx_usage_pack_allocations_subscription_status",
+          "columns": [
+            {
+              "expression": "usage_pack_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_allocations_org_user": {
+          "name": "idx_usage_pack_allocations_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_allocations_org_invitation": {
+          "name": "idx_usage_pack_allocations_org_invitation",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_pack_allocations_usage_pack_subscription_id_usage_pack_subscriptions_id_fk": {
+          "name": "usage_pack_allocations_usage_pack_subscription_id_usage_pack_subscriptions_id_fk",
+          "tableFrom": "usage_pack_allocations",
+          "tableTo": "usage_pack_subscriptions",
+          "columnsFrom": [
+            "usage_pack_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_allocations_owner": {
+          "name": "chk_usage_pack_allocations_owner",
+          "value": "(\"usage_pack_allocations\".\"user_id\" IS NOT NULL AND \"usage_pack_allocations\".\"invitation_id\" IS NULL) OR (\"usage_pack_allocations\".\"user_id\" IS NULL AND \"usage_pack_allocations\".\"invitation_id\" IS NOT NULL)"
+        },
+        "chk_usage_pack_allocations_package": {
+          "name": "chk_usage_pack_allocations_package",
+          "value": "\"usage_pack_allocations\".\"usage_pack_usd\" IN (20, 50, 100, 200)"
+        },
+        "chk_usage_pack_allocations_status": {
+          "name": "chk_usage_pack_allocations_status",
+          "value": "\"usage_pack_allocations\".\"status\" IN ('pending_payment', 'active', 'pending_invitation', 'paid_pending_invitation', 'inactive')"
+        },
+        "chk_usage_pack_allocations_period": {
+          "name": "chk_usage_pack_allocations_period",
+          "value": "(\"usage_pack_allocations\".\"current_period_start\" IS NULL AND \"usage_pack_allocations\".\"current_period_end\" IS NULL) OR (\"usage_pack_allocations\".\"current_period_start\" IS NOT NULL AND \"usage_pack_allocations\".\"current_period_end\" IS NOT NULL AND \"usage_pack_allocations\".\"current_period_end\" > \"usage_pack_allocations\".\"current_period_start\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_invitation_purchases": {
+      "name": "usage_pack_invitation_purchases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "usage_pack_subscription_id": {
+          "name": "usage_pack_subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allocation_id": {
+          "name": "allocation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "normalized_email": {
+          "name": "normalized_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_user_id": {
+          "name": "inviter_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_pack_usd": {
+          "name": "usage_pack_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'checkout_pending'"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proration_timestamp": {
+          "name": "proration_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_amount_cents": {
+          "name": "unit_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_amount_cents": {
+          "name": "expected_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_paid_cents": {
+          "name": "amount_paid_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchased_credits": {
+          "name": "purchased_credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_credits": {
+          "name": "bonus_credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_checkout_expires_at": {
+          "name": "stripe_checkout_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_refund_id": {
+          "name": "stripe_refund_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refund_attempt": {
+          "name": "refund_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "clerk_invitation_id": {
+          "name": "clerk_invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_user_id": {
+          "name": "accepted_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pack_invitation_purchases_current_email": {
+          "name": "uq_usage_pack_invitation_purchases_current_email",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_invitation_purchases\".\"status\" IN ('checkout_pending', 'payment_succeeded', 'creating_invitation', 'invitation_pending', 'accepted_pending_activation', 'activating')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_invitation_purchases_allocation": {
+          "name": "uq_usage_pack_invitation_purchases_allocation",
+          "columns": [
+            {
+              "expression": "allocation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_invitation_purchases\".\"allocation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_invitation_purchases_checkout": {
+          "name": "uq_usage_pack_invitation_purchases_checkout",
+          "columns": [
+            {
+              "expression": "stripe_checkout_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_invitation_purchases\".\"stripe_checkout_session_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_invitation_purchases_payment_intent": {
+          "name": "idx_usage_pack_invitation_purchases_payment_intent",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_pack_invitation_purchases\".\"stripe_payment_intent_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_invitation_purchases_refund": {
+          "name": "uq_usage_pack_invitation_purchases_refund",
+          "columns": [
+            {
+              "expression": "stripe_refund_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_invitation_purchases\".\"stripe_refund_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_invitation_purchases_clerk_invitation": {
+          "name": "uq_usage_pack_invitation_purchases_clerk_invitation",
+          "columns": [
+            {
+              "expression": "clerk_invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_invitation_purchases\".\"clerk_invitation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_invitation_purchases_reconcile": {
+          "name": "idx_usage_pack_invitation_purchases_reconcile",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_invitation_purchases_org": {
+          "name": "idx_usage_pack_invitation_purchases_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_pack_invitation_purchases_usage_pack_subscription_id_usage_pack_subscriptions_id_fk": {
+          "name": "usage_pack_invitation_purchases_usage_pack_subscription_id_usage_pack_subscriptions_id_fk",
+          "tableFrom": "usage_pack_invitation_purchases",
+          "tableTo": "usage_pack_subscriptions",
+          "columnsFrom": [
+            "usage_pack_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_pack_invitation_purchases_allocation_id_usage_pack_allocations_id_fk": {
+          "name": "usage_pack_invitation_purchases_allocation_id_usage_pack_allocations_id_fk",
+          "tableFrom": "usage_pack_invitation_purchases",
+          "tableTo": "usage_pack_allocations",
+          "columnsFrom": [
+            "allocation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_invitation_purchases_role": {
+          "name": "chk_usage_pack_invitation_purchases_role",
+          "value": "\"usage_pack_invitation_purchases\".\"role\" IN ('admin', 'member')"
+        },
+        "chk_usage_pack_invitation_purchases_package": {
+          "name": "chk_usage_pack_invitation_purchases_package",
+          "value": "\"usage_pack_invitation_purchases\".\"usage_pack_usd\" IN (20, 50, 100, 200)"
+        },
+        "chk_usage_pack_invitation_purchases_status": {
+          "name": "chk_usage_pack_invitation_purchases_status",
+          "value": "\"usage_pack_invitation_purchases\".\"status\" IN ('checkout_pending', 'payment_succeeded', 'creating_invitation', 'invitation_pending', 'accepted_pending_activation', 'activating', 'accepted', 'refund_pending', 'refunding', 'refunded', 'failed')"
+        },
+        "chk_usage_pack_invitation_purchases_period": {
+          "name": "chk_usage_pack_invitation_purchases_period",
+          "value": "\"usage_pack_invitation_purchases\".\"current_period_end\" > \"usage_pack_invitation_purchases\".\"current_period_start\""
+        },
+        "chk_usage_pack_invitation_purchases_amounts": {
+          "name": "chk_usage_pack_invitation_purchases_amounts",
+          "value": "\"usage_pack_invitation_purchases\".\"unit_amount_cents\" > 0 AND \"usage_pack_invitation_purchases\".\"expected_amount_cents\" >= 0 AND (\"usage_pack_invitation_purchases\".\"amount_paid_cents\" IS NULL OR \"usage_pack_invitation_purchases\".\"amount_paid_cents\" >= 0) AND \"usage_pack_invitation_purchases\".\"purchased_credits\" >= 0 AND \"usage_pack_invitation_purchases\".\"bonus_credits\" >= 0 AND \"usage_pack_invitation_purchases\".\"refund_attempt\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_invoice_fulfillments": {
+      "name": "usage_pack_invoice_fulfillments",
+      "schema": "",
+      "columns": {
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "usage_pack_subscription_id": {
+          "name": "usage_pack_subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_usage_pack_invoice_fulfillments_subscription": {
+          "name": "idx_usage_pack_invoice_fulfillments_subscription",
+          "columns": [
+            {
+              "expression": "usage_pack_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_pack_invoice_fulfillments_usage_pack_subscription_id_usage_pack_subscriptions_id_fk": {
+          "name": "usage_pack_invoice_fulfillments_usage_pack_subscription_id_usage_pack_subscriptions_id_fk",
+          "tableFrom": "usage_pack_invoice_fulfillments",
+          "tableTo": "usage_pack_subscriptions",
+          "columnsFrom": [
+            "usage_pack_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_invoice_fulfillments_period": {
+          "name": "chk_usage_pack_invoice_fulfillments_period",
+          "value": "\"usage_pack_invoice_fulfillments\".\"period_start\" IS NULL OR \"usage_pack_invoice_fulfillments\".\"period_end\" > \"usage_pack_invoice_fulfillments\".\"period_start\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_pending_snapshot_guards": {
+      "name": "usage_pack_pending_snapshot_guards",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending_snapshot_count": {
+          "name": "pending_snapshot_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_usage_pack_subscriptions_pending_org": {
+          "name": "uq_usage_pack_subscriptions_pending_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_pending_snapshot_guard_count": {
+          "name": "chk_usage_pack_pending_snapshot_guard_count",
+          "value": "\"usage_pack_pending_snapshot_guards\".\"pending_snapshot_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_subscription_changes": {
+      "name": "usage_pack_subscription_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "usage_pack_subscription_id": {
+          "name": "usage_pack_subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_tier": {
+          "name": "source_tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_tier": {
+          "name": "target_tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "proration_timestamp": {
+          "name": "proration_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "immediate_amount_cents": {
+          "name": "immediate_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_recurring_amount_cents": {
+          "name": "next_recurring_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_pending_update_expires_at": {
+          "name": "stripe_pending_update_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pack_subscription_changes_active_org": {
+          "name": "uq_usage_pack_subscription_changes_active_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_subscription_changes\".\"status\" IN ('previewed', 'applying', 'pending_payment')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_subscription_changes_stripe_invoice": {
+          "name": "uq_usage_pack_subscription_changes_stripe_invoice",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_subscription_changes\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_subscription_changes_subscription_status": {
+          "name": "idx_usage_pack_subscription_changes_subscription_status",
+          "columns": [
+            {
+              "expression": "usage_pack_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_subscription_changes_reconcile": {
+          "name": "idx_usage_pack_subscription_changes_reconcile",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_pack_subscription_changes_usage_pack_subscription_id_usage_pack_subscriptions_id_fk": {
+          "name": "usage_pack_subscription_changes_usage_pack_subscription_id_usage_pack_subscriptions_id_fk",
+          "tableFrom": "usage_pack_subscription_changes",
+          "tableTo": "usage_pack_subscriptions",
+          "columnsFrom": [
+            "usage_pack_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_subscription_changes_tiers": {
+          "name": "chk_usage_pack_subscription_changes_tiers",
+          "value": "\"usage_pack_subscription_changes\".\"source_tier\" IN ('pro', 'team') AND \"usage_pack_subscription_changes\".\"target_tier\" IN ('pro', 'team')"
+        },
+        "chk_usage_pack_subscription_changes_status": {
+          "name": "chk_usage_pack_subscription_changes_status",
+          "value": "\"usage_pack_subscription_changes\".\"status\" IN ('previewed', 'applying', 'pending_payment', 'completed', 'failed')"
+        },
+        "chk_usage_pack_subscription_changes_amounts": {
+          "name": "chk_usage_pack_subscription_changes_amounts",
+          "value": "\"usage_pack_subscription_changes\".\"immediate_amount_cents\" >= 0 AND \"usage_pack_subscription_changes\".\"next_recurring_amount_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_subscription_migration_selections": {
+      "name": "usage_pack_subscription_migration_selections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "migration_id": {
+          "name": "migration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_email": {
+          "name": "normalized_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_user_id": {
+          "name": "inviter_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_pack_usd": {
+          "name": "usage_pack_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_amount_cents": {
+          "name": "unit_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchased_credits": {
+          "name": "purchased_credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_credits": {
+          "name": "bonus_credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pack_migration_selections_user": {
+          "name": "uq_usage_pack_migration_selections_user",
+          "columns": [
+            {
+              "expression": "migration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_subscription_migration_selections\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_migration_selections_invitation": {
+          "name": "uq_usage_pack_migration_selections_invitation",
+          "columns": [
+            {
+              "expression": "migration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_subscription_migration_selections\".\"invitation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_migration_selections_migration": {
+          "name": "idx_usage_pack_migration_selections_migration",
+          "columns": [
+            {
+              "expression": "migration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_pack_subscription_migration_selections_migration_id_usage_pack_subscription_migrations_id_fk": {
+          "name": "usage_pack_subscription_migration_selections_migration_id_usage_pack_subscription_migrations_id_fk",
+          "tableFrom": "usage_pack_subscription_migration_selections",
+          "tableTo": "usage_pack_subscription_migrations",
+          "columnsFrom": [
+            "migration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_migration_selections_owner": {
+          "name": "chk_usage_pack_migration_selections_owner",
+          "value": "(\"usage_pack_subscription_migration_selections\".\"user_id\" IS NOT NULL AND \"usage_pack_subscription_migration_selections\".\"invitation_id\" IS NULL AND \"usage_pack_subscription_migration_selections\".\"normalized_email\" IS NULL AND \"usage_pack_subscription_migration_selections\".\"role\" IS NULL AND \"usage_pack_subscription_migration_selections\".\"inviter_user_id\" IS NULL) OR (\"usage_pack_subscription_migration_selections\".\"user_id\" IS NULL AND \"usage_pack_subscription_migration_selections\".\"invitation_id\" IS NOT NULL AND \"usage_pack_subscription_migration_selections\".\"normalized_email\" IS NOT NULL AND \"usage_pack_subscription_migration_selections\".\"role\" IS NOT NULL AND \"usage_pack_subscription_migration_selections\".\"inviter_user_id\" IS NOT NULL)"
+        },
+        "chk_usage_pack_migration_selections_role": {
+          "name": "chk_usage_pack_migration_selections_role",
+          "value": "\"usage_pack_subscription_migration_selections\".\"role\" IS NULL OR \"usage_pack_subscription_migration_selections\".\"role\" IN ('admin', 'member')"
+        },
+        "chk_usage_pack_migration_selections_package": {
+          "name": "chk_usage_pack_migration_selections_package",
+          "value": "\"usage_pack_subscription_migration_selections\".\"usage_pack_usd\" IN (20, 50, 100, 200)"
+        },
+        "chk_usage_pack_migration_selections_amounts": {
+          "name": "chk_usage_pack_migration_selections_amounts",
+          "value": "\"usage_pack_subscription_migration_selections\".\"unit_amount_cents\" > 0 AND \"usage_pack_subscription_migration_selections\".\"purchased_credits\" > 0 AND \"usage_pack_subscription_migration_selections\".\"bonus_credits\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_subscription_migrations": {
+      "name": "usage_pack_subscription_migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_tier": {
+          "name": "source_tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_tier": {
+          "name": "target_tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_stripe_price_id": {
+          "name": "legacy_stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_stripe_item_id": {
+          "name": "legacy_stripe_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_plan_price_id": {
+          "name": "stripe_plan_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "current_recurring_amount_cents": {
+          "name": "current_recurring_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_recurring_amount_cents": {
+          "name": "next_recurring_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_difference_cents": {
+          "name": "recurring_difference_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_schedule_id": {
+          "name": "stripe_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hosted_invoice_url": {
+          "name": "hosted_invoice_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pack_subscription_migrations_open_org": {
+          "name": "uq_usage_pack_subscription_migrations_open_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_subscription_migrations\".\"status\" IN ('previewed', 'applying', 'revising', 'scheduled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_subscription_migrations_open_subscription": {
+          "name": "uq_usage_pack_subscription_migrations_open_subscription",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_subscription_migrations\".\"status\" IN ('previewed', 'applying', 'revising', 'scheduled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_subscription_migrations_invoice": {
+          "name": "uq_usage_pack_subscription_migrations_invoice",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_subscription_migrations\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_subscription_migrations_schedule": {
+          "name": "uq_usage_pack_subscription_migrations_schedule",
+          "columns": [
+            {
+              "expression": "stripe_schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_subscription_migrations\".\"stripe_schedule_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_subscription_migrations_reconcile": {
+          "name": "idx_usage_pack_subscription_migrations_reconcile",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_subscription_migrations_tiers": {
+          "name": "chk_usage_pack_subscription_migrations_tiers",
+          "value": "\"usage_pack_subscription_migrations\".\"source_tier\" IN ('pro', 'team') AND \"usage_pack_subscription_migrations\".\"target_tier\" IN ('pro', 'team')"
+        },
+        "chk_usage_pack_subscription_migrations_status": {
+          "name": "chk_usage_pack_subscription_migrations_status",
+          "value": "\"usage_pack_subscription_migrations\".\"status\" IN ('previewed', 'applying', 'revising', 'scheduled', 'completed', 'failed')"
+        },
+        "chk_usage_pack_subscription_migrations_amounts": {
+          "name": "chk_usage_pack_subscription_migrations_amounts",
+          "value": "\"usage_pack_subscription_migrations\".\"current_recurring_amount_cents\" >= 0 AND \"usage_pack_subscription_migrations\".\"next_recurring_amount_cents\" >= 0 AND \"usage_pack_subscription_migrations\".\"recurring_difference_cents\" = \"usage_pack_subscription_migrations\".\"next_recurring_amount_cents\" - \"usage_pack_subscription_migrations\".\"current_recurring_amount_cents\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_subscriptions": {
+      "name": "usage_pack_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_plan_price_id": {
+          "name": "stripe_plan_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'checkout_pending'"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pack_subscriptions_checkout_session": {
+          "name": "uq_usage_pack_subscriptions_checkout_session",
+          "columns": [
+            {
+              "expression": "stripe_checkout_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_subscriptions\".\"stripe_checkout_session_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_subscriptions_stripe_subscription": {
+          "name": "uq_usage_pack_subscriptions_stripe_subscription",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_subscriptions\".\"stripe_subscription_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_subscriptions_org": {
+          "name": "idx_usage_pack_subscriptions_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_subscriptions_reconcile": {
+          "name": "idx_usage_pack_subscriptions_reconcile",
+          "columns": [
+            {
+              "expression": "subscription_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_subscriptions_tier": {
+          "name": "chk_usage_pack_subscriptions_tier",
+          "value": "\"usage_pack_subscriptions\".\"tier\" IN ('pro', 'team')"
+        },
+        "chk_usage_pack_subscriptions_period": {
+          "name": "chk_usage_pack_subscriptions_period",
+          "value": "(\"usage_pack_subscriptions\".\"current_period_start\" IS NULL AND \"usage_pack_subscriptions\".\"current_period_end\" IS NULL) OR (\"usage_pack_subscriptions\".\"current_period_start\" IS NOT NULL AND \"usage_pack_subscriptions\".\"current_period_end\" IS NOT NULL AND \"usage_pack_subscriptions\".\"current_period_end\" > \"usage_pack_subscriptions\".\"current_period_start\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pricing": {
+      "name": "usage_pricing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_size": {
+          "name": "unit_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pricing_kind_provider_category": {
+          "name": "uq_usage_pricing_kind_provider_category",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_artifact_favorites": {
+      "name": "user_artifact_favorites",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_url": {
+          "name": "artifact_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_artifact_favorites_org_id_user_id_artifact_url_pk": {
+          "name": "user_artifact_favorites_org_id_user_id_artifact_url_pk",
+          "columns": [
+            "org_id",
+            "user_id",
+            "artifact_url"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_behavior_count": {
+      "name": "user_behavior_count",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "behavior_key": {
+          "name": "behavior_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_at": {
+          "name": "first_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_at": {
+          "name": "last_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_behavior_count_org_id_user_id_behavior_key_pk": {
+          "name": "user_behavior_count_org_id_user_id_behavior_key_pk",
+          "columns": [
+            "org_id",
+            "user_id",
+            "behavior_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_cache": {
+      "name": "user_cache",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_list_cached_at": {
+          "name": "org_list_cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_connectors": {
+      "name": "user_connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_slug": {
+          "name": "connector_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_connectors_unique_slug": {
+          "name": "idx_user_connectors_unique_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_connectors_agent_user": {
+          "name": "idx_user_connectors_agent_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_connectors_agent_id_agents_id_fk": {
+          "name": "user_connectors_agent_id_agents_id_fk",
+          "tableFrom": "user_connectors",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_custom_connectors": {
+      "name": "user_custom_connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_connector_id": {
+          "name": "custom_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_names": {
+          "name": "permission_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_custom_connectors_unique": {
+          "name": "idx_user_custom_connectors_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "custom_connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_custom_connectors_agent_user": {
+          "name": "idx_user_custom_connectors_agent_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_custom_connectors_agent_id_agents_id_fk": {
+          "name": "user_custom_connectors_agent_id_agents_id_fk",
+          "tableFrom": "user_custom_connectors",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_user_custom_connectors_custom_connector": {
+          "name": "fk_user_custom_connectors_custom_connector",
+          "tableFrom": "user_custom_connectors",
+          "tableTo": "org_custom_connectors",
+          "columnsFrom": [
+            "custom_connector_id",
+            "org_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_feature_switches": {
+      "name": "user_feature_switches",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "switches": {
+          "name": "switches",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_feature_switches_org_id_user_id_pk": {
+          "name": "user_feature_switches_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_permission_grants": {
+      "name": "user_permission_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_slug": {
+          "name": "connector_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_user_permission_grants_slug_permission": {
+          "name": "uq_user_permission_grants_slug_permission",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_permission_grants_lookup": {
+          "name": "idx_user_permission_grants_lookup",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_permission_grants_user_id": {
+          "name": "idx_user_permission_grants_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_permission_grants_agent_id": {
+          "name": "idx_user_permission_grants_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_permission_grants_agent_id_agents_id_fk": {
+          "name": "user_permission_grants_agent_id_agents_id_fk",
+          "tableFrom": "user_permission_grants",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_user_permission_grants_action": {
+          "name": "chk_user_permission_grants_action",
+          "value": "\"user_permission_grants\".\"action\" IN ('allow', 'deny')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_unsubscribed": {
+          "name": "email_unsubscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variables": {
+      "name": "variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variables_org": {
+          "name": "idx_variables_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_connector": {
+          "name": "idx_variables_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"variables\".\"connector_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_org_user_type_name": {
+          "name": "idx_variables_org_user_type_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"variables\".\"connector_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_connector_name": {
+          "name": "idx_variables_connector_name",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"variables\".\"connector_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_variables_connector_owner": {
+          "name": "fk_variables_connector_owner",
+          "tableFrom": "variables",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id",
+            "org_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_variables_connector_owner_type": {
+          "name": "chk_variables_connector_owner_type",
+          "value": "(\"variables\".\"type\" = 'connector') = (\"variables\".\"connector_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.official_workflow_automation_identities": {
+      "name": "official_workflow_automation_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blueprint_key": {
+          "name": "blueprint_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retained_parameter_bindings": {
+          "name": "retained_parameter_bindings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retained_intended_enabled": {
+          "name": "retained_intended_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retained_applied_fingerprint": {
+          "name": "retained_applied_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_official_workflow_automation_identities_key": {
+          "name": "idx_official_workflow_automation_identities_key",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "blueprint_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_official_workflow_automation_identities_automation_unique": {
+          "name": "idx_official_workflow_automation_identities_automation_unique",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"official_workflow_automation_identities\".\"automation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_official_workflow_automation_identities_workflow": {
+          "name": "idx_official_workflow_automation_identities_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "official_workflow_automation_identity_workflow_fk": {
+          "name": "official_workflow_automation_identity_workflow_fk",
+          "tableFrom": "official_workflow_automation_identities",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "official_workflow_automation_identity_automation_fk": {
+          "name": "official_workflow_automation_identity_automation_fk",
+          "tableFrom": "official_workflow_automation_identities",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "official_workflow_automation_identities_state_check": {
+          "name": "official_workflow_automation_identities_state_check",
+          "value": "(\n          \"official_workflow_automation_identities\".\"state\" = 'active'\n          AND \"official_workflow_automation_identities\".\"automation_id\" IS NOT NULL\n          AND \"official_workflow_automation_identities\".\"retained_parameter_bindings\" IS NULL\n          AND \"official_workflow_automation_identities\".\"retained_intended_enabled\" IS NULL\n          AND \"official_workflow_automation_identities\".\"retained_applied_fingerprint\" IS NULL\n        ) OR (\n          \"official_workflow_automation_identities\".\"state\" IN ('reconciling', 'needs_reconfiguration', 'failed', 'removed')\n          AND \"official_workflow_automation_identities\".\"automation_id\" IS NULL\n          AND jsonb_typeof(\"official_workflow_automation_identities\".\"retained_parameter_bindings\") = 'array'\n          AND \"official_workflow_automation_identities\".\"retained_intended_enabled\" IS NOT NULL\n          AND (\n            \"official_workflow_automation_identities\".\"retained_applied_fingerprint\" IS NULL\n            OR \"official_workflow_automation_identities\".\"retained_applied_fingerprint\" ~ '^[0-9a-f]{64}$'\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_automations": {
+      "name": "workflow_automations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'schedule'"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_config": {
+          "name": "event_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_connector_id": {
+          "name": "event_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at_time": {
+          "name": "at_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "autonomy_budget": {
+          "name": "autonomy_budget",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "official_blueprint_key": {
+          "name": "official_blueprint_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_applied_fingerprint": {
+          "name": "official_applied_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_reconciliation_status": {
+          "name": "official_reconciliation_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_parameter_bindings": {
+          "name": "official_parameter_bindings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_intended_enabled": {
+          "name": "official_intended_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_result_email_enabled": {
+          "name": "official_result_email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflow_automations_workflow": {
+          "name": "idx_workflow_automations_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_automations_org": {
+          "name": "idx_workflow_automations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_automations_event_connector": {
+          "name": "idx_workflow_automations_event_connector",
+          "columns": [
+            {
+              "expression": "event_connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_automations_next_run": {
+          "name": "idx_workflow_automations_next_run",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_automations_official_blueprint_unique": {
+          "name": "idx_workflow_automations_official_blueprint_unique",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "official_blueprint_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_automations\".\"official_blueprint_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_automations_workflow_id_workflows_id_fk": {
+          "name": "workflow_automations_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_automations",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_automations_event_connector_id_connectors_id_fk": {
+          "name": "workflow_automations_event_connector_id_connectors_id_fk",
+          "tableFrom": "workflow_automations",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "event_connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_automations_schedule_config_check": {
+          "name": "workflow_automations_schedule_config_check",
+          "value": "(\n            kind = 'schedule'\n            AND event_type IS NULL\n            AND event_config IS NULL\n            AND (\n              (schedule_type = 'cron' AND cron_expression IS NOT NULL AND interval_seconds IS NULL AND at_time IS NULL)\n              OR (schedule_type = 'loop' AND interval_seconds IS NOT NULL AND cron_expression IS NULL AND at_time IS NULL)\n              OR (schedule_type = 'once' AND at_time IS NOT NULL AND cron_expression IS NULL AND interval_seconds IS NULL)\n            )\n          )\n          OR (\n            kind = 'event'\n            AND event_type IN ('chat-run-finished', 'gmail-new-message', 'gmail-label-applied', 'github-deployment-status-created', 'github-issue-comment-created', 'github-pull-request', 'github-pull-request-review-submitted', 'github-workflow-job-completed', 'github-workflow-run-completed', 'google-calendar-event-created', 'google-calendar-event-updated', 'google-calendar-event-cancelled', 'google-forms-response-submitted', 'google-meet-transcript-generated', 'notion-child-page-created', 'notion-database-item-created', 'notion-page-content-updated', 'stripe-invoice-paid', 'webhook-received')\n            AND event_config IS NOT NULL\n            AND schedule_type IS NULL\n            AND cron_expression IS NULL\n            AND interval_seconds IS NULL\n            AND at_time IS NULL\n          )"
+        },
+        "workflow_automations_autonomy_budget_check": {
+          "name": "workflow_automations_autonomy_budget_check",
+          "value": "\"workflow_automations\".\"autonomy_budget\" BETWEEN 0 AND 10"
+        },
+        "workflow_automations_official_binding_check": {
+          "name": "workflow_automations_official_binding_check",
+          "value": "(\n          \"workflow_automations\".\"official_blueprint_key\" IS NULL\n          AND \"workflow_automations\".\"official_applied_fingerprint\" IS NULL\n          AND \"workflow_automations\".\"official_reconciliation_status\" IS NULL\n          AND \"workflow_automations\".\"official_parameter_bindings\" IS NULL\n          AND \"workflow_automations\".\"official_intended_enabled\" IS NULL\n          AND \"workflow_automations\".\"official_result_email_enabled\" IS NULL\n        ) OR (\n          \"workflow_automations\".\"official_blueprint_key\" IS NOT NULL\n          AND \"workflow_automations\".\"official_applied_fingerprint\" ~ '^[0-9a-f]{64}$'\n          AND \"workflow_automations\".\"official_reconciliation_status\" IN ('current', 'reconciling', 'needs_reconfiguration', 'failed')\n          AND jsonb_typeof(\"workflow_automations\".\"official_parameter_bindings\") = 'array'\n          AND \"workflow_automations\".\"official_intended_enabled\" IS NOT NULL\n          AND \"workflow_automations\".\"official_result_email_enabled\" IS NOT NULL\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_github_processed_events": {
+      "name": "workflow_github_processed_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_delivery_id": {
+          "name": "github_delivery_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_number": {
+          "name": "subject_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_name_normalized": {
+          "name": "label_name_normalized",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflow_github_processed_automation_delivery": {
+          "name": "idx_workflow_github_processed_automation_delivery",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_github_processed_subject": {
+          "name": "idx_workflow_github_processed_subject",
+          "columns": [
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_github_processed_events_automation_id_workflow_automations_id_fk": {
+          "name": "workflow_github_processed_events_automation_id_workflow_automations_id_fk",
+          "tableFrom": "workflow_github_processed_events",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_user_automation_threads": {
+      "name": "workflow_user_automation_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflow_user_automation_threads_unique": {
+          "name": "idx_workflow_user_automation_threads_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_user_automation_threads_chat_thread": {
+          "name": "idx_workflow_user_automation_threads_chat_thread",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_user_automation_threads_workflow_user": {
+          "name": "idx_workflow_user_automation_threads_workflow_user",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_user_automation_threads_workflow_id_workflows_id_fk": {
+          "name": "workflow_user_automation_threads_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_user_automation_threads",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_user_automation_threads_chat_thread_id_chat_threads_id_fk": {
+          "name": "workflow_user_automation_threads_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "workflow_user_automation_threads",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_webhook_automations": {
+      "name": "workflow_webhook_automations",
+      "schema": "",
+      "columns": {
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_token": {
+          "name": "encrypted_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_last_four": {
+          "name": "secret_last_four",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_received_at": {
+          "name": "last_received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflow_webhook_automations_token_hash": {
+          "name": "idx_workflow_webhook_automations_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_webhook_automations_automation_id_workflow_automations_id_fk": {
+          "name": "workflow_webhook_automations_automation_id_workflow_automations_id_fk",
+          "tableFrom": "workflow_webhook_automations",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_webhook_deliveries": {
+      "name": "workflow_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_key": {
+          "name": "delivery_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_sha256": {
+          "name": "body_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflow_webhook_deliveries_automation_key": {
+          "name": "idx_workflow_webhook_deliveries_automation_key",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delivery_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_webhook_deliveries_automation_received": {
+          "name": "idx_workflow_webhook_deliveries_automation_received",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_webhook_deliveries_automation_id_workflow_automations_id_fk": {
+          "name": "workflow_webhook_deliveries_automation_id_workflow_automations_id_fk",
+          "tableFrom": "workflow_webhook_deliveries",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows": {
+      "name": "workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_definition_name": {
+          "name": "official_definition_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_installation_state": {
+          "name": "official_installation_state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflows_agent": {
+          "name": "idx_workflows_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflows_public_agent_name_unique": {
+          "name": "idx_workflows_public_agent_name_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "visibility = 'public'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflows_private_owner_agent_name_unique": {
+          "name": "idx_workflows_private_owner_agent_name_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "visibility = 'private'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflows_org": {
+          "name": "idx_workflows_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflows_org_owner": {
+          "name": "idx_workflows_org_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_agent_id_agents_id_fk": {
+          "name": "workflows_agent_id_agents_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_official_installation_check": {
+          "name": "workflows_official_installation_check",
+          "value": "(\n          \"workflows\".\"official_definition_name\" IS NULL\n          AND \"workflows\".\"official_installation_state\" IS NULL\n        ) OR (\n          \"workflows\".\"official_definition_name\" IS NOT NULL\n          AND \"workflows\".\"official_installation_state\" IN ('installing', 'installed')\n          AND \"workflows\".\"official_definition_name\" = \"workflows\".\"name\"\n          AND \"workflows\".\"visibility\" = 'private'\n          AND \"workflows\".\"instruction\" IS NULL\n          AND \"workflows\".\"display_name\" IS NULL\n          AND \"workflows\".\"description\" IS NULL\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.chat_thread_event_kind": {
+      "name": "chat_thread_event_kind",
+      "schema": "public",
+      "values": [
+        "created",
+        "renamed",
+        "deleted",
+        "pinned",
+        "unpinned",
+        "model_selection_updated",
+        "service_tier_updated",
+        "computer_use_host_updated",
+        "video_model_updated",
+        "image_model_updated",
+        "sort_touched"
+      ]
+    },
+    "public.connector_external_code_session_status": {
+      "name": "connector_external_code_session_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completing",
+        "complete",
+        "expired",
+        "error"
+      ]
+    },
+    "public.connector_oauth_device_authorization_session_status": {
+      "name": "connector_oauth_device_authorization_session_status",
+      "schema": "public",
+      "values": [
+        "awaiting_user_authorization",
+        "polling",
+        "complete",
+        "denied",
+        "expired",
+        "error"
+      ]
+    },
+    "public.device_code_status": {
+      "name": "device_code_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "authenticated",
+        "approved",
+        "consumed",
+        "expired",
+        "denied"
+      ]
+    },
+    "public.model_provider_auth_session_status": {
+      "name": "model_provider_auth_session_status",
+      "schema": "public",
+      "values": [
+        "initializing",
+        "awaiting_user_approval",
+        "completing",
+        "imported",
+        "expired",
+        "cancelled",
+        "error"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/turbo/packages/db/src/migrations/meta/_journal.json
+++ b/turbo/packages/db/src/migrations/meta/_journal.json
@@ -1765,6 +1765,13 @@
       "when": 1788370196726,
       "tag": "1059_restore_pi_memory_selection_watermark",
       "breakpoints": true
+    },
+    {
+      "idx": 1060,
+      "version": "7",
+      "when": 1788376783204,
+      "tag": "1060_steady_talisman",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/packages/db/src/schema/pi-memory-phase2-job.ts
+++ b/turbo/packages/db/src/schema/pi-memory-phase2-job.ts
@@ -1,0 +1,201 @@
+import { sql } from "drizzle-orm";
+import {
+  check,
+  foreignKey,
+  index,
+  integer,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+  uuid,
+  varchar,
+} from "drizzle-orm/pg-core";
+
+import { storages } from "./storage";
+
+export const PI_MEMORY_PHASE2_JOB_STATUSES = [
+  "idle",
+  "pending",
+  "leased",
+  "retryable_failure",
+  "terminal_failure",
+] as const;
+
+export type PiMemoryPhase2JobStatus =
+  (typeof PI_MEMORY_PHASE2_JOB_STATUSES)[number];
+
+export const PI_MEMORY_PHASE2_MAX_ATTEMPTS = 3;
+export const PI_MEMORY_PHASE2_MAX_SELECTED_CANDIDATES = 256;
+export const PI_MEMORY_PHASE2_MAX_SELECTED_UTF8_BYTES = 21_036_800;
+
+/**
+ * Serialized Phase 2 control state for one canonical user memory Storage.
+ * Generated memory content remains outside this row.
+ */
+export const piMemoryPhase2Jobs = pgTable(
+  "pi_memory_phase2_jobs",
+  {
+    memoryStorageId: uuid("memory_storage_id").notNull(),
+    orgId: text("org_id").notNull(),
+    userId: text("user_id").notNull(),
+    status: varchar("status", { length: 32 })
+      .$type<PiMemoryPhase2JobStatus>()
+      .default("pending")
+      .notNull(),
+    inputRevision: integer("input_revision").default(1).notNull(),
+    completedRevision: integer("completed_revision").default(0).notNull(),
+    claimedRevision: integer("claimed_revision"),
+    leaseToken: uuid("lease_token"),
+    leaseExpiresAt: timestamp("lease_expires_at"),
+    retryCount: integer("retry_count").default(0).notNull(),
+    retryAt: timestamp("retry_at"),
+    lastErrorClass: varchar("last_error_class", { length: 128 }),
+    lastSucceededAt: timestamp("last_succeeded_at"),
+    claimedSelectionDigest: varchar("claimed_selection_digest", {
+      length: 64,
+    }),
+    claimedSelectedCount: integer("claimed_selected_count"),
+    claimedSelectedUtf8Bytes: integer("claimed_selected_utf8_bytes"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => {
+    return [
+      primaryKey({
+        name: "pi_memory_phase2_jobs_pkey",
+        columns: [table.memoryStorageId],
+      }),
+      foreignKey({
+        name: "pi_memory_phase2_jobs_storage_owner_fk",
+        columns: [table.memoryStorageId, table.orgId, table.userId],
+        foreignColumns: [storages.id, storages.orgId, storages.userId],
+      }).onDelete("cascade"),
+      index("idx_pi_memory_phase2_jobs_claimable")
+        .on(
+          table.status,
+          table.retryAt,
+          table.leaseExpiresAt,
+          table.lastSucceededAt,
+          table.updatedAt,
+          table.memoryStorageId,
+        )
+        .where(
+          sql`${table.completedRevision} < ${table.inputRevision} AND ${table.status} IN ('pending', 'leased', 'retryable_failure')`,
+        ),
+      index("idx_pi_memory_phase2_jobs_user_export").on(
+        table.userId,
+        table.orgId,
+        table.memoryStorageId,
+      ),
+      check(
+        "pi_memory_phase2_jobs_status_check",
+        sql`${table.status} IN ('idle', 'pending', 'leased', 'retryable_failure', 'terminal_failure')`,
+      ),
+      check(
+        "pi_memory_phase2_jobs_revisions_check",
+        sql`${table.inputRevision} > 0 AND
+          ${table.completedRevision} >= 0 AND
+          ${table.completedRevision} <= ${table.inputRevision} AND
+          (
+            ${table.claimedRevision} IS NULL OR (
+              ${table.completedRevision} < ${table.claimedRevision} AND
+              ${table.claimedRevision} <= ${table.inputRevision}
+            )
+          )`,
+      ),
+      check(
+        "pi_memory_phase2_jobs_retry_count_check",
+        sql`${table.retryCount} >= 0 AND ${table.retryCount} <= 3`,
+      ),
+      check(
+        "pi_memory_phase2_jobs_error_class_check",
+        sql`${table.lastErrorClass} IS NULL OR ${table.lastErrorClass} ~ '^[a-z][a-z0-9_]{0,127}$'`,
+      ),
+      check(
+        "pi_memory_phase2_jobs_selection_check",
+        sql`(
+          ${table.claimedSelectionDigest} IS NULL AND
+          ${table.claimedSelectedCount} IS NULL AND
+          ${table.claimedSelectedUtf8Bytes} IS NULL
+        ) OR (
+          ${table.claimedSelectionDigest} IS NOT NULL AND
+          ${table.claimedSelectedCount} IS NOT NULL AND
+          ${table.claimedSelectedUtf8Bytes} IS NOT NULL AND
+          ${table.claimedSelectionDigest} ~ '^[0-9a-f]{64}$' AND
+          ${table.claimedSelectedCount} >= 0 AND
+          ${table.claimedSelectedCount} <= 256 AND
+          ${table.claimedSelectedUtf8Bytes} >= 0 AND
+          ${table.claimedSelectedUtf8Bytes} <= 21036800
+        )`,
+      ),
+      check(
+        "pi_memory_phase2_jobs_state_check",
+        sql`(
+          ${table.status} = 'idle' AND
+          ${table.completedRevision} = ${table.inputRevision} AND
+          ${table.claimedRevision} IS NULL AND
+          ${table.leaseToken} IS NULL AND
+          ${table.leaseExpiresAt} IS NULL AND
+          ${table.retryCount} = 0 AND
+          ${table.retryAt} IS NULL AND
+          ${table.lastErrorClass} IS NULL AND
+          ${table.claimedSelectionDigest} IS NULL AND
+          ${table.claimedSelectedCount} IS NULL AND
+          ${table.claimedSelectedUtf8Bytes} IS NULL
+        ) OR (
+          ${table.status} = 'pending' AND
+          ${table.completedRevision} < ${table.inputRevision} AND
+          ${table.claimedRevision} IS NULL AND
+          ${table.leaseToken} IS NULL AND
+          ${table.leaseExpiresAt} IS NULL AND
+          ${table.retryCount} = 0 AND
+          ${table.retryAt} IS NULL AND
+          ${table.lastErrorClass} IS NULL AND
+          ${table.claimedSelectionDigest} IS NULL AND
+          ${table.claimedSelectedCount} IS NULL AND
+          ${table.claimedSelectedUtf8Bytes} IS NULL
+        ) OR (
+          ${table.status} = 'leased' AND
+          ${table.claimedRevision} IS NOT NULL AND
+          ${table.completedRevision} < ${table.claimedRevision} AND
+          ${table.claimedRevision} <= ${table.inputRevision} AND
+          ${table.leaseToken} IS NOT NULL AND
+          ${table.leaseExpiresAt} IS NOT NULL AND
+          ${table.retryCount} >= 0 AND
+          ${table.retryCount} < 3 AND
+          ${table.retryAt} IS NULL AND
+          ${table.lastErrorClass} IS NULL AND
+          ${table.claimedSelectionDigest} IS NOT NULL AND
+          ${table.claimedSelectedCount} IS NOT NULL AND
+          ${table.claimedSelectedUtf8Bytes} IS NOT NULL
+        ) OR (
+          ${table.status} = 'retryable_failure' AND
+          ${table.completedRevision} < ${table.inputRevision} AND
+          ${table.claimedRevision} IS NULL AND
+          ${table.leaseToken} IS NULL AND
+          ${table.leaseExpiresAt} IS NULL AND
+          ${table.retryCount} > 0 AND
+          ${table.retryCount} < 3 AND
+          ${table.retryAt} IS NOT NULL AND
+          ${table.lastErrorClass} IS NOT NULL AND
+          ${table.claimedSelectionDigest} IS NULL AND
+          ${table.claimedSelectedCount} IS NULL AND
+          ${table.claimedSelectedUtf8Bytes} IS NULL
+        ) OR (
+          ${table.status} = 'terminal_failure' AND
+          ${table.completedRevision} < ${table.inputRevision} AND
+          ${table.claimedRevision} IS NULL AND
+          ${table.leaseToken} IS NULL AND
+          ${table.leaseExpiresAt} IS NULL AND
+          ${table.retryCount} = 3 AND
+          ${table.retryAt} IS NULL AND
+          ${table.lastErrorClass} IS NOT NULL AND
+          ${table.claimedSelectionDigest} IS NULL AND
+          ${table.claimedSelectedCount} IS NULL AND
+          ${table.claimedSelectedUtf8Bytes} IS NULL
+        )`,
+      ),
+    ];
+  },
+);


### PR DESCRIPTION
## Summary

- add the owner-scoped `pi_memory_phase2_jobs` state machine, generated migration/snapshot, compatibility backfill, and canonical DB exports
- advance the monotonic Phase 2 dirty revision inside the exact successful Stage 1 commit transaction
- add atomic `FOR UPDATE SKIP LOCKED` claim, bounded deterministic selection/digest, heartbeat, retry/terminal, stale-takeover, cooldown, and successful watermark finalization fences
- add deterministic token-free user export metadata and focused real-PostgreSQL concurrency, replay, boundary, cascade, and BDD coverage

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/db exec vitest run src/__tests__/pi-memory-phase2-job-schema.test.ts` (2 passed)
- `pnpm --filter @okouai/db exec tsx scripts/test-pi-memory-phase2-job-migration.ts`
- `pnpm --filter api exec vitest run src/signals/services/__tests__/pi-memory-phase2-job.service.test.ts` (12 passed)
- `pnpm --filter api exec vitest run src/signals/services/__tests__/pi-memory-phase2-selection.service.test.ts` (5 passed)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/pi-memory-stage1-worker.test.ts` (13 passed)
- focused `chat-events.bdd.test.ts` admission case (1 passed, 159 skipped)
- focused `ops-logs.bdd.test.ts` export case (1 passed, 14 skipped)
- static caller, owner-scope, watermark-write, content-log, and non-goal path audit

## Migration consistency note

The aggregate `pnpm --filter @okouai/db test:migration-consistency` completed its migration runner, snapshot chain, tag references, and journal-order checks, then stopped before this slice's validator at the existing `test-connector-account-expansion.ts` foreign-key validation assertion (`fk_chat_thread_connector_selections_connector_slug`). The Slice 4a validator passes directly, and the generated migration applies from a fresh PostgreSQL database and replays over schema 1059 with exact Stage 1 row preservation.

## Scope

This PR contains no Phase 2 executor/cron, model/provider call, workspace or memory-file mutation, Storage version/HEAD publication, feature activation, or production release.

Closes #31237