### PR TITLE
feat(core): open video tools to staff

### DIFF
--- a/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
+++ b/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
@@ -86,10 +86,10 @@ describe("lab page", () => {
       expect(beta.queryByText(key)).not.toBeInTheDocument();
       expect(alpha.queryByText(key)).not.toBeInTheDocument();
     }
+    expect(beta.getByText(FeatureSwitchKey.IntroVideo)).toBeInTheDocument();
     expect(
-      beta.queryByText(FeatureSwitchKey.IntroVideo),
-    ).not.toBeInTheDocument();
-    expect(alpha.getByText(FeatureSwitchKey.IntroVideo)).toBeInTheDocument();
+      beta.getByText(FeatureSwitchKey.DesktopScreenRecording),
+    ).toBeInTheDocument();
     expect(
       alpha.getByText(FeatureSwitchKey.AhrefsConnector),
     ).toBeInTheDocument();

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -180,7 +180,8 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ConnectorAccounts]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PresentationTemplates]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatTranslation]).toBe(false);
-    expect(staffOrgStates[FeatureSwitchKey.IntroVideo]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.IntroVideo]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.DesktopScreenRecording]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.MorningBrief]).toBe(true);
@@ -204,23 +205,19 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.PresentationTemplates]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatTranslation]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.IntroVideo]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.DesktopScreenRecording]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.MorningBrief]).toBe(false);
   });
 
-  it("should enable intro video for Bingjie only", () => {
-    const bingjieStates = getAllFeatureStates({
-      email: "bingjie@vm0.ai",
-      orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
-    });
-    expect(bingjieStates[FeatureSwitchKey.IntroVideo]).toBe(true);
-
-    const otherStaffStates = getAllFeatureStates({
+  it("should enable intro video and desktop recording for staff", () => {
+    const staffStates = getAllFeatureStates({
       email: "ethan@vm0.ai",
       orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
     });
-    expect(otherStaffStates[FeatureSwitchKey.IntroVideo]).toBe(false);
+    expect(staffStates[FeatureSwitchKey.IntroVideo]).toBe(true);
+    expect(staffStates[FeatureSwitchKey.DesktopScreenRecording]).toBe(true);
   });
 
   it("should enable gradient color themes for Ming only", () => {
@@ -333,7 +330,10 @@ describe("getFeatureSwitchMetadata", () => {
       metadata[FeatureSwitchKey.NotionWorkflowAutomations].rolloutStage,
     ).toBe("released");
     expect(metadata[FeatureSwitchKey.Banking].rolloutStage).toBe("beta");
-    expect(metadata[FeatureSwitchKey.IntroVideo].rolloutStage).toBe("alpha");
+    expect(metadata[FeatureSwitchKey.IntroVideo].rolloutStage).toBe("beta");
+    expect(metadata[FeatureSwitchKey.DesktopScreenRecording].rolloutStage).toBe(
+      "beta",
+    );
     expect(metadata[FeatureSwitchKey.AhrefsConnector].rolloutStage).toBe(
       "alpha",
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -322,16 +322,14 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Show the guided intro video upload, screen recording, avatar, and voice workflow in new chat.",
     enabled: false,
-    enabledEmailHashes: ["9fd4ee92"], // fnv1a("bingjie@vm0.ai")
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.DesktopScreenRecording]: {
     maintainer: "bingjie@vm0.ai",
     description:
       "Enable Okou Desktop screen recording: native capture, click track, and delivery back into the intro video workflow.",
     enabled: false,
-    // Scoped to the maintainer while the native capture helper is still
-    // unproven outside CI; widen once it has run on real hardware.
-    enabledEmailHashes: ["9fd4ee92"], // fnv1a("bingjie@vm0.ai")
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.IosPwaStartupImages]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary

- enable the Intro Video feature switch for the staff organization
- enable the Okou Desktop screen recording feature switch for the staff organization
- keep both switches disabled for non-staff organizations and update rollout metadata expectations

## Verification

- `pnpm exec prettier --check packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `pnpm --filter @okouai/core run lint`
- `pnpm knip`
- `pnpm --filter @okouai/core run check-types`
- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` (31 tests passed)
