### PR TITLE
perf(api): select goal from authoritative queue head

### DIFF
--- a/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
@@ -9,6 +9,7 @@ import { pgTextDecoder } from "../../lib/db-structured-result";
 import { nowDate } from "../../lib/time";
 import type { Db } from "../external/db";
 import {
+  chatQueueEventPriority,
   loadPendingChatQueueEvent,
   lockChatQueueThread,
   pendingChatQueueEventCondition,
@@ -154,47 +155,55 @@ export async function loadNextGoalQueueEvent(
       "api_dispatch_pre_create_zero_goal_drain_load_event_select_candidate",
       "nested",
       async () => {
+        const queueHead = tx.$with("goal_queue_head").as(
+          tx
+            .select({
+              id: chatEvents.id,
+              chatThreadId: chatEvents.chatThreadId,
+              eventType: chatEvents.eventType,
+              goalId: canonicalChatEventGoalId().as("goal_id"),
+              createdAt: chatEvents.createdAt,
+            })
+            .from(chatEvents)
+            .where(
+              and(
+                eq(chatEvents.chatThreadId, args.chatThreadId),
+                pendingChatQueueEventCondition(tx),
+                args.queueItemCreatedBefore
+                  ? lt(chatEvents.createdAt, args.queueItemCreatedBefore)
+                  : undefined,
+              ),
+            )
+            .orderBy(
+              chatQueueEventPriority(),
+              asc(chatEvents.createdAt),
+              asc(chatEvents.id),
+            )
+            .limit(1),
+        );
         return await tx
+          .with(queueHead)
           .select({
-            id: chatEvents.id,
-            chatThreadId: chatEvents.chatThreadId,
+            id: queueHead.id,
+            chatThreadId: queueHead.chatThreadId,
             userId: chatThreads.userId,
             orgId: agents.orgId,
-            goalId: canonicalChatEventGoalId(),
-            createdAt: chatEvents.createdAt,
+            goalId: queueHead.goalId,
+            createdAt: queueHead.createdAt,
           })
-          .from(chatEvents)
-          .innerJoin(chatThreads, eq(chatThreads.id, chatEvents.chatThreadId))
+          .from(queueHead)
+          .innerJoin(chatThreads, eq(chatThreads.id, queueHead.chatThreadId))
           .innerJoin(agents, eq(agents.id, chatThreads.agentId))
+          // Keep admission lazy when a prompt or automation owns the queue.
           .where(
-            and(
-              eq(chatEvents.chatThreadId, args.chatThreadId),
-              pendingChatQueueEventCondition(tx),
-              chatEventTypeIn(["input.goal"]),
-              args.queueItemCreatedBefore
-                ? lt(chatEvents.createdAt, args.queueItemCreatedBefore)
-                : undefined,
-              notExists(
-                tx
-                  .select({ id: chatEvents.id })
-                  .from(chatEvents)
-                  .where(
-                    and(
-                      eq(chatEvents.chatThreadId, args.chatThreadId),
-                      pendingChatQueueEventCondition(tx),
-                      chatEventTypeIn(["input.prompt", "input.automation"]),
-                      args.queueItemCreatedBefore
-                        ? lt(chatEvents.createdAt, args.queueItemCreatedBefore)
-                        : undefined,
-                    ),
-                  ),
-              ),
-              chatThreadAdmissionAllowedCondition(tx, {
-                threadId: args.chatThreadId,
-              }),
-            ),
+            sql`CASE
+              WHEN ${queueHead.eventType} = 'input.goal' THEN
+                ${chatThreadAdmissionAllowedCondition(tx, {
+                  threadId: args.chatThreadId,
+                })}
+              ELSE FALSE
+            END`,
           )
-          .orderBy(asc(chatEvents.createdAt), asc(chatEvents.id))
           .limit(1);
       },
       args.timingDimensions,


### PR DESCRIPTION
## Summary

- select the authoritative `prompt > automation > goal` queue head once instead of selecting a goal and independently probing higher-priority events
- reuse the shared pending-event predicate and preserve FIFO and optional cutoff ordering
- evaluate goal admission lazily so prompt and automation heads skip ownership and admission work
- keep the thread lock and candidate read as separate PostgreSQL statements for a fresh post-lock snapshot

## Evidence

- the mature production cohort measured the existing candidate statement at 34.6 ms p90 across 1,614 exact SQL-shape spans
- a rolled-back PostgreSQL fixture with 24 historically revoked prompts reduced candidate-core shared-buffer hits from 147 to 114 (22%) and execution time from 0.084 ms to 0.049 ms in the representative run
- exact generated prompt and automation plans returned no goal and showed the ownership, active-run, cancellation-recovery, and open-delivery outer work as `never executed`
- local absolute timings are shape evidence only; post-deploy validation must use a fixed mature API/Runner cohort

## Compatibility and exclusions

- no schema, migration, public API, queue representation, Runner protocol, cache, feature switch, or coordinated rollout change
- the later goal-target lookup and final queue-first claim remain authoritative
- errors and missing/non-runnable candidates keep their existing behavior

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/chat-goal-queue.service.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/workflow-queue.test.ts --reporter=dot` (34 passed)
- `pnpm knip --workspace api`
- staged pre-commit checks: repository Prettier, Knip, TypeScript, and file-size checks
- `git diff --check`

Closes #31296

Parent objective: #24203
