### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-user-preferences.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-user-preferences.ts
@@ -7,6 +7,7 @@ import { mockApi } from "../msw-contract.ts";
 let mockPreferences: UserPreferencesResponse = {
   timezone: null,
   locale: null,
+  translationLanguage: null,
   supportedLocales: [
     "en-US",
     "pt-BR",
@@ -34,6 +35,7 @@ export function resetMockUserPreferences(): void {
   mockPreferences = {
     timezone: null,
     locale: null,
+    translationLanguage: null,
     supportedLocales: [
       "en-US",
       "pt-BR",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/settings-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/settings-dialog.test.tsx
@@ -67,6 +67,7 @@ function createPreferences(
   return {
     timezone: null,
     locale,
+    translationLanguage: null,
     supportedLocales,
     pinnedAgentIds: [],
     sendMode: "enter",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -4329,6 +4329,7 @@ describe("zero sidebar", () => {
         return respond(200, {
           timezone: null,
           locale: null,
+          translationLanguage: null,
           supportedLocales: [
             "en-US",
             "pt-BR",
@@ -4683,6 +4684,7 @@ describe("zero sidebar", () => {
       return respond(200, {
         timezone: null,
         locale: null,
+        translationLanguage: null,
         supportedLocales: [
           "en-US",
           "pt-BR",

--- a/turbo/packages/api-contracts/src/contracts/user-preferences.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/user-preferences.test.ts
@@ -14,6 +14,7 @@ describe("user preferences contract", () => {
     const preferences = userPreferencesResponseSchema.parse({
       timezone: null,
       locale: "id-ID",
+      translationLanguage: null,
       supportedLocales: ["en-US", "pt-BR", "id-ID"],
       pinnedAgentIds: [],
       sendMode: "enter",
@@ -29,6 +30,7 @@ describe("user preferences contract", () => {
     const preferences = userPreferencesResponseSchema.safeParse({
       timezone: null,
       locale: "zh-CN",
+      translationLanguage: null,
       supportedLocales: [...SUPPORTED_USER_LOCALES],
       pinnedAgentIds: [],
       sendMode: "enter",
@@ -46,6 +48,7 @@ describe("user preferences contract", () => {
       userPreferencesResponseSchema.parse({
         timezone: null,
         locale: "ja-JP",
+        translationLanguage: null,
         supportedLocales: ["en-US", "pt-BR", "ja-JP"],
         pinnedAgentIds: [],
         sendMode: "enter",
@@ -55,6 +58,7 @@ describe("user preferences contract", () => {
       }),
     ).toMatchObject({
       locale: "ja-JP",
+      translationLanguage: null,
       supportedLocales: ["en-US", "pt-BR", "ja-JP"],
     });
   });
@@ -65,6 +69,7 @@ describe("user preferences contract", () => {
       userPreferencesResponseSchema.parse({
         timezone: null,
         locale: "ko-KR",
+        translationLanguage: null,
         supportedLocales: ["en-US", "pt-BR", "ja-JP", "ko-KR"],
         pinnedAgentIds: [],
         sendMode: "enter",
@@ -74,6 +79,7 @@ describe("user preferences contract", () => {
       }),
     ).toMatchObject({
       locale: "ko-KR",
+      translationLanguage: null,
       supportedLocales: ["en-US", "pt-BR", "ja-JP", "ko-KR"],
     });
   });
@@ -84,6 +90,7 @@ describe("user preferences contract", () => {
       userPreferencesResponseSchema.parse({
         timezone: null,
         locale: "es-ES",
+        translationLanguage: null,
         supportedLocales: ["en-US", "pt-BR", "ja-JP", "es-ES"],
         pinnedAgentIds: [],
         sendMode: "enter",
@@ -93,6 +100,7 @@ describe("user preferences contract", () => {
       }),
     ).toMatchObject({
       locale: "es-ES",
+      translationLanguage: null,
       supportedLocales: ["en-US", "pt-BR", "ja-JP", "es-ES"],
     });
   });
@@ -105,6 +113,7 @@ describe("user preferences contract", () => {
     const preferences = userPreferencesResponseSchema.parse({
       timezone: null,
       locale: "it-IT",
+      translationLanguage: null,
       supportedLocales: ["en-US", "it-IT"],
       pinnedAgentIds: [],
       sendMode: "enter",
@@ -134,6 +143,7 @@ describe("user preferences contract", () => {
     const preferences = userPreferencesResponseSchema.parse({
       timezone: null,
       locale: "hi-IN",
+      translationLanguage: null,
       supportedLocales: [...SUPPORTED_USER_LOCALES],
       pinnedAgentIds: [],
       sendMode: "enter",

--- a/turbo/packages/api-contracts/src/contracts/user-preferences.ts
+++ b/turbo/packages/api-contracts/src/contracts/user-preferences.ts
@@ -76,9 +76,7 @@ export const CHAT_TRANSLATION_LANGUAGE_BY_USER_LOCALE = {
 export const userPreferencesResponseSchema = z.object({
   timezone: z.string().nullable(),
   locale: userLocaleSchema.nullable(),
-  // A new app can briefly reach an API rollback target from before this
-  // additive field existed. Remove after those targets are retired (#30862).
-  translationLanguage: chatTranslationLanguageSchema.nullable().optional(),
+  translationLanguage: chatTranslationLanguageSchema.nullable(),
   supportedLocales: z.array(userLocaleSchema),
   // Pinned agents are exposed as membership only. The API returns a stable
   // canonical order and ignores client-provided order on writes.


### PR DESCRIPTION
Removes the new-App-to-old-API optionality on `translationLanguage`. Closes the removal gate in #30862.

## Cohort — user preferences `translationLanguage`

**Old boundary:** #30818 added `translationLanguage` to the user preferences response. During rollout a newly promoted App could still reach an API rollback target from before the additive field, so the contract marked it optional. Because the App's contract client rejects a response missing a required field, that optionality protected the whole preferences load, not just the translation feature.

**New boundary:** `translationLanguage` is required on `userPreferencesResponseSchema`. It stays **nullable**, because `null` is the legitimate no-preference state.

Removed:
- `.optional()` and the rollout comment on `translationLanguage`

Fixture updates: the two shared MSW preference defaults in `mocks/handlers/api-user-preferences.ts`, three typed literals in `settings-dialog` and `sidebar`, and ten locale fixtures in `user-preferences.test.ts` now carry `translationLanguage: null`.

**Deliberately kept:** the `preferences.translationLanguage ?? languageFromLocale(...)` read in `savedChatTranslationLanguage$`. That `??` now only handles `null`, which is the real "user has not chosen a translation language" state, not the rollout. Removing it would change behavior rather than delete compatibility code.

**Windows:** both applicable windows are satisfied, and this cohort is the first in the current backlog where canonical window 2 carries it rather than an elapsed-time judgement call.
- Canonical window 1 (old API drained): the pre-#30818 API left service when the replacement became healthy.
- Canonical window 2 (App/web client, 24 hours after the replacement App version is available in production): **28.2 hours** elapsed.

**Rollout evidence (observed):**
- #30818 merged `2026-09-01T13:20:59Z` (`37c2265c1c6`).
- First `api/production` deployment containing it: `6d135a450a`, `2026-09-01T16:45:27Z`; first `app/production` deployment containing it: the same SHA at `2026-09-01T16:47:34Z`. Both confirmed with `git merge-base --is-ancestor` walking each deployment list forward from oldest.
- **15 further `api/production`** and **11 further `app/production`** deployments have been promoted since, so the pre-#30818 build is deep behind the current rollback target on both surfaces.

**Source evidence that the current API always sets the field:** `userPreferences` in `turbo/apps/api/src/signals/services/user-data.service.ts` selects `orgMembersMetadata.translationLanguage` and returns `translationLanguage` on both branches — `null` on the no-row branch, `parseChatTranslationLanguage(row.translationLanguage)` otherwise. No path omits the key.

**Axiom:** no route-level signal applies. The discriminator is the presence of one response-body key, and `vm0-request-log-prod` records `path_template`, `method`, `status`, and client headers but not response bodies. Recorded as a deliberate non-use rather than a zero-count claim.

**MaskDB:** not applicable. No schema, column, or persisted payload changes; `org_members_metadata.translation_language` is untouched.

## Explicitly deferred

- **`web-files.ts` `publicUrl` (#30847).** Added `2026-09-02`, roughly one day before this run, and its own comment notes the same whole-response failure mode. Not yet past window 2.
- **`chatThreadSnapshotProjection.selectedVideoModel` / `selectedImageModel`.** Their gate includes cached IndexedDB rows resyncing, which is persisted browser data rather than a drained deploy window.
- **`official-workflows.ts` `definition`.** #29991 is now closed, but this field correctly remains: the install and get-installation routes still build the body with a conditional spread and `getOfficialWorkflowInstallationDefinition` returns `null` when the accepted catalog has no matching entry. That omission is live behavior, not expired compatibility.
- **`pi-agent-runtime` / rust-bindings transport values (#31085)** and **`runners.ts:954`** — gates require the previous API rollback, runner/Sandbox drain, and pre-cutover context checks to pass; all landed within the last days.
- **Queued-launch-context brand reads** for Telegram, AgentPhone, and Feishu. MaskDB's projection still does not expose `public_brand` on the context tables and `feishu_chat_ingress` is still absent — eighth consecutive run blocked on this.
- **AgentPhone brandless connect**, **#28571**, **#29908**, **#26519**, **#27786**, **#28914**, **#30468** — unchanged product or evidence gates.

## Checks (run once against the combined diff)

- `pnpm format`
- `pnpm -F @okouai/app lint`, `pnpm -F @okouai/api-contracts lint` (no new warnings)
- `pnpm -F @okouai/api-contracts check-types`, `pnpm -F @okouai/app check-types`, `pnpm -F api check-types` — re-run after refreshing against `main`
- `pnpm knip` (no new unused files, exports, or dependencies)
- `pnpm -F @okouai/api-contracts exec vitest run` — 690 passing across 37 files
- `pnpm -F @okouai/app exec vitest run` on `settings-dialog` + `chat-inline-feedback` (69) and `sidebar` (83)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/user-config.bdd.test.ts` — 14 passing against a local Postgres with `timezone=UTC`

Full coverage is left to the PR pipeline; no full local Vitest run and no local dev server.

Closes #30862.
