### PR TITLE
fix(api): avoid locking empty active-input polls

### DIFF
--- a/docs/active-input-delivery.md
+++ b/docs/active-input-delivery.md
@@ -88,7 +88,14 @@ and the post-commit scheduler may create the successor run.
 
 ## Transaction Boundary
 
-Reservation and direct receipt serialize database state in this order:
+A running recheck with no pending input and no committed open delivery is
+observational. After a fresh run-status and open-delivery read confirms that
+state, it returns `empty` without entering the serialized transaction. Input
+committed after that read uses the realtime notification path, with the
+30-second poll as notification-loss recovery.
+
+Pending reservations, open-delivery retrieval, and direct receipt serialize
+database state in this order:
 
 1. chat thread;
 2. agent run;

--- a/docs/active-input-delivery.md
+++ b/docs/active-input-delivery.md
@@ -88,11 +88,12 @@ and the post-commit scheduler may create the successor run.
 
 ## Transaction Boundary
 
-A running recheck with no pending input and no committed open delivery is
-observational. After a fresh run-status and open-delivery read confirms that
-state, it returns `empty` without entering the serialized transaction. Input
-committed after that read uses the realtime notification path, with the
-30-second poll as notification-loss recovery.
+A running recheck first reads pending input without locks. If that read is
+empty, a fresh non-locking query confirms that the run is still running and no
+committed open delivery exists. It then returns `empty` without entering the
+serialized transaction. Input committed after the pending-input snapshot uses
+the realtime notification path, with the 30-second poll as notification-loss
+recovery.
 
 Pending reservations, open-delivery retrieval, and direct receipt serialize
 database state in this order:

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -2463,6 +2463,55 @@ describe("CHAT-02: interrupting active chat runs", () => {
 });
 
 describe("CHAT-02: queueing and recalling messages", () => {
+  it("returns an empty active-input poll without waiting for the thread row", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const active = await sendChatRun(actor, {
+      agentId,
+      prompt: "keep the empty active-input poll observational",
+    });
+    const claimed = await claimChatRun(runnerGroup, active.runId);
+    const threadLock = await holdChatThreadRowLockFixture({
+      threadId: active.threadId,
+      signal: context.signal,
+    });
+    let reserveSettled = false;
+    const reserveOutcome = api
+      .reserveRunnerActiveInputs(claimed.claim.sandboxToken, active.runId)
+      .then(
+        (value) => {
+          reserveSettled = true;
+          return { ok: true as const, value };
+        },
+        (error: unknown) => {
+          reserveSettled = true;
+          return { ok: false as const, error };
+        },
+      );
+    onTestFinished(async () => {
+      threadLock.release();
+      await threadLock.done;
+      await reserveOutcome;
+    });
+
+    await expect
+      .poll(() => {
+        return reserveSettled;
+      })
+      .toBeTruthy();
+    const outcome = await reserveOutcome;
+    if (!outcome.ok) {
+      throw outcome.error;
+    }
+    expect(outcome.value).toStrictEqual({ outcome: "empty" });
+    await expect(threadLock.blockedWaiterCount()).resolves.toBe(0);
+
+    threadLock.release();
+    await threadLock.done;
+    await cancelChatRun(actor, active.runId);
+  }, 30_000);
+
   it("reserves rich inputs one at a time and settles concurrent receipts once", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();

--- a/turbo/apps/api/src/signals/services/active-input-delivery.service.ts
+++ b/turbo/apps/api/src/signals/services/active-input-delivery.service.ts
@@ -427,6 +427,8 @@ export async function reserveActiveInputDelivery(
       scope.status === "running"
         ? await prepareReservation(db, scope, signal)
         : ({ kind: "empty" } as const);
+    // A committed open delivery hides its source from the pending query, so
+    // recheck for one after an empty preparation before bypassing serialization.
     if (
       scope.status === "running" &&
       prepared.kind === "empty" &&

--- a/turbo/apps/api/src/signals/services/active-input-delivery.service.ts
+++ b/turbo/apps/api/src/signals/services/active-input-delivery.service.ts
@@ -10,7 +10,15 @@ import {
 } from "@okouai/db/schema/active-input-delivery";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { chatEvents } from "@okouai/db/schema/chat-event";
-import { and, asc, eq, inArray, isNotNull, isNull } from "drizzle-orm";
+import {
+  and,
+  asc,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  notExists,
+} from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
 import type { Db } from "../external/db";
@@ -207,6 +215,39 @@ async function prepareReservation(
   };
 }
 
+async function canReturnEmptyReservation(
+  db: Db,
+  scope: ActiveInputDeliveryScope,
+  signal: AbortSignal,
+): Promise<boolean> {
+  const [run] = await db
+    .select({ id: agentRuns.id })
+    .from(agentRuns)
+    .where(
+      and(
+        eq(agentRuns.id, scope.runId),
+        eq(agentRuns.chatThreadId, scope.chatThreadId),
+        eq(agentRuns.userId, scope.userId),
+        eq(agentRuns.orgId, scope.orgId),
+        eq(agentRuns.status, "running"),
+        notExists(
+          db
+            .select({ id: activeInputDeliveries.id })
+            .from(activeInputDeliveries)
+            .where(
+              and(
+                eq(activeInputDeliveries.runId, scope.runId),
+                eq(activeInputDeliveries.status, "open"),
+              ),
+            ),
+        ),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+  return run !== undefined;
+}
+
 async function lockOpenDelivery(
   tx: ActiveInputDeliveryTransaction,
   scope: ActiveInputDeliveryIdentity,
@@ -386,6 +427,13 @@ export async function reserveActiveInputDelivery(
       scope.status === "running"
         ? await prepareReservation(db, scope, signal)
         : ({ kind: "empty" } as const);
+    if (
+      scope.status === "running" &&
+      prepared.kind === "empty" &&
+      (await canReturnEmptyReservation(db, scope, signal))
+    ) {
+      return { outcome: "empty" };
+    }
     const result = await db.transaction(async (tx) => {
       return await transitionReservation(tx, scope, prepared);
     });


### PR DESCRIPTION
## Summary

- return an empty active-input reservation before the serialized transaction when a fresh read confirms the run is still running and has no committed open delivery
- preserve the existing locked transition for pending input, open deliveries, terminal states, and ambiguous concurrent changes
- document the observational empty-poll boundary and cover it with a route integration test that holds the owning thread row

## Scope

- no database migration or API contract change
- no runner, GuestAgent retry, lock-timeout, or run-output projection change

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t "returns an empty active-input poll without waiting for the thread row|reserves rich inputs one at a time and settles concurrent receipts once|classifies delivery lifecycle and authorization without route-level 404"`

Closes #31272
