### PR TITLE
docs(python): fix stale websocket cleanup source link

### DIFF
--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -96,7 +96,7 @@ inbound and outbound close paths.
 The first limit violation on each connection is stored as content-free
 diagnostic state. At terminal flow cleanup,
 `mitm_addon.py`'s
-[`_release_terminal_flow_state()`](../../crates/runner/mitm-addon/src/mitm_addon.py#L1674-L1701)
+[`_release_terminal_flow_state()`](../../crates/runner/mitm-addon/src/mitm_addon.py#L1658-L1684)
 calls `log_limit_violation()` to consume that state and write a
 `websocket_framing_limit` warning for each stored direction. Its structured
 fields are `reason`,


### PR DESCRIPTION
## Summary

Update the canonical WebSocket framing contract link for `_release_terminal_flow_state()` to the complete current implementation range, including the `log_limit_violation()` call and excluding the following `websocket_end()` hook.

## Scope

- Changed only `docs/testing/mitm-addon-testing.md`.
- No Python runtime, tests, dependencies, migrations, APIs, or deployment behavior changed.

## Validation

- `rg -n -F 'mitm_addon.py#L1658-L1684' docs/testing/mitm-addon-testing.md`
- Confirmed `crates/runner/mitm-addon/src/mitm_addon.py` exists.
- Inspected source lines 1658–1687 to verify the function boundary and call location.
- Confirmed the old `#L1674-L1701` fragment is absent.
- `git diff --check`

Closes #31313
