### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -113,8 +113,8 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.27.1"
-CLAUDE_CODE_VERSION="2.1.258"
-CODEX_CLI_VERSION="0.152.1"
+CLAUDE_CODE_VERSION="2.1.259"
+CODEX_CLI_VERSION="0.153.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.3.1"
 AGENT_BROWSER_VERSION="0.33.0-vm0.1"


### PR DESCRIPTION
## Summary

- Update Claude Code from `2.1.258` to `2.1.259`.
- Update Codex CLI from `0.152.1` to `0.153.0`.

The pinned Go, Google Workspace CLI, xurl, agent-browser, pnpm, and Chromium versions remain current. Node.js 24 remains the current LTS major, and PostgreSQL 18 remains the current supported major.

## Verification

- `bash -n crates/runner/scripts/build-template.sh`
- `git diff --check`
- Confirmed Claude Code 2.1.259 standalone binaries and manifest are available for linux-x64 and linux-arm64.
- Confirmed Codex CLI 0.153.0 and its linux-x64 and linux-arm64 packages are published and support the pinned Node.js 24 runtime.
- Executed the published Codex package and confirmed `codex-cli 0.153.0`.
- Reviewed the Codex 0.153.0 release metadata; app-server changes are additive to the existing contract.
- Confirmed the pinned Chromium snapshot still provides version 151.0.7922.173-1~deb12u1 for amd64 and arm64.