### PR TITLE
test(runner): cover periodic firewall refresh recovery

### DIFF
--- a/crates/runner/src/provider/builtin_firewall_catalog.rs
+++ b/crates/runner/src/provider/builtin_firewall_catalog.rs
@@ -910,6 +910,65 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn periodic_refresh_recovers_at_next_interval_after_failure() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let cancel = CancellationToken::new();
+        let cache_path = PathBuf::from("builtin-firewall-catalog-cache.json");
+        let attempts_for_refresh = Arc::clone(&attempts);
+        let refresh = move |_cancel: CancellationToken| {
+            let attempts = Arc::clone(&attempts_for_refresh);
+            async move {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+                if attempt == 1 {
+                    Err(RunnerError::Api("periodic refresh failed".to_string()))
+                } else {
+                    Ok(())
+                }
+            }
+        };
+
+        let interval = Duration::from_secs(60);
+        let future = run_periodic_refresh_with_interval(refresh, &cache_path, &cancel, interval);
+        tokio::pin!(future);
+
+        tokio::select! {
+            biased;
+            _ = &mut future => panic!("periodic refresh should wait for the interval"),
+            () = tokio::task::yield_now() => {}
+        }
+        assert_eq!(attempts.load(Ordering::SeqCst), 0);
+
+        tokio::time::advance(interval).await;
+        tokio::select! {
+            biased;
+            _ = &mut future => panic!("periodic refresh should continue after failure"),
+            () = tokio::task::yield_now() => {}
+        }
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+
+        tokio::time::advance(Duration::from_secs(59)).await;
+        tokio::select! {
+            biased;
+            _ = &mut future => panic!("periodic refresh should wait for the next interval"),
+            () = tokio::task::yield_now() => {}
+        }
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::select! {
+            biased;
+            _ = &mut future => panic!("periodic refresh should keep running after recovery"),
+            () = tokio::task::yield_now() => {}
+        }
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+
+        cancel.cancel();
+        tokio::time::timeout(Duration::from_secs(1), future)
+            .await
+            .expect("periodic refresh should stop after cancellation");
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn periodic_refresh_finishes_in_progress_write_before_cancel_exit() {
         let attempts = Arc::new(AtomicUsize::new(0));
         let entered = Arc::new(tokio::sync::Notify::new());

--- a/crates/runner/src/provider/builtin_firewall_catalog.rs
+++ b/crates/runner/src/provider/builtin_firewall_catalog.rs
@@ -946,7 +946,7 @@ mod tests {
         }
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
 
-        tokio::time::advance(Duration::from_secs(59)).await;
+        tokio::time::advance(interval - Duration::from_nanos(1)).await;
         tokio::select! {
             biased;
             _ = &mut future => panic!("periodic refresh should wait for the next interval"),
@@ -954,7 +954,7 @@ mod tests {
         }
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
 
-        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::time::advance(Duration::from_nanos(1)).await;
         tokio::select! {
             biased;
             _ = &mut future => panic!("periodic refresh should keep running after recovery"),


### PR DESCRIPTION
## Summary

- add deterministic paused-time coverage for ordinary periodic firewall catalog refresh failures
- verify the loop stays alive and does not retry before the next configured interval
- verify a later refresh succeeds and the recovered loop still exits promptly on cancellation

## Scope

- test-only change; production refresh behavior, retry policy, logging, APIs, persisted state, and dependencies are unchanged

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner periodic_refresh_recovers_at_next_interval_after_failure`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml --workspace --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-features` (3418 passed, 24 ignored; integration test also passed)
- staged `lefthook` pre-commit and commit-message hooks

Closes #31270
