### PR TITLE
ci: remove app post-deploy version checks

### DIFF
--- a/.github/scripts/tests/deploy-okou-pages-workflow-test.sh
+++ b/.github/scripts/tests/deploy-okou-pages-workflow-test.sh
@@ -327,7 +327,6 @@ worker_release_source = require_fragments(
         "wrangler deploy",
         "--env production",
         '--message "app artifact ${ARTIFACT_SHA}"',
-        "bash .github/scripts/verify-okou-app-runtime.sh",
         '"https://app.vm0.ai|https://api.vm0.ai"',
         '"https://app.okou.ai|https://api.okou.ai"',
         '"https://app-worker.vm0.ai|https://api.vm0.ai"',
@@ -343,8 +342,6 @@ if worker_release_step.get("env", {}).get("CLOUDFLARE_API_TOKEN") != (
     "${{ secrets.CF_API_WORKER_DEPLOY_API_TOKEN }}"
 ):
     raise RuntimeError("production Worker deployment must use the Worker token")
-if worker_release_step.get("env", {}).get("OKOU_APP_RUNTIME_MAX_ATTEMPTS") != "60":
-    raise RuntimeError("production Worker must use bounded convergence probes")
 if worker_release_step.get("env", {}).get("CF_PAGES_PROJECT_NAME") != (
     "${{ vars.CF_PAGES_PROJECT_NAME }}"
 ):
@@ -352,7 +349,7 @@ if worker_release_step.get("env", {}).get("CF_PAGES_PROJECT_NAME") != (
 if worker_release_source.count("wrangler deploy") != 1:
     raise RuntimeError("production Worker must deploy exactly once")
 if worker_release_finish_step.get("with", {}).get("status") != "${{ job.status }}":
-    raise RuntimeError("production Worker deployment must report failed verification")
+    raise RuntimeError("production Worker deployment must report its final job status")
 if worker_release_start_step.get("with", {}).get("env") != "app/production":
     raise RuntimeError("production Worker must own the canonical App deployment")
 if release_start_step.get("with", {}).get("env") != "app-pages/production-shadow":
@@ -421,27 +418,21 @@ release_step_source = require_fragments(
         '"$CF_PAGES_PROJECT_NAME"',
         "production",
         '"$ARTIFACT_SHA"',
-        "bash .github/scripts/verify-okou-app-runtime.sh",
-        '"$pages_url"',
-        '"https://static.okou.io/okou-app/assets"',
-        '"$CANONICAL_ASSETS"',
         'echo "url=$pages_url"',
     ],
 )
 if release_step_source.count(shared_script) != 1:
-    raise RuntimeError(
-        "production readiness polling must follow exactly one Pages deployment"
-    )
+    raise RuntimeError("production must run exactly one Pages deployment")
 runtime_verifier = "bash .github/scripts/verify-okou-app-runtime.sh"
 domain_verifier = "bash .github/scripts/verify-okou-production-domains.sh"
 if not (
     release_step_source.index(shared_script)
-    < release_step_source.index(runtime_verifier)
     < release_step_source.index('echo "url=$pages_url"')
 ):
-    raise RuntimeError(
-        "Pages fallback readiness must finish before success output"
-    )
+    raise RuntimeError("Pages fallback deployment must finish before success output")
+for deployment_source in (release_step_source, worker_release_source):
+    if runtime_verifier in deployment_source:
+        raise RuntimeError("Release Please App deployment must trust Cloudflare success")
 for fragment in (domain_verifier, '"https://app.vm0.ai"', '"https://app.okou.ai"'):
     if fragment in release_step_source:
         raise RuntimeError(
@@ -449,28 +440,19 @@ for fragment in (domain_verifier, '"https://app.vm0.ai"', '"https://app.okou.ai"
         )
 if not (
     worker_release_source.index("wrangler deploy")
-    < worker_release_source.index(runtime_verifier)
     < worker_release_source.index(domain_verifier)
 ):
     raise RuntimeError(
-        "production Worker deployment must verify live runtime and domains before success"
+        "production Worker deployment must verify domains after Cloudflare succeeds"
     )
-if release_step.get("env", {}).get("CANONICAL_ASSETS") != (
-    "${{ steps.pages-production.outputs.canonical-dist }}/assets"
-):
-    raise RuntimeError("production deploy must verify the canonical App bundles")
-if release_step.get("env", {}).get("OKOU_APP_RUNTIME_MAX_ATTEMPTS") != "60":
-    raise RuntimeError("production runtime convergence must use 60 bounded probes")
 if not (
     release_steps.index(release_step) < release_steps.index(release_finish_step)
 ):
     raise RuntimeError(
-        "production readiness must finish before the GitHub Deployment is reported"
+        "production deployment must finish before the GitHub Deployment is reported"
     )
 if release_finish_step.get("with", {}).get("status") != "${{ job.status }}":
-    raise RuntimeError(
-        "GitHub Deployment completion must fail closed on readiness verification"
-    )
+    raise RuntimeError("GitHub Deployment completion must report its final job status")
 require_fragments(
     rollback_step,
     [shared_script, '"$PAGES_DIST"', '"$CF_PAGES_PROJECT_NAME"', "production", '"$TARGET_COMMIT"'],

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1644,11 +1644,9 @@ jobs:
       - name: Deploy App Worker production
         env:
           ARTIFACT_SHA: ${{ steps.build-commit.outputs.sha }}
-          CANONICAL_ASSETS: ${{ steps.worker-production.outputs.canonical-dist }}/assets
           CF_PAGES_PROJECT_NAME: ${{ vars.CF_PAGES_PROJECT_NAME }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CF_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_WORKER_DEPLOY_API_TOKEN }}
-          OKOU_APP_RUNTIME_MAX_ATTEMPTS: "60"
         run: |
           set -euo pipefail
 
@@ -1668,11 +1666,6 @@ jobs:
             "https://app-worker.vm0.ai|https://api.vm0.ai" \
             "https://app-worker.okou.ai|https://api.okou.ai"; do
             IFS='|' read -r app_origin api_origin <<< "$mapping"
-            bash .github/scripts/verify-okou-app-runtime.sh \
-              "$app_origin" \
-              "https://static.okou.io/okou-app/assets" \
-              "$CANONICAL_ASSETS"
-
             cors_result="$(
               curl -fsS \
                 --connect-timeout 10 \
@@ -1920,11 +1913,9 @@ jobs:
         id: deploy-pages
         env:
           ARTIFACT_SHA: ${{ steps.build-commit.outputs.sha }}
-          CANONICAL_ASSETS: ${{ steps.pages-production.outputs.canonical-dist }}/assets
           CF_PAGES_PROJECT_NAME: ${{ vars.CF_PAGES_PROJECT_NAME }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CF_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_DEPLOY_API_TOKEN }}
-          OKOU_APP_RUNTIME_MAX_ATTEMPTS: "60"
           PAGES_DIST: ${{ steps.pages-production.outputs.pages-dist }}
         run: |
           set -euo pipefail
@@ -1935,10 +1926,6 @@ jobs:
             "$ARTIFACT_SHA"
 
           pages_url="https://${CF_PAGES_PROJECT_NAME}.pages.dev"
-          bash .github/scripts/verify-okou-app-runtime.sh \
-            "$pages_url" \
-            "https://static.okou.io/okou-app/assets" \
-            "$CANONICAL_ASSETS"
           echo "url=$pages_url" >> "$GITHUB_OUTPUT"
 
       - name: Resolve Cloudflare Pages dashboard URL


### PR DESCRIPTION
## Summary

- trust successful Cloudflare Pages and Worker deploy commands instead of polling deployed build metadata
- keep pre-deploy artifact checks and version-independent production domain/CORS checks
- update the Release Please workflow contract test

## Tests

- bash .github/scripts/tests/deploy-okou-pages-workflow-test.sh
- bash -n .github/scripts/tests/deploy-okou-pages-workflow-test.sh
- actionlint .github/workflows/release-please.yml
- pnpm exec prettier --check ../.github/workflows/release-please.yml
- git diff --check