### PR TITLE
feat(cli): review the camera cut at the plan's own moments and record whether each click is in frame

### DIFF
--- a/turbo/apps/cli/src/commands/video/__tests__/camera.test.ts
+++ b/turbo/apps/cli/src/commands/video/__tests__/camera.test.ts
@@ -108,8 +108,13 @@ describe("okou video camera command", () => {
       reviewFrames: number;
       cameraShots: number;
       cameraMoves: number;
+      clicksOutsideFrame: number;
     };
-    expect(result).toMatchObject({ outputPath, cameraShots: 1 });
+    expect(result).toMatchObject({
+      outputPath,
+      cameraShots: 1,
+      clicksOutsideFrame: 0,
+    });
     expect(result.cameraMoves).toBeGreaterThanOrEqual(2);
     const plan = JSON.parse(readFileSync(result.planPath, "utf8")) as {
       algorithm: string;
@@ -138,6 +143,8 @@ describe("okou video camera command", () => {
       }),
     ).toBe(true);
     const review = JSON.parse(readFileSync(result.reviewPath, "utf8")) as {
+      clicks: { tMs: number; inFrame: boolean }[];
+      clicksOutsideFrame: number;
       checkpoints: {
         timeMs: number;
         reasons: { kind: string; offsetMs?: number }[];
@@ -146,6 +153,11 @@ describe("okou video camera command", () => {
       }[];
     };
     expect(review.checkpoints).toHaveLength(result.reviewFrames);
+    expect(review.clicksOutsideFrame).toBe(0);
+    expect(review.clicks).toEqual([
+      { tMs: 2_000, inFrame: true },
+      { tMs: 4_500, inFrame: true },
+    ]);
     expect(
       review.checkpoints.flatMap((checkpoint) => {
         return checkpoint.reasons;
@@ -153,9 +165,8 @@ describe("okou video camera command", () => {
     ).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ kind: "click-before" }),
-        expect.objectContaining({ kind: "click" }),
-        expect.objectContaining({ kind: "click-after", offsetMs: 500 }),
-        expect.objectContaining({ kind: "click-after", offsetMs: 1_500 }),
+        expect.objectContaining({ kind: "click", inFrame: true }),
+        expect.objectContaining({ kind: "click-after", offsetMs: 400 }),
         expect.objectContaining({ kind: "move-start" }),
         expect.objectContaining({ kind: "move-end" }),
         expect.objectContaining({ kind: "shot-end" }),

--- a/turbo/apps/cli/src/commands/video/camera-plan.ts
+++ b/turbo/apps/cli/src/commands/video/camera-plan.ts
@@ -49,6 +49,8 @@ const SMOOTH_WINDOW_MS = 100;
 /** A burst shorter than this is a shortcut, not typing. */
 const TYPING_MIN_MS = 1_000;
 /** Share of pixels that changed after a click for the page to count as changed. */
+/** How long after a click the picture is compared with the click frame. */
+export const REACTION_DELAY_MS = 400;
 const REACTION_LOCAL = 0.12;
 const REACTION_PAGE = 0.35;
 const REACTION_RELEASE_MS = 300;
@@ -222,6 +224,19 @@ export const cameraPlanSchema = z
     }),
     content: pixelRectSchema,
     shots: z.array(cameraShotSchema),
+    /** The clicks the plan serves, so a review can check them against whatever the plan became. */
+    clicks: z
+      .array(
+        z.object({
+          tMs: z.number().int().nonnegative(),
+          x: z.number(),
+          y: z.number(),
+          elementRole: z.string().optional(),
+          /** Share of the picture that changed within `REACTION_DELAY_MS` of the click. */
+          reaction: z.number().min(0).max(1).optional(),
+        }),
+      )
+      .default([]),
   })
   .superRefine((plan, context) => {
     let previousEndMs = 0;
@@ -1179,6 +1194,51 @@ export function createCameraPlan(
     source,
     content,
     shots: toPlanShots(shots),
+    clicks: clicks.map((click) => {
+      const reaction = analysis.reactions.get(click.tMs);
+      return {
+        tMs: click.tMs,
+        x: Math.round(click.x * 1_000) / 1_000,
+        y: Math.round(click.y * 1_000) / 1_000,
+        ...(click.elementRole ? { elementRole: click.elementRole } : {}),
+        ...(reaction === undefined
+          ? {}
+          : { reaction: Math.round(reaction * 1_000) / 1_000 }),
+      };
+    }),
+  });
+}
+
+export interface PlanClickVerification {
+  readonly tMs: number;
+  readonly inFrame: boolean;
+}
+
+/**
+ * Every click of the plan checked against the camera the plan describes, as it
+ * will be rendered. Run on the plan being rendered rather than on the one that
+ * was generated, so an edited plan is judged on its edits.
+ */
+export function verifyPlanClicks(
+  plan: CameraPlan,
+): readonly PlanClickVerification[] {
+  const frames = createCameraFrameStates(plan);
+  return plan.clicks.map((click) => {
+    return {
+      tMs: click.tMs,
+      inFrame: clickInFrame(
+        frames,
+        {
+          tMs: click.tMs,
+          x: click.x,
+          y: click.y,
+          element: null,
+          elementRole: null,
+        },
+        plan.source,
+        CLICK_MARGIN,
+      ),
+    };
   });
 }
 

--- a/turbo/apps/cli/src/commands/video/camera-review.ts
+++ b/turbo/apps/cli/src/commands/video/camera-review.ts
@@ -1,16 +1,26 @@
-import { createCameraFrameStates } from "./camera-plan";
+import {
+  createCameraFrameStates,
+  REACTION_DELAY_MS,
+  verifyPlanClicks,
+} from "./camera-plan";
 import type { CameraPlan, CameraFrameState } from "./camera-plan";
 
 const CLICK_BEFORE_MS = 300;
-const CLICK_AFTER_MS = [500, 1_500] as const;
 
 export type CameraCheckpointReason =
   | { readonly kind: "click-before"; readonly clickMs: number }
-  | { readonly kind: "click"; readonly clickMs: number }
   | {
+      readonly kind: "click";
+      readonly clickMs: number;
+      /** Whether the click point sits inside the rendered viewport at its own moment. */
+      readonly inFrame: boolean;
+    }
+  | {
+      /** The moment the plan compared with the click frame to decide on a pull-back. */
       readonly kind: "click-after";
       readonly clickMs: number;
-      readonly offsetMs: (typeof CLICK_AFTER_MS)[number];
+      readonly offsetMs: number;
+      readonly changedFraction?: number;
     }
   | { readonly kind: "move-start"; readonly keyId: string }
   | { readonly kind: "move-end"; readonly keyId: string }
@@ -80,7 +90,6 @@ function maximumCameraSpeedTime(plan: CameraPlan): number | null {
 
 export function createCameraReviewCheckpoints(
   plan: CameraPlan,
-  clickTimes: readonly number[],
 ): readonly CameraReviewCheckpoint[] {
   const reasonsByTime = new Map<number, CameraCheckpointReason[]>();
   const add = (timeMs: number, reason: CameraCheckpointReason): void => {
@@ -88,15 +97,30 @@ export function createCameraReviewCheckpoints(
     reasonsByTime.set(bounded, [...(reasonsByTime.get(bounded) ?? []), reason]);
   };
 
-  for (const clickMs of clickTimes) {
+  const inFrameByClick = new Map(
+    verifyPlanClicks(plan).map((click) => {
+      return [click.tMs, click.inFrame] as const;
+    }),
+  );
+  for (const click of plan.clicks) {
+    const clickMs = click.tMs;
     if (clickMs > plan.source.durationMs) {
       continue;
     }
     add(clickMs - CLICK_BEFORE_MS, { kind: "click-before", clickMs });
-    add(clickMs, { kind: "click", clickMs });
-    for (const offsetMs of CLICK_AFTER_MS) {
-      add(clickMs + offsetMs, { kind: "click-after", clickMs, offsetMs });
-    }
+    add(clickMs, {
+      kind: "click",
+      clickMs,
+      inFrame: inFrameByClick.get(clickMs) ?? false,
+    });
+    add(clickMs + REACTION_DELAY_MS, {
+      kind: "click-after",
+      clickMs,
+      offsetMs: REACTION_DELAY_MS,
+      ...(click.reaction === undefined
+        ? {}
+        : { changedFraction: click.reaction }),
+    });
   }
 
   for (const shot of plan.shots) {

--- a/turbo/apps/cli/src/commands/video/camera.ts
+++ b/turbo/apps/cli/src/commands/video/camera.ts
@@ -21,10 +21,13 @@ import {
   inputTrackClickTimes,
   inputTrackSchema,
   inputTrackVideoSource,
+  REACTION_DELAY_MS,
+  verifyPlanClicks,
 } from "./camera-plan";
 import type {
   CameraPlan,
   PixelRect,
+  PlanClickVerification,
   SourceAnalysis,
   VideoSource,
 } from "./camera-plan";
@@ -104,7 +107,6 @@ function probeVideo(path: string, declared: VideoSource): VideoSource {
   };
 }
 
-const REACTION_DELAY_MS = 400;
 const REACTION_PROBE_WIDTH = 160;
 const REACTION_PIXEL_DELTA = 40;
 
@@ -356,6 +358,7 @@ function writeCameraReview(args: {
   readonly planPath: string;
   readonly reviewPath: string;
   readonly checkpoints: readonly CameraReviewCheckpoint[];
+  readonly clicks: readonly PlanClickVerification[];
 }): void {
   const framesDirectory = reviewFramesDirectory(args.reviewPath);
   mkdirSync(framesDirectory, { recursive: true });
@@ -380,6 +383,10 @@ function writeCameraReview(args: {
         sourcePath: args.sourcePath,
         outputPath: args.outputPath,
         planPath: args.planPath,
+        clicks: args.clicks,
+        clicksOutsideFrame: args.clicks.filter((click) => {
+          return !click.inFrame;
+        }).length,
         checkpoints,
       },
       null,
@@ -500,7 +507,8 @@ Notes:
         );
       }
       assertWritableOutput(reviewPath, force);
-      const checkpoints = createCameraReviewCheckpoints(plan, clickTimes);
+      const checkpoints = createCameraReviewCheckpoints(plan);
+      const clickChecks = verifyPlanClicks(plan);
       const reviewDirectory = reviewFramesDirectory(reviewPath);
       for (const checkpoint of checkpoints) {
         assertWritableOutput(
@@ -525,6 +533,7 @@ Notes:
         planPath,
         reviewPath,
         checkpoints,
+        clicks: clickChecks,
       });
       const renderMs = Math.round(performance.now() - renderStartedAt);
       process.stdout.write(
@@ -533,6 +542,9 @@ Notes:
           planPath,
           reviewPath,
           reviewFrames: checkpoints.length,
+          clicksOutsideFrame: clickChecks.filter((click) => {
+            return !click.inFrame;
+          }).length,
           durationMs: plan.source.durationMs,
           width: plan.source.width,
           height: plan.source.height,


### PR DESCRIPTION
## Summary

Follow-up to #31202 on the review manifest `okou video camera` writes beside the cut.

- **After-click checkpoints follow the camera's own rhythm.** The fixed 500 ms and 1500 ms offsets came from the first camera. The new camera decides 400 ms after a click whether the picture changed enough to pull back, so the after-click checkpoint now sits at that moment and carries the measured `changedFraction`. When the camera leaves a click is already marked by the next `move-start`.
- **Click verification is written down, not left to the eye.** The plan now lists the clicks it serves (`clicks[]` with position, element role and reaction). The review re-simulates the plan being rendered and marks every `click` checkpoint with `inFrame`; the manifest lists `clicks[]` with the verdicts and a `clicksOutsideFrame` count, and the command's JSON output reports the same count. Because it runs on the plan being rendered, an edited plan is judged on its edits.

## Test plan

- [x] `vitest` for the camera command (checkpoint reasons, `inFrame`, `clicksOutsideFrame`), `lint`, `tsc`, `knip`
- [x] Real recording rendered end to end; manifest shows six clicks in frame and the change fraction on each after-click checkpoint
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
