### PR TITLE
fix(connectors): allow exact public catalog slugs

### DIFF
--- a/turbo/packages/connectors/src/__tests__/connector-catalog-public-leak.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connector-catalog-public-leak.test.ts
@@ -1,0 +1,123 @@
+import { createHash } from "node:crypto";
+
+import {
+  type ConnectorCatalogArtifact,
+  SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+} from "../connector-catalog/artifacts/artifacts";
+import {
+  decodeConnectorCatalogSnapshot,
+  encodeConnectorCatalogSnapshot,
+} from "../connector-catalog/artifacts/loader";
+
+const CONNECTOR_SLUG = "token-security";
+const CATALOG_VERSION = "2026-09-03.exact-public-slug";
+const STORAGE_NAME = `connector-skill@${CONNECTOR_SLUG}`;
+const VERSION_ID = "a".repeat(64);
+const STORAGE_VERSION_PREFIX = `__system__/volume/${STORAGE_NAME}/${VERSION_ID}`;
+const PRIVATE_NAME = "TOKEN_SECURITY_API_TOKEN";
+const VALUE_REF = `$secrets.${PRIVATE_NAME}`;
+
+function catalogArtifact(description: string): ConnectorCatalogArtifact {
+  return {
+    artifactSchemaVersion: SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+    catalogVersion: CATALOG_VERSION,
+    categoryMetadata: {
+      categories: [
+        {
+          id: "testing",
+          label: "Testing",
+          menuLabel: "Testing",
+          groupId: null,
+        },
+      ],
+      groups: [],
+    },
+    connectors: [
+      {
+        slug: CONNECTOR_SLUG,
+        label: "Token Security",
+        description,
+        category: "testing",
+        generation: [],
+        tags: ["fixture"],
+        authMethods: [
+          {
+            id: "api-token",
+            label: "API Token",
+            description: null,
+            visible: true,
+            storage: {
+              version: 1,
+              secrets: [PRIVATE_NAME],
+              variables: [],
+            },
+            grant: {
+              kind: "manual",
+              fields: [
+                {
+                  privateName: PRIVATE_NAME,
+                  publicId: "credential",
+                  label: "API token",
+                  required: true,
+                  placeholder: null,
+                  storage: "secret",
+                },
+              ],
+            },
+            access: {
+              kind: "static",
+              envBindings: { SERVICE_TOKEN: VALUE_REF },
+            },
+            revoke: { kind: "none" },
+          },
+        ],
+        icon: {
+          key: "connectors/token-security.svg",
+          invertInDarkMode: false,
+        },
+        skill: {
+          kind: "bundled",
+          storageName: STORAGE_NAME,
+          versionId: VERSION_ID,
+          storageVersionPrefix: STORAGE_VERSION_PREFIX,
+          size: 128,
+          archiveSize: 256,
+          fileCount: 1,
+        },
+        firewall: { kind: "none" },
+      },
+    ],
+  };
+}
+
+function decodeCatalog(description: string): ConnectorCatalogArtifact {
+  const rawBytes = Buffer.from(
+    `${JSON.stringify(catalogArtifact(description))}\n`,
+  );
+  return decodeConnectorCatalogSnapshot({
+    catalogGzip: encodeConnectorCatalogSnapshot(rawBytes),
+    catalogRawSize: rawBytes.byteLength,
+    catalogVersion: CATALOG_VERSION,
+    catalogDigest: `sha256:${createHash("sha256").update(rawBytes).digest("hex")}`,
+  }).artifact;
+}
+
+describe("connector catalog public projection", () => {
+  it("accepts the exact public slug derived from bundled skill storage", () => {
+    const artifact = decodeCatalog("Public connector description");
+
+    expect(artifact.connectors[0]?.slug).toBe(CONNECTOR_SLUG);
+  });
+
+  it.each([
+    ["full bundled skill storage name", STORAGE_NAME],
+    ["bundled skill version ID", VERSION_ID],
+    ["full bundled skill storage version prefix", STORAGE_VERSION_PREFIX],
+    ["private storage name", PRIVATE_NAME],
+    ["private value reference", VALUE_REF],
+  ])("rejects a leaked %s", (_name, privateValue) => {
+    expect(() => {
+      decodeCatalog(privateValue);
+    }).toThrow("public-leakage");
+  });
+});

--- a/turbo/packages/connectors/src/connector-catalog/artifacts/public-leak.ts
+++ b/turbo/packages/connectors/src/connector-catalog/artifacts/public-leak.ts
@@ -271,9 +271,13 @@ export function validateConnectorCatalogPublicProjection(
     new Set(),
   );
   for (const connector of artifact.connectors) {
+    // A connector slug is public identity even when a private storage name
+    // produces the same credential-like token. Exclude only the exact slug.
+    const sensitiveValues = new Set(connectorCatalogSensitiveValues(connector));
+    sensitiveValues.delete(connector.slug);
     assertPublicValueHasNoPrivateFields(
       publicConnector(connector),
-      connectorCatalogSensitiveValues(connector),
+      sensitiveValues,
       `$.connectors[${connector.slug}]`,
     );
   }


### PR DESCRIPTION
## Summary

- copy each connector's sensitive-value set before excluding only its exact, case-sensitive public slug
- keep the full bundled-skill storage name, version ID, storage prefix, and auth private values under public-leak validation
- add loader-boundary regression coverage for the `token-security` storage-derived false positive and retained private-leak failures

## Fallbacks

- `turbo/packages/connectors/src/connector-catalog/artifacts/public-leak.ts:validateConnectorCatalogPublicProjection` — accepts a current producer artifact when a private bundled-skill storage name causes `privateTokenMatches` to derive the connector's exact public slug. Surface: catalog producer -> consumer. Window and removal condition: permanent schema invariant rather than a cross-version rollout fallback; keep while `connector.slug` remains schema-validated public identity. The exception is scoped to `Set.delete(connector.slug)` on that connector's copied sensitive set; substring, prefix, normalized, length, global-key, and private-token heuristics remain unchanged. Producer precedent: https://github.com/vm0-ai/vm0-connectors/pull/3075 (merge commit `67a58b637555c524394d92fa6779f78cd663690d`).

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm knip`
- `pnpm --filter @okouai/connectors exec vitest run src/__tests__/connector-catalog-public-leak.test.ts` (6 passed)
- `DATABASE_URL=... pnpm --filter api exec vitest run src/signals/routes/__tests__/connector-catalog.test.ts` (33 passed)
- `DATABASE_URL=... pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-connector-catalog.test.ts -t "accepts producer connector order and scopes private-value leak detection|rejects 'public private-value leak'"` (2 passed)

Closes #31248
