### PR TITLE
docs(rust): document workspace mount cancellation and parking semantics

### DIFF
--- a/crates/vsock-host/src/workspace_drive_mount.rs
+++ b/crates/vsock-host/src/workspace_drive_mount.rs
@@ -37,6 +37,13 @@ impl VsockHost {
     /// The request contains no caller input. The guest selects the program,
     /// command, root identity, paths, timeout, output bounds, containment, and
     /// cleanup. `request_timeout` bounds request write and terminal-result wait.
+    ///
+    /// This is a tracked normal operation. Timing out or dropping the request
+    /// after its possible guest-write boundary abandons terminal proof, and any
+    /// late terminal result is ignored. The connection is then not safe to park
+    /// or reuse for future normal operations; callers must close or discard it
+    /// instead of retrying parking or normal operations. Closing the connection
+    /// cancels and reaps the guest-owned mount helper process group.
     pub async fn mount_workspace_drive(
         &self,
         request_timeout: Duration,


### PR DESCRIPTION
Closes #31332

## Summary

- Document `VsockHost::mount_workspace_drive` as a tracked normal operation.
- Clarify that timeout or cancellation after the possible guest-write boundary abandons terminal proof, ignores late terminal results, and makes the connection unsafe to park or reuse.
- Document closing/discarding the connection as the caller action and guest connection teardown as the mount helper process-group cleanup boundary.

## Scope

This PR changes Rustdoc only in `crates/vsock-host/src/workspace_drive_mount.rs`. It does not change runtime behavior, tests, the wire protocol, or connection cleanup.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p vsock-host --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host workspace_drive_mount`
