### PR TITLE
fix(cli): use exact run accounts in diagnostics

### DIFF
--- a/turbo/apps/cli/src/commands/__tests__/helpers/run-connector-accounts.ts
+++ b/turbo/apps/cli/src/commands/__tests__/helpers/run-connector-accounts.ts
@@ -1,0 +1,63 @@
+import { writeFileSync } from "node:fs";
+
+import {
+  connectorAccountsContract,
+  connectorAccountTargetKey,
+  type ConnectorAccountInspectionResult,
+  type ConnectorAccountTarget,
+} from "@okouai/api-contracts/contracts/connector-accounts";
+import { http, HttpResponse } from "msw";
+
+type RunConnectorAccountContextTarget = ConnectorAccountTarget & {
+  readonly connectionId: string | null;
+};
+
+type AvailableConnectorAccount = Extract<
+  ConnectorAccountInspectionResult,
+  { readonly kind: "available" }
+>;
+
+function accountKey(
+  target: ConnectorAccountTarget,
+  connectionId: string,
+): string {
+  return `${connectorAccountTargetKey(target)}:${connectionId}`;
+}
+
+export function writeRunConnectorAccountContext(
+  path: string,
+  targets: readonly RunConnectorAccountContextTarget[],
+): void {
+  writeFileSync(path, JSON.stringify({ schemaVersion: 1, targets }), "utf8");
+}
+
+export function stubRunConnectorAccountInspection(
+  accounts: readonly AvailableConnectorAccount[],
+  origin = "http://localhost:3000",
+) {
+  const accountsByKey = new Map(
+    accounts.map((account) => {
+      return [
+        accountKey(account.target, account.connectionId),
+        account,
+      ] as const;
+    }),
+  );
+  return http.post(
+    `${origin}/api/connector-accounts/inspect`,
+    async ({ request }) => {
+      const body = connectorAccountsContract.inspect.body.parse(
+        await request.json(),
+      );
+      return HttpResponse.json({
+        results: body.selections.map((selection) => {
+          return (
+            accountsByKey.get(
+              accountKey(selection.target, selection.connectionId),
+            ) ?? { kind: "unavailable" as const, ...selection }
+          );
+        }),
+      });
+    },
+  );
+}

--- a/turbo/apps/cli/src/commands/connector/__tests__/check.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/check.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import type { ConnectorResponse } from "@okouai/api-contracts/contracts/connector-schemas";
 import type {
   ConnectorCheckDiagnosticResult,
@@ -6,13 +10,18 @@ import type {
 } from "@okouai/api-contracts/contracts/connector-check";
 import chalk from "chalk";
 import { HttpResponse, http } from "msw";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  stubRunConnectorAccountInspection,
+  writeRunConnectorAccountContext,
+} from "../../__tests__/helpers/run-connector-accounts";
 import { server } from "../../../mocks/server";
 import { checkConnectorCommand } from "../check";
 
 const API_BASE_URL = "https://app.vm0.ai";
 const AGENT_ID = "00000000-0000-4000-8000-000000000001";
+const SELECTED_CONNECTION_ID = "00000000-0000-4000-8000-000000000099";
 
 type ResolvedDiagnostic = Extract<
   ConnectorCheckDiagnosticResult,
@@ -234,17 +243,70 @@ describe("okou connector check command", () => {
   const mockConsoleError = vi
     .spyOn(console, "error")
     .mockImplementation(() => {});
+  let directory = "";
+  let contextPath = "";
+
+  function setRunAccount(
+    connectorSlug: string,
+    connectionStatus: ConnectorResponse["connectionStatus"] | null,
+    options: {
+      readonly connectionId?: string;
+      readonly label?: string;
+      readonly origin?: string;
+    } = {},
+  ): void {
+    const connectionId = options.connectionId ?? SELECTED_CONNECTION_ID;
+    const target = { kind: "builtin" as const, connectorSlug };
+    writeRunConnectorAccountContext(contextPath, [
+      {
+        ...target,
+        connectionId: connectionStatus === null ? null : connectionId,
+      },
+    ]);
+    server.use(
+      stubRunConnectorAccountInspection(
+        connectionStatus === null
+          ? []
+          : [
+              {
+                kind: "available",
+                target,
+                connectionId,
+                authMethod: "oauth",
+                displayName: options.label ?? "Run-selected account",
+                externalId: "run-external-id",
+                externalUsername: "run-user",
+                externalEmail: "run@example.com",
+                connectionStatus,
+                reconnectReason:
+                  connectionStatus === "reconnect-required"
+                    ? "authorization_expired_or_revoked"
+                    : null,
+              },
+            ],
+        options.origin ?? API_BASE_URL,
+      ),
+    );
+  }
 
   beforeEach(() => {
+    directory = mkdtempSync(join(tmpdir(), "okou-check-run-account-"));
+    contextPath = join(directory, "context.json");
     vi.unstubAllEnvs();
     vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("OKOU_API_BACKEND_URL", API_BASE_URL);
     vi.stubEnv("OKOU_TOKEN", buildOkouToken());
     vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
+    vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", contextPath);
     vi.stubEnv("OKOU_CHAT_THREAD_ID", "");
     vi.stubEnv("GH_TOKEN", "");
     vi.stubEnv("GITHUB_TOKEN", "");
+    setRunAccount("github", "connected");
+  });
+
+  afterEach(() => {
+    rmSync(directory, { recursive: true, force: true });
   });
 
   function getOutput(): string {
@@ -265,6 +327,7 @@ describe("okou connector check command", () => {
   describe("request construction and local validation", () => {
     it("sends a sanitized URL request and preserves every selector in the re-diagnosis hint", async () => {
       let capturedBody: unknown;
+      setRunAccount("server-only", "connected");
       stubDiagnostic(
         resolvedUrl({
           connector: connectorIdentity({
@@ -471,6 +534,7 @@ describe("okou connector check command", () => {
       });
       let connectorCalls = 0;
       let authorizationCalls = 0;
+      setRunAccount("server-only", "connected");
       vi.stubEnv("SERVER_ONLY_TOKEN", "placeholder-not-a-secret");
       stubDiagnostic(
         resolvedEnvironment({
@@ -518,7 +582,7 @@ describe("okou connector check command", () => {
         "Credentials are resolved at the network boundary for requests matching these registered base URLs.",
       );
       expect(output).not.toContain("Credentials resolved from:");
-      expect(connectorCalls).toBe(1);
+      expect(connectorCalls).toBe(0);
       expect(authorizationCalls).toBe(1);
     });
 
@@ -554,7 +618,8 @@ describe("okou connector check command", () => {
         identity: connectorIdentity(),
         connector: null,
         enabledConnectorSlugs: ["github"],
-        expected: "authorized for this agent, but it is not connected",
+        expected:
+          "authorized for this agent, but an account is not available for this run",
       },
       {
         name: "expired",
@@ -573,6 +638,7 @@ describe("okou connector check command", () => {
     ])(
       "renders $name connector state",
       async ({ identity, connector, enabledConnectorSlugs, expected }) => {
+        setRunAccount("github", connector?.connectionStatus ?? null);
         stubDiagnostic(resolvedEnvironment({ connector: identity }));
         stubResolvedDependencies("github", {
           connector,
@@ -589,6 +655,129 @@ describe("okou connector check command", () => {
         expect(getOutput()).toContain(expected);
       },
     );
+
+    it("diagnoses the reconnect-required account selected by the run instead of a healthy default sibling", async () => {
+      let defaultAccountRequests = 0;
+      setRunAccount("github", "reconnect-required", {
+        connectionId: SELECTED_CONNECTION_ID,
+        label: "Run account B",
+      });
+      stubDiagnostic(resolvedEnvironment());
+      stubConnector("github", connectorResponse("github"), () => {
+        defaultAccountRequests += 1;
+      });
+      stubAgentConnectors(["github"]);
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--env-name",
+        "GH_TOKEN",
+      ]);
+
+      const text = getOutput();
+      expect(text).toContain("Account used by this run: Run account B");
+      expect(text).toContain(`Connection ID: ${SELECTED_CONNECTION_ID}`);
+      expect(text).toContain(
+        `/connectors/github/reconnect/${SELECTED_CONNECTION_ID}?agentId=${AGENT_ID}`,
+      );
+      expect(text).toContain("After reconnecting, start a new run.");
+      expect(defaultAccountRequests).toBe(0);
+    });
+
+    it("reports the healthy run account without reading a reconnect-required default sibling", async () => {
+      let defaultAccountRequests = 0;
+      setRunAccount("github", "connected", {
+        connectionId: SELECTED_CONNECTION_ID,
+        label: "Run account B",
+      });
+      stubDiagnostic(resolvedEnvironment());
+      stubConnector(
+        "github",
+        connectorResponse("github", "reconnect-required"),
+        () => {
+          defaultAccountRequests += 1;
+        },
+      );
+      stubAgentConnectors(["github"]);
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--env-name",
+        "GH_TOKEN",
+      ]);
+
+      const text = getOutput();
+      expect(text).toContain("Account used by this run: Run account B");
+      expect(text).toContain("connected and active");
+      expect(text).not.toContain("needs to be reconnected");
+      expect(defaultAccountRequests).toBe(0);
+    });
+
+    it("retains a deleted run account ID without offering sibling recovery", async () => {
+      const target = { kind: "builtin" as const, connectorSlug: "github" };
+      writeRunConnectorAccountContext(contextPath, [
+        { ...target, connectionId: SELECTED_CONNECTION_ID },
+      ]);
+      server.use(stubRunConnectorAccountInspection([], API_BASE_URL));
+      stubDiagnostic(resolvedEnvironment());
+      stubResolvedDependencies();
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--env-name",
+        "GH_TOKEN",
+      ]);
+
+      const text = getOutput();
+      expect(text).toContain(
+        `Account used by this run: ${SELECTED_CONNECTION_ID}`,
+      );
+      expect(text).toContain("metadata is unavailable or deleted");
+      expect(text).not.toContain("/connectors/github/connect");
+      expect(text).not.toContain("/connectors/github/reconnect");
+    });
+
+    it("fails closed when a legacy run has no account projection", async () => {
+      vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", "");
+      stubDiagnostic(resolvedEnvironment());
+      stubResolvedDependencies();
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--env-name",
+        "GH_TOKEN",
+      ]);
+
+      const text = getOutput();
+      expect(text).toContain("started without connector account context");
+      expect(text).not.toContain("/connectors/github/connect");
+      expect(text).not.toContain("/connectors/github/reconnect");
+    });
+
+    it("preserves deterministic default status outside a run", async () => {
+      vi.stubEnv("OKOU_TOKEN", "test-session-token");
+      vi.stubEnv("OKOU_AGENT_ID", "");
+      vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", "");
+      stubDiagnostic(resolvedEnvironment({ run: { status: "not-scoped" } }));
+      stubConnector(
+        "github",
+        connectorResponse("github", "reconnect-required"),
+      );
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--env-name",
+        "GH_TOKEN",
+      ]);
+
+      expect(getOutput()).toContain("needs to be reconnected");
+      expect(getOutput()).toContain("/connectors/github/connect");
+    });
 
     it.each([
       {
@@ -660,6 +849,7 @@ describe("okou connector check command", () => {
       "maps $name links to the platform origin",
       async ({ baseUrl, platformOrigin }) => {
         vi.stubEnv("OKOU_API_BACKEND_URL", baseUrl);
+        setRunAccount("github", "connected", { origin: baseUrl });
         stubDiagnostic(resolvedEnvironment(), undefined, baseUrl);
         stubResolvedDependencies("github", {
           connector: null,

--- a/turbo/apps/cli/src/commands/connector/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/search.test.ts
@@ -7,6 +7,10 @@
  * - Real (internal): All CLI code, scoring algorithm, formatters
  */
 
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server";
@@ -14,7 +18,9 @@ import { searchCommand } from "../search";
 import chalk from "chalk";
 import {
   authCodeMethod,
+  catalogItem,
   catalogStatusItem,
+  stubConnectorCatalog,
   stubConnectorCatalogStatus,
 } from "../../__tests__/helpers/connector-catalog";
 import {
@@ -22,9 +28,14 @@ import {
   stubAgentCustomConnectors,
   stubCustomConnectors,
 } from "../../__tests__/helpers/custom-connectors";
+import {
+  stubRunConnectorAccountInspection,
+  writeRunConnectorAccountContext,
+} from "../../__tests__/helpers/run-connector-accounts";
 
 const AGENT_UUID = "550e8400-e29b-41d4-a716-446655440000";
 const ALT_AGENT_UUID = "550e8400-e29b-41d4-a716-446655440099";
+const RUN_CONNECTION_ID = "11111111-1111-4111-8111-111111111111";
 
 const connectedGithub = {
   id: "1",
@@ -146,11 +157,16 @@ describe("okou connector search command", () => {
   const mockConsoleError = vi
     .spyOn(console, "error")
     .mockImplementation(() => {});
+  let directory = "";
+  let contextPath = "";
 
   beforeEach(() => {
+    directory = mkdtempSync(join(tmpdir(), "okou-search-run-account-"));
+    contextPath = join(directory, "context.json");
     chalk.level = 0;
     vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
+    vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", contextPath);
     server.use(stubCustomConnectors([]), stubAgentCustomConnectors([]));
   });
 
@@ -159,6 +175,7 @@ describe("okou connector search command", () => {
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
     vi.unstubAllEnvs();
+    rmSync(directory, { recursive: true, force: true });
   });
 
   describe("keyword validation", () => {
@@ -352,7 +369,36 @@ describe("okou connector search command", () => {
 
     it("adds AUTHORIZED FOR column when OKOU_AGENT_ID is set", async () => {
       vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
+      writeRunConnectorAccountContext(contextPath, [
+        {
+          kind: "builtin",
+          connectorSlug: "github",
+          connectionId: RUN_CONNECTION_ID,
+        },
+      ]);
       server.use(
+        stubConnectorCatalog([
+          catalogItem({
+            connectorSlug: "github",
+            label: "GitHub",
+            tags: ["vcs"],
+            authMethods: [authCodeMethod("oauth")],
+          }),
+        ]),
+        stubRunConnectorAccountInspection([
+          {
+            kind: "available",
+            connectionId: RUN_CONNECTION_ID,
+            target: { kind: "builtin", connectorSlug: "github" },
+            authMethod: "oauth",
+            displayName: "Run account B",
+            externalId: "run-b",
+            externalUsername: "run-b",
+            externalEmail: "run-b@example.com",
+            connectionStatus: "connected",
+            reconnectReason: null,
+          },
+        ]),
         stubAgent(AGENT_UUID, "maya"),
         stubUserConnectors(AGENT_UUID, []),
       );
@@ -362,6 +408,8 @@ describe("okou connector search command", () => {
       const lines = mockConsoleLog.mock.calls.flat() as string[];
       const output = lines.join("\n");
       expect(output).toContain("AUTHORIZED FOR maya");
+      expect(output).toContain("ACCOUNT USED BY THIS RUN");
+      expect(output).toContain("Run account B");
       const githubRow = findDataRows(lines).find((line) => {
         return line.startsWith("github");
       });
@@ -477,6 +525,169 @@ describe("okou connector search command", () => {
 
       const output = (mockConsoleLog.mock.calls.flat() as string[]).join("\n");
       expect(output).toContain("(permissions update available)");
+    });
+  });
+
+  describe("run account column", () => {
+    it("renders the exact reconnect-required run account instead of a healthy default sibling", async () => {
+      let defaultStatusRequests = 0;
+      vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
+      writeRunConnectorAccountContext(contextPath, [
+        {
+          kind: "builtin",
+          connectorSlug: "github",
+          connectionId: RUN_CONNECTION_ID,
+        },
+      ]);
+      server.use(
+        stubConnectorCatalog([
+          catalogItem({
+            connectorSlug: "github",
+            label: "GitHub",
+            tags: ["vcs"],
+            authMethods: [authCodeMethod("oauth")],
+          }),
+        ]),
+        stubRunConnectorAccountInspection([
+          {
+            kind: "available",
+            connectionId: RUN_CONNECTION_ID,
+            target: { kind: "builtin", connectorSlug: "github" },
+            authMethod: "oauth",
+            displayName: "Run account B",
+            externalId: "run-b",
+            externalUsername: "run-b",
+            externalEmail: "run-b@example.com",
+            connectionStatus: "reconnect-required",
+            reconnectReason: "authorization_expired_or_revoked",
+          },
+        ]),
+        stubAgent(AGENT_UUID, "maya"),
+        stubUserConnectors(AGENT_UUID, ["github"]),
+        http.get("http://localhost:3000/api/connector-catalog/status", () => {
+          defaultStatusRequests += 1;
+          return HttpResponse.json({
+            connectors: [
+              catalogStatusItem({
+                connectorSlug: "github",
+                connection: {
+                  authMethod: "oauth",
+                  externalUsername: "default-account-a",
+                  externalEmail: null,
+                  reconnectReason: null,
+                },
+                connected: true,
+                connectionStatus: "connected",
+              }),
+            ],
+          });
+        }),
+      );
+
+      await searchCommand.parseAsync(["node", "cli", "github"]);
+
+      const text = (mockConsoleLog.mock.calls.flat() as string[]).join("\n");
+      expect(text).toContain("ACCOUNT USED BY THIS RUN");
+      expect(text).toContain("Run account B (reconnect needed)");
+      expect(text).not.toContain("default-account-a");
+      expect(defaultStatusRequests).toBe(0);
+    });
+
+    it("matches a custom run account by custom connector ID", async () => {
+      const definition = customConnector({
+        connected: true,
+        missingRequiredFields: [],
+        configuredFieldKeys: ["secret:apiKey"],
+      });
+      vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
+      writeRunConnectorAccountContext(contextPath, [
+        {
+          kind: "custom",
+          customConnectorId: definition.id,
+          connectionId: RUN_CONNECTION_ID,
+        },
+      ]);
+      server.use(
+        stubConnectorCatalog([]),
+        stubCustomConnectors([definition]),
+        stubRunConnectorAccountInspection([
+          {
+            kind: "available",
+            connectionId: RUN_CONNECTION_ID,
+            target: { kind: "custom", customConnectorId: definition.id },
+            authMethod: "api-token",
+            displayName: "Custom run account B",
+            externalId: null,
+            externalUsername: null,
+            externalEmail: null,
+            connectionStatus: "connected",
+            reconnectReason: null,
+          },
+        ]),
+        stubAgent(AGENT_UUID, "maya"),
+        stubUserConnectors(AGENT_UUID, []),
+      );
+
+      await searchCommand.parseAsync(["node", "cli", definition.slug]);
+
+      expect(
+        (mockConsoleLog.mock.calls.flat() as string[]).join("\n"),
+      ).toContain("Custom run account B");
+    });
+
+    it("distinguishes a not-admitted connector from owner disconnection", async () => {
+      vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
+      writeRunConnectorAccountContext(contextPath, [
+        {
+          kind: "builtin",
+          connectorSlug: "github",
+          connectionId: null,
+        },
+      ]);
+      server.use(
+        stubConnectorCatalog([
+          catalogItem({ connectorSlug: "github", label: "GitHub" }),
+        ]),
+        stubAgent(AGENT_UUID, "maya"),
+        stubUserConnectors(AGENT_UUID, ["github"]),
+      );
+
+      await searchCommand.parseAsync(["node", "cli", "github"]);
+
+      expect(
+        (mockConsoleLog.mock.calls.flat() as string[]).join("\n"),
+      ).toContain("(not admitted for this run)");
+    });
+
+    it("retains a deleted exact ID and fails closed for missing legacy context", async () => {
+      vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
+      writeRunConnectorAccountContext(contextPath, [
+        {
+          kind: "builtin",
+          connectorSlug: "github",
+          connectionId: RUN_CONNECTION_ID,
+        },
+      ]);
+      server.use(
+        stubConnectorCatalog([
+          catalogItem({ connectorSlug: "github", label: "GitHub" }),
+        ]),
+        stubRunConnectorAccountInspection([]),
+        stubAgent(AGENT_UUID, "maya"),
+        stubUserConnectors(AGENT_UUID, ["github"]),
+      );
+
+      await searchCommand.parseAsync(["node", "cli", "github"]);
+      expect(
+        (mockConsoleLog.mock.calls.flat() as string[]).join("\n"),
+      ).toContain(`${RUN_CONNECTION_ID} (metadata unavailable or deleted)`);
+
+      mockConsoleLog.mockClear();
+      vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", "");
+      await searchCommand.parseAsync(["node", "cli", "github"]);
+      expect(
+        (mockConsoleLog.mock.calls.flat() as string[]).join("\n"),
+      ).toContain("(run account unavailable)");
     });
   });
 

--- a/turbo/apps/cli/src/commands/connector/check.ts
+++ b/turbo/apps/cli/src/commands/connector/check.ts
@@ -25,6 +25,12 @@ import {
   currentChatSupportsActionCallback,
   printCallbackActionUrlExample,
 } from "./action-url";
+import {
+  isRunBoundConnectorContext,
+  resolveRunConnectorAccountLookups,
+  runConnectorAccountUnavailableMessage,
+  type RunConnectorAccountLookup,
+} from "./run-account-context";
 
 interface CheckConnectorOptions {
   readonly connector?: string;
@@ -66,6 +72,13 @@ interface DiagContext {
   readonly run: ResolvedDiagnostic["run"];
   readonly platformOrigin: string;
   readonly agentId: string | undefined;
+  readonly runBound: boolean;
+}
+
+interface ConnectorConfigurationStatus {
+  readonly isConnected: boolean;
+  readonly isExpired: boolean;
+  readonly runAccount: RunConnectorAccountLookup | null;
 }
 
 function stripUrlQueryAndFragment(url: string): string {
@@ -403,8 +416,7 @@ function diagnosticEnvironmentNames(
 
 function printConnectorConnectionStatus(
   ctx: DiagContext,
-  isConnected: boolean,
-  isExpired: boolean,
+  status: ConnectorConfigurationStatus,
   hasPermission: boolean,
 ): void {
   console.log(
@@ -415,7 +427,20 @@ function printConnectorConnectionStatus(
     console.log(
       `The ${ctx.label} connector is not available for this account.`,
     );
-  } else if (!isConnected) {
+  } else if (status.runAccount?.state === "context-unavailable") {
+    console.log(
+      runConnectorAccountUnavailableMessage(status.runAccount.reason),
+    );
+  } else if (status.runAccount?.state === "not-admitted") {
+    console.log(`No ${ctx.label} account was admitted for this run.`);
+    console.log(
+      "Connect or change the thread selection, then start a new run.",
+    );
+  } else if (status.runAccount?.state === "metadata-unavailable") {
+    console.log(`Account used by this run: ${status.runAccount.connectionId}`);
+    console.log("Current account metadata is unavailable or deleted.");
+    console.log("Select an available account, then start a new run.");
+  } else if (!status.isConnected) {
     console.log(`The ${ctx.label} connector is not connected.`);
     if (ctx.agentId && hasPermission) {
       const connectUrl = connectorActionUrl({
@@ -432,18 +457,32 @@ function printConnectorConnectionStatus(
       });
       console.log(`Connect it at: [Connect ${ctx.label}](${connectUrl})`);
     }
-  } else if (isExpired) {
+  } else if (status.isExpired) {
     const url = connectorActionUrl({
       origin: ctx.platformOrigin,
-      path: `/connectors/${ctx.connectorSlug}/connect`,
+      path:
+        status.runAccount?.state === "available"
+          ? `/connectors/${ctx.connectorSlug}/reconnect/${status.runAccount.connectionId}`
+          : `/connectors/${ctx.connectorSlug}/connect`,
       agentId: ctx.agentId,
     });
+    if (status.runAccount?.state === "available") {
+      console.log(`Account used by this run: ${status.runAccount.label}`);
+      console.log(`Connection ID: ${status.runAccount.connectionId}`);
+    }
     console.log(
       `The ${ctx.label} connector is connected but has expired and needs to be reconnected.`,
     );
     console.log(`Reconnect it at: [Reconnect ${ctx.label}](${url})`);
     printCallbackActionUrlExample(url, ctx.agentId);
+    if (ctx.runBound) {
+      console.log("After reconnecting, start a new run.");
+    }
   } else {
+    if (status.runAccount?.state === "available") {
+      console.log(`Account used by this run: ${status.runAccount.label}`);
+      console.log(`Connection ID: ${status.runAccount.connectionId}`);
+    }
     console.log(`The ${ctx.label} connector is connected and active.`);
   }
   console.log("");
@@ -451,21 +490,22 @@ function printConnectorConnectionStatus(
 
 function printAgentAuthorizationStatus(
   ctx: DiagContext,
-  isConnected: boolean,
-  isExpired: boolean,
+  status: ConnectorConfigurationStatus,
   hasPermission: boolean,
 ): void {
   if (!ctx.agentId) {
     console.log("OKOU_AGENT_ID is not set — cannot check agent authorization.");
-  } else if (isExpired) {
+  } else if (status.isExpired) {
     console.log(
       `Skipped — agent authorization can only be checked once the ${ctx.label} connector is reconnected (see 2a).`,
     );
   } else if (hasPermission) {
     console.log(
-      isConnected
+      status.isConnected
         ? `The ${ctx.label} connector is authorized for this agent.`
-        : `The ${ctx.label} connector is authorized for this agent, but it is not connected.`,
+        : ctx.runBound
+          ? `The ${ctx.label} connector is authorized for this agent, but an account is not available for this run.`
+          : `The ${ctx.label} connector is authorized for this agent, but it is not connected.`,
     );
   } else {
     const url = connectorActionUrl({
@@ -474,19 +514,23 @@ function printAgentAuthorizationStatus(
       agentId: ctx.agentId,
     });
     console.log(
-      isConnected
+      status.isConnected
         ? `The ${ctx.label} connector is not authorized for this agent (${ctx.agentId}).`
-        : `The ${ctx.label} connector needs to be connected and authorized for this agent (${ctx.agentId}).`,
+        : ctx.runBound
+          ? `The ${ctx.label} connector is not authorized for this agent (${ctx.agentId}), and an account is not available for this run.`
+          : `The ${ctx.label} connector needs to be connected and authorized for this agent (${ctx.agentId}).`,
     );
     console.log(`Authorize it at: [Authorize ${ctx.label}](${url})`);
     printCallbackActionUrlExample(url, ctx.agentId);
+    if (ctx.runBound) {
+      console.log("After authorizing it, start a new run.");
+    }
   }
 }
 
 function printConnectorAuthorizationStatus(
   ctx: DiagContext,
-  isConnected: boolean,
-  isExpired: boolean,
+  status: ConnectorConfigurationStatus,
   hasPermission: boolean,
 ): void {
   console.log(
@@ -498,7 +542,7 @@ function printConnectorAuthorizationStatus(
       `Skipped — the ${ctx.label} connector is not available for this account.`,
     );
   } else {
-    printAgentAuthorizationStatus(ctx, isConnected, isExpired, hasPermission);
+    printAgentAuthorizationStatus(ctx, status, hasPermission);
   }
   console.log(
     `This run uses agent-scoped connector authorization for ${ctx.label} access.`,
@@ -556,21 +600,45 @@ async function checkConnectorStatus(ctx: DiagContext): Promise<{
   );
   console.log("");
 
-  const [connector, enabledConnectorSlugs] = await Promise.all([
-    getConnector(ctx.connectorSlug),
+  const [configuration, enabledConnectorSlugs] = await Promise.all([
+    ctx.runBound
+      ? resolveRunConnectorAccountLookups([
+          { kind: "builtin", connectorSlug: ctx.connectorSlug },
+        ]).then((lookups) => {
+          const runAccount = lookups[0];
+          if (!runAccount) {
+            throw new Error("Missing run account lookup for connector");
+          }
+          return {
+            isConnected: runAccount.state === "available",
+            isExpired:
+              runAccount.state === "available" &&
+              runAccount.metadata.connectionStatus === "reconnect-required",
+            runAccount,
+          } satisfies ConnectorConfigurationStatus;
+        })
+      : getConnector(ctx.connectorSlug).then((connector) => {
+          return {
+            isConnected: connector !== null,
+            isExpired: connector?.connectionStatus === "reconnect-required",
+            runAccount: null,
+          } satisfies ConnectorConfigurationStatus;
+        }),
     ctx.agentId ? getAgentUserConnectors(ctx.agentId) : Promise.resolve(null),
   ]);
 
-  const isConnected = connector !== null;
-  const isExpired = connector?.connectionStatus === "reconnect-required";
   const hasPermission =
     enabledConnectorSlugs !== null &&
     enabledConnectorSlugs.includes(ctx.connectorSlug);
 
-  printConnectorConnectionStatus(ctx, isConnected, isExpired, hasPermission);
-  printConnectorAuthorizationStatus(ctx, isConnected, isExpired, hasPermission);
+  printConnectorConnectionStatus(ctx, configuration, hasPermission);
+  printConnectorAuthorizationStatus(ctx, configuration, hasPermission);
 
-  return { isConnected, isExpired, hasPermission };
+  return {
+    isConnected: configuration.isConnected,
+    isExpired: configuration.isExpired,
+    hasPermission,
+  };
 }
 
 function checkConnectorDomains(ctx: DiagContext): boolean | null {
@@ -964,6 +1032,7 @@ How connectors work:
         run: result.run,
         platformOrigin: platformUrl.origin,
         agentId: getOkouAgentId(),
+        runBound: isRunBoundConnectorContext(),
       };
 
       checkEnvironmentNames(ctx);

--- a/turbo/apps/cli/src/commands/connector/discovery.ts
+++ b/turbo/apps/cli/src/commands/connector/discovery.ts
@@ -1,10 +1,14 @@
 import chalk from "chalk";
+import type { ConnectorAccountTarget } from "@okouai/api-contracts/contracts/connector-accounts";
 import type { CustomConnectorResponse } from "@okouai/api-contracts/contracts/custom-connectors";
-import type { ConnectorCatalogStatus } from "../../lib/api/domains/connectors";
+import type {
+  ConnectorCatalogItem,
+  ConnectorCatalogStatus,
+} from "../../lib/api/domains/connectors";
 import type { ConnectorDiscoveryAgentContext } from "./agent-context";
 import { renderConnectedAsCell } from "./connected-as";
 
-interface CatalogConnectorDiscoveryItem {
+interface CatalogConnectorDiscoveryDefinition {
   readonly kind: "catalog";
   readonly slug: string;
   readonly label: string;
@@ -12,7 +16,10 @@ interface CatalogConnectorDiscoveryItem {
   readonly category: string;
   readonly tags: readonly string[];
   readonly generation: readonly string[];
-  readonly authMethods: ConnectorCatalogStatus["authMethods"];
+  readonly authMethods: ConnectorCatalogItem["authMethods"];
+}
+
+interface CatalogConnectorDiscoveryItem extends CatalogConnectorDiscoveryDefinition {
   readonly catalogConnector: ConnectorCatalogStatus;
 }
 
@@ -32,6 +39,41 @@ export type ConnectorDiscoveryItem =
   | CatalogConnectorDiscoveryItem
   | CustomConnectorDiscoveryItem;
 
+export type ConnectorDiscoveryDefinition =
+  | CatalogConnectorDiscoveryDefinition
+  | CustomConnectorDiscoveryItem;
+
+function catalogDiscoveryDefinition(
+  connector: ConnectorCatalogItem,
+): CatalogConnectorDiscoveryDefinition {
+  return {
+    kind: "catalog",
+    slug: connector.slug,
+    label: connector.label,
+    description: connector.description,
+    category: connector.category,
+    tags: connector.tags,
+    generation: connector.generation,
+    authMethods: connector.authMethods,
+  };
+}
+
+function customDiscoveryItem(
+  connector: CustomConnectorResponse,
+): CustomConnectorDiscoveryItem {
+  return {
+    kind: "custom",
+    slug: connector.slug,
+    label: connector.displayName,
+    description: "",
+    category: "custom",
+    tags: [],
+    generation: [],
+    authMethods: [],
+    customConnector: connector,
+  };
+}
+
 export function connectorDiscoveryItems(
   catalogConnectors: readonly ConnectorCatalogStatus[],
   customConnectors: readonly CustomConnectorResponse[],
@@ -39,31 +81,30 @@ export function connectorDiscoveryItems(
   return [
     ...catalogConnectors.map((connector): CatalogConnectorDiscoveryItem => {
       return {
-        kind: "catalog",
-        slug: connector.slug,
-        label: connector.label,
-        description: connector.description,
-        category: connector.category,
-        tags: connector.tags,
-        generation: connector.generation,
-        authMethods: connector.authMethods,
+        ...catalogDiscoveryDefinition(connector),
         catalogConnector: connector,
       };
     }),
-    ...customConnectors.map((connector): CustomConnectorDiscoveryItem => {
-      return {
-        kind: "custom",
-        slug: connector.slug,
-        label: connector.displayName,
-        description: "",
-        category: "custom",
-        tags: [],
-        generation: [],
-        authMethods: [],
-        customConnector: connector,
-      };
-    }),
+    ...customConnectors.map(customDiscoveryItem),
   ];
+}
+
+export function connectorDiscoveryDefinitions(
+  catalogConnectors: readonly ConnectorCatalogItem[],
+  customConnectors: readonly CustomConnectorResponse[],
+): readonly ConnectorDiscoveryDefinition[] {
+  return [
+    ...catalogConnectors.map(catalogDiscoveryDefinition),
+    ...customConnectors.map(customDiscoveryItem),
+  ];
+}
+
+export function connectorDiscoveryTarget(
+  connector: ConnectorDiscoveryDefinition,
+): ConnectorAccountTarget {
+  return connector.kind === "catalog"
+    ? { kind: "builtin", connectorSlug: connector.slug }
+    : { kind: "custom", customConnectorId: connector.customConnector.id };
 }
 
 export function renderConnectorDiscoveryConnectedAsCell(
@@ -84,7 +125,7 @@ export function renderConnectorDiscoveryConnectedAsCell(
 }
 
 export function isConnectorDiscoveryAuthorized(
-  connector: ConnectorDiscoveryItem,
+  connector: ConnectorDiscoveryDefinition,
   agentContext: ConnectorDiscoveryAgentContext,
 ): boolean {
   if (connector.kind === "catalog") {

--- a/turbo/apps/cli/src/commands/connector/run-account-context.ts
+++ b/turbo/apps/cli/src/commands/connector/run-account-context.ts
@@ -81,6 +81,13 @@ export type RunConnectorAccountState =
       readonly connectionId: null;
     };
 
+export type RunConnectorAccountLookup =
+  | RunConnectorAccountState
+  | {
+      readonly state: "context-unavailable";
+      readonly reason: RunConnectorAccountContextUnavailableReason;
+    };
+
 export interface RunConnectorAccountEntry {
   readonly target: ConnectorAccountTarget;
   readonly slug: string;
@@ -208,6 +215,28 @@ function metadataKey(
   return `${connectorAccountTargetKey(target)}:${connectionId}`;
 }
 
+function accountState(
+  projected: RunConnectorAccountTarget | undefined,
+  metadata: ReadonlyMap<string, RunConnectorAccountMetadata>,
+): RunConnectorAccountState {
+  if (!projected?.connectionId) {
+    return { state: "not-admitted", connectionId: null };
+  }
+  const target = projectionTarget(projected);
+  const current = metadata.get(metadataKey(target, projected.connectionId));
+  return current
+    ? {
+        state: "available",
+        connectionId: projected.connectionId,
+        label: connectorAccountCliLabel(current),
+        metadata: current,
+      }
+    : {
+        state: "metadata-unavailable",
+        connectionId: projected.connectionId,
+      };
+}
+
 async function enrichTargets(
   targets: readonly RunConnectorAccountTarget[],
 ): Promise<ReadonlyMap<string, RunConnectorAccountMetadata>> {
@@ -269,6 +298,37 @@ export function isRunBoundConnectorContext(): boolean {
   return getOkouAgentId() !== undefined;
 }
 
+export async function resolveRunConnectorAccountLookups(
+  targets: readonly ConnectorAccountTarget[],
+): Promise<readonly RunConnectorAccountLookup[]> {
+  const projection = await readProjection();
+  if (projection.state === "unavailable") {
+    return targets.map(() => {
+      return {
+        state: "context-unavailable" as const,
+        reason: projection.reason,
+      };
+    });
+  }
+  const projectedByTarget = new Map(
+    projection.targets.map((projected) => {
+      return [
+        connectorAccountTargetKey(projectionTarget(projected)),
+        projected,
+      ] as const;
+    }),
+  );
+  const projectedTargets = targets.flatMap((target) => {
+    const projected = projectedByTarget.get(connectorAccountTargetKey(target));
+    return projected ? [projected] : [];
+  });
+  const metadata = await enrichTargets(projectedTargets);
+  return targets.map((target) => {
+    const projected = projectedByTarget.get(connectorAccountTargetKey(target));
+    return accountState(projected, metadata);
+  });
+}
+
 export async function resolveRunConnectorAccountView(): Promise<RunConnectorAccountView> {
   const projection = await readProjection();
   if (projection.state === "unavailable") {
@@ -291,30 +351,11 @@ export async function resolveRunConnectorAccountView(): Promise<RunConnectorAcco
     connectors: projection.targets.map((projected) => {
       const target = projectionTarget(projected);
       const identity = connectorIdentity(target, catalog, customConnectors);
-      if (!projected.connectionId) {
-        return {
-          target,
-          slug: identity.slug,
-          connectorLabel: identity.label,
-          account: { state: "not-admitted" as const, connectionId: null },
-        };
-      }
-      const current = metadata.get(metadataKey(target, projected.connectionId));
       return {
         target,
         slug: identity.slug,
         connectorLabel: identity.label,
-        account: current
-          ? {
-              state: "available" as const,
-              connectionId: projected.connectionId,
-              label: connectorAccountCliLabel(current),
-              metadata: current,
-            }
-          : {
-              state: "metadata-unavailable" as const,
-              connectionId: projected.connectionId,
-            },
+        account: accountState(projected, metadata),
       };
     }),
   };

--- a/turbo/apps/cli/src/commands/connector/search.ts
+++ b/turbo/apps/cli/src/commands/connector/search.ts
@@ -1,6 +1,8 @@
 import { Command } from "commander";
 import chalk from "chalk";
+import { connectorAccountTargetKey } from "@okouai/api-contracts/contracts/connector-accounts";
 import {
+  listConnectorCatalog,
   listConnectorCatalogStatus,
   listCustomConnectors,
 } from "../../lib/api/domains/connectors";
@@ -8,11 +10,19 @@ import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { resolveConnectorDiscoveryAgentContext } from "./agent-context";
 import { padEndAnsi, stripAnsi } from "./connected-as";
 import {
+  connectorDiscoveryDefinitions,
   connectorDiscoveryItems,
+  connectorDiscoveryTarget,
   isConnectorDiscoveryAuthorized,
   renderConnectorDiscoveryConnectedAsCell,
+  type ConnectorDiscoveryDefinition,
 } from "./discovery";
 import { searchConnectorCatalog } from "./public-catalog";
+import {
+  isRunBoundConnectorContext,
+  resolveRunConnectorAccountLookups,
+  type RunConnectorAccountLookup,
+} from "./run-account-context";
 
 const DEFAULT_LIMIT = 5;
 const EXACT_MATCH_THRESHOLD = 80;
@@ -24,6 +34,95 @@ function parseLimit(raw: string): number {
     throw new Error(`--limit must be a positive integer, got "${raw}".`);
   }
   return n;
+}
+
+function renderRunAccountCell(lookup: RunConnectorAccountLookup): string {
+  switch (lookup.state) {
+    case "available":
+      return lookup.metadata.connectionStatus === "reconnect-required"
+        ? chalk.yellow(`${lookup.label} (reconnect needed)`)
+        : lookup.label;
+    case "metadata-unavailable":
+      return chalk.dim(
+        `${lookup.connectionId} (metadata unavailable or deleted)`,
+      );
+    case "not-admitted":
+      return chalk.dim("(not admitted for this run)");
+    case "context-unavailable":
+      return chalk.dim("(run account unavailable)");
+  }
+}
+
+function printSearchResults<T extends ConnectorDiscoveryDefinition>(args: {
+  readonly connectors: readonly T[];
+  readonly keyword: string;
+  readonly limit: number;
+  readonly accountHeader: string;
+  readonly renderAccount: (connector: T) => string;
+  readonly agentContext: Awaited<
+    ReturnType<typeof resolveConnectorDiscoveryAgentContext>
+  >;
+}): void {
+  const { results, total } = searchConnectorCatalog(
+    args.connectors,
+    args.keyword,
+    args.limit,
+  );
+
+  if (results.length === 0) {
+    console.log("No matches found.");
+    return;
+  }
+
+  const topScore = results[0]!.score;
+  if (topScore < EXACT_MATCH_THRESHOLD) {
+    console.log("No exact match. Showing closest:");
+  }
+  if (total > args.limit) {
+    console.log(`Too many results (top ${args.limit} of ${total}):`);
+  }
+
+  const connectorSlugHeader = "SLUG";
+  const accountCells = results.map((result) => {
+    return args.renderAccount(result.connector);
+  });
+  const connectorSlugWidth = Math.max(
+    connectorSlugHeader.length,
+    ...results.map((result) => {
+      return result.connector.slug.length;
+    }),
+  );
+  const accountWidth = Math.max(
+    args.accountHeader.length,
+    ...accountCells.map((cell) => {
+      return stripAnsi(cell).length;
+    }),
+  );
+
+  const headerParts = [
+    connectorSlugHeader.padEnd(connectorSlugWidth),
+    args.accountHeader.padEnd(accountWidth),
+  ];
+  if (args.agentContext) {
+    headerParts.push(`AUTHORIZED FOR ${args.agentContext.displayName}`);
+  }
+  console.log(chalk.dim(headerParts.join("  ")));
+
+  for (let index = 0; index < results.length; index++) {
+    const result = results[index]!;
+    const parts = [
+      result.connector.slug.padEnd(connectorSlugWidth),
+      padEndAnsi(accountCells[index]!, accountWidth),
+    ];
+    if (args.agentContext) {
+      parts.push(
+        isConnectorDiscoveryAuthorized(result.connector, args.agentContext)
+          ? chalk.green("✓")
+          : chalk.dim("-"),
+      );
+    }
+    console.log(parts.join("  "));
+  }
 }
 
 export const searchCommand = new Command()
@@ -47,74 +146,60 @@ export const searchCommand = new Command()
           throw new Error("Keyword cannot be empty.");
         }
 
-        const [{ connectors }, customConnectors, agentCtx] = await Promise.all([
-          listConnectorCatalogStatus(),
-          listCustomConnectors(),
-          resolveConnectorDiscoveryAgentContext(options.agent),
-        ]);
-        const { results, total } = searchConnectorCatalog(
-          connectorDiscoveryItems(connectors, customConnectors),
-          trimmed,
-          options.limit,
-        );
-
-        if (results.length === 0) {
-          console.log("No matches found.");
+        if (isRunBoundConnectorContext()) {
+          const [{ connectors }, customConnectors, agentContext] =
+            await Promise.all([
+              listConnectorCatalog(),
+              listCustomConnectors(),
+              resolveConnectorDiscoveryAgentContext(options.agent),
+            ]);
+          const definitions = connectorDiscoveryDefinitions(
+            connectors,
+            customConnectors,
+          );
+          const targets = definitions.map(connectorDiscoveryTarget);
+          const lookups = await resolveRunConnectorAccountLookups(targets);
+          const lookupsByTarget = new Map(
+            targets.map((target, index) => {
+              return [
+                connectorAccountTargetKey(target),
+                lookups[index]!,
+              ] as const;
+            }),
+          );
+          printSearchResults({
+            connectors: definitions,
+            keyword: trimmed,
+            limit: options.limit,
+            accountHeader: "ACCOUNT USED BY THIS RUN",
+            renderAccount: (connector) => {
+              const lookup = lookupsByTarget.get(
+                connectorAccountTargetKey(connectorDiscoveryTarget(connector)),
+              );
+              if (!lookup) {
+                throw new Error("Missing run account lookup for connector");
+              }
+              return renderRunAccountCell(lookup);
+            },
+            agentContext,
+          });
           return;
         }
 
-        const topScore = results[0]!.score;
-        if (topScore < EXACT_MATCH_THRESHOLD) {
-          console.log("No exact match. Showing closest:");
-        }
-        if (total > options.limit) {
-          console.log(`Too many results (top ${options.limit} of ${total}):`);
-        }
-
-        const connectorSlugHeader = "SLUG";
-        const connectedAsHeader = "CONNECTED AS";
-
-        const connectedCells = results.map((r) => {
-          return renderConnectorDiscoveryConnectedAsCell(r.connector);
+        const [{ connectors }, customConnectors, agentContext] =
+          await Promise.all([
+            listConnectorCatalogStatus(),
+            listCustomConnectors(),
+            resolveConnectorDiscoveryAgentContext(options.agent),
+          ]);
+        printSearchResults({
+          connectors: connectorDiscoveryItems(connectors, customConnectors),
+          keyword: trimmed,
+          limit: options.limit,
+          accountHeader: "CONNECTED AS",
+          renderAccount: renderConnectorDiscoveryConnectedAsCell,
+          agentContext,
         });
-
-        const connectorSlugWidth = Math.max(
-          connectorSlugHeader.length,
-          ...results.map((r) => {
-            return r.connector.slug.length;
-          }),
-        );
-        const connectedAsWidth = Math.max(
-          connectedAsHeader.length,
-          ...connectedCells.map((c) => {
-            return stripAnsi(c).length;
-          }),
-        );
-
-        const headerParts = [
-          connectorSlugHeader.padEnd(connectorSlugWidth),
-          connectedAsHeader.padEnd(connectedAsWidth),
-        ];
-        if (agentCtx) {
-          headerParts.push(`AUTHORIZED FOR ${agentCtx.displayName}`);
-        }
-        console.log(chalk.dim(headerParts.join("  ")));
-
-        for (let i = 0; i < results.length; i++) {
-          const result = results[i]!;
-          const parts = [
-            result.connector.slug.padEnd(connectorSlugWidth),
-            padEndAnsi(connectedCells[i]!, connectedAsWidth),
-          ];
-          if (agentCtx) {
-            parts.push(
-              isConnectorDiscoveryAuthorized(result.connector, agentCtx)
-                ? chalk.green("✓")
-                : chalk.dim("-"),
-            );
-          }
-          console.log(parts.join("  "));
-        }
       },
     ),
   );

--- a/turbo/apps/cli/src/commands/generate/__tests__/lister.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/lister.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import chalk from "chalk";
@@ -10,8 +14,13 @@ import {
   stubConnectorCatalog,
   stubConnectorCatalogStatus,
 } from "../../__tests__/helpers/connector-catalog";
+import {
+  stubRunConnectorAccountInspection,
+  writeRunConnectorAccountContext,
+} from "../../__tests__/helpers/run-connector-accounts";
 
 const AGENT_ID = "550e8400-e29b-41d4-a716-446655440000";
+const RUN_CONNECTION_ID = "00000000-0000-4000-8000-000000000001";
 
 const CONNECTOR_LABELS: Record<string, string> = {
   elevenlabs: "ElevenLabs",
@@ -37,12 +46,25 @@ const CONNECTOR_GENERATION: Record<string, readonly string[]> = {
   runway: ["image", "video"],
 };
 
+interface TestConnectorAccount {
+  readonly id: string;
+  readonly slug: string;
+  readonly authMethod: "api-token";
+  readonly externalId: string;
+  readonly externalUsername: string | null;
+  readonly externalEmail: null;
+  readonly oauthScopes: null;
+  readonly connectionStatus: "connected" | "reconnect-required";
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
 function connector(
   connectorSlug: string,
   externalUsername: string | null = `${connectorSlug}-user`,
-) {
+): TestConnectorAccount {
   return {
-    id: "00000000-0000-4000-8000-000000000001",
+    id: RUN_CONNECTION_ID,
     slug: connectorSlug,
     authMethod: "api-token",
     externalId: `${connectorSlug}-external-id`,
@@ -55,7 +77,7 @@ function connector(
   };
 }
 
-function stubConnectors(connectors: Array<Record<string, unknown>>) {
+function stubConnectors(connectors: readonly TestConnectorAccount[]) {
   return stubConnectorsWithCatalogSlugs(connectors, [
     "fal",
     "luma",
@@ -67,12 +89,12 @@ function stubConnectors(connectors: Array<Record<string, unknown>>) {
 }
 
 function stubConnectorsWithCatalogSlugs(
-  connectors: Array<Record<string, unknown>>,
-  catalogConnectorSlugs: string[],
+  connectors: readonly TestConnectorAccount[],
+  catalogConnectorSlugs: readonly string[],
 ) {
   const connectedBySlug = new Map(
     connectors.map((item) => {
-      const connectorSlug = item.slug as string;
+      const connectorSlug = item.slug;
       return [
         connectorSlug,
         catalogStatusItem({
@@ -81,15 +103,13 @@ function stubConnectorsWithCatalogSlugs(
           generation: [...(CONNECTOR_GENERATION[connectorSlug] ?? [])],
           authMethods: [manualAuthMethod()],
           connection: {
-            authMethod: item.authMethod as string,
-            externalUsername: (item.externalUsername as string | null) ?? null,
-            externalEmail: (item.externalEmail as string | null) ?? null,
+            authMethod: item.authMethod,
+            externalUsername: item.externalUsername,
+            externalEmail: item.externalEmail,
             reconnectReason: null,
           },
           connected: true,
-          connectionStatus:
-            (item.connectionStatus as "connected" | "reconnect-required") ??
-            "connected",
+          connectionStatus: item.connectionStatus,
         }),
       ] as const;
     }),
@@ -113,6 +133,77 @@ function stubConnectorsWithCatalogSlugs(
   );
 }
 
+function stubRunConnectorsWithCatalogSlugs(
+  contextPath: string,
+  connectors: readonly TestConnectorAccount[],
+  catalogConnectorSlugs: readonly string[],
+) {
+  const connectedBySlug = new Map(
+    connectors.map((item) => {
+      return [item.slug, item] as const;
+    }),
+  );
+  const visibleConnectorSlugs = new Set([
+    ...catalogConnectorSlugs,
+    ...connectedBySlug.keys(),
+  ]);
+  writeRunConnectorAccountContext(
+    contextPath,
+    [...visibleConnectorSlugs].map((connectorSlug) => {
+      return {
+        kind: "builtin" as const,
+        connectorSlug,
+        connectionId: connectedBySlug.get(connectorSlug)?.id ?? null,
+      };
+    }),
+  );
+  return [
+    stubConnectorCatalog(
+      [...visibleConnectorSlugs].map((connectorSlug) => {
+        return catalogItem({
+          connectorSlug,
+          label: CONNECTOR_LABELS[connectorSlug] ?? connectorSlug,
+          generation: [...(CONNECTOR_GENERATION[connectorSlug] ?? [])],
+          authMethods: [manualAuthMethod()],
+        });
+      }),
+    ),
+    stubRunConnectorAccountInspection(
+      connectors.map((item) => {
+        return {
+          kind: "available" as const,
+          connectionId: item.id,
+          target: { kind: "builtin" as const, connectorSlug: item.slug },
+          authMethod: item.authMethod,
+          displayName: null,
+          externalId: item.externalId,
+          externalUsername: item.externalUsername,
+          externalEmail: item.externalEmail,
+          connectionStatus: item.connectionStatus,
+          reconnectReason:
+            item.connectionStatus === "reconnect-required"
+              ? "authorization_expired_or_revoked"
+              : null,
+        };
+      }),
+    ),
+  ] as const;
+}
+
+function stubRunConnectors(
+  contextPath: string,
+  connectors: readonly TestConnectorAccount[],
+) {
+  return stubRunConnectorsWithCatalogSlugs(contextPath, connectors, [
+    "fal",
+    "luma",
+    "luma-ai",
+    "openai",
+    "replicate",
+    "runway",
+  ]);
+}
+
 function stubUserConnectors(enabledConnectorSlugs: string[]) {
   return http.get(
     `http://localhost:3000/api/agents/${AGENT_ID}/user-connectors`,
@@ -121,19 +212,6 @@ function stubUserConnectors(enabledConnectorSlugs: string[]) {
         enabledConnectorSlugs: enabledConnectorSlugs,
       });
     },
-  );
-}
-
-function stubAvailableConnectors(connectorSlugs: string[]) {
-  return stubConnectorCatalogStatus(
-    connectorSlugs.map((connectorSlug) => {
-      return catalogStatusItem({
-        connectorSlug,
-        label: CONNECTOR_LABELS[connectorSlug] ?? connectorSlug,
-        generation: [...(CONNECTOR_GENERATION[connectorSlug] ?? [])],
-        authMethods: [manualAuthMethod()],
-      });
-    }),
   );
 }
 
@@ -179,12 +257,17 @@ describe("okou generate lister", () => {
   const mockConsoleError = vi
     .spyOn(console, "error")
     .mockImplementation(() => {});
+  let directory = "";
+  let contextPath = "";
 
   beforeEach(() => {
+    directory = mkdtempSync(join(tmpdir(), "okou-generate-run-account-"));
+    contextPath = join(directory, "context.json");
     chalk.level = 0;
     vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
+    vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", contextPath);
     server.use(stubBillingStatus(true));
   });
 
@@ -193,6 +276,7 @@ describe("okou generate lister", () => {
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
     vi.unstubAllEnvs();
+    rmSync(directory, { recursive: true, force: true });
   });
 
   function output(): string {
@@ -218,13 +302,33 @@ describe("okou generate lister", () => {
   });
 
   it("lists ready image generation connectors for the current agent", async () => {
+    let defaultStatusRequests = 0;
     server.use(
-      stubConnectors([
+      ...stubRunConnectors(contextPath, [
         connector("fal", "fal-user"),
         connector("openai", "openai-user"),
         connector("replicate", "replicate-user"),
       ]),
       stubUserConnectors(["fal", "openai"]),
+      http.get("http://localhost:3000/api/connector-catalog/status", () => {
+        defaultStatusRequests += 1;
+        return HttpResponse.json({
+          connectors: [
+            catalogStatusItem({
+              connectorSlug: "fal",
+              generation: ["image"],
+              connection: {
+                authMethod: "api-token",
+                externalUsername: "default-account-a",
+                externalEmail: null,
+                reconnectReason: "authorization_expired_or_revoked",
+              },
+              connected: true,
+              connectionStatus: "reconnect-required",
+            }),
+          ],
+        });
+      }),
     );
 
     await generateCommand.parseAsync(["node", "cli", "image"]);
@@ -254,14 +358,17 @@ describe("okou generate lister", () => {
     expect(text).not.toContain("Fallback option:");
     expect(text).not.toContain("Official provider:");
     expect(text).not.toContain("Next actions:");
+    expect(text).not.toContain("default-account-a");
+    expect(defaultStatusRequests).toBe(0);
     expect(text).toContain(
       "Use --all to see every image generation candidate.",
     );
   });
 
   it("shows not-ready candidates and action links with --all", async () => {
+    let defaultStatusRequests = 0;
     server.use(
-      stubConnectors([
+      ...stubRunConnectors(contextPath, [
         connector("fal", "fal-user"),
         connector("replicate", "replicate-user"),
         {
@@ -270,6 +377,25 @@ describe("okou generate lister", () => {
         },
       ]),
       stubUserConnectors(["fal"]),
+      http.get("http://localhost:3000/api/connector-catalog/status", () => {
+        defaultStatusRequests += 1;
+        return HttpResponse.json({
+          connectors: [
+            catalogStatusItem({
+              connectorSlug: "openai",
+              generation: ["image"],
+              connection: {
+                authMethod: "api-token",
+                externalUsername: "healthy-default-a",
+                externalEmail: null,
+                reconnectReason: null,
+              },
+              connected: true,
+              connectionStatus: "connected",
+            }),
+          ],
+        });
+      }),
     );
 
     await generateCommand.parseAsync(["node", "cli", "image", "--all"]);
@@ -280,22 +406,62 @@ describe("okou generate lister", () => {
     expect(text).toContain("Replicate");
     expect(text).toContain("connected, not authorized for current agent");
     expect(text).toContain("Luma AI");
-    expect(text).toContain("not connected or authorized for current agent");
+    expect(text).toContain("not admitted for this run");
     expect(text).toContain("OpenAI");
     expect(text).toContain("connected, reconnect required");
     expect(text).toContain(
       `[Authorize Replicate](http://localhost:3000/connectors/replicate/authorize?agentId=${AGENT_ID})`,
     );
+    expect(text).not.toContain("Connect and authorize Luma AI");
     expect(text).toContain(
-      `[Connect and authorize Luma AI](http://localhost:3000/connectors/luma-ai/connect?agentId=${AGENT_ID})`,
+      `[Reconnect OpenAI](http://localhost:3000/connectors/openai/reconnect/${RUN_CONNECTION_ID}?agentId=${AGENT_ID})`,
     );
-    expect(text).toContain(
-      "[Reconnect OpenAI](http://localhost:3000/connectors)",
+    expect(text).toContain("start a new run");
+    expect(text).not.toContain("healthy-default-a");
+    expect(defaultStatusRequests).toBe(0);
+  });
+
+  it("preserves default-account generation discovery outside a run", async () => {
+    vi.stubEnv("OKOU_AGENT_ID", "");
+    vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", "");
+    server.use(stubConnectors([connector("fal", "default-account-a")]));
+
+    await generateCommand.parseAsync(["node", "cli", "image"]);
+
+    expect(output()).toContain("@default-account-a");
+  });
+
+  it("fails closed when connector-backed discovery has no run projection", async () => {
+    let defaultStatusRequests = 0;
+    vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", "");
+    server.use(
+      stubConnectorCatalog([
+        catalogItem({
+          connectorSlug: "fal",
+          label: "fal.ai",
+          generation: ["image"],
+          authMethods: [manualAuthMethod()],
+        }),
+      ]),
+      stubUserConnectors(["fal"]),
+      http.get("http://localhost:3000/api/connector-catalog/status", () => {
+        defaultStatusRequests += 1;
+        return HttpResponse.json({ connectors: [] });
+      }),
     );
+
+    await generateCommand.parseAsync(["node", "cli", "image", "--all"]);
+
+    expect(output()).toContain("run account context unavailable");
+    expect(output()).toContain("start a new run");
+    expect(defaultStatusRequests).toBe(0);
   });
 
   it("does not list providers that are absent from the public catalog", async () => {
-    server.use(stubAvailableConnectors([]), stubUserConnectors([]));
+    server.use(
+      ...stubRunConnectorsWithCatalogSlugs(contextPath, [], []),
+      stubUserConnectors([]),
+    );
 
     await generateCommand.parseAsync(["node", "cli", "text", "--all"]);
 
@@ -365,7 +531,11 @@ describe("okou generate lister", () => {
 
   it("suggests the built-in video command when no video connector is ready", async () => {
     server.use(
-      stubConnectorsWithCatalogSlugs([], ["fal", "luma-ai", "runway"]),
+      ...stubRunConnectorsWithCatalogSlugs(
+        contextPath,
+        [],
+        ["fal", "luma-ai", "runway"],
+      ),
       stubUserConnectors([]),
     );
 
@@ -402,7 +572,8 @@ describe("okou generate lister", () => {
 
   it("reflects built-in and connector choices for avatar video", async () => {
     server.use(
-      stubConnectorsWithCatalogSlugs(
+      ...stubRunConnectorsWithCatalogSlugs(
+        contextPath,
         [connector("joggai", "jogg-user")],
         ["joggai"],
       ),
@@ -431,7 +602,11 @@ describe("okou generate lister", () => {
 
   it("marks built-in video models as plan-restricted before generation", async () => {
     server.use(
-      stubConnectorsWithCatalogSlugs([], ["fal", "luma-ai", "runway"]),
+      ...stubRunConnectorsWithCatalogSlugs(
+        contextPath,
+        [],
+        ["fal", "luma-ai", "runway"],
+      ),
       stubUserConnectors([]),
       stubBillingStatus(false),
     );
@@ -525,7 +700,8 @@ describe("okou generate lister", () => {
 
   it("suggests the built-in voice command when no voice connector is ready", async () => {
     server.use(
-      stubConnectorsWithCatalogSlugs(
+      ...stubRunConnectorsWithCatalogSlugs(
+        contextPath,
         [],
         ["elevenlabs", "hume", "minimax", "openai"],
       ),
@@ -553,7 +729,8 @@ describe("okou generate lister", () => {
 
   it("also shows the built-in voice provider when a voice connector is ready", async () => {
     server.use(
-      stubConnectorsWithCatalogSlugs(
+      ...stubRunConnectorsWithCatalogSlugs(
+        contextPath,
         [connector("openai", "openai-user")],
         ["elevenlabs", "hume", "minimax", "openai"],
       ),
@@ -576,7 +753,8 @@ describe("okou generate lister", () => {
 
   it("lists music as the public audio connector-backed subtype", async () => {
     server.use(
-      stubConnectorsWithCatalogSlugs(
+      ...stubRunConnectorsWithCatalogSlugs(
+        contextPath,
         [connector("elevenlabs", "elevenlabs-user")],
         ["elevenlabs", "minimax"],
       ),

--- a/turbo/apps/cli/src/commands/generate/lib/lister.ts
+++ b/turbo/apps/cli/src/commands/generate/lib/lister.ts
@@ -1,8 +1,14 @@
 import chalk from "chalk";
-import type { ConnectorCatalogStatus } from "../../../lib/api/domains/connectors";
+import type {
+  ConnectorCatalogItem,
+  ConnectorCatalogStatus,
+} from "../../../lib/api/domains/connectors";
 import { getBillingStatus } from "../../../lib/api/domains/billing";
 import { getAgentUserConnectors } from "../../../lib/api/domains/agents";
-import { listConnectorCatalogStatus } from "../../../lib/api/domains/connectors";
+import {
+  listConnectorCatalog,
+  listConnectorCatalogStatus,
+} from "../../../lib/api/domains/connectors";
 import { getPlatformOrigin } from "../../doctor/platform-url";
 import {
   currentPlanAllowsVideo,
@@ -10,6 +16,12 @@ import {
 } from "../../shared/billing-capabilities";
 import { planUpgradeUrl } from "../../shared/billing-links";
 import { getOkouAgentId } from "../../../lib/okou-env";
+import { connectorActionUrl } from "../../connector/action-url";
+import {
+  isRunBoundConnectorContext,
+  resolveRunConnectorAccountLookups,
+  type RunConnectorAccountLookup,
+} from "../../connector/run-account-context";
 import {
   DEFAULT_VIDEO_MODEL,
   VIDEO_MODEL_CONFIGS,
@@ -321,7 +333,8 @@ type CandidateStatus =
   | "ready"
   | "needs-reconnect"
   | "not-authorized"
-  | "not-connected";
+  | "not-connected"
+  | "unavailable-for-run";
 
 interface ListerOptions {
   all?: boolean;
@@ -384,10 +397,10 @@ function getGenerationContext(
   return GENERATION_CONTEXT[generationType] ?? null;
 }
 
-function getGenerationConnectors(
+function getGenerationConnectors<T extends ConnectorCatalogItem>(
   generationType: ConnectorGenerationType,
-  connectors: readonly ConnectorCatalogStatus[],
-): ConnectorCatalogStatus[] {
+  connectors: readonly T[],
+): T[] {
   return connectors
     .filter((connector) => {
       return connector.generation.includes(generationType);
@@ -407,7 +420,7 @@ function formatAccount(connector: ConnectorCatalogStatus): string | undefined {
   return undefined;
 }
 
-function getAction(
+function getCurrentAction(
   status: CandidateStatus,
   connectorSlug: string,
   label: string,
@@ -445,7 +458,7 @@ function getAction(
   return {};
 }
 
-function toCandidate(params: {
+function toCurrentCandidate(params: {
   connector: ConnectorCatalogStatus;
   authorizedConnectorSlugs: Set<string> | null;
   agentId: string | undefined;
@@ -486,13 +499,98 @@ function toCandidate(params: {
     reason,
     account: connector.connected ? formatAccount(connector) : undefined,
     authMethod: connector.connection?.authMethod,
-    ...getAction(
+    ...getCurrentAction(
       status,
       connectorSlug,
       connector.label,
       agentId,
       platformOrigin,
     ),
+  };
+}
+
+type RunUnavailableAccountLookup = Exclude<
+  RunConnectorAccountLookup,
+  { readonly state: "available" }
+>;
+
+function runUnavailableReason(lookup: RunUnavailableAccountLookup): string {
+  switch (lookup.state) {
+    case "context-unavailable":
+      return "run account context unavailable; start a new run";
+    case "not-admitted":
+      return "not admitted for this run; change the thread selection and start a new run";
+    case "metadata-unavailable":
+      return `selected account ${lookup.connectionId} metadata unavailable or deleted; select an account and start a new run`;
+  }
+}
+
+function toRunCandidate(params: {
+  connector: ConnectorCatalogItem;
+  lookup: RunConnectorAccountLookup;
+  authorizedConnectorSlugs: Set<string> | null;
+  agentId: string | undefined;
+  platformOrigin: string;
+}): GenerationCandidate {
+  const {
+    connector,
+    lookup,
+    authorizedConnectorSlugs,
+    agentId,
+    platformOrigin,
+  } = params;
+  if (lookup.state !== "available") {
+    return {
+      connectorSlug: connector.slug,
+      label: connector.label,
+      status: "unavailable-for-run",
+      reason: runUnavailableReason(lookup),
+    };
+  }
+
+  const needsReconnect =
+    lookup.metadata.connectionStatus === "reconnect-required";
+  const authorized =
+    authorizedConnectorSlugs === null ||
+    authorizedConnectorSlugs.has(connector.slug);
+  const status: CandidateStatus = needsReconnect
+    ? "needs-reconnect"
+    : authorized
+      ? "ready"
+      : "not-authorized";
+  const reason = needsReconnect
+    ? "connected, reconnect required"
+    : authorized
+      ? "connected and authorized for current agent"
+      : "connected, not authorized for current agent";
+  const action = needsReconnect
+    ? {
+        actionLabel: `Reconnect ${connector.label}`,
+        actionUrl: connectorActionUrl({
+          origin: platformOrigin,
+          path: `/connectors/${connector.slug}/reconnect/${lookup.connectionId}`,
+          agentId,
+        }),
+      }
+    : status === "not-authorized" && agentId
+      ? {
+          actionLabel: `Authorize ${connector.label}`,
+          actionUrl: connectorActionUrl({
+            origin: platformOrigin,
+            path: `/connectors/${connector.slug}/authorize`,
+            agentId,
+          }),
+        }
+      : {};
+
+  return {
+    connectorSlug: connector.slug,
+    label: connector.label,
+    status,
+    reason,
+    account: lookup.label,
+    authMethod: lookup.metadata.authMethod,
+    ...action,
   };
 }
 
@@ -525,7 +623,10 @@ function renderRows(candidates: GenerationCandidate[]): void {
   }
 }
 
-function renderActions(candidates: GenerationCandidate[]): void {
+function renderActions(
+  candidates: GenerationCandidate[],
+  runBound: boolean,
+): void {
   const actionable = candidates.filter((candidate) => {
     return candidate.actionLabel && candidate.actionUrl;
   });
@@ -535,6 +636,12 @@ function renderActions(candidates: GenerationCandidate[]): void {
   console.log("Next actions:");
   for (const candidate of actionable) {
     console.log(`  [${candidate.actionLabel}](${candidate.actionUrl})`);
+  }
+  if (runBound) {
+    console.log("");
+    console.log(
+      "After completing connector or authorization changes, start a new run.",
+    );
   }
 }
 
@@ -604,6 +711,7 @@ function renderText(params: {
   showAll: boolean;
   videoGenerationAllowed: boolean | undefined;
   platformOrigin: string;
+  runBound: boolean;
 }): void {
   const {
     generationType,
@@ -613,6 +721,7 @@ function renderText(params: {
     showAll,
     videoGenerationAllowed,
     platformOrigin,
+    runBound,
   } = params;
   const label = GENERATION_TYPE_LABELS[generationType];
   const scope = agentId ? "for current agent" : "(connected connectors)";
@@ -657,8 +766,34 @@ function renderText(params: {
   }
 
   if (showAll) {
-    renderActions(other);
+    renderActions(other, runBound);
   }
+}
+
+type GenerationCatalogSource =
+  | {
+      readonly kind: "run";
+      readonly connectors: readonly ConnectorCatalogItem[];
+    }
+  | {
+      readonly kind: "current";
+      readonly connectors: readonly ConnectorCatalogStatus[];
+    }
+  | { readonly kind: "none"; readonly connectors: readonly [] };
+
+async function loadGenerationCatalog(
+  connectorGenerationType: ConnectorGenerationType | null,
+  runBound: boolean,
+): Promise<GenerationCatalogSource> {
+  if (!connectorGenerationType) {
+    return { kind: "none", connectors: [] };
+  }
+  if (runBound) {
+    const { connectors } = await listConnectorCatalog();
+    return { kind: "run", connectors };
+  }
+  const { connectors } = await listConnectorCatalogStatus();
+  return { kind: "current", connectors };
 }
 
 export async function runLister(
@@ -667,9 +802,10 @@ export async function runLister(
 ): Promise<void> {
   const connectorGenerationType = getConnectorGenerationType(generationType);
   const agentId = getOkouAgentId();
+  const runBound = isRunBoundConnectorContext();
   const [catalog, enabledConnectorSlugs, platformOrigin, billing] =
     await Promise.all([
-      listConnectorCatalogStatus(),
+      loadGenerationCatalog(connectorGenerationType, runBound),
       agentId ? getAgentUserConnectors(agentId) : Promise.resolve(null),
       getPlatformOrigin(),
       (generationType === "video" || generationType === "avatar-video") &&
@@ -680,18 +816,43 @@ export async function runLister(
   const authorizedConnectorSlugs = enabledConnectorSlugs
     ? new Set(enabledConnectorSlugs)
     : null;
-  const candidates = connectorGenerationType
-    ? getGenerationConnectors(connectorGenerationType, catalog.connectors).map(
-        (connector) => {
-          return toCandidate({
-            connector,
-            authorizedConnectorSlugs,
-            agentId,
-            platformOrigin,
-          });
-        },
-      )
-    : [];
+  let candidates: GenerationCandidate[] = [];
+  if (connectorGenerationType && catalog.kind === "run") {
+    const connectors = getGenerationConnectors(
+      connectorGenerationType,
+      catalog.connectors,
+    );
+    const lookups = await resolveRunConnectorAccountLookups(
+      connectors.map((connector) => {
+        return { kind: "builtin", connectorSlug: connector.slug };
+      }),
+    );
+    candidates = connectors.map((connector, index) => {
+      const lookup = lookups[index];
+      if (!lookup) {
+        throw new Error("Missing run account lookup for generation connector");
+      }
+      return toRunCandidate({
+        connector,
+        lookup,
+        authorizedConnectorSlugs,
+        agentId,
+        platformOrigin,
+      });
+    });
+  } else if (connectorGenerationType && catalog.kind === "current") {
+    candidates = getGenerationConnectors(
+      connectorGenerationType,
+      catalog.connectors,
+    ).map((connector) => {
+      return toCurrentCandidate({
+        connector,
+        authorizedConnectorSlugs,
+        agentId,
+        platformOrigin,
+      });
+    });
+  }
   const ready = candidates.filter((candidate) => {
     return candidate.status === "ready";
   });
@@ -708,6 +869,7 @@ export async function runLister(
       ? currentPlanAllowsVideo(billing)
       : undefined,
     platformOrigin,
+    runBound,
   });
 
   const shouldShowOtherHint =


### PR DESCRIPTION
## Summary

- use the Runner-projected exact connector account for run-bound `connector check`, `connector search`, and connector-backed `generate` discovery
- keep public catalog/custom data definition-only in run mode, while preserving logical agent authorization and non-run deterministic-default behavior
- fail closed for missing, not-admitted, or deleted run accounts and route reconnect actions to the exact admitted connection ID
- add command-entry integration coverage for both default-A/run-B disagreement directions, exact reconnect links, custom targets, unavailable context, and non-run regression behavior

## Scope

This is a CLI-only change. It does not change runtime credential selection, thread selections, connector permission scope, account mutation contracts, API contracts, database schema, Runner payloads, queues, or firewall behavior.

## Testing

- `pnpm format`
- `pnpm -F @okouai/cli exec vitest run src/commands/connector/__tests__/check.test.ts src/commands/connector/__tests__/search.test.ts src/commands/connector/__tests__/run-account-context.test.ts src/commands/generate/__tests__/lister.test.ts` (141 passed)
- `pnpm -F @okouai/cli lint`
- `pnpm -F @okouai/cli check-types`
- `pnpm -F @okouai/cli test` (1,122 passed, 1 pre-existing skipped)
- `pnpm knip --workspace @okouai/cli`
- pre-commit full-repository Knip and type checks

Closes #31299
Parent context: #30585
