### PR TITLE
feat(chat): batch shared worker event catch-up

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-event-snapshot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-event-snapshot.test.ts
@@ -250,6 +250,123 @@ describe("chat event snapshot read endpoints", () => {
     });
   }, 60_000);
 
+  it("returns complete batch tails and partitions cursors that need a Snapshot", async () => {
+    const owner = bdd.user({ orgId: `org_${randomUUID()}` });
+    const agent = await bdd.createAgent(owner, {
+      displayName: "Batch catch-up agent",
+    });
+    const firstThreadId = await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      prompt: `batch-catch-up-first-${randomUUID()}`,
+    });
+    await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      threadId: firstThreadId,
+      prompt: `batch-catch-up-tail-${randomUUID()}`,
+    });
+    const secondThreadId = await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      prompt: `batch-catch-up-second-${randomUUID()}`,
+    });
+
+    const stranger = bdd.user({ orgId: `org_${randomUUID()}` });
+    const strangerAgent = await bdd.createAgent(stranger, {
+      displayName: "Batch catch-up stranger agent",
+    });
+    const strangerThreadId = await sendNoCreditMessage(stranger, {
+      agentId: strangerAgent.agentId,
+      prompt: `batch-catch-up-stranger-${randomUUID()}`,
+    });
+    const firstRows = await accept(
+      eventsClient().rows({
+        headers: authenticate(owner),
+        params: { threadId: firstThreadId },
+        query: { sinceSeqId: 0 },
+      }),
+      [200],
+    );
+    const secondRows = await accept(
+      eventsClient().rows({
+        headers: authenticate(owner),
+        params: { threadId: secondThreadId },
+        query: { sinceSeqId: 0 },
+      }),
+      [200],
+    );
+    const firstCursor = firstRows.body.rows[0];
+    const secondCursor = secondRows.body.rows.at(-1);
+    if (!firstCursor || !secondCursor) {
+      throw new Error("Expected Chat Event batch cursor fixtures");
+    }
+    const missingThreadId = randomUUID();
+
+    const response = await accept(
+      eventsClient().catchUp({
+        headers: authenticate(owner),
+        body: [
+          [firstThreadId, firstCursor.seqId],
+          [secondThreadId, secondCursor.seqId],
+          [strangerThreadId, 0],
+          [missingThreadId, 0],
+        ],
+      }),
+      [200],
+    );
+    expect(response.headers.get(CHAT_EVENT_SCHEMA_VERSION_HEADER)).toBe(
+      CURRENT_CHAT_EVENT_SCHEMA_VERSION.toString(),
+    );
+    expect(response.body).toStrictEqual({
+      events: {
+        [firstThreadId]: firstRows.body.rows.filter((row) => {
+          return row.seqId > firstCursor.seqId;
+        }),
+        [secondThreadId]: [],
+      },
+      notFoundThreads: [strangerThreadId, missingThreadId],
+    });
+
+    await projectChatEventSearch(firstThreadId);
+    await runSnapshotCron([firstThreadId]);
+    const head = await readChatEventSnapshotHead(context, firstThreadId);
+    if (head.terminal_seq_id === null) {
+      throw new Error("Expected a terminal Chat Event Snapshot cursor");
+    }
+    const snapshotCursor = await accept(
+      eventsClient().catchUp({
+        headers: authenticate(owner),
+        body: [[firstThreadId, head.terminal_seq_id]],
+      }),
+      [200],
+    );
+    expect(snapshotCursor.body).toStrictEqual({
+      events: { [firstThreadId]: [] },
+      notFoundThreads: [],
+    });
+    expect(head.terminal_seq_id).toBeGreaterThan(firstCursor.seqId);
+    const snapshotCoveredCursor = await accept(
+      eventsClient().catchUp({
+        headers: authenticate(owner),
+        body: [[firstThreadId, firstCursor.seqId]],
+      }),
+      [200],
+    );
+    expect(snapshotCoveredCursor.body).toStrictEqual({
+      events: {},
+      notFoundThreads: [firstThreadId],
+    });
+    const expiredCursor = await accept(
+      eventsClient().catchUp({
+        headers: authenticate(owner),
+        body: [[firstThreadId, 0]],
+      }),
+      [200],
+    );
+    expect(expiredCursor.body).toStrictEqual({
+      events: {},
+      notFoundThreads: [firstThreadId],
+    });
+  }, 60_000);
+
   it("does not repair or publish a retired Morning Brief Snapshot object", async () => {
     const recordedPuts: RecordedChatEventPut[] = [];
     installFakeChatEventR2(context, recordedPuts);

--- a/turbo/apps/api/src/signals/routes/chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 import { authContext$, organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { pathParamsOf, queryOf } from "../context/request";
+import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
 import { request$, setResHeader$ } from "../context/hono";
 import { db$ } from "../external/db";
 import { notFound } from "../../lib/error";
@@ -28,6 +28,7 @@ import {
 } from "../services/chat-thread.service";
 import { chatSearch } from "../services/chat-search.service";
 import {
+  catchUpChatThreadEvents,
   chatThreadEventRows,
   chatThreadEventSnapshot,
 } from "../services/chat-event-snapshot.service";
@@ -56,6 +57,7 @@ import { chatThreadRenameRoutes } from "./chat-threads-rename";
 import { chatThreadUnpinRoutes } from "./chat-threads-unpin";
 
 const chatThreadIdSchema = z.string().uuid();
+const catchUpChatEventsBody$ = bodyResultOf(chatThreadEventsContract.catchUp);
 
 function chatThreadNotFound() {
   return notFound("Chat thread not found");
@@ -143,6 +145,47 @@ const listChatIndicatorsInner$ = computed(async (get) => {
 
   return { status: 200 as const, body: indicators };
 });
+
+const catchUpChatEventsInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const version = resolveChatEventSchemaVersion(
+      get(request$).header(CHAT_EVENT_SCHEMA_VERSION_HEADER),
+    );
+    if (version.kind === "error") {
+      return version.response;
+    }
+    set(
+      setResHeader$,
+      CHAT_EVENT_SCHEMA_VERSION_HEADER,
+      version.version.toString(),
+    );
+    const body = await get(catchUpChatEventsBody$);
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+    const result = await get(
+      catchUpChatThreadEvents({
+        cursors: body.data,
+        userId: auth.userId,
+        orgId: auth.orgId,
+      }),
+    );
+    signal.throwIfAborted();
+    return {
+      status: 200 as const,
+      body: {
+        events: Object.fromEntries(
+          Object.entries(result.events).map(([threadId, events]) => {
+            return [threadId, [...events]];
+          }),
+        ),
+        notFoundThreads: [...result.notFoundThreads],
+      },
+    };
+  },
+);
 
 const getChatEventSnapshotInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -383,6 +426,17 @@ export const chatThreadRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadArtifactsContract.list,
     handler: authRoute({}, listChatThreadArtifactsInner$),
+  },
+  {
+    route: chatThreadEventsContract.catchUp,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "chat-event:read",
+      },
+      catchUpChatEventsInner$,
+    ),
   },
   {
     route: chatThreadEventsContract.snapshot,

--- a/turbo/apps/api/src/signals/services/chat-event-snapshot.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-snapshot.service.ts
@@ -4,7 +4,8 @@ import {
   type ChatEventCursor,
 } from "@okouai/api-contracts/contracts/chat-event-schema-version";
 import { command, computed, type Computed } from "ccstate";
-import { and, asc, eq, gt } from "drizzle-orm";
+import { and, asc, eq, gt, inArray, or } from "drizzle-orm";
+import { agents } from "@okouai/db/schema/agent";
 import { chatEvents } from "@okouai/db/schema/chat-event";
 import { chatEventSnapshots } from "@okouai/db/schema/chat-event-snapshot";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
@@ -22,6 +23,21 @@ import {
 const SNAPSHOT_URL_TTL_SECONDS = 900;
 /** Cursor that reads a thread from its very first event. */
 const THREAD_START_SEQ_ID = 0;
+
+const chatEventRowSelection = {
+  id: chatEvents.id,
+  chatThreadId: chatEvents.chatThreadId,
+  runId: chatEvents.runId,
+  revokesEventId: chatEvents.revokesEventId,
+  eventType: chatEvents.eventType,
+  payload: chatEvents.payload,
+  contextType: chatEvents.contextType,
+  contextId: chatEvents.contextId,
+  runEventSequenceNumber: chatEvents.runEventSequenceNumber,
+  runEventId: chatEvents.runEventId,
+  seqId: chatEvents.seqId,
+  createdAt: chatEvents.createdAt,
+} as const;
 
 type ChatEventSnapshotDownload =
   | { readonly kind: "thread-not-found" }
@@ -201,6 +217,210 @@ async function cursorContinuationSeqId(
   return physicalCursorRow?.id === args.sinceEventId ? args.sinceSeqId : null;
 }
 
+interface ChatEventBatchSnapshotCursor {
+  readonly lastEventId: string | null;
+  readonly lastSeqId: number | null;
+  readonly physicalLastSeqId: number;
+}
+
+interface ChatEventBatchCatchUpResult {
+  readonly events: Readonly<Record<string, readonly ChatEventRow[]>>;
+  readonly notFoundThreads: readonly string[];
+}
+
+interface ChatEventBatchContinuation {
+  readonly threadId: string;
+  readonly lastSeqId: number;
+}
+
+function validatedBatchSnapshotCursor(snapshot: ChatEventBatchSnapshotCursor): {
+  readonly lastSeqId: number;
+  readonly physicalLastSeqId: number;
+} {
+  if (
+    snapshot.lastSeqId === null ||
+    !(
+      (snapshot.lastSeqId === THREAD_START_SEQ_ID &&
+        snapshot.lastEventId === null) ||
+      (snapshot.lastSeqId > THREAD_START_SEQ_ID &&
+        snapshot.lastEventId !== null)
+    )
+  ) {
+    throw new Error("Current Chat Event Snapshot cursor is incomplete");
+  }
+  return {
+    lastSeqId: snapshot.lastSeqId,
+    physicalLastSeqId: snapshot.physicalLastSeqId,
+  };
+}
+
+function resolveBatchContinuations(
+  requested: ReadonlyMap<string, number>,
+  ownedThreadIds: ReadonlySet<string>,
+  snapshotsByThreadId: ReadonlyMap<
+    string,
+    { readonly lastSeqId: number; readonly physicalLastSeqId: number }
+  >,
+  physicalCursorThreadIds: ReadonlySet<string>,
+): {
+  readonly continuations: readonly ChatEventBatchContinuation[];
+  readonly notFoundThreads: readonly string[];
+} {
+  const continuations: ChatEventBatchContinuation[] = [];
+  const notFoundThreads: string[] = [];
+  for (const [threadId, lastSeqId] of requested) {
+    if (!ownedThreadIds.has(threadId)) {
+      notFoundThreads.push(threadId);
+      continue;
+    }
+    const snapshot = snapshotsByThreadId.get(threadId);
+    if (snapshot?.lastSeqId === lastSeqId) {
+      continuations.push({
+        threadId,
+        lastSeqId: snapshot.physicalLastSeqId,
+      });
+      continue;
+    }
+    if (
+      (lastSeqId === THREAD_START_SEQ_ID && snapshot === undefined) ||
+      (physicalCursorThreadIds.has(threadId) &&
+        (snapshot === undefined || lastSeqId > snapshot.physicalLastSeqId))
+    ) {
+      continuations.push({ threadId, lastSeqId });
+      continue;
+    }
+    notFoundThreads.push(threadId);
+  }
+  return { continuations, notFoundThreads };
+}
+
+/**
+ * Resolve complete raw-row tails for a batch of per-thread seq cursors.
+ * Missing threads and cursors that can no longer be continued are deliberately
+ * indistinguishable so the client follows the same Snapshot rebuild path.
+ */
+export function catchUpChatThreadEvents(args: {
+  readonly cursors: readonly (readonly [string, number])[];
+  readonly userId: string;
+  readonly orgId: string;
+}): Computed<Promise<ChatEventBatchCatchUpResult>> {
+  return computed(async (get) => {
+    const requested = new Map(args.cursors);
+    if (requested.size === 0) {
+      return { events: {}, notFoundThreads: [] };
+    }
+
+    const db = get(db$);
+    const threadIds = [...requested.keys()];
+    const ownedRows = await db
+      .select({ threadId: chatThreads.id })
+      .from(chatThreads)
+      .innerJoin(agents, eq(agents.id, chatThreads.agentId))
+      .where(
+        and(
+          inArray(chatThreads.id, threadIds),
+          eq(chatThreads.userId, args.userId),
+          eq(agents.orgId, args.orgId),
+        ),
+      );
+    const ownedThreadIds = new Set(
+      ownedRows.map((row) => {
+        return row.threadId;
+      }),
+    );
+
+    const snapshots =
+      ownedThreadIds.size === 0
+        ? []
+        : await db
+            .select({
+              threadId: chatEventSnapshots.chatThreadId,
+              lastEventId: chatEventSnapshots.terminalEventId,
+              lastSeqId: chatEventSnapshots.terminalSeqId,
+              physicalLastSeqId: chatEventSnapshots.lastSeqId,
+            })
+            .from(chatEventSnapshots)
+            .where(
+              and(
+                inArray(chatEventSnapshots.chatThreadId, [...ownedThreadIds]),
+                eq(
+                  chatEventSnapshots.archiveSchemaVersion,
+                  CURRENT_CHAT_EVENT_SCHEMA_VERSION,
+                ),
+              ),
+            );
+    const snapshotsByThreadId = new Map(
+      snapshots.map((snapshot) => {
+        return [snapshot.threadId, validatedBatchSnapshotCursor(snapshot)];
+      }),
+    );
+
+    const positiveCursors = [...requested].filter(([threadId, lastSeqId]) => {
+      return ownedThreadIds.has(threadId) && lastSeqId > THREAD_START_SEQ_ID;
+    });
+    const physicalCursorRows =
+      positiveCursors.length === 0
+        ? []
+        : await db
+            .select({ threadId: chatEvents.chatThreadId })
+            .from(chatEvents)
+            .where(
+              or(
+                ...positiveCursors.map(([threadId, lastSeqId]) => {
+                  return and(
+                    eq(chatEvents.chatThreadId, threadId),
+                    eq(chatEvents.seqId, lastSeqId),
+                  );
+                }),
+              ),
+            );
+    const physicalCursorThreadIds = new Set(
+      physicalCursorRows.map((row) => {
+        return row.threadId;
+      }),
+    );
+
+    const { continuations, notFoundThreads } = resolveBatchContinuations(
+      requested,
+      ownedThreadIds,
+      snapshotsByThreadId,
+      physicalCursorThreadIds,
+    );
+
+    const physicalRows =
+      continuations.length === 0
+        ? []
+        : await db
+            .select(chatEventRowSelection)
+            .from(chatEvents)
+            .where(
+              or(
+                ...continuations.map(({ threadId, lastSeqId }) => {
+                  return and(
+                    eq(chatEvents.chatThreadId, threadId),
+                    gt(chatEvents.seqId, lastSeqId),
+                  );
+                }),
+              ),
+            )
+            .orderBy(asc(chatEvents.chatThreadId), asc(chatEvents.seqId));
+    const events: Record<string, ChatEventRow[]> = Object.fromEntries(
+      continuations.map(({ threadId }) => {
+        return [threadId, []];
+      }),
+    );
+    for (const row of physicalRows) {
+      const threadEvents = events[row.chatThreadId];
+      if (!threadEvents) {
+        throw new Error("Chat Event tail escaped its requested partition");
+      }
+      threadEvents.push(chatEventRowFromDbRow(row));
+    }
+
+    return { events, notFoundThreads };
+  });
+}
+
 /** Resolve the current persisted Snapshot pointer. */
 export function chatThreadEventSnapshot(args: {
   readonly threadId: string;
@@ -290,20 +510,7 @@ export function chatThreadEventRows(
     }
 
     const physicalRows = await db
-      .select({
-        id: chatEvents.id,
-        chatThreadId: chatEvents.chatThreadId,
-        runId: chatEvents.runId,
-        revokesEventId: chatEvents.revokesEventId,
-        eventType: chatEvents.eventType,
-        payload: chatEvents.payload,
-        contextType: chatEvents.contextType,
-        contextId: chatEvents.contextId,
-        runEventSequenceNumber: chatEvents.runEventSequenceNumber,
-        runEventId: chatEvents.runEventId,
-        seqId: chatEvents.seqId,
-        createdAt: chatEvents.createdAt,
-      })
+      .select(chatEventRowSelection)
       .from(chatEvents)
       .where(
         and(

--- a/turbo/apps/platform/src/shared-database/__tests__/platform-direct-bridge.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/platform-direct-bridge.test.ts
@@ -1,5 +1,6 @@
 import type { ChatEventRow } from "@okouai/api-contracts/contracts/chat-event-rows";
 import { CURRENT_CHAT_EVENT_SCHEMA_VERSION } from "@okouai/api-contracts/contracts/chat-event-schema-version";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   chatThreadsContract,
   chatThreadEventsContract,
@@ -124,7 +125,7 @@ function cachedThread(
 }
 
 describe("shared database direct Platform bridge", () => {
-  it("renders cache first, reacts to append, and catches up active and unread threads in the background", async () => {
+  it("renders cache first, reacts to append, and batch catches up active, unread, and recent threads", async () => {
     const threadId = crypto.randomUUID();
     const unreadThreadId = crypto.randomUUID();
     const activeThreadId = crypto.randomUUID();
@@ -206,6 +207,7 @@ describe("shared database direct Platform bridge", () => {
 
     await setupPage({
       context,
+      featureSwitches: { [FeatureSwitchKey.BatchChatEventCatchUp]: true },
       path: "/error",
       sharedWorkerTestTransport: "message-port",
       withoutRender: true,
@@ -314,6 +316,68 @@ describe("shared database direct Platform bridge", () => {
       }),
     ).toStrictEqual([1, 2, 3, 4]);
     expect(requestedSeqIds).toHaveLength(requestsBeforeReopen);
+  });
+
+  it("keeps the legacy unread and active catch-up path when batch catch-up is disabled", async () => {
+    const cachedThreadId = crypto.randomUUID();
+    const unreadThreadId = crypto.randomUUID();
+    const activeThreadId = crypto.randomUUID();
+    await seedChatEventCache(row(cachedThreadId, 1), [
+      cachedThread(cachedThreadId, CREATED_AT, null),
+    ]);
+
+    const requestedThreadIds: string[] = [];
+    let batchRequestCount = 0;
+    context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+      return respond(200, {
+        agents: {},
+        threads: {
+          [unreadThreadId]: "unread",
+          [activeThreadId]: "active",
+        },
+      });
+    });
+    context.mocks.api(chatThreadEventsContract.snapshot, ({ respond }) => {
+      return respond(404, {
+        error: {
+          code: "CHAT_EVENT_SNAPSHOT_NOT_FOUND",
+          message: "Chat event snapshot not found",
+        },
+      });
+    });
+    context.mocks.api(
+      chatThreadEventsContract.rows,
+      ({ params, query, respond }) => {
+        requestedThreadIds.push(params.threadId);
+        return respond(200, chatEventRowsResponse([], query));
+      },
+    );
+    context.mocks.api(chatThreadEventsContract.catchUp, ({ respond }) => {
+      batchRequestCount += 1;
+      return respond(200, { events: {}, notFoundThreads: [] });
+    });
+
+    await setupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.BatchChatEventCatchUp]: false },
+      path: "/error",
+      sharedWorkerTestTransport: "message-port",
+      withoutRender: true,
+      user: { id: userId(), fullName: "Direct Bridge User" },
+      session: { token: "direct-bridge-token" },
+      org: {
+        activeOrg: { id: orgId(), name: "Direct Bridge Org" },
+        memberships: [{ id: orgId() }],
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(new Set(requestedThreadIds)).toStrictEqual(
+        new Set([unreadThreadId, activeThreadId]),
+      );
+    });
+    expect(requestedThreadIds).not.toContain(cachedThreadId);
+    expect(batchRequestCount).toBe(0);
   });
 
   it("does not turn a healthy SharedWorker connection red when the tab is hidden", () => {

--- a/turbo/apps/platform/src/shared-database/__tests__/platform-direct-bridge.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/platform-direct-bridge.test.ts
@@ -21,6 +21,7 @@ import {
   CHAT_EVENT_CURSOR_STORE,
   CHAT_EVENT_ROWS_STORE,
   CHAT_IDB_VERSION,
+  CHAT_THREAD_SNAPSHOT_STORE,
   upgradeChatIdb,
 } from "../../signals/external/chat-idb-schema.ts";
 import { openDB } from "idb";
@@ -63,7 +64,10 @@ function row(threadId: string, seqId: number): ChatEventRow {
   };
 }
 
-async function seedChatEventCache(cachedRow: ChatEventRow): Promise<void> {
+async function seedChatEventCache(
+  cachedRow: ChatEventRow,
+  chatThreads: readonly ChatThreadSnapshotProjection[] = [],
+): Promise<void> {
   const db = await openDB(`vm0-chat-${userId()}-${orgId()}`, CHAT_IDB_VERSION, {
     upgrade(database, oldVersion) {
       upgradeChatIdb(database, oldVersion);
@@ -71,7 +75,11 @@ async function seedChatEventCache(cachedRow: ChatEventRow): Promise<void> {
   });
   try {
     const tx = db.transaction(
-      [CHAT_EVENT_ROWS_STORE, CHAT_EVENT_CURSOR_STORE],
+      [
+        CHAT_EVENT_ROWS_STORE,
+        CHAT_EVENT_CURSOR_STORE,
+        CHAT_THREAD_SNAPSHOT_STORE,
+      ],
       "readwrite",
     );
     await Promise.all([
@@ -82,11 +90,37 @@ async function seedChatEventCache(cachedRow: ChatEventRow): Promise<void> {
         lastEventId: cachedRow.id,
         lastSeqId: cachedRow.seqId,
       }),
+      tx.objectStore(CHAT_THREAD_SNAPSHOT_STORE).put({
+        id: "current",
+        chatThreads: [...chatThreads],
+        latestEventId: null,
+        latestSeqId: null,
+      }),
       tx.done,
     ]);
   } finally {
     db.close();
   }
+}
+
+function cachedThread(
+  id: string,
+  sortAt: string,
+  pinnedAt: string | null,
+): ChatThreadSnapshotProjection {
+  return {
+    id,
+    agentId: crypto.randomUUID(),
+    title: null,
+    sortAt,
+    createdAt: sortAt,
+    updatedAt: sortAt,
+    pinnedAt,
+    renamedAt: null,
+    selectedModel: null,
+    serviceTier: null,
+    computerUseHostId: null,
+  };
 }
 
 describe("shared database direct Platform bridge", () => {
@@ -98,7 +132,17 @@ describe("shared database direct Platform bridge", () => {
     const caughtUpRow = row(threadId, 2);
     const realtimeRow = row(threadId, 3);
     const backgroundRow = row(threadId, 4);
-    await seedChatEventCache(cachedRow);
+    const cachedThreads = Array.from({ length: 101 }, (_, index) => {
+      const sortAt = new Date(
+        Date.parse(CREATED_AT) + index * 1000,
+      ).toISOString();
+      return cachedThread(
+        `00000000-0000-4000-8000-${(index + 1).toString().padStart(12, "0")}`,
+        sortAt,
+        index === 0 ? sortAt : null,
+      );
+    });
+    await seedChatEventCache(cachedRow, cachedThreads);
 
     const initialPage = context.mocks.deferred<void>();
     let availableRows: readonly ChatEventRow[] = [caughtUpRow];
@@ -107,7 +151,7 @@ describe("shared database direct Platform bridge", () => {
       [activeThreadId]: "active",
     };
     const requestedSeqIds: number[] = [];
-    const prewarmedThreadIds: string[] = [];
+    const catchUpRequests: (readonly (readonly [string, number])[])[] = [];
     context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
       return respond(200, {
         agents: {},
@@ -122,16 +166,28 @@ describe("shared database direct Platform bridge", () => {
         },
       });
     });
+    context.mocks.api(chatThreadEventsContract.catchUp, ({ body, respond }) => {
+      catchUpRequests.push(body);
+      return respond(200, {
+        events: Object.fromEntries(
+          body.map(([candidateThreadId, lastSeqId]) => {
+            return [
+              candidateThreadId,
+              candidateThreadId === threadId
+                ? availableRows.filter((candidate) => {
+                    return candidate.seqId > lastSeqId;
+                  })
+                : [],
+            ];
+          }),
+        ),
+        notFoundThreads: [],
+      });
+    });
     context.mocks.api(
       chatThreadEventsContract.rows,
       async ({ params, query, respond }) => {
-        if (
-          params.threadId === unreadThreadId ||
-          params.threadId === activeThreadId
-        ) {
-          prewarmedThreadIds.push(params.threadId);
-          return respond(200, chatEventRowsResponse([], query));
-        }
+        expect(params.threadId).toBe(threadId);
         requestedSeqIds.push(query.sinceSeqId);
         if (query.sinceSeqId === 1) {
           await initialPage.promise;
@@ -161,8 +217,19 @@ describe("shared database direct Platform bridge", () => {
       },
     });
     await vi.waitFor(() => {
-      expect(prewarmedThreadIds).toContain(unreadThreadId);
-      expect(prewarmedThreadIds).toContain(activeThreadId);
+      expect(catchUpRequests).toHaveLength(1);
+      const requestedThreadIds = catchUpRequests[0]?.map(
+        ([candidateThreadId]) => {
+          return candidateThreadId;
+        },
+      );
+      expect(requestedThreadIds?.slice(0, 2)).toStrictEqual([
+        unreadThreadId,
+        activeThreadId,
+      ]);
+      expect(requestedThreadIds).toHaveLength(102);
+      expect(requestedThreadIds).not.toContain(cachedThreads[0]?.id);
+      expect(requestedThreadIds).toContain(cachedThreads.at(-1)?.id);
     });
 
     const owner = createChildAbortController(context.signal);
@@ -213,7 +280,7 @@ describe("shared database direct Platform bridge", () => {
     ).toBeTruthy();
 
     owner.abort(new DOMException("chat closed", "AbortError"));
-    const prewarmedRequestsBeforeReload = prewarmedThreadIds.length;
+    const catchUpRequestsBeforeReload = catchUpRequests.length;
     availableRows = [caughtUpRow, realtimeRow, backgroundRow];
     indicatorThreads = {
       ...indicatorThreads,
@@ -225,10 +292,16 @@ describe("shared database direct Platform bridge", () => {
     );
     context.mocks.ably.triggerOnChannel(realtimeChannel(), "threadListChanged");
     await vi.waitFor(() => {
-      expect(requestedSeqIds).toContain(3);
-      expect(prewarmedThreadIds.length).toBeGreaterThan(
-        prewarmedRequestsBeforeReload,
+      expect(catchUpRequests.length).toBeGreaterThan(
+        catchUpRequestsBeforeReload,
       );
+      expect(
+        catchUpRequests.some((request) => {
+          return request.some(([candidateThreadId, lastSeqId]) => {
+            return candidateThreadId === threadId && lastSeqId === 3;
+          });
+        }),
+      ).toBeTruthy();
     });
 
     const requestsBeforeReopen = requestedSeqIds.length;

--- a/turbo/apps/platform/src/shared-database/__tests__/platform-direct-bridge.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/platform-direct-bridge.test.ts
@@ -1,5 +1,7 @@
 import type { ChatEventRow } from "@okouai/api-contracts/contracts/chat-event-rows";
 import { CURRENT_CHAT_EVENT_SCHEMA_VERSION } from "@okouai/api-contracts/contracts/chat-event-schema-version";
+import { CLIENT_VERSION_HEADER } from "@okouai/api-contracts/contracts/client-headers";
+import { featureSwitchesContract } from "@okouai/api-contracts/contracts/feature-switches";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   chatThreadsContract,
@@ -378,6 +380,74 @@ describe("shared database direct Platform bridge", () => {
     });
     expect(requestedThreadIds).not.toContain(cachedThreadId);
     expect(batchRequestCount).toBe(0);
+  });
+
+  it("propagates a worker feature-switch failure without falling back", async () => {
+    const workerAppVersion = "worker-feature-switch-failure";
+    let workerFeatureSwitchRequestCount = 0;
+    let chatEventRequestCount = 0;
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    context.mocks.api(featureSwitchesContract.get, ({ request, respond }) => {
+      if (request.headers.get(CLIENT_VERSION_HEADER) === workerAppVersion) {
+        workerFeatureSwitchRequestCount += 1;
+        return respond(500, {
+          error: {
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Worker feature switches are unavailable",
+          },
+        });
+      }
+      return respond(200, { switches: {}, effectiveSwitches: {} });
+    });
+    context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+      return respond(200, {
+        agents: {},
+        threads: { [crypto.randomUUID()]: "unread" },
+      });
+    });
+    context.mocks.api(chatThreadEventsContract.snapshot, ({ respond }) => {
+      chatEventRequestCount += 1;
+      return respond(404, {
+        error: {
+          code: "CHAT_EVENT_SNAPSHOT_NOT_FOUND",
+          message: "Chat event snapshot not found",
+        },
+      });
+    });
+    context.mocks.api(chatThreadEventsContract.rows, ({ query, respond }) => {
+      chatEventRequestCount += 1;
+      return respond(200, chatEventRowsResponse([], query));
+    });
+    context.mocks.api(chatThreadEventsContract.catchUp, ({ respond }) => {
+      chatEventRequestCount += 1;
+      return respond(200, { events: {}, notFoundThreads: [] });
+    });
+
+    await setupPage({
+      context,
+      path: "/error",
+      sharedWorkerAppVersion: workerAppVersion,
+      sharedWorkerTestTransport: "message-port",
+      withoutRender: true,
+      user: { id: userId(), fullName: "Direct Bridge User" },
+      session: { token: "direct-bridge-token" },
+      org: {
+        activeOrg: { id: orgId(), name: "Direct Bridge Org" },
+        memberships: [{ id: orgId() }],
+      },
+    });
+    await vi.waitFor(() => {
+      expect(workerFeatureSwitchRequestCount).toBeGreaterThan(0);
+      expect(consoleWarn).toHaveBeenCalledWith(
+        "[W][Realtime]",
+        "transient error in ably notification",
+        expect.objectContaining({
+          message: "Worker feature switches are unavailable",
+          status: 500,
+        }),
+      );
+    });
+    expect(chatEventRequestCount).toBe(0);
   });
 
   it("does not turn a healthy SharedWorker connection red when the tab is hidden", () => {

--- a/turbo/apps/platform/src/shared-database/__tests__/worker-runtime.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/worker-runtime.test.ts
@@ -14,6 +14,7 @@ import { openDB } from "idb";
 import { HttpResponse } from "msw";
 import { describe, expect, it, vi } from "vitest";
 
+import { mockNow, now } from "../../lib/time.ts";
 import { CHAT_IDB_VERSION } from "../../signals/external/chat-idb-schema.ts";
 import { createAuthedContractClient } from "../../signals/api-client-base.ts";
 import type { ApiClientFactory } from "../../signals/api-client.ts";
@@ -41,6 +42,7 @@ import {
 } from "../worker-context.ts";
 import { SharedDatabaseWorkerRuntime } from "../worker-runtime.ts";
 import {
+  catchUpChatEvent$,
   initializeSharedDatabaseWorker$,
   querySharedDatabaseWorker$,
   startSharedDatabaseWorkerDaemons$,
@@ -425,6 +427,65 @@ describe("shared database worker runtime", () => {
     expect(networkRequests).toBe(0);
   });
 
+  it("coalesces global ChatEvent catch-up into serialized throttle slots", async () => {
+    const store = createWorkerStore();
+    const threadId = crypto.randomUUID();
+    const firstRequest = context.mocks.deferred<void>();
+    const secondRequest = context.mocks.deferred<void>();
+    const startedAt: number[] = [];
+    context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+      return respond(200, {
+        agents: {},
+        threads: { [threadId]: "unread" },
+      });
+    });
+    context.mocks.api(
+      chatThreadEventsContract.catchUp,
+      async ({ body, respond }) => {
+        const requestIndex = startedAt.length;
+        startedAt.push(now());
+        if (requestIndex === 0) {
+          await firstRequest.promise;
+        } else if (requestIndex === 1) {
+          await secondRequest.promise;
+        }
+        return respond(200, {
+          events: Object.fromEntries(
+            body.map(([candidateThreadId]) => {
+              return [candidateThreadId, []];
+            }),
+          ),
+          notFoundThreads: [],
+        });
+      },
+    );
+
+    mockNow(0, context.signal);
+    const first = store.set(catchUpChatEvent$);
+    await vi.waitFor(() => {
+      expect(startedAt).toStrictEqual([0]);
+    });
+    mockNow(100, context.signal);
+    const second = store.set(catchUpChatEvent$);
+    mockNow(200, context.signal);
+    const third = store.set(catchUpChatEvent$);
+
+    mockNow(1000, context.signal);
+    firstRequest.resolve(undefined);
+    await first;
+    await vi.waitFor(() => {
+      expect(startedAt).toStrictEqual([0, 1000]);
+    });
+    mockNow(1100, context.signal);
+    const fourth = store.set(catchUpChatEvent$);
+
+    mockNow(2000, context.signal);
+    secondRequest.resolve(undefined);
+    await Promise.all([second, third]);
+    await fourth;
+    expect(startedAt).toStrictEqual([0, 1000, 2000]);
+  });
+
   it.each(["UnknownError", "TransactionInactiveError", "InvalidStateError"])(
     "reopens IndexedDB and retries a %s transaction once",
     async (errorName) => {
@@ -605,6 +666,82 @@ describe("shared database worker runtime", () => {
       }),
     ).resolves.toStrictEqual([tailRow]);
     expect(requestedSeqIds).toHaveLength(requestCount);
+  });
+
+  it("rebuilds batch misses from a Snapshot and clears deleted thread caches", async () => {
+    const { runtime } = startRuntime();
+    const dataKey = chatEventKey(crypto.randomUUID());
+    const cachedRow = chatEventRow(dataKey.threadId, 1);
+    const snapshotRow = chatEventRow(dataKey.threadId, 5);
+    let phase: "seed" | "rebuild" | "deleted" = "seed";
+    context.mocks.api(chatThreadEventsContract.snapshot, ({ respond }) => {
+      if (phase === "seed") {
+        return respond(404, {
+          error: {
+            code: "CHAT_EVENT_SNAPSHOT_NOT_FOUND",
+            message: "Chat event snapshot not found",
+          },
+        });
+      }
+      if (phase === "deleted") {
+        return respond(404, {
+          error: { code: "NOT_FOUND", message: "Chat thread not found" },
+        });
+      }
+      return respond(200, {
+        url: SNAPSHOT_URL,
+        expiresInSeconds: 900,
+        lastEventId: snapshotRow.id,
+        lastSeqId: snapshotRow.seqId,
+      });
+    });
+    context.mocks.api(chatThreadEventsContract.rows, ({ query, respond }) => {
+      return respond(
+        200,
+        chatEventRowsResponse(
+          phase === "seed" && query.sinceSeqId === 0 ? [cachedRow] : [],
+          query,
+        ),
+      );
+    });
+    context.mocks.api(chatThreadEventsContract.catchUp, ({ respond }) => {
+      return respond(200, {
+        events: {},
+        notFoundThreads: [dataKey.threadId],
+      });
+    });
+    context.mocks.http.get(SNAPSHOT_URL, () => {
+      return new Response(snapshotNdjson([snapshotRow]));
+    });
+
+    await queryRuntime(runtime, {
+      dataKey,
+      afterSeqId: null,
+      consistency: "catch-up",
+    });
+    phase = "rebuild";
+    await expect(
+      runtime.catchUpChatEvents([dataKey.threadId], context.signal),
+    ).resolves.toStrictEqual([dataKey.threadId]);
+    await expect(
+      queryRuntime(runtime, {
+        dataKey,
+        afterSeqId: null,
+        consistency: "cache-only",
+      }),
+    ).resolves.toStrictEqual([snapshotRow]);
+
+    phase = "deleted";
+    await expect(
+      runtime.catchUpChatEvents([dataKey.threadId], context.signal),
+    ).resolves.toStrictEqual([dataKey.threadId]);
+    await expect(
+      queryRuntime(runtime, {
+        dataKey,
+        afterSeqId: null,
+        consistency: "cache-only",
+      }),
+    ).resolves.toStrictEqual([]);
   });
 
   it("runs concurrent connection requests independently and aborts only one connection", async () => {

--- a/turbo/apps/platform/src/shared-database/worker-runtime.ts
+++ b/turbo/apps/platform/src/shared-database/worker-runtime.ts
@@ -110,6 +110,12 @@ interface ChatThreadEventCache {
   readonly degraded: boolean;
 }
 
+interface ChatEventBatchWrite {
+  readonly dataKey: ScopedChatEventDataKey;
+  readonly rows: readonly ChatEventRow[];
+  readonly cursor: ChatEventCursor;
+}
+
 interface SharedDatabaseWorkerRuntimeOptions {
   readonly identity: SharedDatabaseIdentity;
   readonly emit: (message: WorkerRuntimeEvent) => void;
@@ -120,6 +126,13 @@ class SharedDatabaseHttpError extends Error {
   constructor(readonly status: number) {
     super(`Shared database request failed with status ${status}`);
     this.name = "SharedDatabaseHttpError";
+  }
+}
+
+class ChatThreadNotFoundError extends Error {
+  constructor() {
+    super("Chat thread not found");
+    this.name = "ChatThreadNotFoundError";
   }
 }
 
@@ -188,6 +201,17 @@ function mergeChatEventRows(
   return Array.from(byId.values()).sort((left, right) => {
     return left.seqId - right.seqId;
   });
+}
+
+function requireChatEventCursor(
+  cursors: ReadonlyMap<string, ChatEventCursor>,
+  threadId: string,
+): ChatEventCursor {
+  const cursor = cursors.get(threadId);
+  if (!cursor) {
+    throw new Error("ChatEvent catch-up cursor is missing");
+  }
+  return cursor;
 }
 
 function chatThreadEventCursor(
@@ -259,6 +283,263 @@ export class SharedDatabaseWorkerRuntime {
       durationMs: now() - startedAt,
     });
     return result.value;
+  }
+
+  async catchUpChatEvents(
+    requestedThreadIds: readonly string[],
+    signal: AbortSignal,
+  ): Promise<readonly string[]> {
+    signal.throwIfAborted();
+    const threadIds = [...new Set(requestedThreadIds)];
+    if (threadIds.length === 0) {
+      return [];
+    }
+    const dataKeys = threadIds.map((threadId) => {
+      return scopeSharedDatabaseDataKey(
+        { kind: "chat-event", threadId },
+        this.identity,
+      );
+    });
+    const diagnosticDataKey = dataKeys[0];
+    if (!diagnosticDataKey) {
+      throw new Error("ChatEvent catch-up requires a diagnostic data key");
+    }
+    const cachedCursorsResult = await settle(
+      this.runChatIdbOperation(
+        createIdbEventRowStores,
+        (stores) => {
+          return stores.readStore.readCursors(threadIds, signal);
+        },
+        signal,
+      ),
+      signal,
+    );
+    if (!cachedCursorsResult.ok) {
+      reportDataKeyError(
+        diagnosticDataKey,
+        "indexeddb.chat-event-cursors.read.error",
+        cachedCursorsResult.error,
+      );
+    }
+    const cachedCursors = cachedCursorsResult.ok
+      ? cachedCursorsResult.value
+      : new Map<string, ChatEventCursor>();
+    const cursors = new Map<string, ChatEventCursor>(
+      threadIds.map((threadId) => {
+        const cursor: ChatEventCursor = cachedCursors.get(threadId) ?? {
+          lastEventId: null,
+          lastSeqId: THREAD_START_SEQ_ID,
+        };
+        return [threadId, cursor] as const;
+      }),
+    );
+
+    const client = this.createContractClient(chatThreadEventsContract);
+    const response = await client.catchUp({
+      headers: CHAT_EVENT_SCHEMA_VERSION_HEADERS,
+      body: threadIds.map((threadId) => {
+        return [threadId, requireChatEventCursor(cursors, threadId).lastSeqId];
+      }),
+      fetchOptions: { signal },
+    });
+    signal.throwIfAborted();
+    if (response.status === 401) {
+      throw new SharedDatabaseHttpError(response.status);
+    }
+    assertChatEventSchemaVersion(response.headers);
+    if (response.status !== 200) {
+      throw new SharedDatabaseHttpError(response.status);
+    }
+    this.assertChatEventCatchUpPartition(
+      threadIds,
+      cursors,
+      response.body.events,
+      response.body.notFoundThreads,
+    );
+
+    const writes: ChatEventBatchWrite[] = Object.entries(
+      response.body.events,
+    ).map(([threadId, rows]) => {
+      const last = rows.at(-1);
+      return {
+        dataKey: scopeSharedDatabaseDataKey(
+          { kind: "chat-event", threadId },
+          this.identity,
+        ),
+        rows,
+        cursor:
+          last === undefined
+            ? requireChatEventCursor(cursors, threadId)
+            : { lastEventId: last.id, lastSeqId: last.seqId },
+      };
+    });
+    const batchWritten = await this.persistChatEventBatch(writes, signal);
+    const rebuiltThreadIds = await Promise.all(
+      response.body.notFoundThreads.map(async (threadId) => {
+        const dataKey = scopeSharedDatabaseDataKey(
+          { kind: "chat-event", threadId },
+          this.identity,
+        );
+        const rebuilt = await this.replaceChatEventsFromSnapshot(
+          client,
+          dataKey,
+          signal,
+        );
+        return rebuilt ? threadId : null;
+      }),
+    );
+    return [
+      ...(batchWritten
+        ? writes.map(({ dataKey }) => {
+            return dataKey.threadId;
+          })
+        : []),
+      ...rebuiltThreadIds.filter((threadId) => {
+        return threadId !== null;
+      }),
+    ];
+  }
+
+  private assertChatEventCatchUpPartition(
+    threadIds: readonly string[],
+    cursors: ReadonlyMap<string, ChatEventCursor>,
+    events: Readonly<Record<string, readonly ChatEventRow[]>>,
+    notFoundThreads: readonly string[],
+  ): void {
+    const requested = new Set(threadIds);
+    const notFound = new Set(notFoundThreads);
+    if (notFound.size !== notFoundThreads.length) {
+      throw new Error("ChatEvent catch-up returned duplicate missing threads");
+    }
+    for (const threadId of notFound) {
+      if (!requested.has(threadId)) {
+        throw new Error(
+          "ChatEvent catch-up returned an unknown missing thread",
+        );
+      }
+    }
+    for (const [threadId, rows] of Object.entries(events)) {
+      if (!requested.has(threadId) || notFound.has(threadId)) {
+        throw new Error(
+          "ChatEvent catch-up returned an invalid event partition",
+        );
+      }
+      let lastSeqId = requireChatEventCursor(cursors, threadId).lastSeqId;
+      for (const row of rows) {
+        if (row.chatThreadId !== threadId || row.seqId <= lastSeqId) {
+          throw new Error("ChatEvent catch-up returned an invalid event tail");
+        }
+        lastSeqId = row.seqId;
+      }
+    }
+    for (const threadId of requested) {
+      if (!Object.hasOwn(events, threadId) && !notFound.has(threadId)) {
+        throw new Error("ChatEvent catch-up response is incomplete");
+      }
+    }
+  }
+
+  private async persistChatEventBatch(
+    writes: readonly ChatEventBatchWrite[],
+    signal: AbortSignal,
+  ): Promise<boolean> {
+    if (writes.length === 0) {
+      return true;
+    }
+    const written = await settle(
+      this.runChatIdbOperation(
+        createIdbEventRowStores,
+        (stores) => {
+          return stores.writeStore.upsertRowsAndCursors(
+            writes.map(({ dataKey, rows, cursor }) => {
+              return { threadId: dataKey.threadId, rows, cursor };
+            }),
+            signal,
+          );
+        },
+        signal,
+      ),
+      signal,
+    );
+    if (!written.ok) {
+      const firstWrite = writes[0];
+      if (!firstWrite) {
+        throw new Error("ChatEvent batch write diagnostic is missing");
+      }
+      reportDataKeyError(
+        firstWrite.dataKey,
+        "indexeddb.chat-event-batch.write.error",
+        written.error,
+      );
+      return false;
+    }
+    return true;
+  }
+
+  private async replaceChatEventsFromSnapshot(
+    client: ChatEventContractClient,
+    dataKey: ScopedChatEventDataKey,
+    signal: AbortSignal,
+  ): Promise<boolean> {
+    const snapshot = await settle(
+      this.fetchChatEventSnapshot(client, dataKey, signal),
+      signal,
+    );
+    if (!snapshot.ok) {
+      if (snapshot.error instanceof ChatThreadNotFoundError) {
+        return await this.clearChatEventCache(dataKey, signal);
+      }
+      throw snapshot.error;
+    }
+    const state = await settle(
+      this.fetchChatEventRows(
+        { client, dataKey },
+        {
+          remoteRows: snapshot.value.rows,
+          cursor: snapshot.value.cursor,
+          cursorFromServer: true,
+          needsColdStartTailConfirmation: true,
+          replacedCache: true,
+        },
+        signal,
+      ),
+      signal,
+    );
+    if (!state.ok) {
+      if (
+        state.error instanceof SharedDatabaseHttpError &&
+        state.error.status === 404
+      ) {
+        return await this.clearChatEventCache(dataKey, signal);
+      }
+      throw state.error;
+    }
+    return await this.persistChatEventRows(dataKey, state.value, signal);
+  }
+
+  private async clearChatEventCache(
+    dataKey: ScopedChatEventDataKey,
+    signal: AbortSignal,
+  ): Promise<boolean> {
+    const cleared = await settle(
+      this.runChatIdbOperation(
+        createIdbEventRowStores,
+        (stores) => {
+          return stores.writeStore.clearThread(dataKey.threadId, signal);
+        },
+        signal,
+      ),
+      signal,
+    );
+    if (!cleared.ok) {
+      reportDataKeyError(
+        dataKey,
+        "indexeddb.chat-event.clear.error",
+        cleared.error,
+      );
+      return false;
+    }
+    return true;
   }
 
   private async queryData<TKey extends SharedDatabaseDataKey>(
@@ -376,9 +657,9 @@ export class SharedDatabaseWorkerRuntime {
     dataKey: ScopedChatEventDataKey,
     state: ChatEventRemoteState,
     signal: AbortSignal,
-  ): Promise<void> {
+  ): Promise<boolean> {
     if (!state.replacedCache && state.remoteRows.length === 0) {
-      return;
+      return false;
     }
     const written = await settle(
       this.runChatIdbOperation(
@@ -408,7 +689,9 @@ export class SharedDatabaseWorkerRuntime {
         "indexeddb.chat-event.write.error",
         written.error,
       );
+      return false;
     }
+    return true;
   }
 
   private async fetchChatEventRows(
@@ -491,6 +774,9 @@ export class SharedDatabaseWorkerRuntime {
     }
     assertChatEventSchemaVersion(snapshot.headers);
     if (snapshot.status === 404) {
+      if (snapshot.body.error.code !== "CHAT_EVENT_SNAPSHOT_NOT_FOUND") {
+        throw new ChatThreadNotFoundError();
+      }
       return {
         rows: [],
         cursor: { lastEventId: null, lastSeqId: THREAD_START_SEQ_ID },

--- a/turbo/apps/platform/src/shared-database/worker-signals.ts
+++ b/turbo/apps/platform/src/shared-database/worker-signals.ts
@@ -1,5 +1,7 @@
 import type { InboundMessage } from "ably";
 import { command, computed, state } from "ccstate";
+import { replayChatThreadEvents } from "@okouai/core/chat-thread-event-replay";
+import { delay } from "signal-timers";
 
 import {
   derivePlatformServiceOrigin,
@@ -7,6 +9,7 @@ import {
 } from "../lib/platform-host.ts";
 import { CONNECTION_DIAGNOSTICS_PARAM } from "../lib/connection-diagnostics-param.ts";
 import { VERCEL_PROTECTION_BYPASS_NAME } from "../lib/preview-bypass-name.ts";
+import { now } from "../lib/time.ts";
 import { apiClient$ } from "../signals/api-client.ts";
 import { setApiClientRuntime$ } from "../signals/api-client-runtime.ts";
 import { initializeAppVersion$ } from "../signals/app-version.ts";
@@ -33,7 +36,7 @@ import {
   type RealtimeConnectionState,
 } from "../signals/realtime.ts";
 import { rootSignal$, setRootSignal$ } from "../signals/root-signal.ts";
-import { settle } from "../signals/utils.ts";
+import { settle, withCleanup } from "../signals/utils.ts";
 import { clerk$ as workerClerk$ } from "../signals/worker-auth.ts";
 import {
   chatThreadIndicators$,
@@ -82,25 +85,177 @@ function requireRuntime(
   return runtime;
 }
 
-const workerChatThreadIndicators$ = computed(
-  async (get): Promise<ChatThreadIndicators> => {
-    const indicators = await get(chatThreadIndicators$);
-    const signal = get(rootSignal$);
+const CHAT_EVENT_CATCH_UP_THROTTLE_MS = 1000;
+const RECENT_CHAT_EVENT_CATCH_UP_THREAD_COUNT = 100;
+
+interface CatchUpChatEventThrottle {
+  lastStartedAt: number | null;
+  active: Promise<void> | null;
+  trailing: {
+    readonly owner: object;
+    readonly promise: Promise<void>;
+  } | null;
+}
+
+const catchUpChatEventThrottle$ = computed((get): CatchUpChatEventThrottle => {
+  get(rootSignal$).throwIfAborted();
+  return { lastStartedAt: null, active: null, trailing: null };
+});
+
+const executeCatchUpChatEvent$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
     signal.throwIfAborted();
     const runtime = requireRuntime(get(workerRuntimeState$));
-    await Promise.all(
-      Object.keys(indicators.threads).map((threadId) => {
-        return runtime.query(
-          {
-            dataKey: { kind: "chat-event", threadId },
-            afterSeqId: null,
-            consistency: "catch-up",
-          },
-          signal,
-        );
-      }),
+    const [indicators, threadEvents] = await Promise.all([
+      get(chatThreadIndicators$),
+      runtime.query(
+        {
+          dataKey: { kind: "chat-thread-event" },
+          afterSeqId: null,
+          consistency: "cache-only",
+        },
+        signal,
+      ),
+    ]);
+    signal.throwIfAborted();
+    const recentThreadIds = replayChatThreadEvents(
+      threadEvents.snapshot?.chatThreads ?? [],
+      threadEvents.events,
+    )
+      .sort((left, right) => {
+        const sortAt = right.sortAt.localeCompare(left.sortAt);
+        return sortAt === 0 ? right.id.localeCompare(left.id) : sortAt;
+      })
+      .slice(0, RECENT_CHAT_EVENT_CATCH_UP_THREAD_COUNT)
+      .map((thread) => {
+        return thread.id;
+      });
+    const threadIds = [
+      ...new Set([...Object.keys(indicators.threads), ...recentThreadIds]),
+    ];
+    const updatedThreadIds = await runtime.catchUpChatEvents(threadIds, signal);
+    signal.throwIfAborted();
+    for (const threadId of updatedThreadIds) {
+      set(broadcastSharedDatabaseWorkerMessage$, {
+        type: "invalidate",
+        dataKey: { kind: "chat-event", threadId },
+      });
+    }
+  },
+);
+
+const runCatchUpChatEventNow$ = command(
+  async (
+    { set },
+    throttle: CatchUpChatEventThrottle,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    throttle.lastStartedAt = now();
+    const execution = set(executeCatchUpChatEvent$, signal);
+    throttle.active = execution;
+    await withCleanup(execution, () => {
+      if (throttle.active === execution) {
+        throttle.active = null;
+      }
+    });
+  },
+);
+
+const runTrailingCatchUpChatEvent$ = command(
+  async (
+    { set },
+    throttle: CatchUpChatEventThrottle,
+    owner: object,
+    active: Promise<void> | null,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    if (active) {
+      await settle(active, signal);
+    }
+    const remaining = Math.max(
+      0,
+      (throttle.lastStartedAt ?? now()) +
+        CHAT_EVENT_CATCH_UP_THROTTLE_MS -
+        now(),
     );
+    if (remaining > 0) {
+      await delay(remaining, { signal });
+    }
+    if (throttle.trailing?.owner === owner) {
+      throttle.trailing = null;
+    }
+    await set(runCatchUpChatEventNow$, throttle, signal);
+  },
+);
+
+/** Globally serialize ChatEvent catch-up with leading and trailing throttle. */
+export const catchUpChatEvent$ = command(({ get, set }): Promise<void> => {
+  const signal = get(rootSignal$);
+  signal.throwIfAborted();
+  const throttle = get(catchUpChatEventThrottle$);
+  if (throttle.trailing) {
+    return throttle.trailing.promise;
+  }
+  if (
+    throttle.active === null &&
+    (throttle.lastStartedAt === null ||
+      now() - throttle.lastStartedAt >= CHAT_EVENT_CATCH_UP_THROTTLE_MS)
+  ) {
+    return set(runCatchUpChatEventNow$, throttle, signal);
+  }
+  const owner = {};
+  const promise = set(
+    runTrailingCatchUpChatEvent$,
+    throttle,
+    owner,
+    throttle.active,
+    signal,
+  );
+  throttle.trailing = { owner, promise };
+  return promise;
+});
+
+interface WorkerChatThreadIndicatorsCache {
+  source: Promise<ChatThreadIndicators> | null;
+  result: Promise<ChatThreadIndicators> | null;
+}
+
+const workerChatThreadIndicatorsCache$ = computed(
+  (get): WorkerChatThreadIndicatorsCache => {
+    get(rootSignal$).throwIfAborted();
+    return { source: null, result: null };
+  },
+);
+
+const loadWorkerChatThreadIndicators$ = command(
+  async (
+    { set },
+    source: Promise<ChatThreadIndicators>,
+    signal: AbortSignal,
+  ): Promise<ChatThreadIndicators> => {
+    const indicators = await source;
+    signal.throwIfAborted();
+    await set(catchUpChatEvent$);
+    signal.throwIfAborted();
     return indicators;
+  },
+);
+
+const readWorkerChatThreadIndicators$ = command(
+  ({ get, set }): Promise<ChatThreadIndicators> => {
+    const source = get(chatThreadIndicators$);
+    const cache = get(workerChatThreadIndicatorsCache$);
+    if (cache.source === source && cache.result) {
+      return cache.result;
+    }
+    const result = set(
+      loadWorkerChatThreadIndicators$,
+      source,
+      get(rootSignal$),
+    );
+    cache.source = source;
+    cache.result = result;
+    return result;
   },
 );
 
@@ -285,10 +440,10 @@ export const refreshWorkerComputed$ = command(
 );
 
 const refreshWorkerChatIndicators$ = command(
-  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+  async ({ set }, signal: AbortSignal): Promise<void> => {
     signal.throwIfAborted();
     set(reloadWorkerComputed$, "chat-thread-indicators");
-    await get(workerChatThreadIndicators$);
+    await set(readWorkerChatThreadIndicators$);
     signal.throwIfAborted();
   },
 );
@@ -500,7 +655,7 @@ export const getComputedStoreMessage$ = command(
     }
     const value =
       message.computedKey === "chat-thread-indicators"
-        ? await get(workerChatThreadIndicators$)
+        ? await set(readWorkerChatThreadIndicators$)
         : message.computedKey === "computer-use-hosts"
           ? await get(computerUseHosts$)
           : await get(queueData$);

--- a/turbo/apps/platform/src/shared-database/worker-signals.ts
+++ b/turbo/apps/platform/src/shared-database/worker-signals.ts
@@ -39,7 +39,6 @@ import {
   type RealtimeConnectionState,
 } from "../signals/realtime.ts";
 import { rootSignal$, setRootSignal$ } from "../signals/root-signal.ts";
-import { logger } from "../signals/log.ts";
 import { settle, withCleanup } from "../signals/utils.ts";
 import { clerk$ as workerClerk$ } from "../signals/worker-auth.ts";
 import {
@@ -69,8 +68,6 @@ import { SharedDatabaseWorkerRuntime } from "./worker-runtime.ts";
 
 const workerRuntimeState$ = state<SharedDatabaseWorkerRuntime | null>(null);
 const workerDaemonsStartedState$ = state(false);
-const L = logger("SharedDatabaseWorker");
-
 export interface BootstrapSharedDatabaseWorkerOptions {
   readonly appVersion: string;
   readonly identity: SharedDatabaseIdentity;
@@ -98,20 +95,13 @@ const batchChatEventCatchUpEnabled$ = computed(
     const signal = get(rootSignal$);
     signal.throwIfAborted();
     const client = get(apiClient$)(featureSwitchesContract);
-    const response = await settle(
-      accept(client.get({ fetchOptions: { signal } }), [200]),
-      signal,
+    const response = await accept(
+      client.get({ fetchOptions: { signal } }),
+      [200],
     );
-    if (!response.ok) {
-      L.error("feature-switch.load", response.error, {
-        feature: FeatureSwitchKey.BatchChatEventCatchUp,
-      });
-      return false;
-    }
     return (
-      response.value.body.effectiveSwitches[
-        FeatureSwitchKey.BatchChatEventCatchUp
-      ] ?? false
+      response.body.effectiveSwitches[FeatureSwitchKey.BatchChatEventCatchUp] ??
+      false
     );
   },
 );
@@ -223,11 +213,13 @@ const runTrailingCatchUpChatEvent$ = command(
     if (active) {
       await settle(active, signal);
     }
+    const lastStartedAt = throttle.lastStartedAt;
+    if (lastStartedAt === null) {
+      throw new Error("Trailing ChatEvent catch-up has no prior start time");
+    }
     const remaining = Math.max(
       0,
-      (throttle.lastStartedAt ?? now()) +
-        CHAT_EVENT_CATCH_UP_THROTTLE_MS -
-        now(),
+      lastStartedAt + CHAT_EVENT_CATCH_UP_THROTTLE_MS - now(),
     );
     if (remaining > 0) {
       await delay(remaining, { signal });

--- a/turbo/apps/platform/src/shared-database/worker-signals.ts
+++ b/turbo/apps/platform/src/shared-database/worker-signals.ts
@@ -1,6 +1,8 @@
 import type { InboundMessage } from "ably";
 import { command, computed, state } from "ccstate";
+import { featureSwitchesContract } from "@okouai/api-contracts/contracts/feature-switches";
 import { replayChatThreadEvents } from "@okouai/core/chat-thread-event-replay";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { delay } from "signal-timers";
 
 import {
@@ -10,6 +12,7 @@ import {
 import { CONNECTION_DIAGNOSTICS_PARAM } from "../lib/connection-diagnostics-param.ts";
 import { VERCEL_PROTECTION_BYPASS_NAME } from "../lib/preview-bypass-name.ts";
 import { now } from "../lib/time.ts";
+import { accept } from "../lib/accept.ts";
 import { apiClient$ } from "../signals/api-client.ts";
 import { setApiClientRuntime$ } from "../signals/api-client-runtime.ts";
 import { initializeAppVersion$ } from "../signals/app-version.ts";
@@ -36,6 +39,7 @@ import {
   type RealtimeConnectionState,
 } from "../signals/realtime.ts";
 import { rootSignal$, setRootSignal$ } from "../signals/root-signal.ts";
+import { logger } from "../signals/log.ts";
 import { settle, withCleanup } from "../signals/utils.ts";
 import { clerk$ as workerClerk$ } from "../signals/worker-auth.ts";
 import {
@@ -65,6 +69,7 @@ import { SharedDatabaseWorkerRuntime } from "./worker-runtime.ts";
 
 const workerRuntimeState$ = state<SharedDatabaseWorkerRuntime | null>(null);
 const workerDaemonsStartedState$ = state(false);
+const L = logger("SharedDatabaseWorker");
 
 export interface BootstrapSharedDatabaseWorkerOptions {
   readonly appVersion: string;
@@ -87,6 +92,52 @@ function requireRuntime(
 
 const CHAT_EVENT_CATCH_UP_THROTTLE_MS = 1000;
 const RECENT_CHAT_EVENT_CATCH_UP_THREAD_COUNT = 100;
+
+const batchChatEventCatchUpEnabled$ = computed(
+  async (get): Promise<boolean> => {
+    const signal = get(rootSignal$);
+    signal.throwIfAborted();
+    const client = get(apiClient$)(featureSwitchesContract);
+    const response = await settle(
+      accept(client.get({ fetchOptions: { signal } }), [200]),
+      signal,
+    );
+    if (!response.ok) {
+      L.error("feature-switch.load", response.error, {
+        feature: FeatureSwitchKey.BatchChatEventCatchUp,
+      });
+      return false;
+    }
+    return (
+      response.value.body.effectiveSwitches[
+        FeatureSwitchKey.BatchChatEventCatchUp
+      ] ?? false
+    );
+  },
+);
+
+const catchUpLegacyChatEvents$ = command(
+  async (
+    { get },
+    indicators: ChatThreadIndicators,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    signal.throwIfAborted();
+    const runtime = requireRuntime(get(workerRuntimeState$));
+    await Promise.all(
+      Object.keys(indicators.threads).map((threadId) => {
+        return runtime.query(
+          {
+            dataKey: { kind: "chat-event", threadId },
+            afterSeqId: null,
+            consistency: "catch-up",
+          },
+          signal,
+        );
+      }),
+    );
+  },
+);
 
 interface CatchUpChatEventThrottle {
   lastStartedAt: number | null;
@@ -229,13 +280,20 @@ const workerChatThreadIndicatorsCache$ = computed(
 
 const loadWorkerChatThreadIndicators$ = command(
   async (
-    { set },
+    { get, set },
     source: Promise<ChatThreadIndicators>,
     signal: AbortSignal,
   ): Promise<ChatThreadIndicators> => {
-    const indicators = await source;
+    const [indicators, batchCatchUpEnabled] = await Promise.all([
+      source,
+      get(batchChatEventCatchUpEnabled$),
+    ]);
     signal.throwIfAborted();
-    await set(catchUpChatEvent$);
+    if (batchCatchUpEnabled) {
+      await set(catchUpChatEvent$);
+    } else {
+      await set(catchUpLegacyChatEvents$, indicators, signal);
+    }
     signal.throwIfAborted();
     return indicators;
   },

--- a/turbo/apps/platform/src/signals/external/idb-event-row-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-event-row-store.ts
@@ -19,6 +19,10 @@ import { disabledChatIdbError, logChatIdbDisabled } from "./chat-idb-safe.ts";
 const L = logger("ChatEventRowIndexedDb");
 
 interface ChatEventRowReadStore {
+  readCursors(
+    threadIds: readonly string[],
+    signal?: AbortSignal,
+  ): Promise<ReadonlyMap<string, ChatEventCursor>>;
   readCursor(
     threadId: string,
     signal?: AbortSignal,
@@ -31,6 +35,14 @@ interface ChatEventRowReadStore {
 }
 
 interface ChatEventRowWriteStore {
+  upsertRowsAndCursors(
+    entries: readonly {
+      readonly threadId: string;
+      readonly rows: readonly ChatEventRow[];
+      readonly cursor: ChatEventCursor;
+    }[],
+    signal?: AbortSignal,
+  ): Promise<void>;
   upsertRowsAndCursor(
     threadId: string,
     rows: readonly ChatEventRow[],
@@ -99,6 +111,28 @@ function createRowReadStore(
   getDb: GetDb,
 ): ChatEventRowReadStore {
   return {
+    async readCursors(threadIds, signal) {
+      const db = await getDb();
+      signal?.throwIfAborted();
+      const tx = db.transaction(cursorStoreName, "readonly");
+      const rawCursors = await Promise.all(
+        threadIds.map((threadId) => {
+          return tx.store.get(threadId);
+        }),
+      );
+      signal?.throwIfAborted();
+      const cursors = new Map<string, ChatEventCursor>();
+      for (const [index, rawCursor] of rawCursors.entries()) {
+        if (rawCursor !== undefined) {
+          const threadId = threadIds[index];
+          if (threadId === undefined) {
+            throw new Error("Chat Event cursor batch index is invalid");
+          }
+          cursors.set(threadId, storedChatEventCursor(rawCursor));
+        }
+      }
+      return cursors;
+    },
     async readCursor(threadId, signal) {
       const db = await getDb();
       signal?.throwIfAborted();
@@ -140,6 +174,37 @@ function createRowWriteStore(
   getDb: GetDb,
 ): ChatEventRowWriteStore {
   return {
+    async upsertRowsAndCursors(entries, signal) {
+      if (entries.length === 0) {
+        return;
+      }
+      const db = await getDb();
+      signal?.throwIfAborted();
+      const tx = db.transaction([storeName, cursorStoreName], "readwrite");
+      const rowStore = tx.objectStore(storeName);
+      const cursorStore = tx.objectStore(cursorStoreName);
+      const requests = entries.flatMap((entry) => {
+        signal?.throwIfAborted();
+        return [
+          ...entry.rows.map((row) => {
+            return rowStore.put(row);
+          }),
+          cursorStore.put({
+            threadId: entry.threadId,
+            schemaVersion: CURRENT_CHAT_EVENT_SCHEMA_VERSION,
+            lastEventId: entry.cursor.lastEventId,
+            lastSeqId: entry.cursor.lastSeqId,
+          }),
+        ];
+      });
+      await Promise.all([...requests, tx.done]);
+      L.debug("upsertRowsAndCursors:done", {
+        threadCount: entries.length,
+        rowCount: entries.reduce((count, entry) => {
+          return count + entry.rows.length;
+        }, 0),
+      });
+    },
     async upsertRowsAndCursor(threadId, rows, cursor, signal) {
       L.debug("upsertRows:start", { count: rows.length });
       const db = await getDb();

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -57,6 +57,13 @@ const chatEventSnapshotResponseSchema = z.union([
     lastSeqId: z.number().int().positive(),
   }),
 ]);
+const chatEventCatchUpBodySchema = z.array(
+  z.tuple([z.string().uuid(), z.number().int().nonnegative()]),
+);
+const chatEventCatchUpResponseSchema = z.object({
+  events: z.record(z.string().uuid(), z.array(chatEventRowSchema)),
+  notFoundThreads: z.array(z.string().uuid()),
+});
 export const MODEL_FIRST_SELECTION_PROVIDER_ID =
   "00000000-0000-4000-8000-000000000000";
 
@@ -1809,6 +1816,27 @@ export const chatSearchContract = c.router({
 
 /** Canonical ChatEvent read contract. */
 export const chatThreadEventsContract = c.router({
+  /**
+   * Batch tail read for the SharedWorker cache. Every requested thread is
+   * returned exactly once: either as a complete raw-row tail (including an
+   * empty tail) or in `notFoundThreads` when the supplied cursor cannot be
+   * continued and the client must rebuild from a Snapshot.
+   */
+  catchUp: {
+    method: "POST",
+    path: "/api/chat/events/catch-up",
+    headers: chatEventReadHeadersSchema,
+    body: chatEventCatchUpBodySchema,
+    responses: {
+      200: chatEventCatchUpResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      409: apiErrorSchema,
+      426: apiErrorSchema,
+    },
+    summary: "Catch up raw chat events for multiple threads",
+  },
   /**
    * Snapshot-read cold start: a presigned download for the thread's head
    * archive object. The object is gzip NDJSON of chatEventRowSchema lines

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -167,6 +167,7 @@ describe("getAllFeatureStates", () => {
     });
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.BatchChatEventCatchUp]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PiLoop]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PiMemoryRecall]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PiMemoryGeneration]).toBe(false);
@@ -190,6 +191,7 @@ describe("getAllFeatureStates", () => {
     });
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.BatchChatEventCatchUp]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PiLoop]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PiMemoryRecall]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PiMemoryGeneration]).toBe(false);

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -51,6 +51,7 @@ export enum FeatureSwitchKey {
   ZapierConnector = "zapierConnector",
   ComputerUseDesktopPlugins = "computerUseDesktopPlugins",
   ChatErrorRecovery = "chatErrorRecovery",
+  BatchChatEventCatchUp = "batchChatEventCatchUp",
   ResponsiveFollowupCards = "responsiveFollowupCards",
   SidebarSubscriptionUsage = "_sidebarSubscriptionUsage",
   PersonalModelProviderAccounts = "_multipleSubscriptions",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -376,6 +376,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.BatchChatEventCatchUp]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Catch up unread, active, and recent ChatEvent threads through one throttled SharedWorker batch.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ComposerImageAnnotation]: {
     maintainer: "tongx@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- add an exhaustive batch ChatEvent catch-up endpoint that accepts `[threadId, lastSeqId][]` and returns complete tails or `notFoundThreads`
- prewarm unread/active threads plus the 100 most recent IDB-only lifecycle threads, persist successful tails in one IDB transaction, and rebuild misses from Snapshot
- add a SharedWorker-global, root-signal-owned 1-second leading/trailing throttle that coalesces triggers and serializes slow batches
- gate the batch strategy behind the staff-enabled `batchChatEventCatchUp` feature switch
- preserve the previous unread/active per-thread catch-up when the switch is disabled
- fail fast when feature switches cannot be loaded instead of silently selecting the legacy strategy
- intentionally omit an old-API fallback because the API deploys first

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm check-types`
- `pnpm knip`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-event-snapshot.test.ts -t "returns complete batch tails and partitions cursors that need a Snapshot"`
- `pnpm --filter @okouai/app exec vitest run src/shared-database/__tests__/worker-runtime.test.ts src/shared-database/__tests__/platform-direct-bridge.test.ts`
- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts`
