### PR TITLE
fix(models): remove claude fable 5 from new workspace defaults

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -3830,7 +3830,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
       integrations.modelPickerSubmission({
         workspaceId: teamId,
         slackUserId,
-        selectedValue: "claude-fable-5",
+        selectedValue: "claude-fable-5-1",
         channelId: "C_BDD_PICK",
       }),
     );
@@ -3839,13 +3839,13 @@ describe("INT-01: Slack app deep webhook flows", () => {
       expect.objectContaining({
         channel: "C_BDD_PICK",
         user: slackUserId,
-        text: "Switched to *Claude Fable 5* for new Slack threads.",
+        text: "Switched to *Claude Fable 5.1* for new Slack threads.",
       }),
     );
     await expect(
       integrations.readUserModelPreference(actor),
     ).resolves.toMatchObject({
-      selectedModel: "claude-fable-5",
+      selectedModel: "claude-fable-5-1",
     });
 
     const replaceModel = await integrations.postSlackInteractive(

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -659,7 +659,6 @@ describe("model-first canonical catalog", () => {
   it("builds the default org policy seed from the workspace defaults", () => {
     expect(DEFAULT_ORG_MODEL_POLICY_MODELS).toEqual([
       "claude-fable-5-1",
-      "claude-fable-5",
       "gpt-5.6-sol",
       "gpt-5.6-luna",
       "deepseek-v4-flash",

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -131,7 +131,6 @@ const MODEL_PROVIDER_CODEX_RUNTIME_CONFIGS: Partial<
 
 export const DEFAULT_ORG_MODEL_POLICY_MODELS = [
   "claude-fable-5-1",
-  "claude-fable-5",
   "gpt-5.6-sol",
   "gpt-5.6-luna",
   "deepseek-v4-flash",


### PR DESCRIPTION
## Summary

- remove Claude Fable 5 from newly initialized workspace model policy seeds
- keep Claude Fable 5 supported for existing policies and explicit configuration
- keep DeepSeek V4 Flash as the default model for restricted and unrestricted workspaces

## Production impact

- no data migration; existing policies, preferences, threads, agents, providers, and runs remain unchanged
- production queues currently contain no Claude Fable 5 runs

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/api-contracts exec vitest run src/contracts/__tests__/model-providers.test.ts` (175 passed)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/model-policies.test.ts` (43 passed)
