### PR TITLE
fix(platform): send shared worker clerk requests to the frontend api host

### DIFF
--- a/turbo/apps/platform/src/lib/clerk-primary-app-domain-param.ts
+++ b/turbo/apps/platform/src/lib/clerk-primary-app-domain-param.ts
@@ -1,0 +1,4 @@
+// Worker URL parameter carrying the deployment's Clerk primary app domain. The
+// value is substituted into index.html after the build, so only a tab can read
+// it; the SharedWorker bundle is an immutable asset that has no copy of it.
+export const CLERK_PRIMARY_APP_DOMAIN_PARAM = "clerkPrimaryAppDomain";

--- a/turbo/apps/platform/src/lib/clerk-worker-runtime.ts
+++ b/turbo/apps/platform/src/lib/clerk-worker-runtime.ts
@@ -4,8 +4,18 @@ import {
   CLERK_DEV_BROWSER_ROTATION_HEADER,
   withClerkDevBrowserJwt,
 } from "./clerk-dev-browser.ts";
-import { resolveClerkInstanceConfig } from "./clerk-instance-config.ts";
+import { resolveClerkProductionSatelliteDomain } from "./clerk-production-topology.ts";
+import { resolvePlatformRuntimeConfig } from "./platform-host.ts";
 import type { ClerkTokenSource } from "../signals/clerk-token.ts";
+
+export interface ClerkWorkerRuntimeOptions {
+  readonly devBrowserJwt: string | null;
+  /**
+   * The deployment's Clerk primary app domain as the tab read it from
+   * index.html. Unknown values fail closed to the current topology.
+   */
+  readonly productionPrimaryAppDomain: string | null;
+}
 
 /**
  * Mirrors Clerk's own DOM-less client: `@clerk/chrome-extension` builds the
@@ -31,24 +41,24 @@ function attachDevBrowser(clerk: Clerk, devBrowserJwt: string): void {
 }
 
 export async function startClerkWorkerRuntime(
-  devBrowserJwt: string | null,
+  options: ClerkWorkerRuntimeOptions,
 ): Promise<ClerkTokenSource> {
-  const { publishableKey, satelliteConfig } = resolveClerkInstanceConfig();
-  const clerk = new Clerk(
-    publishableKey,
-    satelliteConfig ? { domain: satelliteConfig.domain } : undefined,
+  const satelliteDomain = resolveClerkProductionSatelliteDomain(
+    location.hostname,
+    options.productionPrimaryAppDomain,
   );
-  if (devBrowserJwt) {
-    attachDevBrowser(clerk, devBrowserJwt);
+  // clerk-js derives the Frontend API host from `domain` as given whenever
+  // `window` is undefined: the `clerk.` prefix the page gets for free is only
+  // added in a browser scope. Without it a satellite Worker sends every Clerk
+  // request to the app origin itself. The satellite load options are likewise
+  // ignored in a Worker, so only the host is passed.
+  const clerk = new Clerk(
+    resolvePlatformRuntimeConfig().clerkPublishableKey,
+    satelliteDomain ? { domain: `clerk.${satelliteDomain}` } : undefined,
+  );
+  if (options.devBrowserJwt) {
+    attachDevBrowser(clerk, options.devBrowserJwt);
   }
-  await clerk.load({
-    standardBrowser: false,
-    ...(satelliteConfig
-      ? {
-          isSatellite: satelliteConfig.isSatellite,
-          satelliteAutoSync: satelliteConfig.satelliteAutoSync,
-        }
-      : {}),
-  });
+  await clerk.load({ standardBrowser: false });
   return clerk;
 }

--- a/turbo/apps/platform/src/signals/__tests__/shared-database-browser.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/shared-database-browser.test.ts
@@ -141,9 +141,28 @@ describe("shared database browser bridge", () => {
     });
     const workerUrl = new URL(String(constructorCalls[0]?.scriptURL));
     expect(workerUrl.origin).toBe(window.location.origin);
-    expect(workerUrl.search).toBe("?userId=test-user-123&orgId=test-org-123");
+    expect(workerUrl.search).toBe(
+      "?userId=test-user-123&orgId=test-org-123&clerkPrimaryAppDomain=app.vm0.ai",
+    );
     expect(workers[0]!.port.messages).toStrictEqual([{ type: "register-tab" }]);
     expect(mockedClerk.sessionGetToken).not.toHaveBeenCalled();
+  });
+
+  it("forwards the deployed Clerk primary app domain through the Worker URL", async () => {
+    Reflect.set(window, "__vm0ClerkBootstrap", {
+      productionPrimaryAppDomain: "app.okou.ai",
+    });
+    context.signal.addEventListener("abort", () => {
+      Reflect.deleteProperty(window, "__vm0ClerkBootstrap");
+    });
+    const { constructorCalls } = installSharedWorkerMock();
+
+    await setupBridge();
+
+    const workerUrl = new URL(String(constructorCalls[0]?.scriptURL));
+    expect(workerUrl.searchParams.get("clerkPrimaryAppDomain")).toBe(
+      "app.okou.ai",
+    );
   });
 
   it("forwards a captured Preview bypass through the Worker URL", async () => {

--- a/turbo/apps/platform/src/signals/shared-database-browser.ts
+++ b/turbo/apps/platform/src/signals/shared-database-browser.ts
@@ -8,6 +8,8 @@ import {
   CLERK_DEV_BROWSER_NAME,
   readClerkDevBrowserJwt,
 } from "../lib/clerk-dev-browser.ts";
+import { resolveConfiguredProductionPrimaryAppDomain } from "../lib/clerk-instance-config.ts";
+import { CLERK_PRIMARY_APP_DOMAIN_PARAM } from "../lib/clerk-primary-app-domain-param.ts";
 import { CONNECTION_DIAGNOSTICS_PARAM } from "../lib/connection-diagnostics-param.ts";
 import { derivePlatformServiceOrigin } from "../lib/platform-host.ts";
 import { getCapturedPreviewBypassForTarget } from "../lib/preview-bypass-cookie.ts";
@@ -83,6 +85,12 @@ function createBrowserSharedDatabaseBridge(
   workerUrl.search = "";
   workerUrl.searchParams.set("userId", identity.userId);
   workerUrl.searchParams.set("orgId", identity.orgId);
+  // The Worker bundle has no copy of the deployment's primary app domain (it
+  // is substituted into index.html after the build), so the tab forwards it.
+  workerUrl.searchParams.set(
+    CLERK_PRIMARY_APP_DOMAIN_PARAM,
+    resolveConfiguredProductionPrimaryAppDomain(),
+  );
   const apiBaseUrl = derivePlatformServiceOrigin(location.origin, "api");
   const vercelProtectionBypass = getCapturedPreviewBypassForTarget(apiBaseUrl);
   if (vercelProtectionBypass) {

--- a/turbo/apps/platform/src/signals/worker-auth.ts
+++ b/turbo/apps/platform/src/signals/worker-auth.ts
@@ -1,13 +1,16 @@
 import { computed } from "ccstate";
 
 import { CLERK_DEV_BROWSER_NAME } from "../lib/clerk-dev-browser.ts";
+import { CLERK_PRIMARY_APP_DOMAIN_PARAM } from "../lib/clerk-primary-app-domain-param.ts";
 import { startClerkWorkerRuntime } from "../lib/clerk-worker-runtime.ts";
 
 export const clerk$ = computed(() => {
-  // Only a development instance needs the dev browser JWT, and only a page can
-  // read it, so the tab that starts the Worker passes it on the Worker URL.
-  const devBrowserJwt = new URL(location.href).searchParams.get(
-    CLERK_DEV_BROWSER_NAME,
-  );
-  return startClerkWorkerRuntime(devBrowserJwt);
+  // Only a page can read the dev browser JWT (a development instance needs
+  // it) and the deployment's primary app domain, so the tab that starts the
+  // Worker passes both on the Worker URL.
+  const params = new URL(location.href).searchParams;
+  return startClerkWorkerRuntime({
+    devBrowserJwt: params.get(CLERK_DEV_BROWSER_NAME),
+    productionPrimaryAppDomain: params.get(CLERK_PRIMARY_APP_DOMAIN_PARAM),
+  });
 });


### PR DESCRIPTION
## Summary

- The shared database SharedWorker on `app.okou.ai` sent its Clerk Frontend API requests to `https://app.okou.ai/v1/environment` and `/v1/client` instead of `https://clerk.app.okou.ai`. clerk-js only adds the `clerk.` prefix to a satellite `domain` when `window` exists; in a Worker the raw domain is used as the FAPI host. The app edge Worker answered those paths with the SPA shell, so the Worker could never load a session and shared-database auth failed on `app.okou.ai`.
- `clerk-worker-runtime.ts` now passes `clerk.<satellite domain>` explicitly and drops the satellite load options, which clerk-js also ignores without `window`.
- The tab forwards the deployment's Clerk primary app domain on the Worker URL (`clerkPrimaryAppDomain`). That value is substituted into `index.html` after the build, so the immutable Worker bundle has no copy of it and previously fell back to the hardcoded `app.vm0.ai` topology. After this change the Okou primary cutover only needs the `CLERK_PRODUCTION_PRIMARY_APP_DOMAIN` variable flipped, and the page and the Worker agree on the topology.

## Verification

Built the platform bundle and loaded the emitted `shared-database-worker-*.js` in Node with a stubbed `location` and an intercepted `fetch`; the Clerk requests now resolve to:

| Worker origin | `clerkPrimaryAppDomain` | Clerk host |
| --- | --- | --- |
| app.okou.ai | app.vm0.ai | clerk.app.okou.ai |
| app.vm0.ai | app.vm0.ai | clerk.vm0.ai |
| app.okou.ai | app.okou.ai | clerk.vm0.ai |
| app.vm0.ai | app.okou.ai | clerk.vm0.ai |
| app.okou.ai | (absent) | clerk.app.okou.ai |

Before the fix the first and last rows resolved to `app.okou.ai`.

- `pnpm format`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip`
- `pnpm -F @okouai/app exec vitest run --silent=passed-only` (168 files, 2264 tests)

## Deployment compatibility

Surface: SharedWorker URL contract between the page and the Worker bundle. Both ship in the same App build; a tab on an old build starts the old Worker asset (different hash) and never mixes with the new one. An old Worker URL without the parameter falls back to the current topology exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
