### PR TITLE
fix(runner): include legacy timezone links in guest images

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -353,7 +353,7 @@ install_packages() {
   apt-get install -y \
     procps wget git ripgrep jq file iproute2 sudo ffmpeg \
     fonts-noto-core fonts-noto-cjk fonts-noto-color-emoji \
-    libnss3 p11-kit-modules unzip \
+    libnss3 p11-kit-modules tzdata-legacy unzip \
     nodejs \
     python3 python3-pip \
     ruby-full bundler \

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -302,6 +302,8 @@ check_required_executable "/usr/bin/rmdir" "rmdir"
 check_required_executable "/usr/bin/date" "date"
 check_required_executable "/usr/bin/ln" "ln"
 check_required_executable "/usr/bin/sed" "sed"
+check_required_file_contains "/usr/share/zoneinfo/Asia/Calcutta" "TZif" \
+  "legacy IANA timezone link"
 
 # Storage manifest cleanup and Codex session cleanup helpers.
 check_required_executable "/usr/bin/rm" "rm"

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -587,6 +587,20 @@ wait
     }
 
     #[test]
+    fn template_installs_and_verifies_legacy_timezone_links() {
+        assert!(
+            template_build_installs_apt_package("tzdata-legacy"),
+            "build-template.sh should install legacy IANA timezone links"
+        );
+        assert!(
+            VERIFY_SCRIPT.contains(
+                r#"check_required_file_contains "/usr/share/zoneinfo/Asia/Calcutta" "TZif" \"#
+            ),
+            "verify-rootfs.sh should verify the legacy IANA timezone link resolves to a timezone file"
+        );
+    }
+
+    #[test]
     fn template_installs_and_verifies_noto_fonts() {
         for package in [
             "fonts-noto-core",


### PR DESCRIPTION
## Summary

- install Ubuntu Noble's `tzdata-legacy` package in guest templates so distribution-managed IANA backward links are available
- require `Asia/Calcutta` to resolve to a `TZif` file during both template and customized-rootfs verification
- cover the package input and image invariant in the runner build-script contract tests

## Why

Product clients and ICU accept `Asia/Calcutta`, but Noble packages that compatibility path separately from the canonical `Asia/Kolkata` zone file. Without the compatibility package, guest timezone restoration is best effort and leaves the system timezone unchanged.

## Compatibility and rollout

- no API, queue payload, persisted-state, claim/vsock protocol, runner timezone intent, or `guest-reseed` behavior changes
- the build-script edit automatically changes the template hash, causing the normal template/rootfs rebuild
- older images keep the existing non-fatal unavailable behavior until the rebuilt image is deployed
- `tzdata-legacy` adds approximately 1.1 MiB installed and supplies the distribution-maintained compatibility set rather than a vm0-owned alias map

## Validation

- `bash -n crates/runner/scripts/build-template.sh crates/runner/scripts/verify-rootfs.sh`
- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo test -p runner cmd::build::scripts::tests::template_installs_and_verifies_legacy_timezone_links` (1 passed)
- `cd crates && cargo test -p runner cmd::build::scripts::tests` (29 passed)
- `cd crates && cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cd crates && RUSTDOCFLAGS='-D warnings' cargo doc -p runner --all-features --no-deps`
- `cd crates && cargo test -p runner` (3418 passed, 24 ignored; guest inventory 1 passed)
- pre-commit Rust formatting, workspace rustdoc, workspace Clippy, file-size, and commit-message checks

Full-file `shellcheck` was also run. It reports existing `SC2155` and `SC2034` warnings at untouched lines; both reproduce against `main`, and this change adds no shellcheck diagnostic.

The privileged runner-image CI build is the end-to-end verification that Noble installs the compatibility path in the generated image.

Closes #31271
