### PR TITLE
fix(ui): stop the command input radius from clipping the caret

### DIFF
--- a/turbo/packages/ui/src/components/ui/__tests__/command.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/command.test.tsx
@@ -1,7 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import tailwindcss from "@tailwindcss/postcss";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import postcss from "postcss";
 import { useState } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
 import {
   Command,
   CommandDialog,
@@ -36,6 +42,41 @@ function BasicCommand({
 }
 
 describe("Command", () => {
+  const style = document.createElement("style");
+  const packageRoot = existsSync(resolve(process.cwd(), "src/styles"))
+    ? process.cwd()
+    : resolve(process.cwd(), "packages/ui");
+  const globalStylesPath = resolve(packageRoot, "src/styles/globals.css");
+
+  beforeAll(async () => {
+    const globalStyles = await readFile(globalStylesPath, "utf8");
+    const compiledStyles = await postcss([
+      tailwindcss({ base: packageRoot }),
+    ]).process(globalStyles, { from: globalStylesPath });
+    const radiusRules: string[] = [];
+    compiledStyles.root.walkRules((rule) => {
+      const declarations: string[] = [];
+      rule.walkDecls((declaration) => {
+        if (
+          declaration.parent === rule &&
+          (declaration.prop === "border-radius" ||
+            declaration.prop.startsWith("--radius"))
+        ) {
+          declarations.push(declaration.toString());
+        }
+      });
+      if (declarations.length > 0) {
+        radiusRules.push(`${rule.selector} { ${declarations.join("; ")} }`);
+      }
+    });
+    style.textContent = radiusRules.join("\n");
+    document.head.append(style);
+  });
+
+  afterAll(() => {
+    style.remove();
+  });
+
   it("keeps the caret outside a rounded input clipping boundary", () => {
     render(<BasicCommand onSelect={vi.fn()} />);
     const input = screen.getByRole("combobox", { name: "Search" });
@@ -43,8 +84,11 @@ describe("Command", () => {
       '[data-slot="command-input-wrapper"]',
     );
 
-    expect(input).toHaveClass("rounded-none");
-    expect(wrapper).toHaveClass("rounded-lg");
+    if (wrapper === null) {
+      throw new Error("Command input wrapper was not rendered");
+    }
+    expect(getComputedStyle(input).borderRadius).toBe("0px");
+    expect(getComputedStyle(wrapper).borderRadius).not.toBe("0px");
   });
 
   it("selects with Enter and navigates up, down, and around the item loop", async () => {

--- a/turbo/packages/ui/src/components/ui/__tests__/command.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/command.test.tsx
@@ -36,6 +36,17 @@ function BasicCommand({
 }
 
 describe("Command", () => {
+  it("keeps the caret outside a rounded input clipping boundary", () => {
+    render(<BasicCommand onSelect={vi.fn()} />);
+    const input = screen.getByRole("combobox", { name: "Search" });
+    const wrapper = input.closest<HTMLElement>(
+      '[data-slot="command-input-wrapper"]',
+    );
+
+    expect(input).toHaveClass("rounded-none");
+    expect(wrapper).toHaveClass("rounded-lg");
+  });
+
   it("selects with Enter and navigates up, down, and around the item loop", async () => {
     const user = userEvent.setup();
     const onSelect = vi.fn();

--- a/turbo/packages/ui/src/components/ui/command.tsx
+++ b/turbo/packages/ui/src/components/ui/command.tsx
@@ -108,7 +108,7 @@ const CommandInput = React.forwardRef<HTMLInputElement, CommandInputProps>(
           // so that clip ate its top and bottom ends and left the caret looking
           // notched.
           className={cn(
-            "flex h-full w-full bg-transparent text-sm text-foreground placeholder:text-sm placeholder:text-muted-foreground outline-none disabled:cursor-not-allowed disabled:opacity-50",
+            "flex h-full w-full rounded-none bg-transparent text-sm text-foreground placeholder:text-sm placeholder:text-muted-foreground outline-none disabled:cursor-not-allowed disabled:opacity-50",
             className,
           )}
           {...props}

--- a/turbo/packages/ui/src/components/ui/command.tsx
+++ b/turbo/packages/ui/src/components/ui/command.tsx
@@ -102,8 +102,13 @@ const CommandInput = React.forwardRef<HTMLInputElement, CommandInputProps>(
         <Autocomplete.Input
           ref={ref}
           data-slot="command-input"
+          // No radius of its own: the input is transparent inside the rounded
+          // wrapper, so `rounded-md` painted nothing -- it only added a rounded
+          // clip. The caret sits at x=0 of this box (no horizontal padding),
+          // so that clip ate its top and bottom ends and left the caret looking
+          // notched.
           className={cn(
-            "flex h-full w-full rounded-md bg-transparent text-sm text-foreground placeholder:text-sm placeholder:text-muted-foreground outline-none disabled:cursor-not-allowed disabled:opacity-50",
+            "flex h-full w-full bg-transparent text-sm text-foreground placeholder:text-sm placeholder:text-muted-foreground outline-none disabled:cursor-not-allowed disabled:opacity-50",
             className,
           )}
           {...props}


### PR DESCRIPTION
## Problem

The caret in the workspace search dialog (and every other `CommandInput`) renders with notched, stepped ends instead of a clean bar.

## Cause

`CommandInput`'s inner `<input>` carried `rounded-md`. The input is transparent inside an already-rounded wrapper, so the radius painted nothing — it only installed a rounded clip on the input's own box. Because the input has no horizontal padding, the caret sits at x=0 of that box, right where the 6px corner curves in, so the clip shaved the caret's top and bottom ends.

Measured on a 2x capture: the caret's left device-pixel column ramps out over ~5px at both ends while the right column stays solid — the signature of a rounded-corner clip, not of a blurry layer or a fractional transform.

Verified by isolating the rule in a headless Chromium repro at DPR 2:

- `border-radius: 6px` on the input, caret at x=0 → left column ramps `249 → 137 → … → 20` at the top and mirrors at the bottom, caret 3px shorter at each end. Matches the reported screenshot.
- `border-radius: 0` → both columns solid over the caret's full height.

## Fix

Drop `rounded-md` from the input. Nothing else about the control changes: the visible rounding belongs to the wrapper, which keeps its `rounded-lg`, border, and focus ring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)