### PR TITLE
refactor(runtime): retire vm0 environment ownership wildcard

### DIFF
--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -90,6 +90,11 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
         &user_env_path,
         serde_json::to_vec(&serde_json::json!({
             "CUSTOM_USER_ENV": "visible-to-cli",
+            "VM0_FUTURE_RUNNER_KEY": "ordinary-vm0-value",
+            "VM0_PROMPT": "ordinary-user-prompt",
+            "VM0_API_TOKEN": "ordinary-user-token",
+            "VM0_USER_ENV_FILE": "/ordinary/user-env.json",
+            "VM0_RUN_PAYLOAD_FILE": "/ordinary/payload.json",
             "BASH_ENV": "/tmp/user-bash-env",
             "OKOU_API_BACKEND_URL": "https://canonical-user-env.example.invalid",
             "OPENAI_API_KEY": "sk-user",
@@ -108,6 +113,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     let runtime = GuestRuntime::from_process_env()?;
     assert!(!user_env_path.exists());
     assert!(!user_env_dir.exists());
+    assert_eq!(runtime.config.prompt, prompt);
     assert_eq!(
         runtime.config.agent_execution_timeout,
         Some(std::time::Duration::from_secs(60))
@@ -142,6 +148,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
 
     unsafe {
         std::env::set_var("VM0_PROMPT", "stale prompt after runtime construction");
+        std::env::set_var("VM0_API_TOKEN", "stale token after runtime construction");
         std::env::set_var(
             guest_contracts::env::CANONICAL_API_URL_ENV,
             "https://stale-canonical-api.example.invalid",
@@ -192,6 +199,15 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
         cli_env.get("CUSTOM_USER_ENV").map(String::as_str),
         Some("visible-to-cli")
     );
+    for (key, expected_value) in [
+        ("VM0_FUTURE_RUNNER_KEY", "ordinary-vm0-value"),
+        ("VM0_PROMPT", "ordinary-user-prompt"),
+        ("VM0_API_TOKEN", "ordinary-user-token"),
+        ("VM0_USER_ENV_FILE", "/ordinary/user-env.json"),
+        ("VM0_RUN_PAYLOAD_FILE", "/ordinary/payload.json"),
+    ] {
+        assert_eq!(cli_env.get(key).map(String::as_str), Some(expected_value));
+    }
     assert_eq!(
         cli_env.get("BASH_ENV").map(String::as_str),
         Some("/tmp/user-bash-env")
@@ -240,7 +256,6 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
 
     assert!(!cli_env.contains_key("VM0_SECRET_VALUES"));
     for key in [
-        "VM0_API_TOKEN",
         guest_contracts::env::CANONICAL_API_TOKEN_ENV,
         guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV,
     ] {
@@ -252,9 +267,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     for key in [
         guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
         "VM0_GUEST_RUNTIME_DIR",
-        "VM0_USER_ENV_FILE",
         guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV,
-        "VM0_RUN_PAYLOAD_FILE",
         guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV,
     ] {
         assert!(
@@ -275,7 +288,6 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
             "Claude child env contains {key}"
         );
     }
-    assert!(!cli_env.contains_key("VM0_PROMPT"));
     assert!(!cli_env.contains_key("VM0_APPEND_SYSTEM_PROMPT"));
     for key in [
         "VM0_SANDBOX_ID",

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -5,12 +5,11 @@
 //! through [`CANONICAL_USER_ENV_FILE_ENV`], so user-provided keys cannot override runner
 //! bootstrap controls directly.
 //!
-//! The `OKOU_` and `VM0_` namespaces are runner-owned, including keys defined
-//! in sibling modules such as
-//! [`crate::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV`].
-//! User env filtering should treat current and future `OKOU_` keys plus current,
-//! future, and retired `VM0_` keys as protected. Bootstrap keys outside those
-//! namespaces are listed explicitly below.
+//! The `OKOU_` namespace is runner-owned, including keys defined in sibling
+//! modules such as [`crate::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV`].
+//! User env filtering protects every current and future `OKOU_` key. Bootstrap
+//! keys outside that namespace and the four retained local-only timing inputs
+//! are classified explicitly below.
 //!
 //! [`GUEST_AGENT_TUNING_ENV_KEYS`] is the only intentional exception where
 //! selected runner-owned keys may cross the local user-env boundary as
@@ -533,13 +532,13 @@ pub fn is_guest_agent_tuning_env_key(key: &str) -> bool {
 
 /// Returns whether `key` belongs to the runner-owned bootstrap namespace.
 ///
-/// This covers every `OKOU_` and `VM0_` key, including future and retired names,
-/// plus the explicit bootstrap keys required by established runner, guest-agent,
-/// or integration contracts. Runner and local-submit code use this predicate to
-/// scrub or reject user-provided env keys before the guest-agent starts.
+/// This covers every `OKOU_` key, the four exact retained local-only timing
+/// inputs, and the explicit bootstrap keys required by established runner,
+/// guest-agent, or integration contracts. Runner and local-submit code use this
+/// predicate to scrub or reject those keys before the guest-agent starts.
 pub fn is_runner_owned_env_key(key: &str) -> bool {
     key.starts_with("OKOU_")
-        || key.starts_with("VM0_")
+        || is_guest_agent_tuning_env_key(key)
         || EXPLICIT_RUNNER_OWNED_ENV_KEYS.contains(&key)
 }
 
@@ -862,30 +861,22 @@ mod tests {
     }
 
     #[test]
-    fn runner_owned_key_detection_covers_bootstrap_namespaces() {
+    fn runner_owned_key_detection_covers_terminal_contract() {
         for key in [
             CANONICAL_API_URL_ENV,
             RUN_ID_ENV,
-            "VM0_API_TOKEN",
             CANONICAL_API_TOKEN_ENV,
             CANONICAL_SANDBOX_ID_ENV,
             CANONICAL_SANDBOX_REUSE_RESULT_ENV,
             CANONICAL_WORKSPACE_REUSE_RESULT_ENV,
             CANONICAL_RESUME_SESSION_ID_ENV,
             CANONICAL_API_START_TIME_ENV,
-            "VM0_SANDBOX_ID",
-            "VM0_SANDBOX_REUSE_RESULT",
-            "VM0_WORKSPACE_REUSE_RESULT",
-            "VM0_RESUME_SESSION_ID",
-            "VM0_API_START_TIME",
             PI_SESSION_ID_ENV,
             PI_LAUNCH_CONFIG_ENV,
             PI_LAUNCH_PAYLOAD_FILE_ENV,
             PI_MODEL_CONFIG_ENV,
             CONNECTOR_ACCOUNT_CONTEXT_FILE_ENV,
-            "VM0_USER_ENV_FILE",
             CANONICAL_USER_ENV_FILE_ENV,
-            "VM0_RUN_PAYLOAD_FILE",
             CANONICAL_RUN_PAYLOAD_FILE_ENV,
             CLI_AGENT_TYPE_ENV,
             USE_MOCK_CLAUDE_ENV,
@@ -896,7 +887,20 @@ mod tests {
         }
         assert!(is_runner_owned_env_key("OKOU_TOKEN"));
         assert!(is_runner_owned_env_key("OKOU_UNRELATED"));
-        assert!(!is_runner_owned_env_key("CUSTOM_ENV"));
+        for key in [
+            "VM0_API_TOKEN",
+            "VM0_SANDBOX_ID",
+            "VM0_SANDBOX_REUSE_RESULT",
+            "VM0_WORKSPACE_REUSE_RESULT",
+            "VM0_RESUME_SESSION_ID",
+            "VM0_API_START_TIME",
+            "VM0_USER_ENV_FILE",
+            "VM0_RUN_PAYLOAD_FILE",
+            "VM0_FUTURE_RUNNER_KEY",
+            "CUSTOM_ENV",
+        ] {
+            assert!(!is_runner_owned_env_key(key), "{key} should be user-owned");
+        }
     }
 
     #[test]
@@ -931,6 +935,10 @@ mod tests {
                 POST_RESULT_SIGKILL_GRACE_SECS_ENV,
             ]
         );
+        for key in GUEST_AGENT_TUNING_ENV_KEYS {
+            assert!(is_guest_agent_tuning_env_key(key));
+            assert!(is_runner_owned_env_key(key));
+        }
         for key in [
             CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV,
             CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV,
@@ -1031,7 +1039,8 @@ mod tests {
         assert!(
             unprotected.is_empty(),
             "these bootstrap env keys are not protected from user env injection. Add each to \
-             EXPLICIT_RUNNER_OWNED_ENV_KEYS, or keep an OKOU_/VM0_ prefix:\n  {}",
+             EXPLICIT_RUNNER_OWNED_ENV_KEYS, register an exact local timing input, or keep an \
+             OKOU_ prefix:\n  {}",
             unprotected.join("\n  ")
         );
     }

--- a/crates/runner/src/cmd/local/submit/tests/request.rs
+++ b/crates/runner/src/cmd/local/submit/tests/request.rs
@@ -150,11 +150,16 @@ async fn submit_serializes_env_and_secret_env() {
         "URL=https://example.test/path?a=1&b=2".into(),
         "EMPTY=".into(),
         "MULTILINE=line1\nline2".into(),
+        "VM0_FUTURE_RUNNER_KEY=ordinary-vm0-value".into(),
         "VM0_STUCK_TOOL_TIMEOUT_SECS=3".into(),
+        "VM0_POST_RESULT_SIGTERM_GRACE_SECS=1".into(),
+        "VM0_POST_RESULT_TOTAL_CAP_SECS= 4 ".into(),
+        "VM0_POST_RESULT_SIGKILL_GRACE_SECS=not-a-duration".into(),
     ];
     args.secret_env = vec![
         "ANTHROPIC_API_KEY=sk-ant-local-secret".into(),
         "PRIVATE_KEY=-----BEGIN KEY-----\r\nsecret\r\n-----END KEY-----".into(),
+        "VM0_TEST_VALUE=ordinary-vm0-secret".into(),
     ];
 
     let (code, request) = run_submit_and_write_success(args, home).await.unwrap();
@@ -179,6 +184,26 @@ async fn submit_serializes_env_and_secret_env() {
         Some("3")
     );
     assert_eq!(
+        environment.get("VM0_FUTURE_RUNNER_KEY").map(String::as_str),
+        Some("ordinary-vm0-value")
+    );
+    for (key, expected_value) in [
+        (
+            guest_contracts::env::POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+            "1",
+        ),
+        (guest_contracts::env::POST_RESULT_TOTAL_CAP_SECS_ENV, " 4 "),
+        (
+            guest_contracts::env::POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+            "not-a-duration",
+        ),
+    ] {
+        assert_eq!(
+            environment.get(key).map(String::as_str),
+            Some(expected_value)
+        );
+    }
+    assert_eq!(
         secret_environment
             .get("ANTHROPIC_API_KEY")
             .map(String::as_str),
@@ -188,11 +213,15 @@ async fn submit_serializes_env_and_secret_env() {
         secret_environment.get("PRIVATE_KEY").map(String::as_str),
         Some("-----BEGIN KEY-----\r\nsecret\r\n-----END KEY-----")
     );
+    assert_eq!(
+        secret_environment.get("VM0_TEST_VALUE").map(String::as_str),
+        Some("ordinary-vm0-secret")
+    );
 }
 
 #[tokio::test]
 async fn rejects_invalid_env_entries_before_submit() {
-    let cases = vec![
+    let mut cases = vec![
         (vec!["FOO".to_string()], Vec::new(), "expected KEY=VALUE"),
         (vec!["=VALUE".to_string()], Vec::new(), "expected KEY=VALUE"),
         (
@@ -221,7 +250,7 @@ async fn rejects_invalid_env_entries_before_submit() {
             "NUL characters",
         ),
         (
-            vec!["VM0_PROMPT=value".to_string()],
+            vec!["USE_MOCK_CLAUDE=true".to_string()],
             Vec::new(),
             "runner-owned environment variables",
         ),
@@ -236,11 +265,6 @@ async fn rejects_invalid_env_entries_before_submit() {
             "runner-owned environment variables",
         ),
         (
-            Vec::new(),
-            vec!["VM0_STUCK_TOOL_TIMEOUT_SECS=3".to_string()],
-            "must be passed with --env",
-        ),
-        (
             vec!["FOO=1".to_string(), "FOO=2".to_string()],
             Vec::new(),
             "duplicate --env key 'FOO'",
@@ -251,6 +275,13 @@ async fn rejects_invalid_env_entries_before_submit() {
             "across --env and --secret-env",
         ),
     ];
+    for &key in guest_contracts::env::GUEST_AGENT_TUNING_ENV_KEYS {
+        cases.push((
+            Vec::new(),
+            vec![format!("{key}=secret-tuning-value")],
+            "must be passed with --env",
+        ));
+    }
 
     for (env, secret_env, expected) in cases {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -870,8 +870,8 @@ impl HostEnv {
 }
 
 pub(super) fn is_runner_owned_env_key(key: &str) -> bool {
-    // The entire OKOU_ and VM0_ namespaces are runner-owned. Bootstrap keys
-    // outside them must stay explicit.
+    // The entire OKOU_ namespace and the exact retained local timing inputs are
+    // runner-owned. Bootstrap keys outside that namespace must stay explicit.
     guest_contracts::env::is_runner_owned_env_key(key)
 }
 

--- a/crates/runner/src/executor/tests/diagnostics_tests/environment.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests/environment.rs
@@ -39,10 +39,10 @@ fn agent_env_diagnostics_sort_bounds_and_never_include_values() {
 
     assert_eq!(diagnostics.env_count, AGENT_ENV_KEY_DIAGNOSTIC_LIMIT + 7);
     assert!(diagnostics.env_bytes >= big_value_len);
-    assert_eq!(diagnostics.runner_owned_count, 2);
+    assert_eq!(diagnostics.runner_owned_count, 1);
     assert_eq!(
         diagnostics.external_count,
-        AGENT_ENV_KEY_DIAGNOSTIC_LIMIT + 5
+        AGENT_ENV_KEY_DIAGNOSTIC_LIMIT + 6
     );
     assert_eq!(diagnostics.suspicious_keys, vec!["BASH_ENV".to_string()]);
     assert_eq!(diagnostics.largest_entries[0].key, "BIG_VALUE");
@@ -86,4 +86,29 @@ fn agent_env_diagnostics_sort_bounds_and_never_include_values() {
     assert!(!rendered.contains("stored-secret-value"));
     assert!(!rendered.contains("long-secret-value"));
     assert!(!rendered.contains("escaped-key-secret-value"));
+}
+
+#[test]
+fn agent_env_diagnostics_classifies_terminal_ownership_contract() {
+    let mut env = HashMap::from([
+        (
+            "OKOU_FUTURE_PLATFORM_KEY".to_string(),
+            "canonical".to_string(),
+        ),
+        (
+            guest_contracts::env::CLI_AGENT_TYPE_ENV.to_string(),
+            "explicit".to_string(),
+        ),
+        ("VM0_SECRET_VALUES".to_string(), "ordinary".to_string()),
+        ("CUSTOM_ENV".to_string(), "ordinary".to_string()),
+    ]);
+    for key in guest_contracts::env::GUEST_AGENT_TUNING_ENV_KEYS {
+        env.insert((*key).to_string(), "timing".to_string());
+    }
+
+    let diagnostics = build_agent_env_diagnostics(&env, &HashMap::new());
+
+    assert_eq!(diagnostics.env_count, 8);
+    assert_eq!(diagnostics.runner_owned_count, 6);
+    assert_eq!(diagnostics.external_count, 2);
 }

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -245,7 +245,7 @@ fn execution_context_validation_rejects_user_timezone_nul_before_sandbox() {
 fn execution_context_validation_ignores_runner_owned_user_env_before_sandbox() {
     let mut ctx = minimal_context();
     ctx.environment = Some(HashMap::from([
-        ("VM0_PROMPT".into(), "ignored\0secret".into()),
+        ("OKOU_FUTURE_PLATFORM_KEY".into(), "ignored\0secret".into()),
         (
             guest_contracts::env::RUN_ID_ENV.into(),
             "ignored\0run-identity".into(),
@@ -268,11 +268,24 @@ fn execution_context_validation_ignores_runner_owned_user_env_before_sandbox() {
     assert!(validate_context_for_test(&ctx).is_ok());
     let user_env = build_user_env_json(&ctx);
     assert_eq!(user_env.get("CUSTOM_ENV").unwrap(), "kept");
-    assert!(!user_env.contains_key("VM0_PROMPT"));
+    assert!(!user_env.contains_key("OKOU_FUTURE_PLATFORM_KEY"));
     assert!(!user_env.contains_key(guest_contracts::env::RUN_ID_ENV));
     assert!(!user_env.contains_key(guest_contracts::env::PI_SESSION_ID_ENV));
     assert!(!user_env.contains_key(guest_contracts::env::PI_LAUNCH_CONFIG_ENV));
     assert!(!user_env.contains_key(guest_contracts::env::PI_MODEL_CONFIG_ENV));
+}
+
+#[test]
+fn execution_context_validation_checks_arbitrary_vm0_user_env_before_sandbox() {
+    let secret = "ordinary\0vm0-secret";
+    let ctx = context_with_env(HashMap::from([("VM0_PROMPT".into(), secret.into())]));
+
+    let error = validate_context_for_test(&ctx).unwrap_err();
+
+    assert!(error.contains("user environment"));
+    assert!(error.contains("NUL byte"));
+    assert!(error.contains("VM0_PROMPT"));
+    assert!(!error.contains(secret));
 }
 
 #[test]
@@ -656,7 +669,7 @@ fn build_env_json_unknown_framework_preserves_claude_compatible_env() {
 }
 
 #[test]
-fn platform_environment_claim_filters_untrusted_namespaces_and_applies_trusted_last() {
+fn platform_environment_claim_filters_reserved_keys_and_applies_trusted_last() {
     let mut ctx = minimal_context();
     ctx.environment = Some(HashMap::from([
         ("CUSTOM_ENV".into(), "kept".into()),
@@ -685,6 +698,7 @@ fn platform_environment_claim_filters_untrusted_namespaces_and_applies_trusted_l
         HashMap::from([
             ("CUSTOM_ENV".into(), "kept".into()),
             ("DUPLICATE".into(), "trusted".into()),
+            ("VM0_FUTURE_RUNNER_KEY".into(), "untrusted".into()),
             ("OKOU_TOKEN".into(), "trusted-token".into()),
             ("OKOU_PLATFORM_ONLY".into(), "trusted-platform".into()),
             ("VM0_CODEX_SERVICE_TIER".into(), "fast".into()),
@@ -763,6 +777,10 @@ fn emitted_bootstrap_env_keys_classify_as_runner_owned() {
     }
     assert!(is_runner_owned_env_key("OKOU_TOKEN"));
     assert!(is_runner_owned_env_key("OKOU_UNRELATED"));
+    for key in guest_contracts::env::GUEST_AGENT_TUNING_ENV_KEYS {
+        assert!(is_runner_owned_env_key(key));
+    }
+    assert!(!is_runner_owned_env_key("VM0_FUTURE_RUNNER_KEY"));
 }
 
 #[test]
@@ -1045,12 +1063,13 @@ fn build_env_json_user_vars_cannot_override_system() {
     let env = build_env_for_test(&ctx, "http://localhost");
     let payload = build_run_payload_for_run(&ctx).unwrap();
     let user_env = build_user_env_json(&ctx);
-    // System variables take precedence over user environment
+    // The private run payload remains authoritative even though its retired
+    // diagnostic label is now an ordinary user environment key.
     assert!(!env.contains_key("VM0_PROMPT"));
     assert_eq!(payload.prompt, "test prompt");
     assert!(!env.contains_key("CUSTOM"));
     assert_eq!(user_env.get("CUSTOM").unwrap(), "value");
-    assert!(!user_env.contains_key("VM0_PROMPT"));
+    assert_eq!(user_env.get("VM0_PROMPT").unwrap(), "overridden");
 }
 
 #[tokio::test]
@@ -1527,7 +1546,7 @@ fn build_env_json_user_timezone_not_override_environment() {
 }
 
 #[test]
-fn build_env_json_environment_cannot_override_system() {
+fn retired_env_names_cannot_override_canonical_or_private_payload() {
     let mut ctx = minimal_context();
     ctx.environment = Some(HashMap::from([
         ("VM0_PROMPT".into(), "hacked".into()),
@@ -1538,7 +1557,8 @@ fn build_env_json_environment_cannot_override_system() {
     let env = build_env_for_test(&ctx, "http://localhost");
     let payload = build_run_payload_for_run(&ctx).unwrap();
     let user_env = build_user_env_json(&ctx);
-    // System variables take precedence over user environment
+    // Legacy-looking user keys stay isolated from canonical bootstrap and the
+    // private run payload while remaining visible as ordinary user env.
     assert!(!env.contains_key("VM0_PROMPT"));
     assert_eq!(payload.prompt, "test prompt");
     assert_eq!(
@@ -1549,8 +1569,8 @@ fn build_env_json_environment_cannot_override_system() {
     assert!(!env.contains_key("VM0_API_TOKEN"));
     assert!(!env.contains_key("CUSTOM_ENV"));
     assert_eq!(user_env.get("CUSTOM_ENV").unwrap(), "kept");
-    assert!(!user_env.contains_key("VM0_PROMPT"));
-    assert!(!user_env.contains_key("VM0_API_TOKEN"));
+    assert_eq!(user_env.get("VM0_PROMPT").unwrap(), "hacked");
+    assert_eq!(user_env.get("VM0_API_TOKEN").unwrap(), "stolen");
     assert!(!user_env.contains_key(guest_contracts::env::CANONICAL_API_TOKEN_ENV));
 }
 

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -1105,13 +1105,24 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
         ),
         (
             "VM0_APP_URL".into(),
-            "https://filtered.runner-env.example.test".into(),
+            "https://ordinary.runner-env.example.test".into(),
         ),
         ("BASH_ENV".into(), "/tmp/user-bash-env".into()),
         ("NODE_OPTIONS".into(), "--require /tmp/user-node.js".into()),
+        ("VM0_PROMPT".into(), "hostile-user-prompt".into()),
         ("VM0_API_TOKEN".into(), "stolen-token".into()),
         ("VM0_USER_ENV_FILE".into(), "/tmp/evil-env.json".into()),
+        (
+            "VM0_RUN_PAYLOAD_FILE".into(),
+            "/tmp/evil-payload.json".into(),
+        ),
         ("VM0_STUCK_TOOL_TIMEOUT_SECS".into(), "3".into()),
+        ("VM0_POST_RESULT_SIGTERM_GRACE_SECS".into(), "1".into()),
+        ("VM0_POST_RESULT_TOTAL_CAP_SECS".into(), " 4 ".into()),
+        (
+            "VM0_POST_RESULT_SIGKILL_GRACE_SECS".into(),
+            "not-a-duration".into(),
+        ),
         (
             guest_contracts::env::CONNECTOR_ACCOUNT_CONTEXT_FILE_ENV.into(),
             "/tmp/evil-connector-account-context.json".into(),
@@ -1161,13 +1172,19 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
         "tok"
     );
     assert!(!start_env.contains_key("VM0_API_TOKEN"));
-    assert_eq!(
-        start_env
-            .get(guest_contracts::env::CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV)
-            .map(String::as_str),
-        Some("3")
-    );
-    assert!(!start_env.contains_key(guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV));
+    for ((legacy_input, canonical_bootstrap_output), expected_value) in
+        guest_contracts::env::GUEST_AGENT_TUNING_ENV_MAPPINGS
+            .into_iter()
+            .zip(["3", "1", " 4 ", "not-a-duration"])
+    {
+        assert_eq!(
+            start_env
+                .get(canonical_bootstrap_output)
+                .map(String::as_str),
+            Some(expected_value)
+        );
+        assert!(!start_env.contains_key(legacy_input));
+    }
     assert_eq!(
         start_env
             .get(guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV)
@@ -1259,11 +1276,30 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
         "--require /tmp/user-node.js"
     );
     assert_eq!(user_env.get("TZ").unwrap(), "Asia/Shanghai");
-    assert!(!user_env.contains_key("VM0_APP_URL"));
-    assert!(!user_env.contains_key("VM0_API_TOKEN"));
+    assert_eq!(
+        user_env.get("VM0_APP_URL").map(String::as_str),
+        Some("https://ordinary.runner-env.example.test")
+    );
+    assert_eq!(
+        user_env.get("VM0_PROMPT").map(String::as_str),
+        Some("hostile-user-prompt")
+    );
+    assert_eq!(
+        user_env.get("VM0_API_TOKEN").map(String::as_str),
+        Some("stolen-token")
+    );
     assert!(!user_env.contains_key(guest_contracts::env::CANONICAL_API_TOKEN_ENV));
-    assert!(!user_env.contains_key("VM0_USER_ENV_FILE"));
-    assert!(!user_env.contains_key("VM0_STUCK_TOOL_TIMEOUT_SECS"));
+    assert_eq!(
+        user_env.get("VM0_USER_ENV_FILE").map(String::as_str),
+        Some("/tmp/evil-env.json")
+    );
+    assert_eq!(
+        user_env.get("VM0_RUN_PAYLOAD_FILE").map(String::as_str),
+        Some("/tmp/evil-payload.json")
+    );
+    for key in guest_contracts::env::GUEST_AGENT_TUNING_ENV_KEYS {
+        assert!(!user_env.contains_key(*key));
+    }
     assert_eq!(
         user_env
             .get(guest_contracts::env::CONNECTOR_ACCOUNT_CONTEXT_FILE_ENV)

--- a/crates/runner/src/provider/local/tests/claim.rs
+++ b/crates/runner/src/provider/local/tests/claim.rs
@@ -29,14 +29,14 @@ async fn claim_maps_secret_environment_into_context_and_masking() {
     write_job_with_environments(
         dir.path(),
         job_id,
-        Some(HashMap::from([(
-            "ANTHROPIC_MODEL".into(),
-            "claude-haiku-4-5".into(),
-        )])),
-        Some(HashMap::from([(
-            "ANTHROPIC_API_KEY".into(),
-            "sk-ant-local-secret".into(),
-        )])),
+        Some(HashMap::from([
+            ("ANTHROPIC_MODEL".into(), "claude-haiku-4-5".into()),
+            ("VM0_FUTURE_RUNNER_KEY".into(), "ordinary-vm0-value".into()),
+        ])),
+        Some(HashMap::from([
+            ("ANTHROPIC_API_KEY".into(), "sk-ant-local-secret".into()),
+            ("VM0_TEST_VALUE".into(), "ordinary-vm0-secret".into()),
+        ])),
     );
 
     let candidate = provider.discover().await.unwrap();
@@ -55,8 +55,27 @@ async fn claim_maps_secret_environment_into_context_and_masking() {
         environment.get("ANTHROPIC_API_KEY").map(String::as_str),
         Some("sk-ant-local-secret")
     );
-    assert_eq!(secret_values, &["sk-ant-local-secret".to_string()]);
+    assert_eq!(
+        environment.get("VM0_FUTURE_RUNNER_KEY").map(String::as_str),
+        Some("ordinary-vm0-value")
+    );
+    assert_eq!(
+        environment.get("VM0_TEST_VALUE").map(String::as_str),
+        Some("ordinary-vm0-secret")
+    );
+    assert_eq!(secret_values.len(), 2);
+    assert!(
+        secret_values
+            .iter()
+            .any(|value| value == "sk-ant-local-secret")
+    );
+    assert!(
+        secret_values
+            .iter()
+            .any(|value| value == "ordinary-vm0-secret")
+    );
     assert!(local_secret_env_keys.contains("ANTHROPIC_API_KEY"));
+    assert!(local_secret_env_keys.contains("VM0_TEST_VALUE"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- retire the broad executable `VM0_*` runner-ownership wildcard while preserving the complete `OKOU_*` reservation and explicit bootstrap keys
- keep the four exact local timing inputs runner-owned, ordinary-`--env`-only, canonically translated, and isolated from the general user environment
- prove arbitrary unrelated and retired `VM0_*` names remain untrusted user environment and cannot override canonical bootstrap or private RunPayload state

## JIT inventory

- reviewed base: `3b475f25121716295b2edcfefe3d4c9143c6d671`
- executable `starts_with("VM0_")`: 1 before, 0 after
- baseline residual inventory: 438 occurrences / 103 tokens / 100 files
- final residual inventory: 465 occurrences / 103 tokens / 101 files; all 103 tokens remain partitioned across the issue's eight categories with zero omissions or duplicates
- fully paginated open-PR audit: 22 PRs, 898/898 changed files reconciled; only stale #25722 overlaps three candidate files, with unrelated Cloudflare Access hunks

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo check --manifest-path crates/Cargo.toml -p guest-contracts -p runner -p guest-agent --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p runner -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p runner -p guest-agent --all-features --no-deps`
- focused Guest Contracts ownership/source-inventory tests (13 passed)
- `guest-agent` CLI child environment and timing-alias integration tests (2 passed)
- Runner test binary execution was attempted with GNU ld, one build job/debug disabled, and toolchain LLD; all three were terminated with exit 137 by the local runner resource ceiling. Protected PR CI remains authoritative for those affected Runner tests.
- `git diff --check`

Closes #31247
