### PR TITLE
fix(python): isolate firewall auth cache results

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_auth_cache.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_cache.py
@@ -368,8 +368,8 @@ def _build_token_meta(
 ) -> dict:
     payload = cache_entry.payload
     token_meta: dict = {
-        "headers": payload.headers,
-        "resolved_secrets": payload.resolved_secrets,
+        "headers": dict(payload.headers),
+        "resolved_secrets": list(payload.resolved_secrets),
         "cache_hit": cache_hit,
         "cache_entry_identity": cache_entry.identity,
     }
@@ -380,7 +380,7 @@ def _build_token_meta(
     if payload.base is not None:
         token_meta["base"] = payload.base
     if payload.query is not None:
-        token_meta["query"] = payload.query
+        token_meta["query"] = dict(payload.query)
     if payload.aws_sigv4 is not None:
         token_meta["aws_sigv4"] = payload.aws_sigv4
     return token_meta

--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -565,6 +565,55 @@ class TestFirewallHeaderCache:
         assert fresh_snapshot.resolved_secrets == ["TOKEN"]
         assert fresh_snapshot.query == {"api_key": "original-key"}
 
+    async def test_returned_metadata_is_detached_from_cached_payload(self):
+        cache_key = auth_cache_key()
+        auth_request = firewall_auth_request(
+            auth_headers={"Authorization": "template"},
+            auth_query={"api_key": "template"},
+        )
+        auth_fetch = AsyncMock(
+            return_value=firewall_auth_success(
+                headers={"Authorization": "Bearer original"},
+                resolved_secrets=["TOKEN"],
+                query={"api_key": "original-key"},
+            )
+        )
+
+        with patch.object(auth_cache, "fetch_firewall_headers", auth_fetch):
+            fresh = await auth_cache.get_firewall_headers(cache_key, auth_request)
+            cache_entry_identity = fresh["cache_entry_identity"]
+
+            fresh["headers"]["Authorization"] = "Bearer mutated-fresh"
+            fresh["resolved_secrets"].append("MUTATED_FRESH")
+            fresh["query"]["api_key"] = "mutated-fresh-key"
+
+            snapshot = require_cached_headers(cache_key)
+            assert snapshot.headers == {"Authorization": "Bearer original"}
+            assert snapshot.resolved_secrets == ["TOKEN"]
+            assert snapshot.query == {"api_key": "original-key"}
+            assert snapshot.cache_entry_identity is cache_entry_identity
+
+            cached = await auth_cache.get_firewall_headers(cache_key, auth_request)
+            assert cached["headers"] == {"Authorization": "Bearer original"}
+            assert cached["resolved_secrets"] == ["TOKEN"]
+            assert cached["query"] == {"api_key": "original-key"}
+
+            cached["headers"]["Authorization"] = "Bearer mutated-cached"
+            cached["resolved_secrets"].append("MUTATED_CACHED")
+            cached["query"]["api_key"] = "mutated-cached-key"
+
+            subsequent = await auth_cache.get_firewall_headers(cache_key, auth_request)
+
+        assert fresh["cache_hit"] is False
+        assert cached["cache_hit"] is True
+        assert subsequent["cache_hit"] is True
+        assert cached["cache_entry_identity"] is cache_entry_identity
+        assert subsequent["cache_entry_identity"] is cache_entry_identity
+        assert subsequent["headers"] == {"Authorization": "Bearer original"}
+        assert subsequent["resolved_secrets"] == ["TOKEN"]
+        assert subsequent["query"] == {"api_key": "original-key"}
+        auth_fetch.assert_awaited_once_with(auth_request, force_refresh=False)
+
     async def test_fetch_failure_does_not_cache(self, mitm_ctx):
         """Failed fetch should not populate cache; next caller retries independently."""
         cache_key = auth_cache_key()


### PR DESCRIPTION
## Summary

- detach returned firewall auth headers, query credentials, and resolved-secret metadata from cached payload containers
- cover mutation of both fresh-fetch and cache-hit results through `get_firewall_headers()`
- preserve cache-hit flags, fetch count, and cache-entry identity

## Scope

This changes only result-container ownership. It does not change firewall auth request or response shapes, cache storage, fetch coalescing, admission, registry ownership, TTL, invalidation, or force-refresh behavior.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (7293 passed)

Closes #31278
