### PR TITLE
fix(pi): set stable okou user agent

### DIFF
--- a/turbo/packages/pi-agent-runtime/src/api.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/api.test.ts
@@ -417,10 +417,11 @@ describe("Pi API facade", () => {
     }
   });
 
-  it("sends direct DeepSeek through the exact Responses endpoint without Chat fields", async () => {
+  it("sends direct DeepSeek through Responses with the stable Pi identity and no Chat fields", async () => {
     const providerRequests: Array<{
       readonly url: string | undefined;
       readonly body: Record<string, unknown>;
+      readonly userAgent: string | undefined;
     }> = [];
     const server = createServer((request, response) => {
       void (async () => {
@@ -434,6 +435,7 @@ describe("Pi API facade", () => {
             string,
             unknown
           >,
+          userAgent: request.headers["user-agent"],
         });
         responsesTextSse(response, "DeepSeek API-first answer");
       })().catch((error: unknown) => {
@@ -475,6 +477,7 @@ describe("Pi API facade", () => {
       expect(providerRequests).toHaveLength(1);
       expect(providerRequests[0]).toMatchObject({
         url: "/responses",
+        userAgent: "okou-pi-agent/1.0",
         body: {
           model: "deepseek-v4-flash",
           stream: true,

--- a/turbo/packages/pi-agent-runtime/src/model.ts
+++ b/turbo/packages/pi-agent-runtime/src/model.ts
@@ -17,6 +17,8 @@ import { clampThinkingLevel } from "@earendil-works/pi-ai";
 import type { PiAgentModelConfig } from "./types";
 import type { PiAgentStreamOptions } from "./stream-options";
 
+const PI_AGENT_USER_AGENT = "okou-pi-agent/1.0";
+
 function providerModels(provider: string): readonly Model<Api>[] {
   switch (provider) {
     case "deepseek": {
@@ -210,9 +212,6 @@ export const piAgentRegisteredStream = (
 export function piAgentStreamForConfig(
   config: Pick<PiAgentModelConfig, "requestHeaders" | "serviceTier">,
 ): typeof piAgentRegisteredStream {
-  if (config.serviceTier === undefined && config.requestHeaders === undefined) {
-    return piAgentRegisteredStream;
-  }
   return (model, context, options) => {
     const configuredHeaderNames = new Set(
       Object.keys(config.requestHeaders ?? {}).map((name) => {
@@ -226,14 +225,11 @@ export function piAgentStreamForConfig(
     );
     return piAgentRegisteredStream(model, context, {
       ...options,
-      ...(config.requestHeaders === undefined
-        ? {}
-        : {
-            headers: {
-              ...inheritedHeaders,
-              ...config.requestHeaders,
-            },
-          }),
+      headers: {
+        ...inheritedHeaders,
+        "User-Agent": PI_AGENT_USER_AGENT,
+        ...config.requestHeaders,
+      },
       ...(config.serviceTier === undefined
         ? {}
         : { serviceTier: config.serviceTier }),

--- a/turbo/packages/pi-agent-runtime/src/session-runtime.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-runtime.test.ts
@@ -257,6 +257,7 @@ interface CapturedProviderRequest {
   readonly body: unknown;
   readonly authorization: string | undefined;
   readonly apiKey: string | undefined;
+  readonly userAgent: string | undefined;
 }
 
 async function startResponsesProvider(): Promise<{
@@ -276,6 +277,7 @@ async function startResponsesProvider(): Promise<{
         body: JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown,
         authorization: request.headers.authorization,
         apiKey: request.headers["x-api-key"] as string | undefined,
+        userAgent: request.headers["user-agent"],
       });
       responsesTextSse(response, "Sandbox answer");
     })().catch((error: unknown) => {
@@ -502,7 +504,7 @@ describe("official Pi AgentSession runtime", () => {
   );
 
   it.each(CUSTOM_GATEWAY_CREDENTIAL_CASES)(
-    "uses the custom gateway request model and $name credential header",
+    "uses the stable Pi identity with the custom gateway request model and $name credential header",
     async ({ sessionId, requestHeaders, authorization, apiKey }) => {
       const provider = await startResponsesProvider();
       const sessionManager = SessionManager.inMemory("/home/user/workspace", {
@@ -533,6 +535,7 @@ describe("official Pi AgentSession runtime", () => {
             url: "/v1/responses",
             authorization,
             apiKey,
+            userAgent: "okou-pi-agent/1.0",
             body: expect.objectContaining({
               model: "company-deepseek-production",
             }),


### PR DESCRIPTION
## Summary

- override the OpenAI SDK default user agent with the stable `okou-pi-agent/1.0` identity in the shared Pi Responses stream
- apply the identity to API-first, Sandbox, and other Pi runtime turns without duplicating execution-edge logic
- verify the final HTTP header for direct DeepSeek API-first and custom gateway Sandbox requests

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/pi-agent-runtime exec vitest run src/api.test.ts`
- `pnpm --filter @okouai/pi-agent-runtime exec vitest run src/session-runtime.test.ts`
