### PR TITLE
test(api): stabilize pi gateway run cleanup

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/model-provider-gateways.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/model-provider-gateways.test.ts
@@ -672,6 +672,18 @@ describe("custom model provider gateway routes", () => {
         },
       ]),
     });
-    await runs.requestCancelRun(actor, sent.body.runId, [200]);
+    const cancellation = await runs.requestCancelRun(
+      actor,
+      sent.body.runId,
+      [200, 400],
+    );
+    if (
+      cancellation.status === 400 &&
+      cancellation.body.error.code !== "RUN_NOT_CANCELLABLE"
+    ) {
+      throw new Error(
+        `Expected terminal cleanup error, received ${cancellation.body.error.code}`,
+      );
+    }
   }, 30_000);
 });


### PR DESCRIPTION
## Summary

- accept either successful cancellation or an already-terminal response when cleaning up the focused Pi custom-gateway admission test
- require any accepted 400 response to carry `RUN_NOT_CANCELLABLE`, so unrelated cancellation errors still fail
- preserve the existing Pi agent type, gateway base URL, and upstream model assertions

## Scope

This is a test-only change. It does not change production cancellation semantics, add retries, raise timeouts, or duplicate the full Pi provider-execution fixtures covered elsewhere.

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/model-provider-gateways.test.ts -t 'admits an allowlisted DeepSeek custom gateway to Pi execution'` (11 total passes: one initial run plus 10 sequential repeats)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/model-provider-gateways.test.ts` (8 tests passed on the final worktree)
- `pnpm exec prettier --write apps/api/src/signals/routes/__tests__/model-provider-gateways.test.ts`
- `pnpm -F api exec oxlint src/signals/routes/__tests__/model-provider-gateways.test.ts --type-aware -c ../../.oxlintrc.typeaware.json`
- `pnpm -F api exec eslint src/signals/routes/__tests__/model-provider-gateways.test.ts --max-warnings 0`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit hooks: Prettier, full-repository Knip, full Turbo type checks (15 tasks), and file-size validation

Closes #31266
