### PR TITLE
test(api): isolate workflow watch renewal scopes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
@@ -1,10 +1,8 @@
 import { randomUUID } from "node:crypto";
 
-import {
-  cronRenewGoogleCalendarWatchesContract,
-  cronRenewGoogleFormsWatchesContract,
-} from "@okouai/api-contracts/contracts/cron";
 import { testGmailWatchRenewalContract } from "@okouai/api-contracts/contracts/test-gmail-watch-renewal";
+import { testGoogleCalendarWatchRenewalContract } from "@okouai/api-contracts/contracts/test-google-calendar-watch-renewal";
+import { testGoogleFormsWatchRenewalContract } from "@okouai/api-contracts/contracts/test-google-forms-watch-renewal";
 import {
   workflowAutomationsContract,
   workflowsDetailContract,
@@ -50,6 +48,8 @@ import { cronRenewGmailWatchesRoutes } from "../cron-renew-gmail-watches";
 import { cronRenewGoogleCalendarWatchesRoutes } from "../cron-renew-google-calendar-watches";
 import { cronRenewGoogleFormsWatchesRoutes } from "../cron-renew-google-forms-watches";
 import { testGmailWatchRenewalRoutes } from "../test-gmail-watch-renewal";
+import { testGoogleCalendarWatchRenewalRoutes } from "../test-google-calendar-watch-renewal";
+import { testGoogleFormsWatchRenewalRoutes } from "../test-google-forms-watch-renewal";
 import { workflowAutomationsRoutes } from "../workflow-automations";
 import { workflowsRoutes } from "../workflows";
 import { webhooksGoogleCalendarRoutes } from "../webhooks-google-calendar";
@@ -94,15 +94,15 @@ function renewGmailWatchScopeClient() {
   );
 }
 
-function renewGoogleCalendarWatchesClient() {
-  return setupApp({ context, routes: cronRenewGoogleCalendarWatchesRoutes })(
-    cronRenewGoogleCalendarWatchesContract,
+function renewGoogleCalendarWatchScopeClient() {
+  return setupApp({ context, routes: testGoogleCalendarWatchRenewalRoutes })(
+    testGoogleCalendarWatchRenewalContract,
   );
 }
 
-function renewGoogleFormsWatchesClient() {
-  return setupApp({ context, routes: cronRenewGoogleFormsWatchesRoutes })(
-    cronRenewGoogleFormsWatchesContract,
+function renewGoogleFormsWatchScopeClient() {
+  return setupApp({ context, routes: testGoogleFormsWatchRenewalRoutes })(
+    testGoogleFormsWatchRenewalContract,
   );
 }
 
@@ -148,8 +148,6 @@ const NOTION_DATABASE_URL =
   "https://www.notion.so/22222222222242228222222222222222?v=aaaaaaaaaaaa4aaa8aaaaaaaaaaaaaaa&source=copy_link";
 const NOTION_DATA_SOURCE_URL =
   "https://www.notion.so/Bug-Bash-33333333333343338333333333333333";
-const CRON_SECRET = "workflow-watch-lifecycle-cron-secret";
-
 interface WorkflowsFixture {
   readonly orgId: string;
   readonly userId: string;
@@ -1816,7 +1814,6 @@ describe("okou workflow automations", () => {
   });
 
   it("renews a Google Forms watch in place", async () => {
-    mockEnv("CRON_SECRET", CRON_SECRET);
     const startedAt = Date.parse("2026-08-05T10:00:00.000Z");
     mockNow(startedAt);
     const scenario = await setupFixture();
@@ -1873,14 +1870,20 @@ describe("okou workflow automations", () => {
     mockNow(startedAt + 6 * 24 * 60 * 60 * 1000);
 
     const renewed = await accept(
-      renewGoogleFormsWatchesClient().renew({
-        headers: { authorization: `Bearer ${CRON_SECRET}` },
+      renewGoogleFormsWatchScopeClient().renew({
+        body: {
+          org_id: scenario.fixture.orgId,
+          user_id: scenario.fixture.userId,
+        },
       }),
       [200],
     );
     const unchanged = await accept(
-      renewGoogleFormsWatchesClient().renew({
-        headers: { authorization: `Bearer ${CRON_SECRET}` },
+      renewGoogleFormsWatchScopeClient().renew({
+        body: {
+          org_id: scenario.fixture.orgId,
+          user_id: scenario.fixture.userId,
+        },
       }),
       [200],
     );
@@ -1900,7 +1903,6 @@ describe("okou workflow automations", () => {
   });
 
   it("does not count a stopped Google Forms watch as renewed", async () => {
-    mockEnv("CRON_SECRET", CRON_SECRET);
     const scenario = await setupFixture();
     await enableGoogleFormsWorkflowAutomations(scenario.fixture);
     await connectGoogleForms(scenario);
@@ -1952,8 +1954,11 @@ describe("okou workflow automations", () => {
     );
 
     const reconciled = await accept(
-      renewGoogleFormsWatchesClient().renew({
-        headers: { authorization: `Bearer ${CRON_SECRET}` },
+      renewGoogleFormsWatchScopeClient().renew({
+        body: {
+          org_id: scenario.fixture.orgId,
+          user_id: scenario.fixture.userId,
+        },
       }),
       [200],
     );
@@ -3367,7 +3372,6 @@ describe("okou workflow automations", () => {
   });
 
   it("retries an inactive Calendar stop without renewing the channel", async () => {
-    mockEnv("CRON_SECRET", CRON_SECRET);
     const scenario = await setupFixture();
     await connectGoogleCalendar(scenario);
     const watch = configureGoogleCalendarWatchMock();
@@ -3393,8 +3397,11 @@ describe("okou workflow automations", () => {
     expect(stop.calls).toBe(1);
 
     const reconciled = await accept(
-      renewGoogleCalendarWatchesClient().renew({
-        headers: { authorization: `Bearer ${CRON_SECRET}` },
+      renewGoogleCalendarWatchScopeClient().renew({
+        body: {
+          org_id: scenario.fixture.orgId,
+          user_id: scenario.fixture.userId,
+        },
       }),
       [200],
     );
@@ -3412,7 +3419,6 @@ describe("okou workflow automations", () => {
   });
 
   it("repairs a missing exact Calendar watch in the renewal pass", async () => {
-    mockEnv("CRON_SECRET", CRON_SECRET);
     const scenario = await setupFixture();
     await connectGoogleCalendar(scenario);
     const initialWatch = configureGoogleCalendarWatchMock();
@@ -3449,8 +3455,11 @@ describe("okou workflow automations", () => {
 
     const repairedWatch = configureGoogleCalendarWatchMock();
     const reconciled = await accept(
-      renewGoogleCalendarWatchesClient().renew({
-        headers: { authorization: `Bearer ${CRON_SECRET}` },
+      renewGoogleCalendarWatchScopeClient().renew({
+        body: {
+          org_id: scenario.fixture.orgId,
+          user_id: scenario.fixture.userId,
+        },
       }),
       [200],
     );
@@ -3465,7 +3474,6 @@ describe("okou workflow automations", () => {
   });
 
   it("retains a replaced Calendar channel until its stop succeeds", async () => {
-    mockEnv("CRON_SECRET", CRON_SECRET);
     const startedAt = Date.parse("2026-08-05T08:00:00.000Z");
     mockNow(startedAt);
     const scenario = await setupFixture();
@@ -3495,8 +3503,11 @@ describe("okou workflow automations", () => {
     );
     mockNow(startedAt + 6 * 24 * 60 * 60 * 1000);
     const renewed = await accept(
-      renewGoogleCalendarWatchesClient().renew({
-        headers: { authorization: `Bearer ${CRON_SECRET}` },
+      renewGoogleCalendarWatchScopeClient().renew({
+        body: {
+          org_id: scenario.fixture.orgId,
+          user_id: scenario.fixture.userId,
+        },
       }),
       [200],
     );
@@ -3512,8 +3523,11 @@ describe("okou workflow automations", () => {
     ]);
 
     const reconciled = await accept(
-      renewGoogleCalendarWatchesClient().renew({
-        headers: { authorization: `Bearer ${CRON_SECRET}` },
+      renewGoogleCalendarWatchScopeClient().renew({
+        body: {
+          org_id: scenario.fixture.orgId,
+          user_id: scenario.fixture.userId,
+        },
       }),
       [200],
     );
@@ -3539,7 +3553,6 @@ describe("okou workflow automations", () => {
   });
 
   it("self-heals a renamed primary Calendar target without crossing accounts", async () => {
-    mockEnv("CRON_SECRET", CRON_SECRET);
     mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
     const legacyCalendarId = "legacy-primary@example.com";
     const firstAccessToken = "renamed-primary-first-token";
@@ -3674,15 +3687,32 @@ describe("okou workflow automations", () => {
       [201],
     );
 
-    const renewed = await accept(
-      renewGoogleCalendarWatchesClient().renew({
-        headers: { authorization: `Bearer ${CRON_SECRET}` },
+    const firstRenewed = await accept(
+      renewGoogleCalendarWatchScopeClient().renew({
+        body: {
+          org_id: first.fixture.orgId,
+          user_id: first.fixture.userId,
+        },
       }),
       [200],
     );
-    expect(renewed.body).toStrictEqual({
+    const secondRenewed = await accept(
+      renewGoogleCalendarWatchScopeClient().renew({
+        body: {
+          org_id: second.fixture.orgId,
+          user_id: second.fixture.userId,
+        },
+      }),
+      [200],
+    );
+    expect(firstRenewed.body).toStrictEqual({
       success: true,
-      renewed: 2,
+      renewed: 1,
+      failed: 0,
+    });
+    expect(secondRenewed.body).toStrictEqual({
+      success: true,
+      renewed: 1,
       failed: 0,
     });
 
@@ -3739,7 +3769,6 @@ describe("okou workflow automations", () => {
   });
 
   it("does not remap a shared Calendar when provider resources differ", async () => {
-    mockEnv("CRON_SECRET", CRON_SECRET);
     mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
     const sharedCalendarId = "shared-calendar@example.com";
     const accessToken = "shared-calendar-token";
@@ -3816,8 +3845,11 @@ describe("okou workflow automations", () => {
     );
 
     const renewed = await accept(
-      renewGoogleCalendarWatchesClient().renew({
-        headers: { authorization: `Bearer ${CRON_SECRET}` },
+      renewGoogleCalendarWatchScopeClient().renew({
+        body: {
+          org_id: scenario.fixture.orgId,
+          user_id: scenario.fixture.userId,
+        },
       }),
       [200],
     );

--- a/turbo/apps/api/src/signals/routes/test-google-calendar-watch-renewal.ts
+++ b/turbo/apps/api/src/signals/routes/test-google-calendar-watch-renewal.ts
@@ -1,0 +1,51 @@
+import { testGoogleCalendarWatchRenewalContract } from "@okouai/api-contracts/contracts/test-google-calendar-watch-renewal";
+import { command } from "ccstate";
+
+import { request$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route-entry";
+import { renewGoogleCalendarWatchScope$ } from "../services/google-calendar-automation-event.service";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-endpoint-helpers";
+
+const body$ = bodyResultOf(testGoogleCalendarWatchRenewalContract.renew);
+
+const renewGoogleCalendarWatchScopeRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+
+    const bodyResult = await get(body$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const result = await set(
+      renewGoogleCalendarWatchScope$,
+      {
+        orgId: bodyResult.data.org_id,
+        userId: bodyResult.data.user_id,
+      },
+      signal,
+    );
+    return {
+      status: 200 as const,
+      body: {
+        success: true as const,
+        renewed: result.renewed,
+        failed: result.failed,
+      },
+    };
+  },
+);
+
+export const testGoogleCalendarWatchRenewalRoutes: readonly RouteEntry[] = [
+  {
+    route: testGoogleCalendarWatchRenewalContract.renew,
+    handler: renewGoogleCalendarWatchScopeRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/test-google-forms-watch-renewal.ts
+++ b/turbo/apps/api/src/signals/routes/test-google-forms-watch-renewal.ts
@@ -1,0 +1,51 @@
+import { testGoogleFormsWatchRenewalContract } from "@okouai/api-contracts/contracts/test-google-forms-watch-renewal";
+import { command } from "ccstate";
+
+import { request$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route-entry";
+import { renewGoogleFormsWatchScope$ } from "../services/google-forms-automation-event.service";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-endpoint-helpers";
+
+const body$ = bodyResultOf(testGoogleFormsWatchRenewalContract.renew);
+
+const renewGoogleFormsWatchScopeRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+
+    const bodyResult = await get(body$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const result = await set(
+      renewGoogleFormsWatchScope$,
+      {
+        orgId: bodyResult.data.org_id,
+        userId: bodyResult.data.user_id,
+      },
+      signal,
+    );
+    return {
+      status: 200 as const,
+      body: {
+        success: true as const,
+        renewed: result.renewed,
+        failed: result.failed,
+      },
+    };
+  },
+);
+
+export const testGoogleFormsWatchRenewalRoutes: readonly RouteEntry[] = [
+  {
+    route: testGoogleFormsWatchRenewalContract.renew,
+    handler: renewGoogleFormsWatchScopeRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
@@ -3690,6 +3690,36 @@ export const dispatchGoogleCalendarWebhook$ = command(
   },
 );
 
+async function renewGoogleCalendarWatchStates(
+  args: {
+    readonly db: Db;
+    readonly states: readonly {
+      readonly connectorId: string;
+      readonly calendarId: string;
+    }[];
+    readonly renewBefore: Date;
+  },
+  signal: AbortSignal,
+): Promise<{ readonly renewed: number; readonly failed: number }> {
+  let renewed = 0;
+  let failed = 0;
+  for (const state of args.states) {
+    const result = await reconcileGoogleCalendarWatchState(
+      {
+        db: args.db,
+        connectorId: state.connectorId,
+        calendarId: state.calendarId,
+        renewBefore: args.renewBefore,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    renewed += result.kind === "renewed" ? 1 : 0;
+    failed += result.kind === "failed" ? 1 : 0;
+  }
+  return { renewed, failed };
+}
+
 export const renewGoogleCalendarWatches$ = command(
   async ({ set }, signal: AbortSignal) => {
     const db = set(writeDb$);
@@ -3758,22 +3788,57 @@ export const renewGoogleCalendarWatches$ = command(
       .from(googleCalendarWatchStates);
     signal.throwIfAborted();
 
-    let renewed = 0;
-    for (const state of states) {
-      const result = await reconcileGoogleCalendarWatchState(
-        {
-          db,
-          connectorId: state.connectorId,
-          calendarId: state.calendarId,
-          renewBefore,
-        },
-        signal,
-      );
-      signal.throwIfAborted();
-      renewed += result.kind === "renewed" ? 1 : 0;
-      failed += result.kind === "failed" ? 1 : 0;
-    }
+    const renewedStates = await renewGoogleCalendarWatchStates(
+      { db, states, renewBefore },
+      signal,
+    );
+    return {
+      renewed: renewedStates.renewed,
+      failed: failed + renewedStates.failed,
+    };
+  },
+);
 
-    return { renewed, failed };
+export const renewGoogleCalendarWatchScope$ = command(
+  async (
+    { set },
+    owner: { readonly orgId: string; readonly userId: string },
+    signal: AbortSignal,
+  ) => {
+    const db = set(writeDb$);
+    const renewBefore = new Date(nowDate().getTime() + WATCH_RENEWAL_WINDOW_MS);
+    const prepared = await repairAndEnsureGoogleCalendarWatchesForOwner(
+      { db, ...owner, ensureRefreshRequired: false },
+      signal,
+    );
+    signal.throwIfAborted();
+    if (!prepared) {
+      log.warn("Google Calendar watch repair failed", {
+        provider: "google_calendar",
+        action: "repair",
+        result: "provider_error",
+      });
+    }
+    const states = await db
+      .select({
+        connectorId: googleCalendarWatchStates.connectorId,
+        calendarId: googleCalendarWatchStates.calendarId,
+      })
+      .from(googleCalendarWatchStates)
+      .where(
+        and(
+          eq(googleCalendarWatchStates.orgId, owner.orgId),
+          eq(googleCalendarWatchStates.userId, owner.userId),
+        ),
+      );
+    signal.throwIfAborted();
+    const renewedStates = await renewGoogleCalendarWatchStates(
+      { db, states, renewBefore },
+      signal,
+    );
+    return {
+      renewed: renewedStates.renewed,
+      failed: renewedStates.failed + (prepared ? 0 : 1),
+    };
   },
 );

--- a/turbo/apps/api/src/signals/services/google-forms-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-forms-automation-event.service.ts
@@ -2065,6 +2065,56 @@ export const dispatchGoogleFormsPubSubPush$ = command(
   },
 );
 
+interface GoogleFormsWatchOwner {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+async function renewGoogleFormsWatchOwners(
+  args: {
+    readonly db: Db;
+    readonly owners: readonly GoogleFormsWatchOwner[];
+    readonly renewBefore: Date;
+  },
+  signal: AbortSignal,
+): Promise<{ readonly renewed: number; readonly failed: number }> {
+  let renewed = 0;
+  let failed = 0;
+  for (const owner of args.owners) {
+    const prepared = await prepareGoogleFormsWatchesForOwner(
+      { db: args.db, ...owner },
+      signal,
+    );
+    signal.throwIfAborted();
+    failed += prepared ? 0 : 1;
+    const states = await args.db
+      .select()
+      .from(googleFormsWatchStates)
+      .where(
+        and(
+          eq(googleFormsWatchStates.orgId, owner.orgId),
+          eq(googleFormsWatchStates.userId, owner.userId),
+          or(
+            eq(googleFormsWatchStates.needsRewatch, true),
+            lte(googleFormsWatchStates.expireTime, args.renewBefore),
+          ),
+        ),
+      )
+      .orderBy(asc(googleFormsWatchStates.expireTime));
+    signal.throwIfAborted();
+    for (const state of states) {
+      const result = await reconcileGoogleFormsWatchState(
+        { db: args.db, state, renewBefore: args.renewBefore },
+        signal,
+      );
+      signal.throwIfAborted();
+      renewed += result.kind === "renewed" || result.kind === "created" ? 1 : 0;
+      failed += result.kind === "failed" ? 1 : 0;
+    }
+  }
+  return { renewed, failed };
+}
+
 export const renewGoogleFormsWatches$ = command(
   async ({ set }, signal: AbortSignal) => {
     const db = set(writeDb$);
@@ -2101,41 +2151,22 @@ export const renewGoogleFormsWatches$ = command(
     for (const owner of [...automationOwners, ...stateOwners]) {
       owners.set(`${owner.orgId}\n${owner.userId}`, owner);
     }
-    let renewed = 0;
-    let failed = 0;
-    for (const owner of owners.values()) {
-      const prepared = await prepareGoogleFormsWatchesForOwner(
-        { db, ...owner },
-        signal,
-      );
-      signal.throwIfAborted();
-      failed += prepared ? 0 : 1;
-      const states = await db
-        .select()
-        .from(googleFormsWatchStates)
-        .where(
-          and(
-            eq(googleFormsWatchStates.orgId, owner.orgId),
-            eq(googleFormsWatchStates.userId, owner.userId),
-            or(
-              eq(googleFormsWatchStates.needsRewatch, true),
-              lte(googleFormsWatchStates.expireTime, renewBefore),
-            ),
-          ),
-        )
-        .orderBy(asc(googleFormsWatchStates.expireTime));
-      signal.throwIfAborted();
-      for (const state of states) {
-        const result = await reconcileGoogleFormsWatchState(
-          { db, state, renewBefore },
-          signal,
-        );
-        signal.throwIfAborted();
-        renewed +=
-          result.kind === "renewed" || result.kind === "created" ? 1 : 0;
-        failed += result.kind === "failed" ? 1 : 0;
-      }
-    }
-    return { renewed, failed };
+    return await renewGoogleFormsWatchOwners(
+      { db, owners: [...owners.values()], renewBefore },
+      signal,
+    );
+  },
+);
+
+export const renewGoogleFormsWatchScope$ = command(
+  async ({ set }, owner: GoogleFormsWatchOwner, signal: AbortSignal) => {
+    return await renewGoogleFormsWatchOwners(
+      {
+        db: set(writeDb$),
+        owners: [owner],
+        renewBefore: new Date(nowDate().getTime() + WATCH_RENEWAL_WINDOW_MS),
+      },
+      signal,
+    );
   },
 );

--- a/turbo/packages/api-contracts/src/contracts/test-google-calendar-watch-renewal.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-google-calendar-watch-renewal.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+export const testGoogleCalendarWatchRenewalContract = c.router({
+  renew: {
+    method: "POST",
+    path: "/api/test/google-calendar-watch-renewal/renew",
+    body: z.object({
+      org_id: z.string().min(1),
+      user_id: z.string().min(1),
+    }),
+    responses: {
+      200: z.object({
+        success: z.literal(true),
+        renewed: z.number(),
+        failed: z.number(),
+      }),
+      400: apiErrorSchema,
+      404: z.string(),
+    },
+    summary: "Renew one Google Calendar watch owner in API tests",
+  },
+});
+
+export type TestGoogleCalendarWatchRenewalContract =
+  typeof testGoogleCalendarWatchRenewalContract;

--- a/turbo/packages/api-contracts/src/contracts/test-google-forms-watch-renewal.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-google-forms-watch-renewal.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+export const testGoogleFormsWatchRenewalContract = c.router({
+  renew: {
+    method: "POST",
+    path: "/api/test/google-forms-watch-renewal/renew",
+    body: z.object({
+      org_id: z.string().min(1),
+      user_id: z.string().min(1),
+    }),
+    responses: {
+      200: z.object({
+        success: z.literal(true),
+        renewed: z.number(),
+        failed: z.number(),
+      }),
+      400: apiErrorSchema,
+      404: z.string(),
+    },
+    summary: "Renew one Google Forms watch owner in API tests",
+  },
+});
+
+export type TestGoogleFormsWatchRenewalContract =
+  typeof testGoogleFormsWatchRenewalContract;


### PR DESCRIPTION
## Summary

- add guarded, owner-scoped Google Forms and Google Calendar watch renewal endpoints for API
  integration tests
- reuse count-preserving renewal helpers while keeping production cron discovery and Calendar phase
  ordering global
- update workflow automation renewal examples to operate only on fixture-owned organizations and
  users, including both intentional owners in the cross-account Calendar example

## Explicit exclusions

- no production cron route or contract changes
- no database schema, persisted payload, or migration changes
- no relaxed provider request or result-count assertions
- no test-suite serialization or database residue cleanup

## Validation

- pnpm -F api exec vitest run src/signals/routes/__tests__/workflow-automations.test.ts
  --maxWorkers=1 --silent=passed-only (81 tests passed)
- pnpm -F api lint
- pnpm -F @okouai/api-contracts lint
- pnpm -F api check-types
- pnpm -F @okouai/api-contracts check-types
- pnpm knip
- pnpm -F @okouai/db db:reset
- pnpm vitest run --maxWorkers=4 --silent=passed-only (747 files passed, 10,933 tests passed)
- lefthook pre-commit, including full Turbo check-types

Closes #31240
