### PR TITLE
fix(platform): restore lab maintainer filters

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -4805,12 +4805,16 @@
       },
       "description": "Feature-Schalter nach Einführungsphase anzeigen.",
       "documentTitle": "Labor",
+      "filters": {
+        "all": "Alle"
+      },
       "groups": {
         "alpha": "Alpha",
         "beta": "Beta",
         "internal": "Intern",
         "released": "Veröffentlicht"
       },
+      "maintainer": "Betreuer: {{maintainer}}",
       "title": "Labor"
     },
     "models": {

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -4797,12 +4797,16 @@
       },
       "description": "See feature switches by rollout stage.",
       "documentTitle": "Lab",
+      "filters": {
+        "all": "All"
+      },
       "groups": {
         "alpha": "Alpha",
         "beta": "Beta",
         "internal": "Internal",
         "released": "Released"
       },
+      "maintainer": "Maintainer: {{maintainer}}",
       "title": "Lab"
     },
     "models": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -4860,12 +4860,16 @@
       },
       "description": "Consulta las funciones por fase de lanzamiento.",
       "documentTitle": "Laboratorio",
+      "filters": {
+        "all": "Todos"
+      },
       "groups": {
         "alpha": "Alfa",
         "beta": "Beta",
         "internal": "Internas",
         "released": "Lanzadas"
       },
+      "maintainer": "Responsable: {{maintainer}}",
       "title": "Laboratorio"
     },
     "models": {

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -4860,12 +4860,16 @@
       },
       "description": "Consultez les fonctionnalités par phase de déploiement.",
       "documentTitle": "Laboratoire",
+      "filters": {
+        "all": "Tout"
+      },
       "groups": {
         "alpha": "Alpha",
         "beta": "Bêta",
         "internal": "Internes",
         "released": "Publiées"
       },
+      "maintainer": "Mainteneur : {{maintainer}}",
       "title": "Laboratoire"
     },
     "models": {

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -4805,12 +4805,16 @@
       },
       "description": "रोलआउट चरण के अनुसार फ़ीचर स्विच देखें।",
       "documentTitle": "प्रयोगशाला",
+      "filters": {
+        "all": "सभी"
+      },
       "groups": {
         "alpha": "अल्फ़ा",
         "beta": "बीटा",
         "internal": "आंतरिक",
         "released": "रिलीज़ किया गया"
       },
+      "maintainer": "अनुरक्षक: {{maintainer}}",
       "title": "प्रयोगशाला"
     },
     "models": {

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -4797,12 +4797,16 @@
       },
       "description": "Lihat pengalih fitur berdasarkan tahap peluncuran.",
       "documentTitle": "Lab",
+      "filters": {
+        "all": "Semua"
+      },
       "groups": {
         "alpha": "Alfa",
         "beta": "Beta",
         "internal": "Internal",
         "released": "Dirilis"
       },
+      "maintainer": "Pemelihara: {{maintainer}}",
       "title": "Lab"
     },
     "models": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -4860,12 +4860,16 @@
       },
       "description": "Visualizza le funzionalità per fase di rilascio.",
       "documentTitle": "Laboratorio",
+      "filters": {
+        "all": "Tutto"
+      },
       "groups": {
         "alpha": "Alfa",
         "beta": "Beta",
         "internal": "Interne",
         "released": "Rilasciate"
       },
+      "maintainer": "Manutentore: {{maintainer}}",
       "title": "Laboratorio"
     },
     "models": {

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -4797,12 +4797,16 @@
       },
       "description": "ロールアウト段階別に機能スイッチを確認できます。",
       "documentTitle": "研究室",
+      "filters": {
+        "all": "すべて"
+      },
       "groups": {
         "alpha": "アルファ",
         "beta": "ベータ",
         "internal": "内部",
         "released": "リリース済み"
       },
+      "maintainer": "メンテナ: {{maintainer}}",
       "title": "研究室"
     },
     "models": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -4797,12 +4797,16 @@
       },
       "description": "출시 단계별 기능 스위치를 확인하세요.",
       "documentTitle": "랩",
+      "filters": {
+        "all": "전체"
+      },
       "groups": {
         "alpha": "알파",
         "beta": "베타",
         "internal": "내부",
         "released": "출시됨"
       },
+      "maintainer": "유지관리자: {{maintainer}}",
       "title": "랩"
     },
     "models": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -4860,12 +4860,16 @@
       },
       "description": "Veja os recursos por estágio de lançamento.",
       "documentTitle": "Laboratório",
+      "filters": {
+        "all": "Todos"
+      },
       "groups": {
         "alpha": "Alfa",
         "beta": "Beta",
         "internal": "Internos",
         "released": "Lançados"
       },
+      "maintainer": "Responsável: {{maintainer}}",
       "title": "Laboratório"
     },
     "models": {

--- a/turbo/apps/platform/src/signals/lab-page/lab-page-ui.ts
+++ b/turbo/apps/platform/src/signals/lab-page/lab-page-ui.ts
@@ -1,0 +1,17 @@
+import { command, computed, state } from "ccstate";
+
+export const LAB_ALL_MAINTAINERS = "__all__";
+export type LabMaintainerFilter = string;
+
+const internalLabMaintainerFilter$ =
+  state<LabMaintainerFilter>(LAB_ALL_MAINTAINERS);
+
+export const labMaintainerFilter$ = computed((get): LabMaintainerFilter => {
+  return get(internalLabMaintainerFilter$);
+});
+
+export const setLabMaintainerFilter$ = command(
+  ({ set }, filter: LabMaintainerFilter) => {
+    set(internalLabMaintainerFilter$, filter);
+  },
+);

--- a/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
+++ b/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
@@ -44,6 +44,16 @@ function buttonByText(text: string): HTMLElement {
   return button;
 }
 
+function maintainerFilterButton(label: string): HTMLElement {
+  const button = queryAllByRoleFast("button").find((candidate) => {
+    return candidate.textContent?.trim().toLowerCase().startsWith(label);
+  });
+  if (!button) {
+    throw new Error(`${label} maintainer filter not found`);
+  }
+  return button;
+}
+
 function expectBefore(first: HTMLElement, second: HTMLElement): void {
   expect(
     Boolean(
@@ -126,7 +136,48 @@ describe("lab page", () => {
       internal.getAllByRole("listitem").length,
     );
     expect(buttonByText("Reset all")).toBeInTheDocument();
-    expect(screen.queryByText(/^Maintainer:/u)).not.toBeInTheDocument();
+    expect(screen.getAllByText(/^Maintainer:/u)).toHaveLength(
+      Object.values(FeatureSwitchKey).length,
+    );
+    expect(maintainerFilterButton("lancy")).toBeInTheDocument();
+  });
+
+  it("filters feature switches by maintainer", async () => {
+    context.mocks.api(featureSwitchesContract.get, ({ respond }) => {
+      return respond(200, { switches: {}, effectiveSwitches: {} });
+    });
+
+    detachedSetupPage({ context, path: "/_/lab" });
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Lab" })).toBeInTheDocument();
+      expect(
+        screen.getAllByText("Maintainer: lancy@vm0.ai").length,
+      ).toBeGreaterThan(0);
+    });
+
+    click(maintainerFilterButton("lancy"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(FeatureSwitchKey.NotionWorkflowAutomations),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(FeatureSwitchKey.AhrefsConnector),
+      ).not.toBeInTheDocument();
+      expect(maintainerFilterButton("lancy")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+
+    click(maintainerFilterButton("all"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(FeatureSwitchKey.AhrefsConnector),
+      ).toBeInTheDocument();
+    });
   });
 
   it("lets users toggle and reset feature switches", async () => {

--- a/turbo/apps/platform/src/views/lab-page/lab-page.tsx
+++ b/turbo/apps/platform/src/views/lab-page/lab-page.tsx
@@ -1,4 +1,4 @@
-import { useGet, useLastResolved } from "ccstate-react";
+import { useGet, useLastResolved, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
   getFeatureSwitchMetadata,
@@ -6,7 +6,7 @@ import {
   type FeatureSwitchRolloutStage,
 } from "@okouai/core/feature-switch";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import { Button, Switch } from "@okouai/ui";
+import { Button, Switch, cn } from "@okouai/ui";
 import { useTranslation } from "react-i18next";
 import {
   featureSwitch$,
@@ -15,6 +15,12 @@ import {
 } from "../../signals/external/feature-switch.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
+import {
+  LAB_ALL_MAINTAINERS,
+  labMaintainerFilter$,
+  setLabMaintainerFilter$,
+  type LabMaintainerFilter,
+} from "../../signals/lab-page/lab-page-ui.ts";
 
 type FeatureSwitchStates = Record<FeatureSwitchKey, boolean> | undefined;
 type FeatureSwitchMetadataByKey = Record<
@@ -22,12 +28,62 @@ type FeatureSwitchMetadataByKey = Record<
   FeatureSwitchMetadata
 >;
 
+interface MaintainerFilterOption {
+  readonly value: LabMaintainerFilter;
+  readonly label: string;
+  readonly count: number;
+}
+
 function compareByName(a: FeatureSwitchKey, b: FeatureSwitchKey): number {
   return a.localeCompare(b, undefined, { sensitivity: "base" });
 }
 
 function sortedFeatureSwitchKeys(): FeatureSwitchKey[] {
   return Object.values(FeatureSwitchKey).sort(compareByName);
+}
+
+function maintainerLabel(email: string): string {
+  return email.split("@")[0] ?? email;
+}
+
+function maintainerFilterOptions(params: {
+  readonly keys: readonly FeatureSwitchKey[];
+  readonly metadata: FeatureSwitchMetadataByKey;
+}): readonly MaintainerFilterOption[] {
+  const countsByMaintainer = new Map<string, number>();
+  for (const key of params.keys) {
+    const maintainer = params.metadata[key].maintainer;
+    countsByMaintainer.set(
+      maintainer,
+      (countsByMaintainer.get(maintainer) ?? 0) + 1,
+    );
+  }
+  return [...countsByMaintainer.entries()]
+    .map(([email, count]) => {
+      return {
+        value: email,
+        label: maintainerLabel(email),
+        count,
+      };
+    })
+    .sort((a, b) => {
+      return a.label.localeCompare(b.label, undefined, {
+        sensitivity: "base",
+      });
+    });
+}
+
+function filterFeatureSwitchKeys(params: {
+  readonly keys: readonly FeatureSwitchKey[];
+  readonly maintainerFilter: LabMaintainerFilter;
+  readonly metadata: FeatureSwitchMetadataByKey;
+}): FeatureSwitchKey[] {
+  if (params.maintainerFilter === LAB_ALL_MAINTAINERS) {
+    return [...params.keys];
+  }
+  return params.keys.filter((key) => {
+    return params.metadata[key].maintainer === params.maintainerFilter;
+  });
 }
 
 function LabHeader() {
@@ -59,6 +115,8 @@ function LabFeatureGroup(props: {
   readonly busy: boolean;
   readonly onToggle: (key: FeatureSwitchKey, checked: boolean) => void;
 }) {
+  const { t } = useTranslation();
+
   return (
     <section>
       <h2 className="mb-2 px-1 text-sm font-medium text-muted-foreground">
@@ -78,6 +136,16 @@ function LabFeatureGroup(props: {
                       {featureMetadata.description}
                     </span>
                   )}
+                  <span className="break-all text-xs text-muted-foreground">
+                    {t(
+                      ($) => {
+                        return $.settings.lab.maintainer;
+                      },
+                      {
+                        maintainer: featureMetadata.maintainer,
+                      },
+                    )}
+                  </span>
                 </div>
                 <Switch
                   className="shrink-0"
@@ -96,29 +164,89 @@ function LabFeatureGroup(props: {
   );
 }
 
+function MaintainerFilterPills(props: {
+  readonly value: LabMaintainerFilter;
+  readonly totalCount: number;
+  readonly options: readonly MaintainerFilterOption[];
+  readonly onChange: (value: LabMaintainerFilter) => void;
+}) {
+  const { t } = useTranslation();
+  const options: readonly MaintainerFilterOption[] = [
+    {
+      value: LAB_ALL_MAINTAINERS,
+      label: t(($) => {
+        return $.settings.lab.filters.all;
+      }),
+      count: props.totalCount,
+    },
+    ...props.options,
+  ];
+
+  return (
+    <>
+      {options.map((option) => {
+        const active = option.value === props.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-pressed={active}
+            onClick={() => {
+              props.onChange(option.value);
+            }}
+            className={cn(
+              "inline-flex h-7 shrink-0 cursor-pointer items-center gap-1.5 rounded-md border border-border px-2.5 text-sm font-medium leading-none transition-colors",
+              active
+                ? "bg-muted text-foreground"
+                : "bg-background text-muted-foreground hover:bg-state-hover hover:text-foreground",
+            )}
+          >
+            <span>{option.label}</span>
+            <span className="text-xs text-muted-foreground">
+              {option.count}
+            </span>
+          </button>
+        );
+      })}
+    </>
+  );
+}
+
 function LabControls(props: {
+  readonly maintainerFilter: LabMaintainerFilter;
+  readonly maintainerOptions: readonly MaintainerFilterOption[];
+  readonly totalCount: number;
   readonly busy: boolean;
   readonly resetting: boolean;
+  readonly onMaintainerFilterChange: (filter: LabMaintainerFilter) => void;
   readonly onReset: () => void;
 }) {
   const { t } = useTranslation();
 
   return (
-    <div className="flex justify-end">
-      <Button
-        variant="outline"
-        size="sm"
-        disabled={props.busy}
-        onClick={props.onReset}
-      >
-        {props.resetting
-          ? t(($) => {
-              return $.settings.lab.actions.resetting;
-            })
-          : t(($) => {
-              return $.settings.lab.actions.resetAll;
-            })}
-      </Button>
+    <div className="flex flex-wrap items-center gap-1.5">
+      <MaintainerFilterPills
+        value={props.maintainerFilter}
+        totalCount={props.totalCount}
+        options={props.maintainerOptions}
+        onChange={props.onMaintainerFilterChange}
+      />
+      <div className="ml-auto flex items-center gap-1.5">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={props.busy}
+          onClick={props.onReset}
+        >
+          {props.resetting
+            ? t(($) => {
+                return $.settings.lab.actions.resetting;
+              })
+            : t(($) => {
+                return $.settings.lab.actions.resetAll;
+              })}
+        </Button>
+      </div>
     </div>
   );
 }
@@ -128,12 +256,23 @@ export function LabPage() {
   const features = useLastResolved(featureSwitch$);
   const [toggleLoadable, setFeature] = useLoadableSet(setFeatureSwitch$);
   const [resetLoadable, reset] = useLoadableSet(resetFeatureSwitches$);
+  const maintainerFilter = useGet(labMaintainerFilter$);
+  const setMaintainerFilter = useSet(setLabMaintainerFilter$);
   const resetting = resetLoadable.state === "loading";
   const toggling = toggleLoadable.state === "loading";
   const busy = resetting || toggling;
   const pageSignal = useGet(pageSignal$);
   const metadata = getFeatureSwitchMetadata();
   const sorted = sortedFeatureSwitchKeys();
+  const maintainerOptions = maintainerFilterOptions({
+    keys: sorted,
+    metadata,
+  });
+  const filtered = filterFeatureSwitchKeys({
+    keys: sorted,
+    maintainerFilter,
+    metadata,
+  });
   const groups: readonly {
     readonly stage: FeatureSwitchRolloutStage;
     readonly title: string;
@@ -183,15 +322,22 @@ export function LabPage() {
       <div className="flex-1 overflow-y-auto px-4 sm:px-6 pb-10">
         <div className="mx-auto max-w-[900px] space-y-4">
           <LabControls
+            maintainerFilter={maintainerFilter}
+            maintainerOptions={maintainerOptions}
+            totalCount={sorted.length}
             busy={busy}
             resetting={resetting}
+            onMaintainerFilterChange={setMaintainerFilter}
             onReset={handleReset}
           />
           <div className="space-y-6">
             {groups.map((group) => {
-              const keys = sorted.filter((key) => {
+              const keys = filtered.filter((key) => {
                 return metadata[key].rolloutStage === group.stage;
               });
+              if (keys.length === 0) {
+                return null;
+              }
               return (
                 <LabFeatureGroup
                   key={group.stage}

--- a/turbo/apps/platform/src/views/lab-page/lab-page.tsx
+++ b/turbo/apps/platform/src/views/lab-page/lab-page.tsx
@@ -43,7 +43,7 @@ function sortedFeatureSwitchKeys(): FeatureSwitchKey[] {
 }
 
 function maintainerLabel(email: string): string {
-  return email.split("@")[0] ?? email;
+  return email.replace(/@.*$/u, "");
 }
 
 function maintainerFilterOptions(params: {


### PR DESCRIPTION
## Summary

- restore maintainer metadata on every Lab feature switch row
- restore maintainer filter pills with feature counts while preserving rollout-stage groups
- restore localized labels and page-level regression coverage

## Testing

- `pnpm -F @okouai/app exec vitest run src/views/lab-page/__tests__/lab-page.test.tsx` (6 passed)
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`

## Notes

- This restores the behavior directly without adding a new feature switch.