### PR TITLE
fix(platform): leave intro video editing instructions empty

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/intro-video.ts
+++ b/turbo/apps/platform/src/signals/okou-page/intro-video.ts
@@ -82,8 +82,6 @@ export type IntroVideoVoiceSelection =
 export type IntroVideoPlacement = "left" | "overlay" | "right";
 
 const PRESENTATION_EXTENSIONS = ["html", "pdf", "ppt", "pptx"] as const;
-const DEFAULT_INSTRUCTIONS =
-  "Create a concise 30 second product intro. Zoom in on important actions, remove pauses, and keep the pacing energetic.";
 /**
  * Aspect ratio reported to the agent for the raw avatar take.
  *
@@ -188,7 +186,7 @@ function buildIntroVideoPrompt(args: {
     overlay: "Presenter over the slide, anchored to the bottom right",
     right: "Presenter on the right, slide on the left",
   };
-  const direction = args.instructions.trim() || DEFAULT_INSTRUCTIONS;
+  const instructions = args.instructions.trim();
   return [
     "Create a polished intro video from the attached source.",
     "",
@@ -212,9 +210,7 @@ function buildIntroVideoPrompt(args: {
             : []),
         ]
       : []),
-    "",
-    "Editing direction:",
-    direction,
+    ...(instructions ? ["", "Editing direction:", instructions] : []),
   ].join("\n");
 }
 
@@ -245,7 +241,7 @@ function createIntroVideoInternalState(): IntroVideoInternalState {
     busy$: state(false),
     draftDiscarded$: state(false),
     error$: state<IntroVideoWizardError | null>(null),
-    instructions$: state(DEFAULT_INSTRUCTIONS),
+    instructions$: state(""),
     open$: state(false),
     placement$: state<IntroVideoPlacement>("left"),
     source$: state<IntroVideoSource | null>(null),
@@ -330,7 +326,7 @@ function createResetWizardDraftCommand(internal: IntroVideoInternalState) {
     set(internal.avatar$, null);
     set(internal.voice$, null);
     set(internal.placement$, "left");
-    set(internal.instructions$, DEFAULT_INSTRUCTIONS);
+    set(internal.instructions$, "");
     set(internal.step$, "source");
     set(internal.busy$, false);
     set(internal.open$, false);
@@ -383,7 +379,7 @@ function createOpenWizardCommand(internal: IntroVideoInternalState) {
     set(internal.avatar$, null);
     set(internal.busy$, false);
     set(internal.error$, null);
-    set(internal.instructions$, DEFAULT_INSTRUCTIONS);
+    set(internal.instructions$, "");
     set(internal.sourceUploaded$, false);
     set(internal.placement$, "left");
     set(internal.voice$, null);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-start-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-start-cards.test.tsx
@@ -276,6 +276,9 @@ describe("chat start cards", () => {
       screen.findByText("Review your intro video"),
     ).resolves.toBeInTheDocument();
     expect(screen.queryByText("Where should the presenter stand?")).toBeNull();
+    expect(
+      screen.getByRole("textbox", { name: "Editing instructions" }),
+    ).toHaveValue("");
     const createButton = buttonWithText("Create in chat", dialog);
     expect(createButton).toBeInTheDocument();
     expect(createButton).toBeEnabled();
@@ -314,6 +317,7 @@ describe("chat start cards", () => {
       expect(sentPrompt).toContain("confirm it really is a paginated deck");
       expect(sentPrompt).toContain("okou presentation screenshot");
       expect(sentPrompt).not.toContain("okou video camera");
+      expect(sentPrompt).not.toContain("Editing direction:");
       expect(sentUserMessage?.parts).toContainEqual({
         type: "file",
         fileId: "intro-video-source",
@@ -384,11 +388,18 @@ describe("chat start cards", () => {
     await expect(
       screen.findByText("Review your intro video"),
     ).resolves.toBeInTheDocument();
+    await user.type(
+      screen.getByRole("textbox", { name: "Editing instructions" }),
+      "Keep the source's original pacing.",
+    );
     await user.click(buttonWithText("Create in chat", dialog));
 
     await waitFor(() => {
       expect(sentPrompt).toContain("- Source type: file");
       expect(sentPrompt).toContain("open it and identify it first");
+      expect(sentPrompt).toContain(
+        "Editing direction:\nKeep the source's original pacing.",
+      );
     });
     // Neither of the workflows that assume they already know the source.
     expect(sentPrompt).not.toContain("For an attached presentation source:");


### PR DESCRIPTION
## Summary

- initialize and reset intro video editing instructions to an empty value
- omit the editing-direction prompt section when the user provides no instructions
- preserve custom editing instructions and cover both paths in the page-level integration test

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-start-cards.test.tsx` (14 tests)
- `pnpm exec prettier --check apps/platform/src/signals/okou-page/intro-video.ts apps/platform/src/views/okou-page/__tests__/chat-start-cards.test.tsx`
