### PR TITLE
feat(platform): add locale-aware okou routes

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -236,10 +236,17 @@
         var authOrigin = satellite
           ? "https://" + productionPrimaryAppDomain
           : location.origin;
+        var localePrefix = currentOkouLocalePrefix(hostname, location.pathname);
+        var authHostname = new URL(authOrigin).hostname;
+        var authLocalePrefix = isOkouHostname(authHostname)
+          ? localePrefix
+          : null;
+        var signInPath = localePathname("/sign-in", authLocalePrefix);
+        var signUpPath = localePathname("/sign-up", authLocalePrefix);
         var loadOptions = {
-          afterSignOutUrl: new URL("/sign-in", authOrigin).toString(),
-          signInUrl: new URL("/sign-in", authOrigin).toString(),
-          signUpUrl: new URL("/sign-up", authOrigin).toString(),
+          afterSignOutUrl: new URL(signInPath, authOrigin).toString(),
+          signInUrl: new URL(signInPath, authOrigin).toString(),
+          signUpUrl: new URL(signUpPath, authOrigin).toString(),
         };
         if (satellite) {
           loadOptions.isSatellite = true;
@@ -256,6 +263,49 @@
 
         function isDomainOrSubdomain(value, domain) {
           return value === domain || value.endsWith("." + domain);
+        }
+
+        function isOkouHostname(value) {
+          return (
+            isDomainOrSubdomain(value, "okou.ai") ||
+            isDomainOrSubdomain(value, "omby.ai") ||
+            isDomainOrSubdomain(value, "okou-app.pages.dev") ||
+            /^(?:(?:staging|pr-[0-9]+))-app-okou-app-preview\.vm0\.workers\.dev$/.test(
+              value,
+            )
+          );
+        }
+
+        function currentOkouLocalePrefix(value, pathname) {
+          if (!isOkouHostname(value)) return null;
+          // This runs before modules; keep aliases in sync with
+          // src/i18n/locale-routing.ts.
+          var prefixes = [
+            "en",
+            "pt-BR",
+            "ja",
+            "ko",
+            "id",
+            "de",
+            "es",
+            "it",
+            "fr",
+            "hi",
+          ];
+          for (var index = 0; index < prefixes.length; index += 1) {
+            var prefix = prefixes[index];
+            if (
+              pathname === "/" + prefix ||
+              pathname.startsWith("/" + prefix + "/")
+            ) {
+              return prefix;
+            }
+          }
+          return null;
+        }
+
+        function localePathname(pathname, prefix) {
+          return prefix ? "/" + prefix + pathname : pathname;
         }
 
         function startClerk() {

--- a/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-entrypoint.test.ts
@@ -379,9 +379,18 @@ describe("platform Clerk entrypoint", () => {
     {
       authOrigin: "https://pr-30199-app.omby.ai",
       domain: null,
+      localePrefix: "/fr",
       publishableKey: PREVIEW_PUBLISHABLE_KEY,
       scriptUrl: expectedClerkScriptUrl(),
-      url: "https://pr-30199-app.omby.ai/",
+      url: "https://pr-30199-app.omby.ai/fr/sign-in",
+    },
+    {
+      authOrigin: "https://pr-30199-app-okou-app-preview.vm0.workers.dev",
+      domain: null,
+      localePrefix: "/ja",
+      publishableKey: PREVIEW_PUBLISHABLE_KEY,
+      scriptUrl: expectedClerkScriptUrl(),
+      url: "https://pr-30199-app-okou-app-preview.vm0.workers.dev/ja/sign-up",
     },
     {
       authOrigin: "https://app.vm0.ai",
@@ -395,15 +404,16 @@ describe("platform Clerk entrypoint", () => {
       domain: "app.okou.ai",
       publishableKey: PRODUCTION_PUBLISHABLE_KEY,
       scriptUrl: expectedClerkScriptUrl(),
-      url: "https://app.okou.ai/",
+      url: "https://app.okou.ai/fr/sign-in",
     },
     {
       authOrigin: "https://app.okou.ai",
       domain: null,
+      localePrefix: "/fr",
       productionPrimaryAppDomain: CUTOVER_PRIMARY_APP_DOMAIN,
       publishableKey: PRODUCTION_PUBLISHABLE_KEY,
       scriptUrl: expectedClerkScriptUrl(),
-      url: "https://app.okou.ai/",
+      url: "https://app.okou.ai/fr/sign-in",
     },
     {
       authOrigin: "https://app.okou.ai",
@@ -455,6 +465,7 @@ describe("platform Clerk entrypoint", () => {
     ({
       authOrigin,
       domain,
+      localePrefix,
       productionPrimaryAppDomain,
       publishableKey,
       scriptUrl,
@@ -489,11 +500,12 @@ describe("platform Clerk entrypoint", () => {
         productionPrimaryAppDomain ?? CURRENT_PRIMARY_APP_DOMAIN,
       );
       expect(bootstrap.domain ?? null).toBe(domain);
+      const localizedAuthOrigin = `${authOrigin}${localePrefix ?? ""}`;
       expect(bootstrap.loadOptions).toStrictEqual({
-        afterSignOutUrl: `${authOrigin}/sign-in`,
+        afterSignOutUrl: `${localizedAuthOrigin}/sign-in`,
         ...(domain ? { isSatellite: true, satelliteAutoSync: true } : {}),
-        signInUrl: `${authOrigin}/sign-in`,
-        signUpUrl: `${authOrigin}/sign-up`,
+        signInUrl: `${localizedAuthOrigin}/sign-in`,
+        signUpUrl: `${localizedAuthOrigin}/sign-up`,
       });
     },
   );
@@ -501,7 +513,9 @@ describe("platform Clerk entrypoint", () => {
   it("starts Clerk.load before application bootstrap and adopts the same promise", async () => {
     const loadCanFinish = context.mocks.deferred<void>();
     mockedClerkLoad.mockReturnValue(loadCanFinish.promise);
-    const script = captureClerkBootstrapScript("https://pr-30199-app.omby.ai/");
+    const script = captureClerkBootstrapScript(
+      "https://pr-30199-app.omby.ai/fr/_/error",
+    );
 
     Reflect.set(globalThis, "Clerk", mockedClerk);
     script.dispatchEvent(new Event("load"));
@@ -518,7 +532,7 @@ describe("platform Clerk entrypoint", () => {
 
     const setup = setupPage({
       context,
-      path: "/error",
+      path: "/fr/_/error",
       withoutRender: true,
     });
     expect(mockedClerkLoad).toHaveBeenCalledOnce();

--- a/turbo/apps/platform/src/i18n/__tests__/locale-asset-url.test.ts
+++ b/turbo/apps/platform/src/i18n/__tests__/locale-asset-url.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { resolveLocaleAssetUrl } from "../locale-asset-url.ts";
+
+describe("locale asset URLs", () => {
+  it("uses the standalone Worker preview's same-origin asset proxy", () => {
+    expect(
+      resolveLocaleAssetUrl(
+        "https://static.okou.io/okou-app/assets/ja-JP-test.json?v=1",
+        "https://pr-31304-app-okou-app-preview.vm0.workers.dev/ja/sign-in",
+      ).toString(),
+    ).toBe(
+      "https://pr-31304-app-okou-app-preview.vm0.workers.dev/okou-app/assets/ja-JP-test.json?v=1",
+    );
+  });
+
+  it("keeps production and legacy preview CDN URLs unchanged", () => {
+    const resourceUrl =
+      "https://static.okou.io/okou-app/assets/fr-FR-test.json";
+
+    expect(
+      resolveLocaleAssetUrl(resourceUrl, "https://app.okou.ai/fr/agents"),
+    ).toStrictEqual(new URL(resourceUrl));
+    expect(
+      resolveLocaleAssetUrl(resourceUrl, "https://pr-31304-app.omby.ai/fr"),
+    ).toStrictEqual(new URL(resourceUrl));
+    expect(
+      resolveLocaleAssetUrl(resourceUrl, "https://app.vm0.ai/fr/agents"),
+    ).toStrictEqual(new URL(resourceUrl));
+  });
+
+  it("does not proxy unrelated Worker preview resources", () => {
+    const resourceUrl = "https://static.okou.io/public/locales/ja-JP.json";
+
+    expect(
+      resolveLocaleAssetUrl(
+        resourceUrl,
+        "https://pr-31304-app-okou-app-preview.vm0.workers.dev/ja",
+      ),
+    ).toStrictEqual(new URL(resourceUrl));
+  });
+});

--- a/turbo/apps/platform/src/i18n/__tests__/locale-routing.test.ts
+++ b/turbo/apps/platform/src/i18n/__tests__/locale-routing.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import type { SupportedLocale } from "../resources.ts";
+import {
+  localePathPrefix,
+  localePrefixedPathname,
+  preserveLocalePathPrefix,
+  replaceLocalePathPrefix,
+  resolveLocaleRoute,
+} from "../locale-routing.ts";
+
+const LOCALE_CASES = [
+  ["en", "en-US"],
+  ["pt-BR", "pt-BR"],
+  ["ja", "ja-JP"],
+  ["ko", "ko-KR"],
+  ["id", "id-ID"],
+  ["de", "de-DE"],
+  ["es", "es-ES"],
+  ["it", "it-IT"],
+  ["fr", "fr-FR"],
+  ["hi", "hi-IN"],
+] as const satisfies readonly (readonly [string, SupportedLocale])[];
+
+describe("locale routing", () => {
+  it.each(LOCALE_CASES)(
+    "maps /%s to %s and the logical app root",
+    (prefix, locale) => {
+      expect(localePathPrefix(locale)).toBe(prefix);
+      expect(resolveLocaleRoute(`/${prefix}`, "app.okou.ai")).toStrictEqual({
+        locale,
+        pathname: "/",
+      });
+      expect(resolveLocaleRoute(`/${prefix}/`, "app.okou.ai")).toStrictEqual({
+        locale,
+        pathname: "/",
+      });
+      expect(
+        resolveLocaleRoute(`/${prefix}/agents/example`, "app.okou.ai"),
+      ).toStrictEqual({ locale, pathname: "/agents/example" });
+    },
+  );
+
+  it("recognizes Okou preview hosts", () => {
+    expect(resolveLocaleRoute("/fr/sign-in", "preview.omby.ai")).toStrictEqual({
+      locale: "fr-FR",
+      pathname: "/sign-in",
+    });
+    expect(
+      resolveLocaleRoute(
+        "/ja/sign-up",
+        "pr-123-app-okou-app-preview.vm0.workers.dev",
+      ),
+    ).toStrictEqual({ locale: "ja-JP", pathname: "/sign-up" });
+  });
+
+  it.each(["/zh", "/zh/agents", "/EN", "/pt-br"])(
+    "leaves unsupported prefix %s for the existing 404 policy",
+    (pathname) => {
+      expect(resolveLocaleRoute(pathname, "app.okou.ai")).toStrictEqual({
+        locale: null,
+        pathname,
+      });
+    },
+  );
+
+  it("does not interpret locale prefixes on VM0", () => {
+    expect(resolveLocaleRoute("/en/agents", "app.vm0.ai")).toStrictEqual({
+      locale: null,
+      pathname: "/en/agents",
+    });
+    expect(preserveLocalePathPrefix("/agents", "app.vm0.ai", "fr-FR")).toBe(
+      "/agents",
+    );
+  });
+
+  it("adds, preserves, and replaces canonical Okou prefixes", () => {
+    expect(localePrefixedPathname("/", "en-US")).toBe("/en");
+    expect(localePrefixedPathname("/agents/example", "pt-BR")).toBe(
+      "/pt-BR/agents/example",
+    );
+    expect(preserveLocalePathPrefix("/sign-in", "app.okou.ai", "ja-JP")).toBe(
+      "/ja/sign-in",
+    );
+    expect(
+      replaceLocalePathPrefix("/fr/agents/example", "app.okou.ai", "ko-KR"),
+    ).toBe("/ko/agents/example");
+    expect(
+      replaceLocalePathPrefix("/agents/example", "app.okou.ai", "de-DE"),
+    ).toBe("/de/agents/example");
+  });
+});

--- a/turbo/apps/platform/src/i18n/clerk-localization.ts
+++ b/turbo/apps/platform/src/i18n/clerk-localization.ts
@@ -11,6 +11,7 @@ import koKRUrl from "./clerk-localizations/ko-KR.json?url";
 import ptBRUrl from "./clerk-localizations/pt-BR.json?url";
 import { logger } from "../signals/log.ts";
 import { tapError } from "../signals/utils.ts";
+import { resolveLocaleAssetUrl } from "./locale-asset-url.ts";
 import { DEFAULT_LOCALE, type SupportedLocale } from "./resources.ts";
 
 export type ClerkLocalization = typeof enUS;
@@ -90,8 +91,10 @@ async function fetchClerkLocalization(
   signal?: AbortSignal,
 ): Promise<ClerkLocalization> {
   const response = await fetch(
-    new URL(clerkLocalizationUrl(locale), location.href),
-    { signal },
+    resolveLocaleAssetUrl(clerkLocalizationUrl(locale)),
+    {
+      signal,
+    },
   );
   if (!response.ok) {
     throw new Error(

--- a/turbo/apps/platform/src/i18n/locale-asset-url.ts
+++ b/turbo/apps/platform/src/i18n/locale-asset-url.ts
@@ -1,0 +1,19 @@
+const APP_ASSET_PATH_PREFIX = "/okou-app/assets/";
+const WORKER_PREVIEW_HOST_SUFFIX = ".workers.dev";
+
+export function resolveLocaleAssetUrl(
+  resourceUrl: string,
+  pageUrl = location.href,
+): URL {
+  const page = new URL(pageUrl);
+  const resource = new URL(resourceUrl, page);
+
+  if (
+    page.hostname.endsWith(WORKER_PREVIEW_HOST_SUFFIX) &&
+    resource.pathname.startsWith(APP_ASSET_PATH_PREFIX)
+  ) {
+    return new URL(`${resource.pathname}${resource.search}`, page.origin);
+  }
+
+  return resource;
+}

--- a/turbo/apps/platform/src/i18n/locale-routing.ts
+++ b/turbo/apps/platform/src/i18n/locale-routing.ts
@@ -1,0 +1,91 @@
+import { isOkouHostname } from "../lib/platform-host.ts";
+import { SUPPORTED_LOCALES, type SupportedLocale } from "./resources.ts";
+
+const LOCALE_PATH_PREFIX_BY_LOCALE = {
+  "en-US": "en",
+  "pt-BR": "pt-BR",
+  "ja-JP": "ja",
+  "ko-KR": "ko",
+  "id-ID": "id",
+  "de-DE": "de",
+  "es-ES": "es",
+  "it-IT": "it",
+  "fr-FR": "fr",
+  "hi-IN": "hi",
+} as const satisfies Record<SupportedLocale, string>;
+
+export interface LocaleRoute {
+  readonly locale: SupportedLocale | null;
+  readonly pathname: string;
+}
+
+export function localePathPrefix(locale: SupportedLocale): string {
+  return LOCALE_PATH_PREFIX_BY_LOCALE[locale];
+}
+
+function localeForPathPrefix(prefix: string): SupportedLocale | null {
+  for (const locale of SUPPORTED_LOCALES) {
+    if (localePathPrefix(locale) === prefix) {
+      return locale;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolves an explicit Okou locale prefix and returns the logical app route.
+ * VM0 routes and unsupported prefixes are intentionally left unchanged.
+ */
+export function resolveLocaleRoute(
+  pathname: string,
+  hostname: string,
+): LocaleRoute {
+  if (!isOkouHostname(hostname)) {
+    return { locale: null, pathname };
+  }
+
+  const [prefix = "", ...suffixSegments] = pathname.slice(1).split("/");
+  const locale = localeForPathPrefix(prefix);
+  if (!locale) {
+    return { locale: null, pathname };
+  }
+
+  const suffix = suffixSegments.join("/");
+  return {
+    locale,
+    pathname: suffix ? `/${suffix}` : "/",
+  };
+}
+
+export function localePrefixedPathname(
+  pathname: string,
+  locale: SupportedLocale,
+): string {
+  const prefix = localePathPrefix(locale);
+  return pathname === "/" ? `/${prefix}` : `/${prefix}${pathname}`;
+}
+
+export function replaceLocalePathPrefix(
+  pathname: string,
+  hostname: string,
+  locale: SupportedLocale,
+): string {
+  if (!isOkouHostname(hostname)) {
+    return pathname;
+  }
+  return localePrefixedPathname(
+    resolveLocaleRoute(pathname, hostname).pathname,
+    locale,
+  );
+}
+
+export function preserveLocalePathPrefix(
+  pathname: string,
+  hostname: string,
+  locale: SupportedLocale | null,
+): string {
+  if (!locale || !isOkouHostname(hostname)) {
+    return pathname;
+  }
+  return localePrefixedPathname(pathname, locale);
+}

--- a/turbo/apps/platform/src/i18n/resources.ts
+++ b/turbo/apps/platform/src/i18n/resources.ts
@@ -22,6 +22,7 @@ import koKRAgentsUrl from "./locales/ko-KR/agents.json?url";
 import koKRCommonUrl from "./locales/ko-KR/common.json?url";
 import ptBRAgentsUrl from "./locales/pt-BR/agents.json?url";
 import ptBRCommonUrl from "./locales/pt-BR/common.json?url";
+import { resolveLocaleAssetUrl } from "./locale-asset-url.ts";
 
 export const DEFAULT_LOCALE = "en-US";
 export const DEFAULT_NAMESPACE = "common";
@@ -100,7 +101,7 @@ async function loadLocaleResourceNamespace(
   namespace: "agents" | "common",
   signal?: AbortSignal,
 ): Promise<LocaleResourceNamespace> {
-  const response = await fetch(new URL(resourceUrl, location.href), { signal });
+  const response = await fetch(resolveLocaleAssetUrl(resourceUrl), { signal });
   if (!response.ok) {
     throw new Error(
       `Failed to load ${locale} ${namespace} locale resources (HTTP ${response.status})`,

--- a/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
@@ -76,6 +76,24 @@ describe("platform auth URLs", () => {
     expect(redirectUrl.searchParams.has("domain")).toBeFalsy();
   });
 
+  it("preserves an explicit locale when the auth host is Okou", () => {
+    setBrowserUrl("https://pr-18532-app.omby.ai/fr/agents?view=active#list");
+
+    const signInUrl = new URL(resolveAppAuthUrl("/sign-in"));
+    expect(signInUrl.origin).toBe("https://pr-18532-app.omby.ai");
+    expect(signInUrl.pathname).toBe("/fr/sign-in");
+
+    const taskUrl = new URL(
+      resolveAppAuthUrl("/sign-in/tasks/choose-organization", {
+        redirectUrl: "https://pr-18532-app.omby.ai/fr/agents?view=active#list",
+      }),
+    );
+    expect(taskUrl.pathname).toBe("/fr/sign-in/tasks/choose-organization");
+    expect(taskUrl.searchParams.get("redirect_url")).toBe(
+      "https://pr-18532-app.omby.ai/fr/agents?view=active#list",
+    );
+  });
+
   it("builds web auth URLs on the derived www origin", () => {
     setBrowserUrl("https://app.vm7.ai:8443/agents");
 
@@ -243,7 +261,9 @@ describe("platform auth redirects", () => {
   });
 
   it("redirects users who need org selection to app auth", async () => {
-    setBrowserUrl("https://pr-18532-app.omby.ai/agents");
+    const currentUrl =
+      "https://pr-18532-app.omby.ai/fr/agents?view=active#list";
+    setBrowserUrl(currentUrl);
 
     detachedSetupPage({
       context,
@@ -251,14 +271,15 @@ describe("platform auth redirects", () => {
         activeOrg: null,
         memberships: [{ id: "org_member" }],
       },
-      path: "/agents",
+      path: "/fr/agents?view=active#list",
     });
 
     await waitFor(() => {
       const url = new URL(window.location.href);
       expect(url.origin).toBe("https://pr-18532-app.omby.ai");
-      expect(url.pathname).toBe("/sign-in/tasks/choose-organization");
+      expect(url.pathname).toBe("/fr/sign-in/tasks/choose-organization");
       expect(url.searchParams.has("domain")).toBeFalsy();
+      expect(url.searchParams.get("redirect_url")).toBe(currentUrl);
     });
   });
 
@@ -290,11 +311,11 @@ describe("platform auth redirects", () => {
   });
 
   it("redirects an unauthenticated satellite user through primary auth", async () => {
-    setBrowserUrl("https://app.okou.ai/agents?utm_source=okou-launch");
+    setBrowserUrl("https://app.okou.ai/ja/agents?utm_source=okou-launch#proof");
 
     detachedSetupPage({
       context,
-      path: "/agents",
+      path: "/ja/agents?utm_source=okou-launch#proof",
       session: null,
       user: null,
     });
@@ -303,9 +324,12 @@ describe("platform auth redirects", () => {
       const url = new URL(window.location.href);
       expect(url.origin).toBe("https://app.vm0.ai");
       expect(url.pathname).toBe("/sign-in");
-      expect(url.searchParams.get("redirect_url")).toBe(
-        "https://app.okou.ai/agents?utm_source=okou-launch&__clerk_synced=false",
-      );
+      const redirectUrl = new URL(url.searchParams.get("redirect_url") ?? "");
+      expect(redirectUrl.origin).toBe("https://app.okou.ai");
+      expect(redirectUrl.pathname).toBe("/ja/agents");
+      expect(redirectUrl.searchParams.get("utm_source")).toBe("okou-launch");
+      expect(redirectUrl.searchParams.get("__clerk_synced")).toBe("false");
+      expect(redirectUrl.hash).toBe("#proof");
     });
 
     expect(mockedClerk.initialize).toHaveBeenCalledWith("test_production_key", {

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-locale.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-locale.test.ts
@@ -21,6 +21,8 @@ import {
 } from "../../i18n/resources.ts";
 import { changeI18nLanguage, i18n, initializeI18n } from "../../i18n/index.ts";
 import { locale$, setLocale$ } from "../locale.ts";
+import { hash, pathname, search } from "../location.ts";
+import { pathname$, urlLocale$ } from "../route.ts";
 import { resetSignal } from "../utils.ts";
 import { testContext } from "./test-helpers.ts";
 
@@ -34,6 +36,37 @@ function loadedClerkLocalization(locale: SupportedLocale) {
 }
 
 describe("bootstrap locale", () => {
+  it.each([
+    ["en", "en-US"],
+    ["pt-BR", "pt-BR"],
+    ["ja", "ja-JP"],
+    ["ko", "ko-KR"],
+    ["id", "id-ID"],
+    ["de", "de-DE"],
+    ["es", "es-ES"],
+    ["it", "it-IT"],
+    ["fr", "fr-FR"],
+    ["hi", "hi-IN"],
+  ] as const)(
+    "maps /%s to %s ahead of the saved preference",
+    async (prefix, locale) => {
+      const path = `/${prefix}/_/error?source=locale-test#proof`;
+      context.mocks.browser.url(`https://app.okou.ai${path}`);
+      context.mocks.data.userPreferences({ locale: "en-US" });
+
+      await setupPage({ context, path, withoutRender: true });
+
+      expect(context.store.get(locale$)).toBe(locale);
+      expect(context.store.get(urlLocale$)).toBe(locale);
+      expect(context.store.get(pathname$)).toBe("/_/error");
+      expect(pathname()).toBe(`/${prefix}/_/error`);
+      expect(search()).toBe("?source=locale-test");
+      expect(hash()).toBe("#proof");
+      expect(i18n.language).toBe(locale);
+      expect(document.documentElement.lang).toBe(locale);
+    },
+  );
+
   it("loads English resources for the default locale", async () => {
     context.mocks.browser.language(DEFAULT_LOCALE);
 

--- a/turbo/apps/platform/src/signals/auth-v2-page-setup.ts
+++ b/turbo/apps/platform/src/signals/auth-v2-page-setup.ts
@@ -1,6 +1,7 @@
 import { command } from "ccstate";
 import { createElement } from "react";
 import { i18n } from "../i18n/index.ts";
+import { resolveLocaleRoute } from "../i18n/locale-routing.ts";
 import { captureAuthV2DiagnosticEvent } from "../lib/posthog.ts";
 import {
   AuthV2Page,
@@ -29,6 +30,10 @@ import { ROUTES } from "./route-paths.ts";
 
 function setupAuthV2Page(mode: AuthV2PageMode) {
   return command(async ({ get, set }, signal: AbortSignal) => {
+    const routePathname = resolveLocaleRoute(
+      location.pathname,
+      location.hostname,
+    ).pathname;
     const platformContext = resolveAuthV2PlatformContext(mode);
     const diagnostics = createAuthV2Diagnostics(
       mode,
@@ -36,7 +41,7 @@ function setupAuthV2Page(mode: AuthV2PageMode) {
     );
     const continuationController = createAuthV2ContinuationSignals({
       isContinuationRoute: isAuthV2ContinuationLocation(
-        location.pathname,
+        routePathname,
         location.hash,
       ),
       mode,
@@ -49,9 +54,9 @@ function setupAuthV2Page(mode: AuthV2PageMode) {
     let signInSignals: AuthV2SignInSignals | null = null;
     let signUpSignals: AuthV2SignUpSignals | null = null;
     if (mode === "sign-in") {
-      const isBaseRoute = location.pathname === ROUTES.signIn;
+      const isBaseRoute = routePathname === ROUTES.signIn;
       const isOAuthCallbackRoute =
-        location.pathname === `${ROUTES.signIn}${AUTH_V2_OAUTH_CALLBACK_PATH}`;
+        routePathname === `${ROUTES.signIn}${AUTH_V2_OAUTH_CALLBACK_PATH}`;
       signInSignals = diagnostics.instrumentSignIn(
         createAuthV2SignInSignals({
           continuation: continuationController,
@@ -76,7 +81,7 @@ function setupAuthV2Page(mode: AuthV2PageMode) {
       );
     } else {
       const isOAuthCallbackRoute =
-        location.pathname ===
+        routePathname ===
         `${ROUTES.signUp}${AUTH_V2_SIGN_UP_OAUTH_CALLBACK_PATH}`;
       signUpSignals = diagnostics.instrumentSignUp(
         createAuthV2SignUpSignals({

--- a/turbo/apps/platform/src/signals/auth-v2/navigation.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/navigation.ts
@@ -1,3 +1,5 @@
+import { localePrefixedPathname } from "../../i18n/locale-routing.ts";
+import type { SupportedLocale } from "../../i18n/resources.ts";
 import { ROUTES } from "../route-paths.ts";
 
 export type AuthV2RouteMode = "sign-in" | "sign-up";
@@ -17,6 +19,7 @@ interface CreateAuthV2NavigationOptions {
   readonly completionRedirectUrl: string;
   readonly mode: AuthV2RouteMode;
   readonly signUpCompletionRedirectUrl: string;
+  readonly urlLocale?: SupportedLocale | null;
 }
 
 const AUTH_V2_ROUTE_BY_MODE = {
@@ -84,7 +87,10 @@ export function createAuthV2Navigation(
         options.authHash,
         navigationRedirectUrl,
       );
-      const pathname = `${AUTH_V2_ROUTE_BY_MODE[targetMode]}${stepPath ?? ""}`;
+      const routePathname = `${AUTH_V2_ROUTE_BY_MODE[targetMode]}${stepPath ?? ""}`;
+      const pathname = options.urlLocale
+        ? localePrefixedPathname(routePathname, options.urlLocale)
+        : routePathname;
       return `${pathname}?${search}${hash}`;
     },
   };

--- a/turbo/apps/platform/src/signals/auth-v2/platform-context.test.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/platform-context.test.ts
@@ -13,6 +13,42 @@ function absoluteNavigationUrl(href: string): URL {
 }
 
 describe("Auth v2 platform context", () => {
+  it("preserves an explicit Okou locale across auth navigation and fallback redirects", () => {
+    setBrowserUrl("https://app.okou.ai/ja/sign-up?source=language-test#proof");
+
+    const platformContext = resolveAuthV2PlatformContext("sign-up");
+
+    expect(platformContext.authBrand).toStrictEqual({
+      brandName: "Okou",
+      homeUrl: "/ja",
+    });
+    expect(platformContext.navigation.completionRedirectUrl).toBe(
+      "https://app.okou.ai/ja/onboarding",
+    );
+
+    const signInUrl = absoluteNavigationUrl(
+      platformContext.navigation.href("sign-in"),
+    );
+    expect(signInUrl.pathname).toBe("/ja/sign-in");
+    expect(signInUrl.searchParams.get("source")).toBe("language-test");
+    expect(signInUrl.searchParams.get("redirect_url")).toBe(
+      "https://app.okou.ai/ja/onboarding",
+    );
+    expect(signInUrl.hash).toBe("#proof");
+  });
+
+  it("uses the redirect locale for an Okou home link on primary auth", () => {
+    const redirectUrl = "https://app.okou.ai/fr/agents?source=auth-v2#list";
+    setBrowserUrl(
+      `https://app.vm0.ai/sign-in?redirect_url=${encodeURIComponent(redirectUrl)}`,
+    );
+
+    expect(resolveAuthV2PlatformContext("sign-in").authBrand).toStrictEqual({
+      brandName: "Okou",
+      homeUrl: "https://app.okou.ai/fr",
+    });
+  });
+
   it("uses an allowed Okou redirect as the brand context on the primary app", () => {
     const redirectUrl = "https://app.okou.ai/onboarding?source=auth-v2";
     setBrowserUrl(
@@ -55,7 +91,9 @@ describe("Auth v2 platform context", () => {
     expect(nestedUrl.pathname).toBe("/sign-up/verify-email-address");
     expect(nestedUrl.searchParams.get("redirect_url")).toBe(redirectUrl);
   });
+});
 
+describe("Auth v2 navigation context", () => {
   it("preserves sign-up campaign attribution and onboarding intent across flows", () => {
     setBrowserUrl(
       "https://app.vm0.ai/sign-up/verify-email-address?gclid=click-123&utm_campaign=summer&utm_content=hero&utm_content=footer#/verify?step=code",

--- a/turbo/apps/platform/src/signals/auth-v2/platform-context.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/platform-context.ts
@@ -1,3 +1,4 @@
+import { resolveLocaleRoute } from "../../i18n/locale-routing.ts";
 import {
   buildSignInRedirectUrl,
   buildSignupRedirectUrl,
@@ -56,6 +57,8 @@ export function resolveAuthV2PlatformContext(
       completionRedirectUrl,
       mode,
       signUpCompletionRedirectUrl,
+      urlLocale: resolveLocaleRoute(location.pathname, location.hostname)
+        .locale,
     }),
     satelliteConfig: resolveClerkSatelliteConfig(),
   };

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -13,6 +13,11 @@ import {
 } from "../lib/posthog.ts";
 import { appendCapturedPreviewBypassToUrl } from "../lib/preview-bypass-cookie.ts";
 import {
+  localePrefixedPathname,
+  preserveLocalePathPrefix,
+  resolveLocaleRoute,
+} from "../i18n/locale-routing.ts";
+import {
   derivePlatformServiceOrigin,
   isOkouProductionHostname,
   type PlatformService,
@@ -127,6 +132,18 @@ function resolveAuthOrigin(): string {
     : resolveAppOrigin();
 }
 
+function currentUrlLocale() {
+  return resolveLocaleRoute(location.pathname, location.hostname).locale;
+}
+
+function localizedCurrentPathname(pathname: string): string {
+  return preserveLocalePathPrefix(
+    pathname,
+    location.hostname,
+    currentUrlLocale(),
+  );
+}
+
 export function resolvePrimaryClerkUserProfileUrl(): string {
   return resolveClerkProductionTopology(
     resolveConfiguredProductionPrimaryAppDomain(),
@@ -187,6 +204,11 @@ export function resolveAppAuthUrl(
     return path;
   }
   const url = new URL(path, appOrigin);
+  url.pathname = preserveLocalePathPrefix(
+    path,
+    url.hostname,
+    currentUrlLocale(),
+  );
   if (options.redirectUrl) {
     url.searchParams.set("redirect_url", options.redirectUrl);
   }
@@ -253,7 +275,10 @@ function setCurrentLandingContext(params: URLSearchParams): void {
 function buildVm0OnboardingEntryUrl(paramsInit?: URLSearchParams): string {
   const params = new URLSearchParams(paramsInit);
   setCurrentLandingContext(params);
-  const url = new URL(VM0_ONBOARDING_PATH, resolveAppOrigin());
+  const url = new URL(
+    localizedCurrentPathname(VM0_ONBOARDING_PATH),
+    resolveAppOrigin(),
+  );
   url.search = params.toString();
   appendCapturedPreviewBypassToUrl(url);
   return url.toString();
@@ -322,7 +347,10 @@ export function resolveAuthBrandContext(
 ): AuthBrandContext {
   const currentBrandName = resolveBrandNameForHostname(location.hostname);
   if (currentBrandName === "Okou") {
-    return { brandName: currentBrandName, homeUrl: "/" };
+    return {
+      brandName: currentBrandName,
+      homeUrl: localizedCurrentPathname("/"),
+    };
   }
 
   const redirectUrl = readAllowedRedirectUrl(
@@ -333,7 +361,16 @@ export function resolveAuthBrandContext(
     redirectUrl &&
     resolveBrandNameForHostname(redirectUrl.hostname) === "Okou"
   ) {
-    return { brandName: "Okou", homeUrl: redirectUrl.origin };
+    const redirectLocale = resolveLocaleRoute(
+      redirectUrl.pathname,
+      redirectUrl.hostname,
+    ).locale;
+    return {
+      brandName: "Okou",
+      homeUrl: redirectLocale
+        ? `${redirectUrl.origin}${localePrefixedPathname("/", redirectLocale)}`
+        : redirectUrl.origin,
+    };
   }
 
   return { brandName: currentBrandName, homeUrl: "/" };
@@ -352,7 +389,10 @@ export function buildSignupRedirectUrl(
   }
 
   if (!hasAdTraffic(params)) {
-    return new URL(VM0_ONBOARDING_PATH, appUrl).toString();
+    return new URL(
+      localizedCurrentPathname(VM0_ONBOARDING_PATH),
+      appUrl,
+    ).toString();
   }
 
   const redirectParams = new URLSearchParams();
@@ -368,7 +408,15 @@ export function buildSignInRedirectUrl(
   const params = readAuthRedirectParams(signInSearch, signInHash);
   const redirectUrl = readAllowedRedirectUrl(params, allowedRedirectOrigins);
 
-  return redirectUrl?.toString() ?? resolveAppUrl();
+  if (redirectUrl) {
+    return redirectUrl.toString();
+  }
+
+  const appUrl = resolveAppUrl();
+  const homePathname = localizedCurrentPathname("/");
+  return homePathname === "/"
+    ? appUrl
+    : new URL(homePathname, appUrl).toString();
 }
 
 /** Loaded Clerk instance for consumers that need authentication state. */
@@ -507,7 +555,7 @@ export const watchOrgSwitch$ = command(
             return await clerk.session?.getToken({ skipCache: true });
           })(),
         );
-        location.href = "/";
+        location.href = localizedCurrentPathname("/");
       }),
     );
     signal.addEventListener("abort", unsubscribe);

--- a/turbo/apps/platform/src/signals/bootstrap/inspect-log-input.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/inspect-log-input.ts
@@ -1,8 +1,7 @@
 import { state, computed, command } from "ccstate";
 import { onRef } from "../utils.ts";
 import { loadInspectLogFile$ } from "../activity-page/inspect-log-signals";
-import { detachedNavigateTo$ } from "../route";
-import { pathname } from "../location";
+import { detachedNavigateTo$, pathname$ } from "../route";
 import { ROUTES } from "../route-paths";
 
 const internalInspectLogInput$ = state<HTMLInputElement | null>(null);
@@ -21,9 +20,9 @@ export const setInspectLogInput$ = onRef(
 );
 
 export const handleInspectLogFileChange$ = command(
-  async ({ set }, file: File, signal: AbortSignal) => {
+  async ({ get, set }, file: File, signal: AbortSignal) => {
     await set(loadInspectLogFile$, file, signal);
-    if (pathname() !== "/activities/inspect") {
+    if (get(pathname$) !== "/activities/inspect") {
       set(detachedNavigateTo$, ROUTES.activityInspect);
     }
   },

--- a/turbo/apps/platform/src/signals/locale.ts
+++ b/turbo/apps/platform/src/signals/locale.ts
@@ -9,12 +9,14 @@ import {
   loadI18nLanguageResources,
   loadInitialLocaleResources,
 } from "../i18n/index.ts";
+import { resolveLocaleRoute } from "../i18n/locale-routing.ts";
 import { DEFAULT_LOCALE, type SupportedLocale } from "../i18n/resources.ts";
 import { clerk$ } from "./auth.ts";
 import {
   updateUserPreference$,
   userPreferences$,
 } from "./okou-page/settings/user-preferences.ts";
+import { replaceUrlLocale$, urlLocale$ } from "./route.ts";
 
 const internalLocale$ = state<SupportedLocale>(DEFAULT_LOCALE);
 
@@ -29,7 +31,9 @@ export const availableLocalePreferences$ = computed(async (get) => {
 
 export const initLocale$ = command(
   async ({ set }, signal: AbortSignal): Promise<void> => {
-    const requestedLocale = DEFAULT_LOCALE;
+    const requestedLocale =
+      resolveLocaleRoute(location.pathname, location.hostname).locale ??
+      DEFAULT_LOCALE;
     const [initial, clerkLocalization] = await Promise.all([
       loadInitialLocaleResources(requestedLocale, signal),
       set(loadClerkLocalization$, requestedLocale, signal),
@@ -68,6 +72,10 @@ const applyLocalePreference$ = command(
 
 export const syncLocalePreference$ = command(
   async ({ get, set }, signal: AbortSignal) => {
+    if (get(urlLocale$)) {
+      return;
+    }
+
     const clerk = await get(clerk$);
     signal.throwIfAborted();
     if (!clerk.user || !clerk.organization) {
@@ -105,6 +113,7 @@ export const updateLocalePreference$ = command(
     }
 
     await set(applyLocalePreference$, locale, signal);
+    set(replaceUrlLocale$, locale);
     await set(updateUserPreference$, { locale }, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/okou-page/onboard-guard.ts
+++ b/turbo/apps/platform/src/signals/okou-page/onboard-guard.ts
@@ -125,6 +125,7 @@ export const bootstrapOnboardingGuard$ = command(
       if (memberships.length > 0) {
         window.location.href = resolveAppAuthUrl(
           "/sign-in/tasks/choose-organization",
+          { redirectUrl: location.href },
         );
         return;
       }

--- a/turbo/apps/platform/src/signals/okou-page/settings/workspace-settings-state.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/workspace-settings-state.ts
@@ -522,6 +522,7 @@ export const leaveOrg$ = command(
     );
     window.location.href = resolveAppAuthUrl(
       "/sign-in/tasks/choose-organization",
+      { redirectUrl: location.href },
     );
   },
 );
@@ -548,6 +549,7 @@ export const deleteOrg$ = command(
     );
     window.location.href = resolveAppAuthUrl(
       "/sign-in/tasks/choose-organization",
+      { redirectUrl: location.href },
     );
   },
 );

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -24,6 +24,12 @@ import {
 import { recordAdAttribution$ } from "./bootstrap/ad-attribution.ts";
 import { recordSignupAttribution$ } from "./bootstrap/signup-attribution.ts";
 import { bootstrapGoogleAdsConversionMilestones$ } from "./bootstrap/google-ads-conversion-milestones.ts";
+import {
+  preserveLocalePathPrefix,
+  replaceLocalePathPrefix,
+  resolveLocaleRoute,
+} from "../i18n/locale-routing.ts";
+import type { SupportedLocale } from "../i18n/resources.ts";
 
 const L = logger("Route");
 
@@ -32,7 +38,12 @@ const internalHistoryState$ = state<unknown>(window.history.state);
 
 export const pathname$ = computed((get) => {
   get(reloadPathname$);
-  return pathname();
+  return resolveLocaleRoute(pathname(), location.hostname).pathname;
+});
+
+export const urlLocale$ = computed((get) => {
+  get(reloadPathname$);
+  return resolveLocaleRoute(pathname(), location.hostname).locale;
 });
 
 export const searchParams$ = computed((get) => {
@@ -73,20 +84,43 @@ export const replaceSearchParams$ = command(
 
 export const replacePathSilently$ = command(
   (
-    { set },
+    { get, set },
     pathnameTemplate: Parameters<typeof generateRouterPath>[0],
     pathParams?: Parameters<typeof generateRouterPath>[1],
     searchParams?: URLSearchParams,
   ) => {
     const newPath = generateRouterPath(pathnameTemplate, pathParams);
+    const localizedPath = preserveLocalePathPrefix(
+      newPath,
+      location.hostname,
+      get(urlLocale$),
+    );
     const searchStr = searchParams?.toString();
-    replaceState({}, "", `${newPath}${searchStr ? `?${searchStr}` : ""}`);
+    replaceState({}, "", `${localizedPath}${searchStr ? `?${searchStr}` : ""}`);
     set(internalHistoryState$, {});
     set(reloadPathname$, (x) => {
       return x + 1;
     });
   },
 );
+
+export const replaceUrlLocale$ = command(({ set }, locale: SupportedLocale) => {
+  const currentPathname = pathname();
+  const localizedPath = replaceLocalePathPrefix(
+    currentPathname,
+    location.hostname,
+    locale,
+  );
+  if (localizedPath === currentPathname) {
+    return;
+  }
+  const historyState = window.history.state;
+  replaceState(historyState, "", `${localizedPath}${search()}${hash()}`);
+  set(internalHistoryState$, historyState);
+  set(reloadPathname$, (x) => {
+    return x + 1;
+  });
+});
 
 interface Route {
   path: string;
@@ -123,7 +157,11 @@ const currentRoute$ = computed((get) => {
 const clearPageForRouteBoundary$ = command(
   ({ get, set }, nextPathname: string) => {
     const config = get(internalRouteConfig$);
-    const nextRoute = config ? findRoute(config, nextPathname) : null;
+    const normalizedPathname = resolveLocaleRoute(
+      nextPathname,
+      location.hostname,
+    ).pathname;
+    const nextRoute = config ? findRoute(config, normalizedPathname) : null;
     if (get(currentRoute$) !== nextRoute) {
       set(clearPage$);
     }
@@ -240,7 +278,12 @@ const navigate$ = command(
     signal: AbortSignal,
   ) => {
     const searchStr = options.searchParams?.toString();
-    const newPath = `${pathname}${searchStr ? `?${searchStr}` : ""}${routeHash(options.hash)}`;
+    const localizedPathname = preserveLocalePathPrefix(
+      pathname,
+      location.hostname,
+      get(urlLocale$),
+    );
+    const newPath = `${localizedPathname}${searchStr ? `?${searchStr}` : ""}${routeHash(options.hash)}`;
     L.debug("navigating to", newPath);
     set(clearPageForRouteBoundary$, pathname);
     if (options.replace) {
@@ -368,6 +411,7 @@ export const setupAuthPageWrapper = (
       );
       window.location.href = resolveAppAuthUrl(
         "/sign-in/tasks/choose-organization",
+        { redirectUrl: location.href },
       );
       return;
     }

--- a/turbo/apps/platform/src/signals/sign-in-token-setup.ts
+++ b/turbo/apps/platform/src/signals/sign-in-token-setup.ts
@@ -1,6 +1,7 @@
 import { command } from "ccstate";
+import { preserveLocalePathPrefix } from "../i18n/locale-routing.ts";
 import { clerk$ } from "./auth.ts";
-import { searchParams$, detachedNavigateTo$ } from "./route.ts";
+import { detachedNavigateTo$, searchParams$, urlLocale$ } from "./route.ts";
 import { logger } from "./log.ts";
 
 const L = logger("SignInToken");
@@ -16,6 +17,7 @@ const L = logger("SignInToken");
 export const setupSignInTokenPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const params = get(searchParams$);
+    const urlLocale = get(urlLocale$);
     const token = params.get("token");
 
     if (!token) {
@@ -51,7 +53,9 @@ export const setupSignInTokenPage$ = command(
         const destination = session.currentTask
           ? `/sign-in/tasks/${session.currentTask.key}`
           : "/";
-        window.location.href = decorateUrl(destination);
+        window.location.href = decorateUrl(
+          preserveLocalePathPrefix(destination, location.hostname, urlLocale),
+        );
       },
     });
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
@@ -67,6 +67,43 @@ function buttonByLabel(label: string): HTMLButtonElement {
 }
 
 describe("auth v2 presentation", () => {
+  it("renders the current auth UI at /en/sign-in", async () => {
+    setBrowserUrl("https://app.okou.ai/en/sign-in");
+
+    detachedSetupPage({ context, path: "/en/sign-in" });
+
+    await screen.findByRole("heading", {
+      level: 1,
+      name: "Choose an account",
+    });
+    expect(linkByLabel("Go to Okou home")).toHaveAttribute("href", "/en");
+    expect(
+      screen.queryByRole("heading", { name: "Page not found" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("uses an explicit Okou URL locale ahead of the saved preference", async () => {
+    context.mocks.data.userPreferences({
+      locale: "en-US",
+      supportedLocales: ["en-US", "ja-JP"],
+    });
+    const path = "/ja/sign-up?source=language-test#proof";
+    setBrowserUrl(`https://app.okou.ai${path}`);
+
+    detachedSetupPage({ context, path });
+
+    await screen.findByLabelText("メールアドレス");
+    expect(
+      screen.getByRole("heading", { level: 1, name: "アカウントを作成" }),
+    ).toBeVisible();
+    expect(linkByLabel("Okou のホームに移動")).toHaveAttribute("href", "/ja");
+    const signInLink = linkByText("サインイン");
+    const signInUrl = new URL(signInLink.href);
+    expect(signInUrl.pathname).toBe("/ja/sign-in");
+    expect(signInUrl.searchParams.get("source")).toBe("language-test");
+    expect(signInUrl.hash).toBe("#proof");
+  });
+
   it("provides branded landmarks, descriptions, announcements, and initial focus", async () => {
     setBrowserUrl("https://app.vm0.ai/sign-in");
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/settings-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/settings-dialog.test.tsx
@@ -16,6 +16,7 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { hash, pathname, search } from "../../../signals/location.ts";
 import { openSettingsDialogAt$ } from "../../../signals/okou-page/settings/settings-dialog.ts";
 import { billingStatus } from "./chat-composer-test-helpers.ts";
 
@@ -24,6 +25,7 @@ const context = testContext();
 async function openDialog(
   role: "admin" | "member" = "admin",
   section: "debug" | "general" | "model" | "preference" = "general",
+  path = `/?settings=${section}`,
 ): Promise<void> {
   context.mocks.data.org({
     id: "org_1",
@@ -40,7 +42,7 @@ async function openDialog(
   });
   detachedSetupPage({
     context,
-    path: `/?settings=${section}`,
+    path,
     featureSwitches:
       section === "debug" ? { [FeatureSwitchKey.OkouDebug]: true } : {},
   });
@@ -123,6 +125,37 @@ function buttonWithText(
 }
 
 describe("settings dialog", () => {
+  it("switches an explicit Okou URL locale without losing route state", async () => {
+    const submittedLocales: UserLocale[] = [];
+    const path = "/de/agents?settings=preference&source=launch#language";
+    context.mocks.browser.url(`https://app.okou.ai${path}`);
+    context.mocks.api(userPreferencesContract.get, ({ respond }) => {
+      return respond(200, createPreferences("en-US"));
+    });
+    context.mocks.api(userPreferencesContract.update, ({ body, respond }) => {
+      if (body.locale !== undefined) {
+        submittedLocales.push(body.locale);
+      }
+      return respond(200, createPreferences(body.locale ?? "en-US"));
+    });
+
+    await openDialog("admin", "preference", path);
+
+    click(await screen.findByRole("combobox", { name: "Sprache" }));
+    click(screen.getByRole("option", { name: "日本語" }));
+
+    await waitFor(() => {
+      expect(submittedLocales).toStrictEqual(["ja-JP"]);
+      expect(screen.getByRole("combobox", { name: "言語" })).toHaveTextContent(
+        "日本語",
+      );
+      expect(document.documentElement.lang).toBe("ja-JP");
+      expect(pathname()).toBe("/ja/agents");
+      expect(search()).toBe("?settings=preference&source=launch");
+      expect(hash()).toBe("#language");
+    });
+  });
+
   it("keeps every available locale in the language menu", async () => {
     context.mocks.data.userPreferences(
       createPreferences("en-US", [

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
@@ -1406,10 +1406,12 @@ describe("zero sidebar account menu", () => {
 
   it("shows account switching, add-account, and sign-out actions", async () => {
     prepareDefaultAgent();
+    const path = `/en/agents/${AGENT_ID}/chat`;
+    context.mocks.browser.url(`https://app.okou.ai${path}`);
 
     detachedSetupPage({
       context,
-      path: `/agents/${AGENT_ID}/chat`,
+      path,
       user: {
         id: "test-user-123",
         fullName: "Alex Rivera",
@@ -1473,6 +1475,7 @@ describe("zero sidebar account menu", () => {
       expect(mockedClerk.setActive).toHaveBeenCalledWith(
         expect.objectContaining({ session: "session-jamie" }),
       );
+      expect(window.location.pathname).toBe("/en");
     });
 
     menu = await openAccountMenu();

--- a/turbo/apps/platform/src/views/okou-page/sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-account.tsx
@@ -72,11 +72,13 @@ import { DropdownMenuModalItem } from "../components/dropdown-menu-modal-item.ts
 import { UserAvatar } from "../components/avatar.tsx";
 import { formatLocalizedNumber } from "../../i18n/format.ts";
 import { i18n } from "../../i18n/index.ts";
+import { preserveLocalePathPrefix } from "../../i18n/locale-routing.ts";
 import {
   okouDebugRealtimeIndicator$,
   type OkouDebugRealtimeIndicator,
 } from "../../signals/okou-page/realtime-status.ts";
 import { openAuthV2AddAccountDialog$ } from "../../signals/okou-page/auth-v2-add-account-dialog.ts";
+import { urlLocale$ } from "../../signals/route.ts";
 
 interface SessionAccount {
   sessionId: string;
@@ -761,6 +763,7 @@ export function AccountDropdown({
   const actionLoadable = useLoadable(personalActionPromise$);
   const setSidebarExpanded = useSet(setSidebarExpanded$);
   const pageSignal = useGet(pageSignal$);
+  const urlLocale = useGet(urlLocale$);
   const openAuthV2AddAccountDialog = useSet(openAuthV2AddAccountDialog$);
 
   const current = accounts.find((a) => {
@@ -807,7 +810,9 @@ export function AccountDropdown({
           const destination = session.currentTask
             ? `/sign-in/tasks/${session.currentTask.key}`
             : "/";
-          window.location.href = decorateUrl(destination);
+          window.location.href = decorateUrl(
+            preserveLocalePathPrefix(destination, location.hostname, urlLocale),
+          );
         },
       }),
       Reason.DomCallback,

--- a/turbo/apps/platform/src/views/router/__tests__/link-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/router/__tests__/link-navigation.test.tsx
@@ -8,7 +8,7 @@ import {
 } from "../../../__tests__/page-helper.ts";
 import { initializeI18n } from "../../../i18n/index.ts";
 import { DEFAULT_LOCALE } from "../../../i18n/resources.ts";
-import { pathname } from "../../../signals/location.ts";
+import { hash, pathname, search } from "../../../signals/location.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { reportForceUpgradeRequired } from "../../../signals/force-upgrade.ts";
 import { setLocale$ } from "../../../signals/locale.ts";
@@ -33,6 +33,59 @@ function mockAPIs(): void {
 }
 
 describe("link navigation", () => {
+  it.each(["/en", "/en/"])(
+    "renders the current Okou app at locale root %s",
+    async (path) => {
+      mockAPIs();
+      context.mocks.browser.url(`https://app.okou.ai${path}`);
+
+      detachedSetupPage({ context, path });
+
+      await waitFor(() => {
+        expect(
+          within(screen.getByTestId("labeled-nav-rail")).getByText("Agents"),
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByRole("heading", { name: "Page not found" }),
+        ).not.toBeInTheDocument();
+      });
+      expect(pathname()).toMatch(/^\/en(?:\/|$)/u);
+    },
+  );
+
+  it("renders a locale-prefixed authenticated nested route without losing its URL", async () => {
+    mockAPIs();
+    const path = "/ja/agents?view=active#list";
+    context.mocks.browser.url(`https://app.okou.ai${path}`);
+    context.mocks.data.userPreferences({ locale: "en-US" });
+
+    detachedSetupPage({ context, path });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { level: 1, name: "エージェント" }),
+      ).toBeInTheDocument();
+    });
+    expect(pathname()).toBe("/ja/agents");
+    expect(search()).toBe("?view=active");
+    expect(hash()).toBe("#list");
+  });
+
+  it.each([
+    ["https://app.okou.ai/zh", "/zh"],
+    ["https://app.vm0.ai/en", "/en"],
+  ] as const)(
+    "keeps unsupported or cross-brand locale URL %s on the existing 404 policy",
+    async (url, path) => {
+      context.mocks.browser.url(url);
+
+      detachedSetupPage({ context, path });
+
+      await screen.findByRole("heading", { name: "Page not found" });
+      expect(pathname()).toBe(path);
+    },
+  );
+
   it("renders the not found page for unknown routes", async () => {
     mockAPIs();
     detachedSetupPage({ context, path: "/missing-platform-route" });
@@ -173,18 +226,55 @@ describe("link navigation", () => {
     });
   });
 
+  it("preserves an explicit Okou locale in links and in-app navigation", async () => {
+    mockAPIs();
+    const openedTargets = context.mocks.browser.open();
+    context.mocks.browser.url("https://app.okou.ai/ja");
+
+    detachedSetupPage({ context, path: "/ja" });
+
+    const link = await waitFor(() => {
+      const rail = screen.getByTestId("labeled-nav-rail");
+      return within(rail).getByText("エージェント").closest("a");
+    });
+    expect(link).toHaveAttribute("href", "/ja/agents");
+
+    fireEvent.click(link!);
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/ja/agents");
+      expect(
+        screen.getByRole("heading", { level: 1, name: "エージェント" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(link!, { metaKey: true });
+
+    await waitFor(() => {
+      expect(openedTargets.calls).toStrictEqual([
+        expect.objectContaining({
+          target: "_blank",
+          url: "https://app.okou.ai/ja/agents",
+        }),
+      ]);
+    });
+  });
+
   it("completes a sign-in token route and returns home", async () => {
     mockAPIs();
+    context.mocks.browser.url(
+      "https://app.okou.ai/en/sign-in-token?token=clerk-ticket",
+    );
 
     detachedSetupPage({
       context,
-      path: "/sign-in-token?token=clerk-ticket",
+      path: "/en/sign-in-token?token=clerk-ticket",
       user: null,
       session: null,
     });
 
     await waitFor(() => {
-      expect(pathname()).toBe("/");
+      expect(pathname()).toBe("/en");
     });
     expect(mockedClerk.clientSignInCreate).toHaveBeenCalledWith({
       strategy: "ticket",

--- a/turbo/apps/platform/src/views/router/link.tsx
+++ b/turbo/apps/platform/src/views/router/link.tsx
@@ -1,8 +1,10 @@
-import { useSet } from "ccstate-react";
+import { useGet, useSet } from "ccstate-react";
 import type { MouseEvent, Ref } from "react";
+import { preserveLocalePathPrefix } from "../../i18n/locale-routing.ts";
 import {
-  generateRouterPath,
   detachedNavigateTo$,
+  generateRouterPath,
+  urlLocale$,
 } from "../../signals/route.ts";
 
 type PathName = Parameters<typeof generateRouterPath>[0];
@@ -47,8 +49,14 @@ export function Link({
   ...rest
 }: LinkProps) {
   const navigate = useSet(detachedNavigateTo$);
+  const urlLocale = useGet(urlLocale$);
   const path = generateRouterPath(pathname, options?.pathParams);
-  const href = buildHref(path, options?.searchParams, options?.hash);
+  const localizedPath = preserveLocalePathPrefix(
+    path,
+    location.hostname,
+    urlLocale,
+  );
+  const href = buildHref(localizedPath, options?.searchParams, options?.hash);
 
   const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
     onClick?.(e);

--- a/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
@@ -13,6 +13,51 @@ const context = testContext();
 const SHARED_THREAD_ID = "30000000-0000-4000-8000-000000000702";
 
 describe("shared thread page", () => {
+  it("preserves an explicit Okou locale in public handoff and auth links", async () => {
+    const path = `/fr/share/threads/${SHARED_THREAD_ID}`;
+    context.mocks.browser.url(`https://app.okou.ai${path}`);
+    context.mocks.api(sharedThreadsContract.get, ({ respond }) => {
+      return respond(200, {
+        id: SHARED_THREAD_ID,
+        title: "Locale handoff",
+        publicBrand: "okou",
+        messages: [],
+      });
+    });
+
+    detachedSetupPage({ context, path, user: null });
+
+    await screen.findByRole("heading", { name: "Locale handoff" });
+    const links = queryAllByRoleFast("link");
+    const brandLink = links.find((link) => {
+      return link.getAttribute("aria-label") === "Okou";
+    });
+    expect(brandLink).toHaveAttribute("href", "https://app.okou.ai/fr");
+
+    const urls = links.flatMap((link) => {
+      const href = link.getAttribute("href");
+      return href ? [new URL(href, window.location.origin)] : [];
+    });
+    const signInUrls = urls.filter((url) => {
+      return url.pathname === "/fr/sign-in";
+    });
+    expect(signInUrls).toHaveLength(2);
+    const handoffUrl = new URL(
+      signInUrls[0]?.searchParams.get("redirect_url") ?? "",
+    );
+    expect(handoffUrl.pathname).toBe("/fr");
+    expect(handoffUrl.searchParams.get("prompt")).toContain(
+      `/fr/share/threads/${SHARED_THREAD_ID}`,
+    );
+
+    const signUpUrl = urls.find((url) => {
+      return url.pathname === "/fr/sign-up";
+    });
+    expect(signUpUrl?.searchParams.get("redirect_url")).toBe(
+      handoffUrl.toString(),
+    );
+  });
+
   it("renders the immutable public DTO without owner or agent identity", async () => {
     const user = userEvent.setup({ delay: null });
     const clipboard = context.mocks.browser.clipboardWriteText();

--- a/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
@@ -15,6 +15,8 @@ import {
 } from "@okouai/core/public-brand";
 
 import type { BrandName } from "../../signals/branding.ts";
+import { preserveLocalePathPrefix } from "../../i18n/locale-routing.ts";
+import { urlLocale$ } from "../../signals/route.ts";
 import type { SharedThreadRichContentSignals } from "../../signals/shared-thread-page/shared-thread-rich-content.ts";
 import { writeToClipboard } from "../../signals/okou-page/clipboard.ts";
 import { detach, Reason } from "../../signals/utils.ts";
@@ -490,9 +492,21 @@ export function SharedThreadPage({
   const groups = sharedThread ? groupSharedMessages(sharedThread.messages) : [];
   const publicBrand = sharedThread?.publicBrand ?? "vm0";
   const presentation = publicBrandPresentation(publicBrand);
-  const homeUrl = appUrlForPublicBrand(window.location.origin, publicBrand);
+  const urlLocale = useGet(urlLocale$);
+  const homeUrlBase = new URL(
+    appUrlForPublicBrand(window.location.origin, publicBrand),
+  );
+  const homeOrigin = homeUrlBase.origin;
+  const homeHostname = homeUrlBase.hostname;
+  const homePathname = preserveLocalePathPrefix("/", homeHostname, urlLocale);
+  const homeUrl =
+    homePathname === "/" ? homeOrigin : `${homeOrigin}${homePathname}`;
   const shareUrl = sharedThread
-    ? `${window.location.origin}/share/threads/${encodeURIComponent(sharedThread.id)}`
+    ? `${window.location.origin}${preserveLocalePathPrefix(
+        `/share/threads/${encodeURIComponent(sharedThread.id)}`,
+        window.location.hostname,
+        urlLocale,
+      )}`
     : null;
   const handoffUrl = new URL(homeUrl);
   if (shareUrl) {
@@ -506,9 +520,15 @@ export function SharedThreadPage({
       ),
     );
   }
-  const signInUrl = new URL("/sign-in", `${homeUrl}/`);
+  const signInUrl = new URL(
+    preserveLocalePathPrefix("/sign-in", homeHostname, urlLocale),
+    `${homeOrigin}/`,
+  );
   signInUrl.searchParams.set("redirect_url", handoffUrl.toString());
-  const signUpUrl = new URL("/sign-up", `${homeUrl}/`);
+  const signUpUrl = new URL(
+    preserveLocalePathPrefix("/sign-up", homeHostname, urlLocale),
+    `${homeOrigin}/`,
+  );
   signUpUrl.searchParams.set("redirect_url", handoffUrl.toString());
 
   return (


### PR DESCRIPTION
## Summary

- route canonical Okou locale prefixes through the existing platform router while keeping locale-free URLs backward compatible
- initialize i18next and Clerk localization from an explicit URL locale, then fall back to the saved authenticated preference and `en-US`
- preserve locale, route suffix, query, and hash across in-app links, language switching, public handoff links, and Clerk authentication/organization/account redirects
- load non-English resources through the standalone Worker preview's existing same-origin asset proxy while leaving production, legacy preview, and VM0 asset URLs unchanged
- keep VM0 routing isolated and leave unsupported prefixes such as `/zh` on the existing not-found policy

## Route and locale mapping

| Prefix | Locale |
| --- | --- |
| `/en` | `en-US` |
| `/pt-BR` | `pt-BR` |
| `/ja` | `ja-JP` |
| `/ko` | `ko-KR` |
| `/id` | `id-ID` |
| `/de` | `de-DE` |
| `/es` | `es-ES` |
| `/it` | `it-IT` |
| `/fr` | `fr-FR` |
| `/hi` | `hi-IN` |

Precedence is: explicit supported prefix on an Okou hostname, authenticated workspace preference for a locale-free URL, then `en-US`. Prefix parsing is exact and Okou-only; VM0 and unsupported prefixes continue through normal route matching and 404 handling.

## Verification

- `pnpm --filter @okouai/app check-types`
- `pnpm exec tsc -p tsconfig.tests.json --noEmit`
- targeted and full app Oxlint, type-aware Oxlint, ESLint, and Prettier checks on changed files
- `pnpm --filter @okouai/app lint:localized-ui`
- `pnpm --filter @okouai/app lint:i18n`
- 129 focused locale/router/auth/settings/public-page tests across 9 files
- 42 focused locale-asset/bootstrap/Clerk tests across 3 files
- focused platform-context and account-switch regression tests
- exact-head GitHub Actions: Turbo, Security Scanning, CodeQL, Crates, and Runner Image all passed

## Browser evidence

- PR head: `4e84db92bd85eb22158a5a5d6dcfdd7823d8b7d6`
- deployed synthetic merge: `a0ba8d2731ffdf41e6bb3542d39396d089f3a656`
- App: `https://pr-31304-app-okou-app-preview.vm0.workers.dev`
- API: `https://pr-31304-api.vm6.ai`
- environment: Chromium 151, 1440×900, no feature switches; fresh Clerk test account; localized onboarding was rendered before onboarding was bypassed solely to exercise authenticated app routes; API preview protection was bypassed only for the exact API origin
- screenshots: [English sign-in](https://cdn.vm0.io/artifacts/xps2z5mdz2.png), [Japanese sign-up](https://cdn.vm0.io/artifacts/aqrzg7jlda.png), [German persisted settings](https://cdn.vm0.io/artifacts/f9q2cwh1ve.png)

| Check | Result |
| --- | --- |
| `/en/sign-in?source=browser-qa#proof` | PASS — current Okou Auth v2 UI, English Clerk copy, correct locale, no early/runtime Clerk configuration mismatch |
| `/ja/sign-up?source=browser-qa#proof` | PASS — Japanese Clerk and app copy; locale resources fetched from the Worker same-origin asset proxy |
| unauthenticated `/ja/agents?view=all&source=nested-qa#section` | PASS — localized sign-in and full nested return URL, query, and hash preserved |
| authenticated `/ja/agents?settings=preference&source=browser-qa#language` | PASS — current localized app and existing language control |
| Japanese → German switch | PASS — immediate German UI and URL replacement to `/de/agents?settings=preference&source=browser-qa#language` |
| reload and saved preference | PASS — German prefix/query/hash and selection persisted; locale-free `/agents` loaded the saved German preference |
| explicit URL precedence | PASS — `/ja/agents` overrode the saved German preference for that URL without replacing the saved preference |
| `/en` and `/en/` | PASS — entered the current authenticated app rather than the not-found shell |
| unsupported `/zh` | PASS — remained on the localized existing 404 policy rather than being accepted as a locale |
| VM0 isolation | PASS in exact-head unit/integration coverage; production baseline showed `/sign-in` unchanged and `/en` still follows VM0's existing 404 behavior |

The per-PR deployment exposes only the Okou standalone Worker hostname, so there is no exact-head `app.vm0.ai` custom-host browser target. VM0 isolation is therefore covered by exact-head automated tests plus the production baseline smoke above.

Co-authored-by: Okou <okou@vm0.ai>
