### PR TITLE
feat: launch morning brief for future workspace creators

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -2014,6 +2014,7 @@ describe.sequential("Morning Brief preference", () => {
       await cleanupCatalog();
     });
     await setOfficialWorkflowsEnabled(actor, true);
+    await setMorningBriefEnabled(actor, false);
     const headers = authHeaders(actor);
     const installations = await Promise.all(
       [onboarding.defaultAgentId, alternate.agentId].map(async (agentId) => {
@@ -2077,6 +2078,81 @@ describe.sequential("Morning Brief preference", () => {
 });
 
 describe.sequential("Morning Brief default onboarding", () => {
+  it("uses the production boundary with Morning Brief released and Official Workflows off", async () => {
+    installCatalogStorageFixture();
+    await syncDeployedCatalog();
+    const activationAt = new Date("2026-09-07T01:00:00.000Z");
+    const beforeActivation = new Date(activationAt.getTime() - 1);
+    const preActivationActor = bdd.user();
+    const eligibleCreator = bdd.user();
+    onTestFinished(async () => {
+      installCatalogStorageFixture();
+      await cleanupCatalog();
+    });
+
+    for (const actor of [preActivationActor, eligibleCreator]) {
+      await setOfficialWorkflowsEnabled(actor, false);
+    }
+
+    await deliverClerkOrganizationCreated(preActivationActor, beforeActivation);
+    await deliverClerkOrganizationCreated(eligibleCreator, activationAt);
+
+    await expect(
+      readMorningBriefDefaultEligibilityFixture({
+        orgId: preActivationActor.orgId ?? "",
+        userId: preActivationActor.userId,
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      readMorningBriefDefaultEligibilityFixture({
+        orgId: eligibleCreator.orgId ?? "",
+        userId: eligibleCreator.userId,
+      }),
+    ).resolves.toStrictEqual(activationAt);
+
+    expect(
+      (
+        await bdd.completeOnboarding(preActivationActor, {
+          timezone: "Asia/Shanghai",
+        })
+      ).status,
+    ).toBe(200);
+    await expect(
+      listMorningBriefInstallations(preActivationActor),
+    ).resolves.toHaveLength(0);
+
+    expect(
+      (
+        await bdd.completeOnboarding(eligibleCreator, {
+          timezone: "Asia/Shanghai",
+        })
+      ).status,
+    ).toBe(200);
+    const installations = await listMorningBriefInstallations(eligibleCreator);
+    expect(installations).toHaveLength(1);
+    const installation = installations[0];
+    if (!installation) {
+      throw new Error("Expected a default Morning Brief installation");
+    }
+    const detail = await accept(
+      installationClient().get({
+        headers: authHeaders(eligibleCreator),
+        params: { workflowId: installation.id },
+      }),
+      [200],
+    );
+    expect(detail.body.workflow.automations).toHaveLength(1);
+    expect(detail.body.workflow.automations).toMatchObject([
+      {
+        enabled: true,
+        official: {
+          blueprintKey: "daily-delivery",
+          reconciliationStatus: "current",
+        },
+      },
+    ]);
+  });
+
   it("marks only post-activation organization creators and preserves the first source timestamp", async () => {
     installCatalogStorageFixture();
     await syncDeployedCatalog();

--- a/turbo/apps/api/src/signals/services/morning-brief-default-eligibility.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-default-eligibility.service.ts
@@ -2,8 +2,10 @@ import { AsyncLocalStorage } from "node:async_hooks";
 
 import { singleton } from "../../lib/singleton";
 
-// Phase A ships inert. A reviewed Phase C change must set this instant.
-const MORNING_BRIEF_DEFAULT_ACTIVATION_AT: Date | null = null;
+// Monday 2026-09-07 09:00 Asia/Shanghai.
+const MORNING_BRIEF_DEFAULT_ACTIVATION_AT: Readonly<Date> = new Date(
+  "2026-09-07T01:00:00.000Z",
+);
 
 interface ScopedActivationInstant {
   readonly value: Date | null;

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -96,32 +96,31 @@ describe("isFeatureEnabled", () => {
     ).toBe(true);
   });
 
-  it("should keep Morning Brief default-off with an independent staff rollout and user override", () => {
-    const staffOrgId = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
+  it("should release Morning Brief independently from Official Workflows and preserve false overrides", () => {
+    const ordinaryOrgId = "org_nonexistent";
     expect(FeatureSwitchKey.MorningBrief).toBe("morningBrief");
-    expect(isFeatureEnabled(FeatureSwitchKey.MorningBrief, {})).toBe(false);
+    expect(isFeatureEnabled(FeatureSwitchKey.MorningBrief, {})).toBe(true);
     expect(
       isFeatureEnabled(FeatureSwitchKey.MorningBrief, {
-        orgId: staffOrgId,
+        orgId: ordinaryOrgId,
       }),
     ).toBe(true);
     expect(
       isFeatureEnabled(FeatureSwitchKey.MorningBrief, {
-        orgId: staffOrgId,
+        orgId: ordinaryOrgId,
         overrides: { [FeatureSwitchKey.MorningBrief]: false },
       }),
     ).toBe(false);
     expect(
-      isFeatureEnabled(FeatureSwitchKey.MorningBrief, {
-        orgId: "org_nonexistent",
-        overrides: { [FeatureSwitchKey.MorningBrief]: true },
+      isFeatureEnabled(FeatureSwitchKey.OfficialWorkflows, {
+        orgId: ordinaryOrgId,
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(getFeatureSwitchMetadata()[FeatureSwitchKey.MorningBrief]).toEqual({
       maintainer: "lancy@vm0.ai",
       description:
         "Enable the first-class Morning Brief experience in Preferences.",
-      rolloutStage: "beta",
+      rolloutStage: "released",
     });
   });
 
@@ -208,7 +207,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.DesktopScreenRecording]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.MorningBrief]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.MorningBrief]).toBe(true);
   });
 
   it("should enable intro video and desktop recording for staff", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -233,8 +233,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "lancy@vm0.ai",
     description:
       "Enable the first-class Morning Brief experience in Preferences.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.TestOauthConnector]: {
     maintainer: "liangyou@vm0.ai",


### PR DESCRIPTION
## Summary

- globally release only `FeatureSwitchKey.MorningBrief`, while keeping `FeatureSwitchKey.OfficialWorkflows` independently default-off for ordinary organizations
- activate default installation for verified workspace creators at the inclusive production boundary `2026-09-07T01:00:00.000Z` (Monday 09:00 Asia/Shanghai)
- cover ordinary-org switch metadata and overrides plus the real unscoped boundary-to-onboarding installation path

## Rollout safety

- required starting base SHA recorded before implementation: `35a1d9d1e76a6b0135c4d73ea8b44a51531e1291`
- final pre-queue current-main base: `cc5b2f96cb15d04ced3e36ce9c8a5425ded92908`
- reviewed candidate head: `fd0b463bc51b88adf70158ae4a6aaef30e9e5771`
- final activation instant: `2026-09-07T01:00:00.000Z`
- pre-queue activation check at `2026-09-03T04:47:29.390Z`: `92.209` hours remaining, satisfying the required `>=48h` buffer
- Phase A remains rolling-compatible: eligibility is still captured only from the verified `organization.created` timestamp, and onboarding continues to accept an optional timezone
- Phase B remains rolling-compatible: the deployed App already supplies the browser-resolved timezone; this PR changes no API contract or Platform request
- no backfill proof: the focused four-file diff contains no migration, batch/reconciliation path, or existing-user automation mutation; the existing-installation-first/idempotent provisioning and opt-out behavior are unchanged

## Verification

- exact-head focused Prettier check passed
- exact-head filtered Core/API lint passed (`456` pre-existing API warnings, `0` errors)
- exact-head Core and staged API type checks passed
- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` (`31` passed)
- `DATABASE_URL='postgresql://postgres@localhost:5432/vm0_test' pnpm --filter api exec vitest run src/signals/routes/__tests__/official-workflows.test.ts -t 'Morning Brief'` (`9` passed, `41` skipped by the targeted name filter)
- exact-head required CI passed: `ci-gate-turbo`, `ci-gate-security`, and `ci-gate-crates`

Refs #31156
Closes #31280
