### PR TITLE
fix(platform): use selected drive account for artifact readiness

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -3429,6 +3429,7 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
       })?.googleDriveSync,
     ).toStrictEqual({
       status: "synced",
+      accountReady: true,
       id: "drive-file-1",
       name: "data.csv",
       webViewLink: "https://drive.google.com/file/d/drive-file-1/view",
@@ -3437,7 +3438,7 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
       artifacts.runs[0]?.files.find((file) => {
         return file.id === pdfId;
       })?.googleDriveSync,
-    ).toStrictEqual({ status: "not_synced" });
+    ).toStrictEqual({ status: "not_synced", accountReady: true });
     expect(listRecorder.queries[0]).toContain("vm0Artifact");
     expect(listRecorder.queries[0]).toContain(run.threadId);
 
@@ -3476,7 +3477,11 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
       artifacts.runs[0]?.files.find((file) => {
         return file.id === csvId;
       })?.googleDriveSync,
-    ).toMatchObject({ status: "synced", id: "drive-file-refreshed" });
+    ).toMatchObject({
+      status: "synced",
+      accountReady: true,
+      id: "drive-file-refreshed",
+    });
     await chat.listThreadArtifacts(actor, run.threadId);
     expect(successfulRefresh.refreshBodies).toHaveLength(1);
     expect(refreshedList.authorizationHeaders).toStrictEqual([
@@ -3494,7 +3499,10 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
     });
     for (let attempt = 0; attempt < 2; attempt += 1) {
       artifacts = await chat.listThreadArtifacts(actor, run.threadId);
-      expectDriveStatuses(artifacts, { status: "unknown" });
+      expectDriveStatuses(artifacts, {
+        status: "unknown",
+        accountReady: true,
+      });
     }
     expect(transientRefresh.refreshBodies).toHaveLength(2);
     await expect(
@@ -3571,7 +3579,11 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
       artifacts.runs[0]?.files.find((file) => {
         return file.id === csvId;
       })?.googleDriveSync,
-    ).toMatchObject({ status: "synced", id: "drive-file-reconnected" });
+    ).toMatchObject({
+      status: "synced",
+      accountReady: true,
+      id: "drive-file-reconnected",
+    });
 
     // Google session-control expiry retains its precise reconnect reason.
     const sessionExpiredRefresh = mockGoogleDriveConnectorOAuth({
@@ -3765,7 +3777,10 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
       return { status: 200, files: [] };
     });
     artifacts = await chat.listThreadArtifacts(actor, run.threadId);
-    expectDriveStatuses(artifacts, { status: "not_synced" });
+    expectDriveStatuses(artifacts, {
+      status: "not_synced",
+      accountReady: true,
+    });
     expect(selectedStatusRecorder.authorizationHeaders).toStrictEqual([
       "Bearer drive-access-drive-selected",
     ]);
@@ -3985,7 +4000,10 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
     artifacts = await chat.listThreadArtifacts(actor, run1.threadId);
     for (const group of artifacts.runs) {
       for (const file of group.files) {
-        expect(file.googleDriveSync).toStrictEqual({ status: "unknown" });
+        expect(file.googleDriveSync).toStrictEqual({
+          status: "unknown",
+          accountReady: true,
+        });
       }
     }
 

--- a/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
@@ -422,10 +422,12 @@ function resolveGoogleDriveArtifactSyncStatus(
     return { status: "disconnected", recovery: lookup.recovery };
   }
   if (lookup.type === "unknown") {
-    return { status: "unknown" };
+    return { status: "unknown", accountReady: true };
   }
   const synced = lookup.syncedByKey.get(artifactKey(runId, fileId));
-  return synced ? { status: "synced", ...synced } : { status: "not_synced" };
+  return synced
+    ? { status: "synced", accountReady: true, ...synced }
+    : { status: "not_synced", accountReady: true };
 }
 
 export function applyGoogleDriveArtifactSyncStatuses(

--- a/turbo/apps/platform/src/signals/okou-page/attachment-chips.ts
+++ b/turbo/apps/platform/src/signals/okou-page/attachment-chips.ts
@@ -32,6 +32,7 @@ import { createZoomableImageCanvasSignals } from "../zoomable-image-canvas.ts";
 const LIGHTBOX_DIALOG_EXIT_DURATION_MS = 180;
 
 export type AttachmentArtifactMetadata = {
+  readonly googleDriveAccountReady: boolean;
   readonly agentId?: string | null;
   readonly artifactKind?: "hosted-site" | "presentation-html";
   readonly contentType: string;

--- a/turbo/apps/platform/src/views/okou-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/thread-sidebar.test.tsx
@@ -1242,6 +1242,98 @@ describe("thread-owned utility sidebar", () => {
     },
   );
 
+  it("uploads with the selected ready Drive account when the default needs reconnect", async () => {
+    const user = userEvent.setup({ delay: null });
+    const markdownUrl =
+      "https://cdn.vm7.io/artifacts/test/run-sidebar/drive-ready-selected-notes.md";
+    const summary = catalogArtifact({ title: "drive-ready-selected-notes.md" });
+    const artifactFiles = [
+      threadArtifactFile(markdownUrl, {
+        id: "artifact-drive-ready-selected-notes",
+        filename: "drive-ready-selected-notes.md",
+        googleDriveSync: {
+          status: "not_synced",
+          accountReady: true,
+        },
+      }),
+    ];
+
+    setupArtifactCatalog(
+      [summary],
+      new Map([
+        [
+          summary.id,
+          catalogFileDetail({
+            contentType: "text/markdown",
+            filename: "drive-ready-selected-notes.md",
+            fileId: "f0000000-0000-4000-a000-000000000007",
+            summary,
+            url: markdownUrl,
+          }),
+        ],
+      ]),
+    );
+    context.mocks.data.connectors([
+      googleDriveConnector({
+        connectionStatus: "reconnect-required",
+        reconnectReason: "authorization_expired_or_revoked",
+      }),
+    ]);
+    context.mocks.api(connectorCatalogContract.status, ({ never }) => {
+      return never();
+    });
+    context.mocks.api(userConnectorsContract.update, ({ never }) => {
+      return never();
+    });
+    context.mocks.api(connectorOauthStartContract.start, ({ never }) => {
+      return never();
+    });
+    context.mocks.http.get(markdownUrl, () => {
+      return new Response("# Selected notes\n\nReady for Drive.", {
+        headers: { "Content-Type": "text/plain" },
+      });
+    });
+
+    let artifactSynced = false;
+    context.mocks.api(
+      chatThreadArtifactsContract.syncGoogleDrive,
+      ({ body, respond }) => {
+        expect(body).toStrictEqual({
+          runId: "run-sidebar",
+          fileId: "artifact-drive-ready-selected-notes",
+        });
+        artifactFiles[0] = {
+          ...artifactFiles[0]!,
+          googleDriveSync: {
+            status: "synced",
+            accountReady: true,
+            id: "drive-file-ready-selected-notes",
+            name: "drive-ready-selected-notes.md",
+            webViewLink: "https://drive.test/drive-file-ready-selected-notes",
+          },
+        };
+        artifactSynced = true;
+        return respond(200, {
+          id: "drive-file-ready-selected-notes",
+          name: "drive-ready-selected-notes.md",
+          webViewLink: "https://drive.test/drive-file-ready-selected-notes",
+        });
+      },
+    );
+
+    setupChatThread({ artifactFiles });
+    await openCatalogArtifact("drive-ready-selected-notes.md");
+    await screen.findByText("Ready for Drive.");
+
+    await user.click(screen.getByLabelText("Download artifact"));
+    await user.click(await screen.findByText("Upload to Google Drive"));
+
+    await waitFor(() => {
+      expect(artifactSynced).toBeTruthy();
+      expect(screen.getByText("Synced to Google Drive")).toBeInTheDocument();
+    });
+  });
+
   it("reconnects the selected Drive account before syncing the artifact", async () => {
     const user = userEvent.setup({ delay: null });
     const markdownUrl =

--- a/turbo/apps/platform/src/views/okou-page/artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/okou-page/artifact-actions.tsx
@@ -85,6 +85,7 @@ function artifactDownloadFilename(
 }
 
 export type ArtifactDownloadSyncTarget = {
+  readonly accountReady: boolean;
   readonly agentId: string | null | undefined;
   readonly disconnected: boolean;
   readonly fileId: string;
@@ -231,15 +232,19 @@ function useGoogleDriveAvailability(
     googleDriveConnector === null
       ? null
       : getOnlyAvailableCatalogBrowserAuthMethodDetail(googleDriveConnector);
+  const accountReady = syncTarget?.accountReady === true;
 
   return {
     connectorListLoaded:
-      connectorList !== undefined &&
-      (googleDriveConnected || catalogBySlug !== undefined),
+      accountReady ||
+      (connectorList !== undefined &&
+        (googleDriveConnected || catalogBySlug !== undefined)),
     googleDriveAuthMethod,
     googleDriveConnected,
     googleDriveConnector,
-    googleDriveReady: googleDriveConnected && syncTarget?.disconnected !== true,
+    googleDriveReady:
+      accountReady ||
+      (googleDriveConnected && syncTarget?.disconnected !== true),
   };
 }
 

--- a/turbo/apps/platform/src/views/okou-page/artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/okou-page/artifact-actions.tsx
@@ -233,6 +233,10 @@ function useGoogleDriveAvailability(
       ? null
       : getOnlyAvailableCatalogBrowserAuthMethodDetail(googleDriveConnector);
   const accountReady = syncTarget?.accountReady === true;
+  // Remove the default-connector fallback after pre-accountReady APIs are
+  // outside the serving and rollback window.
+  const legacyDefaultAccountReady =
+    googleDriveConnected && syncTarget?.disconnected !== true;
 
   return {
     connectorListLoaded:
@@ -242,9 +246,7 @@ function useGoogleDriveAvailability(
     googleDriveAuthMethod,
     googleDriveConnected,
     googleDriveConnector,
-    googleDriveReady:
-      accountReady ||
-      (googleDriveConnected && syncTarget?.disconnected !== true),
+    googleDriveReady: accountReady || legacyDefaultAccountReady,
   };
 }
 

--- a/turbo/apps/platform/src/views/okou-page/artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/artifact-sidebar.tsx
@@ -463,6 +463,9 @@ function artifactSidebarSyncTarget(params: {
   threadId: string;
 }): ArtifactDownloadSyncTarget {
   return {
+    accountReady:
+      params.item.file.googleDriveSync?.status !== "disconnected" &&
+      params.item.file.googleDriveSync?.accountReady === true,
     agentId: params.agentId,
     disconnected: params.item.file.googleDriveSync?.status === "disconnected",
     recovery:

--- a/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
@@ -337,6 +337,7 @@ function artifactDialogSyncTarget(
     return undefined;
   }
   return {
+    accountReady: artifact.googleDriveAccountReady,
     agentId: artifact.agentId,
     disconnected: artifact.googleDriveDisconnected,
     recovery: artifact.googleDriveRecovery,
@@ -385,6 +386,9 @@ function artifactDialogMetadataFromItem(params: {
     createdAt: params.item.file.createdAt,
     fileId: params.item.file.id,
     filename: params.item.file.filename,
+    googleDriveAccountReady:
+      params.item.file.googleDriveSync?.status !== "disconnected" &&
+      params.item.file.googleDriveSync?.accountReady === true,
     googleDriveDisconnected:
       params.item.file.googleDriveSync?.status === "disconnected",
     googleDriveRecovery:

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
@@ -17,6 +17,33 @@ import {
 } from "../chat-threads";
 
 describe("google drive artifact recovery contract", () => {
+  it("keeps account readiness additive across API and Platform versions", () => {
+    const legacyNotSynced = { status: "not_synced" } as const;
+    const accountReadyNotSynced = {
+      status: "not_synced",
+      accountReady: true,
+    } as const;
+    const previousNotSyncedSchema = z.object({
+      status: z.literal("not_synced"),
+    });
+
+    expect(
+      chatThreadArtifactGoogleDriveSyncSchema.parse(legacyNotSynced),
+    ).toStrictEqual(legacyNotSynced);
+    expect(previousNotSyncedSchema.parse(accountReadyNotSynced)).toStrictEqual(
+      legacyNotSynced,
+    );
+    expect(
+      chatThreadArtifactGoogleDriveSyncSchema.parse(accountReadyNotSynced),
+    ).toStrictEqual(accountReadyNotSynced);
+    expect(
+      chatThreadArtifactGoogleDriveSyncSchema.parse({
+        status: "unknown",
+        accountReady: true,
+      }),
+    ).toStrictEqual({ status: "unknown", accountReady: true });
+  });
+
   it("keeps disconnected recovery additive across API and Platform versions", () => {
     const legacyDisconnected = { status: "disconnected" } as const;
     const exactReconnect = {

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -228,19 +228,33 @@ const chatThreadArtifactGoogleDriveRecoverySchema = z.discriminatedUnion(
   ],
 );
 
+const chatThreadArtifactGoogleDriveAccountReadyShape = {
+  // New App -> old API fallback. Current APIs always emit this marker after
+  // resolving the thread account, credentials, and agent authorization.
+  // Keep it optional while pre-marker APIs remain available for rollback.
+  accountReady: z.literal(true).optional(),
+};
+
 const chatThreadArtifactGoogleDriveSyncSchema = z.discriminatedUnion("status", [
   z.object({
     status: z.literal("synced"),
+    ...chatThreadArtifactGoogleDriveAccountReadyShape,
     id: z.string(),
     name: z.string(),
     webViewLink: z.string().nullable(),
   }),
-  z.object({ status: z.literal("not_synced") }),
+  z.object({
+    status: z.literal("not_synced"),
+    ...chatThreadArtifactGoogleDriveAccountReadyShape,
+  }),
   z.object({
     status: z.literal("disconnected"),
     recovery: chatThreadArtifactGoogleDriveRecoverySchema.optional(),
   }),
-  z.object({ status: z.literal("unknown") }),
+  z.object({
+    status: z.literal("unknown"),
+    ...chatThreadArtifactGoogleDriveAccountReadyShape,
+  }),
 ]);
 
 const chatThreadArtifactFileSchema = resolvedAttachFileSchema.extend({


### PR DESCRIPTION
## Summary

- mark artifact Drive statuses as account-ready only after the API resolves the thread-selected account, usable credentials, and agent authorization
- let the Platform use that exact-account readiness instead of blocking on the default connector returned by the connector list
- preserve old API/new Platform and new API/old Platform behavior with an optional additive response field

## Scope

- no connector selection, OAuth flow, persistence, migration, runner, or UI copy changes
- `disconnected` responses continue to use their exact recovery action
- `unknown` continues to allow the existing upload attempt because only the provider file-list result is indeterminate

## Validation

- `pnpm format`
- `pnpm turbo run lint --filter=@okouai/api-contracts --filter=api --filter=@okouai/app`
- `pnpm turbo run check-types --filter=@okouai/api-contracts --filter=api --filter=@okouai/app`
- `pnpm knip --workspace @okouai/api-contracts --workspace api --workspace @okouai/app`
- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/chat-threads.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/thread-sidebar.test.tsx`
- pre-commit hooks: full Knip, full workspace type checking, staged Prettier, and file-size validation

Closes #31300

Parent: #30585
