### PR TITLE
refactor(rust): centralize guest binary paths

### DIFF
--- a/crates/guest-agent/src/cli/provider_event_normalization.rs
+++ b/crates/guest-agent/src/cli/provider_event_normalization.rs
@@ -288,7 +288,7 @@ mod tests {
             managed[..envelope_end].to_string(),
             format!(
                 "exec {} --shell \"$0\"",
-                guest_contracts::process_containment::TOOL_EXEC_PATH
+                guest_contracts::guest_binary::TOOL_EXEC_PATH
             ),
         ];
         for command in invalid {
@@ -328,7 +328,7 @@ mod tests {
 
         let malformed = format!(
             "exec {} --command-envelope=vm0.command.v1.12.cHJpbnRm --shell \"$0\"",
-            guest_contracts::process_containment::TOOL_EXEC_PATH
+            guest_contracts::guest_binary::TOOL_EXEC_PATH
         );
         let event = json!({
             "type": "assistant",

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -58,11 +58,11 @@ impl Framework {
 /// Production install location for the mock-claude binary. Exposed so
 /// tests can assert against a single source of truth when the
 /// mock Claude path aliases are absent or non-Unicode.
-pub const DEFAULT_MOCK_CLAUDE_PATH: &str = "/usr/local/bin/guest-mock-claude";
+pub const DEFAULT_MOCK_CLAUDE_PATH: &str = guest_contracts::guest_binary::MOCK_CLAUDE_PATH;
 
 /// Production install location for the mock-codex binary, mirroring
 /// `DEFAULT_MOCK_CLAUDE_PATH`.
-pub const DEFAULT_MOCK_CODEX_PATH: &str = "/usr/local/bin/guest-mock-codex";
+pub const DEFAULT_MOCK_CODEX_PATH: &str = guest_contracts::guest_binary::MOCK_CODEX_PATH;
 
 fn u64_value_or(name: &str, value: Option<&str>, default: u64) -> u64 {
     match value {

--- a/crates/guest-contracts/src/guest_binary.rs
+++ b/crates/guest-contracts/src/guest_binary.rs
@@ -1,0 +1,29 @@
+//! Canonical executable destinations for binaries delivered in the guest rootfs.
+//!
+//! The runner's `guest-binaries.json` inventory remains authoritative for
+//! delivery metadata. Its integration test requires every inventory entry to
+//! match these paths so runner and guest runtime consumers stay in lockstep.
+
+/// Production path of the Guest Agent executable.
+pub const AGENT_PATH: &str = "/usr/local/bin/guest-agent";
+
+/// Production path of the guest storage-download executable.
+pub const DOWNLOAD_PATH: &str = "/usr/local/bin/guest-download";
+
+/// Production path of the guest init executable.
+pub const INIT_PATH: &str = "/sbin/guest-init";
+
+/// Production path of the guest state-reseed executable.
+pub const RESEED_PATH: &str = "/sbin/guest-reseed";
+
+/// Production path of the privileged guest file-writer executable.
+pub const WRITE_FILE_PATH: &str = "/sbin/guest-write-file";
+
+/// Production path of the managed guest tool executor.
+pub const TOOL_EXEC_PATH: &str = "/usr/local/bin/guest-tool-exec";
+
+/// Production path of the shipped Claude mock executable.
+pub const MOCK_CLAUDE_PATH: &str = "/usr/local/bin/guest-mock-claude";
+
+/// Production path of the shipped Codex mock executable.
+pub const MOCK_CODEX_PATH: &str = "/usr/local/bin/guest-mock-codex";

--- a/crates/guest-contracts/src/lib.rs
+++ b/crates/guest-contracts/src/lib.rs
@@ -19,6 +19,7 @@ pub mod epoch_milliseconds;
 pub mod exec_limits;
 pub mod exec_terminal;
 pub mod file_write;
+pub mod guest_binary;
 pub mod managed_command;
 pub mod process_containment;
 pub mod reuse_preparation;

--- a/crates/guest-contracts/src/managed_command.rs
+++ b/crates/guest-contracts/src/managed_command.rs
@@ -9,7 +9,7 @@ use std::fmt;
 
 use base64::Engine as _;
 
-use crate::process_containment::TOOL_EXEC_PATH;
+use crate::guest_binary::TOOL_EXEC_PATH;
 
 /// Prefix of the executor argument carrying one managed command envelope.
 pub const COMMAND_ENVELOPE_ARGUMENT_PREFIX: &str = "--command-envelope=";

--- a/crates/guest-contracts/src/process_containment.rs
+++ b/crates/guest-contracts/src/process_containment.rs
@@ -34,9 +34,6 @@ pub const TOOLS_CGROUP_NAME: &str = "tools";
 /// Prefix for one shell invocation cgroup below [`TOOLS_CGROUP_NAME`].
 pub const TOOL_CGROUP_NAME_PREFIX: &str = "tool-";
 
-/// Guest shell executor selected by supported agent runtimes at tool dispatch.
-pub const TOOL_EXEC_PATH: &str = "/usr/local/bin/guest-tool-exec";
-
 /// Cgroup v2 controllers required for workload resource isolation.
 pub const REQUIRED_CGROUP_CONTROLLERS: [&str; 3] = ["cpu", "memory", "pids"];
 
@@ -52,7 +49,7 @@ pub const REQUIRED_CGROUP_SUBTREE_CONTROL: &str = "+cpu +memory +pids";
 /// CLI-child `pre_exec` hooks.
 pub const CANONICAL_WORKLOAD_CGROUP_PROCS_ENV: &str = "OKOU_WORKLOAD_CGROUP_PROCS_ENDPOINT";
 
-/// Runner-owned endpoint used by [`TOOL_EXEC_PATH`] to request a unique tool
+/// Runner-owned endpoint used by [`crate::guest_binary::TOOL_EXEC_PATH`] to request a unique tool
 /// cgroup before it executes user code.
 ///
 /// `vsock-guest` writes this key to Guest Agent, whose root bootstrap reader

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -4,7 +4,8 @@ mod stream_json_input;
 
 use crate::args::ParsedArgs;
 use crate::scenario::MockScenario;
-use guest_contracts::process_containment::{CANONICAL_TOOL_CGROUP_PROCS_ENV, TOOL_EXEC_PATH};
+use guest_contracts::guest_binary::TOOL_EXEC_PATH;
+use guest_contracts::process_containment::CANONICAL_TOOL_CGROUP_PROCS_ENV;
 use std::ffi::OsStr;
 use std::io::BufReader;
 use std::process::{Command, ExitCode};

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -733,16 +733,20 @@ wait
 
     #[test]
     fn rootfs_scripts_install_explicit_runtime_tool_hooks_without_replacing_bash() {
+        let tool_exec_path = guest_contracts::guest_binary::TOOL_EXEC_PATH;
+        let tool_exec_assignment = format!(r#"TOOL_EXEC_DEST="{tool_exec_path}""#);
+        let claude_hook_command = format!(r#""command": "{tool_exec_path} hook""#);
+        let codex_hook_command = format!(r#"command = "{tool_exec_path} hook""#);
         assert!(
-            CUSTOMIZE_SCRIPT.contains("TOOL_EXEC_DEST=\"/usr/local/bin/guest-tool-exec\""),
+            CUSTOMIZE_SCRIPT.contains(&tool_exec_assignment),
             "customize-rootfs.sh should use the canonical tool executor path"
         );
         assert!(
-            CUSTOMIZE_SCRIPT.contains("\"command\": \"/usr/local/bin/guest-tool-exec hook\""),
+            CUSTOMIZE_SCRIPT.contains(&claude_hook_command),
             "customize-rootfs.sh should configure the Claude Code tool hook"
         );
         assert!(
-            CUSTOMIZE_SCRIPT.contains("command = \"/usr/local/bin/guest-tool-exec hook\""),
+            CUSTOMIZE_SCRIPT.contains(&codex_hook_command),
             "customize-rootfs.sh should configure the Codex tool hook"
         );
         assert!(
@@ -754,8 +758,16 @@ wait
             "verify-rootfs.sh should verify the Claude Code tool hook"
         );
         assert!(
+            VERIFY_SCRIPT.contains(&claude_hook_command),
+            "verify-rootfs.sh should require the canonical Claude Code tool hook command"
+        );
+        assert!(
             VERIFY_SCRIPT.contains("check_required_file_contains \"$CODEX_TOOL_HOOK_DEST\""),
             "verify-rootfs.sh should verify the Codex tool hook"
+        );
+        assert!(
+            VERIFY_SCRIPT.contains(&codex_hook_command),
+            "verify-rootfs.sh should require the canonical Codex tool hook command"
         );
     }
 

--- a/crates/runner/src/executor/guest_state.rs
+++ b/crates/runner/src/executor/guest_state.rs
@@ -15,7 +15,6 @@ use crate::ids::RunId;
 use crate::types::ExecutionContext;
 
 const ENTROPY_SIZE: usize = 256;
-const GUEST_RESEED_PATH: &str = "/sbin/guest-reseed";
 const TIMEZONE_SYNC_MODE_ARG: &str = "--sync-timezone";
 const TIMEZONE_SYNC_FAILED_MARKER: &str = "guest timezone sync failed";
 const TIMEZONE_UNAVAILABLE_MARKER: &str = "guest timezone unavailable";
@@ -65,7 +64,10 @@ pub(crate) fn is_shell_safe_guest_timezone_name(tz: &str) -> bool {
 }
 
 fn timezone_sync_command(tz: &str) -> String {
-    format!("{GUEST_RESEED_PATH} {TIMEZONE_SYNC_MODE_ARG} {tz}")
+    format!(
+        "{} {TIMEZONE_SYNC_MODE_ARG} {tz}",
+        guest_contracts::guest_binary::RESEED_PATH
+    )
 }
 
 fn stderr_contains_marker(result: &sandbox::ExecResult, marker: &str) -> bool {

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -1032,6 +1032,16 @@ async fn execute_inner_abnormal_exit_collects_guest_diagnostics() {
     );
     assert!(active_diagnostic_cmd.contains("df -P -k / /home/user/workspace"));
     assert!(active_diagnostic_cmd.contains("df -P -i / /home/user/workspace"));
+    for command in ["ls -l", "stat", "file", "sha256sum"] {
+        let expected = format!(
+            "{command} {} 2>&1",
+            guest_contracts::guest_binary::AGENT_PATH
+        );
+        assert!(
+            active_diagnostic_cmd.lines().any(|line| line == expected),
+            "diagnostic command must inspect the canonical Guest Agent path with {command}"
+        );
+    }
     assert!(active_diagnostic_cmd.contains("section rootfs-usage"));
     assert!(active_diagnostic_cmd.contains("timeout 1s du -sxh -- \"$target_path\""));
     assert!(active_diagnostic_cmd.contains("du -sxh -- \"$target_path\""));

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -103,8 +103,8 @@ pub fn touch_mtime(dir: &Path) {
 /// Guest paths (must match rootfs layout).
 pub mod guest {
     pub const STORAGE_MANIFEST: &str = guest_contracts::runtime_paths::STORAGE_MANIFEST_PATH;
-    pub const DOWNLOAD_BIN: &str = "/usr/local/bin/guest-download";
-    pub const RUN_AGENT: &str = "/usr/local/bin/guest-agent";
+    pub const DOWNLOAD_BIN: &str = guest_contracts::guest_binary::DOWNLOAD_PATH;
+    pub const RUN_AGENT: &str = guest_contracts::guest_binary::AGENT_PATH;
 }
 
 /// Runner-level paths derived from the base directory.

--- a/crates/runner/tests/guest_inventory.rs
+++ b/crates/runner/tests/guest_inventory.rs
@@ -56,6 +56,21 @@ fn assert_unique<'a>(label: &str, values: impl IntoIterator<Item = &'a str>) {
     }
 }
 
+fn expected_runtime_destinations() -> BTreeMap<&'static str, &'static str> {
+    use guest_contracts::guest_binary;
+
+    BTreeMap::from([
+        ("guest-agent", guest_binary::AGENT_PATH),
+        ("guest-download", guest_binary::DOWNLOAD_PATH),
+        ("guest-init", guest_binary::INIT_PATH),
+        ("guest-reseed", guest_binary::RESEED_PATH),
+        ("guest-write-file", guest_binary::WRITE_FILE_PATH),
+        ("guest-tool-exec", guest_binary::TOOL_EXEC_PATH),
+        ("guest-mock-claude", guest_binary::MOCK_CLAUDE_PATH),
+        ("guest-mock-codex", guest_binary::MOCK_CODEX_PATH),
+    ])
+}
+
 #[test]
 fn delivered_guests_match_cargo_and_release_contracts() {
     let root = repo_root();
@@ -99,6 +114,12 @@ fn delivered_guests_match_cargo_and_release_contracts() {
             guest.destination
         );
     }
+
+    let inventory_destinations: BTreeMap<_, _> = inventory
+        .iter()
+        .map(|guest| (guest.binary.as_str(), guest.destination.as_str()))
+        .collect();
+    assert_eq!(inventory_destinations, expected_runtime_destinations());
 
     let output = Command::new(env!("CARGO"))
         .args([

--- a/crates/sandbox-fc/src/network/guest.rs
+++ b/crates/sandbox-fc/src/network/guest.rs
@@ -50,7 +50,8 @@ pub(crate) fn generate_boot_args() -> String {
     format!(
         "console=ttyS0 reboot=k panic=1 pci=off nomodules random.trust_cpu=on \
          quiet loglevel=0 nokaslr audit=0 numa=off mitigations=off noresume \
-         root=/dev/vda rootfstype=ext4 rw init=/sbin/guest-init {}",
+         root=/dev/vda rootfstype=ext4 rw init={} {}",
+        guest_contracts::guest_binary::INIT_PATH,
         generate_guest_network_boot_args(),
     )
 }
@@ -75,8 +76,9 @@ mod tests {
             args.contains("root=/dev/vda rootfstype=ext4 rw"),
             "boot args must specify root device: {args}"
         );
+        let init_arg = format!("init={}", guest_contracts::guest_binary::INIT_PATH);
         assert!(
-            args.contains("init=/sbin/guest-init"),
+            args.contains(&init_arg),
             "boot args must specify init: {args}"
         );
     }

--- a/crates/vsock-guest/src/agent_command.rs
+++ b/crates/vsock-guest/src/agent_command.rs
@@ -18,8 +18,6 @@ use guest_contracts::session_history_identity::SessionHistoryIdentityVerifyReque
 use crate::process_containment::{ExecProcessContainment, ProcessContainmentCleanupMode};
 use crate::shell_command::{SpawnedCommand, spawn_command_in_containment};
 
-pub(crate) const GUEST_AGENT_EXECUTABLE: &str = "/usr/local/bin/guest-agent";
-
 #[derive(Clone)]
 pub(crate) enum GuestAgentProgram {
     Production,
@@ -37,7 +35,7 @@ impl GuestAgentProgram {
 
     fn executable(&self) -> &Path {
         match self {
-            Self::Production => Path::new(GUEST_AGENT_EXECUTABLE),
+            Self::Production => Path::new(guest_contracts::guest_binary::AGENT_PATH),
             Self::Test(path) => path,
         }
     }

--- a/crates/vsock-guest/src/guest_state_restore.rs
+++ b/crates/vsock-guest/src/guest_state_restore.rs
@@ -25,7 +25,6 @@ use crate::worker_ownership::{
 };
 use crate::writer::GuestWriter;
 
-const PRODUCTION_PROGRAM: &str = "/sbin/guest-reseed";
 const THREAD_WORKER: &str = "vsock-guest-state-restore";
 const THREAD_STDIN: &str = "vsock-guest-state-stdin";
 const THREAD_STDERR: &str = "vsock-guest-state-stderr";
@@ -48,7 +47,7 @@ impl GuestStateRestoreProgram {
 
     fn path(&self) -> &Path {
         match self {
-            Self::Production => Path::new(PRODUCTION_PROGRAM),
+            Self::Production => Path::new(guest_contracts::guest_binary::RESEED_PATH),
             Self::Test(path) => path,
         }
     }

--- a/crates/vsock-guest/src/guest_storage_manifest.rs
+++ b/crates/vsock-guest/src/guest_storage_manifest.rs
@@ -26,7 +26,6 @@ use crate::worker_ownership::{
 };
 use crate::writer::GuestWriter;
 
-const PRODUCTION_PROGRAM: &str = "/usr/local/bin/guest-download";
 const THREAD_WORKER: &str = "vsock-guest-storage-manifest";
 const THREAD_STDIN: &str = "vsock-guest-storage-stdin";
 const THREAD_STDOUT: &str = "vsock-guest-storage-stdout";
@@ -50,7 +49,7 @@ impl GuestStorageManifestProgram {
 
     fn path(&self) -> &Path {
         match self {
-            Self::Production => Path::new(PRODUCTION_PROGRAM),
+            Self::Production => Path::new(guest_contracts::guest_binary::DOWNLOAD_PATH),
             Self::Test(path) => path,
         }
     }

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -26,7 +26,6 @@ use crate::wait::{
 
 const THREAD_WRITE_STDERR: &str = "vsock-write-stderr";
 const THREAD_WRITE_STDIN: &str = "vsock-write-stdin";
-const GUEST_WRITE_FILE_PATH: &str = "/sbin/guest-write-file";
 #[cfg(any(debug_assertions, feature = "test-support"))]
 static DEBUG_GUEST_WRITE_FILE_PATH: Mutex<Option<PathBuf>> = Mutex::new(None);
 
@@ -306,12 +305,12 @@ fn guest_write_file_path() -> PathBuf {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .clone()
-            .unwrap_or_else(|| PathBuf::from(GUEST_WRITE_FILE_PATH))
+            .unwrap_or_else(|| PathBuf::from(guest_contracts::guest_binary::WRITE_FILE_PATH))
     }
 
     #[cfg(not(any(debug_assertions, feature = "test-support")))]
     {
-        PathBuf::from(GUEST_WRITE_FILE_PATH)
+        PathBuf::from(guest_contracts::guest_binary::WRITE_FILE_PATH)
     }
 }
 


### PR DESCRIPTION
## Summary

- centralize the eight delivered guest executable destinations in `guest-contracts`
- bind Rust launch paths to the shared contract and compare the complete delivery inventory against it
- verify rootfs tool hooks and abnormal-exit diagnostics use the canonical executable paths

## Compatibility

This refactor does not change binary destinations, rootfs contents or hashes, CLI behavior, wire protocols, or persisted state. Test and debug executable overrides remain available where they existed before.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-contracts -p guest-agent -p guest-mock-claude -p runner -p vsock-guest -p sandbox-fc --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-contracts -p guest-agent -p guest-mock-claude -p runner -p vsock-guest -p sandbox-fc --no-deps`
- `cargo test -p guest-contracts -p guest-agent -p guest-mock-claude -p runner -p vsock-guest -p sandbox-fc`

Closes #31275
