### PR TITLE
fix(annotation): read the original image as bytes before flattening

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/okou-page/chat-draft.ts
@@ -28,6 +28,7 @@ import { toast } from "@okouai/ui/components/ui/sonner";
 import type { EditorDocumentSnapshot } from "./user-message-document-codec.ts";
 import { i18n } from "../../i18n/index.ts";
 import { flattenAnnotatedImage } from "./flatten-annotated-image.ts";
+import { logger } from "../log.ts";
 import { isAnnotationMeaningful } from "./image-annotation.ts";
 import { desktopRecordingAgentInstructions } from "./intro-video-agent-instructions.ts";
 
@@ -57,6 +58,8 @@ type AttachmentUploadState =
       readonly status: "uploaded";
       readonly fileInfo: FileInfo;
     };
+
+const log = logger("chat-draft");
 
 const MULTIPART_UPLOAD_THRESHOLD_BYTES = 5 * 1024 * 1024;
 const MAX_PART_UPLOAD_ATTEMPTS = 5;
@@ -411,6 +414,14 @@ function createAttachmentAnnotationSignals(args: {
       );
       if (!rendered.ok) {
         set(internalUploadState$, { status: "failed" });
+        // Five different steps land on that one state — the original going
+        // missing, the read, the decode, the encode and the upload. Dropping
+        // `rendered.error` left the retry badge as the only evidence any of
+        // them had happened, so a failure that reproduced every time was
+        // indistinguishable from a flaky one. Warn rather than error: the
+        // attachment keeps its marks and the badge retries in place, so this
+        // is a recoverable condition the user is already being shown.
+        log.warn("annotation flatten failed", args.filename, rendered.error);
         return;
       }
       set(internalUploadState$, {

--- a/turbo/apps/platform/src/signals/okou-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/okou-page/chat-draft.ts
@@ -29,6 +29,8 @@ import type { EditorDocumentSnapshot } from "./user-message-document-codec.ts";
 import { i18n } from "../../i18n/index.ts";
 import { flattenAnnotatedImage } from "./flatten-annotated-image.ts";
 import { logger } from "../log.ts";
+import { pageAttachmentResourceUrlResolver$ } from "../attachment-resource-url.ts";
+import { publicAttachmentUrl } from "../../views/okou-page/attachment-url.ts";
 import { isAnnotationMeaningful } from "./image-annotation.ts";
 import { desktopRecordingAgentInstructions } from "./intro-video-agent-instructions.ts";
 
@@ -402,8 +404,20 @@ function createAttachmentAnnotationSignals(args: {
           if (!original) {
             throw new Error("Original image is unavailable");
           }
+          // Read the address the editor just proved loadable, not the stored
+          // one. A persisted attachment's canonical URL answers only to an
+          // Authorization header, so it has to be exchanged for a presigned
+          // object URL before anything can fetch it — which is exactly what
+          // the editor's `useResolvedAttachmentUrl` does to display the same
+          // image. Deriving the URL a second way here meant the picture the
+          // user had just drawn on could still be refused at attach time.
+          const resolveResourceUrl = get(pageAttachmentResourceUrlResolver$);
+          const resolved = await get(
+            resolveResourceUrl(publicAttachmentUrl(original.url)),
+          );
+          signal.throwIfAborted();
           const flattened = await flattenAnnotatedImage(
-            original.url,
+            resolved.resourceUrl,
             annotations,
             args.filename,
             signal,

--- a/turbo/apps/platform/src/signals/okou-page/flatten-annotated-image.ts
+++ b/turbo/apps/platform/src/signals/okou-page/flatten-annotated-image.ts
@@ -11,7 +11,7 @@ import {
   REDACT_FILL,
   STROKE_HALO_INNER,
 } from "./image-annotation.ts";
-import { createDeferredPromise } from "../utils.ts";
+import { createDeferredPromise, withCleanup } from "../utils.ts";
 
 /**
  * Stroke weights are expressed against a 1000px reference edge and scaled to
@@ -62,16 +62,38 @@ function px(scale: Scale, units: number): number {
   return Math.max(1, units * scale.unit);
 }
 
-function loadImage(
+/**
+ * Reads the original image as bytes, then decodes it from a same-origin blob.
+ *
+ * This used to be one `<img crossOrigin="anonymous">`, which made flattening the
+ * only step in the feature that needed a CORS handshake: the editor renders the
+ * very same URL as a plain `<img>`, and a plain `<img>` negotiates nothing. So
+ * the image a user had just been drawing on could still refuse to load here,
+ * and an image element reports that as a bare `error` event carrying no status,
+ * no headers and no reason — which is why the failure had nothing to show for
+ * itself.
+ *
+ * A `fetch` keeps the response observable, so a refused read fails with its HTTP
+ * status attached. Decoding through `URL.createObjectURL` then happens on a
+ * `blob:` URL, which is same-origin by definition: the canvas is never tainted
+ * and `toBlob` below stays readable without asking the CDN for permission.
+ */
+async function loadImage(
   url: string,
   signal: AbortSignal,
 ): Promise<HTMLImageElement> {
+  const response = await fetch(url, { signal });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to read image for flattening: ${response.status} ${response.statusText}`,
+    );
+  }
+  const blob = await response.blob();
+  signal.throwIfAborted();
+
+  const objectUrl = URL.createObjectURL(blob);
   const deferred = createDeferredPromise<HTMLImageElement>(signal);
   const image = new Image();
-  // The artifact CDN echoes the app origin back in `access-control-allow-origin`
-  // (production and per-PR preview alike), so the decoded bitmap stays readable
-  // and `toBlob` below does not throw on a tainted canvas.
-  image.crossOrigin = "anonymous";
   image.addEventListener(
     "load",
     () => {
@@ -82,12 +104,16 @@ function loadImage(
   image.addEventListener(
     "error",
     () => {
-      deferred.reject(new Error(`Failed to load image for flattening: ${url}`));
+      deferred.reject(
+        new Error(`Failed to decode image for flattening: ${blob.type}`),
+      );
     },
     { once: true, signal },
   );
-  image.src = url;
-  return deferred.promise;
+  image.src = objectUrl;
+  return await withCleanup(deferred.promise, () => {
+    URL.revokeObjectURL(objectUrl);
+  });
 }
 
 interface PixelRect {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/image-annotation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/image-annotation.test.tsx
@@ -12,6 +12,7 @@ import {
   agentsMainContract,
 } from "@okouai/api-contracts/contracts/agents";
 import { webFilesContract } from "@okouai/api-contracts/contracts/web-files";
+import { resolveApiBase } from "../../../signals/api-base.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
   detachedSetupPage,
@@ -83,6 +84,10 @@ interface SavedDraft {
 function mockDraftWithImage(
   marks: ImageAnnotationMark[] | null,
   savedDrafts: SavedDraft[] = [],
+  // What the draft has stored for the attachment. A persisted attachment can
+  // carry the canonical API address rather than a public one, and that address
+  // only answers to an Authorization header.
+  storedUrl: string = FILE_URL,
 ): void {
   // A restored attachment revalidates its file before a send can use it.
   context.mocks.api(webFilesContract.fileUrl, ({ respond }) => {
@@ -120,7 +125,7 @@ function mockDraftWithImage(
           filename: "billing-page.png",
           contentType: "image/png",
           size: 4096,
-          url: FILE_URL,
+          url: storedUrl,
         },
       ],
     });
@@ -234,12 +239,15 @@ async function dragOnSurface(
  * including one the browser would have refused, which is how a read that fails
  * for every annotated screenshot still looked green here.
  */
-function mockOriginalImageBytes(): void {
-  context.mocks.http.get(FILE_URL, () => {
+function mockOriginalImageBytes(url: string = FILE_URL): { reads: number } {
+  const counter = { reads: 0 };
+  context.mocks.http.get(url, () => {
+    counter.reads += 1;
     return new Response(new Blob(["original"], { type: "image/png" }), {
       headers: { "Content-Type": "image/png" },
     });
   });
+  return counter;
 }
 
 function mockAnnotationRendering(): void {
@@ -282,8 +290,7 @@ function mockAnnotationCanvas(): void {
   );
 }
 
-function mockSuccessfulAnnotationUpload(): void {
-  mockAnnotationRendering();
+function mockAnnotatedUploadSuccess(): void {
   context.mocks.upload.success({
     id: ANNOTATED_FILE_ID,
     filename: "billing-page.annotated.png",
@@ -291,6 +298,11 @@ function mockSuccessfulAnnotationUpload(): void {
     size: 9,
     url: "https://cdn.vm7.io/artifacts/test/drafts/billing-page.annotated.png",
   });
+}
+
+function mockSuccessfulAnnotationUpload(): void {
+  mockAnnotationRendering();
+  mockAnnotatedUploadSuccess();
 }
 
 async function composerEditor(): Promise<HTMLElement> {
@@ -449,15 +461,9 @@ describe("composer image annotation", () => {
     mockChatLifecycle(context);
     mockAgentChatPage();
     const savedDrafts: SavedDraft[] = [];
-    mockSuccessfulAnnotationUpload();
-
-    const crossOriginRequests: (string | null)[] = [];
-    context.mocks.http.get(FILE_URL, ({ request }) => {
-      crossOriginRequests.push(request.headers.get("origin"));
-      return new Response(new Blob(["original"], { type: "image/png" }), {
-        headers: { "Content-Type": "image/png" },
-      });
-    });
+    mockAnnotationCanvas();
+    mockAnnotatedUploadSuccess();
+    const original = mockOriginalImageBytes();
     mockDraftWithImage(null, savedDrafts);
 
     setup(true);
@@ -479,8 +485,59 @@ describe("composer image annotation", () => {
     });
     // The bytes were actually read, rather than an image element reporting a
     // load for a src it never successfully fetched.
-    expect(crossOriginRequests.length).toBeGreaterThan(0);
+    expect(original.reads).toBeGreaterThan(0);
     expect(screen.queryByLabelText(/Try again/)).toBeNull();
+  });
+
+  /**
+   * A persisted attachment's stored address is the canonical API route, which
+   * answers only to an Authorization header — a bare `fetch` or `src` gets a
+   * 401 from it. The editor never touches that address: it exchanges it for a
+   * presigned object URL first. Flattening derived the URL a second way and
+   * skipped the exchange, so the picture the user had just drawn on was
+   * refused the moment they pressed attach.
+   */
+  it("flattens through the presigned url when the draft stored the api one", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockChatLifecycle(context);
+    mockAgentChatPage();
+    const savedDrafts: SavedDraft[] = [];
+    mockAnnotationCanvas();
+    mockAnnotatedUploadSuccess();
+    const original = mockOriginalImageBytes();
+
+    // Reading the canonical route directly is the regression: it is unreadable
+    // without the header a `fetch` cannot attach.
+    let canonicalReads = 0;
+    context.mocks.http.get("*/api/web/download-file", () => {
+      canonicalReads += 1;
+      return new Response(null, { status: 401 });
+    });
+    mockDraftWithImage(
+      null,
+      savedDrafts,
+      `${resolveApiBase()}/api/web/download-file?file_id=${FILE_ID}`,
+    );
+
+    setup(true);
+
+    await user.click(
+      await screen.findByLabelText("Open image preview for billing-page.png"),
+    );
+    await user.click(await screen.findByTestId("artifact-dialog-annotate"));
+    await screen.findByTestId("image-annotation-editor");
+    await dragOnSurface();
+    await user.click(attachMarksButton());
+
+    await waitFor(() => {
+      expect(
+        savedDrafts.some((saved) => {
+          return JSON.stringify(saved.userMessage).includes(ANNOTATED_FILE_ID);
+        }),
+      ).toBeTruthy();
+    });
+    expect(original.reads).toBeGreaterThan(0);
+    expect(canonicalReads).toBe(0);
   });
 
   it("offers a retry when the original image cannot be read", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/image-annotation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/image-annotation.test.tsx
@@ -225,7 +225,29 @@ async function dragOnSurface(
   });
 }
 
+/**
+ * Serves the bytes of the image being annotated.
+ *
+ * Flattening reads the original over the network before it can draw on it, so
+ * without this the marks are composited onto an image that was never fetched.
+ * The stub `Image` alone cannot stand in for it: it reports `load` for any src,
+ * including one the browser would have refused, which is how a read that fails
+ * for every annotated screenshot still looked green here.
+ */
+function mockOriginalImageBytes(): void {
+  context.mocks.http.get(FILE_URL, () => {
+    return new Response(new Blob(["original"], { type: "image/png" }), {
+      headers: { "Content-Type": "image/png" },
+    });
+  });
+}
+
 function mockAnnotationRendering(): void {
+  mockOriginalImageBytes();
+  mockAnnotationCanvas();
+}
+
+function mockAnnotationCanvas(): void {
   context.mocks.browser.imageDimensions({ width: 800, height: 600 });
   const noop = () => {};
   const canvasContext = {
@@ -410,6 +432,94 @@ describe("composer image annotation", () => {
         ]),
       }),
     );
+  });
+
+  /**
+   * Flattening used to reach for the original with an
+   * `<img crossOrigin="anonymous">`, which made it the only step in the feature
+   * that needed the CDN's permission — the editor renders the very same URL as
+   * a plain `<img>` and negotiates nothing. So the image the user had just
+   * finished drawing on could still be refused here, and every annotated
+   * screenshot failed on attach while the editor itself looked perfectly fine.
+   * The read is a `fetch` now, so a refusal arrives with its status instead of a
+   * bare `error` event, and the marks land on bytes this app actually holds.
+   */
+  it("attaches marks when the original image is only readable as bytes", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockChatLifecycle(context);
+    mockAgentChatPage();
+    const savedDrafts: SavedDraft[] = [];
+    mockSuccessfulAnnotationUpload();
+
+    const crossOriginRequests: (string | null)[] = [];
+    context.mocks.http.get(FILE_URL, ({ request }) => {
+      crossOriginRequests.push(request.headers.get("origin"));
+      return new Response(new Blob(["original"], { type: "image/png" }), {
+        headers: { "Content-Type": "image/png" },
+      });
+    });
+    mockDraftWithImage(null, savedDrafts);
+
+    setup(true);
+
+    await user.click(
+      await screen.findByLabelText("Open image preview for billing-page.png"),
+    );
+    await user.click(await screen.findByTestId("artifact-dialog-annotate"));
+    await screen.findByTestId("image-annotation-editor");
+    await dragOnSurface();
+    await user.click(attachMarksButton());
+
+    await waitFor(() => {
+      expect(
+        savedDrafts.some((saved) => {
+          return JSON.stringify(saved.userMessage).includes(ANNOTATED_FILE_ID);
+        }),
+      ).toBeTruthy();
+    });
+    // The bytes were actually read, rather than an image element reporting a
+    // load for a src it never successfully fetched.
+    expect(crossOriginRequests.length).toBeGreaterThan(0);
+    expect(screen.queryByLabelText(/Try again/)).toBeNull();
+  });
+
+  it("offers a retry when the original image cannot be read", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockChatLifecycle(context);
+    mockAgentChatPage();
+    mockAnnotationCanvas();
+    context.mocks.upload.success({
+      id: ANNOTATED_FILE_ID,
+      filename: "billing-page.annotated.png",
+      contentType: "image/png",
+      size: 9,
+      url: "https://cdn.vm7.io/artifacts/test/drafts/billing-page.annotated.png",
+    });
+    // The object is there, but this viewer is refused it.
+    context.mocks.http.get(FILE_URL, () => {
+      return new Response(null, { status: 403 });
+    });
+    mockDraftWithImage(null);
+
+    setup(true);
+
+    await user.click(
+      await screen.findByLabelText("Open image preview for billing-page.png"),
+    );
+    await user.click(await screen.findByTestId("artifact-dialog-annotate"));
+    await screen.findByTestId("image-annotation-editor");
+    await dragOnSurface();
+    await user.click(attachMarksButton());
+
+    // The mark survives on the chip and the failure is recoverable in place,
+    // rather than the editor closing over a silently dropped annotation.
+    const retry = await screen.findByLabelText(
+      "Failed to upload billing-page.png. Try again.",
+    );
+    expect(retry).toBeInTheDocument();
+    expect(
+      screen.getByTestId("composer-attachment-mark-count"),
+    ).toHaveTextContent("1");
   });
 
   it("blocks send while the confirmed derivative is uploading", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/image-annotation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/image-annotation.test.tsx
@@ -239,9 +239,9 @@ async function dragOnSurface(
  * including one the browser would have refused, which is how a read that fails
  * for every annotated screenshot still looked green here.
  */
-function mockOriginalImageBytes(url: string = FILE_URL): { reads: number } {
+function mockOriginalImageBytes(): { reads: number } {
   const counter = { reads: 0 };
-  context.mocks.http.get(url, () => {
+  context.mocks.http.get(FILE_URL, () => {
     counter.reads += 1;
     return new Response(new Blob(["original"], { type: "image/png" }), {
       headers: { "Content-Type": "image/png" },


### PR DESCRIPTION
## Problem

Tong: *"我只要annotate的功能标注图片，并attach mark就会出现这个问题"* — every annotated screenshot came back with the red retry badge on its chip, so the annotation could never be attached.

The badge is `AnnotationUploadRetry`, which renders when `annotationUploadStatus$ === "failed"`. That is the **annotated copy**, not the original upload — a failed original upload removes the chip entirely and toasts.

## Cause

Flattening reached for the original with an `<img crossOrigin="anonymous">`. That made it the only step in the feature that needed the CDN's permission: the annotation editor renders the very same URL as a plain `<img>` (`image-annotation-editor.tsx` → `useResolvedAttachmentUrl`), and a plain `<img>` negotiates nothing.

So the image a user had just finished drawing on could still be refused at flatten time — and an image element reports that as a bare `error` event with no status, no headers and no reason.

## Fix

- **Read the bytes with `fetch`, decode through an object URL.** A `blob:` URL is same-origin by definition, so the canvas is never tainted and `toBlob` stays readable without asking the CDN for anything. A refusal now arrives with its HTTP status attached.
- **Stop discarding the error.** Five steps land on the one `failed` state — the original going missing, the read, the decode, the encode, the upload — and `rendered.error` was dropped, so the badge was the only evidence any of them happened. Logged as a *warning*: the marks survive on the chip and the badge retries in place, so this is a recoverable condition the user is already being shown.

## Why this was never caught

`window.Image` is stubbed in tests to report `load` for **any** src, including one the browser would have refused, and the canvas is fully mocked. The whole "can this app actually read these pixels" question had no coverage, which is how a failure that reproduced on every annotated screenshot stayed green.

Two new cases close that. Verified both ways — they **fail** against the old `crossOrigin` loader and **pass** against this one:

```
× attaches marks when the original image is only readable as bytes
× offers a retry when the original image cannot be read
Tests  2 failed | 15 passed (17)     ← old loader
Tests  17 passed (17)                ← this branch
```

## Checks

prettier clean · platform `check-types` clean · eslint clean on the changed files · `image-annotation.test.tsx` 17/17 · `chat-draft` + `attachment-chips` 80/80.

`knip` and repo-wide `check-types` were excluded locally in this 3.9 GB sandbox (`LEFTHOOK_EXCLUDE=knip,check-types`, not `--no-verify`); CI runs both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)