### PR TITLE
fix: surface paused goal context in thread runs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1998,6 +1998,7 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     expect(goalContext.body.prompt).not.toContain(goalObjective);
     const appendSystemPrompt = goalContext.body.appendSystemPrompt ?? "";
     expect(appendSystemPrompt).toContain("# Active thread goal");
+    expect(appendSystemPrompt).not.toContain("# Thread Goal\n\nStatus: paused");
     expect(appendSystemPrompt).toContain(goalObjective);
     expect(appendSystemPrompt).toContain("# User-visible objective brief");
     expect(appendSystemPrompt).toContain(goalBrief);
@@ -2029,6 +2030,60 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
       eventType: "goal.close",
       content: null,
     });
+  }, 90_000);
+
+  it("adds paused goal context to a later thread run", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    await enableGoalWorkflows(actor);
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const first = await startChatRun(actor, {
+      agentId,
+      prompt: "pause this goal before finishing",
+    });
+    const goalBrief = "Keep improving the paused goal context";
+    await createGoalForRun(actor, first.runId, goalBrief);
+    const paused = await accept(
+      goalsClient().pause({
+        headers: goalHeaders(actor, first.runId),
+      }),
+      [200],
+    );
+    expect(paused.body.status).toBe("paused");
+
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(0, "finished after pausing the goal"),
+    ]);
+    const sandboxHeaders = await claimChatRun(runnerGroup, first.runId);
+    await completeChatRunOk(first.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+    await flushWaitUntilForTest();
+
+    const second = await startChatRun(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "handle a new user request",
+    });
+    const runContext = await waitForRunContext(actor, second.runId);
+    const appendSystemPrompt = runContext.body.appendSystemPrompt ?? "";
+    expect(appendSystemPrompt).toContain(`# Thread Goal
+
+Status: paused
+Objective: ${goalBrief}
+
+A paused goal does not continue automatically.
+
+Goal CLI:
+- Check: \`okou goal get\`
+- Resume: \`okou goal resume\`
+- Block: \`okou goal block\`
+- Complete: \`okou goal complete\``);
+    expect(appendSystemPrompt).not.toContain("okou goal pause");
+
+    await api.requestCancelRun(actor, second.runId, [200]);
+    await waitForRunStatus(actor, second.runId, "cancelled");
+    await flushWaitUntilForTest();
   }, 90_000);
 
   it("falls back to the terminal scheduler when the chat callback fails", async () => {

--- a/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
@@ -27,6 +27,7 @@ import {
 import { agentSessions } from "@okouai/db/schema/agent-session";
 import { agents } from "@okouai/db/schema/agent";
 import { orgMetadata } from "@okouai/db/schema/org-metadata";
+import { threadGoals } from "@okouai/db/schema/thread-goal";
 import { command } from "ccstate";
 import { and, eq } from "drizzle-orm";
 import type { z } from "zod";
@@ -1055,6 +1056,40 @@ interface AgentRunAfterPreCreate {
   readonly threadSessionResolution?: ChatThreadSessionResolution;
 }
 
+async function resolvePausedThreadGoalPrompt(
+  db: Db,
+  args: { readonly orgId: string; readonly threadId: string },
+): Promise<string | undefined> {
+  const [goal] = await db
+    .select({ objectiveBrief: threadGoals.objectiveBrief })
+    .from(threadGoals)
+    .where(
+      and(
+        eq(threadGoals.orgId, args.orgId),
+        eq(threadGoals.chatThreadId, args.threadId),
+        eq(threadGoals.status, "paused"),
+      ),
+    )
+    .limit(1);
+
+  if (!goal) {
+    return undefined;
+  }
+
+  return `# Thread Goal
+
+Status: paused
+Objective: ${goal.objectiveBrief}
+
+A paused goal does not continue automatically.
+
+Goal CLI:
+- Check: \`okou goal get\`
+- Resume: \`okou goal resume\`
+- Block: \`okou goal block\`
+- Complete: \`okou goal complete\``;
+}
+
 async function resolveThreadSessionForAgentRun(
   db: Db,
   input: AgentRunAfterPreCreate,
@@ -1081,8 +1116,12 @@ async function resolveThreadSessionForAgentRun(
       });
     },
   );
+  const pausedThreadGoalPrompt = await resolvePausedThreadGoalPrompt(db, {
+    orgId: input.command.auth.orgId,
+    threadId,
+  });
   const webChatSessionPromptContext = input.command.webChatSessionPromptContext;
-  const appendSystemPrompt = webChatSessionPromptContext
+  const sessionPrompt = webChatSessionPromptContext
     ? await measureZeroPreCreate(
         input.timing,
         "api_dispatch_pre_create_zero_web_chat_resolve_session_prompt_context",
@@ -1096,6 +1135,16 @@ async function resolveThreadSessionForAgentRun(
         },
       )
     : input.command.appendSystemPrompt;
+  const appendSystemPromptParts = [
+    pausedThreadGoalPrompt,
+    sessionPrompt,
+  ].filter((part): part is string => {
+    return Boolean(part);
+  });
+  const appendSystemPrompt =
+    appendSystemPromptParts.length > 0
+      ? appendSystemPromptParts.join("\n\n")
+      : undefined;
   const body: AgentRunCreateBody = { ...input.command.body };
   if (resolution.sessionId) {
     body.sessionId = resolution.sessionId;


### PR DESCRIPTION
## Summary

- inject the current paused Goal status and objective into every thread-bound run's system context
- explain that paused Goals do not continue automatically and expose the relevant `okou goal` commands
- leave active, blocked, and complete Goal behavior unchanged

## Verification

- `pnpm exec prettier --write apps/api/src/signals/services/agent-runs-create.service.ts apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts`
- `pnpm --filter api lint`
- `pnpm --filter api check-types`
- `pnpm knip`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts -t "sources the goal system prompt from thread goals|adds paused goal context to a later thread run"` (2 passed, 54 skipped)

## Scope

- no incomplete-history provenance changes
- no new feature switch; this corrects existing Goal behavior
