### PR TITLE
perf(api): reuse persisted plan capabilities

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -88,7 +88,10 @@ import {
   setSyntheticPiMemoryStage1SelectionFixture,
 } from "../../../test-fixtures/pi-memory-stage1-candidates";
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
-import { upsertOrgPlanEntitlementFixture } from "../../../test-fixtures/org-plan-entitlement";
+import {
+  deleteOrgPlanEntitlementFixture,
+  upsertOrgPlanEntitlementFixture,
+} from "../../../test-fixtures/org-plan-entitlement";
 import { setOrgModelPolicyProviderTypeFixture } from "../../../test-fixtures/org-model-policies";
 import {
   createUsagePricingFixture,
@@ -5175,14 +5178,6 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(followUpEnvironment.OPENAI_MODEL).toBe("deepseek-v4-flash");
     await cancelChatRun(actor, followUp.runId);
 
-    // Restore spendable credits before exercising the built-in branch.
-    await seedOrgMetadata({ orgId, tier: "pro", credits: 1_000_000 });
-
-    // A vm0 provider pin in an entitled org passes the spendable-credits
-    // admission. The outcome past admission is race-dependent on the shared
-    // database: 503 when no vm0 execution key exists (no public provisioning
-    // surface), 201 when another suite's alive legacy test has seeded a
-    // global vm0 key. Both prove the credits-ok admission arm.
     await api.updateOrgModelPolicies(actor, [
       {
         model: "claude-sonnet-5",
@@ -5192,6 +5187,28 @@ describe("CHAT-02: model-first provider policies", () => {
         modelProviderId: null,
       },
     ]);
+    const insufficientVm0 = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        prompt: "reject built-in admission without spendable credits",
+        model: "claude-sonnet-5",
+      },
+      [201],
+    );
+    if (insufficientVm0.status !== 201) {
+      throw new Error("Expected insufficient-credit send to return 201");
+    }
+    expect(insufficientVm0.body.runId).toBeNull();
+
+    // Restore spendable credits before exercising the built-in branch.
+    await seedOrgMetadata({ orgId, tier: "pro", credits: 1_000_000 });
+
+    // A vm0 provider pin in an entitled org passes the spendable-credits
+    // admission. The outcome past admission is race-dependent on the shared
+    // database: 503 when no vm0 execution key exists (no public provisioning
+    // surface), 201 when another suite's alive legacy test has seeded a
+    // global vm0 key. Both prove the credits-ok admission arm.
     await setOrgModelPolicyProviderTypeFixture({
       orgId,
       model: "claude-sonnet-5",
@@ -5220,6 +5237,244 @@ describe("CHAT-02: model-first provider policies", () => {
         await api.requestCancelRun(actor, vm0Body.runId, [200]);
       }
     }
+  }, 90_000);
+
+  it("preserves persisted external model plan-state outcomes", async () => {
+    const { actor, agentId, runnerGroup, providerId } =
+      await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    const orgId = requireOrgId(actor);
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "claude-sonnet-5",
+        isDefault: true,
+        defaultProviderType: "anthropic-api-key",
+        credentialScope: "org",
+        modelProviderId: providerId,
+      },
+    ]);
+
+    const initial = await sendChatRun(actor, {
+      agentId,
+      prompt: "establish external plan capability admission",
+      model: "claude-sonnet-5",
+    });
+    const initialClaim = await claimChatRun(runnerGroup, initial.runId);
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(initial.runId, initialClaim.sandboxHeaders);
+    await flushWaitUntilForTest();
+
+    const activeFollowUp = await sendChatRun(actor, {
+      agentId,
+      threadId: initial.threadId,
+      prompt: "continue with active plan capabilities",
+    });
+    await cancelChatRun(actor, activeFollowUp.runId);
+
+    await upsertOrgPlanEntitlementFixture({
+      orgId,
+      status: "suspended",
+      supportByok: true,
+      restrictedVm0Models: false,
+    });
+    const suspendedEventId = randomUUID();
+    const suspended = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: initial.threadId,
+        prompt: "reject suspended persisted admission",
+        clientEventId: suspendedEventId,
+      },
+      [201],
+    );
+    if (suspended.status !== 201) {
+      throw new Error("Expected suspended-plan send to return 201");
+    }
+    expect(suspended.body.runId).toBeNull();
+    const suspendedMessages = await chat.listThreadEvents(
+      actor,
+      initial.threadId,
+    );
+    expect(userMessages(suspendedMessages.events)).toContainEqual(
+      expect.objectContaining({
+        eventType: "input.rejected",
+        revokesEventId: suspendedEventId,
+        error: "insufficient_credits",
+      }),
+    );
+
+    await upsertOrgPlanEntitlementFixture({
+      orgId,
+      status: "active",
+      supportByok: true,
+      restrictedVm0Models: false,
+    });
+    await deleteOrgPlanEntitlementFixture(orgId);
+    const missing = await requestSendEventRaw(actor, {
+      agentId,
+      threadId: initial.threadId,
+      prompt: "reject missing persisted plan authority",
+      userMessage: {
+        version: 1,
+        parts: [
+          { type: "text", text: "reject missing persisted plan authority" },
+        ],
+      },
+      hasTextContent: true,
+    });
+    expect(missing.status).toBe(500);
+
+    await upsertOrgPlanEntitlementFixture({
+      orgId,
+      status: "active",
+      supportByok: false,
+      restrictedVm0Models: false,
+    });
+    await seedVm0BuiltInModelKey("claude-sonnet-5");
+    const byokDisabled = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: initial.threadId,
+        prompt: "fall back from a BYOK-disabled persisted route",
+      },
+      [201],
+    );
+    if (byokDisabled.status !== 201) {
+      throw new Error("Expected BYOK-disabled send to return 201");
+    }
+    if (!byokDisabled.body.runId) {
+      throw new Error("Expected BYOK-disabled policy fallback to create a run");
+    }
+    const byokDisabledPolicies = await misc.listModelPolicies(actor);
+    expect(byokDisabledPolicies.policies).toContainEqual(
+      expect.objectContaining({
+        model: "deepseek-v4-flash",
+        isDefault: true,
+        defaultProviderType: "built-in",
+        modelProviderId: null,
+      }),
+    );
+    await cancelChatRun(actor, byokDisabled.body.runId);
+
+    await upsertOrgPlanEntitlementFixture({
+      orgId,
+      status: "active",
+      supportByok: true,
+      restrictedVm0Models: false,
+    });
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "claude-sonnet-5",
+        isDefault: true,
+        defaultProviderType: "anthropic-api-key",
+        credentialScope: "org",
+        modelProviderId: providerId,
+      },
+    ]);
+    await upsertOrgPlanEntitlementFixture({
+      orgId,
+      status: "active",
+      supportByok: true,
+      restrictedVm0Models: true,
+    });
+    await seedVm0BuiltInModelKey("deepseek-v4-flash");
+    const restricted = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: initial.threadId,
+        prompt: "fall back from a restricted persisted model",
+      },
+      [201],
+    );
+    if (restricted.status !== 201) {
+      throw new Error("Expected restricted-model send to return 201");
+    }
+    if (!restricted.body.runId) {
+      throw new Error(
+        "Expected restricted-model policy fallback to create a run",
+      );
+    }
+    const restrictedPolicies = await misc.listModelPolicies(actor);
+    expect(restrictedPolicies.policies).toContainEqual(
+      expect.objectContaining({
+        model: "deepseek-v4-flash",
+        isDefault: true,
+        defaultProviderType: "built-in",
+        modelProviderId: null,
+      }),
+    );
+    await cancelChatRun(actor, restricted.body.runId);
+  }, 90_000);
+
+  it("reloads external plan capabilities at final admission", async () => {
+    const { actor, agentId, runnerGroup, providerId } =
+      await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    const orgId = requireOrgId(actor);
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "claude-sonnet-5",
+        isDefault: true,
+        defaultProviderType: "anthropic-api-key",
+        credentialScope: "org",
+        modelProviderId: providerId,
+      },
+    ]);
+
+    const initial = await sendChatRun(actor, {
+      agentId,
+      prompt: "establish final plan admission freshness",
+      model: "claude-sonnet-5",
+    });
+    const initialClaim = await claimChatRun(runnerGroup, initial.runId);
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(initial.runId, initialClaim.sandboxHeaders);
+    await flushWaitUntilForTest();
+
+    const threadLock = await holdChatThreadRowLockFixture({
+      threadId: initial.threadId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      threadLock.release();
+      await threadLock.done;
+    });
+    const prompt = "reject plan changed after persisted preflight";
+    const followUp = chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: initial.threadId,
+        prompt,
+      },
+      [402],
+    );
+    await expect.poll(threadLock.blockedWaiterCount).toBe(1);
+
+    await upsertOrgPlanEntitlementFixture({
+      orgId,
+      status: "suspended",
+      supportByok: true,
+      restrictedVm0Models: false,
+    });
+    threadLock.release();
+    const rejected = await followUp;
+    await threadLock.done;
+    expectApiError(rejected.body);
+    expect(rejected.body.error.code).toBe("INSUFFICIENT_CREDITS");
+
+    const runs = await api.listAgentRuns(actor, {
+      status: "queued,pending,running,completed,failed,timeout,cancelled",
+      limit: 100,
+    });
+    expect(
+      runs.runs.filter((run) => {
+        return run.prompt === prompt;
+      }),
+    ).toHaveLength(0);
   }, 90_000);
 
   it("keeps captured Pi admission after PiLoop turns off", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -5304,12 +5304,6 @@ describe("CHAT-02: model-first provider policies", () => {
       }),
     );
 
-    await upsertOrgPlanEntitlementFixture({
-      orgId,
-      status: "active",
-      supportByok: true,
-      restrictedVm0Models: false,
-    });
     await deleteOrgPlanEntitlementFixture(orgId);
     const missing = await requestSendEventRaw(actor, {
       agentId,
@@ -5331,7 +5325,7 @@ describe("CHAT-02: model-first provider policies", () => {
       supportByok: false,
       restrictedVm0Models: false,
     });
-    await seedVm0BuiltInModelKey("claude-sonnet-5");
+    await seedVm0BuiltInModelKey("deepseek-v4-flash");
     const byokDisabled = await chat.requestSendEvent(
       actor,
       {
@@ -5379,7 +5373,6 @@ describe("CHAT-02: model-first provider policies", () => {
       supportByok: true,
       restrictedVm0Models: true,
     });
-    await seedVm0BuiltInModelKey("deepseek-v4-flash");
     const restricted = await chat.requestSendEvent(
       actor,
       {

--- a/turbo/apps/api/src/signals/services/chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/chat-events.command.ts
@@ -1027,6 +1027,7 @@ async function resolveExplicitRunConfiguration(params: {
         userId: params.userId,
         modelPin,
         requestedModelProvider: undefined,
+        externalPlanCapabilities: { kind: "load-current" },
       });
     },
   );

--- a/turbo/apps/api/src/signals/services/chat-thread-model.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-model.service.ts
@@ -18,6 +18,7 @@ import {
   isCodexFastServiceTierSupported,
   resolveDefaultModelFirstPin,
   type DefaultModelFirstPin,
+  type ExternalModelProviderPlanCapabilitiesSource,
   resolveModelFirstProviderAdmission,
   resolvePersistedModelFirstRoute,
   type ModelFirstPin,
@@ -302,6 +303,9 @@ async function evaluatePersistedChatThreadModel(
 ): Promise<PersistedChatThreadModelEvaluationResult> {
   let pin: ModelFirstPin;
   let selectedModelChanged: boolean;
+  let externalPlanCapabilities: ExternalModelProviderPlanCapabilitiesSource = {
+    kind: "load-current",
+  };
   if (thread.selectedModel === null) {
     const defaultPin = await resolveDefaultModelFirstPin(
       db,
@@ -348,6 +352,10 @@ async function evaluatePersistedChatThreadModel(
     selectedModelChanged =
       modelResolution.selectedModelChanged ||
       thread.selectedModel !== pin.selectedModel;
+    externalPlanCapabilities = {
+      kind: "resolved",
+      capabilities: modelResolution.orgPlanCapabilities,
+    };
   }
   const providerAdmission = await resolveModelFirstProviderAdmission({
     db,
@@ -355,6 +363,7 @@ async function evaluatePersistedChatThreadModel(
     userId: params.userId,
     modelPin: pin,
     requestedModelProvider: undefined,
+    externalPlanCapabilities,
   });
   const tier = resolveCodexTier({
     persistedTier: thread.codexServiceTier,

--- a/turbo/apps/api/src/signals/services/model-selection.service.ts
+++ b/turbo/apps/api/src/signals/services/model-selection.service.ts
@@ -74,7 +74,15 @@ interface ResolvedModelFirstPolicyRoute {
 interface PersistedModelFirstRouteResolution {
   readonly route: ResolvedModelFirstPolicyRoute | null;
   readonly selectedModelChanged: boolean;
+  readonly orgPlanCapabilities: OrgPlanCapabilities | null;
 }
+
+export type ExternalModelProviderPlanCapabilitiesSource =
+  | { readonly kind: "load-current" }
+  | {
+      readonly kind: "resolved";
+      readonly capabilities: OrgPlanCapabilities | null;
+    };
 
 interface ModelSelectionRequest {
   readonly modelProviderId: string;
@@ -109,11 +117,9 @@ function isOAuthMemberProviderType(type: ModelProviderType): boolean {
   return type === "claude-code-oauth-token" || type === "codex-oauth-token";
 }
 
-async function orgModelCapabilities(
-  db: Db,
-  orgId: string,
-): Promise<Pick<OrgPlanCapabilities, "restrictedVm0Models" | "supportByok">> {
-  const capabilities = await loadOrgPlanCapabilities(db, orgId);
+function modelRouteCapabilities(
+  capabilities: OrgPlanCapabilities | null,
+): Pick<OrgPlanCapabilities, "restrictedVm0Models" | "supportByok"> {
   if (capabilities?.status !== "active") {
     return {
       restrictedVm0Models: false,
@@ -353,7 +359,9 @@ export async function resolveDefaultModelFirstPin(
   if (userId !== "__no_preference__") {
     await ensureOrgModelPolicies(db, orgId, userId);
   }
-  const capabilities = await orgModelCapabilities(db, orgId);
+  const capabilities = modelRouteCapabilities(
+    await loadOrgPlanCapabilities(db, orgId),
+  );
   if (userId !== "__no_preference__") {
     const [preference] = await db
       .select({
@@ -448,7 +456,11 @@ export async function resolvePersistedModelFirstRoute(params: {
   readonly selectedModel: string | null;
 }): Promise<PersistedModelFirstRouteResolution> {
   await ensureOrgModelPolicies(params.db, params.orgId, params.userId);
-  const capabilities = await orgModelCapabilities(params.db, params.orgId);
+  const orgPlanCapabilities = await loadOrgPlanCapabilities(
+    params.db,
+    params.orgId,
+  );
+  const capabilities = modelRouteCapabilities(orgPlanCapabilities);
   const currentRoute = params.selectedModel
     ? await resolveValidPolicyRoute({
         db: params.db,
@@ -458,7 +470,11 @@ export async function resolvePersistedModelFirstRoute(params: {
       })
     : null;
   if (currentRoute) {
-    return { route: currentRoute, selectedModelChanged: false };
+    return {
+      route: currentRoute,
+      selectedModelChanged: false,
+      orgPlanCapabilities,
+    };
   }
 
   const defaultRoute = await resolveWorkspaceDefaultModelFirstRoute({
@@ -471,6 +487,7 @@ export async function resolvePersistedModelFirstRoute(params: {
     selectedModelChanged:
       defaultRoute !== null &&
       defaultRoute.selectedModel !== params.selectedModel,
+    orgPlanCapabilities,
   };
 }
 
@@ -508,7 +525,9 @@ export async function resolveModelSelectionPin(params: {
   | ReturnType<typeof insufficientCredits>
 > {
   const { db, orgId, userId, modelSelection } = params;
-  const capabilities = await orgModelCapabilities(db, orgId);
+  const capabilities = modelRouteCapabilities(
+    await loadOrgPlanCapabilities(db, orgId),
+  );
   if (
     !modelAllowedForOrgPlan({
       capabilities,
@@ -605,6 +624,7 @@ export async function resolveModelFirstProviderAdmission(params: {
   readonly userId: string;
   readonly modelPin: ModelFirstPin;
   readonly requestedModelProvider: string | undefined;
+  readonly externalPlanCapabilities: ExternalModelProviderPlanCapabilitiesSource;
 }): Promise<{
   readonly effectiveModelProvider: string | null | undefined;
   readonly cliAgentType: SupportedFramework | null;
@@ -678,7 +698,10 @@ export async function resolveModelFirstProviderAdmission(params: {
         selectedModel,
       })
     : checkOrgPlanRunAdmission({
-        capabilities: await loadOrgPlanCapabilities(params.db, params.orgId),
+        capabilities:
+          params.externalPlanCapabilities.kind === "resolved"
+            ? params.externalPlanCapabilities.capabilities
+            : await loadOrgPlanCapabilities(params.db, params.orgId),
         modelProviderType: effectiveModelProvider,
         selectedModel,
       });


### PR DESCRIPTION
## Summary

- reuse the raw organization plan-capability snapshot already loaded by persisted model-route resolution for the immediately adjacent external provider admission
- require each provider-admission caller to choose current or resolved capabilities while keeping built-in credit admission and final run admission fresh
- cover active, suspended, missing, BYOK-disabled, restricted-model, built-in insufficient-credit, and final-admission state-change behavior through the public chat API

## Scope

- no database migration or persisted-state change
- no public API, queue payload, frontend, or Runner protocol change
- no cross-request or process-wide capability cache

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/model-selection.service.ts apps/api/src/signals/services/chat-thread-model.service.ts apps/api/src/signals/services/chat-events.command.ts apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts --maxWorkers=1 --silent=passed-only` (162 passed)
- `pnpm knip --workspace api`
- `lefthook run pre-commit`
- `git diff --check`

Closes #31297

Parent context: #24203
