### PR TITLE
feat(pi-memory): compose bounded phase 2 archive worker

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -396,13 +396,16 @@ export default [
       // with the sandbox runtime; route output cannot expose its full virtual
       // filesystem, ignore-rule, and precedence matrix.
       "src/signals/services/__tests__/pi-resource-snapshot.service.test.ts",
-      // Slices 4a and 5a intentionally have no Phase 2 worker or public
-      // mutation API. These real-PostgreSQL tests pin their finite job,
-      // publication, Storage notification, and concurrency contracts until a
-      // later slice exposes that boundary.
+      // Slices 4a through 5b intentionally have no Phase 2 public mutation API
+      // or activation hook. These focused tests pin the finite job, archive,
+      // usage, worker composition, publication, Storage notification, and
+      // concurrency contracts until a later slice exposes that boundary.
+      "src/signals/services/__tests__/pi-memory-phase2-archive.service.test.ts",
       "src/signals/services/__tests__/pi-memory-phase2-job.service.test.ts",
       "src/signals/services/__tests__/pi-memory-phase2-publication.service.test.ts",
       "src/signals/services/__tests__/pi-memory-phase2-selection.service.test.ts",
+      "src/signals/services/__tests__/pi-memory-phase2-usage.service.test.ts",
+      "src/signals/services/__tests__/pi-memory-phase2-worker.service.test.ts",
       "src/signals/services/__tests__/storage-write-phase2-reconciliation.service.test.ts",
       // Terra route activation is explicitly deferred. This compatibility
       // slice must pin the pre-admission provider/transport contract before a
@@ -554,13 +557,16 @@ export default [
       // with the sandbox runtime; route output cannot expose its full virtual
       // filesystem, ignore-rule, and precedence matrix.
       "src/signals/services/__tests__/pi-resource-snapshot.service.test.ts",
-      // Slices 4a and 5a intentionally have no Phase 2 worker or public
-      // mutation API. Keep their exact PostgreSQL concurrency, publication,
-      // Storage notification, and selection contracts isolated until a later
-      // slice exposes a route.
+      // Slices 4a through 5b intentionally have no Phase 2 public mutation API
+      // or activation hook. Keep their exact archive, usage, worker,
+      // PostgreSQL concurrency, publication, Storage notification, and
+      // selection contracts isolated until a later slice exposes a route.
+      "src/signals/services/__tests__/pi-memory-phase2-archive.service.test.ts",
       "src/signals/services/__tests__/pi-memory-phase2-job.service.test.ts",
       "src/signals/services/__tests__/pi-memory-phase2-publication.service.test.ts",
       "src/signals/services/__tests__/pi-memory-phase2-selection.service.test.ts",
+      "src/signals/services/__tests__/pi-memory-phase2-usage.service.test.ts",
+      "src/signals/services/__tests__/pi-memory-phase2-worker.service.test.ts",
       "src/signals/services/__tests__/storage-write-phase2-reconciliation.service.test.ts",
       "src/signals/services/__tests__/pi-memory-phase2-job.test-fixture.ts",
       // Terra route activation is explicitly deferred, so its pre-admission

--- a/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-archive.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-archive.service.test.ts
@@ -1,0 +1,319 @@
+import { createHash } from "node:crypto";
+import { gunzipSync, gzipSync } from "node:zlib";
+
+import type {
+  PiMemoryPhase2ConsolidationResult,
+  PiMemoryPhase2PreparedFile,
+} from "@okouai/pi-agent-runtime/api";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPiMemoryPhase2Archive,
+  PiMemoryPhase2ArchiveError,
+  validatePiMemoryPhase2PreparedResult,
+  verifyPiMemoryPhase2Archive,
+} from "../pi-memory-phase2-archive.service";
+import { computeContentHashFromHashes } from "../storage-content-hash.service";
+
+const STORAGE_ID = "92d1f947-21f0-46b7-a0e8-ddb0964103ee";
+const DIGEST_ENCODING = "vm0.pi-memory.phase2.manifest.v1";
+
+function uint32(value: number): Buffer {
+  const result = Buffer.alloc(4);
+  result.writeUInt32BE(value);
+  return result;
+}
+
+function digest(files: readonly PiMemoryPhase2PreparedFile[]): string {
+  const parts: Buffer[] = [uint32(files.length)];
+  for (const file of files) {
+    const path = Buffer.from(file.path, "utf8");
+    const hash = Buffer.from(file.hash, "utf8");
+    parts.push(
+      uint32(path.length),
+      path,
+      uint32(hash.length),
+      hash,
+      uint32(file.size),
+    );
+  }
+  const version = Buffer.from(DIGEST_ENCODING, "utf8");
+  return createHash("sha256")
+    .update(Buffer.concat([uint32(version.length), version, ...parts]))
+    .digest("hex");
+}
+
+function preparedFile(
+  path: string,
+  content: string,
+): PiMemoryPhase2PreparedFile {
+  const bytes = Buffer.from(content, "utf8");
+  return {
+    path,
+    hash: createHash("sha256").update(bytes).digest("hex"),
+    size: bytes.length,
+    contentBase64: bytes.toString("base64"),
+  };
+}
+
+function archiveWithFirstEntryType(archive: Buffer, type: number): Buffer {
+  const tar = gunzipSync(archive);
+  tar[156] = type;
+  tar.fill(32, 148, 156);
+  let checksum = 0;
+  for (let index = 0; index < 512; index += 1) {
+    checksum += tar.readUInt8(index);
+  }
+  tar.write(checksum.toString(8).padStart(6, "0"), 148, 6, "ascii");
+  tar[154] = 0;
+  tar[155] = 32;
+  return gzipSync(tar, { level: 9 });
+}
+
+function result(
+  input: readonly Readonly<{
+    readonly path: string;
+    readonly content: string;
+  }>[],
+): PiMemoryPhase2ConsolidationResult {
+  const files = input
+    .map((file) => {
+      return preparedFile(file.path, file.content);
+    })
+    .sort((left, right) => {
+      return left.path === right.path ? 0 : left.path < right.path ? -1 : 1;
+    });
+  const metadata = files.map((file) => {
+    return { path: file.path, hash: file.hash, size: file.size };
+  });
+  return {
+    status: "prepared",
+    files,
+    manifest: {
+      version: 1,
+      files: metadata,
+      fileCount: files.length,
+      pathBytes: files.reduce((sum, file) => {
+        return sum + Buffer.byteLength(file.path, "utf8");
+      }, 0),
+      totalBytes: files.reduce((sum, file) => {
+        return sum + file.size;
+      }, 0),
+      digest: digest(files),
+    },
+    contentIdentity: computeContentHashFromHashes(STORAGE_ID, metadata),
+    diff: {
+      added: 1,
+      changed: 0,
+      deleted: 0,
+      renderedBytes: 0,
+      truncated: false,
+      digest: "0".repeat(64),
+    },
+    selectionDigest: "1".repeat(64),
+    responseId: "response-31291",
+    usage: { input: 10, output: 5, cacheRead: 3, cacheWrite: 2, reasoning: 1 },
+  };
+}
+
+const PRESERVED_FILES = [
+  { path: ".git/config", content: "codex git state" },
+  { path: "MEMORY.md", content: "# Durable external fact" },
+  { path: "memory_summary.md", content: "v1\n## User Profile\n- durable" },
+  { path: "legacy-topic.md", content: "legacy flat topic" },
+  { path: "unknown/data.bin", content: "unknown file" },
+  {
+    path: `unknown/${"long-segment/".repeat(24)}evidence.md`,
+    content: "long path evidence",
+  },
+  { path: "rollout_summaries/codex.md", content: "codex evidence" },
+  { path: "rollout_summaries/pi/nested.md", content: "nested pi evidence" },
+] as const;
+
+describe("Pi memory Phase 2 archive boundary", () => {
+  it("creates deterministic bytes and completely verifies preserved files", () => {
+    const first = buildPiMemoryPhase2Archive(
+      STORAGE_ID,
+      result(PRESERVED_FILES),
+    );
+    const second = buildPiMemoryPhase2Archive(
+      STORAGE_ID,
+      result([...PRESERVED_FILES].reverse()),
+    );
+
+    expect(second.versionId).toBe(first.versionId);
+    expect(second.manifestBytes).toStrictEqual(first.manifestBytes);
+    expect(second.archiveBytes).toStrictEqual(first.archiveBytes);
+
+    const verified = verifyPiMemoryPhase2Archive({
+      storageId: STORAGE_ID,
+      versionId: first.versionId,
+      size: first.size,
+      archiveSize: first.archiveSize,
+      fileCount: first.fileCount,
+      manifestBytes: first.manifestBytes,
+      archiveBytes: first.archiveBytes,
+    });
+    expect(
+      verified.files.map((file) => {
+        return [file.path, Buffer.from(file.bytes).toString("utf8")];
+      }),
+    ).toStrictEqual(
+      [...PRESERVED_FILES]
+        .sort((left, right) => {
+          return left.path < right.path ? -1 : left.path > right.path ? 1 : 0;
+        })
+        .map((file) => {
+          return [file.path, file.content];
+        }),
+    );
+  });
+
+  it("rejects API-returned path collisions and identity mismatches", () => {
+    const collision = result([
+      { path: "Topic.md", content: "first" },
+      { path: "topic.md", content: "second" },
+    ]);
+    expect(() => {
+      validatePiMemoryPhase2PreparedResult(STORAGE_ID, collision);
+    }).toThrow(PiMemoryPhase2ArchiveError);
+
+    const mismatched = result([{ path: "MEMORY.md", content: "durable" }]);
+    const first = mismatched.files[0];
+    if (!first) {
+      throw new Error("Prepared fixture is missing");
+    }
+    const changed = {
+      ...mismatched,
+      files: [
+        { ...first, contentBase64: Buffer.from("changed").toString("base64") },
+      ],
+    };
+    expect(() => {
+      validatePiMemoryPhase2PreparedResult(STORAGE_ID, changed);
+    }).toThrow(PiMemoryPhase2ArchiveError);
+
+    for (const path of [
+      "/absolute.md",
+      "../parent.md",
+      "topic/../escape.md",
+      String.raw`topic\ambiguous.md`,
+      "topic//empty.md",
+      "C:/drive.md",
+    ]) {
+      expect(() => {
+        validatePiMemoryPhase2PreparedResult(
+          STORAGE_ID,
+          result([{ path, content: "rejected" }]),
+        );
+      }).toThrow(PiMemoryPhase2ArchiveError);
+    }
+
+    expect(() => {
+      validatePiMemoryPhase2PreparedResult(
+        STORAGE_ID,
+        result([
+          { path: "e\u0301.md", content: "first" },
+          { path: "é.md", content: "second" },
+        ]),
+      );
+    }).toThrow(PiMemoryPhase2ArchiveError);
+  });
+
+  it("rejects archive corruption, trailing tar data, and registered metadata drift", () => {
+    const prepared = buildPiMemoryPhase2Archive(
+      STORAGE_ID,
+      result(PRESERVED_FILES),
+    );
+    const corrupted = Buffer.from(prepared.archiveBytes);
+    const corruptedIndex = Math.floor(corrupted.length / 2);
+    corrupted.writeUInt8(
+      corrupted.readUInt8(corruptedIndex) ^ 1,
+      corruptedIndex,
+    );
+    expect(() => {
+      verifyPiMemoryPhase2Archive({
+        storageId: STORAGE_ID,
+        versionId: prepared.versionId,
+        size: prepared.size,
+        archiveSize: corrupted.length,
+        fileCount: prepared.fileCount,
+        manifestBytes: prepared.manifestBytes,
+        archiveBytes: corrupted,
+      });
+    }).toThrow(PiMemoryPhase2ArchiveError);
+
+    for (const type of ["2", "3", "4", "5", "7"]) {
+      const unsupported = archiveWithFirstEntryType(
+        prepared.archiveBytes,
+        type.charCodeAt(0),
+      );
+      expect(() => {
+        verifyPiMemoryPhase2Archive({
+          storageId: STORAGE_ID,
+          versionId: prepared.versionId,
+          size: prepared.size,
+          archiveSize: unsupported.length,
+          fileCount: prepared.fileCount,
+          manifestBytes: prepared.manifestBytes,
+          archiveBytes: unsupported,
+        });
+      }).toThrow(PiMemoryPhase2ArchiveError);
+    }
+
+    expect(() => {
+      verifyPiMemoryPhase2Archive({
+        storageId: STORAGE_ID,
+        versionId: prepared.versionId,
+        size: prepared.size,
+        archiveSize: prepared.archiveSize,
+        fileCount: prepared.fileCount,
+        manifestBytes: Buffer.from([0xff]),
+        archiveBytes: prepared.archiveBytes,
+      });
+    }).toThrow(PiMemoryPhase2ArchiveError);
+
+    const concatenated = Buffer.concat([
+      prepared.archiveBytes,
+      gzipSync(Buffer.alloc(1024)),
+    ]);
+    expect(() => {
+      verifyPiMemoryPhase2Archive({
+        storageId: STORAGE_ID,
+        versionId: prepared.versionId,
+        size: prepared.size,
+        archiveSize: concatenated.length,
+        fileCount: prepared.fileCount,
+        manifestBytes: prepared.manifestBytes,
+        archiveBytes: concatenated,
+      });
+    }).toThrow(PiMemoryPhase2ArchiveError);
+
+    const tar = gunzipSync(prepared.archiveBytes);
+    const trailingTar = Buffer.concat([tar, Buffer.alloc(512, 1)]);
+    const trailingArchive = gzipSync(trailingTar, { level: 9 });
+    expect(() => {
+      verifyPiMemoryPhase2Archive({
+        storageId: STORAGE_ID,
+        versionId: prepared.versionId,
+        size: prepared.size,
+        archiveSize: trailingArchive.length,
+        fileCount: prepared.fileCount,
+        manifestBytes: prepared.manifestBytes,
+        archiveBytes: trailingArchive,
+      });
+    }).toThrow(PiMemoryPhase2ArchiveError);
+
+    expect(() => {
+      verifyPiMemoryPhase2Archive({
+        storageId: STORAGE_ID,
+        versionId: "f".repeat(64),
+        size: prepared.size,
+        archiveSize: prepared.archiveSize,
+        fileCount: prepared.fileCount,
+        manifestBytes: prepared.manifestBytes,
+        archiveBytes: prepared.archiveBytes,
+      });
+    }).toThrow(PiMemoryPhase2ArchiveError);
+  });
+});

--- a/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-job.test-fixture.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-job.test-fixture.ts
@@ -94,15 +94,31 @@ async function insertFixtureBlobs(
 
 export async function createPhase2TestScope(
   label: string,
-  overrides: { readonly userId?: string } = {},
+  overrides: {
+    readonly userId?: string;
+    readonly emptyBase?: boolean;
+    readonly s3Prefix?: string;
+  } = {},
 ): Promise<Phase2TestScope> {
   const memoryStorageId = randomUUID();
   const orgId = `phase2-${label}-org-${randomUUID()}`;
   const userId = overrides.userId ?? `phase2-${label}-user-${randomUUID()}`;
-  const baseVersion = phase2TestVersion(
+  const generatedBaseVersion = phase2TestVersion(
     { memoryStorageId, orgId, userId },
     "base",
   );
+  const baseVersion = overrides.emptyBase
+    ? {
+        ...generatedBaseVersion,
+        versionId: createHash("sha256")
+          .update(`storage:${memoryStorageId}\n`)
+          .digest("hex"),
+        s3Key: `${orgId}/${memoryStorageId}/empty`,
+        size: 0,
+        archiveSize: 0,
+        fileCount: 0,
+      }
+    : generatedBaseVersion;
   const scope = {
     memoryStorageId,
     orgId,
@@ -123,7 +139,7 @@ export async function createPhase2TestScope(
       orgId: scope.orgId,
       userId: scope.userId,
       name: MEMORY_ARTIFACT_NAME,
-      s3Prefix: `${scope.orgId}/${scope.memoryStorageId}`,
+      s3Prefix: overrides.s3Prefix ?? `${scope.orgId}/${scope.memoryStorageId}`,
     });
   await db().insert(storageVersions).values(storageVersionRow(baseVersion));
   await db()
@@ -164,7 +180,7 @@ export async function createPhase2TestScope(
 function phase2TestVersion(
   scope: Pick<Phase2TestScope, "memoryStorageId" | "orgId" | "userId">,
   label: string,
-  overrides: Partial<Omit<Phase2TestVersion, "storageId" | "versionId">> = {},
+  overrides: Partial<Omit<Phase2TestVersion, "storageId">> = {},
 ): Phase2TestVersion {
   const versionId = createHash("sha256")
     .update(`${scope.memoryStorageId}:${label}:${randomUUID()}`)
@@ -198,7 +214,7 @@ function storageVersionRow(version: Phase2TestVersion) {
 export async function insertPhase2StorageVersion(
   scope: Phase2TestScope,
   label: string,
-  overrides: Partial<Omit<Phase2TestVersion, "storageId" | "versionId">> = {},
+  overrides: Partial<Omit<Phase2TestVersion, "storageId">> = {},
 ): Promise<Phase2TestVersion> {
   const version = phase2TestVersion(scope, label, overrides);
   await db().insert(storageVersions).values(storageVersionRow(version));

--- a/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-usage.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-usage.service.test.ts
@@ -1,0 +1,77 @@
+import { randomUUID } from "node:crypto";
+
+import { usageEvent } from "@okouai/db/schema/usage-event";
+import { and, eq } from "drizzle-orm";
+import { onTestFinished, describe, expect, it } from "vitest";
+
+import { db } from "../../../lib/db";
+import {
+  PI_MEMORY_PHASE2_MODEL,
+  recordPiMemoryPhase2Usage,
+} from "../pi-memory-phase2-usage.service";
+
+describe("Pi memory Phase 2 usage", () => {
+  it("persists one owner-scoped runless ledger set idempotently", async () => {
+    const memoryStorageId = randomUUID();
+    const orgId = `phase2-usage-org-${randomUUID()}`;
+    const userId = `phase2-usage-user-${randomUUID()}`;
+    const args = {
+      memoryStorageId,
+      claimedRevision: 7,
+      selectionDigest: "a".repeat(64),
+      orgId,
+      userId,
+      responseId: "phase2-response-31291",
+      usage: {
+        input: 101,
+        output: 29,
+        cacheRead: 17,
+        cacheWrite: 11,
+        reasoning: 13,
+      },
+    } as const;
+    onTestFinished(async () => {
+      await db()
+        .delete(usageEvent)
+        .where(and(eq(usageEvent.orgId, orgId), eq(usageEvent.userId, userId)));
+    });
+
+    await recordPiMemoryPhase2Usage(db(), args);
+    await recordPiMemoryPhase2Usage(db(), args);
+
+    const rows = await db()
+      .select({
+        runId: usageEvent.runId,
+        orgId: usageEvent.orgId,
+        userId: usageEvent.userId,
+        provider: usageEvent.provider,
+        category: usageEvent.category,
+        quantity: usageEvent.quantity,
+      })
+      .from(usageEvent)
+      .where(and(eq(usageEvent.orgId, orgId), eq(usageEvent.userId, userId)));
+    expect(rows).toHaveLength(4);
+    expect(rows).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ category: "tokens.input", quantity: 101 }),
+        expect.objectContaining({ category: "tokens.output", quantity: 29 }),
+        expect.objectContaining({
+          category: "tokens.cache_read",
+          quantity: 17,
+        }),
+        expect.objectContaining({
+          category: "tokens.cache_creation",
+          quantity: 11,
+        }),
+      ]),
+    );
+    for (const row of rows) {
+      expect(row).toMatchObject({
+        runId: null,
+        orgId,
+        userId,
+        provider: PI_MEMORY_PHASE2_MODEL,
+      });
+    }
+  });
+});

--- a/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-worker.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-worker.service.test.ts
@@ -809,17 +809,23 @@ describe("Pi memory Phase 2 worker composition", () => {
     const finalPaths = verified.files.map((file) => {
       return file.path;
     });
-    for (const file of externalFiles) {
+    for (const file of externalFiles.filter((candidate) => {
+      return !candidate.path.startsWith("rollout_summaries/pi/");
+    })) {
       expect(finalPaths).toContain(file.path);
     }
-    expect(
-      finalPaths.some((path) => {
-        return (
-          path.startsWith("rollout_summaries/pi/") &&
-          path !== "rollout_summaries/pi/older.md"
-        );
-      }),
-    ).toBeTruthy();
+    expect(finalPaths).not.toContain("rollout_summaries/pi/older.md");
+    const nestedPiEvidence = verified.files.filter((file) => {
+      return file.path.startsWith("rollout_summaries/pi/");
+    });
+    expect(nestedPiEvidence).toHaveLength(1);
+    const [replacementPiEvidence] = nestedPiEvidence;
+    if (!replacementPiEvidence) {
+      throw new Error("Replacement Pi evidence is missing");
+    }
+    expect(Buffer.from(replacementPiEvidence.bytes).toString("utf8")).toContain(
+      "replacement Pi rollout fact",
+    );
 
     const [selectedCandidate] = await db()
       .select({

--- a/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-worker.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-worker.service.test.ts
@@ -1,0 +1,1181 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { piMemoryPhase2Jobs } from "@okouai/db/schema/pi-memory-phase2-job";
+import { piMemoryPublicationProvenance } from "@okouai/db/schema/pi-memory-publication-provenance";
+import { piMemoryStage1Candidates } from "@okouai/db/schema/pi-memory-stage1-candidate";
+import { memorySummaryProjections } from "@okouai/db/schema/memory-summary-projection";
+import { storages, storageVersions } from "@okouai/db/schema/storage";
+import { usageEvent } from "@okouai/db/schema/usage-event";
+import type {
+  PiMemoryPhase2ConsolidationResult,
+  PiMemoryPhase2PreparedFile,
+} from "@okouai/pi-agent-runtime/api";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { HttpResponse, http } from "msw";
+import { onTestFinished, describe, expect, it } from "vitest";
+
+import { testContext } from "../../../__tests__/test-context";
+import { db } from "../../../lib/db";
+import { mockEnv } from "../../../lib/env";
+import { withMockNowForTest } from "../../../lib/time";
+import { server } from "../../../mocks/server";
+import { seedVm0BuiltInModelKey } from "../../routes/__tests__/helpers/runtime-state";
+import { createDeferredPromise } from "../../utils";
+import {
+  buildPiMemoryPhase2Archive,
+  verifyPiMemoryPhase2Archive,
+} from "../pi-memory-phase2-archive.service";
+import {
+  advancePiMemoryPhase2InputRevision,
+  notifyPiMemoryPhase2ExternalHeadChange,
+  PI_MEMORY_PHASE2_LEASE_DURATION_MS,
+  PI_MEMORY_PHASE2_SUCCESS_COOLDOWN_MS,
+} from "../pi-memory-phase2-job.service";
+import {
+  executePiMemoryPhase2Work$,
+  type PiMemoryPhase2WorkerResult,
+} from "../pi-memory-phase2-worker.service";
+import { computeContentHashFromHashes } from "../storage-content-hash.service";
+import {
+  createPhase2TestScope,
+  insertPendingPhase2Job,
+  insertPhase2Candidates,
+  insertPhase2StorageVersion,
+  readPhase2Job,
+  replacePhase2CandidateSource,
+  setPhase2StorageHead,
+  type Phase2TestScope,
+} from "./pi-memory-phase2-job.test-fixture";
+
+const BUCKET = "pi-memory-phase2-worker-test";
+const NOW_MS = 1_788_408_000_000;
+const DIGEST_ENCODING = "vm0.pi-memory.phase2.manifest.v1";
+const MEMORY_SECRET = "PHASE2_MEMORY_CONTENT_SECRET_31291";
+const PATH_SECRET = "unknown/path-secret-31291.txt";
+const PROVIDER_ID_SECRET = "PHASE2_PROVIDER_ID_SECRET_31291";
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function uint32(value: number): Buffer {
+  const result = Buffer.alloc(4);
+  result.writeUInt32BE(value);
+  return result;
+}
+
+function preparedFile(
+  path: string,
+  content: string | Buffer,
+): PiMemoryPhase2PreparedFile {
+  const bytes = Buffer.isBuffer(content)
+    ? Buffer.from(content)
+    : Buffer.from(content, "utf8");
+  return {
+    path,
+    hash: createHash("sha256").update(bytes).digest("hex"),
+    size: bytes.length,
+    contentBase64: bytes.toString("base64"),
+  };
+}
+
+function preparedDigest(files: readonly PiMemoryPhase2PreparedFile[]): string {
+  const parts: Buffer[] = [uint32(files.length)];
+  for (const file of files) {
+    const path = Buffer.from(file.path, "utf8");
+    const hash = Buffer.from(file.hash, "utf8");
+    parts.push(
+      uint32(path.length),
+      path,
+      uint32(hash.length),
+      hash,
+      uint32(file.size),
+    );
+  }
+  const version = Buffer.from(DIGEST_ENCODING, "utf8");
+  return createHash("sha256")
+    .update(Buffer.concat([uint32(version.length), version, ...parts]))
+    .digest("hex");
+}
+
+function preparedResult(
+  storageId: string,
+  input: readonly Readonly<{
+    readonly path: string;
+    readonly content: string | Buffer;
+  }>[],
+): PiMemoryPhase2ConsolidationResult {
+  const files = input
+    .map((file) => {
+      return preparedFile(file.path, file.content);
+    })
+    .sort((left, right) => {
+      return left.path < right.path ? -1 : left.path > right.path ? 1 : 0;
+    });
+  const metadata = files.map((file) => {
+    return { path: file.path, hash: file.hash, size: file.size };
+  });
+  return {
+    status: "prepared",
+    files,
+    manifest: {
+      version: 1,
+      files: metadata,
+      fileCount: files.length,
+      pathBytes: files.reduce((sum, file) => {
+        return sum + Buffer.byteLength(file.path, "utf8");
+      }, 0),
+      totalBytes: files.reduce((sum, file) => {
+        return sum + file.size;
+      }, 0),
+      digest: preparedDigest(files),
+    },
+    contentIdentity: computeContentHashFromHashes(storageId, metadata),
+    diff: {
+      added: 1,
+      changed: 0,
+      deleted: 0,
+      renderedBytes: 0,
+      truncated: false,
+      digest: "d".repeat(64),
+    },
+    selectionDigest: "e".repeat(64),
+    responseId: "fixture-response",
+    usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+  };
+}
+
+function asyncBody(body: Uint8Array): AsyncIterable<Uint8Array> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield body;
+    },
+  };
+}
+
+function installS3(
+  objects: Map<string, Buffer>,
+  pauseFirstPut?: Readonly<{
+    readonly started: Deferred<void>;
+    readonly release: Promise<void>;
+  }>,
+): void {
+  let firstPut = true;
+  testContext().mocks.s3.send.mockImplementation(
+    async (commandValue: unknown) => {
+      if (commandValue instanceof PutObjectCommand) {
+        const key = commandValue.input.Key;
+        if (!key) {
+          throw new Error("S3 test PUT has no key");
+        }
+        if (firstPut && pauseFirstPut) {
+          firstPut = false;
+          pauseFirstPut.started.resolve();
+          await pauseFirstPut.release;
+        }
+        if (objects.has(key)) {
+          const error = new Error("immutable object exists");
+          error.name = "PreconditionFailed";
+          throw error;
+        }
+        const body = commandValue.input.Body;
+        if (typeof body !== "string" && !(body instanceof Uint8Array)) {
+          throw new Error("S3 test PUT body is not bounded bytes");
+        }
+        objects.set(key, Buffer.from(body));
+        return {};
+      }
+      if (commandValue instanceof GetObjectCommand) {
+        const key = commandValue.input.Key;
+        const body = key ? objects.get(key) : undefined;
+        if (!body) {
+          const error = new Error("object missing");
+          error.name = "NotFound";
+          throw error;
+        }
+        return { Body: asyncBody(body), ContentLength: body.length };
+      }
+      return {};
+    },
+  );
+}
+
+function usage() {
+  return {
+    input_tokens: 11,
+    output_tokens: 7,
+    input_tokens_details: { cached_tokens: 2, cache_write_tokens: 3 },
+    output_tokens_details: { reasoning_tokens: 2 },
+    total_tokens: 18,
+  };
+}
+
+function sse(events: readonly unknown[]): string {
+  return events
+    .map((event) => {
+      return `data: ${JSON.stringify(event)}\n\n`;
+    })
+    .join("");
+}
+
+function toolSse(index: number, path: string, content: string): string {
+  const responseId = `resp_worker_tool_${index.toString()}`;
+  const itemId = `fc_worker_${index.toString()}`;
+  const callId = `call_worker_${index.toString()}`;
+  const functionArguments = JSON.stringify({ path, content });
+  const item = {
+    type: "function_call",
+    id: itemId,
+    call_id: callId,
+    name: "phase2_write",
+    arguments: functionArguments,
+    status: "completed",
+  };
+  return sse([
+    {
+      type: "response.created",
+      response: {
+        id: responseId,
+        object: "response",
+        status: "in_progress",
+        output: [],
+        usage: null,
+      },
+    },
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...item, arguments: "", status: "in_progress" },
+    },
+    {
+      type: "response.function_call_arguments.delta",
+      output_index: 0,
+      item_id: itemId,
+      delta: functionArguments,
+    },
+    {
+      type: "response.function_call_arguments.done",
+      output_index: 0,
+      item_id: itemId,
+      arguments: functionArguments,
+    },
+    { type: "response.output_item.done", output_index: 0, item },
+    {
+      type: "response.completed",
+      response: {
+        id: responseId,
+        object: "response",
+        status: "completed",
+        output: [item],
+        usage: usage(),
+      },
+    },
+  ]);
+}
+
+function textSse(index: number): string {
+  const responseId = `${PROVIDER_ID_SECRET}_${index.toString()}`;
+  const item = {
+    type: "message",
+    id: `msg_worker_${index.toString()}`,
+    role: "assistant",
+    status: "completed",
+    content: [
+      { type: "output_text", text: "maintenance complete", annotations: [] },
+    ],
+  };
+  return sse([
+    {
+      type: "response.created",
+      response: {
+        id: responseId,
+        object: "response",
+        status: "in_progress",
+        output: [],
+        usage: null,
+      },
+    },
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...item, status: "in_progress", content: [] },
+    },
+    {
+      type: "response.output_text.delta",
+      output_index: 0,
+      content_index: 0,
+      delta: "maintenance complete",
+    },
+    { type: "response.output_item.done", output_index: 0, item },
+    {
+      type: "response.completed",
+      response: {
+        id: responseId,
+        object: "response",
+        status: "completed",
+        output: [item],
+        usage: usage(),
+      },
+    },
+  ]);
+}
+
+function installProvider(
+  replay = false,
+): Readonly<{ readonly calls: { value: number } }> {
+  const calls = { value: 0 };
+  server.use(
+    http.post(
+      /https:\/\/(?:api\.openai\.com|openrouter\.ai)\/.*\/responses/u,
+      () => {
+        const index = calls.value;
+        calls.value += 1;
+        const phase = replay ? index % 3 : index;
+        const body =
+          phase === 0
+            ? toolSse(phase, "memory/MEMORY.md", `# ${MEMORY_SECRET}\n`)
+            : phase === 1
+              ? toolSse(
+                  phase,
+                  "memory/memory_summary.md",
+                  "v1\n## User Profile\n- first Pi fact\n",
+                )
+              : textSse(phase);
+        return new HttpResponse(body, {
+          headers: { "content-type": "text/event-stream" },
+        });
+      },
+    ),
+  );
+  return { calls };
+}
+
+function installTextOnlyProvider(): Readonly<{
+  readonly calls: { value: number };
+}> {
+  const calls = { value: 0 };
+  server.use(
+    http.post(
+      /https:\/\/(?:api\.openai\.com|openrouter\.ai)\/.*\/responses/u,
+      () => {
+        const index = calls.value;
+        calls.value += 1;
+        return new HttpResponse(textSse(index), {
+          headers: { "content-type": "text/event-stream" },
+        });
+      },
+    ),
+  );
+  return { calls };
+}
+
+function cleanupUsage(scope: Phase2TestScope): void {
+  onTestFinished(async () => {
+    await db()
+      .delete(usageEvent)
+      .where(
+        and(
+          eq(usageEvent.orgId, scope.orgId),
+          eq(usageEvent.userId, scope.userId),
+        ),
+      );
+  });
+}
+
+async function verifyStoredArchive(
+  scope: Phase2TestScope,
+  versionId: string,
+  objects: ReadonlyMap<string, Buffer>,
+) {
+  const [version] = await db()
+    .select({
+      s3Key: storageVersions.s3Key,
+      size: storageVersions.size,
+      archiveSize: storageVersions.archiveSize,
+      fileCount: storageVersions.fileCount,
+    })
+    .from(storageVersions)
+    .where(
+      and(
+        eq(storageVersions.storageId, scope.memoryStorageId),
+        eq(storageVersions.id, versionId),
+      ),
+    );
+  if (!version) {
+    throw new Error("Stored Phase 2 version is missing");
+  }
+  const manifestBytes = objects.get(`${version.s3Key}/manifest.json`);
+  const archiveBytes = objects.get(`${version.s3Key}/archive.tar.gz`);
+  if (!manifestBytes || !archiveBytes) {
+    throw new Error("Stored Phase 2 objects are missing");
+  }
+  return {
+    version,
+    archive: verifyPiMemoryPhase2Archive({
+      storageId: scope.memoryStorageId,
+      versionId,
+      size: version.size,
+      archiveSize: version.archiveSize,
+      fileCount: version.fileCount,
+      manifestBytes,
+      archiveBytes,
+    }),
+  };
+}
+
+async function executeAt(args: {
+  readonly store: ReturnType<typeof createStore>;
+  readonly scope: Phase2TestScope;
+  readonly currentTime: Date;
+  readonly signal: AbortSignal;
+}): Promise<PiMemoryPhase2WorkerResult> {
+  return await withMockNowForTest(args.currentTime, async () => {
+    return (await args.store.set(
+      executePiMemoryPhase2Work$,
+      { scope: args.scope, currentTime: args.currentTime },
+      args.signal,
+    )) as PiMemoryPhase2WorkerResult;
+  });
+}
+
+describe("Pi memory Phase 2 worker composition", () => {
+  it("converges when Pi publishes before an external writer", async () => {
+    const context = testContext();
+    mockEnv("R2_USER_STORAGES_BUCKET_NAME", BUCKET);
+    await seedVm0BuiltInModelKey(context, "gpt-5.6-terra");
+    const provider = installProvider();
+    const objects = new Map<string, Buffer>();
+    installS3(objects);
+
+    const persistedPrefix = `legacy/pi-first/${randomUUID()}`;
+    const scope = await createPhase2TestScope("worker-pi-first", {
+      emptyBase: true,
+      s3Prefix: persistedPrefix,
+    });
+    cleanupUsage(scope);
+    await insertPhase2Candidates(scope, [
+      {
+        piSessionId: randomUUID(),
+        rawMemory: "first Pi durable fact",
+        rolloutSummary: "first Pi durable evidence",
+      },
+    ]);
+    await insertPendingPhase2Job(scope, {
+      inputRevision: 1,
+      updatedAt: new Date(NOW_MS),
+    });
+
+    const store = createStore();
+    const first = await executeAt({
+      store,
+      scope,
+      currentTime: new Date(NOW_MS),
+      signal: context.signal,
+    });
+    expect(first.outcome).toBe("published");
+    if (first.outcome !== "published") {
+      throw new Error("Expected the first Pi publication");
+    }
+    const firstStored = await verifyStoredArchive(
+      scope,
+      first.publishedVersionId,
+      objects,
+    );
+    expect(firstStored.version.s3Key).toBe(
+      `${persistedPrefix}/${first.publishedVersionId}`,
+    );
+
+    const externalFiles = [
+      ...firstStored.archive.files.map((file) => {
+        return { path: file.path, content: Buffer.from(file.bytes) };
+      }),
+      { path: ".git/config", content: "external Codex git state" },
+      { path: "external-fact.md", content: "external durable fact" },
+    ];
+    const externalArchive = buildPiMemoryPhase2Archive(
+      scope.memoryStorageId,
+      preparedResult(scope.memoryStorageId, externalFiles),
+    );
+    const externalS3Key = `legacy/codex-writer/${externalArchive.versionId}`;
+    objects.set(
+      `${externalS3Key}/manifest.json`,
+      externalArchive.manifestBytes,
+    );
+    objects.set(
+      `${externalS3Key}/archive.tar.gz`,
+      externalArchive.archiveBytes,
+    );
+    const externalVersion = await insertPhase2StorageVersion(
+      scope,
+      "pi-first-external",
+      {
+        versionId: externalArchive.versionId,
+        s3Key: externalS3Key,
+        size: externalArchive.size,
+        archiveSize: externalArchive.archiveSize,
+        fileCount: externalArchive.fileCount,
+        createdBy: "external-writer",
+      },
+    );
+    const externalTime = new Date(NOW_MS + 1);
+    await setPhase2StorageHead(scope, externalVersion, externalTime);
+    await db().transaction(async (tx) => {
+      await notifyPiMemoryPhase2ExternalHeadChange(tx, {
+        ...scope,
+        observedHeadVersionId: externalVersion.versionId,
+        changedAt: externalTime,
+      });
+    });
+    const secondInputTime = new Date(NOW_MS + 2);
+    await insertPhase2Candidates(scope, [
+      {
+        piSessionId: randomUUID(),
+        sourceCompletedAt: secondInputTime,
+        rawMemory: "second Pi durable fact",
+        rolloutSummary: "second Pi durable evidence",
+      },
+    ]);
+    await db().transaction(async (tx) => {
+      await advancePiMemoryPhase2InputRevision(tx, {
+        ...scope,
+        enqueuedAt: secondInputTime,
+      });
+    });
+
+    const second = await executeAt({
+      store,
+      scope,
+      currentTime: new Date(NOW_MS + 3),
+      signal: context.signal,
+    });
+    expect(second.outcome).toBe("published");
+    if (second.outcome !== "published") {
+      throw new Error("Expected the reconciled Pi publication");
+    }
+    expect(provider.calls.value).toBe(4);
+    const finalStored = await verifyStoredArchive(
+      scope,
+      second.publishedVersionId,
+      objects,
+    );
+    expect(finalStored.version.s3Key).toBe(
+      `${persistedPrefix}/${second.publishedVersionId}`,
+    );
+    const finalByPath = new Map(
+      finalStored.archive.files.map((file) => {
+        return [file.path, Buffer.from(file.bytes).toString("utf8")] as const;
+      }),
+    );
+    expect(finalByPath.get(".git/config")).toBe("external Codex git state");
+    expect(finalByPath.get("external-fact.md")).toBe("external durable fact");
+    expect(finalByPath.get("MEMORY.md")).toContain(MEMORY_SECRET);
+    expect(
+      [...finalByPath.keys()].filter((path) => {
+        return path.startsWith("rollout_summaries/pi/");
+      }),
+    ).toHaveLength(2);
+    const [head] = await db()
+      .select({ versionId: storages.headVersionId })
+      .from(storages)
+      .where(eq(storages.id, scope.memoryStorageId));
+    expect(head?.versionId).toBe(second.publishedVersionId);
+    const provenance = await db()
+      .select({
+        outcome: piMemoryPublicationProvenance.outcome,
+        writer: piMemoryPublicationProvenance.writer,
+      })
+      .from(piMemoryPublicationProvenance)
+      .where(
+        eq(
+          piMemoryPublicationProvenance.memoryStorageId,
+          scope.memoryStorageId,
+        ),
+      );
+    expect(provenance).toStrictEqual(
+      expect.arrayContaining([
+        { outcome: "published", writer: "pi" },
+        { outcome: "published", writer: "reconciler" },
+      ]),
+    );
+  });
+
+  it("lets an external upload win, then reclaims its exact archive and converges", async () => {
+    const context = testContext();
+    mockEnv("R2_USER_STORAGES_BUCKET_NAME", BUCKET);
+    await seedVm0BuiltInModelKey(context, "gpt-5.6-terra");
+    const provider = installProvider();
+    const objects = new Map<string, Buffer>();
+    const uploadStarted = createDeferredPromise<void>(context.signal);
+    const uploadRelease = createDeferredPromise<void>(context.signal);
+    installS3(objects, {
+      started: uploadStarted,
+      release: uploadRelease.promise,
+    });
+
+    const persistedPrefix = `legacy/pi-memory/${randomUUID()}`;
+    const scope = await createPhase2TestScope("worker-convergence", {
+      emptyBase: true,
+      s3Prefix: persistedPrefix,
+    });
+    onTestFinished(async () => {
+      await db()
+        .delete(usageEvent)
+        .where(
+          and(
+            eq(usageEvent.orgId, scope.orgId),
+            eq(usageEvent.userId, scope.userId),
+          ),
+        );
+    });
+    const piSessionId = randomUUID();
+    await insertPhase2Candidates(scope, [
+      {
+        piSessionId,
+        rawMemory: "first Pi raw fact",
+        rolloutSummary: "first Pi rollout fact",
+      },
+    ]);
+    await insertPendingPhase2Job(scope, {
+      inputRevision: 1,
+      updatedAt: new Date(NOW_MS),
+    });
+
+    const externalFiles = [
+      { path: ".git/config", content: "codex git state" },
+      { path: "MEMORY.md", content: "# External writer fact\n" },
+      {
+        path: "memory_summary.md",
+        content: "v1\n## User Profile\n- external writer fact\n",
+      },
+      { path: "legacy-topic.md", content: "legacy flat fact" },
+      { path: PATH_SECRET, content: "unknown external fact" },
+      { path: "rollout_summaries/codex.md", content: "Codex flat evidence" },
+      {
+        path: "rollout_summaries/pi/older.md",
+        content: "older nested Pi evidence",
+      },
+    ] as const;
+    const externalArchive = buildPiMemoryPhase2Archive(
+      scope.memoryStorageId,
+      preparedResult(scope.memoryStorageId, externalFiles),
+    );
+    const externalS3Key = `legacy/external-memory/${externalArchive.versionId}`;
+    objects.set(
+      `${externalS3Key}/manifest.json`,
+      externalArchive.manifestBytes,
+    );
+    objects.set(
+      `${externalS3Key}/archive.tar.gz`,
+      externalArchive.archiveBytes,
+    );
+    const externalVersion = await insertPhase2StorageVersion(
+      scope,
+      "external",
+      {
+        versionId: externalArchive.versionId,
+        s3Key: externalS3Key,
+        size: externalArchive.size,
+        archiveSize: externalArchive.archiveSize,
+        fileCount: externalArchive.fileCount,
+        createdBy: "external-writer",
+      },
+    );
+
+    const store = createStore();
+    const firstPromise = executeAt({
+      store,
+      scope,
+      currentTime: new Date(NOW_MS),
+      signal: context.signal,
+    });
+    await uploadStarted.promise;
+    await setPhase2StorageHead(scope, externalVersion, new Date(NOW_MS + 1));
+    await db().transaction(async (tx) => {
+      await notifyPiMemoryPhase2ExternalHeadChange(tx, {
+        ...scope,
+        observedHeadVersionId: externalVersion.versionId,
+        changedAt: new Date(NOW_MS + 1),
+      });
+    });
+    const replacementTime = new Date(NOW_MS + 2);
+    const replacementHash = await replacePhase2CandidateSource({
+      scope,
+      piSessionId,
+      sourceCompletedAt: replacementTime,
+    });
+    await db()
+      .update(piMemoryStage1Candidates)
+      .set({
+        status: "succeeded",
+        rawMemory: "replacement Pi raw fact",
+        rolloutSummary: "replacement Pi rollout fact",
+        generatedAt: replacementTime,
+        updatedAt: replacementTime,
+      })
+      .where(
+        and(
+          eq(piMemoryStage1Candidates.memoryStorageId, scope.memoryStorageId),
+          eq(piMemoryStage1Candidates.piSessionId, piSessionId),
+        ),
+      );
+    await db().transaction(async (tx) => {
+      await advancePiMemoryPhase2InputRevision(tx, {
+        ...scope,
+        enqueuedAt: replacementTime,
+      });
+    });
+    uploadRelease.resolve();
+
+    await expect(firstPromise).resolves.toStrictEqual({
+      outcome: "conflicted",
+      currentHeadVersionId: externalVersion.versionId,
+    });
+    await expect(readPhase2Job(scope)).resolves.toMatchObject({
+      status: "pending",
+      retryCount: 0,
+      inputRevision: 3,
+      completedRevision: 0,
+      lastObservedHeadVersionId: externalVersion.versionId,
+    });
+    const [afterConflictCandidate] = await db()
+      .select({
+        sourceHistoryHash: piMemoryStage1Candidates.sourceHistoryHash,
+        selected: piMemoryStage1Candidates.lastSelectedSourceHistoryHash,
+      })
+      .from(piMemoryStage1Candidates)
+      .where(
+        and(
+          eq(piMemoryStage1Candidates.memoryStorageId, scope.memoryStorageId),
+          eq(piMemoryStage1Candidates.piSessionId, piSessionId),
+        ),
+      );
+    expect(afterConflictCandidate).toStrictEqual({
+      sourceHistoryHash: replacementHash,
+      selected: null,
+    });
+
+    const secondTime = new Date(
+      NOW_MS + PI_MEMORY_PHASE2_SUCCESS_COOLDOWN_MS + 2,
+    );
+    const second = await executeAt({
+      store,
+      scope,
+      currentTime: secondTime,
+      signal: context.signal,
+    });
+    expect(second.outcome).toBe("published");
+    if (second.outcome !== "published") {
+      throw new Error("Expected converged publication");
+    }
+    expect(provider.calls.value).toBe(4);
+
+    const [head] = await db()
+      .select({ versionId: storages.headVersionId })
+      .from(storages)
+      .where(eq(storages.id, scope.memoryStorageId));
+    expect(head?.versionId).toBe(second.publishedVersionId);
+    const [version] = await db()
+      .select({
+        s3Key: storageVersions.s3Key,
+        size: storageVersions.size,
+        archiveSize: storageVersions.archiveSize,
+        fileCount: storageVersions.fileCount,
+      })
+      .from(storageVersions)
+      .where(eq(storageVersions.id, second.publishedVersionId));
+    if (!version) {
+      throw new Error("Published version is missing");
+    }
+    expect(version.s3Key).toBe(
+      `${persistedPrefix}/${second.publishedVersionId}`,
+    );
+    const manifestBytes = objects.get(`${version.s3Key}/manifest.json`);
+    const archiveBytes = objects.get(`${version.s3Key}/archive.tar.gz`);
+    if (!manifestBytes || !archiveBytes) {
+      throw new Error("Published immutable objects are missing");
+    }
+    const verified = verifyPiMemoryPhase2Archive({
+      storageId: scope.memoryStorageId,
+      versionId: second.publishedVersionId,
+      size: version.size,
+      archiveSize: version.archiveSize,
+      fileCount: version.fileCount,
+      manifestBytes,
+      archiveBytes,
+    });
+    const finalPaths = verified.files.map((file) => {
+      return file.path;
+    });
+    for (const file of externalFiles) {
+      expect(finalPaths).toContain(file.path);
+    }
+    expect(
+      finalPaths.some((path) => {
+        return (
+          path.startsWith("rollout_summaries/pi/") &&
+          path !== "rollout_summaries/pi/older.md"
+        );
+      }),
+    ).toBeTruthy();
+
+    const [selectedCandidate] = await db()
+      .select({
+        selected: piMemoryStage1Candidates.lastSelectedSourceHistoryHash,
+      })
+      .from(piMemoryStage1Candidates)
+      .where(
+        eq(piMemoryStage1Candidates.memoryStorageId, scope.memoryStorageId),
+      );
+    expect(selectedCandidate?.selected).toBe(replacementHash);
+    const usageRows = await db()
+      .select({ runId: usageEvent.runId })
+      .from(usageEvent)
+      .where(
+        and(
+          eq(usageEvent.orgId, scope.orgId),
+          eq(usageEvent.userId, scope.userId),
+        ),
+      );
+    expect(usageRows).toHaveLength(8);
+    expect(
+      usageRows.every((row) => {
+        return row.runId === null;
+      }),
+    ).toBeTruthy();
+    const provenance = await db()
+      .select({ outcome: piMemoryPublicationProvenance.outcome })
+      .from(piMemoryPublicationProvenance)
+      .where(
+        eq(
+          piMemoryPublicationProvenance.memoryStorageId,
+          scope.memoryStorageId,
+        ),
+      );
+    expect(provenance).toStrictEqual(
+      expect.arrayContaining([
+        { outcome: "conflicted" },
+        { outcome: "published" },
+      ]),
+    );
+    const projections = await db()
+      .select({ versionId: memorySummaryProjections.storageVersionId })
+      .from(memorySummaryProjections)
+      .where(
+        eq(memorySummaryProjections.memoryStorageId, scope.memoryStorageId),
+      );
+    expect(projections).toStrictEqual([
+      { versionId: second.publishedVersionId },
+    ]);
+
+    const capturedLogs =
+      JSON.stringify(context.mocks.axiomLogging.debug.mock.calls) +
+      JSON.stringify(context.mocks.axiomLogging.info.mock.calls) +
+      JSON.stringify(context.mocks.axiomLogging.warn.mock.calls);
+    expect(capturedLogs).not.toContain(MEMORY_SECRET);
+    expect(capturedLogs).not.toContain(PATH_SECRET);
+    expect(capturedLogs).not.toContain(PROVIDER_ID_SECRET);
+  });
+
+  it("reuses a detached registered archive and provider usage after a stale replay", async () => {
+    const context = testContext();
+    mockEnv("R2_USER_STORAGES_BUCKET_NAME", BUCKET);
+    await seedVm0BuiltInModelKey(context, "gpt-5.6-terra");
+    const provider = installProvider(true);
+    const objects = new Map<string, Buffer>();
+    const uploadStarted = createDeferredPromise<void>(context.signal);
+    const uploadRelease = createDeferredPromise<void>(context.signal);
+    installS3(objects, {
+      started: uploadStarted,
+      release: uploadRelease.promise,
+    });
+
+    const scope = await createPhase2TestScope("worker-replay", {
+      emptyBase: true,
+      s3Prefix: `legacy/replay/${randomUUID()}`,
+    });
+    cleanupUsage(scope);
+    const [sourceHistoryHash] = await insertPhase2Candidates(scope, [
+      {
+        piSessionId: randomUUID(),
+        rawMemory: "replayed Pi raw fact",
+        rolloutSummary: "replayed Pi evidence",
+      },
+    ]);
+    await insertPendingPhase2Job(scope, {
+      inputRevision: 1,
+      updatedAt: new Date(NOW_MS),
+    });
+
+    const store = createStore();
+    const firstPromise = executeAt({
+      store,
+      scope,
+      currentTime: new Date(NOW_MS),
+      signal: context.signal,
+    });
+    await uploadStarted.promise;
+    await db()
+      .update(piMemoryPhase2Jobs)
+      .set({ leaseToken: randomUUID() })
+      .where(eq(piMemoryPhase2Jobs.memoryStorageId, scope.memoryStorageId));
+    uploadRelease.resolve();
+    await expect(firstPromise).resolves.toStrictEqual({ outcome: "stale" });
+    const putCountAfterFirst = context.mocks.s3.send.mock.calls.filter(
+      ([command]) => {
+        return command instanceof PutObjectCommand;
+      },
+    ).length;
+    expect(putCountAfterFirst).toBe(2);
+
+    const detachedVersions = await db()
+      .select({ id: storageVersions.id })
+      .from(storageVersions)
+      .where(eq(storageVersions.storageId, scope.memoryStorageId));
+    expect(detachedVersions).toHaveLength(2);
+    const detachedVersionId = detachedVersions.find((version) => {
+      return version.id !== scope.baseVersion.versionId;
+    })?.id;
+    if (!detachedVersionId) {
+      throw new Error("Expected one detached prepared version");
+    }
+    const firstUsage = await db()
+      .select({ idempotencyKey: usageEvent.idempotencyKey })
+      .from(usageEvent)
+      .where(
+        and(
+          eq(usageEvent.orgId, scope.orgId),
+          eq(usageEvent.userId, scope.userId),
+        ),
+      );
+    expect(firstUsage).toHaveLength(4);
+
+    const retryTime = new Date(
+      NOW_MS + PI_MEMORY_PHASE2_LEASE_DURATION_MS * 24,
+    );
+    const replay = await executeAt({
+      store,
+      scope,
+      currentTime: retryTime,
+      signal: context.signal,
+    });
+    expect(replay).toStrictEqual({
+      outcome: "published",
+      publishedVersionId: detachedVersionId,
+    });
+    expect(provider.calls.value).toBe(6);
+    expect(
+      context.mocks.s3.send.mock.calls.filter(([command]) => {
+        return command instanceof PutObjectCommand;
+      }),
+    ).toHaveLength(putCountAfterFirst);
+
+    await db().transaction(async (tx) => {
+      await advancePiMemoryPhase2InputRevision(tx, {
+        ...scope,
+        enqueuedAt: new Date(retryTime.getTime() + 1),
+      });
+    });
+    const noDiff = await executeAt({
+      store,
+      scope,
+      currentTime: new Date(
+        retryTime.getTime() + PI_MEMORY_PHASE2_SUCCESS_COOLDOWN_MS + 2,
+      ),
+      signal: context.signal,
+    });
+    expect(noDiff).toStrictEqual({
+      outcome: "no_diff",
+      headVersionId: detachedVersionId,
+    });
+    expect(provider.calls.value).toBe(6);
+
+    const versions = await db()
+      .select({ id: storageVersions.id })
+      .from(storageVersions)
+      .where(eq(storageVersions.storageId, scope.memoryStorageId));
+    expect(versions).toHaveLength(2);
+    const usageRows = await db()
+      .select({ runId: usageEvent.runId })
+      .from(usageEvent)
+      .where(
+        and(
+          eq(usageEvent.orgId, scope.orgId),
+          eq(usageEvent.userId, scope.userId),
+        ),
+      );
+    expect(usageRows).toHaveLength(4);
+    expect(
+      usageRows.every((row) => {
+        return row.runId === null;
+      }),
+    ).toBeTruthy();
+    const provenance = await db()
+      .select({ outcome: piMemoryPublicationProvenance.outcome })
+      .from(piMemoryPublicationProvenance)
+      .where(
+        eq(
+          piMemoryPublicationProvenance.memoryStorageId,
+          scope.memoryStorageId,
+        ),
+      );
+    expect(provenance).toStrictEqual([{ outcome: "published" }]);
+    const projections = await db()
+      .select({ versionId: memorySummaryProjections.storageVersionId })
+      .from(memorySummaryProjections)
+      .where(
+        eq(memorySummaryProjections.memoryStorageId, scope.memoryStorageId),
+      );
+    expect(projections).toStrictEqual([{ versionId: detachedVersionId }]);
+    const [candidate] = await db()
+      .select({
+        selected: piMemoryStage1Candidates.lastSelectedSourceHistoryHash,
+      })
+      .from(piMemoryStage1Candidates)
+      .where(
+        eq(piMemoryStage1Candidates.memoryStorageId, scope.memoryStorageId),
+      );
+    expect(candidate?.selected).toBe(sourceHistoryHash);
+  });
+
+  it("persists terminal usage but publishes nothing after invalid provider output", async () => {
+    const context = testContext();
+    mockEnv("R2_USER_STORAGES_BUCKET_NAME", BUCKET);
+    await seedVm0BuiltInModelKey(context, "gpt-5.6-terra");
+    const provider = installTextOnlyProvider();
+    const objects = new Map<string, Buffer>();
+    installS3(objects);
+
+    const scope = await createPhase2TestScope("worker-invalid-output", {
+      emptyBase: true,
+    });
+    cleanupUsage(scope);
+    await insertPhase2Candidates(scope, [
+      {
+        piSessionId: randomUUID(),
+        rawMemory: "invalid-output raw fact",
+        rolloutSummary: "invalid-output evidence",
+      },
+    ]);
+    await insertPendingPhase2Job(scope, {
+      inputRevision: 1,
+      updatedAt: new Date(NOW_MS),
+    });
+
+    const response = executeAt({
+      store: createStore(),
+      scope,
+      currentTime: new Date(NOW_MS),
+      signal: context.signal,
+    });
+    await expect(response).resolves.toStrictEqual({
+      outcome: "failed",
+      errorClass: "agent_output_invalid",
+    });
+    expect(provider.calls.value).toBe(1);
+    const [storage] = await db()
+      .select({ headVersionId: storages.headVersionId })
+      .from(storages)
+      .where(eq(storages.id, scope.memoryStorageId));
+    expect(storage?.headVersionId).toBe(scope.baseVersion.versionId);
+    const versions = await db()
+      .select({ id: storageVersions.id })
+      .from(storageVersions)
+      .where(eq(storageVersions.storageId, scope.memoryStorageId));
+    expect(versions).toStrictEqual([{ id: scope.baseVersion.versionId }]);
+    const usageRows = await db()
+      .select({ runId: usageEvent.runId })
+      .from(usageEvent)
+      .where(
+        and(
+          eq(usageEvent.orgId, scope.orgId),
+          eq(usageEvent.userId, scope.userId),
+        ),
+      );
+    expect(usageRows).toHaveLength(4);
+    expect(
+      usageRows.every((row) => {
+        return row.runId === null;
+      }),
+    ).toBeTruthy();
+    await expect(readPhase2Job(scope)).resolves.toMatchObject({
+      status: "retryable_failure",
+      retryCount: 1,
+      completedRevision: 0,
+      lastErrorClass: "agent_output_invalid",
+    });
+    await expect(
+      db()
+        .select()
+        .from(piMemoryPublicationProvenance)
+        .where(
+          eq(
+            piMemoryPublicationProvenance.memoryStorageId,
+            scope.memoryStorageId,
+          ),
+        ),
+    ).resolves.toHaveLength(0);
+    await expect(
+      db()
+        .select()
+        .from(memorySummaryProjections)
+        .where(
+          eq(memorySummaryProjections.memoryStorageId, scope.memoryStorageId),
+        ),
+    ).resolves.toHaveLength(0);
+  });
+
+  it("fails closed when an exact registered non-empty base object is missing", async () => {
+    const context = testContext();
+    mockEnv("R2_USER_STORAGES_BUCKET_NAME", BUCKET);
+    await seedVm0BuiltInModelKey(context, "gpt-5.6-terra");
+    const objects = new Map<string, Buffer>();
+    installS3(objects);
+    const scope = await createPhase2TestScope("worker-missing-base");
+    await insertPhase2Candidates(scope, [
+      {
+        piSessionId: randomUUID(),
+        rawMemory: "must not reach provider",
+        rolloutSummary: "must not reach provider",
+      },
+    ]);
+    await insertPendingPhase2Job(scope, {
+      inputRevision: 1,
+      updatedAt: new Date(NOW_MS),
+    });
+
+    const response = executeAt({
+      store: createStore(),
+      scope,
+      currentTime: new Date(NOW_MS),
+      signal: context.signal,
+    });
+    await expect(response).resolves.toMatchObject({ outcome: "failed" });
+    const [storage] = await db()
+      .select({ headVersionId: storages.headVersionId })
+      .from(storages)
+      .where(eq(storages.id, scope.memoryStorageId));
+    expect(storage?.headVersionId).toBe(scope.baseVersion.versionId);
+    await expect(readPhase2Job(scope)).resolves.toMatchObject({
+      status: "retryable_failure",
+      retryCount: 1,
+      completedRevision: 0,
+    });
+  });
+
+  it("returns a successful no-op when no exact claim exists", async () => {
+    const context = testContext();
+    const scope = await createPhase2TestScope("worker-no-work", {
+      emptyBase: true,
+    });
+    const result = executeAt({
+      store: createStore(),
+      scope,
+      currentTime: new Date(NOW_MS),
+      signal: context.signal,
+    });
+    await expect(result).resolves.toStrictEqual({ outcome: "no_work" });
+  });
+});

--- a/turbo/apps/api/src/signals/services/pi-memory-phase2-archive.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-phase2-archive.service.ts
@@ -1,0 +1,901 @@
+import { createHash } from "node:crypto";
+import { posix } from "node:path";
+import { gunzipSync, gzipSync, inflateRawSync } from "node:zlib";
+
+import {
+  MAX_FILE_SIZE_BYTES,
+  STORAGE_MANIFEST_MAX_FILES,
+  STORAGE_MANIFEST_MAX_PATH_BYTES,
+} from "@okouai/api-contracts/contracts/storages";
+import {
+  PI_MEMORY_PHASE2_PREPARED_MAX_BYTES,
+  type PiMemoryPhase2BaseFile,
+  type PiMemoryPhase2ConsolidationResult,
+  type PiMemoryPhase2PreparedFile,
+} from "@okouai/pi-agent-runtime/api";
+
+import { safeJsonParse, safeSync } from "../utils";
+import { computeContentHashFromHashes } from "./storage-content-hash.service";
+
+export const PI_MEMORY_PHASE2_MANIFEST_MAX_BYTES = 16 * 1024 * 1024;
+const TAR_BLOCK_BYTES = 512;
+const TAR_MAX_ENTRY_OVERHEAD_BYTES = TAR_BLOCK_BYTES * 4 + 64;
+const PI_MEMORY_PHASE2_TAR_MAX_BYTES =
+  PI_MEMORY_PHASE2_PREPARED_MAX_BYTES +
+  STORAGE_MANIFEST_MAX_PATH_BYTES +
+  STORAGE_MANIFEST_MAX_FILES * TAR_MAX_ENTRY_OVERHEAD_BYTES +
+  1024;
+export const PI_MEMORY_PHASE2_ARCHIVE_MAX_BYTES =
+  PI_MEMORY_PHASE2_TAR_MAX_BYTES + 1024 * 1024;
+
+const SAFE_SHA256 = /^[a-f0-9]{64}$/u;
+const WINDOWS_DRIVE = /^[A-Za-z]:/u;
+const MANIFEST_DIGEST_ENCODING = "vm0.pi-memory.phase2.manifest.v1";
+
+interface ArchiveFile {
+  readonly path: string;
+  readonly hash: string;
+  readonly size: number;
+  readonly bytes: Buffer;
+}
+
+interface CanonicalManifest {
+  readonly version: 1;
+  readonly files: readonly Readonly<{
+    readonly path: string;
+    readonly hash: string;
+    readonly size: number;
+  }>[];
+  readonly createdAt: string;
+}
+
+export interface PiMemoryPhase2ArchiveIdentity {
+  readonly files: readonly PiMemoryPhase2BaseFile[];
+  readonly versionId: string;
+  readonly size: number;
+  readonly archiveSize: number;
+  readonly fileCount: number;
+}
+
+export interface PreparedPiMemoryPhase2Archive extends PiMemoryPhase2ArchiveIdentity {
+  readonly manifestBytes: Buffer;
+  readonly archiveBytes: Buffer;
+}
+
+export class PiMemoryPhase2ArchiveError extends Error {
+  constructor(readonly errorClass: string) {
+    super("Pi memory Phase 2 archive validation failed");
+    this.name = "PiMemoryPhase2ArchiveError";
+  }
+}
+
+function fail(errorClass: string): never {
+  throw new PiMemoryPhase2ArchiveError(errorClass);
+}
+
+function hashBytes(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function compareText(left: string, right: string): number {
+  return left === right ? 0 : left < right ? -1 : 1;
+}
+
+function safePath(path: string): boolean {
+  if (
+    path.length === 0 ||
+    path.startsWith("/") ||
+    WINDOWS_DRIVE.test(path) ||
+    path.includes("\\") ||
+    path.includes("\0") ||
+    path.includes("//") ||
+    posix.normalize(path) !== path ||
+    Buffer.from(path, "utf8").toString("utf8") !== path
+  ) {
+    return false;
+  }
+  return path.split("/").every((part) => {
+    return part.length > 0 && part !== "." && part !== "..";
+  });
+}
+
+function validatePaths(paths: readonly string[]): void {
+  const ordered = [...paths].sort(compareText);
+  const folded = ordered
+    .map((path) => {
+      return path.normalize("NFC").toLocaleLowerCase("en");
+    })
+    .sort(compareText);
+  for (const collection of [ordered, folded]) {
+    for (let index = 0; index < collection.length; index += 1) {
+      const current = collection[index];
+      const previous = collection[index - 1];
+      if (
+        current === undefined ||
+        !safePath(current) ||
+        current === previous ||
+        (previous !== undefined && current.startsWith(`${previous}/`))
+      ) {
+        fail("path_invalid");
+      }
+    }
+  }
+}
+
+function validateFiles(files: readonly ArchiveFile[]): readonly ArchiveFile[] {
+  if (files.length > STORAGE_MANIFEST_MAX_FILES) {
+    fail("file_count_exceeded");
+  }
+  validatePaths(
+    files.map((file) => {
+      return file.path;
+    }),
+  );
+  let pathBytes = 0;
+  let totalBytes = 0;
+  for (const file of files) {
+    pathBytes += Buffer.byteLength(file.path, "utf8");
+    totalBytes += file.size;
+    if (
+      !Number.isSafeInteger(file.size) ||
+      file.size < 0 ||
+      file.size > MAX_FILE_SIZE_BYTES ||
+      file.bytes.length !== file.size ||
+      !SAFE_SHA256.test(file.hash) ||
+      hashBytes(file.bytes) !== file.hash ||
+      pathBytes > STORAGE_MANIFEST_MAX_PATH_BYTES ||
+      totalBytes > PI_MEMORY_PHASE2_PREPARED_MAX_BYTES ||
+      !Number.isSafeInteger(totalBytes)
+    ) {
+      fail("file_identity_mismatch");
+    }
+  }
+  return [...files].sort((left, right) => {
+    return (
+      compareText(left.path, right.path) || compareText(left.hash, right.hash)
+    );
+  });
+}
+
+function objectRecord(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail("manifest_invalid");
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+): boolean {
+  const actual = Object.keys(value).sort(compareText);
+  return (
+    actual.length === expected.length &&
+    actual.every((key, index) => {
+      return key === [...expected].sort(compareText)[index];
+    })
+  );
+}
+
+function parseManifest(bytes: Buffer): CanonicalManifest {
+  if (
+    bytes.length === 0 ||
+    bytes.length > PI_MEMORY_PHASE2_MANIFEST_MAX_BYTES
+  ) {
+    fail("manifest_size_invalid");
+  }
+  const decoded = safeSync(() => {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  });
+  if (!("ok" in decoded)) {
+    fail("manifest_invalid");
+  }
+  const parsed = safeJsonParse(decoded.ok);
+  const manifest = objectRecord(parsed);
+  if (
+    !exactKeys(manifest, ["version", "files", "createdAt"]) ||
+    manifest.version !== 1 ||
+    typeof manifest.createdAt !== "string" ||
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/u.test(
+      manifest.createdAt,
+    ) ||
+    !Array.isArray(manifest.files) ||
+    manifest.files.length > STORAGE_MANIFEST_MAX_FILES
+  ) {
+    fail("manifest_invalid");
+  }
+  const createdAt = manifest.createdAt as string;
+  const canonicalCreatedAt = safeSync(() => {
+    return new Date(createdAt).toISOString();
+  });
+  if (!("ok" in canonicalCreatedAt) || canonicalCreatedAt.ok !== createdAt) {
+    fail("manifest_invalid");
+  }
+  const files = manifest.files.map((candidate) => {
+    const file = objectRecord(candidate);
+    if (
+      !exactKeys(file, ["path", "hash", "size"]) ||
+      typeof file.path !== "string" ||
+      typeof file.hash !== "string" ||
+      typeof file.size !== "number"
+    ) {
+      fail("manifest_invalid");
+    }
+    return { path: file.path, hash: file.hash, size: file.size };
+  });
+  return { version: 1, files, createdAt };
+}
+
+function zeroBlock(block: Buffer): boolean {
+  return block.every((byte) => {
+    return byte === 0;
+  });
+}
+
+function rawField(block: Buffer, offset: number, length: number): Buffer {
+  const field = block.subarray(offset, offset + length);
+  const end = field.indexOf(0);
+  if (end === -1) {
+    return field;
+  }
+  if (!zeroBlock(field.subarray(end))) {
+    fail("tar_header_invalid");
+  }
+  return field.subarray(0, end);
+}
+
+function utf8Field(block: Buffer, offset: number, length: number): string {
+  const decoded = safeSync(() => {
+    return new TextDecoder("utf-8", { fatal: true }).decode(
+      rawField(block, offset, length),
+    );
+  });
+  if (!("ok" in decoded)) {
+    fail("path_utf8_invalid");
+  }
+  return decoded.ok;
+}
+
+function octalField(block: Buffer, offset: number, length: number): number {
+  const field = block.subarray(offset, offset + length).toString("ascii");
+  let start = 0;
+  while (field.charCodeAt(start) === 32) {
+    start += 1;
+  }
+  let end = field.length;
+  while (
+    end > start &&
+    (field.charCodeAt(end - 1) === 0 || field.charCodeAt(end - 1) === 32)
+  ) {
+    end -= 1;
+  }
+  const raw = field.slice(start, end);
+  if (!/^[0-7]+$/u.test(raw)) {
+    fail("tar_header_invalid");
+  }
+  const value = Number.parseInt(raw, 8);
+  if (!Number.isSafeInteger(value) || value < 0) {
+    fail("tar_header_invalid");
+  }
+  return value;
+}
+
+function verifyHeader(block: Buffer): void {
+  const expected = octalField(block, 148, 8);
+  let actual = 0;
+  for (let index = 0; index < TAR_BLOCK_BYTES; index += 1) {
+    actual += index >= 148 && index < 156 ? 32 : block.readUInt8(index);
+  }
+  if (expected !== actual) {
+    fail("tar_checksum_mismatch");
+  }
+}
+
+function parsePax(payload: Buffer): Readonly<{ path?: string; size?: number }> {
+  let offset = 0;
+  const fields = new Map<string, string>();
+  while (offset < payload.length) {
+    const space = payload.indexOf(32, offset);
+    if (space === -1) {
+      fail("tar_pax_invalid");
+    }
+    const lengthText = payload.subarray(offset, space).toString("ascii");
+    if (!/^[1-9][0-9]*$/u.test(lengthText)) {
+      fail("tar_pax_invalid");
+    }
+    const length = Number(lengthText);
+    const end = offset + length;
+    if (
+      !Number.isSafeInteger(length) ||
+      end > payload.length ||
+      payload[end - 1] !== 10
+    ) {
+      fail("tar_pax_invalid");
+    }
+    const decoded = safeSync(() => {
+      return new TextDecoder("utf-8", { fatal: true }).decode(
+        payload.subarray(space + 1, end - 1),
+      );
+    });
+    if (!("ok" in decoded)) {
+      fail("tar_pax_invalid");
+    }
+    const record = decoded.ok;
+    const equals = record.indexOf("=");
+    if (equals <= 0) {
+      fail("tar_pax_invalid");
+    }
+    const key = record.slice(0, equals);
+    if ((key !== "path" && key !== "size") || fields.has(key)) {
+      fail("tar_pax_unsupported");
+    }
+    fields.set(key, record.slice(equals + 1));
+    offset = end;
+  }
+  const sizeText = fields.get("size");
+  if (sizeText !== undefined && !/^(?:0|[1-9][0-9]*)$/u.test(sizeText)) {
+    fail("tar_pax_invalid");
+  }
+  return {
+    ...(fields.has("path") ? { path: fields.get("path") } : {}),
+    ...(sizeText === undefined ? {} : { size: Number(sizeText) }),
+  };
+}
+
+interface TarParseState {
+  pendingPath?: string;
+  pendingSize?: number;
+}
+
+function tarPayload(
+  tarBytes: Buffer,
+  header: Buffer,
+  offset: number,
+): Readonly<{ payload: Buffer; nextOffset: number; headerSize: number }> {
+  const headerSize = octalField(header, 124, 12);
+  const paddedSize = Math.ceil(headerSize / TAR_BLOCK_BYTES) * TAR_BLOCK_BYTES;
+  if (offset + paddedSize > tarBytes.length) {
+    fail("tar_truncated");
+  }
+  const payload = tarBytes.subarray(offset, offset + headerSize);
+  const padding = tarBytes.subarray(offset + headerSize, offset + paddedSize);
+  if (!zeroBlock(padding)) {
+    fail("tar_padding_invalid");
+  }
+  return { payload, nextOffset: offset + paddedSize, headerSize };
+}
+
+function consumePax(state: TarParseState, payload: Buffer): void {
+  if (state.pendingPath !== undefined || state.pendingSize !== undefined) {
+    fail("tar_metadata_ambiguous");
+  }
+  const pax = parsePax(payload);
+  state.pendingPath = pax.path;
+  state.pendingSize = pax.size;
+  if (state.pendingPath === undefined && state.pendingSize === undefined) {
+    fail("tar_pax_invalid");
+  }
+}
+
+function consumeLongPath(state: TarParseState, payload: Buffer): void {
+  if (
+    state.pendingPath !== undefined ||
+    state.pendingSize !== undefined ||
+    payload.length < 2 ||
+    payload.at(-1) !== 0
+  ) {
+    fail("tar_metadata_ambiguous");
+  }
+  const name = payload.subarray(0, -1);
+  if (name.includes(0)) {
+    fail("tar_metadata_ambiguous");
+  }
+  const decoded = safeSync(() => {
+    return new TextDecoder("utf-8", { fatal: true }).decode(name);
+  });
+  if (!("ok" in decoded)) {
+    fail("path_utf8_invalid");
+  }
+  state.pendingPath = decoded.ok;
+}
+
+function consumeRegularFile(args: {
+  readonly state: TarParseState;
+  readonly header: Buffer;
+  readonly payload: Buffer;
+  readonly headerSize: number;
+  readonly files: ArchiveFile[];
+}): void {
+  if (args.files.length >= STORAGE_MANIFEST_MAX_FILES) {
+    fail("file_count_exceeded");
+  }
+  const name = utf8Field(args.header, 0, 100);
+  const prefix = utf8Field(args.header, 345, 155);
+  const path =
+    args.state.pendingPath ?? (prefix.length > 0 ? `${prefix}/${name}` : name);
+  const size = args.state.pendingSize ?? args.headerSize;
+  if (size !== args.headerSize) {
+    fail("tar_size_mismatch");
+  }
+  args.files.push({
+    path,
+    hash: hashBytes(args.payload),
+    size,
+    bytes: Buffer.from(args.payload),
+  });
+  args.state.pendingPath = undefined;
+  args.state.pendingSize = undefined;
+}
+
+function consumeTarEntry(args: {
+  readonly state: TarParseState;
+  readonly header: Buffer;
+  readonly payload: Buffer;
+  readonly headerSize: number;
+  readonly files: ArchiveFile[];
+}): void {
+  const type = args.header.readUInt8(156);
+  if (type === 120) {
+    consumePax(args.state, args.payload);
+    return;
+  }
+  if (type === 76) {
+    consumeLongPath(args.state, args.payload);
+    return;
+  }
+  if (type !== 0 && type !== 48) {
+    fail("tar_type_unsupported");
+  }
+  consumeRegularFile(args);
+}
+
+function verifyTarEnd(
+  tarBytes: Buffer,
+  offset: number,
+  state: TarParseState,
+): void {
+  const second = tarBytes.subarray(offset, offset + TAR_BLOCK_BYTES);
+  if (second.length !== TAR_BLOCK_BYTES || !zeroBlock(second)) {
+    fail("tar_truncated");
+  }
+  if (
+    !zeroBlock(tarBytes.subarray(offset + TAR_BLOCK_BYTES)) ||
+    state.pendingPath !== undefined ||
+    state.pendingSize !== undefined
+  ) {
+    fail("tar_trailing_ambiguity");
+  }
+}
+
+function parseTar(tarBytes: Buffer): readonly ArchiveFile[] {
+  if (
+    tarBytes.length < TAR_BLOCK_BYTES * 2 ||
+    tarBytes.length > PI_MEMORY_PHASE2_TAR_MAX_BYTES ||
+    tarBytes.length % TAR_BLOCK_BYTES !== 0
+  ) {
+    fail("tar_size_invalid");
+  }
+  const files: ArchiveFile[] = [];
+  const state: TarParseState = {};
+  let offset = 0;
+  while (offset < tarBytes.length) {
+    const header = tarBytes.subarray(offset, offset + TAR_BLOCK_BYTES);
+    offset += TAR_BLOCK_BYTES;
+    if (zeroBlock(header)) {
+      verifyTarEnd(tarBytes, offset, state);
+      return validateFiles(files);
+    }
+    verifyHeader(header);
+    const entry = tarPayload(tarBytes, header, offset);
+    offset = entry.nextOffset;
+    consumeTarEntry({ state, header, files, ...entry });
+  }
+  fail("tar_truncated");
+}
+
+function manifestFiles(files: readonly ArchiveFile[]) {
+  return files.map((file) => {
+    return { path: file.path, hash: file.hash, size: file.size };
+  });
+}
+
+function assertManifestMatches(
+  manifest: CanonicalManifest,
+  files: readonly ArchiveFile[],
+): void {
+  const expected = manifestFiles(files);
+  const actual = [...manifest.files].sort((left, right) => {
+    return (
+      compareText(left.path, right.path) || compareText(left.hash, right.hash)
+    );
+  });
+  if (
+    actual.length !== expected.length ||
+    actual.some((file, index) => {
+      const wanted = expected[index];
+      return (
+        wanted === undefined ||
+        file.path !== wanted.path ||
+        file.hash !== wanted.hash ||
+        file.size !== wanted.size
+      );
+    })
+  ) {
+    fail("manifest_payload_mismatch");
+  }
+}
+
+function writeOctal(
+  block: Buffer,
+  offset: number,
+  length: number,
+  value: number,
+): void {
+  const text = value.toString(8).padStart(length - 1, "0");
+  if (text.length > length - 1) {
+    fail("tar_header_overflow");
+  }
+  block.write(text, offset, length - 1, "ascii");
+  block[offset + length - 1] = 0;
+}
+
+function pathFields(
+  path: string,
+): { readonly name: string; readonly prefix: string } | null {
+  if (Buffer.byteLength(path, "utf8") <= 100) {
+    return { name: path, prefix: "" };
+  }
+  const separators = [...path.matchAll(/\//gu)].map((match) => {
+    return match.index;
+  });
+  for (let index = separators.length - 1; index >= 0; index -= 1) {
+    const separator = separators[index];
+    if (separator === undefined) {
+      continue;
+    }
+    const prefix = path.slice(0, separator);
+    const name = path.slice(separator + 1);
+    if (
+      Buffer.byteLength(prefix, "utf8") <= 155 &&
+      Buffer.byteLength(name, "utf8") <= 100
+    ) {
+      return { name, prefix };
+    }
+  }
+  return null;
+}
+
+function tarHeader(path: string, size: number, type: number): Buffer {
+  const fields = pathFields(path);
+  if (!fields) {
+    fail("tar_path_too_long");
+  }
+  const block = Buffer.alloc(TAR_BLOCK_BYTES);
+  block.write(fields.name, 0, 100, "utf8");
+  writeOctal(block, 100, 8, 0o644);
+  writeOctal(block, 108, 8, 0);
+  writeOctal(block, 116, 8, 0);
+  writeOctal(block, 124, 12, size);
+  writeOctal(block, 136, 12, 0);
+  block.fill(32, 148, 156);
+  block[156] = type;
+  block.write("ustar\0", 257, 6, "ascii");
+  block.write("00", 263, 2, "ascii");
+  block.write(fields.prefix, 345, 155, "utf8");
+  let checksum = 0;
+  for (const byte of block) {
+    checksum += byte;
+  }
+  const checksumText = checksum.toString(8).padStart(6, "0");
+  block.write(checksumText, 148, 6, "ascii");
+  block[154] = 0;
+  block[155] = 32;
+  return block;
+}
+
+function paxRecord(key: string, value: string): Buffer {
+  let length = Buffer.byteLength(`${key}=${value}\n`, "utf8") + 2;
+  while (true) {
+    const record = `${length} ${key}=${value}\n`;
+    const bytes = Buffer.from(record, "utf8");
+    if (bytes.length === length) {
+      return bytes;
+    }
+    length = bytes.length;
+  }
+}
+
+function appendTarEntry(parts: Buffer[], path: string, bytes: Buffer): void {
+  let headerPath = path;
+  if (pathFields(path) === null) {
+    const identity = hashBytes(Buffer.from(path, "utf8"));
+    const pax = paxRecord("path", path);
+    parts.push(
+      tarHeader(`PaxHeaders/${identity}`, pax.length, 120),
+      pax,
+      Buffer.alloc(
+        (TAR_BLOCK_BYTES - (pax.length % TAR_BLOCK_BYTES)) % TAR_BLOCK_BYTES,
+      ),
+    );
+    headerPath = `Files/${identity}`;
+  }
+  parts.push(
+    tarHeader(headerPath, bytes.length, 48),
+    bytes,
+    Buffer.alloc(
+      (TAR_BLOCK_BYTES - (bytes.length % TAR_BLOCK_BYTES)) % TAR_BLOCK_BYTES,
+    ),
+  );
+}
+
+function buildTar(files: readonly ArchiveFile[]): Buffer {
+  const parts: Buffer[] = [];
+  for (const file of files) {
+    appendTarEntry(parts, file.path, file.bytes);
+  }
+  parts.push(Buffer.alloc(TAR_BLOCK_BYTES * 2));
+  const tar = Buffer.concat(parts);
+  if (tar.length > PI_MEMORY_PHASE2_TAR_MAX_BYTES) {
+    fail("tar_size_invalid");
+  }
+  return tar;
+}
+
+function archiveFilesFromPrepared(
+  prepared: readonly PiMemoryPhase2PreparedFile[],
+): readonly ArchiveFile[] {
+  const files = prepared.map((file) => {
+    if (
+      !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u.test(
+        file.contentBase64,
+      )
+    ) {
+      fail("prepared_base64_invalid");
+    }
+    return {
+      path: file.path,
+      hash: file.hash,
+      size: file.size,
+      bytes: Buffer.from(file.contentBase64, "base64"),
+    };
+  });
+  return validateFiles(files);
+}
+
+function uint32(value: number): Buffer {
+  const result = Buffer.alloc(4);
+  result.writeUInt32BE(value);
+  return result;
+}
+
+function preparedManifestDigest(files: readonly ArchiveFile[]): string {
+  const parts: Buffer[] = [uint32(files.length)];
+  for (const file of files) {
+    const path = Buffer.from(file.path, "utf8");
+    const hash = Buffer.from(file.hash, "utf8");
+    parts.push(
+      uint32(path.length),
+      path,
+      uint32(hash.length),
+      hash,
+      uint32(file.size),
+    );
+  }
+  const version = Buffer.from(MANIFEST_DIGEST_ENCODING, "utf8");
+  return createHash("sha256")
+    .update(Buffer.concat([uint32(version.length), version, ...parts]))
+    .digest("hex");
+}
+
+function skipGzipTextField(bytes: Buffer, offset: number): number {
+  const end = bytes.indexOf(0, offset);
+  if (end === -1) {
+    fail("archive_decompression_failed");
+  }
+  return end + 1;
+}
+
+function gzipDeflateOffset(bytes: Buffer): number {
+  if (
+    bytes.length < 18 ||
+    bytes[0] !== 0x1f ||
+    bytes[1] !== 0x8b ||
+    bytes[2] !== 8
+  ) {
+    fail("archive_decompression_failed");
+  }
+  const flags = bytes.readUInt8(3);
+  if ((flags & 0xe0) !== 0) {
+    fail("archive_decompression_failed");
+  }
+  let offset = 10;
+  if ((flags & 0x04) !== 0) {
+    if (offset + 2 > bytes.length) {
+      fail("archive_decompression_failed");
+    }
+    const length = bytes.readUInt16LE(offset);
+    offset += 2 + length;
+  }
+  if ((flags & 0x08) !== 0) {
+    offset = skipGzipTextField(bytes, offset);
+  }
+  if ((flags & 0x10) !== 0) {
+    offset = skipGzipTextField(bytes, offset);
+  }
+  if ((flags & 0x02) !== 0) {
+    offset += 2;
+  }
+  if (offset > bytes.length - 8) {
+    fail("archive_decompression_failed");
+  }
+  return offset;
+}
+
+function assertSingleGzipMember(bytes: Buffer): void {
+  const offset = gzipDeflateOffset(bytes);
+  const inflated = safeSync(() => {
+    return inflateRawSync(bytes.subarray(offset), {
+      info: true,
+      maxOutputLength: PI_MEMORY_PHASE2_TAR_MAX_BYTES,
+    }) as unknown as Readonly<{
+      buffer: Buffer;
+      engine: Readonly<{ bytesWritten: number }>;
+    }>;
+  });
+  if (!("ok" in inflated)) {
+    fail("archive_decompression_failed");
+  }
+  if (offset + inflated.ok.engine.bytesWritten + 8 !== bytes.length) {
+    fail("archive_trailing_ambiguity");
+  }
+}
+
+export function validatePiMemoryPhase2PreparedResult(
+  storageId: string,
+  result: PiMemoryPhase2ConsolidationResult,
+): readonly ArchiveFile[] {
+  const files = archiveFilesFromPrepared(result.files);
+  const metadata = manifestFiles(files);
+  const totalBytes = files.reduce((sum, file) => {
+    return sum + file.size;
+  }, 0);
+  const pathBytes = files.reduce((sum, file) => {
+    return sum + Buffer.byteLength(file.path, "utf8");
+  }, 0);
+  const versionId = computeContentHashFromHashes(storageId, metadata);
+  if (
+    result.contentIdentity !== versionId ||
+    result.manifest.version !== 1 ||
+    result.manifest.fileCount !== files.length ||
+    result.manifest.pathBytes !== pathBytes ||
+    result.manifest.totalBytes !== totalBytes ||
+    result.manifest.digest !== preparedManifestDigest(files) ||
+    JSON.stringify(result.manifest.files) !== JSON.stringify(metadata)
+  ) {
+    fail("prepared_identity_mismatch");
+  }
+  return files;
+}
+
+export function buildPiMemoryPhase2Archive(
+  storageId: string,
+  result: PiMemoryPhase2ConsolidationResult,
+): PreparedPiMemoryPhase2Archive {
+  const files = validatePiMemoryPhase2PreparedResult(storageId, result);
+  if (files.length === 0) {
+    fail("prepared_empty_invalid");
+  }
+  const manifest: CanonicalManifest = {
+    version: 1,
+    files: manifestFiles(files),
+    createdAt: "1970-01-01T00:00:00.000Z",
+  };
+  const manifestBytes = Buffer.from(JSON.stringify(manifest), "utf8");
+  if (manifestBytes.length > PI_MEMORY_PHASE2_MANIFEST_MAX_BYTES) {
+    fail("manifest_size_invalid");
+  }
+  const archiveBytes = gzipSync(buildTar(files), { level: 9 });
+  archiveBytes[9] = 255;
+  if (archiveBytes.length > PI_MEMORY_PHASE2_ARCHIVE_MAX_BYTES) {
+    fail("archive_size_invalid");
+  }
+  const size = files.reduce((sum, file) => {
+    return sum + file.size;
+  }, 0);
+  return {
+    files: files.map((file) => {
+      return {
+        type: "file",
+        path: file.path,
+        hash: file.hash,
+        size: file.size,
+        bytes: file.bytes,
+      };
+    }),
+    versionId: computeContentHashFromHashes(storageId, manifest.files),
+    size,
+    archiveSize: archiveBytes.length,
+    fileCount: files.length,
+    manifestBytes,
+    archiveBytes,
+  };
+}
+
+export function verifyPiMemoryPhase2Archive(args: {
+  readonly storageId: string;
+  readonly versionId: string;
+  readonly size: number;
+  readonly archiveSize: number;
+  readonly fileCount: number;
+  readonly manifestBytes: Buffer;
+  readonly archiveBytes: Buffer;
+}): PiMemoryPhase2ArchiveIdentity {
+  if (
+    args.archiveBytes.length !== args.archiveSize ||
+    args.archiveSize <= 0 ||
+    args.archiveSize > PI_MEMORY_PHASE2_ARCHIVE_MAX_BYTES
+  ) {
+    fail("archive_size_mismatch");
+  }
+  assertSingleGzipMember(args.archiveBytes);
+  const decompressed = safeSync(() => {
+    return gunzipSync(args.archiveBytes, {
+      maxOutputLength: PI_MEMORY_PHASE2_TAR_MAX_BYTES,
+    });
+  });
+  if (!("ok" in decompressed)) {
+    fail("archive_decompression_failed");
+  }
+  const tarBytes = decompressed.ok;
+  const files = parseTar(tarBytes);
+  const manifest = parseManifest(args.manifestBytes);
+  assertManifestMatches(manifest, files);
+  const size = files.reduce((sum, file) => {
+    return sum + file.size;
+  }, 0);
+  const versionId = computeContentHashFromHashes(
+    args.storageId,
+    manifest.files,
+  );
+  if (
+    args.versionId !== versionId ||
+    args.size !== size ||
+    args.fileCount !== files.length
+  ) {
+    fail("registered_identity_mismatch");
+  }
+  return {
+    files: files.map((file) => {
+      return {
+        type: "file",
+        path: file.path,
+        hash: file.hash,
+        size: file.size,
+        bytes: file.bytes,
+      };
+    }),
+    versionId,
+    size,
+    archiveSize: args.archiveSize,
+    fileCount: files.length,
+  };
+}
+
+export function verifyEmptyPiMemoryPhase2Version(args: {
+  readonly storageId: string;
+  readonly versionId: string;
+  readonly size: number;
+  readonly archiveSize: number;
+  readonly fileCount: number;
+}): PiMemoryPhase2ArchiveIdentity {
+  const versionId = computeContentHashFromHashes(args.storageId, []);
+  if (
+    args.versionId !== versionId ||
+    args.size !== 0 ||
+    args.archiveSize !== 0 ||
+    args.fileCount !== 0
+  ) {
+    fail("empty_version_identity_mismatch");
+  }
+  return { files: [], versionId, size: 0, archiveSize: 0, fileCount: 0 };
+}

--- a/turbo/apps/api/src/signals/services/pi-memory-phase2-job.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-phase2-job.service.ts
@@ -72,9 +72,11 @@ interface ClaimedPiMemoryPhase2BaseVersion {
 }
 
 interface ClaimedPiMemoryPhase2Job extends PiMemoryPhase2OwnerScope {
+  readonly s3Prefix: string;
   readonly leaseToken: string;
   readonly leaseExpiresAt: Date;
   readonly claimedRevision: number;
+  readonly reconciliationQueuedAt: Date | null;
   readonly baseVersion: ClaimedPiMemoryPhase2BaseVersion;
   readonly selected: readonly PiMemoryPhase2SelectedCandidate[];
 }
@@ -581,9 +583,14 @@ export async function claimPiMemoryPhase2Job(
     }
     return {
       ...scope,
+      s3Prefix: claimableStorage.s3Prefix,
       leaseToken,
       leaseExpiresAt,
       claimedRevision: job.inputRevision,
+      reconciliationQueuedAt:
+        job.reconciliationRevision > job.completedRevision
+          ? job.updatedAt
+          : null,
       baseVersion,
       selected,
     };
@@ -599,12 +606,15 @@ interface LockedClaimableJob extends PiMemoryPhase2OwnerScope {
     | "terminal_failure";
   readonly inputRevision: number;
   readonly completedRevision: number;
+  readonly reconciliationRevision: number;
   readonly claimedRevision: number | null;
   readonly retryCount: number;
+  readonly updatedAt: Date;
 }
 
 interface LockedClaimableStorage extends PiMemoryPhase2OwnerScope {
   readonly baseVersionId: string;
+  readonly s3Prefix: string;
 }
 
 function claimableJobCondition(args: ClaimPiMemoryPhase2JobArgs) {
@@ -646,6 +656,7 @@ async function lockNextClaimableStorage(
       orgId: piMemoryPhase2Jobs.orgId,
       userId: piMemoryPhase2Jobs.userId,
       baseVersionId: storages.headVersionId,
+      s3Prefix: storages.s3Prefix,
     })
     .from(piMemoryPhase2Jobs)
     .innerJoin(
@@ -680,6 +691,7 @@ async function lockNextClaimableStorage(
     orgId: storage.orgId,
     userId: storage.userId,
     baseVersionId: storage.baseVersionId,
+    s3Prefix: storage.s3Prefix,
   };
 }
 
@@ -696,8 +708,10 @@ async function lockClaimableJob(
       status: piMemoryPhase2Jobs.status,
       inputRevision: piMemoryPhase2Jobs.inputRevision,
       completedRevision: piMemoryPhase2Jobs.completedRevision,
+      reconciliationRevision: piMemoryPhase2Jobs.reconciliationRevision,
       claimedRevision: piMemoryPhase2Jobs.claimedRevision,
       retryCount: piMemoryPhase2Jobs.retryCount,
+      updatedAt: piMemoryPhase2Jobs.updatedAt,
     })
     .from(piMemoryPhase2Jobs)
     .where(

--- a/turbo/apps/api/src/signals/services/pi-memory-phase2-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-phase2-usage.service.ts
@@ -1,0 +1,155 @@
+import { MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS } from "@okouai/api-contracts/contracts/model-price-tiers";
+import { usageEvent } from "@okouai/db/schema/usage-event";
+import type { PiMemoryPhase2ProviderUsage } from "@okouai/pi-agent-runtime/api";
+import { inArray } from "drizzle-orm";
+import { v5 as uuidv5 } from "uuid";
+
+import type { Db } from "../external/db";
+
+const PI_MEMORY_PHASE2_USAGE_NAMESPACE = "cae7f79f-7180-46db-aaed-84228c63d0d8";
+export const PI_MEMORY_PHASE2_MODEL = "gpt-5.6-terra";
+
+type UsageCategoryBase =
+  | "tokens.input"
+  | "tokens.output"
+  | "tokens.cache_read"
+  | "tokens.cache_creation";
+type UsageCategory = UsageCategoryBase | `${UsageCategoryBase}.long_context`;
+
+interface UsageEntry {
+  readonly category: UsageCategory;
+  readonly quantity: number;
+}
+
+interface RecordPiMemoryPhase2UsageArgs {
+  readonly memoryStorageId: string;
+  readonly claimedRevision: number;
+  readonly selectionDigest: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly responseId: string;
+  readonly usage: PiMemoryPhase2ProviderUsage;
+}
+
+function quantity(value: number, field: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`Pi memory Phase 2 ${field} usage is invalid`);
+  }
+  return value;
+}
+
+function usageEntries(usage: PiMemoryPhase2ProviderUsage): UsageEntry[] {
+  const input = quantity(usage.input, "input");
+  const output = quantity(usage.output, "output");
+  const cacheRead = quantity(usage.cacheRead, "cache-read");
+  const cacheCreation = quantity(usage.cacheWrite, "cache-creation");
+  quantity(usage.reasoning, "reasoning");
+  const minimum =
+    MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS[PI_MEMORY_PHASE2_MODEL];
+  if (minimum === undefined) {
+    throw new Error("Pi memory Phase 2 pricing threshold is missing");
+  }
+  const longContext = input + cacheRead + cacheCreation >= minimum;
+  const category = (base: UsageCategoryBase): UsageCategory => {
+    return longContext ? `${base}.long_context` : base;
+  };
+  return [
+    { category: category("tokens.input"), quantity: input },
+    { category: category("tokens.output"), quantity: output },
+    { category: category("tokens.cache_read"), quantity: cacheRead },
+    {
+      category: category("tokens.cache_creation"),
+      quantity: cacheCreation,
+    },
+  ].filter((entry) => {
+    return entry.quantity > 0;
+  });
+}
+
+function idempotencyKey(
+  args: RecordPiMemoryPhase2UsageArgs,
+  category: UsageCategory,
+): string {
+  return uuidv5(
+    JSON.stringify([
+      args.memoryStorageId,
+      args.claimedRevision,
+      args.selectionDigest,
+      args.responseId,
+      category,
+    ]),
+    PI_MEMORY_PHASE2_USAGE_NAMESPACE,
+  );
+}
+
+/** Persist one terminal Phase 2 provider attempt outside foreground runs. */
+export async function recordPiMemoryPhase2Usage(
+  db: Db,
+  args: RecordPiMemoryPhase2UsageArgs,
+): Promise<void> {
+  const expected = usageEntries(args.usage).map((entry) => {
+    return {
+      runId: null,
+      idempotencyKey: idempotencyKey(args, entry.category),
+      orgId: args.orgId,
+      userId: args.userId,
+      kind: "model",
+      provider: PI_MEMORY_PHASE2_MODEL,
+      category: entry.category,
+      quantity: entry.quantity,
+    } as const;
+  });
+  if (expected.length === 0) {
+    return;
+  }
+  await db.transaction(async (tx) => {
+    await tx
+      .insert(usageEvent)
+      .values(expected)
+      .onConflictDoNothing({ target: [usageEvent.idempotencyKey] });
+    const stored = await tx
+      .select({
+        idempotencyKey: usageEvent.idempotencyKey,
+        runId: usageEvent.runId,
+        orgId: usageEvent.orgId,
+        userId: usageEvent.userId,
+        kind: usageEvent.kind,
+        provider: usageEvent.provider,
+        category: usageEvent.category,
+        quantity: usageEvent.quantity,
+      })
+      .from(usageEvent)
+      .where(
+        inArray(
+          usageEvent.idempotencyKey,
+          expected.map((row) => {
+            return row.idempotencyKey;
+          }),
+        ),
+      );
+    const remaining = new Map(
+      expected.map((row) => {
+        return [row.idempotencyKey, row] as const;
+      }),
+    );
+    for (const row of stored) {
+      const wanted = remaining.get(row.idempotencyKey);
+      if (
+        !wanted ||
+        row.runId !== null ||
+        row.orgId !== wanted.orgId ||
+        row.userId !== wanted.userId ||
+        row.kind !== wanted.kind ||
+        row.provider !== wanted.provider ||
+        row.category !== wanted.category ||
+        row.quantity !== wanted.quantity
+      ) {
+        throw new Error("Pi memory Phase 2 usage identity collision");
+      }
+      remaining.delete(row.idempotencyKey);
+    }
+    if (remaining.size > 0) {
+      throw new Error("Pi memory Phase 2 usage persistence is incomplete");
+    }
+  });
+}

--- a/turbo/apps/api/src/signals/services/pi-memory-phase2-worker.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-phase2-worker.service.ts
@@ -1,0 +1,1041 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import { getModelProviderPiEndpoint } from "@okouai/api-contracts/contracts/model-provider-firewalls";
+import { builtInModelKeys } from "@okouai/db/schema/built-in-model-key";
+import { storageVersions } from "@okouai/db/schema/storage";
+import {
+  PiMemoryPhase2EngineError,
+  runPiMemoryPhase2Consolidation,
+  type PiMemoryPhase2ConsolidationResult,
+  type PiMemoryPhase2LifecycleEvent,
+  type PiMemoryPhase2UsageEvent,
+} from "@okouai/pi-agent-runtime/api";
+import { command } from "ccstate";
+import { eq } from "drizzle-orm";
+import { delay } from "signal-timers";
+
+import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { nowDate } from "../../lib/time";
+import { writeDb$, type Db } from "../external/db";
+import {
+  downloadS3BufferWithMaxBytes,
+  putImmutableS3Object,
+} from "../external/s3";
+import { safeSync, settleIncludingAbort } from "../utils";
+import { resolveBuiltInModelRuntimeRoute } from "./built-in-model-runtime-route.service";
+import {
+  buildPiMemoryPhase2Archive,
+  PI_MEMORY_PHASE2_ARCHIVE_MAX_BYTES,
+  PiMemoryPhase2ArchiveError,
+  type PiMemoryPhase2ArchiveIdentity,
+  PI_MEMORY_PHASE2_MANIFEST_MAX_BYTES,
+  type PreparedPiMemoryPhase2Archive,
+  verifyEmptyPiMemoryPhase2Version,
+  verifyPiMemoryPhase2Archive,
+} from "./pi-memory-phase2-archive.service";
+import {
+  claimPiMemoryPhase2Job,
+  failPiMemoryPhase2Job,
+  finalizePiMemoryPhase2Job,
+  heartbeatPiMemoryPhase2Job,
+  PI_MEMORY_PHASE2_EXPECTED_HEARTBEAT_CADENCE_MS,
+  piMemoryPhase2SelectionDigest,
+} from "./pi-memory-phase2-job.service";
+import {
+  PI_MEMORY_PHASE2_MODEL,
+  recordPiMemoryPhase2Usage,
+} from "./pi-memory-phase2-usage.service";
+import {
+  registerPreparedStorageVersions,
+  storageVersionMatches,
+  type PreparedStorageVersion,
+} from "./storage-version-registration.service";
+
+const log = logger("PiMemoryPhase2Worker");
+const PREPARED_VERSION_MESSAGE = "Pi memory Phase 2 consolidation";
+
+interface PiMemoryPhase2WorkerScope {
+  readonly memoryStorageId: string;
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+interface PiMemoryPhase2WorkerInput {
+  readonly scope?: PiMemoryPhase2WorkerScope;
+  readonly currentTime: Date;
+}
+
+export type PiMemoryPhase2WorkerResult =
+  | { readonly outcome: "no_work" }
+  | { readonly outcome: "no_diff"; readonly headVersionId: string }
+  | { readonly outcome: "published"; readonly publishedVersionId: string }
+  | { readonly outcome: "conflicted"; readonly currentHeadVersionId: string }
+  | { readonly outcome: "stale" }
+  | { readonly outcome: "failed"; readonly errorClass: string };
+
+interface ExactLeaseFence extends PiMemoryPhase2WorkerScope {
+  readonly leaseOwner: string;
+  readonly leaseToken: string;
+  readonly claimedRevision: number;
+  readonly claimedBaseVersionId: string;
+}
+
+class PiMemoryPhase2HeartbeatError extends Error {
+  constructor(readonly errorClass: "heartbeat_failed" | "lease_lost") {
+    super("Pi memory Phase 2 heartbeat failed");
+    this.name = "PiMemoryPhase2HeartbeatError";
+  }
+}
+
+class PiMemoryPhase2WorkerError extends Error {
+  constructor(readonly errorClass: string) {
+    super("Pi memory Phase 2 worker failed");
+    this.name = "PiMemoryPhase2WorkerError";
+  }
+}
+
+interface HeartbeatGuard {
+  readonly operationSignal: AbortSignal;
+  readonly cadenceController: AbortController;
+  readonly monitor: Promise<void>;
+  readonly removeCallerAbort: () => void;
+  readonly failure: { value: PiMemoryPhase2HeartbeatError | undefined };
+}
+
+type OperationResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly error: unknown };
+
+function settleSync<T>(operation: () => T): OperationResult<T> {
+  const result = safeSync(operation);
+  return "ok" in result
+    ? { ok: true, value: result.ok }
+    : { ok: false, error: result.error };
+}
+
+async function startHeartbeatGuard(
+  heartbeat: () => Promise<boolean>,
+  callerSignal: AbortSignal,
+): Promise<HeartbeatGuard> {
+  callerSignal.throwIfAborted();
+  const firstHeartbeat = await settleIncludingAbort(heartbeat());
+  callerSignal.throwIfAborted();
+  if (!firstHeartbeat.ok) {
+    throw new PiMemoryPhase2HeartbeatError("heartbeat_failed");
+  }
+  if (!firstHeartbeat.value) {
+    throw new PiMemoryPhase2HeartbeatError("lease_lost");
+  }
+  const operationController = new AbortController();
+  const cadenceController = new AbortController();
+  const failure: HeartbeatGuard["failure"] = { value: undefined };
+  const abortOperation = () => {
+    operationController.abort(callerSignal.reason);
+    cadenceController.abort(callerSignal.reason);
+  };
+  callerSignal.addEventListener("abort", abortOperation, { once: true });
+  const monitor = (async () => {
+    while (!cadenceController.signal.aborted) {
+      await settleIncludingAbort(
+        delay(PI_MEMORY_PHASE2_EXPECTED_HEARTBEAT_CADENCE_MS, {
+          signal: cadenceController.signal,
+        }),
+      );
+      if (cadenceController.signal.aborted) {
+        return;
+      }
+      const beat = await settleIncludingAbort(heartbeat());
+      failure.value = beat.ok
+        ? beat.value
+          ? undefined
+          : new PiMemoryPhase2HeartbeatError("lease_lost")
+        : new PiMemoryPhase2HeartbeatError("heartbeat_failed");
+      if (failure.value) {
+        operationController.abort(failure.value);
+        cadenceController.abort(failure.value);
+      }
+    }
+  })();
+  return {
+    operationSignal: operationController.signal,
+    cadenceController,
+    monitor,
+    removeCallerAbort() {
+      callerSignal.removeEventListener("abort", abortOperation);
+    },
+    failure,
+  };
+}
+
+async function finishHeartbeatGuard<T>(
+  guard: HeartbeatGuard,
+  operation: OperationResult<T>,
+  callerSignal: AbortSignal,
+): Promise<T> {
+  const heartbeatFailureAtSettlement = guard.failure.value;
+  const callerAbortedAtSettlement = callerSignal.aborted;
+  guard.cadenceController.abort();
+  await guard.monitor;
+  guard.removeCallerAbort();
+  if (heartbeatFailureAtSettlement) {
+    throw heartbeatFailureAtSettlement;
+  }
+  if (callerAbortedAtSettlement) {
+    callerSignal.throwIfAborted();
+  }
+  if (!operation.ok) {
+    throw operation.error;
+  }
+  if (guard.failure.value) {
+    throw guard.failure.value;
+  }
+  callerSignal.throwIfAborted();
+  return operation.value;
+}
+
+function exactFence(
+  claim: NonNullable<Awaited<ReturnType<typeof claimPiMemoryPhase2Job>>>,
+  leaseOwner: string,
+): ExactLeaseFence {
+  return {
+    memoryStorageId: claim.memoryStorageId,
+    orgId: claim.orgId,
+    userId: claim.userId,
+    leaseOwner,
+    leaseToken: claim.leaseToken,
+    claimedRevision: claim.claimedRevision,
+    claimedBaseVersionId: claim.baseVersion.versionId,
+  };
+}
+
+function lifecycleLog(event: PiMemoryPhase2LifecycleEvent): void {
+  log.debug("Pi memory Phase 2 engine lifecycle", {
+    stage: event.stage,
+    orgId: event.orgId,
+    userId: event.userId,
+    memoryStorageId: event.memoryStorageId,
+    claimedRevision: event.claimedRevision,
+    selectionDigest: event.selectionDigest,
+    candidateCount: event.candidateCount,
+    fileCount: event.fileCount,
+    totalBytes: event.totalBytes,
+    heartbeatCount: event.heartbeatCount,
+    durationMs: event.durationMs,
+    outcome: event.outcome,
+    errorClass: event.errorClass,
+    contentIdentity: event.contentIdentity,
+  });
+}
+
+function providerConfig(args: {
+  readonly route: NonNullable<
+    Awaited<ReturnType<typeof resolveBuiltInModelRuntimeRoute>>
+  >;
+  readonly apiKey: string;
+}) {
+  const endpoint = getModelProviderPiEndpoint(
+    args.route.providerType,
+    "openai-responses",
+  );
+  const provider =
+    args.route.providerType === "openai-api-key"
+      ? "openai"
+      : args.route.providerType === "openrouter-codex"
+        ? "openrouter"
+        : null;
+  if (!endpoint || provider === null) {
+    throw new PiMemoryPhase2WorkerError("model_route_unavailable");
+  }
+  return {
+    provider,
+    baseUrl: endpoint.baseUrl,
+    apiKey: args.apiKey,
+    model: args.route.upstreamModel,
+    catalogModel: PI_MEMORY_PHASE2_MODEL,
+    api: "openai-responses" as const,
+    thinkingLevel: "medium" as const,
+  };
+}
+
+async function resolveProviderConfig(db: Db, signal: AbortSignal) {
+  const route = await resolveBuiltInModelRuntimeRoute(
+    db,
+    PI_MEMORY_PHASE2_MODEL,
+  );
+  signal.throwIfAborted();
+  if (!route) {
+    throw new PiMemoryPhase2WorkerError("model_route_unavailable");
+  }
+  const [key] = await db
+    .select({ apiKey: builtInModelKeys.apiKey })
+    .from(builtInModelKeys)
+    .where(eq(builtInModelKeys.id, route.modelKeyId))
+    .limit(1);
+  signal.throwIfAborted();
+  if (!key) {
+    throw new PiMemoryPhase2WorkerError("model_route_unavailable");
+  }
+  return providerConfig({ route, apiKey: key.apiKey });
+}
+
+function errorClass(error: unknown, signal: AbortSignal): string {
+  if (error instanceof PiMemoryPhase2ArchiveError) {
+    return error.errorClass;
+  }
+  if (error instanceof PiMemoryPhase2EngineError) {
+    return error.errorClass;
+  }
+  if (error instanceof PiMemoryPhase2HeartbeatError) {
+    return error.errorClass;
+  }
+  if (error instanceof PiMemoryPhase2WorkerError) {
+    return error.errorClass;
+  }
+  return signal.aborted ? "aborted" : "worker_failed";
+}
+
+function logOutcome(args: {
+  readonly claim: NonNullable<
+    Awaited<ReturnType<typeof claimPiMemoryPhase2Job>>
+  >;
+  readonly leaseOwner: string;
+  readonly outcome: PiMemoryPhase2WorkerResult["outcome"];
+  readonly startedAt: number;
+  readonly errorClass?: string;
+  readonly versionId?: string;
+}): void {
+  log.debug("Pi memory Phase 2 work completed", {
+    orgId: args.claim.orgId,
+    userId: args.claim.userId,
+    memoryStorageId: args.claim.memoryStorageId,
+    leaseOwner: args.leaseOwner,
+    claimedRevision: args.claim.claimedRevision,
+    claimedBaseVersionId: args.claim.baseVersion.versionId,
+    selectedCount: args.claim.selected.length,
+    outcome: args.outcome,
+    errorClass: args.errorClass,
+    versionId: args.versionId,
+    durationMs: Math.max(0, Math.round(performance.now() - args.startedAt)),
+    reconciliationLatencyMs:
+      args.claim.reconciliationQueuedAt === null
+        ? undefined
+        : Math.max(
+            0,
+            nowDate().getTime() - args.claim.reconciliationQueuedAt.getTime(),
+          ),
+  });
+}
+
+type ClaimedJob = NonNullable<
+  Awaited<ReturnType<typeof claimPiMemoryPhase2Job>>
+>;
+type PreparedEngineResult = Extract<
+  PiMemoryPhase2ConsolidationResult,
+  { readonly status: "prepared" }
+>;
+
+interface PreparedRegistration {
+  readonly version: PreparedStorageVersion;
+  readonly reused: boolean;
+}
+
+function heartbeatFor(db: Db, fence: ExactLeaseFence): () => Promise<boolean> {
+  return async () => {
+    return await heartbeatPiMemoryPhase2Job(db, {
+      ...fence,
+      currentTime: nowDate(),
+    });
+  };
+}
+
+const loadBaseArchive$ = command(
+  async (
+    { get },
+    args: {
+      readonly claim: ClaimedJob;
+      readonly bucket: string;
+      readonly heartbeat: () => Promise<boolean>;
+    },
+    signal: AbortSignal,
+  ): Promise<PiMemoryPhase2ArchiveIdentity> => {
+    const base = args.claim.baseVersion;
+    if (base.fileCount === 0) {
+      return verifyEmptyPiMemoryPhase2Version({
+        storageId: args.claim.memoryStorageId,
+        versionId: base.versionId,
+        size: base.size,
+        archiveSize: base.archiveSize,
+        fileCount: base.fileCount,
+      });
+    }
+    const guard = await startHeartbeatGuard(args.heartbeat, signal);
+    const manifest = await settleIncludingAbort(
+      get(
+        downloadS3BufferWithMaxBytes(
+          args.bucket,
+          `${base.s3Key}/manifest.json`,
+          PI_MEMORY_PHASE2_MANIFEST_MAX_BYTES,
+          guard.operationSignal,
+        ),
+      ),
+    );
+    if (signal.aborted) {
+      return await finishHeartbeatGuard(
+        guard,
+        { ok: false, error: signal.reason },
+        signal,
+      );
+    }
+    if (!manifest.ok) {
+      return await finishHeartbeatGuard(guard, manifest, signal);
+    }
+    const archive = await settleIncludingAbort(
+      get(
+        downloadS3BufferWithMaxBytes(
+          args.bucket,
+          `${base.s3Key}/archive.tar.gz`,
+          PI_MEMORY_PHASE2_ARCHIVE_MAX_BYTES,
+          guard.operationSignal,
+        ),
+      ),
+    );
+    if (signal.aborted) {
+      return await finishHeartbeatGuard(
+        guard,
+        { ok: false, error: signal.reason },
+        signal,
+      );
+    }
+    if (!archive.ok) {
+      return await finishHeartbeatGuard(guard, archive, signal);
+    }
+    if (guard.operationSignal.aborted) {
+      return await finishHeartbeatGuard(
+        guard,
+        { ok: false, error: guard.operationSignal.reason },
+        signal,
+      );
+    }
+    const verified = settleSync(() => {
+      return verifyPiMemoryPhase2Archive({
+        storageId: args.claim.memoryStorageId,
+        versionId: base.versionId,
+        size: base.size,
+        archiveSize: base.archiveSize,
+        fileCount: base.fileCount,
+        manifestBytes: manifest.value,
+        archiveBytes: archive.value,
+      });
+    });
+    return await finishHeartbeatGuard(guard, verified, signal);
+  },
+);
+
+function logVerifiedBase(
+  claim: ClaimedJob,
+  base: PiMemoryPhase2ArchiveIdentity,
+): void {
+  log.debug("Pi memory Phase 2 base archive verified", {
+    orgId: claim.orgId,
+    userId: claim.userId,
+    memoryStorageId: claim.memoryStorageId,
+    claimedRevision: claim.claimedRevision,
+    versionId: base.versionId,
+    fileCount: base.fileCount,
+    totalBytes: base.size,
+    archiveBytes: base.archiveSize,
+  });
+}
+
+function responseIdentityHash(responseId: string): string {
+  return createHash("sha256").update(responseId, "utf8").digest("hex");
+}
+
+function usageIdentityMatches(
+  claim: ClaimedJob,
+  event: PiMemoryPhase2UsageEvent,
+): boolean {
+  return (
+    event.orgId === claim.orgId &&
+    event.userId === claim.userId &&
+    event.memoryStorageId === claim.memoryStorageId &&
+    event.claimedRevision === claim.claimedRevision &&
+    event.selectionDigest === piMemoryPhase2SelectionDigest(claim.selected)
+  );
+}
+
+function usageObserver(db: Db, claim: ClaimedJob) {
+  return async (event: PiMemoryPhase2UsageEvent): Promise<void> => {
+    const responseIdHash = responseIdentityHash(event.responseId);
+    if (!usageIdentityMatches(claim, event)) {
+      log.warn("Pi memory Phase 2 usage identity rejected", {
+        orgId: claim.orgId,
+        userId: claim.userId,
+        memoryStorageId: claim.memoryStorageId,
+        claimedRevision: claim.claimedRevision,
+        responseIdHash,
+        errorClass: "usage_identity_mismatch",
+      });
+      throw new PiMemoryPhase2WorkerError("usage_identity_mismatch");
+    }
+    const recorded = await settleIncludingAbort(
+      recordPiMemoryPhase2Usage(db, {
+        memoryStorageId: claim.memoryStorageId,
+        claimedRevision: claim.claimedRevision,
+        selectionDigest: event.selectionDigest,
+        orgId: claim.orgId,
+        userId: claim.userId,
+        responseId: event.responseId,
+        usage: event.usage,
+      }),
+    );
+    if (!recorded.ok) {
+      log.warn("Pi memory Phase 2 usage persistence failed", {
+        orgId: claim.orgId,
+        userId: claim.userId,
+        memoryStorageId: claim.memoryStorageId,
+        claimedRevision: claim.claimedRevision,
+        responseIdHash,
+        errorClass:
+          recorded.error instanceof Error &&
+          recorded.error.message ===
+            "Pi memory Phase 2 usage identity collision"
+            ? "usage_identity_collision"
+            : "usage_persistence_failure",
+      });
+      throw recorded.error;
+    }
+    log.debug("Pi memory Phase 2 usage persisted", {
+      orgId: claim.orgId,
+      userId: claim.userId,
+      memoryStorageId: claim.memoryStorageId,
+      claimedRevision: claim.claimedRevision,
+      responseIdHash,
+      inputTokens: event.usage.input,
+      outputTokens: event.usage.output,
+      cacheReadTokens: event.usage.cacheRead,
+      cacheWriteTokens: event.usage.cacheWrite,
+      reasoningTokens: event.usage.reasoning,
+    });
+  };
+}
+
+function validateEngineIdentity(
+  claim: ClaimedJob,
+  result: PiMemoryPhase2ConsolidationResult,
+): void {
+  if (
+    result.selectionDigest !== piMemoryPhase2SelectionDigest(claim.selected)
+  ) {
+    throw new PiMemoryPhase2WorkerError("engine_identity_mismatch");
+  }
+}
+
+async function runEngine(
+  args: {
+    readonly db: Db;
+    readonly claim: ClaimedJob;
+    readonly base: PiMemoryPhase2ArchiveIdentity;
+    readonly heartbeat: () => Promise<boolean>;
+  },
+  signal: AbortSignal,
+): Promise<PiMemoryPhase2ConsolidationResult> {
+  const model = await resolveProviderConfig(args.db, signal);
+  return await runPiMemoryPhase2Consolidation(
+    {
+      orgId: args.claim.orgId,
+      userId: args.claim.userId,
+      memoryStorageId: args.claim.memoryStorageId,
+      claimedRevision: args.claim.claimedRevision,
+      leaseToken: args.claim.leaseToken,
+      baseFiles: args.base.files,
+      selected: args.claim.selected,
+      model,
+      heartbeat: args.heartbeat,
+      onLifecycle: lifecycleLog,
+      onUsage: usageObserver(args.db, args.claim),
+    },
+    signal,
+  );
+}
+
+interface UploadedArchiveBytes {
+  readonly manifestBytes: Buffer;
+  readonly archiveBytes: Buffer;
+}
+
+const uploadAndReadBackArchive$ = command(
+  async (
+    { get },
+    args: {
+      readonly bucket: string;
+      readonly s3Key: string;
+      readonly prepared: PreparedPiMemoryPhase2Archive;
+      readonly upload: boolean;
+    },
+    signal: AbortSignal,
+  ): Promise<UploadedArchiveBytes> => {
+    if (args.upload) {
+      await get(
+        putImmutableS3Object(
+          args.bucket,
+          `${args.s3Key}/manifest.json`,
+          args.prepared.manifestBytes,
+          "application/json",
+          signal,
+        ),
+      );
+      signal.throwIfAborted();
+      await get(
+        putImmutableS3Object(
+          args.bucket,
+          `${args.s3Key}/archive.tar.gz`,
+          args.prepared.archiveBytes,
+          "application/gzip",
+          signal,
+        ),
+      );
+      signal.throwIfAborted();
+    }
+    const manifestBytes = await get(
+      downloadS3BufferWithMaxBytes(
+        args.bucket,
+        `${args.s3Key}/manifest.json`,
+        PI_MEMORY_PHASE2_MANIFEST_MAX_BYTES,
+        signal,
+      ),
+    );
+    signal.throwIfAborted();
+    const archiveBytes = await get(
+      downloadS3BufferWithMaxBytes(
+        args.bucket,
+        `${args.s3Key}/archive.tar.gz`,
+        PI_MEMORY_PHASE2_ARCHIVE_MAX_BYTES,
+        signal,
+      ),
+    );
+    signal.throwIfAborted();
+    return { manifestBytes, archiveBytes };
+  },
+);
+
+function verifyUploadedArchive(args: {
+  readonly storageId: string;
+  readonly prepared: PreparedPiMemoryPhase2Archive;
+  readonly uploaded: UploadedArchiveBytes;
+}): PiMemoryPhase2ArchiveIdentity {
+  if (
+    !args.uploaded.manifestBytes.equals(args.prepared.manifestBytes) ||
+    !args.uploaded.archiveBytes.equals(args.prepared.archiveBytes)
+  ) {
+    throw new PiMemoryPhase2ArchiveError("immutable_object_mismatch");
+  }
+  return verifyPiMemoryPhase2Archive({
+    storageId: args.storageId,
+    versionId: args.prepared.versionId,
+    size: args.prepared.size,
+    archiveSize: args.prepared.archiveSize,
+    fileCount: args.prepared.fileCount,
+    manifestBytes: args.uploaded.manifestBytes,
+    archiveBytes: args.uploaded.archiveBytes,
+  });
+}
+
+function preparedStorageVersion(args: {
+  readonly claim: ClaimedJob;
+  readonly s3Key: string;
+  readonly verified: PiMemoryPhase2ArchiveIdentity;
+}): PreparedStorageVersion {
+  return {
+    storageId: args.claim.memoryStorageId,
+    versionId: args.verified.versionId,
+    s3Key: args.s3Key,
+    size: args.verified.size,
+    archiveSize: args.verified.archiveSize,
+    fileCount: args.verified.fileCount,
+    message: PREPARED_VERSION_MESSAGE,
+    createdBy: args.claim.userId,
+  };
+}
+
+async function findRegisteredVersion(
+  db: Db,
+  versionId: string,
+  signal: AbortSignal,
+): Promise<PreparedStorageVersion | null> {
+  const [version] = await db
+    .select({
+      storageId: storageVersions.storageId,
+      versionId: storageVersions.id,
+      s3Key: storageVersions.s3Key,
+      size: storageVersions.size,
+      archiveSize: storageVersions.archiveSize,
+      fileCount: storageVersions.fileCount,
+      message: storageVersions.message,
+      createdBy: storageVersions.createdBy,
+    })
+    .from(storageVersions)
+    .where(eq(storageVersions.id, versionId))
+    .limit(1);
+  signal.throwIfAborted();
+  return version ?? null;
+}
+
+async function findReusableRegisteredVersion(
+  args: { readonly db: Db; readonly expected: PreparedStorageVersion },
+  signal: AbortSignal,
+): Promise<PreparedStorageVersion | null> {
+  const existing = await findRegisteredVersion(
+    args.db,
+    args.expected.versionId,
+    signal,
+  );
+  if (existing && !storageVersionMatches(existing, args.expected)) {
+    throw new PiMemoryPhase2ArchiveError("registered_metadata_mismatch");
+  }
+  return existing;
+}
+
+function buildPreparedArchive(
+  claim: ClaimedJob,
+  result: PreparedEngineResult,
+): PreparedPiMemoryPhase2Archive {
+  return buildPiMemoryPhase2Archive(claim.memoryStorageId, result);
+}
+
+const prepareAndRegister$ = command(
+  async (
+    { set },
+    args: {
+      readonly db: Db;
+      readonly claim: ClaimedJob;
+      readonly result: PreparedEngineResult;
+      readonly bucket: string;
+      readonly heartbeat: () => Promise<boolean>;
+    },
+    signal: AbortSignal,
+  ): Promise<PreparedRegistration> => {
+    const guard = await startHeartbeatGuard(args.heartbeat, signal);
+    const built = settleSync(() => {
+      return buildPreparedArchive(args.claim, args.result);
+    });
+    if (!built.ok) {
+      return await finishHeartbeatGuard(guard, built, signal);
+    }
+    if (guard.operationSignal.aborted) {
+      return await finishHeartbeatGuard(
+        guard,
+        { ok: false, error: guard.operationSignal.reason },
+        signal,
+      );
+    }
+    const prepared = built.value;
+    const s3Key = `${args.claim.s3Prefix}/${prepared.versionId}`;
+    const expectedVersion = preparedStorageVersion({
+      claim: args.claim,
+      s3Key,
+      verified: prepared,
+    });
+    const existing = await settleIncludingAbort(
+      findReusableRegisteredVersion(
+        { db: args.db, expected: expectedVersion },
+        guard.operationSignal,
+      ),
+    );
+    if (signal.aborted) {
+      return await finishHeartbeatGuard(
+        guard,
+        { ok: false, error: signal.reason },
+        signal,
+      );
+    }
+    if (!existing.ok) {
+      return await finishHeartbeatGuard(guard, existing, signal);
+    }
+    const uploaded = await settleIncludingAbort(
+      set(
+        uploadAndReadBackArchive$,
+        {
+          bucket: args.bucket,
+          s3Key,
+          prepared,
+          upload: existing.value === null,
+        },
+        guard.operationSignal,
+      ),
+    );
+    if (signal.aborted) {
+      return await finishHeartbeatGuard(
+        guard,
+        { ok: false, error: signal.reason },
+        signal,
+      );
+    }
+    if (!uploaded.ok) {
+      return await finishHeartbeatGuard(
+        guard,
+        existing.value === null
+          ? uploaded
+          : {
+              ok: false,
+              error: new PiMemoryPhase2ArchiveError(
+                "registered_object_unavailable",
+              ),
+            },
+        signal,
+      );
+    }
+    if (guard.operationSignal.aborted) {
+      return await finishHeartbeatGuard(
+        guard,
+        { ok: false, error: guard.operationSignal.reason },
+        signal,
+      );
+    }
+    const verified = settleSync(() => {
+      return verifyUploadedArchive({
+        storageId: args.claim.memoryStorageId,
+        prepared,
+        uploaded: uploaded.value,
+      });
+    });
+    if (!verified.ok) {
+      return await finishHeartbeatGuard(guard, verified, signal);
+    }
+    const version = preparedStorageVersion({
+      claim: args.claim,
+      s3Key,
+      verified: verified.value,
+    });
+    const registered = await settleIncludingAbort(
+      registerPreparedStorageVersions(
+        { db: args.db, versions: [version] },
+        guard.operationSignal,
+      ),
+    );
+    if (signal.aborted) {
+      return await finishHeartbeatGuard(
+        guard,
+        { ok: false, error: signal.reason },
+        signal,
+      );
+    }
+    if (!registered.ok) {
+      return await finishHeartbeatGuard(guard, registered, signal);
+    }
+    return await finishHeartbeatGuard(
+      guard,
+      {
+        ok: true,
+        value: { version, reused: existing.value !== null },
+      },
+      signal,
+    );
+  },
+);
+
+function logPreparedArchive(
+  claim: ClaimedJob,
+  registration: PreparedRegistration,
+): void {
+  log.debug("Pi memory Phase 2 archive prepared and registered", {
+    orgId: claim.orgId,
+    userId: claim.userId,
+    memoryStorageId: claim.memoryStorageId,
+    claimedRevision: claim.claimedRevision,
+    versionId: registration.version.versionId,
+    fileCount: registration.version.fileCount,
+    totalBytes: registration.version.size,
+    archiveBytes: registration.version.archiveSize,
+    reused: registration.reused,
+  });
+}
+
+async function finalizeEngineResult(args: {
+  readonly db: Db;
+  readonly claim: ClaimedJob;
+  readonly fence: ExactLeaseFence;
+  readonly result: PiMemoryPhase2ConsolidationResult;
+  readonly prepared?: PreparedStorageVersion;
+}): Promise<PiMemoryPhase2WorkerResult> {
+  if (args.result.status === "no_diff") {
+    if (args.result.contentIdentity !== args.claim.baseVersion.versionId) {
+      throw new PiMemoryPhase2WorkerError("no_diff_identity_mismatch");
+    }
+    return await finalizePiMemoryPhase2Job(args.db, {
+      ...args.fence,
+      currentTime: nowDate(),
+      selected: args.claim.selected,
+      result: { kind: "no_diff" },
+    });
+  }
+  if (!args.prepared) {
+    throw new PiMemoryPhase2WorkerError("prepared_version_missing");
+  }
+  return await finalizePiMemoryPhase2Job(args.db, {
+    ...args.fence,
+    currentTime: nowDate(),
+    selected: args.claim.selected,
+    result: { kind: "prepared", version: args.prepared },
+  });
+}
+
+function outcomeVersion(
+  result: PiMemoryPhase2WorkerResult,
+): string | undefined {
+  return result.outcome === "published"
+    ? result.publishedVersionId
+    : result.outcome === "conflicted"
+      ? result.currentHeadVersionId
+      : result.outcome === "no_diff"
+        ? result.headVersionId
+        : undefined;
+}
+
+const processClaim$ = command(
+  async (
+    { set },
+    args: {
+      readonly db: Db;
+      readonly claim: ClaimedJob;
+      readonly fence: ExactLeaseFence;
+      readonly heartbeat: () => Promise<boolean>;
+    },
+    signal: AbortSignal,
+  ): Promise<PiMemoryPhase2WorkerResult> => {
+    const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+    log.debug("Pi memory Phase 2 base archive loading", {
+      orgId: args.claim.orgId,
+      userId: args.claim.userId,
+      memoryStorageId: args.claim.memoryStorageId,
+      leaseOwner: args.fence.leaseOwner,
+      claimedRevision: args.claim.claimedRevision,
+      versionId: args.claim.baseVersion.versionId,
+      fileCount: args.claim.baseVersion.fileCount,
+      totalBytes: args.claim.baseVersion.size,
+      archiveBytes: args.claim.baseVersion.archiveSize,
+    });
+    const base = await set(
+      loadBaseArchive$,
+      { claim: args.claim, bucket, heartbeat: args.heartbeat },
+      signal,
+    );
+    logVerifiedBase(args.claim, base);
+    const result = await runEngine({ ...args, base }, signal);
+    validateEngineIdentity(args.claim, result);
+    const registration =
+      result.status === "prepared"
+        ? await set(prepareAndRegister$, { ...args, result, bucket }, signal)
+        : undefined;
+    if (registration) {
+      logPreparedArchive(args.claim, registration);
+    }
+    return await finalizeEngineResult({
+      ...args,
+      result,
+      prepared: registration?.version,
+    });
+  },
+);
+
+export const executePiMemoryPhase2Work$ = command(
+  async (
+    { set },
+    input: PiMemoryPhase2WorkerInput,
+    signal: AbortSignal,
+  ): Promise<PiMemoryPhase2WorkerResult> => {
+    const startedAt = performance.now();
+    const leaseOwner = randomUUID();
+    const db = set(writeDb$);
+    signal.throwIfAborted();
+    const claim = await claimPiMemoryPhase2Job(db, input);
+    signal.throwIfAborted();
+    if (!claim) {
+      log.debug("Pi memory Phase 2 claim found no work", { leaseOwner });
+      return { outcome: "no_work" };
+    }
+    const fence = exactFence(claim, leaseOwner);
+    log.debug("Pi memory Phase 2 job claimed", {
+      orgId: claim.orgId,
+      userId: claim.userId,
+      memoryStorageId: claim.memoryStorageId,
+      leaseOwner,
+      claimedRevision: claim.claimedRevision,
+      claimedBaseVersionId: claim.baseVersion.versionId,
+      selectedCount: claim.selected.length,
+    });
+    const processed = await settleIncludingAbort(
+      set(
+        processClaim$,
+        {
+          db,
+          claim,
+          fence,
+          heartbeat: heartbeatFor(db, fence),
+        },
+        signal,
+      ),
+    );
+    if (signal.aborted) {
+      log.debug("Pi memory Phase 2 cancellation observed", {
+        orgId: claim.orgId,
+        userId: claim.userId,
+        memoryStorageId: claim.memoryStorageId,
+        claimedRevision: claim.claimedRevision,
+        leaseOwner,
+      });
+    }
+    if (processed.ok) {
+      const response = processed.value;
+      logOutcome({
+        claim,
+        leaseOwner,
+        outcome: response.outcome,
+        startedAt,
+        versionId: outcomeVersion(response),
+      });
+      return response;
+    }
+    const failureClass = errorClass(processed.error, signal);
+    const failureTransition = await settleIncludingAbort(
+      failPiMemoryPhase2Job(db, {
+        ...fence,
+        currentTime: nowDate(),
+        errorClass: failureClass,
+      }),
+    );
+    if (signal.aborted) {
+      log.debug("Pi memory Phase 2 cancellation persisted", {
+        orgId: claim.orgId,
+        userId: claim.userId,
+        memoryStorageId: claim.memoryStorageId,
+        claimedRevision: claim.claimedRevision,
+        leaseOwner,
+      });
+    }
+    if (!failureTransition.ok) {
+      logOutcome({
+        claim,
+        leaseOwner,
+        outcome: "failed",
+        startedAt,
+        errorClass: "failure_transition_failed",
+      });
+      signal.throwIfAborted();
+      throw failureTransition.error;
+    }
+    const response: PiMemoryPhase2WorkerResult = failureTransition.value
+      ? { outcome: "failed", errorClass: failureClass }
+      : { outcome: "stale" };
+    logOutcome({
+      claim,
+      leaseOwner,
+      outcome: response.outcome,
+      startedAt,
+      errorClass: failureClass,
+    });
+    signal.throwIfAborted();
+    return response;
+  },
+);

--- a/turbo/packages/pi-agent-runtime/src/api.ts
+++ b/turbo/packages/pi-agent-runtime/src/api.ts
@@ -38,6 +38,33 @@ import {
   runPiMemoryStage1Extraction,
   truncatePiMemoryStage1History,
 } from "./stage1-memory";
+import { runPiMemoryPhase2Consolidation as runPiMemoryPhase2ConsolidationImpl } from "./phase2-memory";
+import {
+  PI_MEMORY_PHASE2_EXPECTED_HEARTBEAT_CADENCE_MS,
+  PI_MEMORY_PHASE2_MAINTENANCE_REASONING,
+  PI_MEMORY_PHASE2_MAX_CHANGED_SKILL_BYTES,
+  PI_MEMORY_PHASE2_MAX_CHANGED_SKILL_FILE_BYTES,
+  PI_MEMORY_PHASE2_MAX_CHANGED_SKILL_FILES,
+  PI_MEMORY_PHASE2_MEMORY_MAX_BYTES,
+  PI_MEMORY_PHASE2_PREPARED_MAX_BYTES,
+  PI_MEMORY_PHASE2_WORKSPACE_DIFF_MAX_BYTES,
+  PiMemoryPhase2EngineError,
+  type PiMemoryPhase2BaseFile,
+  type PiMemoryPhase2ConsolidationArgs,
+  type PiMemoryPhase2ConsolidationResult,
+  type PiMemoryPhase2DiffSummary,
+  type PiMemoryPhase2FailureClass,
+  type PiMemoryPhase2FailureCounts,
+  type PiMemoryPhase2LifecycleEvent,
+  type PiMemoryPhase2NoDiffResult,
+  type PiMemoryPhase2PreparedFile,
+  type PiMemoryPhase2PreparedManifest,
+  type PiMemoryPhase2PreparedResult,
+  type PiMemoryPhase2ProviderUsage,
+  type PiMemoryPhase2SelectedSnapshot,
+  type PiMemoryPhase2UsageEvent,
+  type RunPiMemoryPhase2Consolidation,
+} from "./phase2-memory-types";
 import type {
   PiMemoryStage1ProviderResult,
   PiMemoryStage1ProviderUsage,
@@ -53,6 +80,15 @@ export {
   PiApiFirstTurnCompactionRequiredError,
   UnsupportedPiResourceSnapshotError,
   UnsupportedPiSessionVersionError,
+  PI_MEMORY_PHASE2_EXPECTED_HEARTBEAT_CADENCE_MS,
+  PI_MEMORY_PHASE2_MAINTENANCE_REASONING,
+  PI_MEMORY_PHASE2_MAX_CHANGED_SKILL_BYTES,
+  PI_MEMORY_PHASE2_MAX_CHANGED_SKILL_FILE_BYTES,
+  PI_MEMORY_PHASE2_MAX_CHANGED_SKILL_FILES,
+  PI_MEMORY_PHASE2_MEMORY_MAX_BYTES,
+  PI_MEMORY_PHASE2_PREPARED_MAX_BYTES,
+  PI_MEMORY_PHASE2_WORKSPACE_DIFF_MAX_BYTES,
+  PiMemoryPhase2EngineError,
 };
 export { createPiApiFirstTurnOwnership };
 export type {
@@ -76,7 +112,26 @@ export type {
   PiApiFirstTurnOwnershipStage,
   PiMemoryStage1ProviderResult,
   PiMemoryStage1ProviderUsage,
+  PiMemoryPhase2BaseFile,
+  PiMemoryPhase2ConsolidationArgs,
+  PiMemoryPhase2ConsolidationResult,
+  PiMemoryPhase2DiffSummary,
+  PiMemoryPhase2FailureClass,
+  PiMemoryPhase2FailureCounts,
+  PiMemoryPhase2LifecycleEvent,
+  PiMemoryPhase2NoDiffResult,
+  PiMemoryPhase2PreparedFile,
+  PiMemoryPhase2PreparedManifest,
+  PiMemoryPhase2PreparedResult,
+  PiMemoryPhase2ProviderUsage,
+  PiMemoryPhase2SelectedSnapshot,
+  PiMemoryPhase2UsageEvent,
+  RunPiMemoryPhase2Consolidation,
 };
+
+/** Run one restricted Phase 2 maintenance attempt behind a stable API type. */
+export const runPiMemoryPhase2Consolidation: RunPiMemoryPhase2Consolidation =
+  runPiMemoryPhase2ConsolidationImpl;
 
 /** Run one provider turn without exposing Pi's native declaration surface. */
 export const runPiApiFirstTurn: RunPiApiFirstTurn = runPiApiFirstTurnImpl;

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-types.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-types.ts
@@ -80,7 +80,7 @@ export interface PiMemoryPhase2ConsolidationArgs {
   readonly model: PiAgentModelConfig;
   readonly heartbeat: () => Promise<boolean>;
   readonly onLifecycle?: (event: PiMemoryPhase2LifecycleEvent) => void;
-  readonly onUsage?: (event: PiMemoryPhase2UsageEvent) => void;
+  readonly onUsage?: (event: PiMemoryPhase2UsageEvent) => Promise<void> | void;
 }
 
 export interface PiMemoryPhase2PreparedFile {
@@ -135,6 +135,11 @@ export interface PiMemoryPhase2PreparedResult extends PiMemoryPhase2ResultBase {
 export type PiMemoryPhase2ConsolidationResult =
   | PiMemoryPhase2NoDiffResult
   | PiMemoryPhase2PreparedResult;
+
+export type RunPiMemoryPhase2Consolidation = (
+  args: PiMemoryPhase2ConsolidationArgs,
+  signal: AbortSignal,
+) => Promise<PiMemoryPhase2ConsolidationResult>;
 
 export type PiMemoryPhase2FailureClass =
   | "aborted"

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory.test.ts
@@ -945,6 +945,47 @@ describe("Pi memory Phase 2 consolidation engine", () => {
     expect(disposedSessions).toBe(1);
   });
 
+  it("awaits terminal usage before a later output-validation failure", async () => {
+    const provider = await startProvider([
+      { type: "text", text: "finished without required files" },
+    ]);
+    const usages: PiMemoryPhase2UsageEvent[] = [];
+    await expectBoundedFailure(
+      runPiMemoryPhase2Consolidation(
+        args(provider.baseUrl, {
+          baseFiles: [],
+          async onUsage(event) {
+            await Promise.resolve();
+            usages.push(event);
+          },
+        }),
+        new AbortController().signal,
+      ),
+      "agent_output_invalid",
+    );
+
+    expect(usages).toHaveLength(1);
+    expect(usages[0]?.responseId).toBe("resp_phase2_final_0");
+  });
+
+  it("classifies an asynchronous usage persistence failure as observer failure", async () => {
+    const provider = await startProvider([
+      { type: "text", text: "finished before usage observer" },
+    ]);
+    await expectBoundedFailure(
+      runPiMemoryPhase2Consolidation(
+        args(provider.baseUrl, {
+          async onUsage() {
+            await Promise.resolve();
+            throw new Error("USAGE_PERSISTENCE_SECRET_31291");
+          },
+        }),
+        new AbortController().signal,
+      ),
+      "observer_failed",
+    );
+  });
+
   it("observes abort from the staged observer before selecting no-diff", async () => {
     const controller = new AbortController();
     const lifecycle: PiMemoryPhase2LifecycleEvent[] = [];
@@ -1027,7 +1068,7 @@ describe("Pi memory Phase 2 consolidation engine", () => {
     );
 
     expect(provider.requests).toHaveLength(1);
-    expect(usages).toStrictEqual([]);
+    expect(usages).toHaveLength(1);
     expect(disposedSessions).toBe(1);
     expect(
       lifecycle.map((event) => {

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory.ts
@@ -755,6 +755,19 @@ async function executeConsolidation(
     testHooks,
   });
   emitLifecycle(input, state, startedAt, "model_completed");
+  try {
+    await input.onUsage?.({
+      orgId: input.orgId,
+      userId: input.userId,
+      memoryStorageId: input.memoryStorageId,
+      claimedRevision: input.claimedRevision,
+      selectionDigest: input.selectionDigest,
+      responseId: provider.responseId,
+      usage: provider.usage,
+    });
+  } catch {
+    throw engineError("observer_failed", input, state);
+  }
   signal.throwIfAborted();
   await testHooks?.beforeOutputValidation?.(workspace);
   signal.throwIfAborted();
@@ -802,20 +815,6 @@ function commitConsolidationResult(
     outcome: "prepared",
     contentIdentity: result.contentIdentity,
   });
-  signal.throwIfAborted();
-  try {
-    input.onUsage?.({
-      orgId: input.orgId,
-      userId: input.userId,
-      memoryStorageId: input.memoryStorageId,
-      claimedRevision: input.claimedRevision,
-      selectionDigest: input.selectionDigest,
-      responseId: result.responseId,
-      usage: result.usage,
-    });
-  } catch {
-    throw engineError("observer_failed", input, state);
-  }
   signal.throwIfAborted();
   return result;
 }


### PR DESCRIPTION
## Summary

- compose an inert, one-claim-at-a-time Phase 2 archive worker around the accepted claim, terminal-arbitration, and CAS-finalization seams
- strictly validate bounded manifests and tar/gzip payloads, preserve unknown and nested evidence, and deterministically verify immutable archives before registration
- capture terminal restricted-Terra usage before downstream validation or publication, persist it idempotently to the owning organization/user, and keep conflict reconciliation detached from HEAD until the accepted finalizer

## Testing

- `pnpm run lint` (`turbo/apps/api`)
- `pnpm run check-types` (`turbo/apps/api`)
- `pnpm run build` (`turbo/apps/api`)
- `pnpm run lint && pnpm run build && pnpm run test` (`turbo/packages/pi-agent-runtime`; 16 files, 119 tests)
- focused archive tests (3 deterministic/bounds/corruption cases)
- `pnpm run knip` (`turbo`)
- Prettier check for all changed files
- `git diff --check`

The two DB-backed focused suites could not execute locally because this runner has no PostgreSQL service (`ECONNREFUSED` on port 5432); they remain enabled for the PR pipeline.

## Scope

No worker activation, scheduler/startup hook, feature switch, migration/schema change, recovery/deletion path, generic Storage/Volume semantic change, shared `.git` rewrite, Codex behavior change, or production release is included.

Closes #31291
