### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1981,9 +1981,9 @@ checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d317b4b9eb398e6acce275758ec6125535505e7a146fb1a9b8bda2451b0ff4c"
+checksum = "ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25"
 dependencies = [
  "hashbrown",
 ]
@@ -2061,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "wasi",
@@ -3472,9 +3472,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",


### PR DESCRIPTION
## Summary

- Update `lru` from 0.18.3 to 0.18.4.
- Update `mio` from 1.2.2 to 1.2.3.
- Update `toml` from 1.1.4+spec-1.1.0 to 1.1.5+spec-1.1.0.

## Dependencies not updated

- `generic-array` remains at 0.14.7 because `crypto-common` 0.1.7 requires exactly `generic-array = 0.14.7`.

## Manual version bumps

- None. This PR only updates `crates/Cargo.lock`.

## Test status

- `cargo test --workspace --exclude runner --no-fail-fast`: all executed targets passed except `sandbox-fc`'s `workspace_drive_image::tests::prepare_workspace_drive_image_without_seed_truncates_and_formats_fresh_image` (834 of 835 `sandbox-fc` tests passed). The test requires `mkfs.ext4`, which is unavailable in the current environment.
- `cargo check -p runner --tests`: passed. Runner test execution was not attempted in this constrained environment; all runner test targets compiled successfully.
