### PR TITLE
fix(platform): use inbound agentphone connection flow

### DIFF
--- a/turbo/apps/platform/scripts/check-localized-ui.mjs
+++ b/turbo/apps/platform/scripts/check-localized-ui.mjs
@@ -140,6 +140,10 @@ function getInternalAllowedLiterals() {
 function getConnectorAllowedLiterals() {
   return [
     [
+      "src/views/okou-page/agentphone-card.tsx\u0000hi",
+      "AgentPhone inbound connection handshake message",
+    ],
+    [
       "src/views/okou-page/components/model-provider-picker.tsx\u0000BYOK",
       "bring-your-own-key product acronym",
     ],

--- a/turbo/apps/platform/scripts/check-localized-ui.mjs
+++ b/turbo/apps/platform/scripts/check-localized-ui.mjs
@@ -140,10 +140,6 @@ function getInternalAllowedLiterals() {
 function getConnectorAllowedLiterals() {
   return [
     [
-      "src/views/okou-page/agentphone-card.tsx\u0000hi",
-      "AgentPhone inbound connection handshake message",
-    ],
-    [
       "src/views/okou-page/components/model-provider-picker.tsx\u0000BYOK",
       "bring-your-own-key product acronym",
     ],

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -2929,19 +2929,20 @@
       "agentphone": {
         "authorizedSender": "Autorisierter Absender",
         "connectAria": "Telefon anschließen",
-        "connectDescription": "Senden Sie eine Direktnachricht von der Telefonnummer, die Sie verbinden möchten.",
+        "connectDescription": "Senden Sie von dem Telefon, das Sie verbinden möchten, eine Nachricht an diese AgentPhone-Nummer.",
         "connectTitle": "Telefon anschließen",
         "copyAria": "Kopieren Sie {{phone}}",
         "copyError": "Telefonnummer konnte nicht kopiert werden",
         "copySuccess": "Telefonnummer kopiert",
         "description": "SMS-Zugriff auf {{assistantName}}",
         "destination": "iMessage oder SMS an",
-        "messageInstruction": "Senden Sie „hi“ an diese Nummer",
+        "messageInstruction": "Senden Sie „hi“",
         "openMessages": "Nachrichten öffnen",
         "options": "Telefonoptionen",
         "phoneLabel": "Telefon",
-        "replyInstruction": "Wir antworten mit einem Verbindungslink. Öffnen Sie ihn innerhalb von 10 Minuten, um die Verbindung abzuschließen.",
-        "risk": "SMS- und MMS-Antworten werden möglicherweise nicht zuverlässig zugestellt. Für ein möglichst zuverlässiges Erlebnis verwenden Sie iMessage mit dieser AgentPhone-Nummer."
+        "replyInstruction": "Öffnen Sie den Verbindungslink innerhalb von 10 Minuten, um die Verbindung abzuschließen.",
+        "replyTitle": "Öffnen Sie unsere Antwort",
+        "risk": "Verwenden Sie nach Möglichkeit iMessage. SMS- und MMS-Antworten kommen möglicherweise nicht zuverlässig an."
       },
       "catalogDiagnostics": {
         "fields": {

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -2929,21 +2929,19 @@
       "agentphone": {
         "authorizedSender": "Autorisierter Absender",
         "connectAria": "Telefon anschließen",
-        "connectDescription": "Geben Sie Ihre Telefonnummer ein. Wir senden Ihnen einen Bestätigungslink per SMS, der diesen Arbeitsbereich verbindet.",
+        "connectDescription": "Senden Sie eine Direktnachricht von der Telefonnummer, die Sie verbinden möchten.",
         "connectTitle": "Telefon anschließen",
         "copyAria": "Kopieren Sie {{phone}}",
         "copyError": "Telefonnummer konnte nicht kopiert werden",
         "copySuccess": "Telefonnummer kopiert",
         "description": "SMS-Zugriff auf {{assistantName}}",
         "destination": "iMessage oder SMS an",
-        "normalized": "Wir werden {{phone}} eine SMS senden.",
+        "messageInstruction": "Senden Sie „hi“ an diese Nummer",
+        "openMessages": "Nachrichten öffnen",
         "options": "Telefonoptionen",
         "phoneLabel": "Telefon",
-        "phoneNumber": "Telefonnummer",
-        "risk": "SMS- und MMS-Antworten werden möglicherweise nicht zuverlässig zugestellt. Für ein möglichst zuverlässiges Erlebnis verwenden Sie iMessage mit dieser AgentPhone-Nummer.",
-        "sending": "Senden...",
-        "sendVerification": "Bestätigung senden",
-        "verificationSent": "Bestätigungstext an {{phone}} gesendet. Öffnen Sie den Link in diesem Text, um die Verbindung abzuschließen."
+        "replyInstruction": "Wir antworten mit einem Verbindungslink. Öffnen Sie ihn innerhalb von 10 Minuten, um die Verbindung abzuschließen.",
+        "risk": "SMS- und MMS-Antworten werden möglicherweise nicht zuverlässig zugestellt. Für ein möglichst zuverlässiges Erlebnis verwenden Sie iMessage mit dieser AgentPhone-Nummer."
       },
       "catalogDiagnostics": {
         "fields": {
@@ -3006,7 +3004,6 @@
         }
       },
       "errors": {
-        "agentphonePhone": "Geben Sie eine Telefonnummer mit Landesvorwahl ein, z. B. +1 555 555 1212.",
         "githubAuthorizationWindow": "Das Autorisierungsfenster konnte nicht geöffnet werden",
         "telegramDomain": "Die Domain ist für Telegram noch nicht sichtbar. Überprüfen Sie BotFather und versuchen Sie es erneut.",
         "telegramPrivacy": "Der Datenschutzmodus scheint immer noch aktiviert zu sein. Schalten Sie es in BotFather aus und versuchen Sie es dann erneut."
@@ -3212,7 +3209,6 @@
       "toasts": {
         "agentphoneConnected": "AgentPhone verbunden",
         "agentphoneDisconnected": "AgentPhone getrennt",
-        "agentphoneVerificationSent": "Bestätigungstext gesendet",
         "feishuBotInstalled": "Der Feishu-Bot wurde erfolgreich installiert",
         "feishuBotUninstalled": "Feishu-Bot deinstalliert",
         "feishuConnected": "Feishu hat erfolgreich eine Verbindung hergestellt",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -2921,21 +2921,19 @@
       "agentphone": {
         "authorizedSender": "Authorized sender",
         "connectAria": "Connect phone",
-        "connectDescription": "Enter your phone number. We will text a verification link that connects this workspace.",
+        "connectDescription": "Send a direct message from the phone number you want to connect.",
         "connectTitle": "Connect phone",
         "copyAria": "Copy {{phone}}",
         "copyError": "Failed to copy phone number",
         "copySuccess": "Phone number copied",
         "description": "Text-message access to {{assistantName}}",
         "destination": "iMessage or SMS to",
-        "normalized": "We will text {{phone}}.",
+        "messageInstruction": "Send “hi” to this number",
+        "openMessages": "Open Messages",
         "options": "Phone options",
         "phoneLabel": "Phone",
-        "phoneNumber": "Phone number",
-        "risk": "SMS and MMS replies may not be delivered reliably. For the most reliable experience, use iMessage with this AgentPhone number.",
-        "sending": "Sending...",
-        "sendVerification": "Send verification",
-        "verificationSent": "Verification text sent to {{phone}}. Open the link in that text to finish connecting."
+        "replyInstruction": "We’ll reply with a connection link. Open it within 10 minutes to finish connecting.",
+        "risk": "SMS and MMS replies may not be delivered reliably. For the most reliable experience, use iMessage with this AgentPhone number."
       },
       "catalogDiagnostics": {
         "fields": {
@@ -2998,7 +2996,6 @@
         }
       },
       "errors": {
-        "agentphonePhone": "Enter a phone number with country code, like +1 555 555 1212.",
         "githubAuthorizationWindow": "Failed to open authorization window",
         "telegramDomain": "Domain is not visible to Telegram yet. Check BotFather and try again.",
         "telegramPrivacy": "Privacy mode still appears to be on. Turn it off in BotFather, then try again."
@@ -3204,7 +3201,6 @@
       "toasts": {
         "agentphoneConnected": "AgentPhone connected",
         "agentphoneDisconnected": "AgentPhone disconnected",
-        "agentphoneVerificationSent": "Verification text sent",
         "feishuBotInstalled": "Feishu bot installed successfully",
         "feishuBotUninstalled": "Feishu bot uninstalled",
         "feishuConnected": "Feishu connected successfully",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -2921,19 +2921,20 @@
       "agentphone": {
         "authorizedSender": "Authorized sender",
         "connectAria": "Connect phone",
-        "connectDescription": "Send a direct message from the phone number you want to connect.",
+        "connectDescription": "Message this AgentPhone number from the phone you want to connect.",
         "connectTitle": "Connect phone",
         "copyAria": "Copy {{phone}}",
         "copyError": "Failed to copy phone number",
         "copySuccess": "Phone number copied",
         "description": "Text-message access to {{assistantName}}",
         "destination": "iMessage or SMS to",
-        "messageInstruction": "Send “hi” to this number",
+        "messageInstruction": "Send “hi”",
         "openMessages": "Open Messages",
         "options": "Phone options",
         "phoneLabel": "Phone",
-        "replyInstruction": "We’ll reply with a connection link. Open it within 10 minutes to finish connecting.",
-        "risk": "SMS and MMS replies may not be delivered reliably. For the most reliable experience, use iMessage with this AgentPhone number."
+        "replyInstruction": "Tap the connection link within 10 minutes to finish.",
+        "replyTitle": "Open our reply",
+        "risk": "Use iMessage when possible. SMS and MMS replies may not arrive reliably."
       },
       "catalogDiagnostics": {
         "fields": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -2980,21 +2980,19 @@
       "agentphone": {
         "authorizedSender": "Remitente autorizado",
         "connectAria": "Conectar teléfono",
-        "connectDescription": "Introduce tu número de teléfono. Enviaremos un enlace de verificación por mensaje que conecte este espacio de trabajo.",
+        "connectDescription": "Envía un mensaje directo desde el número de teléfono que quieres conectar.",
         "connectTitle": "Conectar teléfono",
         "copyAria": "Copiar {{phone}}",
         "copyError": "No se pudo copiar el número de teléfono",
         "copySuccess": "Número de teléfono copiado",
         "description": "Acceso por mensajes de texto a {{assistantName}}",
         "destination": "iMessage o SMS a",
-        "normalized": "Enviaremos un mensaje a {{phone}}.",
+        "messageInstruction": "Envía «hi» a este número",
+        "openMessages": "Abrir Mensajes",
         "options": "Opciones de teléfono",
         "phoneLabel": "Teléfono",
-        "phoneNumber": "Número de teléfono",
-        "risk": "Las respuestas SMS y MMS pueden no entregarse de forma fiable. Para una experiencia fiable, utiliza iMessage con este número de AgentPhone.",
-        "sending": "Enviando...",
-        "sendVerification": "Enviar verificación",
-        "verificationSent": "Mensaje de verificación enviado a {{phone}}. Abre el enlace en ese mensaje para terminar de conectar."
+        "replyInstruction": "Responderemos con un enlace de conexión. Ábrelo en un plazo de 10 minutos para terminar la conexión.",
+        "risk": "Las respuestas SMS y MMS pueden no entregarse de forma fiable. Para una experiencia fiable, utiliza iMessage con este número de AgentPhone."
       },
       "catalogDiagnostics": {
         "fields": {
@@ -3057,7 +3055,6 @@
         }
       },
       "errors": {
-        "agentphonePhone": "Introduce un número de teléfono con código de país, como +1 555 555 1212.",
         "githubAuthorizationWindow": "No se abrió la ventana de autorización",
         "telegramDomain": "El dominio aún no es visible para Telegram. Comprueba BotFather y vuelve a intentarlo.",
         "telegramPrivacy": "El modo de privacidad sigue activado. Desactívalo en BotFather y vuelve a intentarlo."
@@ -3263,7 +3260,6 @@
       "toasts": {
         "agentphoneConnected": "AgentPhone conectado",
         "agentphoneDisconnected": "AgentPhone desconectado",
-        "agentphoneVerificationSent": "Mensaje de verificación enviado",
         "feishuBotInstalled": "Feishu bot instalado correctamente",
         "feishuBotUninstalled": "Feishu bot desinstalado",
         "feishuConnected": "Feishu conectado con éxito",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -2980,19 +2980,20 @@
       "agentphone": {
         "authorizedSender": "Remitente autorizado",
         "connectAria": "Conectar teléfono",
-        "connectDescription": "Envía un mensaje directo desde el número de teléfono que quieres conectar.",
+        "connectDescription": "Envía un mensaje a este número de AgentPhone desde el teléfono que quieres conectar.",
         "connectTitle": "Conectar teléfono",
         "copyAria": "Copiar {{phone}}",
         "copyError": "No se pudo copiar el número de teléfono",
         "copySuccess": "Número de teléfono copiado",
         "description": "Acceso por mensajes de texto a {{assistantName}}",
         "destination": "iMessage o SMS a",
-        "messageInstruction": "Envía «hi» a este número",
+        "messageInstruction": "Envía «hi»",
         "openMessages": "Abrir Mensajes",
         "options": "Opciones de teléfono",
         "phoneLabel": "Teléfono",
-        "replyInstruction": "Responderemos con un enlace de conexión. Ábrelo en un plazo de 10 minutos para terminar la conexión.",
-        "risk": "Las respuestas SMS y MMS pueden no entregarse de forma fiable. Para una experiencia fiable, utiliza iMessage con este número de AgentPhone."
+        "replyInstruction": "Toca el enlace de conexión en un plazo de 10 minutos para terminar.",
+        "replyTitle": "Abre nuestra respuesta",
+        "risk": "Usa iMessage cuando sea posible. Es posible que las respuestas por SMS y MMS no lleguen de forma fiable."
       },
       "catalogDiagnostics": {
         "fields": {

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -2980,21 +2980,19 @@
       "agentphone": {
         "authorizedSender": "Expéditeur autorisé",
         "connectAria": "Connecter le téléphone",
-        "connectDescription": "Entrez votre numéro de téléphone. Nous enverrons un lien de vérification par SMS pour connecter cet espace de travail.",
+        "connectDescription": "Envoyez un message direct depuis le numéro de téléphone que vous souhaitez connecter.",
         "connectTitle": "Connecter le téléphone",
         "copyAria": "Copier {{phone}}",
         "copyError": "Échec de la copie du numéro de téléphone",
         "copySuccess": "Numéro de téléphone copié",
         "description": "Accès aux messages texte pour {{assistantName}}",
         "destination": "iMessage ou SMS à",
-        "normalized": "Nous enverrons un SMS à {{phone}}.",
+        "messageInstruction": "Envoyez « hi » à ce numéro",
+        "openMessages": "Ouvrir Messages",
         "options": "Options de téléphone",
         "phoneLabel": "Téléphone",
-        "phoneNumber": "Numéro de téléphone",
-        "risk": "Les réponses SMS et MMS peuvent ne pas être délivrées de manière fiable. Pour une expérience plus fiable, utilisez iMessage avec ce numéro AgentPhone.",
-        "sending": "Envoi...",
-        "sendVerification": "Envoyer la vérification",
-        "verificationSent": "Texte de vérification envoyé à {{phone}}. Ouvrez le lien dans ce texte pour terminer la connexion."
+        "replyInstruction": "Nous répondrons avec un lien de connexion. Ouvrez-le dans les 10 minutes pour terminer la connexion.",
+        "risk": "Les réponses SMS et MMS peuvent ne pas être délivrées de manière fiable. Pour une expérience plus fiable, utilisez iMessage avec ce numéro AgentPhone."
       },
       "catalogDiagnostics": {
         "fields": {
@@ -3057,7 +3055,6 @@
         }
       },
       "errors": {
-        "agentphonePhone": "Entrez un numéro de téléphone avec le code du pays, comme +1 555 555 1212.",
         "githubAuthorizationWindow": "Échec de l'ouverture de la fenêtre d'autorisation",
         "telegramDomain": "Le domaine n'est pas encore visible pour Telegram. Vérifiez BotFather et essayez à nouveau.",
         "telegramPrivacy": "Le mode de confidentialité semble toujours activé. Désactivez-le dans BotFather, puis réessayez."
@@ -3263,7 +3260,6 @@
       "toasts": {
         "agentphoneConnected": "AgentPhone connecté",
         "agentphoneDisconnected": "AgentPhone déconnecté",
-        "agentphoneVerificationSent": "Texte de vérification envoyé",
         "feishuBotInstalled": "Bot Feishu installé avec succès",
         "feishuBotUninstalled": "Bot Feishu désinstallé",
         "feishuConnected": "Feishu connecté avec succès",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -2980,19 +2980,20 @@
       "agentphone": {
         "authorizedSender": "Expéditeur autorisé",
         "connectAria": "Connecter le téléphone",
-        "connectDescription": "Envoyez un message direct depuis le numéro de téléphone que vous souhaitez connecter.",
+        "connectDescription": "Envoyez un message à ce numéro AgentPhone depuis le téléphone que vous souhaitez connecter.",
         "connectTitle": "Connecter le téléphone",
         "copyAria": "Copier {{phone}}",
         "copyError": "Échec de la copie du numéro de téléphone",
         "copySuccess": "Numéro de téléphone copié",
         "description": "Accès aux messages texte pour {{assistantName}}",
         "destination": "iMessage ou SMS à",
-        "messageInstruction": "Envoyez « hi » à ce numéro",
+        "messageInstruction": "Envoyez « hi »",
         "openMessages": "Ouvrir Messages",
         "options": "Options de téléphone",
         "phoneLabel": "Téléphone",
-        "replyInstruction": "Nous répondrons avec un lien de connexion. Ouvrez-le dans les 10 minutes pour terminer la connexion.",
-        "risk": "Les réponses SMS et MMS peuvent ne pas être délivrées de manière fiable. Pour une expérience plus fiable, utilisez iMessage avec ce numéro AgentPhone."
+        "replyInstruction": "Ouvrez le lien de connexion dans les 10 minutes pour terminer.",
+        "replyTitle": "Ouvrez notre réponse",
+        "risk": "Utilisez iMessage lorsque c’est possible. Les réponses par SMS et MMS peuvent ne pas arriver de manière fiable."
       },
       "catalogDiagnostics": {
         "fields": {

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -2929,19 +2929,20 @@
       "agentphone": {
         "authorizedSender": "अधिकृत प्रेषक",
         "connectAria": "फ़ोन कनेक्ट करें",
-        "connectDescription": "जिस फ़ोन नंबर को आप कनेक्ट करना चाहते हैं, उससे एक सीधा संदेश भेजें।",
+        "connectDescription": "जिस फ़ोन को आप कनेक्ट करना चाहते हैं, उससे इस AgentPhone नंबर पर मैसेज भेजें।",
         "connectTitle": "फ़ोन कनेक्ट करें",
         "copyAria": "{{phone}} कॉपी करें",
         "copyError": "फ़ोन नंबर कॉपी करने में विफल",
         "copySuccess": "फ़ोन नंबर कॉपी किया गया",
         "description": "{{assistantName}} तक टेक्स्ट-संदेश पहुंच",
         "destination": "iMessage या SMS को",
-        "messageInstruction": "इस नंबर पर “hi” भेजें",
+        "messageInstruction": "“hi” भेजें",
         "openMessages": "मैसेज खोलें",
         "options": "फ़ोन विकल्प",
         "phoneLabel": "फ़ोन",
-        "replyInstruction": "हम कनेक्शन लिंक के साथ जवाब देंगे। कनेक्शन पूरा करने के लिए इसे 10 मिनट के अंदर खोलें।",
-        "risk": "SMS और MMS उत्तर विश्वसनीय रूप से वितरित नहीं किए जा सकते हैं। सबसे विश्वसनीय अनुभव के लिए, इस AgentPhone नंबर के साथ iMessage का उपयोग करें।"
+        "replyInstruction": "कनेक्शन पूरा करने के लिए 10 मिनट के अंदर कनेक्शन लिंक खोलें।",
+        "replyTitle": "हमारा जवाब खोलें",
+        "risk": "जहाँ संभव हो iMessage का उपयोग करें। SMS और MMS के जवाब भरोसेमंद तरीके से नहीं पहुँच सकते हैं।"
       },
       "catalogDiagnostics": {
         "fields": {

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -2929,21 +2929,19 @@
       "agentphone": {
         "authorizedSender": "अधिकृत प्रेषक",
         "connectAria": "फ़ोन कनेक्ट करें",
-        "connectDescription": "अपना फोन नंबर डालें। हम एक सत्यापन लिंक टेक्स्ट करेंगे जो इस वर्कस्पेस को जोड़ता है।",
+        "connectDescription": "जिस फ़ोन नंबर को आप कनेक्ट करना चाहते हैं, उससे एक सीधा संदेश भेजें।",
         "connectTitle": "फ़ोन कनेक्ट करें",
         "copyAria": "{{phone}} कॉपी करें",
         "copyError": "फ़ोन नंबर कॉपी करने में विफल",
         "copySuccess": "फ़ोन नंबर कॉपी किया गया",
         "description": "{{assistantName}} तक टेक्स्ट-संदेश पहुंच",
         "destination": "iMessage या SMS को",
-        "normalized": "हम {{phone}} टेक्स्ट करेंगे।",
+        "messageInstruction": "इस नंबर पर “hi” भेजें",
+        "openMessages": "मैसेज खोलें",
         "options": "फ़ोन विकल्प",
         "phoneLabel": "फ़ोन",
-        "phoneNumber": "फ़ोन नंबर",
-        "risk": "SMS और MMS उत्तर विश्वसनीय रूप से वितरित नहीं किए जा सकते हैं। सबसे विश्वसनीय अनुभव के लिए, इस AgentPhone नंबर के साथ iMessage का उपयोग करें।",
-        "sending": "भेजा जा रहा है...",
-        "sendVerification": "सत्यापन भेजें",
-        "verificationSent": "सत्यापन पाठ {{phone}} को भेजा गया। कनेक्ट करना समाप्त करने के लिए उस टेक्स्ट में लिंक खोलें।"
+        "replyInstruction": "हम कनेक्शन लिंक के साथ जवाब देंगे। कनेक्शन पूरा करने के लिए इसे 10 मिनट के अंदर खोलें।",
+        "risk": "SMS और MMS उत्तर विश्वसनीय रूप से वितरित नहीं किए जा सकते हैं। सबसे विश्वसनीय अनुभव के लिए, इस AgentPhone नंबर के साथ iMessage का उपयोग करें।"
       },
       "catalogDiagnostics": {
         "fields": {
@@ -3006,7 +3004,6 @@
         }
       },
       "errors": {
-        "agentphonePhone": "देश कोड के साथ एक फ़ोन नंबर दर्ज करें, जैसे +1 555 555 1212।",
         "githubAuthorizationWindow": "प्राधिकरण विंडो खोलने में विफल",
         "telegramDomain": "डोमेन अभी तक Telegram को दिखाई नहीं दे रहा है। BotFather की जाँच करें और पुनः प्रयास करें।",
         "telegramPrivacy": "गोपनीयता मोड अभी भी चालू प्रतीत होता है. इसे BotFather में बंद करें, फिर पुनः प्रयास करें।"
@@ -3212,7 +3209,6 @@
       "toasts": {
         "agentphoneConnected": "AgentPhone जुड़ा",
         "agentphoneDisconnected": "AgentPhone डिस्कनेक्ट हो गया",
-        "agentphoneVerificationSent": "सत्यापन पाठ भेजा गया",
         "feishuBotInstalled": "Feishu बॉट सफलतापूर्वक स्थापित हुआ",
         "feishuBotUninstalled": "Feishu बॉट अनइंस्टॉल किया गया",
         "feishuConnected": "Feishu सफलतापूर्वक कनेक्ट हुआ",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -2921,21 +2921,19 @@
       "agentphone": {
         "authorizedSender": "Pengirim yang diizinkan",
         "connectAria": "Hubungkan telepon",
-        "connectDescription": "Masukkan nomor telepon Anda. Kami akan mengirim tautan verifikasi yang menghubungkan workspace ini.",
+        "connectDescription": "Kirim pesan langsung dari nomor telepon yang ingin Anda hubungkan.",
         "connectTitle": "Hubungkan telepon",
         "copyAria": "Salin {{phone}}",
         "copyError": "Gagal menyalin nomor telepon",
         "copySuccess": "Nomor telepon disalin",
         "description": "Akses {{assistantName}} lewat pesan teks",
         "destination": "iMessage atau SMS ke",
-        "normalized": "Kami akan mengirim SMS ke {{phone}}.",
+        "messageInstruction": "Kirim “hi” ke nomor ini",
+        "openMessages": "Buka Pesan",
         "options": "Opsi telepon",
         "phoneLabel": "Telepon",
-        "phoneNumber": "Nomor telepon",
-        "risk": "Balasan SMS dan MMS mungkin tidak terkirim dengan andal. Untuk pengalaman paling andal, gunakan iMessage dengan nomor AgentPhone ini.",
-        "sending": "Mengirim...",
-        "sendVerification": "Kirim verifikasi",
-        "verificationSent": "SMS verifikasi telah dikirim ke {{phone}}. Buka tautan di SMS tersebut untuk menyelesaikan koneksi."
+        "replyInstruction": "Kami akan membalas dengan tautan koneksi. Buka dalam 10 menit untuk menyelesaikan koneksi.",
+        "risk": "Balasan SMS dan MMS mungkin tidak terkirim dengan andal. Untuk pengalaman paling andal, gunakan iMessage dengan nomor AgentPhone ini."
       },
       "catalogDiagnostics": {
         "fields": {
@@ -2998,7 +2996,6 @@
         }
       },
       "errors": {
-        "agentphonePhone": "Masukkan nomor telepon dengan kode negara, seperti +1 555 555 1212.",
         "githubAuthorizationWindow": "Gagal membuka jendela otorisasi",
         "telegramDomain": "Domain belum terlihat oleh Telegram. Periksa BotFather dan coba lagi.",
         "telegramPrivacy": "Mode privasi masih tampaknya aktif. Matikan di BotFather, lalu coba lagi."
@@ -3204,7 +3201,6 @@
       "toasts": {
         "agentphoneConnected": "AgentPhone terhubung",
         "agentphoneDisconnected": "AgentPhone terputus",
-        "agentphoneVerificationSent": "Teks verifikasi terkirim",
         "feishuBotInstalled": "Bot Feishu berhasil diinstal",
         "feishuBotUninstalled": "Bot Feishu di-uninstall",
         "feishuConnected": "Feishu berhasil terhubung",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -2921,19 +2921,20 @@
       "agentphone": {
         "authorizedSender": "Pengirim yang diizinkan",
         "connectAria": "Hubungkan telepon",
-        "connectDescription": "Kirim pesan langsung dari nomor telepon yang ingin Anda hubungkan.",
+        "connectDescription": "Kirim pesan ke nomor AgentPhone ini dari telepon yang ingin Anda hubungkan.",
         "connectTitle": "Hubungkan telepon",
         "copyAria": "Salin {{phone}}",
         "copyError": "Gagal menyalin nomor telepon",
         "copySuccess": "Nomor telepon disalin",
         "description": "Akses {{assistantName}} lewat pesan teks",
         "destination": "iMessage atau SMS ke",
-        "messageInstruction": "Kirim “hi” ke nomor ini",
+        "messageInstruction": "Kirim “hi”",
         "openMessages": "Buka Pesan",
         "options": "Opsi telepon",
         "phoneLabel": "Telepon",
-        "replyInstruction": "Kami akan membalas dengan tautan koneksi. Buka dalam 10 menit untuk menyelesaikan koneksi.",
-        "risk": "Balasan SMS dan MMS mungkin tidak terkirim dengan andal. Untuk pengalaman paling andal, gunakan iMessage dengan nomor AgentPhone ini."
+        "replyInstruction": "Buka tautan koneksi dalam 10 menit untuk menyelesaikannya.",
+        "replyTitle": "Buka balasan kami",
+        "risk": "Gunakan iMessage jika memungkinkan. Balasan SMS dan MMS mungkin tidak selalu terkirim."
       },
       "catalogDiagnostics": {
         "fields": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -2980,19 +2980,20 @@
       "agentphone": {
         "authorizedSender": "Mittente autorizzato",
         "connectAria": "Collega il telefono",
-        "connectDescription": "Invia un messaggio diretto dal numero di telefono che vuoi collegare.",
+        "connectDescription": "Invia un messaggio a questo numero AgentPhone dal telefono che vuoi collegare.",
         "connectTitle": "Collega il telefono",
         "copyAria": "Copia {{phone}}",
         "copyError": "Impossibile copiare il numero di telefono",
         "copySuccess": "Numero di telefono copiato",
         "description": "Accesso via SMS a {{assistantName}}",
         "destination": "iMessage o SMS a",
-        "messageInstruction": "Invia “hi” a questo numero",
+        "messageInstruction": "Invia “hi”",
         "openMessages": "Apri Messaggi",
         "options": "Opzioni del telefono",
         "phoneLabel": "Telefono",
-        "replyInstruction": "Risponderemo con un link di connessione. Aprilo entro 10 minuti per completare la connessione.",
-        "risk": "Le risposte SMS e MMS potrebbero non essere consegnate in modo affidabile. Per un'esperienza più affidabile, utilizza iMessage con questo numero AgentPhone."
+        "replyInstruction": "Apri il link di connessione entro 10 minuti per completare.",
+        "replyTitle": "Apri la nostra risposta",
+        "risk": "Usa iMessage quando possibile. Le risposte SMS e MMS potrebbero non arrivare in modo affidabile."
       },
       "catalogDiagnostics": {
         "fields": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -2980,21 +2980,19 @@
       "agentphone": {
         "authorizedSender": "Mittente autorizzato",
         "connectAria": "Collega il telefono",
-        "connectDescription": "Inserisci il tuo numero di telefono. Invieremo un SMS con un collegamento di verifica che collega questa area di lavoro.",
+        "connectDescription": "Invia un messaggio diretto dal numero di telefono che vuoi collegare.",
         "connectTitle": "Collega il telefono",
         "copyAria": "Copia {{phone}}",
         "copyError": "Impossibile copiare il numero di telefono",
         "copySuccess": "Numero di telefono copiato",
         "description": "Accesso via SMS a {{assistantName}}",
         "destination": "iMessage o SMS a",
-        "normalized": "Ti invieremo un SMS con {{phone}}.",
+        "messageInstruction": "Invia “hi” a questo numero",
+        "openMessages": "Apri Messaggi",
         "options": "Opzioni del telefono",
         "phoneLabel": "Telefono",
-        "phoneNumber": "Numero di telefono",
-        "risk": "Le risposte SMS e MMS potrebbero non essere consegnate in modo affidabile. Per un'esperienza più affidabile, utilizza iMessage con questo numero AgentPhone.",
-        "sending": "Invio...",
-        "sendVerification": "Invia verifica",
-        "verificationSent": "Testo di verifica inviato a {{phone}}. Apri il collegamento in quel testo per completare la connessione."
+        "replyInstruction": "Risponderemo con un link di connessione. Aprilo entro 10 minuti per completare la connessione.",
+        "risk": "Le risposte SMS e MMS potrebbero non essere consegnate in modo affidabile. Per un'esperienza più affidabile, utilizza iMessage con questo numero AgentPhone."
       },
       "catalogDiagnostics": {
         "fields": {
@@ -3057,7 +3055,6 @@
         }
       },
       "errors": {
-        "agentphonePhone": "Inserisci un numero di telefono con prefisso internazionale, ad esempio +1 555 555 1212.",
         "githubAuthorizationWindow": "Impossibile aprire la finestra di autorizzazione",
         "telegramDomain": "Il dominio non è ancora visibile a Telegram. Controlla BotFather e riprova.",
         "telegramPrivacy": "La modalità privacy sembra essere ancora attiva. Disattivalo in BotFather, quindi riprova."
@@ -3263,7 +3260,6 @@
       "toasts": {
         "agentphoneConnected": "AgentPhone connesso",
         "agentphoneDisconnected": "AgentPhone disconnesso",
-        "agentphoneVerificationSent": "SMS di verifica inviato",
         "feishuBotInstalled": "Feishu bot installato correttamente",
         "feishuBotUninstalled": "Feishu bot disinstallato",
         "feishuConnected": "Feishu si è connesso correttamente",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -2921,19 +2921,20 @@
       "agentphone": {
         "authorizedSender": "承認された送信者",
         "connectAria": "電話を接続する",
-        "connectDescription": "接続したい電話番号からダイレクトメッセージを送信してください。",
+        "connectDescription": "接続したい電話から、この AgentPhone 番号にメッセージを送信してください。",
         "connectTitle": "電話を接続する",
         "copyAria": "{{phone}} をコピーします",
         "copyError": "電話番号のコピーに失敗しました",
         "copySuccess": "電話番号をコピーしました",
         "description": "{{assistantName}} へのテキスト メッセージ アクセス",
         "destination": "iMessage または SMS で",
-        "messageInstruction": "この番号に「hi」と送信",
+        "messageInstruction": "「hi」と送信",
         "openMessages": "メッセージを開く",
         "options": "電話オプション",
         "phoneLabel": "電話",
-        "replyInstruction": "接続リンクを返信します。10分以内に開いて接続を完了してください。",
-        "risk": "SMS および MMS の返信は確実に配信されない可能性があります。最も信頼性の高いエクスペリエンスを得るには、この AgentPhone 番号で iMessage を使用してください。"
+        "replyInstruction": "10分以内に接続リンクを開いて完了してください。",
+        "replyTitle": "返信を開く",
+        "risk": "可能な場合は iMessage を使用してください。SMS および MMS の返信は確実に届かないことがあります。"
       },
       "catalogDiagnostics": {
         "fields": {

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -2921,21 +2921,19 @@
       "agentphone": {
         "authorizedSender": "承認された送信者",
         "connectAria": "電話を接続する",
-        "connectDescription": "電話番号を入力してください。このワークスペースに接続する確認リンクをテキストで送信します。",
+        "connectDescription": "接続したい電話番号からダイレクトメッセージを送信してください。",
         "connectTitle": "電話を接続する",
         "copyAria": "{{phone}} をコピーします",
         "copyError": "電話番号のコピーに失敗しました",
         "copySuccess": "電話番号をコピーしました",
         "description": "{{assistantName}} へのテキスト メッセージ アクセス",
         "destination": "iMessage または SMS で",
-        "normalized": "{{phone}} にテキスト メッセージを送信します。",
+        "messageInstruction": "この番号に「hi」と送信",
+        "openMessages": "メッセージを開く",
         "options": "電話オプション",
         "phoneLabel": "電話",
-        "phoneNumber": "電話番号",
-        "risk": "SMS および MMS の返信は確実に配信されない可能性があります。最も信頼性の高いエクスペリエンスを得るには、この AgentPhone 番号で iMessage を使用してください。",
-        "sending": "送信中...",
-        "sendVerification": "確認の送信",
-        "verificationSent": "検証テキストが {{phone}} に送信されました。接続を完了するには、そのテキスト内のリンクを開いてください。"
+        "replyInstruction": "接続リンクを返信します。10分以内に開いて接続を完了してください。",
+        "risk": "SMS および MMS の返信は確実に配信されない可能性があります。最も信頼性の高いエクスペリエンスを得るには、この AgentPhone 番号で iMessage を使用してください。"
       },
       "catalogDiagnostics": {
         "fields": {
@@ -2998,7 +2996,6 @@
         }
       },
       "errors": {
-        "agentphonePhone": "+1 555 555 1212 のように、国コードを含む電話番号を入力します。",
         "githubAuthorizationWindow": "認証ウィンドウを開けませんでした",
         "telegramDomain": "ドメインはまだ Telegram に表示されていません。 BotFather を確認して再試行してください。",
         "telegramPrivacy": "プライバシーモードはまだオンになっているようです。 BotFather でこれをオフにして、もう一度試してください。"
@@ -3204,7 +3201,6 @@
       "toasts": {
         "agentphoneConnected": "エージェントフォンが接続されました",
         "agentphoneDisconnected": "AgentPhone が切断されました",
-        "agentphoneVerificationSent": "確認テキストが送信されました",
         "feishuBotInstalled": "Feishu ボットは正常にインストールされました",
         "feishuBotUninstalled": "Feishu ボットがアンインストールされました",
         "feishuConnected": "Feishu は正常に接続されました",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -2921,19 +2921,20 @@
       "agentphone": {
         "authorizedSender": "승인된 발신자",
         "connectAria": "전화 연결",
-        "connectDescription": "연결하려는 전화번호에서 다이렉트 메시지를 보내세요.",
+        "connectDescription": "연결하려는 휴대폰에서 이 AgentPhone 번호로 메시지를 보내세요.",
         "connectTitle": "전화 연결",
         "copyAria": "{{phone}} 복사",
         "copyError": "전화번호 복사 실패",
         "copySuccess": "전화번호가 복사되었습니다",
         "description": "{{assistantName}}에 문자 메시지 접근",
         "destination": "iMessage 또는 SMS 수신처",
-        "messageInstruction": "이 번호로 “hi” 보내기",
+        "messageInstruction": "“hi” 보내기",
         "openMessages": "메시지 열기",
         "options": "전화 옵션",
         "phoneLabel": "전화",
-        "replyInstruction": "연결 링크를 답장으로 보내드릴게요. 10분 안에 링크를 열어 연결을 완료하세요.",
-        "risk": "SMS 및 MMS 답장은 신뢰할 수 없을 수 있습니다. 가장 안정적인 사용을 위해 이 AgentPhone 번호로 iMessage를 사용하세요."
+        "replyInstruction": "10분 안에 연결 링크를 열어 완료하세요.",
+        "replyTitle": "답장 열기",
+        "risk": "가능하면 iMessage를 사용하세요. SMS 및 MMS 답장은 안정적으로 도착하지 않을 수 있습니다."
       },
       "catalogDiagnostics": {
         "fields": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -2921,21 +2921,19 @@
       "agentphone": {
         "authorizedSender": "승인된 발신자",
         "connectAria": "전화 연결",
-        "connectDescription": "전화번호를 입력하세요. 이 워크스페이스를 연결하는 확인 링크를 문자로 보내드립니다.",
+        "connectDescription": "연결하려는 전화번호에서 다이렉트 메시지를 보내세요.",
         "connectTitle": "전화 연결",
         "copyAria": "{{phone}} 복사",
         "copyError": "전화번호 복사 실패",
         "copySuccess": "전화번호가 복사되었습니다",
         "description": "{{assistantName}}에 문자 메시지 접근",
         "destination": "iMessage 또는 SMS 수신처",
-        "normalized": "{{phone}}로 문자 메시지를 보냅니다.",
+        "messageInstruction": "이 번호로 “hi” 보내기",
+        "openMessages": "메시지 열기",
         "options": "전화 옵션",
         "phoneLabel": "전화",
-        "phoneNumber": "전화번호",
-        "risk": "SMS 및 MMS 답장은 신뢰할 수 없을 수 있습니다. 가장 안정적인 사용을 위해 이 AgentPhone 번호로 iMessage를 사용하세요.",
-        "sending": "전송 중...",
-        "sendVerification": "확인 문자 보내기",
-        "verificationSent": "{{phone}}로 확인 문자가 전송되었습니다. 문자 내 링크를 열어 연결을 완료하세요."
+        "replyInstruction": "연결 링크를 답장으로 보내드릴게요. 10분 안에 링크를 열어 연결을 완료하세요.",
+        "risk": "SMS 및 MMS 답장은 신뢰할 수 없을 수 있습니다. 가장 안정적인 사용을 위해 이 AgentPhone 번호로 iMessage를 사용하세요."
       },
       "catalogDiagnostics": {
         "fields": {
@@ -2998,7 +2996,6 @@
         }
       },
       "errors": {
-        "agentphonePhone": "국가 코드가 포함된 전화번호를 입력하세요. 예: +1 555 555 1212.",
         "githubAuthorizationWindow": "권한 부여 창을 열지 못했습니다",
         "telegramDomain": "도메인이 아직 Telegram에 표시되지 않습니다. BotFather에서 확인 후 다시 시도하세요.",
         "telegramPrivacy": "개인정보 보호 모드가 여전히 켜져 있는 것 같습니다. BotFather에서 끈 후 다시 시도하세요."
@@ -3204,7 +3201,6 @@
       "toasts": {
         "agentphoneConnected": "AgentPhone 연결됨",
         "agentphoneDisconnected": "AgentPhone 연결 해제됨",
-        "agentphoneVerificationSent": "인증 문자 전송됨",
         "feishuBotInstalled": "Feishu 봇이 성공적으로 설치되었습니다",
         "feishuBotUninstalled": "Feishu 봇이 제거되었습니다",
         "feishuConnected": "Feishu가 성공적으로 연결되었습니다",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -2980,19 +2980,20 @@
       "agentphone": {
         "authorizedSender": "Remetente autorizado",
         "connectAria": "Conectar telefone",
-        "connectDescription": "Envie uma mensagem direta do número de telefone que você quer conectar.",
+        "connectDescription": "Envie uma mensagem para este número do AgentPhone usando o telefone que você quer conectar.",
         "connectTitle": "Conectar telefone",
         "copyAria": "Copiar {{phone}}",
         "copyError": "Falha ao copiar o número de telefone",
         "copySuccess": "Número de telefone copiado",
         "description": "Acesso ao {{assistantName}} por mensagens de texto",
         "destination": "iMessage ou SMS para",
-        "messageInstruction": "Envie “hi” para este número",
+        "messageInstruction": "Envie “hi”",
         "openMessages": "Abrir Mensagens",
         "options": "Opções do telefone",
         "phoneLabel": "Telefone",
-        "replyInstruction": "Responderemos com um link de conexão. Abra-o em até 10 minutos para concluir a conexão.",
-        "risk": "As respostas por SMS e MMS podem não ser entregues de forma confiável. Para uma experiência mais confiável, use o iMessage com este número do AgentPhone."
+        "replyInstruction": "Abra o link de conexão em até 10 minutos para concluir.",
+        "replyTitle": "Abra nossa resposta",
+        "risk": "Use o iMessage quando possível. As respostas por SMS e MMS podem não chegar de forma confiável."
       },
       "catalogDiagnostics": {
         "fields": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -2980,21 +2980,19 @@
       "agentphone": {
         "authorizedSender": "Remetente autorizado",
         "connectAria": "Conectar telefone",
-        "connectDescription": "Digite seu número de telefone. Enviaremos por mensagem um link de verificação que conecta este workspace.",
+        "connectDescription": "Envie uma mensagem direta do número de telefone que você quer conectar.",
         "connectTitle": "Conectar telefone",
         "copyAria": "Copiar {{phone}}",
         "copyError": "Falha ao copiar o número de telefone",
         "copySuccess": "Número de telefone copiado",
         "description": "Acesso ao {{assistantName}} por mensagens de texto",
         "destination": "iMessage ou SMS para",
-        "normalized": "Enviaremos uma mensagem para {{phone}}.",
+        "messageInstruction": "Envie “hi” para este número",
+        "openMessages": "Abrir Mensagens",
         "options": "Opções do telefone",
         "phoneLabel": "Telefone",
-        "phoneNumber": "Número de telefone",
-        "risk": "As respostas por SMS e MMS podem não ser entregues de forma confiável. Para uma experiência mais confiável, use o iMessage com este número do AgentPhone.",
-        "sending": "Enviando...",
-        "sendVerification": "Enviar verificação",
-        "verificationSent": "Mensagem de verificação enviada para {{phone}}. Abra o link dessa mensagem para concluir a conexão."
+        "replyInstruction": "Responderemos com um link de conexão. Abra-o em até 10 minutos para concluir a conexão.",
+        "risk": "As respostas por SMS e MMS podem não ser entregues de forma confiável. Para uma experiência mais confiável, use o iMessage com este número do AgentPhone."
       },
       "catalogDiagnostics": {
         "fields": {
@@ -3057,7 +3055,6 @@
         }
       },
       "errors": {
-        "agentphonePhone": "Digite um número de telefone com código do país, como +1 555 555 1212.",
         "githubAuthorizationWindow": "Falha ao abrir a janela de autorização",
         "telegramDomain": "O domínio ainda não está visível para o Telegram. Verifique o BotFather e tente novamente.",
         "telegramPrivacy": "O modo de privacidade ainda parece estar ativado. Desative-o no BotFather e tente novamente."
@@ -3263,7 +3260,6 @@
       "toasts": {
         "agentphoneConnected": "AgentPhone conectado",
         "agentphoneDisconnected": "AgentPhone desconectado",
-        "agentphoneVerificationSent": "Mensagem de verificação enviada",
         "feishuBotInstalled": "Bot do Feishu instalado com sucesso",
         "feishuBotUninstalled": "Bot do Feishu desinstalado",
         "feishuConnected": "Feishu conectado com sucesso",

--- a/turbo/apps/platform/src/signals/okou-page/agentphone.ts
+++ b/turbo/apps/platform/src/signals/okou-page/agentphone.ts
@@ -3,7 +3,6 @@ import { toast } from "@okouai/ui/components/ui/sonner";
 import {
   integrationsAgentPhoneContract,
   type AgentPhoneLinkStatusResponse,
-  type AgentPhoneStartLinkResponse,
 } from "@okouai/api-contracts/contracts/integrations-agentphone";
 import { apiClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
@@ -11,99 +10,18 @@ import { setAblyLoop$ } from "../realtime.ts";
 import { i18n } from "../../i18n/index.ts";
 
 const internalReload$ = state(0);
-const internalPhoneForm$ = state("");
 const internalConnectDialogOpen$ = state(false);
-const internalConnectDialogCloseComplete$ = state(true);
-const internalVerificationPhone$ = state<string | null>(null);
-const internalShowPhoneError$ = state(false);
 const internalAgentPhoneStatus$ = state<AgentPhoneLinkStatusResponse | null>(
   null,
 );
-
-function normalizeAgentPhoneHandle(value: string): string {
-  return value.trim().replace(/[^\d+]/gu, "");
-}
-
-function isValidAgentPhoneHandle(value: string): boolean {
-  return /^\+[1-9]\d{7,14}$/u.test(value);
-}
-
-export const agentPhonePhoneForm$ = computed((get) => {
-  return get(internalPhoneForm$);
-});
 
 export const agentPhoneConnectDialogOpen$ = computed((get) => {
   return get(internalConnectDialogOpen$);
 });
 
-export const agentPhoneVerificationPhone$ = computed((get) => {
-  return get(internalVerificationPhone$);
-});
-
-export const agentPhoneShowPhoneError$ = computed((get) => {
-  return get(internalShowPhoneError$);
-});
-
-export const agentPhonePhoneFormNormalized$ = computed((get) => {
-  return normalizeAgentPhoneHandle(get(internalPhoneForm$));
-});
-
-export const agentPhonePhoneFormError$ = computed((get) => {
-  const raw = get(internalPhoneForm$);
-  if (!raw.trim()) {
-    return null;
-  }
-  return isValidAgentPhoneHandle(get(agentPhonePhoneFormNormalized$))
-    ? null
-    : i18n.t(($) => {
-        return $.connectors.providerSettings.errors.agentphonePhone;
-      });
-});
-
-export const setAgentPhonePhoneForm$ = command(({ set }, value: string) => {
-  set(internalPhoneForm$, value);
-});
-
-export const resetAgentPhoneConnectUi$ = command(({ set }) => {
-  set(internalPhoneForm$, "");
-  set(internalVerificationPhone$, null);
-  set(internalShowPhoneError$, false);
-});
-
 export const setAgentPhoneConnectDialogOpen$ = command(
-  ({ get, set }, value: boolean) => {
-    const connecting =
-      get(internalVerificationPhone$) !== null &&
-      get(internalAgentPhoneStatus$)?.linked !== true;
-    if (value && !connecting) {
-      set(resetAgentPhoneConnectUi$);
-    }
-    if (value) {
-      set(internalConnectDialogCloseComplete$, false);
-    }
-    set(internalConnectDialogOpen$, value);
-  },
-);
-
-export const completeAgentPhoneConnectDialogClose$ = command(({ get, set }) => {
-  if (get(internalConnectDialogOpen$)) {
-    return;
-  }
-  set(internalConnectDialogCloseComplete$, true);
-  if (get(internalAgentPhoneStatus$)?.linked) {
-    set(resetAgentPhoneConnectUi$);
-  }
-});
-
-export const setAgentPhoneVerificationPhone$ = command(
-  ({ set }, value: string | null) => {
-    set(internalVerificationPhone$, value);
-  },
-);
-
-export const setAgentPhoneShowPhoneError$ = command(
   ({ set }, value: boolean) => {
-    set(internalShowPhoneError$, value);
+    set(internalConnectDialogOpen$, value);
   },
 );
 
@@ -164,11 +82,6 @@ const refreshAgentPhoneFromChange$ = command(
       toastAgentPhoneStatusChange(previous, data);
       if (data.linked) {
         set(internalConnectDialogOpen$, false);
-        if (get(internalConnectDialogCloseComplete$)) {
-          set(resetAgentPhoneConnectUi$);
-        }
-      } else {
-        set(resetAgentPhoneConnectUi$);
       }
     }
 
@@ -192,42 +105,6 @@ export const watchAgentPhoneConnection$ = command(
   },
 );
 
-export const startAgentPhoneLink$ = command(
-  async (
-    { get, set },
-    signal: AbortSignal,
-  ): Promise<AgentPhoneStartLinkResponse> => {
-    const phoneHandle = get(agentPhonePhoneFormNormalized$);
-    if (!isValidAgentPhoneHandle(phoneHandle)) {
-      throw new Error(
-        i18n.t(($) => {
-          return $.connectors.providerSettings.errors.agentphonePhone;
-        }),
-      );
-    }
-
-    const client = get(apiClient$)(integrationsAgentPhoneContract, {
-      apiBase: "api",
-    });
-    await accept(
-      client.startLink({
-        headers: {},
-        body: { phoneHandle },
-        fetchOptions: { signal },
-      }),
-      [200],
-    );
-    signal.throwIfAborted();
-    set(reloadAgentPhoneLinkStatus$);
-    toast.success(
-      i18n.t(($) => {
-        return $.connectors.providerSettings.toasts.agentphoneVerificationSent;
-      }),
-    );
-    return { phoneHandle, verificationSent: true };
-  },
-);
-
 export const disconnectAgentPhone$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<void> => {
     const client = get(apiClient$)(integrationsAgentPhoneContract, {
@@ -242,6 +119,5 @@ export const disconnectAgentPhone$ = command(
     );
     signal.throwIfAborted();
     set(reloadAgentPhoneLinkStatus$);
-    set(resetAgentPhoneConnectUi$);
   },
 );

--- a/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
+++ b/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
@@ -8,7 +8,6 @@ import { initSlackOrg$, watchSlackConnection$ } from "../okou-page/slack.ts";
 import { watchTeamsConnection$ } from "../okou-page/teams.ts";
 import { watchGithubIntegration$ } from "../okou-page/github.ts";
 import {
-  resetAgentPhoneConnectUi$,
   setAgentPhoneConnectDialogOpen$,
   watchAgentPhoneConnection$,
 } from "../okou-page/agentphone.ts";
@@ -41,7 +40,6 @@ const initWorksRedirect$ = command(({ get, set }) => {
 });
 
 export const setupWorksPage$ = command(async ({ set }, signal: AbortSignal) => {
-  set(resetAgentPhoneConnectUi$);
   set(setAgentPhoneConnectDialogOpen$, false);
   set(updatePage$, createElement(WorksPage), "sidebar");
   set(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/works-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/works-page.test.tsx
@@ -28,9 +28,13 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 const context = testContext();
 const AGENT_PHONE_HANDLE = "+15555550123";
 
-function queryRole(role: "button" | "link", name: string): HTMLElement | null {
+function queryRole(
+  role: "button" | "link",
+  name: string,
+  container?: HTMLElement,
+): HTMLElement | null {
   return (
-    queryAllByRoleFast(role).find((candidate) => {
+    queryAllByRoleFast(role, container).find((candidate) => {
       return (
         candidate.getAttribute("aria-label") === name ||
         candidate.textContent?.trim() === name
@@ -39,8 +43,12 @@ function queryRole(role: "button" | "link", name: string): HTMLElement | null {
   );
 }
 
-function getRole(role: "button" | "link", name: string): HTMLElement {
-  const element = queryRole(role, name);
+function getRole(
+  role: "button" | "link",
+  name: string,
+  container?: HTMLElement,
+): HTMLElement {
+  const element = queryRole(role, name, container);
   if (!element) {
     throw new Error(`Expected ${role} named "${name}"`);
   }
@@ -128,11 +136,7 @@ function setupWorksPage(
   });
 }
 
-async function openAgentPhoneVerification(): Promise<{
-  dialog: HTMLElement;
-  phoneInput: HTMLElement;
-  verificationStatus: HTMLElement;
-}> {
+async function openAgentPhoneConnectDialog(): Promise<HTMLElement> {
   context.mocks.data.agentPhoneIntegration({
     linked: false,
     agentPhoneNumber: "+19039853128",
@@ -150,13 +154,7 @@ async function openAgentPhoneVerification(): Promise<{
   const dialog = await screen.findByRole("dialog", {
     name: "Connect phone",
   });
-  const phoneInput = within(dialog).getByLabelText("Phone number");
-  await fill(phoneInput, AGENT_PHONE_HANDLE);
-  click(within(dialog).getByText("Send verification"));
-
-  const verificationStatus = await within(dialog).findByRole("status");
-  expect(verificationStatus).toHaveTextContent(AGENT_PHONE_HANDLE);
-  return { dialog, phoneInput, verificationStatus };
+  return dialog;
 }
 
 function publishAgentPhoneLinked(): void {
@@ -327,47 +325,35 @@ describe("works page", () => {
     });
   });
 
-  it("keeps AgentPhone verification visible when success closes the dialog", async () => {
-    const { dialog, phoneInput, verificationStatus } =
-      await openAgentPhoneVerification();
-    const finishCloseAnimation = holdElementAnimations(dialog);
+  it("guides an unlinked AgentPhone user to message the shared number", async () => {
+    const dialog = await openAgentPhoneConnectDialog();
 
-    publishAgentPhoneLinked();
-
-    await expect(
-      screen.findByTestId("agentphone-connected-indicator"),
-    ).resolves.toHaveTextContent(AGENT_PHONE_HANDLE);
-    expect(dialog).toBeInTheDocument();
-    expect(dialog).toBeVisible();
-    expect(phoneInput).toHaveValue(AGENT_PHONE_HANDLE);
-    expect(verificationStatus).toBeVisible();
-
-    finishCloseAnimation();
-
-    await waitFor(() => {
-      expect(
-        screen.queryByRole("dialog", { name: "Connect phone" }),
-      ).not.toBeInTheDocument();
-    });
-
-    const reopenedDialog = await disconnectAndReopenAgentPhone();
-    expect(within(reopenedDialog).getByLabelText("Phone number")).toHaveValue(
-      "",
+    expect(within(dialog).queryByRole("textbox")).toBeNull();
+    expect(within(dialog).getByText("Send “hi” to this number")).toBeVisible();
+    expect(within(dialog).getByText("hi")).toBeVisible();
+    expect(getRole("button", "Copy +1 (903) 985-3128", dialog)).toBeVisible();
+    expect(getRole("link", "Open Messages", dialog)).toHaveAttribute(
+      "href",
+      "sms:+19039853128",
     );
-    expect(within(reopenedDialog).queryByRole("status")).toBeNull();
+    expect(
+      within(dialog).getByText(
+        "We’ll reply with a connection link. Open it within 10 minutes to finish connecting.",
+      ),
+    ).toBeVisible();
   });
 
-  it("cleans AgentPhone verification when success arrives after close", async () => {
-    const { dialog, phoneInput, verificationStatus } =
-      await openAgentPhoneVerification();
+  it("closes AgentPhone instructions when the phone is linked", async () => {
+    const dialog = await openAgentPhoneConnectDialog();
     const finishCloseAnimation = holdElementAnimations(dialog);
 
-    click(within(dialog).getByText("Cancel"));
+    publishAgentPhoneLinked();
 
+    await expect(
+      screen.findByTestId("agentphone-connected-indicator"),
+    ).resolves.toHaveTextContent(AGENT_PHONE_HANDLE);
     expect(dialog).toBeInTheDocument();
     expect(dialog).toBeVisible();
-    expect(phoneInput).toHaveValue(AGENT_PHONE_HANDLE);
-    expect(verificationStatus).toBeVisible();
 
     finishCloseAnimation();
 
@@ -377,16 +363,9 @@ describe("works page", () => {
       ).not.toBeInTheDocument();
     });
 
-    publishAgentPhoneLinked();
-    await expect(
-      screen.findByTestId("agentphone-connected-indicator"),
-    ).resolves.toHaveTextContent(AGENT_PHONE_HANDLE);
-
     const reopenedDialog = await disconnectAndReopenAgentPhone();
-    expect(within(reopenedDialog).getByLabelText("Phone number")).toHaveValue(
-      "",
-    );
-    expect(within(reopenedDialog).queryByRole("status")).toBeNull();
+    expect(within(reopenedDialog).queryByRole("textbox")).toBeNull();
+    expect(getRole("link", "Open Messages", reopenedDialog)).toBeVisible();
   });
 
   it("opens Telegram settings from the integrations list", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/works-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/works-page.test.tsx
@@ -329,16 +329,22 @@ describe("works page", () => {
     const dialog = await openAgentPhoneConnectDialog();
 
     expect(within(dialog).queryByRole("textbox")).toBeNull();
-    expect(within(dialog).getByText("Send “hi” to this number")).toBeVisible();
-    expect(within(dialog).getByText("hi")).toBeVisible();
+    const warning = within(dialog).getByText(
+      "Use iMessage when possible. SMS and MMS replies may not arrive reliably.",
+    );
+    const messageInstruction = within(dialog).getByText("Send “hi”");
+    expect(warning).toBeVisible();
+    expect(messageInstruction).toBeVisible();
+    expect(warning.compareDocumentPosition(messageInstruction) & 4).toBe(4);
     expect(getRole("button", "Copy +1 (903) 985-3128", dialog)).toBeVisible();
     expect(getRole("link", "Open Messages", dialog)).toHaveAttribute(
       "href",
-      "sms:+19039853128",
+      "sms:+19039853128?body=hi",
     );
+    expect(within(dialog).getByText("Open our reply")).toBeVisible();
     expect(
       within(dialog).getByText(
-        "We’ll reply with a connection link. Open it within 10 minutes to finish connecting.",
+        "Tap the connection link within 10 minutes to finish.",
       ),
     ).toBeVisible();
   });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/works-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/works-page.test.tsx
@@ -328,7 +328,6 @@ describe("works page", () => {
   it("guides an unlinked AgentPhone user to message the shared number", async () => {
     const dialog = await openAgentPhoneConnectDialog();
 
-    expect(within(dialog).queryByRole("textbox")).toBeNull();
     const warning = within(dialog).getByText(
       "Use iMessage when possible. SMS and MMS replies may not arrive reliably.",
     );
@@ -370,7 +369,6 @@ describe("works page", () => {
     });
 
     const reopenedDialog = await disconnectAndReopenAgentPhone();
-    expect(within(reopenedDialog).queryByRole("textbox")).toBeNull();
     expect(getRole("link", "Open Messages", reopenedDialog)).toBeVisible();
   });
 

--- a/turbo/apps/platform/src/views/okou-page/agentphone-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/agentphone-card.tsx
@@ -1,12 +1,6 @@
-import type { FormEvent } from "react";
-import {
-  useGet,
-  useLastLoadable,
-  useLastResolved,
-  useSet,
-} from "ccstate-react";
+import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import { CircleCheck, Copy, EllipsisVertical, Loader2 } from "lucide-react";
+import { CircleCheck, Copy, EllipsisVertical } from "lucide-react";
 import { Button } from "@okouai/ui";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import {
@@ -28,25 +22,14 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@okouai/ui/components/ui/tooltip";
-import { Input } from "@okouai/ui/components/ui/input";
 import { useTranslation } from "react-i18next";
 import { i18n } from "../../i18n/index.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   agentPhoneLinkStatus$,
   agentPhoneConnectDialogOpen$,
-  agentPhonePhoneForm$,
-  agentPhonePhoneFormError$,
-  agentPhonePhoneFormNormalized$,
-  agentPhoneShowPhoneError$,
-  agentPhoneVerificationPhone$,
-  completeAgentPhoneConnectDialogClose$,
   disconnectAgentPhone$,
   setAgentPhoneConnectDialogOpen$,
-  setAgentPhonePhoneForm$,
-  setAgentPhoneShowPhoneError$,
-  setAgentPhoneVerificationPhone$,
-  startAgentPhoneLink$,
 } from "../../signals/okou-page/agentphone.ts";
 import { writeToClipboard } from "../../signals/okou-page/clipboard.ts";
 import { detach, Reason } from "../../signals/utils.ts";
@@ -111,87 +94,28 @@ function PhoneNumberCopyButton({
   );
 }
 
-function AgentPhoneVerificationStatus({
-  verificationPhone,
-  connecting,
-}: {
-  readonly verificationPhone: string | null;
-  readonly connecting: boolean;
-}) {
-  const { t } = useTranslation();
-  if (!verificationPhone) {
-    return null;
-  }
-
-  return (
-    <div
-      className="rounded-lg bg-muted px-3 py-2 text-sm text-muted-foreground"
-      role="status"
-    >
-      <span className="flex items-center gap-2">
-        {connecting ? (
-          <Loader2 size={14} className="shrink-0 animate-spin" />
-        ) : (
-          <CircleCheck size={14} className="shrink-0 text-green-600" />
-        )}
-        <span>
-          {t(
-            ($) => {
-              return $.connectors.providerSettings.agentphone.verificationSent;
-            },
-            { phone: verificationPhone },
-          )}
-        </span>
-      </span>
-    </div>
-  );
-}
-
 function AgentPhoneConnectActions({
-  starting,
-  connecting,
-  normalizedPhone,
-  phoneError,
-  onCancel,
+  messageHref,
+  onClose,
 }: {
-  readonly starting: boolean;
-  readonly connecting: boolean;
-  readonly normalizedPhone: string;
-  readonly phoneError: string | null;
-  readonly onCancel: () => void;
+  readonly messageHref: string;
+  readonly onClose: () => void;
 }) {
   const { t } = useTranslation();
-  const busy = starting || connecting;
 
   return (
     <DialogFooter>
-      <Button
-        type="button"
-        variant="outline"
-        disabled={starting}
-        onClick={onCancel}
-      >
+      <Button type="button" variant="outline" onClick={onClose}>
         {t(($) => {
-          return $.connectors.actions.cancel;
+          return $.connectors.actions.close;
         })}
       </Button>
-      <Button
-        type="submit"
-        disabled={!normalizedPhone || Boolean(phoneError) || busy}
-      >
-        {busy ? <Loader2 size={14} className="animate-spin" /> : null}
-        {starting
-          ? t(($) => {
-              return $.connectors.providerSettings.agentphone.sending;
-            })
-          : connecting
-            ? t(($) => {
-                return $.connectors.actions.connecting;
-              })
-            : t(($) => {
-                return $.connectors.providerSettings.agentphone
-                  .sendVerification;
-              })}
+      <Button asChild>
+        <a href={messageHref}>
+          {t(($) => {
+            return $.connectors.providerSettings.agentphone.openMessages;
+          })}
+        </a>
       </Button>
     </DialogFooter>
   );
@@ -200,152 +124,88 @@ function AgentPhoneConnectActions({
 function AgentPhoneConnectIntro() {
   const { t } = useTranslation();
   return (
-    <>
-      <DialogHeader>
-        <DialogTitle>
-          {t(($) => {
-            return $.connectors.providerSettings.agentphone.connectTitle;
-          })}
-        </DialogTitle>
-        <DialogDescription>
-          {t(($) => {
-            return $.connectors.providerSettings.agentphone.connectDescription;
-          })}
-        </DialogDescription>
-      </DialogHeader>
-      <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-800 dark:text-amber-200">
+    <DialogHeader>
+      <DialogTitle>
         {t(($) => {
-          return $.connectors.providerSettings.agentphone.risk;
+          return $.connectors.providerSettings.agentphone.connectTitle;
         })}
-      </div>
-    </>
+      </DialogTitle>
+      <DialogDescription>
+        {t(($) => {
+          return $.connectors.providerSettings.agentphone.connectDescription;
+        })}
+      </DialogDescription>
+    </DialogHeader>
   );
 }
 
-function AgentPhoneConnectDialog() {
+function AgentPhoneConnectDialog({
+  phoneNumber,
+}: {
+  readonly phoneNumber: string | null;
+}) {
   const { t } = useTranslation();
   const open = useGet(agentPhoneConnectDialogOpen$);
-  const phoneForm = useGet(agentPhonePhoneForm$);
-  const normalizedPhone = useLastResolved(agentPhonePhoneFormNormalized$) ?? "";
-  const phoneError = useLastResolved(agentPhonePhoneFormError$) ?? null;
-  const verificationPhone =
-    useLastResolved(agentPhoneVerificationPhone$) ?? null;
-  const showPhoneError = useLastResolved(agentPhoneShowPhoneError$) ?? false;
-  const setPhoneForm = useSet(setAgentPhonePhoneForm$);
   const setOpen = useSet(setAgentPhoneConnectDialogOpen$);
-  const completeClose = useSet(completeAgentPhoneConnectDialogClose$);
-  const setVerificationPhone = useSet(setAgentPhoneVerificationPhone$);
-  const setShowPhoneError = useSet(setAgentPhoneShowPhoneError$);
-  const pageSignal = useGet(pageSignal$);
-  const [startLoadable, startLink] = useLoadableSet(startAgentPhoneLink$);
-  const status = useLastResolved(agentPhoneLinkStatus$);
-  const starting = startLoadable.state === "loading";
-  const connecting = verificationPhone !== null && status?.linked !== true;
-  const busy = starting || connecting;
-  const visiblePhoneError = showPhoneError ? phoneError : null;
-
-  const close = (nextOpen: boolean) => {
-    if (!nextOpen && starting) {
-      return;
-    }
-    setOpen(nextOpen);
-  };
-
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!normalizedPhone || phoneError || busy) {
-      setShowPhoneError(true);
-      return;
-    }
-    setVerificationPhone(null);
-    setShowPhoneError(false);
-    detach(
-      (async () => {
-        const result = await startLink(pageSignal);
-        setVerificationPhone(result.phoneHandle);
-      })(),
-      Reason.DomCallback,
-    );
-  };
+  if (!phoneNumber) {
+    return null;
+  }
 
   return (
     <Dialog
       open={open}
-      onOpenChange={close}
-      onOpenChangeComplete={(nextOpen) => {
-        if (!nextOpen) {
-          completeClose();
-        }
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
       }}
     >
       <DialogContent>
         <AgentPhoneConnectIntro />
-        <form className="grid gap-3" onSubmit={submit}>
-          <label
-            htmlFor="agentphone-phone-input"
-            className="text-sm font-medium text-foreground"
-          >
+        <div className="grid gap-3">
+          <div className="rounded-xl border border-border/60 bg-muted/30 p-4">
+            <p className="text-sm text-muted-foreground">
+              {t(($) => {
+                return $.connectors.providerSettings.agentphone
+                  .messageInstruction;
+              })}
+            </p>
+            <div className="mt-3 flex items-center justify-between gap-3 rounded-lg border border-border bg-background px-3 py-2.5">
+              <span className="inline-flex min-w-0 items-center gap-2">
+                <img src={imessageIconImg} alt="" className="h-5 w-5" />
+                <PhoneNumberCopyButton phoneNumber={phoneNumber} />
+              </span>
+              <span className="shrink-0 rounded-full bg-primary px-3 py-1 text-sm font-medium text-primary-foreground">
+                hi
+              </span>
+            </div>
+            <p className="mt-3 text-xs leading-5 text-muted-foreground">
+              {t(($) => {
+                return $.connectors.providerSettings.agentphone
+                  .replyInstruction;
+              })}
+            </p>
+          </div>
+          <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-800 dark:text-amber-200">
             {t(($) => {
-              return $.connectors.providerSettings.agentphone.phoneNumber;
+              return $.connectors.providerSettings.agentphone.risk;
             })}
-          </label>
-          <Input
-            id="agentphone-phone-input"
-            data-testid="agentphone-phone-input"
-            type="tel"
-            inputMode="tel"
-            placeholder="+1 555 555 1212"
-            value={phoneForm}
-            disabled={busy}
-            onBlur={() => {
-              setShowPhoneError(true);
-            }}
-            onChange={(event) => {
-              setVerificationPhone(null);
-              setPhoneForm(event.target.value);
-            }}
-            onFocus={() => {
-              setShowPhoneError(false);
-            }}
-          />
-          {normalizedPhone ? (
-            <p
-              className="text-xs text-muted-foreground"
-              data-testid="agentphone-normalized-phone"
-            >
-              {t(
-                ($) => {
-                  return $.connectors.providerSettings.agentphone.normalized;
-                },
-                { phone: normalizedPhone },
-              )}
-            </p>
-          ) : null}
-          {visiblePhoneError ? (
-            <p className="text-sm text-destructive" role="alert">
-              {visiblePhoneError}
-            </p>
-          ) : null}
-          <AgentPhoneVerificationStatus
-            verificationPhone={verificationPhone}
-            connecting={connecting}
-          />
+          </div>
           <AgentPhoneConnectActions
-            starting={starting}
-            connecting={connecting}
-            normalizedPhone={normalizedPhone}
-            phoneError={phoneError}
-            onCancel={() => {
-              close(false);
+            messageHref={`sms:${phoneNumber}`}
+            onClose={() => {
+              setOpen(false);
             }}
           />
-        </form>
+        </div>
       </DialogContent>
     </Dialog>
   );
 }
 
-function AgentPhoneCardActions() {
+function AgentPhoneCardActions({
+  canConnect,
+}: {
+  readonly canConnect: boolean;
+}) {
   const { t } = useTranslation();
   const statusLoadable = useLastLoadable(agentPhoneLinkStatus$);
   const status =
@@ -387,7 +247,7 @@ function AgentPhoneCardActions() {
           </Tooltip>
         </TooltipProvider>
       ) : null}
-      {status !== null && !isConnected ? (
+      {status !== null && !isConnected && canConnect ? (
         <Button
           type="button"
           variant="outline"
@@ -491,10 +351,10 @@ export function AgentPhoneCard() {
               )}
             </div>
           </div>
-          <AgentPhoneCardActions />
+          <AgentPhoneCardActions canConnect={agentPhoneNumber !== null} />
         </div>
       </div>
-      <AgentPhoneConnectDialog />
+      <AgentPhoneConnectDialog phoneNumber={agentPhoneNumber} />
     </>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/agentphone-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/agentphone-card.tsx
@@ -1,6 +1,11 @@
 import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import { CircleCheck, Copy, EllipsisVertical } from "lucide-react";
+import {
+  AlertTriangle,
+  CircleCheck,
+  Copy,
+  EllipsisVertical,
+} from "lucide-react";
 import { Button } from "@okouai/ui";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import {
@@ -37,6 +42,7 @@ import { settingsIconAssetUrl } from "./components/settings/settings-icon-assets
 import { IconTooltipButton } from "../components/icon-tooltip.tsx";
 
 const imessageIconImg = settingsIconAssetUrl("imessage");
+const AGENTPHONE_HANDSHAKE_MESSAGE = "hi";
 
 /** Render a US/Canada E.164 number as `+1 (NXX) NXX-XXXX`; other formats are
  *  returned unchanged. */
@@ -150,6 +156,7 @@ function AgentPhoneConnectDialog({
   if (!phoneNumber) {
     return null;
   }
+  const messageHref = `sms:${phoneNumber}?body=${encodeURIComponent(AGENTPHONE_HANDSHAKE_MESSAGE)}`;
 
   return (
     <Dialog
@@ -160,37 +167,56 @@ function AgentPhoneConnectDialog({
     >
       <DialogContent>
         <AgentPhoneConnectIntro />
-        <div className="grid gap-3">
-          <div className="rounded-xl border border-border/60 bg-muted/30 p-4">
-            <p className="text-sm text-muted-foreground">
+        <div className="grid gap-5">
+          <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-800 dark:text-amber-200">
+            <AlertTriangle size={16} className="mt-0.5 shrink-0" />
+            <p className="min-w-0 leading-5">
               {t(($) => {
-                return $.connectors.providerSettings.agentphone
-                  .messageInstruction;
-              })}
-            </p>
-            <div className="mt-3 flex items-center justify-between gap-3 rounded-lg border border-border bg-background px-3 py-2.5">
-              <span className="inline-flex min-w-0 items-center gap-2">
-                <img src={imessageIconImg} alt="" className="h-5 w-5" />
-                <PhoneNumberCopyButton phoneNumber={phoneNumber} />
-              </span>
-              <span className="shrink-0 rounded-full bg-primary px-3 py-1 text-sm font-medium text-primary-foreground">
-                hi
-              </span>
-            </div>
-            <p className="mt-3 text-xs leading-5 text-muted-foreground">
-              {t(($) => {
-                return $.connectors.providerSettings.agentphone
-                  .replyInstruction;
+                return $.connectors.providerSettings.agentphone.risk;
               })}
             </p>
           </div>
-          <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-800 dark:text-amber-200">
-            {t(($) => {
-              return $.connectors.providerSettings.agentphone.risk;
-            })}
-          </div>
+          <ol className="divide-y divide-border/60">
+            <li className="flex items-start gap-3 pb-4">
+              <span className="mt-0.5 grid size-6 shrink-0 place-items-center rounded-full bg-primary/10 text-xs font-medium text-primary">
+                1
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-foreground">
+                  {t(($) => {
+                    return $.connectors.providerSettings.agentphone
+                      .messageInstruction;
+                  })}
+                </p>
+                <div className="mt-2 flex items-center gap-2">
+                  <span className="grid size-8 shrink-0 place-items-center rounded-lg bg-gray-50">
+                    <img src={imessageIconImg} alt="" className="h-5 w-5" />
+                  </span>
+                  <PhoneNumberCopyButton phoneNumber={phoneNumber} />
+                </div>
+              </div>
+            </li>
+            <li className="flex items-start gap-3 pt-4">
+              <span className="mt-0.5 grid size-6 shrink-0 place-items-center rounded-full bg-primary/10 text-xs font-medium text-primary">
+                2
+              </span>
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-foreground">
+                  {t(($) => {
+                    return $.connectors.providerSettings.agentphone.replyTitle;
+                  })}
+                </p>
+                <p className="mt-0.5 text-xs leading-5 text-muted-foreground">
+                  {t(($) => {
+                    return $.connectors.providerSettings.agentphone
+                      .replyInstruction;
+                  })}
+                </p>
+              </div>
+            </li>
+          </ol>
           <AgentPhoneConnectActions
-            messageHref={`sms:${phoneNumber}`}
+            messageHref={messageHref}
             onClose={() => {
               setOpen(false);
             }}


### PR DESCRIPTION
## Summary

- replace the outbound phone-verification form with an inbound message flow to the shared AgentPhone number
- redesign the connection dialog with the delivery warning first and a lightweight two-step layout
- open the device Messages app with `hi` prefilled, then let the user send it and open the 10-minute connection link in the reply
- preserve realtime linked-state updates while removing obsolete client form state and translated verification copy

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app lint`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/works-page.test.tsx` (21 passed)
