### PR TITLE
fix(platform): stop hidden uploaded cover preloading

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
@@ -3672,7 +3672,7 @@ describe("chat composer templates", () => {
     });
   });
 
-  it("caches stable uploaded preview assets while preloading only covers", async () => {
+  it("caches stable uploaded preview assets without preloading closed picker covers", async () => {
     const user = userEvent.setup({ delay: null });
     mockNow(context.signal, new Date("2026-08-23T03:00:00.000Z").getTime());
     mockChatLifecycle(context, { threadId: THREAD_ID });
@@ -3766,37 +3766,13 @@ describe("chat composer templates", () => {
       path: `/chats/${THREAD_ID}`,
     });
 
-    const preloadedCover = await waitFor(() => {
-      const found = document.querySelector(
-        'img[src="https://example.com/prefetch-primary-page-1.png"]',
-      );
-      if (!(found instanceof HTMLImageElement)) {
-        throw new Error("Uploaded template cover was not prefetched");
-      }
-      return found;
+    await waitFor(() => {
+      expect(catalogRequestCount).toBe(1);
     });
-    expect(preloadedCover).toHaveAttribute("loading", "eager");
-    expect(preloadedCover).toHaveAttribute("fetchpriority", "high");
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    for (const coverUrl of [primaryPageUrls[0], secondaryPageUrls[0]]) {
-      const cover = document.querySelector(`img[src="${coverUrl}"]`);
-      expect(cover).toHaveAttribute("loading", "eager");
-      expect(cover).toHaveAttribute("fetchpriority", "high");
-    }
     expect(
       document.querySelectorAll('img[src^="https://example.com/prefetch-"]'),
-    ).toHaveLength(2);
-    expect(
-      document.querySelector(
-        'img[src="https://example.com/prefetch-primary-page-2.png"]',
-      ),
-    ).not.toBeInTheDocument();
-    expect(
-      document.querySelector(
-        'img[src="https://example.com/prefetch-secondary-page-2.png"]',
-      ),
-    ).not.toBeInTheDocument();
-    expect(catalogRequestCount).toBe(1);
+    ).toHaveLength(0);
     expect(primaryDetailRequestCount).toBe(0);
     expect(secondaryDetailRequestCount).toBe(0);
     expect(previewUrlRequestCount).toBe(0);
@@ -3808,7 +3784,7 @@ describe("chat composer templates", () => {
         `[data-imported-presentation-template="${primaryTemplateId}"]`,
       );
       if (!(found instanceof HTMLElement)) {
-        throw new Error("Prefetched template card not found");
+        throw new Error("Uploaded template card not found");
       }
       return found;
     });
@@ -3955,11 +3931,12 @@ describe("chat composer templates", () => {
     });
 
     await waitFor(() => {
-      expect(document.querySelector(`img[src="${renewedUrl}"]`)).toBeTruthy();
+      expect(previewUrlRequestCount).toBe(1);
     });
+    expect(document.querySelector(`img[src="${oldUrl}"]`)).toBeNull();
+    expect(document.querySelector(`img[src="${renewedUrl}"]`)).toBeNull();
     expect(catalogRequestCount).toBe(1);
     expect(detailRequestCount).toBe(0);
-    expect(previewUrlRequestCount).toBe(1);
     expect(resolvedPreviewAssetIds).toStrictEqual([previewAssetId]);
 
     await user.click(screen.getByLabelText("Template"));
@@ -4015,7 +3992,9 @@ describe("chat composer templates", () => {
       createdAt: "2026-08-25T03:00:00.000Z",
       updatedAt: "2026-08-25T03:00:00.000Z",
     };
+    let catalogRequestCount = 0;
     context.mocks.api(presentationTemplatesContract.list, ({ respond }) => {
+      catalogRequestCount += 1;
       return respond(200, [presentationTemplateCatalogEntry(template)]);
     });
     context.mocks.api(
@@ -4032,15 +4011,10 @@ describe("chat composer templates", () => {
       path: `/chats/${THREAD_ID}`,
     });
 
-    const preloadedCover = await waitFor(() => {
-      const found = document.querySelector(`img[src="${cardCoverUrl}"]`);
-      if (!(found instanceof HTMLImageElement)) {
-        throw new Error("Resized uploaded template cover was not prefetched");
-      }
-      return found;
+    await waitFor(() => {
+      expect(catalogRequestCount).toBe(1);
     });
-    expect(preloadedCover).toHaveAttribute("loading", "eager");
-    expect(preloadedCover).toHaveAttribute("fetchpriority", "high");
+    expect(document.querySelector(`img[src="${cardCoverUrl}"]`)).toBeNull();
     expect(document.querySelector(`img[src="${coverUrl}"]`)).toBeNull();
 
     await user.click(screen.getByLabelText("Template"));

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -7109,15 +7109,6 @@ function ComposerTemplateAttachmentSync({
     picker?.value,
     importedTemplates,
   );
-  const importedTemplateCoverUrls = uniqueTemplatePreviewImageUrls(
-    importedTemplates.flatMap((template) => {
-      const coverUrl = importedPptImageVariant(
-        template.coverUrl,
-        TEMPLATE_CARD_PREVIEW_SIZE,
-      );
-      return coverUrl === null ? [] : [coverUrl];
-    }),
-  );
   const openPicker = (category: string) => {
     prewarmTemplatePreviewImages(
       runtime,
@@ -7143,20 +7134,7 @@ function ComposerTemplateAttachmentSync({
         ref={setImportedTemplateUrlRefreshLifecycleRef}
         aria-hidden="true"
         className="pointer-events-none absolute size-px overflow-hidden opacity-0"
-      >
-        {importedTemplateCoverUrls.map((coverUrl) => {
-          return (
-            <img
-              key={coverUrl}
-              alt=""
-              src={coverUrl}
-              loading="eager"
-              decoding="async"
-              fetchPriority="high"
-            />
-          );
-        })}
-      </span>
+      />
       <button
         key={composerTemplateAttachmentLifecycleKey(attachment)}
         ref={setLifecycleRef}


### PR DESCRIPTION
## Summary

- stop mounting hidden eager, high-priority images for every uploaded presentation template cover while the picker is closed
- keep the signed preview URL refresh lifecycle and the existing decoded-cover swap and placeholder behavior
- load covers through the actual picker cards after the user opens the picker; leave Shared Worker prewarming to a separate future design

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx -t "caches stable uploaded preview assets without preloading closed picker covers|renews an expiring uploaded preview before the picker opens|loads resized uploaded deck previews with bounded thumbnail priority"`
