### PR TITLE
fix(platform): sync okou theme across subdomains

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -84,18 +84,59 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
     />
-    <script>
+    <script id="theme-bootstrap">
       // Inline theme detection — mirrors signals/theme.ts resolveTheme() + applyTheme()
       (function () {
-        var p = localStorage.getItem("theme");
+        var root = document.documentElement;
+        var isOkou = root.dataset.appBrandName === "Okou";
+        if (!isOkou) {
+          var vm0Preference = localStorage.getItem("theme");
+          var vm0Theme =
+            vm0Preference === "dark" || vm0Preference === "light"
+              ? vm0Preference
+              : window.matchMedia("(prefers-color-scheme: dark)").matches
+                ? "dark"
+                : "light";
+          root.dataset.theme = vm0Theme;
+          if (vm0Theme === "dark") root.classList.add("dark");
+          return;
+        }
+        var p = null;
+        try {
+          var prefix = "__Secure-okou-theme=";
+          var cookies = document.cookie.split(";");
+          for (var i = 0; i < cookies.length; i += 1) {
+            var cookie = cookies[i].trim();
+            if (cookie.indexOf(prefix) === 0) {
+              var value = cookie.slice(prefix.length);
+              if (
+                value === "v1.light" ||
+                value === "v1.dark" ||
+                value === "v1.system"
+              ) {
+                p = value.slice(3);
+              }
+              if (p) break;
+            }
+          }
+        } catch (_) {}
+        if (!p) {
+          try {
+            var saved = localStorage.getItem("theme");
+            if (saved === "light" || saved === "dark" || saved === "system") {
+              p = saved;
+            }
+          } catch (_) {}
+        }
+        if (!p) p = "system";
         var t =
           p === "dark" || p === "light"
             ? p
             : window.matchMedia("(prefers-color-scheme: dark)").matches
               ? "dark"
               : "light";
-        document.documentElement.dataset.theme = t;
-        if (t === "dark") document.documentElement.classList.add("dark");
+        root.dataset.theme = t;
+        root.classList.toggle("dark", t === "dark");
       })();
     </script>
     <style id="app-bootstrap-critical-styles">

--- a/turbo/apps/platform/src/__tests__/theme-bootstrap.test.ts
+++ b/turbo/apps/platform/src/__tests__/theme-bootstrap.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from "vitest";
+
+import INDEX_HTML from "../../index.html?raw";
+import {
+  OKOU_THEME_COOKIE_NAME,
+  decodeOkouThemePreference,
+  encodeOkouThemePreference,
+  readOkouThemePreferenceCookie,
+  serializeOkouThemePreferenceCookie,
+} from "../lib/okou-theme-cookie.ts";
+
+function themeBootstrapScript(): string {
+  const sourceDocument = new DOMParser().parseFromString(
+    INDEX_HTML,
+    "text/html",
+  );
+  const script = sourceDocument.getElementById("theme-bootstrap");
+  if (!(script instanceof HTMLScriptElement)) {
+    throw new Error("Missing #theme-bootstrap in the Platform index");
+  }
+  return script.textContent ?? "";
+}
+
+function runThemeBootstrap({
+  brandName = "Okou",
+  cookie = "",
+  cookieBlocked = false,
+  path = "/",
+  savedTheme = null,
+  storageBlocked = false,
+  systemDark = false,
+}: {
+  brandName?: "Okou" | "VM0";
+  cookie?: string;
+  cookieBlocked?: boolean;
+  path?: string;
+  savedTheme?: string | null;
+  storageBlocked?: boolean;
+  systemDark?: boolean;
+} = {}) {
+  const dataset: Record<string, string> = { appBrandName: brandName };
+  const classes = new Set<string>();
+  const document = {
+    documentElement: {
+      dataset,
+      classList: {
+        add(name: string) {
+          classes.add(name);
+        },
+        toggle(name: string, enabled: boolean) {
+          if (enabled) {
+            classes.add(name);
+          } else {
+            classes.delete(name);
+          }
+        },
+      },
+    },
+  } as {
+    cookie: string;
+    documentElement: {
+      classList: {
+        add(name: string): void;
+        toggle(name: string, enabled: boolean): void;
+      };
+      dataset: Record<string, string>;
+    };
+  };
+  Object.defineProperty(document, "cookie", {
+    get() {
+      if (cookieBlocked) {
+        throw new Error("Cookies blocked");
+      }
+      return cookie;
+    },
+  });
+
+  const executeBootstrap = new Function(
+    "document",
+    "localStorage",
+    "window",
+    `${themeBootstrapScript()}\n//# sourceURL=platform-theme-bootstrap-test.js`,
+  ) as (document: object, localStorage: object, window: object) => void;
+  executeBootstrap(
+    document,
+    {
+      getItem: () => {
+        if (storageBlocked) {
+          throw new Error("Storage blocked");
+        }
+        return savedTheme;
+      },
+    },
+    {
+      location: { pathname: path },
+      matchMedia: () => ({ matches: systemDark }),
+    },
+  );
+
+  return { classes, dataset };
+}
+
+describe("platform theme bootstrap", () => {
+  it("runs before critical styles so the first paint uses the resolved theme", () => {
+    expect(INDEX_HTML.indexOf('id="theme-bootstrap"')).toBeGreaterThan(-1);
+    expect(
+      INDEX_HTML.indexOf('id="app-bootstrap-critical-styles"'),
+    ).toBeGreaterThan(-1);
+    expect(INDEX_HTML.indexOf('id="theme-bootstrap"')).toBeLessThan(
+      INDEX_HTML.indexOf('id="app-bootstrap-critical-styles"'),
+    );
+  });
+
+  it.each(["/", "/sign-in", "/sign-up"])(
+    "applies a shared dark preference on %s before application startup",
+    (path) => {
+      const { classes, dataset } = runThemeBootstrap({
+        cookie: `${OKOU_THEME_COOKIE_NAME}=v1.dark`,
+        path,
+        savedTheme: "light",
+      });
+
+      expect(dataset.theme).toBe("dark");
+      expect(classes.has("dark")).toBeTruthy();
+    },
+  );
+
+  it.each([
+    ["light", true, "light", false],
+    ["dark", false, "dark", true],
+    ["system", false, "light", false],
+    ["system", true, "dark", true],
+  ] as const)(
+    "resolves shared %s with system-dark=%s to %s",
+    (preference, systemDark, expectedTheme, expectedDarkClass) => {
+      const { classes, dataset } = runThemeBootstrap({
+        cookie: `${OKOU_THEME_COOKIE_NAME}=v1.${preference}`,
+        savedTheme: preference === "dark" ? "light" : "dark",
+        systemDark,
+      });
+
+      expect(dataset.theme).toBe(expectedTheme);
+      expect(classes.has("dark")).toBe(expectedDarkClass);
+    },
+  );
+
+  it.each(["v0.dark", "v1.invalid", "dark", ""])(
+    "falls back from malformed shared value %s to existing app storage",
+    (value) => {
+      const { classes, dataset } = runThemeBootstrap({
+        cookie: `${OKOU_THEME_COOKIE_NAME}=${value}`,
+        savedTheme: "light",
+        systemDark: true,
+      });
+
+      expect(dataset.theme).toBe("light");
+      expect(classes.has("dark")).toBeFalsy();
+    },
+  );
+
+  it("falls back to the system when cookie and storage access are blocked", () => {
+    const { classes, dataset } = runThemeBootstrap({
+      cookieBlocked: true,
+      storageBlocked: true,
+      systemDark: true,
+    });
+
+    expect(dataset.theme).toBe("dark");
+    expect(classes.has("dark")).toBeTruthy();
+  });
+
+  it("never reads the Okou cookie for the VM0 app", () => {
+    const { classes, dataset } = runThemeBootstrap({
+      brandName: "VM0",
+      cookie: `${OKOU_THEME_COOKIE_NAME}=v1.dark`,
+      savedTheme: "light",
+      systemDark: true,
+    });
+
+    expect(dataset.theme).toBe("light");
+    expect(classes.has("dark")).toBeFalsy();
+  });
+
+  it("encodes only versioned semantic values on Okou parent domains", () => {
+    expect(
+      (["light", "dark", "system"] as const).map((preference) => {
+        return decodeOkouThemePreference(encodeOkouThemePreference(preference));
+      }),
+    ).toStrictEqual(["light", "dark", "system"]);
+    expect(decodeOkouThemePreference("v0.dark")).toBeNull();
+    expect(decodeOkouThemePreference("v1.blue")).toBeNull();
+    expect(serializeOkouThemePreferenceCookie("dark", "app.okou.ai")).toBe(
+      `${OKOU_THEME_COOKIE_NAME}=v1.dark; Domain=.okou.ai; Path=/; Max-Age=31536000; SameSite=Lax; Secure`,
+    );
+    expect(
+      serializeOkouThemePreferenceCookie("system", "pr-123-app.omby.ai"),
+    ).toContain("Domain=.omby.ai");
+    expect(
+      serializeOkouThemePreferenceCookie(
+        "light",
+        "pr-123-app-okou-app-preview.vm0.workers.dev",
+      ),
+    ).toBe(
+      `${OKOU_THEME_COOKIE_NAME}=v1.light; Path=/; Max-Age=31536000; SameSite=Lax; Secure`,
+    );
+    expect(serializeOkouThemePreferenceCookie("dark", "app.vm0.ai")).toBeNull();
+    expect(
+      readOkouThemePreferenceCookie(
+        `${OKOU_THEME_COOKIE_NAME}=v0.dark; ${OKOU_THEME_COOKIE_NAME}=v1.system`,
+      ),
+    ).toBe("system");
+  });
+});

--- a/turbo/apps/platform/src/lib/okou-theme-cookie.ts
+++ b/turbo/apps/platform/src/lib/okou-theme-cookie.ts
@@ -1,0 +1,107 @@
+import type { ThemePreference } from "@okouai/api-contracts/contracts/user-preferences";
+import { isOkouHostname } from "./platform-host.ts";
+
+export const OKOU_THEME_COOKIE_NAME = "__Secure-okou-theme";
+export const OKOU_THEME_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+const OKOU_THEME_COOKIE_VERSION = "v1";
+
+export function decodeOkouThemePreference(
+  value: string | null,
+): ThemePreference | null {
+  if (!value?.startsWith(`${OKOU_THEME_COOKIE_VERSION}.`)) {
+    return null;
+  }
+
+  const preference = value.slice(OKOU_THEME_COOKIE_VERSION.length + 1);
+  return preference === "light" ||
+    preference === "dark" ||
+    preference === "system"
+    ? preference
+    : null;
+}
+
+export function encodeOkouThemePreference(preference: ThemePreference): string {
+  return `${OKOU_THEME_COOKIE_VERSION}.${preference}`;
+}
+
+export function readOkouThemePreferenceCookie(
+  cookieHeader: string,
+): ThemePreference | null {
+  const prefix = `${OKOU_THEME_COOKIE_NAME}=`;
+  for (const part of cookieHeader.split(";")) {
+    const cookie = part.trim();
+    if (cookie.startsWith(prefix)) {
+      const preference = decodeOkouThemePreference(cookie.slice(prefix.length));
+      if (preference) {
+        return preference;
+      }
+    }
+  }
+  return null;
+}
+
+export function resolveOkouThemeCookieDomain(
+  hostname: string,
+): ".okou.ai" | ".omby.ai" | null {
+  const normalizedHostname = hostname.toLowerCase();
+  if (
+    normalizedHostname === "okou.ai" ||
+    normalizedHostname.endsWith(".okou.ai")
+  ) {
+    return ".okou.ai";
+  }
+  if (
+    normalizedHostname === "omby.ai" ||
+    normalizedHostname.endsWith(".omby.ai")
+  ) {
+    return ".omby.ai";
+  }
+  return null;
+}
+
+export function serializeOkouThemePreferenceCookie(
+  preference: ThemePreference,
+  hostname: string,
+): string | null {
+  if (!isOkouHostname(hostname)) {
+    return null;
+  }
+
+  const domain = resolveOkouThemeCookieDomain(hostname);
+  const domainAttribute = domain ? `; Domain=${domain}` : "";
+  return `${OKOU_THEME_COOKIE_NAME}=${encodeOkouThemePreference(preference)}${domainAttribute}; Path=/; Max-Age=${OKOU_THEME_COOKIE_MAX_AGE_SECONDS}; SameSite=Lax; Secure`;
+}
+
+export function readOkouThemePreferenceFromDocument(): ThemePreference | null {
+  /* eslint-disable ccstate/no-catch-abort -- synchronous DOM access cannot carry an application AbortSignal. */
+  // eslint-disable-next-line no-restricted-syntax -- cookie access may throw under browser privacy policies, and theme bootstrap must fall back safely.
+  try {
+    return readOkouThemePreferenceCookie(document.cookie);
+  } catch {
+    return null;
+  }
+  /* eslint-enable ccstate/no-catch-abort */
+}
+
+export function writeOkouThemePreferenceToDocument(
+  preference: ThemePreference,
+): void {
+  const cookie = serializeOkouThemePreferenceCookie(
+    preference,
+    window.location.hostname,
+  );
+  if (!cookie) {
+    return;
+  }
+
+  /* eslint-disable ccstate/no-catch-abort -- synchronous DOM access cannot carry an application AbortSignal. */
+  // eslint-disable-next-line no-restricted-syntax -- synchronous cookie persistence may be blocked and must not break theme application.
+  try {
+    // oxlint-disable-next-line unicorn/no-document-cookie -- first-paint continuity requires a synchronous cross-subdomain preference write.
+    document.cookie = cookie;
+  } catch {
+    // Cookie access can be blocked. Theme still applies for this page load.
+  }
+  /* eslint-enable ccstate/no-catch-abort */
+}

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-theme.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-theme.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { setupBootstrap } from "../../__tests__/page-helper.ts";
+import { OKOU_THEME_COOKIE_NAME } from "../../lib/okou-theme-cookie.ts";
+import { localStorageSignals } from "../external/local-storage.ts";
+import { theme$, themePreference$, updateThemePreference$ } from "../theme.ts";
+import { userPreferences$ } from "../okou-page/settings/user-preferences.ts";
+import { testContext } from "./test-helpers.ts";
+
+const context = testContext();
+const themeStorage = localStorageSignals("theme");
+
+function captureCookieWrites(): string[] {
+  const writes: string[] = [];
+  vi.spyOn(document, "cookie", "set").mockImplementation((value: string) => {
+    writes.push(value);
+  });
+  return writes;
+}
+
+describe("okou theme preference bootstrap", () => {
+  it("prefers the authenticated workspace selection over the shared cookie", async () => {
+    context.mocks.browser.url("https://app.okou.ai/");
+    context.mocks.browser.cookie(`${OKOU_THEME_COOKIE_NAME}=v1.dark`);
+    context.mocks.data.userPreferences({ theme: "light" });
+    context.store.set(themeStorage.set$, "dark");
+    const cookieWrites = captureCookieWrites();
+
+    await setupBootstrap({ context, path: "/error" });
+
+    expect(context.store.get(themePreference$)).toBe("light");
+    expect(context.store.get(theme$)).toBe("light");
+    expect(document.documentElement.dataset.theme).toBe("light");
+    expect(context.store.get(themeStorage.get$)).toBe("light");
+    await expect(context.store.get(userPreferences$)).resolves.toMatchObject({
+      theme: "light",
+    });
+    expect(cookieWrites).toContainEqual(
+      expect.stringContaining(`${OKOU_THEME_COOKIE_NAME}=v1.light`),
+    );
+  });
+
+  it("uses the shared cookie when the workspace has no theme selection", async () => {
+    context.mocks.browser.url("https://app.okou.ai/");
+    context.mocks.browser.cookie(`${OKOU_THEME_COOKIE_NAME}=v1.dark`);
+    context.mocks.data.userPreferences({ theme: null });
+    context.store.set(themeStorage.set$, "light");
+
+    await setupBootstrap({ context, path: "/error" });
+
+    expect(context.store.get(themePreference$)).toBe("dark");
+    expect(context.store.get(theme$)).toBe("dark");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(context.store.get(themeStorage.get$)).toBe("dark");
+    await expect(context.store.get(userPreferences$)).resolves.toMatchObject({
+      theme: "dark",
+    });
+  });
+
+  it("uses the existing workspace preference when the shared value is invalid", async () => {
+    context.mocks.browser.url("https://app.okou.ai/");
+    context.mocks.browser.cookie(`${OKOU_THEME_COOKIE_NAME}=v0.light`);
+    context.mocks.data.userPreferences({ theme: "dark" });
+    context.store.set(themeStorage.set$, "light");
+
+    await setupBootstrap({ context, path: "/error" });
+
+    expect(context.store.get(themePreference$)).toBe("dark");
+    expect(context.store.get(theme$)).toBe("dark");
+    await expect(context.store.get(userPreferences$)).resolves.toMatchObject({
+      theme: "dark",
+    });
+  });
+
+  it("publishes the logged-out app fallback for navigation back to marketing", async () => {
+    context.mocks.browser.url("https://app.okou.ai/sign-in");
+    context.mocks.browser.cookie("");
+    context.store.set(themeStorage.set$, "dark");
+    const cookieWrites = captureCookieWrites();
+
+    await setupBootstrap({ context, path: "/sign-in", user: null });
+
+    expect(context.store.get(themePreference$)).toBe("dark");
+    expect(cookieWrites).toContainEqual(
+      expect.stringContaining(`${OKOU_THEME_COOKIE_NAME}=v1.dark`),
+    );
+  });
+
+  it("updates local state, the shared cookie, and the workspace together", async () => {
+    context.mocks.browser.url("https://app.okou.ai/");
+    context.mocks.browser.cookie(`${OKOU_THEME_COOKIE_NAME}=v1.light`);
+    context.mocks.browser.matchMedia(true);
+    context.mocks.data.userPreferences({ theme: "light" });
+    const cookieWrites = captureCookieWrites();
+    await setupBootstrap({ context, path: "/error" });
+
+    await context.store.set(updateThemePreference$, "system", context.signal);
+
+    expect(context.store.get(themePreference$)).toBe("system");
+    expect(context.store.get(theme$)).toBe("dark");
+    expect(context.store.get(themeStorage.get$)).toBe("system");
+    expect(cookieWrites.at(-1)).toContain(
+      `${OKOU_THEME_COOKIE_NAME}=v1.system`,
+    );
+    await expect(context.store.get(userPreferences$)).resolves.toMatchObject({
+      theme: "system",
+    });
+  });
+
+  it("does not read or write the shared Okou preference on VM0", async () => {
+    context.mocks.browser.url("https://app.vm0.ai/sign-in");
+    context.mocks.browser.cookie(`${OKOU_THEME_COOKIE_NAME}=v1.dark`);
+    context.store.set(themeStorage.set$, "light");
+    const cookieWrites = captureCookieWrites();
+
+    await setupBootstrap({ context, path: "/sign-in", user: null });
+
+    expect(context.store.get(themePreference$)).toBe("light");
+    expect(context.store.get(theme$)).toBe("light");
+    expect(
+      cookieWrites.some((cookie) => {
+        return cookie.includes(OKOU_THEME_COOKIE_NAME);
+      }),
+    ).toBeFalsy();
+  });
+});

--- a/turbo/apps/platform/src/signals/theme.ts
+++ b/turbo/apps/platform/src/signals/theme.ts
@@ -10,6 +10,11 @@ import {
   updateUserPreference$,
   userPreferences$,
 } from "./okou-page/settings/user-preferences.ts";
+import { isOkouHostname } from "../lib/platform-host.ts";
+import {
+  readOkouThemePreferenceFromDocument,
+  writeOkouThemePreferenceToDocument,
+} from "../lib/okou-theme-cookie.ts";
 
 export { COLOR_THEMES };
 export type { ColorTheme, ThemePreference };
@@ -82,7 +87,19 @@ export const setTheme$ = command(({ set }, preference: ThemePreference) => {
   const resolved = resolveTheme(preference);
   set(internalResolved$, resolved);
   applyTheme(resolved);
-  set(themeStorageSet$, preference);
+  if (isOkouHostname(location.hostname)) {
+    /* eslint-disable ccstate/no-catch-abort -- synchronous storage access cannot carry an application AbortSignal. */
+    // eslint-disable-next-line no-restricted-syntax -- localStorage may be blocked; the cookie and in-memory theme remain valid fallbacks.
+    try {
+      set(themeStorageSet$, preference);
+    } catch {
+      // Storage can be blocked; the in-memory and document themes still apply.
+    }
+    /* eslint-enable ccstate/no-catch-abort */
+    writeOkouThemePreferenceToDocument(preference);
+  } else {
+    set(themeStorageSet$, preference);
+  }
 });
 
 /**
@@ -90,7 +107,18 @@ export const setTheme$ = command(({ set }, preference: ThemePreference) => {
  */
 export const setColorTheme$ = command(({ set }, colorTheme: ColorTheme) => {
   set(internalColorTheme$, colorTheme);
-  set(colorThemeStorageSet$, colorTheme);
+  if (isOkouHostname(location.hostname)) {
+    /* eslint-disable ccstate/no-catch-abort -- synchronous storage access cannot carry an application AbortSignal. */
+    // eslint-disable-next-line no-restricted-syntax -- blocked localStorage must not prevent the authenticated theme preference from synchronizing.
+    try {
+      set(colorThemeStorageSet$, colorTheme);
+    } catch {
+      // Keep Okou usable when browser storage is unavailable.
+    }
+    /* eslint-enable ccstate/no-catch-abort */
+  } else {
+    set(colorThemeStorageSet$, colorTheme);
+  }
 });
 
 /**
@@ -114,14 +142,17 @@ export const updateColorThemePreference$ = command(
 );
 
 /**
- * Reconcile the fast local bootstrap cache with the workspace preference.
- * Null server values migrate the current device choice.
+ * Reconcile the fast local bootstrap cache with the authoritative workspace
+ * preference. Null server values migrate the cookie or current device choice.
  */
 export const syncThemePreferences$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const clerk = await get(clerk$);
     signal.throwIfAborted();
     if (!clerk.user || !clerk.organization) {
+      if (isOkouHostname(location.hostname)) {
+        writeOkouThemePreferenceToDocument(get(themePreference$));
+      }
       return;
     }
 
@@ -134,11 +165,12 @@ export const syncThemePreferences$ = command(
     set(setTheme$, theme);
     set(setColorTheme$, colorTheme);
 
-    if (preferences.theme === null || preferences.colorTheme === null) {
+    const shouldUpdateTheme = preferences.theme === null;
+    if (shouldUpdateTheme || preferences.colorTheme === null) {
       await set(
         updateUserPreference$,
         {
-          ...(preferences.theme === null && { theme }),
+          ...(shouldUpdateTheme && { theme }),
           ...(preferences.colorTheme === null && { colorTheme }),
         },
         signal,
@@ -186,9 +218,30 @@ export function applyTypefaceDocumentAttribute(enabled: boolean) {
  * Initialize theme from localStorage or system preference.
  */
 export const initTheme$ = command(({ get, set }) => {
-  const rawStored = get(themeStorageGet$);
-  const preference = isThemePreference(rawStored) ? rawStored : "system";
-  const rawStoredColorTheme = get(colorThemeStorageGet$);
+  const isOkou = isOkouHostname(location.hostname);
+  const bootstrapOkouThemePreference = isOkou
+    ? readOkouThemePreferenceFromDocument()
+    : null;
+
+  let rawStored: string | null = null;
+  let rawStoredColorTheme: string | null = null;
+  if (isOkou) {
+    /* eslint-disable ccstate/no-catch-abort -- synchronous storage access cannot carry an application AbortSignal. */
+    // eslint-disable-next-line no-restricted-syntax -- browser privacy policies can block localStorage, in which case Okou safely follows the system.
+    try {
+      rawStored = get(themeStorageGet$);
+      rawStoredColorTheme = get(colorThemeStorageGet$);
+    } catch {
+      // Browser storage can be blocked; fall through to safe defaults.
+    }
+    /* eslint-enable ccstate/no-catch-abort */
+  } else {
+    rawStored = get(themeStorageGet$);
+    rawStoredColorTheme = get(colorThemeStorageGet$);
+  }
+  const preference =
+    bootstrapOkouThemePreference ??
+    (isThemePreference(rawStored) ? rawStored : "system");
   const colorTheme = isColorTheme(rawStoredColorTheme)
     ? rawStoredColorTheme
     : DEFAULT_COLOR_THEME;
@@ -202,8 +255,13 @@ export const initTheme$ = command(({ get, set }) => {
   window
     .matchMedia("(prefers-color-scheme: dark)")
     .addEventListener("change", () => {
-      const currentPref = get(themeStorageGet$);
-      if (!isThemePreference(currentPref) || currentPref === "system") {
+      const currentPreference = isOkouHostname(location.hostname)
+        ? get(internalPreference$)
+        : get(themeStorageGet$);
+      if (
+        !isThemePreference(currentPreference) ||
+        currentPreference === "system"
+      ) {
         const newResolved = window.matchMedia("(prefers-color-scheme: dark)")
           .matches
           ? "dark"


### PR DESCRIPTION
## Summary

- read the versioned, non-sensitive `__Secure-okou-theme` preference synchronously on Okou hosts before critical styles, ahead of the app-local cache
- preserve `light`, `dark`, and `system`, with safe fallback to the existing app cache/system behavior for absent, stale, malformed, or blocked values
- keep the authenticated workspace preference authoritative, mirror it to the shared cookie, and use the bootstrap cookie only when the workspace has no theme preference
- update the workspace preference, app cache, and shared cookie together on subsequent app theme changes
- keep the VM0 bootstrap, storage, and workspace preference paths isolated and behaviorally unchanged

## Shared protocol

- values: `v1.light`, `v1.dark`, or `v1.system`
- production scope: `.okou.ai`; shared custom-domain preview scope: `.omby.ai`
- standalone `workers.dev` Okou previews use the same value as a host-only cookie because they have no registrable parent shared with marketing previews
- attributes: `Path=/; Max-Age=31536000; SameSite=Lax; Secure`
- payload contains only the theme preference; this does not change authentication or session cookies and adds no URL parameters

This is the app half of a two-repository compatibility change. Companion marketing PR: https://github.com/vm0-ai/vm0-marketing/pull/546. Either PR can merge first because both sides retain their previous local/system fallback; end-to-end continuity becomes active after both are deployed. No production release is included.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged workspace, app, and API type checks
- `pnpm --filter @okouai/app exec vitest run src/__tests__/theme-bootstrap.test.ts` (15 tests)
- `pnpm --filter @okouai/app exec vitest run src/signals/__tests__/bootstrap-theme.test.ts` (6 tests)

Tests cover `/`, `/sign-in`, `/sign-up`, first-paint script ordering, light/dark/system resolution, workspace-over-cookie precedence, cookie fallback when the workspace preference is absent, stale/malformed/blocked fallback, explicit app changes, reverse continuity for logged-out fallback, standalone preview persistence, and VM0 isolation.
